### PR TITLE
fix: build sprite hook test paths the way the hook builds them

### DIFF
--- a/server/services/sprites/localAnimationJobHook.test.js
+++ b/server/services/sprites/localAnimationJobHook.test.js
@@ -11,6 +11,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { EventEmitter } from 'events';
+import { join } from 'path';
 
 const mediaJobEvents = new EventEmitter();
 let queuedJobs = [];
@@ -34,7 +35,13 @@ vi.mock('../../lib/fileUtils.js', async (importOriginal) => ({
   atomicWrite: async (path, value) => { runRecords[path] = value; },
 }));
 
-const runPath = (recordId, runId) => `/sprites/${recordId}/runs/${runId}/animation-run.json`;
+// Built with `join`, exactly as the hook builds them. Hard-coding POSIX
+// separators here made every path the hook derives miss its mock entry on
+// Windows, where `join` yields backslashes — the suite then exercised only
+// the record-not-found branch while reading like a green run.
+const spritePath = (recordId, runId, ...rest) => join(`/sprites/${recordId}`, `runs/${runId}`, ...rest);
+const runPath = (recordId, runId) => spritePath(recordId, runId, 'animation-run.json');
+const clipPath = (recordId, runId) => spritePath(recordId, runId, 'generated', 'source-video.mp4');
 
 const collectLocalAnimationClip = vi.fn(async () => true);
 vi.mock('./localAnimationRender.js', () => ({
@@ -129,10 +136,10 @@ describe('settleSpriteAnimationJob', () => {
     await settleSpriteAnimationJob(walkJob());
     expect(collectLocalAnimationClip).toHaveBeenCalledWith(expect.objectContaining({
       jobId: 'mjob-1',
-      videoAbs: '/sprites/hero/runs/walk-east-abc12345/generated/source-video.mp4',
+      videoAbs: clipPath('hero', 'walk-east-abc12345'),
     }));
     expect(attachTuiWalkResult).toHaveBeenCalledWith(
-      'hero', 'walk-east-abc12345', '/sprites/hero/runs/walk-east-abc12345/generated/source-video.mp4',
+      'hero', 'walk-east-abc12345', clipPath('hero', 'walk-east-abc12345'),
     );
     expect(attachTrackTuiResult).not.toHaveBeenCalled();
   });
@@ -141,7 +148,7 @@ describe('settleSpriteAnimationJob', () => {
     await settleSpriteAnimationJob(trackJob());
     expect(attachTrackTuiResult).toHaveBeenCalledWith(
       'scanner', 'hero', 'scanner-east-abc12345',
-      '/sprites/hero/runs/scanner-east-abc12345/generated/source-video.mp4',
+      clipPath('hero', 'scanner-east-abc12345'),
     );
     expect(attachTuiWalkResult).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary

`server/services/sprites/localAnimationJobHook.test.js` hard-coded POSIX separators for paths the hook derives with `path.join`. On Windows `join` yields backslashes, so every derived path missed its mocked fixture entry — `readJSONFile` returned `null` and the hook took its record-not-found early return on every call.

Visible symptom: the Windows CI job failed on `settleSpriteAnimationJob > stages the clip and files it through the WALK attach` with `Number of calls: 0`. The quieter cost was coverage — the settle path, the once-only guard, the retry re-file and the boot reconcile were all exercising the not-found branch while the job otherwise read as green.

The file is new (from #4876) and this was its first exposure to the Windows job, which is impact-gated and had not run for it before. Unrelated to any in-flight branch; it blocks the Windows gate on #4974.

## Test plan

- `cd server && npx vitest run services/sprites/localAnimationJobHook.test.js` — 29/29 passed.
- Simulated Windows semantics by substituting `path/win32` for `path` in a scratch copy: the pre-fix file fails **16 of 29**, the fixed file passes **29/29**.
- `cd server && CI=1 npx vitest run` (full server suite) — 1625 files, 34131 passed, 8 skipped.