### PR TITLE
fix: validate report route path parameters (#4880)

### DIFF
--- a/server/routes/cos.test.js
+++ b/server/routes/cos.test.js
@@ -811,6 +811,13 @@ describe('CoS Routes', () => {
 
       expect(response.status).toBe(404);
     });
+
+    it('should reject traversal-shaped dates before reading the report', async () => {
+      const response = await request(app).get('/api/cos/reports/../secrets');
+
+      expect(response.status).toBe(400);
+      expect(cos.getReport).not.toHaveBeenCalled();
+    });
   });
 
   describe('GET /api/cos/watcher', () => {
@@ -1623,6 +1630,13 @@ describe('CoS Routes', () => {
       const response = await request(app).get('/api/cos/briefings/1999-01-01');
 
       expect(response.status).toBe(404);
+    });
+
+    it('should reject traversal-shaped dates before reading the briefing', async () => {
+      const response = await request(app).get('/api/cos/briefings/../secrets');
+
+      expect(response.status).toBe(400);
+      expect(cos.getBriefing).not.toHaveBeenCalled();
     });
   });
 

--- a/server/routes/cos.test.js
+++ b/server/routes/cos.test.js
@@ -813,7 +813,7 @@ describe('CoS Routes', () => {
     });
 
     it('should reject traversal-shaped dates before reading the report', async () => {
-      const response = await request(app).get('/api/cos/reports/../secrets');
+      const response = await request(app).get('/api/cos/reports/not-a-date');
 
       expect(response.status).toBe(400);
       expect(cos.getReport).not.toHaveBeenCalled();
@@ -1633,7 +1633,7 @@ describe('CoS Routes', () => {
     });
 
     it('should reject traversal-shaped dates before reading the briefing', async () => {
-      const response = await request(app).get('/api/cos/briefings/../secrets');
+      const response = await request(app).get('/api/cos/briefings/not-a-date');
 
       expect(response.status).toBe(400);
       expect(cos.getBriefing).not.toHaveBeenCalled();

--- a/server/routes/cos.test.js
+++ b/server/routes/cos.test.js
@@ -812,7 +812,7 @@ describe('CoS Routes', () => {
       expect(response.status).toBe(404);
     });
 
-    it('should reject traversal-shaped dates before reading the report', async () => {
+    it('should reject malformed dates before reading the report', async () => {
       const response = await request(app).get('/api/cos/reports/not-a-date');
 
       expect(response.status).toBe(400);
@@ -1632,7 +1632,7 @@ describe('CoS Routes', () => {
       expect(response.status).toBe(404);
     });
 
-    it('should reject traversal-shaped dates before reading the briefing', async () => {
+    it('should reject malformed dates before reading the briefing', async () => {
       const response = await request(app).get('/api/cos/briefings/not-a-date');
 
       expect(response.status).toBe(400);

--- a/server/routes/cosReportRoutes.js
+++ b/server/routes/cosReportRoutes.js
@@ -13,6 +13,10 @@ import { validateRequest } from '../lib/validation.js';
 
 const router = Router();
 
+const dateParamSchema = z.object({
+  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'date must be YYYY-MM-DD')
+});
+
 // The date is both a date-bucket key and the report's filename, so it must be a
 // bare YYYY-MM-DD day. A full ISO timestamp would match no bucket (and no
 // agent's `completedAt` prefix), silently writing an all-zero report under a
@@ -47,7 +51,8 @@ router.get('/reports/today', asyncHandler(async (req, res) => {
 
 // GET /api/cos/reports/:date - Get report by date
 router.get('/reports/:date', asyncHandler(async (req, res) => {
-  const report = await cos.getReport(req.params.date);
+  const { date } = validateRequest(dateParamSchema, req.params);
+  const report = await cos.getReport(date);
   if (!report) {
     throw new ServerError('Report not found', { status: 404, code: 'NOT_FOUND' });
   }
@@ -75,7 +80,8 @@ router.get('/briefings/latest', asyncHandler(async (req, res) => {
 
 // GET /api/cos/briefings/:date - Get briefing by date
 router.get('/briefings/:date', asyncHandler(async (req, res) => {
-  const briefing = await cos.getBriefing(req.params.date);
+  const { date } = validateRequest(dateParamSchema, req.params);
+  const briefing = await cos.getBriefing(date);
   if (!briefing) {
     throw new ServerError('Briefing not found', { status: 404, code: 'NOT_FOUND' });
   }

--- a/server/routes/jira.js
+++ b/server/routes/jira.js
@@ -35,6 +35,11 @@ const jiraTicketCreateSchema = z.object({
 
 const jiraTicketUpdateSchema = jiraTicketCreateSchema.partial();
 
+const reportParamsSchema = z.object({
+  appId: z.string().regex(/^[A-Za-z0-9._-]+$/, 'appId contains invalid characters'),
+  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'date must be YYYY-MM-DD')
+});
+
 const router = express.Router();
 
 /**
@@ -353,7 +358,8 @@ router.get('/reports/:appId/latest', asyncHandler(async (req, res) => {
  * Get a specific report by app and date
  */
 router.get('/reports/:appId/:date', asyncHandler(async (req, res) => {
-  const report = await jiraReports.getReport(req.params.appId, req.params.date);
+  const { appId, date } = validateRequest(reportParamsSchema, req.params);
+  const report = await jiraReports.getReport(appId, date);
   if (!report) {
     throw new ServerError('Report not found', { status: 404, code: 'NOT_FOUND' });
   }

--- a/server/routes/jira.test.js
+++ b/server/routes/jira.test.js
@@ -32,6 +32,7 @@ vi.mock('../services/jiraReports.js', () => ({
 vi.mock('../services/apps.js', () => ({ getAppById: vi.fn() }));
 
 import * as jiraService from '../services/jira.js';
+import * as jiraReports from '../services/jiraReports.js';
 import { errorMiddleware } from '../lib/errorHandler.js';
 import jiraRoutes from './jira.js';
 
@@ -42,6 +43,22 @@ function makeApp() {
   app.use(errorMiddleware);
   return app;
 }
+
+describe('GET /reports/:appId/:date', () => {
+  it('rejects unsafe path parameters before reading a report', async () => {
+    const response = await request(makeApp()).get('/api/jira/reports/bad@app/2026-01-01');
+
+    expect(response.status).toBe(400);
+    expect(jiraReports.getReport).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid dates before reading a report', async () => {
+    const response = await request(makeApp()).get('/api/jira/reports/example-app/not-a-date');
+
+    expect(response.status).toBe(400);
+    expect(jiraReports.getReport).not.toHaveBeenCalled();
+  });
+});
 
 describe('GET /instances/:instanceId/my-sprint-tickets/:projectKey', () => {
   let app;


### PR DESCRIPTION
## Summary
- validate ISO date parameters on CoS report and briefing read routes
- validate app IDs and dates on JIRA report reads before filesystem access
- add regression coverage for malformed path parameters

## Test plan
- `cd server && npm test -- --run routes/cos.test.js routes/jira.test.js` (unable to run: vitest is not installed in this worktree)

Closes #4880
