### PR TITLE
refactor: migrate settings forms to FormField

### DIFF
--- a/client/src/components/settings/AiAssignmentsTab.jsx
+++ b/client/src/components/settings/AiAssignmentsTab.jsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router';
 import { ArrowRight, Bot, RefreshCw, Save, Search } from 'lucide-react';
 import toast from '../ui/Toast';
+import FormField from '../ui/FormField';
 import ToolUseWarning from '../ui/ToolUseWarning.jsx';
 import TabPills from '../ui/TabPills.jsx';
 import { getAiAssignments, updateAiAssignment } from '../../services/api';
@@ -223,27 +224,31 @@ export default function AiAssignmentsTab() {
 
         <div className="w-full min-w-0 max-w-full shrink-0 bg-port-card border border-port-border rounded-lg p-3 space-y-2 xl:w-[520px]">
           <div className="flex flex-col sm:flex-row gap-2">
-            <select
-              value={fromProvider}
-              onChange={(e) => setFromProvider(e.target.value)}
-              aria-label="Migrate from provider"
-              className="min-w-0 flex-1 bg-port-bg border border-port-border rounded px-2 py-2 text-sm text-white"
-            >
-              <option value="">From provider</option>
-              {data.providers.map((p) => <option key={p.id} value={p.id}>{p.name}</option>)}
-            </select>
+            <FormField label="Migrate from provider" labelClassName="sr-only" className="min-w-0 flex-1">
+              <select
+                value={fromProvider}
+                onChange={(e) => setFromProvider(e.target.value)}
+                aria-label="Migrate from provider"
+                className="w-full min-w-0 bg-port-bg border border-port-border rounded px-2 py-2 text-sm text-white"
+              >
+                <option value="">From provider</option>
+                {data.providers.map((p) => <option key={p.id} value={p.id}>{p.name}</option>)}
+              </select>
+            </FormField>
             <div className="hidden sm:flex items-center text-gray-500">
               <ArrowRight size={16} />
             </div>
-            <select
-              value={toProvider}
-              onChange={(e) => setToProvider(e.target.value)}
-              aria-label="Migrate to provider"
-              className="min-w-0 flex-1 bg-port-bg border border-port-border rounded px-2 py-2 text-sm text-white"
-            >
-              <option value="">To provider</option>
-              {data.providers.map((p) => <option key={p.id} value={p.id}>{p.name}</option>)}
-            </select>
+            <FormField label="Migrate to provider" labelClassName="sr-only" className="min-w-0 flex-1">
+              <select
+                value={toProvider}
+                onChange={(e) => setToProvider(e.target.value)}
+                aria-label="Migrate to provider"
+                className="w-full min-w-0 bg-port-bg border border-port-border rounded px-2 py-2 text-sm text-white"
+              >
+                <option value="">To provider</option>
+                {data.providers.map((p) => <option key={p.id} value={p.id}>{p.name}</option>)}
+              </select>
+            </FormField>
             <button
               type="button"
               onClick={runBulkMigration}
@@ -262,23 +267,29 @@ export default function AiAssignmentsTab() {
       <div className="flex flex-col lg:flex-row gap-2">
         <div className="relative flex-1">
           <Search size={15} className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-500" />
-          <input
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-            placeholder="Search assignments"
-            aria-label="Search assignments"
-            className="w-full bg-port-bg border border-port-border rounded pl-9 pr-3 py-2 text-sm text-white"
-          />
+          <FormField label="Search assignments" labelClassName="sr-only" className="flex-1">
+            <input
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Search assignments"
+              aria-label="Search assignments"
+              className="w-full bg-port-bg border border-port-border rounded pl-9 pr-3 py-2 text-sm text-white"
+            />
+          </FormField>
         </div>
-        <select value={area} onChange={(e) => setArea(e.target.value)} aria-label="Filter by area" className="bg-port-bg border border-port-border rounded px-3 py-2 text-sm text-white">
-          {areas.map((a) => <option key={a} value={a}>{a === 'all' ? 'All areas' : a}</option>)}
-        </select>
-        <select value={scope} onChange={(e) => setScope(e.target.value)} aria-label="Filter by scope" className="bg-port-bg border border-port-border rounded px-3 py-2 text-sm text-white">
-          <option value="all">All scopes</option>
-          <option value="global">Global</option>
-          <option value="record">Record pins</option>
-          <option value="runtime">Runtime call sites</option>
-        </select>
+        <FormField label="Filter by area" labelClassName="sr-only" className="contents">
+          <select value={area} onChange={(e) => setArea(e.target.value)} aria-label="Filter by area" className="bg-port-bg border border-port-border rounded px-3 py-2 text-sm text-white">
+            {areas.map((a) => <option key={a} value={a}>{a === 'all' ? 'All areas' : a}</option>)}
+          </select>
+        </FormField>
+        <FormField label="Filter by scope" labelClassName="sr-only" className="contents">
+          <select value={scope} onChange={(e) => setScope(e.target.value)} aria-label="Filter by scope" className="bg-port-bg border border-port-border rounded px-3 py-2 text-sm text-white">
+            <option value="all">All scopes</option>
+            <option value="global">Global</option>
+            <option value="record">Record pins</option>
+            <option value="runtime">Runtime call sites</option>
+          </select>
+        </FormField>
         <button type="button" onClick={load} className="flex items-center justify-center gap-1.5 px-3 py-2 bg-port-border hover:bg-port-border/80 text-sm text-white rounded">
           <RefreshCw size={14} />
           Refresh
@@ -329,51 +340,57 @@ export default function AiAssignmentsTab() {
                     {entry.providerEditable === false ? (
                       <div className="text-sm text-gray-300 py-2">{providerName(data.providers, draft.providerId)}</div>
                     ) : (
-                      <select
-                        value={draft.providerId}
-                        onChange={(e) => {
-                          const nextProviderId = e.target.value;
-                          // Vision-filtered rows (e.g. Scene evaluation) seed the
-                          // first eligible VLM when the provider default is text-only.
-                          const nextDefault = assignmentDefaultModel(entry, data.providers, nextProviderId, visionIdsByProvider);
-                          setDraft(entry.id, { providerId: nextProviderId, model: entry.modelEditable === false ? draft.model : nextDefault });
-                        }}
-                        aria-label={`Provider for ${entry.label}`}
-                        disabled={visionUnknown}
-                        className="w-full bg-port-card border border-port-border rounded px-2 py-2 text-sm text-white disabled:opacity-50"
-                      >
-                        <option value="">Default / unset</option>
-                        {providerOptions.map((p) => <option key={p.id} value={p.id}>{p.name}</option>)}
-                      </select>
+                      <FormField label={`Provider for ${entry.label}`} labelClassName="sr-only">
+                        <select
+                          value={draft.providerId}
+                          onChange={(e) => {
+                            const nextProviderId = e.target.value;
+                            // Vision-filtered rows (e.g. Scene evaluation) seed the
+                            // first eligible VLM when the provider default is text-only.
+                            const nextDefault = assignmentDefaultModel(entry, data.providers, nextProviderId, visionIdsByProvider);
+                            setDraft(entry.id, { providerId: nextProviderId, model: entry.modelEditable === false ? draft.model : nextDefault });
+                          }}
+                          aria-label={`Provider for ${entry.label}`}
+                          disabled={visionUnknown}
+                          className="w-full bg-port-card border border-port-border rounded px-2 py-2 text-sm text-white disabled:opacity-50"
+                        >
+                          <option value="">Default / unset</option>
+                          {providerOptions.map((p) => <option key={p.id} value={p.id}>{p.name}</option>)}
+                        </select>
+                      </FormField>
                     )}
                   </td>
                   <td className="px-3 py-3">
                     {entry.modelEditable === false ? (
                       <div className="text-sm text-gray-300 py-2">{draft.model || 'Default'}</div>
                     ) : modelOptions.length > 0 ? (
-                      <select
-                        value={draft.model}
-                        onChange={(e) => setDraft(entry.id, { model: e.target.value })}
-                        aria-label={`Model for ${entry.label}`}
-                        className="w-full bg-port-card border border-port-border rounded px-2 py-2 text-sm text-white"
-                      >
-                        <option value="">Default / auto</option>
-                        {modelOptions.map((m) => (
-                          <option key={m} value={m}>
-                            {annotateToolUse
-                              ? withToolUseOptionLabel(m, m, selectedProvider, toolUseIdsByProvider)
-                              : m}
-                          </option>
-                        ))}
-                      </select>
+                      <FormField label={`Model for ${entry.label}`} labelClassName="sr-only">
+                        <select
+                          value={draft.model}
+                          onChange={(e) => setDraft(entry.id, { model: e.target.value })}
+                          aria-label={`Model for ${entry.label}`}
+                          className="w-full bg-port-card border border-port-border rounded px-2 py-2 text-sm text-white"
+                        >
+                          <option value="">Default / auto</option>
+                          {modelOptions.map((m) => (
+                            <option key={m} value={m}>
+                              {annotateToolUse
+                                ? withToolUseOptionLabel(m, m, selectedProvider, toolUseIdsByProvider)
+                                : m}
+                            </option>
+                          ))}
+                        </select>
+                      </FormField>
                     ) : (
-                      <input
-                        value={draft.model}
-                        onChange={(e) => setDraft(entry.id, { model: e.target.value })}
-                        placeholder="Default / auto"
-                        aria-label={`Model for ${entry.label}`}
-                        className="w-full bg-port-card border border-port-border rounded px-2 py-2 text-sm text-white placeholder-gray-600"
-                      />
+                      <FormField label={`Model for ${entry.label}`} labelClassName="sr-only">
+                        <input
+                          value={draft.model}
+                          onChange={(e) => setDraft(entry.id, { model: e.target.value })}
+                          placeholder="Default / auto"
+                          aria-label={`Model for ${entry.label}`}
+                          className="w-full bg-port-card border border-port-border rounded px-2 py-2 text-sm text-white placeholder-gray-600"
+                        />
+                      </FormField>
                     )}
                     {toolIncapable && (
                       <ToolUseWarning model={effectiveModel} isProviderDefault={!draft.model} className="mt-1.5">

--- a/client/src/components/settings/ImageGenTab.jsx
+++ b/client/src/components/settings/ImageGenTab.jsx
@@ -12,6 +12,7 @@ import {
   Sparkles, Terminal, Key, Check, Trash2, SlidersHorizontal
 } from 'lucide-react';
 import toast from '../ui/Toast';
+import FormField from '../ui/FormField';
 import TabPills from '../ui/TabPills';
 import BrailleSpinner from '../BrailleSpinner';
 import LocalSetupPanel from './LocalSetupPanel';
@@ -727,24 +728,23 @@ export function ImageGenTab() {
           on the surface itself.
         </p>
         <div className="grid grid-cols-1 sm:grid-cols-[1fr_auto] gap-2 sm:items-center border border-port-border rounded-lg px-3 py-2 bg-port-bg/40">
-          <label htmlFor="video-default-mode" className="text-sm text-gray-300">
-            Default video backend
-            <span className="block text-xs text-gray-500 mt-0.5">
-              Used when a video render names no backend and its surface has no pin. Grok clips
-              render at 6s or 10s on xAI&rsquo;s fixed video backend.
-            </span>
-          </label>
-          <select
-            id="video-default-mode"
-            value={videoGenMode}
-            onChange={(e) => setVideoGenMode(e.target.value)}
-            className="bg-port-bg border border-port-border rounded-lg px-2 py-2 text-sm text-white focus:outline-none focus:border-port-accent sm:w-44"
+          <FormField
+            label={<>Default video backend<span className="block text-xs text-gray-500 mt-0.5">Used when a video render names no backend and its surface has no pin. Grok clips render at 6s or 10s on xAI&rsquo;s fixed video backend.</span></>}
+            labelClassName="text-sm text-gray-300"
+            className="contents"
           >
-            <option value="">Auto (Local)</option>
-            {VIDEO_RENDER_MODES.map((m) => (
-              <option key={m} value={m}>{modeLabel(m)}</option>
-            ))}
-          </select>
+            <select
+              id="video-default-mode"
+              value={videoGenMode}
+              onChange={(e) => setVideoGenMode(e.target.value)}
+              className="bg-port-bg border border-port-border rounded-lg px-2 py-2 text-sm text-white focus:outline-none focus:border-port-accent sm:w-44"
+            >
+              <option value="">Auto (Local)</option>
+              {VIDEO_RENDER_MODES.map((m) => (
+                <option key={m} value={m}>{modeLabel(m)}</option>
+              ))}
+            </select>
+          </FormField>
         </div>
         <div className="space-y-3">
           {RENDER_TARGET_OPTIONS.map(({ id, label, video }) => {
@@ -763,52 +763,57 @@ export function ImageGenTab() {
             });
             return (
               <div key={id} className={`grid grid-cols-1 ${video ? 'sm:grid-cols-[1fr_auto_auto_auto]' : 'sm:grid-cols-[1fr_auto_auto]'} gap-2 sm:items-center border border-port-border rounded-lg px-3 py-2`}>
-                <label htmlFor={modeSelectId} className="text-sm text-gray-300">{label}</label>
-                <select
-                  id={modeSelectId}
-                  value={pinnedMode}
-                  onChange={(e) => {
-                    const v = e.target.value;
-                    setPin('imageMode', v || null);
-                    // ANY backend change invalidates the pinned model — model ids
-                    // are namespaced per provider, and a codex→agy switch that
-                    // kept the gpt-* id would save a pin agy errors on. The
-                    // server's leak guard can't catch this case (mode and model
-                    // are pinned together), so the clear must happen here.
-                    setPin('imageModel', null);
-                  }}
-                  className="bg-port-bg border border-port-border rounded-lg px-2 py-2 text-sm text-white focus:outline-none focus:border-port-accent sm:w-44"
-                >
-                  <option value="">Auto (install default)</option>
-                  {[IMAGE_GEN_MODE.LOCAL, IMAGE_GEN_MODE.CODEX, IMAGE_GEN_MODE.GROK, IMAGE_GEN_MODE.AGY].map((m) => (
-                    <option key={m} value={m}>{modeLabel(m)}</option>
-                  ))}
-                </select>
-                {supportsCloudModelOverride(pinnedMode) ? (
-                  <input
-                    id={modelInputId}
-                    type="text"
-                    value={entry.imageModel || ''}
-                    onChange={(e) => setPin('imageModel', e.target.value.trim() || null)}
-                    placeholder="Model (optional)"
-                    aria-label={`${label} model`}
-                    className="bg-port-bg border border-port-border rounded-lg px-2 py-2 text-sm text-white focus:outline-none focus:border-port-accent sm:w-52"
-                  />
-                ) : <span className="hidden sm:block sm:w-52" />}
-                {video && (
+                <FormField label={label} labelClassName="text-sm text-gray-300" className="contents">
                   <select
-                    id={videoSelectId}
-                    value={pinnedVideoMode}
-                    onChange={(e) => setPin('videoMode', e.target.value || null)}
-                    aria-label={`${label} video backend`}
-                    title="Video backend for this surface — no model choice (Grok video has none; local video models are picked on the surface)"
+                    id={modeSelectId}
+                    value={pinnedMode}
+                    onChange={(e) => {
+                      const v = e.target.value;
+                      setPin('imageMode', v || null);
+                      // ANY backend change invalidates the pinned model — model ids
+                      // are namespaced per provider, and a codex→agy switch that
+                      // kept the gpt-* id would save a pin agy errors on. The
+                      // server's leak guard can't catch this case (mode and model
+                      // are pinned together), so the clear must happen here.
+                      setPin('imageModel', null);
+                    }}
                     className="bg-port-bg border border-port-border rounded-lg px-2 py-2 text-sm text-white focus:outline-none focus:border-port-accent sm:w-44"
                   >
-                    <option value="">Video: Auto</option>
-                    {VIDEO_RENDER_MODES.map((m) => (
-                      <option key={m} value={m}>Video: {modeLabel(m)}</option>
+                    <option value="">Auto (install default)</option>
+                    {[IMAGE_GEN_MODE.LOCAL, IMAGE_GEN_MODE.CODEX, IMAGE_GEN_MODE.GROK, IMAGE_GEN_MODE.AGY].map((m) => (
+                      <option key={m} value={m}>{modeLabel(m)}</option>
                     ))}
                   </select>
+                </FormField>
+                {supportsCloudModelOverride(pinnedMode) ? (
+                  <FormField label={`${label} model`} labelClassName="sr-only" className="contents">
+                    <input
+                      id={modelInputId}
+                      type="text"
+                      value={entry.imageModel || ''}
+                      onChange={(e) => setPin('imageModel', e.target.value.trim() || null)}
+                      placeholder="Model (optional)"
+                      aria-label={`${label} model`}
+                      className="bg-port-bg border border-port-border rounded-lg px-2 py-2 text-sm text-white focus:outline-none focus:border-port-accent sm:w-52"
+                    />
+                  </FormField>
+                ) : <span className="hidden sm:block sm:w-52" />}
+                {video && (
+                  <FormField label={`${label} video backend`} labelClassName="sr-only" className="contents">
+                    <select
+                      id={videoSelectId}
+                      value={pinnedVideoMode}
+                      onChange={(e) => setPin('videoMode', e.target.value || null)}
+                      aria-label={`${label} video backend`}
+                      title="Video backend for this surface — no model choice (Grok video has none; local video models are picked on the surface)"
+                      className="bg-port-bg border border-port-border rounded-lg px-2 py-2 text-sm text-white focus:outline-none focus:border-port-accent sm:w-44"
+                    >
+                      <option value="">Video: Auto</option>
+                      {VIDEO_RENDER_MODES.map((m) => (
+                        <option key={m} value={m}>Video: {modeLabel(m)}</option>
+                      ))}
+                    </select>
+                  </FormField>
                 )}
               </div>
             );
@@ -819,16 +824,17 @@ export function ImageGenTab() {
 
       {mediaTab === 'external' && (
         <div className="bg-port-card border border-port-border rounded-xl p-6 space-y-4">
-          <label htmlFor="sdapi-url" className="text-sm font-medium text-gray-300">External AUTOMATIC1111 / Forge URL</label>
-          <input
-            id="sdapi-url"
-            type="text"
-            value={sdapiUrl}
-            onChange={(e) => setSdapiUrl(e.target.value)}
-            className="w-full bg-port-bg border border-port-border rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-port-accent"
-            placeholder="http://localhost:7860"
-          />
-          <p className="text-xs text-gray-500">Base URL for the SD WebUI server PortOS should send generation requests to.</p>
+          <FormField label="External AUTOMATIC1111 / Forge URL" labelClassName="text-sm font-medium text-gray-300">
+            <input
+              id="sdapi-url"
+              type="text"
+              value={sdapiUrl}
+              onChange={(e) => setSdapiUrl(e.target.value)}
+              className="w-full bg-port-bg border border-port-border rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-port-accent"
+              placeholder="http://localhost:7860"
+            />
+            <p className="text-xs text-gray-500">Base URL for the SD WebUI server PortOS should send generation requests to.</p>
+          </FormField>
           <CleanersToggles
             cleanC2PA={cleanC2PAByMode.external}
             denoise={denoiseByMode.external}
@@ -895,8 +901,7 @@ export function ImageGenTab() {
         </label>
         {codexEnabled && (
           <div className="space-y-3 pl-6 border-l-2 border-port-border">
-            <div>
-              <label htmlFor={codexPathId} className="block text-xs font-medium text-gray-400 mb-1">Codex binary path (optional)</label>
+            <FormField label="Codex binary path (optional)" labelClassName="block text-xs font-medium text-gray-400 mb-1">
               <input
                 id={codexPathId}
                 type="text"
@@ -906,9 +911,8 @@ export function ImageGenTab() {
                 placeholder="codex (uses $PATH)"
               />
               <p className="text-xs text-gray-500 mt-1">Leave empty to invoke <code>codex</code> from $PATH.</p>
-            </div>
-            <div>
-              <label htmlFor={codexModelId} className="block text-xs font-medium text-gray-400 mb-1">Model override (optional)</label>
+            </FormField>
+            <FormField label="Model override (optional)" labelClassName="block text-xs font-medium text-gray-400 mb-1">
               <input
                 id={codexModelId}
                 type="text"
@@ -918,9 +922,8 @@ export function ImageGenTab() {
                 placeholder={`${CODEX_IMAGEGEN_DEFAULT_MODEL} (default)`}
               />
               <p className="text-xs text-gray-500 mt-1">Passed as <code>codex exec -m &lt;model&gt;</code>. Leave empty to use the cheap default (<code>{CODEX_IMAGEGEN_DEFAULT_MODEL}</code>).</p>
-            </div>
-            <div>
-              <label htmlFor={codexEffortId} className="block text-xs font-medium text-gray-400 mb-1">Reasoning effort (optional)</label>
+            </FormField>
+            <FormField label="Reasoning effort (optional)" labelClassName="block text-xs font-medium text-gray-400 mb-1">
               <select
                 id={codexEffortId}
                 value={codexEffort}
@@ -933,9 +936,8 @@ export function ImageGenTab() {
                 ))}
               </select>
               <p className="text-xs text-gray-500 mt-1">Passed as <code>codex exec -c model_reasoning_effort=&lt;level&gt;</code>. Lower effort is cheaper; leave on the shipped default (<code>{CODEX_IMAGEGEN_DEFAULT_EFFORT}</code>) or drop to <code>minimal</code> for the cheapest possible renders.</p>
-            </div>
-            <div>
-              <label htmlFor={codexParallelId} className="block text-xs font-medium text-gray-400 mb-1">Parallel render limit</label>
+            </FormField>
+            <FormField label="Parallel render limit" labelClassName="block text-xs font-medium text-gray-400 mb-1">
               <input
                 id={codexParallelId}
                 type="number"
@@ -961,7 +963,7 @@ export function ImageGenTab() {
                   </span>
                 )}
               </p>
-            </div>
+            </FormField>
             <CleanersToggles
               cleanC2PA={cleanC2PAByMode.codex}
               denoise={denoiseByMode.codex}
@@ -1012,8 +1014,7 @@ export function ImageGenTab() {
         </label>
         {grokEnabled && (
           <div className="space-y-3 pl-6 border-l-2 border-port-border">
-            <div>
-              <label htmlFor={grokPathId} className="block text-xs font-medium text-gray-400 mb-1">Grok binary path (optional)</label>
+            <FormField label="Grok binary path (optional)" labelClassName="block text-xs font-medium text-gray-400 mb-1">
               <input
                 id={grokPathId}
                 type="text"
@@ -1023,9 +1024,8 @@ export function ImageGenTab() {
                 placeholder="grok (uses $PATH)"
               />
               <p className="text-xs text-gray-500 mt-1">Leave empty to invoke <code>grok</code> from $PATH.</p>
-            </div>
-            <div>
-              <label htmlFor={grokRatioId} className="block text-xs font-medium text-gray-400 mb-1">Default aspect ratio (optional)</label>
+            </FormField>
+            <FormField label="Default aspect ratio (optional)" labelClassName="block text-xs font-medium text-gray-400 mb-1">
               <select
                 id={grokRatioId}
                 value={grokAspectRatio}
@@ -1040,7 +1040,7 @@ export function ImageGenTab() {
               <p className="text-xs text-gray-500 mt-1">
                 Applied when a render doesn't specify dimensions. A render's width/height maps to the nearest supported ratio automatically.
               </p>
-            </div>
+            </FormField>
             <CleanersToggles
               cleanC2PA={cleanC2PAByMode.grok}
               denoise={denoiseByMode.grok}
@@ -1080,8 +1080,7 @@ export function ImageGenTab() {
         </label>
         {agyEnabled && (
           <div className="space-y-3 pl-6 border-l-2 border-port-border">
-            <div>
-              <label htmlFor={agyPathId} className="block text-xs font-medium text-gray-400 mb-1">Agy binary path (optional)</label>
+            <FormField label="Agy binary path (optional)" labelClassName="block text-xs font-medium text-gray-400 mb-1">
               <input
                 id={agyPathId}
                 type="text"
@@ -1090,28 +1089,29 @@ export function ImageGenTab() {
                 className="w-full bg-port-bg border border-port-border rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-port-accent"
                 placeholder="agy (uses $PATH)"
               />
+            </FormField>
+            <div className="flex items-end justify-between gap-3 mb-1">
+              <FormField label="Agent model (drives the session — not the image model)" labelClassName="block text-xs font-medium text-gray-400" className="flex-1">
+                <input
+                  id={agyModelId}
+                  list={agyModelsListId}
+                  type="text"
+                  value={agyModel}
+                  onChange={(e) => setAgyModel(e.target.value)}
+                  className="w-full bg-port-bg border border-port-border rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-port-accent"
+                  placeholder={`${AGY_IMAGEGEN_DEFAULT_MODEL} (default)`}
+                />
+              </FormField>
+              <button
+                type="button"
+                onClick={refreshAgyModels}
+                disabled={agyModelsLoading}
+                className="text-xs text-port-accent hover:underline disabled:opacity-50"
+              >
+                {agyModelsLoading ? <BrailleSpinner text="Loading…" /> : 'Refresh models'}
+              </button>
             </div>
             <div>
-              <div className="flex items-end justify-between gap-3 mb-1">
-                <label htmlFor={agyModelId} className="block text-xs font-medium text-gray-400">Agent model (drives the session — not the image model)</label>
-                <button
-                  type="button"
-                  onClick={refreshAgyModels}
-                  disabled={agyModelsLoading}
-                  className="text-xs text-port-accent hover:underline disabled:opacity-50"
-                >
-                  {agyModelsLoading ? <BrailleSpinner text="Loading…" /> : 'Refresh models'}
-                </button>
-              </div>
-              <input
-                id={agyModelId}
-                list={agyModelsListId}
-                type="text"
-                value={agyModel}
-                onChange={(e) => setAgyModel(e.target.value)}
-                className="w-full bg-port-bg border border-port-border rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-port-accent"
-                placeholder={`${AGY_IMAGEGEN_DEFAULT_MODEL} (default)`}
-              />
               <datalist id={agyModelsListId}>
                 {agyModels.map((modelId) => <option key={modelId} value={modelId} />)}
               </datalist>
@@ -1193,11 +1193,8 @@ export function ImageGenTab() {
           </div>
         )}
 
-        <div>
-          <label htmlFor="hf-token-input" className="block text-xs font-medium text-gray-400 mb-1">
-            {hfTokenSource === 'stored' ? 'Replace stored token' : 'Paste a token'}
-          </label>
-          <div className="flex flex-col sm:flex-row gap-2">
+        <div className="flex flex-col sm:flex-row gap-2 items-end">
+          <FormField label={hfTokenSource === 'stored' ? 'Replace stored token' : 'Paste a token'} labelClassName="block text-xs font-medium text-gray-400 mb-1" className="flex-1 w-full">
             <input
               id="hf-token-input"
               type="password"
@@ -1210,16 +1207,16 @@ export function ImageGenTab() {
               spellCheck={false}
               className="flex-1 bg-port-bg border border-port-border rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-port-accent disabled:opacity-50"
             />
-            <button
-              type="button"
-              onClick={handleSaveHfToken}
-              disabled={hfTokenBusy !== null || !hfTokenInput.trim()}
-              className="whitespace-nowrap inline-flex items-center justify-center gap-2 px-4 py-2 rounded-lg bg-port-accent text-white text-sm font-medium hover:bg-port-accent/80 disabled:opacity-50 min-h-[40px]"
-            >
-              {hfTokenBusy === 'saving' ? <BrailleSpinner /> : <Save size={14} />}
-              Save token
-            </button>
-          </div>
+          </FormField>
+          <button
+            type="button"
+            onClick={handleSaveHfToken}
+            disabled={hfTokenBusy !== null || !hfTokenInput.trim()}
+            className="whitespace-nowrap inline-flex items-center justify-center gap-2 px-4 py-2 rounded-lg bg-port-accent text-white text-sm font-medium hover:bg-port-accent/80 disabled:opacity-50 min-h-[40px]"
+          >
+            {hfTokenBusy === 'saving' ? <BrailleSpinner /> : <Save size={14} />}
+            Save token
+          </button>
         </div>
 
         {hfTokenSource === 'stored' && (
@@ -1282,8 +1279,7 @@ export function ImageGenTab() {
           Send a prompt through {modeLabel(effectiveTestMode)} to verify end-to-end. For richer controls, visit the
           <a href="/media/image" className="text-port-accent hover:underline ml-1">Image Gen</a> page.
         </p>
-        <div>
-          <label htmlFor={testModeId} className="block text-sm text-gray-300 mb-1">Backend</label>
+        <FormField label="Backend" labelClassName="block text-sm text-gray-300 mb-1">
           <select
             id={testModeId}
             value={effectiveTestMode}
@@ -1300,17 +1296,18 @@ export function ImageGenTab() {
           <p className="text-xs text-gray-500 mt-1">
             Only enabled backends are listed — smoke-test one without making it your default.
           </p>
-        </div>
-        <label htmlFor="test-render-prompt" className="sr-only">Test prompt</label>
-        <textarea
-          id="test-render-prompt"
-          value={testPrompt}
-          onChange={(e) => setTestPrompt(e.target.value)}
-          rows={2}
-          disabled={rendering}
-          className="w-full bg-port-bg border border-port-border rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-port-accent disabled:opacity-50 resize-y"
-          placeholder="Describe the image you want..."
-        />
+        </FormField>
+        <FormField label="Test prompt" labelClassName="sr-only">
+          <textarea
+            id="test-render-prompt"
+            value={testPrompt}
+            onChange={(e) => setTestPrompt(e.target.value)}
+            rows={2}
+            disabled={rendering}
+            className="w-full bg-port-bg border border-port-border rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-port-accent disabled:opacity-50 resize-y"
+            placeholder="Describe the image you want..."
+          />
+        </FormField>
         <button
           type="button"
           onClick={handleRenderTest}

--- a/client/src/components/settings/ImageGenTab.jsx
+++ b/client/src/components/settings/ImageGenTab.jsx
@@ -1205,7 +1205,7 @@ export function ImageGenTab() {
               placeholder="hf_…"
               autoComplete="off"
               spellCheck={false}
-              className="flex-1 bg-port-bg border border-port-border rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-port-accent disabled:opacity-50"
+              className="w-full flex-1 bg-port-bg border border-port-border rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-port-accent disabled:opacity-50"
             />
           </FormField>
           <button

--- a/client/src/components/settings/LocalLlmTab.jsx
+++ b/client/src/components/settings/LocalLlmTab.jsx
@@ -1498,7 +1498,7 @@ export function LocalLlmTab() {
               value={query}
               onChange={(e) => setQuery(e.target.value)}
               placeholder={catalogSource === 'huggingface' ? (activeCategory === 'audio' ? 'Search Hugging Face audio models…' : 'Search Hugging Face GGUF models…') : `Search the ${labelFor(selected)} catalog…`}
-              className="flex-1 bg-transparent py-2 text-sm text-white placeholder-gray-600 focus:outline-none"
+              className="w-full flex-1 bg-transparent py-2 text-sm text-white placeholder-gray-600 focus:outline-none"
             />
             </FormField>
           </div>
@@ -1509,7 +1509,7 @@ export function LocalLlmTab() {
               value={manualId}
               onChange={(e) => setManualId(e.target.value)}
               placeholder={selected === 'ollama' ? 'pull by name e.g. llama3.2' : 'publisher/Model-GGUF'}
-              className="flex-1 sm:w-56 bg-port-bg border border-port-border rounded-lg px-3 py-2 text-sm text-white placeholder-gray-600 focus:outline-none focus:border-port-accent"
+              className="w-full flex-1 sm:w-56 bg-port-bg border border-port-border rounded-lg px-3 py-2 text-sm text-white placeholder-gray-600 focus:outline-none focus:border-port-accent"
             />
             </FormField>
             <button

--- a/client/src/components/settings/LocalLlmTab.jsx
+++ b/client/src/components/settings/LocalLlmTab.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import { Link, useNavigate } from 'react-router';
 import { Cpu, Box, Download, RefreshCw, Search, Plus, ExternalLink, Star, Link2, Copy, Play, Power, PowerOff, AlertTriangle, Zap, ChevronDown, ChevronUp, Terminal } from 'lucide-react';
 import toast from '../ui/Toast';
+import FormField from '../ui/FormField';
 import BrailleSpinner from '../BrailleSpinner';
 import { formatAgeDays, formatBytes, formatContextLength, timeAgo, recommendedRamGb, formatDateNumeric } from '../../utils/formatters';
 import { localLlmTargetKey } from '../../lib/localLlmTargetKey';
@@ -1135,26 +1136,26 @@ export function LocalLlmTab() {
             <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-2">
               <span className="text-xs font-medium text-gray-300">Launch Speculative Decoding Server</span>
               <div className="flex items-center gap-1.5">
-                <label htmlFor="llama-preset-select" className="text-[11px] text-gray-500">Preset:</label>
-                <select
-                  id="llama-preset-select"
-                  aria-label="Preset"
-                  onChange={(e) => handlePresetSelect(e.target.value)}
-                  value={llamaPresetId}
-                  className="bg-port-card border border-port-border rounded px-2 py-1 text-xs text-port-accent focus:outline-none"
-                >
-                  {specPresets.map((p) => (
-                    <option key={p.id} value={p.id}>
-                      {p.label}
-                    </option>
-                  ))}
-                </select>
+                <FormField label="Preset" labelClassName="text-[11px] text-gray-500" className="flex items-center gap-1.5">
+                  <select
+                    id="llama-preset-select"
+                    aria-label="Preset"
+                    onChange={(e) => handlePresetSelect(e.target.value)}
+                    value={llamaPresetId}
+                    className="bg-port-card border border-port-border rounded px-2 py-1 text-xs text-port-accent focus:outline-none"
+                  >
+                    {specPresets.map((p) => (
+                      <option key={p.id} value={p.id}>
+                        {p.label}
+                      </option>
+                    ))}
+                  </select>
+                </FormField>
               </div>
             </div>
 
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
-              <div>
-                <label htmlFor="llama-base-model" className="text-[11px] text-gray-400 block mb-1">Target Base Model (GGUF Path) *</label>
+              <FormField label="Target Base Model (GGUF Path) *" labelClassName="text-[11px] text-gray-400 block mb-1">
                 <input
                   id="llama-base-model"
                   aria-label="Target Base Model (GGUF Path)"
@@ -1164,9 +1165,8 @@ export function LocalLlmTab() {
                   placeholder={activeSpecPreset?.model?.path || 'models/your-target-Q4_K_M.gguf'}
                   className="w-full bg-port-card border border-port-border rounded px-2.5 py-1.5 text-xs text-white placeholder-gray-600 focus:outline-none focus:border-port-accent"
                 />
-              </div>
-              <div>
-                <label htmlFor="llama-draft-model" className="text-[11px] text-gray-400 block mb-1">Draft Model (Optional)</label>
+              </FormField>
+              <FormField label="Draft Model (Optional)" labelClassName="text-[11px] text-gray-400 block mb-1">
                 <input
                   id="llama-draft-model"
                   aria-label="Draft Model (Optional)"
@@ -1176,7 +1176,7 @@ export function LocalLlmTab() {
                   placeholder={activeSpecPreset?.draftModel?.path || 'models/your-drafter.gguf'}
                   className="w-full bg-port-card border border-port-border rounded px-2.5 py-1.5 text-xs text-white placeholder-gray-600 focus:outline-none focus:border-port-accent"
                 />
-              </div>
+              </FormField>
             </div>
 
             {activeSpecWeights.length > 0 && (
@@ -1199,8 +1199,7 @@ export function LocalLlmTab() {
 
             {showLlamaAdvanced && (
               <div className="grid grid-cols-2 sm:grid-cols-4 gap-2 pt-1 border-t border-port-border/40 text-xs">
-                <div>
-                  <label htmlFor="llama-port" className="text-[11px] text-gray-400 block mb-1">Port</label>
+                <FormField label="Port" labelClassName="text-[11px] text-gray-400 block mb-1">
                   <input
                     id="llama-port"
                     aria-label="Port"
@@ -1209,9 +1208,8 @@ export function LocalLlmTab() {
                     onChange={(e) => setLlamaNumber('port', e.target.value)}
                     className="w-full bg-port-card border border-port-border rounded px-2 py-1 text-xs text-white"
                   />
-                </div>
-                <div>
-                  <label htmlFor="llama-ctx-size" className="text-[11px] text-gray-400 block mb-1">Context Size</label>
+                </FormField>
+                <FormField label="Context Size" labelClassName="text-[11px] text-gray-400 block mb-1">
                   <input
                     id="llama-ctx-size"
                     aria-label="Context Size"
@@ -1220,9 +1218,8 @@ export function LocalLlmTab() {
                     onChange={(e) => setLlamaNumber('ctxSize', e.target.value)}
                     className="w-full bg-port-card border border-port-border rounded px-2 py-1 text-xs text-white"
                   />
-                </div>
-                <div>
-                  <label htmlFor="llama-gpu-layers" className="text-[11px] text-gray-400 block mb-1">GPU Layers (-ngl)</label>
+                </FormField>
+                <FormField label="GPU Layers (-ngl)" labelClassName="text-[11px] text-gray-400 block mb-1">
                   <input
                     id="llama-gpu-layers"
                     aria-label="GPU Layers (-ngl)"
@@ -1231,9 +1228,8 @@ export function LocalLlmTab() {
                     onChange={(e) => setLlamaNumber('nGpuLayers', e.target.value)}
                     className="w-full bg-port-card border border-port-border rounded px-2 py-1 text-xs text-white"
                   />
-                </div>
-                <div className="col-span-2">
-                  <label htmlFor="llama-parallel" className="text-[11px] text-gray-400 block mb-1">Parallel slots</label>
+                </FormField>
+                <FormField label="Parallel slots" labelClassName="text-[11px] text-gray-400 block mb-1" className="col-span-2">
                   <input
                     id="llama-parallel"
                     aria-label="Parallel slots"
@@ -1247,9 +1243,8 @@ export function LocalLlmTab() {
                   <p className="text-[11px] text-gray-500 mt-1">
                     llama.cpp divides context across this many request slots. 1 is right for a TUI agent.
                   </p>
-                </div>
-                <div className="col-span-2 sm:col-span-4">
-                  <label htmlFor="llama-spec-type" className="text-[11px] text-gray-400 block mb-1">Spec Type</label>
+                </FormField>
+                <FormField label="Spec Type" labelClassName="text-[11px] text-gray-400 block mb-1" className="col-span-2 sm:col-span-4">
                   <input
                     id="llama-spec-type"
                     aria-label="Spec Type"
@@ -1273,9 +1268,8 @@ export function LocalLlmTab() {
                   {specTypeNotice && (
                     <p className="text-[11px] text-port-warning mt-1">{specTypeNotice}</p>
                   )}
-                </div>
-                <div>
-                  <label htmlFor="llama-alias" className="text-[11px] text-gray-400 block mb-1">Model id (alias)</label>
+                </FormField>
+                <FormField label="Model id (alias)" labelClassName="text-[11px] text-gray-400 block mb-1">
                   <input
                     id="llama-alias"
                     aria-label="Model id (alias)"
@@ -1284,7 +1278,7 @@ export function LocalLlmTab() {
                     onChange={(e) => setLlamaForm((prev) => ({ ...prev, alias: e.target.value }))}
                     className="w-full bg-port-card border border-port-border rounded px-2 py-1 text-xs text-white"
                   />
-                </div>
+                </FormField>
 
                 {/* Performance tuning. Unlike the fields above, these have no
                     PortOS default — an empty one is stripped from the launch
@@ -1295,8 +1289,7 @@ export function LocalLlmTab() {
                   <Link to="/models/performance" className="text-port-accent hover:underline">Measure the difference</Link>{' '}
                   after changing one.
                 </p>
-                <div>
-                  <label htmlFor="llama-batch-size" className="text-[11px] text-gray-400 block mb-1">Batch size (-b)</label>
+                <FormField label="Batch size (-b)" labelClassName="text-[11px] text-gray-400 block mb-1">
                   <input
                     id="llama-batch-size"
                     aria-label="Batch size (-b)"
@@ -1306,9 +1299,8 @@ export function LocalLlmTab() {
                     onChange={(e) => setLlamaNumber('batchSize', e.target.value)}
                     className="w-full bg-port-card border border-port-border rounded px-2 py-1 text-xs text-white"
                   />
-                </div>
-                <div>
-                  <label htmlFor="llama-ubatch-size" className="text-[11px] text-gray-400 block mb-1">Micro-batch (-ub)</label>
+                </FormField>
+                <FormField label="Micro-batch (-ub)" labelClassName="text-[11px] text-gray-400 block mb-1">
                   <input
                     id="llama-ubatch-size"
                     aria-label="Micro-batch (-ub)"
@@ -1318,9 +1310,8 @@ export function LocalLlmTab() {
                     onChange={(e) => setLlamaNumber('ubatchSize', e.target.value)}
                     className="w-full bg-port-card border border-port-border rounded px-2 py-1 text-xs text-white"
                   />
-                </div>
-                <div>
-                  <label htmlFor="llama-threads" className="text-[11px] text-gray-400 block mb-1">CPU threads (-t)</label>
+                </FormField>
+                <FormField label="CPU threads (-t)" labelClassName="text-[11px] text-gray-400 block mb-1">
                   <input
                     id="llama-threads"
                     aria-label="CPU threads (-t)"
@@ -1330,7 +1321,7 @@ export function LocalLlmTab() {
                     onChange={(e) => setLlamaNumber('threads', e.target.value)}
                     className="w-full bg-port-card border border-port-border rounded px-2 py-1 text-xs text-white"
                   />
-                </div>
+                </FormField>
                 <div className="flex items-end gap-2 pb-1">
                   <input
                     id="llama-flash-attn"
@@ -1341,8 +1332,7 @@ export function LocalLlmTab() {
                   />
                   <label htmlFor="llama-flash-attn" className="text-[11px] text-gray-400">Flash attention</label>
                 </div>
-                <div>
-                  <label htmlFor="llama-cache-type-k" className="text-[11px] text-gray-400 block mb-1">KV cache K</label>
+                <FormField label="KV cache K" labelClassName="text-[11px] text-gray-400 block mb-1">
                   <select
                     id="llama-cache-type-k"
                     aria-label="KV cache K"
@@ -1353,9 +1343,8 @@ export function LocalLlmTab() {
                     <option value="">default</option>
                     {LLAMA_CACHE_TYPES.map((t) => <option key={t} value={t}>{t}</option>)}
                   </select>
-                </div>
-                <div>
-                  <label htmlFor="llama-cache-type-v" className="text-[11px] text-gray-400 block mb-1">KV cache V</label>
+                </FormField>
+                <FormField label="KV cache V" labelClassName="text-[11px] text-gray-400 block mb-1">
                   <select
                     id="llama-cache-type-v"
                     aria-label="KV cache V"
@@ -1366,7 +1355,7 @@ export function LocalLlmTab() {
                     <option value="">default</option>
                     {LLAMA_CACHE_TYPES.map((t) => <option key={t} value={t}>{t}</option>)}
                   </select>
-                </div>
+                </FormField>
               </div>
             )}
 
@@ -1503,7 +1492,7 @@ export function LocalLlmTab() {
         <div className="flex flex-col sm:flex-row gap-2">
           <div className="flex-1 flex items-center gap-2 bg-port-bg border border-port-border rounded-lg px-3 focus-within:border-port-accent">
             <Search size={14} className="text-gray-500" />
-            <label htmlFor="llm-catalog-search" className="sr-only">{`Search the ${labelFor(selected)} model catalog`}</label>
+            <FormField label={`Search the ${labelFor(selected)} model catalog`} labelClassName="sr-only" className="flex-1">
             <input
               id="llm-catalog-search"
               value={query}
@@ -1511,9 +1500,10 @@ export function LocalLlmTab() {
               placeholder={catalogSource === 'huggingface' ? (activeCategory === 'audio' ? 'Search Hugging Face audio models…' : 'Search Hugging Face GGUF models…') : `Search the ${labelFor(selected)} catalog…`}
               className="flex-1 bg-transparent py-2 text-sm text-white placeholder-gray-600 focus:outline-none"
             />
+            </FormField>
           </div>
           <div className="flex items-center gap-2">
-            <label htmlFor="llm-manual-install" className="sr-only">{`Install a ${labelFor(selected)} model by id`}</label>
+            <FormField label={`Install a ${labelFor(selected)} model by id`} labelClassName="sr-only" className="flex-1 sm:w-56">
             <input
               id="llm-manual-install"
               value={manualId}
@@ -1521,6 +1511,7 @@ export function LocalLlmTab() {
               placeholder={selected === 'ollama' ? 'pull by name e.g. llama3.2' : 'publisher/Model-GGUF'}
               className="flex-1 sm:w-56 bg-port-bg border border-port-border rounded-lg px-3 py-2 text-sm text-white placeholder-gray-600 focus:outline-none focus:border-port-accent"
             />
+            </FormField>
             <button
               onClick={() => { const id = manualId.trim(); if (id) { install(id); setManualId(''); } }}
               disabled={busy || !manualId.trim()}
@@ -1660,8 +1651,7 @@ export function LocalLlmTab() {
                       )}
                       {m.note && <div className="text-[11px] text-port-warning/90 mt-0.5">{m.note}</div>}
                       {hasVariantPicker && (
-                        <div className="flex items-center gap-1.5 flex-wrap mt-1">
-                          <label htmlFor={`quant-${m.key}`} className="text-[11px] text-gray-500">Quant</label>
+                        <FormField label="Quant" labelClassName="text-[11px] text-gray-500" className="flex items-center gap-1.5 flex-wrap mt-1">
                           <select
                             id={`quant-${m.key}`}
                             value={chosenId}
@@ -1681,7 +1671,7 @@ export function LocalLlmTab() {
                               {fitMeta.label}{fitMeasured ? ' (measured)' : ''}
                             </span>
                           )}
-                        </div>
+                        </FormField>
                       )}
                       <div className="flex items-center gap-1.5 flex-wrap text-[11px] text-gray-600 mt-1">
                         <span className="text-gray-500">{categoryLabel(m.category)}</span>


### PR DESCRIPTION
## Summary
- Migrated the Image Generation, Local LLM, and AI Assignments settings controls to the shared FormField component.
- Preserved native checkbox label controls and existing settings behavior, responsive layout, and model-selection flows.

## Test plan
- `npm test -- --run src/components/settings/ImageGenTab.test.jsx src/components/settings/LocalLlmTab.test.jsx src/components/settings/AiAssignmentsTab.test.jsx`
- `npm run lint`
- `npm run build`

Refs #4930

## Remaining
- Migrate the remaining settings tabs outside Image Generation, Local LLM, and AI Assignments.
- Migrate raw controls outside settings in subsystem-scoped slices.
