### PR TITLE
fix: theme the auto-fix widget's tier colors and use dvh for the FableLoom reader

### DIFF
--- a/client/src/components/dashboard/builtins/AutoFixMetricsWidget.jsx
+++ b/client/src/components/dashboard/builtins/AutoFixMetricsWidget.jsx
@@ -68,12 +68,12 @@ function TrendSparkline({ trend }) {
       <polyline
         points={coords.join(' ')}
         fill="none"
-        stroke="#3b82f6"
+        stroke="rgb(var(--port-accent))"
         strokeWidth="1.5"
         strokeLinejoin="round"
         strokeLinecap="round"
       />
-      <circle cx={lastX} cy={lastY} r="2" fill="#3b82f6" />
+      <circle cx={lastX} cy={lastY} r="2" fill="rgb(var(--port-accent))" />
     </svg>
   );
 }

--- a/client/src/components/dashboard/builtins/AutoFixMetricsWidget.jsx
+++ b/client/src/components/dashboard/builtins/AutoFixMetricsWidget.jsx
@@ -68,12 +68,12 @@ function TrendSparkline({ trend }) {
       <polyline
         points={coords.join(' ')}
         fill="none"
-        stroke="rgb(var(--port-accent))"
+        style={{ stroke: 'rgb(var(--port-accent))' }}
         strokeWidth="1.5"
         strokeLinejoin="round"
         strokeLinecap="round"
       />
-      <circle cx={lastX} cy={lastY} r="2" fill="rgb(var(--port-accent))" />
+      <circle cx={lastX} cy={lastY} r="2" style={{ fill: 'rgb(var(--port-accent))' }} />
     </svg>
   );
 }

--- a/client/src/components/dashboard/builtins/AutoFixMetricsWidget.jsx
+++ b/client/src/components/dashboard/builtins/AutoFixMetricsWidget.jsx
@@ -14,10 +14,10 @@ import { formatDurationMs } from '../../../utils/formatters';
 // fallback-tier breakdown, and median time-to-recovery.
 
 const TIER_COLORS = {
-  1: '#22c55e', // port-success — config/env (cheapest fix)
-  2: '#3b82f6', // port-accent  — schema/type
-  3: '#f59e0b', // port-warning — constrained-agent-retry
-  4: '#ef4444', // port-error   — escalate
+  1: 'rgb(var(--port-success))', // config/env (cheapest fix)
+  2: 'rgb(var(--port-accent))', // schema/type
+  3: 'rgb(var(--port-warning))', // constrained-agent-retry
+  4: 'rgb(var(--port-error))', // escalate
 };
 
 // Render a rate in [0,1] as a percent string, or an em dash for the null
@@ -147,7 +147,7 @@ function AutoFixMetricsWidget() {
           <div key={t.tier} className="flex items-center gap-2 text-xs">
             <span
               className="inline-block w-2 h-2 rounded-full shrink-0"
-              style={{ backgroundColor: TIER_COLORS[t.tier] || '#6b7280' }}
+              style={{ backgroundColor: TIER_COLORS[t.tier] || 'rgb(var(--port-text-muted))' }}
               aria-hidden="true"
             />
             <span className="text-gray-300 flex-1 truncate" title={t.label}>

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -278,7 +278,7 @@ body {
 @utility max-h-dvh-cap {
   max-height: min(var(--dvh-cap, 100vh), calc(100vh - var(--dvh-inset, 0px)));
   @supports (height: 1dvh) {
-    max-height: min(var(--dvh-cap, 100dvh), calc(100dvh - var(--dvh-inset, 0px)));
+    max-height: min(var(--dvh-cap-dynamic, var(--dvh-cap, 100dvh)), calc(100dvh - var(--dvh-inset, 0px)));
   }
 }
 @utility min-h-dvh-cap {

--- a/client/src/pages/FableLoomStory.jsx
+++ b/client/src/pages/FableLoomStory.jsx
@@ -295,7 +295,10 @@ export default function FableLoomStory() {
               </div>
             )}
           </section>
-          <aside className="lg:w-[380px] lg:shrink-0 max-h-[45dvh] lg:max-h-none border-t lg:border-t-0 lg:border-l border-port-border overflow-y-auto">
+          <aside
+            className="lg:w-[380px] lg:shrink-0 max-h-dvh-cap lg:max-h-none border-t lg:border-t-0 lg:border-l border-port-border overflow-y-auto"
+            style={{ '--dvh-cap': '45vh', '--dvh-cap-dynamic': '45dvh' }}
+          >
             {node ? (
               <LoomNodeEditor
                 key={node.id}

--- a/client/src/pages/FableLoomStory.jsx
+++ b/client/src/pages/FableLoomStory.jsx
@@ -295,7 +295,7 @@ export default function FableLoomStory() {
               </div>
             )}
           </section>
-          <aside className="lg:w-[380px] lg:shrink-0 max-h-[45vh] lg:max-h-none border-t lg:border-t-0 lg:border-l border-port-border overflow-y-auto">
+          <aside className="lg:w-[380px] lg:shrink-0 max-h-[45dvh] lg:max-h-none border-t lg:border-t-0 lg:border-l border-port-border overflow-y-auto">
             {node ? (
               <LoomNodeEditor
                 key={node.id}


### PR DESCRIPTION
Closes #4934

## Summary

- `AutoFixMetricsWidget` hardcoded hex tier colors (and the sparkline stroke/dot), ignoring the user's theme. All four tiers, the fallback swatch, and the sparkline now read `rgb(var(--port-*))` like every sibling widget.
- `FableLoomStory`'s reader pane used `max-h-[45vh]`, which jumps around mobile dynamic toolbars. It now uses the existing `max-h-dvh-cap` utility.
- `max-h-dvh-cap` gained an optional `--dvh-cap-dynamic` override so a caller can supply a `dvh` value for the `@supports` branch while keeping its `vh` fallback. Unset, it resolves exactly as before.

## Test plan

- `client`: dashboard and FableLoomStory suites pass (8 files / 86 tests).