### PR TITLE
fix: validate legacy request bodies

### DIFF
--- a/server/lib/validation.js
+++ b/server/lib/validation.js
@@ -92,6 +92,26 @@ export const datadogConfigSchema = z.object({
   environment: z.string().optional()
 });
 
+// POST /api/datadog/instances. API keys may be empty when updating an
+// existing instance because the route preserves the stored secret in that
+// case.
+export const datadogInstanceRequestSchema = z.object({
+  id: z.string().trim().min(1).max(128),
+  name: z.string().trim().min(1).max(120),
+  site: z.string().trim().min(1).max(253),
+  apiKey: z.string().max(512).optional(),
+  appKey: z.string().max(512).optional(),
+});
+
+// POST /api/datadog/instances/:id/search-errors.
+export const datadogSearchErrorsRequestSchema = z.object({
+  serviceName: z.string().trim().min(1).max(256),
+  environment: z.string().trim().max(128).optional(),
+  fromTime: z.string().trim().refine(value => !Number.isNaN(Date.parse(value)), {
+    message: 'fromTime must be a valid ISO 8601 date string',
+  }).optional(),
+});
+
 // Reference-repo entry. Each app can list upstream repos it watches for
 // clean-room reimplementation;
 // the `reference-watch` scheduled task fetches each one, finds commits since
@@ -483,6 +503,33 @@ export const providerSchema = z.object({
   tuiPromptDelayMs: z.number().int().min(250).max(60000).optional(),
   tuiIdleTimeoutMs: z.number().int().min(1000).max(86400000).optional()
 });
+
+// POST /api/providers/:id/test-vision.
+export const providerVisionTestSchema = z.object({
+  imagePath: z.string().trim().min(1).max(255),
+  prompt: z.string().max(8_000).optional(),
+  expectedContent: z.union([
+    z.string().trim().min(1).max(128),
+    z.array(z.string().trim().min(1).max(128)).max(50),
+  ]).optional(),
+  model: z.preprocess(emptyToUndefined, z.string().trim().min(1).max(256).optional()),
+});
+
+// POST /api/providers/:id/vision-suite.
+export const providerVisionSuiteSchema = z.object({
+  model: z.preprocess(emptyToUndefined, z.string().trim().min(1).max(256).optional()),
+});
+
+// POST /api/uploads and POST /api/attachments. The shared upload helper
+// enforces decoded-byte limits and extension allowlists; this schema bounds
+// the JSON shape before the helper receives it.
+export const base64FileUploadSchema = z.object({
+  data: z.string().trim().min(1, 'data is required (base64)').max(64 * 1024 * 1024),
+  filename: z.string().min(1, 'filename is required').max(255),
+});
+
+export const uploadRequestSchema = base64FileUploadSchema;
+export const attachmentUploadRequestSchema = base64FileUploadSchema;
 
 // Run command schema
 export const runSchema = z.object({

--- a/server/lib/validation.js
+++ b/server/lib/validation.js
@@ -100,7 +100,9 @@ export const datadogInstanceRequestSchema = z.object({
   // outside the current preferred length/whitespace convention, and changing
   // the lookup key here would make those instances impossible to edit.
   id: z.string().min(1),
-  name: z.string().trim().min(1).max(120),
+  // Existing installs may have stored names longer than the current preferred
+  // display length, and updates should not make those records uneditable.
+  name: z.string().trim().min(1),
   site: z.string().trim().min(1).max(253),
   apiKey: z.string().max(512).optional(),
   appKey: z.string().max(512).optional(),

--- a/server/lib/validation.js
+++ b/server/lib/validation.js
@@ -513,10 +513,10 @@ export const providerSchema = z.object({
 export const providerVisionTestSchema = z.object({
   imagePath: z.string().trim().min(1).max(255),
   prompt: z.string().max(8_000).optional(),
-  expectedContent: z.union([
+  expectedContent: z.preprocess(emptyToUndefined, z.union([
     z.string().trim().min(1).max(128),
     z.array(z.string().trim().min(1).max(128)).max(50),
-  ]).optional(),
+  ]).optional()),
   model: z.preprocess(emptyToUndefined, z.string().trim().min(1).max(256).optional()),
 });
 
@@ -530,7 +530,8 @@ export const providerVisionSuiteSchema = z.object({
 // the JSON shape before the helper receives it.
 export const base64FileUploadSchema = z.object({
   data: z.string().trim().min(1, 'data is required (base64)').max(64 * 1024 * 1024),
-  filename: z.string().min(1, 'filename is required').max(255),
+  // The upload helper prefixes the sanitized name with a 9-byte UUID marker.
+  filename: z.string().min(1, 'filename is required').max(246),
 });
 
 export const uploadRequestSchema = base64FileUploadSchema;

--- a/server/lib/validation.js
+++ b/server/lib/validation.js
@@ -110,8 +110,8 @@ export const datadogInstanceRequestSchema = z.object({
 
 // POST /api/datadog/instances/:id/search-errors.
 export const datadogSearchErrorsRequestSchema = z.object({
-  serviceName: z.string().trim().min(1).max(256),
-  environment: z.string().trim().max(128).optional(),
+  serviceName: z.string().trim().min(1),
+  environment: z.string().trim().optional(),
   fromTime: z.preprocess(emptyToUndefined, z.string().trim().refine(value => !Number.isNaN(Date.parse(value)), {
     message: 'fromTime must be a valid ISO 8601 date string',
   }).optional()),

--- a/server/lib/validation.js
+++ b/server/lib/validation.js
@@ -110,9 +110,9 @@ export const datadogInstanceRequestSchema = z.object({
 export const datadogSearchErrorsRequestSchema = z.object({
   serviceName: z.string().trim().min(1).max(256),
   environment: z.string().trim().max(128).optional(),
-  fromTime: z.string().trim().refine(value => !Number.isNaN(Date.parse(value)), {
+  fromTime: z.preprocess(emptyToUndefined, z.string().trim().refine(value => !Number.isNaN(Date.parse(value)), {
     message: 'fromTime must be a valid ISO 8601 date string',
-  }).optional(),
+  }).optional()),
 });
 
 // Reference-repo entry. Each app can list upstream repos it watches for

--- a/server/lib/validation.js
+++ b/server/lib/validation.js
@@ -96,7 +96,10 @@ export const datadogConfigSchema = z.object({
 // existing instance because the route preserves the stored secret in that
 // case.
 export const datadogInstanceRequestSchema = z.object({
-  id: z.string().trim().min(1).max(128),
+  // Preserve the exact key for updates. Older installs may have stored IDs
+  // outside the current preferred length/whitespace convention, and changing
+  // the lookup key here would make those instances impossible to edit.
+  id: z.string().min(1),
   name: z.string().trim().min(1).max(120),
   site: z.string().trim().min(1).max(253),
   apiKey: z.string().max(512).optional(),

--- a/server/lib/validation.test.js
+++ b/server/lib/validation.test.js
@@ -48,6 +48,12 @@ import {
   databaseSwitchSchema,
   databaseBackendSchema,
   databaseExportSchema,
+  datadogInstanceRequestSchema,
+  datadogSearchErrorsRequestSchema,
+  providerVisionTestSchema,
+  providerVisionSuiteSchema,
+  uploadRequestSchema,
+  attachmentUploadRequestSchema,
   spriteTrackFrameCountSchema,
   spriteTrackFpsSchema,
   spriteRuntimeContractSchema,
@@ -72,6 +78,45 @@ import {
 } from './brainValidation.js';
 
 describe('validation.js', () => {
+  describe('issue #4922 request schemas', () => {
+    it('accepts the DataDog instance and error-search request shapes', () => {
+      expect(datadogInstanceRequestSchema.safeParse({
+        id: 'example-datadog',
+        name: 'Example DataDog',
+        site: 'api.datadoghq.com',
+        apiKey: '',
+        appKey: 'example-app-key',
+      }).success).toBe(true);
+      expect(datadogSearchErrorsRequestSchema.safeParse({
+        serviceName: 'example-service',
+        environment: 'staging',
+        fromTime: '2026-08-23T00:00:00.000Z',
+      }).success).toBe(true);
+    });
+
+    it('rejects malformed upload and vision request bodies', () => {
+      expect(uploadRequestSchema.safeParse({ filename: 'example.txt' }).success).toBe(false);
+      expect(attachmentUploadRequestSchema.safeParse({ data: 123, filename: 'example.txt' }).success).toBe(false);
+      expect(datadogSearchErrorsRequestSchema.safeParse({
+        serviceName: 'example-service',
+        fromTime: 'not-a-date',
+      }).success).toBe(false);
+      expect(providerVisionTestSchema.safeParse({
+        imagePath: 'example.png',
+        expectedContent: [123],
+      }).success).toBe(false);
+    });
+
+    it('normalizes blank optional vision models to undefined', () => {
+      expect(providerVisionTestSchema.parse({ imagePath: 'example.png', model: '' }).model).toBeUndefined();
+      expect(providerVisionSuiteSchema.parse({ model: '' }).model).toBeUndefined();
+      expect(providerVisionTestSchema.parse({
+        imagePath: 'example.png',
+        expectedContent: ['button', 'text'],
+      }).expectedContent).toEqual(['button', 'text']);
+    });
+  });
+
   describe('parseIndexParam', () => {
     it('returns a non-negative integer route parameter', () => {
       expect(parseIndexParam('0')).toBe(0);

--- a/server/lib/validation.test.js
+++ b/server/lib/validation.test.js
@@ -101,6 +101,10 @@ describe('validation.js', () => {
         serviceName: 'example-service',
         fromTime: '',
       }).fromTime).toBeUndefined();
+      expect(datadogSearchErrorsRequestSchema.safeParse({
+        serviceName: 's'.repeat(257),
+        environment: 'e'.repeat(129),
+      }).success).toBe(true);
       expect(providerVisionTestSchema.parse({
         imagePath: 'example.png',
         expectedContent: '',

--- a/server/lib/validation.test.js
+++ b/server/lib/validation.test.js
@@ -101,6 +101,14 @@ describe('validation.js', () => {
         serviceName: 'example-service',
         fromTime: '',
       }).fromTime).toBeUndefined();
+      expect(providerVisionTestSchema.parse({
+        imagePath: 'example.png',
+        expectedContent: '',
+      }).expectedContent).toBeUndefined();
+      expect(uploadRequestSchema.safeParse({
+        data: 'aGVsbG8=',
+        filename: `${'a'.repeat(247)}.txt`,
+      }).success).toBe(false);
     });
 
     it('rejects malformed upload and vision request bodies', () => {

--- a/server/lib/validation.test.js
+++ b/server/lib/validation.test.js
@@ -87,6 +87,11 @@ describe('validation.js', () => {
         apiKey: '',
         appKey: 'example-app-key',
       }).success).toBe(true);
+      expect(datadogInstanceRequestSchema.safeParse({
+        id: ` ${'legacy-id-'.repeat(20)} `,
+        name: 'Legacy DataDog',
+        site: 'api.datadoghq.com',
+      }).data.id).toBe(` ${'legacy-id-'.repeat(20)} `);
       expect(datadogSearchErrorsRequestSchema.safeParse({
         serviceName: 'example-service',
         environment: 'staging',

--- a/server/lib/validation.test.js
+++ b/server/lib/validation.test.js
@@ -97,6 +97,10 @@ describe('validation.js', () => {
         environment: 'staging',
         fromTime: '2026-08-23T00:00:00.000Z',
       }).success).toBe(true);
+      expect(datadogSearchErrorsRequestSchema.parse({
+        serviceName: 'example-service',
+        fromTime: '',
+      }).fromTime).toBeUndefined();
     });
 
     it('rejects malformed upload and vision request bodies', () => {

--- a/server/lib/validation.test.js
+++ b/server/lib/validation.test.js
@@ -89,7 +89,7 @@ describe('validation.js', () => {
       }).success).toBe(true);
       expect(datadogInstanceRequestSchema.safeParse({
         id: ` ${'legacy-id-'.repeat(20)} `,
-        name: 'Legacy DataDog',
+        name: ` ${'Legacy DataDog '.repeat(20)} `,
         site: 'api.datadoghq.com',
       }).data.id).toBe(` ${'legacy-id-'.repeat(20)} `);
       expect(datadogSearchErrorsRequestSchema.safeParse({

--- a/server/routes/attachments.js
+++ b/server/routes/attachments.js
@@ -12,6 +12,7 @@ import {
   ATTACHMENT_ALLOWED_EXTENSIONS, isPathInsideDir, saveBase64Upload, serveLocalFile,
 } from '../lib/fileUtils.js';
 import { MAX_BASE64_UPLOAD_BYTES } from '../lib/uploadLimits.js';
+import { validateRequest, attachmentUploadRequestSchema } from '../lib/validation.js';
 
 const ATTACHMENTS_DIR = PATHS.cosAttachments;
 
@@ -23,15 +24,7 @@ const MAX_FILE_SIZE = MAX_BASE64_UPLOAD_BYTES;
 
 // POST /api/attachments - Upload a file attachment (base64)
 router.post('/', asyncHandler(async (req, res) => {
-  const { data, filename } = req.body;
-
-  if (!data) {
-    throw new ServerError('data is required (base64)', { status: 400, code: 'VALIDATION_ERROR' });
-  }
-
-  if (!filename) {
-    throw new ServerError('filename is required', { status: 400, code: 'VALIDATION_ERROR' });
-  }
+  const { data, filename } = validateRequest(attachmentUploadRequestSchema, req.body);
 
   // Shared pipeline: allowlist → decode → size cap → `<uuid8>-name` → write.
   const saved = await saveBase64Upload(ATTACHMENTS_DIR, { filename, data }, {

--- a/server/routes/datadog.js
+++ b/server/routes/datadog.js
@@ -5,6 +5,11 @@
 import express from 'express';
 import * as datadogService from '../services/datadog.js';
 import { asyncHandler, ServerError } from '../lib/errorHandler.js';
+import {
+  validateRequest,
+  datadogInstanceRequestSchema,
+  datadogSearchErrorsRequestSchema,
+} from '../lib/validation.js';
 
 const router = express.Router();
 
@@ -41,14 +46,7 @@ router.get('/instances', asyncHandler(async (req, res) => {
  * Create or update DataDog instance
  */
 router.post('/instances', asyncHandler(async (req, res) => {
-  const { id, name, site, apiKey, appKey } = req.body;
-
-  if (!id || !name || !site) {
-    throw new ServerError('Missing required fields: id, name, site', {
-      status: 400,
-      code: 'INVALID_INPUT'
-    });
-  }
+  const { id, name, site, apiKey, appKey } = validateRequest(datadogInstanceRequestSchema, req.body);
 
   // For new instances, both keys are required
   const config = await datadogService.getInstances();
@@ -93,21 +91,7 @@ router.post('/instances/:id/test', asyncHandler(async (req, res) => {
  * Search for errors in DataDog logs
  */
 router.post('/instances/:id/search-errors', asyncHandler(async (req, res) => {
-  const { serviceName, environment, fromTime } = req.body;
-
-  if (!serviceName) {
-    throw new ServerError('serviceName is required', {
-      status: 400,
-      code: 'INVALID_INPUT'
-    });
-  }
-
-  if (fromTime && isNaN(Date.parse(fromTime))) {
-    throw new ServerError('fromTime must be a valid ISO 8601 date string', {
-      status: 400,
-      code: 'INVALID_INPUT'
-    });
-  }
+  const { serviceName, environment, fromTime } = validateRequest(datadogSearchErrorsRequestSchema, req.body);
 
   const result = await datadogService.searchErrors(
     req.params.id,

--- a/server/routes/providers.js
+++ b/server/routes/providers.js
@@ -8,6 +8,11 @@ import { createLineReader } from '../lib/streamLines.js';
 import { onClientDisconnect, openSseStream } from '../lib/sseDownload.js';
 import { createInstallLogger } from '../lib/installLogger.js';
 import {
+  validateRequest,
+  providerVisionTestSchema,
+  providerVisionSuiteSchema,
+} from '../lib/validation.js';
+import {
   describeRuntimeInstall,
   getProviderRuntime,
   getProviderRuntimeStatus,
@@ -588,11 +593,7 @@ export function createPortOSProviderRoutes(aiToolkit) {
   }));
 
   router.post('/:id/test-vision', asyncHandler(async (req, res) => {
-    const { imagePath, prompt, expectedContent, model } = req.body;
-
-    if (!imagePath) {
-      throw new ServerError('imagePath is required', { status: 400, code: 'VALIDATION_ERROR' });
-    }
+    const { imagePath, prompt, expectedContent, model } = validateRequest(providerVisionTestSchema, req.body);
 
     const result = await testVision({
       imagePath,
@@ -606,7 +607,7 @@ export function createPortOSProviderRoutes(aiToolkit) {
   }));
 
   router.post('/:id/vision-suite', asyncHandler(async (req, res) => {
-    const { model } = req.body;
+    const { model } = validateRequest(providerVisionSuiteSchema, req.body);
     const result = await runVisionTestSuite(req.params.id, model);
     res.json(result);
   }));

--- a/server/routes/uploads.js
+++ b/server/routes/uploads.js
@@ -12,6 +12,7 @@ import {
   EXTENSION_MIME_MAP, isPathInsideDir, saveBase64Upload, serveLocalFile,
 } from '../lib/fileUtils.js';
 import { MAX_BASE64_UPLOAD_BYTES } from '../lib/uploadLimits.js';
+import { validateRequest, uploadRequestSchema } from '../lib/validation.js';
 
 const UPLOADS_DIR = PATHS.uploads;
 
@@ -44,15 +45,7 @@ function formatSize(bytes) {
 
 // POST /api/uploads - Upload a file (base64)
 router.post('/', asyncHandler(async (req, res) => {
-  const { data, filename } = req.body;
-
-  if (!data) {
-    throw new ServerError('data is required (base64)', { status: 400, code: 'VALIDATION_ERROR' });
-  }
-
-  if (!filename) {
-    throw new ServerError('filename is required', { status: 400, code: 'VALIDATION_ERROR' });
-  }
+  const { data, filename } = validateRequest(uploadRequestSchema, req.body);
 
   // Shared pipeline: allowlist → decode → size cap → `<uuid8>-name` → write.
   const saved = await saveBase64Upload(UPLOADS_DIR, { filename, data }, {


### PR DESCRIPTION
## Summary
- add shared Zod request schemas for DataDog, uploads, attachments, and provider vision routes
- wire request validation while preserving legacy DataDog IDs, long names/search values, and blank defaults
- add regression coverage for malformed bodies and compatibility sentinels

Closes #4922

## Test plan
- `npm test -- --run lib/validation.test.js routes/attachments.test.js routes/uploads.test.js services/datadog.test.js services/visionTest.test.js routes/providers.status.test.js routes/providers.prerequisites.test.js routes/providers.readiness.test.js` (366 passed)
- Full server suite has one pre-existing Node 26 `checkNpmVersion.test.js` incompatibility; focused affected suites pass