### PR TITLE
refactor: reuse shared date formatters (#4933)

### DIFF
--- a/client/src/components/meatspace/AlcoholChart.jsx
+++ b/client/src/components/meatspace/AlcoholChart.jsx
@@ -5,7 +5,7 @@ import {
 import * as api from '../../services/api';
 import BrailleSpinner from '../BrailleSpinner';
 import useChartColors from '../../hooks/useChartColors.js';
-import { localDateKey } from '../../utils/formatters';
+import { formatMonthDay, localDateKey } from '../../utils/formatters';
 
 const VIEWS = [
   { id: '7d', label: '7 Days', days: 7 },
@@ -46,7 +46,7 @@ export default function AlcoholChart({ sex = 'male', onRefreshKey, onViewChange 
       const drinks = dateMap[dateStr] || 0;
       chartData.push({
         date: dateStr,
-        label: `${cursor.getMonth() + 1}/${cursor.getDate()}`,
+        label: formatMonthDay(cursor),
         drinks,
         grams: Math.round(drinks * GRAMS_PER_STD_DRINK * 100) / 100
       });

--- a/client/src/components/meatspace/BloodPressureCard.jsx
+++ b/client/src/components/meatspace/BloodPressureCard.jsx
@@ -6,6 +6,7 @@ import { HeartPulse, Plus, X, Check, TrendingUp, TrendingDown } from 'lucide-rea
 import * as api from '../../services/api';
 import BrailleSpinner from '../BrailleSpinner';
 import useChartColors from '../../hooks/useChartColors.js';
+import { formatMonthDay } from '../../utils/formatters.js';
 import { classifyBP, bpLongevityImpact, BP_CATEGORIES } from './bpClassification';
 
 // Stage 1 hypertension reference line sits between the warning (elevated) and
@@ -62,7 +63,7 @@ export default function BloodPressureCard() {
 
   const chartData = readings.map(r => ({
     date: r.date,
-    label: `${new Date(r.date).getMonth() + 1}/${new Date(r.date).getDate()}`,
+    label: formatMonthDay(r.date),
     systolic: r.systolic,
     diastolic: r.diastolic
   }));

--- a/client/src/components/meatspace/BodyCompChart.jsx
+++ b/client/src/components/meatspace/BodyCompChart.jsx
@@ -5,7 +5,7 @@ import {
 import * as api from '../../services/api';
 import BrailleSpinner from '../BrailleSpinner';
 import useChartColors from '../../hooks/useChartColors.js';
-import { formatWeight, formatPercent } from '../../utils/formatters.js';
+import { formatMonthDay, formatPercent, formatWeight } from '../../utils/formatters.js';
 
 export default function BodyCompChart() {
   const chartColors = useChartColors();
@@ -16,7 +16,7 @@ export default function BodyCompChart() {
     const history = await api.getBodyHistory().catch(() => []);
     const chartData = history.map(entry => ({
       date: entry.date,
-      label: `${new Date(entry.date).getMonth() + 1}/${new Date(entry.date).getDate()}`,
+      label: formatMonthDay(entry.date),
       weight: entry.weightLbs || null,
       fatPct: entry.fatPct || null,
       musclePct: entry.musclePct || null

--- a/client/src/components/meatspace/NicotineChart.jsx
+++ b/client/src/components/meatspace/NicotineChart.jsx
@@ -5,7 +5,7 @@ import {
 import * as api from '../../services/api';
 import BrailleSpinner from '../BrailleSpinner';
 import useChartColors from '../../hooks/useChartColors.js';
-import { localDateKey } from '../../utils/formatters';
+import { formatMonthDay, localDateKey } from '../../utils/formatters';
 
 const VIEWS = [
   { id: '7d', label: '7 Days', days: 7 },
@@ -53,7 +53,7 @@ export default function NicotineChart({ onRefreshKey, onViewChange }) {
       const mg = dateMap[dateStr] || 0;
       chartData.push({
         date: dateStr,
-        label: `${cursor.getMonth() + 1}/${cursor.getDate()}`,
+        label: formatMonthDay(cursor),
         mg
       });
       cursor.setDate(cursor.getDate() + 1);

--- a/client/src/components/settings/LocalLlmTab.jsx
+++ b/client/src/components/settings/LocalLlmTab.jsx
@@ -125,7 +125,7 @@ function fitTitle(source, entry) {
       : '';
     return `Estimated fit on this machine — model weights + ~20% overhead vs. usable memory.${stale}`;
   }
-  const measuredAt = entry?.assessedAt ? ` on ${new Date(entry.assessedAt).toLocaleDateString()}` : '';
+  const measuredAt = entry?.assessedAt ? ` on ${formatDateNumeric(entry.assessedAt)}` : '';
   const disagree = entry?.disagrees
     ? ` The size estimate said "${FIT_META[entry.estimatedFit]?.label || entry.estimatedFit}".`
     : '';

--- a/client/src/components/system-resources/StoragePanel.jsx
+++ b/client/src/components/system-resources/StoragePanel.jsx
@@ -5,7 +5,7 @@ import ProviderModelSelector from '../ProviderModelSelector.jsx';
 import Banner from '../ui/Banner.jsx';
 import CleanupControl from './CleanupControl.jsx';
 import useProviderModels from '../../hooks/useProviderModels.js';
-import { formatBytes } from '../../utils/formatters.js';
+import { formatBytes, formatDateTime } from '../../utils/formatters.js';
 import * as api from '../../services/api.js';
 import toast from '../ui/Toast.jsx';
 
@@ -272,7 +272,7 @@ function AiTriage({ report, onReport }) {
 
 export default function StoragePanel({ report, loading, onRunReport, onReport, cleanup }) {
   if (!report) return <ReportEmpty loading={loading} onRun={onRunReport} />;
-  const generated = new Date(report.generatedAt).toLocaleString();
+  const generated = formatDateTime(report.generatedAt);
   return (
     <div className="space-y-4">
       <div className="flex flex-col gap-3 rounded-xl border border-port-border bg-port-card p-3 sm:flex-row sm:items-center sm:justify-between">


### PR DESCRIPTION
## Summary

- replace remaining inline date rendering in the targeted settings, storage, and MeatSpace views with shared formatter helpers
- preserve local-calendar dates for date-only health records while standardizing localized labels

## Test plan

- `cd client && npm test` (9,738 tests)
- `cd client && npm run lint`
- `cd client && npm run build`

Closes #4933
