### PR TITLE
fix: centralize direct-invocation guards

### DIFF
--- a/scripts/ci-base-sha.js
+++ b/scripts/ci-base-sha.js
@@ -26,8 +26,7 @@
  */
 
 import { spawnSync } from 'child_process';
-import { resolve } from 'path';
-import { fileURLToPath } from 'url';
+import { isDirectlyInvoked } from './lib/directInvocation.js';
 import { writeStepEnv } from './lib/githubOutput.js';
 
 /** Resolve a revision to a commit sha, or null when git cannot. */
@@ -73,7 +72,4 @@ function main() {
   console.log('No pull-request merge base to resolve — this run tests the complete suite.');
 }
 
-const isMain = process.argv[1]
-  && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url));
-
-if (isMain) main();
+if (isDirectlyInvoked(import.meta.url)) main();

--- a/scripts/ci-test-plan.js
+++ b/scripts/ci-test-plan.js
@@ -1,8 +1,7 @@
 #!/usr/bin/env node
 
 import { execFileSync } from 'child_process';
-import { fileURLToPath } from 'url';
-import { resolve } from 'path';
+import { isDirectlyInvoked } from './lib/directInvocation.js';
 import { writeStepOutput } from './lib/githubOutput.js';
 
 const TEST_FILE_RE = /\.(?:test|spec)\.[cm]?[jt]sx?$/i;
@@ -466,7 +465,4 @@ function main() {
   emitGitHubPlan(buildCiTestPlan(changedFiles, { trackedFiles, forceFull, forceFullReason }));
 }
 
-const isMain = process.argv[1]
-  && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url));
-
-if (isMain) main();
+if (isDirectlyInvoked(import.meta.url)) main();

--- a/scripts/direct-invocation-drift.test.js
+++ b/scripts/direct-invocation-drift.test.js
@@ -1,0 +1,38 @@
+/**
+ * Drift guard for direct-invocation checks (issue #4868).
+ *
+ * A hand-rolled comparison between process.argv[1] and import.meta.url misses
+ * symlink and case-folding behavior handled by scripts/lib/directInvocation.js.
+ * Keep every import-safe CLI on the shared helper so a direct run cannot
+ * silently no-op under a symlinked checkout.
+ */
+import { describe, expect, it } from 'vitest';
+import { readdirSync, readFileSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const SCRIPT_DIRS = ['scripts', 'server/scripts'];
+
+const scriptFiles = SCRIPT_DIRS.flatMap((relativeDir) => {
+  const directory = join(REPO_ROOT, relativeDir);
+  return readdirSync(directory, { withFileTypes: true })
+    .filter((entry) => (
+      entry.isFile()
+      && entry.name.endsWith('.js')
+      && !entry.name.endsWith('.test.js')
+    ))
+    .map((entry) => `${relativeDir}/${entry.name}`);
+});
+
+describe('direct-invocation checks have one owner (issue #4868)', () => {
+  it('top-level JavaScript scripts do not compare argv[1] with import.meta.url themselves', () => {
+    const offenders = scriptFiles.filter((relativePath) => {
+      const source = readFileSync(join(REPO_ROOT, relativePath), 'utf8');
+      return /process\.argv\[1\][\s\S]{0,200}import\.meta\.url/.test(source)
+        || /import\.meta\.url[\s\S]{0,200}process\.argv\[1\]/.test(source);
+    });
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/scripts/generate-prompt-stage-call-sites.js
+++ b/scripts/generate-prompt-stage-call-sites.js
@@ -28,6 +28,7 @@ import { execFileSync } from 'node:child_process';
 import { readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { isDirectlyInvoked } from './lib/directInvocation.js';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 
@@ -182,4 +183,4 @@ function main() {
   console.log(`📜 Wrote ${MANIFEST_RELATIVE_PATH}: ${Object.keys(manifest).length} stages across ${paths.size} files`);
 }
 
-if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) main();
+if (isDirectlyInvoked(import.meta.url)) main();

--- a/scripts/run-ci-lint.js
+++ b/scripts/run-ci-lint.js
@@ -2,8 +2,9 @@
 
 import { spawnSync } from 'child_process';
 import { existsSync } from 'fs';
-import { dirname, join, resolve } from 'path';
+import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
+import { isDirectlyInvoked } from './lib/directInvocation.js';
 
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
 
@@ -69,7 +70,4 @@ function main() {
   process.exit(result.status ?? 1);
 }
 
-const isMain = process.argv[1]
-  && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url));
-
-if (isMain) main();
+if (isDirectlyInvoked(import.meta.url)) main();

--- a/scripts/run-ci-tests.js
+++ b/scripts/run-ci-tests.js
@@ -2,10 +2,11 @@
 
 import { spawnSync } from 'child_process';
 import { appendFileSync } from 'fs';
-import { dirname, join, resolve } from 'path';
+import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 import { prepareCliSpawn } from '../server/lib/bufferedSpawn.js';
 import { ALWAYS_RUN_TESTS } from './ci-test-plan.js';
+import { isDirectlyInvoked } from './lib/directInvocation.js';
 
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
 
@@ -193,7 +194,4 @@ function main() {
   process.exit(spawnNpm(scope, union, 'selected tests'));
 }
 
-const isMain = process.argv[1]
-  && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url));
-
-if (isMain) main();
+if (isDirectlyInvoked(import.meta.url)) main();

--- a/scripts/run-migrations.js
+++ b/scripts/run-migrations.js
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
 import { readdir, readFile, writeFile, mkdir, rename } from 'fs/promises';
-import { join, dirname, resolve } from 'path';
+import { join, dirname } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
 import { resolveInstallRoot, isWorktreeRoot } from '../server/lib/dataRoot.js';
+import { isDirectlyInvoked } from './lib/directInvocation.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 // Prefer an explicit PORTOS_DATA_ROOT env var over the executing-file location
@@ -171,15 +172,7 @@ export async function runMigrations({
   return ran;
 }
 
-// Only run as CLI when invoked directly (not when imported as a module).
-// `pathToFileURL()` requires an absolute path, so we `resolve()` argv[1]
-// first (it may be relative when launched as `node scripts/run-migrations.js`).
-// URL-vs-URL comparison normalizes slashes / drive-letter casing on Windows.
-// Kept synchronous so importing the module doesn't make it an async module
-// or trigger filesystem I/O at evaluation time.
-const invokedAsScript = process.argv[1]
-  && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
-if (invokedAsScript) {
+if (isDirectlyInvoked(import.meta.url)) {
   runMigrations().catch(err => {
     console.error(`❌ Migration failed: ${err?.stack ?? err}`);
     process.exit(1);

--- a/scripts/trusted-rebuild-stamp.js
+++ b/scripts/trusted-rebuild-stamp.js
@@ -31,9 +31,9 @@
  */
 import { createHash } from 'crypto';
 import { existsSync, readFileSync, writeFileSync } from 'fs';
-import { join, resolve } from 'path';
-import { fileURLToPath } from 'url';
+import { join } from 'path';
 
+import { isDirectlyInvoked } from './lib/directInvocation.js';
 import { TRUSTED_REBUILDS, discoverWorkspaces, workspaceDir } from './trusted-rebuilds.js';
 
 export const STAMP_FILE = '.portos-trusted-rebuild.json';
@@ -100,7 +100,4 @@ function tryRead(path) {
   }
 }
 
-const isMain = process.argv[1]
-  && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url));
-
-if (isMain) process.exit(runCli(process.argv.slice(2)));
+if (isDirectlyInvoked(import.meta.url)) process.exit(runCli(process.argv.slice(2)));

--- a/scripts/trusted-rebuilds.js
+++ b/scripts/trusted-rebuilds.js
@@ -19,9 +19,10 @@
  */
 import { execFileSync } from 'child_process';
 import { existsSync, readdirSync } from 'fs';
-import { join, dirname, resolve } from 'path';
+import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { prepareCliSpawn } from '../server/lib/bufferedSpawn.js';
+import { isDirectlyInvoked } from './lib/directInvocation.js';
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 
@@ -144,9 +145,4 @@ export function runCli(argv, { spawn = execFileSync } = {}) {
   return rebuildTrusted(dirOverride ?? workspaceDir(label), label, { spawn }) ? 0 : 1;
 }
 
-// Matches the entry-guard idiom in scripts/run-ci-lint.js — `resolve()` on both
-// sides so a relative `node scripts/…` invocation still matches.
-const isMain = process.argv[1]
-  && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url));
-
-if (isMain) process.exit(runCli(process.argv.slice(2)));
+if (isDirectlyInvoked(import.meta.url)) process.exit(runCli(process.argv.slice(2)));

--- a/scripts/verify-ci-status.js
+++ b/scripts/verify-ci-status.js
@@ -20,8 +20,7 @@
 // `verified=false`, and the release workflow runs the complete suite.
 
 import { spawnSync } from 'child_process';
-import { fileURLToPath } from 'url';
-import { resolve } from 'path';
+import { isDirectlyInvoked } from './lib/directInvocation.js';
 import { writeStepOutput } from './lib/githubOutput.js';
 
 // Must match the `Full CI Gate` job name in .github/workflows/ci.yml.
@@ -137,7 +136,4 @@ function main() {
   emit(false, `no successful ${FULL_CI_GATE_CHECK_NAME} for this tree`);
 }
 
-const isMain = process.argv[1]
-  && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url));
-
-if (isMain) main();
+if (isDirectlyInvoked(import.meta.url)) main();

--- a/server/scripts/run-db-migrations.js
+++ b/server/scripts/run-db-migrations.js
@@ -30,8 +30,9 @@
  */
 
 import { readdir, readFile } from 'fs/promises';
-import { join, dirname, resolve } from 'path';
+import { join, dirname } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
+import { isDirectlyInvoked } from '../../scripts/lib/directInvocation.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const DEFAULT_MIGRATIONS_DIR = join(__dirname, 'db-migrations');
@@ -106,13 +107,7 @@ export async function runDbMigrations({
   return ran;
 }
 
-// Only run as CLI when invoked directly (not when imported as a module).
-// `pathToFileURL()` requires an absolute path, so we `resolve()` argv[1] first
-// (it may be relative when launched as `node server/scripts/run-db-migrations.js`).
-// URL-vs-URL comparison normalizes slashes / drive-letter casing on Windows.
-const invokedAsScript = process.argv[1]
-  && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
-if (invokedAsScript) {
+if (isDirectlyInvoked(import.meta.url)) {
   const { close } = await import('../lib/db.js');
   await runDbMigrations()
     .then(() => close())


### PR DESCRIPTION
## Summary
- replace the nine hand-rolled entrypoint comparisons from #4868 with the shared `isDirectlyInvoked` helper
- migrate the same weaker guard in `generate-prompt-stage-call-sites.js`, found while adding the drift check
- add a drift test that rejects future direct comparisons in top-level JavaScript scripts

## Test plan
- `cd server && ./node_modules/.bin/vitest run ../scripts/direct-invocation-drift.test.js ../scripts/ci-base-sha.test.js ../scripts/ci-test-plan.test.js ../scripts/generate-prompt-stage-call-sites.test.js ../scripts/run-ci-lint.test.js ../scripts/run-ci-tests.test.js ../scripts/run-migrations.test.js ../scripts/trusted-rebuild-stamp.test.js ../scripts/trusted-rebuilds.test.js ../scripts/verify-ci-status.test.js` (142 passed)
- invoked `scripts/ci-base-sha.js` through a symlinked checkout path; the CLI body ran instead of silently exiting
- full server suite: 33,450 passed, 9 skipped, 1 environment-specific failure in the unchanged `lib/connectivity.test.js` because `192.0.2.1` is reachable from this machine

Closes #4868