### PR TITLE
feat: allow deleting Creative Director projects

### DIFF
--- a/client/src/pages/CreativeDirectorDetail.jsx
+++ b/client/src/pages/CreativeDirectorDetail.jsx
@@ -1,12 +1,13 @@
 import { useEffect, useState, useCallback, useRef } from 'react';
 import { useParams, useNavigate, useSearchParams, Link } from 'react-router';
-import { ArrowLeft, Play, Pause, RefreshCw, SlidersHorizontal, Square } from 'lucide-react';
+import { ArrowLeft, Play, Pause, RefreshCw, SlidersHorizontal, Square, Trash2 } from 'lucide-react';
 import PageSkeleton from '../components/ui/PageSkeleton';
 import toast from '../components/ui/Toast';
 import ConfirmButtonPair from '../components/ui/ConfirmButtonPair';
 import { useConfirmDelete } from '../hooks/useConfirmDelete';
 import {
   getCreativeDirectorProject,
+  deleteCreativeDirectorProject,
   startCreativeDirectorProject,
   pauseCreativeDirectorProject,
   stopCreativeDirectorProject,
@@ -158,7 +159,19 @@ export default function CreativeDirectorDetail() {
   // Stop is destructive and irreversible (SIGKILLs a live agent, cancels queued
   // GPU renders) and sits beside Pause, so it takes the same two-step confirm
   // every other destructive action in the app uses.
-  const { isConfirming, requestDelete, cancelDelete, confirmDelete } = useConfirmDelete();
+  const {
+    isConfirming: isConfirmingStop,
+    requestDelete: requestStop,
+    cancelDelete: cancelStop,
+    confirmDelete: confirmStop,
+  } = useConfirmDelete();
+  const {
+    isConfirming: isConfirmingDelete,
+    requestDelete,
+    cancelDelete,
+    confirmDelete,
+  } = useConfirmDelete();
+  const [deleting, setDeleting] = useState(false);
 
   const handleAction = async (kind) => {
     // Map action → past-tense label and optimistic status up-front.
@@ -182,6 +195,18 @@ export default function CreativeDirectorDetail() {
       if (optimisticStatus) setProject((p) => p ? { ...p, status: optimisticStatus } : p);
     } catch (err) {
       toast.error(err.message || `Failed to ${kind}`);
+    }
+  };
+
+  const handleDelete = async () => {
+    setDeleting(true);
+    try {
+      await deleteCreativeDirectorProject(id, { silent: true });
+      toast.success('Creative Director project deleted');
+      navigate('/creative-director');
+    } catch (err) {
+      toast.error(err.message || 'Failed to delete project');
+      setDeleting(false);
     }
   };
 
@@ -221,7 +246,7 @@ export default function CreativeDirectorDetail() {
               </div>
             </div>
           </div>
-          <div className="flex gap-1">
+          <div className="flex flex-wrap justify-end gap-1">
             <button onClick={fetchProject} className="flex items-center gap-1 px-2 py-1 bg-port-card border border-port-border rounded text-xs">
               <RefreshCw className="w-3 h-3" /> Refresh
             </button>
@@ -244,18 +269,18 @@ export default function CreativeDirectorDetail() {
               </button>
             )}
             {!['complete', 'failed', 'draft'].includes(project.status) && (
-              isConfirming(project.id) ? (
+              isConfirmingStop(project.id) ? (
                 <ConfirmButtonPair
                   prompt="Stop?"
                   confirmText="Stop"
                   ariaLabel={`Confirm stop project ${project.name}`}
-                  onConfirm={() => confirmDelete(() => handleAction('stop'))}
-                  onCancel={cancelDelete}
+                  onConfirm={() => confirmStop(() => handleAction('stop'))}
+                  onCancel={cancelStop}
                 />
               ) : (
                 <button
                   type="button"
-                  onClick={() => requestDelete(project.id)}
+                  onClick={() => requestStop(project.id)}
                   title="Stop: kill the running agent, retire its queued tasks, and cancel pending renders. Pause only stops NEW work being queued."
                   aria-label={`Stop project ${project.name}`}
                   className="flex items-center gap-1 px-2 py-1 bg-port-card border border-port-border rounded text-xs hover:text-port-error"
@@ -263,6 +288,27 @@ export default function CreativeDirectorDetail() {
                   <Square className="w-3 h-3" /> Stop
                 </button>
               )
+            )}
+            {isConfirmingDelete(project.id) ? (
+              <ConfirmButtonPair
+                prompt="Delete?"
+                confirmText="Delete"
+                ariaLabel={`Confirm delete project ${project.name}`}
+                onConfirm={() => confirmDelete(handleDelete)}
+                onCancel={cancelDelete}
+              />
+            ) : (
+              <button
+                type="button"
+                onClick={() => requestDelete(project.id)}
+                disabled={deleting}
+                title={deleting ? 'Deleting Creative Director project…' : 'Delete this Creative Director project'}
+                aria-label={`${deleting ? 'Deleting' : 'Delete'} project ${project.name}`}
+                aria-busy={deleting}
+                className="flex items-center gap-1 px-2 py-1 bg-port-card border border-port-border rounded text-xs hover:bg-port-error/20 hover:text-port-error disabled:opacity-50"
+              >
+                <Trash2 className="w-3 h-3" /> {deleting ? 'Deleting…' : 'Delete'}
+              </button>
             )}
           </div>
         </div>

--- a/client/src/pages/CreativeDirectorDetail.test.jsx
+++ b/client/src/pages/CreativeDirectorDetail.test.jsx
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router';
+
+vi.mock('../services/apiCreativeDirector.js', () => ({
+  getCreativeDirectorProject: vi.fn(),
+  deleteCreativeDirectorProject: vi.fn(),
+  startCreativeDirectorProject: vi.fn(),
+  pauseCreativeDirectorProject: vi.fn(),
+  stopCreativeDirectorProject: vi.fn(),
+  resumeCreativeDirectorProject: vi.fn(),
+}));
+vi.mock('../services/apiAgents.js', () => ({ getCosAgents: vi.fn(() => Promise.resolve([])) }));
+vi.mock('../hooks/useMediaJobProgress', () => ({ default: () => ({ status: 'unknown', error: null }) }));
+vi.mock('../components/creative-director/OverviewTab.jsx', () => ({ default: () => <div>Overview content</div> }));
+vi.mock('../components/creative-director/TreatmentTab.jsx', () => ({ default: () => null }));
+vi.mock('../components/creative-director/SegmentsTab.jsx', () => ({ default: () => null }));
+vi.mock('../components/creative-director/PlanTab.jsx', () => ({ default: () => null }));
+vi.mock('../components/creative-director/RunsTab.jsx', () => ({ default: () => null }));
+vi.mock('../components/creative-director/ActiveAgentsBanner.jsx', () => ({ default: () => null }));
+vi.mock('../components/creative-director/CreativeDirectorModelsDrawer.jsx', () => ({ default: () => null }));
+vi.mock('../components/ui/Toast', () => ({
+  default: { success: vi.fn(), error: vi.fn(), info: vi.fn(), warning: vi.fn() },
+}));
+
+import * as cdApi from '../services/apiCreativeDirector.js';
+import CreativeDirectorDetail from './CreativeDirectorDetail';
+
+const PROJECT = {
+  id: 'cd-example',
+  name: 'Example project',
+  status: 'draft',
+  treatment: null,
+};
+
+function LocationProbe() {
+  const { pathname } = useLocation();
+  return <div data-testid="location">{pathname}</div>;
+}
+
+const renderPage = async () => {
+  render(
+    <MemoryRouter initialEntries={['/creative-director/cd-example/overview']}>
+      <LocationProbe />
+      <Routes>
+        <Route path="/creative-director/:id/:tab" element={<CreativeDirectorDetail />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+  await screen.findByRole('heading', { name: PROJECT.name });
+};
+
+describe('CreativeDirectorDetail project deletion', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    cdApi.getCreativeDirectorProject.mockResolvedValue(PROJECT);
+    cdApi.deleteCreativeDirectorProject.mockResolvedValue({ ok: true });
+  });
+
+  it('requires confirmation before deleting the project', async () => {
+    const user = userEvent.setup();
+    await renderPage();
+
+    await user.click(screen.getByRole('button', { name: `Delete project ${PROJECT.name}` }));
+
+    expect(cdApi.deleteCreativeDirectorProject).not.toHaveBeenCalled();
+    expect(screen.getByRole('button', { name: 'Delete', exact: true })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeTruthy();
+  });
+
+  it('deletes the project and returns to the Creative Director list', async () => {
+    const user = userEvent.setup();
+    await renderPage();
+
+    await user.click(screen.getByRole('button', { name: `Delete project ${PROJECT.name}` }));
+    await user.click(screen.getByRole('button', { name: 'Delete', exact: true }));
+
+    await waitFor(() => expect(cdApi.deleteCreativeDirectorProject).toHaveBeenCalledWith(PROJECT.id, { silent: true }));
+    expect(screen.getByTestId('location')).toHaveTextContent('/creative-director');
+  });
+});


### PR DESCRIPTION
## Summary
- Add a confirmed Delete action to Creative Director project detail pages.
- Reuse the existing server delete endpoint and return to the Creative Director list after success.
- Add focused UI coverage for confirmation, deletion, and navigation.

## Test plan
- `npm test -- --run src/pages/CreativeDirector.test.jsx src/pages/CreativeDirectorDetail.test.jsx`
- `npx biome lint --error-on-warnings src/pages/CreativeDirectorDetail.jsx src/pages/CreativeDirectorDetail.test.jsx`
- `npm run build`