### PR TITLE
feat: configure per-instance feature participation

### DIFF
--- a/client/src/components/DailyPostWidget.jsx
+++ b/client/src/components/DailyPostWidget.jsx
@@ -15,9 +15,18 @@ export default function DailyPostWidget() {
   const [statsWeek, setStatsWeek] = useState(null);
   const [config, setConfig] = useState(null);
   const [topRec, setTopRec] = useState(null);
+  const [featureEnabled, setFeatureEnabled] = useState(true);
   const [loaded, setLoaded] = useState(false);
 
   const fetchData = useCallback(async () => {
+    const featureData = await api.getInstanceFeatures({ silent: true }).catch(() => null);
+    const postFeature = featureData?.features?.find((feature) => feature.id === 'post');
+    if (postFeature?.enabled === false) {
+      setFeatureEnabled(false);
+      setLoaded(true);
+      return;
+    }
+
     // Recommendations/config/week-stats are best-effort — a failure just hides
     // the extra rows; the streak card still renders from `stats`.
     const [data, week, cfg, recs] = await Promise.all([
@@ -30,6 +39,7 @@ export default function DailyPostWidget() {
     setStatsWeek(week);
     setConfig(cfg);
     setTopRec(recs?.recommendations?.[0] || null);
+    setFeatureEnabled(true);
     setLoaded(true);
   }, []);
 
@@ -37,7 +47,7 @@ export default function DailyPostWidget() {
     fetchData();
   }, [fetchData]);
 
-  if (!loaded) return null;
+  if (!loaded || !featureEnabled) return null;
 
   const streak = stats?.currentStreak ?? 0;
   const longest = stats?.longestStreak ?? 0;

--- a/client/src/components/DailyPostWidget.jsx
+++ b/client/src/components/DailyPostWidget.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { Link } from 'react-router';
 import { Brain, ArrowRight, Compass } from 'lucide-react';
 import * as api from '../services/api';
@@ -18,9 +18,12 @@ export default function DailyPostWidget() {
   const [topRec, setTopRec] = useState(null);
   const [featureEnabled, setFeatureEnabled] = useState(true);
   const [loaded, setLoaded] = useState(false);
+  const fetchGeneration = useRef(0);
 
   const fetchData = useCallback(async () => {
+    const generation = ++fetchGeneration.current;
     const featureData = await api.getInstanceFeatures({ silent: true }).catch(() => null);
+    if (generation !== fetchGeneration.current) return;
     const postFeature = featureData?.features?.find((feature) => feature.id === 'post');
     if (postFeature?.enabled !== true) {
       setFeatureEnabled(false);
@@ -36,6 +39,7 @@ export default function DailyPostWidget() {
       api.getPostConfig().catch(() => null),
       api.getPostRecommendations(1).catch(() => null),
     ]);
+    if (generation !== fetchGeneration.current) return;
     setStats(data);
     setStatsWeek(week);
     setConfig(cfg);
@@ -52,7 +56,10 @@ export default function DailyPostWidget() {
       fetchData();
     };
     window.addEventListener(INSTANCE_FEATURES_CHANGED, handleFeatureChange);
-    return () => window.removeEventListener(INSTANCE_FEATURES_CHANGED, handleFeatureChange);
+    return () => {
+      fetchGeneration.current += 1;
+      window.removeEventListener(INSTANCE_FEATURES_CHANGED, handleFeatureChange);
+    };
   }, [fetchData]);
 
   if (!loaded || !featureEnabled) return null;

--- a/client/src/components/DailyPostWidget.jsx
+++ b/client/src/components/DailyPostWidget.jsx
@@ -4,6 +4,7 @@ import { Brain, ArrowRight, Compass } from 'lucide-react';
 import * as api from '../services/api';
 import { streakGlyph } from '../lib/streakGlyph.js';
 import { computeGoalProgress } from './meatspace/post/constants';
+import { INSTANCE_FEATURES_CHANGED } from '../constants/events.js';
 
 // Surfaces the daily POST cognitive self-test on the dashboard: today's
 // completion status, the current practice streak, the top "what to practice
@@ -21,7 +22,7 @@ export default function DailyPostWidget() {
   const fetchData = useCallback(async () => {
     const featureData = await api.getInstanceFeatures({ silent: true }).catch(() => null);
     const postFeature = featureData?.features?.find((feature) => feature.id === 'post');
-    if (postFeature?.enabled === false) {
+    if (postFeature?.enabled !== true) {
       setFeatureEnabled(false);
       setLoaded(true);
       return;
@@ -45,6 +46,13 @@ export default function DailyPostWidget() {
 
   useEffect(() => {
     fetchData();
+    const handleFeatureChange = (event) => {
+      if (event.detail?.featureId !== 'post') return;
+      if (event.detail.enabled === false) setFeatureEnabled(false);
+      fetchData();
+    };
+    window.addEventListener(INSTANCE_FEATURES_CHANGED, handleFeatureChange);
+    return () => window.removeEventListener(INSTANCE_FEATURES_CHANGED, handleFeatureChange);
   }, [fetchData]);
 
   if (!loaded || !featureEnabled) return null;

--- a/client/src/components/DailyPostWidget.test.jsx
+++ b/client/src/components/DailyPostWidget.test.jsx
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { render, waitFor } from '@testing-library/react';
+import { act, render, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { INSTANCE_FEATURES_CHANGED } from '../constants/events.js';
 
 const mock = vi.hoisted(() => ({
   getInstanceFeatures: vi.fn(),
@@ -21,12 +23,43 @@ describe('DailyPostWidget', () => {
   });
 
   it('does not collect or render POST metrics when the feature is disabled', async () => {
-    const { container } = render(<DailyPostWidget />);
+    const { container } = render(<MemoryRouter><DailyPostWidget /></MemoryRouter>);
 
     await waitFor(() => expect(mock.getInstanceFeatures).toHaveBeenCalledWith({ silent: true }));
     expect(mock.getPostStats).not.toHaveBeenCalled();
     expect(mock.getPostConfig).not.toHaveBeenCalled();
     expect(mock.getPostRecommendations).not.toHaveBeenCalled();
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('does not collect POST metrics when feature participation cannot be read', async () => {
+    mock.getInstanceFeatures.mockRejectedValue(new Error('offline'));
+
+    const { container } = render(<MemoryRouter><DailyPostWidget /></MemoryRouter>);
+
+    await waitFor(() => expect(mock.getInstanceFeatures).toHaveBeenCalledWith({ silent: true }));
+    expect(mock.getPostStats).not.toHaveBeenCalled();
+    expect(mock.getPostConfig).not.toHaveBeenCalled();
+    expect(mock.getPostRecommendations).not.toHaveBeenCalled();
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('refreshes the mounted widget after POST participation changes', async () => {
+    mock.getInstanceFeatures
+      .mockResolvedValueOnce({ features: [{ id: 'post', enabled: true }] })
+      .mockResolvedValueOnce({ features: [{ id: 'post', enabled: false }] });
+    mock.getPostStats.mockResolvedValue({ completedToday: false, currentStreak: 2 });
+    mock.getPostConfig.mockResolvedValue({});
+    mock.getPostRecommendations.mockResolvedValue({ recommendations: [] });
+
+    const { container } = render(<MemoryRouter><DailyPostWidget /></MemoryRouter>);
+    await waitFor(() => expect(mock.getPostStats).toHaveBeenCalled());
+
+    act(() => window.dispatchEvent(new CustomEvent(INSTANCE_FEATURES_CHANGED, {
+      detail: { featureId: 'post', enabled: false },
+    })));
+
+    await waitFor(() => expect(mock.getInstanceFeatures).toHaveBeenCalledTimes(2));
     expect(container).toBeEmptyDOMElement();
   });
 });

--- a/client/src/components/DailyPostWidget.test.jsx
+++ b/client/src/components/DailyPostWidget.test.jsx
@@ -1,0 +1,32 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+
+const mock = vi.hoisted(() => ({
+  getInstanceFeatures: vi.fn(),
+  getPostStats: vi.fn(),
+  getPostConfig: vi.fn(),
+  getPostRecommendations: vi.fn(),
+}));
+
+vi.mock('../services/api', () => mock);
+
+import DailyPostWidget from './DailyPostWidget';
+
+describe('DailyPostWidget', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mock.getInstanceFeatures.mockResolvedValue({
+      features: [{ id: 'post', enabled: false }],
+    });
+  });
+
+  it('does not collect or render POST metrics when the feature is disabled', async () => {
+    const { container } = render(<DailyPostWidget />);
+
+    await waitFor(() => expect(mock.getInstanceFeatures).toHaveBeenCalledWith({ silent: true }));
+    expect(mock.getPostStats).not.toHaveBeenCalled();
+    expect(mock.getPostConfig).not.toHaveBeenCalled();
+    expect(mock.getPostRecommendations).not.toHaveBeenCalled();
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/client/src/components/DailyPostWidget.test.jsx
+++ b/client/src/components/DailyPostWidget.test.jsx
@@ -62,4 +62,26 @@ describe('DailyPostWidget', () => {
     await waitFor(() => expect(mock.getInstanceFeatures).toHaveBeenCalledTimes(2));
     expect(container).toBeEmptyDOMElement();
   });
+
+  it('ignores an in-flight POST read that started before opt-out', async () => {
+    let resolveStats;
+    const stats = new Promise((resolve) => { resolveStats = resolve; });
+    mock.getInstanceFeatures
+      .mockResolvedValueOnce({ features: [{ id: 'post', enabled: true }] })
+      .mockResolvedValueOnce({ features: [{ id: 'post', enabled: false }] });
+    mock.getPostStats.mockReturnValue(stats);
+    mock.getPostConfig.mockResolvedValue({});
+    mock.getPostRecommendations.mockResolvedValue({ recommendations: [] });
+
+    const { container } = render(<MemoryRouter><DailyPostWidget /></MemoryRouter>);
+    await waitFor(() => expect(mock.getPostStats).toHaveBeenCalled());
+
+    act(() => window.dispatchEvent(new CustomEvent(INSTANCE_FEATURES_CHANGED, {
+      detail: { featureId: 'post', enabled: false },
+    })));
+    await waitFor(() => expect(mock.getInstanceFeatures).toHaveBeenCalledTimes(2));
+
+    await act(async () => { resolveStats({ completedToday: false, currentStreak: 9 }); });
+    expect(container).toBeEmptyDOMElement();
+  });
 });

--- a/client/src/components/dashboard/WidgetSuggestions.test.jsx
+++ b/client/src/components/dashboard/WidgetSuggestions.test.jsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import WidgetSuggestions from './WidgetSuggestions';
+import { WIDGETS_BY_ID } from './widgetRegistry.jsx';
 
 // `quick-stats` ships with gate: (s) => s.apps.length > 0 — a deterministic
 // fixture lets us exercise the "data populated but widget missing" path
@@ -12,6 +13,14 @@ describe('WidgetSuggestions', () => {
     apps: [{ id: 'a1', name: 'app', overallStatus: 'online' }],
     usage: { currentStreak: 5, longestStreak: 5, hourlyActivity: [0, 0, 1, 0] },
   };
+
+  it('gates the Daily POST registry entry on instance participation', () => {
+    const gate = WIDGETS_BY_ID['daily-post'].gate;
+
+    expect(gate({ instanceFeatures: { features: [{ id: 'post', enabled: false }] } })).toBe(false);
+    expect(gate({ instanceFeatures: { features: [{ id: 'post', enabled: true }] } })).toBe(true);
+    expect(gate({})).toBe(false);
+  });
 
   it('renders nothing when every gated widget is already present', () => {
     const { container } = render(

--- a/client/src/components/dashboard/builtins/DailyDriverWidget.jsx
+++ b/client/src/components/dashboard/builtins/DailyDriverWidget.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { Link } from 'react-router';
 import {
   Compass, ArrowRight, X, CheckCircle2, Target, Sparkles,
@@ -37,6 +37,7 @@ export default function DailyDriverWidget({ dashboardState }) {
   const [goalsFailed, setGoalsFailed] = useState(false);
   const [loaded, setLoaded] = useState(false);
   const [dismissing, setDismissing] = useState(false);
+  const fetchGeneration = useRef(0);
 
   const refetchDashboard = dashboardState?.refetch;
   // The first landing of the local day (recorded server-side by the dashboard's
@@ -46,7 +47,9 @@ export default function DailyDriverWidget({ dashboardState }) {
   const firstVisitToday = !!dashboardState?.dailyDriver?.firstVisitToday;
 
   const fetchData = useCallback(async () => {
+    const generation = ++fetchGeneration.current;
     const featureData = await api.getInstanceFeatures({ silent: true }).catch(() => null);
+    if (generation !== fetchGeneration.current) return;
     const enabled = featureData?.features?.find((feature) => feature.id === 'post')?.enabled === true;
     setPostEnabled(enabled);
     const [stats, recs, goalsData] = await Promise.all([
@@ -54,6 +57,7 @@ export default function DailyDriverWidget({ dashboardState }) {
       enabled ? api.getPostRecommendations(1).catch(() => null) : Promise.resolve(null),
       api.getGoals({ silent: true }).catch(() => null),
     ]);
+    if (generation !== fetchGeneration.current) return;
     setPost(stats);
     setTopRec(recs?.recommendations?.[0] || null);
     // `goalsData?.goals` present ⇒ authoritative list; null ⇒ fetch failed.
@@ -75,7 +79,10 @@ export default function DailyDriverWidget({ dashboardState }) {
       fetchData();
     };
     window.addEventListener(INSTANCE_FEATURES_CHANGED, handleFeatureChange);
-    return () => window.removeEventListener(INSTANCE_FEATURES_CHANGED, handleFeatureChange);
+    return () => {
+      fetchGeneration.current += 1;
+      window.removeEventListener(INSTANCE_FEATURES_CHANGED, handleFeatureChange);
+    };
   }, [fetchData]);
 
   // Mark the day handled, then refetch dashboard state so the registry gate

--- a/client/src/components/dashboard/builtins/DailyDriverWidget.jsx
+++ b/client/src/components/dashboard/builtins/DailyDriverWidget.jsx
@@ -28,6 +28,7 @@ const AREA_ICONS = {
 export default function DailyDriverWidget({ dashboardState }) {
   const [post, setPost] = useState(null);
   const [topRec, setTopRec] = useState(null);
+  const [postEnabled, setPostEnabled] = useState(true);
   const [goals, setGoals] = useState([]);
   // Sentinel: distinguish "goals failed to load" from "no goals exist" so a
   // transient fetch failure doesn't show the "Define your goals" CTA to a user
@@ -44,9 +45,12 @@ export default function DailyDriverWidget({ dashboardState }) {
   const firstVisitToday = !!dashboardState?.dailyDriver?.firstVisitToday;
 
   const fetchData = useCallback(async () => {
+    const featureData = await api.getInstanceFeatures({ silent: true }).catch(() => null);
+    const enabled = featureData?.features?.find((feature) => feature.id === 'post')?.enabled !== false;
+    setPostEnabled(enabled);
     const [stats, recs, goalsData] = await Promise.all([
-      api.getPostStats().catch(() => null),
-      api.getPostRecommendations(1).catch(() => null),
+      enabled ? api.getPostStats().catch(() => null) : Promise.resolve(null),
+      enabled ? api.getPostRecommendations(1).catch(() => null) : Promise.resolve(null),
       api.getGoals({ silent: true }).catch(() => null),
     ]);
     setPost(stats);
@@ -107,30 +111,32 @@ export default function DailyDriverWidget({ dashboardState }) {
       </div>
 
       <div className="flex-1 overflow-y-auto space-y-3">
-        {/* ① Daily POST */}
-        <Link
-          to="/post/launcher"
-          className="flex items-center gap-2 p-2 rounded-lg border border-port-border hover:border-gray-600 transition-colors"
-        >
-          <Brain size={16} className="text-port-accent shrink-0" />
-          <div className="min-w-0 flex-1">
-            <div className="text-sm font-medium text-white">Daily POST</div>
-            <div className="text-xs text-gray-500 truncate">
-              {completedToday
-                ? `Done today · ${streak} day streak`
-                : topRec
-                  ? `Up next: ${topRec.title}`
-                  : 'Start your cognitive session'}
+        {/* ① Daily POST — omitted entirely when this install does not use POST. */}
+        {postEnabled && (
+          <Link
+            to="/post/launcher"
+            className="flex items-center gap-2 p-2 rounded-lg border border-port-border hover:border-gray-600 transition-colors"
+          >
+            <Brain size={16} className="text-port-accent shrink-0" />
+            <div className="min-w-0 flex-1">
+              <div className="text-sm font-medium text-white">Daily POST</div>
+              <div className="text-xs text-gray-500 truncate">
+                {completedToday
+                  ? `Done today · ${streak} day streak`
+                  : topRec
+                    ? `Up next: ${topRec.title}`
+                    : 'Start your cognitive session'}
+              </div>
             </div>
-          </div>
-          {completedToday ? (
-            <CheckCircle2 size={16} className="text-port-success shrink-0" />
-          ) : (
-            <span className="flex items-center gap-1 text-xs text-port-accent shrink-0">
-              Start <ArrowRight size={12} />
-            </span>
-          )}
-        </Link>
+            {completedToday ? (
+              <CheckCircle2 size={16} className="text-port-success shrink-0" />
+            ) : (
+              <span className="flex items-center gap-1 text-xs text-port-accent shrink-0">
+                Start <ArrowRight size={12} />
+              </span>
+            )}
+          </Link>
+        )}
 
         {/* ② Goal next-actions, empty-state nudge, or (on fetch failure) a
             neutral unavailable row — NOT the empty-state, which would wrongly
@@ -157,7 +163,7 @@ export default function DailyDriverWidget({ dashboardState }) {
           <>
             <div className="text-xs font-medium text-gray-400 uppercase tracking-wide">Next actions</div>
             {goals.map((goal) => {
-              const areas = getGoalFeatureAreas(goal);
+              const areas = getGoalFeatureAreas(goal).filter((area) => postEnabled || area.area !== 'post');
               const latestRec = goal.checkIns?.[goal.checkIns.length - 1]?.recommendations?.[0];
               return (
                 <div key={goal.id} className="p-2 rounded-lg border border-port-border">

--- a/client/src/components/dashboard/builtins/DailyDriverWidget.jsx
+++ b/client/src/components/dashboard/builtins/DailyDriverWidget.jsx
@@ -7,6 +7,7 @@ import {
 } from 'lucide-react';
 import * as api from '../../../services/api';
 import { getGoalFeatureAreas } from '../../../lib/goalFeatureMap.js';
+import { INSTANCE_FEATURES_CHANGED } from '../../../constants/events.js';
 
 // Resolve a feature-area icon NAME (kept as a string in goalFeatureMap so that
 // module stays React-free and server-mirrorable) to a lucide component.
@@ -46,7 +47,7 @@ export default function DailyDriverWidget({ dashboardState }) {
 
   const fetchData = useCallback(async () => {
     const featureData = await api.getInstanceFeatures({ silent: true }).catch(() => null);
-    const enabled = featureData?.features?.find((feature) => feature.id === 'post')?.enabled !== false;
+    const enabled = featureData?.features?.find((feature) => feature.id === 'post')?.enabled === true;
     setPostEnabled(enabled);
     const [stats, recs, goalsData] = await Promise.all([
       enabled ? api.getPostStats().catch(() => null) : Promise.resolve(null),
@@ -66,7 +67,16 @@ export default function DailyDriverWidget({ dashboardState }) {
     setLoaded(true);
   }, []);
 
-  useEffect(() => { fetchData(); }, [fetchData]);
+  useEffect(() => {
+    fetchData();
+    const handleFeatureChange = (event) => {
+      if (event.detail?.featureId !== 'post') return;
+      if (event.detail.enabled === false) setPostEnabled(false);
+      fetchData();
+    };
+    window.addEventListener(INSTANCE_FEATURES_CHANGED, handleFeatureChange);
+    return () => window.removeEventListener(INSTANCE_FEATURES_CHANGED, handleFeatureChange);
+  }, [fetchData]);
 
   // Mark the day handled, then refetch dashboard state so the registry gate
   // drops the card (which unmounts this widget). On failure, re-enable the

--- a/client/src/components/dashboard/builtins/DailyDriverWidget.test.jsx
+++ b/client/src/components/dashboard/builtins/DailyDriverWidget.test.jsx
@@ -4,6 +4,7 @@ import { MemoryRouter } from 'react-router';
 import DailyDriverWidget from './DailyDriverWidget';
 
 const mocks = vi.hoisted(() => ({
+  getInstanceFeatures: vi.fn(),
   getPostStats: vi.fn(),
   getPostRecommendations: vi.fn(),
   getGoals: vi.fn(),
@@ -21,6 +22,7 @@ const renderWidget = (dashboardState = {}) =>
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mocks.getInstanceFeatures.mockResolvedValue({ features: [{ id: 'post', enabled: true }] });
   mocks.getPostStats.mockResolvedValue({ completedToday: false, currentStreak: 3 });
   mocks.getPostRecommendations.mockResolvedValue({ recommendations: [{ title: 'Morse copy drill' }] });
   mocks.getGoals.mockResolvedValue({ goals: [] });
@@ -38,6 +40,21 @@ describe('DailyDriverWidget', () => {
     mocks.getPostStats.mockResolvedValue({ completedToday: true, currentStreak: 5 });
     renderWidget();
     expect(await screen.findByText(/Done today · 5 day streak/)).toBeTruthy();
+  });
+
+  it('does not collect or prompt for POST when it is disabled on this instance', async () => {
+    mocks.getInstanceFeatures.mockResolvedValue({ features: [{ id: 'post', enabled: false }] });
+    mocks.getGoals.mockResolvedValue({
+      goals: [{ id: 'g1', title: 'Finish the novel', category: 'mastery', status: 'active', checkIns: [] }],
+    });
+
+    renderWidget();
+
+    expect(await screen.findByText('Finish the novel')).toBeTruthy();
+    expect(screen.queryByText('Daily POST')).toBeNull();
+    expect(screen.queryByText('Memory')).toBeTruthy();
+    expect(mocks.getPostStats).not.toHaveBeenCalled();
+    expect(mocks.getPostRecommendations).not.toHaveBeenCalled();
   });
 
   it('shows the "Define your goals" empty-state when there are no active goals', async () => {

--- a/client/src/components/dashboard/builtins/DailyDriverWidget.test.jsx
+++ b/client/src/components/dashboard/builtins/DailyDriverWidget.test.jsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { act, render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
+import { INSTANCE_FEATURES_CHANGED } from '../../../constants/events.js';
 import DailyDriverWidget from './DailyDriverWidget';
 
 const mocks = vi.hoisted(() => ({
@@ -55,6 +56,33 @@ describe('DailyDriverWidget', () => {
     expect(screen.queryByText('Memory')).toBeTruthy();
     expect(mocks.getPostStats).not.toHaveBeenCalled();
     expect(mocks.getPostRecommendations).not.toHaveBeenCalled();
+  });
+
+  it('does not collect or prompt for POST when feature participation cannot be read', async () => {
+    mocks.getInstanceFeatures.mockRejectedValue(new Error('offline'));
+
+    renderWidget();
+
+    expect(await screen.findByText('Define your goals')).toBeTruthy();
+    expect(screen.queryByText('Daily POST')).toBeNull();
+    expect(mocks.getPostStats).not.toHaveBeenCalled();
+    expect(mocks.getPostRecommendations).not.toHaveBeenCalled();
+  });
+
+  it('removes the mounted POST prompt after participation changes', async () => {
+    mocks.getInstanceFeatures
+      .mockResolvedValueOnce({ features: [{ id: 'post', enabled: true }] })
+      .mockResolvedValueOnce({ features: [{ id: 'post', enabled: false }] });
+
+    renderWidget();
+    expect(await screen.findByText('Daily POST')).toBeTruthy();
+
+    act(() => window.dispatchEvent(new CustomEvent(INSTANCE_FEATURES_CHANGED, {
+      detail: { featureId: 'post', enabled: false },
+    })));
+
+    await waitFor(() => expect(screen.queryByText('Daily POST')).toBeNull());
+    expect(mocks.getInstanceFeatures).toHaveBeenCalledTimes(2);
   });
 
   it('shows the "Define your goals" empty-state when there are no active goals', async () => {

--- a/client/src/components/dashboard/builtins/DailyDriverWidget.test.jsx
+++ b/client/src/components/dashboard/builtins/DailyDriverWidget.test.jsx
@@ -85,6 +85,26 @@ describe('DailyDriverWidget', () => {
     expect(mocks.getInstanceFeatures).toHaveBeenCalledTimes(2);
   });
 
+  it('ignores an in-flight POST read that started before opt-out', async () => {
+    let resolveStats;
+    const stats = new Promise((resolve) => { resolveStats = resolve; });
+    mocks.getInstanceFeatures
+      .mockResolvedValueOnce({ features: [{ id: 'post', enabled: true }] })
+      .mockResolvedValueOnce({ features: [{ id: 'post', enabled: false }] });
+    mocks.getPostStats.mockReturnValue(stats);
+
+    renderWidget();
+    await waitFor(() => expect(mocks.getPostStats).toHaveBeenCalled());
+
+    act(() => window.dispatchEvent(new CustomEvent(INSTANCE_FEATURES_CHANGED, {
+      detail: { featureId: 'post', enabled: false },
+    })));
+    await waitFor(() => expect(mocks.getInstanceFeatures).toHaveBeenCalledTimes(2));
+
+    await act(async () => { resolveStats({ completedToday: false, currentStreak: 9 }); });
+    expect(screen.queryByText('Daily POST')).toBeNull();
+  });
+
   it('shows the "Define your goals" empty-state when there are no active goals', async () => {
     renderWidget();
     expect(await screen.findByText('Define your goals')).toBeTruthy();

--- a/client/src/components/dashboard/widgetRegistry.jsx
+++ b/client/src/components/dashboard/widgetRegistry.jsx
@@ -31,6 +31,10 @@ const DailyDriverWidget     = lazyWithReload(() => import('./builtins/DailyDrive
 const ActiveProcessingWidget = lazyWithReload(() => import('./ActiveProcessingWidget'));
 const DailyActionsWidget   = lazyWithReload(() => import('../DailyActionsWidget'));
 
+const postFeatureEnabled = (state) => state?.instanceFeatures?.features?.some(
+  (feature) => feature.id === 'post' && feature.enabled === true
+) === true;
+
 // Each entry: { id, label, Component, width, defaultH?, gate? }.
 // `gate(state) => bool` skips the widget when it has nothing useful to show.
 // The Apps tile is intentionally un-gated — it renders its own empty-state
@@ -60,7 +64,7 @@ export const WIDGETS = [
   { id: 'network-exposure',  label: 'Network Exposure',      Component: NetworkExposureWidget,  width: 'quarter', defaultH: 5 },
   { id: 'backup',            label: 'Backup',                Component: BackupWidget,           width: 'quarter', defaultH: 5 },
   { id: 'death-clock',       label: 'Death Clock',           Component: DeathClockWidget,       width: 'quarter', defaultH: 4 },
-  { id: 'daily-post',        label: 'Daily POST',            Component: DailyPostWidget,        width: 'quarter', defaultH: 3 },
+  { id: 'daily-post',        label: 'Daily POST',            Component: DailyPostWidget,        width: 'quarter', defaultH: 3, gate: postFeatureEnabled },
   { id: 'tribe-care',        label: 'Tribe Care',            Component: TribeCareWidget,        width: 'quarter', defaultH: 4, gate: (s) => !!s.tribeCare?.hasPeople },
   { id: 'quick-stats',       label: 'Quick Stats',           Component: QuickStatsWidget,       width: 'quarter', defaultH: 3, gate: (s) => s.apps.length > 0 },
   { id: 'decision-log',      label: 'Decision Log',          Component: DecisionLogWidget,      width: 'quarter', defaultH: 4 },

--- a/client/src/components/settings/InstanceFeaturesTab.jsx
+++ b/client/src/components/settings/InstanceFeaturesTab.jsx
@@ -1,0 +1,106 @@
+import { useCallback, useEffect, useState } from 'react';
+import toast from '../ui/Toast';
+import BrailleSpinner from '../BrailleSpinner';
+import ToggleSwitch from '../ToggleSwitch';
+import { getInstanceFeatures, updateInstanceFeature } from '../../services/api';
+
+export function InstanceFeaturesTab() {
+  const [features, setFeatures] = useState(null);
+  const [loadError, setLoadError] = useState(null);
+  const [savingId, setSavingId] = useState(null);
+
+  const loadFeatures = useCallback(() => {
+    setLoadError(null);
+    getInstanceFeatures({ silent: true })
+      .then((data) => setFeatures(Array.isArray(data?.features) ? data.features : []))
+      .catch((error) => {
+        setFeatures(null);
+        setLoadError(error.message || 'Failed to load instance features');
+      });
+  }, []);
+
+  useEffect(() => {
+    loadFeatures();
+  }, [loadFeatures]);
+
+  const handleToggle = async (feature) => {
+    if (!feature?.id || savingId) return;
+    const enabled = !feature.enabled;
+    const previous = features;
+    setSavingId(feature.id);
+    setFeatures((current) => current?.map((item) => (
+      item.id === feature.id ? { ...item, enabled } : item
+    )) || current);
+
+    const result = await updateInstanceFeature(feature.id, enabled, { silent: true }).catch((error) => {
+      toast.error(error.message || `Could not update ${feature.label}`);
+      return null;
+    });
+
+    if (!result) {
+      setFeatures(previous);
+    } else if (Array.isArray(result.features)) {
+      setFeatures(result.features);
+    }
+    setSavingId(null);
+  };
+
+  if (loadError) {
+    return (
+      <div className="space-y-3 max-w-3xl">
+        <p className="text-sm text-port-error">{loadError}</p>
+        <button
+          type="button"
+          onClick={loadFeatures}
+          className="inline-flex items-center justify-center min-h-[44px] px-3 text-sm bg-port-border hover:bg-port-border/70 text-white rounded transition-colors"
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  if (features === null) return <BrailleSpinner text="Loading instance features" />;
+
+  return (
+    <div className="space-y-6 max-w-3xl">
+      <div>
+        <h2 className="text-lg font-semibold text-white">Instance features</h2>
+        <p className="text-sm text-gray-400 mt-1">
+          Choose which optional PortOS features this install actively uses. Disabled features remain available when opened directly, but do not contribute passive metrics, reminders, or proactive prompts.
+        </p>
+      </div>
+
+      <div className="space-y-3">
+        {features.map((feature) => (
+          <div
+            key={feature.id}
+            className="flex items-start justify-between gap-4 bg-port-card border border-port-border rounded-lg p-4"
+          >
+            <div className="min-w-0">
+              <h3 className="text-sm font-semibold text-white">{feature.label}</h3>
+              <p className="text-sm text-gray-400 mt-1">{feature.description}</p>
+              <p className={`text-xs mt-2 ${feature.enabled ? 'text-port-success' : 'text-gray-500'}`}>
+                {feature.enabled ? 'Active on this instance' : 'Not used on this instance'}
+              </p>
+            </div>
+            <ToggleSwitch
+              enabled={feature.enabled}
+              onChange={() => handleToggle(feature)}
+              disabled={savingId !== null}
+              ariaLabel={`${feature.enabled ? 'Disable' : 'Enable'} ${feature.label} on this instance`}
+              className="mt-1"
+            />
+          </div>
+        ))}
+        {features.length === 0 && (
+          <div className="bg-port-card border border-port-border rounded-lg p-4 text-sm text-gray-400">
+            No optional features are registered for this version of PortOS.
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default InstanceFeaturesTab;

--- a/client/src/components/settings/InstanceFeaturesTab.test.jsx
+++ b/client/src/components/settings/InstanceFeaturesTab.test.jsx
@@ -1,0 +1,45 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+const mock = vi.hoisted(() => ({
+  getInstanceFeatures: vi.fn(),
+  updateInstanceFeature: vi.fn(),
+}));
+
+vi.mock('../../services/api', () => mock);
+
+import InstanceFeaturesTab from './InstanceFeaturesTab';
+
+const POST_FEATURE = {
+  id: 'post',
+  label: 'POST',
+  description: 'Daily cognitive practice, progress metrics, and reminder prompts.',
+  enabled: true,
+};
+
+describe('InstanceFeaturesTab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mock.getInstanceFeatures.mockResolvedValue({ features: [POST_FEATURE] });
+    mock.updateInstanceFeature.mockResolvedValue({ features: [{ ...POST_FEATURE, enabled: false }] });
+  });
+
+  it('shows the instance-local feature switch', async () => {
+    render(<InstanceFeaturesTab />);
+
+    const toggle = await screen.findByRole('switch', { name: 'Disable POST on this instance' });
+    expect(toggle).toHaveAttribute('aria-checked', 'true');
+    expect(screen.getByText('Active on this instance')).toBeInTheDocument();
+  });
+
+  it('persists a toggle and reflects the saved state', async () => {
+    render(<InstanceFeaturesTab />);
+    const toggle = await screen.findByRole('switch', { name: 'Disable POST on this instance' });
+
+    fireEvent.click(toggle);
+
+    await waitFor(() => expect(mock.updateInstanceFeature).toHaveBeenCalledWith('post', false, { silent: true }));
+    expect(toggle).toHaveAttribute('aria-checked', 'false');
+    expect(screen.getByText('Not used on this instance')).toBeInTheDocument();
+  });
+});

--- a/client/src/components/settings/SettingsTabsHeader.jsx
+++ b/client/src/components/settings/SettingsTabsHeader.jsx
@@ -16,6 +16,7 @@ export const TABS = [
   { id: 'catalog', label: 'Catalog', to: '/settings/catalog' },
   { id: 'code-reviewers', label: 'Code Reviewers', to: '/settings/code-reviewers' },
   { id: 'database', label: 'Database', to: '/settings/database' },
+  { id: 'features', label: 'Features', to: '/settings/features' },
   { id: 'general', label: 'General', to: '/settings/general' },
   { id: 'mortalloom', label: 'MortalLoom', to: '/settings/mortalloom' },
   { id: 'openclaw', label: 'OpenClaw', to: '/openclaw' },

--- a/client/src/constants/events.js
+++ b/client/src/constants/events.js
@@ -2,3 +2,4 @@
 // so the publisher and listener can't drift on spelling.
 
 export const DASHBOARD_LAYOUT_CHANGED = 'portos:dashboard-layout-changed';
+export const INSTANCE_FEATURES_CHANGED = 'portos:instance-features-changed';

--- a/client/src/hooks/useEngagementReminderToast.jsx
+++ b/client/src/hooks/useEngagementReminderToast.jsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import { Link } from 'react-router';
 import toast from '../components/ui/Toast';
 import * as api from '../services/api';
@@ -9,6 +9,24 @@ const SESSION_KEY = 'portos:engagement-reminders:v1';
 const MAX_REMINDER_KEYS = 100;
 
 function ReminderToast({ t, action }) {
+  const [disabling, setDisabling] = useState(false);
+  const canDisable = typeof action.featureId === 'string' && action.featureId.length > 0;
+
+  const handleDisable = async () => {
+    if (!canDisable || disabling) return;
+    setDisabling(true);
+    const result = await api.updateInstanceFeature(action.featureId, false, { silent: true }).catch((error) => {
+      toast.error(error.message || 'Could not disable this feature on the instance');
+      return null;
+    });
+    if (!result) {
+      setDisabling(false);
+      return;
+    }
+    toast.dismiss(t.id);
+    toast.success(`${action.featureLabel || action.featureId} disabled on this instance`);
+  };
+
   return (
     <div className="flex flex-col gap-2 max-w-[min(480px,calc(100vw-4rem))]">
       <div className="flex items-start gap-2">
@@ -20,14 +38,24 @@ function ReminderToast({ t, action }) {
         <Link
           to={action.link || '/'}
           onClick={() => toast.dismiss(t.id)}
-          className="inline-flex items-center justify-center min-h-[40px] px-3 rounded bg-port-accent/20 text-port-accent hover:bg-port-accent/30 text-xs font-medium"
+          className="inline-flex items-center justify-center min-h-[44px] px-3 rounded bg-port-accent/20 text-port-accent hover:bg-port-accent/30 text-xs font-medium"
         >
           Open action
         </Link>
+        {canDisable && (
+          <button
+            type="button"
+            onClick={handleDisable}
+            disabled={disabling}
+            className="inline-flex items-center justify-center min-h-[44px] px-3 text-xs text-port-warning hover:text-port-warning/80 disabled:opacity-50"
+          >
+            {disabling ? 'Disabling…' : 'Disable on this instance'}
+          </button>
+        )}
         <button
           type="button"
           onClick={() => toast.dismiss(t.id)}
-          className="inline-flex items-center justify-center min-h-[40px] px-3 text-xs text-port-text-muted hover:text-port-text"
+          className="inline-flex items-center justify-center min-h-[44px] px-3 text-xs text-port-text-muted hover:text-port-text"
         >
           Dismiss
         </button>

--- a/client/src/hooks/useEngagementReminderToast.jsx
+++ b/client/src/hooks/useEngagementReminderToast.jsx
@@ -4,6 +4,7 @@ import toast from '../components/ui/Toast';
 import * as api from '../services/api';
 import { safeReadJsonSession, safeWriteJsonSession } from '../lib/safeStorage';
 import { useAutoRefetch } from './useAutoRefetch';
+import { INSTANCE_FEATURES_CHANGED } from '../constants/events.js';
 
 const SESSION_KEY = 'portos:engagement-reminders:v1';
 const MAX_REMINDER_KEYS = 100;
@@ -24,6 +25,9 @@ function ReminderToast({ t, action }) {
       return;
     }
     toast.dismiss(t.id);
+    window.dispatchEvent(new CustomEvent(INSTANCE_FEATURES_CHANGED, {
+      detail: { featureId: action.featureId, enabled: false },
+    }));
     toast.success(`${action.featureLabel || action.featureId} disabled on this instance`);
   };
 

--- a/client/src/hooks/useEngagementReminderToast.test.jsx
+++ b/client/src/hooks/useEngagementReminderToast.test.jsx
@@ -10,6 +10,7 @@ const mock = vi.hoisted(() => ({
 vi.mock('../services/api', () => mock);
 
 import { toast, Toaster } from '../components/ui/Toast';
+import { INSTANCE_FEATURES_CHANGED } from '../constants/events.js';
 import { useEngagementReminderToast } from './useEngagementReminderToast';
 
 function Harness() {
@@ -51,10 +52,15 @@ describe('useEngagementReminderToast', () => {
 
   it('disables the feature and closes the reminder', async () => {
     render(<MemoryRouter><Harness /><Toaster /></MemoryRouter>);
+    const featureChanged = vi.fn();
+    window.addEventListener(INSTANCE_FEATURES_CHANGED, featureChanged);
     fireEvent.click(await screen.findByRole('button', { name: 'Disable on this instance' }));
 
     await waitFor(() => expect(mock.updateInstanceFeature).toHaveBeenCalledWith('post', false, { silent: true }));
+    await waitFor(() => expect(featureChanged).toHaveBeenCalledTimes(1));
+    expect(featureChanged.mock.calls[0][0].detail).toEqual({ featureId: 'post', enabled: false });
     expect(screen.queryByText('Daily POST is waiting')).toBeNull();
     expect(await screen.findByText('POST disabled on this instance')).toBeInTheDocument();
+    window.removeEventListener(INSTANCE_FEATURES_CHANGED, featureChanged);
   });
 });

--- a/client/src/hooks/useEngagementReminderToast.test.jsx
+++ b/client/src/hooks/useEngagementReminderToast.test.jsx
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+
+const mock = vi.hoisted(() => ({
+  getDailyActions: vi.fn(),
+  updateInstanceFeature: vi.fn(),
+}));
+
+vi.mock('../services/api', () => mock);
+
+import { toast, Toaster } from '../components/ui/Toast';
+import { useEngagementReminderToast } from './useEngagementReminderToast';
+
+function Harness() {
+  useEngagementReminderToast();
+  return null;
+}
+
+describe('useEngagementReminderToast', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    vi.clearAllMocks();
+    mock.getDailyActions.mockResolvedValue({
+      today: '2026-08-24',
+      actions: [{
+        id: 'daily-post',
+        type: 'post_engagement',
+        title: 'Daily POST is waiting',
+        detail: 'No POST activity today.',
+        link: '/post/launcher',
+        featureId: 'post',
+        featureLabel: 'POST',
+      }],
+    });
+    mock.updateInstanceFeature.mockResolvedValue({ features: [{ id: 'post', enabled: false }] });
+  });
+
+  afterEach(() => {
+    act(() => toast.dismiss());
+    cleanup();
+  });
+
+  it('keeps the action link and offers a per-instance disable button', async () => {
+    render(<MemoryRouter><Harness /><Toaster /></MemoryRouter>);
+
+    const link = await screen.findByRole('link', { name: 'Open action' });
+    expect(link).toHaveAttribute('href', '/post/launcher');
+    expect(screen.getByRole('button', { name: 'Disable on this instance' })).toBeInTheDocument();
+  });
+
+  it('disables the feature and closes the reminder', async () => {
+    render(<MemoryRouter><Harness /><Toaster /></MemoryRouter>);
+    fireEvent.click(await screen.findByRole('button', { name: 'Disable on this instance' }));
+
+    await waitFor(() => expect(mock.updateInstanceFeature).toHaveBeenCalledWith('post', false, { silent: true }));
+    expect(screen.queryByText('Daily POST is waiting')).toBeNull();
+    expect(await screen.findByText('POST disabled on this instance')).toBeInTheDocument();
+  });
+});

--- a/client/src/pages/Dashboard.jsx
+++ b/client/src/pages/Dashboard.jsx
@@ -14,6 +14,7 @@ import * as api from '../services/api';
 import socket from '../services/socket';
 import toast from '../components/ui/Toast';
 import { pickActiveLayoutId, recordManualLayoutPick } from '../utils/timeWindow.js';
+import { INSTANCE_FEATURES_CHANGED } from '../constants/events.js';
 
 export default function Dashboard() {
   const [apps, setApps] = useState([]);
@@ -114,8 +115,15 @@ export default function Dashboard() {
   useEffect(() => {
     fetchData();
     const handleAppsChanged = () => fetchData();
+    const handleFeatureChange = (event) => {
+      if (event.detail?.featureId === 'post') fetchData();
+    };
     socket.on('apps:changed', handleAppsChanged);
-    return () => socket.off('apps:changed', handleAppsChanged);
+    window.addEventListener(INSTANCE_FEATURES_CHANGED, handleFeatureChange);
+    return () => {
+      socket.off('apps:changed', handleAppsChanged);
+      window.removeEventListener(INSTANCE_FEATURES_CHANGED, handleFeatureChange);
+    };
   }, [fetchData]);
 
   // One-shot per mount — guards against re-evaluation stomping manual picks.

--- a/client/src/pages/Dashboard.jsx
+++ b/client/src/pages/Dashboard.jsx
@@ -8,13 +8,12 @@ import WidgetSuggestions from '../components/dashboard/WidgetSuggestions';
 import DashboardGrid, { readingOrderIds, reconcileGrid, synthesizeGrid } from '../components/dashboard/DashboardGrid.jsx';
 import { WIDGETS_BY_ID, FALLBACK_LAYOUT } from '../components/dashboard/widgetRegistry.jsx';
 import WidgetSkeleton from '../components/dashboard/WidgetSkeleton';
-import { DASHBOARD_LAYOUT_CHANGED } from '../constants/events.js';
+import { DASHBOARD_LAYOUT_CHANGED, INSTANCE_FEATURES_CHANGED } from '../constants/events.js';
 import { ChevronsDownUp, GripHorizontal, Monitor, Move, Save, X } from 'lucide-react';
 import * as api from '../services/api';
 import socket from '../services/socket';
 import toast from '../components/ui/Toast';
 import { pickActiveLayoutId, recordManualLayoutPick } from '../utils/timeWindow.js';
-import { INSTANCE_FEATURES_CHANGED } from '../constants/events.js';
 
 export default function Dashboard() {
   const [apps, setApps] = useState([]);
@@ -25,6 +24,7 @@ export default function Dashboard() {
   const [meatspaceLogging, setMeatspaceLogging] = useState(null);
   const [dailyDriver, setDailyDriver] = useState(null);
   const [dailyActions, setDailyActions] = useState(null);
+  const [instanceFeatures, setInstanceFeatures] = useState(null);
   const [loading, setLoading] = useState(true);
   const [dataError, setDataError] = useState(null);
   const [layoutsError, setLayoutsError] = useState(null);
@@ -78,6 +78,7 @@ export default function Dashboard() {
   // closure captured a possibly-stale activeLayout — lets it skip arming the
   // scroll when the user switched layouts while the add was still saving.
   const activeLayoutIdRef = useRef(null);
+  const instanceFeatureGenerationRef = useRef(0);
 
   const refreshHealth = useCallback(async () => {
     // Keep the last good snapshot visible when a manual refresh hits a
@@ -85,6 +86,14 @@ export default function Dashboard() {
     // response is always an object, even when some of its collections are empty.
     const data = await api.getSystemHealth({ silent: true }).catch(() => undefined);
     if (data) setHealth(data);
+    return data;
+  }, []);
+
+  const refreshInstanceFeatures = useCallback(async () => {
+    const generation = ++instanceFeatureGenerationRef.current;
+    const data = await api.getInstanceFeatures({ silent: true }).catch(() => null);
+    if (generation !== instanceFeatureGenerationRef.current) return null;
+    setInstanceFeatures(data);
     return data;
   }, []);
 
@@ -101,6 +110,7 @@ export default function Dashboard() {
       // hides the Daily Driver card via its gate. No LLM calls here.
       api.getDailyDriverState().catch(() => null),
       api.getDailyActions({ silent: true }).catch(() => null),
+      refreshInstanceFeatures(),
     ]);
     setApps(appsData);
     setUsage(usageData);
@@ -110,17 +120,28 @@ export default function Dashboard() {
     setDailyDriver(dailyDriverData);
     setDailyActions(dailyActionsData);
     setLoading(false);
-  }, [refreshHealth]);
+  }, [refreshHealth, refreshInstanceFeatures]);
 
   useEffect(() => {
     fetchData();
     const handleAppsChanged = () => fetchData();
     const handleFeatureChange = (event) => {
-      if (event.detail?.featureId === 'post') fetchData();
+      if (event.detail?.featureId !== 'post') return;
+      const enabled = event.detail.enabled === true;
+      setInstanceFeatures((current) => {
+        const features = Array.isArray(current?.features) ? current.features : [];
+        const hasPost = features.some((feature) => feature.id === 'post');
+        const nextFeatures = hasPost
+          ? features.map((feature) => feature.id === 'post' ? { ...feature, enabled } : feature)
+          : [...features, { id: 'post', enabled }];
+        return { ...(current || {}), features: nextFeatures };
+      });
+      fetchData();
     };
     socket.on('apps:changed', handleAppsChanged);
     window.addEventListener(INSTANCE_FEATURES_CHANGED, handleFeatureChange);
     return () => {
+      instanceFeatureGenerationRef.current += 1;
       socket.off('apps:changed', handleAppsChanged);
       window.removeEventListener(INSTANCE_FEATURES_CHANGED, handleFeatureChange);
     };
@@ -212,8 +233,8 @@ export default function Dashboard() {
   }), [activeApps]);
 
   const dashboardState = useMemo(
-    () => ({ apps, sortedApps, activeApps, appStats, health, usage, tribeCare, feeds, meatspaceLogging, dailyDriver, dailyActions, refetch: fetchData, refetchHealth: refreshHealth }),
-    [apps, sortedApps, activeApps, appStats, health, usage, tribeCare, feeds, meatspaceLogging, dailyDriver, dailyActions, fetchData, refreshHealth]
+    () => ({ apps, sortedApps, activeApps, appStats, health, usage, tribeCare, feeds, meatspaceLogging, dailyDriver, dailyActions, instanceFeatures, refetch: fetchData, refetchHealth: refreshHealth }),
+    [apps, sortedApps, activeApps, appStats, health, usage, tribeCare, feeds, meatspaceLogging, dailyDriver, dailyActions, instanceFeatures, fetchData, refreshHealth]
   );
 
   // Falls back to a local minimal layout only AFTER the initial fetch has

--- a/client/src/pages/Settings.jsx
+++ b/client/src/pages/Settings.jsx
@@ -8,6 +8,7 @@ import { BackupTab } from '../components/settings/BackupTab';
 import { CatalogTypesTab } from '../components/settings/CatalogTypesTab';
 import CodeReviewersTab from '../components/settings/CodeReviewersTab';
 import { DatabaseTab } from '../components/settings/DatabaseTab';
+import InstanceFeaturesTab from '../components/settings/InstanceFeaturesTab';
 import { TelegramTab } from '../components/settings/TelegramTab';
 import { GeneralTab } from '../components/settings/GeneralTab';
 import { MortalLoomTab } from '../components/settings/MortalLoomTab';
@@ -45,6 +46,7 @@ export default function Settings() {
       case 'catalog': return <CatalogTypesTab />;
       case 'code-reviewers': return <CodeReviewersTab />;
       case 'database': return <DatabaseTab />;
+      case 'features': return <InstanceFeaturesTab />;
       case 'security': return <SecurityTab />;
       case 'sharing': return <SharingTab />;
       case 'signal': return <SignalTab />;

--- a/client/src/pages/Settings.tabs.test.jsx
+++ b/client/src/pages/Settings.tabs.test.jsx
@@ -18,6 +18,9 @@ vi.mock('../components/settings/CodeReviewersTab', () => ({
 vi.mock('../components/settings/GeneralTab', () => ({
   GeneralTab: () => <div data-testid="general-tab" />,
 }));
+vi.mock('../components/settings/InstanceFeaturesTab', () => ({
+  default: () => <div data-testid="instance-features-tab" />,
+}));
 
 const Settings = (await import('./Settings')).default;
 
@@ -38,6 +41,19 @@ describe('Settings — Code Reviewers tab', () => {
   it('routes /settings/code-reviewers to the Code Reviewers panel', () => {
     renderTab('/settings/code-reviewers');
     expect(screen.getByTestId('code-reviewers-tab')).toBeTruthy();
+    expect(screen.queryByTestId('general-tab')).toBeNull();
+  });
+});
+
+describe('Settings — Instance Features tab', () => {
+  it('is listed in the settings sub-nav', () => {
+    const tab = TABS.find(t => t.id === 'features');
+    expect(tab?.to).toBe('/settings/features');
+  });
+
+  it('routes /settings/features to the feature participation panel', () => {
+    renderTab('/settings/features');
+    expect(screen.getByTestId('instance-features-tab')).toBeTruthy();
     expect(screen.queryByTestId('general-tab')).toBeNull();
   });
 });

--- a/client/src/services/apiSystem.js
+++ b/client/src/services/apiSystem.js
@@ -65,6 +65,12 @@ export const syncPortosFork = (opts = {}, requestOpts = {}) => request('/update/
 
 // Settings
 export const getSettings = (options) => request('/settings', options);
+export const getInstanceFeatures = (options) => request('/settings/features', options);
+export const updateInstanceFeature = (featureId, enabled, options = {}) => request(`/settings/features/${encodeURIComponent(featureId)}`, {
+  method: 'PUT',
+  body: JSON.stringify({ enabled }),
+  ...options,
+});
 export const updateSettings = (data, options) => request('/settings', {
   method: 'PUT',
   body: JSON.stringify(data),

--- a/server/lib/navManifest.js
+++ b/server/lib/navManifest.js
@@ -282,6 +282,7 @@ export const NAV_COMMANDS = [
   { id: 'nav.settings.catalog', path: '/settings/catalog', label: 'Catalog Types', section: 'Settings', aliases: ['settings-catalog', 'catalog-types'], keywords: ['catalog', 'types', 'character', 'place', 'object', 'taxonomy'] },
   { id: 'nav.settings.code-reviewers', path: '/settings/code-reviewers', label: 'Code Reviewers', section: 'Settings', aliases: ['code-reviewers', 'settings-code-reviewers', 'code-review', 'review-defaults', 'reviewers'], keywords: ['review loop', 'reviewer chain', 'codex', 'copilot', 'ollama', 'stop mode', 'max rounds', 'defaults'] },
   { id: 'nav.settings.database', path: '/settings/database', label: 'Database', section: 'Settings', aliases: ['settings-database', 'database'] },
+  { id: 'nav.settings.features', path: '/settings/features', label: 'Features', section: 'Settings', aliases: ['settings-features', 'instance-features', 'feature-usage'], keywords: ['enabled', 'disabled', 'instance', 'optional', 'participation', 'metrics', 'reminders'] },
   { id: 'nav.settings.general', path: '/settings/general', label: 'General', section: 'Settings', aliases: ['settings', 'settings-general', 'general'] },
   // Local-model management is its own top-level section (#4736), which grew to
   // cover every KIND of model this install manages (#4728) — image/video

--- a/server/lib/validation.js
+++ b/server/lib/validation.js
@@ -756,6 +756,21 @@ export const apiAccessSettingsSchema = z.object({
   sdapi: apiAccessEntrySchema.optional(),
 }).strict();
 
+// Install-local feature participation flags. The registry owns the available
+// feature ids; this schema keeps generic settings saves from persisting an
+// unknown or malformed feature state.
+export const instanceFeatureSettingsSchema = z.object({
+  post: z.object({
+    enabled: z.boolean().optional(),
+  }).strict().optional(),
+}).strict();
+
+export const instanceFeatureIdSchema = z.enum(['post']);
+
+export const instanceFeatureUpdateSchema = z.object({
+  enabled: z.boolean(),
+}).strict();
+
 export const subdirFilterSchema = z.string()
   .refine(isSafeSubdirFilter, 'subdirFilter must be a relative path with no wildcard, ".." , or leading "/" segments');
 

--- a/server/routes/settings.js
+++ b/server/routes/settings.js
@@ -10,10 +10,11 @@ import {
   CODEX_PARALLEL_DEFAULT,
 } from '../services/mediaJobQueue/index.js';
 import { assertMediaRoutingConfig } from '../services/federatedMedia/routingPolicy.js';
+import { getInstanceFeatures, updateInstanceFeature } from '../services/instanceFeatures.js';
 import { asyncHandler } from '../lib/errorHandler.js';
 import { isPlainObject } from '../lib/objects.js';
 import { agentContextSettingsSchema } from '../lib/agentContextValidation.js';
-import { backupConfigSchema, sharingSettingsPatchSchema, featureProviderConfigSchema, autofixerSettingsSchema, codeReviewSettingsSchema, locationSettingsSchema, settingsEmbeddingsSchema, localLlmSettingsSchema, openWorldSnapshotConfigSchema, imessageConfigSchema, signalConfigSchema, spotifyConfigSchema, youtubeConfigSchema, apiAccessSettingsSchema, loraTrainingConfigSchema, pipelineEditorialChecksSettingsSchema, creativeDirectorSettingsSchema, musicSettingsSchema, federationSettingsSchema, privacySettingsSchema, seriesAutopilotSettingsSchema, layeredIntelligenceSettingsSchema, imageGenGrokSettingsSchema, imageGenAgySettingsSchema, renderDefaultsSettingsSchema, videoGenSettingsSchema, subscriptionCostsMapSchema, validateRequest } from '../lib/validation.js';
+import { backupConfigSchema, sharingSettingsPatchSchema, featureProviderConfigSchema, autofixerSettingsSchema, codeReviewSettingsSchema, locationSettingsSchema, settingsEmbeddingsSchema, localLlmSettingsSchema, openWorldSnapshotConfigSchema, imessageConfigSchema, signalConfigSchema, spotifyConfigSchema, youtubeConfigSchema, apiAccessSettingsSchema, instanceFeatureSettingsSchema, instanceFeatureIdSchema, instanceFeatureUpdateSchema, loraTrainingConfigSchema, pipelineEditorialChecksSettingsSchema, creativeDirectorSettingsSchema, musicSettingsSchema, federationSettingsSchema, privacySettingsSchema, seriesAutopilotSettingsSchema, layeredIntelligenceSettingsSchema, imageGenGrokSettingsSchema, imageGenAgySettingsSchema, renderDefaultsSettingsSchema, videoGenSettingsSchema, subscriptionCostsMapSchema, validateRequest } from '../lib/validation.js';
 
 const router = Router();
 
@@ -153,6 +154,18 @@ router.get('/ai-assignments', asyncHandler(async (_req, res) => {
   res.json(await getAiAssignments());
 }));
 
+// GET /api/settings/features
+router.get('/features', asyncHandler(async (_req, res) => {
+  res.json(await getInstanceFeatures());
+}));
+
+// PUT /api/settings/features/:featureId
+router.put('/features/:featureId', asyncHandler(async (req, res) => {
+  const featureId = validateRequest(instanceFeatureIdSchema, req.params.featureId);
+  const { enabled } = validateRequest(instanceFeatureUpdateSchema, req.body || {});
+  res.json(await updateInstanceFeature(featureId, enabled));
+}));
+
 // PUT /api/settings/ai-assignments/:id
 router.put('/ai-assignments/:id', asyncHandler(async (req, res) => {
   const payload = validateRequest(aiAssignmentUpdateSchema, req.body || {});
@@ -260,6 +273,9 @@ router.put('/', asyncHandler(async (req, res) => {
   // disk (the registry would then silently treat it as its default).
   if (req.body?.apiAccess !== undefined) {
     validateRequest(apiAccessSettingsSchema.partial(), req.body.apiAccess);
+  }
+  if (req.body?.instanceFeatures !== undefined) {
+    validateRequest(instanceFeatureSettingsSchema, req.body.instanceFeatures);
   }
   // Local MCP agent-context opt-in. Validate the whole strict slice so an
   // unknown scope/profile cannot silently broaden what the server exposes.

--- a/server/routes/settings.test.js
+++ b/server/routes/settings.test.js
@@ -91,6 +91,46 @@ describe('Settings routes — apiAccess slice', () => {
   });
 });
 
+describe('Settings routes — instance feature participation', () => {
+  beforeEach(() => {
+    store = {};
+    vi.clearAllMocks();
+  });
+
+  it('lists local feature participation with the backward-compatible default', async () => {
+    const res = await request(buildApp()).get('/api/settings/features');
+
+    expect(res.status).toBe(200);
+    expect(res.body.features).toEqual([expect.objectContaining({ id: 'post', label: 'POST', enabled: true })]);
+  });
+
+  it('updates one feature without replacing unrelated settings', async () => {
+    store = { theme: 'dark', instanceFeatures: { post: { enabled: true } } };
+
+    const res = await request(buildApp())
+      .put('/api/settings/features/post')
+      .send({ enabled: false });
+
+    expect(res.status).toBe(200);
+    expect(res.body.features).toEqual([expect.objectContaining({ id: 'post', enabled: false })]);
+    expect(store).toEqual({ theme: 'dark', instanceFeatures: { post: { enabled: false } } });
+  });
+
+  it('rejects unknown feature ids and malformed enabled values', async () => {
+    const unknown = await request(buildApp())
+      .put('/api/settings/features/not-registered')
+      .send({ enabled: false });
+    const malformed = await request(buildApp())
+      .put('/api/settings/features/post')
+      .send({ enabled: 'false' });
+
+    expect(unknown.status).toBe(400);
+    expect(malformed.status).toBe(400);
+    expect(unknown.body.code).toBe('VALIDATION_ERROR');
+    expect(malformed.body.code).toBe('VALIDATION_ERROR');
+  });
+});
+
 // A peer that satisfies every durable gate the routing policy checks: enabled,
 // enabled as a provider, allowlisted for the routed pair, and on the tailnet.
 const routablePeer = (overrides = {}) => ({

--- a/server/routes/settings.test.js
+++ b/server/routes/settings.test.js
@@ -7,6 +7,7 @@ let store = {};
 
 vi.mock('../services/settings.js', () => ({
   getSettings: vi.fn(async () => ({ ...store })),
+  getSettingsWithStatus: vi.fn(async () => ({ corrupt: false, settings: { ...store } })),
   updateSettings: vi.fn(async (patch) => {
     store = { ...store, ...patch };
     return { ...store };

--- a/server/services/characterMetrics.js
+++ b/server/services/characterMetrics.js
@@ -123,13 +123,19 @@ export const METRICS = [
     // array and a throw here lands in `readMetric`'s `unavailable`, so a shape mismatch can
     // never render as a confident "0 days active" for someone with years of history.
     compute: async (read) => {
-      const [logging, sessions, training, timezone] = await Promise.all([
+      const [logging, postEnabled, timezone] = await Promise.all([
         read('loggingStats'),
-        read('postSessions'),
-        read('postTraining'),
+        read('postEnabled'),
         read('userTimezone'),
       ]);
       if (!Array.isArray(logging?.activeDayKeys)) throw new Error('logging stats reported no activeDayKeys');
+
+      if (!postEnabled) return unionActiveDayKeys([logging.activeDayKeys], timezone).length;
+
+      const [sessions, training] = await Promise.all([
+        read('postSessions'),
+        read('postTraining'),
+      ]);
       if (!Array.isArray(sessions)) throw new Error('POST sessions unreadable');
       if (!Array.isArray(training)) throw new Error('POST training log unreadable');
 
@@ -273,5 +279,7 @@ async function readMetric(metric, read) {
  * `getCharacterSkills`) or the six signals the two registries share get read twice.
  */
 export async function getCharacterMetrics(read = createSignalContext()) {
-  return Promise.all(METRICS.map((metric) => readMetric(metric, read)));
+  const postEnabled = await read('postEnabled');
+  const metrics = postEnabled ? METRICS : METRICS.filter((metric) => metric.id !== 'postStreakDays');
+  return Promise.all(metrics.map((metric) => readMetric(metric, read)));
 }

--- a/server/services/characterMetrics.test.js
+++ b/server/services/characterMetrics.test.js
@@ -33,6 +33,9 @@ vi.mock('./meatspaceLoggingStats.js', () => ({ getLoggingStats: vi.fn(async () =
 vi.mock('./identity/goals.js', () => ({ getGoals: vi.fn(async () => stats.goals) }));
 vi.mock('./memoryBackend.js', () => ({ countMemories: vi.fn(async () => stats.memories) }));
 vi.mock('./mediaAssetIndex/db.js', () => ({ countAssets: vi.fn(async () => stats.assets) }));
+vi.mock('./instanceFeatures.js', () => ({
+  isInstanceFeatureEnabled: vi.fn(async () => true),
+}));
 // PARTIAL mock: only the two settings-backed reads are stubbed. `todayInTimezone` must stay
 // REAL — `lib/activeDays.js` (behind the daysActive tile) derives its day keys through it, and
 // a factory that dropped it would leave that tile throwing on an undefined import and reading
@@ -56,6 +59,7 @@ import { countWorks } from './writersRoom/local.js';
 import { getPostSessions } from './meatspacePost.js';
 import { getAllTrainingEntries } from './meatspacePostTraining.js';
 import { userLocalToday, getUserTimezone } from '../lib/timezone.js';
+import { isInstanceFeatureEnabled } from './instanceFeatures.js';
 
 const goal = (status) => ({ status });
 
@@ -84,6 +88,7 @@ beforeEach(() => {
   vi.mocked(getAllTrainingEntries).mockImplementation(async () => stats.training);
   vi.mocked(userLocalToday).mockImplementation(async () => stats.today);
   vi.mocked(getUserTimezone).mockImplementation(async () => stats.timezone);
+  vi.mocked(isInstanceFeatureEnabled).mockResolvedValue(true);
   vi.spyOn(console, 'warn').mockImplementation(() => {});
 });
 
@@ -92,6 +97,18 @@ afterEach(() => {
 });
 
 const byId = (metrics, id) => metrics.find((m) => m.id === id);
+
+describe('getCharacterMetrics — disabled features', () => {
+  it('omits POST metrics and POST activity reads when POST is disabled on this instance', async () => {
+    isInstanceFeatureEnabled.mockResolvedValue(false);
+
+    const metrics = await getCharacterMetrics();
+
+    expect(byId(metrics, 'postStreakDays')).toBeUndefined();
+    expect(getPostSessions).not.toHaveBeenCalled();
+    expect(getAllTrainingEntries).not.toHaveBeenCalled();
+  });
+});
 
 describe('the registry', () => {
   it('declares a unique id, label, unit, hint and compute for each metric', () => {

--- a/server/services/characterSignals.js
+++ b/server/services/characterSignals.js
@@ -42,6 +42,7 @@ import { getLoggingStats } from './meatspaceLoggingStats.js';
 import { getGoals } from './identity/goals.js';
 import { countMemories } from './memoryBackend.js';
 import { countAssets } from './mediaAssetIndex/db.js';
+import { isInstanceFeatureEnabled } from './instanceFeatures.js';
 import { getUserTimezone, userLocalToday } from '../lib/timezone.js';
 
 /**
@@ -65,6 +66,7 @@ export const SIGNAL_READERS = {
   catalogStats: () => getCatalogStats(),
   postSessions: () => getPostSessions(undefined, undefined, { strict: true }),
   postTraining: () => getAllTrainingEntries({ strict: true }),
+  postEnabled: () => isInstanceFeatureEnabled('post'),
   // Today's `YYYY-MM-DD` in the USER's configured timezone — the same day boundary
   // meatspacePost.js anchors its streaks to. Deriving "today" from the server's local clock
   // instead would let the Character sheet's POST streak disagree with the Progress page's by

--- a/server/services/characterSignals.test.js
+++ b/server/services/characterSignals.test.js
@@ -21,6 +21,9 @@ vi.mock('./memoryBackend.js', () => ({
   countMemories: vi.fn(async () => { calls.memories += 1; return 42; }),
 }));
 vi.mock('./mediaAssetIndex/db.js', () => ({ countAssets: vi.fn(async () => 7) }));
+vi.mock('./instanceFeatures.js', () => ({
+  isInstanceFeatureEnabled: vi.fn(async () => true),
+}));
 // PARTIAL mock — only the settings-backed reads are stubbed, so the pure `todayInTimezone`
 // that `lib/activeDays.js` derives day keys through stays real.
 vi.mock('../lib/timezone.js', async (importOriginal) => ({
@@ -32,6 +35,7 @@ vi.mock('../lib/timezone.js', async (importOriginal) => ({
 import { createSignalContext, SIGNAL_READERS } from './characterSignals.js';
 import { countUniverses } from './universeBuilder.js';
 import { countMemories } from './memoryBackend.js';
+import { isInstanceFeatureEnabled } from './instanceFeatures.js';
 
 beforeEach(() => {
   calls.universes = 0;
@@ -39,6 +43,7 @@ beforeEach(() => {
   calls.memories = 0;
   vi.mocked(countUniverses).mockImplementation(async () => { calls.universes += 1; return 3; });
   vi.mocked(countMemories).mockImplementation(async () => { calls.memories += 1; return 42; });
+  vi.mocked(isInstanceFeatureEnabled).mockResolvedValue(true);
 });
 
 afterEach(() => {
@@ -51,7 +56,7 @@ describe('the signal registry', () => {
     // → the consumer classifies it `unavailable` → the tile lies about the domain being down).
     expect(Object.keys(SIGNAL_READERS).sort()).toEqual([
       'assetCount', 'catalogStats', 'goals', 'loggingStats', 'memoryCount',
-      'postSessions', 'postToday', 'postTraining', 'universeCount', 'userTimezone',
+      'postEnabled', 'postSessions', 'postToday', 'postTraining', 'universeCount', 'userTimezone',
       'workCount',
     ]);
   });

--- a/server/services/characterSkills.js
+++ b/server/services/characterSkills.js
@@ -203,5 +203,7 @@ async function readSkill(skill, read) {
  * context so a skills-only caller stays a one-liner.
  */
 export async function getCharacterSkills(read = createSignalContext()) {
-  return Promise.all(SKILLS.map((skill) => readSkill(skill, read)));
+  const postEnabled = await read('postEnabled');
+  const skills = postEnabled ? SKILLS : SKILLS.filter((skill) => skill.domain !== 'post');
+  return Promise.all(skills.map((skill) => readSkill(skill, read)));
 }

--- a/server/services/characterSkills.test.js
+++ b/server/services/characterSkills.test.js
@@ -63,6 +63,9 @@ vi.mock('./meatspaceLoggingStats.js', () => ({ getLoggingStats: vi.fn(async () =
 vi.mock('./identity/goals.js', () => ({ getGoals: vi.fn(async () => stats.goals) }));
 vi.mock('./memoryBackend.js', () => ({ countMemories: vi.fn(async () => stats.memories) }));
 vi.mock('./mediaAssetIndex/db.js', () => ({ countAssets: vi.fn(async () => stats.assets) }));
+vi.mock('./instanceFeatures.js', () => ({
+  isInstanceFeatureEnabled: vi.fn(async () => true),
+}));
 
 import { getCharacterSkills, levelFromValue, SKILLS, MAX_SKILL_LEVEL } from './characterSkills.js';
 import { countUniverses } from './universeBuilder.js';
@@ -71,6 +74,7 @@ import { getLoggingStats } from './meatspaceLoggingStats.js';
 import { countMemories } from './memoryBackend.js';
 import { countAssets } from './mediaAssetIndex/db.js';
 import { countWorks } from './writersRoom/local.js';
+import { isInstanceFeatureEnabled } from './instanceFeatures.js';
 
 const rows = (list) => Array.from({ length: list }, (_, i) => ({ id: `r${i}` }));
 
@@ -93,6 +97,7 @@ beforeEach(() => {
   vi.mocked(getLoggingStats).mockImplementation(async () => stats.logging);
   vi.mocked(countMemories).mockImplementation(async () => stats.memories);
   vi.mocked(countAssets).mockImplementation(async () => stats.assets);
+  vi.mocked(isInstanceFeatureEnabled).mockResolvedValue(true);
   vi.spyOn(console, 'warn').mockImplementation(() => {});
 });
 
@@ -187,6 +192,17 @@ describe('getCharacterSkills — empty domains', () => {
       expect(skill).toMatchObject({ level: 0, value: 0, unavailable: false });
       expect(skill.level).not.toBeNull();
     }
+  });
+});
+
+describe('getCharacterSkills — disabled features', () => {
+  it('omits POST skill derivation when POST is disabled on this instance', async () => {
+    isInstanceFeatureEnabled.mockResolvedValue(false);
+
+    const skills = await getCharacterSkills();
+
+    expect(skills).toHaveLength(SKILLS.length - 1);
+    expect(byId(skills, 'mentalist')).toBeUndefined();
   });
 });
 

--- a/server/services/instanceFeatures.js
+++ b/server/services/instanceFeatures.js
@@ -1,6 +1,6 @@
 import { ServerError } from '../lib/errorHandler.js';
 import { isPlainObject } from '../lib/objects.js';
-import { getSettings, updateSettingsWith } from './settings.js';
+import { getSettingsWithStatus, updateSettingsWith } from './settings.js';
 
 // Instance features are local to one PortOS install. They are deliberately
 // separate from per-feature configuration so a feature can remain available
@@ -30,19 +30,21 @@ const featureEnabled = (feature, settings) => {
   return typeof stored === 'boolean' ? stored : false;
 };
 
-export const resolveInstanceFeatures = (settings = {}) => INSTANCE_FEATURES.map((feature) => ({
+export const resolveInstanceFeatures = (settings = {}, { corrupt = false } = {}) => INSTANCE_FEATURES.map((feature) => ({
   ...feature,
-  enabled: featureEnabled(feature, settings),
+  enabled: !corrupt && featureEnabled(feature, settings),
 }));
 
 export async function getInstanceFeatures() {
-  return { features: resolveInstanceFeatures(await getSettings()) };
+  const { corrupt, settings } = await getSettingsWithStatus();
+  return { features: resolveInstanceFeatures(settings, { corrupt }) };
 }
 
 export async function isInstanceFeatureEnabled(featureId) {
   const feature = FEATURE_BY_ID.get(featureId);
   if (!feature) return false;
-  return featureEnabled(feature, await getSettings());
+  const { corrupt, settings } = await getSettingsWithStatus();
+  return !corrupt && featureEnabled(feature, settings);
 }
 
 export async function updateInstanceFeature(featureId, enabled) {

--- a/server/services/instanceFeatures.js
+++ b/server/services/instanceFeatures.js
@@ -1,0 +1,58 @@
+import { ServerError } from '../lib/errorHandler.js';
+import { isPlainObject } from '../lib/objects.js';
+import { getSettings, updateSettingsWith } from './settings.js';
+
+// Instance features are local to one PortOS install. They are deliberately
+// separate from per-feature configuration so a feature can remain available
+// when opened directly while its passive metrics, reminders, and proactive
+// prompts stay quiet on installs that do not use it.
+export const INSTANCE_FEATURES = Object.freeze([
+  Object.freeze({
+    id: 'post',
+    label: 'POST',
+    description: 'Daily cognitive practice, progress metrics, and reminder prompts.',
+    defaultEnabled: true,
+  }),
+]);
+
+const FEATURE_BY_ID = new Map(INSTANCE_FEATURES.map((feature) => [feature.id, feature]));
+
+const featureEnabled = (feature, settings) => {
+  const stored = settings?.instanceFeatures?.[feature.id]?.enabled;
+  return typeof stored === 'boolean' ? stored : feature.defaultEnabled;
+};
+
+export const resolveInstanceFeatures = (settings = {}) => INSTANCE_FEATURES.map((feature) => ({
+  ...feature,
+  enabled: featureEnabled(feature, settings),
+}));
+
+export async function getInstanceFeatures() {
+  return { features: resolveInstanceFeatures(await getSettings()) };
+}
+
+export async function isInstanceFeatureEnabled(featureId) {
+  const feature = FEATURE_BY_ID.get(featureId);
+  if (!feature) return false;
+  return featureEnabled(feature, await getSettings());
+}
+
+export async function updateInstanceFeature(featureId, enabled) {
+  if (!FEATURE_BY_ID.has(featureId)) {
+    throw new ServerError(`Unknown instance feature: ${featureId}`, { status: 404, code: 'NOT_FOUND' });
+  }
+
+  const settings = await updateSettingsWith((current) => {
+    const instanceFeatures = isPlainObject(current.instanceFeatures) ? current.instanceFeatures : {};
+    const currentFeature = isPlainObject(instanceFeatures[featureId]) ? instanceFeatures[featureId] : {};
+    return {
+      ...current,
+      instanceFeatures: {
+        ...instanceFeatures,
+        [featureId]: { ...currentFeature, enabled },
+      },
+    };
+  });
+
+  return { features: resolveInstanceFeatures(settings) };
+}

--- a/server/services/instanceFeatures.js
+++ b/server/services/instanceFeatures.js
@@ -18,8 +18,16 @@ export const INSTANCE_FEATURES = Object.freeze([
 const FEATURE_BY_ID = new Map(INSTANCE_FEATURES.map((feature) => [feature.id, feature]));
 
 const featureEnabled = (feature, settings) => {
-  const stored = settings?.instanceFeatures?.[feature.id]?.enabled;
-  return typeof stored === 'boolean' ? stored : feature.defaultEnabled;
+  const instanceFeatures = settings?.instanceFeatures;
+  if (instanceFeatures === undefined) return feature.defaultEnabled;
+  if (!isPlainObject(instanceFeatures)) return false;
+  if (!Object.prototype.hasOwnProperty.call(instanceFeatures, feature.id)) return feature.defaultEnabled;
+
+  const featureSettings = instanceFeatures[feature.id];
+  if (!isPlainObject(featureSettings)) return false;
+  const stored = featureSettings.enabled;
+  if (stored === undefined) return feature.defaultEnabled;
+  return typeof stored === 'boolean' ? stored : false;
 };
 
 export const resolveInstanceFeatures = (settings = {}) => INSTANCE_FEATURES.map((feature) => ({

--- a/server/services/instanceFeatures.test.js
+++ b/server/services/instanceFeatures.test.js
@@ -36,6 +36,14 @@ describe('instance features', () => {
     });
   });
 
+  it('fails closed for malformed persisted feature flags', async () => {
+    const settings = { instanceFeatures: { post: { enabled: 'false' } } };
+
+    expect(resolveInstanceFeatures(settings)[0]).toMatchObject({ id: 'post', enabled: false });
+    mock.settings = settings;
+    expect(await isInstanceFeatureEnabled('post')).toBe(false);
+  });
+
   it('updates one feature inside the instance-local settings slice', async () => {
     mock.settings = { theme: 'dark', instanceFeatures: { post: { enabled: true, future: 'keep' } } };
 

--- a/server/services/instanceFeatures.test.js
+++ b/server/services/instanceFeatures.test.js
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+const mock = vi.hoisted(() => ({ settings: {}, updateSettingsWith: vi.fn() }));
+
+vi.mock('./settings.js', () => ({
+  getSettings: vi.fn(async () => structuredClone(mock.settings)),
+  updateSettingsWith: mock.updateSettingsWith,
+}));
+
+import {
+  getInstanceFeatures,
+  isInstanceFeatureEnabled,
+  resolveInstanceFeatures,
+  updateInstanceFeature,
+} from './instanceFeatures.js';
+
+describe('instance features', () => {
+  beforeEach(() => {
+    mock.settings = {};
+    mock.updateSettingsWith.mockReset();
+    mock.updateSettingsWith.mockImplementation(async (mutate) => {
+      mock.settings = await mutate(structuredClone(mock.settings));
+      return structuredClone(mock.settings);
+    });
+  });
+
+  it('keeps POST enabled by default for existing installs', async () => {
+    expect(await isInstanceFeatureEnabled('post')).toBe(true);
+    expect((await getInstanceFeatures()).features[0]).toMatchObject({ id: 'post', enabled: true });
+  });
+
+  it('resolves an explicit disable without changing POST configuration', () => {
+    expect(resolveInstanceFeatures({ instanceFeatures: { post: { enabled: false } } })[0]).toMatchObject({
+      id: 'post',
+      enabled: false,
+    });
+  });
+
+  it('updates one feature inside the instance-local settings slice', async () => {
+    mock.settings = { theme: 'dark', instanceFeatures: { post: { enabled: true, future: 'keep' } } };
+
+    const result = await updateInstanceFeature('post', false);
+
+    expect(mock.settings).toEqual({
+      theme: 'dark',
+      instanceFeatures: { post: { enabled: false, future: 'keep' } },
+    });
+    expect(result.features[0]).toMatchObject({ id: 'post', enabled: false });
+    expect(await isInstanceFeatureEnabled('post')).toBe(false);
+  });
+});

--- a/server/services/instanceFeatures.test.js
+++ b/server/services/instanceFeatures.test.js
@@ -1,9 +1,9 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 
-const mock = vi.hoisted(() => ({ settings: {}, updateSettingsWith: vi.fn() }));
+const mock = vi.hoisted(() => ({ settings: {}, corrupt: false, updateSettingsWith: vi.fn() }));
 
 vi.mock('./settings.js', () => ({
-  getSettings: vi.fn(async () => structuredClone(mock.settings)),
+  getSettingsWithStatus: vi.fn(async () => ({ corrupt: mock.corrupt, settings: structuredClone(mock.settings) })),
   updateSettingsWith: mock.updateSettingsWith,
 }));
 
@@ -17,6 +17,7 @@ import {
 describe('instance features', () => {
   beforeEach(() => {
     mock.settings = {};
+    mock.corrupt = false;
     mock.updateSettingsWith.mockReset();
     mock.updateSettingsWith.mockImplementation(async (mutate) => {
       mock.settings = await mutate(structuredClone(mock.settings));
@@ -42,6 +43,14 @@ describe('instance features', () => {
     expect(resolveInstanceFeatures(settings)[0]).toMatchObject({ id: 'post', enabled: false });
     mock.settings = settings;
     expect(await isInstanceFeatureEnabled('post')).toBe(false);
+  });
+
+  it('fails closed when settings cannot be read or parsed', async () => {
+    mock.corrupt = true;
+
+    expect(resolveInstanceFeatures({}, { corrupt: true })[0]).toMatchObject({ id: 'post', enabled: false });
+    expect(await isInstanceFeatureEnabled('post')).toBe(false);
+    expect((await getInstanceFeatures()).features[0]).toMatchObject({ id: 'post', enabled: false });
   });
 
   it('updates one feature inside the instance-local settings slice', async () => {

--- a/server/services/layeredIntelligence.test.js
+++ b/server/services/layeredIntelligence.test.js
@@ -1510,6 +1510,18 @@ describe('buildPrompt', () => {
     expect(prompt.match(/### productMetrics/g)).toHaveLength(1);
   });
 
+  it('does not treat an omitted feature as an inactive improvement target', () => {
+    const prompt = buildPrompt({
+      app,
+      isPortos: true,
+      config: { allowedScopes: ['app-improvement'], rules: '' },
+      sources: { productMetrics: '{"creativeCommissions":{"unreviewedRenders":2}}' },
+    });
+
+    expect(prompt).toContain('An omitted feature is not an inactive feature');
+    expect(prompt).not.toContain('"post"');
+  });
+
   it('injects the scope-awareness block only when present, under its own heading (#2760)', () => {
     const base = { app, isPortos: true, config: { allowedScopes: ['loop-meta'], rules: '' } };
     const without = buildPrompt(base);

--- a/server/services/layeredIntelligence/prompt.js
+++ b/server/services/layeredIntelligence/prompt.js
@@ -85,7 +85,7 @@ export function buildPrompt({ app, config, sources = {}, openIssues = [], isPort
   // aggregate signal so inactivity is evaluated as product evidence, not as a
   // generic request to add more telemetry.
   const productMetricsBlock = (isPortos && typeof sources.productMetrics === 'string' && sources.productMetrics.trim())
-    ? `\n### productMetrics\n${sources.productMetrics.trim()}\n\nThese are current PortOS product-engagement signals. Treat an inactive daily POST or overdue creative feedback as evidence that the product should improve its prompts, visibility, or action flow. Prefer a concrete user-facing improvement grounded in these numbers; do not propose generic telemetry when the signal already identifies the engagement gap. If the source says unavailable, do not infer zero activity.\n`
+    ? `\n### productMetrics\n${sources.productMetrics.trim()}\n\nThese are current PortOS product-engagement signals. Treat an inactive daily POST or overdue creative feedback as evidence that the product should improve its prompts, visibility, or action flow only when that signal appears in the source. An omitted feature is not an inactive feature and must not be treated as a missing metric or improvement target. Prefer a concrete user-facing improvement grounded in these numbers; do not propose generic telemetry when the signal already identifies the engagement gap. If the source says unavailable, do not infer zero activity.\n`
     : '';
 
   // Feedback loop (#2428): show the reasoner how its own past proposals fared so

--- a/server/services/meatspacePostReminder.js
+++ b/server/services/meatspacePostReminder.js
@@ -26,6 +26,7 @@
 import { schedule, cancel, parseCronToPrevRun } from './eventScheduler.js';
 import { getUserTimezone, getTimezoneUpdatedAt, getLocalParts, todayInTimezone, HHMM_STRICT_RE } from '../lib/timezone.js';
 import { getPostConfig, getPostSessions, postConfigEvents } from './meatspacePost.js';
+import { isInstanceFeatureEnabled } from './instanceFeatures.js';
 import { addNotification, getNotifications, NOTIFICATION_TYPES, PRIORITY_LEVELS } from './notifications.js';
 import { settingsEvents } from './settings.js';
 
@@ -68,6 +69,11 @@ function isOnLocalDay(timestamp, timezone, dayStr) {
  * scheduled minute is respected instead of nagging once more.
  */
 export async function firePostReminderIfIncomplete() {
+  if (!await isInstanceFeatureEnabled('post')) {
+    console.log(`🔔 POST reminder: feature disabled on this instance — skipping`);
+    return;
+  }
+
   const config = await getPostConfig();
   if (config.reminder?.enabled !== true) {
     console.log(`🔔 POST reminder: disabled since registration — skipping`);
@@ -200,6 +206,12 @@ async function catchUpMissedSlot(cron, timezone, reminderUpdatedAt, timezoneUpda
  *   config/timezone save should NOT replay a slot the user didn't miss.
  */
 export async function registerPostReminderSchedule({ catchUpMissedSlot: shouldCatchUp = false } = {}) {
+  if (!await isInstanceFeatureEnabled('post')) {
+    cancel(POST_REMINDER_EVENT_ID);
+    lastAppliedTimezone = null;
+    return;
+  }
+
   const config = await getPostConfig();
   const { enabled, time, updatedAt } = config.reminder || {};
 
@@ -244,6 +256,12 @@ export async function registerPostReminderSchedule({ catchUpMissedSlot: shouldCa
  * changed, so tweaking an unrelated setting doesn't spam a reschedule.
  */
 async function refreshTimezoneIfChanged() {
+  if (!await isInstanceFeatureEnabled('post')) {
+    cancel(POST_REMINDER_EVENT_ID);
+    lastAppliedTimezone = null;
+    return;
+  }
+
   const config = await getPostConfig();
   if (config.reminder?.enabled !== true) return; // nothing scheduled to refresh
 

--- a/server/services/meatspacePostReminder.test.js
+++ b/server/services/meatspacePostReminder.test.js
@@ -50,6 +50,10 @@ vi.mock('./meatspacePost.js', () => ({
   postConfigEvents: postConfigEventEmitter
 }));
 
+vi.mock('./instanceFeatures.js', () => ({
+  isInstanceFeatureEnabled: vi.fn().mockResolvedValue(true),
+}));
+
 vi.mock('./notifications.js', () => ({
   addNotification: vi.fn().mockResolvedValue({ id: 'n1' }),
   getNotifications: vi.fn().mockResolvedValue([]),
@@ -64,6 +68,7 @@ vi.mock('./settings.js', () => ({
 import { schedule, cancel, parseCronToPrevRun } from './eventScheduler.js';
 import { getUserTimezone, getTimezoneUpdatedAt, getLocalParts, todayInTimezone } from '../lib/timezone.js';
 import { getPostConfig, getPostSessions } from './meatspacePost.js';
+import { isInstanceFeatureEnabled } from './instanceFeatures.js';
 import { addNotification, getNotifications } from './notifications.js';
 import {
   reminderTimeToCron,
@@ -92,6 +97,7 @@ describe('reminderTimeToCron', () => {
 describe('registerPostReminderSchedule', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    isInstanceFeatureEnabled.mockResolvedValue(true);
     getUserTimezone.mockResolvedValue('UTC');
     getTimezoneUpdatedAt.mockResolvedValue(null);
     parseCronToPrevRun.mockReturnValue(null);
@@ -102,6 +108,17 @@ describe('registerPostReminderSchedule', () => {
     await registerPostReminderSchedule();
     expect(schedule).not.toHaveBeenCalled();
     expect(cancel).toHaveBeenCalledWith(POST_REMINDER_EVENT_ID);
+  });
+
+  it('cancels the schedule when POST is disabled for this instance', async () => {
+    isInstanceFeatureEnabled.mockResolvedValue(false);
+    getPostConfig.mockResolvedValue({ reminder: { enabled: true, time: '09:00' } });
+
+    await registerPostReminderSchedule();
+
+    expect(schedule).not.toHaveBeenCalled();
+    expect(cancel).toHaveBeenCalledWith(POST_REMINDER_EVENT_ID);
+    expect(getPostConfig).not.toHaveBeenCalled();
   });
 
   it('cancels and skips scheduling when the reminder block is entirely absent', async () => {
@@ -434,8 +451,18 @@ describe('stopPostReminderSchedule', () => {
 });
 
 describe('firePostReminderIfIncomplete', () => {
+  it('does not notify when POST is disabled for this instance', async () => {
+    isInstanceFeatureEnabled.mockResolvedValue(false);
+
+    await firePostReminderIfIncomplete();
+
+    expect(addNotification).not.toHaveBeenCalled();
+    expect(getPostConfig).not.toHaveBeenCalled();
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
+    isInstanceFeatureEnabled.mockResolvedValue(true);
     getPostSessions.mockResolvedValue([]);
     getNotifications.mockResolvedValue([]);
     getUserTimezone.mockResolvedValue('UTC');

--- a/server/services/portosProductMetrics.instanceFeatures.test.js
+++ b/server/services/portosProductMetrics.instanceFeatures.test.js
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mock = vi.hoisted(() => ({
+  getPostSessions: vi.fn(),
+  getAllTrainingEntries: vi.fn(),
+  listCommissions: vi.fn(),
+  getProjectsByIds: vi.fn(),
+  isInstanceFeatureEnabled: vi.fn(),
+  getUserTimezone: vi.fn(),
+  todayInTimezone: vi.fn(),
+}));
+
+vi.mock('./meatspacePost.js', () => ({ getPostSessions: mock.getPostSessions }));
+vi.mock('./postTrainingLogStore.js', () => ({ getAllTrainingEntries: mock.getAllTrainingEntries }));
+vi.mock('./creativeCommissions/store.js', () => ({ listCommissions: mock.listCommissions }));
+vi.mock('./creativeDirector/local.js', () => ({ getProjectsByIds: mock.getProjectsByIds }));
+vi.mock('./instanceFeatures.js', () => ({ isInstanceFeatureEnabled: mock.isInstanceFeatureEnabled }));
+vi.mock('../lib/timezone.js', () => ({
+  getUserTimezone: mock.getUserTimezone,
+  todayInTimezone: mock.todayInTimezone,
+}));
+
+import { getProductEngagement } from './portosProductMetrics.js';
+
+describe('getProductEngagement — instance feature participation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mock.isInstanceFeatureEnabled.mockResolvedValue(false);
+    mock.getUserTimezone.mockResolvedValue('UTC');
+    mock.todayInTimezone.mockReturnValue('2026-08-24');
+    mock.listCommissions.mockResolvedValue([]);
+    mock.getProjectsByIds.mockResolvedValue([]);
+    mock.getPostSessions.mockResolvedValue([]);
+    mock.getAllTrainingEntries.mockResolvedValue([]);
+  });
+
+  it('skips POST reads and actions when POST is disabled on this instance', async () => {
+    const result = await getProductEngagement({ now: new Date('2026-08-24T12:00:00.000Z') });
+
+    expect(result.post).toEqual({ status: 'disabled', reason: 'instance-feature-disabled' });
+    expect(result.actions).toEqual([]);
+    expect(mock.getPostSessions).not.toHaveBeenCalled();
+    expect(mock.getAllTrainingEntries).not.toHaveBeenCalled();
+  });
+});

--- a/server/services/portosProductMetrics.js
+++ b/server/services/portosProductMetrics.js
@@ -13,6 +13,7 @@ import { getPostSessions } from './meatspacePost.js';
 import { getAllTrainingEntries } from './postTrainingLogStore.js';
 import { listCommissions } from './creativeCommissions/store.js';
 import { getProjectsByIds } from './creativeDirector/local.js';
+import { isInstanceFeatureEnabled } from './instanceFeatures.js';
 import { computeUnifiedStreak, recordDayKey, ymdShift, ymdToUTC } from '../lib/postStreak.js';
 import { getUserTimezone, todayInTimezone } from '../lib/timezone.js';
 
@@ -193,6 +194,8 @@ export function buildProductActions({ post, creativeCommissions }) {
       title: 'Daily POST is waiting',
       detail,
       link: '/post/launcher',
+      featureId: 'post',
+      featureLabel: 'POST',
       metadata: {
         completedToday: false,
         daysSinceActivity: daysSince,
@@ -231,11 +234,15 @@ export function buildProductActions({ post, creativeCommissions }) {
 
 export function toProductMetricsAggregate(metrics) {
   const { pendingReviews: _pendingReviews, ...creative } = metrics.creativeCommissions || {};
-  return {
+  const aggregate = {
     today: metrics.today,
-    post: metrics.post,
     creativeCommissions: creative,
   };
+  // A disabled feature is not a metric. Keep the explicit disabled sentinel in
+  // the full result for user-facing callers, but do not hand it to Layered
+  // Intelligence as a product signal to interpret or improve.
+  if (metrics.post?.status !== 'disabled') aggregate.post = metrics.post;
+  return aggregate;
 }
 
 /**
@@ -248,10 +255,13 @@ export async function getProductEngagement({ now = new Date(), timezone: configu
   const timezoneResult = configuredTimezone
     ? Promise.resolve(configuredTimezone)
     : getUserTimezone().catch(() => null);
-  const timezone = await timezoneResult;
+  const [timezone, postEnabled] = await Promise.all([
+    timezoneResult,
+    isInstanceFeatureEnabled('post'),
+  ]);
   const today = timezone ? todayInTimezone(timezone, nowDate) : null;
 
-  const postPromise = timezone && today
+  const postPromise = postEnabled && timezone && today
     ? Promise.all([
       getPostSessions(undefined, undefined, { strict: true }),
       getAllTrainingEntries({ strict: true }),
@@ -273,7 +283,9 @@ export async function getProductEngagement({ now = new Date(), timezone: configu
   const [postData, creativeData] = await Promise.all([postPromise, creativePromise]);
   const metrics = {
     today,
-    post: postData || unavailableMetrics('post-read-failed'),
+    post: postEnabled
+      ? postData || unavailableMetrics('post-read-failed')
+      : { status: 'disabled', reason: 'instance-feature-disabled' },
     creativeCommissions: creativeData || unavailableMetrics('creative-read-failed'),
   };
   return {

--- a/server/services/portosProductMetrics.test.js
+++ b/server/services/portosProductMetrics.test.js
@@ -98,7 +98,13 @@ describe('buildProductActions', () => {
     });
 
     expect(actions).toHaveLength(2);
-    expect(actions[0]).toMatchObject({ type: 'post_engagement', severity: 'high', link: '/post/launcher' });
+    expect(actions[0]).toMatchObject({
+      type: 'post_engagement',
+      severity: 'high',
+      link: '/post/launcher',
+      featureId: 'post',
+      featureLabel: 'POST',
+    });
     expect(actions[1]).toMatchObject({
       type: 'commission_feedback',
       severity: 'high',
@@ -133,6 +139,19 @@ describe('toProductMetricsAggregate', () => {
       today,
       post: { status: 'ok', completedToday: false },
       creativeCommissions: { status: 'ok', unreviewedRenders: 1 },
+    });
+  });
+
+  it('omits disabled features from the intelligence aggregate', () => {
+    const result = toProductMetricsAggregate({
+      today,
+      post: { status: 'disabled', reason: 'instance-feature-disabled' },
+      creativeCommissions: { status: 'unavailable', reason: 'creative-read-failed' },
+    });
+
+    expect(result).toEqual({
+      today,
+      creativeCommissions: { status: 'unavailable', reason: 'creative-read-failed' },
     });
   });
 });


### PR DESCRIPTION
## Summary

- Add instance-local feature participation settings with a centralized Settings page and navigation entry.
- Add a POST disable action to engagement toasts while preserving the direct action link.
- Gate POST passive metrics, reminders, dashboard prompts, character derivations, and improvement signals when disabled.

## Test plan

- `npm test --prefix server` — 1,633 test files passed; 34,190 tests passed.
- `npm run lint --prefix client` — passed.
- `npm run build --prefix client` — passed.
- Focused client/server regression suites — passed.
- `npm test --prefix client` — 759 files and 9,781 tests passed; one unrelated existing `SongBookViewer` `act(...)` failure remains.