### PR TITLE
feat: allow repo studies to override AI settings

### DIFF
--- a/client/src/components/QuickBrainCapture.jsx
+++ b/client/src/components/QuickBrainCapture.jsx
@@ -256,6 +256,10 @@ export default function QuickBrainCapture() {
         onTargetAppChange={repoIntake.setTargetAppId}
         studyContext={repoIntake.studyContext}
         onStudyContextChange={repoIntake.setStudyContext}
+        providerOverride={repoIntake.providerOverride}
+        providers={repoIntake.providers}
+        activeProviderId={repoIntake.activeProviderId}
+        onProviderOverrideChange={repoIntake.setProviderOverride}
         onToggle={repoIntake.toggle}
       />
 

--- a/client/src/components/QuickBrainCapture.test.jsx
+++ b/client/src/components/QuickBrainCapture.test.jsx
@@ -6,6 +6,7 @@ vi.mock('../services/api', () => ({
   captureBrainThought: vi.fn(),
   getYoutubeIngestSettings: vi.fn(),
   getApps: vi.fn(),
+  getProviders: vi.fn(),
 }));
 // The ingest hook reaches for apiBrain directly (not through the `api` barrel),
 // so mock it separately — that keeps the REAL useYoutubeIngest/useSseJobSlot
@@ -31,7 +32,7 @@ class StubEventSource {
 }
 globalThis.EventSource = StubEventSource;
 
-import { captureBrainThought, getApps, getYoutubeIngestSettings } from '../services/api';
+import { captureBrainThought, getApps, getProviders, getYoutubeIngestSettings } from '../services/api';
 import { startYoutubeIngest } from '../services/apiBrain.js';
 import toast from './ui/Toast';
 import QuickBrainCapture from './QuickBrainCapture';
@@ -69,6 +70,13 @@ describe('QuickBrainCapture', () => {
       { id: 'portos-default', name: 'PortOS', repoPath: '/srv/portos' },
       { id: 'app-example', name: 'Example App', repoPath: '/srv/example-app' },
     ]);
+    getProviders.mockResolvedValue({
+      activeProvider: 'codex',
+      providers: [
+        { id: 'codex', name: 'Codex', type: 'cli', command: 'codex', enabled: true, defaultModel: 'gpt-5', models: ['gpt-5'] },
+        { id: 'claude-code', name: 'Claude Code', type: 'cli', command: 'claude', enabled: true, defaultModel: 'claude-sonnet', models: ['claude-sonnet'] },
+      ],
+    });
     startYoutubeIngest.mockResolvedValue({ jobId: 'job-1' });
   });
 
@@ -183,6 +191,26 @@ describe('QuickBrainCapture', () => {
         learn: true,
         targetAppId: 'portos-default',
         studyContext: 'Look for the indexing approach and where it could fit in search.',
+      });
+    });
+
+    it('sends a provider, model, and effort override with the repo study request', async () => {
+      renderWidget();
+      type(REPO);
+      fireEvent.click(screen.getByLabelText('Study for app ideas'));
+      fireEvent.change(screen.getByLabelText('Provider'), { target: { value: 'claude-code' } });
+      fireEvent.change(screen.getByLabelText('Model'), { target: { value: 'claude-sonnet' } });
+      fireEvent.change(screen.getByLabelText('Thinking effort'), { target: { value: 'high' } });
+      fireEvent.click(screen.getByLabelText('Capture'));
+
+      await waitFor(() => expect(captureBrainThought).toHaveBeenCalled());
+      expect(captureBrainThought.mock.calls[0][3].repoIntake).toEqual({
+        malwareScan: false,
+        learn: true,
+        targetAppId: 'portos-default',
+        providerId: 'claude-code',
+        model: 'claude-sonnet',
+        effort: 'high',
       });
     });
 

--- a/client/src/components/QuickBrainCapture.test.jsx
+++ b/client/src/components/QuickBrainCapture.test.jsx
@@ -198,6 +198,7 @@ describe('QuickBrainCapture', () => {
       renderWidget();
       type(REPO);
       fireEvent.click(screen.getByLabelText('Study for app ideas'));
+      await waitFor(() => expect(screen.getByLabelText('Provider')).toBeInTheDocument());
       fireEvent.change(screen.getByLabelText('Provider'), { target: { value: 'claude-code' } });
       fireEvent.change(screen.getByLabelText('Model'), { target: { value: 'claude-sonnet' } });
       fireEvent.change(screen.getByLabelText('Thinking effort'), { target: { value: 'high' } });

--- a/client/src/components/brain/RepoIntakeOptions.jsx
+++ b/client/src/components/brain/RepoIntakeOptions.jsx
@@ -1,5 +1,6 @@
 import { GitBranch, ShieldCheck, Lightbulb } from 'lucide-react';
 import ToggleChip from '../ui/ToggleChip';
+import AgentJobProviderFields from '../cos/AgentJobProviderFields';
 
 /**
  * The "this URL is a GitHub repo" affordance shared by both Brain capture boxes
@@ -34,9 +35,13 @@ export const REPO_INTAKE_OPTIONS = [
  * @param {{malwareScan: boolean, learn: boolean}} props.options
  * @param {string} props.studyContext
  * @param {(context: string) => void} props.onStudyContextChange
+ * @param {{providerId: string, model: string, effort: string}} props.providerOverride
+ * @param {Array} props.providers
+ * @param {string} props.activeProviderId
+ * @param {(patch: object) => void} props.onProviderOverrideChange
  * @param {(key: string) => void} props.onToggle
  */
-export default function RepoIntakeOptions({ idPrefix, repo, options, managedApps = [], targetAppId, onTargetAppChange, studyContext = '', onStudyContextChange, onToggle }) {
+export default function RepoIntakeOptions({ idPrefix, repo, options, managedApps = [], targetAppId, onTargetAppChange, studyContext = '', onStudyContextChange, providerOverride = { providerId: '', model: '', effort: '' }, providers = [], activeProviderId = '', onProviderOverrideChange, onToggle }) {
   if (!repo) return null;
 
   return (
@@ -87,6 +92,21 @@ export default function RepoIntakeOptions({ idPrefix, repo, options, managedApps
             placeholder="What should the agent look for, and where might an implementation fit?"
             className="w-full px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white text-sm"
           />
+        </div>
+      )}
+      {options.learn && (
+        <div className="pt-1">
+          <AgentJobProviderFields
+            data={providerOverride}
+            providers={providers}
+            activeProviderId={activeProviderId}
+            onChange={onProviderOverrideChange}
+          />
+          {providers.length > 0 && (
+            <p className="mt-1 text-xs text-gray-500">
+              Optional override for this study only. Leave it on the default to use the configured CoS provider.
+            </p>
+          )}
         </div>
       )}
       {REPO_INTAKE_OPTIONS.some(({ key }) => options[key]) && (

--- a/client/src/components/brain/tabs/InboxTab.jsx
+++ b/client/src/components/brain/tabs/InboxTab.jsx
@@ -372,6 +372,10 @@ export default function InboxTab({ onRefresh, settings }) {
           onTargetAppChange={repoIntake.setTargetAppId}
           studyContext={repoIntake.studyContext}
           onStudyContextChange={repoIntake.setStudyContext}
+          providerOverride={repoIntake.providerOverride}
+          providers={repoIntake.providers}
+          activeProviderId={repoIntake.activeProviderId}
+          onProviderOverrideChange={repoIntake.setProviderOverride}
           onToggle={repoIntake.toggle}
         />
       </form>

--- a/client/src/hooks/useProviderModels.js
+++ b/client/src/hooks/useProviderModels.js
@@ -58,10 +58,11 @@ const sourceModels = (provider, withEffort) => {
  *   — then list BASE models instead, with effort picked separately. Leave off
  *   for a picker with no effort control: there the suffixed ids are the only
  *   way to express a tier, so collapsing them would strip the capability.
- * @returns {{ providers, selectedProviderId, selectedModel, availableModels, selectedProvider, setSelectedProviderId, setSelectedModel, loading }}
+ * @returns {{ providers, activeProviderId, selectedProviderId, selectedModel, availableModels, selectedProvider, setSelectedProviderId, setSelectedModel, loading }}
  */
 export default function useProviderModels({ filter, allowDefault = false, silent = false, modelFilter, withEffort = false } = {}) {
   const [providers, setProviders] = useState([]);
+  const [activeProviderId, setActiveProviderId] = useState('');
   const [selectedProviderId, setSelectedProviderId] = useState('');
   const [selectedModel, setSelectedModel] = useState('');
   const [loading, setLoading] = useState(true);
@@ -112,8 +113,9 @@ export default function useProviderModels({ filter, allowDefault = false, silent
       // Log even when `silent` suppresses the toast, so a failed fetch leaves
       // a breadcrumb (matches the prior inline console.warn behavior).
       console.warn(`⚠️ Provider list fetch failed: ${err?.message || err}`);
-      return { providers: [] };
+      return { activeProvider: '', providers: [] };
     });
+    setActiveProviderId(typeof data?.activeProvider === 'string' ? data.activeProvider : '');
     const filterFn = filter || (p => p.enabled);
     const filtered = (data.providers || [])
       .filter(isProviderHardwareCompatible)
@@ -202,6 +204,7 @@ export default function useProviderModels({ filter, allowDefault = false, silent
 
   return {
     providers,
+    activeProviderId,
     selectedProviderId,
     selectedModel,
     availableModels,

--- a/client/src/hooks/useProviderModels.js
+++ b/client/src/hooks/useProviderModels.js
@@ -58,14 +58,16 @@ const sourceModels = (provider, withEffort) => {
  *   — then list BASE models instead, with effort picked separately. Leave off
  *   for a picker with no effort control: there the suffixed ids are the only
  *   way to express a tier, so collapsing them would strip the capability.
+ * @param {boolean} [options.enabled] - Load the provider catalog only when true.
+ *   Disabled pickers keep an empty catalog and do not issue a provider request.
  * @returns {{ providers, activeProviderId, selectedProviderId, selectedModel, availableModels, selectedProvider, setSelectedProviderId, setSelectedModel, loading }}
  */
-export default function useProviderModels({ filter, allowDefault = false, silent = false, modelFilter, withEffort = false } = {}) {
+export default function useProviderModels({ filter, allowDefault = false, silent = false, modelFilter, withEffort = false, enabled = true } = {}) {
   const [providers, setProviders] = useState([]);
   const [activeProviderId, setActiveProviderId] = useState('');
   const [selectedProviderId, setSelectedProviderId] = useState('');
   const [selectedModel, setSelectedModel] = useState('');
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(enabled);
   const hasSetInitialRef = useRef(false);
   // Latched once the model is chosen deliberately — a picker change, or a
   // caller restoring a saved pin. The auto re-pick below then stands down for
@@ -129,7 +131,15 @@ export default function useProviderModels({ filter, allowDefault = false, silent
     setLoading(false);
   }, [filter, allowDefault, silent]);
 
-  useEffect(() => { load(); }, [load]);
+  useEffect(() => {
+    if (!enabled) {
+      setProviders([]);
+      setActiveProviderId('');
+      setLoading(false);
+      return;
+    }
+    load();
+  }, [enabled, load]);
 
   const currentProvider = useMemo(
     () => providers.find(p => p.id === selectedProviderId),

--- a/client/src/hooks/useProviderModels.js
+++ b/client/src/hooks/useProviderModels.js
@@ -68,6 +68,7 @@ export default function useProviderModels({ filter, allowDefault = false, silent
   const [selectedProviderId, setSelectedProviderId] = useState('');
   const [selectedModel, setSelectedModel] = useState('');
   const [loading, setLoading] = useState(enabled);
+  const loadGenerationRef = useRef(0);
   const hasSetInitialRef = useRef(false);
   // Latched once the model is chosen deliberately — a picker change, or a
   // caller restoring a saved pin. The auto re-pick below then stands down for
@@ -110,6 +111,7 @@ export default function useProviderModels({ filter, allowDefault = false, silent
   useEffect(() => { pickInitialModelRef.current = pickInitialModel; }, [pickInitialModel]);
 
   const load = useCallback(async () => {
+    const loadGeneration = ++loadGenerationRef.current;
     setLoading(true);
     const data = await api.getProviders(silent ? { silent: true } : undefined).catch((err) => {
       // Log even when `silent` suppresses the toast, so a failed fetch leaves
@@ -117,6 +119,7 @@ export default function useProviderModels({ filter, allowDefault = false, silent
       console.warn(`⚠️ Provider list fetch failed: ${err?.message || err}`);
       return { activeProvider: '', providers: [] };
     });
+    if (loadGeneration !== loadGenerationRef.current) return;
     setActiveProviderId(typeof data?.activeProvider === 'string' ? data.activeProvider : '');
     const filterFn = filter || (p => p.enabled);
     const filtered = (data.providers || [])
@@ -133,12 +136,14 @@ export default function useProviderModels({ filter, allowDefault = false, silent
 
   useEffect(() => {
     if (!enabled) {
+      loadGenerationRef.current += 1;
       setProviders([]);
       setActiveProviderId('');
       setLoading(false);
       return;
     }
     load();
+    return () => { loadGenerationRef.current += 1; };
   }, [enabled, load]);
 
   const currentProvider = useMemo(

--- a/client/src/hooks/useProviderModels.test.js
+++ b/client/src/hooks/useProviderModels.test.js
@@ -120,6 +120,34 @@ describe('useProviderModels — lazy loading', () => {
     expect(api.getProviders).toHaveBeenCalledTimes(1);
     expect(hook.result.current.providers).toEqual([CODEX]);
   });
+
+  it('ignores a provider response from a load invalidated by disable and re-enable', async () => {
+    const deferred = () => {
+      let resolve;
+      const promise = new Promise((res) => { resolve = res; });
+      return { promise, resolve };
+    };
+    const first = deferred();
+    const second = deferred();
+    api.getProviders.mockReturnValueOnce(first.promise).mockReturnValueOnce(second.promise);
+    const replacement = { ...CODEX, id: 'replacement', name: 'Replacement' };
+    const hook = renderHook(
+      ({ enabled }) => useProviderModels({ allowDefault: true, enabled }),
+      { initialProps: { enabled: true } },
+    );
+
+    await waitFor(() => expect(api.getProviders).toHaveBeenCalledTimes(1));
+    hook.rerender({ enabled: false });
+    await waitFor(() => expect(hook.result.current.loading).toBe(false));
+    hook.rerender({ enabled: true });
+    await waitFor(() => expect(api.getProviders).toHaveBeenCalledTimes(2));
+
+    await act(async () => { first.resolve({ providers: [CODEX] }); });
+    expect(hook.result.current.providers).toEqual([]);
+
+    await act(async () => { second.resolve({ providers: [replacement] }); });
+    await waitFor(() => expect(hook.result.current.providers).toEqual([replacement]));
+  });
 });
 
 // A capability-scoped picker (vision) starts on the client-side id regex and

--- a/client/src/hooks/useProviderModels.test.js
+++ b/client/src/hooks/useProviderModels.test.js
@@ -102,6 +102,26 @@ describe('useProviderModels — provider envelope metadata', () => {
   });
 });
 
+describe('useProviderModels — lazy loading', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('does not fetch while disabled and fetches when enabled', async () => {
+    api.getProviders.mockResolvedValue({ providers: [CODEX] });
+    const hook = renderHook(
+      ({ enabled }) => useProviderModels({ allowDefault: true, enabled }),
+      { initialProps: { enabled: false } },
+    );
+
+    expect(hook.result.current.loading).toBe(false);
+    expect(api.getProviders).not.toHaveBeenCalled();
+
+    hook.rerender({ enabled: true });
+    await waitFor(() => expect(hook.result.current.loading).toBe(false));
+    expect(api.getProviders).toHaveBeenCalledTimes(1);
+    expect(hook.result.current.providers).toEqual([CODEX]);
+  });
+});
+
 // A capability-scoped picker (vision) starts on the client-side id regex and
 // widens once the server's authoritative list resolves, so its `modelFilter`
 // identity changes AFTER the first load. Stand-in filters here: the contract

--- a/client/src/hooks/useProviderModels.test.js
+++ b/client/src/hooks/useProviderModels.test.js
@@ -91,6 +91,17 @@ describe('useProviderModels — Antigravity base models', () => {
   });
 });
 
+describe('useProviderModels — provider envelope metadata', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('exposes the configured active provider alongside the catalog', async () => {
+    api.getProviders.mockResolvedValue({ activeProvider: 'codex', providers: [CODEX] });
+    const { result } = renderHook(() => useProviderModels({ allowDefault: true }));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.activeProviderId).toBe('codex');
+  });
+});
+
 // A capability-scoped picker (vision) starts on the client-side id regex and
 // widens once the server's authoritative list resolves, so its `modelFilter`
 // identity changes AFTER the first load. Stand-in filters here: the contract

--- a/client/src/hooks/useRepoIntake.js
+++ b/client/src/hooks/useRepoIntake.js
@@ -50,19 +50,20 @@ export function capturedGitHubRepo(text) {
  *   can't ride along on a capture the user retyped into a plain thought.
  */
 export function useRepoIntake(text) {
+  const [malwareScan, setMalwareScan] = useLocalStorageBool(STORAGE_KEYS.malwareScan, false);
+  const [learn, setLearn] = useLocalStorageBool(STORAGE_KEYS.learn, false);
+  const repo = useMemo(() => capturedGitHubRepo(text), [text]);
   const { providers, activeProviderId } = useProviderModels({
     allowDefault: true,
     silent: true,
     withEffort: true,
+    enabled: Boolean(repo && learn),
   });
-  const [malwareScan, setMalwareScan] = useLocalStorageBool(STORAGE_KEYS.malwareScan, false);
-  const [learn, setLearn] = useLocalStorageBool(STORAGE_KEYS.learn, false);
   const [managedApps, setManagedApps] = useState([{ id: PORTOS_APP_ID, name: 'PortOS' }]);
   const [targetAppId, setTargetAppId] = useState(PORTOS_APP_ID);
   const [studyContext, setStudyContext] = useState('');
   const [providerOverride, setProviderOverride] = useState({ providerId: '', model: '', effort: '' });
 
-  const repo = useMemo(() => capturedGitHubRepo(text), [text]);
   const repoKey = repo ? `${repo.owner}/${repo.repo}` : null;
   const options = useMemo(() => ({ malwareScan, learn }), [malwareScan, learn]);
   const setters = { malwareScan: setMalwareScan, learn: setLearn };

--- a/client/src/hooks/useRepoIntake.js
+++ b/client/src/hooks/useRepoIntake.js
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useLocalStorageBool } from './useLocalStorageBool.js';
+import useProviderModels from './useProviderModels.js';
 import { parseBareUrl } from '../lib/bareUrl.js';
 import { parseGitHubUrl } from '../lib/githubRepoUrl.js';
 import * as api from '../services/api.js';
@@ -38,7 +39,8 @@ export function capturedGitHubRepo(text) {
 /**
  * @param {string} text the current capture text
  * @returns {{ repo: object|null, options: object, studyContext: string,
- *   setStudyContext: (context: string) => void, toggle: (key: string) => void,
+ *   setStudyContext: (context: string) => void, providerOverride: object,
+ *   setProviderOverride: (patch: object) => void, toggle: (key: string) => void,
  *   intakeFor: (text: string) => object|undefined }}
  *   `repo` is the parsed `{ owner, repo }` (null when the text isn't a bare repo
  *   URL) — both the panel and the host's hint read it, so the text is parsed
@@ -48,11 +50,17 @@ export function capturedGitHubRepo(text) {
  *   can't ride along on a capture the user retyped into a plain thought.
  */
 export function useRepoIntake(text) {
+  const { providers, activeProviderId } = useProviderModels({
+    allowDefault: true,
+    silent: true,
+    withEffort: true,
+  });
   const [malwareScan, setMalwareScan] = useLocalStorageBool(STORAGE_KEYS.malwareScan, false);
   const [learn, setLearn] = useLocalStorageBool(STORAGE_KEYS.learn, false);
   const [managedApps, setManagedApps] = useState([{ id: PORTOS_APP_ID, name: 'PortOS' }]);
   const [targetAppId, setTargetAppId] = useState(PORTOS_APP_ID);
   const [studyContext, setStudyContext] = useState('');
+  const [providerOverride, setProviderOverride] = useState({ providerId: '', model: '', effort: '' });
 
   const repo = useMemo(() => capturedGitHubRepo(text), [text]);
   const repoKey = repo ? `${repo.owner}/${repo.repo}` : null;
@@ -61,6 +69,7 @@ export function useRepoIntake(text) {
 
   useEffect(() => {
     setStudyContext('');
+    setProviderOverride({ providerId: '', model: '', effort: '' });
   }, [repoKey]);
 
   useEffect(() => {
@@ -84,11 +93,18 @@ export function useRepoIntake(text) {
     setTargetAppId,
     studyContext,
     setStudyContext,
+    providers,
+    activeProviderId,
+    providerOverride,
+    setProviderOverride: (patch) => setProviderOverride(current => ({ ...current, ...patch })),
     toggle: (key) => setters[key](v => !v),
     intakeFor: (submitted) => (capturedGitHubRepo(submitted)
       ? { ...options, ...(learn ? {
         targetAppId,
         ...(studyContext.trim() ? { studyContext: studyContext.trim() } : {}),
+        ...(providerOverride.providerId ? { providerId: providerOverride.providerId } : {}),
+        ...(providerOverride.model ? { model: providerOverride.model } : {}),
+        ...(providerOverride.effort ? { effort: providerOverride.effort } : {}),
       } : {}) }
       : undefined),
   };

--- a/client/src/services/apiBrain.js
+++ b/client/src/services/apiBrain.js
@@ -10,9 +10,10 @@ export const updateBrainSettings = (settings, options = {}) => request('/brain/s
 });
 
 // Brain - Capture & Inbox
-// `repoIntake` ({ malwareScan, learn, targetAppId, studyContext }) is the
-// capture box's post-clone agent opt-in; the server ignores it unless the text
-// is a bare GitHub repo URL.
+// `repoIntake` ({ malwareScan, learn, targetAppId, studyContext, providerId,
+// model, effort }) is the capture box's post-clone agent opt-in; the server
+// ignores it unless the text is a bare GitHub repo URL. Provider pins apply to
+// the optional repo study only.
 export const captureBrainThought = (text, providerOverride, modelOverride, { creative, repoIntake } = {}, options = {}) => request('/brain/capture', {
   method: 'POST',
   body: JSON.stringify({ text, providerOverride, modelOverride, creative, repoIntake }),

--- a/server/lib/brainValidation.js
+++ b/server/lib/brainValidation.js
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { partialWithoutDefaults, optionalBooleanMap } from './zodCompat.js';
 import { REPO_INTAKE_KEYS } from './repoIntakeActions.js';
+import { EFFORT_LEVELS } from './providerModels.js';
 import { MAX_QUALITY } from './spacedRepetition.js';
 
 // Destination enum. `links` is reachable only from the bare-URL capture
@@ -193,7 +194,16 @@ export const reviewRecordSchema = z.object({
 // that reads it (server/lib/repoIntakeActions.js).
 export const repoIntakeSchema = z.object(optionalBooleanMap(REPO_INTAKE_KEYS)).extend({
   targetAppId: z.string().trim().min(1).max(200).optional(),
-  studyContext: z.string().trim().max(5000).optional()
+  studyContext: z.string().trim().max(5000).optional(),
+  // These pins apply only to the opt-in repo-study CoS task. Empty values are
+  // the UI's "use the configured default" sentinel and are omitted before
+  // the link stores the intake request.
+  providerId: z.string().trim().min(1).max(120).optional(),
+  model: z.string().trim().min(1).max(200).optional(),
+  effort: z.preprocess(
+    value => typeof value === 'string' ? (value.trim().toLowerCase() || undefined) : value,
+    z.enum(EFFORT_LEVELS).optional()
+  )
 });
 const repoIntakeInputSchema = repoIntakeSchema.optional();
 

--- a/server/lib/brainValidation.test.js
+++ b/server/lib/brainValidation.test.js
@@ -438,6 +438,27 @@ describe('brainValidation.js', () => {
       expect(result.success).toBe(true);
     });
 
+    it('should allow provider pins inside a repo-study intake', () => {
+      const result = captureInputSchema.safeParse({
+        text: 'https://github.com/example/repo',
+        repoIntake: {
+          learn: true,
+          providerId: 'codex',
+          model: 'gpt-5',
+          effort: 'high',
+        },
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('should reject an unknown repo-study effort', () => {
+      const result = captureInputSchema.safeParse({
+        text: 'https://github.com/example/repo',
+        repoIntake: { learn: true, effort: 'unlimited' },
+      });
+      expect(result.success).toBe(false);
+    });
+
     it('should reject empty text', () => {
       expect(captureInputSchema.safeParse({ text: '' }).success).toBe(false);
     });

--- a/server/lib/repoIntakeActions.js
+++ b/server/lib/repoIntakeActions.js
@@ -10,19 +10,31 @@
  */
 
 import { isPlainObject } from './objects.js';
+import { EFFORT_LEVELS } from './providerModels.js';
 
 export const REPO_INTAKE_KEYS = ['malwareScan', 'learn'];
 
+const normalizeOptionalString = (value, maxLength) => {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed && trimmed.length <= maxLength ? trimmed : undefined;
+};
+
+const normalizeOptionalEffort = (value) => {
+  const effort = normalizeOptionalString(value, 32)?.toLowerCase();
+  return effort && EFFORT_LEVELS.includes(effort) ? effort : undefined;
+};
+
 /**
- * Normalize a client-supplied intake object to `{ malwareScan, learn }` booleans,
- * or null when nothing was requested.
+ * Normalize a client-supplied intake object to the two action booleans plus
+ * optional repo-study context/provider pins, or null when nothing was requested.
  *
  * Returning null rather than an all-false object matters: it's what keeps
  * "the user ticked nothing" from being persisted onto every captured link and
  * from scheduling a no-op intake pass after each clone.
  *
  * @param {unknown} input
- * @returns {{ malwareScan: boolean, learn: boolean, targetAppId?: string, studyContext?: string } | null}
+ * @returns {{ malwareScan: boolean, learn: boolean, targetAppId?: string, studyContext?: string, providerId?: string, model?: string, effort?: string } | null}
  */
 export function normalizeRepoIntake(input) {
   if (!isPlainObject(input)) return null;
@@ -33,6 +45,14 @@ export function normalizeRepoIntake(input) {
   }
   if (normalized.learn && typeof input.studyContext === 'string' && input.studyContext.trim()) {
     normalized.studyContext = input.studyContext.trim();
+  }
+  if (normalized.learn) {
+    const providerId = normalizeOptionalString(input.providerId, 120);
+    const model = normalizeOptionalString(input.model, 200);
+    const effort = normalizeOptionalEffort(input.effort);
+    if (providerId) normalized.providerId = providerId;
+    if (model) normalized.model = model;
+    if (effort) normalized.effort = effort;
   }
   return normalized;
 }

--- a/server/lib/repoIntakeActions.test.js
+++ b/server/lib/repoIntakeActions.test.js
@@ -52,6 +52,34 @@ describe('normalizeRepoIntake', () => {
     });
   });
 
+  it('keeps provider, model, and effort pins only for repo study', () => {
+    expect(normalizeRepoIntake({
+      learn: true,
+      providerId: ' codex ',
+      model: ' gpt-5 ',
+      effort: ' HIGH ',
+    })).toEqual({
+      malwareScan: false,
+      learn: true,
+      providerId: 'codex',
+      model: 'gpt-5',
+      effort: 'high',
+    });
+    expect(normalizeRepoIntake({
+      malwareScan: true,
+      providerId: 'codex',
+      model: 'gpt-5',
+      effort: 'high',
+    })).toEqual({ malwareScan: true, learn: false });
+  });
+
+  it('drops an unknown effort rather than persisting an unsafe task override', () => {
+    expect(normalizeRepoIntake({ learn: true, effort: 'unlimited' })).toEqual({
+      malwareScan: false,
+      learn: true,
+    });
+  });
+
   it('covers exactly the two documented actions', () => {
     expect(REPO_INTAKE_KEYS).toEqual(['malwareScan', 'learn']);
   });

--- a/server/services/agentProviderResolution.js
+++ b/server/services/agentProviderResolution.js
@@ -36,12 +36,14 @@ export async function resolveAgentProviderAndModel(task) {
   // availability/fallback logic below as any other resolved provider.
   let provider = null;
   const userProviderId = task.metadata?.provider;
+  let userProviderMissing = false;
   if (userProviderId) {
     const userProvider = await getProviderById(userProviderId);
     if (userProvider) {
       emitLog('info', `Using user-specified provider: ${userProviderId}`, { taskId: task.id });
       provider = userProvider;
     } else {
+      userProviderMissing = true;
       emitLog('warn', `User-specified provider "${userProviderId}" not found, using active provider`, { taskId: task.id });
     }
   }
@@ -170,16 +172,21 @@ export async function resolveAgentProviderAndModel(task) {
   // model"), on every retry, until the task hit max retries and blocked. So a
   // provider swap drops the pin back to the new provider's own default unless
   // that provider actually lists it.
-  const providerSwapped = provider.id !== directProviderId;
+  // A missing pinned provider is also a provider swap, even when the active
+  // provider happens to be the same object the resolver returned. The task's
+  // model was selected for the missing provider and must not silently become a
+  // pin for the active provider.
+  const providerSwapped = userProviderMissing || provider.id !== directProviderId;
+  const pinnedProviderId = userProviderId || directProviderId;
   const isUserPin = modelSelection.tier === 'user-specified' && !fallbackModelPin;
   const isUserPinnedModel = isUserPin && !providerSwapped;
   if (isUserPin && providerSwapped && !(provider.models || []).includes(selectedModel)) {
     // Handled here rather than left to the list check below, which can't fire at
     // all for a fallback provider that enumerates no `models`.
-    emitLog('warn', `Dropping model "${selectedModel}" pinned for unavailable provider "${directProviderId}" — running on fallback "${provider.id}" with its default model`, {
+    emitLog('warn', `Dropping model "${selectedModel}" pinned for provider "${pinnedProviderId}" — running on fallback "${provider.id}" with its default model`, {
       taskId: task.id,
       requestedModel: selectedModel,
-      pinnedProviderId: directProviderId,
+      pinnedProviderId,
       providerId: provider.id
     });
     selectedModel = provider.defaultModel || null;

--- a/server/services/agentProviderResolution.test.js
+++ b/server/services/agentProviderResolution.test.js
@@ -104,6 +104,26 @@ describe('resolveAgentProviderAndModel', () => {
     expect(r.permanent).toBe(true);
   });
 
+  it('drops a model pin when the requested provider disappeared before the task ran', async () => {
+    const active = { id: 'codex', type: 'cli', models: ['gpt-5'], defaultModel: 'gpt-5' };
+    getProviderById.mockResolvedValue(null);
+    getActiveProvider.mockResolvedValue(active);
+    selectModelForTask.mockResolvedValue({
+      model: 'claude-sonnet',
+      tier: 'user-specified',
+      reason: 'user-preference',
+    });
+
+    const r = await resolveAgentProviderAndModel({
+      id: 't',
+      metadata: { provider: 'claude-code', model: 'claude-sonnet' },
+    });
+
+    expect(r.ok).toBe(true);
+    expect(r.provider).toBe(active);
+    expect(r.selectedModel).toBe('gpt-5');
+  });
+
   it('switches to the fallback provider and pins its model when one is available', async () => {
     const primary = { id: 'p1', type: 'cli' };
     const fallback = { id: 'p2', type: 'cli', models: ['fb-model'] };

--- a/server/services/backup.test.js
+++ b/server/services/backup.test.js
@@ -1226,7 +1226,7 @@ describe('restoreSnapshot snapshotId, filter flags, and settings re-sync', () =>
     const proc = fakeProc();
     spawn.mockReturnValue(proc);
     const pending = restoreSnapshot(...args);
-    await flush();
+    await vi.waitFor(() => expect(spawn).toHaveBeenCalled());
     proc.emit('close', 0);
     return pending;
   }
@@ -1319,7 +1319,7 @@ describe('restoreSnapshot snapshotId, filter flags, and settings re-sync', () =>
       const proc = fakeProc();
       spawn.mockReturnValue(proc);
       const pending = restoreSnapshot('/dest', 'snap-1', { dryRun: false });
-      await flush();
+      await vi.waitFor(() => expect(spawn).toHaveBeenCalled());
       proc.stderr.emit('data', Buffer.from('boom'));
       proc.emit('close', 1);
 

--- a/server/services/backup.test.js
+++ b/server/services/backup.test.js
@@ -118,11 +118,10 @@ function fakeProc() {
   return proc;
 }
 
-// dumpPostgres awaits checkHealth() before calling spawn() and attaching its
-// close/error listeners. Flush the microtask queue so the listeners exist
-// before the test drives the fake process — otherwise an 'error' emit throws
-// (no listener) and 'close' emits fall into the void (test hangs).
-const flush = () => new Promise((r) => setTimeout(r, 0));
+// The restore/dump helpers await filesystem and health checks before calling
+// spawn() and attaching child-process listeners. Wait for the mocked spawn
+// call itself so CI scheduling cannot emit into an uninitialized fake process.
+const flush = () => vi.waitFor(() => expect(spawn).toHaveBeenCalled());
 
 const overridable = DEFAULT_EXCLUDES.filter(e => e.overridable).map(e => e.path);
 const nonOverridable = DEFAULT_EXCLUDES.filter(e => !e.overridable).map(e => e.path);

--- a/server/services/brain.test.js
+++ b/server/services/brain.test.js
@@ -366,6 +366,23 @@ describe('brain service', () => {
         }));
       });
 
+      it('persists repo-study provider pins with the requested intake', async () => {
+        asGitHub();
+        await captureThought('https://github.com/acme/widgets', undefined, undefined, {
+          repoIntake: { learn: true, providerId: 'codex', model: 'gpt-5', effort: 'high' },
+        });
+
+        expect(storage.createLink).toHaveBeenCalledWith(expect.objectContaining({
+          repoIntake: {
+            malwareScan: false,
+            learn: true,
+            providerId: 'codex',
+            model: 'gpt-5',
+            effort: 'high',
+          }
+        }));
+      });
+
       it('stores nothing when every box is unticked', async () => {
         asGitHub();
         await captureThought('https://github.com/acme/widgets', undefined, undefined, {

--- a/server/services/repoIntake.js
+++ b/server/services/repoIntake.js
@@ -10,6 +10,7 @@
  *   - `learn`       → a `repo-study` review: read the clone as a source of IDEAS
  *     for PortOS and file the adoptable ones into PortOS's configured work
  *     tracker. Clean-room — propose reimplementation, never copy upstream code.
+ *     Its optional provider/model/effort pins travel with the stored request.
  *
  * Both are queued only AFTER the clone succeeds (there is nothing to read
  * before that), and only because the user asked for them in the same request —
@@ -145,7 +146,7 @@ End with: the studied repo, its license, how many proposals you filed (with thei
  *
  * @returns {Promise<{ queued: boolean, reason?: string, taskId?: string, linkPatch?: object }>}
  */
-export async function queueRepoStudy(link, targetAppId = PORTOS_APP_ID, studyContext) {
+export async function queueRepoStudy(link, targetAppId = PORTOS_APP_ID, studyContext, { providerId, model, effort } = {}) {
   if (!isCloneReadable(link)) return { queued: false, reason: 'not-cloned' };
 
   const app = await getAppById(targetAppId || PORTOS_APP_ID);
@@ -187,6 +188,9 @@ export async function queueRepoStudy(link, targetAppId = PORTOS_APP_ID, studyCon
       // without pretending to be a scheduled task type — see
       // taskTypeHooks.js#isTrackerFilingDispatch.
       workTracker,
+      ...(providerId ? { provider: providerId } : {}),
+      ...(model ? { model } : {}),
+      ...(effort ? { effort } : {}),
       repoStudy: { linkId: link.id },
     },
     'user'
@@ -222,7 +226,7 @@ export async function runRepoIntake(link, intake) {
   for (const [key, queue] of Object.entries(INTAKE_QUEUERS)) {
     if (!requested[key]) continue;
     const result = key === 'learn'
-      ? await queue(link, requested.targetAppId, requested.studyContext).catch(err => ({ queued: false, reason: err.message }))
+      ? await queue(link, requested.targetAppId, requested.studyContext, requested).catch(err => ({ queued: false, reason: err.message }))
       : await queue(link).catch(err => ({ queued: false, reason: err.message }));
     if (result.queued) patch = { ...patch, ...result.linkPatch };
     else console.error(`❌ Capture-time ${key} not queued for link ${link.id}: ${result.reason}`);

--- a/server/services/repoIntake.test.js
+++ b/server/services/repoIntake.test.js
@@ -114,6 +114,20 @@ describe('queueRepoStudy', () => {
     expect(addTask.mock.calls[0][0].context).not.toContain('current PortOS area vocabulary');
   });
 
+  it('passes the selected provider, model, and effort to the repo-study task', async () => {
+    await queueRepoStudy(LINK, undefined, undefined, {
+      providerId: 'codex',
+      model: 'gpt-5',
+      effort: 'high',
+    });
+
+    expect(addTask.mock.calls[0][0]).toEqual(expect.objectContaining({
+      provider: 'codex',
+      model: 'gpt-5',
+      effort: 'high',
+    }));
+  });
+
   // `analysisType` enrolls a task in taskSchedule's per-type consecutive-failure
   // ledger (agentFinalization.js), which auto-parks and notifies. A hand-queued
   // repo study has no schedule to park, so it must reach the no-commit gate via
@@ -210,6 +224,20 @@ describe('runRepoIntake', () => {
   it('passes requester context into the queued repo study', async () => {
     await runRepoIntake(LINK, { learn: true, studyContext: 'Focus on the search architecture.' });
     expect(addTask.mock.calls[0][0].context).toContain('Focus on the search architecture.');
+  });
+
+  it('passes provider pins from the stored intake into the queued repo study', async () => {
+    await runRepoIntake(LINK, {
+      learn: true,
+      providerId: 'codex',
+      model: 'gpt-5',
+      effort: 'high',
+    });
+    expect(addTask.mock.calls[0][0]).toEqual(expect.objectContaining({
+      provider: 'codex',
+      model: 'gpt-5',
+      effort: 'high',
+    }));
   });
 
   it('stamps a queued scan as `queued`, so the UI does not link at a missing report', async () => {


### PR DESCRIPTION
## Summary
- Add optional provider, model, and reasoning-effort controls to the GitHub repo-study intake prompt.
- Reuse the shared CoS agent provider controls while preserving default-provider inheritance.
- Validate, normalize, persist, and forward per-study AI pins into the queued CoS task.

## Test plan
- `cd client && npm test -- --run src/components/QuickBrainCapture.test.jsx src/hooks/useProviderModels.test.js`
- `cd server && npm test -- --run lib/repoIntakeActions.test.js lib/brainValidation.test.js services/repoIntake.test.js services/brain.test.js`
- `cd client && npm run lint`
- `cd client && npm run build`