### PR TITLE
fix: use local calendar dates for Tribe touchpoints and the daily review

### DIFF
--- a/client/src/components/calendar/ReviewTab.jsx
+++ b/client/src/components/calendar/ReviewTab.jsx
@@ -4,9 +4,10 @@ import toast from '../ui/Toast';
 import * as api from '../../services/api';
 import { formatDurationMin, formatTimeOfDay } from '../../utils/formatters';
 import BrailleSpinner from '../BrailleSpinner';
+import { localDateStr } from '../meatspace/constants';
 
 export default function ReviewTab() {
-  const [date, setDate] = useState(new Date().toISOString().slice(0, 10));
+  const [date, setDate] = useState(localDateStr());
   const [review, setReview] = useState(null);
   const [loading, setLoading] = useState(true);
   const [confirming, setConfirming] = useState(null);
@@ -92,7 +93,7 @@ export default function ReviewTab() {
     fetchReview();
   };
 
-  const isToday = date === new Date().toISOString().slice(0, 10);
+  const isToday = date === localDateStr();
   const isSyncStale = review?.lastSyncAt
     ? (Date.now() - new Date(review.lastSyncAt).getTime()) > 12 * 60 * 60 * 1000
     : true;
@@ -125,7 +126,7 @@ export default function ReviewTab() {
           </button>
           {!isToday && (
             <button
-              onClick={() => setDate(new Date().toISOString().slice(0, 10))}
+              onClick={() => setDate(localDateStr())}
               className="px-2 py-1 text-xs rounded bg-port-accent/20 text-port-accent"
             >
               Today

--- a/client/src/components/calendar/ReviewTab.jsx
+++ b/client/src/components/calendar/ReviewTab.jsx
@@ -28,7 +28,7 @@ export default function ReviewTab() {
   const changeDate = (delta) => {
     const d = new Date(date + 'T12:00:00');
     d.setDate(d.getDate() + delta);
-    setDate(d.toISOString().slice(0, 10));
+    setDate(localDateStr(d));
   };
 
   const handleConfirm = async (event, happened) => {

--- a/client/src/components/calendar/ReviewTab.test.jsx
+++ b/client/src/components/calendar/ReviewTab.test.jsx
@@ -1,0 +1,29 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../services/api', () => ({
+  getDailyReview: vi.fn(() => Promise.resolve({
+    events: [],
+    progressEntries: [],
+    summary: { totalEvents: 0, confirmed: 0, skipped: 0, unreviewed: 0 },
+  })),
+}));
+
+import * as api from '../../services/api';
+import ReviewTab from './ReviewTab';
+
+describe('ReviewTab', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('defaults to the local calendar date', async () => {
+    vi.setSystemTime(new Date(2026, 0, 1, 20));
+
+    render(<ReviewTab />);
+
+    await waitFor(() => expect(api.getDailyReview).toHaveBeenCalledWith('2026-01-01'));
+    expect(screen.getByLabelText('Review date').value).toBe('2026-01-01');
+    expect(screen.queryByRole('button', { name: 'Today' })).toBeNull();
+  });
+});

--- a/client/src/components/calendar/ReviewTab.test.jsx
+++ b/client/src/components/calendar/ReviewTab.test.jsx
@@ -13,9 +13,13 @@ import * as api from '../../services/api';
 import ReviewTab from './ReviewTab';
 
 describe('ReviewTab', () => {
+  // Restore the ambient zone rather than pinning UTC: vitest reuses a worker
+  // across files, so clobbering TZ here would follow the next suite in.
+  const ambientTZ = process.env.TZ;
   afterEach(() => {
     vi.useRealTimers();
-    process.env.TZ = 'UTC';
+    if (ambientTZ === undefined) delete process.env.TZ;
+    else process.env.TZ = ambientTZ;
   });
 
   it('defaults to the local calendar date', async () => {

--- a/client/src/components/calendar/ReviewTab.test.jsx
+++ b/client/src/components/calendar/ReviewTab.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('../../services/api', () => ({
@@ -15,6 +15,7 @@ import ReviewTab from './ReviewTab';
 describe('ReviewTab', () => {
   afterEach(() => {
     vi.useRealTimers();
+    process.env.TZ = 'UTC';
   });
 
   it('defaults to the local calendar date', async () => {
@@ -25,5 +26,18 @@ describe('ReviewTab', () => {
     await waitFor(() => expect(api.getDailyReview).toHaveBeenCalledWith('2026-01-01'));
     expect(screen.getByLabelText('Review date').value).toBe('2026-01-01');
     expect(screen.queryByRole('button', { name: 'Today' })).toBeNull();
+  });
+
+  it('navigates by local calendar day in positive UTC offsets', async () => {
+    process.env.TZ = 'Pacific/Kiritimati';
+    vi.setSystemTime(new Date(2026, 0, 1, 20));
+
+    render(<ReviewTab />);
+    await waitFor(() => expect(api.getDailyReview).toHaveBeenCalledWith('2026-01-01'));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }));
+
+    await waitFor(() => expect(api.getDailyReview).toHaveBeenCalledWith('2026-01-02'));
+    expect(screen.getByLabelText('Review date').value).toBe('2026-01-02');
   });
 });

--- a/client/src/pages/Tribe.jsx
+++ b/client/src/pages/Tribe.jsx
@@ -25,6 +25,7 @@ import * as api from '../services/api';
 import socket from '../services/socket';
 import BrailleSpinner from '../components/BrailleSpinner';
 import PageHeader from '../components/PageHeader';
+import { localDateStr } from '../components/meatspace/constants';
 import toast from '../components/ui/Toast';
 import TabPills from '../components/ui/TabPills';
 import TribeCircleMap from '../components/tribe/TribeCircleMap.jsx';
@@ -80,10 +81,6 @@ function withParam(params, key, value, defaultValue) {
   if (value === defaultValue) params.delete(key);
   else params.set(key, value);
   return params;
-}
-
-function todayISO() {
-  return new Date().toISOString().slice(0, 10);
 }
 
 function parseStoredContacts(value) {
@@ -1114,7 +1111,7 @@ export default function Tribe() {
   };
 
   const logTouch = async (id) => {
-    const date = todayISO();
+    const date = localDateStr();
     const result = await api.createTribeTouchpoint(id, {
       happenedAt: new Date().toISOString(),
       channel: contacts.find((contact) => contact.id === id)?.channel || '',

--- a/client/src/pages/Tribe.jsx
+++ b/client/src/pages/Tribe.jsx
@@ -1111,9 +1111,11 @@ export default function Tribe() {
   };
 
   const logTouch = async (id) => {
-    const date = localDateStr();
+    const now = new Date();
+    const date = localDateStr(now);
     const result = await api.createTribeTouchpoint(id, {
-      happenedAt: new Date().toISOString(),
+      happenedAt: now.toISOString(),
+      localDate: date,
       channel: contacts.find((contact) => contact.id === id)?.channel || '',
       summary: 'Manual touchpoint',
       source: 'user',

--- a/client/src/pages/Tribe.test.jsx
+++ b/client/src/pages/Tribe.test.jsx
@@ -156,7 +156,11 @@ describe('Tribe care filter', () => {
     await screen.findByText('Example Person');
     fireEvent.click(screen.getAllByRole('button', { name: 'Touch' })[0]);
 
-    await waitFor(() => expect(api.createTribeTouchpoint).toHaveBeenCalled());
+    await waitFor(() => expect(api.createTribeTouchpoint).toHaveBeenCalledWith(
+      'p1',
+      expect.objectContaining({ localDate: '2026-01-01' }),
+      { silent: true },
+    ));
     expect(screen.getByText('Last 2026-01-01')).toBeTruthy();
   });
 });

--- a/client/src/pages/Tribe.test.jsx
+++ b/client/src/pages/Tribe.test.jsx
@@ -161,6 +161,6 @@ describe('Tribe care filter', () => {
       expect.objectContaining({ localDate: '2026-01-01' }),
       { silent: true },
     ));
-    expect(screen.getByText('Last 2026-01-01')).toBeTruthy();
+    expect(await screen.findByText('Last 2026-01-01')).toBeTruthy();
   });
 });

--- a/client/src/pages/Tribe.test.jsx
+++ b/client/src/pages/Tribe.test.jsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { MemoryRouter, useLocation } from 'react-router';
 
@@ -6,6 +6,7 @@ vi.mock('../services/api', () => ({
   getTribePeople: vi.fn(() => Promise.resolve({ people: [] })),
   // OutreachQueue (care tab) fetches unanswered threads on mount (#2158).
   getTribeOutreach: vi.fn(() => Promise.resolve({ threads: [] })),
+  createTribeTouchpoint: vi.fn(),
 }));
 
 vi.mock('../services/socket', () => ({
@@ -14,6 +15,10 @@ vi.mock('../services/socket', () => ({
 
 import Tribe from './Tribe';
 import * as api from '../services/api';
+
+afterEach(() => {
+  vi.useRealTimers();
+});
 
 // Surfaces the current URL (path + search) so tests can assert deep-link state.
 function LocationProbe() {
@@ -141,5 +146,17 @@ describe('Tribe care filter', () => {
     renderAt('/tribe?tab=circle&status=overdue');
     expect(await screen.findByText('Example Person')).toBeTruthy();
     expect(screen.queryByText('Placeholder Pal')).toBeNull();
+  });
+
+  it('records a manual touch on the local calendar date', async () => {
+    vi.setSystemTime(new Date(2026, 0, 1, 20));
+    api.createTribeTouchpoint.mockResolvedValue({ id: 'touch-1' });
+
+    renderAt('/tribe');
+    await screen.findByText('Example Person');
+    fireEvent.click(screen.getAllByRole('button', { name: 'Touch' })[0]);
+
+    await waitFor(() => expect(api.createTribeTouchpoint).toHaveBeenCalled());
+    expect(screen.getByText('Last 2026-01-01')).toBeTruthy();
   });
 });

--- a/server/routes/tribe.js
+++ b/server/routes/tribe.js
@@ -40,6 +40,7 @@ const personUpdateSchema = partialWithoutDefaults(personSchema).extend({
 
 const touchpointSchema = z.object({
   happenedAt: z.string().datetime().optional(),
+  localDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
   channel: z.string().max(200).optional().default(''),
   summary: z.string().max(2000).optional().default(''),
   source: z.enum(['user', 'calendar', 'message', 'import']).optional().default('user'),

--- a/server/routes/tribe.test.js
+++ b/server/routes/tribe.test.js
@@ -125,6 +125,7 @@ describe('Tribe Routes', () => {
       .post(`/api/tribe/people/${PERSON_ID}/touchpoints`)
       .send({
         happenedAt: '2026-06-18T15:00:00.000Z',
+        localDate: '2026-06-19',
         source: 'calendar',
         calendarAccountId: ACCOUNT_ID,
         calendarEventId: 'event-1',
@@ -135,10 +136,20 @@ describe('Tribe Routes', () => {
     expect(response.body.calendarEventId).toBe('event-1');
     expect(tribe.createTouchpoint).toHaveBeenCalledWith(PERSON_ID, expect.objectContaining({
       source: 'calendar',
+      localDate: '2026-06-19',
       calendarAccountId: ACCOUNT_ID,
       calendarEventId: 'event-1',
       metadata: { title: 'Walk' },
     }));
+  });
+
+  it('rejects an invalid local date on a manual touchpoint', async () => {
+    const response = await request(app)
+      .post(`/api/tribe/people/${PERSON_ID}/touchpoints`)
+      .send({ localDate: '06/19/2026' });
+
+    expect(response.status).toBe(400);
+    expect(tribe.createTouchpoint).not.toHaveBeenCalled();
   });
 
   it('creates touchpoints from calendar events', async () => {

--- a/server/services/tribe.js
+++ b/server/services/tribe.js
@@ -335,6 +335,8 @@ export async function createTouchpoint(personId, data = {}) {
   await ensureReady();
   const person = await getPerson(personId);
   if (!person) throw new ServerError('Person not found', { status: 404 });
+  const happenedAt = data.happenedAt || new Date().toISOString();
+  const contactDate = data.localDate || happenedAt;
 
   return withTransaction(async (client) => {
     const result = await client.query(
@@ -346,7 +348,7 @@ export async function createTouchpoint(personId, data = {}) {
       [
         data.id || uuidv4(),
         personId,
-        data.happenedAt || new Date().toISOString(),
+        happenedAt,
         data.channel || '',
         data.summary || '',
         data.source || 'user',
@@ -362,7 +364,7 @@ export async function createTouchpoint(personId, data = {}) {
            channel = CASE WHEN $3::text = '' THEN channel ELSE $3::text END,
            updated_at = NOW()
        WHERE id = $1`,
-      [personId, data.happenedAt || new Date().toISOString(), data.channel || ''],
+      [personId, contactDate, data.channel || ''],
     );
     return rowToTouchpoint(result.rows[0]);
   });

--- a/server/services/tribe.test.js
+++ b/server/services/tribe.test.js
@@ -13,6 +13,7 @@ import { query, withTransaction } from '../lib/db.js';
 import {
   listPeople,
   createPerson,
+  createTouchpoint,
   normalizeTags,
   normalizeEmails,
   isoDate,
@@ -164,6 +165,32 @@ describe('tribe service — listPeople query builder', () => {
     expect(sql).toContain('ring = $1');
     expect(sql).toContain('ILIKE $2');
     expect(params).toEqual(['core', '%ada%']);
+  });
+});
+
+describe('tribe service — createTouchpoint', () => {
+  beforeEach(() => {
+    query.mockReset();
+    withTransaction.mockReset();
+  });
+
+  it('persists the browser-local date independently from the UTC timestamp', async () => {
+    query.mockResolvedValue({ rows: [{ id: 'person-1', name: 'Example Person', ring: 'tribe', cadence_days: 45 }] });
+    const clientQuery = vi.fn()
+      .mockResolvedValueOnce({ rows: [{ id: 'touch-1', person_id: 'person-1', happened_at: '2026-01-02T04:00:00.000Z' }] })
+      .mockResolvedValueOnce({ rows: [] });
+    withTransaction.mockImplementation(async (fn) => fn({ query: clientQuery }));
+
+    await createTouchpoint('person-1', {
+      happenedAt: '2026-01-02T04:00:00.000Z',
+      localDate: '2026-01-01',
+    });
+
+    expect(clientQuery).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining('SET last_contact_on'),
+      ['person-1', '2026-01-01', ''],
+    );
   });
 });
 


### PR DESCRIPTION
Closes #4919

## Summary

- `Tribe.jsx` stamped `lastContact` from `getUTC*`, so west-of-UTC users saw yesterday's date until mid-morning local time. It now sends the browser's local date as an explicit `localDate` alongside the UTC `happenedAt`, and the server uses it for `last_contact_on` while keeping the timestamp untouched.
- `ReviewTab.jsx` was self-inconsistent: it defaulted the selected date via UTC-today but anchored date arithmetic at local `T12`. Both now go through the shared `localDateStr` helper.
- `localDate` is validated at the route (`YYYY-MM-DD`) and optional, so existing callers and older peers keep working.

## Test plan

- `client`: `ReviewTab.test.jsx` (new) covers the local default and day-stepping under a positive UTC offset; `Tribe.test.jsx` covers a manual touch landing on the local date.
- `server`: `tribe.test.js` asserts `last_contact_on` takes `localDate` independently of the UTC timestamp; `routes/tribe.test.js` covers the validation reject.
- Ran both suites locally, green.