### PR TITLE
fix: recover schedules view from load failures

### DIFF
--- a/client/src/components/agents/tabs/SchedulesTab.jsx
+++ b/client/src/components/agents/tabs/SchedulesTab.jsx
@@ -11,6 +11,7 @@ export default function SchedulesTab({ agentId }) {
   const [accounts, setAccounts] = useState([]);
   const [stats, setStats] = useState(null);
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState(false);
   const [showForm, setShowForm] = useState(false);
   const [formData, setFormData] = useState({
     agentId: agentId,
@@ -23,15 +24,21 @@ export default function SchedulesTab({ agentId }) {
   const [runningId, setRunningId] = useState(null);
 
   const fetchData = useCallback(async () => {
-    const [schedulesData, accountsData, statsData] = await Promise.all([
-      api.getAutomationSchedules(agentId),
-      api.getPlatformAccounts(agentId),
-      api.getScheduleStats()
-    ]);
-    setSchedules(schedulesData);
-    setAccounts(accountsData);
-    setStats(statsData);
-    setLoading(false);
+    setLoading(true);
+    setLoadError(false);
+    await Promise.all([
+      api.getAutomationSchedules(agentId, null, { silent: true }),
+      api.getPlatformAccounts(agentId, null, { silent: true }),
+      api.getScheduleStats({ silent: true })
+    ]).then(([nextSchedules, nextAccounts, nextStats]) => {
+      setSchedules(nextSchedules);
+      setAccounts(nextAccounts);
+      setStats(nextStats);
+    }).catch(() => {
+      setLoadError(true);
+    }).finally(() => {
+      setLoading(false);
+    });
   }, [agentId]);
 
   useEffect(() => {
@@ -119,6 +126,23 @@ export default function SchedulesTab({ agentId }) {
 
   if (loading) {
     return <div className="p-4"><BrailleSpinner text="Loading schedules" /></div>;
+  }
+
+  if (loadError) {
+    return (
+      <div className="p-4">
+        <div role="alert" className="rounded border border-port-error/40 bg-port-error/10 p-4 text-sm text-port-error">
+          <p>Could not load automation schedules.</p>
+          <button
+            type="button"
+            onClick={fetchData}
+            className="mt-3 rounded bg-port-error/20 px-3 py-1.5 text-xs font-medium hover:bg-port-error/30"
+          >
+            Retry
+          </button>
+        </div>
+      </div>
+    );
   }
 
   return (

--- a/client/src/components/agents/tabs/SchedulesTab.test.jsx
+++ b/client/src/components/agents/tabs/SchedulesTab.test.jsx
@@ -1,0 +1,39 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import SchedulesTab from './SchedulesTab.jsx';
+
+vi.mock('../../../services/api', () => ({
+  getAutomationSchedules: vi.fn(),
+  getPlatformAccounts: vi.fn(),
+  getScheduleStats: vi.fn(),
+}));
+
+import * as api from '../../../services/api';
+
+describe('SchedulesTab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('explains an initial load failure and retries without duplicate error toasts', async () => {
+    api.getAutomationSchedules
+      .mockRejectedValueOnce(new Error('network unavailable'))
+      .mockResolvedValueOnce([]);
+    api.getPlatformAccounts.mockResolvedValue([]);
+    api.getScheduleStats.mockResolvedValue(null);
+
+    render(<SchedulesTab agentId="agent-1" />);
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Could not load automation schedules.');
+    expect(api.getAutomationSchedules).toHaveBeenLastCalledWith('agent-1', null, { silent: true });
+    expect(api.getPlatformAccounts).toHaveBeenLastCalledWith('agent-1', null, { silent: true });
+    expect(api.getScheduleStats).toHaveBeenLastCalledWith({ silent: true });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+    });
+
+    expect(await screen.findByText('No schedules')).toBeInTheDocument();
+    expect(api.getAutomationSchedules).toHaveBeenCalledTimes(2);
+  });
+});

--- a/client/src/services/apiAccounts.js
+++ b/client/src/services/apiAccounts.js
@@ -1,12 +1,12 @@
 import { request } from './apiCore.js';
 
 // Platform Accounts
-export const getPlatformAccounts = (agentId = null, platform = null) => {
+export const getPlatformAccounts = (agentId = null, platform = null, options = {}) => {
   const params = new URLSearchParams();
   if (agentId) params.set('agentId', agentId);
   if (platform) params.set('platform', platform);
   const query = params.toString();
-  return request(`/agents/accounts${query ? `?${query}` : ''}`);
+  return request(`/agents/accounts${query ? `?${query}` : ''}`, options);
 };
 export const getPlatformAccount = (id) => request(`/agents/accounts/${id}`);
 export const createPlatformAccount = (data) => request('/agents/accounts', {

--- a/client/src/services/apiSchedules.js
+++ b/client/src/services/apiSchedules.js
@@ -1,15 +1,15 @@
 import { request } from './apiCore.js';
 
 // Automation Schedules
-export const getAutomationSchedules = (agentId = null, accountId = null) => {
+export const getAutomationSchedules = (agentId = null, accountId = null, options = {}) => {
   const params = new URLSearchParams();
   if (agentId) params.set('agentId', agentId);
   if (accountId) params.set('accountId', accountId);
   const query = params.toString();
-  return request(`/agents/schedules${query ? `?${query}` : ''}`);
+  return request(`/agents/schedules${query ? `?${query}` : ''}`, options);
 };
 export const getAutomationSchedule = (id) => request(`/agents/schedules/${id}`);
-export const getScheduleStats = () => request('/agents/schedules/stats');
+export const getScheduleStats = (options = {}) => request('/agents/schedules/stats', options);
 export const createAutomationSchedule = (data) => request('/agents/schedules', {
   method: 'POST',
   body: JSON.stringify(data)


### PR DESCRIPTION
## Summary
- Replace the indefinite Schedules loading state with an accessible failure message and Retry action.
- Suppress duplicate request toasts because the page now presents its own recovery UI.
- Add a regression test covering failed initial load and retry.

## Test plan
- `cd client && npm test -- --run src/components/agents/tabs/SchedulesTab.test.jsx src/components/CronSchedulePicker.test.jsx`
- `cd client && npm run build`