### PR TITLE
feat: add plan-only quick task issue mode

### DIFF
--- a/client/src/components/cos/TaskAddForm.jsx
+++ b/client/src/components/cos/TaskAddForm.jsx
@@ -17,6 +17,7 @@ import EffortSelect from './EffortSelect';
 import useReviewerModelOptions from '../../hooks/useReviewerModelOptions';
 import useAssignableInstances from '../../hooks/useAssignableInstances';
 import { reviewerModelsFromDefaults, reviewerEffortsFromDefaults } from '../../lib/reviewerModels';
+import { PORTOS_APP_ID } from '../../lib/appIdentity';
 
 export default function TaskAddForm({ providers, apps, onTaskAdded, compact = false, defaultExpanded = false, defaultApp = '' }) {
   const [newTask, setNewTask] = useState({ description: '', model: '', provider: '', effort: '', temperature: '', thinking: '', app: defaultApp });
@@ -148,12 +149,12 @@ export default function TaskAddForm({ providers, apps, onTaskAdded, compact = fa
   // apps cannot queue an issue workflow their tracker does not support.
   useEffect(() => {
     const configuredTracker = selectedApp?.workTracker;
-    if (!selectedApp?.id || (configuredTracker && configuredTracker !== 'auto')) {
-      setResolvedWorkTracker({ appId: selectedApp?.id || null, tracker: null });
+    const appId = selectedApp?.id || PORTOS_APP_ID;
+    if (selectedApp && configuredTracker && configuredTracker !== 'auto') {
+      setResolvedWorkTracker({ appId, tracker: configuredTracker });
       return undefined;
     }
 
-    const appId = selectedApp.id;
     setResolvedWorkTracker({ appId, tracker: null });
     let cancelled = false;
     Promise.resolve(api.getAppWorkTracker(appId, { silent: true }))
@@ -167,11 +168,10 @@ export default function TaskAddForm({ providers, apps, onTaskAdded, compact = fa
   }, [selectedApp?.id, selectedApp?.workTracker]);
 
   const planOnlyTrackerStatus = useMemo(() => {
-    if (!selectedApp) return 'supported';
-    const configuredTracker = selectedApp.workTracker;
+    const configuredTracker = selectedApp?.workTracker;
     const tracker = configuredTracker && configuredTracker !== 'auto'
       ? configuredTracker
-      : resolvedWorkTracker.appId === selectedApp.id ? resolvedWorkTracker.tracker : null;
+      : resolvedWorkTracker.appId === (selectedApp?.id || PORTOS_APP_ID) ? resolvedWorkTracker.tracker : null;
     if (!tracker) return 'pending';
     return tracker === 'github' || tracker === 'gitlab' ? 'supported' : 'unsupported';
   }, [resolvedWorkTracker, selectedApp]);

--- a/client/src/components/cos/TaskAddForm.jsx
+++ b/client/src/components/cos/TaskAddForm.jsx
@@ -141,6 +141,52 @@ export default function TaskAddForm({ providers, apps, onTaskAdded, compact = fa
     [apps, newTask.app]
   );
   const appHasJira = selectedApp?.jira?.enabled;
+  const [resolvedWorkTracker, setResolvedWorkTracker] = useState({ appId: null, tracker: null });
+
+  // Plan-and-file uses the bundled issue-only `plan-task` command. Resolve an
+  // app's effective tracker before exposing the toggle so PLAN.md and JIRA
+  // apps cannot queue an issue workflow their tracker does not support.
+  useEffect(() => {
+    const configuredTracker = selectedApp?.workTracker;
+    if (!selectedApp?.id || (configuredTracker && configuredTracker !== 'auto')) {
+      setResolvedWorkTracker({ appId: selectedApp?.id || null, tracker: null });
+      return undefined;
+    }
+
+    const appId = selectedApp.id;
+    setResolvedWorkTracker({ appId, tracker: null });
+    let cancelled = false;
+    Promise.resolve(api.getAppWorkTracker(appId, { silent: true }))
+      .then(info => {
+        if (!cancelled) setResolvedWorkTracker({ appId, tracker: info?.resolved || null });
+      })
+      .catch(() => {
+        if (!cancelled) setResolvedWorkTracker({ appId, tracker: null });
+      });
+    return () => { cancelled = true; };
+  }, [selectedApp?.id, selectedApp?.workTracker]);
+
+  const planOnlyTrackerStatus = useMemo(() => {
+    if (!selectedApp) return 'supported';
+    const configuredTracker = selectedApp.workTracker;
+    const tracker = configuredTracker && configuredTracker !== 'auto'
+      ? configuredTracker
+      : resolvedWorkTracker.appId === selectedApp.id ? resolvedWorkTracker.tracker : null;
+    if (!tracker) return 'pending';
+    return tracker === 'github' || tracker === 'gitlab' ? 'supported' : 'unsupported';
+  }, [resolvedWorkTracker, selectedApp]);
+  const planOnlySupported = planOnlyTrackerStatus === 'supported';
+
+  // Clear a template or an already-selected mode when an app resolves to a
+  // tracker that cannot receive the issue-only plan-task workflow.
+  useEffect(() => {
+    if (planOnlyTrackerStatus !== 'unsupported' || !planOnly) return;
+    setPlanOnly(false);
+    if (slashdoCommand === 'plan-task') {
+      setSlashdoCommand('');
+      setWorktreeChangesExpected(undefined);
+    }
+  }, [planOnly, planOnlyTrackerStatus, slashdoCommand]);
 
   // Gate on a content signature of the selected app's defaults (not the
   // `apps` array reference) so periodic re-fetches in the parent don't
@@ -194,6 +240,7 @@ export default function TaskAddForm({ providers, apps, onTaskAdded, compact = fa
   })();
 
   const handlePlanOnlyChange = (enabled) => {
+    if (enabled && !planOnlySupported) return;
     setPlanOnly(enabled);
     if (enabled) {
       setSlashdoCommand('plan-task');
@@ -395,7 +442,7 @@ export default function TaskAddForm({ providers, apps, onTaskAdded, compact = fa
       targetInstanceId: targetInstanceId || undefined,
       planOnly,
       slashdoCommand: planOnly ? 'plan-task' : (slashdoCommand || undefined),
-      slashdoArgs: planOnly ? '--issues --yes' : undefined,
+      slashdoArgs: planOnly ? '--yes' : undefined,
       createJiraTicket: planOnly ? false : createJiraTicket,
       useWorktree: planOnly ? false : useWorktree,
       openPR: planOnly ? false : useWorktree && openPR,
@@ -618,19 +665,32 @@ export default function TaskAddForm({ providers, apps, onTaskAdded, compact = fa
               Enhance
             </span>
           </label>
-          <label htmlFor="task-plan-only" className="flex items-center gap-2 cursor-pointer select-none whitespace-nowrap py-1">
-            <input
-              id="task-plan-only"
-              type="checkbox"
-              checked={planOnly}
-              onChange={(e) => handlePlanOnlyChange(e.target.checked)}
-              className="w-4 h-4 rounded border-port-border bg-port-bg text-port-accent focus:ring-port-accent focus:ring-offset-0"
-            />
-            <span className="flex items-center gap-1.5 text-sm text-gray-400" title="Read the codebase and file a GitHub or GitLab issue without implementing the task.">
-              <FileText size={14} className="text-port-accent" />
-              Plan &amp; file issue
-            </span>
-          </label>
+          {planOnlyTrackerStatus !== 'unsupported' && (
+            <label htmlFor="task-plan-only" className="flex items-center gap-2 cursor-pointer select-none whitespace-nowrap py-1">
+              <input
+                id="task-plan-only"
+                type="checkbox"
+                checked={planOnly}
+                disabled={!planOnlySupported}
+                onChange={(e) => handlePlanOnlyChange(e.target.checked)}
+                className="w-4 h-4 rounded border-port-border bg-port-bg text-port-accent focus:ring-port-accent focus:ring-offset-0 disabled:opacity-40"
+              />
+              <span className="flex items-center gap-1.5 text-sm text-gray-400" title="Read the codebase and file a GitHub or GitLab issue without implementing the task.">
+                <FileText size={14} className="text-port-accent" />
+                Plan &amp; file issue
+              </span>
+            </label>
+          )}
+          {planOnlyTrackerStatus === 'pending' && (
+            <p className="basis-full text-xs text-gray-500">
+              Checking the app&apos;s work tracker before enabling issue planning.
+            </p>
+          )}
+          {planOnlyTrackerStatus === 'unsupported' && (
+            <p className="basis-full text-xs text-gray-500">
+              Plan &amp; file issue is available for GitHub or GitLab issue trackers.
+            </p>
+          )}
           {planOnly && (
             <p className="basis-full text-xs text-gray-500">
               Read-only planning: file the issue without code changes, a worktree, PR, simplify pass, or review.

--- a/client/src/components/cos/TaskAddForm.jsx
+++ b/client/src/components/cos/TaskAddForm.jsx
@@ -177,7 +177,7 @@ export default function TaskAddForm({ providers, apps, onTaskAdded, compact = fa
     setUseWorktree(defaultUseWorktree);
     setOpenPR(defaultOpenPR);
     setPrCompletion(selectedApp?.defaultPrCompletion || DEFAULT_PR_COMPLETION);
-  }, [appDefaultsSig]);
+  }, [appDefaultsSig, planOnly]);
 
   // Get models for selected provider. The form carries its own Thinking Effort
   // select and submits it, so Antigravity lists BASE models (`gemini-3.6-flash`)

--- a/client/src/components/cos/TaskAddForm.jsx
+++ b/client/src/components/cos/TaskAddForm.jsx
@@ -30,6 +30,7 @@ export default function TaskAddForm({ providers, apps, onTaskAdded, compact = fa
   const [useWorktree, setUseWorktree] = useState(true);
   const [openPR, setOpenPR] = useState(true);
   const [simplify, setSimplify] = useState(true);
+  const [planOnly, setPlanOnly] = useState(false);
   // Hidden run-shape state, never a user-facing toggle: the slashdo catalog's
   // deliverable posture (#3636/#3651). `undefined` = the form pins no opinion,
   // so the server keeps its own default. Only a slashdo-backed template sets it.
@@ -159,6 +160,13 @@ export default function TaskAddForm({ providers, apps, onTaskAdded, compact = fa
       templateAppChangeRef.current = false;
       return;
     }
+    if (planOnly) {
+      setCreateJiraTicket(false);
+      setUseWorktree(false);
+      setOpenPR(false);
+      setSimplify(false);
+      return;
+    }
     // Absent (app never configured, or no app selected) falls back to the
     // form's on-by-default posture; an explicit `false` on the app record is a
     // deliberate opt-out and is honored.
@@ -184,6 +192,21 @@ export default function TaskAddForm({ providers, apps, onTaskAdded, compact = fa
     if (isCliProvider(selectedProvider)) return `${selectedProvider.name} uses its CLI configured default model.`;
     return 'No models are configured. PortOS will use the provider default.';
   })();
+
+  const handlePlanOnlyChange = (enabled) => {
+    setPlanOnly(enabled);
+    if (enabled) {
+      setSlashdoCommand('plan-task');
+      setCreateJiraTicket(false);
+      setUseWorktree(false);
+      setOpenPR(false);
+      setSimplify(false);
+      setWorktreeChangesExpected(false);
+    } else if (slashdoCommand === 'plan-task') {
+      setSlashdoCommand('');
+      setWorktreeChangesExpected(undefined);
+    }
+  };
 
   // Apply template to form. A slashdo-backed template also pins the workflow
   // (`slashdoCommand`) and applies its implied run-shape `settings`.
@@ -214,7 +237,9 @@ export default function TaskAddForm({ providers, apps, onTaskAdded, compact = fa
         ? { provider: template.provider, model: seeded.model, effort: seeded.effort }
         : {})
     }));
+    const templatePlanOnly = template.slashdoCommand === 'plan-task';
     setSlashdoCommand(template.slashdoCommand || '');
+    setPlanOnly(templatePlanOnly);
     // Hidden posture, so it follows `slashdoCommand` (set unconditionally above)
     // rather than the tri-state rule the three visible toggles use: with no UI
     // control to reveal or correct it, a posture left over from a previous
@@ -228,6 +253,13 @@ export default function TaskAddForm({ providers, apps, onTaskAdded, compact = fa
       if (settings.useWorktree !== undefined) setUseWorktree(settings.useWorktree);
       if (settings.openPR !== undefined) setOpenPR(settings.openPR);
       if (settings.simplify !== undefined) setSimplify(settings.simplify);
+    }
+    if (templatePlanOnly) {
+      setCreateJiraTicket(false);
+      setUseWorktree(false);
+      setOpenPR(false);
+      setSimplify(false);
+      setWorktreeChangesExpected(false);
     }
     descriptionRef.current?.focus();
     await api.applyCosTaskTemplate(template.id).catch(() => {});
@@ -258,7 +290,16 @@ export default function TaskAddForm({ providers, apps, onTaskAdded, compact = fa
       provider: newTask.provider,
       model: newTask.model,
       effort: newTask.effort,
-      app: newTask.app
+      app: newTask.app,
+      ...(planOnly ? {
+        slashdoCommand: 'plan-task',
+        settings: {
+          useWorktree: false,
+          openPR: false,
+          simplify: false,
+          worktreeChangesExpected: false,
+        },
+      } : {})
     }, { silent: true }).catch(err => {
       toast.error(err.message);
       return null;
@@ -272,7 +313,7 @@ export default function TaskAddForm({ providers, apps, onTaskAdded, compact = fa
         .then(data => setTemplates(data.templates || []))
         .catch(err => console.warn('refresh templates:', err?.message ?? String(err)));
     }
-  }, [newTask, templateNameInput, showTemplateSave]);
+  }, [newTask, planOnly, templateNameInput, showTemplateSave]);
 
   // Delete a user template
   const deleteTemplate = useCallback(async (templateId, e) => {
@@ -352,18 +393,22 @@ export default function TaskAddForm({ providers, apps, onTaskAdded, compact = fa
       thinking: newTask.thinking === '' ? undefined : newTask.thinking === 'true',
       app: newTask.app || undefined,
       targetInstanceId: targetInstanceId || undefined,
-      slashdoCommand: slashdoCommand || undefined,
-      createJiraTicket,
-      useWorktree,
-      openPR: useWorktree && openPR,
-      simplify,
+      planOnly,
+      slashdoCommand: planOnly ? 'plan-task' : (slashdoCommand || undefined),
+      slashdoArgs: planOnly ? '--issues --yes' : undefined,
+      createJiraTicket: planOnly ? false : createJiraTicket,
+      useWorktree: planOnly ? false : useWorktree,
+      openPR: planOnly ? false : useWorktree && openPR,
+      simplify: planOnly ? false : simplify,
       // Omitted entirely when no template pinned a posture — sending `undefined`
       // would be indistinguishable from a deliberate `false` on the wire.
-      ...(worktreeChangesExpected !== undefined ? { worktreeChangesExpected } : {}),
-      prCompletion: useWorktree && openPR ? prCompletion : undefined,
+      ...(planOnly
+        ? { worktreeChangesExpected: false }
+        : worktreeChangesExpected !== undefined ? { worktreeChangesExpected } : {}),
+      prCompletion: !planOnly && useWorktree && openPR ? prCompletion : undefined,
       // One gate for every per-reviewer field: they only apply when this task
       // opens a PR that PortOS reviews before merging.
-      ...(openPR && prCompletion === 'review-then-merge' ? {
+      ...(!planOnly && openPR && prCompletion === 'review-then-merge' ? {
         reviewers,
         usernames: reviewUsernames,
         optionalReviewers,
@@ -395,13 +440,13 @@ export default function TaskAddForm({ providers, apps, onTaskAdded, compact = fa
 
     // Only clear form inputs after successful submission
     setNewTask(t => ({ ...t, description: '' }));
-    setSlashdoCommand('');
+    setSlashdoCommand(planOnly ? 'plan-task' : '');
     // targetInstanceId deliberately SURVIVES the clear, like app/model/provider
     // and the worktree toggles: it is a run setting, and someone queueing work
     // onto the GPU box is usually queueing more than one item.
     // The posture belongs to the workflow the cleared template pinned, so it
     // must not survive into the next, template-less task.
-    setWorktreeChangesExpected(undefined);
+    setWorktreeChangesExpected(planOnly ? false : undefined);
     setScreenshots([]);
     setAttachments([]);
 
@@ -444,7 +489,7 @@ export default function TaskAddForm({ providers, apps, onTaskAdded, compact = fa
               className="flex items-center gap-1 px-3 py-2 bg-port-accent/20 hover:bg-port-accent/30 text-port-accent rounded-lg text-sm transition-colors disabled:opacity-50 min-h-[44px]"
             >
               {(isSubmitting || isEnhancing) ? <Loader2 size={14} className="animate-spin" /> : <Plus size={14} />}
-              {isSubmitting ? 'Adding...' : 'Add'}
+              {isSubmitting ? (planOnly ? 'Planning...' : 'Adding...') : planOnly ? 'Plan & File' : 'Add'}
             </button>
           </div>
         </div>
@@ -573,105 +618,127 @@ export default function TaskAddForm({ providers, apps, onTaskAdded, compact = fa
               Enhance
             </span>
           </label>
-          <label className="flex items-center gap-2 cursor-pointer select-none whitespace-nowrap py-1">
+          <label htmlFor="task-plan-only" className="flex items-center gap-2 cursor-pointer select-none whitespace-nowrap py-1">
             <input
+              id="task-plan-only"
               type="checkbox"
-              checked={useWorktree}
-              onChange={(e) => {
-                // Enabling a worktree defaults "Open PR" on (safer than an
-                // unreviewed auto-merge to the default branch); the user can
-                // still uncheck it. Disabling forces it off (openPR is
-                // meaningless without a worktree).
-                setUseWorktree(e.target.checked);
-                setOpenPR(e.target.checked);
-              }}
+              checked={planOnly}
+              onChange={(e) => handlePlanOnlyChange(e.target.checked)}
               className="w-4 h-4 rounded border-port-border bg-port-bg text-port-accent focus:ring-port-accent focus:ring-offset-0"
             />
-            <span className="flex items-center gap-1.5 text-sm text-gray-400" title="Work in an isolated git worktree on a feature branch. If unchecked, commits directly to the default branch.">
-              <GitBranch size={14} className="text-emerald-400" />
-              Worktree
+            <span className="flex items-center gap-1.5 text-sm text-gray-400" title="Read the codebase and file a GitHub or GitLab issue without implementing the task.">
+              <FileText size={14} className="text-port-accent" />
+              Plan &amp; file issue
             </span>
           </label>
-          <label className="flex items-center gap-2 cursor-pointer select-none whitespace-nowrap py-1">
-            <input
-              type="checkbox"
-              checked={openPR}
-              disabled={!useWorktree}
-              onChange={(e) => setOpenPR(e.target.checked)}
-              className="w-4 h-4 rounded border-port-border bg-port-bg text-port-accent focus:ring-port-accent focus:ring-offset-0 disabled:opacity-40"
-            />
-            <span className={`flex items-center gap-1.5 text-sm ${useWorktree ? 'text-gray-400' : 'text-gray-600'}`} title="Open a pull request to the default branch. If unchecked with worktree enabled, auto-merges on completion.">
-              <GitPullRequest size={14} className={useWorktree ? 'text-port-accent' : 'text-gray-600'} />
-              Open PR
-            </span>
-          </label>
-          <label className="flex items-center gap-2 cursor-pointer select-none whitespace-nowrap py-1">
-            <input
-              type="checkbox"
-              checked={simplify}
-              onChange={(e) => setSimplify(e.target.checked)}
-              className="w-4 h-4 rounded border-port-border bg-port-bg text-port-accent focus:ring-port-accent focus:ring-offset-0"
-            />
-            <span className="flex items-center gap-1.5 text-sm text-gray-400">
-              <Wand2 size={14} className="text-port-accent-2" />
-              Simplify
-            </span>
-          </label>
-          {openPR && (
-            <label htmlFor="task-pr-completion" className="flex items-center gap-2 py-1 basis-full sm:basis-auto">
-              <span className="text-sm text-gray-400">After opening PR</span>
-              <select
-                id="task-pr-completion"
-                value={prCompletion}
-                title={prCompletionOption(prCompletion)?.description}
-                onChange={(e) => setPrCompletion(e.target.value)}
-                className="min-w-44 rounded border border-port-border bg-port-bg px-2 py-1 text-sm text-white focus:border-port-accent focus:outline-hidden"
-              >
-                {PR_COMPLETION_OPTIONS.map(option => (
-                  <option key={option.value} value={option.value}>{option.label}</option>
-                ))}
-              </select>
-            </label>
+          {planOnly && (
+            <p className="basis-full text-xs text-gray-500">
+              Read-only planning: file the issue without code changes, a worktree, PR, simplify pass, or review.
+            </p>
           )}
-          {openPR && prCompletion === 'review-then-merge' && (
-            <div className="basis-full mt-1">
-              <ReviewerPicker
-                reviewers={reviewers}
-                usernames={reviewUsernames}
-                optionalReviewers={optionalReviewers}
-                reviewerMaxRounds={reviewerMaxRounds}
-                reviewerModels={reviewerModels}
-                reviewerEfforts={reviewerEfforts}
-                modelOptions={reviewerModelOptions}
-                installed={reviewerCliInstalled}
-                stopMode={reviewStopMode}
-                reviewerApplies={reviewerApplies}
-                onChange={({ reviewers: r, usernames: u, optionalReviewers: o, reviewerMaxRounds: m, reviewerModels: rm, reviewerEfforts: re, stopMode, reviewerApplies: ra }) => {
-                  setReviewers(r);
-                  setReviewUsernames(u);
-                  setOptionalReviewers(o);
-                  setReviewerMaxRounds(m);
-                  setReviewerModels(rm);
-                  setReviewerEfforts(re);
-                  setReviewStopMode(stopMode);
-                  setReviewerApplies(ra);
-                }}
-              />
-            </div>
-          )}
-          {appHasJira && (
-            <label className="flex items-center gap-2 cursor-pointer select-none whitespace-nowrap py-1">
-              <input
-                type="checkbox"
-                checked={createJiraTicket}
-                onChange={(e) => setCreateJiraTicket(e.target.checked)}
-                className="w-4 h-4 rounded border-port-border bg-port-bg text-port-accent focus:ring-port-accent focus:ring-offset-0"
-              />
-              <span className="flex items-center gap-1.5 text-sm text-gray-400">
-                <Ticket size={14} className="text-port-accent" />
-                JIRA ticket
-              </span>
-            </label>
+          {!planOnly && (
+            <>
+              <label className="flex items-center gap-2 cursor-pointer select-none whitespace-nowrap py-1">
+                <input
+                  type="checkbox"
+                  checked={useWorktree}
+                  onChange={(e) => {
+                    // Enabling a worktree defaults "Open PR" on (safer than an
+                    // unreviewed auto-merge to the default branch); the user can
+                    // still uncheck it. Disabling forces it off (openPR is
+                    // meaningless without a worktree).
+                    setUseWorktree(e.target.checked);
+                    setOpenPR(e.target.checked);
+                  }}
+                  className="w-4 h-4 rounded border-port-border bg-port-bg text-port-accent focus:ring-port-accent focus:ring-offset-0"
+                />
+                <span className="flex items-center gap-1.5 text-sm text-gray-400" title="Work in an isolated git worktree on a feature branch. If unchecked, commits directly to the default branch.">
+                  <GitBranch size={14} className="text-emerald-400" />
+                  Worktree
+                </span>
+              </label>
+              <label className="flex items-center gap-2 cursor-pointer select-none whitespace-nowrap py-1">
+                <input
+                  type="checkbox"
+                  checked={openPR}
+                  disabled={!useWorktree}
+                  onChange={(e) => setOpenPR(e.target.checked)}
+                  className="w-4 h-4 rounded border-port-border bg-port-bg text-port-accent focus:ring-port-accent focus:ring-offset-0 disabled:opacity-40"
+                />
+                <span className={`flex items-center gap-1.5 text-sm ${useWorktree ? 'text-gray-400' : 'text-gray-600'}`} title="Open a pull request to the default branch. If unchecked with worktree enabled, auto-merges on completion.">
+                  <GitPullRequest size={14} className={useWorktree ? 'text-port-accent' : 'text-gray-600'} />
+                  Open PR
+                </span>
+              </label>
+              <label className="flex items-center gap-2 cursor-pointer select-none whitespace-nowrap py-1">
+                <input
+                  type="checkbox"
+                  checked={simplify}
+                  onChange={(e) => setSimplify(e.target.checked)}
+                  className="w-4 h-4 rounded border-port-border bg-port-bg text-port-accent focus:ring-port-accent focus:ring-offset-0"
+                />
+                <span className="flex items-center gap-1.5 text-sm text-gray-400">
+                  <Wand2 size={14} className="text-port-accent-2" />
+                  Simplify
+                </span>
+              </label>
+              {openPR && (
+                <label htmlFor="task-pr-completion" className="flex items-center gap-2 py-1 basis-full sm:basis-auto">
+                  <span className="text-sm text-gray-400">After opening PR</span>
+                  <select
+                    id="task-pr-completion"
+                    value={prCompletion}
+                    title={prCompletionOption(prCompletion)?.description}
+                    onChange={(e) => setPrCompletion(e.target.value)}
+                    className="min-w-44 rounded border border-port-border bg-port-bg px-2 py-1 text-sm text-white focus:border-port-accent focus:outline-hidden"
+                  >
+                    {PR_COMPLETION_OPTIONS.map(option => (
+                      <option key={option.value} value={option.value}>{option.label}</option>
+                    ))}
+                  </select>
+                </label>
+              )}
+              {openPR && prCompletion === 'review-then-merge' && (
+                <div className="basis-full mt-1">
+                  <ReviewerPicker
+                    reviewers={reviewers}
+                    usernames={reviewUsernames}
+                    optionalReviewers={optionalReviewers}
+                    reviewerMaxRounds={reviewerMaxRounds}
+                    reviewerModels={reviewerModels}
+                    reviewerEfforts={reviewerEfforts}
+                    modelOptions={reviewerModelOptions}
+                    installed={reviewerCliInstalled}
+                    stopMode={reviewStopMode}
+                    reviewerApplies={reviewerApplies}
+                    onChange={({ reviewers: r, usernames: u, optionalReviewers: o, reviewerMaxRounds: m, reviewerModels: rm, reviewerEfforts: re, stopMode, reviewerApplies: ra }) => {
+                      setReviewers(r);
+                      setReviewUsernames(u);
+                      setOptionalReviewers(o);
+                      setReviewerMaxRounds(m);
+                      setReviewerModels(rm);
+                      setReviewerEfforts(re);
+                      setReviewStopMode(stopMode);
+                      setReviewerApplies(ra);
+                    }}
+                  />
+                </div>
+              )}
+              {appHasJira && (
+                <label className="flex items-center gap-2 cursor-pointer select-none whitespace-nowrap py-1">
+                  <input
+                    type="checkbox"
+                    checked={createJiraTicket}
+                    onChange={(e) => setCreateJiraTicket(e.target.checked)}
+                    className="w-4 h-4 rounded border-port-border bg-port-bg text-port-accent focus:ring-port-accent focus:ring-offset-0"
+                  />
+                  <span className="flex items-center gap-1.5 text-sm text-gray-400">
+                    <Ticket size={14} className="text-port-accent" />
+                    JIRA ticket
+                  </span>
+                </label>
+              )}
+            </>
           )}
         </div>
         <div className="flex flex-col sm:flex-row gap-3">
@@ -909,12 +976,12 @@ export default function TaskAddForm({ providers, apps, onTaskAdded, compact = fa
               {(isSubmitting || isEnhancing) ? (
                 <>
                   <Loader2 size={14} className="animate-spin" aria-hidden="true" />
-                  {isSubmitting ? 'Adding...' : 'Enhancing...'}
+                  {isSubmitting ? (planOnly ? 'Planning...' : 'Adding...') : planOnly ? 'Enhancing plan...' : 'Enhancing...'}
                 </>
               ) : (
                 <>
                   <Plus size={14} aria-hidden="true" />
-                  {enhancePrompt ? 'Enhance & Add' : 'Add'}
+                  {planOnly ? (enhancePrompt ? 'Enhance & Plan' : 'Plan & File Issue') : enhancePrompt ? 'Enhance & Add' : 'Add'}
                 </>
               )}
             </button>

--- a/client/src/components/cos/TaskAddForm.jsx
+++ b/client/src/components/cos/TaskAddForm.jsx
@@ -223,7 +223,7 @@ export default function TaskAddForm({ providers, apps, onTaskAdded, compact = fa
     setUseWorktree(defaultUseWorktree);
     setOpenPR(defaultOpenPR);
     setPrCompletion(selectedApp?.defaultPrCompletion || DEFAULT_PR_COMPLETION);
-  }, [appDefaultsSig, planOnly]);
+  }, [appDefaultsSig]);
 
   // Get models for selected provider. The form carries its own Thinking Effort
   // select and submits it, so Antigravity lists BASE models (`gemini-3.6-flash`)
@@ -252,6 +252,13 @@ export default function TaskAddForm({ providers, apps, onTaskAdded, compact = fa
     } else if (slashdoCommand === 'plan-task') {
       setSlashdoCommand('');
       setWorktreeChangesExpected(undefined);
+      const worktreeOptOut = selectedApp?.defaultUseWorktree === false;
+      const defaultOpenPR = selectedApp?.defaultOpenPR ?? !worktreeOptOut;
+      const defaultUseWorktree = (selectedApp?.defaultUseWorktree ?? true) || defaultOpenPR;
+      setUseWorktree(defaultUseWorktree);
+      setOpenPR(defaultOpenPR);
+      setSimplify(true);
+      setPrCompletion(selectedApp?.defaultPrCompletion || DEFAULT_PR_COMPLETION);
     }
   };
 
@@ -285,6 +292,15 @@ export default function TaskAddForm({ providers, apps, onTaskAdded, compact = fa
         : {})
     }));
     const templatePlanOnly = template.slashdoCommand === 'plan-task';
+    if (planOnly && !templatePlanOnly) {
+      const worktreeOptOut = selectedApp?.defaultUseWorktree === false;
+      const defaultOpenPR = selectedApp?.defaultOpenPR ?? !worktreeOptOut;
+      const defaultUseWorktree = (selectedApp?.defaultUseWorktree ?? true) || defaultOpenPR;
+      setUseWorktree(defaultUseWorktree);
+      setOpenPR(defaultOpenPR);
+      setSimplify(true);
+      setPrCompletion(selectedApp?.defaultPrCompletion || DEFAULT_PR_COMPLETION);
+    }
     setSlashdoCommand(template.slashdoCommand || '');
     setPlanOnly(templatePlanOnly);
     // Hidden posture, so it follows `slashdoCommand` (set unconditionally above)
@@ -311,7 +327,7 @@ export default function TaskAddForm({ providers, apps, onTaskAdded, compact = fa
     descriptionRef.current?.focus();
     await api.applyCosTaskTemplate(template.id).catch(() => {});
     toast.success(`Template applied: ${template.name}`);
-  }, [newTask.app, providers]);
+  }, [newTask.app, planOnly, providers, selectedApp]);
 
   // Save current form as template (inline input instead of window.prompt)
   const saveAsTemplate = useCallback(async () => {

--- a/client/src/components/cos/TaskAddForm.test.jsx
+++ b/client/src/components/cos/TaskAddForm.test.jsx
@@ -21,6 +21,7 @@ vi.mock('../../services/api', () => api);
 
 const worktreeToggle = () => screen.getByTitle(/isolated git worktree/i).closest('label').querySelector('input');
 const openPrToggle = () => screen.getByTitle(/Open a pull request/i).closest('label').querySelector('input');
+const planOnlyToggle = () => screen.getByLabelText(/Plan & file issue/i);
 
 describe('TaskAddForm responsive layout', () => {
   beforeEach(() => {
@@ -76,6 +77,33 @@ describe('TaskAddForm responsive layout', () => {
       provider: 'opencode-ollama', effort: 'high', thinking: false, temperature: 0.25,
     });
   });
+
+  it('queues plan-and-file mode without implementation delivery controls', async () => {
+    const user = userEvent.setup();
+    api.addCosTask.mockResolvedValue({ success: true });
+    render(<TaskAddForm providers={[]} apps={[]} onTaskAdded={vi.fn()} />);
+
+    await user.type(screen.getByPlaceholderText('Task description *'), 'Add export filtering');
+    await user.click(planOnlyToggle());
+
+    expect(planOnlyToggle()).toBeChecked();
+    expect(screen.queryByTitle(/isolated git worktree/i)).toBeNull();
+    expect(screen.queryByTitle(/Open a pull request/i)).toBeNull();
+    expect(screen.queryByText('Simplify')).toBeNull();
+
+    await user.click(screen.getByRole('button', { name: 'Plan & File Issue' }));
+    await waitFor(() => expect(api.addCosTask).toHaveBeenCalled());
+    expect(api.addCosTask.mock.calls.at(-1)[0]).toMatchObject({
+      planOnly: true,
+      slashdoCommand: 'plan-task',
+      slashdoArgs: '--issues --yes',
+      useWorktree: false,
+      openPR: false,
+      simplify: false,
+      worktreeChangesExpected: false,
+      createJiraTicket: false,
+    });
+  });
 });
 
 // A slashdo quick-template carries the run shape its workflow implies (#3089).
@@ -121,11 +149,13 @@ describe('TaskAddForm quick templates', () => {
     renderForm();
     await openTemplates(user);
 
-    // The app defaults turned the worktree on; the template turns it back off.
+    // The app defaults turned the worktree on; plan-only hides implementation
+    // delivery controls rather than leaving an unchecked worktree control.
     expect(worktreeToggle()).toBeChecked();
     await user.click(screen.getByText('Plan a Task'));
 
-    await waitFor(() => expect(worktreeToggle()).not.toBeChecked());
+    await waitFor(() => expect(planOnlyToggle()).toBeChecked());
+    expect(screen.queryByTitle(/isolated git worktree/i)).toBeNull();
     expect(screen.getByPlaceholderText('Task description *')).toHaveValue('Investigate and file an issue for: ');
     expect(api.applyCosTaskTemplate).toHaveBeenCalledWith('builtin-do-plan-task');
   });

--- a/client/src/components/cos/TaskAddForm.test.jsx
+++ b/client/src/components/cos/TaskAddForm.test.jsx
@@ -86,6 +86,7 @@ describe('TaskAddForm responsive layout', () => {
     render(<TaskAddForm providers={[]} apps={[]} onTaskAdded={vi.fn()} />);
 
     await user.type(screen.getByPlaceholderText('Task description *'), 'Add export filtering');
+    await waitFor(() => expect(planOnlyToggle()).toBeInTheDocument());
     await user.click(planOnlyToggle());
 
     expect(planOnlyToggle()).toBeChecked();

--- a/client/src/components/cos/TaskAddForm.test.jsx
+++ b/client/src/components/cos/TaskAddForm.test.jsx
@@ -103,6 +103,13 @@ describe('TaskAddForm responsive layout', () => {
       worktreeChangesExpected: false,
       createJiraTicket: false,
     });
+
+    await user.click(planOnlyToggle());
+    await waitFor(() => {
+      expect(planOnlyToggle()).not.toBeChecked();
+      expect(worktreeToggle()).toBeChecked();
+      expect(openPrToggle()).toBeChecked();
+    });
   });
 });
 

--- a/client/src/components/cos/TaskAddForm.test.jsx
+++ b/client/src/components/cos/TaskAddForm.test.jsx
@@ -9,6 +9,7 @@ const api = vi.hoisted(() => ({
   // Back the reviewer table's Model column (useReviewerModelOptions).
   getLocalLlmStatus: vi.fn(),
   getProviders: vi.fn(),
+  getAppWorkTracker: vi.fn(),
   applyCosTaskTemplate: vi.fn(),
   addCosTask: vi.fn()
 }));
@@ -30,6 +31,7 @@ describe('TaskAddForm responsive layout', () => {
     api.getCodeReviewDefaults.mockResolvedValue(null);
     api.getLocalLlmStatus.mockResolvedValue({ ollama: { models: [] }, lmstudio: { models: [] } });
     api.getProviders.mockResolvedValue({ providers: [] });
+    api.getAppWorkTracker.mockResolvedValue({ resolved: 'github' });
     api.applyCosTaskTemplate.mockResolvedValue({ success: true });
     apiSystem.getAssignableInstances.mockResolvedValue({ instances: [] });
   });
@@ -96,7 +98,7 @@ describe('TaskAddForm responsive layout', () => {
     expect(api.addCosTask.mock.calls.at(-1)[0]).toMatchObject({
       planOnly: true,
       slashdoCommand: 'plan-task',
-      slashdoArgs: '--issues --yes',
+      slashdoArgs: '--yes',
       useWorktree: false,
       openPR: false,
       simplify: false,
@@ -110,6 +112,30 @@ describe('TaskAddForm responsive layout', () => {
       expect(worktreeToggle()).toBeChecked();
       expect(openPrToggle()).toBeChecked();
     });
+  });
+
+  it.each([
+    ['PLAN.md', 'plan', 'plan'],
+    ['JIRA', 'jira', 'jira'],
+    ['auto-resolved JIRA', 'auto', 'jira'],
+  ])('does not offer plan-and-file mode for %s apps', async (_label, workTracker, resolvedTracker) => {
+    api.getAppWorkTracker.mockResolvedValue({ resolved: resolvedTracker });
+    render(
+      <TaskAddForm
+        providers={[]}
+        apps={[{
+          id: 'tracker-app',
+          name: 'Tracker App',
+          repoPath: 'example.com/repo',
+          workTracker,
+        }]}
+        defaultApp="tracker-app"
+        onTaskAdded={vi.fn()}
+      />
+    );
+
+    await waitFor(() => expect(screen.getByText(/Plan & file issue is available for GitHub or GitLab/i)).toBeInTheDocument());
+    expect(screen.queryByLabelText(/Plan & file issue/i)).toBeNull();
   });
 });
 
@@ -125,7 +151,7 @@ describe('TaskAddForm quick templates', () => {
   const renderForm = () => render(
     <TaskAddForm
       providers={[]}
-      apps={[{ id: 'example-app', name: 'Example App', repoPath: 'example.com/repo', defaultOpenPR: true, defaultUseWorktree: true }]}
+      apps={[{ id: 'example-app', name: 'Example App', repoPath: 'example.com/repo', workTracker: 'github', defaultOpenPR: true, defaultUseWorktree: true }]}
       defaultApp="example-app"
       onTaskAdded={vi.fn()}
     />
@@ -136,6 +162,7 @@ describe('TaskAddForm quick templates', () => {
     api.getCodeReviewDefaults.mockResolvedValue(null);
     api.getLocalLlmStatus.mockResolvedValue({ ollama: { models: [] }, lmstudio: { models: [] } });
     api.getProviders.mockResolvedValue({ providers: [] });
+    api.getAppWorkTracker.mockResolvedValue({ resolved: 'github' });
     api.applyCosTaskTemplate.mockResolvedValue({ success: true });
   });
 

--- a/server/lib/cosValidation.js
+++ b/server/lib/cosValidation.js
@@ -1258,6 +1258,13 @@ export const createCosTaskSchema = z.object({
     v => v === 'true' ? true : v === 'false' ? false : v,
     z.boolean().optional()
   ),
+  // Read-only planning mode: investigate the codebase and file the issue, but
+  // do not start implementation delivery. The task store expands this into
+  // the safe no-worktree/no-PR/no-simplify posture before persistence.
+  planOnly: z.preprocess(
+    v => v === 'true' ? true : v === 'false' ? false : v,
+    z.boolean().optional()
+  ),
   openPR: z.preprocess(
     v => v === 'true' ? true : v === 'false' ? false : v,
     z.boolean().optional()

--- a/server/lib/cosValidation.test.js
+++ b/server/lib/cosValidation.test.js
@@ -156,6 +156,16 @@ describe('cosValidation quick-template deliverable posture (#3651)', () => {
   });
 });
 
+describe('cosValidation plan-only task mode', () => {
+  it('accepts boolean and form-encoded planOnly values while preserving absence', () => {
+    expect(createCosTaskSchema.parse({ description: 'x', planOnly: true }).planOnly).toBe(true);
+    expect(createCosTaskSchema.parse({ description: 'x', planOnly: 'false' }).planOnly).toBe(false);
+    expect(createCosTaskSchema.parse({ description: 'x' }).planOnly).toBeUndefined();
+    expect(createCosTaskSchema.safeParse({ description: 'x', planOnly: 'maybe' }).success).toBe(false);
+  });
+
+});
+
 describe('cosValidation reviewer CLI binaries', () => {
   // The bug this exists to prevent: `antigravity` is the stored, federated
   // reviewer identity, but the shipped executable is `agy` — no `antigravity`

--- a/server/lib/schemaVersions.js
+++ b/server/lib/schemaVersions.js
@@ -584,7 +584,14 @@ export const PORTOS_SCHEMA_VERSIONS = Object.freeze({
   // run's state back onto the v6 peer — which by then had correctly passed over
   // the task. Per-category gate → only cos-tasks sync pauses until the peer
   // upgrades.
-  cosTasks: 6,
+  // v7 = plan-only issue-filing tasks (metadata.planOnly, the forced
+  // plan-task --issues --yes invocation, and the task-description context
+  // bridge). A <=v6 peer accepts the permissive metadata map but does not
+  // understand the no-delivery execution contract, so it can claim the task
+  // and run the workflow without the description context needed to file the
+  // issue. Per-category gate -> only cos-tasks sync pauses until the peer
+  // upgrades.
+  cosTasks: 7,
   // NOTE: `videoHistory` is intentionally NOT listed here. The version gate
   // rejects the ENTIRE snapshot/push payload on ANY ahead-mismatch (the
   // comparator walks the union of keys), so declaring a brand-new key would

--- a/server/lib/schemaVersions.js
+++ b/server/lib/schemaVersions.js
@@ -585,7 +585,7 @@ export const PORTOS_SCHEMA_VERSIONS = Object.freeze({
   // the task. Per-category gate → only cos-tasks sync pauses until the peer
   // upgrades.
   // v7 = plan-only issue-filing tasks (metadata.planOnly, the forced
-  // plan-task --issues --yes invocation, and the task-description context
+  // plan-task --yes invocation, and the task-description context
   // bridge). A <=v6 peer accepts the permissive metadata map but does not
   // understand the no-delivery execution contract, so it can claim the task
   // and run the workflow without the description context needed to file the

--- a/server/lib/slashdoInvocation.js
+++ b/server/lib/slashdoInvocation.js
@@ -424,14 +424,21 @@ export function oversizedBodyPointer(bodyPath, body) {
  *   suffix, so the prose would just have the agent pass the flag twice. Unpinned,
  *   the workflow resolves reviewers itself and this is the pin's only route to the
  *   CLI it spawns.
+ * @param {boolean} [opts.includeTaskContext=false] - keep the task-context bridge
+ *   even when the invocation has explicit flags instead of a free-text target
  * @returns {string} markdown section, or '' when `resolved` is null
  */
-export function buildSlashdoSection(resolved, body = null, { bodyPath = null, reviewWith = '', reviewerEffortNote = '' } = {}) {
+export function buildSlashdoSection(resolved, body = null, {
+  bodyPath = null,
+  reviewWith = '',
+  reviewerEffortNote = '',
+  includeTaskContext = false,
+} = {}) {
   if (!resolved) return '';
 
   // Without explicit args the workflow operates on the task described above —
   // say so rather than re-printing the whole description inside the invocation.
-  const target = resolved.args ? '' : ' Apply it to the task described above.';
+  const target = resolved.args && !includeTaskContext ? '' : ' Apply it to the task described above.';
 
   const lines = ['### Slashdo Workflow'];
   if (resolved.style === SLASHDO_INVOCATION_STYLES.SKILL) {

--- a/server/routes/cos.test.js
+++ b/server/routes/cos.test.js
@@ -100,7 +100,9 @@ vi.mock('../services/cosTaskGenerator.js', async (importActual) => ({
   buildClaimWorkTask: vi.fn()
 }));
 vi.mock('../services/apps.js', () => ({
-  getAppById: vi.fn()
+  getAppById: vi.fn(),
+  getAppWorkTracker: vi.fn(),
+  PORTOS_APP_ID: 'portos-default'
 }));
 
 // The per-ticket `/tasks/jira-ticket` route loads the claim-issue-jira prompt

--- a/server/routes/cos.test.js
+++ b/server/routes/cos.test.js
@@ -123,7 +123,7 @@ import * as claudeChangelog from '../services/claudeChangelog.js';
 import { enhanceTaskPrompt } from '../services/taskEnhancer.js';
 import { loadSlashdoCommand } from '../services/subAgentSpawner.js';
 import { buildClaimWorkTask } from '../services/cosTaskGenerator.js';
-import { getAppById } from '../services/apps.js';
+import { getAppById, getAppWorkTracker } from '../services/apps.js';
 import { getTaskPrompt } from '../services/taskPromptService.js';
 import { getCodeReviewDefaults } from '../services/codeReview.js';
 
@@ -1007,6 +1007,19 @@ describe('CoS Routes', () => {
       // The app's display NAME, not its id slug — matching the `next` branch.
       expect(taskData.description).toContain('MyApp');
       expect(loadSlashdoCommand).not.toHaveBeenCalled();
+    });
+
+    it('rejects plan-task for an app whose tracker cannot file forge issues', async () => {
+      getAppById.mockResolvedValue({ id: 'my-app', name: 'MyApp', type: 'web', repoPath: '/repo' });
+      getAppWorkTracker.mockResolvedValue({ resolved: 'jira' });
+
+      const response = await request(app)
+        .post('/api/cos/tasks/slashdo')
+        .send({ command: 'plan-task', app: 'my-app' });
+
+      expect(response.status).toBe(400);
+      expect(response.body.code).toBe('UNSUPPORTED_PLAN_ONLY_TRACKER');
+      expect(cos.addTask).not.toHaveBeenCalled();
     });
 
     // #3636: the catalog posture's `worktreeChangesExpected` must reach the task,

--- a/server/routes/cos.test.js
+++ b/server/routes/cos.test.js
@@ -1011,7 +1011,7 @@ describe('CoS Routes', () => {
 
     it('rejects plan-task for an app whose tracker cannot file forge issues', async () => {
       getAppById.mockResolvedValue({ id: 'my-app', name: 'MyApp', type: 'web', repoPath: '/repo' });
-      getAppWorkTracker.mockResolvedValue({ resolved: 'jira' });
+      getAppWorkTracker.mockResolvedValueOnce({ resolved: 'jira' });
 
       const response = await request(app)
         .post('/api/cos/tasks/slashdo')

--- a/server/routes/cosTaskRoutes.js
+++ b/server/routes/cosTaskRoutes.js
@@ -8,7 +8,7 @@ import * as cos from '../services/cos.js';
 import * as taskWatcher from '../services/taskWatcher.js';
 import { enhanceTaskPrompt } from '../services/taskEnhancer.js';
 import { buildClaimWorkTask, buildJiraTicketTask } from '../services/cosTaskGenerator.js';
-import { getAppById } from '../services/apps.js';
+import { getAppById, getAppWorkTracker, PORTOS_APP_ID } from '../services/apps.js';
 import { getAssignableInstances } from '../services/instances.js';
 import { workTrackerLabel } from '../lib/workTracker.js';
 import { getSlashdoWorkflow, slashdoWorkflowAppliesTo, SLASHDO_COMMAND_NAMES } from '../lib/slashdoCatalog.js';
@@ -46,6 +46,21 @@ async function assertAssignableInstance(instanceId) {
   const assignable = await getAssignableInstances();
   if (assignable.some(i => i.instanceId === instanceId)) return;
   throw new ServerError('Unknown instance — pick one of this install\'s federated instances', { status: 400, code: 'UNKNOWN_INSTANCE' });
+}
+
+const ISSUE_TRACKERS = new Set(['github', 'gitlab']);
+
+// The bundled plan-task workflow files an issue; it cannot target PLAN.md or
+// JIRA. Keep the API contract aligned with the quick-task form so direct
+// callers cannot bypass the tracker gate.
+async function assertPlanOnlyTracker(taskData) {
+  if (taskData.planOnly !== true && taskData.slashdoCommand !== 'plan-task') return;
+  const trackerInfo = await getAppWorkTracker(taskData.app || PORTOS_APP_ID);
+  if (!trackerInfo || ISSUE_TRACKERS.has(trackerInfo.resolved)) return;
+  throw new ServerError(
+    `Plan-and-file tasks require a GitHub or GitLab issue tracker (resolved to ${trackerInfo.resolved})`,
+    { status: 400, code: 'UNSUPPORTED_PLAN_ONLY_TRACKER' }
+  );
 }
 
 const router = Router();
@@ -305,6 +320,7 @@ router.post('/tasks', asyncHandler(async (req, res) => {
   if (!parsed.success) failValidation(parsed);
   const { type, ...taskData } = parsed.data;
   if (taskData.targetInstanceId) await assertAssignableInstance(taskData.targetInstanceId);
+  await assertPlanOnlyTracker(taskData);
   const result = await cos.addTask(taskData, type);
 
   if (result?.duplicate) {

--- a/server/routes/cosTaskRoutes.js
+++ b/server/routes/cosTaskRoutes.js
@@ -169,6 +169,11 @@ router.post('/tasks/slashdo', asyncHandler(async (req, res) => {
     throw new ServerError(`App not found: ${app}`, { status: 404, code: 'APP_NOT_FOUND' });
   }
 
+  // `plan-task` is also a plan-only quick action, so it must use the same
+  // forge-only gate as the general task endpoint rather than reaching
+  // `cos.addTask` through this separate route.
+  if (command === 'plan-task') await assertPlanOnlyTracker({ app });
+
   // Enforce the catalog's stack gate server-side. The Agent Operations panel only
   // offers the applicable one of `better` / `better-swift`, but the API must not
   // trust that — queuing a SwiftUI audit against a web app (or vice versa) burns

--- a/server/routes/cosTaskRoutes.js
+++ b/server/routes/cosTaskRoutes.js
@@ -172,7 +172,7 @@ router.post('/tasks/slashdo', asyncHandler(async (req, res) => {
   // `plan-task` is also a plan-only quick action, so it must use the same
   // forge-only gate as the general task endpoint rather than reaching
   // `cos.addTask` through this separate route.
-  if (command === 'plan-task') await assertPlanOnlyTracker({ app });
+  if (command === 'plan-task') await assertPlanOnlyTracker({ app, slashdoCommand: command });
 
   // Enforce the catalog's stack gate server-side. The Agent Operations panel only
   // offers the applicable one of `better` / `better-swift`, but the API must not

--- a/server/routes/cosTaskRoutes.test.js
+++ b/server/routes/cosTaskRoutes.test.js
@@ -33,12 +33,13 @@ vi.mock('../services/cosTaskGenerator.js', () => ({
   buildClaimWorkTask: vi.fn(),
   buildJiraTicketTask: vi.fn(),
 }));
-vi.mock('../services/apps.js', () => ({ getAppById: vi.fn() }));
+vi.mock('../services/apps.js', () => ({ getAppById: vi.fn(), getAppWorkTracker: vi.fn(), PORTOS_APP_ID: 'portos-default' }));
 vi.mock('../services/streamingDetect.js', () => ({ NON_PM2_TYPES: new Set() }));
 vi.mock('../services/instances.js', () => ({ getAssignableInstances: vi.fn() }));
 
 import * as cos from '../services/cos.js';
 import { getAssignableInstances } from '../services/instances.js';
+import { getAppWorkTracker } from '../services/apps.js';
 import cosTaskRoutes from './cosTaskRoutes.js';
 
 const SELF = 'self-instance-id';
@@ -84,6 +85,31 @@ describe('POST /api/cos/tasks — targetInstanceId (#4520)', () => {
     expect(res.status).toBe(200);
     expect(getAssignableInstances).not.toHaveBeenCalled();
     expect(cos.addTask.mock.calls[0][0].targetInstanceId).toBeUndefined();
+  });
+});
+
+describe('POST /api/cos/tasks — plan-only tracker gate', () => {
+  it('rejects issue-only planning for a non-issue tracker', async () => {
+    getAppWorkTracker.mockResolvedValue({ resolved: 'jira' });
+
+    const res = await request(buildApp())
+      .post('/api/cos/tasks')
+      .send({ description: 'plan the change', app: 'jira-app', planOnly: true });
+
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('UNSUPPORTED_PLAN_ONLY_TRACKER');
+    expect(cos.addTask).not.toHaveBeenCalled();
+  });
+
+  it('allows issue-only planning for a GitLab tracker', async () => {
+    getAppWorkTracker.mockResolvedValue({ resolved: 'gitlab' });
+
+    const res = await request(buildApp())
+      .post('/api/cos/tasks')
+      .send({ description: 'plan the change', app: 'gitlab-app', planOnly: true });
+
+    expect(res.status).toBe(200);
+    expect(cos.addTask).toHaveBeenCalledWith(expect.objectContaining({ planOnly: true }), 'user');
   });
 });
 

--- a/server/services/agentPromptBuilder.test.js
+++ b/server/services/agentPromptBuilder.test.js
@@ -2615,6 +2615,28 @@ describe('buildAgentPrompt — slashdo-backed tasks', () => {
     expect(prompt).toContain('/do:plan-task --issues 42');
   });
 
+  it('keeps plan-only issue filing non-interactive and outside the delivery loop', async () => {
+    const prompt = await buildAgentPrompt(
+      slashdoTask({
+        planOnly: true,
+        slashdoArgs: '--issues --yes',
+        readOnly: true,
+        noCodeOutput: true,
+        useWorktree: false,
+        openPR: false,
+        simplify: false,
+        reviewLoop: false,
+      }), {}, '/r', null, isTruthyMeta,
+      { providerType: 'cli', providerId: 'codex' });
+
+    expect(prompt).toContain('--issues --yes');
+    expect(prompt).toContain('## Completion (No Code Output)');
+    expect(prompt).not.toContain('## Completion Workflow');
+    expect(prompt).not.toContain('## Simplify Step');
+    expect(prompt).not.toContain('Commit and push using');
+    expect(prompt).not.toContain('gh pr merge');
+  });
+
   it('reaches the api-path briefing template through task.description', async () => {
     vi.mocked(buildPrompt).mockClear();
     await buildAgentPrompt(slashdoTask(), {}, '/r', null, isTruthyMeta, { providerType: 'api', providerId: 'claude-code' });

--- a/server/services/agentPromptBuilder.test.js
+++ b/server/services/agentPromptBuilder.test.js
@@ -2630,6 +2630,7 @@ describe('buildAgentPrompt — slashdo-backed tasks', () => {
       { providerType: 'cli', providerId: 'codex' });
 
     expect(prompt).toContain('--issues --yes');
+    expect(prompt).toContain('Apply it to the task described above.');
     expect(prompt).toContain('## Completion (No Code Output)');
     expect(prompt).not.toContain('## Completion Workflow');
     expect(prompt).not.toContain('## Simplify Step');

--- a/server/services/agentPromptBuilder.test.js
+++ b/server/services/agentPromptBuilder.test.js
@@ -2619,7 +2619,7 @@ describe('buildAgentPrompt — slashdo-backed tasks', () => {
     const prompt = await buildAgentPrompt(
       slashdoTask({
         planOnly: true,
-        slashdoArgs: '--issues --yes',
+        slashdoArgs: '--yes',
         readOnly: true,
         noCodeOutput: true,
         useWorktree: false,
@@ -2629,7 +2629,7 @@ describe('buildAgentPrompt — slashdo-backed tasks', () => {
       }), {}, '/r', null, isTruthyMeta,
       { providerType: 'cli', providerId: 'codex' });
 
-    expect(prompt).toContain('--issues --yes');
+    expect(prompt).toContain('--yes');
     expect(prompt).toContain('Apply it to the task described above.');
     expect(prompt).toContain('## Completion (No Code Output)');
     expect(prompt).not.toContain('## Completion Workflow');

--- a/server/services/agentWorkspacePrep.test.js
+++ b/server/services/agentWorkspacePrep.test.js
@@ -113,6 +113,27 @@ describe('prepareAgentWorkspace', () => {
     expect(ensureLatest).not.toHaveBeenCalled();
   });
 
+  it('plan-only task: keeps the no-worktree path even with delivery flags present', async () => {
+    const task = {
+      id: 't-plan-only',
+      taskType: 'user',
+      metadata: {
+        planOnly: true,
+        readOnly: true,
+        noCodeOutput: true,
+        useWorktree: false,
+        openPR: false,
+        simplify: false,
+      },
+    };
+    const r = await prepareAgentWorkspace({ agentId: 'agent-plan-only', task });
+    expect(r.outcome).toBe('ready');
+    expect(r.worktreeInfo).toBeNull();
+    expect(r.explicitWorktree).toBe(false);
+    expect(ensureLatest).not.toHaveBeenCalled();
+    expect(createWorktree).not.toHaveBeenCalled();
+  });
+
   it('defers when the pre-task git pull hits an unresolvable conflict', async () => {
     ensureLatest.mockResolvedValue({ conflict: true, branch: 'feature/x', error: 'rebase failed' });
     const task = { id: 't-conflict', taskType: 'user', metadata: {} };

--- a/server/services/cosTaskStore.js
+++ b/server/services/cosTaskStore.js
@@ -508,11 +508,11 @@ export async function addTask(taskData, taskType = 'user', { raw = false, ignore
     }
     if (planOnly) {
       // Plan-and-file is a single bounded CoS action. The bundled plan-task
-      // command defaults to PLAN.md, so force issue mode as well as `--yes` to
-      // make this toggle's GitHub/GitLab deliverable unambiguous and unattended.
+      // command is already issue-only, so pass its supported `--yes` flag to
+      // make this toggle's issue-filing action unattended.
       metadata.planOnly = true;
       metadata.slashdoCommand = 'plan-task';
-      metadata.slashdoArgs = '--issues --yes';
+      metadata.slashdoArgs = '--yes';
       metadata.readOnly = true;
       metadata.noCodeOutput = true;
       metadata.useWorktree = false;

--- a/server/services/cosTaskStore.js
+++ b/server/services/cosTaskStore.js
@@ -318,6 +318,10 @@ export async function addTask(taskData, taskType = 'user', { raw = false, ignore
   } else {
     // Generate a unique ID if not provided
     const id = taskData.id || `${taskType === 'user' ? 'task' : 'sys'}-${Date.now().toString(36)}`;
+    // Planning is an explicit workflow mode, not just a collection of UI
+    // toggles. Keep the server-side contract authoritative for direct API
+    // callers and for older clients that only send the plan-task command.
+    const planOnly = taskData.planOnly === true || taskData.slashdoCommand === 'plan-task';
 
     // Build metadata object
     const metadata = {};
@@ -501,6 +505,31 @@ export async function addTask(taskData, taskType = 'user', { raw = false, ignore
     // it gates on still reads healthy). See quotaBurnDenials.js.
     if (Number.isFinite(taskData.quotaBurnLimitingResetAt)) {
       metadata.quotaBurnLimitingResetAt = taskData.quotaBurnLimitingResetAt;
+    }
+    if (planOnly) {
+      // Plan-and-file is a single bounded CoS action. The bundled plan-task
+      // command defaults to PLAN.md, so force issue mode as well as `--yes` to
+      // make this toggle's GitHub/GitLab deliverable unambiguous and unattended.
+      metadata.planOnly = true;
+      metadata.slashdoCommand = 'plan-task';
+      metadata.slashdoArgs = '--issues --yes';
+      metadata.readOnly = true;
+      metadata.noCodeOutput = true;
+      metadata.useWorktree = false;
+      metadata.openPR = false;
+      metadata.simplify = false;
+      metadata.reviewLoop = false;
+      metadata.worktreeChangesExpected = false;
+      delete metadata.createJiraTicket;
+      delete metadata.prCompletion;
+      delete metadata.reviewers;
+      delete metadata.usernames;
+      delete metadata.optionalReviewers;
+      delete metadata.reviewerMaxRounds;
+      delete metadata.reviewerModels;
+      delete metadata.reviewerEfforts;
+      delete metadata.reviewStopMode;
+      delete metadata.reviewerApplies;
     }
     // Content-edit timestamp for cross-peer newest-edit-wins LWW (#1714). Stamped
     // at creation so a freshly-added task always carries a stamp; the merge treats

--- a/server/services/cosTaskStore.test.js
+++ b/server/services/cosTaskStore.test.js
@@ -513,7 +513,7 @@ describe('cosTaskStore.addTask', () => {
     expect(created.metadata).toMatchObject({
       planOnly: true,
       slashdoCommand: 'plan-task',
-      slashdoArgs: '--issues --yes',
+      slashdoArgs: '--yes',
       readOnly: true,
       noCodeOutput: true,
       useWorktree: false,

--- a/server/services/cosTaskStore.test.js
+++ b/server/services/cosTaskStore.test.js
@@ -495,6 +495,41 @@ describe('cosTaskStore.addTask', () => {
     expect(tasks.find(t => t.id === created.id).metadata.slashdoCommand).toBe('plan-task');
   });
 
+  it('normalizes plan-only tasks to the issue-filing, no-delivery posture', async () => {
+    const created = await addTask({
+      description: 'Plan the widget API',
+      planOnly: true,
+      slashdoCommand: 'review',
+      slashdoArgs: '--label plan',
+      createJiraTicket: true,
+      useWorktree: true,
+      openPR: true,
+      simplify: true,
+      reviewLoop: true,
+      reviewers: ['codex'],
+      worktreeChangesExpected: true,
+    }, 'user');
+
+    expect(created.metadata).toMatchObject({
+      planOnly: true,
+      slashdoCommand: 'plan-task',
+      slashdoArgs: '--issues --yes',
+      readOnly: true,
+      noCodeOutput: true,
+      useWorktree: false,
+      openPR: false,
+      simplify: false,
+      reviewLoop: false,
+      worktreeChangesExpected: false,
+    });
+    expect(created.metadata.createJiraTicket).toBeUndefined();
+    expect(created.metadata.prCompletion).toBeUndefined();
+    expect(created.metadata.reviewers).toBeUndefined();
+
+    const { tasks } = await getUserTasks();
+    expect(tasks.find(t => t.id === created.id).metadata.slashdoCommand).toBe('plan-task');
+  });
+
   it('persists a pinned claim target through the task markdown round-trip', async () => {
     const created = await addTask({
       description: 'Claim GitHub issue 42 for Example App',

--- a/server/services/promptSections/slashdo.js
+++ b/server/services/promptSections/slashdo.js
@@ -147,6 +147,14 @@ export async function applySlashdoInvocation(task, {
   // spawns (the `/do:pr` completion step further down is a different invocation
   // entirely, and for a slashdo-backed task usually isn't reached).
   const reviewerEffortNote = buildReviewerEffortNote(resolvedReviewers, resolvedEfforts, { reviewWith, reviewerModels: resolvedModels });
-  const section = buildSlashdoSection(resolved, body, { bodyPath, reviewWith, reviewerEffortNote });
+  // Plan-only supplies destination/approval flags as slashdo args, so preserve
+  // the task description bridge that those flags would otherwise suppress.
+  const includeTaskContext = task.metadata?.planOnly === true || task.metadata?.planOnly === 'true';
+  const section = buildSlashdoSection(resolved, body, {
+    bodyPath,
+    reviewWith,
+    reviewerEffortNote,
+    includeTaskContext,
+  });
   return { ...task, description: `${task.description}\n\n${section}` };
 }

--- a/server/services/sharing/cosTasksSync.test.js
+++ b/server/services/sharing/cosTasksSync.test.js
@@ -40,6 +40,7 @@ import {
   buildCosTasksPayload,
   syncCosTasksFromPeer,
 } from './peerSync.js';
+import { PORTOS_SCHEMA_VERSIONS } from '../../lib/schemaVersions.js';
 import { getPeers } from '../instances.js';
 import { peerFetch } from '../../lib/peerHttpClient.js';
 import { getUserTasks, getCosTasks, mergePeerTasks } from '../cosTaskStore.js';
@@ -69,7 +70,7 @@ describe('buildCosTasksPayload', () => {
     vi.mocked(getUserTasks).mockResolvedValue({ tasks: [task('task-a', 'pending')] });
     vi.mocked(getCosTasks).mockResolvedValue({ tasks: [task('sys-b', 'in_progress', { metadata: { claimedBy: 'i1' } })] });
     const p = await buildCosTasksPayload();
-    expect(p.schemaVersion).toBe(6); // v6: metadata.targetInstanceId — per-task instance pin (#4520)
+    expect(p.schemaVersion).toBe(PORTOS_SCHEMA_VERSIONS.cosTasks); // v7: plan-only issue-filing execution semantics
     expect(p.listHash).toMatch(/^[a-f0-9]{64}$/);
     expect(p.tasks).toHaveLength(2);
     const user = p.tasks.find((t) => t.id === 'task-a');
@@ -104,7 +105,7 @@ describe('buildCosTasksPayload', () => {
   it('returns an empty payload when there are no tasks', async () => {
     const p = await buildCosTasksPayload();
     expect(p.tasks).toEqual([]);
-    expect(p.schemaVersion).toBe(6); // v6: metadata.targetInstanceId — per-task instance pin (#4520)
+    expect(p.schemaVersion).toBe(PORTOS_SCHEMA_VERSIONS.cosTasks); // v7: plan-only issue-filing execution semantics
   });
 });
 
@@ -116,7 +117,11 @@ describe('syncCosTasksFromPeer', () => {
   });
 
   it('gently skips a sender whose payload schema is ahead', async () => {
-    vi.mocked(peerFetch).mockResolvedValue(payloadRes({ schemaVersion: 999, listHash: sha('x'), tasks: [] }));
+    vi.mocked(peerFetch).mockResolvedValue(payloadRes({
+      schemaVersion: PORTOS_SCHEMA_VERSIONS.cosTasks + 1,
+      listHash: sha('x'),
+      tasks: [],
+    }));
     const r = await syncCosTasksFromPeer(PEER);
     expect(r).toEqual({ merged: 0, skipped: 'schema-ahead' });
     expect(mergePeerTasks).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- Add a Quick Task toggle that queues the existing plan-task action in GitHub/GitLab issue mode.
- Enforce read-only, no-worktree, no-PR, no-simplify, and no-review behavior at task persistence and prompt/workspace boundaries.
- Persist plan-only templates with the same safe run shape.

## Test plan
- npm run lint
- npm run build
- npm test -- --run src/components/cos/TaskAddForm.test.jsx
- npm test -- --run lib/cosValidation.test.js services/cosTaskStore.test.js services/agentPromptBuilder.test.js services/agentWorkspacePrep.test.js
- Full client suite: 752 files / 9,736 tests passed
- Full server suite: 34,135 tests run; one unrelated Node 26 npm-version compatibility failure in scripts/checkNpmVersion.test.js