### PR TITLE
fix: declare phantom dependencies in manifests

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -21,11 +21,13 @@
         "react-router": "8.3.0",
         "recharts": "3.10.1",
         "socket.io-client": "4.8.3",
-        "three": "0.185.1"
+        "three": "0.185.1",
+        "three-stdlib": "2.36.1"
       },
       "devDependencies": {
         "@biomejs/biome": "2.5.9",
         "@tailwindcss/postcss": "4.3.3",
+        "@testing-library/dom": "10.4.1",
         "@testing-library/jest-dom": "7.0.1",
         "@testing-library/react": "16.3.2",
         "@testing-library/user-event": "14.6.5",
@@ -120,7 +122,6 @@
       "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
@@ -136,7 +137,6 @@
       "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -1400,7 +1400,6 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -1504,8 +1503,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -1846,7 +1844,6 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -2333,8 +2330,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/draco3d": {
       "version": "1.5.7",
@@ -2710,8 +2706,7 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/jsdom": {
       "version": "30.0.1",
@@ -3076,7 +3071,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -3293,7 +3287,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -3309,7 +3302,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -3322,8 +3314,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/promise-worker-transferable": {
       "version": "1.0.4",

--- a/client/package.json
+++ b/client/package.json
@@ -31,11 +31,13 @@
     "react-router": "8.3.0",
     "recharts": "3.10.1",
     "socket.io-client": "4.8.3",
-    "three": "0.185.1"
+    "three": "0.185.1",
+    "three-stdlib": "2.36.1"
   },
   "devDependencies": {
     "@biomejs/biome": "2.5.9",
     "@tailwindcss/postcss": "4.3.3",
+    "@testing-library/dom": "10.4.1",
     "@testing-library/jest-dom": "7.0.1",
     "@testing-library/react": "16.3.2",
     "@testing-library/user-event": "14.6.5",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@googleapis/calendar": "^16.0.0",
         "@googleapis/gmail": "^18.0.0",
+        "chokidar": "3.6.0",
         "express": "5.2.1",
         "google-auth-library": "^11.0.2",
         "kokoro-js": "1.2.1",
@@ -21,6 +22,7 @@
         "socket.io": "4.8.3",
         "socket.io-client": "4.8.3",
         "undici": "^8.10.0",
+        "ws": "8.21.3",
         "zod": "^4.4.3"
       },
       "devDependencies": {

--- a/server/package.json
+++ b/server/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@googleapis/calendar": "^16.0.0",
     "@googleapis/gmail": "^18.0.0",
+    "chokidar": "3.6.0",
     "express": "5.2.1",
     "google-auth-library": "^11.0.2",
     "kokoro-js": "1.2.1",
@@ -33,6 +34,7 @@
     "socket.io": "4.8.3",
     "socket.io-client": "4.8.3",
     "undici": "^8.10.0",
+    "ws": "8.21.3",
     "zod": "^4.4.3"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- Declare chokidar, ws, and three-stdlib directly in the workspace manifests with the versions already resolving successfully.
- Declare @testing-library/dom as a direct client devDependency for the existing WorkEditor tests that import it directly.
- Refresh both workspace lockfiles.

## Test plan
- `cd client && npm test` — 752 files, 9,739 tests passed.
- `cd server && npm test` — 34,110 tests passed and 19 skipped; the suite still reports the existing npm-version shape mismatch and Trellis normal-bake timeout.
- Focused WorkEditor tests — 2 files, 15 tests passed.
- `npm install` in both workspaces — completed with 0 vulnerabilities.

Closes #4931