### PR TITLE
docs: document operator env overrides (#4926)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -69,8 +69,29 @@ PGPASSWORD=portos
 # LM Studio local inference server URL
 # LM_STUDIO_URL=http://localhost:1234
 
+# LM Studio model used by the Moltworld explorer (default: gpt-oss-20b)
+# LM_STUDIO_MODEL=gpt-oss-20b
+
+# Enable LM Studio thoughts in the Moltworld explorer (default: true)
+# LM_STUDIO_ENABLED=true
+
 # Ollama local inference server URL (defaults to http://localhost:11434)
 # OLLAMA_URL=http://localhost:11434
+
+# Ollama-compatible host:port alias used when OLLAMA_URL is unset (default: localhost:11434)
+# OLLAMA_HOST=localhost:11434
+
+# Maximum simultaneous requests to each local LLM endpoint (default: 1)
+# LOCAL_LLM_MAX_CONCURRENCY=1
+
+# Maximum Codex image-generation runtime in milliseconds (default: 1200000 / 20 minutes)
+# CODEX_TIMEOUT_MS=1200000
+
+# Maximum Grok image-generation runtime in milliseconds (default: 1200000 / 20 minutes)
+# GROK_TIMEOUT_MS=1200000
+
+# Maximum Antigravity image-generation runtime in milliseconds (default: 1200000 / 20 minutes)
+# AGY_IMAGEGEN_TIMEOUT_MS=1200000
 
 # Path to the Claude CLI binary (defaults to system PATH)
 # CLAUDE_PATH=/usr/local/bin/claude
@@ -144,8 +165,55 @@ PGPASSWORD=portos
 # Ollama context window size passed to new model loads (default: 32768)
 # OLLAMA_NUM_CTX=32768
 
+# Video process grace period after output completion in milliseconds (default: 40000)
+# VIDEOGEN_COMPLETION_WATCHDOG_MS=40000
+
+# Terminate a video render after this many idle milliseconds (default: 600000 / 10 minutes)
+# VIDEOGEN_IDLE_STALL_MS=600000
+
+# Terminate an idle queued video job after this many milliseconds (default: 1800000 / 30 minutes)
+# MEDIA_JOB_WATCHDOG_VIDEO_MS=1800000
+
+# Terminate an idle queued image job after this many milliseconds (default: 300000 / 5 minutes)
+# MEDIA_JOB_WATCHDOG_IMAGE_MS=300000
+
+# Terminate an idle queued Codex job after this many milliseconds (default: 1200000 / 20 minutes)
+# MEDIA_JOB_WATCHDOG_CODEX_MS=1200000
+
+# Terminate an idle queued training job after this many milliseconds (default: 1800000 / 30 minutes)
+# MEDIA_JOB_WATCHDOG_TRAINING_MS=1800000
+
+# Terminate an idle queued audio job after this many milliseconds (default: 600000 / 10 minutes)
+# MEDIA_JOB_WATCHDOG_AUDIO_MS=600000
+
+# LoRA step-time multiplier used to detect a soft training stall (default: 6)
+# LORA_TRAIN_STALL_STEP_MULTIPLIER=6
+
+# Step intervals required before the adaptive LoRA stall budget arms (default: 3)
+# LORA_TRAIN_STALL_MIN_SAMPLES=3
+
+# Minimum adaptive LoRA stall budget in milliseconds (default: 90000)
+# LORA_TRAIN_STALL_MIN_BUDGET_MS=90000
+
+# Maximum adaptive LoRA stall budget in milliseconds (default: 900000 / 15 minutes)
+# LORA_TRAIN_STALL_MAX_BUDGET_MS=900000
+
+# LoRA warmup stall budget before step timing stabilizes (default: 1200000 / 20 minutes)
+# LORA_TRAIN_STALL_WARMUP_BUDGET_MS=1200000
+
+# Automatic LoRA checkpoint resumes allowed after soft stalls (default: 2; 0 disables)
+# LORA_TRAIN_STALL_MAX_AUTO_RESUMES=2
+
+# Ingredient catalog revisions retained per ingredient (default: 50)
+# CATALOG_REVISION_RETENTION=50
+
+# LM Studio model id auto-installed for voice tool calling (default: built-in fallback chain)
+# PORTOS_VOICE_DEFAULT_TOOL_MODEL=lmstudio-community/Qwen2.5-3B-Instruct-GGUF
+
+# Signal sync config file path (default: SIGNAL_DIR/config.json)
+# SIGNAL_CONFIG_PATH=/path/to/signal/config.json
+
 # Privacy Center PII Vault encryption key — 32 bytes, hex (64 chars) or base64.
 # Auto-generated and appended to .env on the first vault write if unset. Back
 # it up: losing it makes every encrypted vault value unrecoverable.
 # PRIVACY_VAULT_KEY=<64 hex chars>
-

--- a/server/scripts/moltworld-explore.mjs
+++ b/server/scripts/moltworld-explore.mjs
@@ -23,9 +23,9 @@
  *   MOLTWORLD_MAX_INTERVAL      - Max seconds between joins (default: 540 = 9 min)
  *   MOLTWORLD_USE_WS            - Set to "true" to route moves through PortOS WS relay
  *   PORTOS_API_BASE              - PortOS server URL (default: http://localhost:5555)
- *   LMSTUDIO_BASE_URL           - LM Studio URL (default: http://localhost:1234)
- *   LMSTUDIO_MODEL              - Model name (default: gpt-oss-20b)
- *   LMSTUDIO_ENABLED            - Set to "false" to disable (default: true)
+ *   LM_STUDIO_URL               - LM Studio URL (default: http://localhost:1234)
+ *   LM_STUDIO_MODEL             - Model name (default: gpt-oss-20b)
+ *   LM_STUDIO_ENABLED           - Set to "false" to disable (default: true)
  *
  * Example:
  *   node server/scripts/moltworld-explore.mjs 60
@@ -57,9 +57,11 @@ const USE_WS = process.env.MOLTWORLD_USE_WS === 'true';
 const PORTOS_API_BASE = process.env.PORTOS_API_BASE || 'http://localhost:5555';
 
 // LM Studio config
-const LMSTUDIO_URL = process.env.LMSTUDIO_BASE_URL || 'http://localhost:1234';
-const LMSTUDIO_MODEL = process.env.LMSTUDIO_MODEL || 'gpt-oss-20b';
-const LMSTUDIO_ENABLED = process.env.LMSTUDIO_ENABLED !== 'false';
+// Keep the historical LMSTUDIO_* spellings as compatibility fallbacks while
+// aligning new configuration with PortOS's shared LM_STUDIO_* convention.
+const LMSTUDIO_URL = process.env.LM_STUDIO_URL || process.env.LMSTUDIO_BASE_URL || 'http://localhost:1234';
+const LMSTUDIO_MODEL = process.env.LM_STUDIO_MODEL || process.env.LMSTUDIO_MODEL || 'gpt-oss-20b';
+const LMSTUDIO_ENABLED = (process.env.LM_STUDIO_ENABLED || process.env.LMSTUDIO_ENABLED) !== 'false';
 
 // Move to a new position every Nth join (not every time)
 const MOVE_EVERY_N_JOINS = 3;

--- a/server/scripts/moltworld-explore.mjs
+++ b/server/scripts/moltworld-explore.mjs
@@ -59,7 +59,8 @@ const PORTOS_API_BASE = process.env.PORTOS_API_BASE || 'http://localhost:5555';
 // LM Studio config
 // Keep the historical LMSTUDIO_* spellings as compatibility fallbacks while
 // aligning new configuration with PortOS's shared LM_STUDIO_* convention.
-const LMSTUDIO_URL = process.env.LM_STUDIO_URL || process.env.LMSTUDIO_BASE_URL || 'http://localhost:1234';
+const LMSTUDIO_URL = (process.env.LM_STUDIO_URL || process.env.LMSTUDIO_BASE_URL || 'http://localhost:1234')
+  .replace(/\/+$/, '').replace(/\/v1$/, '');
 const LMSTUDIO_MODEL = process.env.LM_STUDIO_MODEL || process.env.LMSTUDIO_MODEL || 'gpt-oss-20b';
 const LMSTUDIO_ENABLED = (process.env.LM_STUDIO_ENABLED || process.env.LMSTUDIO_ENABLED) !== 'false';
 


### PR DESCRIPTION
## Summary
- document operator-tunable local LLM, media watchdog, LoRA stall, catalog, voice, and Signal overrides
- document the supported `OLLAMA_HOST` alias alongside `OLLAMA_URL`
- standardize the Moltworld explorer on `LM_STUDIO_*` names while retaining legacy aliases and normalizing versioned URLs

## Test plan
- `node --check server/scripts/moltworld-explore.mjs`
- verify the requested environment-variable inventory is present in `.env.example`
- smoke-test LM Studio URL normalization for bare, trailing-slash, and `/v1` forms
- `git diff --check origin/main...HEAD`

Closes #4926
