### PR TITLE
fix: run grep-based repo-hygiene guards on every PR

### DIFF
--- a/docs/GITHUB_ACTIONS.md
+++ b/docs/GITHUB_ACTIONS.md
@@ -39,11 +39,24 @@ unknown artifacts, or wide diffs.
 PRs into `release` skip the planner entirely and force the full suite: that PR
 is the single gate a release ships behind.
 
-A short always-run list (`ALWAYS_RUN_TESTS` in the planner) is added to every
-plan, so no impact scope can drop it — currently
-`server/services/taskPromptDefaults.test.js` (cross-install prompt-upgrade). A
-documentation-only PR therefore still runs the server job with that file
-selected.
+An always-run list (`ALWAYS_RUN_TESTS` in the planner) is added to every plan,
+so no impact scope can drop it. A documentation-only PR therefore still runs the
+server job with those files selected. Two kinds of test qualify:
+
+- **Cross-install contract snapshots** — `server/services/taskPromptDefaults.test.js`
+  pins the prompt-upgrade contract, and nothing else in the suite notices when
+  it breaks.
+- **Repo-hygiene guards that enumerate the tracked tree** with `git grep` /
+  `git ls-files` and assert over files they never import. Impact selection is
+  import-graph-driven, so it has no edge that can reach them — the violating
+  file is always some *other* file the guard sees only as a path string. Left
+  off the list they are structurally unselectable and can sit red on `main`
+  while every PR reports green (issue #5055).
+
+`scripts/repo-scan-guards.test.js` keeps the second half honest: it re-derives
+the scanner set from the tree and fails when a new scanner is added without
+being registered, either in `ALWAYS_RUN_TESTS` or in its own
+`STRUCTURALLY_SELECTED` map naming the selector that already reaches it.
 
 ### Vitest runner tuning
 

--- a/scripts/ci-test-plan.js
+++ b/scripts/ci-test-plan.js
@@ -97,15 +97,43 @@ export const WINDOWS_CONTRACT_TESTS = [
 ];
 
 // Contract guards that run on EVERY plan, whatever the impact scope selects.
-// `taskPromptDefaults.test.js` pins the cross-install prompt-upgrade contract
-// (AGENTS.md "Distribution model"): edit a preserved historical default and
-// other installs stop recognizing their stored prompt, so they are treated as
-// having customized it and stay on it forever. Nothing else in the suite
-// notices, and neither can a scoped run that happens not to select this file —
-// so it is never scoped out. The file runs in ~150ms and imports only prompt
-// data, which is cheap enough to pay on every PR including documentation-only
-// ones, where the alternative is reasoning per-scope about what can reach it.
+//
+// Two kinds of test land here, and both share one property: no impact scope can
+// be trusted to select them, because what they assert is not reachable through
+// the import graph the scoped modes walk.
+//
+//   1. Cross-install contract snapshots. `taskPromptDefaults.test.js` pins the
+//      prompt-upgrade contract (AGENTS.md "Distribution model"): edit a
+//      preserved historical default and other installs stop recognizing their
+//      stored prompt, so they are treated as having customized it and stay on
+//      it forever. Nothing else in the suite notices.
+//
+//   2. Repo-hygiene guards that enumerate the tracked tree with `git grep` /
+//      `git ls-files` and assert over files they never import (issue #5055).
+//      Impact selection is import-graph-driven by construction, so it has no
+//      edge that can reach them: the violating file is some *other* file, in
+//      some other directory, that the guard only ever sees as a path string.
+//      They sat structurally unselectable — `agent-instructions-files.test.js`
+//      went red on `main` and stayed there while every PR reported green — and
+//      the always-run list is the only mechanism that can reach them at all.
+//      `repo-scan-guards.test.js` keeps this half of the list honest: it
+//      re-derives the scanner set from the tree and fails when a new one is
+//      added without being registered here or named as structurally selected.
+//
+// Everything here is deliberately cheap — the whole set runs in ~3s and reads
+// only prompt data or `git` output, which is affordable on every PR including
+// documentation-only ones, where the alternative is reasoning per-scope about
+// what can reach it.
 export const ALWAYS_RUN_TESTS = [
+  'scripts/agent-instructions-files.test.js',
+  'scripts/direct-invocation-drift.test.js',
+  'scripts/node-version-drift.test.js',
+  'scripts/repo-scan-guards.test.js',
+  'scripts/tailnet-identity-leak.test.js',
+  'server/lib/qwenAgentParsers.test.js',
+  'server/lib/testDataIsolation.guards.test.js',
+  'server/lib/testHelper.test.js',
+  'server/services/imageGen/renderTargets.guard.test.js',
   'server/services/taskPromptDefaults.test.js',
 ];
 
@@ -237,6 +265,20 @@ const uniqueSorted = (values) => [...new Set(values)].sort();
 // Guarded by trackedSet like every other selector: an untracked path handed to
 // Vitest as an exact selector makes the run exit non-zero.
 const alwaysRunTests = (trackedSet) => ALWAYS_RUN_TESTS.filter((path) => trackedSet.has(path));
+
+/**
+ * Split a set of always-run selectors across the two Vitest runners.
+ *
+ * The docs-only plan names its files directly instead of going through the
+ * runner split the scoped branches use, so it has to do that split itself: an
+ * entry added to ALWAYS_RUN_TESTS under client/src would otherwise be handed to
+ * the server runner, which does not glob client/, and the guard would report
+ * green having run nowhere.
+ */
+export const splitByRunner = (paths) => ({
+  server: paths.filter((path) => runnerForTest(path) === 'server'),
+  client: paths.filter((path) => runnerForTest(path) === 'client'),
+});
 const windowsContractTests = (trackedSet) => WINDOWS_CONTRACT_TESTS.filter((path) => trackedSet.has(path));
 
 const skippedRunner = () => ({ mode: 'skip', files: [] });
@@ -288,12 +330,13 @@ export function buildCiTestPlan(changedFiles, {
 
   const relevant = changed.filter((path) => !isDocumentationOnly(path));
   if (relevant.length === 0) {
+    const { server: alwaysRunServer, client: alwaysRunClient } = splitByRunner(alwaysRun);
     return {
       full: false,
       reason: changed.length ? 'documentation-only change' : 'no changed files',
       changedFiles: changed,
-      server: alwaysRun.length > 0 ? { mode: 'files', files: alwaysRun } : skippedRunner(),
-      client: skippedRunner(),
+      server: alwaysRunServer.length > 0 ? { mode: 'files', files: alwaysRunServer } : skippedRunner(),
+      client: alwaysRunClient.length > 0 ? { mode: 'files', files: alwaysRunClient } : skippedRunner(),
       db: false,
       lint: { mode: 'skip', files: [] },
       build: false,

--- a/scripts/ci-test-plan.test.js
+++ b/scripts/ci-test-plan.test.js
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest';
 
-import { buildCiTestPlan, forceFullReasonFor, WINDOWS_CONTRACT_TESTS } from './ci-test-plan.js';
+import {
+  ALWAYS_RUN_TESTS,
+  buildCiTestPlan,
+  forceFullReasonFor,
+  splitByRunner,
+  WINDOWS_CONTRACT_TESTS,
+} from './ci-test-plan.js';
 
 const TRACKED = [
   'server/lib/index.test.js',
@@ -70,6 +76,54 @@ describe('CI test impact planner', () => {
     // A full plan runs everything, so it carries no explicit selector list.
     const full = buildCiTestPlan(['.github/workflows/ci.yml'], { trackedFiles: TRACKED });
     expect(full.server.mode).toBe('full');
+  });
+
+  // The docs-only branch names its selectors directly rather than going through
+  // the runner split the scoped branches use, so it splits them itself. Handing
+  // a client/src guard to the server runner (which does not glob client/) would
+  // report green having run it nowhere.
+  it('routes always-run selectors to the runner that globs them', () => {
+    expect(splitByRunner([
+      'server/services/taskPromptDefaults.test.js',
+      'scripts/agent-instructions-files.test.js',
+      'client/src/a11yConventions.test.js',
+    ])).toEqual({
+      server: ['server/services/taskPromptDefaults.test.js', 'scripts/agent-instructions-files.test.js'],
+      client: ['client/src/a11yConventions.test.js'],
+    });
+  });
+
+  // Every guard on the list is unreachable by import-graph selection, so a
+  // docs-only plan is the one scope where the complete list has to survive.
+  it('carries every tracked always-run guard on a docs-only plan', () => {
+    const tracked = [...TRACKED, ...ALWAYS_RUN_TESTS];
+    const plan = buildCiTestPlan(['docs/GITHUB_ACTIONS.md'], { trackedFiles: tracked });
+    const { server, client } = splitByRunner(ALWAYS_RUN_TESTS);
+
+    expect(plan.server.mode).toBe('files');
+    for (const guard of server) {
+      expect(plan.server.files, guard).toContain(guard);
+    }
+    expect(plan.server.files.filter((path) => path.startsWith('client/'))).toEqual([]);
+
+    if (client.length > 0) {
+      expect(plan.client.mode).toBe('files');
+      for (const guard of client) {
+        expect(plan.client.files, guard).toContain(guard);
+      }
+    } else {
+      expect(plan.client.mode).toBe('skip');
+    }
+  });
+
+  it('maps every always-run guard to a runner', () => {
+    // splitByRunner drops a path whose runnerForTest is null. A root-level
+    // entry on ALWAYS_RUN_TESTS would then vanish from both jobs and the
+    // docs-only plan would report green having run it nowhere.
+    for (const path of ALWAYS_RUN_TESTS) {
+      const { server, client } = splitByRunner([path]);
+      expect(server.includes(path) || client.includes(path), path).toBe(true);
+    }
   });
 
   it('omits an untracked always-run guard rather than handing Vitest a missing selector', () => {

--- a/scripts/repo-scan-guards.test.js
+++ b/scripts/repo-scan-guards.test.js
@@ -1,0 +1,124 @@
+/**
+ * Coverage guard for repo-scanning guards (issue #5055).
+ *
+ * A handful of tests assert over the *tracked tree* rather than over anything
+ * they import: they shell out to `git grep` / `git ls-files`, read the matched
+ * files as text, and fail when some unrelated file anywhere in the repo breaks
+ * a convention. `scripts/agent-instructions-files.test.js` is the archetype.
+ *
+ * CI selects tests by impact (`scripts/ci-test-plan.js`), and both scoped modes
+ * are import-graph-driven — Vitest's `--changed` walk plus sibling/feature path
+ * matching. Neither can reach a scanner: the file that violates the convention
+ * is never imported by the guard, so no edge exists to follow. The consequence
+ * is not a flaky selection, it is a structural one — a scanner can sit red on
+ * `main` indefinitely while every PR reports green, which is exactly what
+ * happened to the agent-instructions guard.
+ *
+ * `ALWAYS_RUN_TESTS` is the only mechanism that can reach them. This test
+ * re-derives the scanner set from the tree on every run, so a newly added
+ * scanner fails here until it is registered rather than joining the list of
+ * guards nobody notices has stopped running.
+ */
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'child_process';
+import { readFileSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+import { ALWAYS_RUN_TESTS } from './ci-test-plan.js';
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+/**
+ * Scanners that another selector already reaches whenever they can newly fail,
+ * so they do not need the always-run list. Each entry names that selector —
+ * an entry without a live mechanism behind it is worse than no entry.
+ */
+const STRUCTURALLY_SELECTED = new Map([
+  // structuralTestsFor() in ci-test-plan.js adds these whenever any
+  // client/src/**.jsx (a11y) or .js/.jsx (mounted-ref) file changes, which is
+  // the only way either can start failing.
+  ['client/src/a11yConventions.test.js', 'structuralTestsFor: client/src/**.jsx'],
+  ['client/src/hooks/mountedRefConventions.test.js', 'structuralTestsFor: client/src/**.js(x)'],
+  // `.ps1` is not in EXECUTABLE_RE, so touching one is an "unclassified changed
+  // file" and forces the complete suite. The guard also rides the Windows
+  // contract list.
+  ['scripts/ps1-bom.test.js', 'unclassified-file full-suite trigger: *.ps1'],
+]);
+
+/** A `git` invocation… */
+const GIT_CALL = /execFileSync\(\s*['"]git['"]/;
+/** …carrying a tree-enumerating subcommand. */
+const GIT_ENUMERATION = /['"](?:ls-files|grep)['"]/;
+/** The client's shared enumerator, which shells out to `git ls-files` for them. */
+const TRACKED_HELPER = /from\s+['"][^'"]*test\/trackedFiles\.js['"]/;
+
+/** True when `source` asserts over the tracked tree instead of over its imports. */
+export const scansTrackedTree = (source) => (
+  (GIT_CALL.test(source) && GIT_ENUMERATION.test(source)) || TRACKED_HELPER.test(source)
+);
+
+const trackedTests = execFileSync('git', ['ls-files', '*.test.js', '*.test.jsx'], {
+  cwd: REPO_ROOT,
+  encoding: 'utf8',
+  maxBuffer: 64 * 1024 * 1024,
+})
+  .split('\n')
+  .filter(Boolean);
+
+const scanners = trackedTests.filter((rel) => scansTrackedTree(readFileSync(join(REPO_ROOT, rel), 'utf8')));
+
+describe('repo-scanning guards are reachable by CI selection (#5055)', () => {
+  it('finds tracked test files to scan', () => {
+    // Fails loudly if the glob or the cwd stops matching, rather than reporting
+    // a vacuous pass over zero files.
+    expect(trackedTests.length).toBeGreaterThan(100);
+  });
+
+  it('detects the scan shape it registers, and leaves ordinary tests alone', () => {
+    // Bypass probe: proves the detector bites, so the assertion below cannot
+    // pass because the regexes quietly stopped matching anything.
+    expect(scansTrackedTree("const files = execFileSync('git', ['ls-files', '*.js'], opts);")).toBe(true);
+    expect(scansTrackedTree("execFileSync(\n  'git',\n  ['grep', '-n', 'x'],\n);")).toBe(true);
+    expect(scansTrackedTree("import { trackedSourceFiles } from './test/trackedFiles.js';")).toBe(true);
+    expect(scansTrackedTree("import { thing } from './thing.js';\nexpect(thing()).toBe(1);")).toBe(false);
+    // A comment mentioning the command is not an invocation.
+    expect(scansTrackedTree('// enumerated via git ls-files rather than a walk')).toBe(false);
+  });
+
+  it('finds the known scanners', () => {
+    expect(scanners).toContain('scripts/agent-instructions-files.test.js');
+    expect(scanners).toContain('scripts/tailnet-identity-leak.test.js');
+    expect(scanners.length).toBeGreaterThanOrEqual(8);
+  });
+
+  it('registers every scanner in ALWAYS_RUN_TESTS or names the selector that reaches it', () => {
+    const unreachable = scanners.filter((rel) => (
+      !ALWAYS_RUN_TESTS.includes(rel) && !STRUCTURALLY_SELECTED.has(rel)
+    ));
+    expect(
+      unreachable,
+      'These tests assert over the tracked tree, so CI\'s import-graph selection can never reach them. '
+      + 'Add each to ALWAYS_RUN_TESTS in scripts/ci-test-plan.js, or to STRUCTURALLY_SELECTED here with '
+      + `the selector that already covers it: ${unreachable.join(', ')}`,
+    ).toEqual([]);
+  });
+
+  it('keeps both registries free of paths that no longer exist', () => {
+    const tracked = new Set(trackedTests);
+    const stale = [...ALWAYS_RUN_TESTS, ...STRUCTURALLY_SELECTED.keys()].filter((rel) => !tracked.has(rel));
+    expect(
+      stale,
+      `These registered paths are not tracked test files — a renamed or deleted guard left a dead entry, and `
+      + `ALWAYS_RUN_TESTS silently drops anything untracked: ${stale.join(', ')}`,
+    ).toEqual([]);
+  });
+
+  it('does not park a scanner in STRUCTURALLY_SELECTED that is no longer one', () => {
+    // An entry here is a claim that some other selector covers the file. Once
+    // the file stops scanning the tree the claim is meaningless, and leaving it
+    // hides the fact that nothing is being asserted.
+    const scannerSet = new Set(scanners);
+    const obsolete = [...STRUCTURALLY_SELECTED.keys()].filter((rel) => !scannerSet.has(rel));
+    expect(obsolete, `No longer scans the tracked tree — drop the entry: ${obsolete.join(', ')}`).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- CI's impact planner (`scripts/ci-test-plan.js`) selects tests by walking the import graph, but a handful of guards (`agent-instructions-files.test.js`, `tailnet-identity-leak.test.js`, `node-version-drift.test.js`, `direct-invocation-drift.test.js`, `qwenAgentParsers.test.js`, `testDataIsolation.guards.test.js`, `testHelper.test.js`, `renderTargets.guard.test.js`) instead assert over the tracked tree via `git grep`/`git ls-files`. No import edge exists to those guards, so scoped selection could never reach them — one had gone red on `main` while every PR still reported green (#5055).
- Added all of them to `ALWAYS_RUN_TESTS` so they run on every PR regardless of impact scope, and split that list by test runner so a future client-side guard added to the list doesn't silently get handed to the server runner.
- Added `scripts/repo-scan-guards.test.js`, a coverage guard that re-derives the scanner set from the tracked tree and fails when a new scanner is added without being registered in `ALWAYS_RUN_TESTS` (or named in a `STRUCTURALLY_SELECTED` map for the guards another selector already reaches).
- Updated `docs/GITHUB_ACTIONS.md` to describe both categories of always-run test.

## Test plan
- `cd server && npx vitest run scripts/ci-test-plan.test.js scripts/repo-scan-guards.test.js` — 30/30 passing
- `cd client && npm run lint` — clean
- Full `cd server && npm test` was run twice; both runs show only pre-existing, unrelated timeout failures (services/sprites/atlas.test.js, services/videoGen/local.test.js, and others) under heavy concurrent host load (multiple sibling test suites running in parallel), none touching files this change modifies