### PR TITLE
fix([issue-4910]): release failed transaction clients

### DIFF
--- a/server/lib/db.js
+++ b/server/lib/db.js
@@ -251,18 +251,19 @@ export async function withTransaction(fn) {
   // client.query accepts either a SQL string or a { text, values } config —
   // GUARDED_CLIENT_HANDLER reads the SQL out of both.
   const guardedClient = new Proxy(client, GUARDED_CLIENT_HANDLER);
-  await client.query('BEGIN');
-  let result;
+  let began = false;
   try {
-    result = await fn(guardedClient);
+    await client.query('BEGIN');
+    began = true;
+    const result = await fn(guardedClient);
     await client.query('COMMIT');
+    return result;
   } catch (err) {
-    await client.query('ROLLBACK');
+    if (began) await client.query('ROLLBACK');
     throw err;
   } finally {
     client.release();
   }
-  return result;
 }
 
 /**

--- a/server/lib/db.transaction.test.js
+++ b/server/lib/db.transaction.test.js
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const pool = vi.hoisted(() => ({
+  client: null,
+  connect: vi.fn(),
+  on: vi.fn(),
+  query: vi.fn(),
+}));
+
+vi.mock('pg', () => ({
+  default: {
+    Pool: vi.fn(function Pool() { return pool; }),
+  },
+}));
+
+import { withTransaction } from './db.js';
+
+function makeClient(query) {
+  return {
+    query,
+    release: vi.fn(),
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  pool.connect.mockImplementation(async () => pool.client);
+});
+
+describe('withTransaction', () => {
+  it('releases the checked-out client when BEGIN fails', async () => {
+    const beginError = new Error('connection reset during BEGIN');
+    const client = makeClient(vi.fn().mockRejectedValueOnce(beginError));
+    pool.client = client;
+
+    await expect(withTransaction(vi.fn())).rejects.toBe(beginError);
+
+    expect(client.query.mock.calls).toEqual([['BEGIN']]);
+    expect(client.release).toHaveBeenCalledOnce();
+  });
+
+  it('rolls back and releases the client when the handler throws', async () => {
+    const handlerError = new Error('handler failed');
+    const client = makeClient(vi.fn().mockResolvedValue({}));
+    pool.client = client;
+
+    await expect(withTransaction(async () => { throw handlerError; })).rejects.toBe(handlerError);
+
+    expect(client.query.mock.calls).toEqual([['BEGIN'], ['ROLLBACK']]);
+    expect(client.release).toHaveBeenCalledOnce();
+  });
+
+  it('commits, releases, and returns the handler result on success', async () => {
+    const client = makeClient(vi.fn().mockResolvedValue({}));
+    pool.client = client;
+
+    await expect(withTransaction(async () => 'saved')).resolves.toBe('saved');
+
+    expect(client.query.mock.calls).toEqual([['BEGIN'], ['COMMIT']]);
+    expect(client.release).toHaveBeenCalledOnce();
+  });
+
+  it('keeps savepoint queries available to transaction handlers', async () => {
+    const client = makeClient(vi.fn().mockResolvedValue({}));
+    pool.client = client;
+
+    await withTransaction(async (transaction) => {
+      await transaction.query('SAVEPOINT nested_work');
+      await transaction.query('ROLLBACK TO SAVEPOINT nested_work');
+    });
+
+    expect(client.query.mock.calls).toEqual([
+      ['BEGIN'],
+      ['SAVEPOINT nested_work'],
+      ['ROLLBACK TO SAVEPOINT nested_work'],
+      ['COMMIT'],
+    ]);
+    expect(client.release).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## Summary

- Release a checked-out PostgreSQL client if starting its transaction fails.
- Cover failed begin, handler rollback, successful commit, and savepoint forwarding with mocked transaction tests.

## Tests

- `npm test --prefix server -- --run lib/db.transaction.test.js`
- `npm test --prefix server -- --run lib/db.guards.test.js`
- `npm test --prefix server`

Closes #4910
