### PR TITLE
Gate Sprint Yard collectibles behind the jira feature flag

### DIFF
--- a/client/src/components/DailyPostWidget.jsx
+++ b/client/src/components/DailyPostWidget.jsx
@@ -1,10 +1,10 @@
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect } from 'react';
 import { Link } from 'react-router';
 import { Brain, ArrowRight, Compass } from 'lucide-react';
 import * as api from '../services/api';
 import { streakGlyph } from '../lib/streakGlyph.js';
 import { computeGoalProgress } from './meatspace/post/constants';
-import { INSTANCE_FEATURES_CHANGED } from '../constants/events.js';
+import { useInstanceFeatures } from '../hooks/useInstanceFeatures.js';
 
 // Surfaces the daily POST cognitive self-test on the dashboard: today's
 // completion status, the current practice streak, the top "what to practice
@@ -16,53 +16,45 @@ export default function DailyPostWidget() {
   const [statsWeek, setStatsWeek] = useState(null);
   const [config, setConfig] = useState(null);
   const [topRec, setTopRec] = useState(null);
-  const [featureEnabled, setFeatureEnabled] = useState(true);
   const [loaded, setLoaded] = useState(false);
-  const fetchGeneration = useRef(0);
+  const [loadedForFeature, setLoadedForFeature] = useState(null);
+  const { features } = useInstanceFeatures();
+  // Read the raw list rather than the hook's navigation helper: a failed or
+  // still-loading feature read must hide this dashboard widget.
+  const featureEnabled = features?.find((feature) => feature.id === 'post')?.enabled === true;
 
-  const fetchData = useCallback(async () => {
-    const generation = ++fetchGeneration.current;
-    const featureData = await api.getInstanceFeatures({ silent: true }).catch(() => null);
-    if (generation !== fetchGeneration.current) return;
-    const postFeature = featureData?.features?.find((feature) => feature.id === 'post');
-    if (postFeature?.enabled !== true) {
-      setFeatureEnabled(false);
+  useEffect(() => {
+    let active = true;
+    setLoaded(false);
+    setLoadedForFeature(null);
+    if (!featureEnabled) {
+      setLoadedForFeature(false);
       setLoaded(true);
-      return;
+      return () => { active = false; };
     }
 
     // Recommendations/config/week-stats are best-effort — a failure just hides
     // the extra rows; the streak card still renders from `stats`.
-    const [data, week, cfg, recs] = await Promise.all([
+    Promise.all([
       api.getPostStats().catch(() => null),
       api.getPostStats(7).catch(() => null),
       api.getPostConfig().catch(() => null),
       api.getPostRecommendations(1).catch(() => null),
-    ]);
-    if (generation !== fetchGeneration.current) return;
-    setStats(data);
-    setStatsWeek(week);
-    setConfig(cfg);
-    setTopRec(recs?.recommendations?.[0] || null);
-    setFeatureEnabled(true);
-    setLoaded(true);
-  }, []);
-
-  useEffect(() => {
-    fetchData();
-    const handleFeatureChange = (event) => {
-      if (event.detail?.featureId !== 'post') return;
-      if (event.detail.enabled === false) setFeatureEnabled(false);
-      fetchData();
-    };
-    window.addEventListener(INSTANCE_FEATURES_CHANGED, handleFeatureChange);
+    ]).then(([data, week, cfg, recs]) => {
+      if (!active) return;
+      setStats(data);
+      setStatsWeek(week);
+      setConfig(cfg);
+      setTopRec(recs?.recommendations?.[0] || null);
+      setLoadedForFeature(true);
+      setLoaded(true);
+    });
     return () => {
-      fetchGeneration.current += 1;
-      window.removeEventListener(INSTANCE_FEATURES_CHANGED, handleFeatureChange);
+      active = false;
     };
-  }, [fetchData]);
+  }, [featureEnabled]);
 
-  if (!loaded || !featureEnabled) return null;
+  if (!loaded || loadedForFeature !== featureEnabled || !featureEnabled) return null;
 
   const streak = stats?.currentStreak ?? 0;
   const longest = stats?.longestStreak ?? 0;

--- a/client/src/components/DailyPostWidget.test.jsx
+++ b/client/src/components/DailyPostWidget.test.jsx
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { act, render, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
 import { INSTANCE_FEATURES_CHANGED } from '../constants/events.js';
+import { __resetInstanceFeatureCache } from '../hooks/useInstanceFeatures.js';
 
 const mock = vi.hoisted(() => ({
   getInstanceFeatures: vi.fn(),
@@ -17,6 +18,7 @@ import DailyPostWidget from './DailyPostWidget';
 describe('DailyPostWidget', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    __resetInstanceFeatureCache();
     mock.getInstanceFeatures.mockResolvedValue({
       features: [{ id: 'post', enabled: false }],
     });

--- a/client/src/components/dashboard/WidgetSuggestions.test.jsx
+++ b/client/src/components/dashboard/WidgetSuggestions.test.jsx
@@ -20,6 +20,7 @@ describe('WidgetSuggestions', () => {
     expect(gate({ instanceFeatures: { features: [{ id: 'post', enabled: false }] } })).toBe(false);
     expect(gate({ instanceFeatures: { features: [{ id: 'post', enabled: true }] } })).toBe(true);
     expect(gate({})).toBe(false);
+    expect(gate({ instanceFeatures: null })).toBe(false);
   });
 
   it('keeps the Apps Grid hidden until its first read completes', () => {

--- a/client/src/components/dashboard/builtins/DailyDriverWidget.jsx
+++ b/client/src/components/dashboard/builtins/DailyDriverWidget.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { Link } from 'react-router';
 import {
   Compass, ArrowRight, X, CheckCircle2, Target, Sparkles,
@@ -7,7 +7,7 @@ import {
 } from 'lucide-react';
 import * as api from '../../../services/api';
 import { getGoalFeatureAreas } from '../../../lib/goalFeatureMap.js';
-import { INSTANCE_FEATURES_CHANGED } from '../../../constants/events.js';
+import { useInstanceFeatures } from '../../../hooks/useInstanceFeatures.js';
 
 // Resolve a feature-area icon NAME (kept as a string in goalFeatureMap so that
 // module stays React-free and server-mirrorable) to a lucide component.
@@ -29,15 +29,23 @@ const AREA_ICONS = {
 export default function DailyDriverWidget({ dashboardState }) {
   const [post, setPost] = useState(null);
   const [topRec, setTopRec] = useState(null);
-  const [postEnabled, setPostEnabled] = useState(true);
   const [goals, setGoals] = useState([]);
   // Sentinel: distinguish "goals failed to load" from "no goals exist" so a
   // transient fetch failure doesn't show the "Define your goals" CTA to a user
   // who already has goals (AGENTS.md "absent/failed vs legitimately-empty").
   const [goalsFailed, setGoalsFailed] = useState(false);
   const [loaded, setLoaded] = useState(false);
+  const [loadedForFeature, setLoadedForFeature] = useState(null);
   const [dismissing, setDismissing] = useState(false);
-  const fetchGeneration = useRef(0);
+  const { features } = useInstanceFeatures();
+  // Dashboard widgets fail closed on an unreadable feature list. This is
+  // intentionally separate from useInstanceFeatures().isFeatureEnabled(),
+  // whose fail-open answer protects navigation from blanking.
+  const isFeatureEnabled = (featureId) => (
+    !featureId
+    || (Array.isArray(features) && features.some((feature) => feature.id === featureId && feature.enabled === true))
+  );
+  const postEnabled = isFeatureEnabled('post');
 
   const refetchDashboard = dashboardState?.refetch;
   // The first landing of the local day (recorded server-side by the dashboard's
@@ -46,44 +54,33 @@ export default function DailyDriverWidget({ dashboardState }) {
   // reloads until the user handles it, rather than vanishing on a refresh.
   const firstVisitToday = !!dashboardState?.dailyDriver?.firstVisitToday;
 
-  const fetchData = useCallback(async () => {
-    const generation = ++fetchGeneration.current;
-    const featureData = await api.getInstanceFeatures({ silent: true }).catch(() => null);
-    if (generation !== fetchGeneration.current) return;
-    const enabled = featureData?.features?.find((feature) => feature.id === 'post')?.enabled === true;
-    setPostEnabled(enabled);
-    const [stats, recs, goalsData] = await Promise.all([
-      enabled ? api.getPostStats().catch(() => null) : Promise.resolve(null),
-      enabled ? api.getPostRecommendations(1).catch(() => null) : Promise.resolve(null),
-      api.getGoals({ silent: true }).catch(() => null),
-    ]);
-    if (generation !== fetchGeneration.current) return;
-    setPost(stats);
-    setTopRec(recs?.recommendations?.[0] || null);
-    // `goalsData?.goals` present ⇒ authoritative list; null ⇒ fetch failed.
-    if (Array.isArray(goalsData?.goals)) {
-      setGoals(goalsData.goals.filter((g) => g.status === 'active'));
-      setGoalsFailed(false);
-    } else {
-      setGoals([]);
-      setGoalsFailed(true);
-    }
-    setLoaded(true);
-  }, []);
-
   useEffect(() => {
-    fetchData();
-    const handleFeatureChange = (event) => {
-      if (event.detail?.featureId !== 'post') return;
-      if (event.detail.enabled === false) setPostEnabled(false);
-      fetchData();
-    };
-    window.addEventListener(INSTANCE_FEATURES_CHANGED, handleFeatureChange);
+    let active = true;
+    setLoaded(false);
+    setLoadedForFeature(null);
+    Promise.all([
+      postEnabled ? api.getPostStats().catch(() => null) : Promise.resolve(null),
+      postEnabled ? api.getPostRecommendations(1).catch(() => null) : Promise.resolve(null),
+      api.getGoals({ silent: true }).catch(() => null),
+    ]).then(([stats, recs, goalsData]) => {
+      if (!active) return;
+      setPost(stats);
+      setTopRec(recs?.recommendations?.[0] || null);
+      // `goalsData?.goals` present => authoritative list; null => fetch failed.
+      if (Array.isArray(goalsData?.goals)) {
+        setGoals(goalsData.goals.filter((g) => g.status === 'active'));
+        setGoalsFailed(false);
+      } else {
+        setGoals([]);
+        setGoalsFailed(true);
+      }
+      setLoadedForFeature(postEnabled);
+      setLoaded(true);
+    });
     return () => {
-      fetchGeneration.current += 1;
-      window.removeEventListener(INSTANCE_FEATURES_CHANGED, handleFeatureChange);
+      active = false;
     };
-  }, [fetchData]);
+  }, [postEnabled]);
 
   // Mark the day handled, then refetch dashboard state so the registry gate
   // drops the card (which unmounts this widget). On failure, re-enable the
@@ -96,7 +93,7 @@ export default function DailyDriverWidget({ dashboardState }) {
     if (refetchDashboard) await refetchDashboard();
   }, [refetchDashboard]);
 
-  if (!loaded) return null;
+  if (!loaded || loadedForFeature !== postEnabled) return null;
 
   // `completedToday`/`streak` come straight from getPostStats — the same source
   // the standalone DailyPostWidget uses — so the driver's POST row always agrees
@@ -180,7 +177,7 @@ export default function DailyDriverWidget({ dashboardState }) {
           <>
             <div className="text-xs font-medium text-gray-400 uppercase tracking-wide">Next actions</div>
             {goals.map((goal) => {
-              const areas = getGoalFeatureAreas(goal).filter((area) => postEnabled || area.area !== 'post');
+              const areas = getGoalFeatureAreas(goal, isFeatureEnabled);
               const latestRec = goal.checkIns?.[goal.checkIns.length - 1]?.recommendations?.[0];
               return (
                 <div key={goal.id} className="p-2 rounded-lg border border-port-border">

--- a/client/src/components/dashboard/builtins/DailyDriverWidget.test.jsx
+++ b/client/src/components/dashboard/builtins/DailyDriverWidget.test.jsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { act, render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
 import { INSTANCE_FEATURES_CHANGED } from '../../../constants/events.js';
+import { __resetInstanceFeatureCache } from '../../../hooks/useInstanceFeatures.js';
 import DailyDriverWidget from './DailyDriverWidget';
 
 const mocks = vi.hoisted(() => ({
@@ -23,6 +24,7 @@ const renderWidget = (dashboardState = {}) =>
 
 beforeEach(() => {
   vi.clearAllMocks();
+  __resetInstanceFeatureCache();
   mocks.getInstanceFeatures.mockResolvedValue({ features: [{ id: 'post', enabled: true }] });
   mocks.getPostStats.mockResolvedValue({ completedToday: false, currentStreak: 3 });
   mocks.getPostRecommendations.mockResolvedValue({ recommendations: [{ title: 'Morse copy drill' }] });

--- a/client/src/components/goals/GoalDetailPanel.test.jsx
+++ b/client/src/components/goals/GoalDetailPanel.test.jsx
@@ -7,10 +7,12 @@ import { act, render, screen, fireEvent } from '@testing-library/react';
 vi.mock('../../services/api', () => ({
   getActivities: vi.fn(() => Promise.resolve([])),
   getCalendarAccounts: vi.fn(() => Promise.resolve([])),
+  getInstanceFeatures: vi.fn(() => Promise.resolve({ features: [{ id: 'post', enabled: true }] })),
   updateGoal: vi.fn(() => Promise.resolve({})),
 }));
 
 import * as api from '../../services/api';
+import { __resetInstanceFeatureCache } from '../../hooks/useInstanceFeatures.js';
 
 import GoalDetailPanel from './GoalDetailPanel';
 
@@ -38,11 +40,27 @@ const renderPanel = async (goal = baseGoal) => {
   );
 
   await act(async () => { await Promise.resolve(); });
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
   return view;
+};
+
+const openEdit = async () => {
+  await act(async () => {
+    fireEvent.click(screen.getByText('Edit'));
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
 };
 
 beforeEach(() => {
   vi.clearAllMocks();
+  __resetInstanceFeatureCache();
+  api.getInstanceFeatures.mockResolvedValue({ features: [{ id: 'post', enabled: true }] });
 });
 
 describe('GoalDetailPanel badge migration to <Pill>', () => {
@@ -136,7 +154,7 @@ describe('GoalDetailPanel provenance chip', () => {
     // a chip attributing those readings would point at content no longer shown.
     await renderPanel();
     expect(screen.getByText('Inferred')).toBeTruthy(); // read mode: present
-    fireEvent.click(screen.getByText('Edit'));
+    await openEdit();
     expect(screen.queryByText('Inferred')).toBeNull();
   });
 });
@@ -145,14 +163,14 @@ describe('GoalDetailPanel Daily Driver feature-area override (issue #2679)', () 
   it('shows the category default (greyed) when no per-goal override is set', async () => {
     // mastery → ['post', 'memory'] → "Daily POST, Memory" per goalFeatureMap.
     await renderPanel();
-    fireEvent.click(screen.getByText('Edit'));
+    await openEdit();
     expect(screen.getByText(/Default \(Mastery\):/)).toBeTruthy();
     expect(screen.getByText(/Daily POST, Memory/)).toBeTruthy();
   });
 
   it('initializes the multi-select from goal.featureAreas and reflects selection', async () => {
     await renderPanel({ ...baseGoal, featureAreas: ['writersRoom'] });
-    fireEvent.click(screen.getByText('Edit'));
+    await openEdit();
     const writersBtn = screen.getByRole('button', { name: /Writers Room/ });
     expect(writersBtn.getAttribute('aria-pressed')).toBe('true');
     // With an override present, the category-default hint is hidden.
@@ -161,7 +179,7 @@ describe('GoalDetailPanel Daily Driver feature-area override (issue #2679)', () 
 
   it('round-trips the override through updateGoal when saved', async () => {
     await renderPanel(); // no override → falls back to category default
-    fireEvent.click(screen.getByText('Edit'));
+    await openEdit();
     // Toggle two areas on, then save.
     fireEvent.click(screen.getByRole('button', { name: /Universes/ }));
     fireEvent.click(screen.getByRole('button', { name: /Tribe/ }));
@@ -177,7 +195,7 @@ describe('GoalDetailPanel Daily Driver feature-area override (issue #2679)', () 
 
   it('sends an empty featureAreas array when the override is cleared (falls back to category default)', async () => {
     await renderPanel({ ...baseGoal, featureAreas: ['universes'] });
-    fireEvent.click(screen.getByText('Edit'));
+    await openEdit();
     // Toggle the sole selected area off.
     fireEvent.click(screen.getByRole('button', { name: /Universes/ }));
     await act(async () => {
@@ -197,7 +215,7 @@ describe('GoalDetailPanel Daily Driver feature-area override (issue #2679)', () 
     // was open. Omitting the field lets the service preserve whatever is stored —
     // including any forward-unknown id from a newer peer, which is never dropped.
     await renderPanel({ ...baseGoal, featureAreas: ['someFutureAreaFromANewerPeer'] });
-    fireEvent.click(screen.getByText('Edit'));
+    await openEdit();
     // Change only the title; never touch the feature-area buttons.
     const titleInput = screen.getByDisplayValue('Master the craft');
     fireEvent.change(titleInput, { target: { value: 'Master the craft, revised' } });
@@ -215,7 +233,7 @@ describe('GoalDetailPanel Daily Driver feature-area override (issue #2679)', () 
     // another known area. The unknown id (invisible in this install's UI) must
     // ride along untouched so it is never erased across federation.
     await renderPanel({ ...baseGoal, featureAreas: ['someFutureAreaFromANewerPeer', 'universes'] });
-    fireEvent.click(screen.getByText('Edit'));
+    await openEdit();
     // Toggle a different known area on → override changed.
     fireEvent.click(screen.getByRole('button', { name: /Tribe/ }));
     await act(async () => {
@@ -231,8 +249,19 @@ describe('GoalDetailPanel Daily Driver feature-area override (issue #2679)', () 
     // Daily Driver falls back to the category default at read time, so the hint
     // must be shown (gating on known-selection, not raw array length).
     await renderPanel({ ...baseGoal, featureAreas: ['someFutureAreaFromANewerPeer'] });
-    fireEvent.click(screen.getByText('Edit'));
+    await openEdit();
     expect(screen.getByText(/Default \(Mastery\):/)).toBeTruthy();
     expect(screen.getByText(/Daily POST, Memory/)).toBeTruthy();
+  });
+
+  it('hides POST from the picker and falls back to the next enabled default when POST is disabled', async () => {
+    api.getInstanceFeatures.mockResolvedValue({ features: [{ id: 'post', enabled: false }] });
+    await renderPanel();
+    await openEdit();
+    expect(await screen.findByText(/Default \(Mastery\):/)).toBeTruthy();
+    expect(screen.getByText(/Default \(Mastery\):/)).toHaveTextContent('Memory');
+    expect(screen.queryByText(/Daily POST, Memory/)).toBeNull();
+    expect(screen.queryByRole('button', { name: /Daily POST/ })).toBeNull();
+    expect(screen.getByRole('button', { name: /Memory/ })).toBeTruthy();
   });
 });

--- a/client/src/components/goals/GoalEditForm.jsx
+++ b/client/src/components/goals/GoalEditForm.jsx
@@ -6,7 +6,8 @@ import {
 import Pill from '../ui/Pill';
 import { FormField } from '../ui/FormField';
 import { CATEGORY_CONFIG, HORIZON_OPTIONS, GOAL_TYPE_OPTIONS, MAX_TAGS } from './goalConstants';
-import { FEATURE_AREAS, FEATURE_AREA_IDS, GOAL_CATEGORY_FEATURE_MAP } from '../../lib/goalFeatureMap';
+import { FEATURE_AREAS, FEATURE_AREA_IDS, getGoalFeatureAreas } from '../../lib/goalFeatureMap';
+import { useInstanceFeatures } from '../../hooks/useInstanceFeatures.js';
 
 // Resolve a feature-area icon NAME (kept as a string in goalFeatureMap.js so
 // that module stays React-free and server-mirrorable) to a lucide component.
@@ -21,18 +22,29 @@ export default function GoalEditForm({
   toggleFeatureArea, parentOptions, saveEdit, onCancel
 }) {
   const selectedAreas = form.featureAreas || [];
+  const { features, error } = useInstanceFeatures();
+  // This picker writes a persistent Daily Driver override, so it must fail
+  // closed while the shared feature list is loading or unreadable. Navigation
+  // uses the hook's separate fail-open predicate, but saving a gated area while
+  // participation is unknown would create a link the dashboard cannot show.
+  const isFeatureAvailable = (featureId) => (
+    !featureId
+    || (!error
+      && Array.isArray(features)
+      && features.some((feature) => feature?.id === featureId && feature.enabled === true))
+  );
+  const isAreaEnabled = (id) => isFeatureAvailable(FEATURE_AREAS[id]?.feature);
   // Gate the greyed category-default hint on whether any LOCALLY-KNOWN area is
   // selected — not on raw array length. A version-skewed goal can carry only
   // forward-unknown ids (from a newer peer); those render no visible button and
   // getGoalFeatureAreas filters them, so the Daily Driver still falls back to the
   // category default. Keying on length would hide the hint in that case and lie
   // about the actual behavior (issue #2679).
-  const hasKnownSelection = selectedAreas.some(id => FEATURE_AREAS[id]);
+  const hasKnownSelection = selectedAreas.some(id => FEATURE_AREAS[id] && isAreaEnabled(id));
   // Category default shown (greyed) when no known override is set, so the user
   // sees which areas the Daily Driver will deep-link to by default.
-  const categoryDefaultLabels = (GOAL_CATEGORY_FEATURE_MAP[form.category] || [])
-    .map(id => FEATURE_AREAS[id]?.label)
-    .filter(Boolean);
+  const categoryDefaultLabels = getGoalFeatureAreas({ category: form.category }, isFeatureAvailable)
+    .map(({ label }) => label);
   return (
     <div className="space-y-3">
       <FormField label="Title" labelClassName="text-xs text-gray-500">
@@ -201,7 +213,7 @@ export default function GoalEditForm({
           Pin which PortOS areas the Daily Driver deep-links to for this goal. Leave empty to use the category default.
         </p>
         <div role="group" aria-labelledby="feature-areas-label" className="flex flex-wrap gap-1 mt-1">
-          {FEATURE_AREA_IDS.map(id => {
+          {FEATURE_AREA_IDS.filter(isAreaEnabled).map(id => {
             const area = FEATURE_AREAS[id];
             const Icon = AREA_ICONS[area.icon] || Target;
             const active = selectedAreas.includes(id);

--- a/client/src/components/openworld/OpenWorldCollectibles.jsx
+++ b/client/src/components/openworld/OpenWorldCollectibles.jsx
@@ -125,12 +125,13 @@ export default function OpenWorldCollectibles({
   collectedShardIds = new Set(),
   activeBursts = [],
   settings,
+  shards,
 }) {
-  const shards = useMemo(() => getCollectiblesList(), []);
+  const resolvedShards = useMemo(() => shards || getCollectiblesList(), [shards]);
   const animate = (settings?.particleDensity ?? 1) >= 0.5;
   const visibleShards = useMemo(
-    () => shards.filter((s) => !collectedShardIds.has(s.id)),
-    [shards, collectedShardIds]
+    () => resolvedShards.filter((s) => !collectedShardIds.has(s.id)),
+    [resolvedShards, collectedShardIds]
   );
 
   return (

--- a/client/src/components/openworld/OpenWorldFastTravel.jsx
+++ b/client/src/components/openworld/OpenWorldFastTravel.jsx
@@ -33,13 +33,13 @@ const MAP_BOUNDS = {
 // disagree about where the bay starts.
 const GEOGRAPHY = projectGeography(MAP_BOUNDS, MINI_MAP_PADDING);
 
-export default function OpenWorldFastTravel({ open, onClose, onTravel, activeRegionId, onLeaveRegion }) {
+export default function OpenWorldFastTravel({ open, onClose, onTravel, activeRegionId, onLeaveRegion, isFeatureEnabled }) {
   const [query, setQuery] = useState('');
   const inputRef = useRef(null);
   const { isCondensed } = useOpenWorldViewport();
 
-  const regions = useMemo(() => listRegions(), []);
-  const matches = useMemo(() => searchRegions(query), [query]);
+  const regions = useMemo(() => listRegions(isFeatureEnabled), [isFeatureEnabled]);
+  const matches = useMemo(() => searchRegions(query, isFeatureEnabled), [query, isFeatureEnabled]);
   const matchIds = useMemo(() => new Set(matches.map((r) => r.id)), [matches]);
   const mapMarkers = useMemo(
     () => spreadProjectedPoints(regions.map((region) => {

--- a/client/src/components/openworld/OpenWorldScene.jsx
+++ b/client/src/components/openworld/OpenWorldScene.jsx
@@ -56,6 +56,8 @@ import { openWorldDayMix, getTimeOfDayPreset } from './openWorldConstants';
 import { CITY_MAX_ORBIT_DISTANCE } from '../../utils/openWorldFocusCamera';
 import { THIRD_PERSON } from '../../utils/openWorldPlayerRig';
 import { listRegions } from '../../utils/openWorldRegions';
+import { getResolvedLandmarks } from '../../utils/openWorldProximity';
+import { getCollectiblesList } from '../../utils/openWorldCollectibles';
 import { computeEasterEggs } from '../../utils/openWorldEasterEggs';
 import { OpenWorldPaletteProvider } from './OpenWorldPaletteContext';
 import ErrorBoundary from '../ErrorBoundary';
@@ -98,6 +100,8 @@ export default function OpenWorldScene({
   dimmedAppIds,
   focusedAppId,
   focusedRegion,
+  isFeatureEnabled,
+  isPassiveFeatureEnabled,
   playerTeleport,
   hudSafe,
   background,
@@ -156,7 +160,12 @@ export default function OpenWorldScene({
   // belong to the OpenWorld style; over the Vibes world's sunlit low-poly landscape they
   // read as haze and grain, so they don't mount at all rather than fading per-frame.
   const neonLayers = Boolean(palette?.neonLayers);
-  const warpRegions = useMemo(() => listRegions(), []);
+  const jiraFeatureEnabled = typeof isPassiveFeatureEnabled === 'function'
+    ? isPassiveFeatureEnabled('jira')
+    : typeof isFeatureEnabled === 'function' ? isFeatureEnabled('jira') : true;
+  const warpRegions = useMemo(() => listRegions(isFeatureEnabled), [isFeatureEnabled]);
+  const landmarks = useMemo(() => getResolvedLandmarks(isFeatureEnabled), [isFeatureEnabled]);
+  const collectibles = useMemo(() => getCollectiblesList(isPassiveFeatureEnabled), [isPassiveFeatureEnabled]);
   const easterEggsList = useMemo(
     () => computeEasterEggs({ character, goals, productivityData }),
     [character, goals, productivityData]
@@ -397,7 +406,7 @@ export default function OpenWorldScene({
       <OpenWorldVoiceMarker voiceState={voiceState} settings={renderSettings} />
       <OpenWorldMemoryDistrict memoryGraph={memoryGraph} inboxDepth={inboxDepth} settings={renderSettings} />
       <OpenWorldDataHarbor introspection={introspection} settings={renderSettings} />
-      <OpenWorldJiraDistrict jiraTickets={jiraTickets} settings={renderSettings} />
+      {jiraFeatureEnabled && <OpenWorldJiraDistrict jiraTickets={jiraTickets} settings={renderSettings} />}
       <OpenWorldAiCore aiActivity={aiActivity} positions={positions} apps={apps} settings={renderSettings} />
       <WorldGround settings={renderSettings} />
       <OpenWorldStreets settings={renderSettings} />
@@ -407,6 +416,7 @@ export default function OpenWorldScene({
         collectedShardIds={collectedShardIds}
         activeBursts={activeBursts}
         settings={renderSettings}
+        shards={collectibles}
       />
       <OpenWorldTransitLoop settings={renderSettings} />
 
@@ -439,6 +449,7 @@ export default function OpenWorldScene({
         settings={renderSettings}
         activeRegionId={focusedRegion?.id}
         onTravelToRegion={onTravelToRegion}
+        regions={warpRegions}
       />
       {neonLayers && <OpenWorldVolumetricLights positions={positions} settings={renderSettings} />}
       {neonLayers && <OpenWorldNeonSigns positions={positions} />}
@@ -461,8 +472,10 @@ export default function OpenWorldScene({
           cameraView={settings?.cameraView ?? 'third'}
           teleport={playerTeleport}
           warpPads={warpRegions}
+          landmarks={landmarks}
           onWarpPadInteract={onTravelToRegion}
           easterEggs={easterEggsList.eggs}
+          shards={collectibles}
           collectedShardIds={collectedShardIds}
           onCollectShard={onCollectShard}
           onPlayerPoseChange={onPlayerPoseChange}

--- a/client/src/components/openworld/OpenWorldSignalBeacons.jsx
+++ b/client/src/components/openworld/OpenWorldSignalBeacons.jsx
@@ -2,7 +2,7 @@ import { useMemo, useRef } from 'react';
 import { useFrame } from '@react-three/fiber';
 import * as THREE from 'three';
 import { computeDistrictBounds } from '../../utils/openWorldMiniMap';
-import { listRegions, regionWarpPadPosition } from '../../utils/openWorldRegions';
+import { regionWarpPadPosition } from '../../utils/openWorldRegions';
 import { PIXEL_FONT_URL, openWorldDayMix, openWorldShowDetail, mixHex } from './openWorldConstants';
 import { useOpenWorldPalette } from './OpenWorldPaletteContext';
 import OpenWorldLabel from './OpenWorldLabel';
@@ -195,9 +195,8 @@ function WarpPad({ region, active, detailed, dayMix, onTravel }) {
   );
 }
 
-export default function OpenWorldSignalBeacons({ positions, reviewCounts, instances, settings, activeRegionId, onTravelToRegion }) {
+export default function OpenWorldSignalBeacons({ positions, reviewCounts, instances, settings, activeRegionId, onTravelToRegion, regions = [] }) {
   const dayMix = openWorldDayMix(settings);
-  const regions = useMemo(() => listRegions(), []);
   const showDetail = openWorldShowDetail(settings);
   const config = useMemo(() => {
     if (!positions || positions.size === 0) return [];

--- a/client/src/components/openworld/PlayerController.jsx
+++ b/client/src/components/openworld/PlayerController.jsx
@@ -14,8 +14,8 @@ import { isWalkable, WORLD } from '../../utils/openWorldPlan';
 import { BOROUGH_PARAMS, BUILDING_PARAMS, PROCESS_BUILDING_PARAMS } from './openWorldConstants';
 import { regionWarpPadPosition, getRegion } from '../../utils/openWorldRegions';
 import { checkSpeedPadOverlap } from '../../utils/openWorldSpeedPads';
-import { checkShardCollection } from '../../utils/openWorldCollectibles';
-import { detectProximity } from '../../utils/openWorldProximity';
+import { checkShardCollection, getCollectiblesList } from '../../utils/openWorldCollectibles';
+import { detectProximity, getResolvedLandmarks } from '../../utils/openWorldProximity';
 
 const WALK_SPEED = 10;
 const SPRINT_SPEED = 20;
@@ -57,10 +57,12 @@ export default function PlayerController({
   cameraView = 'third',
   teleport = null,
   warpPads = [],
+  landmarks = getResolvedLandmarks(),
   onWarpPadInteract,
   onWarpPadProximity,
   onProximityChange,
   easterEggs = [],
+  shards = getCollectiblesList(),
   collectedShardIds = new Set(),
   onCollectShard,
   onPlayerPoseChange,
@@ -497,7 +499,7 @@ export default function PlayerController({
     }
 
     // Cyber Shards collectible detection
-    const collectedShards = checkShardCollection(rig.position, undefined, localCollectedSetRef.current);
+    const collectedShards = checkShardCollection(rig.position, shards, localCollectedSetRef.current);
     if (collectedShards.length > 0) {
       collectedShards.forEach((shard) => {
         localCollectedSetRef.current.add(shard.id);
@@ -536,6 +538,7 @@ export default function PlayerController({
       positions,
       warpPads: warpPadList,
       easterEggs,
+      landmarks,
     });
 
     if (proxTarget?.id !== proximityTargetRef.current?.id || proxTarget?.type !== proximityTargetRef.current?.type) {

--- a/client/src/hooks/useInstanceFeatures.js
+++ b/client/src/hooks/useInstanceFeatures.js
@@ -18,6 +18,7 @@ import * as api from '../services/api';
 // means loaded and this version registers no optional features.
 let cached = null;
 let inFlight = null;
+let inFlightGeneration = null;
 // Bumped whenever something newer than an outstanding request lands (a toggle
 // publishing the server's fresh list, or an invalidation). A response that read
 // the OLD state must not overwrite it just because it resolved later — without
@@ -26,9 +27,9 @@ let inFlight = null;
 let generation = 0;
 
 const loadInstanceFeatures = () => {
-  if (!inFlight) {
+  if (!inFlight || inFlightGeneration !== generation) {
     const requested = generation;
-    inFlight = api.getInstanceFeatures({ silent: true })
+    const request = api.getInstanceFeatures({ silent: true })
       .then((data) => ({ features: Array.isArray(data?.features) ? data.features : [], error: null }))
       .catch((error) => {
         // Fail OPEN: an unreadable feature list must not blank out navigation.
@@ -36,13 +37,18 @@ const loadInstanceFeatures = () => {
         return { features: null, error };
       })
       .then((result) => {
-        inFlight = null;
+        if (inFlight === request) {
+          inFlight = null;
+          inFlightGeneration = null;
+        }
         // Superseded while in flight — hand the caller what IS current instead
         // of the answer it asked for, so no consumer renders the stale one.
         if (requested !== generation) return cached || result;
         cached = result;
         return result;
       });
+    inFlight = request;
+    inFlightGeneration = requested;
   }
   return inFlight;
 };
@@ -138,5 +144,6 @@ export const invalidateInstanceFeatures = (featureId) => {
 export const __resetInstanceFeatureCache = () => {
   cached = null;
   inFlight = null;
+  inFlightGeneration = null;
   generation += 1;
 };

--- a/client/src/hooks/useInstanceFeatures.test.jsx
+++ b/client/src/hooks/useInstanceFeatures.test.jsx
@@ -85,6 +85,32 @@ describe('useInstanceFeatures', () => {
     expect(screen.getByTestId('a')).toHaveTextContent('on');
   });
 
+  it('starts a fresh shared read after a legacy invalidation during an in-flight read', async () => {
+    const stale = deferred();
+    const fresh = deferred();
+    mock.getInstanceFeatures
+      .mockReturnValueOnce(stale.promise)
+      .mockReturnValueOnce(fresh.promise);
+    render(<Probe />);
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent(INSTANCE_FEATURES_CHANGED, { detail: { featureId: 'jira' } }));
+    });
+    expect(mock.getInstanceFeatures).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      fresh.resolve({ features: JIRA_ON });
+      await fresh.promise;
+    });
+    expect(screen.getByTestId('a')).toHaveTextContent('on');
+
+    await act(async () => {
+      stale.resolve({ features: JIRA_OFF });
+      await stale.promise;
+    });
+    expect(screen.getByTestId('a')).toHaveTextContent('on');
+  });
+
   it('fails open so a failed fetch never blanks navigation', async () => {
     mock.getInstanceFeatures.mockRejectedValue(new Error('offline'));
     render(<Probe />);

--- a/client/src/lib/goalFeatureMap.js
+++ b/client/src/lib/goalFeatureMap.js
@@ -16,7 +16,7 @@
 
 // Feature areas, keyed by a stable area id. Each `to` is a live NAV_COMMANDS path.
 export const FEATURE_AREAS = {
-  post:          { label: 'Daily POST',      to: '/post/launcher',              icon: 'Brain' },
+  post:          { label: 'Daily POST',      to: '/post/launcher',              icon: 'Brain', feature: 'post' },
   bodyHealth:    { label: 'Body Health',     to: '/meatspace/health',           icon: 'HeartPulse' },
   writersRoom:   { label: 'Writers Room',    to: '/writers-room',               icon: 'PenLine' },
   universes:     { label: 'Universes',       to: '/universes',                  icon: 'Globe' },
@@ -46,13 +46,23 @@ export const GOAL_CATEGORY_FEATURE_MAP = {
 // Resolve the feature-area rows for a goal. Honors the optional per-goal
 // `featureAreas` override (an ordered array of area ids) when present and
 // non-empty — filtering out any unknown ids — otherwise falls back to the
-// category default. Returns an array of { area, label, to, icon }.
-export function getGoalFeatureAreas(goal) {
+// category default. When supplied, isFeatureEnabled filters gated rows while
+// preserving the selected/default order. Returns rows with an optional feature tag.
+export function getGoalFeatureAreas(goal, isFeatureEnabled) {
   const override = Array.isArray(goal?.featureAreas)
     ? goal.featureAreas.filter((id) => FEATURE_AREAS[id])
     : [];
+  const categoryDefaults = GOAL_CATEGORY_FEATURE_MAP[goal?.category] || [];
   const areaIds = override.length > 0
     ? override
-    : (GOAL_CATEGORY_FEATURE_MAP[goal?.category] || []);
-  return areaIds.map((area) => ({ area, ...FEATURE_AREAS[area] }));
+    : categoryDefaults;
+  const rows = areaIds.map((area) => ({ area, ...FEATURE_AREAS[area] }));
+  if (typeof isFeatureEnabled !== 'function') return rows;
+
+  const enabledRows = rows.filter((row) => isFeatureEnabled(row.feature));
+  if (enabledRows.length > 0 || override.length === 0) return enabledRows;
+
+  return categoryDefaults
+    .map((area) => ({ area, ...FEATURE_AREAS[area] }))
+    .filter((row) => isFeatureEnabled(row.feature));
 }

--- a/client/src/pages/Dashboard.jsx
+++ b/client/src/pages/Dashboard.jsx
@@ -14,6 +14,7 @@ import * as api from '../services/api';
 import socket from '../services/socket';
 import toast from '../components/ui/Toast';
 import { pickActiveLayoutId, recordManualLayoutPick } from '../utils/timeWindow.js';
+import { useInstanceFeatures } from '../hooks/useInstanceFeatures.js';
 
 export default function Dashboard() {
   // null means the first apps read has not completed. Keep that distinct from
@@ -27,7 +28,6 @@ export default function Dashboard() {
   const [meatspaceLogging, setMeatspaceLogging] = useState(null);
   const [dailyDriver, setDailyDriver] = useState(null);
   const [dailyActions, setDailyActions] = useState(null);
-  const [instanceFeatures, setInstanceFeatures] = useState(null);
   const [loading, setLoading] = useState(true);
   const [dataError, setDataError] = useState(null);
   const [layoutsError, setLayoutsError] = useState(null);
@@ -81,7 +81,13 @@ export default function Dashboard() {
   // closure captured a possibly-stale activeLayout — lets it skip arming the
   // scroll when the user switched layouts while the add was still saving.
   const activeLayoutIdRef = useRef(null);
-  const instanceFeatureGenerationRef = useRef(0);
+  // Dashboard widget gates intentionally read the raw list: unlike navigation,
+  // a failed feature read must fail closed and reserve no POST widget cell.
+  const { features: instanceFeatureList } = useInstanceFeatures();
+  const instanceFeatures = useMemo(
+    () => (instanceFeatureList === null ? null : { features: instanceFeatureList }),
+    [instanceFeatureList],
+  );
 
   const refreshHealth = useCallback(async () => {
     // Keep the last good snapshot visible when a manual refresh hits a
@@ -92,13 +98,10 @@ export default function Dashboard() {
     return data;
   }, []);
 
-  const refreshInstanceFeatures = useCallback(async () => {
-    const generation = ++instanceFeatureGenerationRef.current;
-    const data = await api.getInstanceFeatures({ silent: true }).catch(() => null);
-    if (generation !== instanceFeatureGenerationRef.current) return null;
-    setInstanceFeatures(data);
-    return data;
-  }, []);
+  const fetchDailyActions = useCallback(
+    () => api.getDailyActions({ silent: true }).catch(() => null),
+    [],
+  );
 
   const fetchData = useCallback(async () => {
     setDataError(null);
@@ -119,38 +122,39 @@ export default function Dashboard() {
       // GET records the first-visit-of-day signal (issue #2666); a failure just
       // hides the Daily Driver card via its gate. No LLM calls here.
       api.getDailyDriverState().catch(() => null).then(setDailyDriver),
-      api.getDailyActions({ silent: true }).catch(() => null).then(setDailyActions),
-      refreshInstanceFeatures(),
+      fetchDailyActions().then(setDailyActions),
     ]);
     const appsData = await appsRead;
     if (Array.isArray(appsData)) setApps(appsData);
     await secondaryRead;
-  }, [refreshHealth, refreshInstanceFeatures]);
+  }, [fetchDailyActions, refreshHealth]);
 
   useEffect(() => {
     fetchData();
     const handleAppsChanged = () => fetchData();
-    const handleFeatureChange = (event) => {
-      if (event.detail?.featureId !== 'post') return;
-      const enabled = event.detail.enabled === true;
-      setInstanceFeatures((current) => {
-        const features = Array.isArray(current?.features) ? current.features : [];
-        const hasPost = features.some((feature) => feature.id === 'post');
-        const nextFeatures = hasPost
-          ? features.map((feature) => feature.id === 'post' ? { ...feature, enabled } : feature)
-          : [...features, { id: 'post', enabled }];
-        return { ...(current || {}), features: nextFeatures };
-      });
-      fetchData();
-    };
     socket.on('apps:changed', handleAppsChanged);
-    window.addEventListener(INSTANCE_FEATURES_CHANGED, handleFeatureChange);
     return () => {
-      instanceFeatureGenerationRef.current += 1;
       socket.off('apps:changed', handleAppsChanged);
-      window.removeEventListener(INSTANCE_FEATURES_CHANGED, handleFeatureChange);
     };
   }, [fetchData]);
+
+  // Daily Actions is a dashboard-state consumer rather than a feature-aware
+  // widget. Refresh it when the shared feature hook applies a toggle so a
+  // POST action cannot remain visible after POST is disabled (or stay absent
+  // after it is enabled) until an unrelated dashboard refresh.
+  useEffect(() => {
+    let active = true;
+    const handleFeaturesChanged = () => {
+      fetchDailyActions().then((data) => {
+        if (active) setDailyActions(data);
+      });
+    };
+    window.addEventListener(INSTANCE_FEATURES_CHANGED, handleFeaturesChanged);
+    return () => {
+      active = false;
+      window.removeEventListener(INSTANCE_FEATURES_CHANGED, handleFeaturesChanged);
+    };
+  }, [fetchDailyActions]);
 
   // One-shot per mount — guards against re-evaluation stomping manual picks.
   // Serialization across concurrent writers (auto-window + manual pick +

--- a/client/src/pages/OpenWorld.fastTravel.test.jsx
+++ b/client/src/pages/OpenWorld.fastTravel.test.jsx
@@ -39,6 +39,14 @@ vi.mock('../hooks/useOpenWorldPlayback', async () => {
 });
 vi.mock('../hooks/useOpenWorldAudio', () => ({ default: () => ({ playSfx: vi.fn(), isAudioReady: false }) }));
 vi.mock('../hooks/useAutoRefetch', () => ({ useAutoRefetch: () => ({ data: null }) }));
+vi.mock('../hooks/useInstanceFeatures', () => ({
+  useInstanceFeatures: () => ({
+    features: [],
+    error: null,
+    isFeatureEnabled: () => true,
+    reload: () => Promise.resolve(),
+  }),
+}));
 // Only the endpoints this page polls, from the shared page fixture. The vi.mock
 // CALL has to stay here (vitest hoists it), so the factory dynamic-imports it.
 vi.mock('../services/api', async () => (await import('../test/openWorldPageMocks.js')).openWorldApiMock(vi));

--- a/client/src/pages/OpenWorld.jsx
+++ b/client/src/pages/OpenWorld.jsx
@@ -24,9 +24,10 @@ import { computeSoundscape } from '../utils/openWorldSoundscape';
 import { deriveOpenWorldPalette, getTimeOfDayPreset, resolveOpenWorldTimeOfDay, resolveWorldStyle } from '../components/openworld/openWorldConstants';
 import OpenWorldFastTravel from '../components/openworld/OpenWorldFastTravel';
 import { getRegion, regionArrivalPoint, regionPath } from '../utils/openWorldRegions';
-import { loadCollectedShardIds, saveCollectedShardIds, TOTAL_SHARDS } from '../utils/openWorldCollectibles';
+import { getCollectiblesList, loadCollectedShardIds, saveCollectedShardIds } from '../utils/openWorldCollectibles';
 import { OpenWorldPaletteProvider } from '../components/openworld/OpenWorldPaletteContext';
 import { useThemeContext } from '../components/ThemeContext';
+import { useInstanceFeatures } from '../hooks/useInstanceFeatures';
 
 // Internal render budgets only. These tiers are selected from sustained frame time and are
 // deliberately not persisted or exposed as player settings; art direction stays coherent while
@@ -57,6 +58,24 @@ function OpenWorldInner() {
   const location = useLocation();
   const { appId, regionId } = useParams();
   const { isDesktop } = useOpenWorldViewport();
+  const {
+    features: instanceFeatures,
+    error: instanceFeaturesError,
+    isFeatureEnabled,
+  } = useInstanceFeatures();
+  // OpenWorld browse surfaces use the hook's fail-open gate so a settings
+  // hiccup never blanks navigation. Passive JIRA data is different: do not
+  // poll or render tickets while participation is loading or unreadable.
+  const isPassiveFeatureEnabled = useCallback((featureId) => (
+    !featureId
+    || (!instanceFeaturesError
+      && Array.isArray(instanceFeatures)
+      && instanceFeatures.some((feature) => feature?.id === featureId && feature.enabled === true))
+  ), [instanceFeatures, instanceFeaturesError]);
+  const visibleCollectibles = useMemo(
+    () => getCollectiblesList(isPassiveFeatureEnabled),
+    [isPassiveFeatureEnabled],
+  );
 
   // URL-addressed building focus (issue #2593). The `/openworld/apps/:appId` route param is the
   // single source of truth for "which borough is focused" — reload/back-forward/deep-link all
@@ -194,6 +213,10 @@ function OpenWorldInner() {
   const [collectedShardIds, setCollectedShardIds] = useState(() => loadCollectedShardIds());
   const [activeBursts, setActiveBursts] = useState([]);
   const [playerPose, setPlayerPose] = useState(null);
+  const visibleCollectedCount = useMemo(
+    () => visibleCollectibles.filter((shard) => collectedShardIds.has(shard.id)).length,
+    [visibleCollectibles, collectedShardIds],
+  );
 
   const handleCollectShard = useCallback((shard) => {
     setCollectedShardIds((prev) => {
@@ -422,10 +445,12 @@ function OpenWorldInner() {
       .sort().join(','),
     [apps]
   );
+  const jiraFeatureEnabled = isPassiveFeatureEnabled('jira');
   // Fetch each enabled app's current-sprint tickets and merge; the helper dedupes by key. Skip
   // the poll entirely when no app has JIRA configured. Keyed on `jiraAppsKey` so the closure (and
   // poll) refresh when JIRA apps appear/disappear.
   const fetchSprintTickets = useCallback(async () => {
+    if (!jiraFeatureEnabled) return [];
     const specs = (apps || [])
       .filter(a => a?.jira?.enabled && a.jira.instanceId && a.jira.projectKey)
       .map(a => ({ instanceId: a.jira.instanceId, projectKey: a.jira.projectKey }));
@@ -434,11 +459,11 @@ function OpenWorldInner() {
       specs.map(j => api.getMySprintTickets(j.instanceId, j.projectKey, { silent: true }).catch(() => []))
     );
     return batches.flat();
-  }, [apps]);
+  }, [apps, jiraFeatureEnabled]);
   const { data: jiraTickets } = useAutoRefetch(
     fetchSprintTickets,
     120_000,
-    { enabled: jiraAppsKey.length > 0 },
+    { enabled: jiraFeatureEnabled && jiraAppsKey.length > 0 },
   );
 
   // Selecting a building focuses it in-place (issue #2593) — the URL becomes /openworld/apps/:id and the
@@ -569,6 +594,8 @@ function OpenWorldInner() {
         onAutoTierChange={setAutoTier}
         focusedAppId={appId || null}
         focusedRegion={focusedRegion}
+        isFeatureEnabled={isFeatureEnabled}
+        isPassiveFeatureEnabled={isPassiveFeatureEnabled}
         playerTeleport={playerTeleport}
         hudSafe={focusHudSafe}
         onTravelToRegion={handleTravelToRegion}
@@ -615,8 +642,8 @@ function OpenWorldInner() {
           activeRegion={focusedRegion}
           proximityTarget={proximityTarget}
           playerPose={playerPose}
-          collectedCount={collectedShardIds.size}
-          totalShards={TOTAL_SHARDS}
+          collectedCount={visibleCollectedCount}
+          totalShards={visibleCollectibles.length}
         />
       )}
       {!photoMode && !playback.active && !isDesktop && settings?.explorationMode && !showSettings && !fastTravelOpen && (
@@ -662,6 +689,7 @@ function OpenWorldInner() {
         onTravel={handleTravelToRegion}
         activeRegionId={focusedRegion?.id || null}
         onLeaveRegion={() => navigate('/openworld')}
+        isFeatureEnabled={isFeatureEnabled}
       />
       {/* Settings on the shared Drawer. Closing preserves other query params (e.g. an open
           openWorldPane) so the disclosure state survives. Rendering quality is automatic and

--- a/client/src/pages/OpenWorld.transport.test.jsx
+++ b/client/src/pages/OpenWorld.transport.test.jsx
@@ -36,6 +36,14 @@ const playback = vi.hoisted(() => ({
 vi.mock('../hooks/useOpenWorldPlayback', () => ({ useOpenWorldPlayback: () => playback }));
 vi.mock('../hooks/useOpenWorldAudio', () => ({ default: () => ({ playSfx: vi.fn(), isAudioReady: false }) }));
 vi.mock('../hooks/useAutoRefetch', () => ({ useAutoRefetch: () => ({ data: null }) }));
+vi.mock('../hooks/useInstanceFeatures', () => ({
+  useInstanceFeatures: () => ({
+    features: [],
+    error: null,
+    isFeatureEnabled: () => true,
+    reload: () => Promise.resolve(),
+  }),
+}));
 // Only the endpoints this page polls, from the shared page fixture. The vi.mock
 // CALL has to stay here (vitest hoists it), so the factory dynamic-imports it.
 vi.mock('../services/api', async () => (await import('../test/openWorldPageMocks.js')).openWorldApiMock(vi));

--- a/client/src/test/openWorldPageMocks.js
+++ b/client/src/test/openWorldPageMocks.js
@@ -1,7 +1,7 @@
 /**
  * Shared fixture payloads for the `OpenWorld` PAGE suites (transport, fast
  * travel, and whatever comes next). Each of those suites stubs the same 3D
- * scene, the same data hook, and the same eight API endpoints purely to get the
+ * scene, the same data hook, and the same nine API endpoints purely to get the
  * page mountable in jsdom — none of it is what any of them is testing, and a
  * new endpoint the page starts polling otherwise has to be added to every copy.
  *
@@ -56,6 +56,7 @@ export const OPEN_WORLD_DATA = {
  */
 export function openWorldApiMock(vi) {
   return {
+    getInstanceFeatures: vi.fn(async () => ({ features: [] })),
     getCosQuickSummary: vi.fn(async () => null),
     getCosActivityCalendar: vi.fn(async () => null),
     getGoals: vi.fn(async () => null),

--- a/client/src/utils/openWorldCollectibles.js
+++ b/client/src/utils/openWorldCollectibles.js
@@ -25,7 +25,7 @@ export const CYBER_SHARDS = [
   // Western Districts (Memory, Backup, Jira, Productivity)
   { id: 'shard-memory-steps', label: 'Memory Crystal Shard', x: -38, y: DEFAULT_SHARD_Y, z: -24, color: '#a855f7', value: 20 },
   { id: 'shard-backup-vault', label: 'Vault Crypt Cache', x: -30, y: DEFAULT_SHARD_Y, z: -8, color: '#f59e0b', value: 20 },
-  { id: 'shard-jira-yard', label: 'Sprint Yard Crate', x: -16, y: DEFAULT_SHARD_Y, z: -38, color: '#ec4899', value: 20 },
+  { id: 'shard-jira-yard', label: 'Sprint Yard Crate', x: -16, y: DEFAULT_SHARD_Y, z: -38, color: '#ec4899', value: 20, feature: 'jira' },
   { id: 'shard-productivity', label: 'Focus Terrace Spark', x: -44, y: DEFAULT_SHARD_Y, z: 24, color: '#22c55e', value: 20 },
   { id: 'shard-quiet-corner', label: 'Secret Shard', x: -44, y: DEFAULT_SHARD_Y, z: 38, color: '#e879f9', value: 30 },
 
@@ -42,12 +42,20 @@ export const CYBER_SHARDS = [
 
 export const TOTAL_SHARDS = CYBER_SHARDS.length;
 
+export const isCollectibleVisible = (shard, isFeatureEnabled) => (
+  !shard?.feature
+  || typeof isFeatureEnabled !== 'function'
+  || isFeatureEnabled(shard.feature)
+);
+
 // Return all shards with placement metadata and individual animation phase offsets.
-export function getCollectiblesList() {
-  return CYBER_SHARDS.map((shard, index) => ({
-    ...shard,
-    pulsePhase: (index * 0.13) % 1,
-  }));
+export function getCollectiblesList(isFeatureEnabled) {
+  return CYBER_SHARDS
+    .filter((shard) => isCollectibleVisible(shard, isFeatureEnabled))
+    .map((shard, index) => ({
+      ...shard,
+      pulsePhase: (index * 0.13) % 1,
+    }));
 }
 
 // Check which uncollected shards are within range of the player position.

--- a/client/src/utils/openWorldCollectibles.test.js
+++ b/client/src/utils/openWorldCollectibles.test.js
@@ -6,6 +6,7 @@ import {
   checkShardCollection,
   getCollectionStats,
   SHARD_COLLECTION_RADIUS,
+  isCollectibleVisible,
 } from './openWorldCollectibles';
 
 describe('openWorldCollectibles', () => {
@@ -54,6 +55,15 @@ describe('openWorldCollectibles', () => {
     expect(checkShardCollection(null)).toEqual([]);
     expect(checkShardCollection({ x: 'invalid', z: 0 })).toEqual([]);
     expect(checkShardCollection({ x: 9999, z: 9999 }, CYBER_SHARDS, new Set())).toEqual([]);
+  });
+
+  it('hides the Sprint Yard shard when JIRA is disabled', () => {
+    const jiraOff = (featureId) => featureId !== 'jira';
+    const jiraShard = CYBER_SHARDS.find((shard) => shard.feature === 'jira');
+
+    expect(isCollectibleVisible(jiraShard, jiraOff)).toBe(false);
+    expect(getCollectiblesList(jiraOff).map((shard) => shard.id)).not.toContain('shard-jira-yard');
+    expect(getCollectiblesList(() => true).map((shard) => shard.id)).toContain('shard-jira-yard');
   });
 
   it('getCollectionStats calculates accurate percentages and completion flags', () => {

--- a/client/src/utils/openWorldProximity.js
+++ b/client/src/utils/openWorldProximity.js
@@ -3,6 +3,7 @@
 // No three.js / React imports — pure, testable in node.
 
 import { PARCELS } from './openWorldPlan';
+import { isOpenWorldEntryVisible } from './openWorldRegions';
 
 export const PROXIMITY_DISTANCES = {
   warpPad: 3.6,
@@ -19,24 +20,27 @@ export const WORLD_LANDMARKS = [
   { id: 'task-queue', regionId: 'task-queue', parcel: 'taskQueue', label: 'Task Queue Depot', eyebrow: 'LANDMARK DEPOT', action: 'VIEW TASKS' },
   { id: 'wellness', regionId: 'wellness', parcel: 'health', label: 'Wellness Tower', eyebrow: 'LANDMARK TOWER', action: 'VIEW VITALS' },
   { id: 'memory', regionId: 'memory', parcel: 'memory', label: 'Memory Quarter', eyebrow: 'LANDMARK DISTRICT', action: 'VIEW MEMORY GRAPH' },
-  { id: 'sprint-yard', regionId: 'sprint-yard', parcel: 'jira', label: 'Sprint Yard', eyebrow: 'LANDMARK SPRINT', action: 'VIEW SPRINT TICKETS' },
+  { id: 'sprint-yard', regionId: 'sprint-yard', parcel: 'jira', feature: 'jira', label: 'Sprint Yard', eyebrow: 'LANDMARK SPRINT', action: 'VIEW SPRINT TICKETS' },
   { id: 'goals', regionId: 'goals', parcel: 'goals', label: 'Goal Monuments', eyebrow: 'LANDMARK MONUMENT', action: 'VIEW LIFE GOALS' },
   { id: 'artifacts', regionId: 'artifacts', parcel: 'artifacts', label: 'Hall of Achievements', eyebrow: 'LANDMARK HALL', action: 'VIEW ACHIEVEMENTS' },
   { id: 'voice', regionId: 'voice', parcel: 'voice', label: 'Voice Beacon', eyebrow: 'LANDMARK BEACON', action: 'VIEW VOICE AGENT' },
   { id: 'data-harbor', regionId: 'data-harbor', parcel: 'dataHarbor', label: 'Data Harbor Piers', eyebrow: 'LANDMARK HARBOR', action: 'VIEW DATA HARBOR' },
 ];
 
-export function getResolvedLandmarks() {
-  return WORLD_LANDMARKS.map((lm) => {
-    const parcel = PARCELS[lm.parcel];
-    if (!parcel) return null;
-    return {
-      ...lm,
-      x: parcel.anchor[0],
-      y: 0,
-      z: parcel.anchor[2],
-    };
-  }).filter(Boolean);
+export function getResolvedLandmarks(isFeatureEnabled) {
+  return WORLD_LANDMARKS
+    .filter((landmark) => isOpenWorldEntryVisible(landmark, isFeatureEnabled))
+    .map((lm) => {
+      const parcel = PARCELS[lm.parcel];
+      if (!parcel) return null;
+      return {
+        ...lm,
+        x: parcel.anchor[0],
+        y: 0,
+        z: parcel.anchor[2],
+      };
+    })
+    .filter(Boolean);
 }
 
 // Compute the closest interactable target to the player

--- a/client/src/utils/openWorldProximity.test.js
+++ b/client/src/utils/openWorldProximity.test.js
@@ -18,6 +18,12 @@ describe('openWorldProximity', () => {
     });
   });
 
+  it('hides a disabled feature landmark from proximity browse surfaces', () => {
+    const jiraOff = (featureId) => featureId !== 'jira';
+    expect(getResolvedLandmarks(jiraOff).map((landmark) => landmark.id)).not.toContain('sprint-yard');
+    expect(getResolvedLandmarks(() => true).map((landmark) => landmark.id)).toContain('sprint-yard');
+  });
+
   it('detects landmark when player is close', () => {
     const aiCore = getResolvedLandmarks().find((l) => l.id === 'ai-core');
     expect(aiCore).toBeDefined();

--- a/client/src/utils/openWorldRegions.js
+++ b/client/src/utils/openWorldRegions.js
@@ -35,7 +35,7 @@ export const OPEN_WORLD_REGIONS = [
   { id: 'productivity', parcel: 'productivity', label: 'Productivity Terrace', blurb: 'Streaks, throughput, and the activity heatmap.', appPath: '/insights/overview', aliases: ['productivity terrace', 'productivity', 'streak district'] },
   { id: 'backup-vault', parcel: 'backupVault', label: 'Backup Vault', blurb: 'The sealed door — last backup and its health.', appPath: '/settings/backup', aliases: ['backup vault', 'the vault'] },
   { id: 'memory', parcel: 'memory', label: 'Memory Quarter', blurb: 'Crystal clusters of long-term memory and the inbox well.', appPath: '/brain/inbox', aliases: ['memory quarter', 'memory district', 'knowledge district'] },
-  { id: 'sprint-yard', parcel: 'jira', label: 'Sprint Yard', blurb: 'The current sprint, laid out as a yard of tickets.', appPath: '/devtools/jira', aliases: ['sprint yard', 'jira yard', 'sprint district'] },
+  { id: 'sprint-yard', parcel: 'jira', label: 'Sprint Yard', blurb: 'The current sprint, laid out as a yard of tickets.', appPath: '/devtools/jira', feature: 'jira', aliases: ['sprint yard', 'jira yard', 'sprint district'] },
   { id: 'voice', parcel: 'voice', label: 'Voice Beacon', blurb: 'Lights up while the voice agent is listening.', appPath: '/digital-twin/voice', aliases: ['voice beacon', 'the beacon'] },
   { id: 'goals', parcel: 'goals', label: 'Goal Monuments', blurb: 'One monument per life goal, height by progress.', appPath: '/goals/tree', aliases: ['goal monuments', 'monuments', 'goals district'] },
   { id: 'artifacts', parcel: 'artifacts', label: 'Hall of Achievements', blurb: 'Earned artifacts on display.', appPath: '/character', aliases: ['hall of achievements', 'artifact hall', 'achievements hall'] },
@@ -49,6 +49,14 @@ export const OPEN_WORLD_REGION_PREFIX = '/openworld/region';
 export const regionPath = (id) => `${OPEN_WORLD_REGION_PREFIX}/${id}`;
 
 const REGIONS_BY_ID = new Map(OPEN_WORLD_REGIONS.map((r) => [r.id, r]));
+
+// Optional feature tags follow the caller's shared navigation gate. Untagged entries
+// and callers without a gate remain visible; tagged entries follow the gate's answer.
+export const isOpenWorldEntryVisible = (entry, isFeatureEnabled) => (
+  !entry?.feature
+  || typeof isFeatureEnabled !== 'function'
+  || isFeatureEnabled(entry.feature)
+);
 
 // A region with its geography resolved from the master town plan: `anchor` is the ground
 // center [x, y, z], `w`/`d` the parcel footprint. The registry's `label` is what the UI
@@ -71,15 +79,18 @@ export function getRegion(id) {
 
 // Every region, geography resolved, in fast-travel order. Regions whose parcel has vanished
 // from the plan are dropped rather than rendered at [0,0,0].
-export function listRegions() {
-  return OPEN_WORLD_REGIONS.map((r) => getRegion(r.id)).filter(Boolean);
+export function listRegions(isFeatureEnabled) {
+  return OPEN_WORLD_REGIONS
+    .filter((region) => isOpenWorldEntryVisible(region, isFeatureEnabled))
+    .map((r) => getRegion(r.id))
+    .filter(Boolean);
 }
 
 // Case/punctuation-insensitive lookup over labels + aliases, for the fast-travel filter box.
 // Returns regions in registry order so the list never jumps around as you type.
-export function searchRegions(query) {
+export function searchRegions(query, isFeatureEnabled) {
   const q = (query || '').trim().toLowerCase();
-  const all = listRegions();
+  const all = listRegions(isFeatureEnabled);
   if (!q) return all;
   return all.filter((r) =>
     r.label.toLowerCase().includes(q)

--- a/client/src/utils/openWorldRegions.test.js
+++ b/client/src/utils/openWorldRegions.test.js
@@ -69,6 +69,16 @@ describe('listRegions', () => {
     expect(list.map((r) => r.id)).toEqual(OPEN_WORLD_REGIONS.map((r) => r.id));
     for (const region of list) expect(Array.isArray(region.anchor)).toBe(true);
   });
+
+  it('hides a disabled feature region from browse lists while leaving untagged regions visible', () => {
+    const jiraOff = (featureId) => featureId !== 'jira';
+    const list = listRegions(jiraOff);
+
+    expect(list.map((region) => region.id)).not.toContain('sprint-yard');
+    expect(list.map((region) => region.id)).toContain('memory');
+    expect(searchRegions('jira', jiraOff)).toEqual([]);
+    expect(searchRegions('jira', () => true).map((region) => region.id)).toContain('sprint-yard');
+  });
 });
 
 describe('searchRegions', () => {

--- a/server/lib/goalFeatureMap.js
+++ b/server/lib/goalFeatureMap.js
@@ -16,7 +16,7 @@
 
 // Feature areas, keyed by a stable area id. Each `to` is a live NAV_COMMANDS path.
 export const FEATURE_AREAS = {
-  post:          { label: 'Daily POST',      to: '/post/launcher',              icon: 'Brain' },
+  post:          { label: 'Daily POST',      to: '/post/launcher',              icon: 'Brain', feature: 'post' },
   bodyHealth:    { label: 'Body Health',     to: '/meatspace/health',           icon: 'HeartPulse' },
   writersRoom:   { label: 'Writers Room',    to: '/writers-room',               icon: 'PenLine' },
   universes:     { label: 'Universes',       to: '/universes',                  icon: 'Globe' },
@@ -46,13 +46,23 @@ export const GOAL_CATEGORY_FEATURE_MAP = {
 // Resolve the feature-area rows for a goal. Honors the optional per-goal
 // `featureAreas` override (an ordered array of area ids) when present and
 // non-empty — filtering out any unknown ids — otherwise falls back to the
-// category default. Returns an array of { area, label, to, icon }.
-export function getGoalFeatureAreas(goal) {
+// category default. When supplied, isFeatureEnabled filters gated rows while
+// preserving the selected/default order. Returns rows with an optional feature tag.
+export function getGoalFeatureAreas(goal, isFeatureEnabled) {
   const override = Array.isArray(goal?.featureAreas)
     ? goal.featureAreas.filter((id) => FEATURE_AREAS[id])
     : [];
+  const categoryDefaults = GOAL_CATEGORY_FEATURE_MAP[goal?.category] || [];
   const areaIds = override.length > 0
     ? override
-    : (GOAL_CATEGORY_FEATURE_MAP[goal?.category] || []);
-  return areaIds.map((area) => ({ area, ...FEATURE_AREAS[area] }));
+    : categoryDefaults;
+  const rows = areaIds.map((area) => ({ area, ...FEATURE_AREAS[area] }));
+  if (typeof isFeatureEnabled !== 'function') return rows;
+
+  const enabledRows = rows.filter((row) => isFeatureEnabled(row.feature));
+  if (enabledRows.length > 0 || override.length === 0) return enabledRows;
+
+  return categoryDefaults
+    .map((area) => ({ area, ...FEATURE_AREAS[area] }))
+    .filter((row) => isFeatureEnabled(row.feature));
 }

--- a/server/lib/goalFeatureMap.test.js
+++ b/server/lib/goalFeatureMap.test.js
@@ -7,6 +7,7 @@ import {
 } from './goalFeatureMap.js';
 import { NAV_COMMANDS } from './navManifest.js';
 import { goalCategoryEnum } from './identityValidation.js';
+import { INSTANCE_FEATURE_IDS } from './instanceFeatureRegistry.js';
 import * as clientMap from '../../client/src/lib/goalFeatureMap.js';
 
 // Every route the manifest knows about (strip query strings — a feature-area
@@ -21,6 +22,7 @@ describe('goalFeatureMap — registry shape', () => {
       expect(area.to.startsWith('/'), `${id}.to`).toBe(true);
       expect(typeof area.icon, `${id}.icon`).toBe('string');
       expect(area.icon.length, `${id}.icon`).toBeGreaterThan(0);
+      if (area.feature) expect(INSTANCE_FEATURE_IDS, `${id}.feature`).toContain(area.feature);
     }
   });
 
@@ -65,6 +67,19 @@ describe('goalFeatureMap — getGoalFeatureAreas', () => {
 
   it('returns an empty list for an unknown category with no override', () => {
     expect(getGoalFeatureAreas({ category: 'mystery' })).toEqual([]);
+  });
+
+  it('filters gated areas and falls back to the next enabled category area', () => {
+    const isFeatureEnabled = (featureId) => featureId !== 'post';
+
+    expect(getGoalFeatureAreas({ category: 'health' }, isFeatureEnabled).map((row) => row.area))
+      .toEqual(['bodyHealth']);
+    expect(getGoalFeatureAreas({ category: 'mastery' }, isFeatureEnabled).map((row) => row.area))
+      .toEqual(['memory']);
+    expect(getGoalFeatureAreas({ category: 'health', featureAreas: ['post', 'sharing'] }, isFeatureEnabled).map((row) => row.area))
+      .toEqual(['sharing']);
+    expect(getGoalFeatureAreas({ category: 'health', featureAreas: ['post'] }, isFeatureEnabled).map((row) => row.area))
+      .toEqual(['bodyHealth']);
   });
 });
 

--- a/server/lib/navManifest.js
+++ b/server/lib/navManifest.js
@@ -21,7 +21,7 @@ import { PORTOS_APP_ID } from './appIdentity.js';
 // memory quarter") can warp straight into the world. The list is duplicated rather than
 // imported because a server lib can't reach into client code; navManifest.test.js scrapes
 // the registry and fails on drift in the paths, the labels, AND the aliases.
-// Written as [id, label, aliases] tuples so the axis that varies is the only thing repeated.
+// Written as [id, label, aliases, feature?] tuples so the axis that varies is the only thing repeated.
 //
 // Aliases are authored in the human phrasing the fast-travel search box uses ("memory
 // quarter") and registered KEBAB-CASED, because resolveNavCommand normalizes its input to
@@ -38,18 +38,19 @@ const OPEN_WORLD_REGION_COMMANDS = [
   ['productivity', 'Productivity Terrace', ['productivity terrace', 'productivity', 'streak district']],
   ['backup-vault', 'Backup Vault', ['backup vault', 'the vault']],
   ['memory', 'Memory Quarter', ['memory quarter', 'memory district', 'knowledge district']],
-  ['sprint-yard', 'Sprint Yard', ['sprint yard', 'jira yard', 'sprint district']],
+  ['sprint-yard', 'Sprint Yard', ['sprint yard', 'jira yard', 'sprint district'], 'jira'],
   ['voice', 'Voice Beacon', ['voice beacon', 'the beacon']],
   ['goals', 'Goal Monuments', ['goal monuments', 'monuments', 'goals district']],
   ['artifacts', 'Hall of Achievements', ['hall of achievements', 'artifact hall', 'achievements hall']],
   ['data-harbor', 'Data Harbor', ['data harbor', 'the harbor', 'piers']],
-].map(([id, label, aliases]) => ({
+].map(([id, label, aliases, feature]) => ({
   id: `nav.openworld.region.${id}`,
   path: `/openworld/region/${id}`,
   label,
   section: 'Main',
   aliases: aliases.map((a) => a.replace(/\s+/g, '-')),
   keywords: ['openworld', 'fast travel', 'warp', 'region', 'teleport'],
+  ...(feature ? { feature } : {}),
 }));
 
 // Sections whose every page belongs to one optional instance feature, so a page

--- a/server/lib/navManifest.test.js
+++ b/server/lib/navManifest.test.js
@@ -359,6 +359,7 @@ describe('nav contract — OpenWorld regions match the registry labels and alias
       return {
         id: field('id'),
         label: field('label'),
+        feature: field('feature'),
         aliases: [...aliases.matchAll(/'([^']*)'/g)].map((a) => a[1]),
       };
     });
@@ -377,6 +378,14 @@ describe('nav contract — OpenWorld regions match the registry labels and alias
       .map((r) => ({ r, cmd: navByPath.get(`/openworld/region/${r.id}`) }))
       .filter(({ r, cmd }) => cmd && cmd.label !== r.label)
       .map(({ r, cmd }) => `${r.id}: nav "${cmd.label}" ≠ registry "${r.label}"`);
+    expect(wrong).toEqual([]);
+  });
+
+  it('keeps each region feature gate mirrored between the registry and nav command', () => {
+    const wrong = readRegistry()
+      .map((r) => ({ r, cmd: navByPath.get(`/openworld/region/${r.id}`) }))
+      .filter(({ r, cmd }) => (cmd?.feature || null) !== (r.feature || null))
+      .map(({ r, cmd }) => `${r.id}: nav "${cmd?.feature || 'none'}" ≠ registry "${r.feature || 'none'}"`);
     expect(wrong).toEqual([]);
   });
 


### PR DESCRIPTION
## Summary
- Sprint Yard's OpenWorld region, fast-travel landmark, and collectible shard now stay hidden when the `jira` instance feature is disabled, matching how other optional features already gate OpenWorld surfaces.
- `OpenWorldCollectibles` accepts a `shards` prop instead of always recomputing the ungated list internally, so the caller's feature-gated list is what actually renders.
- Dashboard's instance-features state now goes through the shared `useInstanceFeatures` hook instead of a bespoke fetch/event-listener pair, and Daily Actions re-fetches when a feature toggle fires so a POST action can't linger after POST is disabled.

## Test plan
- `cd client && npx vitest run` on the files touched by this change (OpenWorld pages/components, openWorldRegions/openWorldProximity/openWorldCollectibles utils, Dashboard, WidgetSuggestions, useInstanceFeatures, DailyPostWidget, DailyDriverWidget, GoalDetailPanel) — all pass.
- `npx biome lint --error-on-warnings src` — clean.