### PR TITLE
Fix agent activity timeline pagination

### DIFF
--- a/server/services/agentActivity.js
+++ b/server/services/agentActivity.js
@@ -263,16 +263,51 @@ export async function getAgentStats(agentId, days = 7) {
  */
 export async function getActivityTimeline(options = {}) {
   const { agentIds = null, limit = 100, beforeTimestamp = null } = options;
+  const before = beforeTimestamp ? new Date(beforeTimestamp).getTime() : null;
 
-  const activities = await getRecentActivities({ limit: limit * 2, agentIds });
+  await ensureActivityDir();
+  if (!existsSync(ACTIVITY_DIR)) return [];
 
-  // Filter by timestamp if provided
-  let filtered = activities;
-  if (beforeTimestamp) {
-    filtered = activities.filter(a => new Date(a.timestamp) < new Date(beforeTimestamp));
+  const entries = await readdir(ACTIVITY_DIR, { withFileTypes: true });
+  const agentDirs = entries
+    .filter(entry => entry.isDirectory() && (!agentIds || agentIds.includes(entry.name)))
+    .map(entry => entry.name);
+  const dates = new Set();
+
+  for (const agentId of agentDirs) {
+    const files = await readdir(join(ACTIVITY_DIR, agentId));
+    for (const file of files) {
+      if (/^\d{4}-\d{2}-\d{2}\.json$/.test(file)) dates.add(file.slice(0, -5));
+    }
   }
 
-  return filtered.slice(0, limit);
+  const activities = [];
+  for (const date of [...dates].sort().reverse()) {
+    const dayActivities = [];
+    for (const agentId of agentDirs) {
+      const data = await loadActivity(agentId, date);
+      for (const activity of data.activities || []) {
+        const timestamp = new Date(activity.timestamp).getTime();
+        if (before === null || timestamp < before) {
+          dayActivities.push({ agentId, ...activity });
+        }
+      }
+    }
+
+    dayActivities.sort((a, b) => {
+      const timestampOrder = new Date(b.timestamp) - new Date(a.timestamp);
+      if (timestampOrder !== 0) return timestampOrder;
+      const agentOrder = a.agentId.localeCompare(b.agentId);
+      return agentOrder || String(a.id).localeCompare(String(b.id));
+    });
+    activities.push(...dayActivities);
+
+    // Files are visited newest-day first. Once a complete day fills the page,
+    // older files cannot contribute an entry ahead of the current window.
+    if (activities.length >= limit) break;
+  }
+
+  return activities.slice(0, limit);
 }
 
 /**

--- a/server/services/agentActivity.test.js
+++ b/server/services/agentActivity.test.js
@@ -1,0 +1,75 @@
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdir, rm, writeFile } from 'fs/promises';
+import { join } from 'path';
+import { mockPathsDataRoot } from '../lib/mockPathsDataRoot.js';
+
+const { tempRoot, makeProxy, cleanup } = mockPathsDataRoot({ prefix: 'portos-agent-activity-' });
+
+vi.mock('../lib/fileUtils.js', async () => {
+  const actual = await vi.importActual('../lib/fileUtils.js');
+  return makeProxy(actual);
+});
+
+const { getActivityTimeline } = await import('./agentActivity.js');
+
+const activityRoot = join(tempRoot, 'agents', 'activity');
+
+const writeDay = async (agentId, date, activities) => {
+  const directory = join(activityRoot, agentId);
+  await mkdir(directory, { recursive: true });
+  await writeFile(join(directory, `${date}.json`), JSON.stringify({ activities }));
+};
+
+const entry = (id, timestamp) => ({ id, action: 'example', status: 'completed', timestamp });
+
+describe('getActivityTimeline', () => {
+  beforeEach(async () => {
+    await rm(activityRoot, { recursive: true, force: true });
+  });
+
+  afterAll(cleanup);
+
+  it('continues across midnight into older day files', async () => {
+    await writeDay('agent-a', '2026-08-23', [entry('new', '2026-08-23T00:01:00.000Z')]);
+    await writeDay('agent-a', '2026-08-22', [entry('old', '2026-08-22T23:59:00.000Z')]);
+
+    await expect(getActivityTimeline({ limit: 2 })).resolves.toMatchObject([
+      { id: 'new', agentId: 'agent-a' },
+      { id: 'old', agentId: 'agent-a' },
+    ]);
+  });
+
+  it('pages beyond three times the page limit without repeating the shallow window', async () => {
+    await writeDay('agent-a', '2026-08-23', Array.from({ length: 10 }, (_, index) => (
+      entry(`item-${index}`, `2026-08-23T00:00:${String(10 - index).padStart(2, '0')}.000Z`)
+    )));
+
+    await expect(getActivityTimeline({
+      limit: 2,
+      beforeTimestamp: '2026-08-23T00:00:05.000Z',
+    })).resolves.toMatchObject([{ id: 'item-6' }, { id: 'item-7' }]);
+  });
+
+  it('returns a stable newest-first order across agents', async () => {
+    await writeDay('agent-b', '2026-08-23', [
+      entry('b-later', '2026-08-23T12:00:01.000Z'),
+      entry('b-tie', '2026-08-23T12:00:00.000Z'),
+    ]);
+    await writeDay('agent-a', '2026-08-23', [entry('a-tie', '2026-08-23T12:00:00.000Z')]);
+
+    const first = await getActivityTimeline({ limit: 3 });
+    const second = await getActivityTimeline({ limit: 3 });
+
+    expect(first.map(({ id }) => id)).toEqual(['b-later', 'a-tie', 'b-tie']);
+    expect(second).toEqual(first);
+  });
+
+  it('skips empty days while walking backward', async () => {
+    await writeDay('agent-a', '2026-08-23', []);
+    await writeDay('agent-a', '2026-08-21', [entry('older', '2026-08-21T09:00:00.000Z')]);
+
+    await expect(getActivityTimeline({ limit: 1 })).resolves.toMatchObject([
+      { id: 'older', agentId: 'agent-a' },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

- walk agent activity day files newest-first so timeline pagination crosses midnight
- apply deep timestamp cursors without a shallow pre-window
- make equal-timestamp ordering deterministic across agents and add direct service coverage

## Test plan

- `cd server && npm test -- services/agentActivity.test.js routes/agentActivity.test.js`
- pinned Codex local review (`gpt-5.6-luna`, max reasoning)

Closes #4918
