### PR TITLE
fix: improve touch affordances in navigation banners

### DIFF
--- a/client/src/components/Layout.jsx
+++ b/client/src/components/Layout.jsx
@@ -404,7 +404,7 @@ function PinButton({ label, pinned, onTogglePin }) {
       type="button"
       aria-label={pinned ? `Unpin ${label}` : `Pin ${label}`}
       onClick={(e) => { e.preventDefault(); e.stopPropagation(); onTogglePin(); }}
-      className={`px-2 rounded-lg hover:bg-port-border/50 ${pinned ? 'text-port-accent' : 'text-gray-500 opacity-40 [@media(hover:hover)]:sm:opacity-0 [@media(hover:hover)]:sm:group-hover:opacity-100 group-focus-within:opacity-100'}`}
+      className={`inline-flex min-w-[44px] min-h-[44px] items-center justify-center rounded-lg hover:bg-port-border/50 lg:min-w-0 lg:min-h-0 lg:px-2 lg:py-1.5 ${pinned ? 'text-port-accent' : 'text-gray-500 opacity-40 [@media(hover:hover)]:sm:opacity-0 [@media(hover:hover)]:sm:group-hover:opacity-100 group-focus-within:opacity-100'}`}
     >
       {pinned ? <PinOff size={14} /> : <Pin size={14} />}
     </button>

--- a/client/src/components/Layout.jsx
+++ b/client/src/components/Layout.jsx
@@ -404,7 +404,7 @@ function PinButton({ label, pinned, onTogglePin }) {
       type="button"
       aria-label={pinned ? `Unpin ${label}` : `Pin ${label}`}
       onClick={(e) => { e.preventDefault(); e.stopPropagation(); onTogglePin(); }}
-      className={`px-2 rounded-lg hover:bg-port-border/50 ${pinned ? 'text-port-accent' : 'text-gray-500 opacity-40 sm:opacity-0 sm:group-hover:opacity-100 group-focus-within:opacity-100'}`}
+      className={`px-2 rounded-lg hover:bg-port-border/50 ${pinned ? 'text-port-accent' : 'text-gray-500 opacity-40 [@media(hover:hover)]:sm:opacity-0 [@media(hover:hover)]:sm:group-hover:opacity-100 group-focus-within:opacity-100'}`}
     >
       {pinned ? <PinOff size={14} /> : <Pin size={14} />}
     </button>

--- a/client/src/components/Layout.jsx
+++ b/client/src/components/Layout.jsx
@@ -419,7 +419,7 @@ function PinButton({ label, pinned, onTogglePin }) {
 function WorkingSetRow({ entry, pinned, onTogglePin, onNavigate, isActive }) {
   const Icon = entry.icon;
   return (
-    <div className="group relative mx-2 min-w-0">
+    <div className="group relative mx-2 min-w-0 min-h-[44px] lg:min-h-0">
       <NavLink
         to={entry.path}
         end={entry.end}
@@ -452,7 +452,7 @@ export function SingleNavRow({ item, collapsed, active, badgeCount, pinned, onTo
   const showBadge = item.showBadge && badgeCount > 0;
   const badgeText = badgeCount > 9 ? '9+' : badgeCount;
   return (
-    <div className={`group relative min-w-0 mx-2 ${collapsed ? 'lg:flex lg:justify-center' : ''}`}>
+    <div className={`group relative min-w-0 mx-2 min-h-[44px] lg:min-h-0 ${collapsed ? 'lg:flex lg:justify-center' : ''}`}>
       <NavLink
         to={item.to}
         end={item.to === '/'}

--- a/client/src/components/UpdateBanners.jsx
+++ b/client/src/components/UpdateBanners.jsx
@@ -30,14 +30,14 @@ export default function UpdateBanners() {
               <button
                 type="button"
                 onClick={() => { clearOutOfSync(); goToUpdate(); }}
-                className="px-2 py-1 bg-port-warning text-black text-xs rounded hover:bg-port-warning/80"
+                className="min-h-[44px] px-2 py-2 bg-port-warning text-black text-xs rounded hover:bg-port-warning/80 sm:min-h-0 sm:py-1"
               >
                 Reconcile
               </button>
               <button
                 type="button"
                 onClick={dismissOutOfSync}
-                className="px-2 py-1 bg-gray-600 text-white text-xs rounded hover:bg-gray-500"
+                className="min-h-[44px] px-2 py-2 bg-gray-600 text-white text-xs rounded hover:bg-gray-500 sm:min-h-0 sm:py-1"
               >
                 Dismiss
               </button>
@@ -58,14 +58,14 @@ export default function UpdateBanners() {
               <button
                 type="button"
                 onClick={() => { dismissUpdate(); goToUpdate(); }}
-                className="px-2 py-1 bg-port-accent text-white text-xs rounded hover:bg-port-accent/80"
+                className="min-h-[44px] px-2 py-2 bg-port-accent text-white text-xs rounded hover:bg-port-accent/80 sm:min-h-0 sm:py-1"
               >
                 Update
               </button>
               <button
                 type="button"
                 onClick={ignoreUpdate}
-                className="px-2 py-1 bg-gray-600 text-white text-xs rounded hover:bg-gray-500"
+                className="min-h-[44px] px-2 py-2 bg-gray-600 text-white text-xs rounded hover:bg-gray-500 sm:min-h-0 sm:py-1"
               >
                 Ignore
               </button>

--- a/client/src/components/UpdateBanners.jsx
+++ b/client/src/components/UpdateBanners.jsx
@@ -30,14 +30,14 @@ export default function UpdateBanners() {
               <button
                 type="button"
                 onClick={() => { clearOutOfSync(); goToUpdate(); }}
-                className="min-h-[44px] px-2 py-2 bg-port-warning text-black text-xs rounded hover:bg-port-warning/80 sm:min-h-0 sm:py-1"
+                className="min-h-[44px] px-2 py-2 bg-port-warning text-black text-xs rounded hover:bg-port-warning/80 lg:min-h-0 lg:py-1"
               >
                 Reconcile
               </button>
               <button
                 type="button"
                 onClick={dismissOutOfSync}
-                className="min-h-[44px] px-2 py-2 bg-gray-600 text-white text-xs rounded hover:bg-gray-500 sm:min-h-0 sm:py-1"
+                className="min-h-[44px] px-2 py-2 bg-gray-600 text-white text-xs rounded hover:bg-gray-500 lg:min-h-0 lg:py-1"
               >
                 Dismiss
               </button>
@@ -58,14 +58,14 @@ export default function UpdateBanners() {
               <button
                 type="button"
                 onClick={() => { dismissUpdate(); goToUpdate(); }}
-                className="min-h-[44px] px-2 py-2 bg-port-accent text-white text-xs rounded hover:bg-port-accent/80 sm:min-h-0 sm:py-1"
+                className="min-h-[44px] px-2 py-2 bg-port-accent text-white text-xs rounded hover:bg-port-accent/80 lg:min-h-0 lg:py-1"
               >
                 Update
               </button>
               <button
                 type="button"
                 onClick={ignoreUpdate}
-                className="min-h-[44px] px-2 py-2 bg-gray-600 text-white text-xs rounded hover:bg-gray-500 sm:min-h-0 sm:py-1"
+                className="min-h-[44px] px-2 py-2 bg-gray-600 text-white text-xs rounded hover:bg-gray-500 lg:min-h-0 lg:py-1"
               >
                 Ignore
               </button>

--- a/client/src/components/UpdateBanners.test.jsx
+++ b/client/src/components/UpdateBanners.test.jsx
@@ -70,6 +70,22 @@ describe('UpdateBanners', () => {
     expect(document.querySelector('.fixed')).toBeNull();
   });
 
+  it('gives banner actions a 44px touch target while preserving desktop density', async () => {
+    getUpdateStatus.mockResolvedValue({
+      installState: { outOfSync: true, currentCommit: 'abc123' },
+      updateAvailable: true,
+      currentVersion: '1.0.0',
+      latestRelease: { version: '1.1.0' },
+    });
+    renderBanners();
+    await screen.findByRole('button', { name: 'Reconcile' });
+
+    screen.getAllByRole('button').forEach((button) => {
+      expect(button.className).toContain('min-h-[44px]');
+      expect(button.className).toContain('sm:min-h-0');
+    });
+  });
+
   it('persists the out-of-sync dismissal per commit so it does not re-raise', async () => {
     getUpdateStatus.mockResolvedValue({
       installState: { outOfSync: true, currentCommit: 'abc123' }

--- a/client/src/components/UpdateBanners.test.jsx
+++ b/client/src/components/UpdateBanners.test.jsx
@@ -82,7 +82,7 @@ describe('UpdateBanners', () => {
 
     screen.getAllByRole('button').forEach((button) => {
       expect(button.className).toContain('min-h-[44px]');
-      expect(button.className).toContain('sm:min-h-0');
+      expect(button.className).toContain('lg:min-h-0');
     });
   });
 


### PR DESCRIPTION
## Summary
- Keep the sidebar pin affordance visible on non-hover/touch layouts with a reserved 44px touch target.
- Raise update banner actions to a 44px touch target through tablet widths while retaining compact desktop density.

## Test plan
- `npm test -- --run src/components/UpdateBanners.test.jsx src/components/Layout.test.jsx`
- `npm run lint`
- `npm run build`

Closes #4932