### PR TITLE
fix: serialize calendar account writes (#4914)

### DIFF
--- a/server/services/calendarAccounts.js
+++ b/server/services/calendarAccounts.js
@@ -1,9 +1,13 @@
 import { join } from 'path';
 import { v4 as uuidv4 } from '../lib/uuid.js';
 import { ensureDir, PATHS, readJSONFile, atomicWrite } from '../lib/fileUtils.js';
+import { createFileWriteQueue } from '../lib/fileWriteQueue.js';
 import { isPlainObject } from '../lib/objects.js';
 
 const ACCOUNTS_FILE = join(PATHS.calendar, 'accounts.json');
+// Every account mutator reads and rewrites this one file, so even writes for
+// different accounts must share one tail to preserve both changes.
+const queueWrite = createFileWriteQueue();
 
 async function loadAccounts() {
   await ensureDir(PATHS.calendar);
@@ -27,26 +31,78 @@ export async function getAccount(id) {
 }
 
 export async function createAccount(data) {
-  const accounts = await loadAccounts();
-  const id = uuidv4();
-  accounts[id] = {
-    id,
-    name: data.name,
-    type: data.type, // outlook-calendar
-    email: data.email || '',
-    enabled: true,
-    syncConfig: {
-      maxAge: data.syncConfig?.maxAge || '90d',
-      syncInterval: data.syncConfig?.syncInterval || 300000,
-      calendarIds: data.syncConfig?.calendarIds || ['default']
-    },
-    lastSyncAt: null,
-    lastSyncStatus: null,
-    createdAt: new Date().toISOString()
-  };
-  // For google-calendar, initialize subcalendars
-  if (data.type === 'google-calendar') {
-    accounts[id].subcalendars = (data.subcalendars || []).map(sc => ({
+  return queueWrite(async () => {
+    const accounts = await loadAccounts();
+    const id = uuidv4();
+    accounts[id] = {
+      id,
+      name: data.name,
+      type: data.type, // outlook-calendar
+      email: data.email || '',
+      enabled: true,
+      syncConfig: {
+        maxAge: data.syncConfig?.maxAge || '90d',
+        syncInterval: data.syncConfig?.syncInterval || 300000,
+        calendarIds: data.syncConfig?.calendarIds || ['default']
+      },
+      lastSyncAt: null,
+      lastSyncStatus: null,
+      createdAt: new Date().toISOString()
+    };
+    // For google-calendar, initialize subcalendars
+    if (data.type === 'google-calendar') {
+      accounts[id].subcalendars = (data.subcalendars || []).map(sc => ({
+        calendarId: sc.calendarId,
+        name: sc.name,
+        color: sc.color || '',
+        enabled: sc.enabled !== false,
+        dormant: sc.dormant || false,
+        goalIds: sc.goalIds || [],
+        addedAt: sc.addedAt || new Date().toISOString()
+      }));
+      // Default to google-api if OAuth is configured, otherwise claude-mcp
+      const { getAuthStatus } = await import('./googleAuth.js');
+      const authStatus = await getAuthStatus().catch(() => ({}));
+      accounts[id].syncMethod = authStatus.hasTokens ? 'google-api' : 'claude-mcp';
+    }
+    await saveAccounts(accounts);
+    console.log(`📅 Calendar account created: ${data.name} (${data.type})`);
+    return accounts[id];
+  });
+}
+
+export async function updateAccount(id, updates) {
+  return queueWrite(async () => {
+    const accounts = await loadAccounts();
+    if (!accounts[id]) return null;
+    const { name, email, enabled, syncConfig } = updates;
+    if (name !== undefined) accounts[id].name = name;
+    if (email !== undefined) accounts[id].email = email;
+    if (enabled !== undefined) accounts[id].enabled = enabled;
+    if (syncConfig) accounts[id].syncConfig = { ...accounts[id].syncConfig, ...syncConfig };
+    if (updates.syncMethod !== undefined) accounts[id].syncMethod = updates.syncMethod;
+    accounts[id].updatedAt = new Date().toISOString();
+    await saveAccounts(accounts);
+    return accounts[id];
+  });
+}
+
+export async function deleteAccount(id) {
+  return queueWrite(async () => {
+    const accounts = await loadAccounts();
+    if (!accounts[id]) return false;
+    delete accounts[id];
+    await saveAccounts(accounts);
+    console.log(`🗑️ Calendar account deleted: ${id}`);
+    return true;
+  });
+}
+
+export async function updateSubcalendars(id, subcalendars) {
+  return queueWrite(async () => {
+    const accounts = await loadAccounts();
+    if (!accounts[id]) return null;
+    accounts[id].subcalendars = subcalendars.map(sc => ({
       calendarId: sc.calendarId,
       name: sc.name,
       color: sc.color || '',
@@ -55,55 +111,11 @@ export async function createAccount(data) {
       goalIds: sc.goalIds || [],
       addedAt: sc.addedAt || new Date().toISOString()
     }));
-    // Default to google-api if OAuth is configured, otherwise claude-mcp
-    const { getAuthStatus } = await import('./googleAuth.js');
-    const authStatus = await getAuthStatus().catch(() => ({}));
-    accounts[id].syncMethod = authStatus.hasTokens ? 'google-api' : 'claude-mcp';
-  }
-  await saveAccounts(accounts);
-  console.log(`📅 Calendar account created: ${data.name} (${data.type})`);
-  return accounts[id];
-}
-
-export async function updateAccount(id, updates) {
-  const accounts = await loadAccounts();
-  if (!accounts[id]) return null;
-  const { name, email, enabled, syncConfig } = updates;
-  if (name !== undefined) accounts[id].name = name;
-  if (email !== undefined) accounts[id].email = email;
-  if (enabled !== undefined) accounts[id].enabled = enabled;
-  if (syncConfig) accounts[id].syncConfig = { ...accounts[id].syncConfig, ...syncConfig };
-  if (updates.syncMethod !== undefined) accounts[id].syncMethod = updates.syncMethod;
-  accounts[id].updatedAt = new Date().toISOString();
-  await saveAccounts(accounts);
-  return accounts[id];
-}
-
-export async function deleteAccount(id) {
-  const accounts = await loadAccounts();
-  if (!accounts[id]) return false;
-  delete accounts[id];
-  await saveAccounts(accounts);
-  console.log(`🗑️ Calendar account deleted: ${id}`);
-  return true;
-}
-
-export async function updateSubcalendars(id, subcalendars) {
-  const accounts = await loadAccounts();
-  if (!accounts[id]) return null;
-  accounts[id].subcalendars = subcalendars.map(sc => ({
-    calendarId: sc.calendarId,
-    name: sc.name,
-    color: sc.color || '',
-    enabled: sc.enabled !== false,
-    dormant: sc.dormant || false,
-    goalIds: sc.goalIds || [],
-    addedAt: sc.addedAt || new Date().toISOString()
-  }));
-  accounts[id].updatedAt = new Date().toISOString();
-  await saveAccounts(accounts);
-  console.log(`📅 Updated subcalendars for account ${accounts[id].name}: ${subcalendars.length} calendars`);
-  return accounts[id];
+    accounts[id].updatedAt = new Date().toISOString();
+    await saveAccounts(accounts);
+    console.log(`📅 Updated subcalendars for account ${accounts[id].name}: ${subcalendars.length} calendars`);
+    return accounts[id];
+  });
 }
 
 export function mergeDiscoveredSubcalendars(existing, discovered) {
@@ -123,10 +135,12 @@ export function mergeDiscoveredSubcalendars(existing, discovered) {
 }
 
 export async function updateSyncStatus(id, status) {
-  const accounts = await loadAccounts();
-  if (!accounts[id]) return null;
-  accounts[id].lastSyncAt = new Date().toISOString();
-  accounts[id].lastSyncStatus = status;
-  await saveAccounts(accounts);
-  return accounts[id];
+  return queueWrite(async () => {
+    const accounts = await loadAccounts();
+    if (!accounts[id]) return null;
+    accounts[id].lastSyncAt = new Date().toISOString();
+    accounts[id].lastSyncStatus = status;
+    await saveAccounts(accounts);
+    return accounts[id];
+  });
 }

--- a/server/services/calendarAccounts.test.js
+++ b/server/services/calendarAccounts.test.js
@@ -5,6 +5,7 @@ import { join } from 'path';
 import { makePathsProxy } from '../lib/mockPathsDataRoot.js';
 
 const TEST_DATA_ROOT = mkdtempSync(join(tmpdir(), 'calendar-accounts-test-'));
+const { getAuthStatus } = vi.hoisted(() => ({ getAuthStatus: vi.fn() }));
 
 vi.mock('../lib/fileUtils.js', async (importOriginal) =>
   makePathsProxy(await importOriginal(), { dataRoot: TEST_DATA_ROOT }));
@@ -12,6 +13,8 @@ vi.mock('../lib/fileUtils.js', async (importOriginal) =>
 vi.mock('../lib/uuid.js', () => ({
   v4: vi.fn().mockReturnValue('test-uuid-1234'),
 }));
+
+vi.mock('./googleAuth.js', () => ({ getAuthStatus }));
 
 const calendarAccounts = await import('./calendarAccounts.js');
 
@@ -21,6 +24,7 @@ describe('calendarAccounts', () => {
   beforeEach(() => {
     rmSync(TEST_DATA_ROOT, { recursive: true, force: true });
     mkdirSync(TEST_DATA_ROOT, { recursive: true });
+    getAuthStatus.mockResolvedValue({ hasTokens: false });
   });
 
   describe('createAccount', () => {
@@ -50,6 +54,24 @@ describe('calendarAccounts', () => {
         type: 'outlook-calendar',
       });
       expect(acc.email).toBe('');
+    });
+
+    it.each([
+      [{ hasTokens: true }, 'google-api'],
+      [{ hasTokens: false }, 'claude-mcp'],
+    ])('uses %o OAuth status to select %s for Google accounts', async (authStatus, syncMethod) => {
+      getAuthStatus.mockResolvedValue(authStatus);
+
+      const account = await calendarAccounts.createAccount({
+        name: 'Google',
+        type: 'google-calendar',
+        subcalendars: [{ calendarId: 'primary', name: 'Primary' }],
+      });
+
+      expect(account.syncMethod).toBe(syncMethod);
+      expect(account.subcalendars).toEqual([expect.objectContaining({
+        calendarId: 'primary', name: 'Primary', enabled: true, dormant: false, goalIds: [],
+      })]);
     });
   });
 
@@ -97,6 +119,59 @@ describe('calendarAccounts', () => {
     it('returns null for an absent account id', async () => {
       const result = await calendarAccounts.updateSyncStatus('absent-id', 'ok');
       expect(result).toBeNull();
+    });
+
+    it('preserves a concurrent account edit', async () => {
+      await calendarAccounts.createAccount({ name: 'Sync Test', type: 'outlook-calendar' });
+
+      await Promise.all([
+        calendarAccounts.updateAccount('test-uuid-1234', { name: 'Renamed' }),
+        calendarAccounts.updateSyncStatus('test-uuid-1234', 'success'),
+      ]);
+
+      const account = await calendarAccounts.getAccount('test-uuid-1234');
+      expect(account).toMatchObject({ name: 'Renamed', lastSyncStatus: 'success' });
+      expect(account.lastSyncAt).toBeTruthy();
+    });
+  });
+
+  describe('updateSubcalendars', () => {
+    it.each([
+      [{ calendarId: 'primary', name: 'Primary' }, {
+        calendarId: 'primary', name: 'Primary', color: '', enabled: true, dormant: false, goalIds: [],
+      }],
+      [{ calendarId: 'team', name: 'Team', color: '#123456', enabled: false, dormant: true, goalIds: ['goal-1'], addedAt: '2026-01-01T00:00:00.000Z' }, {
+        calendarId: 'team', name: 'Team', color: '#123456', enabled: false, dormant: true, goalIds: ['goal-1'], addedAt: '2026-01-01T00:00:00.000Z',
+      }],
+    ])('normalizes subcalendar input %#', async (input, expected) => {
+      await calendarAccounts.createAccount({ name: 'Google', type: 'google-calendar' });
+
+      const account = await calendarAccounts.updateSubcalendars('test-uuid-1234', [input]);
+
+      expect(account.subcalendars[0]).toMatchObject(expected);
+      expect(account.updatedAt).toBeTruthy();
+    });
+
+    it('returns null for an absent account id', async () => {
+      await expect(calendarAccounts.updateSubcalendars('absent-id', [])).resolves.toBeNull();
+    });
+  });
+
+  describe('mergeDiscoveredSubcalendars', () => {
+    it.each([
+      [[], [{ id: 'primary', name: 'Primary', color: '#abcdef' }], [{
+        calendarId: 'primary', name: 'Primary', color: '#abcdef', enabled: false, dormant: false, goalIds: [],
+      }]],
+      [[{ calendarId: 'team', name: 'Old name', color: '#111111', enabled: true, dormant: true, goalIds: ['goal-1'], addedAt: '2026-01-01T00:00:00.000Z' }], [{ id: 'team', name: 'New name' }], [{
+        calendarId: 'team', name: 'New name', color: '#111111', enabled: true, dormant: true, goalIds: ['goal-1'], addedAt: '2026-01-01T00:00:00.000Z',
+      }]],
+      [[{ calendarId: 'hidden', name: 'Hidden' }], [{ id: 'primary' }], [{
+        calendarId: 'primary', name: 'primary', color: '', enabled: false, dormant: false, goalIds: [],
+      }]],
+    ])('merges discovered calendars without retaining removed entries %#', (existing, discovered, expected) => {
+      expect(calendarAccounts.mergeDiscoveredSubcalendars(existing, discovered)).toEqual(
+        expected.map(calendar => expect.objectContaining(calendar)),
+      );
     });
   });
 });


### PR DESCRIPTION
## Summary

- Serialize every calendar account read-modify-write mutation through one shared file queue.
- Preserve user edits when background sync status updates land concurrently.
- Add Google-account, subcalendar normalization, discovery merge, and concurrency coverage.

## Tests

- `npx vitest run services/calendarAccounts.test.js`
- `npx vitest run services/calendarAccounts.test.js services/calendarGoogleSync.test.js services/calendarSync.test.js`
- Full server suite
- Local Codex review: `gpt-5.6-luna`, max effort (clean)

Closes #4914
