### PR TITLE
fix: use released diffusers for MiniMax H3 CUDA (#4141)

### DIFF
--- a/scripts/requirements-minimax-h3-cuda.txt
+++ b/scripts/requirements-minimax-h3-cuda.txt
@@ -12,14 +12,7 @@
 # it first, from the host's correct index (see WIN_TORCH_CUDA_INDEX in
 # server/lib/pythonSetup.js, and PORTOS_TORCH_CUDA_INDEX to override).
 
-# diffusers' MiniMax-H3 integration (PR #14355) merged to main on 2026-08-05 and
-# is NOT in any tagged release — v0.39.0 predates it. Pinned to a main commit
-# until a release ships it; when one does, swap this for the `==` version and
-# drop the git URL. The runtime's import probe checks for
-# `MiniMaxH3Transformer3DModel` specifically, so an install that silently
-# resolved to a release without the integration reports as not-ready rather than
-# failing deep inside a render.
-diffusers @ git+https://github.com/huggingface/diffusers.git@2da7040be1a2e5f2fcbc8b985083342a308f5a86
+diffusers==0.40.0
 
 # int8 weight-only quantization. This is what makes H3 fit a consumer card at
 # all: the bf16 transformer + Qwen3-VL conditioner are 133 GB together, and

--- a/scripts/setup-image-video.sh
+++ b/scripts/setup-image-video.sh
@@ -484,15 +484,6 @@ if [[ "$INSTALL_MINIMAX_H3_CUDA" == "1" ]]; then
   # Windows and Linux both reach this model: since #4142 the catalog picks
   # video.cuda[] vs video.mlx[] on `process.platform === 'darwin'`, so a Linux
   # install is served the same CUDA list a Windows one is.
-  # diffusers is pinned to a git commit until a release carries the MiniMax-H3
-  # integration (see the note in requirements-minimax-h3-cuda.txt), so pip needs
-  # git to build that wheel. Say so up front rather than failing several minutes
-  # into a torch download.
-  if ! have git; then
-    echo "❌ INSTALL_MINIMAX_H3_CUDA=1 requires git (the diffusers pin is a git commit)." >&2
-    exit 1
-  fi
-
   MINIMAX_H3_CUDA_DIR="${HOME}/.portos/minimax-h3-cuda"
   MINIMAX_H3_CUDA_VENV="${MINIMAX_H3_CUDA_DIR}/.venv"
   MINIMAX_H3_CUDA_REQS="${SCRIPT_DIR}/requirements-minimax-h3-cuda.txt"

--- a/server/services/videoGen/runtimes.js
+++ b/server/services/videoGen/runtimes.js
@@ -178,9 +178,9 @@ export const BYOV_RUNTIME_INFO = Object.freeze({
     installSourceLabel: 'pinned PyPI wheels',
     // Three things must hold before a render is even attempted, and each fails
     // as an unusable install rather than as a bad render: diffusers must carry
-    // the H3 modular integration (merged to main after v0.39.0 and in no tagged
-    // release yet, so a released wheel imports fine and then has no pipeline —
-    // which is why the requirements file pins a commit), torchao must be present
+    // the H3 modular integration (merged to main after v0.39.0 and released in
+    // diffusers 0.40.0, which is the version pinned by the requirements file),
+    // torchao must be present
     // (int8 weight-only is the only way the 133 GB bf16 pair fits a consumer
     // card), and CUDA must actually be visible. A CPU-only torch is the trap
     // here: it installs cleanly on Windows, hides the setup banner, and then


### PR DESCRIPTION
## Summary
- Pin the MiniMax H3 CUDA runtime to released `diffusers==0.40.0`.
- Remove the obsolete Git prerequisite from the PyPI-based CUDA installer.
- Update the runtime comment to match the released dependency.

## Test plan
- `bash -n scripts/setup-image-video.sh`
- `npm test --prefix server -- ../scripts/setup-image-video.test.js`
- `npm test --prefix server -- services/videoGen/runtimes.test.js`
- `git diff --check`

Closes #4141