### PR TITLE
fix: remove dead PORT_UI fallback from UI URL (#4927)

### DIFF
--- a/server/lib/ports.js
+++ b/server/lib/ports.js
@@ -30,6 +30,6 @@ export const resolvePostgresPort = (pgMode) =>
 
 export const DEFAULT_PEER_PORT = PORTS.API;
 export const PORTOS_UI_URL = process.env.PORTOS_UI_URL
-  || `http://${process.env.PORTOS_HOST || 'localhost'}:${process.env.PORT_UI || PORTS.UI}`;
+  || `http://${process.env.PORTOS_HOST || 'localhost'}:${PORTS.UI}`;
 export const PORTOS_API_URL = process.env.PORTOS_API_URL
   || `http://${process.env.PORTOS_HOST || 'localhost'}:${process.env.PORT || PORTS.API}`;


### PR DESCRIPTION
## Summary

- Remove the unused PORT_UI environment fallback from the canonical UI URL.
- Keep the fixed PORTS.UI value and documented PORTOS_UI_URL/PORTOS_HOST overrides intact.

## Test plan

- `cd server && npm test -- --run lib/ports.test.js`
- `PORT_UI=5999 node --input-type=module -e "import('./server/lib/ports.js').then(({PORTOS_UI_URL}) => { if (PORTOS_UI_URL !== 'http://localhost:5554') throw new Error(PORTOS_UI_URL); })"`
- Full server suite: 1 unrelated `scripts/checkNpmVersion.test.js` failure under the installed Node/npm runtime; 1,625 files and 34,141 tests passed.

Closes #4927