### PR TITLE
fix: close double-submit window in CivitAI LoRA installs

### DIFF
--- a/server/services/loras.js
+++ b/server/services/loras.js
@@ -67,6 +67,11 @@ import { getSettings } from './settings.js';
 
 const SIDECAR_SUFFIX = '.metadata.json';
 
+// One install attempt per Civitai model at a time. The slot is a promise so a
+// duplicate submit shares the original result instead of racing it to the same
+// destination files. Different model ids remain independent.
+const civitaiInstalls = new Map();
+
 const sidecarPath = (loraFilename) => join(PATHS.loras, `${loraFilename}${SIDECAR_SUFFIX}`);
 
 // Reads the sidecar JSON next to a LoRA file. Returns `null` when the
@@ -517,8 +522,7 @@ const verifyDownloadedLora = async (destPath, { expectedSha256 = null, source = 
 
 // Install a LoRA from a Civitai URL. Returns the new sidecar JSON so the
 // client can render it immediately without a second list round-trip.
-export const installFromCivitai = async (input, { fetchImpl = fetch } = {}) => {
-  const { modelId, versionId } = parseCivitaiUrl(input?.url);
+const performCivitaiInstall = async (input, { modelId, versionId, fetchImpl }) => {
   const apiKey = (typeof input?.apiKey === 'string' && input.apiKey.trim()) || (await resolveCivitaiKey());
   const model = await fetchCivitaiModel(modelId, { apiKey, fetchImpl });
   const version = pickVersion(model, versionId);
@@ -589,6 +593,19 @@ export const installFromCivitai = async (input, { fetchImpl = fetch } = {}) => {
   await writeSidecar(filename, sidecar);
   console.log(`✅ Installed Civitai LoRA: ${filename} [layout=${sidecar.keyLayout || 'unknown'}]`);
   return sidecar;
+};
+
+export const installFromCivitai = async (input, { fetchImpl = fetch } = {}) => {
+  const { modelId, versionId } = parseCivitaiUrl(input?.url);
+  const active = civitaiInstalls.get(modelId);
+  if (active) return active;
+
+  const attempt = performCivitaiInstall(input, { modelId, versionId, fetchImpl });
+  const tracked = attempt.finally(() => {
+    if (civitaiInstalls.get(modelId) === tracked) civitaiInstalls.delete(modelId);
+  });
+  civitaiInstalls.set(modelId, tracked);
+  return tracked;
 };
 
 // Set of recognized LoRA families an HF import may target (image runners +

--- a/server/services/loras.js
+++ b/server/services/loras.js
@@ -30,6 +30,7 @@ import { verifySafetensorsStructure } from '../lib/hfCache.js';
 import { isPlainObject } from '../lib/objects.js';
 import { readCachedLoraEffectReport } from '../lib/loraEffect.js';
 import { createKeyedFileWriteQueue } from '../lib/fileWriteQueue.js';
+import { createSingleFlight } from '../lib/singleFlight.js';
 import {
   applyDownloadToken,
   baseModelToRunner,
@@ -67,10 +68,10 @@ import { getSettings } from './settings.js';
 
 const SIDECAR_SUFFIX = '.metadata.json';
 
-// One install attempt per Civitai model at a time. The slot is a promise so a
-// duplicate submit shares the original result instead of racing it to the same
-// destination files. Different model ids remain independent.
-const civitaiInstalls = new Map();
+// One install attempt per requested Civitai model version at a time. A duplicate
+// submit shares the original result instead of racing it to the same destination
+// files, while two explicitly different versions remain independent.
+const civitaiInstalls = createSingleFlight();
 
 const sidecarPath = (loraFilename) => join(PATHS.loras, `${loraFilename}${SIDECAR_SUFFIX}`);
 
@@ -597,15 +598,11 @@ const performCivitaiInstall = async (input, { modelId, versionId, fetchImpl }) =
 
 export const installFromCivitai = async (input, { fetchImpl = fetch } = {}) => {
   const { modelId, versionId } = parseCivitaiUrl(input?.url);
-  const active = civitaiInstalls.get(modelId);
-  if (active) return active;
-
-  const attempt = performCivitaiInstall(input, { modelId, versionId, fetchImpl });
-  const tracked = attempt.finally(() => {
-    if (civitaiInstalls.get(modelId) === tracked) civitaiInstalls.delete(modelId);
-  });
-  civitaiInstalls.set(modelId, tracked);
-  return tracked;
+  const installKey = `${modelId}:${versionId ?? 'latest'}`;
+  return civitaiInstalls.run(
+    installKey,
+    () => performCivitaiInstall(input, { modelId, versionId, fetchImpl }),
+  );
 };
 
 // Set of recognized LoRA families an HF import may target (image runners +

--- a/server/services/loras.test.js
+++ b/server/services/loras.test.js
@@ -469,6 +469,56 @@ describe('installFromCivitai', () => {
     expect(downloadCalls).toBe(1);
   });
 
+  it('keeps concurrent installs for different versions of one model independent', async () => {
+    const downloadedBytes = validSafetensors();
+    const model = {
+      ...FAKE_MODEL,
+      modelVersions: [
+        ...FAKE_MODEL.modelVersions,
+        {
+          ...FAKE_MODEL.modelVersions[0],
+          id: 8,
+          files: [{
+            ...FAKE_MODEL.modelVersions[0].files[0],
+            downloadUrl: 'https://civitai.com/api/download/models/8',
+          }],
+        },
+      ],
+    };
+    let releaseMetadata;
+    const metadataGate = new Promise((resolve) => { releaseMetadata = resolve; });
+    let metadataCalls = 0;
+    let downloadCalls = 0;
+    const fetchImpl = async (url) => {
+      if (url.startsWith('https://civitai.com/api/v1/models/2600698')) {
+        metadataCalls += 1;
+        await metadataGate;
+        return mockJsonResponse(model);
+      }
+      if (url.startsWith('https://civitai.com/api/download/models/')) {
+        downloadCalls += 1;
+        const stream = new ReadableStream({
+          start(c) { c.enqueue(new Uint8Array(downloadedBytes)); c.close(); },
+        });
+        return { ok: true, status: 200, body: stream };
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    };
+
+    const version7 = lorasService.installFromCivitai({
+      url: 'https://civitai.com/models/2600698?modelVersionId=7',
+    }, { fetchImpl });
+    const version8 = lorasService.installFromCivitai({
+      url: 'https://civitai.com/models/2600698?modelVersionId=8',
+    }, { fetchImpl });
+
+    await vi.waitFor(() => expect(metadataCalls).toBe(2));
+    releaseMetadata();
+    const results = await Promise.all([version7, version8]);
+    expect(results.map((result) => result.civitai.versionId)).toEqual([7, 8]);
+    expect(downloadCalls).toBe(2);
+  });
+
   it('releases the in-flight slot after a failed install so retry can proceed', async () => {
     let metadataCalls = 0;
     const fetchImpl = async () => {

--- a/server/services/loras.test.js
+++ b/server/services/loras.test.js
@@ -436,6 +436,56 @@ describe('installFromCivitai', () => {
     expect(calls).toHaveLength(2);
   });
 
+  it('shares one in-flight install between duplicate model submissions', async () => {
+    const downloadedBytes = validSafetensors();
+    let releaseMetadata;
+    let metadataCalls = 0;
+    let downloadCalls = 0;
+    const fetchImpl = async (url) => {
+      if (url.startsWith('https://civitai.com/api/v1/models/2600698')) {
+        metadataCalls += 1;
+        return new Promise((resolve) => {
+          releaseMetadata = () => resolve(mockJsonResponse(FAKE_MODEL));
+        });
+      }
+      if (url.startsWith('https://civitai.com/api/download/models/7')) {
+        downloadCalls += 1;
+        const stream = new ReadableStream({
+          start(c) { c.enqueue(new Uint8Array(downloadedBytes)); c.close(); },
+        });
+        return { ok: true, status: 200, body: stream };
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    };
+
+    const first = lorasService.installFromCivitai({ url: 'https://civitai.com/models/2600698' }, { fetchImpl });
+    await vi.waitFor(() => expect(releaseMetadata).toBeTypeOf('function'));
+    const second = lorasService.installFromCivitai({ url: 'https://civitai.com/models/2600698' }, { fetchImpl });
+
+    releaseMetadata();
+    const [firstResult, secondResult] = await Promise.all([first, second]);
+    expect(secondResult).toEqual(firstResult);
+    expect(metadataCalls).toBe(1);
+    expect(downloadCalls).toBe(1);
+  });
+
+  it('releases the in-flight slot after a failed install so retry can proceed', async () => {
+    let metadataCalls = 0;
+    const fetchImpl = async () => {
+      metadataCalls += 1;
+      if (metadataCalls === 1) throw new Error('metadata unavailable');
+      return mockJsonResponse({ ...FAKE_MODEL, type: 'Checkpoint' });
+    };
+
+    await expect(
+      lorasService.installFromCivitai({ url: 'https://civitai.com/models/2600698' }, { fetchImpl }),
+    ).rejects.toThrow(/metadata unavailable/);
+    await expect(
+      lorasService.installFromCivitai({ url: 'https://civitai.com/models/2600698' }, { fetchImpl }),
+    ).rejects.toThrow(/not a LoRA/);
+    expect(metadataCalls).toBe(2);
+  });
+
   it('refuses to install non-LoRA model types', async () => {
     const fetchImpl = async () => (mockJsonResponse({ ...FAKE_MODEL, type: 'Checkpoint' }));
     await expect(


### PR DESCRIPTION
## Summary
- Adds a keyed in-flight slot (`createSingleFlight`) around `installFromCivitai` so a duplicate submit for the same model/version shares the original install instead of racing a second one against the same destination files.
- Different versions of the same model still install independently; the slot clears on settle so a retry after a failed install is not blocked.

## Test plan
- `cd server && NODE_ENV=test npx vitest run services/loras.test.js` — 60/60 passing, including new coverage for: sharing one in-flight install between duplicate submissions, independent concurrent installs for different versions, and slot release after a failed install.

Closes #4917