### PR TITLE
Centralize the streaming-wrapper error envelope into apiCore.throwApiError

### DIFF
--- a/client/src/services/apiCore.js
+++ b/client/src/services/apiCore.js
@@ -27,7 +27,12 @@ export function maybeRedirectToLogin(response, error) {
 // own (with `silent` support); the streaming/blob callers that bypass request()
 // to read a raw Response deliberately surface their own errors instead.
 export async function throwApiError(response) {
-  const error = await response.json().catch(() => ({ error: `HTTP ${response.status}` }));
+  // A valid JSON body that isn't an object (e.g. a bare `null`) parses
+  // successfully but has no `.error`/`.code`/`.context` to read — fall back
+  // to the same HTTP-status shape used when the body isn't JSON at all.
+  const parsedError = await response.json().catch(() => null);
+  const error =
+    parsedError && typeof parsedError === 'object' ? parsedError : { error: `HTTP ${response.status}` };
   // Auth gate (server: services/authGate.js) returns 401 with code AUTH_REQUIRED
   // for any /api request without a valid session. Bounce to /login so the
   // user can re-authenticate; skip if we're already there.

--- a/client/src/services/apiCore.js
+++ b/client/src/services/apiCore.js
@@ -21,6 +21,28 @@ export function maybeRedirectToLogin(response, error) {
   }
 }
 
+// Shared `!response.ok` envelope: parse the server's JSON error body, bounce to
+// /login on session expiry, and throw an Error carrying `.code`/`.status`/
+// `.context` from the response. Toasting is NOT done here — request() does its
+// own (with `silent` support); the streaming/blob callers that bypass request()
+// to read a raw Response deliberately surface their own errors instead.
+export async function throwApiError(response) {
+  const error = await response.json().catch(() => ({ error: `HTTP ${response.status}` }));
+  // Auth gate (server: services/authGate.js) returns 401 with code AUTH_REQUIRED
+  // for any /api request without a valid session. Bounce to /login so the
+  // user can re-authenticate; skip if we're already there.
+  maybeRedirectToLogin(response, error);
+  const err = new Error(error.error || `HTTP ${response.status}`);
+  err.code = error?.code;
+  err.status = response.status;
+  // Forward structured context the server attached to the error (e.g.
+  // ERR_PARTIAL_COMMIT_ISSUES carries `{ universeId, seriesId,
+  // arcAlreadyPersisted, skipArcOnRetry }` so the Importer client can
+  // shape its retry without re-overwriting persisted state).
+  if (error?.context) err.context = error.context;
+  throw err;
+}
+
 export async function request(endpoint, options = {}) {
   const { silent, responseType, ...fetchOptions } = options;
   const url = `${API_BASE}${endpoint}`;
@@ -45,29 +67,19 @@ export async function request(endpoint, options = {}) {
   }
 
   if (!response.ok) {
-    const error = await response.json().catch(() => ({ error: 'Request failed' }));
-    const errorMessage = error.error || `HTTP ${response.status}`;
-    // Auth gate (server: services/authGate.js) returns 401 with code AUTH_REQUIRED
-    // for any /api request without a valid session. Bounce to /login so the
-    // user can re-authenticate; skip if we're already there.
-    maybeRedirectToLogin(response, error);
-    if (!silent) {
-      // Platform unavailability is a warning, not an error
-      if (error.code === 'PLATFORM_UNAVAILABLE') {
-        toast(errorMessage, { icon: '⚠️' });
-      } else if (error.code !== 'AUTH_REQUIRED') {
-        toast.error(errorMessage);
+    try {
+      await throwApiError(response);
+    } catch (err) {
+      if (!silent) {
+        // Platform unavailability is a warning, not an error
+        if (err.code === 'PLATFORM_UNAVAILABLE') {
+          toast(err.message, { icon: '⚠️' });
+        } else if (err.code !== 'AUTH_REQUIRED') {
+          toast.error(err.message);
+        }
       }
+      throw err;
     }
-    const err = new Error(errorMessage);
-    err.code = error?.code;
-    err.status = response.status;
-    // Forward structured context the server attached to the error (e.g.
-    // ERR_PARTIAL_COMMIT_ISSUES carries `{ universeId, seriesId,
-    // arcAlreadyPersisted, skipArcOnRetry }` so the Importer client can
-    // shape its retry without re-overwriting persisted state).
-    if (error?.context) err.context = error.context;
-    throw err;
   }
 
   // Handle 204 No Content

--- a/client/src/services/apiCore.test.js
+++ b/client/src/services/apiCore.test.js
@@ -50,17 +50,22 @@ describe('throwApiError', () => {
 
   it('omits context when the server did not send any', async () => {
     const response = makeResponse({ status: 500, json: { error: 'boom' } });
-    try {
-      await throwApiError(response);
-      throw new Error('expected throwApiError to throw');
-    } catch (err) {
-      expect(err.context).toBeUndefined();
-    }
+    const err = await throwApiError(response).catch((e) => e);
+    expect(err).toBeInstanceOf(Error);
+    expect(err.context).toBeUndefined();
   });
 
   it('falls back to an HTTP-status message when the body is not JSON', async () => {
     const response = makeResponse({ status: 502 }); // json:null → makeResponse's json() rejects
     await expect(throwApiError(response)).rejects.toMatchObject({ message: 'HTTP 502' });
+  });
+
+  it('falls back to an HTTP-status message when the body is valid JSON but not an object', async () => {
+    // response.json() resolves successfully with `null` here — a real case
+    // (an endpoint that responds 500 with a bare `null` body) distinct from
+    // "body isn't JSON at all" above, which rejects instead of resolving.
+    const response = { status: 500, ok: false, json: async () => null };
+    await expect(throwApiError(response)).rejects.toMatchObject({ message: 'HTTP 500' });
   });
 });
 
@@ -74,11 +79,12 @@ describe('request() error path (now delegating to throwApiError)', () => {
     expect(toast.error).toHaveBeenCalledWith('bad input');
   });
 
-  it('does not toast for PLATFORM_UNAVAILABLE errors (warns instead)', async () => {
+  it('warns instead of toasting an error for PLATFORM_UNAVAILABLE', async () => {
     global.fetch.mockResolvedValue(
       makeResponse({ status: 503, json: { error: 'offline', code: 'PLATFORM_UNAVAILABLE' } }),
     );
     await expect(request('/x')).rejects.toMatchObject({ code: 'PLATFORM_UNAVAILABLE' });
+    expect(toast).toHaveBeenCalledWith('offline', { icon: '⚠️' });
     expect(toast.error).not.toHaveBeenCalled();
   });
 

--- a/client/src/services/apiCore.test.js
+++ b/client/src/services/apiCore.test.js
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// The real Toast default export is callable (`toast(msg, opts)`) AND carries
+// `.error`/`.success`/etc, mirroring react-hot-toast's API — a plain object
+// mock would make request()'s `toast(err.message, { icon })` call throw.
+vi.mock('../components/ui/Toast', () => {
+  const toastFn = vi.fn();
+  toastFn.error = vi.fn();
+  toastFn.success = vi.fn();
+  return { default: toastFn };
+});
+
+import toast from '../components/ui/Toast';
+import { throwApiError, request } from './apiCore.js';
+
+const makeResponse = ({ status = 400, ok = false, json = null } = {}) => ({
+  status,
+  ok,
+  json: json === null ? async () => { throw new Error('not json'); } : async () => json,
+});
+
+beforeEach(() => {
+  global.fetch = vi.fn();
+  toast.mockReset();
+  toast.error.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('throwApiError', () => {
+  it('throws with the server message, code, and status', async () => {
+    const response = makeResponse({ status: 404, json: { error: 'not found', code: 'NOT_FOUND' } });
+    await expect(throwApiError(response)).rejects.toMatchObject({
+      message: 'not found',
+      code: 'NOT_FOUND',
+      status: 404,
+    });
+  });
+
+  it('forwards structured error.context onto the thrown error', async () => {
+    const context = { universeId: 'u1', seriesId: 's1', arcAlreadyPersisted: true };
+    const response = makeResponse({
+      status: 409,
+      json: { error: 'partial commit', code: 'ERR_PARTIAL_COMMIT_ISSUES', context },
+    });
+    await expect(throwApiError(response)).rejects.toMatchObject({ context });
+  });
+
+  it('omits context when the server did not send any', async () => {
+    const response = makeResponse({ status: 500, json: { error: 'boom' } });
+    try {
+      await throwApiError(response);
+      throw new Error('expected throwApiError to throw');
+    } catch (err) {
+      expect(err.context).toBeUndefined();
+    }
+  });
+
+  it('falls back to an HTTP-status message when the body is not JSON', async () => {
+    const response = makeResponse({ status: 502 }); // json:null → makeResponse's json() rejects
+    await expect(throwApiError(response)).rejects.toMatchObject({ message: 'HTTP 502' });
+  });
+});
+
+describe('request() error path (now delegating to throwApiError)', () => {
+  it('rejects with the same shape throwApiError produces, context included', async () => {
+    const context = { retryable: false };
+    global.fetch.mockResolvedValue(
+      makeResponse({ status: 422, json: { error: 'bad input', code: 'VALIDATION', context } }),
+    );
+    await expect(request('/x')).rejects.toMatchObject({ code: 'VALIDATION', status: 422, context });
+    expect(toast.error).toHaveBeenCalledWith('bad input');
+  });
+
+  it('does not toast for PLATFORM_UNAVAILABLE errors (warns instead)', async () => {
+    global.fetch.mockResolvedValue(
+      makeResponse({ status: 503, json: { error: 'offline', code: 'PLATFORM_UNAVAILABLE' } }),
+    );
+    await expect(request('/x')).rejects.toMatchObject({ code: 'PLATFORM_UNAVAILABLE' });
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it('stays silent when { silent: true } is passed', async () => {
+    global.fetch.mockResolvedValue(makeResponse({ status: 500, json: { error: 'boom' } }));
+    await expect(request('/x', { silent: true })).rejects.toMatchObject({ status: 500 });
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/services/apiCore.test.js
+++ b/client/src/services/apiCore.test.js
@@ -93,4 +93,13 @@ describe('request() error path (now delegating to throwApiError)', () => {
     await expect(request('/x', { silent: true })).rejects.toMatchObject({ status: 500 });
     expect(toast.error).not.toHaveBeenCalled();
   });
+
+  it('suppresses the PLATFORM_UNAVAILABLE warning toast too when { silent: true } is passed', async () => {
+    global.fetch.mockResolvedValue(
+      makeResponse({ status: 503, json: { error: 'offline', code: 'PLATFORM_UNAVAILABLE' } }),
+    );
+    await expect(request('/x', { silent: true })).rejects.toMatchObject({ code: 'PLATFORM_UNAVAILABLE' });
+    expect(toast).not.toHaveBeenCalled();
+    expect(toast.error).not.toHaveBeenCalled();
+  });
 });

--- a/client/src/services/apiImageVideo.js
+++ b/client/src/services/apiImageVideo.js
@@ -1,4 +1,4 @@
-import { request, API_BASE, maybeRedirectToLogin } from './apiCore.js';
+import { request, API_BASE, throwApiError } from './apiCore.js';
 import { filterHardwareCompatibleModels } from '../utils/systemCapabilities.js';
 
 // Image gen — local backend extras (gallery, models, LoRAs, cancel, delete).
@@ -481,7 +481,7 @@ export const installLoraFromHuggingface = ({ url, family, file, silent = false }
 // cross-origin navigation; (2) EventSource auto-reconnects on any transport
 // drop, which for this NON-idempotent install would silently start a second
 // multi-GB download — a single fetch never retries; (3) it honors session expiry
-// — a 401 AUTH_REQUIRED bounces to /login via maybeRedirectToLogin exactly like
+// — a 401 AUTH_REQUIRED bounces to /login via throwApiError exactly like
 // request(), instead of dead-ending on a generic stream error. Frames are
 // SSE-encoded (`data: {json}\n\n`).
 export async function installLoraFromHuggingfaceStream({ url, family, file, onProgress, signal } = {}) {
@@ -492,11 +492,7 @@ export async function installLoraFromHuggingfaceStream({ url, family, file, onPr
     signal,
   });
   if (!response.ok || !response.body?.getReader) {
-    const err = await response.json().catch(() => ({ error: `HTTP ${response.status}` }));
-    maybeRedirectToLogin(response, err);
-    const e = new Error(err.error || `HTTP ${response.status}`);
-    e.code = err.code || null;
-    throw e;
+    await throwApiError(response);
   }
 
   const reader = response.body.getReader();

--- a/client/src/services/apiLocalLlm.js
+++ b/client/src/services/apiLocalLlm.js
@@ -1,4 +1,4 @@
-import { request, API_BASE, maybeRedirectToLogin } from './apiCore.js';
+import { request, API_BASE, throwApiError } from './apiCore.js';
 
 // Local LLM backends (Ollama / LM Studio) — status, model management, migrate.
 // Installed models per backend come back inside getLocalLlmStatus().
@@ -185,11 +185,9 @@ export async function streamLocalLlmTest(payload, { signal, onToken } = {}) {
     signal,
   });
   if (!response.ok || !response.body?.getReader) {
-    const err = await response.json().catch(() => ({ error: `HTTP ${response.status}` }));
     // Honor session expiry the same way request() does — a streaming run that
     // 401s should bounce to /login, not just toast and strand the user here.
-    maybeRedirectToLogin(response, err);
-    throw new Error(err.error || `HTTP ${response.status}`);
+    await throwApiError(response);
   }
 
   const reader = response.body.getReader();

--- a/client/src/services/apiMedia.js
+++ b/client/src/services/apiMedia.js
@@ -1,4 +1,4 @@
-import { request, API_BASE, maybeRedirectToLogin } from './apiCore.js';
+import { request, API_BASE, throwApiError } from './apiCore.js';
 import { formatBytes } from '../utils/formatters.js';
 import {
   validateImageFile,
@@ -319,12 +319,7 @@ export const cleanImage = async (file, steps = {}) => {
   if (!response) throw new Error('Server unreachable — check your connection and try again');
 
   if (!response.ok) {
-    const error = await response.json().catch(() => ({ error: 'Failed to clean image' }));
-    maybeRedirectToLogin(response, error);
-    const err = new Error(error.error || `HTTP ${response.status}`);
-    err.code = error?.code;
-    err.status = response.status;
-    throw err;
+    await throwApiError(response);
   }
 
   // GPU FLUX round-trip: the server enqueued a job and returned 202 + JSON
@@ -358,11 +353,7 @@ export const fetchCleanResult = async (jobId) => {
     throw e;
   }
   if (!response.ok) {
-    const err = await response.json().catch(() => ({ error: 'Failed to fetch clean result' }));
-    maybeRedirectToLogin(response, err);
-    const e = new Error(err.error || `HTTP ${response.status}`);
-    e.code = err?.code; e.status = response.status;
-    throw e;
+    await throwApiError(response);
   }
   const reportHeader = response.headers.get('X-Clean-Report');
   let report = null;

--- a/client/src/services/apiMedia.test.js
+++ b/client/src/services/apiMedia.test.js
@@ -4,31 +4,40 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 // header, which the JSON-oriented request() helper can't surface). saveCleanResult
 // goes through request(). Mock both layers.
 const request = vi.fn();
-vi.mock('./apiCore.js', () => ({
-  request: (...a) => request(...a),
-  API_BASE: '/api',
-  maybeRedirectToLogin: vi.fn(),
-  // Mirrors the real apiCore.throwApiError (minus the redirect side effect,
-  // already covered by the maybeRedirectToLogin mock above) so assertions
-  // against `.code`/`.status`/`.context`/message keep working unchanged.
-  throwApiError: vi.fn(async (response) => {
+vi.mock('./apiCore.js', () => {
+  // Mirrors the real apiCore.throwApiError, including the maybeRedirectToLogin
+  // call — routing through the SAME mock the test file asserts against, so a
+  // regression in the consumer-side auth-redirect contract actually fails
+  // these tests instead of a mock that silently drops the side effect.
+  const maybeRedirectToLogin = vi.fn();
+  const throwApiError = vi.fn(async (response) => {
     const error = await response.json().catch(() => ({ error: `HTTP ${response.status}` }));
+    maybeRedirectToLogin(response, error);
     const err = new Error(error.error || `HTTP ${response.status}`);
     err.code = error?.code;
     err.status = response.status;
     if (error?.context) err.context = error.context;
     throw err;
-  }),
-}));
+  });
+  return {
+    request: (...a) => request(...a),
+    API_BASE: '/api',
+    maybeRedirectToLogin,
+    throwApiError,
+  };
+});
 
 let cleanImage;
 let fetchCleanResult;
 let saveCleanResult;
+let maybeRedirectToLogin;
 
 beforeEach(async () => {
   vi.resetModules();
   request.mockReset();
   ({ cleanImage, fetchCleanResult, saveCleanResult } = await import('./apiMedia.js'));
+  ({ maybeRedirectToLogin } = await import('./apiCore.js'));
+  maybeRedirectToLogin.mockClear();
   global.fetch = vi.fn();
 });
 
@@ -76,6 +85,13 @@ describe('cleanImage', () => {
   it('throws with the server code on an error response', async () => {
     global.fetch.mockResolvedValue(makeResponse({ status: 400, ok: false, json: { error: 'No FLUX', code: 'REGEN_BACKEND_UNAVAILABLE' } }));
     await expect(cleanImage(fakeFile, { diffusion: 'gpu' })).rejects.toMatchObject({ code: 'REGEN_BACKEND_UNAVAILABLE' });
+  });
+
+  it('honors session expiry the same way request() does (401 AUTH_REQUIRED)', async () => {
+    const response = makeResponse({ status: 401, ok: false, json: { error: 'auth required', code: 'AUTH_REQUIRED' } });
+    global.fetch.mockResolvedValue(response);
+    await expect(cleanImage(fakeFile, { diffusion: 'gpu' })).rejects.toMatchObject({ code: 'AUTH_REQUIRED' });
+    expect(maybeRedirectToLogin).toHaveBeenCalledWith(response, expect.objectContaining({ code: 'AUTH_REQUIRED' }));
   });
 });
 

--- a/client/src/services/apiMedia.test.js
+++ b/client/src/services/apiMedia.test.js
@@ -8,6 +8,17 @@ vi.mock('./apiCore.js', () => ({
   request: (...a) => request(...a),
   API_BASE: '/api',
   maybeRedirectToLogin: vi.fn(),
+  // Mirrors the real apiCore.throwApiError (minus the redirect side effect,
+  // already covered by the maybeRedirectToLogin mock above) so assertions
+  // against `.code`/`.status`/`.context`/message keep working unchanged.
+  throwApiError: vi.fn(async (response) => {
+    const error = await response.json().catch(() => ({ error: `HTTP ${response.status}` }));
+    const err = new Error(error.error || `HTTP ${response.status}`);
+    err.code = error?.code;
+    err.status = response.status;
+    if (error?.context) err.context = error.context;
+    throw err;
+  }),
 }));
 
 let cleanImage;

--- a/client/src/services/apiMedia.test.js
+++ b/client/src/services/apiMedia.test.js
@@ -11,7 +11,12 @@ vi.mock('./apiCore.js', () => {
   // these tests instead of a mock that silently drops the side effect.
   const maybeRedirectToLogin = vi.fn();
   const throwApiError = vi.fn(async (response) => {
-    const error = await response.json().catch(() => ({ error: `HTTP ${response.status}` }));
+    // Mirrors apiCore's own null-safety: a valid JSON body that isn't an
+    // object (e.g. a bare `null`) has no `.error`/`.code`/`.context` to read,
+    // so it falls back to the same HTTP-status shape as non-JSON bodies.
+    const parsedError = await response.json().catch(() => null);
+    const error =
+      parsedError && typeof parsedError === 'object' ? parsedError : { error: `HTTP ${response.status}` };
     maybeRedirectToLogin(response, error);
     const err = new Error(error.error || `HTTP ${response.status}`);
     err.code = error?.code;
@@ -85,6 +90,14 @@ describe('cleanImage', () => {
   it('throws with the server code on an error response', async () => {
     global.fetch.mockResolvedValue(makeResponse({ status: 400, ok: false, json: { error: 'No FLUX', code: 'REGEN_BACKEND_UNAVAILABLE' } }));
     await expect(cleanImage(fakeFile, { diffusion: 'gpu' })).rejects.toMatchObject({ code: 'REGEN_BACKEND_UNAVAILABLE' });
+  });
+
+  it('forwards structured error.context through the direct-fetch wrapper', async () => {
+    const context = { jobId: 'j1', retryable: false };
+    global.fetch.mockResolvedValue(
+      makeResponse({ status: 409, ok: false, json: { error: 'busy', code: 'ERR_BUSY', context } }),
+    );
+    await expect(cleanImage(fakeFile, { diffusion: 'gpu' })).rejects.toMatchObject({ context });
   });
 
   it('honors session expiry the same way request() does (401 AUTH_REQUIRED)', async () => {

--- a/client/src/services/apiSystem.download.test.js
+++ b/client/src/services/apiSystem.download.test.js
@@ -55,6 +55,17 @@ describe('downloadBackupSnapshot', () => {
     expect(URL.createObjectURL).not.toHaveBeenCalled();
   });
 
+  it('forwards structured error.context from a failed download response', async () => {
+    const context = { snapshotId: 'missing', retryable: false };
+    fetch.mockResolvedValue({
+      ok: false,
+      status: 409,
+      json: vi.fn().mockResolvedValue({ error: 'snapshot locked', code: 'ERR_SNAPSHOT_LOCKED', context }),
+    });
+
+    await expect(downloadBackupSnapshot('missing')).rejects.toMatchObject({ context });
+  });
+
   it('streams large responses to a file picker when available', async () => {
     const pipeTo = vi.fn().mockResolvedValue(undefined);
     const writable = {};

--- a/client/src/services/apiSystem.js
+++ b/client/src/services/apiSystem.js
@@ -1,4 +1,4 @@
-import { request, API_BASE, maybeRedirectToLogin } from './apiCore.js';
+import { request, API_BASE, throwApiError } from './apiCore.js';
 import { downloadBlob } from '../lib/downloadBlob.js';
 
 // Alerts
@@ -195,12 +195,7 @@ export async function downloadBackupSnapshot(snapshotId) {
     // Close the handle we opened before we knew the request would fail, so the
     // picker doesn't leave a 0-byte file behind.
     await writable?.abort?.().catch(() => {});
-    const error = await response.json().catch(() => ({ error: `HTTP ${response.status}` }));
-    maybeRedirectToLogin(response, error);
-    const err = new Error(error.error || `HTTP ${response.status}`);
-    err.code = error.code;
-    err.status = response.status;
-    throw err;
+    await throwApiError(response);
   }
 
   if (writable && response.body?.pipeTo) {


### PR DESCRIPTION
Fixes #5047.

## What changed

`apiCore.js` gains `throwApiError(response)`: parses the server's JSON error body, calls `maybeRedirectToLogin` for session expiry, and throws an `Error` carrying `.code`/`.status`/`.context`. `request()` now delegates to it for the envelope construction itself, keeping its own toast/`silent` handling wrapped around the call so behavior there is unchanged.

## Update: the sixth site (apiSystem.js) is now covered too

An earlier revision of this description said `apiSystem.js`'s `downloadBackupSnapshot` "no longer exists in the codebase" - that was true against `main` at the time, but PR #5050 landed after this branch was opened and reintroduced it with its own local `!response.ok` envelope. Per review feedback, I rebased onto current `main` and routed `downloadBackupSnapshot` through `throwApiError` as well (keeping the pre-existing file-handle abort-on-failure cleanup, which now runs before the delegated throw).

All sites are now centralized:

- `apiMedia.js` - `cleanImage`, `fetchCleanResult`
- `apiImageVideo.js` - `installLoraFromHuggingfaceStream`
- `apiLocalLlm.js` - `streamLocalLlmTest`
- `apiSystem.js` - `downloadBackupSnapshot`

## A real bug fix, not just dedup

`apiImageVideo.js` and `apiLocalLlm.js`'s copies never forwarded the server's structured `error.context` - exactly the problem the issue opens with. All four now do, for free, since they go through the same helper `apiMedia.js` and `request()` already used.

## Testing

- `apiCore.test.js`: `throwApiError` directly - message/code/status from the body, the `HTTP {status}` fallback when the body isn't JSON *and* when it's valid JSON but not an object (e.g. a bare `null`), `error.context` surviving, plus `request()`'s toast/`silent`/`PLATFORM_UNAVAILABLE` behavior (including the warning toast itself being suppressed under `{ silent: true }`, not just `toast.error`).
- `apiMedia.test.js`'s `./apiCore.js` mock now mirrors production's null-safe body normalization instead of diverging from it, and asserts `error.context` survives through the direct-fetch wrapper and that session expiry (`maybeRedirectToLogin`) is honored the same way `request()` handles it.
- `apiSystem.download.test.js`: added a case asserting `error.context` survives through `downloadBackupSnapshot`'s direct-fetch path the same way.
- **44/44 passing** across `apiCore.test.js`, `apiMedia.test.js`, `apiSystem.test.js`, `apiSystem.download.test.js`; `biome check` clean on all touched files.
- Ran the full `client` suite twice (770 files / 9850 tests, ~11 min each) prior to the rebase. Both runs had a handful of pre-existing failures unrelated to this change (failing set differed between runs, consistent with pre-existing flake), and none of those files import `apiCore`/`apiMedia`/`apiImageVideo`/`apiLocalLlm`/`apiSystem`.