### PR TITLE
fix: reduce CoS and dashboard load latency

### DIFF
--- a/client/src/components/cos/tabs/HealthTab.jsx
+++ b/client/src/components/cos/tabs/HealthTab.jsx
@@ -4,7 +4,7 @@ import * as api from '../../../services/api';
 import { formatDateTime } from '../../../utils/formatters';
 import ProviderStatusCard from './ProviderStatusCard';
 
-export default function HealthTab({ health, onCheck }) {
+export default function HealthTab({ health, healthLoading = false, onCheck }) {
   const [learning, setLearning] = useState(null);
   const [loadingLearning, setLoadingLearning] = useState(true);
   const [backfilling, setBackfilling] = useState(false);
@@ -145,7 +145,12 @@ export default function HealthTab({ health, onCheck }) {
             </button>
           </div>
 
-          {!health?.issues || health.issues.length === 0 ? (
+          {healthLoading ? (
+            <div className="text-center py-4 text-gray-500">
+              <RefreshCw size={16} className="animate-spin mx-auto mb-2" />
+              Loading health...
+            </div>
+          ) : !health?.issues || health.issues.length === 0 ? (
             <div className="bg-port-success/10 border border-port-success/30 rounded-lg p-4 text-center">
               <CheckCircle className="w-8 h-8 text-port-success mx-auto mb-2" />
               <p className="text-port-success font-medium text-sm">All Systems Healthy</p>

--- a/client/src/components/dashboard/WidgetSuggestions.test.jsx
+++ b/client/src/components/dashboard/WidgetSuggestions.test.jsx
@@ -22,6 +22,13 @@ describe('WidgetSuggestions', () => {
     expect(gate({})).toBe(false);
   });
 
+  it('keeps the Apps Grid hidden until its first read completes', () => {
+    const gate = WIDGETS_BY_ID.apps.gate;
+
+    expect(gate({ apps: [], appsLoading: true })).toBe(false);
+    expect(gate({ apps: [], appsLoading: false })).toBe(true);
+  });
+
   it('renders nothing when every gated widget is already present', () => {
     const { container } = render(
       <WidgetSuggestions

--- a/client/src/components/dashboard/widgetRegistry.jsx
+++ b/client/src/components/dashboard/widgetRegistry.jsx
@@ -37,8 +37,9 @@ const postFeatureEnabled = (state) => state?.instanceFeatures?.features?.some(
 
 // Each entry: { id, label, Component, width, defaultH?, gate? }.
 // `gate(state) => bool` skips the widget when it has nothing useful to show.
-// The Apps tile is intentionally un-gated — it renders its own empty-state
-// CTA so the "add your first app" path is always visible on a blank install.
+// The Apps tile waits for its first read before rendering so a slow response
+// cannot flash the empty-state CTA over an existing installation. It still
+// renders its own empty-state CTA after a successful empty response.
 //
 // `defaultH` is the row count (each row ≈ 80px) used when a widget is first
 // auto-placed into a grid. It is a STARTING size, not the rendered height:
@@ -53,7 +54,7 @@ export const WIDGETS = [
   { id: 'quick-idea',        label: 'Quick Idea (Catalog)',  Component: QuickIdeaCapture,       width: 'half',    defaultH: 4 },
   { id: 'quick-image',       label: 'Quick Image Prompt',    Component: QuickImagePrompt,       width: 'half',    defaultH: 6 },
   { id: 'quick-task',        label: 'Quick Task',            Component: QuickTaskWidget,        width: 'half',    defaultH: 5 },
-  { id: 'apps',              label: 'Apps Grid',             Component: AppsGridWidget,         width: 'full',    defaultH: 5 },
+  { id: 'apps',              label: 'Apps Grid',             Component: AppsGridWidget,         width: 'full',    defaultH: 5, gate: (s) => s.appsLoading === false },
   { id: 'cos',               label: 'Chief of Staff',        Component: CosDashboardWidget,     width: 'third',   defaultH: 6 },
   { id: 'goal-progress',     label: 'Goal Progress',         Component: GoalProgressWidget,     width: 'third',   defaultH: 5 },
   { id: 'upcoming-tasks',    label: 'Upcoming Tasks',        Component: UpcomingTasksWidget,    width: 'third',   defaultH: 5 },

--- a/client/src/pages/ChiefOfStaff.jsx
+++ b/client/src/pages/ChiefOfStaff.jsx
@@ -90,6 +90,7 @@ export default function ChiefOfStaff() {
   const [tasks, setTasks] = useState({ user: null, cos: null });
   const [agents, setAgents] = useState([]);
   const [health, setHealth] = useState(null);
+  const [healthLoaded, setHealthLoaded] = useState(false);
   const [providers, setProviders] = useState([]);
   // Which provider an unpinned task actually runs on — the Schedule tab names it
   // on the "Default" option and resolves model/effort choices against it.
@@ -152,6 +153,7 @@ export default function ChiefOfStaff() {
     const resolved = merge ? fresherHealth(healthRef.current, next) : next;
     healthRef.current = resolved;
     setHealth(resolved);
+    setHealthLoaded(true);
     return resolved;
   }, []);
 
@@ -181,8 +183,15 @@ export default function ChiefOfStaff() {
       api.getCosTasks().catch(() => ({ user: null, cos: null })),
       api.getCosAgents().catch(() => []),
     ]);
+    const healthRead = api.getCosHealth().catch(() => null).then((data) => {
+      // Health is independently useful to the Health tab. Commit it as soon
+      // as its own read settles instead of making that tab wait for the slower
+      // actionable-insights request in the same batch.
+      applyHealth(data, { merge: true });
+      return data;
+    });
     const secondaryRead = Promise.all([
-      api.getCosHealth().catch(() => null),
+      healthRead,
       api.getProviders().catch(() => ({ providers: [] })),
       api.getApps().catch(() => []),
       api.getCosLearningSummary().catch(() => null),
@@ -215,7 +224,7 @@ export default function ChiefOfStaff() {
     const runningAgent = agentsData.find(a => a.status === 'running');
     setActiveAgentMeta(runningAgent?.metadata || null);
 
-    const [healthData, providersData, appsData, learningSummaryData, insightsData] = await secondaryRead;
+    const [, providersData, appsData, learningSummaryData, insightsData] = await secondaryRead;
     // `getCosHealth` above reads the *pre-check* persisted health, while the
     // getCosActionableInsights call in this same batch triggers a fresh server
     // health check (cos.runHealthCheck) that emits `cos:health:check` — the
@@ -223,7 +232,7 @@ export default function ChiefOfStaff() {
     // keeps whichever check is newer (and keeps the last-good one when this read
     // failed); everything below derives from what it returned, never from the
     // raw read, so the bubble can't name an older issue than the tile shows.
-    const mergedHealth = applyHealth(healthData, { merge: true });
+    const mergedHealth = healthRef.current;
     setProviders(providersData.providers || []);
     setActiveProviderId(providersData.activeProvider || null);
     // Filter out PortOS Autofixer (it's part of PortOS project)
@@ -1150,7 +1159,7 @@ export default function ChiefOfStaff() {
         {activeTab === 'health' && (
           <div role="tabpanel" id="tabpanel-health" aria-labelledby="tab-health">
             <Suspense fallback={<TabLoadFallback label="health" />}>
-              <HealthTab health={health} onCheck={handleHealthCheck} />
+              <HealthTab health={health} healthLoading={!healthLoaded} onCheck={handleHealthCheck} />
             </Suspense>
           </div>
         )}

--- a/client/src/pages/ChiefOfStaff.jsx
+++ b/client/src/pages/ChiefOfStaff.jsx
@@ -19,30 +19,19 @@ import {
   summarizeHealthIssues,
   healthIssueTone,
   fresherHealth,
-  CoSCharacter,
-  StateLabel,
-  TerminalCoSPanel,
-  StatusIndicator,
-  StatCard,
-  StatusBubble,
-  EventLog,
-  QuickSummary,
-  ActionableInsightsBanner,
-  TasksTab,
-  AgentsTab,
-  JobsTab,
-  ScheduleTab,
-  WorkflowTab,
-  DigestTab,
-  GsdTab,
-  ProductivityTab,
-  LearningTab,
-  MemoryTab,
-  HealthTab,
-  ConfigTab,
-  BriefingTab
-} from '../components/cos';
-import { resolveDynamicAvatar } from '../components/cos/constants';
+  resolveDynamicAvatar,
+} from '../components/cos/constants';
+import CoSCharacter from '../components/cos/CoSCharacter';
+import StateLabel from '../components/cos/StateLabel';
+import TerminalCoSPanel from '../components/cos/TerminalCoSPanel';
+import StatusIndicator from '../components/cos/StatusIndicator';
+import StatCard from '../components/cos/StatCard';
+import StatusBubble from '../components/cos/StatusBubble';
+import EventLog from '../components/cos/EventLog';
+import QuickSummary from '../components/cos/QuickSummary';
+import ActionableInsightsBanner from '../components/cos/ActionableInsightsBanner';
+import TasksTab from '../components/cos/tabs/TasksTab';
+import AgentsTab from '../components/cos/tabs/AgentsTab';
 
 // The Runs tab (full AI run history + its log modal) is lazy-loaded so its weight
 // stays out of the eager CoS chunk every /cos/* visit pays for — same reason the
@@ -52,6 +41,20 @@ const RunsTab = lazy(() => import('../components/cos/tabs/RunsTab'));
 // post-mortem surface nobody opens on a normal day, and it pulls the whole
 // ledger read path with it.
 const RunEventsTab = lazy(() => import('../components/cos/tabs/RunEventsTab'));
+// The task and agent tabs are the default CoS landing surfaces and stay eager.
+// Every other tab is loaded only when selected so the common queue view does
+// not pay for charts, memory graphs, briefing readers, or configuration forms.
+const JobsTab = lazy(() => import('../components/cos/tabs/JobsTab'));
+const ScheduleTab = lazy(() => import('../components/cos/tabs/ScheduleTab'));
+const WorkflowTab = lazy(() => import('../components/cos/tabs/WorkflowTab'));
+const DigestTab = lazy(() => import('../components/cos/tabs/DigestTab'));
+const GsdTab = lazy(() => import('../components/cos/tabs/GsdTab'));
+const ProductivityTab = lazy(() => import('../components/cos/tabs/ProductivityTab'));
+const LearningTab = lazy(() => import('../components/cos/tabs/LearningTab'));
+const MemoryTab = lazy(() => import('../components/cos/tabs/MemoryTab'));
+const HealthTab = lazy(() => import('../components/cos/tabs/HealthTab'));
+const ConfigTab = lazy(() => import('../components/cos/tabs/ConfigTab'));
+const BriefingTab = lazy(() => import('../components/cos/tabs/BriefingTab'));
 
 // Three.js-based avatars lazy-loaded so the R3F stack isn't bundled unless the
 // user's chosen avatar style actually needs it.
@@ -73,6 +76,10 @@ const CANVAS_AVATAR_STYLES = new Set([
 
 // Shared brand gradient for the "CoS" wordmark headings (clipped to text).
 const COS_TITLE_GRADIENT = 'linear-gradient(135deg, #6366f1, #8b5cf6, #06b6d4)';
+
+function TabLoadFallback({ label }) {
+  return <div className="flex items-center justify-center py-12"><BrailleSpinner text={`Loading ${label}`} /></div>;
+}
 
 export default function ChiefOfStaff() {
   const { tab } = useParams();
@@ -164,10 +171,17 @@ export default function ChiefOfStaff() {
 
   const fetchData = useCallback(async () => {
     const queueSeq = queueSeqRef.current;
-    const [statusData, tasksData, agentsData, healthData, providersData, appsData, learningSummaryData, insightsData] = await Promise.all([
+    // The queue is the critical path for both the Tasks and Agents tabs. Start
+    // the secondary reads at the same time, but do not make the first paint
+    // wait for them: actionable insights runs a server-side PM2/memory health
+    // check, and provider/app/learning data can be hydrated after the queue is
+    // already usable.
+    const coreRead = Promise.all([
       api.getCosStatus().catch(() => null),
       api.getCosTasks().catch(() => ({ user: null, cos: null })),
       api.getCosAgents().catch(() => []),
+    ]);
+    const secondaryRead = Promise.all([
       api.getCosHealth().catch(() => null),
       api.getProviders().catch(() => ({ providers: [] })),
       api.getApps().catch(() => []),
@@ -176,16 +190,32 @@ export default function ChiefOfStaff() {
       // retired 60s poll; `.catch(() => null)` → preserve last-good below.
       api.getCosActionableInsights({ silent: true }).catch(() => null)
     ]);
+
+    const [statusData, tasksData, agentsData] = await coreRead;
     setStatus(statusData);
-    // fetchData is the SLOW read (8 endpoints, one of which runs a server health
-    // check), so a queue refresh started later routinely resolves first. Its task
-    // payload would then be clobbered by this older, pre-flip one — restoring the
-    // pending-AND-active render this change exists to remove. Drop only the queue
-    // half of a superseded read; the rest of the batch has no fresher writer.
+    // A queue refresh started later can still resolve first. Its task payload
+    // must not be clobbered by this older, pre-flip read — otherwise the row
+    // returns to the pending-AND-active state this guard exists to remove.
     if (queueSeqRef.current === queueSeq) {
       setTasks(tasksData);
       setAgents(agentsData);
     }
+
+    setLoading(false);
+
+    // Paint the shell and queue before waiting for health, providers, apps,
+    // learning, and insights. Those values fill in below without delaying the
+    // tab the user asked to open.
+    const initialHealth = healthRef.current;
+    const initialState = deriveAgentState(statusData, agentsData, initialHealth);
+    setAgentState(initialState);
+    setStatusMessage(statusData?.paused
+      ? `Paused${statusData.pauseReason ? ` — ${statusData.pauseReason}` : ''}`
+      : (initialState === 'investigating' && summarizeHealthIssues(initialHealth?.issues)) || STATE_MESSAGES[initialState]);
+    const runningAgent = agentsData.find(a => a.status === 'running');
+    setActiveAgentMeta(runningAgent?.metadata || null);
+
+    const [healthData, providersData, appsData, learningSummaryData, insightsData] = await secondaryRead;
     // `getCosHealth` above reads the *pre-check* persisted health, while the
     // getCosActionableInsights call in this same batch triggers a fresh server
     // health check (cos.runHealthCheck) that emits `cos:health:check` — the
@@ -203,7 +233,6 @@ export default function ChiefOfStaff() {
     // from a failed/transient fetch preserves the last-good array so the banner
     // doesn't flicker empty on a blip.
     if (insightsData?.insights) setInsights(insightsData.insights);
-    setLoading(false);
 
     const newState = deriveAgentState(statusData, agentsData, mergedHealth);
     setAgentState(newState);
@@ -215,9 +244,6 @@ export default function ChiefOfStaff() {
       ? `Paused${statusData.pauseReason ? ` — ${statusData.pauseReason}` : ''}`
       : (newState === 'investigating' && summarizeHealthIssues(mergedHealth?.issues)) || STATE_MESSAGES[newState]);
 
-    // Set active agent metadata for dynamic avatar (use first running agent)
-    const runningAgent = agentsData.find(a => a.status === 'running');
-    setActiveAgentMeta(runningAgent?.metadata || null);
   }, [deriveAgentState, applyHealth]);
 
   // A cheap, read-only refresh of just the queue — the task lists plus the agent
@@ -1032,7 +1058,9 @@ export default function ChiefOfStaff() {
         {/* Tab Content */}
         {activeTab === 'briefing' && (
           <div role="tabpanel" id="tabpanel-briefing" aria-labelledby="tab-briefing">
-            <BriefingTab />
+            <Suspense fallback={<TabLoadFallback label="briefing" />}>
+              <BriefingTab />
+            </Suspense>
           </div>
         )}
         {activeTab === 'tasks' && (
@@ -1051,66 +1079,86 @@ export default function ChiefOfStaff() {
         )}
         {activeTab === 'jobs' && (
           <div role="tabpanel" id="tabpanel-jobs" aria-labelledby="tab-jobs">
-            <JobsTab />
+            <Suspense fallback={<TabLoadFallback label="jobs" />}>
+              <JobsTab />
+            </Suspense>
           </div>
         )}
         {activeTab === 'runs' && (
           <div role="tabpanel" id="tabpanel-runs" aria-labelledby="tab-runs">
-            <Suspense fallback={<div className="flex items-center justify-center py-12"><BrailleSpinner text="Loading runs" /></div>}>
+            <Suspense fallback={<TabLoadFallback label="runs" />}>
               <RunsTab />
             </Suspense>
           </div>
         )}
         {activeTab === 'run-events' && (
           <div role="tabpanel" id="tabpanel-run-events" aria-labelledby="tab-run-events">
-            <Suspense fallback={<div className="flex items-center justify-center py-12"><BrailleSpinner text="Loading run events" /></div>}>
+            <Suspense fallback={<TabLoadFallback label="run events" />}>
               <RunEventsTab />
             </Suspense>
           </div>
         )}
         {activeTab === 'schedule' && (
           <div role="tabpanel" id="tabpanel-schedule" aria-labelledby="tab-schedule">
-            <ScheduleTab apps={apps} providers={providers} activeProviderId={activeProviderId} />
+            <Suspense fallback={<TabLoadFallback label="schedule" />}>
+              <ScheduleTab apps={apps} providers={providers} activeProviderId={activeProviderId} />
+            </Suspense>
           </div>
         )}
         {activeTab === 'workflow' && (
           <div role="tabpanel" id="tabpanel-workflow" aria-labelledby="tab-workflow">
-            <WorkflowTab apps={apps} providers={providers} />
+            <Suspense fallback={<TabLoadFallback label="workflow" />}>
+              <WorkflowTab apps={apps} providers={providers} />
+            </Suspense>
           </div>
         )}
         {activeTab === 'digest' && (
           <div role="tabpanel" id="tabpanel-digest" aria-labelledby="tab-digest">
-            <DigestTab />
+            <Suspense fallback={<TabLoadFallback label="digest" />}>
+              <DigestTab />
+            </Suspense>
           </div>
         )}
         {activeTab === 'gsd' && (
           <div role="tabpanel" id="tabpanel-gsd" aria-labelledby="tab-gsd">
-            <GsdTab />
+            <Suspense fallback={<TabLoadFallback label="GSD" />}>
+              <GsdTab />
+            </Suspense>
           </div>
         )}
         {activeTab === 'productivity' && (
           <div role="tabpanel" id="tabpanel-productivity" aria-labelledby="tab-productivity">
-            <ProductivityTab />
+            <Suspense fallback={<TabLoadFallback label="productivity" />}>
+              <ProductivityTab />
+            </Suspense>
           </div>
         )}
         {activeTab === 'learning' && (
           <div role="tabpanel" id="tabpanel-learning" aria-labelledby="tab-learning">
-            <LearningTab />
+            <Suspense fallback={<TabLoadFallback label="learning" />}>
+              <LearningTab />
+            </Suspense>
           </div>
         )}
         {activeTab === 'memory' && (
           <div role="tabpanel" id="tabpanel-memory" aria-labelledby="tab-memory">
-            <MemoryTab apps={apps} />
+            <Suspense fallback={<TabLoadFallback label="memory" />}>
+              <MemoryTab apps={apps} />
+            </Suspense>
           </div>
         )}
         {activeTab === 'health' && (
           <div role="tabpanel" id="tabpanel-health" aria-labelledby="tab-health">
-            <HealthTab health={health} onCheck={handleHealthCheck} />
+            <Suspense fallback={<TabLoadFallback label="health" />}>
+              <HealthTab health={health} onCheck={handleHealthCheck} />
+            </Suspense>
           </div>
         )}
         {activeTab === 'config' && (
           <div role="tabpanel" id="tabpanel-config" aria-labelledby="tab-config">
-            <ConfigTab config={status?.config} onUpdate={fetchData} onEvaluate={handleForceEvaluate} avatarStyle={configAvatarStyle} setAvatarStyle={setAvatarStyle} />
+            <Suspense fallback={<TabLoadFallback label="configuration" />}>
+              <ConfigTab config={status?.config} onUpdate={fetchData} onEvaluate={handleForceEvaluate} avatarStyle={configAvatarStyle} setAvatarStyle={setAvatarStyle} />
+            </Suspense>
           </div>
         )}
       </div>

--- a/client/src/pages/ChiefOfStaff.test.jsx
+++ b/client/src/pages/ChiefOfStaff.test.jsx
@@ -114,6 +114,30 @@ describe('ChiefOfStaff loading skeleton', () => {
     // The old spinner shell — a fixed 16rem box centering its child.
     expect(container.querySelector('.h-64')).toBeNull();
   });
+
+  it('shows the queue before the slow ancillary reads settle', async () => {
+    let releaseInsights;
+    api.getCosTasks.mockResolvedValue({
+      user: { tasks: [{ id: 'task-1', description: 'Example queued task', status: 'pending', metadata: {} }] },
+      cos: { tasks: [] },
+    });
+    api.getCosActionableInsights.mockReturnValue(new Promise((resolve) => { releaseInsights = resolve; }));
+
+    render(
+      <MemoryRouter initialEntries={['/cos/tasks']}>
+        <Routes>
+          <Route path="/cos/:tab" element={<ChiefOfStaff />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText('Example queued task')).toBeInTheDocument();
+    expect(screen.queryByRole('status', { name: 'Loading Chief of Staff' })).toBeNull();
+
+    await act(async () => {
+      releaseInsights({ insights: [] });
+    });
+  });
 });
 
 describe('ChiefOfStaff handleForceEvaluate', () => {

--- a/client/src/pages/ChiefOfStaff.test.jsx
+++ b/client/src/pages/ChiefOfStaff.test.jsx
@@ -410,6 +410,20 @@ describe('ChiefOfStaff insight freshness (#2654)', () => {
     expect(api.getCosActionableInsights.mock.calls.length).toBe(before);
   });
 
+  it('keeps the Health tab pending until its own read settles', async () => {
+    let releaseHealth;
+    api.getCosHealth.mockReturnValue(new Promise((resolve) => { releaseHealth = resolve; }));
+    renderAt('health');
+
+    expect(await screen.findByText('Loading health...')).toBeInTheDocument();
+    expect(screen.queryByText('All Systems Healthy')).not.toBeInTheDocument();
+
+    await act(async () => {
+      releaseHealth({ lastCheck: '2026-01-01T00:00:01Z', issues: [] });
+    });
+    expect(await screen.findByText('All Systems Healthy')).toBeInTheDocument();
+  });
+
   it('does not let a stale fetchData health read clobber a fresher one', async () => {
     // The insights call inside fetchData triggers a fresh server health check
     // whose socket emit can update `health` before fetchData's own getCosHealth

--- a/client/src/pages/Dashboard.jsx
+++ b/client/src/pages/Dashboard.jsx
@@ -99,8 +99,15 @@ export default function Dashboard() {
 
   const fetchData = useCallback(async () => {
     setDataError(null);
-    const [appsData, , usageData, tribeCareData, feedsData, meatspaceLoggingData, dailyDriverData, dailyActionsData] = await Promise.all([
-      api.getApps().catch((err) => { setDataError(err.message); return []; }),
+    // The shell and layout have their own loading states. Release the page
+    // immediately so a slow PM2/apps read cannot hold the entire dashboard
+    // behind a single network response.
+    setLoading(false);
+    // Apps and the remaining widgets are independent hydration streams. Health
+    // and daily-actions in particular can involve slow subsystem/database work
+    // that should not hold every widget behind one Promise.all barrier.
+    const appsRead = api.getApps().catch((err) => { setDataError(err.message); return []; });
+    const secondaryRead = Promise.all([
       refreshHealth(),
       api.getUsage().catch(() => null),
       api.getTribeCareSummary({ silent: true }).catch(() => null),
@@ -112,14 +119,16 @@ export default function Dashboard() {
       api.getDailyActions({ silent: true }).catch(() => null),
       refreshInstanceFeatures(),
     ]);
+    const appsData = await appsRead;
     setApps(appsData);
+
+    const [, usageData, tribeCareData, feedsData, meatspaceLoggingData, dailyDriverData, dailyActionsData] = await secondaryRead;
     setUsage(usageData);
     setTribeCare(tribeCareData);
     setFeeds(feedsData);
     setMeatspaceLogging(meatspaceLoggingData);
     setDailyDriver(dailyDriverData);
     setDailyActions(dailyActionsData);
-    setLoading(false);
   }, [refreshHealth, refreshInstanceFeatures]);
 
   useEffect(() => {

--- a/client/src/pages/Dashboard.jsx
+++ b/client/src/pages/Dashboard.jsx
@@ -16,7 +16,10 @@ import toast from '../components/ui/Toast';
 import { pickActiveLayoutId, recordManualLayoutPick } from '../utils/timeWindow.js';
 
 export default function Dashboard() {
-  const [apps, setApps] = useState([]);
+  // null means the first apps read has not completed. Keep that distinct from
+  // a successful empty response so the Apps tile cannot flash its empty-state
+  // CTA while an existing installation is still being read.
+  const [apps, setApps] = useState(null);
   const [health, setHealth] = useState(null);
   const [usage, setUsage] = useState(null);
   const [tribeCare, setTribeCare] = useState(null);
@@ -106,29 +109,22 @@ export default function Dashboard() {
     // Apps and the remaining widgets are independent hydration streams. Health
     // and daily-actions in particular can involve slow subsystem/database work
     // that should not hold every widget behind one Promise.all barrier.
-    const appsRead = api.getApps().catch((err) => { setDataError(err.message); return []; });
+    const appsRead = api.getApps().catch((err) => { setDataError(err.message); return null; });
     const secondaryRead = Promise.all([
       refreshHealth(),
-      api.getUsage().catch(() => null),
-      api.getTribeCareSummary({ silent: true }).catch(() => null),
-      api.getFeedStats({ silent: true }).catch(() => null),
-      api.getMeatspaceLoggingStats({ silent: true }).catch(() => null),
+      api.getUsage().catch(() => null).then(setUsage),
+      api.getTribeCareSummary({ silent: true }).catch(() => null).then(setTribeCare),
+      api.getFeedStats({ silent: true }).catch(() => null).then(setFeeds),
+      api.getMeatspaceLoggingStats({ silent: true }).catch(() => null).then(setMeatspaceLogging),
       // GET records the first-visit-of-day signal (issue #2666); a failure just
       // hides the Daily Driver card via its gate. No LLM calls here.
-      api.getDailyDriverState().catch(() => null),
-      api.getDailyActions({ silent: true }).catch(() => null),
+      api.getDailyDriverState().catch(() => null).then(setDailyDriver),
+      api.getDailyActions({ silent: true }).catch(() => null).then(setDailyActions),
       refreshInstanceFeatures(),
     ]);
     const appsData = await appsRead;
-    setApps(appsData);
-
-    const [, usageData, tribeCareData, feedsData, meatspaceLoggingData, dailyDriverData, dailyActionsData] = await secondaryRead;
-    setUsage(usageData);
-    setTribeCare(tribeCareData);
-    setFeeds(feedsData);
-    setMeatspaceLogging(meatspaceLoggingData);
-    setDailyDriver(dailyDriverData);
-    setDailyActions(dailyActionsData);
+    if (Array.isArray(appsData)) setApps(appsData);
+    await secondaryRead;
   }, [refreshHealth, refreshInstanceFeatures]);
 
   useEffect(() => {
@@ -221,16 +217,18 @@ export default function Dashboard() {
     };
   }, []);
 
+  const appList = useMemo(() => (Array.isArray(apps) ? apps : []), [apps]);
+  const appsLoading = !Array.isArray(apps);
   const sortedApps = useMemo(() =>
-    [...apps].sort((a, b) => {
+    [...appList].sort((a, b) => {
       const archiveDiff = (a.archived ? 1 : 0) - (b.archived ? 1 : 0);
       if (archiveDiff !== 0) return archiveDiff;
       return a.name.localeCompare(b.name);
     }),
-    [apps]
+    [appList]
   );
 
-  const activeApps = useMemo(() => apps.filter((a) => !a.archived), [apps]);
+  const activeApps = useMemo(() => appList.filter((a) => !a.archived), [appList]);
   const appStats = useMemo(() => ({
     total: activeApps.length,
     online: activeApps.filter((a) => a.overallStatus === 'online').length,
@@ -242,8 +240,8 @@ export default function Dashboard() {
   }), [activeApps]);
 
   const dashboardState = useMemo(
-    () => ({ apps, sortedApps, activeApps, appStats, health, usage, tribeCare, feeds, meatspaceLogging, dailyDriver, dailyActions, instanceFeatures, refetch: fetchData, refetchHealth: refreshHealth }),
-    [apps, sortedApps, activeApps, appStats, health, usage, tribeCare, feeds, meatspaceLogging, dailyDriver, dailyActions, instanceFeatures, fetchData, refreshHealth]
+    () => ({ apps: appList, appsLoading, sortedApps, activeApps, appStats, health, usage, tribeCare, feeds, meatspaceLogging, dailyDriver, dailyActions, instanceFeatures, refetch: fetchData, refetchHealth: refreshHealth }),
+    [appList, appsLoading, sortedApps, activeApps, appStats, health, usage, tribeCare, feeds, meatspaceLogging, dailyDriver, dailyActions, instanceFeatures, fetchData, refreshHealth]
   );
 
   // Falls back to a local minimal layout only AFTER the initial fetch has

--- a/server/routes/cos.test.js
+++ b/server/routes/cos.test.js
@@ -522,8 +522,9 @@ describe('CoS Routes', () => {
   });
 
   describe('GET /api/cos/agents', () => {
-    it('should return state-resident agents after cleaning zombies', async () => {
-      cos.cleanupZombieAgents.mockResolvedValue({ cleaned: [], count: 0 });
+    it('should return state-resident agents without waiting for zombie cleanup', async () => {
+      let releaseCleanup;
+      cos.cleanupZombieAgents.mockReturnValue(new Promise((resolve) => { releaseCleanup = resolve; }));
       cos.getAgents.mockResolvedValue([
         { id: 'agent-001', status: 'running' },
         { id: 'agent-002', status: 'completed' }
@@ -534,6 +535,7 @@ describe('CoS Routes', () => {
       expect(response.status).toBe(200);
       expect(response.body).toHaveLength(2);
       expect(cos.cleanupZombieAgents).toHaveBeenCalled();
+      releaseCleanup({ cleaned: [], count: 0 });
     });
   });
 

--- a/server/routes/cosAgentRoutes.js
+++ b/server/routes/cosAgentRoutes.js
@@ -38,7 +38,14 @@ router.post('/health/check', asyncHandler(async (req, res) => {
 // GET /api/cos/agents - Get state-resident agents (running + recently completed, auto-cleans zombies)
 // Strips output arrays from listing — output is loaded on demand via GET /agents/:id
 router.get('/agents', asyncHandler(async (req, res) => {
-  await cos.cleanupZombieAgents();
+  // Zombie cleanup probes the standalone runner and can wait up to its
+  // transport timeout when that optional process is restarting or offline.
+  // The state listing is still useful while that repair runs, so keep cleanup
+  // off the response critical path and let it complete independently; the next
+  // normal refresh will see any repaired records.
+  void cos.cleanupZombieAgents().catch((err) => {
+    console.error(`🧹 Background zombie cleanup failed: ${err.message}`);
+  });
   const agents = await cos.getAgents();
   res.json(agents.map(({ output, ...rest }) => rest));
 }));


### PR DESCRIPTION
## Summary
- Release CoS task and agent pages after the fast status, queue, and agent reads instead of waiting for health and insight work.
- Lazy-load secondary CoS tabs so the common Tasks/Agents visit does not download every tab up front.
- Render the dashboard shell immediately and hydrate apps and independent widgets progressively.
- Return the agent listing while zombie cleanup runs in the background, avoiding the runner timeout on the response path.

## Test plan
- `npm test` (client): 779 files, 9,923 tests passed
- `npx vitest run routes/cos.test.js` (server): 135 tests passed
- `npm run lint` (client)
- `npm run build` (client)