### PR TITLE
feat: allow removing managed app registrations

### DIFF
--- a/client/src/components/apps/AppDetailView.jsx
+++ b/client/src/components/apps/AppDetailView.jsx
@@ -85,10 +85,19 @@ export default function AppDetailView() {
 
   // Real-time updates
   useEffect(() => {
-    const handleAppsChanged = () => fetchApp();
+    const handleAppsChanged = (change) => {
+      // The delete event reaches this mounted detail view before the DELETE
+      // response can navigate it away. Avoid refetching the known-deleted app,
+      // which would turn the expected 404 into an error toast beside success.
+      if (change?.action === 'delete' && change.appId === appId) {
+        navigate('/apps');
+        return;
+      }
+      fetchApp();
+    };
     socket.on('apps:changed', handleAppsChanged);
     return () => socket.off('apps:changed', handleAppsChanged);
-  }, [fetchApp]);
+  }, [appId, fetchApp, navigate]);
 
   const handleStart = async () => {
     setActionLoading('start');

--- a/client/src/components/apps/AppDetailView.test.jsx
+++ b/client/src/components/apps/AppDetailView.test.jsx
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { act, render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router';
+
+const socketHandlers = new Map();
+
+vi.mock('../../services/api', () => ({
+  PORTOS_APP_ID: 'portos-default',
+  getApp: vi.fn(),
+}));
+
+vi.mock('../../services/socket', () => ({
+  default: {
+    on: vi.fn((event, handler) => socketHandlers.set(event, handler)),
+    off: vi.fn((event, handler) => {
+      if (socketHandlers.get(event) === handler) socketHandlers.delete(event);
+    }),
+  },
+}));
+
+vi.mock('../../services/appUrls', () => ({
+  getLaunchUrls: vi.fn(() => ({ https: null, http: null, dev: null })),
+}));
+
+vi.mock('../ui/Toast', () => ({
+  default: { error: vi.fn(), success: vi.fn(), loading: vi.fn(), dismiss: vi.fn() },
+}));
+vi.mock('../BrailleSpinner', () => ({ default: () => null }));
+vi.mock('../StatusBadge', () => ({ default: () => null }));
+vi.mock('./DeployPanel', () => ({ default: () => null }));
+vi.mock('./EditAppDrawer', () => ({ default: () => null }));
+vi.mock('./DesktopLaunchProgress', () => ({ default: () => null }));
+vi.mock('./tabs/OverviewTab', () => ({ default: () => null }));
+vi.mock('./tabs/TasksTab', () => ({ default: () => null }));
+vi.mock('./tabs/AutomationTab', () => ({ default: () => null }));
+vi.mock('./tabs/DocumentsTab', () => ({ default: () => null }));
+vi.mock('./tabs/GitTab', () => ({ default: () => null }));
+vi.mock('./tabs/GsdTab', () => ({ default: () => null }));
+vi.mock('./tabs/IssuesTab', () => ({ default: () => null }));
+vi.mock('./tabs/JiraTab', () => ({ default: () => null }));
+vi.mock('./tabs/ProcessesTab', () => ({ default: () => null }));
+vi.mock('./tabs/ReferencesTab', () => ({ default: () => null }));
+vi.mock('./tabs/SubmodulesTab', () => ({ default: () => null }));
+vi.mock('./tabs/DatadogTab', () => ({ default: () => null }));
+vi.mock('./tabs/UpdateTab', () => ({ default: () => null }));
+
+import * as api from '../../services/api';
+import AppDetailView from './AppDetailView';
+
+const APP = {
+  id: 'app-1',
+  name: 'Example App',
+  type: 'static',
+  repoPath: '/mock/example-app',
+  pm2ProcessNames: [],
+  processes: [],
+};
+
+function LocationProbe() {
+  const { pathname } = useLocation();
+  return <output data-testid="location">{pathname}</output>;
+}
+
+function renderDetail() {
+  return render(
+    <MemoryRouter initialEntries={['/apps/app-1/overview']}>
+      <LocationProbe />
+      <Routes>
+        <Route path="/apps/:appId/:tab" element={<AppDetailView />} />
+        <Route path="/apps" element={<div>Apps index</div>} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('AppDetailView app-removal socket handling', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    socketHandlers.clear();
+    api.getApp.mockResolvedValue(APP);
+  });
+
+  it('navigates away without refetching a detail record known to be deleted', async () => {
+    renderDetail();
+
+    await screen.findByRole('heading', { name: 'Example App' });
+    const handleAppsChanged = socketHandlers.get('apps:changed');
+    expect(handleAppsChanged).toBeTypeOf('function');
+
+    await act(async () => {
+      handleAppsChanged({ action: 'delete', appId: 'app-1' });
+    });
+
+    expect(screen.getByTestId('location')).toHaveTextContent('/apps');
+    expect(api.getApp).toHaveBeenCalledTimes(1);
+  });
+});

--- a/client/src/components/apps/tabs/OverviewTab.jsx
+++ b/client/src/components/apps/tabs/OverviewTab.jsx
@@ -1,7 +1,8 @@
 import { useState, useEffect, useMemo } from 'react';
-import { Link } from 'react-router';
-import { FolderOpen, Gamepad2, Terminal, Code, RefreshCw, Wrench, Archive, ArchiveRestore, Download, Tag, AlertTriangle, Rocket, Camera, Image, Sparkles } from 'lucide-react';
+import { Link, useNavigate } from 'react-router';
+import { FolderOpen, Gamepad2, Terminal, Code, RefreshCw, Wrench, Archive, ArchiveRestore, Download, Tag, AlertTriangle, Rocket, Camera, Image, Sparkles, Trash2 } from 'lucide-react';
 import toast from '../../ui/Toast';
+import InlineConfirmRow from '../../ui/InlineConfirmRow';
 import { isStandardizable } from '../constants';
 import ActivityLog from '../ActivityLog';
 import SlashDoPanel from '../SlashDoPanel';
@@ -17,8 +18,11 @@ const SCRIPT_ICONS = {
 };
 
 export default function OverviewTab({ app, onRefresh }) {
+  const navigate = useNavigate();
   const [refreshingConfig, setRefreshingConfig] = useState(false);
   const [archiving, setArchiving] = useState(false);
+  const [confirmingDelete, setConfirmingDelete] = useState(false);
+  const [deleting, setDeleting] = useState(false);
   const [installingScripts, setInstallingScripts] = useState(false);
   const [detectingIcon, setDetectingIcon] = useState(false);
   // Reverse lookup (#2991): sprite records that publish assets into this app.
@@ -100,6 +104,19 @@ export default function OverviewTab({ app, onRefresh }) {
   const handleArchive = () => setArchived(true);
 
   const handleUnarchive = () => setArchived(false);
+
+  const handleDelete = async () => {
+    if (deleting) return;
+    setDeleting(true);
+    // DELETE returns 204, so success is represented by resolution rather than
+    // a response body. request() owns the failure toast; this handler only
+    // adds the success path and returns the user to the registry.
+    const removed = await api.deleteApp(app.id).then(() => true, () => false);
+    setDeleting(false);
+    if (!removed) return;
+    toast.success(`${app.name} removed from PortOS — files kept on disk`);
+    navigate('/apps');
+  };
 
   return (
     <div className="space-y-6">
@@ -341,6 +358,41 @@ export default function OverviewTab({ app, onRefresh }) {
           </button>
         )}
       </div>
+
+      {app.id !== api.PORTOS_APP_ID && (
+        <div className="border-t border-port-border pt-4">
+          <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
+            <div>
+              <h3 className="text-sm font-medium text-white">PortOS registration</h3>
+              <p className="text-xs text-gray-500 mt-1">
+                Remove PortOS&apos;s record of this app without deleting its repository from disk.
+              </p>
+            </div>
+            {!confirmingDelete && (
+              <button
+                onClick={() => setConfirmingDelete(true)}
+                disabled={deleting}
+                className="self-start sm:self-auto px-3 py-1.5 bg-port-error/10 text-port-error hover:bg-port-error/20 rounded-lg text-xs flex items-center gap-1 disabled:opacity-50"
+              >
+                <Trash2 size={14} />
+                Remove from PortOS
+              </button>
+            )}
+          </div>
+          {confirmingDelete && (
+            <InlineConfirmRow
+              className="mt-3"
+              autoFocus
+              aria-label={`Confirm removal of ${app.name} from PortOS`}
+              question={`Remove ${app.name} from PortOS? Its repository will stay on disk.`}
+              confirmText={deleting ? 'Removing…' : 'Remove'}
+              cancelText="Keep"
+              onConfirm={handleDelete}
+              onCancel={() => setConfirmingDelete(false)}
+            />
+          )}
+        </div>
+      )}
 
       {/* Activity Log */}
       <ActivityLog steps={steps} error={error} completed={completed} />

--- a/client/src/components/apps/tabs/OverviewTab.test.jsx
+++ b/client/src/components/apps/tabs/OverviewTab.test.jsx
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router';
+
+vi.mock('../../../services/api', () => ({
+  PORTOS_APP_ID: 'portos-default',
+  getAppSpriteBindings: vi.fn(() => Promise.resolve({ bindings: [] })),
+  deleteApp: vi.fn(() => Promise.resolve(null)),
+  archiveApp: vi.fn(() => Promise.resolve({})),
+  unarchiveApp: vi.fn(() => Promise.resolve({})),
+  openAppInEditor: vi.fn(() => Promise.resolve({})),
+  openAppFolder: vi.fn(() => Promise.resolve({})),
+  refreshAppConfig: vi.fn(() => Promise.resolve({})),
+  detectAppIcon: vi.fn(() => Promise.resolve({ detected: false })),
+  installXcodeScripts: vi.fn(() => Promise.resolve({})),
+}));
+
+vi.mock('../../../hooks/useAppOperation', () => ({
+  useAppOperation: vi.fn(() => ({
+    steps: [],
+    isOperating: false,
+    operationType: null,
+    error: null,
+    completed: false,
+    startUpdate: vi.fn(),
+    startStandardize: vi.fn(),
+  })),
+}));
+
+vi.mock('../ActivityLog', () => ({ default: () => null }));
+vi.mock('../SlashDoPanel', () => ({ default: () => null }));
+vi.mock('../../ui/Banner', () => ({ default: () => null }));
+vi.mock('../../ui/Toast', () => ({
+  default: { success: vi.fn(), error: vi.fn() },
+}));
+
+import * as api from '../../../services/api';
+import toast from '../../ui/Toast';
+import OverviewTab from './OverviewTab';
+
+const APP = {
+  id: 'app-1',
+  name: 'Example App',
+  type: 'static',
+  repoPath: '/mock/example-app',
+};
+
+function renderOverview(app = APP) {
+  return render(
+    <MemoryRouter>
+      <OverviewTab app={app} onRefresh={vi.fn()} />
+    </MemoryRouter>,
+  );
+}
+
+describe('OverviewTab PortOS registration removal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    api.deleteApp.mockResolvedValue(null);
+    api.getAppSpriteBindings.mockResolvedValue({ bindings: [] });
+  });
+
+  it('explains that removal keeps the repository and requires confirmation', async () => {
+    const user = userEvent.setup();
+    renderOverview();
+
+    expect(screen.getByRole('button', { name: 'Remove from PortOS' })).toBeTruthy();
+    expect(screen.getByText(/without deleting its repository from disk/)).toBeTruthy();
+
+    await user.click(screen.getByRole('button', { name: 'Remove from PortOS' }));
+
+    expect(screen.getByText('Remove Example App from PortOS? Its repository will stay on disk.')).toBeTruthy();
+    expect(api.deleteApp).not.toHaveBeenCalled();
+  });
+
+  it('removes the association and returns to the app registry after confirmation', async () => {
+    const user = userEvent.setup();
+    renderOverview();
+
+    await user.click(screen.getByRole('button', { name: 'Remove from PortOS' }));
+    await user.click(screen.getByRole('button', { name: 'Remove' }));
+
+    await waitFor(() => expect(api.deleteApp).toHaveBeenCalledWith('app-1'));
+    expect(toast.success).toHaveBeenCalledWith('Example App removed from PortOS — files kept on disk');
+  });
+
+  it('does not offer removal for the PortOS baseline app', async () => {
+    renderOverview({ ...APP, id: 'portos-default', name: 'PortOS' });
+
+    expect(screen.queryByRole('button', { name: 'Remove from PortOS' })).toBeNull();
+    await waitFor(() => expect(api.getAppSpriteBindings).toHaveBeenCalledWith('portos-default'));
+  });
+});

--- a/client/src/pages/Apps.jsx
+++ b/client/src/pages/Apps.jsx
@@ -69,9 +69,11 @@ export default function Apps() {
   }, [fetchApps]);
 
   const handleDelete = async (app) => {
-    await api.deleteApp(app.id);
+    const removed = await api.deleteApp(app.id).then(() => true, () => false);
+    if (!removed) return;
     setConfirmingDelete(null);
-    fetchApps();
+    setApps(prev => prev.filter(candidate => candidate.id !== app.id));
+    toast.success(`${app.name} removed from PortOS — files kept on disk`);
   };
 
   const handleStart = async (app) => {
@@ -461,8 +463,8 @@ export default function Apps() {
                     )}
 
                     {/* Manage is the row's single primary action; the rare and
-                        destructive ones (Archive/Delete) live behind the "…"
-                        menu so Delete isn't the loudest control on the card. */}
+                        destructive ones (Archive/Remove) live behind the "…"
+                        menu so removal isn't the loudest control on the card. */}
                     <div className="flex items-center gap-2">
                       <Link
                         to={`/apps/${app.id}/overview`}
@@ -471,7 +473,7 @@ export default function Apps() {
                       >
                         Manage
                       </Link>
-                      {/* Archive + Delete are withheld for the PortOS baseline app */}
+                      {/* Archive + Remove are withheld for the PortOS baseline app */}
                       {app.id !== api.PORTOS_APP_ID && (
                         <OverflowMenu
                           label={`More actions for ${app.name}`}
@@ -485,8 +487,8 @@ export default function Apps() {
                               onSelect: () => (app.archived ? handleUnarchive(app) : handleArchive(app)),
                             },
                             {
-                              id: 'delete',
-                              label: 'Delete',
+                              id: 'remove',
+                              label: 'Remove from PortOS',
                               icon: Trash2,
                               tone: 'danger',
                               onSelect: () => setConfirmingDelete(app.id),
@@ -502,10 +504,10 @@ export default function Apps() {
                   <InlineConfirmRow
                     className="mt-3"
                     autoFocus
-                    question={`Delete ${app.name}? This removes it from PortOS and cannot be undone.`}
-                    confirmText="Delete"
-                    cancelText="Cancel"
-                    aria-label={`Confirm deletion of ${app.name}`}
+                    question={`Remove ${app.name} from PortOS? Its repository will stay on disk.`}
+                    confirmText="Remove"
+                    cancelText="Keep"
+                    aria-label={`Confirm removal of ${app.name} from PortOS`}
                     onConfirm={() => handleDelete(app)}
                     onCancel={() => {
                       setConfirmingDelete(null);

--- a/client/src/pages/Apps.test.jsx
+++ b/client/src/pages/Apps.test.jsx
@@ -67,12 +67,12 @@ describe('Apps row action hierarchy', () => {
     api.getApps.mockResolvedValue(APPS);
   });
 
-  it('keeps Archive and Delete out of the resting row, leaving Manage as the visible action', async () => {
+  it('keeps Archive and PortOS removal out of the resting row, leaving Manage as the visible action', async () => {
     await renderApps();
 
     expect(screen.getByRole('link', { name: 'Manage Example App' })).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Stop Example App' })).toBeTruthy();
-    expect(screen.queryByRole('button', { name: /^Delete$/ })).toBeNull();
+    expect(screen.queryByRole('button', { name: /^Remove from PortOS$/ })).toBeNull();
     expect(screen.queryByRole('button', { name: /^Archive$/ })).toBeNull();
   });
 
@@ -85,13 +85,13 @@ describe('Apps row action hierarchy', () => {
     expect(nameLink.className).toContain('underline');
   });
 
-  it('exposes Archive and Delete only through the overflow menu', async () => {
+  it('exposes Archive and PortOS removal only through the overflow menu', async () => {
     const user = userEvent.setup();
     await renderApps();
 
     await openRowMenu(user);
     expect(screen.getByRole('menuitem', { name: 'Archive' })).toBeTruthy();
-    expect(screen.getByRole('menuitem', { name: 'Delete' })).toBeTruthy();
+    expect(screen.getByRole('menuitem', { name: 'Remove from PortOS' })).toBeTruthy();
   });
 
   it('requires an inline confirm before deleting, and cancelling leaves the app alone', async () => {
@@ -99,19 +99,19 @@ describe('Apps row action hierarchy', () => {
     await renderApps();
 
     await openRowMenu(user);
-    await user.click(screen.getByRole('menuitem', { name: 'Delete' }));
+    await user.click(screen.getByRole('menuitem', { name: 'Remove from PortOS' }));
 
     expect(api.deleteApp).not.toHaveBeenCalled();
-    const confirm = screen.getByLabelText('Confirm deletion of Example App');
-    expect(confirm.textContent).toContain('cannot be undone');
+    const confirm = screen.getByLabelText('Confirm removal of Example App from PortOS');
+    expect(confirm.textContent).toContain('repository will stay on disk');
 
     // Focus follows the revealed confirmation instead of being stranded on the
     // "…" trigger whose menu just closed.
     expect(document.activeElement).toBe(confirm);
 
-    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+    await user.click(screen.getByRole('button', { name: 'Keep' }));
     expect(api.deleteApp).not.toHaveBeenCalled();
-    expect(screen.queryByLabelText('Confirm deletion of Example App')).toBeNull();
+    expect(screen.queryByLabelText('Confirm removal of Example App from PortOS')).toBeNull();
     // Dismissing hands focus back to the trigger it came from, not to <body>.
     expect(document.activeElement).toBe(screen.getByRole('button', { name: 'More actions for Example App' }));
   });
@@ -121,10 +121,12 @@ describe('Apps row action hierarchy', () => {
     await renderApps();
 
     await openRowMenu(user);
-    await user.click(screen.getByRole('menuitem', { name: 'Delete' }));
-    await user.click(screen.getByRole('button', { name: 'Delete' }));
+    await user.click(screen.getByRole('menuitem', { name: 'Remove from PortOS' }));
+    await user.click(screen.getByRole('button', { name: 'Remove' }));
 
     await waitFor(() => expect(api.deleteApp).toHaveBeenCalledWith('app-alpha'));
+    expect(toast.success).toHaveBeenCalledWith('Example App removed from PortOS — files kept on disk');
+    expect(screen.queryByRole('link', { name: 'Example App' })).toBeNull();
   });
 
   it('archives from the overflow menu', async () => {

--- a/server/routes/apps/crud.js
+++ b/server/routes/apps/crud.js
@@ -5,7 +5,7 @@
  *   GET    /:id              → App    (PM2-status-enriched, + appVersion)
  *   POST   /                 → App
  *   PUT    /:id              → App    (ports written back to ecosystem config)
- *   DELETE /:id              → 204
+ *   DELETE /:id              → 204  (removes the PortOS registry association only)
  *   POST   /:id/archive      → App
  *   POST   /:id/unarchive    → App
  */
@@ -180,6 +180,10 @@ router.delete('/:id', asyncHandler(async (req, res, next) => {
     throw new ServerError('App not found', { status: 404, code: 'NOT_FOUND' });
   }
 
+  // Keep the dashboard, sidebar, OpenWorld, and any open detail view in sync
+  // with the registry removal. This only removes PortOS's association; the
+  // app's repository is not touched by appsService.deleteApp().
+  notifyAppsChanged('delete');
   res.status(204).send();
 }));
 

--- a/server/routes/apps/crud.js
+++ b/server/routes/apps/crud.js
@@ -183,7 +183,7 @@ router.delete('/:id', asyncHandler(async (req, res, next) => {
   // Keep the dashboard, sidebar, OpenWorld, and any open detail view in sync
   // with the registry removal. This only removes PortOS's association; the
   // app's repository is not touched by appsService.deleteApp().
-  notifyAppsChanged('delete');
+  notifyAppsChanged('delete', req.params.id);
   res.status(204).send();
 }));
 

--- a/server/routes/apps/crud.test.js
+++ b/server/routes/apps/crud.test.js
@@ -487,6 +487,7 @@ describe('Apps CRUD Routes', () => {
 
       expect(response.status).toBe(204);
       expect(appsService.deleteApp).toHaveBeenCalledWith('app-001');
+      expect(appsService.notifyAppsChanged).toHaveBeenCalledWith('delete');
     });
 
     it('should return 404 if app not found', async () => {

--- a/server/routes/apps/crud.test.js
+++ b/server/routes/apps/crud.test.js
@@ -487,7 +487,7 @@ describe('Apps CRUD Routes', () => {
 
       expect(response.status).toBe(204);
       expect(appsService.deleteApp).toHaveBeenCalledWith('app-001');
-      expect(appsService.notifyAppsChanged).toHaveBeenCalledWith('delete');
+      expect(appsService.notifyAppsChanged).toHaveBeenCalledWith('delete', 'app-001');
     });
 
     it('should return 404 if app not found', async () => {

--- a/server/services/apps.js
+++ b/server/services/apps.js
@@ -470,7 +470,8 @@ export async function updateApp(id, updates) {
 }
 
 /**
- * Delete an app (PortOS baseline app cannot be deleted)
+ * Remove an app from PortOS's registry (the repository on disk is untouched).
+ * The PortOS baseline app cannot be removed.
  */
 export async function deleteApp(id) {
   if (id === PORTOS_APP_ID) return false;

--- a/server/services/apps.js
+++ b/server/services/apps.js
@@ -158,8 +158,12 @@ export function invalidateCache() {
  * Notify clients that apps data has changed
  * Call this after any operation that modifies app state
  */
-export function notifyAppsChanged(action = 'update') {
-  appsEvents.emit('changed', { action, timestamp: Date.now() });
+export function notifyAppsChanged(action = 'update', appId) {
+  appsEvents.emit('changed', {
+    action,
+    ...(appId ? { appId } : {}),
+    timestamp: Date.now()
+  });
 }
 
 /**

--- a/server/services/apps.test.js
+++ b/server/services/apps.test.js
@@ -37,7 +37,7 @@ vi.mock('./pm2.js', () => ({
 import { atomicWrite, readJSONFile } from '../lib/fileUtils.js';
 import { listProcessesStrict } from './pm2.js';
 import { resetExecutionHistory } from './taskSchedule.js';
-import { annotateExpectedExit, createApp, getAppStatuses, getAppStatusSummary, getDesktopProcessNames, getReservedPorts, invalidateCache, PORTOS_APP_ID, resolvePm2HomeForProcess, updateAppTaskTypeOverride } from './apps.js';
+import { annotateExpectedExit, createApp, deleteApp, getAppStatuses, getAppStatusSummary, getDesktopProcessNames, getReservedPorts, invalidateCache, PORTOS_APP_ID, resolvePm2HomeForProcess, updateAppTaskTypeOverride } from './apps.js';
 
 describe('pr-watcher cooldown reset', () => {
   beforeEach(() => {
@@ -475,6 +475,34 @@ describe('resolvePm2HomeForProcess', () => {
     });
 
     await expect(resolvePm2HomeForProcess('example-api')).resolves.toBeNull();
+  });
+});
+
+describe('deleteApp', () => {
+  beforeEach(() => {
+    invalidateCache();
+    vi.clearAllMocks();
+  });
+
+  it('removes only the PortOS registry record and preserves the app path data', async () => {
+    readJSONFile.mockResolvedValue({
+      apps: {
+        [PORTOS_APP_ID]: { name: 'PortOS' },
+        'app-1': { name: 'Example App', repoPath: '/mock/example-app' },
+      },
+    });
+
+    await expect(deleteApp('app-1')).resolves.toBe(true);
+
+    const persisted = atomicWrite.mock.calls.at(-1)[1];
+    expect(persisted.apps['app-1']).toBeUndefined();
+    expect(persisted.apps[PORTOS_APP_ID]).toMatchObject({ name: 'PortOS' });
+  });
+
+  it('protects the PortOS baseline record', async () => {
+    await expect(deleteApp(PORTOS_APP_ID)).resolves.toBe(false);
+    expect(readJSONFile).not.toHaveBeenCalled();
+    expect(atomicWrite).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Summary
- Add a confirmed Remove from PortOS action to managed-app detail and list views.
- Remove only the PortOS registry association; repositories and app files remain on disk.
- Broadcast registry removal so connected app consumers refresh.

## Test plan
- `npm exec vitest run src/components/apps/tabs/OverviewTab.test.jsx src/pages/Apps.test.jsx` (client)
- `npm exec vitest run routes/apps/crud.test.js services/apps.test.js` (server)
- `npm run build` (client)
- `npm test` (server; 3 unrelated pre-existing failures in npm-version and backup timeout tests; 34,448 tests passed).