### PR TITLE
hide the app JIRA tab until the app is wired to JIRA

### DIFF
--- a/client/src/components/apps/EditAppDrawer.jsx
+++ b/client/src/components/apps/EditAppDrawer.jsx
@@ -593,7 +593,11 @@ export default function EditAppDrawer({ app, onClose, onSave }) {
                 {formData.workTracker === 'jira' && (
                   <p className="text-xs text-gray-500 mt-1">
                     {appUsesJira(app) ? (
-                      <>Instance, project, and board live on the app’s <Link to={`/apps/${app.id}/jira`} className="underline hover:text-white">JIRA tab</Link>.</>
+                      // Closing is load-bearing, not politeness: AppDetailView only
+                      // clears `editing` when the appId CHANGES, so a same-app tab
+                      // link would leave this portaled drawer sitting over the JIRA
+                      // tab it just navigated to.
+                      <>Instance, project, and board live on the app’s <Link to={`/apps/${app.id}/jira`} onClick={onClose} className="underline hover:text-white">JIRA tab</Link>.</>
                     ) : (
                       <>Save to reveal the app’s JIRA tab, where the instance, project, and board are configured.</>
                     )}

--- a/client/src/components/apps/EditAppDrawer.jsx
+++ b/client/src/components/apps/EditAppDrawer.jsx
@@ -12,13 +12,17 @@ import { copyToClipboard } from '../../lib/clipboard';
 import LayeredIntelligenceTab, { buildLayeredIntelligenceUpdate, buildLayeredIntelligenceScheduleUpdate } from './LayeredIntelligenceTab';
 import { PROVIDER_TYPES } from '../../utils/providers';
 import { DEFAULT_PR_COMPLETION, PR_COMPLETION_OPTIONS, prCompletionOption } from '../cos/constants';
-import { WORK_TRACKER_OPTIONS, WORK_TRACKER_LABELS } from './constants';
+import { WORK_TRACKER_OPTIONS, WORK_TRACKER_LABELS, appUsesJira } from './constants';
 
 // JIRA is deliberately absent: its config moved to the app detail page's JIRA
 // tab (/apps/:id/jira), where it sits next to the sprint board it drives and has
 // the width the instance/project/board pickers need. This drawer therefore never
 // sends a `jira` key — the PUT shallow-merges server-side, so the stored config
 // is preserved untouched.
+// The Workflow tab's work-tracker picker is the ONLY entry point into that tab
+// for an app that has never had JIRA turned on — the tab itself is hidden until
+// `appUsesJira(app)` holds (see constants.js), so choosing JIRA here is what
+// reveals it.
 const TABS = [
   { id: 'general', label: 'General' },
   { id: 'ports', label: 'Ports & TLS' },
@@ -586,6 +590,15 @@ export default function EditAppDrawer({ app, onClose, onSave }) {
                     </p>
                   );
                 })()}
+                {formData.workTracker === 'jira' && (
+                  <p className="text-xs text-gray-500 mt-1">
+                    {appUsesJira(app) ? (
+                      <>Instance, project, and board live on the app’s <Link to={`/apps/${app.id}/jira`} className="underline hover:text-white">JIRA tab</Link>.</>
+                    ) : (
+                      <>Save to reveal the app’s JIRA tab, where the instance, project, and board are configured.</>
+                    )}
+                  </p>
+                )}
               </div>
 
               <label className="flex items-center gap-2 cursor-pointer">

--- a/client/src/components/apps/constants.js
+++ b/client/src/components/apps/constants.js
@@ -100,6 +100,22 @@ export const WORK_TRACKER_LABELS = Object.fromEntries(
 export const workItemNoun = (tracker) =>
   tracker === 'jira' ? 'ticket' : (tracker === 'github' || tracker === 'gitlab') ? 'issue' : 'item';
 
+/**
+ * Whether an app has been configured for a JIRA workflow.
+ *
+ * Either opt-in counts on its own:
+ *   - `jira.enabled` — the integration is switched on (the JIRA tab's own config panel)
+ *   - `workTracker === 'jira'` — the app's work items live in JIRA (Edit App → Workflow)
+ *
+ * The second clause is the bootstrap path: JIRA's config panel lives ON the JIRA
+ * tab, so gating the tab on `jira.enabled` alone would make a never-configured app
+ * unable to ever reach it. Picking JIRA as the work tracker in the Edit App drawer
+ * reveals the tab, and the panel there does the rest. `'auto'` never resolves to
+ * JIRA (it classifies the git origin host → github/gitlab/plan), so an app only
+ * lands here by an explicit choice.
+ */
+export const appUsesJira = (app) => !!app?.jira?.enabled || app?.workTracker === 'jira';
+
 // Overview first, then alphabetical. Every id is a real route segment
 // (`/apps/:appId/:tab`) so each tab is linkable, bookmarkable, and reachable
 // from ⌘K — see the routing rules in client/src/AGENTS.md.
@@ -115,7 +131,8 @@ export const APP_DETAIL_TABS = [
   { id: 'git', label: 'Git' },
   { id: 'gsd', label: 'GSD' },
   { id: 'issues', label: 'Issues' },
-  { id: 'jira', label: 'JIRA' },
+  // JIRA config is only meaningful for an app wired to JIRA — see appUsesJira.
+  { id: 'jira', label: 'JIRA', visibleWhen: appUsesJira },
   { id: 'processes', label: 'Processes' },
   { id: 'references', label: 'References' },
   // Only repos that declare submodules (a .gitmodules file) get the tab — most

--- a/client/src/components/apps/constants.test.js
+++ b/client/src/components/apps/constants.test.js
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { APP_DETAIL_TABS, appUsesJira } from './constants';
+
+const visibleIds = (app) =>
+  APP_DETAIL_TABS.filter(t => (t.visibleWhen ? t.visibleWhen(app) : true)).map(t => t.id);
+
+describe('appUsesJira', () => {
+  it('is false for an app with no JIRA config at all', () => {
+    expect(appUsesJira({ id: 'a', workTracker: 'auto' })).toBe(false);
+    expect(appUsesJira({ id: 'a' })).toBe(false);
+    expect(appUsesJira(null)).toBe(false);
+  });
+
+  it('is true once the integration is enabled', () => {
+    expect(appUsesJira({ jira: { enabled: true } })).toBe(true);
+  });
+
+  it('is true when JIRA is the chosen work tracker, before any integration config exists', () => {
+    // The bootstrap path: the JIRA tab hosts its own config panel, so this is
+    // what makes the tab reachable for a never-configured app.
+    expect(appUsesJira({ workTracker: 'jira' })).toBe(true);
+  });
+
+  it('is false for a disabled integration left behind by a previous setup', () => {
+    expect(appUsesJira({ workTracker: 'github', jira: { enabled: false, projectKey: 'PROJ' } })).toBe(false);
+  });
+});
+
+describe('APP_DETAIL_TABS jira visibility', () => {
+  it('hides the JIRA tab for an app that is not wired to JIRA', () => {
+    expect(visibleIds({ id: 'a', workTracker: 'github' })).not.toContain('jira');
+  });
+
+  it('shows the JIRA tab when the integration is enabled', () => {
+    expect(visibleIds({ id: 'a', jira: { enabled: true } })).toContain('jira');
+  });
+
+  it('shows the JIRA tab when JIRA is the work tracker', () => {
+    expect(visibleIds({ id: 'a', workTracker: 'jira' })).toContain('jira');
+  });
+
+  it('leaves the unconditional tabs alone', () => {
+    const ids = visibleIds({ id: 'a' });
+    expect(ids).toEqual(expect.arrayContaining(['overview', 'automation', 'documents', 'git', 'gsd', 'issues', 'processes', 'references', 'tasks']));
+  });
+});


### PR DESCRIPTION
## Summary

- Every managed app showed a **JIRA tab** whose only content — for the vast majority of them — was an unchecked "Enable JIRA Integration" box. It's now gated the same way the DataDog, Submodules, and Update tabs already are: a `visibleWhen` predicate on the `APP_DETAIL_TABS` entry.
- An app earns the tab when **either** opt-in holds: `jira.enabled` (integration on) or `workTracker === 'jira'` (its work items live in JIRA).
- The second clause is what keeps the tab **reachable**. JIRA's config panel lives *on* that tab, so gating on `jira.enabled` alone would strand a never-configured app with no way in. Picking JIRA in Edit App → Workflow reveals the tab, and that picker now says so.
- Following that hint's link closes the Edit App drawer — `AppDetailView` clears `editing` only when the appId *changes*, so a same-app tab link would otherwise leave the portaled drawer sitting over the tab it just opened.

`'auto'` never resolves to JIRA (it classifies the git origin host → github/gitlab/plan), so an app only lands in the visible set by an explicit choice.

## Test plan

- New `client/src/components/apps/constants.test.js` covers `appUsesJira` (both opt-ins, neither, and a disabled leftover integration) and asserts the tab actually appears/disappears from the filtered `APP_DETAIL_TABS` list, plus that the unconditional tabs are untouched.
- `npx vitest run src/components/apps` — 166/166 pass across 15 files.
- `npx biome lint --error-on-warnings src/components/apps` — clean.
- Reviewed by `codex` (gpt-5.6-luna, effort=max): one finding (the drawer-overlay issue above), fixed; re-review clean.