### PR TITLE
make the direct-invocation drift guard trustworthy and repo-wide

### DIFF
--- a/scripts/direct-invocation-drift.test.js
+++ b/scripts/direct-invocation-drift.test.js
@@ -5,25 +5,30 @@
  * symlink and case-folding behavior handled by scripts/lib/directInvocation.js.
  * Keep every import-safe CLI on the shared helper so a direct run cannot
  * silently no-op under a symlinked checkout.
+ *
+ * The scan covers every tracked non-test .js file rather than a directory list:
+ * CLI entrypoints are not confined to scripts/, and the tenth copy is most
+ * likely to appear exactly where nobody thought to look. Reading the whole
+ * tracked tree costs ~65ms, so scoping it any tighter buys nothing.
  */
 import { describe, expect, it } from 'vitest';
-import { readdirSync, readFileSync } from 'fs';
+import { execFileSync } from 'child_process';
+import { readFileSync } from 'fs';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 
 const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
-const SCRIPT_DIRS = ['scripts', 'server/scripts'];
 
-const scriptFiles = SCRIPT_DIRS.flatMap((relativeDir) => {
-  const directory = join(REPO_ROOT, relativeDir);
-  return readdirSync(directory, { withFileTypes: true })
-    .filter((entry) => (
-      entry.isFile()
-      && entry.name.endsWith('.js')
-      && !entry.name.endsWith('.test.js')
-    ))
-    .map((entry) => `${relativeDir}/${entry.name}`);
-});
+/** The helper itself compares the two by definition — it is the one owner. */
+const OWNER = 'scripts/lib/directInvocation.js';
+
+const scriptFiles = execFileSync('git', ['ls-files', '*.js'], { cwd: REPO_ROOT, encoding: 'utf8' })
+  .split('\n')
+  .filter((relativePath) => (
+    relativePath
+    && !relativePath.endsWith('.test.js')
+    && relativePath !== OWNER
+  ));
 
 /** True when `source` hand-rolls the argv[1] <-> import.meta.url comparison. */
 const handRollsCheck = (source) => (
@@ -42,7 +47,7 @@ describe('direct-invocation checks have one owner (issue #4868)', () => {
     expect(handRollsCheck('if (isDirectlyInvoked(import.meta.url)) main();')).toBe(false);
   });
 
-  it('top-level JavaScript scripts do not compare argv[1] with import.meta.url themselves', () => {
+  it('tracked JavaScript files do not compare argv[1] with import.meta.url themselves', () => {
     expect(scriptFiles.length).toBeGreaterThan(0);
 
     const offenders = scriptFiles.filter((relativePath) => (

--- a/scripts/direct-invocation-drift.test.js
+++ b/scripts/direct-invocation-drift.test.js
@@ -25,13 +25,29 @@ const scriptFiles = SCRIPT_DIRS.flatMap((relativeDir) => {
     .map((entry) => `${relativeDir}/${entry.name}`);
 });
 
+/** True when `source` hand-rolls the argv[1] <-> import.meta.url comparison. */
+const handRollsCheck = (source) => (
+  /process\.argv\[1\][\s\S]{0,200}import\.meta\.url/.test(source)
+  || /import\.meta\.url[\s\S]{0,200}process\.argv\[1\]/.test(source)
+);
+
 describe('direct-invocation checks have one owner (issue #4868)', () => {
+  // The scan below can only fail while the detector still fires and the file
+  // list is still populated, so both are verified rather than trusted — a
+  // broken regex or an empty glob would otherwise pass silently forever.
+  it('handRollsCheck flags hand-rolled guards and clears the shared helper', () => {
+    expect(handRollsCheck('const isMain = process.argv[1]\n  && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url));')).toBe(true);
+    expect(handRollsCheck('if (import.meta.url === pathToFileURL(process.argv[1]).href) main();')).toBe(true);
+    expect(handRollsCheck('if (import.meta.url === `file://${process.argv[1]}`) main();')).toBe(true);
+    expect(handRollsCheck('if (isDirectlyInvoked(import.meta.url)) main();')).toBe(false);
+  });
+
   it('top-level JavaScript scripts do not compare argv[1] with import.meta.url themselves', () => {
-    const offenders = scriptFiles.filter((relativePath) => {
-      const source = readFileSync(join(REPO_ROOT, relativePath), 'utf8');
-      return /process\.argv\[1\][\s\S]{0,200}import\.meta\.url/.test(source)
-        || /import\.meta\.url[\s\S]{0,200}process\.argv\[1\]/.test(source);
-    });
+    expect(scriptFiles.length).toBeGreaterThan(0);
+
+    const offenders = scriptFiles.filter((relativePath) => (
+      handRollsCheck(readFileSync(join(REPO_ROOT, relativePath), 'utf8'))
+    ));
 
     expect(offenders).toEqual([]);
   });

--- a/scripts/lib/directInvocation.js
+++ b/scripts/lib/directInvocation.js
@@ -15,6 +15,11 @@
  *     and still name the same file, so those platforms compare case-folded.
  *   - fileURLToPath (rather than a `file://` string template) is what handles
  *     paths containing spaces or non-ASCII characters.
+ *
+ * Lives in scripts/lib/, not server/lib/ with the other pure helpers, because
+ * the CI impact job runs scripts/ci-base-sha.js and scripts/ci-test-plan.js
+ * before any `npm ci` — both import this, so it has to load from a bare
+ * checkout. Builtins only; scripts/pre-install-entrypoints.test.js enforces it.
  */
 
 import { realpathSync } from 'fs';

--- a/scripts/pre-install-entrypoints.test.js
+++ b/scripts/pre-install-entrypoints.test.js
@@ -1,0 +1,79 @@
+/**
+ * Guard for the pre-install zone: the CI `Plan test impact` job checks out the
+ * repo and immediately runs `node scripts/ci-base-sha.js` and
+ * `node scripts/ci-test-plan.js` — with no `npm ci` before them. Those two
+ * scripts, and everything they transitively import, therefore have to load
+ * from a bare checkout, using Node builtins only.
+ *
+ * Nothing enforces that today, and the failure is invisible until it isn't:
+ * `server/lib/` is one `import { z } from 'zod'` away from unloadable (its
+ * barrel already is), so "just move the shared helper somewhere tidier" would
+ * take out the first job in CI — the one that decides what every other job
+ * runs. That makes it latent rather than live, which is exactly why it needs a
+ * guard rather than a comment.
+ *
+ * This is also why scripts/lib/directInvocation.js stays in scripts/lib/
+ * rather than moving to server/lib/ alongside the other pure helpers: it is
+ * imported by both pre-install entrypoints.
+ */
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'fs';
+import { builtinModules } from 'module';
+import { dirname, join, relative, resolve } from 'path';
+import { fileURLToPath } from 'url';
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+/** Run by the CI `impact` job before any dependency install. */
+const PRE_INSTALL_ENTRYPOINTS = ['scripts/ci-base-sha.js', 'scripts/ci-test-plan.js'];
+
+const BUILTINS = new Set(builtinModules);
+const isBuiltin = (specifier) => BUILTINS.has(specifier.replace(/^node:/, ''));
+
+/** Static `from '...'` / bare `import '...'` specifiers, comments stripped. */
+function importSpecifiers(source) {
+  const code = source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+  return [...code.matchAll(/(?:from|import)\s*['"]([^'"]+)['"]/g)].map(([, s]) => s);
+}
+
+/** Every bare (non-relative) specifier reachable from `entry`, transitively. */
+function bareSpecifiersReachableFrom(entry) {
+  const seen = new Set();
+  const bare = new Set();
+  const walk = (relativePath) => {
+    if (seen.has(relativePath)) return;
+    seen.add(relativePath);
+    for (const specifier of importSpecifiers(readFileSync(join(REPO_ROOT, relativePath), 'utf8'))) {
+      if (!specifier.startsWith('.')) {
+        bare.add(specifier);
+        continue;
+      }
+      walk(relative(REPO_ROOT, resolve(dirname(join(REPO_ROOT, relativePath)), specifier)));
+    }
+  };
+  walk(entry);
+  return [...bare];
+}
+
+describe('CI pre-install entrypoints load from a bare checkout', () => {
+  // The walker decides whether the assertions below mean anything, so it is
+  // verified against this file's own known imports rather than trusted.
+  it('bareSpecifiersReachableFrom follows relative imports and collects bare ones', () => {
+    const found = bareSpecifiersReachableFrom('scripts/ci-base-sha.js');
+    expect(found).toContain('child_process');
+    // Reached only through ./lib/directInvocation.js — proves it recursed.
+    expect(found).toContain('fs');
+    expect(found.every(isBuiltin)).toBe(true);
+    expect(isBuiltin('zod')).toBe(false);
+  });
+
+  it.each(PRE_INSTALL_ENTRYPOINTS)('%s is still wired into the CI impact job', (entry) => {
+    const workflow = readFileSync(join(REPO_ROOT, '.github/workflows/ci.yml'), 'utf8');
+    expect(workflow).toContain(`node ${entry}`);
+  });
+
+  it.each(PRE_INSTALL_ENTRYPOINTS)('%s imports only Node builtins, transitively', (entry) => {
+    const nonBuiltins = bareSpecifiersReachableFrom(entry).filter((s) => !isBuiltin(s));
+    expect(nonBuiltins).toEqual([]);
+  });
+});

--- a/server/services/pipeline/migrateSeriesCanon.js
+++ b/server/services/pipeline/migrateSeriesCanon.js
@@ -19,6 +19,7 @@ import { updateSeries } from './series.js';
 import { PATHS, readJSONFile } from '../../lib/fileUtils.js';
 import { getUniverse, insertUniverseWithId, updateUniverse, ERR_DUPLICATE } from '../universeBuilder.js';
 import { mergeExtractedBible, BIBLE_FIELD, BIBLE_SOURCE } from '../../lib/storyBible.js';
+import { isDirectlyInvoked } from '../../../scripts/lib/directInvocation.js';
 
 // Derive a stable universe id from the importing series so a retry after a
 // mid-helper throw (insert succeeded, a later write failed) reuses the orphan
@@ -223,7 +224,7 @@ export async function migrateSeriesCanon({ dryRun = false, log = console.log } =
 }
 
 // CLI entrypoint: `node server/services/pipeline/migrateSeriesCanon.js [--dry-run]`
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (isDirectlyInvoked(import.meta.url)) {
   const dryRun = process.argv.includes('--dry-run');
   migrateSeriesCanon({ dryRun })
     .then(() => process.exit(0))


### PR DESCRIPTION
## Summary

Follow-up to #4871, picking up the improvement raised in its review after it merged.

- **Verify the drift detector instead of trusting it.** The guard asserted `offenders` was empty — which is also what it reports once the detector stops working. A broken regex or an empty file list would have passed silently forever, letting the tenth hand-rolled copy land unchallenged. `handRollsCheck` is now probed against all three hand-rolled spellings the repo has carried plus a clean site, and the scanned file list is asserted non-empty. Same reasoning `node-version-drift.test.js` already applies to `pinSatisfiesFloor`.
- **Scan every tracked `.js`, not just two directory tops.** The old scan enumerated the top level of `scripts/` and `server/scripts/`, so `scripts/lib/*.js`, any future `scripts/<subdir>/`, and the whole server tree were unguarded. Now it walks git-tracked `*.js` (the convention the other repo-hygiene tests use), excluding tests and the helper that owns the comparison by definition.
- **Fix the one offender widening it exposed.** `server/services/pipeline/migrateSeriesCanon.js` carried the weakest spelling of all, ``import.meta.url === `file://${process.argv[1]}` ``, and now uses `isDirectlyInvoked`.
- **Guard the pre-install zone**, after checking whether the shared helper should move to `server/lib/`. It should not — see below.

## Why the migrateSeriesCanon fix matters

That file is a documented recovery path. Its header notes it deliberately reads the raw `pipeline-series.json` rather than going through `listSeries()` "so the recovery path stays viable until the user runs it." A guard that silently no-ops under a symlinked checkout means the recovery a user finally reaches for exits 0 having migrated nothing — the same silent-success failure #4868 was filed about, on the path where it is least recoverable.

Verified at the helper level rather than by executing the migration (running it would touch real data):

```
naive (old form) via symlink:       false   ← the bug
isDirectlyInvoked via symlink:      true    ← fixed
isDirectlyInvoked when imported:    false   ← still import-safe
```

## Why the helper stays in `scripts/lib/`

#4871's review flagged that `server/services/pipeline/migrateSeriesCanon.js` now imports from `scripts/lib/` — server runtime reaching into the tooling tree — and asked whether the helper belongs in `server/lib/` with the other pure helpers. It does not, and the reason is load-bearing:

The CI `Plan test impact` job checks out the repo and immediately runs `node scripts/ci-base-sha.js` and `node scripts/ci-test-plan.js` — **with no `npm ci` before them**. Both import this helper, so it has to load from a bare checkout. Confirmed in a checkout with no `node_modules` at all:

```
node scripts/ci-base-sha.js   → runs, exit 0
node scripts/ci-test-plan.js  → loads, reaches its own CI_BASE_SHA validation
import server/lib/index.js    → Cannot find package 'zod'
```

`server/lib/` is not importable pre-install, and the barrel rule in AGENTS.md would formally place the helper in that graph. Moving it would work the day it landed and break CI's *first* job — the one deciding what every other job runs — the day someone added a dependency nearby.

So the helper stays, the reason is recorded on it, and `scripts/pre-install-entrypoints.test.js` walks the transitive imports of both entrypoints to keep the zone builtins-only. Its walker is probed against known imports rather than trusted, matching `root-runtime-deps.test.js`, which guards the same shape of latent-until-fatal packaging constraint.

## Notes

- The repo-wide scan costs **~65ms for 2507 tracked files**, so the narrower scope was buying nothing.
- Node absolutizes `process.argv[1]`, so a relative invocation was never the problem; the symlinked-checkout divergence is, and it reproduces.

## Test plan

- `cd server && NODE_ENV=test ./node_modules/.bin/vitest run ../scripts` → **2125 passed**, 13 skipped. The single failure is `scripts/checkNpmVersion.test.js > reads the running Node's own bundled npm`, which **fails identically on unmodified `main`** — a local environment artifact, not from this branch.
- **Drift-guard bypass probe:** appended a hand-rolled guard to `server/services/sharing/importer.js` — a file the old directory-scoped scan could never have seen — and the guard failed naming it, while the detector probe kept passing. Reverted.
- **Pre-install bypass probe:** added `import { z } from 'zod'` to `scripts/lib/directInvocation.js`; the new guard failed for both entrypoints. Reverted.
- **Pre-install reality check:** ran both entrypoints in a worktree with no `node_modules`, as CI does.
