### PR TITLE
fix: preserve chained video render settings (#4935)

### DIFF
--- a/client/src/components/media/normalize.js
+++ b/client/src/components/media/normalize.js
@@ -183,6 +183,7 @@ export function getRenderConfigForItem(item) {
       seed: raw.seed,
       tiling: raw.tiling,
       disableAudio: raw.disableAudio ?? raw.disable_audio,
+      textEncoderId: raw.textEncoderId,
       loraFilenames: pickLoraFilenames(raw),
       loraScales: raw.loraScales ?? raw.lora_scales,
     };

--- a/client/src/components/media/normalize.test.js
+++ b/client/src/components/media/normalize.test.js
@@ -214,11 +214,12 @@ describe('normalize loraNames - snake_case sidecar coverage', () => {
 });
 
 describe('getRenderConfigForItem - video', () => {
-  it('reads camelCase sidecar fields directly', () => {
+  it('round-trips a stitched chain\'s inherited camelCase render fields', () => {
     const video = normalizeVideo({
       id: 'v1',
       filename: 'a.mp4',
       prompt: 'pan',
+      chainedFrom: ['chunk-a', 'chunk-b'],
       width: 720,
       height: 480,
       numFrames: 64,
@@ -230,6 +231,7 @@ describe('getRenderConfigForItem - video', () => {
       seed: 100,
       tiling: true,
       disableAudio: false,
+      textEncoderId: 'example-encoder',
       loraFilenames: ['lora-cinematic.safetensors'],
       loraScales: [0.9],
     });
@@ -246,6 +248,7 @@ describe('getRenderConfigForItem - video', () => {
       seed: 100,
       tiling: true,
       disableAudio: false,
+      textEncoderId: 'example-encoder',
       loraFilenames: ['lora-cinematic.safetensors'],
       loraScales: [0.9],
     });

--- a/client/src/hooks/useVideoGenForm.test.jsx
+++ b/client/src/hooks/useVideoGenForm.test.jsx
@@ -672,7 +672,7 @@ describe('useVideoGenForm', () => {
     expect(payload.loraScales).toEqual([0.8]);
   });
 
-  it('applyRemix restores the render params and clears stale conditioning inputs', async () => {
+  it('applyRemix restores a stitched chain\'s render params and clears stale conditioning inputs', async () => {
     const { result } = render();
     act(() => result.current.handleModeChange('image'));
     act(() => result.current.pickSourceImage('old.png'));
@@ -681,17 +681,28 @@ describe('useVideoGenForm', () => {
     act(() => result.current.applyRemix({
       prompt: 'remixed', negativePrompt: 'blurry', modelId: LTX2.id,
       width: 1024, height: 576, numFrames: 49, fps: 30, seed: 7,
-      steps: 20, guidanceScale: 0, tiling: 'both', disableAudio: true,
+      steps: 20, guidanceScale: 0, tiling: 'spatial', disableAudio: true,
+      imageStrength: 0.35, chainedFrom: ['chunk-a', 'chunk-b'],
+      chunkPrompts: ['opening beat', 'closing beat'],
       loraFilenames: ['v.safetensors'], loraScales: [0.5],
     }));
 
     expect(result.current.prompt).toBe('remixed');
     expect(result.current.negativePrompt).toBe('blurry');
+    expect(result.current.modelId).toBe(LTX2.id);
+    expect(result.current.width).toBe(1024);
+    expect(result.current.height).toBe(576);
+    expect(result.current.numFrames).toBe(49);
+    expect(result.current.fps).toBe(30);
     expect(result.current.seed).toBe('7');
     expect(result.current.steps).toBe('20');
     // guidanceScale 0 (CFG off) must survive the round-trip as "0", not "".
     expect(result.current.guidanceScale).toBe('0');
+    expect(result.current.tiling).toBe('spatial');
     expect(result.current.disableAudio).toBe(true);
+    expect(result.current.imageStrength).toBe('0.35');
+    expect(result.current.chunks).toBe(2);
+    expect(result.current.chunkPrompts).toEqual(['opening beat', 'closing beat']);
     expect(result.current.mode).toBe('text');
     expect(result.current.sourceImageFile).toBeNull();
     expect(result.current.selectedLoras).toEqual([

--- a/server/services/videoGen/local.js
+++ b/server/services/videoGen/local.js
@@ -3235,6 +3235,22 @@ export async function stitchVideos(videoIds, opts = {}) {
     createdAt: new Date().toISOString(),
     [historyKey]: videoIds,
     ...(Array.isArray(chunkPrompts) ? { chunkPrompts } : {}),
+    // The stitched clip is the chain's visible history row, so it must carry
+    // the same render controls and provenance as the hidden chunks. Preserve
+    // meaningful falsey values (guidance 0, audio enabled, empty conditioning)
+    // while keeping legacy/partial entries free of explicit undefined fields.
+    ...Object.fromEntries([
+      'steps',
+      'guidanceScale',
+      'tiling',
+      'disableAudio',
+      'mode',
+      'textEncoderId',
+      'imageStrength',
+      'i2vReferenceMode',
+      'conditioning',
+      'renderInputsVersion',
+    ].flatMap((key) => videos[0][key] === undefined ? [] : [[key, videos[0][key]]])),
     // Inherit applied LoRAs from the first constituent clip (a chunk chain
     // shares one LoRA set across all chunks), so the visible stitched entry
     // round-trips LoRAs on Remix the same way a single render does — mirrors

--- a/server/services/videoGen/local.test.js
+++ b/server/services/videoGen/local.test.js
@@ -371,12 +371,13 @@ let updateHistoryItemPrompt;
 let generateChainedVideo;
 let generateVideo;
 let extractLastFrame;
+let stitchVideos;
 let videoGenEvents;
 
 beforeEach(async () => {
   vi.resetModules();
   // Re-import fresh copies so mock reset above applies cleanly
-  ({ generateChainedVideo, generateVideo, extractLastFrame, updateHistoryItemPrompt } = await import('./local.js'));
+  ({ generateChainedVideo, generateVideo, extractLastFrame, stitchVideos, updateHistoryItemPrompt } = await import('./local.js'));
   ({ videoGenEvents } = await import('./events.js'));
 });
 
@@ -387,6 +388,68 @@ afterEach(() => {
   spawnState.nextExitCode = null;
   anchorPick.best = null;
   vi.clearAllMocks();
+});
+
+describe('stitchVideos — history provenance', () => {
+  const renderFields = [
+    'steps',
+    'guidanceScale',
+    'tiling',
+    'disableAudio',
+    'mode',
+    'textEncoderId',
+    'imageStrength',
+    'i2vReferenceMode',
+    'conditioning',
+    'renderInputsVersion',
+  ];
+
+  const stitchHistory = async (firstChunkFields = {}) => {
+    const { readJSONFile } = await import('../../lib/fileUtils.js');
+    const chunkIds = ['chunk-a', 'chunk-b'];
+    vi.mocked(readJSONFile).mockResolvedValue([
+      {
+        id: chunkIds[0], filename: 'chunk-a.mp4', prompt: 'first beat',
+        modelId: 'ltx2_unified', seed: 42, width: 768, height: 512,
+        numFrames: 49, fps: 24, ...firstChunkFields,
+      },
+      {
+        id: chunkIds[1], filename: 'chunk-b.mp4', prompt: 'second beat',
+        modelId: 'ltx2_unified', seed: 43, width: 768, height: 512,
+        numFrames: 49, fps: 24,
+      },
+    ]);
+    return stitchVideos(chunkIds, {
+      id: randomUUID(),
+      filenamePrefix: 'chained',
+      historyKey: 'chainedFrom',
+    });
+  };
+
+  it('inherits every render dial and provenance field from the first chunk', async () => {
+    const chunkRenderConfig = {
+      steps: 20,
+      guidanceScale: 0,
+      tiling: 'none',
+      disableAudio: false,
+      mode: 'image',
+      textEncoderId: 'example-encoder',
+      imageStrength: 0,
+      i2vReferenceMode: 'inspire',
+      conditioning: [],
+      renderInputsVersion: 1,
+    };
+
+    const stitched = await stitchHistory(chunkRenderConfig);
+
+    expect(stitched).toMatchObject(chunkRenderConfig);
+  });
+
+  it('does not stamp absent render fields onto a legacy stitched entry', async () => {
+    const stitched = await stitchHistory();
+
+    for (const field of renderFields) expect(stitched).not.toHaveProperty(field);
+  });
 });
 
 describe('extractLastFrame — anchor selection', () => {


### PR DESCRIPTION
## Summary
- inherit sampler controls, mode, text encoder, image-strength/reference metadata, and render provenance from the first chain chunk
- preserve meaningful falsey values while leaving legacy stitched entries sparse
- cover the stitched history shape through the server, Prompt Refine config, and in-page Remix consumers

## Test plan
- server: npm test -- services/videoGen/local.test.js (229 passed)
- client: focused normalize and useVideoGenForm Vitest files (80 passed)
- client: Biome lint on affected source/tests

Closes #4935