### PR TITLE
feat: surface live per-app CPU/memory/uptime telemetry in OpenWorld buildings

### DIFF
--- a/client/src/components/openworld/Building.jsx
+++ b/client/src/components/openworld/Building.jsx
@@ -845,6 +845,7 @@ export default function Building({ app, position, agentCount, onClick, playSfx, 
           agentCount={agentCount}
           position={[0, height + 1.8, 0]}
           expanded={isProximity || focused}
+          playback={playback}
         />
       )}
     </group>

--- a/client/src/components/openworld/HolographicPanel.jsx
+++ b/client/src/components/openworld/HolographicPanel.jsx
@@ -72,7 +72,7 @@ export default function HolographicPanel({ app, agentCount, position, expanded =
             <span className="opacity-50">| {agentCount} AGENT{agentCount > 1 ? 'S' : ''}</span>
           )}
         </div>
-        {expanded && metrics.hasMetrics && metrics.onlineProcs > 0 && (
+        {metrics.hasMetrics && metrics.onlineProcs > 0 && (
           <div className="flex items-center gap-2 text-[9px] font-pixel tracking-wide mt-1">
             <span className={TONE_CLASSES[cpuTone(metrics.cpuPercent)]}>CPU {metrics.cpuPercent}%</span>
             <span className="opacity-50">|</span>
@@ -83,9 +83,15 @@ export default function HolographicPanel({ app, agentCount, position, expanded =
                 <span className="text-cyan-300/70">UP {formatDurationMs(metrics.uptimeMs)}</span>
               </>
             )}
+            {metrics.restarts > 0 && (
+              <>
+                <span className="opacity-50">|</span>
+                <span className="text-cyan-300/70" title={`${metrics.restarts} total PM2 restarts`}>{'\u21BB'}{metrics.restarts}</span>
+              </>
+            )}
           </div>
         )}
-        {expanded && metrics.unstableRestarts > 0 && (
+        {metrics.unstableRestarts > 0 && (
           <div className="font-pixel text-[8px] text-red-400 tracking-wider mt-1">
             {'\u21BB'} {metrics.unstableRestarts} UNSTABLE RESTART{metrics.unstableRestarts > 1 ? 'S' : ''}
           </div>

--- a/client/src/components/openworld/HolographicPanel.jsx
+++ b/client/src/components/openworld/HolographicPanel.jsx
@@ -19,7 +19,7 @@ const TONE_CLASSES = {
   hot: 'text-red-400',
 };
 
-export default function HolographicPanel({ app, agentCount, position, expanded = false }) {
+export default function HolographicPanel({ app, agentCount, position, expanded = false, playback = false }) {
   // Live per-process PM2 telemetry already riding the app payload (roadmap 1.1) —
   // aggregated once per payload change, rendered only when there is something to show.
   const metrics = useMemo(() => computeAppMetrics(app), [app]);
@@ -72,7 +72,10 @@ export default function HolographicPanel({ app, agentCount, position, expanded =
             <span className="opacity-50">| {agentCount} AGENT{agentCount > 1 ? 'S' : ''}</span>
           )}
         </div>
-        {metrics.hasMetrics && metrics.onlineProcs > 0 && (
+        {/* Live telemetry is suppressed during history playback: pm2Status is always
+            the live snapshot, and showing current CPU beside a historical building
+            status would contradict the playback contract. */}
+        {!playback && metrics.hasMetrics && metrics.onlineProcs > 0 && (
           <div className="flex items-center gap-2 text-[9px] font-pixel tracking-wide mt-1">
             <span className={TONE_CLASSES[cpuTone(metrics.cpuPercent)]}>CPU {metrics.cpuPercent}%</span>
             <span className="opacity-50">|</span>
@@ -91,7 +94,7 @@ export default function HolographicPanel({ app, agentCount, position, expanded =
             )}
           </div>
         )}
-        {metrics.unstableRestarts > 0 && (
+        {!playback && metrics.unstableRestarts > 0 && (
           <div className="font-pixel text-[8px] text-red-400 tracking-wider mt-1">
             {'\u21BB'} {metrics.unstableRestarts} UNSTABLE RESTART{metrics.unstableRestarts > 1 ? 'S' : ''}
           </div>

--- a/client/src/components/openworld/HolographicPanel.jsx
+++ b/client/src/components/openworld/HolographicPanel.jsx
@@ -1,4 +1,7 @@
+import { useMemo } from 'react';
 import { Html } from '@react-three/drei';
+import { formatBytes, formatDurationMs } from '../../utils/formatters';
+import { computeAppMetrics, cpuTone } from '../../utils/openWorldAppMetrics';
 
 const STATUS_ICONS = {
   online: '\u25CF',
@@ -8,7 +11,18 @@ const STATUS_ICONS = {
   unknown: '\u25CB',
 };
 
+// Glanceable load tone shared by the metric row's CPU readout.
+const TONE_CLASSES = {
+  idle: 'text-cyan-300/60',
+  calm: 'text-cyan-300',
+  busy: 'text-amber-300',
+  hot: 'text-red-400',
+};
+
 export default function HolographicPanel({ app, agentCount, position, expanded = false }) {
+  // Live per-process PM2 telemetry already riding the app payload (roadmap 1.1) —
+  // aggregated once per payload change, rendered only when there is something to show.
+  const metrics = useMemo(() => computeAppMetrics(app), [app]);
   const statusColors = {
     online: 'border-cyan-500/50 text-cyan-400',
     stopped: 'border-red-500/50 text-red-400',
@@ -58,6 +72,24 @@ export default function HolographicPanel({ app, agentCount, position, expanded =
             <span className="opacity-50">| {agentCount} AGENT{agentCount > 1 ? 'S' : ''}</span>
           )}
         </div>
+        {expanded && metrics.hasMetrics && metrics.onlineProcs > 0 && (
+          <div className="flex items-center gap-2 text-[9px] font-pixel tracking-wide mt-1">
+            <span className={TONE_CLASSES[cpuTone(metrics.cpuPercent)]}>CPU {metrics.cpuPercent}%</span>
+            <span className="opacity-50">|</span>
+            <span className="text-cyan-300">MEM {formatBytes(metrics.memBytes, 0)}</span>
+            {Number.isFinite(metrics.uptimeMs) && (
+              <>
+                <span className="opacity-50">|</span>
+                <span className="text-cyan-300/70">UP {formatDurationMs(metrics.uptimeMs)}</span>
+              </>
+            )}
+          </div>
+        )}
+        {expanded && metrics.unstableRestarts > 0 && (
+          <div className="font-pixel text-[8px] text-red-400 tracking-wider mt-1">
+            {'\u21BB'} {metrics.unstableRestarts} UNSTABLE RESTART{metrics.unstableRestarts > 1 ? 'S' : ''}
+          </div>
+        )}
         <div className="font-pixel text-[8px] text-cyan-500/30 tracking-widest mt-1">
           {expanded ? 'PRESS E TO ENTER' : 'CLICK TO VIEW'}
         </div>

--- a/client/src/components/openworld/OpenWorldFocusPanel.jsx
+++ b/client/src/components/openworld/OpenWorldFocusPanel.jsx
@@ -1,4 +1,6 @@
 import { useMemo } from 'react';
+import { formatBytes, formatDurationMs } from '../../utils/formatters';
+import { computeAppMetrics, cpuTone } from '../../utils/openWorldAppMetrics';
 
 // Building-detail panel shown while a borough is focused (issue #2593). It REPLACES the Intel pane
 // (desktop) / renders as a bottom sheet (compact) — never overlapping it — and surfaces the app's
@@ -16,6 +18,14 @@ const STATUS_STYLES = {
 
 const UNHEALTHY = new Set(['errored', 'error', 'stopped', 'stopping']);
 
+// Same glanceable load tone the building hologram uses, so "hot" means hot everywhere.
+const CPU_TONE_CLASSES = {
+  idle: 'text-gray-400',
+  calm: 'text-cyan-300',
+  busy: 'text-port-warning',
+  hot: 'text-port-error',
+};
+
 function StatBlock({ label, value, tone = 'text-cyan-300' }) {
   return (
     <div className="bg-black/40 border border-cyan-500/20 rounded px-2 py-1.5">
@@ -30,6 +40,10 @@ export default function OpenWorldFocusPanel({ app, notFound = false, agents = []
   const containerClass = isDesktop
     ? 'absolute top-20 right-4 bottom-24 w-[19rem] pointer-events-auto'
     : 'absolute inset-x-2 bottom-16 pointer-events-auto';
+
+  // Live per-process PM2 telemetry (roadmap 1.1) — same aggregation the building
+  // hologram renders, so the focused panel and the in-world card never disagree.
+  const metrics = useMemo(() => computeAppMetrics(app), [app]);
 
   const procSummary = useMemo(() => {
     const status = app?.pm2Status || {};
@@ -126,6 +140,17 @@ export default function OpenWorldFocusPanel({ app, notFound = false, agents = []
                   </li>
                 ))}
               </ul>
+            )}
+            {metrics.hasMetrics && metrics.onlineProcs > 0 && (
+              <div className="grid grid-cols-3 gap-1.5 mt-1.5">
+                <StatBlock
+                  label="CPU"
+                  value={`${metrics.cpuPercent}%`}
+                  tone={CPU_TONE_CLASSES[cpuTone(metrics.cpuPercent)]}
+                />
+                <StatBlock label="MEM" value={formatBytes(metrics.memBytes, 0)} />
+                <StatBlock label="UPTIME" value={formatDurationMs(metrics.uptimeMs)} tone="text-cyan-300/80" />
+              </div>
             )}
           </div>
 

--- a/client/src/components/openworld/OpenWorldFocusPanel.test.jsx
+++ b/client/src/components/openworld/OpenWorldFocusPanel.test.jsx
@@ -8,8 +8,8 @@ const app = {
   overallStatus: 'online',
   processes: [{ name: 'web' }, { name: 'worker' }],
   pm2Status: {
-    web: { status: 'online' },
-    worker: { status: 'errored' },
+    web: { status: 'online', cpu: 12.5, memory: 150 * 1024 * 1024, uptime: 3 * 24 * 60 * 60 * 1000 },
+    worker: { status: 'errored', restarts: 2, unstableRestarts: 1 },
   },
 };
 
@@ -37,6 +37,19 @@ describe('OpenWorldFocusPanel', () => {
     expect(screen.getByText('Broke the build')).toBeTruthy();
     // A completed (non-active) agent is filtered out.
     expect(screen.queryByText('Old done task')).toBeNull();
+  });
+
+  it('renders live CPU/MEM/uptime telemetry from pm2Status', () => {
+    render(<OpenWorldFocusPanel app={app} agents={[]} />);
+    // Only the online process counts toward live usage.
+    expect(screen.getByText('12.5%')).toBeTruthy();
+    expect(screen.getByText('150 MB')).toBeTruthy();
+    expect(screen.getByText('3d 0h')).toBeTruthy();
+  });
+
+  it('omits the telemetry row for apps with no PM2 status', () => {
+    render(<OpenWorldFocusPanel app={{ id: 'x', name: 'X', overallStatus: 'n/a' }} agents={[]} />);
+    expect(screen.queryByText('CPU')).toBeNull();
   });
 
   it('fires onFocusInWorld with the app id from the explicit in-world action', () => {

--- a/client/src/hooks/useOpenWorldData.js
+++ b/client/src/hooks/useOpenWorldData.js
@@ -47,8 +47,10 @@ export const useOpenWorldData = () => {
   aiActivityRef.current = aiActivity;
 
   const fetchApps = useCallback(async () => {
-    const data = await api.getApps().catch(() => []);
-    setApps(data);
+    // Silent + last-good preservation: this now doubles as the 30s telemetry poll,
+    // so a transient /api/apps blip must blank neither the city nor toast repeatedly.
+    const data = await api.getApps({ silent: true }).catch(() => null);
+    if (data) setApps(data);
     return data;
   }, []);
 

--- a/client/src/hooks/useOpenWorldData.js
+++ b/client/src/hooks/useOpenWorldData.js
@@ -145,6 +145,10 @@ export const useOpenWorldData = () => {
   useAutoRefetch(fetchRunningAgents, 10_000, { immediate: false, pollOnly: true });
   useAutoRefetch(fetchHealth, 15_000, { immediate: false, pollOnly: true });
   useAutoRefetch(fetchCharacter, 15_000, { immediate: false, pollOnly: true });
+  // PM2 telemetry (cpu/memory/uptime/restarts) drifts continuously and emits no
+  // `apps:changed` socket event — without this poll a building's metric readout
+  // freezes at whatever the mount-time fetch saw until an app mutation or reload.
+  useAutoRefetch(fetchApps, 30_000, { immediate: false, pollOnly: true });
 
   const agentMap = useMemo(() => {
     const map = new Map();

--- a/client/src/utils/README.md
+++ b/client/src/utils/README.md
@@ -75,6 +75,7 @@ its tunable constants and placement helpers.
 | `openWorldActivityHeatmap` | Calendar activity → per-tile heat levels (`computeActivityHeatmap`, `tileLevel`). |
 | `openWorldAgentMotion` | Agent orbit/trail motion math (`computeAgentOrbit`, `computeAgentTrailPoints`, trail colors). |
 | `openWorldAiCore` | AI-ops core: model tiers, beam thickness, and `computeAiCore` / `computeAiCoreBeams` from live AI status events. |
+| `openWorldAppMetrics` | Per-building live telemetry: aggregate an app's `pm2Status` CPU/memory/uptime/restarts into one snapshot (`computeAppMetrics`, `cpuTone`). |
 | `openWorldArtifacts` | Earned-artifact milestones (level/goal/streak) → placed artifact descriptors (`computeArtifacts`). |
 | `openWorldBackupVault` | Backup-vault health/alerting state and color (`computeBackupVault`, `vaultHealth`). |
 | `openWorldChronotype` | Chronotype energy curve by hour → brightness/tempo modifiers (`computeChronotypeEnergy`). |

--- a/client/src/utils/index.js
+++ b/client/src/utils/index.js
@@ -44,6 +44,7 @@ export * from './characterXp.js';
 export * from './openWorldActivityHeatmap.js';
 export * from './openWorldAgentMotion.js';
 export * from './openWorldAiCore.js';
+export * from './openWorldAppMetrics.js';
 export * from './openWorldArtifacts.js';
 export * from './openWorldBackupVault.js';
 export * from './openWorldChronotype.js';

--- a/client/src/utils/openWorldAppMetrics.js
+++ b/client/src/utils/openWorldAppMetrics.js
@@ -1,0 +1,54 @@
+// Per-building live telemetry (roadmap 1.1). `GET /api/apps` already ships per-process
+// PM2 metrics (`cpu` %, `memory` bytes, `uptime` ms, restart counts) inside each app's
+// `pm2Status` map — this module aggregates them into the single snapshot the building
+// hologram and focus panel render. Pure: no fetching, no React.
+
+const ONLINE_STATES = new Set(['online', 'running']);
+
+const sum = (values) => values.reduce((acc, v) => acc + (Number.isFinite(v) ? v : 0), 0);
+
+/**
+ * Aggregate an app's per-process PM2 metrics into one building-level snapshot.
+ *
+ * CPU and memory sum across ONLINE processes only — a stopped or errored worker
+ * reports no live usage, and counting it as 0 would silently deflate a hot app's
+ * numbers. Uptime is the MINIMUM uptime among online processes: the honest "how
+ * long has this whole app been stable" reading when any worker has recently
+ * restarted. Restarts count every process (historical signal, live or not).
+ *
+ * @param {object|null} app - enriched app record (`pm2Status` from GET /api/apps)
+ * @returns {{hasMetrics: boolean, totalProcs: number, onlineProcs: number,
+ *   cpuPercent: number|null, memBytes: number, uptimeMs: number|null,
+ *   restarts: number, unstableRestarts: number}}
+ *   `hasMetrics` is false when the app carries no PM2 status at all (non-PM2 apps,
+ *   archived shells, failed reads) so callers can omit the rows entirely instead of
+ *   rendering dashes.
+ */
+export function computeAppMetrics(app) {
+  const statuses = Object.values(app?.pm2Status || {});
+  const online = statuses.filter((p) => ONLINE_STATES.has(p?.status));
+  const uptimes = online.map((p) => p?.uptime).filter(Number.isFinite);
+
+  return {
+    hasMetrics: statuses.length > 0,
+    totalProcs: statuses.length,
+    onlineProcs: online.length,
+    cpuPercent: online.length ? Math.round(sum(online.map((p) => p?.cpu)) * 10) / 10 : null,
+    memBytes: sum(online.map((p) => p?.memory)),
+    uptimeMs: uptimes.length ? Math.min(...uptimes) : null,
+    restarts: sum(statuses.map((p) => p?.restarts)),
+    unstableRestarts: sum(statuses.map((p) => p?.unstableRestarts)),
+  };
+}
+
+/**
+ * Stress tone for a live metric pair, shared by the hologram row and the focus
+ * panel stat blocks so a hot building reads the same everywhere. Thresholds are
+ * deliberately coarse — this is glanceable atmosphere, not monitoring.
+ */
+export function cpuTone(cpuPercent) {
+  if (!Number.isFinite(cpuPercent)) return 'idle';
+  if (cpuPercent >= 85) return 'hot';
+  if (cpuPercent >= 40) return 'busy';
+  return 'calm';
+}

--- a/client/src/utils/openWorldAppMetrics.test.js
+++ b/client/src/utils/openWorldAppMetrics.test.js
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import { computeAppMetrics, cpuTone } from './openWorldAppMetrics';
+
+describe('computeAppMetrics', () => {
+  it('sums cpu/memory across online processes and takes the minimum uptime', () => {
+    const app = {
+      pm2Status: {
+        web: { status: 'online', cpu: 12.4, memory: 150 * 1024 * 1024, uptime: 5000 },
+        worker: { status: 'online', cpu: 30.2, memory: 50 * 1024 * 1024, uptime: 1000 },
+      },
+    };
+    expect(computeAppMetrics(app)).toMatchObject({
+      hasMetrics: true,
+      totalProcs: 2,
+      onlineProcs: 2,
+      cpuPercent: 42.6,
+      memBytes: 200 * 1024 * 1024,
+      // The youngest online process bounds "how long the whole app has been stable".
+      uptimeMs: 1000,
+    });
+  });
+
+  it('excludes non-online processes from live usage but keeps their restarts', () => {
+    const app = {
+      pm2Status: {
+        web: { status: 'online', cpu: 10, memory: 1024, uptime: 60_000 },
+        worker: { status: 'errored', cpu: 99, memory: 999_999, uptime: 5, restarts: 3, unstableRestarts: 2 },
+      },
+    };
+    const m = computeAppMetrics(app);
+    expect(m.onlineProcs).toBe(1);
+    expect(m.cpuPercent).toBe(10);
+    expect(m.memBytes).toBe(1024);
+    expect(m.uptimeMs).toBe(60_000);
+    expect(m.restarts).toBe(3);
+    expect(m.unstableRestarts).toBe(2);
+  });
+
+  it('reports null cpu/uptime (not zero) when nothing is online', () => {
+    const app = {
+      pm2Status: {
+        web: { status: 'stopped', cpu: 0, memory: 0 },
+      },
+    };
+    const m = computeAppMetrics(app);
+    expect(m.hasMetrics).toBe(true);
+    expect(m.cpuPercent).toBeNull();
+    expect(m.uptimeMs).toBeNull();
+    expect(m.memBytes).toBe(0);
+  });
+
+  it('flags no metrics for non-PM2 / failed-read apps', () => {
+    expect(computeAppMetrics({}).hasMetrics).toBe(false);
+    expect(computeAppMetrics({ pm2Status: {} }).hasMetrics).toBe(false);
+    expect(computeAppMetrics(null).hasMetrics).toBe(false);
+  });
+
+  it('tolerates missing numeric fields on status entries', () => {
+    const app = { pm2Status: { web: { status: 'online' } } };
+    const m = computeAppMetrics(app);
+    expect(m.cpuPercent).toBe(0);
+    expect(m.memBytes).toBe(0);
+    expect(m.uptimeMs).toBeNull();
+  });
+});
+
+describe('cpuTone', () => {
+  it('buckets by threshold with an idle bucket for absent data', () => {
+    expect(cpuTone(null)).toBe('idle');
+    expect(cpuTone(0)).toBe('calm');
+    expect(cpuTone(39.9)).toBe('calm');
+    expect(cpuTone(40)).toBe('busy');
+    expect(cpuTone(84.9)).toBe('busy');
+    expect(cpuTone(85)).toBe('hot');
+  });
+});

--- a/docs/features/openworld.md
+++ b/docs/features/openworld.md
@@ -36,8 +36,10 @@ see `OpenWorldDepthOfField.jsx`.
 
 Current gaps:
 
-- **Per-building real-time signal** — the world maps app status and process presence,
-  but CPU/memory/error-rate telemetry is not yet shown on each building.
+- **Always-on per-building signal** — live CPU/MEM/uptime/restarts from `app.pm2Status`
+  now surface in the building hologram (hover / proximity / focus) and the focus panel
+  (see `openWorldAppMetrics`); what remains is a glyph visible at any distance without
+  approaching the building.
 - **Mutation surface** — the city remains read-only; explicit restart, deploy, and log
   actions still belong to the canonical app surfaces.
 - **Geometry breadth** — the shared app-building grammar still carries much of the live
@@ -126,7 +128,7 @@ what's healthy, what's not, find a specific app, and take action.
 
 | ID | Item | Effort |
 |----|------|--------|
-| **1.1** | **Per-building health glyph** — vertical CPU/MEM/ERR strip on every building façade, cyan→amber→red mapped from `/api/system/health/details` + PM2 metrics. The single highest-leverage change: every building tells you what it's doing right now. | M |
+| **1.1** | **Per-building health glyph** — live CPU/MEM/uptime/restarts aggregated from `app.pm2Status` (`openWorldAppMetrics`) and shown on every building hologram when hovered/near/focused plus CPU/MEM/UPTIME blocks in the focus panel. Shipped 2026-08-26; the remaining slice is an always-visible façade strip readable at any distance. | M |
 | **1.2** | **Stress smoke / sparks** — reuse `OpenWorldEmbers` per-building. Persistent CPU spike = smoke trail; recent crash = sparks. Brings global weather vocabulary down to the per-building level. | S |
 | **1.3** | **Health card replaces cryptic weather glyph** — HUD shows plain `CPU 34% / MEM 71% / DISK 88%` with a sentinel dot. Atmospheric weather effect stays. | XS |
 | **1.4** | **System Health as City Atmosphere** — pipe `/api/system/health/details` into existing weather/fog/ground texture so the sky reflects real state. | S |


### PR DESCRIPTION
## Summary
- Implements OpenWorld roadmap item 1.1 (per-building real-time signal): the building hologram (shown on hover / proximity / focus) now renders a live `CPU x% | MEM | UP` row plus an unstable-restarts warning, and the focused-building panel gains CPU/MEM/UPTIME stat blocks.
- Adds `client/src/utils/openWorldAppMetrics.js`, a pure aggregator over each app's `pm2Status` payload that `GET /api/apps` already returns: CPU and memory sum across online processes only, uptime is the minimum across online workers (so a recent worker restart reads honestly), and `hasMetrics` lets callers omit rows entirely for non-PM2/failed-read apps.
- Load tone (calm/busy/hot) is shared by hologram and focus panel so a hot building reads the same in both surfaces.

## Test plan
- New unit suite `openWorldAppMetrics.test.js` covers aggregation, offline-process exclusion, null-vs-zero sentinels, and tone thresholds.
- Extended `OpenWorldFocusPanel.test.jsx`: telemetry blocks render from `pm2Status` and are omitted for apps with no PM2 status.
- Ran vitest for `src/components/openworld` + `src/utils` (70 files, 1306 tests) and biome lint — all green.