### PR TITLE
fix: centralize client API fetch errors (#5047)

### DIFF
--- a/client/src/services/README.md
+++ b/client/src/services/README.md
@@ -29,7 +29,7 @@ toasts on throw). **Custom catch ⇒ `silent: true`** — otherwise toasts fire 
 | File | Purpose |
 |---|---|
 | `api.js` | Barrel — re-exports every `apiX.js`. |
-| `apiCore.js` | `request()` helper + stable PortOS-app id. Shared error / toast handling. |
+| `apiCore.js` | `request()` and `throwApiError(response)` helpers + stable PortOS-app id. Shared error / toast handling. |
 | `apiBatch.js` | `fetchByIds(path, ids, options)` — batch-fetch records through a list route's `?ids=a,b,c` filter (dedupe, empty-list short-circuit, `{ items }` envelope unwrap). |
 | `socket.js` | Singleton Socket.IO client over relative path (Tailscale-friendly). |
 | `appUrls.js` | Compute candidate launch URLs for an app from page context. |

--- a/client/src/services/apiCore.js
+++ b/client/src/services/apiCore.js
@@ -21,6 +21,19 @@ export function maybeRedirectToLogin(response, error) {
   }
 }
 
+// Shared by raw-response callers that need to consume a stream or blob instead
+// of handing the response to request(). Keep the envelope construction here so
+// structured server context and status metadata survive every API surface.
+export async function throwApiError(response, parsedError) {
+  const error = parsedError ?? await response.json().catch(() => ({ error: `HTTP ${response.status}` }));
+  maybeRedirectToLogin(response, error);
+  const err = new Error(error.error || `HTTP ${response.status}`);
+  err.code = error?.code;
+  err.status = response.status;
+  if (error?.context) err.context = error.context;
+  throw err;
+}
+
 export async function request(endpoint, options = {}) {
   const { silent, responseType, ...fetchOptions } = options;
   const url = `${API_BASE}${endpoint}`;
@@ -45,29 +58,17 @@ export async function request(endpoint, options = {}) {
   }
 
   if (!response.ok) {
-    const error = await response.json().catch(() => ({ error: 'Request failed' }));
-    const errorMessage = error.error || `HTTP ${response.status}`;
-    // Auth gate (server: services/authGate.js) returns 401 with code AUTH_REQUIRED
-    // for any /api request without a valid session. Bounce to /login so the
-    // user can re-authenticate; skip if we're already there.
-    maybeRedirectToLogin(response, error);
-    if (!silent) {
-      // Platform unavailability is a warning, not an error
-      if (error.code === 'PLATFORM_UNAVAILABLE') {
-        toast(errorMessage, { icon: '⚠️' });
-      } else if (error.code !== 'AUTH_REQUIRED') {
-        toast.error(errorMessage);
+    await throwApiError(response).catch((error) => {
+      if (!silent) {
+        // Platform unavailability is a warning, not an error
+        if (error.code === 'PLATFORM_UNAVAILABLE') {
+          toast(error.message, { icon: '⚠️' });
+        } else if (error.code !== 'AUTH_REQUIRED') {
+          toast.error(error.message);
+        }
       }
-    }
-    const err = new Error(errorMessage);
-    err.code = error?.code;
-    err.status = response.status;
-    // Forward structured context the server attached to the error (e.g.
-    // ERR_PARTIAL_COMMIT_ISSUES carries `{ universeId, seriesId,
-    // arcAlreadyPersisted, skipArcOnRetry }` so the Importer client can
-    // shape its retry without re-overwriting persisted state).
-    if (error?.context) err.context = error.context;
-    throw err;
+      throw error;
+    });
   }
 
   // Handle 204 No Content

--- a/client/src/services/apiImageVideo.js
+++ b/client/src/services/apiImageVideo.js
@@ -1,4 +1,4 @@
-import { request, API_BASE, maybeRedirectToLogin } from './apiCore.js';
+import { request, API_BASE, throwApiError } from './apiCore.js';
 import { filterHardwareCompatibleModels } from '../utils/systemCapabilities.js';
 
 // Image gen — local backend extras (gallery, models, LoRAs, cancel, delete).
@@ -284,13 +284,10 @@ export function buildFormData(fields) {
 // the optional sourceImage upload (and uniform multipart parsing for both
 // upload and no-upload paths is simpler than branching on Content-Type).
 export async function generateVideo(fields) {
-  const res = await fetch('/api/video-gen', { method: 'POST', body: buildFormData(fields) });
+  const res = await fetch('/api/video-gen', { method: 'POST', body: buildFormData(fields) }).catch(() => null);
+  if (!res) throw new Error('Server unreachable — check your connection and try again');
   if (!res.ok) {
-    const body = await res.json().catch(() => ({ error: `HTTP ${res.status}` }));
-    const err = new Error(body.error || `HTTP ${res.status}`);
-    err.code = body.code;
-    err.status = res.status;
-    throw err;
+    await throwApiError(res);
   }
   return res.json();
 }
@@ -490,13 +487,13 @@ export async function installLoraFromHuggingfaceStream({ url, family, file, onPr
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ url, ...(family ? { family } : {}), ...(file ? { file } : {}) }),
     signal,
+  }).catch((error) => {
+    if (error?.name === 'AbortError') throw error;
+    return null;
   });
+  if (!response) throw new Error('Server unreachable — check your connection and try again');
   if (!response.ok || !response.body?.getReader) {
-    const err = await response.json().catch(() => ({ error: `HTTP ${response.status}` }));
-    maybeRedirectToLogin(response, err);
-    const e = new Error(err.error || `HTTP ${response.status}`);
-    e.code = err.code || null;
-    throw e;
+    await throwApiError(response);
   }
 
   const reader = response.body.getReader();

--- a/client/src/services/apiLocalLlm.js
+++ b/client/src/services/apiLocalLlm.js
@@ -1,4 +1,4 @@
-import { request, API_BASE, maybeRedirectToLogin } from './apiCore.js';
+import { request, API_BASE, throwApiError } from './apiCore.js';
 
 // Local LLM backends (Ollama / LM Studio) — status, model management, migrate.
 // Installed models per backend come back inside getLocalLlmStatus().
@@ -183,13 +183,13 @@ export async function streamLocalLlmTest(payload, { signal, onToken } = {}) {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(payload),
     signal,
+  }).catch((error) => {
+    if (error?.name === 'AbortError') throw error;
+    return null;
   });
+  if (!response) throw new Error('Server unreachable — check your connection and try again');
   if (!response.ok || !response.body?.getReader) {
-    const err = await response.json().catch(() => ({ error: `HTTP ${response.status}` }));
-    // Honor session expiry the same way request() does — a streaming run that
-    // 401s should bounce to /login, not just toast and strand the user here.
-    maybeRedirectToLogin(response, err);
-    throw new Error(err.error || `HTTP ${response.status}`);
+    await throwApiError(response);
   }
 
   const reader = response.body.getReader();

--- a/client/src/services/apiMedia.js
+++ b/client/src/services/apiMedia.js
@@ -1,4 +1,4 @@
-import { request, API_BASE, maybeRedirectToLogin } from './apiCore.js';
+import { request, API_BASE, throwApiError } from './apiCore.js';
 import { formatBytes } from '../utils/formatters.js';
 import {
   validateImageFile,
@@ -318,14 +318,7 @@ export const cleanImage = async (file, steps = {}) => {
 
   if (!response) throw new Error('Server unreachable — check your connection and try again');
 
-  if (!response.ok) {
-    const error = await response.json().catch(() => ({ error: 'Failed to clean image' }));
-    maybeRedirectToLogin(response, error);
-    const err = new Error(error.error || `HTTP ${response.status}`);
-    err.code = error?.code;
-    err.status = response.status;
-    throw err;
-  }
+  if (!response.ok) await throwApiError(response);
 
   // GPU FLUX round-trip: the server enqueued a job and returned 202 + JSON
   // (no image bytes). Hand the job descriptor back so the caller tracks progress
@@ -353,17 +346,9 @@ export const fetchCleanResult = async (jobId) => {
   if (response.status === 409) {
     const err = await response.json().catch(() => ({}));
     if (err?.code === 'RESULT_NOT_READY') return { pending: true };
-    const e = new Error(err.error || 'Clean job failed');
-    e.code = err.code; e.status = 409;
-    throw e;
+    await throwApiError(response, err);
   }
-  if (!response.ok) {
-    const err = await response.json().catch(() => ({ error: 'Failed to fetch clean result' }));
-    maybeRedirectToLogin(response, err);
-    const e = new Error(err.error || `HTTP ${response.status}`);
-    e.code = err?.code; e.status = response.status;
-    throw e;
-  }
+  if (!response.ok) await throwApiError(response);
   const reportHeader = response.headers.get('X-Clean-Report');
   let report = null;
   if (reportHeader) { try { report = JSON.parse(reportHeader); } catch { report = null; } }

--- a/client/src/services/apiMedia.test.js
+++ b/client/src/services/apiMedia.test.js
@@ -4,11 +4,13 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 // header, which the JSON-oriented request() helper can't surface). saveCleanResult
 // goes through request(). Mock both layers.
 const request = vi.fn();
-vi.mock('./apiCore.js', () => ({
-  request: (...a) => request(...a),
-  API_BASE: '/api',
-  maybeRedirectToLogin: vi.fn(),
-}));
+vi.mock('./apiCore.js', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    request: (...a) => request(...a),
+  };
+});
 
 let cleanImage;
 let fetchCleanResult;
@@ -62,9 +64,18 @@ describe('cleanImage', () => {
     expect(out.mimeType).toBe('image/png');
   });
 
-  it('throws with the server code on an error response', async () => {
-    global.fetch.mockResolvedValue(makeResponse({ status: 400, ok: false, json: { error: 'No FLUX', code: 'REGEN_BACKEND_UNAVAILABLE' } }));
-    await expect(cleanImage(fakeFile, { diffusion: 'gpu' })).rejects.toMatchObject({ code: 'REGEN_BACKEND_UNAVAILABLE' });
+  it('throws with the server code and context on an error response', async () => {
+    const context = { retryable: true, backend: 'example' };
+    global.fetch.mockResolvedValue(makeResponse({
+      status: 400,
+      ok: false,
+      json: { error: 'No FLUX', code: 'REGEN_BACKEND_UNAVAILABLE', context },
+    }));
+    await expect(cleanImage(fakeFile, { diffusion: 'gpu' })).rejects.toMatchObject({
+      code: 'REGEN_BACKEND_UNAVAILABLE',
+      status: 400,
+      context,
+    });
   });
 });
 

--- a/client/src/services/apiSystem.js
+++ b/client/src/services/apiSystem.js
@@ -1,4 +1,4 @@
-import { request, API_BASE, maybeRedirectToLogin } from './apiCore.js';
+import { request, API_BASE, throwApiError } from './apiCore.js';
 import { downloadBlob } from '../lib/downloadBlob.js';
 
 // Alerts
@@ -190,17 +190,16 @@ export async function downloadBackupSnapshot(snapshotId) {
 
   const response = await fetch(`${API_BASE}/backup/snapshots/${encodeURIComponent(snapshotId)}/download`, {
     credentials: 'same-origin',
-  });
+  }).catch(() => null);
+  if (!response) {
+    await writable?.abort?.().catch(() => {});
+    throw new Error('Server unreachable — check your connection and try again');
+  }
   if (!response.ok) {
     // Close the handle we opened before we knew the request would fail, so the
     // picker doesn't leave a 0-byte file behind.
     await writable?.abort?.().catch(() => {});
-    const error = await response.json().catch(() => ({ error: `HTTP ${response.status}` }));
-    maybeRedirectToLogin(response, error);
-    const err = new Error(error.error || `HTTP ${response.status}`);
-    err.code = error.code;
-    err.status = response.status;
-    throw err;
+    await throwApiError(response);
   }
 
   if (writable && response.body?.pipeTo) {


### PR DESCRIPTION
## Summary

- Extract the shared fetch error envelope into `throwApiError` in `apiCore`.
- Route raw stream/blob responses through it so code, status, and structured context stay consistent.
- Preserve connection errors and abort semantics for the affected fetch wrappers.

Closes #5047

## Test plan

- `npm test` (client)
- `npm run build` (client)
- `npx biome lint --error-on-warnings` on changed client service files
