### PR TITLE
fix: honor cloud claim swarm worker counts

### DIFF
--- a/server/lib/providerModels.js
+++ b/server/lib/providerModels.js
@@ -457,6 +457,25 @@ export function buildEffortArgs(effort, provider, existingArgs = [], model = nul
 // update check. Kept as a named constant so a codex-side rename is a one-line
 // edit rather than a four-builder grep.
 export const CODEX_UPDATE_CHECK_KEY = 'check_for_update_on_startup';
+export const CODEX_AGENT_THREADS_KEY = 'agents.max_concurrent_threads_per_session';
+
+/**
+ * Give a Codex swarm enough session threads for its root orchestrator plus
+ * every configured worker. The CLI counts the root against this limit, so a
+ * six-worker claim run needs seven threads rather than six.
+ *
+ * Callers deliberately supply this only for cloud-backed Codex agents. Local
+ * inference stays bounded by its runtime-specific concurrency posture instead
+ * of turning one CoS task into an unbounded fan-out against a single GPU.
+ *
+ * @param {unknown} maxConcurrentThreads
+ * @returns {string[]}
+ */
+export function buildCodexAgentThreadArgs(maxConcurrentThreads) {
+  const limit = Number(maxConcurrentThreads);
+  if (!Number.isSafeInteger(limit) || limit < 1) return [];
+  return ['-c', `${CODEX_AGENT_THREADS_KEY}=${limit}`];
+}
 
 /**
  * True when the codex argv already pins the startup-update-check config, so a
@@ -514,7 +533,11 @@ export function buildCodexStartupArgs(existingArgs = []) {
  * of the same CLI had written a variant the CLI on PATH rejects into the shared
  * config file.
  */
-export const PORTOS_CLI_CONFIG_KEYS = Object.freeze([CODEX_EFFORT_KEY, CODEX_UPDATE_CHECK_KEY]);
+export const PORTOS_CLI_CONFIG_KEYS = Object.freeze([
+  CODEX_AGENT_THREADS_KEY,
+  CODEX_EFFORT_KEY,
+  CODEX_UPDATE_CHECK_KEY,
+]);
 
 /**
  * True when `key` is a config key PortOS supplies via `-c` (see

--- a/server/lib/providerModels.test.js
+++ b/server/lib/providerModels.test.js
@@ -38,6 +38,7 @@ import {
   CODEX_EFFORT_KEY,
   CODEX_UPDATE_CHECK_KEY,
   PORTOS_CLI_CONFIG_KEYS,
+  CODEX_AGENT_THREADS_KEY,
   isPortosSuppliedConfigKey,
   hasCodexUpdateCheckConfig,
   buildCodexStartupArgs,
@@ -591,7 +592,11 @@ describe('providerModels', () => {
   // without a row here would be blamed on the user (incident 2026-08-18).
   describe('isPortosSuppliedConfigKey / PORTOS_CLI_CONFIG_KEYS', () => {
     it('covers exactly the keys the -c builders emit', () => {
-      expect([...PORTOS_CLI_CONFIG_KEYS].sort()).toEqual([CODEX_EFFORT_KEY, CODEX_UPDATE_CHECK_KEY].sort());
+      expect([...PORTOS_CLI_CONFIG_KEYS].sort()).toEqual([
+        CODEX_AGENT_THREADS_KEY,
+        CODEX_EFFORT_KEY,
+        CODEX_UPDATE_CHECK_KEY,
+      ].sort());
       // Guard against a third emitter appearing without a row: both builders
       // that produce `-c` are asserted to use a listed key.
       const emitted = [

--- a/server/lib/providerVendors.js
+++ b/server/lib/providerVendors.js
@@ -63,6 +63,7 @@ import {
   resolveInjectedTuiModel,
   resolveBedrockCliModel,
   buildCodexStartupArgs,
+  buildCodexAgentThreadArgs,
   buildEffortArgs,
   isOpencodeCommand,
   prefixOpencodeModel,
@@ -115,11 +116,16 @@ function codexCliArgs(baseArgs, { model, effort, provider }) {
   return args;
 }
 
-function codexSpawnArgs(provider, { effectiveModel, effort }) {
+function codexSpawnArgs(provider, { effectiveModel, effort, maxConcurrentThreads }) {
   // Injected UNCONDITIONALLY: this arm builds codex's argv from scratch and
   // never forwards provider.args, so there's no pin to detect here (see the
   // long-form comment history on this in agentCliSpawning.js before #3618).
-  const args = ['exec', '--dangerously-bypass-approvals-and-sandbox', ...buildCodexStartupArgs()];
+  const args = [
+    'exec',
+    '--dangerously-bypass-approvals-and-sandbox',
+    ...buildCodexStartupArgs(),
+    ...buildCodexAgentThreadArgs(maxConcurrentThreads),
+  ];
   if (effectiveModel) {
     args.push('--model', effectiveModel);
   }

--- a/server/routes/cos.test.js
+++ b/server/routes/cos.test.js
@@ -1126,7 +1126,8 @@ describe('CoS Routes', () => {
           optionalReviewers: [],
           reviewerMaxRounds: { codex: 2 },
           reviewerModels: {},
-          reviewerEfforts: { codex: 'high' }
+          reviewerEfforts: { codex: 'high' },
+          swarmCount: 6
         }
       });
       cos.addTask.mockResolvedValue({ id: 'task-sd-next-reviewers', status: 'pending' });
@@ -1144,6 +1145,7 @@ describe('CoS Routes', () => {
         reviewerMaxRounds: { codex: 2 },
         reviewerModels: {},
         reviewerEfforts: { codex: 'high' },
+        swarmCount: 6,
         claimFlow: true
       });
       // `reviewLoop` stays off — the claim prompt owns its own review sequence.

--- a/server/services/agentCliSpawning.js
+++ b/server/services/agentCliSpawning.js
@@ -264,11 +264,21 @@ export function createStreamJsonParser() {
  * no gemini-cli row so a legacy gemini-cli provider falls through to claude's
  * default, exactly as before this registry existed).
  */
-export function buildCliSpawnConfig(provider, model, settingsEnv = {}, { systemPromptFile = null, effort = null } = {}) {
+export function buildCliSpawnConfig(provider, model, settingsEnv = {}, {
+  systemPromptFile = null,
+  effort = null,
+  maxConcurrentThreads = null,
+} = {}) {
   // Configured-default sentinels (Codex / Antigravity / Grok Build) → null so
   // the CLI uses its own default without a --model flag.
   const effectiveModel = resolveCliModel(model);
-  return buildVendorSpawnConfig(provider, { effectiveModel, effort, systemPromptFile, settingsEnv });
+  return buildVendorSpawnConfig(provider, {
+    effectiveModel,
+    effort,
+    maxConcurrentThreads,
+    systemPromptFile,
+    settingsEnv,
+  });
 }
 
 /**

--- a/server/services/agentCliSpawning.test.js
+++ b/server/services/agentCliSpawning.test.js
@@ -222,6 +222,17 @@ describe('buildCliSpawnConfig', () => {
     expect(config.args).toEqual(['exec', '--dangerously-bypass-approvals-and-sandbox', '-c', 'check_for_update_on_startup=false', '--model', 'gpt-5.4']);
   });
 
+  it('gives a cloud Codex swarm enough threads for its root plus every worker', () => {
+    const config = buildCliSpawnConfig(
+      { id: 'codex', command: 'codex' },
+      'gpt-5.4',
+      {},
+      { maxConcurrentThreads: 7 },
+    );
+
+    expect(config.args).toContain('agents.max_concurrent_threads_per_session=7');
+  });
+
   it('disables the codex update check unconditionally on the headless agent path (ignores provider.args)', () => {
     // This builder constructs codex argv from scratch and never forwards
     // provider.args, so a provider.args pin is NOT honored here — a headless CoS

--- a/server/services/agentLifecycle.js
+++ b/server/services/agentLifecycle.js
@@ -75,7 +75,7 @@ import { v4 as uuidv4 } from '../lib/uuid.js';
 // Imported for use here only; the pass-through re-exports that used to sit
 // below them were retired with the `subAgentSpawner.js` barrel (#3450).
 import { resolveAgentProviderAndModel } from './agentProviderResolution.js';
-import { providerBaseUrl } from './cosLocalEndpointSlots.js';
+import { cloudSwarmThreadCapacity, providerBaseUrl } from './cosLocalEndpointSlots.js';
 import { prepareAgentWorkspace } from './agentWorkspacePrep.js';
 // `releaseRetryHold` is imported STATICALLY here (the TUI/direct-CLI spawners
 // reach for it via `await import()` only because they sit BELOW this module and
@@ -684,9 +684,15 @@ async function runAgentSpawn(task) {
     // Per-task reasoning-effort override (task form / schedule config). The
     // builders no-op it for providers without an effort control.
     const taskEffort = task.metadata?.effort || null;
+    // Codex counts the root orchestrator against its per-session thread cap.
+    // Lift that cap to root + configured workers for cloud swarms so a six-way
+    // claim run can actually fan out six issue agents. Never lift it for a
+    // provider whose inference lands on this machine: local runtimes retain
+    // their deliberately bounded GPU concurrency posture.
+    const maxConcurrentThreads = cloudSwarmThreadCapacity(runProvider, task.metadata?.swarmCount);
     const cliConfig = isTui
-      ? buildTuiSpawnConfig(runProvider, selectedModel, { systemPromptFile, effort: taskEffort })
-      : buildCliSpawnConfig(runProvider, selectedModel, cliSettingsEnv, { systemPromptFile, effort: taskEffort });
+      ? buildTuiSpawnConfig(runProvider, selectedModel, { systemPromptFile, effort: taskEffort, maxConcurrentThreads })
+      : buildCliSpawnConfig(runProvider, selectedModel, cliSettingsEnv, { systemPromptFile, effort: taskEffort, maxConcurrentThreads });
 
     emitLog('success', `Spawning agent for task ${task.id}`, {
       agentId,

--- a/server/services/agentTuiSpawning.js
+++ b/server/services/agentTuiSpawning.js
@@ -30,10 +30,11 @@ import { resolveReviewLoopOptions } from './codeReview.js';
 import { spawnTuiSessionViaRunner, classifyRunnerSpawnFailure, RUNNER_SPAWN_REFUSED, RUNNER_SPAWN_AMBIGUOUS } from './cosRunnerClient.js';
 import { resolveInteractiveShell } from '../lib/interactiveShellResolver.js';
 import { formatShellCommandLine } from '../lib/shellCd.js';
-import { isClaudeCommand, applyLeanClaudeArgs, providerSuppliesGithubToken } from '../lib/providerModels.js';
+import { buildCodexAgentThreadArgs, isClaudeCommand, applyLeanClaudeArgs, providerSuppliesGithubToken } from '../lib/providerModels.js';
 import { createStreamingAnsiStripper, stripAnsi } from '../lib/ansiStrip.js';
 import { createImmediateFallbackSignalDetector, createLocalRuntimeOomDetector } from '../lib/aiToolkit/errorDetection.js';
 import { isAntigravityCommand } from '../lib/antigravity.js';
+import { isCodexCommand } from '../lib/codex.js';
 import {
   DEFAULT_TUI_PROMPT_DELAY_MS,
   READY_POLL_INTERVAL_MS,
@@ -190,6 +191,7 @@ export async function createAgentTuiSession({
 export function buildTuiSpawnConfig(provider, model, {
   systemPromptFile = null,
   effort = null,
+  maxConcurrentThreads = null,
   shell = resolveInteractiveShell(),
 } = {}) {
   const command = provider?.command || inferTuiCommand(provider?.id);
@@ -199,6 +201,9 @@ export function buildTuiSpawnConfig(provider, model, {
   // providerVendors.js#injectTuiModelAndEffort, so the two spawn paths can't
   // drift — they already had once, on cursor, before #3618.
   let args = injectTuiModelAndEffort(command, baseArgs, provider, model, effort);
+  if (isCodexCommand(command)) {
+    args = [...args, ...buildCodexAgentThreadArgs(maxConcurrentThreads)];
+  }
   // Lean mode for Ollama-backed claude sessions (no-op otherwise) — must come
   // before the system-prompt flag so `--bare` is present when the contract
   // file rides along.

--- a/server/services/agentTuiSpawning.test.js
+++ b/server/services/agentTuiSpawning.test.js
@@ -450,6 +450,16 @@ describe('agent TUI spawning', () => {
     expect(codex.args).not.toContain('--effort');
   });
 
+  it('gives a cloud Codex swarm enough threads for its root plus every worker', () => {
+    const config = buildTuiSpawnConfig(
+      { id: 'codex-tui', command: 'codex', type: 'tui', args: [] },
+      null,
+      { maxConcurrentThreads: 7 },
+    );
+
+    expect(config.args).toContain('agents.max_concurrent_threads_per_session=7');
+  });
+
   it('omits effort args when unset or when the TUI has no effort control', () => {
     const noEffort = buildTuiSpawnConfig({ id: 'claude-code-tui', command: 'claude', type: 'tui', args: [] }, null);
     expect(noEffort.args).not.toContain('--effort');

--- a/server/services/cos.test.js
+++ b/server/services/cos.test.js
@@ -39,6 +39,7 @@ import { canQueueImprovementTasks } from './cosState.js';
 import { createDequeueCapacity, countRunningAgentsByLocalEndpoint, isMissionTierEligible, isIdleTierEligible } from './cosDequeue.js';
 import {
   createLocalEndpointSlotContext,
+  cloudSwarmThreadCapacity,
   localEndpointOfProvider,
   providerBaseUrl,
   reserveLocalEndpointSpawn,
@@ -799,6 +800,23 @@ describe('localEndpointOfProvider (#4834)', () => {
     // The issue is explicit: a TUI provider whose endpoint isn't recorded stays
     // ungated even when its model id names a local runtime.
     expect(localEndpointOfProvider({ type: 'tui', defaultModel: 'mtplx/local-qwen-27b', endpoint: null })).toBeNull();
+  });
+});
+
+describe('cloudSwarmThreadCapacity', () => {
+  it('reserves one root thread in addition to every configured cloud worker', () => {
+    expect(cloudSwarmThreadCapacity(CLOUD_PROVIDER, 6)).toBe(7);
+    expect(cloudSwarmThreadCapacity(CLOUD_PROVIDER, '6')).toBe(7);
+  });
+
+  it('does not lift the harness cap for a local inference endpoint', () => {
+    expect(cloudSwarmThreadCapacity(LOCAL_TUI_PROVIDER, 6)).toBeNull();
+  });
+
+  it('does not override the harness outside a valid multi-worker swarm', () => {
+    expect(cloudSwarmThreadCapacity(CLOUD_PROVIDER, 1)).toBeNull();
+    expect(cloudSwarmThreadCapacity(CLOUD_PROVIDER, 2.5)).toBeNull();
+    expect(cloudSwarmThreadCapacity(CLOUD_PROVIDER, null)).toBeNull();
   });
 });
 

--- a/server/services/cos.test.js
+++ b/server/services/cos.test.js
@@ -816,6 +816,7 @@ describe('cloudSwarmThreadCapacity', () => {
   it('does not override the harness outside a valid multi-worker swarm', () => {
     expect(cloudSwarmThreadCapacity(CLOUD_PROVIDER, 1)).toBeNull();
     expect(cloudSwarmThreadCapacity(CLOUD_PROVIDER, 2.5)).toBeNull();
+    expect(cloudSwarmThreadCapacity(CLOUD_PROVIDER, 7)).toBeNull();
     expect(cloudSwarmThreadCapacity(CLOUD_PROVIDER, null)).toBeNull();
   });
 });

--- a/server/services/cosLocalEndpointSlots.js
+++ b/server/services/cosLocalEndpointSlots.js
@@ -23,6 +23,7 @@
  */
 
 import { LOCAL_LLM_MAX_CONCURRENCY } from '../lib/promptRunner.js';
+import { SWARM_COUNT_MAX, SWARM_COUNT_MIN } from '../lib/validation.js';
 import { localRuntimeForProvider, localEndpointPort, normalizeOpenAiBaseUrl } from '../lib/localProviderRuntime.js';
 import { listProviders, getActiveProvider } from './providers.js';
 import { isProviderAvailable, getFallbackProvider } from './providerStatus.js';
@@ -82,7 +83,7 @@ export function localEndpointOfProvider(provider) {
  */
 export function cloudSwarmThreadCapacity(provider, swarmCount) {
   const workers = Number(swarmCount);
-  if (!Number.isSafeInteger(workers) || workers < 2) return null;
+  if (!Number.isSafeInteger(workers) || workers < SWARM_COUNT_MIN || workers > SWARM_COUNT_MAX) return null;
   return localEndpointOfProvider(provider) ? null : workers + 1;
 }
 

--- a/server/services/cosLocalEndpointSlots.js
+++ b/server/services/cosLocalEndpointSlots.js
@@ -74,6 +74,18 @@ export function localEndpointOfProvider(provider) {
   return localSlotKey(providerBaseUrl(provider));
 }
 
+/**
+ * Codex's multi-agent limit includes the root orchestrator. Cloud claim swarms
+ * therefore need `workers + 1` session threads to honor the configured worker
+ * count. A provider on this machine deliberately gets no override: local
+ * inference remains governed by its bounded GPU concurrency posture.
+ */
+export function cloudSwarmThreadCapacity(provider, swarmCount) {
+  const workers = Number(swarmCount);
+  if (!Number.isSafeInteger(workers) || workers < 2) return null;
+  return localEndpointOfProvider(provider) ? null : workers + 1;
+}
+
 // Normalize first so a schemeless value still parses — `localEndpointPort` goes
 // through `new URL`, which reads `localhost:1234` as a SCHEME and yields null.
 // Providers configured through the UI can carry a bare `host:port`.

--- a/server/services/cosTaskGenerator.js
+++ b/server/services/cosTaskGenerator.js
@@ -541,6 +541,12 @@ export async function buildClaimWorkTask(app, {
   // names — the reviewer pin is emitted once from there (#4770).
   const delegatedMeta = taskSchedule.DEFAULT_TASK_INTERVALS[promptTaskType]?.taskMetadata || {};
   const taskMetadata = { ...reviewerConfigMetadata(claimReviewers), claimFlow: true };
+  // The manual `/do:next` path persists this non-raw task through addTask's
+  // metadata allowlist before agentLifecycle sees it. Carry the same count that
+  // rendered the swarm block so Codex can size its session to root + workers.
+  // A pinned target suppresses swarmBlock above and therefore must not retain a
+  // stale configured count.
+  if (swarmBlock) taskMetadata.swarmCount = metadata.swarmCount;
   if ('useWorktree' in delegatedMeta) taskMetadata.useWorktree = delegatedMeta.useWorktree;
   if ('openPR' in delegatedMeta) taskMetadata.openPR = delegatedMeta.openPR;
 

--- a/server/services/cosTaskGenerator.test.js
+++ b/server/services/cosTaskGenerator.test.js
@@ -80,7 +80,7 @@ import {
   applyPerpetualDrainCap
 } from './cosTaskGenerator.js';
 import { cosEvents } from './cosEvents.js';
-import { DEFAULT_TASK_INTERVALS } from './taskSchedule.js';
+import { DEFAULT_TASK_INTERVALS, getTaskInterval } from './taskSchedule.js';
 import { MAX_TOTAL_SPAWNS } from '../lib/validation.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -1680,5 +1680,29 @@ describe('buildClaimWorkTask reviewer pin', () => {
     const { prompt, taskMetadata } = await buildClaimWorkTask(app, { reviewers: ['claude'] });
     expect(prompt).toContain('Reviewers: claude,@alice');
     expect(taskMetadata.reviewers).toEqual(['claude']);
+  });
+
+  it('persists the cloud swarm count that the manual claim prompt renders', async () => {
+    getTaskInterval.mockResolvedValueOnce({
+      prompt: null,
+      taskMetadata: { reviewers: ['codex'], swarmCount: 6 },
+    });
+
+    const { prompt, taskMetadata } = await buildClaimWorkTask(app);
+
+    expect(prompt).toContain('--swarm=6');
+    expect(taskMetadata.swarmCount).toBe(6);
+  });
+
+  it('does not persist a configured swarm count when a manual claim pins one target', async () => {
+    getTaskInterval.mockResolvedValueOnce({
+      prompt: null,
+      taskMetadata: { reviewers: ['codex'], swarmCount: 6 },
+    });
+
+    const { prompt, taskMetadata } = await buildClaimWorkTask(app, { target: '42' });
+
+    expect(prompt).not.toContain('--swarm=6');
+    expect(taskMetadata.swarmCount).toBeUndefined();
   });
 });

--- a/server/services/cosTaskStore.js
+++ b/server/services/cosTaskStore.js
@@ -16,7 +16,7 @@ import { readFile, writeFile, stat } from 'fs/promises';
 import { existsSync } from 'fs';
 import { join } from 'path';
 import { parseTasksMarkdown, groupTasksByStatus, getAutoApprovedTasks, getAwaitingApprovalTasks, generateTasksMarkdown, hasKnownPrefix } from '../lib/taskParser.js';
-import { REVIEW_STOP_MODES, normalizeReviewers, normalizeReviewUsernames, normalizeOptionalReviewers, KEYED_REVIEWER_PINS } from '../lib/validation.js';
+import { KEYED_REVIEWER_PINS, MAX_TOTAL_SPAWNS, REVIEW_STOP_MODES, SWARM_COUNT_MAX, SWARM_COUNT_MIN, normalizeReviewers, normalizeReviewUsernames, normalizeOptionalReviewers } from '../lib/validation.js';
 import { isPlainObject } from '../lib/objects.js';
 import { PR_COMPLETIONS, PR_COMPLETION_VALUES } from '../lib/prDisposition.js';
 import { RETRY_HOLD_KEY, RETRY_HOLD_SINCE_KEY } from '../lib/taskRetryHold.js';
@@ -31,7 +31,6 @@ import { cosEvents } from './cosEvents.js';
 import { CLAIM_METADATA_KEYS, TARGET_INSTANCE_KEY, getTargetInstance } from './cosTaskClaim.js';
 import { mergeTaskLists } from './cosTaskMerge.js';
 import { canChallenge, getChallengeCount, buildChallengePatch, buildChallengeResolutionPatch, classifyRecheckOutcome, MAX_CHALLENGES_PER_TASK } from './cosChallenge.js';
-import { MAX_TOTAL_SPAWNS } from '../lib/validation.js';
 import { runLocalCodeReview, getCodeReviewDefaults } from './codeReview.js';
 
 // First non-empty line of a string. Used by addTask dedup: stored descriptions
@@ -445,6 +444,13 @@ export async function addTask(taskData, taskType = 'user', { raw = false, ignore
     // known (see server/lib/slashdoInvocation.js).
     if (taskData.slashdoCommand) metadata.slashdoCommand = taskData.slashdoCommand;
     if (taskData.slashdoArgs) metadata.slashdoArgs = taskData.slashdoArgs;
+    // Manual `/do:next` claim swarms are non-raw tasks. Their prompt already
+    // names the fan-out, and agentLifecycle needs this count after the markdown
+    // round-trip to lift a cloud Codex session to root + configured workers.
+    const swarmCount = Number(taskData.swarmCount);
+    if (Number.isSafeInteger(swarmCount) && swarmCount >= SWARM_COUNT_MIN && swarmCount <= SWARM_COUNT_MAX) {
+      metadata.swarmCount = swarmCount;
+    }
     if (taskData.malwareScan && typeof taskData.malwareScan === 'object' && !Array.isArray(taskData.malwareScan)) {
       metadata.malwareScan = taskData.malwareScan;
     }

--- a/server/services/cosTaskStore.test.js
+++ b/server/services/cosTaskStore.test.js
@@ -516,7 +516,9 @@ describe('cosTaskStore.addTask', () => {
 
     expect(created.metadata.swarmCount).toBe(6);
     const { tasks } = await getUserTasks();
-    expect(tasks.find(t => t.id === created.id).metadata.swarmCount).toBe(6);
+    // Scalar task metadata parses from markdown as text; the lifecycle resolver
+    // normalizes it with Number() before applying the bounded thread override.
+    expect(Number(tasks.find(t => t.id === created.id).metadata.swarmCount)).toBe(6);
   });
 
   it('drops an out-of-range manual claim swarm count', async () => {

--- a/server/services/cosTaskStore.test.js
+++ b/server/services/cosTaskStore.test.js
@@ -507,6 +507,23 @@ describe('cosTaskStore.addTask', () => {
     expect(tasks.find(t => t.id === created.id).metadata.claimTarget).toBe('42');
   });
 
+  it('persists a manual claim swarm count through the task markdown round-trip', async () => {
+    const created = await addTask({
+      description: 'Claim six independent GitHub issues for Example App',
+      app: 'example-app',
+      swarmCount: 6,
+    }, 'user');
+
+    expect(created.metadata.swarmCount).toBe(6);
+    const { tasks } = await getUserTasks();
+    expect(tasks.find(t => t.id === created.id).metadata.swarmCount).toBe(6);
+  });
+
+  it('drops an out-of-range manual claim swarm count', async () => {
+    const created = await addTask({ description: 'Invalid claim swarm', swarmCount: 7 }, 'user');
+    expect(created.metadata.swarmCount).toBeUndefined();
+  });
+
   it('persists malware scan report ownership through the task markdown round-trip', async () => {
     const malwareScan = { linkId: 'a3d2c4e8-810a-4d1a-8ab1-94d3e0a13f8d', reportId: 'b38bdf75-3fe2-498c-9c36-7d512dc078d1' };
     const created = await addTask({ description: 'Malware scan: example/repo', malwareScan }, 'user');


### PR DESCRIPTION
## Summary
- size Codex multi-agent sessions to the configured claim-swarm worker count plus the root orchestrator
- apply the override only to cloud-backed providers so local inference keeps its bounded GPU posture
- cover CLI, TUI, cloud, and local-runtime behavior

## Test plan
- `cd server && npm test -- --run services/agentLifecycle.test.js services/agentLifecycle.spawnViaRunner.test.js services/cos.test.js services/agentCliSpawning.test.js services/agentTuiSpawning.test.js lib/providerModels.test.js`
- `codex -c agents.max_concurrent_threads_per_session=7 --version`