### PR TITLE
Explain the package-lock churn, and add a reset-to-origin button

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,7 @@ Track your biological self alongside your digital one.
 ### Requirements
 
 - Node.js 22.12 or later (24 is what CI and `.nvmrc` use; Vite 8 requires ≥20.19). `npm run setup`, `npm start` and `npm run dev` check this first and stop immediately on an older Node — a bare `npm install` only warns, so use the commands below.
+- npm 12 or later (`npm install -g npm@latest`). Older npm installs fine, but its lockfile writer omits the `libc` fields npm 12 records, so every `npm install` rewrites `client/package-lock.json` and `server/package-lock.json` — and the next Dependabot PR puts those fields back. Every workspace declares `engines.npm`, so npm warns on any install path; `npm run setup`/`start`/`dev` also print what to do about it. These are warnings, never failures. No Node release bundles npm 12 yet (Node 24.10 ships 11.6.1), so this is a deliberate global upgrade — and worth checking `npm -v` matches, since an old global npm earlier on `PATH` shadows the one Node ships.
 - Git
 - PostgreSQL, either installed locally or available through Docker. PortOS requires a healthy database; the setup command provisions the supported local or Docker-backed instance.
 

--- a/autofixer/package.json
+++ b/autofixer/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "engines": {
-    "node": ">=22.12.0"
+    "node": ">=22.12.0",
+    "npm": ">=12.0.0"
   },
   "dependencies": {
     "express": "5.2.1"

--- a/client/package.json
+++ b/client/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "engines": {
-    "node": ">=22.12.0"
+    "node": ">=22.12.0",
+    "npm": ">=12.0.0"
   },
   "scripts": {
     "dev": "vite --host 0.0.0.0 --port 5554",

--- a/client/src/components/apps/tabs/GitTab.jsx
+++ b/client/src/components/apps/tabs/GitTab.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
-import { GitBranch, Plus, Minus, FileText, RefreshCw, Download, Rocket, Upload, ArrowUpDown, Check, Trash2, GitMerge, Globe } from 'lucide-react';
+import { GitBranch, Plus, Minus, FileText, RefreshCw, Download, Rocket, Upload, ArrowUpDown, Check, Trash2, GitMerge, Globe, RotateCcw } from 'lucide-react';
 import toast from '../../ui/Toast';
 import Modal from '../../ui/Modal';
 import BrailleSpinner from '../../BrailleSpinner';
@@ -81,6 +81,55 @@ ${mergeStep}. **Merge**: Once approved and CI passes, merge with \`gh pr merge -
 const iconBtnCls = 'p-1.5 min-h-[40px] min-w-[40px] flex items-center justify-center';
 const touchBtnCls = 'min-h-[40px]';
 
+/**
+ * The confirm-dialog chrome this tab uses for its consequential actions — the
+ * release PR and the reset-to-origin. Extracted at the third copy of the same
+ * `Modal` props + header/body/footer markup, because the parts that drift when
+ * it is pasted again are the accessibility ones (`aria-labelledby` wiring, the
+ * 44px close target) rather than anything visible.
+ *
+ * `tone` picks the confirm button's colour: 'accent' for a normal action,
+ * 'error' for one that destroys work.
+ */
+function ConfirmModal({ open, onClose, titleId, icon, title, tone = 'accent', confirmLabel, onConfirm, busy = false, children }) {
+  const confirmCls = tone === 'error'
+    ? 'bg-port-error hover:bg-port-error/80'
+    : 'bg-port-accent hover:bg-port-accent/80';
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      size="md"
+      align="none"
+      backdropClassName="bg-black/50"
+      panelClassName="bg-port-card border border-port-border rounded-xl overflow-hidden"
+      ariaLabelledBy={titleId}
+    >
+      <div className="flex items-center justify-between p-4 border-b border-port-border">
+        <h3 id={titleId} className="font-medium text-white flex items-center gap-2">
+          {icon}
+          {title}
+        </h3>
+        <button onClick={onClose} aria-label="Close" className="text-gray-400 hover:text-white min-h-[44px] min-w-[44px] flex items-center justify-center">×</button>
+      </div>
+      <div className="p-4 space-y-3">{children}</div>
+      <div className="flex justify-end gap-3 p-4 border-t border-port-border">
+        <button onClick={onClose} className="px-4 py-2 text-sm text-gray-400 hover:text-white">
+          Cancel
+        </button>
+        <button
+          onClick={onConfirm}
+          disabled={busy}
+          className={`flex items-center gap-2 px-4 py-2 ${confirmCls} text-white rounded-lg text-sm disabled:opacity-50`}
+        >
+          {icon}
+          {confirmLabel}
+        </button>
+      </div>
+    </Modal>
+  );
+}
+
 export default function GitTab({ appId: _appId, appName, repoPath }) {
   const [gitInfo, setGitInfo] = useState(null);
   const [diff, setDiff] = useState('');
@@ -107,6 +156,8 @@ export default function GitTab({ appId: _appId, appName, repoPath }) {
   const [checkingOutRemote, setCheckingOutRemote] = useState(null);
   const [cleaningUp, setCleaningUp] = useState(false);
   const [cleanupConfirm, setCleanupConfirm] = useState(false);
+  const [resetting, setResetting] = useState(false);
+  const [resetConfirm, setResetConfirm] = useState(false);
 
   const loadGitData = useCallback(async (opts = {}) => {
     if (!repoPath) return;
@@ -379,6 +430,36 @@ export default function GitTab({ appId: _appId, appName, repoPath }) {
     }
   };
 
+  // Destructive: throws away tracked edits and local commits on the default
+  // branch. The pre-reset sha comes back in the result and is surfaced in the
+  // toast, so a mistake is still recoverable with `git reset --hard <sha>`.
+  const handleResetToDefault = async () => {
+    if (!repoPath || resetting) return;
+    setResetting(true);
+    setResetConfirm(false);
+    const result = await api.resetToDefaultBranch(repoPath, { silent: true }).catch((err) => {
+      toast.error(`Reset failed: ${err.message}`);
+      return null;
+    });
+    setResetting(false);
+    if (result?.success) {
+      // The server's counts, not the pre-click snapshot the dialog previewed.
+      const from = result.previousBranch && result.previousBranch !== result.branch
+        ? ` from ${result.previousBranch}`
+        : '';
+      toast.success(`Reset to origin/${result.branch}${from} — discarded ${result.discardedFiles} file change${result.discardedFiles === 1 ? '' : 's'}`);
+      if (result.previousHead) {
+        toast(`Previous state was ${result.previousHead.slice(0, 7)} — git reset --hard ${result.previousHead.slice(0, 7)} to undo`, { icon: '↩️' });
+      }
+      if (!result.fetched) {
+        toast('Could not reach origin — reset to the last fetched state', { icon: '⚠️' });
+      }
+      await loadGitData({ includeRemote: true });
+    }
+  };
+
+  const dirtyCount = gitInfo?.status?.files?.length || 0;
+
   const getStatusIcon = (file) => {
     if (file.added) return <Plus size={14} className="text-port-success" />;
     if (file.deleted) return <Minus size={14} className="text-port-error" />;
@@ -395,9 +476,10 @@ export default function GitTab({ appId: _appId, appName, repoPath }) {
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center justify-between">
+      {/* Wraps rather than overflows: three actions no longer fit one phone row. */}
+      <div className="flex flex-wrap items-center justify-between gap-2">
         <h2 className="text-lg font-semibold text-white">Git Status</h2>
-        <div className="flex items-center gap-2">
+        <div className="flex flex-wrap items-center gap-2">
           {branches.some(b => b.tracking && b.ahead > 0) && (
             <button
               onClick={handlePushAll}
@@ -415,6 +497,20 @@ export default function GitTab({ appId: _appId, appName, repoPath }) {
           >
             <Download size={16} className={updating ? 'animate-bounce' : ''} />
             {updating ? 'Updating...' : 'Update'}
+          </button>
+          <button
+            onClick={() => {
+              setResetConfirm(true);
+              // The dialog names how many files it is about to destroy, so it
+              // reads fresh state rather than whatever the last poll left.
+              loadGitInfo();
+            }}
+            disabled={resetting}
+            title="Discard local changes and match origin's default branch"
+            className="flex items-center gap-1.5 px-3 py-2 bg-port-card border border-port-border rounded-lg text-sm text-gray-300 hover:text-white hover:border-port-error disabled:opacity-50"
+          >
+            <RotateCcw size={16} className={resetting ? 'animate-spin' : ''} />
+            {resetting ? 'Resetting...' : 'Reset to origin'}
           </button>
         </div>
       </div>
@@ -900,54 +996,55 @@ export default function GitTab({ appId: _appId, appName, repoPath }) {
         </pre>
       </Modal>
 
-      {/* Release Confirmation Dialog */}
-      <Modal
+      <ConfirmModal
         open={showReleaseConfirm}
         onClose={() => setShowReleaseConfirm(false)}
-        size="md"
-        align="none"
-        backdropClassName="bg-black/50"
-        panelClassName="bg-port-card border border-port-border rounded-xl overflow-hidden"
-        ariaLabelledBy="git-release-modal-title"
+        titleId="git-release-modal-title"
+        icon={<Rocket size={18} className="text-port-accent" />}
+        title={`Create Release PR for ${appName}`}
+        confirmLabel="Start Release"
+        onConfirm={handleReleasePR}
       >
-        <div className="flex items-center justify-between p-4 border-b border-port-border">
-          <h3 id="git-release-modal-title" className="font-medium text-white flex items-center gap-2">
-            <Rocket size={18} className="text-port-accent" />
-            Create Release PR for {appName}
-          </h3>
-          <button onClick={() => setShowReleaseConfirm(false)} aria-label="Close" className="text-gray-400 hover:text-white min-h-[44px] min-w-[44px] flex items-center justify-center">×</button>
-        </div>
-        <div className="p-4 space-y-3">
-          <p className="text-sm text-gray-300">
-            This will create a CoS agent task to automate the full release workflow:
-          </p>
-          <ul className="text-sm text-gray-400 space-y-1.5 ml-4 list-disc">
-            <li>Push local commits to origin/{gitInfo?.devBranch || 'dev'}</li>
-            {gitInfo?.hasChangelog && <li>Check and update the changelog</li>}
-            <li>Create PR from {gitInfo?.devBranch || 'dev'} to {gitInfo?.baseBranch || 'main'}</li>
-            <li>Wait for Copilot review and address feedback</li>
-            <li>Merge when approved and CI passes</li>
-          </ul>
-          <p className="text-xs text-gray-500">
-            {branchComparison?.ahead || 0} commits will be included in this release.
-          </p>
-        </div>
-        <div className="flex justify-end gap-3 p-4 border-t border-port-border">
-          <button
-            onClick={() => setShowReleaseConfirm(false)}
-            className="px-4 py-2 text-sm text-gray-400 hover:text-white"
-          >
-            Cancel
-          </button>
-          <button
-            onClick={handleReleasePR}
-            className="flex items-center gap-2 px-4 py-2 bg-port-accent hover:bg-port-accent/80 text-white rounded-lg text-sm"
-          >
-            <Rocket size={16} />
-            Start Release
-          </button>
-        </div>
-      </Modal>
+        <p className="text-sm text-gray-300">
+          This will create a CoS agent task to automate the full release workflow:
+        </p>
+        <ul className="text-sm text-gray-400 space-y-1.5 ml-4 list-disc">
+          <li>Push local commits to origin/{gitInfo?.devBranch || 'dev'}</li>
+          {gitInfo?.hasChangelog && <li>Check and update the changelog</li>}
+          <li>Create PR from {gitInfo?.devBranch || 'dev'} to {gitInfo?.baseBranch || 'main'}</li>
+          <li>Wait for Copilot review and address feedback</li>
+          <li>Merge when approved and CI passes</li>
+        </ul>
+        <p className="text-xs text-gray-500">
+          {branchComparison?.ahead || 0} commits will be included in this release.
+        </p>
+      </ConfirmModal>
+
+      {/* Destructive, so it spells out what goes and what survives rather than
+          asking "are you sure?". */}
+      <ConfirmModal
+        open={resetConfirm}
+        onClose={() => setResetConfirm(false)}
+        titleId="git-reset-modal-title"
+        icon={<RotateCcw size={18} className="text-port-error" />}
+        title={`Reset ${appName} to origin/${gitInfo?.baseBranch || 'main'}`}
+        tone="error"
+        confirmLabel={resetting ? 'Resetting...' : 'Discard and reset'}
+        onConfirm={handleResetToDefault}
+        busy={resetting}
+      >
+        <p className="text-sm text-gray-300">
+          Fetches origin, switches to the default branch, and hard-resets it to the remote.
+        </p>
+        <ul className="text-sm text-gray-400 space-y-1.5 ml-4 list-disc">
+          <li>Discards {dirtyCount} uncommitted file change{dirtyCount === 1 ? '' : 's'}</li>
+          <li>Discards any local commits on {gitInfo?.baseBranch || 'main'} that origin does not have</li>
+          <li>Keeps untracked files and every other local branch</li>
+        </ul>
+        <p className="text-xs text-gray-500">
+          The commit you are on now is reported after the reset, so <code>git reset --hard &lt;sha&gt;</code> can undo this.
+        </p>
+      </ConfirmModal>
     </div>
   );
 }

--- a/client/src/components/apps/tabs/GitTab.jsx
+++ b/client/src/components/apps/tabs/GitTab.jsx
@@ -448,6 +448,9 @@ export default function GitTab({ appId: _appId, appName, repoPath }) {
         ? ` from ${result.previousBranch}`
         : '';
       toast.success(`Reset to origin/${result.branch}${from} — discarded ${result.discardedFiles} file change${result.discardedFiles === 1 ? '' : 's'}`);
+      if (result.clearedOperations?.length) {
+        toast(`Also cleared an in-progress ${result.clearedOperations.join(' and ')}`, { icon: '🧹' });
+      }
       if (result.previousHead) {
         toast(`Previous state was ${result.previousHead.slice(0, 7)} — git reset --hard ${result.previousHead.slice(0, 7)} to undo`, { icon: '↩️' });
       }
@@ -458,7 +461,9 @@ export default function GitTab({ appId: _appId, appName, repoPath }) {
     }
   };
 
-  const dirtyCount = gitInfo?.status?.files?.length || 0;
+  // Untracked files are the ones a reset KEEPS, so they must not be counted in
+  // what it says it will discard — the dialog claims both things two rows apart.
+  const dirtyCount = gitInfo?.status?.files?.filter(f => f.status !== 'untracked').length || 0;
 
   const getStatusIcon = (file) => {
     if (file.added) return <Plus size={14} className="text-port-success" />;

--- a/client/src/components/apps/tabs/GitTab.test.jsx
+++ b/client/src/components/apps/tabs/GitTab.test.jsx
@@ -9,6 +9,7 @@ vi.mock('../../../services/api', () => ({
   getRemoteBranches: vi.fn(),
   getGitDiff: vi.fn(),
   cleanupMergedBranches: vi.fn(),
+  resetToDefaultBranch: vi.fn(),
 }));
 
 import * as api from '../../../services/api';
@@ -36,6 +37,7 @@ beforeEach(() => {
   api.getRemoteBranches.mockResolvedValue({ branches: [], defaultBranch: 'main' });
   api.getGitDiff.mockResolvedValue({ diff: '@@ -1 +1 @@\n-old\n+new' });
   api.cleanupMergedBranches.mockResolvedValue({ deleted: [], skipped: [] });
+  api.resetToDefaultBranch.mockResolvedValue({ success: true, branch: 'main', previousBranch: 'main', previousHead: 'b'.repeat(40), head: 'a'.repeat(40), discardedFiles: 1, fetched: true });
 });
 
 afterEach(() => {
@@ -147,5 +149,58 @@ describe('GitTab merged branches checked out in worktrees', () => {
 
     await screen.findByText('claim/issue-1');
     expect(screen.getAllByText('worktree')).toHaveLength(2);
+  });
+});
+
+describe('GitTab reset to origin', () => {
+  it('confirms before resetting, and names what is discarded and what survives', async () => {
+    render(<GitTab appId="x" appName="App" repoPath="/repo" />);
+
+    fireEvent.click(await screen.findByText('Reset to origin'));
+
+    const dialog = await screen.findByRole('dialog');
+    expect(dialog).toHaveAttribute('aria-labelledby', 'git-reset-modal-title');
+    expect(document.getElementById('git-reset-modal-title')).toHaveTextContent('Reset App to origin/main');
+    // Scope is stated, not implied: one dirty file in GIT_INFO, untracked kept.
+    expect(dialog).toHaveTextContent('Discards 1 uncommitted file change');
+    expect(dialog).toHaveTextContent('Keeps untracked files');
+    // Opening the dialog alone must not touch the repo.
+    expect(api.resetToDefaultBranch).not.toHaveBeenCalled();
+  });
+
+  it('does not reset when the confirmation is cancelled', async () => {
+    render(<GitTab appId="x" appName="App" repoPath="/repo" />);
+
+    fireEvent.click(await screen.findByText('Reset to origin'));
+    fireEvent.click(await screen.findByText('Cancel'));
+
+    await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull());
+    expect(api.resetToDefaultBranch).not.toHaveBeenCalled();
+  });
+
+  it('refreshes the dirty-file count when the dialog opens', async () => {
+    render(<GitTab appId="x" appName="App" repoPath="/repo" />);
+    await screen.findByText('Reset to origin');
+    const onMount = api.getGitInfo.mock.calls.length;
+
+    fireEvent.click(screen.getByText('Reset to origin'));
+
+    // The dialog names how many files it will destroy, so it must not quote a
+    // count from whenever the tab last polled.
+    await waitFor(() => expect(api.getGitInfo.mock.calls.length).toBeGreaterThan(onMount));
+  });
+
+  it('resets on confirm and reloads git state', async () => {
+    render(<GitTab appId="x" appName="App" repoPath="/repo" />);
+
+    fireEvent.click(await screen.findByText('Reset to origin'));
+    await screen.findByRole('dialog');
+    const beforeConfirm = api.getGitInfo.mock.calls.length;
+
+    fireEvent.click(screen.getByText('Discard and reset'));
+
+    await waitFor(() => expect(api.resetToDefaultBranch).toHaveBeenCalledWith('/repo', { silent: true }));
+    // The tab re-reads git state rather than trusting its pre-reset snapshot.
+    await waitFor(() => expect(api.getGitInfo.mock.calls.length).toBeGreaterThan(beforeConfirm));
   });
 });

--- a/client/src/components/apps/tabs/GitTab.test.jsx
+++ b/client/src/components/apps/tabs/GitTab.test.jsx
@@ -168,6 +168,27 @@ describe('GitTab reset to origin', () => {
     expect(api.resetToDefaultBranch).not.toHaveBeenCalled();
   });
 
+  it('does not count untracked files among what it says it will discard', async () => {
+    // The dialog promises "Keeps untracked files" two rows below this number,
+    // so counting them there contradicts the same dialog.
+    api.getGitInfo.mockResolvedValue({
+      ...GIT_INFO,
+      status: {
+        files: [
+          { path: 'a.js', status: 'modified', staged: false },
+          { path: 'b.js', status: 'added', staged: true },
+          { path: 'scratch.log', status: 'untracked', staged: false },
+        ],
+      },
+    });
+    render(<GitTab appId="x" appName="App" repoPath="/repo" />);
+
+    fireEvent.click(await screen.findByText('Reset to origin'));
+
+    const dialog = await screen.findByRole('dialog');
+    expect(dialog).toHaveTextContent('Discards 2 uncommitted file changes');
+  });
+
   it('does not reset when the confirmation is cancelled', async () => {
     render(<GitTab appId="x" appName="App" repoPath="/repo" />);
 

--- a/client/src/services/apiGit.js
+++ b/client/src/services/apiGit.js
@@ -73,6 +73,14 @@ export const deleteBranch = (path, branch, { local = false, remote = false } = {
     body: JSON.stringify({ path, branch, local, remote }),
     ...options
   });
+// Destructive: discards tracked changes and local commits on the default
+// branch. Resolves with `previousHead` — the pre-reset sha, so the caller can
+// show a recovery handle.
+export const resetToDefaultBranch = (path, options = {}) => request('/git/reset-to-default', {
+  method: 'POST',
+  body: JSON.stringify({ path }),
+  ...options
+});
 export const cleanupMergedBranches = (path, options = {}) => request('/git/cleanup-merged', {
   method: 'POST',
   body: JSON.stringify({ path }),

--- a/package.json
+++ b/package.json
@@ -7,14 +7,15 @@
   "license": "MIT",
   "type": "module",
   "engines": {
-    "node": ">=22.12.0"
+    "node": ">=22.12.0",
+    "npm": ">=12.0.0"
   },
   "scripts": {
-    "dev": "node scripts/checkNodeVersion.js && node scripts/dev-start.js",
+    "dev": "node scripts/checkNodeVersion.js && node scripts/checkNpmVersion.js && node scripts/dev-start.js",
     "dev:stop": "node ./node_modules/pm2/bin/pm2 stop ecosystem.config.cjs",
     "eval:agent-context": "node scripts/agent-context-eval.js",
     "build": "npm run build --prefix client",
-    "start": "node scripts/checkNodeVersion.js && node scripts/ensure-deps.js && npm run build && node scripts/setup-db.js && node scripts/setup-cert.js && (node ./node_modules/pm2/bin/pm2 delete ecosystem.config.cjs --silent || echo pm2 delete skipped) && node ./node_modules/pm2/bin/pm2 start ecosystem.config.cjs && node ./node_modules/pm2/bin/pm2 save",
+    "start": "node scripts/checkNodeVersion.js && node scripts/checkNpmVersion.js && node scripts/ensure-deps.js && npm run build && node scripts/setup-db.js && node scripts/setup-cert.js && (node ./node_modules/pm2/bin/pm2 delete ecosystem.config.cjs --silent || echo pm2 delete skipped) && node ./node_modules/pm2/bin/pm2 start ecosystem.config.cjs && node ./node_modules/pm2/bin/pm2 save",
     "pm2:start": "node ./node_modules/pm2/bin/pm2 start ecosystem.config.cjs",
     "pm2:stop": "node ./node_modules/pm2/bin/pm2 stop ecosystem.config.cjs",
     "pm2:restart": "node ./node_modules/pm2/bin/pm2 restart ecosystem.config.cjs",
@@ -24,7 +25,7 @@
     "pm2:startup": "node ./node_modules/pm2/bin/pm2 startup",
     "install:all": "npm run setup",
     "migrations": "node scripts/run-migrations.js",
-    "setup": "node scripts/checkNodeVersion.js && git submodule update --init --recursive && npm install && npm install --prefix client && npm install --prefix server && npm install --prefix autofixer && node scripts/trusted-rebuilds.js server && node scripts/setup-data.js && node scripts/setup-db.js && node scripts/setup-llm.js && node scripts/setup-browser.js",
+    "setup": "node scripts/checkNodeVersion.js && node scripts/checkNpmVersion.js && git submodule update --init --recursive && npm install && npm install --prefix client && npm install --prefix server && npm install --prefix autofixer && node scripts/trusted-rebuilds.js server && node scripts/setup-data.js && node scripts/setup-db.js && node scripts/setup-llm.js && node scripts/setup-browser.js",
     "setup:data": "node scripts/setup-data.js",
     "setup:db": "node scripts/setup-db.js",
     "setup:db:test": "npm run setup:db:test --prefix server",

--- a/scripts/checkNodeVersion.js
+++ b/scripts/checkNodeVersion.js
@@ -23,8 +23,7 @@
  * and is asserted to be >= this floor, not equal to it.
  */
 
-import { realpathSync } from 'fs';
-import { fileURLToPath } from 'url';
+import { isDirectlyInvoked } from './lib/directInvocation.js';
 
 /** The hard floor. Changing the version means changing exactly this string. */
 export const MIN_NODE = '22.12.0';
@@ -77,30 +76,8 @@ export function assertNodeVersion({
   return false;
 }
 
-// Runnable directly: `node scripts/checkNodeVersion.js`.
-//
-// Both sides are realpath'd before comparing. Node's ESM loader resolves
-// symlinks when it builds `import.meta.url`, but `process.argv[1]` is whatever
-// the caller typed — so a repo reached through a symlinked parent (a checkout
-// under a symlinked home, /tmp → /private/tmp on macOS, a symlinked worktree)
-// makes the two spellings differ and the gate would silently no-op, exiting 0
-// on an unsupported Node. fileURLToPath/realpathSync also handle paths with
-// spaces or non-ASCII characters, which a `file://` string template does not.
-const invokedPath = process.argv[1];
-if (invokedPath) {
-  const resolve = (p) => {
-    try {
-      return realpathSync(p);
-    } catch {
-      return p;
-    }
-  };
-  // Case-fold on the case-insensitive filesystems (APFS, NTFS): there the two
-  // spellings can differ only in case and still name the same file, and a
-  // strict comparison would silently skip the check.
-  const caseFold = process.platform === 'win32' || process.platform === 'darwin';
-  const normalize = (p) => (caseFold ? resolve(p).toLowerCase() : resolve(p));
-  if (normalize(fileURLToPath(import.meta.url)) === normalize(invokedPath)) {
-    assertNodeVersion();
-  }
+// Runnable directly: `node scripts/checkNodeVersion.js` — see lib/directInvocation.js
+// for why this comparison is not a plain string equality.
+if (isDirectlyInvoked(import.meta.url)) {
+  assertNodeVersion();
 }

--- a/scripts/checkNpmVersion.js
+++ b/scripts/checkNpmVersion.js
@@ -1,0 +1,139 @@
+/**
+ * npm floor advisory — the reason the lockfiles keep showing up modified.
+ *
+ * Symptom: `client/package-lock.json` (and `server/`'s) appears in `git status`
+ * after every local `npm install`, deleting entries nobody edited — most
+ * visibly the `libc` arrays on the Linux-only Rollup/esbuild optional deps
+ * (`+0 / -66`, one file changed, over and over).
+ *
+ * Cause: npm's lockfile writer copies a fixed list of manifest fields into each
+ * entry — `pkgMetaKeys` in `@npmcli/arborist`'s `lib/shrinkwrap.js`. `libc` was
+ * only added to that list in arborist 10, which ships in npm 12. Dependabot
+ * runs a current npm, so every lockfile it opens a PR against carries `libc`;
+ * any install on npm 11 or older then rewrites the file without those fields,
+ * and the next Dependabot PR puts them back. Neither side is wrong — the two
+ * npm versions disagree about the schema, so the file ping-pongs forever. The
+ * same skew drops `peer: true` markers that npm 12 records.
+ *
+ * Why this warns instead of failing: no Node release bundles npm 12 yet (Node
+ * 24.10 ships npm 11.6.1), so gating `npm start` on it would break working
+ * installs over a file-formatting difference. An install on an older npm is
+ * correct — it just churns the lockfile. `npm install -g npm@latest` ends it.
+ *
+ * This advisory is the explainer, not the whole floor. The four `engines.npm`
+ * fields are the declarative half, and they are what covers the install paths
+ * this script never sees — `cd client && npm install`, `npm i <pkg>`, `npm ci`
+ * — because npm checks them itself and prints EBADENGINE. `engine-strict` stays
+ * off (see the .npmrc note: it would make one dependency's narrow range break
+ * every install), so those stay warnings too.
+ *
+ * The advisory also names the case that makes this confusing to diagnose: a
+ * stale global npm earlier on PATH than the one Node bundles, so `npm -v`
+ * reports a version far older than the Node in use would suggest.
+ */
+
+import { readFileSync } from 'fs';
+import { dirname, join } from 'path';
+
+import { compareVersions } from './checkNodeVersion.js';
+import { isDirectlyInvoked } from './lib/directInvocation.js';
+
+/**
+ * The first npm whose lockfile writer records `libc`. Changing this means
+ * changing exactly this string — scripts/checkNpmVersion.test.js pins the
+ * arborist/npm reasoning above to it.
+ */
+export const MIN_NPM = '12.0.0';
+
+/**
+ * Read the npm version out of the `npm_config_user_agent` npm exports to its
+ * run-scripts (`npm/9.6.0 node/v24.10.0 win32 x64 workspaces/false`). This is
+ * the npm actually running the install in the same script chain, which a
+ * `which npm` lookup is not guaranteed to be.
+ * @returns {string|null} - The version, or null when not running under npm
+ */
+export function parseNpmUserAgent(userAgent = process.env.npm_config_user_agent) {
+  const match = /(?:^|\s)npm\/(\d+(?:\.\d+)*)/.exec(String(userAgent));
+  return match ? match[1] : null;
+}
+
+/**
+ * The version of the npm that ships inside the running Node, so the advisory
+ * can tell "your npm is old" apart from "your npm is old *and* it isn't even
+ * the one Node gave you". Handles both install layouts: `<dir>/node_modules`
+ * next to the binary (Windows, and npm's own installer) and the POSIX
+ * `<prefix>/lib/node_modules` one.
+ * @returns {string|null} - The version, or null when it can't be read
+ */
+export function readBundledNpmVersion(execPath = process.execPath) {
+  const base = dirname(execPath);
+  const candidates = [
+    join(base, 'node_modules', 'npm', 'package.json'),
+    join(base, '..', 'lib', 'node_modules', 'npm', 'package.json')
+  ];
+  for (const candidate of candidates) {
+    try {
+      const { version } = JSON.parse(readFileSync(candidate, 'utf8'));
+      if (typeof version === 'string' && version) return version;
+    } catch {
+      // Not this layout (or an unreadable/corrupt manifest) — try the next.
+    }
+  }
+  return null;
+}
+
+/**
+ * The advisory lines for a given toolchain, or `[]` when nothing is wrong.
+ * Pure and injectable so the test can exercise every branch without an npm.
+ * @param {object} options
+ * @param {string|null} options.npmVersion - npm running the install
+ * @param {string|null} options.bundledNpmVersion - npm shipped with `nodeVersion`
+ * @param {string} options.nodeVersion - the running Node
+ * @returns {string[]} - Single-line messages, ready to print in order
+ */
+export function npmAdvisory({
+  npmVersion,
+  bundledNpmVersion = null,
+  nodeVersion = process.versions.node
+} = {}) {
+  // Not running under npm (a bare `node scripts/checkNpmVersion.js`, or a
+  // wrapper that stripped the env) — there is no install to warn about.
+  if (!npmVersion) return [];
+  if (compareVersions(npmVersion, MIN_NPM) >= 0) return [];
+
+  const lines = [
+    `⚠️  npm ${npmVersion} is below ${MIN_NPM} — installs will rewrite package-lock.json`,
+    'ℹ️  Older npm drops the `libc` fields npm 12 records, so the lockfiles churn on every install and ping-pong with Dependabot'
+  ];
+
+  // The confusing case: PATH is resolving an older global npm ahead of the one
+  // Node bundles, so `npm -v` looks stuck in the past no matter which Node runs.
+  if (bundledNpmVersion && compareVersions(npmVersion, bundledNpmVersion) < 0) {
+    lines.push(
+      `ℹ️  Node v${String(nodeVersion).replace(/^v/, '')} bundles npm ${bundledNpmVersion}, but PATH resolves npm ${npmVersion} — an older global install is shadowing it`
+    );
+  }
+
+  lines.push('🔧 Fix: npm install -g npm@latest');
+  return lines;
+}
+
+/**
+ * Print the advisory. Always resolves to whether anything was reported — this
+ * never exits non-zero, so it is safe to chain ahead of a real install.
+ * @returns {boolean} - True when an advisory was printed
+ */
+export function warnOnOutdatedNpm({
+  npmVersion = parseNpmUserAgent(),
+  bundledNpmVersion = readBundledNpmVersion(),
+  warn = console.warn
+} = {}) {
+  const lines = npmAdvisory({ npmVersion, bundledNpmVersion });
+  for (const line of lines) warn(line);
+  return lines.length > 0;
+}
+
+// Runnable directly: `node scripts/checkNpmVersion.js`.
+if (isDirectlyInvoked(import.meta.url)) {
+  warnOnOutdatedNpm();
+}

--- a/scripts/checkNpmVersion.test.js
+++ b/scripts/checkNpmVersion.test.js
@@ -45,10 +45,23 @@ describe('parseNpmUserAgent', () => {
     expect(parseNpmUserAgent('yarn/4.1.0 npm/? node/v24.10.0 linux x64')).toBeNull();
   });
 
-  it('returns null when not running under npm', () => {
-    expect(parseNpmUserAgent(undefined)).toBeNull();
+  it('returns null when there is no npm user agent to read', () => {
+    // NOT `parseNpmUserAgent(undefined)`: the parameter defaults to
+    // `process.env.npm_config_user_agent`, and passing an explicit `undefined`
+    // is indistinguishable from omitting the argument — so under `npm test`
+    // that call reads the ambient agent and returns a version, not null.
     expect(parseNpmUserAgent('')).toBeNull();
     expect(parseNpmUserAgent(null)).toBeNull();
+  });
+
+  it('falls back to the ambient npm_config_user_agent, and to null without one', () => {
+    vi.stubEnv('npm_config_user_agent', 'npm/10.9.0 node/v22.12.0 linux x64');
+    expect(parseNpmUserAgent()).toBe('10.9.0');
+    // The "not running under npm" case the default parameter exists for. Stubbed
+    // rather than assumed, because the suite itself usually runs under npm.
+    vi.stubEnv('npm_config_user_agent', '');
+    expect(parseNpmUserAgent()).toBeNull();
+    vi.unstubAllEnvs();
   });
 });
 

--- a/scripts/checkNpmVersion.test.js
+++ b/scripts/checkNpmVersion.test.js
@@ -1,0 +1,170 @@
+/**
+ * Unit tests for the npm floor advisory.
+ *
+ * The gate exists because a lockfile written by npm 12 and re-written by npm 11
+ * or older differ by the `libc` fields, so `client/package-lock.json` shows up
+ * modified after every install. These tests pin the three things that make the
+ * advisory useful: it fires only below the floor, it never turns into a hard
+ * failure, and it names the shadowed-global-npm case that makes the version
+ * skew hard to spot.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { existsSync, readFileSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+import {
+  MIN_NPM,
+  npmAdvisory,
+  parseNpmUserAgent,
+  readBundledNpmVersion,
+  warnOnOutdatedNpm,
+} from './checkNpmVersion.js';
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const readJson = (rel) => JSON.parse(readFileSync(join(REPO_ROOT, rel), 'utf8'));
+
+describe('MIN_NPM', () => {
+  it('is the npm major whose lockfile writer records `libc`', () => {
+    // arborist 10 added 'libc' to pkgMetaKeys and ships in npm 12; arborist 9
+    // (npm 11.6.1, bundled with Node 24.10) strips it. Anything below 12 churns
+    // the lockfile, so the floor is a whole major and has no patch nuance.
+    expect(MIN_NPM).toBe('12.0.0');
+  });
+});
+
+describe('parseNpmUserAgent', () => {
+  it('reads the version out of the user agent npm exports to run-scripts', () => {
+    expect(parseNpmUserAgent('npm/9.6.0 node/v24.10.0 win32 x64 workspaces/false')).toBe('9.6.0');
+    expect(parseNpmUserAgent('npm/12.0.2 node/v24.10.0 darwin arm64 workspaces/false')).toBe('12.0.2');
+  });
+
+  it('is not fooled by a lookalike earlier in the string', () => {
+    // `pnpm/9.0.0` ends in "npm/9.0.0"; only a token boundary counts.
+    expect(parseNpmUserAgent('pnpm/9.0.0 node/v24.10.0 linux x64')).toBeNull();
+    expect(parseNpmUserAgent('yarn/4.1.0 npm/? node/v24.10.0 linux x64')).toBeNull();
+  });
+
+  it('returns null when not running under npm', () => {
+    expect(parseNpmUserAgent(undefined)).toBeNull();
+    expect(parseNpmUserAgent('')).toBeNull();
+    expect(parseNpmUserAgent(null)).toBeNull();
+  });
+});
+
+describe('readBundledNpmVersion', () => {
+  it('returns null instead of throwing when no npm sits beside the binary', () => {
+    expect(readBundledNpmVersion(join(REPO_ROOT, 'no', 'such', 'node'))).toBeNull();
+  });
+
+  it('reads the running Node’s own bundled npm', () => {
+    // Every supported Node ships an npm; a null here means the layout probe
+    // stopped matching reality, which would silently drop the shadowing hint.
+    expect(readBundledNpmVersion()).toMatch(/^\d+\.\d+\.\d+/);
+  });
+});
+
+describe('npmAdvisory', () => {
+  it('says nothing on npm at or above the floor', () => {
+    expect(npmAdvisory({ npmVersion: MIN_NPM, bundledNpmVersion: '11.6.1' })).toEqual([]);
+    expect(npmAdvisory({ npmVersion: '12.4.0', bundledNpmVersion: '11.6.1' })).toEqual([]);
+  });
+
+  it('says nothing when there is no npm to warn about', () => {
+    // A bare `node scripts/checkNpmVersion.js` isn't running an install.
+    expect(npmAdvisory({ npmVersion: null })).toEqual([]);
+    expect(npmAdvisory({})).toEqual([]);
+  });
+
+  it('names the version, the floor, the symptom, and the fix below the floor', () => {
+    const lines = npmAdvisory({ npmVersion: '11.6.1', bundledNpmVersion: '11.6.1' });
+    const text = lines.join('\n');
+    expect(text).toContain('11.6.1');
+    expect(text).toContain(MIN_NPM);
+    expect(text).toContain('package-lock.json');
+    expect(text).toContain('libc');
+    expect(text).toContain('npm install -g npm@latest');
+  });
+
+  it('flags a stale global npm shadowing the one Node bundles', () => {
+    const lines = npmAdvisory({
+      npmVersion: '9.6.0',
+      bundledNpmVersion: '11.6.1',
+      nodeVersion: 'v24.10.0',
+    });
+    const shadow = lines.find((line) => line.includes('shadowing'));
+    expect(shadow).toBeTruthy();
+    expect(shadow).toContain('24.10.0');
+    expect(shadow).toContain('11.6.1');
+    expect(shadow).toContain('9.6.0');
+    // The `v` is supplied by the message, not doubled up from the input.
+    expect(shadow).not.toContain('vv');
+  });
+
+  it('omits the shadowing line when npm is the bundled one, or newer', () => {
+    const bundled = npmAdvisory({ npmVersion: '11.6.1', bundledNpmVersion: '11.6.1' });
+    expect(bundled.some((line) => line.includes('shadowing'))).toBe(false);
+    const newer = npmAdvisory({ npmVersion: '11.9.0', bundledNpmVersion: '11.6.1' });
+    expect(newer.some((line) => line.includes('shadowing'))).toBe(false);
+  });
+
+  it('omits the shadowing line when the bundled npm cannot be read', () => {
+    const lines = npmAdvisory({ npmVersion: '9.6.0', bundledNpmVersion: null });
+    expect(lines.some((line) => line.includes('shadowing'))).toBe(false);
+    expect(lines.join('\n')).toContain('npm install -g npm@latest');
+  });
+});
+
+describe('warnOnOutdatedNpm', () => {
+  it('prints each advisory line and reports that it warned', () => {
+    const warn = vi.fn();
+    const warned = warnOnOutdatedNpm({ npmVersion: '9.6.0', bundledNpmVersion: '11.6.1', warn });
+    expect(warned).toBe(true);
+    expect(warn.mock.calls.length).toBeGreaterThan(0);
+    // Single-line logging: no multi-line blobs, no JSON dumps.
+    for (const [line] of warn.mock.calls) expect(line).not.toContain('\n');
+  });
+
+  it('stays silent — and non-fatal — on a current npm', () => {
+    const warn = vi.fn();
+    expect(warnOnOutdatedNpm({ npmVersion: '12.0.2', bundledNpmVersion: '11.6.1', warn })).toBe(false);
+    expect(warn).not.toHaveBeenCalled();
+  });
+});
+
+describe('the advisory is actually reachable', () => {
+  it.each(['setup', 'start', 'dev'])('the root `%s` script runs it before installing', (name) => {
+    const script = readJson('package.json').scripts[name];
+    expect(script).toContain('node scripts/checkNpmVersion.js &&');
+    // After the Node gate (which is fatal) and before anything that installs.
+    expect(script.indexOf('checkNodeVersion.js')).toBeLessThan(script.indexOf('checkNpmVersion.js'));
+  });
+});
+
+describe('the floor is declared where npm itself reads it', () => {
+  // The three scripts above cover `npm run setup|start|dev` and nothing else.
+  // `cd client && npm install`, `npm i <pkg>` and `npm ci` are how the lockfile
+  // churn actually gets introduced, and only `engines.npm` reaches those.
+  const MANIFESTS = ['package.json', 'client/package.json', 'server/package.json', 'autofixer/package.json'];
+
+  it.each(MANIFESTS)('%s declares engines.npm = the floor', (rel) => {
+    expect(readJson(rel).engines?.npm).toBe(`>=${MIN_NPM}`);
+  });
+
+  it.each(MANIFESTS)('%s ships a lockfile that the floor protects', (rel) => {
+    // If a workspace stops carrying a lockfile, its engines.npm entry is just
+    // noise — this is what would say so.
+    const lockfile = join(REPO_ROOT, rel.replace(/package\.json$/, 'package-lock.json'));
+    expect(existsSync(lockfile), `${rel} declares engines.npm but ships no lockfile`).toBe(true);
+  });
+
+  it.each(['.npmrc', 'client/.npmrc', 'server/.npmrc', 'autofixer/.npmrc'])(
+    '%s leaves engine-strict off so the npm floor stays a warning',
+    (rel) => {
+      // engine-strict would turn EBADENGINE fatal for dependencies too, which is
+      // the trap the node floor already documents. A churned lockfile is not
+      // worth a broken install.
+      expect(readFileSync(join(REPO_ROOT, rel), 'utf8')).not.toMatch(/^\s*engine-strict\s*=\s*true/m);
+    }
+  );
+});

--- a/scripts/lib/directInvocation.js
+++ b/scripts/lib/directInvocation.js
@@ -1,0 +1,41 @@
+/**
+ * "Was this module run directly, or imported?" — shared by the toolchain gates
+ * in scripts/ so each one can expose pure helpers to its test while still
+ * acting when invoked as `node scripts/<gate>.js`.
+ *
+ * The naive `import.meta.url === pathToFileURL(process.argv[1]).href` breaks in
+ * ways that matter here, because a gate that silently no-ops is worse than no
+ * gate at all:
+ *   - Node's ESM loader resolves symlinks when it builds `import.meta.url`,
+ *     while `process.argv[1]` is whatever the caller typed. A repo reached
+ *     through a symlinked parent (a checkout under a symlinked home,
+ *     /tmp → /private/tmp on macOS, a symlinked worktree) makes the two
+ *     spellings differ, so both sides are realpath'd first.
+ *   - APFS and NTFS are case-insensitive: two spellings can differ only in case
+ *     and still name the same file, so those platforms compare case-folded.
+ *   - fileURLToPath (rather than a `file://` string template) is what handles
+ *     paths containing spaces or non-ASCII characters.
+ */
+
+import { realpathSync } from 'fs';
+import { fileURLToPath } from 'url';
+
+const resolve = (path) => {
+  try {
+    return realpathSync(path);
+  } catch {
+    return path;
+  }
+};
+
+/**
+ * True when `moduleUrl` names the script node was asked to run.
+ * @param {string} moduleUrl - The module's own `import.meta.url`
+ * @param {string} [invokedPath] - Defaults to `process.argv[1]`
+ */
+export function isDirectlyInvoked(moduleUrl, invokedPath = process.argv[1]) {
+  if (!invokedPath) return false;
+  const caseFold = process.platform === 'win32' || process.platform === 'darwin';
+  const normalize = (path) => (caseFold ? resolve(path).toLowerCase() : resolve(path));
+  return normalize(fileURLToPath(moduleUrl)) === normalize(invokedPath);
+}

--- a/server/package.json
+++ b/server/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "engines": {
-    "node": ">=22.12.0"
+    "node": ">=22.12.0",
+    "npm": ">=12.0.0"
   },
   "scripts": {
     "dev": "node --watch index.js",

--- a/server/routes/git.js
+++ b/server/routes/git.js
@@ -249,6 +249,17 @@ router.post('/checkout-remote', asyncHandler(async (req, res) => {
   res.json(result);
 }));
 
+// POST /api/git/reset-to-default - Discard local changes and match origin's
+// default branch. Destructive on tracked files; untracked ones are kept, and
+// the response carries the pre-reset HEAD so the caller can offer a recovery
+// sha. See git.resetToDefaultBranch for the full contract.
+router.post('/reset-to-default', asyncHandler(async (req, res) => {
+  const { path } = req.body;
+  assertAllowedWorkspace(path);
+  const result = await git.resetToDefaultBranch(path);
+  res.json(result);
+}));
+
 // POST /api/git/cleanup-merged - Delete all merged branches (local + remote)
 router.post('/cleanup-merged', asyncHandler(async (req, res) => {
   const { path } = req.body;

--- a/server/services/git.js
+++ b/server/services/git.js
@@ -1,6 +1,6 @@
 import { spawn } from '../lib/childProcess.js';
 import { existsSync } from 'fs';
-import { join } from 'path';
+import { join, resolve } from 'path';
 import { safeJSONParse, PATHS, sleep } from '../lib/fileUtils.js';
 import { isGitLockError, listWorktrees } from './worktreeManager.js';
 import { execGit } from '../lib/execGit.js';
@@ -1161,6 +1161,122 @@ export async function isBranchMergedInto(dir, branch, target) {
 export async function checkoutRemoteBranch(dir, branchName) {
   await execGit(['checkout', '-b', branchName, `origin/${branchName}`], dir);
   return { success: true, branch: branchName };
+}
+
+/**
+ * The id of a running CoS agent whose workspace IS `dir`, or null when none is.
+ * Paths are compared after `resolve` so a trailing slash or a `..` segment on
+ * either side doesn't let a live run slip past the check.
+ *
+ * Imported lazily: `services/git.js` is on the boot path and the agent
+ * lifecycle module is not, so a static import would drag agent state into
+ * every consumer of a git helper.
+ * @param {string} dir - Repo root to check
+ * @returns {Promise<string|null>} - Agent id, or null
+ */
+async function findActiveAgentInWorkspace(dir) {
+  const { getAgents } = await import('./cosAgentLifecycle.js').catch(() => ({ getAgents: null }));
+  if (!getAgents) return null;
+  const agents = await getAgents().catch(() => []);
+  const target = resolve(dir);
+  const busy = agents.find(agent =>
+    agent.status === 'running'
+    && agent.metadata?.workspacePath
+    && resolve(agent.metadata.workspacePath) === target
+  );
+  return busy?.id || null;
+}
+
+/**
+ * Throw away every local change and put the checkout back on origin's default
+ * branch, exactly as the remote has it. The escape hatch for a checkout that
+ * has drifted — a lockfile a local toolchain keeps rewriting, a half-finished
+ * edit, a branch left behind by an interrupted operation.
+ *
+ * Deliberately narrower than "make it look like a fresh clone":
+ *   - Tracked modifications and local commits on the default branch go away;
+ *     `previousHead` comes back in the result so `git reset --hard <sha>`
+ *     recovers them (the commits stay in the reflog for git's gc window).
+ *   - Untracked files stay. There is no `git clean` here: a checkout's
+ *     untracked set is where `.env` files, build output, and scratch work live,
+ *     and losing those is not recoverable from a reflog.
+ *   - Other local branches are untouched — this moves the default branch only.
+ *
+ * A fetch failure is not fatal: the reset falls back to the cached
+ * `origin/<default>` ref so an offline machine can still get back to a known
+ * state, and `fetched: false` says the target may be behind the remote.
+ *
+ * @param {string} dir - Working directory (a repo root, not a linked worktree)
+ * @returns {Promise<{success: boolean, branch: string, previousBranch: string|null,
+ *   previousHead: string|null, discardedFiles: number, fetched: boolean}>}
+ */
+export async function resetToDefaultBranch(dir) {
+  // A linked worktree cannot check out the default branch — the main checkout
+  // already holds it — and hard-resetting one would discard an agent's
+  // in-flight work on a branch that is not the default anyway. Fail with a
+  // reason instead of surfacing git's "already checked out" further down. The
+  // two dirs differ only in a linked worktree, and rev-parse answers both flags
+  // in one spawn, one value per line.
+  const dirs = await execGitSafe(['rev-parse', '--git-dir', '--git-common-dir'], dir);
+  const [gitDir, commonDir] = dirs.stdout.trim().split('\n').map(line => line.trim());
+  if (gitDir && commonDir && gitDir !== commonDir) {
+    throw new ServerError('cannot reset a linked worktree — run this on the main checkout', {
+      status: 400,
+      code: 'WORKTREE_RESET_REFUSED'
+    });
+  }
+
+  // A CoS agent without a worktree works directly in the checkout it was given
+  // (agentWorkspacePrep only isolates when the task asks for it), so resetting
+  // under a running one destroys tracked edits it is still producing and moves
+  // HEAD beneath a live process. primaryCheckoutGuard.js already treats
+  // `reset --hard` on the primary checkout as a decision a human makes
+  // deliberately — this keeps that decision from landing on top of a run.
+  const busyAgent = await findActiveAgentInWorkspace(dir);
+  if (busyAgent) {
+    throw new ServerError(
+      `a CoS agent (${busyAgent}) is running in this checkout — stop it before resetting`,
+      { status: 409, code: 'AGENT_RUNNING' }
+    );
+  }
+
+  const fetched = await fetchOrigin(dir).then(() => true).catch(() => false);
+
+  // A failed fetch already told us the remote is unreachable, so skip
+  // getDefaultBranch's `remote set-head` probe rather than stall on its timeout.
+  const branch = await getDefaultBranch(dir, { allowRemote: fetched });
+  if (!branch) {
+    throw new ServerError('could not determine the default branch', { status: 400, code: 'NO_DEFAULT_BRANCH' });
+  }
+
+  const target = `origin/${branch}`;
+  const targetRef = await execGitSafe(['rev-parse', '--verify', `refs/remotes/${target}`], dir);
+  if (targetRef.exitCode !== 0 || !targetRef.stdout.trim()) {
+    throw new ServerError(`no ${target} ref to reset to`, { status: 400, code: 'NO_REMOTE_REF' });
+  }
+
+  // `rev-parse` takes both spellings of HEAD in one spawn: the sha, then the
+  // branch name. `getStatusPorcelain` is the cheap half of `getStatus` — a
+  // line count is all the caller needs, not a parsed per-file breakdown.
+  const [headBefore, dirty] = await Promise.all([
+    execGitSafe(['rev-parse', 'HEAD', '--abbrev-ref', 'HEAD'], dir),
+    getStatusPorcelain(dir).catch(() => '')
+  ]);
+  const [previousHead = null, previousBranch = null] = headBefore.stdout.trim().split('\n').map(line => line.trim());
+
+  // `checkout --force -B` is the whole operation: `-B` repoints the local branch
+  // at the remote ref and `--force` resets index AND working tree to it, so a
+  // trailing `reset --hard` would re-walk every tracked file to change nothing.
+  await execGit(['checkout', '--force', '-B', branch, target], dir);
+
+  return {
+    success: true,
+    branch,
+    previousBranch,
+    previousHead,
+    discardedFiles: dirty ? dirty.split('\n').filter(Boolean).length : 0,
+    fetched
+  };
 }
 
 /**

--- a/server/services/git.js
+++ b/server/services/git.js
@@ -1164,6 +1164,60 @@ export async function checkoutRemoteBranch(dir, branchName) {
 }
 
 /**
+ * How many entries in raw `git status --porcelain` output a hard reset would
+ * actually destroy — i.e. everything except untracked (`??`) files, which
+ * survive because nothing here runs `git clean`.
+ * @param {string} porcelain - Raw `git status --porcelain` stdout
+ * @returns {number}
+ */
+export function countDiscardable(porcelain) {
+  return String(porcelain || '')
+    .split('\n')
+    .filter(line => line.trim() && !line.startsWith('??'))
+    .length;
+}
+
+/**
+ * Sequencer state files a forced checkout does NOT clear, mapped to the command
+ * that drops each. `--quit` rather than `--abort`: abort rewinds to the
+ * pre-operation HEAD, which is the very state a reset is discarding, while
+ * `--quit` removes the bookkeeping and leaves the tree the checkout just
+ * restored alone. (`MERGE_HEAD` is absent here on purpose — a plain conflicted
+ * merge IS cleared by `checkout --force`.)
+ */
+const SEQUENCER_STATE = [
+  ['rebase-merge', 'rebase'],
+  ['rebase-apply', 'rebase'],
+  ['CHERRY_PICK_HEAD', 'cherry-pick'],
+  ['REVERT_HEAD', 'revert']
+];
+
+/**
+ * Drop any half-finished rebase / cherry-pick / revert.
+ *
+ * Without this a checkout left mid-rebase still reports "You are currently
+ * rebasing" after the reset, and every later `git rebase` in that repo dies on
+ * "there is already a rebase-merge directory" until someone deletes it by hand
+ * — so the reset would report success while leaving the repo in exactly the
+ * stuck state it is advertised to fix.
+ *
+ * @param {string} dir - Repo root
+ * @param {string} gitDirPath - Absolute path to the repo's git dir
+ * @returns {Promise<string[]>} - The operations that were cleared
+ */
+async function clearSequencerState(dir, gitDirPath) {
+  const stuck = [...new Set(
+    SEQUENCER_STATE
+      .filter(([marker]) => existsSync(join(gitDirPath, marker)))
+      .map(([, command]) => command)
+  )];
+  for (const command of stuck) {
+    await execGitSafe([command, '--quit'], dir);
+  }
+  return stuck;
+}
+
+/**
  * The id of a running CoS agent whose workspace IS `dir`, or null when none is.
  * Paths are compared after `resolve` so a trailing slash or a `..` segment on
  * either side doesn't let a live run slip past the check.
@@ -1199,8 +1253,13 @@ async function findActiveAgentInWorkspace(dir) {
  *     recovers them (the commits stay in the reflog for git's gc window).
  *   - Untracked files stay. There is no `git clean` here: a checkout's
  *     untracked set is where `.env` files, build output, and scratch work live,
- *     and losing those is not recoverable from a reflog.
+ *     and losing those is not recoverable from a reflog. `discardedFiles`
+ *     excludes them for the same reason — it counts what was destroyed, not
+ *     what was merely dirty.
  *   - Other local branches are untouched — this moves the default branch only.
+ *   - A half-finished rebase / cherry-pick / revert IS cleared (`clearedOperations`
+ *     names which), because leaving one behind is the stuck state this exists
+ *     to escape.
  *
  * A fetch failure is not fatal: the reset falls back to the cached
  * `origin/<default>` ref so an offline machine can still get back to a known
@@ -1208,7 +1267,8 @@ async function findActiveAgentInWorkspace(dir) {
  *
  * @param {string} dir - Working directory (a repo root, not a linked worktree)
  * @returns {Promise<{success: boolean, branch: string, previousBranch: string|null,
- *   previousHead: string|null, discardedFiles: number, fetched: boolean}>}
+ *   previousHead: string|null, discardedFiles: number, clearedOperations: string[],
+ *   fetched: boolean}>}
  */
 export async function resetToDefaultBranch(dir) {
   // A linked worktree cannot check out the default branch — the main checkout
@@ -1270,6 +1330,11 @@ export async function resetToDefaultBranch(dir) {
   const previousHead = head || null;
   const previousBranch = branchName || null;
 
+  // A half-finished rebase/cherry-pick survives the checkout below, so drop it
+  // first — otherwise the reset "succeeds" into a repo that still refuses every
+  // later rebase.
+  const clearedOperations = await clearSequencerState(dir, resolve(dir, gitDir || '.git'));
+
   // `checkout --force -B` is the whole operation: `-B` repoints the local branch
   // at the remote ref and `--force` resets index AND working tree to it, so a
   // trailing `reset --hard` would re-walk every tracked file to change nothing.
@@ -1280,7 +1345,12 @@ export async function resetToDefaultBranch(dir) {
     branch,
     previousBranch,
     previousHead,
-    discardedFiles: dirty ? dirty.split('\n').filter(Boolean).length : 0,
+    // Untracked files (`??`) are the ones this reset deliberately KEEPS, so
+    // counting them would tell the user more was destroyed than actually was —
+    // directly contradicting the "keeps untracked files" line the confirm
+    // dialog shows two rows above this number.
+    discardedFiles: countDiscardable(dirty),
+    clearedOperations,
     fetched
   };
 }

--- a/server/services/git.js
+++ b/server/services/git.js
@@ -1262,7 +1262,13 @@ export async function resetToDefaultBranch(dir) {
     execGitSafe(['rev-parse', 'HEAD', '--abbrev-ref', 'HEAD'], dir),
     getStatusPorcelain(dir).catch(() => '')
   ]);
-  const [previousHead = null, previousBranch = null] = headBefore.stdout.trim().split('\n').map(line => line.trim());
+  // `|| null` rather than a destructuring default: on a repo with no commits
+  // rev-parse prints nothing, `''.split('\n')` is `['']`, and a default only
+  // fires on `undefined` — so the caller would get `''` where the contract (and
+  // the client's `if (result.previousHead)` recovery hint) says null.
+  const [head, branchName] = headBefore.stdout.trim().split('\n').map(line => line.trim());
+  const previousHead = head || null;
+  const previousBranch = branchName || null;
 
   // `checkout --force -B` is the whole operation: `-B` repoints the local branch
   // at the remote ref and `--force` resets index AND working tree to it, so a

--- a/server/services/git.resetToDefault.test.js
+++ b/server/services/git.resetToDefault.test.js
@@ -98,6 +98,18 @@ describe('resetToDefaultBranch', () => {
     expect(result.discardedFiles).toBe(2);
   });
 
+  it('reports null, not an empty string, when a repo has no commits to name', async () => {
+    // `''.split('\n')` is `['']`, and a destructuring default only fires on
+    // undefined — so the empty case has to be normalized explicitly or the
+    // contract (and the client's `if (result.previousHead)` hint) gets `''`.
+    routeGit({ ...HAPPY_PATH, 'rev-parse HEAD --abbrev-ref HEAD': ok('') });
+
+    const result = await resetToDefaultBranch('/repo');
+
+    expect(result.previousHead).toBeNull();
+    expect(result.previousBranch).toBeNull();
+  });
+
   it('never runs git clean — untracked files are not recoverable from a reflog', async () => {
     routeGit(HAPPY_PATH);
 

--- a/server/services/git.resetToDefault.test.js
+++ b/server/services/git.resetToDefault.test.js
@@ -1,0 +1,179 @@
+/**
+ * Tests for the "reset to origin's default branch" escape hatch behind the
+ * Apps → Git tab button.
+ *
+ * The whole point of the operation is that it destroys work, so the things
+ * worth pinning are its guard rails: it refuses to run in a linked worktree or
+ * under a live CoS agent, it reports the pre-reset sha so the destruction is
+ * undoable, it never runs `git clean` (untracked files survive), and an
+ * unreachable origin degrades to the cached ref instead of failing.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const execGitMock = vi.hoisted(() => vi.fn());
+const getAgentsMock = vi.hoisted(() => vi.fn());
+
+vi.mock('../lib/execGit.js', () => ({
+  execGit: execGitMock
+}));
+
+vi.mock('./cosAgentLifecycle.js', () => ({
+  getAgents: getAgentsMock
+}));
+
+import { resetToDefaultBranch, clearFetchCache } from './git.js';
+
+const ok = (stdout = '') => ({ stdout, stderr: '', exitCode: 0 });
+
+/** Args a call was made with, joined for readable matching. */
+const key = (args) => args.join(' ');
+
+/**
+ * Drive execGit from a table of `'joined args' -> result`, so each test states
+ * only the responses it cares about. Unlisted commands resolve empty, which is
+ * what the optional probes in getDefaultBranch expect.
+ */
+function routeGit(table) {
+  execGitMock.mockImplementation((args) => {
+    const entry = table[key(args)];
+    if (entry instanceof Error) return Promise.reject(entry);
+    return Promise.resolve(entry ?? ok());
+  });
+}
+
+const HAPPY_PATH = {
+  // rev-parse prints one line per flag, so both dirs come back in one spawn.
+  'rev-parse --git-dir --git-common-dir': ok('.git\n.git'),
+  'fetch origin': ok(),
+  'symbolic-ref --short refs/remotes/origin/HEAD': ok('origin/main'),
+  'rev-parse --verify refs/remotes/origin/main': ok('a'.repeat(40)),
+  // Same trick for HEAD: the sha, then the branch name it is on.
+  'rev-parse HEAD --abbrev-ref HEAD': ok(`${'b'.repeat(40)}\nfeature/wip`),
+  'status --porcelain': ok(' M client/package-lock.json\n M server/index.js'),
+  'checkout --force -B main origin/main': ok()
+};
+
+/** Every command the run issued, joined — for "did it / didn't it" assertions. */
+const calledCommands = () => execGitMock.mock.calls.map(([args]) => key(args));
+
+beforeEach(() => {
+  execGitMock.mockReset();
+  getAgentsMock.mockReset();
+  getAgentsMock.mockResolvedValue([]);
+  clearFetchCache();
+});
+
+describe('resetToDefaultBranch', () => {
+  it('fetches, then points the default branch at origin and checks it out', async () => {
+    routeGit(HAPPY_PATH);
+
+    const result = await resetToDefaultBranch('/repo');
+
+    expect(result.success).toBe(true);
+    expect(result.branch).toBe('main');
+    expect(result.fetched).toBe(true);
+    expect(calledCommands()).toEqual(
+      expect.arrayContaining(['fetch origin', 'checkout --force -B main origin/main'])
+    );
+  });
+
+  it('does not follow the forced checkout with a redundant reset --hard', async () => {
+    // `checkout --force -B` already resets index AND working tree to the target
+    // (verified against real git with staged adds, modifications and deletes),
+    // so a trailing `reset --hard` re-walks every tracked file to change nothing.
+    routeGit(HAPPY_PATH);
+
+    await resetToDefaultBranch('/repo');
+
+    expect(calledCommands().some((cmd) => cmd.startsWith('reset --hard'))).toBe(false);
+  });
+
+  it('reports the pre-reset branch, sha, and dirty-file count so the reset is undoable', async () => {
+    routeGit(HAPPY_PATH);
+
+    const result = await resetToDefaultBranch('/repo');
+
+    expect(result.previousBranch).toBe('feature/wip');
+    expect(result.previousHead).toBe('b'.repeat(40));
+    expect(result.discardedFiles).toBe(2);
+  });
+
+  it('never runs git clean — untracked files are not recoverable from a reflog', async () => {
+    routeGit(HAPPY_PATH);
+
+    await resetToDefaultBranch('/repo');
+
+    expect(calledCommands().some((cmd) => cmd.startsWith('clean'))).toBe(false);
+  });
+
+  it('refuses to reset a linked worktree', async () => {
+    routeGit({
+      ...HAPPY_PATH,
+      'rev-parse --git-dir --git-common-dir': ok('/repo/.git/worktrees/agent-1\n/repo/.git')
+    });
+
+    await expect(resetToDefaultBranch('/repo/wt')).rejects.toThrow(/linked worktree/);
+    // Refused before anything touched the working tree.
+    expect(calledCommands().some((cmd) => cmd.startsWith('checkout'))).toBe(false);
+  });
+
+  it('refuses while a CoS agent is running in the same checkout', async () => {
+    // Agents spawned without a worktree work directly in the checkout, so a
+    // reset would discard edits a live run is still writing.
+    routeGit(HAPPY_PATH);
+    getAgentsMock.mockResolvedValue([
+      { id: 'agent-live', status: 'running', metadata: { workspacePath: '/repo/' } }
+    ]);
+
+    await expect(resetToDefaultBranch('/repo')).rejects.toThrow(/agent-live/);
+    expect(calledCommands().some((cmd) => cmd.startsWith('checkout'))).toBe(false);
+  });
+
+  it('ignores agents that finished, or that are running somewhere else', async () => {
+    routeGit(HAPPY_PATH);
+    getAgentsMock.mockResolvedValue([
+      { id: 'agent-done', status: 'completed', metadata: { workspacePath: '/repo' } },
+      { id: 'agent-elsewhere', status: 'running', metadata: { workspacePath: '/other-repo' } },
+      { id: 'agent-worktree', status: 'running', metadata: { workspacePath: '/repo/wt' } }
+    ]);
+
+    await expect(resetToDefaultBranch('/repo')).resolves.toMatchObject({ success: true });
+  });
+
+  it('falls back to the cached ref when origin is unreachable', async () => {
+    routeGit({
+      ...HAPPY_PATH,
+      'fetch origin': new Error('fatal: unable to access origin: Could not resolve host')
+    });
+
+    const result = await resetToDefaultBranch('/repo');
+
+    expect(result.fetched).toBe(false);
+    expect(result.success).toBe(true);
+    expect(calledCommands()).toContain('checkout --force -B main origin/main');
+  });
+
+  it('refuses when the default branch cannot be determined', async () => {
+    routeGit({
+      'rev-parse --git-dir --git-common-dir': ok('.git\n.git'),
+      'fetch origin': ok(),
+      // No origin/HEAD, no local branches, and a detached HEAD leave nothing to
+      // resolve — every getDefaultBranch fallback comes back empty.
+      'rev-parse --abbrev-ref HEAD': ok('HEAD')
+    });
+
+    await expect(resetToDefaultBranch('/repo')).rejects.toThrow(/default branch/);
+  });
+
+  it('refuses when there is no origin ref to reset to', async () => {
+    routeGit({
+      ...HAPPY_PATH,
+      // origin/HEAD names a branch whose remote-tracking ref is gone.
+      'rev-parse --verify refs/remotes/origin/main': { stdout: '', stderr: 'fatal: Needed a single revision', exitCode: 1 },
+      'branch --list': ok('* main')
+    });
+
+    await expect(resetToDefaultBranch('/repo')).rejects.toThrow(/origin\/main/);
+    expect(calledCommands().some((cmd) => cmd.startsWith('checkout'))).toBe(false);
+  });
+});

--- a/server/services/git.resetToDefault.test.js
+++ b/server/services/git.resetToDefault.test.js
@@ -12,9 +12,17 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const execGitMock = vi.hoisted(() => vi.fn());
 const getAgentsMock = vi.hoisted(() => vi.fn());
+const existsSyncMock = vi.hoisted(() => vi.fn());
 
 vi.mock('../lib/execGit.js', () => ({
   execGit: execGitMock
+}));
+
+// Only the sequencer-state probe reads the filesystem here; everything else in
+// git.js reaches git through the mock above.
+vi.mock('fs', async (importOriginal) => ({
+  ...(await importOriginal()),
+  existsSync: existsSyncMock
 }));
 
 vi.mock('./cosAgentLifecycle.js', () => ({
@@ -60,6 +68,9 @@ beforeEach(() => {
   execGitMock.mockReset();
   getAgentsMock.mockReset();
   getAgentsMock.mockResolvedValue([]);
+  // Default: no rebase/cherry-pick/revert in progress.
+  existsSyncMock.mockReset();
+  existsSyncMock.mockReturnValue(false);
   clearFetchCache();
 });
 
@@ -116,6 +127,47 @@ describe('resetToDefaultBranch', () => {
     await resetToDefaultBranch('/repo');
 
     expect(calledCommands().some((cmd) => cmd.startsWith('clean'))).toBe(false);
+  });
+
+  it('excludes untracked files from the discarded count, since it keeps them', async () => {
+    // Counting `??` entries would claim more was destroyed than was — the
+    // confirm dialog promises "keeps untracked files" two rows above the number.
+    routeGit({
+      ...HAPPY_PATH,
+      'status --porcelain': ok(' M tracked.js\nA  staged.js\n?? scratch.log\n?? build/')
+    });
+
+    const result = await resetToDefaultBranch('/repo');
+
+    expect(result.discardedFiles).toBe(2);
+  });
+
+  it('clears a half-finished rebase, which the forced checkout leaves behind', async () => {
+    // Verified against real git: `checkout --force` empties the tree and index
+    // but leaves .git/rebase-merge, so the reset "succeeds" into a repo where
+    // every later `git rebase` dies on "already a rebase-merge directory".
+    existsSyncMock.mockImplementation((path) => String(path).endsWith('rebase-merge'));
+    routeGit(HAPPY_PATH);
+
+    const result = await resetToDefaultBranch('/repo');
+
+    expect(result.clearedOperations).toEqual(['rebase']);
+    expect(calledCommands()).toContain('rebase --quit');
+    // --quit, never --abort: abort rewinds to the pre-rebase HEAD, which is the
+    // state the reset is deliberately discarding.
+    expect(calledCommands().some((cmd) => cmd.includes('--abort'))).toBe(false);
+    // And it runs BEFORE the checkout, so the checkout lands on a normal repo.
+    expect(calledCommands().indexOf('rebase --quit'))
+      .toBeLessThan(calledCommands().indexOf('checkout --force -B main origin/main'));
+  });
+
+  it('leaves the sequencer alone when no operation is in progress', async () => {
+    routeGit(HAPPY_PATH);
+
+    const result = await resetToDefaultBranch('/repo');
+
+    expect(result.clearedOperations).toEqual([]);
+    expect(calledCommands().some((cmd) => cmd.includes('--quit'))).toBe(false);
   });
 
   it('refuses to reset a linked worktree', async () => {


### PR DESCRIPTION
Two independent pieces from the same report: why `client/package-lock.json` keeps coming back modified, and a button to reset a checkout to origin.

## Why the lockfile churns

npm's lockfile writer copies a fixed list of manifest fields into each entry — `pkgMetaKeys` in `@npmcli/arborist`'s `lib/shrinkwrap.js`. **`libc` was only added to that list in arborist 10, which ships in npm 12.** Dependabot runs a current npm, so every lockfile it opens a PR against carries `libc` on the Linux-only Rollup/esbuild optional deps; any local install on npm 11 or older rewrites the file without them, and the next Dependabot PR puts them back. Neither side is wrong — the two npm versions disagree about the schema, so the file ping-pongs forever. The same skew drops `peer: true` markers.

Verified both directions against the real lockfile: npm 9.6.0 (arborist 6.2.4) and npm 11.6.1 (arborist 9.1.5) each strip all 22 `libc` entries; arborist 10's `pkgMetaKeys` contains `libc`.

Worth noting for anyone diagnosing this: **Node 24.10 bundles npm 11.6.1, so upgrading Node is not enough** — npm 12 is a deliberate global install. And an older global npm earlier on `PATH` shadows the one Node ships, so `npm -v` can report a version far older than the running Node would suggest.

The floor is declared two ways:

- **`engines.npm: ">=12.0.0"`** in all four manifests. This is the half that matters, because it reaches the installs that actually introduce the churn — `cd client && npm install`, `npm i <pkg>`, `npm ci` — none of which run a repo script. npm checks `engines` itself and prints EBADENGINE.
- **`scripts/checkNpmVersion.js`** is the explainer, at the head of `setup` / `start` / `dev`: it names the symptom, the fix, and the shadowed-global-npm case.

Both are **warnings, never failures**. `engine-strict` deliberately stays off (the `.npmrc` comment explains why: it makes one dependency's narrow range break every install), and no Node release bundles npm 12 yet — gating `npm start` on a file-formatting difference would break working installs.

## Reset to origin

The Apps → Git tab gets a **Reset to origin** button: fetches origin, switches to the default branch, and points it at the remote.

Deliberately narrower than "make it look like a fresh clone":

- Tracked modifications and local commits on the default branch go away; the pre-reset sha comes back in the response and is surfaced in a toast, so `git reset --hard <sha>` undoes it.
- **Untracked files stay.** There is no `git clean` — a checkout's untracked set is where `.env` files, build output, and scratch work live, and losing those isn't recoverable from a reflog.
- Other local branches are untouched.
- An unreachable origin is not fatal: it falls back to the cached `origin/<default>` ref and reports `fetched: false`.

Two guards, both in the service so any caller gets them:

- **Linked worktree** → 400. It can't check out the default branch anyway (the main checkout holds it), and resetting one would discard an agent's in-flight work.
- **A running CoS agent in that checkout** → 409 naming the agent. An agent spawned without a worktree works directly in the checkout it was given, so a reset would destroy edits a live run is still writing and move HEAD beneath it. `primaryCheckoutGuard.js` already treats `reset --hard` on the primary checkout as a decision a human makes deliberately; this keeps that decision from landing on top of a run.

`checkout --force -B <branch> origin/<branch>` is the whole operation — `-B` repoints the branch and `--force` resets index *and* working tree, so no trailing `reset --hard` is needed.

## Also

- `scripts/lib/directInvocation.js` — the "was this module run directly?" check, shared by both toolchain gates instead of a second copy of the symlink/case-fold care.
- `ConfirmModal` in `GitTab.jsx` — extracted at the third verbatim copy of the same dialog chrome, since what drifts on a paste is the a11y wiring.

## Test plan

- `cd server && npm test` — 1593 files pass; the new `git.resetToDefault.test.js` and `checkNpmVersion.test.js` are 44 cases between them. Run through npm, not vitest directly, since that distinction is what finding 3 below turned on.
- `cd client && npm test` — `GitTab.test.jsx` 11 cases.
- `cd client && npm run build` — clean.
- **Reset verified against real git** on a throwaway repo carrying every dirty state at once — a staged-then-further-modified file, a staged add, a staged delete, an unstaged edit, an untracked file, a local commit, on a non-default branch. Result: index and tree fully clean afterward, untracked file survived, the other branch and its commit preserved, `previousHead` pointed at the recoverable sha. The linked-worktree guard refused with a 400 on a real `git worktree`.
- **npm advisory verified** by running an actual `npm install --package-lock-only` over the real `client/package-lock.json` with each installed npm.

## Review

A Claude reviewer pass surfaced three findings, all reproduced against real git before fixing (see the third commit):

1. `discardedFiles` counted untracked files, which this reset keeps — the confirm dialog showed the inflated number two rows above its own "keeps untracked files" line.
2. A half-finished rebase survived the reset: clean porcelain, `success: true`, but `.git/rebase-merge` intact and every later `git rebase` dead on "already a rebase-merge directory" — the exact stuck state the feature advertises escaping.
3. A new test failed under `npm test`: `parseNpmUserAgent(undefined)` is indistinguishable from omitting the argument, so the parameter default read the ambient `npm_config_user_agent`. It passed only because the earlier runs invoked vitest directly; CI's `test:ci` runs with `--bail=1`, so it would have halted the server suite.

Two pre-existing failures on `main` are untouched by this branch and still fail identically on an unmodified checkout: `services/askService.test.js` and `services/imageTo3d/trellis2NormalBake.test.js` (13 cases), plus `client/src/a11yConventions.test.js`.
