### PR TITLE
fix: stop per-frame easter-egg crash that left OpenWorld a blank sky on mobile

### DIFF
--- a/client/src/components/openworld/OpenWorldScene.jsx
+++ b/client/src/components/openworld/OpenWorldScene.jsx
@@ -462,7 +462,7 @@ export default function OpenWorldScene({
           teleport={playerTeleport}
           warpPads={warpRegions}
           onWarpPadInteract={onTravelToRegion}
-          easterEggs={easterEggsList}
+          easterEggs={easterEggsList.eggs}
           collectedShardIds={collectedShardIds}
           onCollectShard={onCollectShard}
           onPlayerPoseChange={onPlayerPoseChange}

--- a/client/src/components/openworld/PlayerController.test.jsx
+++ b/client/src/components/openworld/PlayerController.test.jsx
@@ -6,9 +6,12 @@ import { installVoiceHotkeySpy } from '../../test/voiceHotkeySpy';
 // PlayerController is an r3f component, but its Space handling is plain DOM wiring. The
 // fiber hooks are stubbed so it can mount in jsdom without a WebGL canvas; rendering in
 // first-person camera mode returns null, so nothing three.js-specific ever paints.
+// The useFrame stub CAPTURES the per-frame callback so tests can drive the frame loop
+// (the path where a thrown TypeError would kill scene rendering) without WebGL.
+const frameCallbacks = [];
 vi.mock('@react-three/fiber', () => ({
   useThree: () => ({ camera: new THREE.PerspectiveCamera(), gl: { domElement: document.createElement('canvas') } }),
-  useFrame: () => {},
+  useFrame: (cb) => { frameCallbacks.push(cb); },
 }));
 
 const PlayerController = (await import('./PlayerController')).default;
@@ -17,7 +20,7 @@ describe('PlayerController Space (jump) capture', () => {
   const voiceHotkey = installVoiceHotkeySpy();
   let keysRef;
 
-  beforeEach(() => { keysRef = { current: new Set() }; });
+  beforeEach(() => { keysRef = { current: new Set() }; frameCallbacks.length = 0; });
 
   const renderRig = (props = {}) => render(
     <PlayerController keysRef={keysRef} active cameraView="first" positions={new Map()} apps={[]} {...props} />,
@@ -77,5 +80,26 @@ describe('PlayerController Space (jump) capture', () => {
 
     expect(keysRef.current.has(' ')).toBe(false);
     expect(voiceHotkey()).toHaveBeenCalledTimes(1);
+  });
+
+  it('runs a frame without throwing on a non-iterable easterEggs payload', () => {
+    // Regression (#4702): the scene passed computeEasterEggs' wrapper object as
+    // easterEggs; the per-frame detectProximity loop then threw "not iterable"
+    // every frame, halting the render loop — on a default install the world never
+    // painted at all (mobile: "all I see is sky"). The frame path must survive.
+    renderRig({ easterEggs: { eggs: [], total: 0, hasData: false } });
+    const runFrame = frameCallbacks.at(-1);
+    expect(typeof runFrame).toBe('function');
+
+    expect(() => act(() => runFrame({}, 1 / 60))).not.toThrow();
+  });
+
+  it('runs a frame with a well-formed easterEggs array without throwing', () => {
+    renderRig({
+      easterEggs: [{ id: 'leet', label: '1337', hint: 'LEET', position: [0, 1.2, 52] }],
+    });
+    const runFrame = frameCallbacks.at(-1);
+
+    expect(() => act(() => runFrame({}, 1 / 60))).not.toThrow();
   });
 });

--- a/client/src/utils/openWorldProximity.js
+++ b/client/src/utils/openWorldProximity.js
@@ -52,6 +52,12 @@ export function detectProximity({
     return null;
   }
 
+  // Validate collection-shaped inputs before iterating: this runs inside the r3f frame
+  // loop, where a thrown TypeError kills rendering for the whole scene (the canvas would
+  // show only its clear color). A wrong-shaped payload degrades to "no targets" instead.
+  const pads = Array.isArray(warpPads) ? warpPads : [];
+  const eggs = Array.isArray(easterEggs) ? easterEggs : [];
+
   const px = playerPos.x;
   const pz = playerPos.z;
 
@@ -59,7 +65,7 @@ export function detectProximity({
   let closestDist = Infinity;
 
   // 1. Warp pads (highest priority for fast travel nodes)
-  for (const pad of warpPads) {
+  for (const pad of pads) {
     if (!pad) continue;
     const pos = pad.position || (pad.region ? [pad.region.anchor[0], 0, pad.region.anchor[2]] : null);
     if (!pos) continue;
@@ -103,7 +109,7 @@ export function detectProximity({
   }
 
   // 3. Easter eggs
-  for (const egg of easterEggs) {
+  for (const egg of eggs) {
     if (!egg || !egg.position) continue;
     const dx = px - egg.position[0];
     const dz = pz - egg.position[2];

--- a/client/src/utils/openWorldProximity.test.js
+++ b/client/src/utils/openWorldProximity.test.js
@@ -83,4 +83,17 @@ describe('openWorldProximity', () => {
     });
     expect(target).toBeNull();
   });
+
+  it('degrades non-iterable collection payloads to "no targets" instead of throwing', () => {
+    // Regression: OpenWorldScene once passed computeEasterEggs' wrapper object
+    // ({ base, eggs, total, hasData }) as easterEggs. detectProximity runs inside
+    // the r3f frame loop, so the resulting TypeError killed rendering every frame —
+    // the world never painted and no interaction worked. A bad shape must degrade.
+    const target = detectProximity({
+      playerPos: { x: -45.5, y: 1.6, z: 40.5 },
+      easterEggs: { eggs: [], total: 0, hasData: false },
+      warpPads: { warpPadList: [] },
+    });
+    expect(target).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary
- OpenWorld loaded to a solid sky with a dead HUD on any device whose stored settings had exploration mode on (default true) — every phone browser, hence the mobile report.
- Root cause: #4702 passed `computeEasterEggs`()'s wrapper object (`{ base, eggs, total, hasData }`) as `PlayerController`'s `easterEggs` prop. `detectProximity`'s `for..of` threw `TypeError: not iterable` inside the r3f frame loop on every frame, so the scene never rendered a single draw and nothing in-world responded.
- Fix: pass `easterEggsList.eggs`, and validate the collection inputs inside `detectProximity` so a wrong shape degrades to "no targets" rather than killing the render loop.

## Test plan
- New unit tests: `detectProximity` tolerates non-iterable `easterEggs`/`warpPads`; `PlayerController`'s captured frame callback runs clean with both the wrapper object and a well-formed eggs array (`openWorldProximity.test.js`, `PlayerController.test.jsx`).
- `cd client && npm test` — 764 files / 9809 tests green.
- `npm run lint` (biome) clean.
- Verified in headless Chromium at 390x844 touch viewport against the live API: before the fix the canvas painted only sky with a repeating `TypeError: i is not iterable`; after, the city, rover, warp pads and streets render with zero page errors, the joystick drives, and the world-map dock button opens fast travel.