### PR TITLE
fix: fail closed on unreadable autofixer history

### DIFF
--- a/autofixer/server.js
+++ b/autofixer/server.js
@@ -143,7 +143,13 @@ async function ensureHistoryDir() {
 
 async function loadIndex() {
   const index = await readJsonSafe(INDEX_FILE, null);
-  return index ?? [];
+  if (index == null) {
+    throw new Error('Autofixer history index is unreadable');
+  }
+  if (!Array.isArray(index)) {
+    throw new Error('Autofixer history index must be an array');
+  }
+  return index;
 }
 
 async function saveIndex(index) {

--- a/autofixer/server.js
+++ b/autofixer/server.js
@@ -142,8 +142,8 @@ async function ensureHistoryDir() {
 }
 
 async function loadIndex() {
-  const data = await readFile(INDEX_FILE, 'utf8').catch(() => '[]');
-  return JSON.parse(data);
+  const index = await readJsonSafe(INDEX_FILE, null);
+  return index ?? [];
 }
 
 async function saveIndex(index) {


### PR DESCRIPTION
## Summary
- `loadIndex()` in `autofixer/server.js` silently returned `[]` whenever the history index file was unreadable or contained corrupt JSON, so the very next `saveSession` write would overwrite the index with just one entry — permanently destroying whatever fix history existed on a transient read failure.
- `loadIndex()` now throws when the index can't be read or parsed, or isn't an array. The autofixer's check-cycle loop (`runCheckCycle`) already wraps this path in try/catch and logs + retries on the next 15-minute interval, so this fails that one cycle's history write instead of silently corrupting it.

## Test plan
- `cd server && npx vitest run ../autofixer/sandbox.test.js ../autofixer/sandbox.git.test.js` — 29/29 passed
- `node --check autofixer/server.js` — syntax OK
- Confirmed no test file imports `autofixer/server.js` directly (it's a standalone daemon entrypoint); full server suite run showed 14 unrelated files (e.g. `services/sprites/atlas.test.js`) with uniform 10000ms timeouts caused by concurrent load from other in-flight worktrees on this machine, not this change