### PR TITLE
fix: preserve local LLM migration safety

### DIFF
--- a/scripts/migrations/299-refresh-local-llm-catalog-custom-task.test.js
+++ b/scripts/migrations/299-refresh-local-llm-catalog-custom-task.test.js
@@ -131,6 +131,51 @@ describe('migration 299 — local-LLM catalog refresh → PortOS custom task', (
     expect(readJson(legacySchedulePath).tasks).toEqual({})
   })
 
+  it('disables an invalid legacy cron instead of breaking autonomous-job registration', async () => {
+    writeJson(schedulePath, {
+      tasks: {
+        'refresh-local-llm-catalog': {
+          enabled: true,
+          type: 'cron',
+          cronExpression: '60 0 * * *'
+        }
+      },
+      executions: {}
+    })
+    writeJson(appsPath, {
+      apps: { [PORTOS_APP_ID]: { taskTypeOverrides: { 'refresh-local-llm-catalog': { enabled: true } } } }
+    })
+
+    await migration.up({ rootDir })
+    const job = readJson(jobsPath).jobs.find((candidate) => candidate.id === PORTOS_CATALOG_REFRESH_JOB_ID)
+    expect(job).toMatchObject({ enabled: false, interval: 'weekly' })
+    expect(job).not.toHaveProperty('cronExpression')
+  })
+
+  it('keeps a failure-parked PortOS schedule disabled', async () => {
+    writeJson(schedulePath, {
+      tasks: { 'refresh-local-llm-catalog': { enabled: true, type: 'weekly' } },
+      executions: {
+        'task:refresh-local-llm-catalog': {
+          perApp: {
+            [PORTOS_APP_ID]: {
+              count: 4,
+              failureParkedAt: '2026-08-25T00:00:00.000Z',
+              failureParkReason: 'auth-error'
+            }
+          }
+        }
+      }
+    })
+    writeJson(appsPath, {
+      apps: { [PORTOS_APP_ID]: { taskTypeOverrides: { 'refresh-local-llm-catalog': { enabled: true } } } }
+    })
+
+    await migration.up({ rootDir })
+    const job = readJson(jobsPath).jobs.find((candidate) => candidate.id === PORTOS_CATALOG_REFRESH_JOB_ID)
+    expect(job).toMatchObject({ enabled: false, runCount: 4 })
+  })
+
   it('preserves an existing destination job while completing a partial migration cleanup', async () => {
     writeJson(schedulePath, {
       tasks: { 'refresh-local-llm-catalog': { enabled: true, type: 'weekly' } },

--- a/server/services/autonomousJobs/portosCatalogRefresh.js
+++ b/server/services/autonomousJobs/portosCatalogRefresh.js
@@ -8,6 +8,7 @@
 
 import { PORTOS_APP_ID } from '../../lib/appIdentity.js'
 import { DEFAULT_TASK_PROMPTS, PREVIOUS_DEFAULT_PROMPTS } from '../taskPromptDefaults.js'
+import { isValidCron } from '../eventScheduler.js'
 import { DAY, WEEK } from './constants.js'
 
 export const PORTOS_CATALOG_REFRESH_JOB_ID = 'job-refresh-local-llm-catalog'
@@ -58,8 +59,10 @@ export function catalogRefreshJobScheduleFields(task = {}, appOverride = {}) {
     ? type
     : (type === 'cron' && typeof task.cronExpression === 'string' ? task.cronExpression.trim() : '')
 
-  if (cronExpression.split(/\s+/).length === 5) {
-    return { interval: 'daily', intervalMs: DAY, cronExpression }
+  if (cronExpression) {
+    return isValidCron(cronExpression)
+      ? { interval: 'daily', intervalMs: DAY, cronExpression }
+      : { interval: 'weekly', intervalMs: WEEK, unsupportedScheduleType: 'invalid-cron' }
   }
   if (type === 'daily') return { interval: 'daily', intervalMs: DAY }
   if (type === 'weekly') return { interval: 'weekly', intervalMs: WEEK }
@@ -86,6 +89,7 @@ export function buildMigratedCatalogRefreshJob({ task = {}, appOverride = {}, ex
   const effectiveExecution = isObject(execution.perApp?.[PORTOS_APP_ID])
     ? execution.perApp[PORTOS_APP_ID]
     : execution
+  const failureParked = Boolean(effectiveExecution.failureParkedAt)
   const globalMetadata = isObject(task.taskMetadata) ? task.taskMetadata : {}
   const appMetadata = isObject(appOverride.taskMetadata) ? appOverride.taskMetadata : {}
   const storedPrompt = task.prompt || DEFAULT_TASK_PROMPTS[PORTOS_CATALOG_REFRESH_TASK_TYPE]
@@ -96,7 +100,7 @@ export function buildMigratedCatalogRefreshJob({ task = {}, appOverride = {}, ex
   return {
     ...PORTOS_CATALOG_REFRESH_JOB,
     ...persistedScheduleFields,
-    enabled: unsupportedScheduleType
+    enabled: unsupportedScheduleType || failureParked
       ? false
       : task.enabled === true && appOverride.enabled === true,
     promptTemplate: catalogRefreshPromptForCustomJob(prompt),

--- a/server/services/autonomousJobs/portosCatalogRefresh.test.js
+++ b/server/services/autonomousJobs/portosCatalogRefresh.test.js
@@ -53,6 +53,18 @@ describe('PortOS local-LLM catalog refresh custom task', () => {
       .toEqual({ interval: 'daily', intervalMs: 86_400_000, cronExpression: '0 6 * * 1' })
   })
 
+  it('disables malformed cron schedules instead of persisting a startup-breaking expression', () => {
+    expect(catalogRefreshJobScheduleFields({ type: 'cron', cronExpression: '60 0 * * *' }))
+      .toEqual({ interval: 'weekly', intervalMs: 604_800_000, unsupportedScheduleType: 'invalid-cron' })
+
+    const job = buildMigratedCatalogRefreshJob({
+      task: { enabled: true, type: 'cron', cronExpression: '60 0 * * *' },
+      appOverride: { enabled: true }
+    })
+    expect(job).toMatchObject({ enabled: false, interval: 'weekly' })
+    expect(job).not.toHaveProperty('cronExpression')
+  })
+
   it('preserves effective pins, metadata, prompt, and PortOS execution history', () => {
     const job = buildMigratedCatalogRefreshJob({
       task: {
@@ -124,5 +136,23 @@ describe('PortOS local-LLM catalog refresh custom task', () => {
     })
     expect(once).toMatchObject({ enabled: false, interval: 'weekly' })
     expect(once).not.toHaveProperty('unsupportedScheduleType')
+  })
+
+  it('keeps a failure-parked PortOS schedule disabled after migration', () => {
+    const parked = buildMigratedCatalogRefreshJob({
+      task: { enabled: true, type: 'weekly' },
+      appOverride: { enabled: true },
+      execution: {
+        perApp: {
+          [PORTOS_APP_ID]: {
+            count: 3,
+            failureParkedAt: '2026-08-25T00:00:00.000Z',
+            failureParkReason: 'auth-error'
+          }
+        }
+      }
+    })
+
+    expect(parked).toMatchObject({ enabled: false, runCount: 3 })
   })
 })


### PR DESCRIPTION
## Summary
- reject invalid legacy cron expressions during the local-LLM catalog task migration and keep the resulting custom job disabled for manual correction
- preserve the scheduled task failure-park safety boundary by migrating a parked PortOS execution as a disabled autonomous job
- add focused builder and persisted-migration regression coverage for both upgrade paths

## Test plan
- `cd server && npm test -- --run services/autonomousJobs/portosCatalogRefresh.test.js ../scripts/migrations/299-refresh-local-llm-catalog-custom-task.test.js services/eventScheduler.test.js` (68 passed)
- `git diff --check`

Follow-up to #5076.
