### PR TITLE
Remove dead isCommandActive export from commands service

### DIFF
--- a/server/services/commands.js
+++ b/server/services/commands.js
@@ -111,16 +111,8 @@ export function stopCommand(commandId) {
 }
 
 /**
- * Check if a command is active
- */
-export function isCommandActive(commandId) {
-  return activeCommands.has(commandId);
-}
-
-/**
  * Get list of allowed commands
  */
 export function getAllowedCommands() {
   return Array.from(ALLOWED_COMMANDS).sort();
 }
-


### PR DESCRIPTION
## Summary
- Removes the unused `isCommandActive` export from `server/services/commands.js` — no remaining callers found anywhere in the repo.

## Test plan
- `grep -rn "isCommandActive" --include="*.js" --include="*.jsx" .` — no matches
- `cd server && npm test` — full suite passes except a handful of unrelated 10s-timeout flakes (loras, trellis normal-bake, sprite atlas, settings-secrets-strip tests) reproduced identically under heavy local machine load (load average ~130-200 on 18 cores); confirmed load-induced by re-running with `--testTimeout=60000`, which brought failures down to near zero. None of these touch `commands.js` or its callers.