### PR TITLE
feat: add in-app llama.cpp updates

### DIFF
--- a/client/src/components/settings/LocalLlmTab.jsx
+++ b/client/src/components/settings/LocalLlmTab.jsx
@@ -10,7 +10,7 @@ import { useConfirmDelete } from '../../hooks/useConfirmDelete';
 import {
   getLocalLlmStatus, getLocalLlmCatalog, getLocalLlmHuggingFaceSearch, installLocalLlmModel,
   deleteLocalLlmModel, migrateLocalLlmBackend, installLocalLlmBackend, upgradeLocalLlmBackend, controlOllamaService,
-  installAudioModel, patchSettingsSlice, getLlamaServerStatus, startLlamaServer, stopLlamaServer, installLlamaServer, upgradeLlamaServer,
+  installAudioModel, patchSettingsSlice, getLlamaServerStatus, getLlamaServerUpdateStatus, startLlamaServer, stopLlamaServer, installLlamaServer, upgradeLlamaServer,
   downloadSpecDecodeModel, cancelSpecDecodeModelDownload, controlLmStudioService, getMtplxServerStatus, stopMtplxServer, installMtplx,
   searchMtplxModels, pullMtplxModel, removeMtplxModel,
   saveRuntimeStartupList
@@ -225,7 +225,19 @@ export function LocalLlmTab() {
   const loadLlamaStatus = useCallback(() => {
     return getLlamaServerStatus({ silent: true })
       .then((res) => {
-        if (res) setLlamaStatus(res);
+        if (res) {
+          setLlamaStatus(res);
+          // Version/Homebrew metadata is deliberately a separate, non-blocking
+          // request. A slow `--version` probe must not hold up lifecycle state,
+          // presets, or the rest of the Local LLMs page.
+          if (res.installed) {
+            getLlamaServerUpdateStatus({ silent: true })
+              .then((update) => {
+                if (update) setLlamaStatus((previous) => previous ? { ...previous, ...update } : previous);
+              })
+              .catch(() => null);
+          }
+        }
         return res;
       })
       .catch(() => null);

--- a/client/src/components/settings/LocalLlmTab.jsx
+++ b/client/src/components/settings/LocalLlmTab.jsx
@@ -10,7 +10,7 @@ import { useConfirmDelete } from '../../hooks/useConfirmDelete';
 import {
   getLocalLlmStatus, getLocalLlmCatalog, getLocalLlmHuggingFaceSearch, installLocalLlmModel,
   deleteLocalLlmModel, migrateLocalLlmBackend, installLocalLlmBackend, upgradeLocalLlmBackend, controlOllamaService,
-  installAudioModel, patchSettingsSlice, getLlamaServerStatus, startLlamaServer, stopLlamaServer, installLlamaServer,
+  installAudioModel, patchSettingsSlice, getLlamaServerStatus, startLlamaServer, stopLlamaServer, installLlamaServer, upgradeLlamaServer,
   downloadSpecDecodeModel, cancelSpecDecodeModelDownload, controlLmStudioService, getMtplxServerStatus, stopMtplxServer, installMtplx,
   searchMtplxModels, pullMtplxModel, removeMtplxModel,
   saveRuntimeStartupList
@@ -478,6 +478,11 @@ export function LocalLlmTab() {
     () => installLlamaServer(),
     'llama.cpp installed'
   ).then(loadLlamaStatus);
+  const runtimeUpgradeLlama = () => runAction(
+    'runtime-upgrade-llama',
+    () => upgradeLlamaServer(),
+    (r) => r?.note || 'llama.cpp updated'
+  ).then(loadLlamaStatus);
   const runtimeStopLlama = () => runAction(
     'runtime-stop-llama',
     () => stopLlamaServer(),
@@ -916,6 +921,7 @@ export function LocalLlmTab() {
         onControlLmStudio={controlLmStudio}
         onInstallBackend={installRuntimeBackend}
         onInstallLlama={runtimeInstallLlama}
+        onUpgradeLlama={runtimeUpgradeLlama}
         onStopLlama={runtimeStopLlama}
         onConfigureLlama={() => scrollTo(llamaSectionRef)}
         onConfigureMtplx={() => scrollTo(mtplxSectionRef)}

--- a/client/src/components/settings/LocalLlmTab.test.jsx
+++ b/client/src/components/settings/LocalLlmTab.test.jsx
@@ -29,6 +29,7 @@ vi.mock('../../services/api', () => ({
   startLlamaServer: vi.fn(),
   stopLlamaServer: vi.fn(),
   installLlamaServer: vi.fn().mockResolvedValue({ success: true }),
+  upgradeLlamaServer: vi.fn().mockResolvedValue({ success: true, note: 'updated' }),
   downloadSpecDecodeModel: vi.fn(),
   cancelSpecDecodeModelDownload: vi.fn(),
 }));
@@ -885,6 +886,25 @@ describe('LocalLlmTab llama-server management', () => {
 
     await waitFor(() => {
       expect(installLlamaServer).toHaveBeenCalled();
+    });
+  });
+
+  it('updates llama.cpp from the unified runtime row', async () => {
+    const { getLlamaServerStatus, upgradeLlamaServer } = await import('../../services/api');
+    getLlamaServerStatus.mockResolvedValue(llamaReady({
+      version: '0.1.1-dev',
+      latestVersion: '0.3.0',
+      updateAvailable: true,
+      canUpgrade: true,
+    }));
+    upgradeLlamaServer.mockResolvedValueOnce({ success: true, note: 'updated and restarted' });
+
+    await renderTab();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Update to v0.3.0' }));
+
+    await waitFor(() => {
+      expect(upgradeLlamaServer).toHaveBeenCalledWith();
     });
   });
 

--- a/client/src/components/settings/LocalLlmTab.test.jsx
+++ b/client/src/components/settings/LocalLlmTab.test.jsx
@@ -26,6 +26,7 @@ vi.mock('../../services/api', () => ({
   installAudioModel: vi.fn(),
   patchSettingsSlice: vi.fn(),
   getLlamaServerStatus: vi.fn().mockResolvedValue({ installed: false, running: false }),
+  getLlamaServerUpdateStatus: vi.fn().mockResolvedValue(null),
   startLlamaServer: vi.fn(),
   stopLlamaServer: vi.fn(),
   installLlamaServer: vi.fn().mockResolvedValue({ success: true }),
@@ -270,7 +271,7 @@ describe('LocalLlmTab installed models', () => {
     expect(location).toMatch(/^\/local-llm\/playground\?/);
     const targets = JSON.parse(new URLSearchParams(location.split('?')[1]).get('targets'));
     expect(targets).toEqual(models.slice(0, 6).map((model) => ({ backend: 'ollama', modelId: model.id })));
-  });
+  }, 10_000);
 
   it('requires inline confirmation before deleting an installed model', async () => {
     await renderTab();
@@ -574,9 +575,11 @@ describe('LocalLlmTab llama-server management', () => {
   // component consumes leaks it into the next test's first status read. Reset
   // the mock outright here and give it a sane standing default.
   beforeEach(async () => {
-    const { getLlamaServerStatus } = await import('../../services/api');
+    const { getLlamaServerStatus, getLlamaServerUpdateStatus } = await import('../../services/api');
     getLlamaServerStatus.mockReset();
     getLlamaServerStatus.mockResolvedValue(llamaReady());
+    getLlamaServerUpdateStatus.mockReset();
+    getLlamaServerUpdateStatus.mockResolvedValue(null);
   });
 
   it('renders start form and launches server when llama-server is installed', async () => {
@@ -890,13 +893,15 @@ describe('LocalLlmTab llama-server management', () => {
   });
 
   it('updates llama.cpp from the unified runtime row', async () => {
-    const { getLlamaServerStatus, upgradeLlamaServer } = await import('../../services/api');
-    getLlamaServerStatus.mockResolvedValue(llamaReady({
+    const { getLlamaServerStatus, getLlamaServerUpdateStatus, upgradeLlamaServer } = await import('../../services/api');
+    getLlamaServerStatus.mockResolvedValue(llamaReady());
+    getLlamaServerUpdateStatus.mockResolvedValueOnce({
       version: '0.1.1-dev',
       latestVersion: '0.3.0',
       updateAvailable: true,
       canUpgrade: true,
-    }));
+      downloadUrl: 'https://github.com/ggml-org/llama.cpp/releases',
+    });
     upgradeLlamaServer.mockResolvedValueOnce({ success: true, note: 'updated and restarted' });
 
     await renderTab();

--- a/client/src/components/settings/RuntimeServersCard.jsx
+++ b/client/src/components/settings/RuntimeServersCard.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Link } from 'react-router';
-import { Cpu, Box, Zap, Gauge, Play, Square, Download, Power, PowerOff, RefreshCw, Save, Settings2, ExternalLink } from 'lucide-react';
+import { Cpu, Box, Zap, Gauge, Play, Square, Download, ArrowUpCircle, Power, PowerOff, RefreshCw, Save, Settings2, ExternalLink } from 'lucide-react';
 import BrailleSpinner from '../BrailleSpinner';
 
 /**
@@ -65,8 +65,9 @@ function backendRow({ id, label, icon, data, onStart, onStop, onInstall }) {
  * answers on the port means a server the user started in a terminal, which
  * PortOS must not offer to stop.
  */
-function pm2Row({ id, label, icon, status, platformReason, onStart, onStop, onInstall, startBlockedReason, detail }) {
+function pm2Row({ id, label, icon, status, platformReason, onStart, onStop, onInstall, onUpgrade, startBlockedReason, detail }) {
   const external = status?.running && status?.managed === false;
+  const updateAvailable = !platformReason && status?.installed && status?.updateAvailable === true;
   const state = platformReason ? 'unsupported'
     : status?.running ? (external ? 'external' : 'running')
       : status?.installed ? 'stopped' : 'missing';
@@ -86,6 +87,11 @@ function pm2Row({ id, label, icon, status, platformReason, onStart, onStop, onIn
     onStart: !platformReason && status?.installed && !status?.running && !startBlockedReason ? onStart : null,
     startBlockedReason: status?.installed && !status?.running ? startBlockedReason : null,
     onStop: !external && status?.running ? onStop : null,
+    version: status?.version || null,
+    latestVersion: status?.latestVersion || null,
+    updateAvailable,
+    onUpgrade: updateAvailable && status?.canUpgrade ? onUpgrade : null,
+    updateUrl: updateAvailable && !status?.canUpgrade ? status?.downloadUrl : null,
   };
 }
 
@@ -168,6 +174,15 @@ function ServerRow({ row, busy, actionInProgress, children }) {
         {row.endpoint && (
           <code className="text-xs text-gray-500 truncate max-w-full">{row.endpoint}</code>
         )}
+        {row.version && <span className="text-xs text-gray-500">v{row.version}</span>}
+        {row.updateAvailable && row.latestVersion && (
+          <span
+            className="text-xs text-port-warning"
+            title={`${row.label} v${row.latestVersion} is available (you have ${row.version ? `v${row.version}` : 'an older version'})`}
+          >
+            v{row.latestVersion} available
+          </span>
+        )}
         {row.pm2 && row.runAtStartup && (
           <span className="px-1.5 py-0.5 text-xs rounded border border-port-success/40 text-port-success" title="This PM2 process is in the saved list `pm2 resurrect` replays at boot">
             starts at boot
@@ -225,6 +240,29 @@ function ServerRow({ row, busy, actionInProgress, children }) {
             Stop
           </button>
         )}
+        {row.onUpgrade && (
+          <button
+            onClick={() => row.onUpgrade()}
+            disabled={busy}
+            className={`${accentBtn} bg-port-success/20 hover:bg-port-success/30 text-port-success`}
+            title={row.latestVersion ? `Update ${row.label} to v${row.latestVersion} through Homebrew` : `Update ${row.label} through Homebrew`}
+          >
+            {actionInProgress === `runtime-upgrade-${row.id}` ? <BrailleSpinner /> : <ArrowUpCircle size={12} />}
+            {row.latestVersion ? `Update to v${row.latestVersion}` : 'Update'}
+          </button>
+        )}
+        {row.updateUrl && (
+          <a
+            href={row.updateUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={`${neutralBtn} no-underline text-port-warning`}
+            title={`${row.label} has an update, but PortOS cannot update this installation automatically`}
+          >
+            <ExternalLink size={12} />
+            Update available
+          </a>
+        )}
       </div>
     </div>
   );
@@ -242,6 +280,7 @@ export default function RuntimeServersCard({
   onControlLmStudio,
   onInstallBackend,
   onInstallLlama,
+  onUpgradeLlama,
   onStopLlama,
   onConfigureLlama,
   onConfigureMtplx,
@@ -282,6 +321,7 @@ export default function RuntimeServersCard({
       icon: Zap,
       status: llamaStatus,
       onInstall: onInstallLlama,
+      onUpgrade: onUpgradeLlama,
       onStop: onStopLlama,
       // llama-server takes a REQUIRED model path, and which GGUF (plus which
       // drafter and spec type) is a real choice — so there is no honest one-click

--- a/client/src/components/settings/RuntimeServersCard.test.jsx
+++ b/client/src/components/settings/RuntimeServersCard.test.jsx
@@ -14,6 +14,7 @@ const renderCard = (props = {}) => {
     onControlLmStudio: vi.fn(),
     onInstallBackend: vi.fn(),
     onInstallLlama: vi.fn(),
+    onUpgradeLlama: vi.fn(),
     onStopLlama: vi.fn(),
     onConfigureLlama: vi.fn(),
     onConfigureMtplx: vi.fn(),
@@ -81,6 +82,46 @@ describe('RuntimeServersCard', () => {
 
     fireEvent.click(within(llama).getByRole('button', { name: /Configure/ }));
     expect(handlers.onConfigureLlama).toHaveBeenCalled();
+  });
+
+  it('shows a llama.cpp update and delegates the action to the runtime handler', () => {
+    const handlers = renderCard({
+      llamaStatus: {
+        installed: true,
+        running: false,
+        version: '0.1.1-dev',
+        latestVersion: '0.3.0',
+        updateAvailable: true,
+        canUpgrade: true,
+      },
+    });
+    const llama = row('llama.cpp');
+
+    expect(within(llama).getByText('v0.1.1-dev')).toBeInTheDocument();
+    expect(within(llama).getByText('v0.3.0 available')).toBeInTheDocument();
+    fireEvent.click(within(llama).getByRole('button', { name: 'Update to v0.3.0' }));
+
+    expect(handlers.onUpgradeLlama).toHaveBeenCalledWith();
+  });
+
+  it('links to llama.cpp release notes when Homebrew cannot update the installation', () => {
+    renderCard({
+      llamaStatus: {
+        installed: true,
+        running: false,
+        latestVersion: '0.3.0',
+        updateAvailable: true,
+        canUpgrade: false,
+        downloadUrl: 'https://github.com/ggml-org/llama.cpp/releases',
+      },
+    });
+    const llama = row('llama.cpp');
+
+    expect(within(llama).queryByRole('button', { name: /Update to/ })).toBeNull();
+    expect(within(llama).getByRole('link', { name: /Update available/ })).toHaveAttribute(
+      'href',
+      'https://github.com/ggml-org/llama.cpp/releases',
+    );
   });
 
   // MTPLX cannot unload its checkpoint in place, so PortOS stops the process

--- a/client/src/services/apiLocalLlm.js
+++ b/client/src/services/apiLocalLlm.js
@@ -101,6 +101,12 @@ export const saveRuntimeStartupList = () =>
 export const getLlamaServerStatus = (options) =>
   request('/local-llm/llama-server/status', options);
 
+// Optional version/Homebrew metadata for the Local LLMs runtime card. Kept
+// separate from lifecycle status because the provider version probe and Homebrew
+// query can be slow on a cold machine.
+export const getLlamaServerUpdateStatus = (options) =>
+  request('/local-llm/llama-server/update-status', options);
+
 export const startLlamaServer = (config) =>
   request('/local-llm/llama-server/start', { method: 'POST', body: JSON.stringify(config) });
 

--- a/client/src/services/apiLocalLlm.js
+++ b/client/src/services/apiLocalLlm.js
@@ -110,6 +110,11 @@ export const stopLlamaServer = () =>
 export const installLlamaServer = () =>
   request('/local-llm/llama-server/install', { method: 'POST' });
 
+// Upgrade a Homebrew-installed llama.cpp binary. A managed llama-server is
+// restarted by the server with its existing launch configuration.
+export const upgradeLlamaServer = () =>
+  request('/local-llm/llama-server/upgrade', { method: 'POST' });
+
 // Fetch one speculative-decoding preset's GGUF (role: 'model' | 'draftModel')
 // from Hugging Face into the path the launcher passes llama.cpp. Byte progress
 // arrives on the `llamaServer:download` socket event, not in this response —

--- a/server/routes/localLlm.js
+++ b/server/routes/localLlm.js
@@ -39,7 +39,14 @@ import {
   localLlmMtplxRemoveSchema,
   localLlmSpecModelDownloadSchema
 } from '../lib/validation.js'
-import { getLlamaServerStatus, startLlamaServer, stopLlamaServer, installLlamaServer } from '../services/llamaServerManager.js'
+import {
+  getLlamaServerStatus,
+  getLlamaServerUpdateStatus,
+  startLlamaServer,
+  stopLlamaServer,
+  installLlamaServer,
+  upgradeLlamaServer,
+} from '../services/llamaServerManager.js'
 import { MTPLX_APP, getMtplxServerStatus, startMtplxServer, stopMtplxServer, installMtplx } from '../services/mtplxServerManager.js'
 import { searchMtplxCatalog, pullMtplxModel, removeMtplxModel } from '../services/mtplxModelManager.js'
 import { saveProcessList } from '../services/pm2.js'
@@ -636,10 +643,14 @@ router.post('/capability-tests/delete', asyncHandler(async (req, res) => {
 // card can render "not downloaded + Download" instead of making the user press
 // Start to discover a missing file. Disk-only: no Hugging Face call here.
 router.get('/llama-server/status', asyncHandler(async (_req, res) => {
-  const [status, presets] = await Promise.all([getLlamaServerStatus(), getSpecDecodePresetStatus()])
+  const [status, update, presets] = await Promise.all([
+    getLlamaServerStatus(),
+    getLlamaServerUpdateStatus(),
+    getSpecDecodePresetStatus(),
+  ])
   // Spec-type suggestions ride along for the same reason the presets do: the
   // card renders the server's list instead of keeping a copy that can rot.
-  res.json({ ...status, presets, specTypes: SPEC_TYPE_SUGGESTIONS })
+  res.json({ ...status, ...update, presets, specTypes: SPEC_TYPE_SUGGESTIONS })
 }))
 
 // POST /api/local-llm/llama-server/download-model — fetch one preset's GGUF from
@@ -692,6 +703,25 @@ router.post('/llama-server/install', asyncHandler(async (req, res) => {
   const onProgress = (data) => io?.emit('localLlm:progress', data)
   const result = await installLlamaServer({ onProgress })
   resetProviderReadinessCache()
+  res.json(result)
+}))
+
+// POST /api/local-llm/llama-server/upgrade — update a Homebrew-installed
+// llama.cpp binary, restarting a llama-server process PortOS owns with the same
+// launch configuration. An externally-started process is left alone.
+router.post('/llama-server/upgrade', asyncHandler(async (req, res) => {
+  const io = req.app.get('io')
+  const onProgress = (data) => io?.emit('localLlm:progress', data)
+  const result = await upgradeLlamaServer({ onProgress }).catch((err) => {
+    onProgress({ event: 'error', message: `llama.cpp update failed: ${err.message}` })
+    throw err
+  })
+  resetProviderReadinessCache()
+  if (!result.success) {
+    onProgress({ event: 'error', message: result.error || 'llama.cpp update failed' })
+    throw new ServerError(result.error || 'llama.cpp update failed', { status: 502 })
+  }
+  onProgress({ event: 'complete', message: `llama.cpp updated${result.note ? ` — ${result.note}` : ''}` })
   res.json(result)
 }))
 

--- a/server/routes/localLlm.js
+++ b/server/routes/localLlm.js
@@ -641,16 +641,21 @@ router.post('/capability-tests/delete', asyncHandler(async (req, res) => {
 // logs, and the curated target/drafter presets with each GGUF's on-disk state.
 // The presets ride along on the status call the launcher already makes so the
 // card can render "not downloaded + Download" instead of making the user press
-// Start to discover a missing file. Disk-only: no Hugging Face call here.
+// Start to discover a missing file. Disk-only: no Homebrew or Hugging Face call
+// here.
 router.get('/llama-server/status', asyncHandler(async (_req, res) => {
-  const [status, update, presets] = await Promise.all([
-    getLlamaServerStatus(),
-    getLlamaServerUpdateStatus(),
-    getSpecDecodePresetStatus(),
-  ])
+  const [status, presets] = await Promise.all([getLlamaServerStatus(), getSpecDecodePresetStatus()])
   // Spec-type suggestions ride along for the same reason the presets do: the
   // card renders the server's list instead of keeping a copy that can rot.
-  res.json({ ...status, ...update, presets, specTypes: SPEC_TYPE_SUGGESTIONS })
+  res.json({ ...status, presets, specTypes: SPEC_TYPE_SUGGESTIONS })
+}))
+
+// GET /api/local-llm/llama-server/update-status — optional Homebrew/version
+// metadata for the Local LLMs page. Keep it out of the lifecycle status request:
+// a slow Homebrew installation or a backend-initializing `--version` probe must
+// not delay ordinary runtime status and preset rendering.
+router.get('/llama-server/update-status', asyncHandler(async (_req, res) => {
+  res.json(await getLlamaServerUpdateStatus())
 }))
 
 // POST /api/local-llm/llama-server/download-model — fetch one preset's GGUF from

--- a/server/routes/localLlm.test.js
+++ b/server/routes/localLlm.test.js
@@ -87,9 +87,17 @@ vi.mock('../services/localModelAgentBenchmark.js', () => ({
 
 vi.mock('../services/llamaServerManager.js', () => ({
   getLlamaServerStatus: vi.fn(async () => ({ installed: true, running: false })),
+  getLlamaServerUpdateStatus: vi.fn(async () => ({
+    version: null,
+    latestVersion: null,
+    updateAvailable: false,
+    canUpgrade: false,
+    downloadUrl: 'https://github.com/ggml-org/llama.cpp/releases',
+  })),
   startLlamaServer: vi.fn(async () => ({ success: true, pid: 123 })),
   stopLlamaServer: vi.fn(async () => ({ success: true })),
   installLlamaServer: vi.fn(async () => ({ success: true, message: 'installed' })),
+  upgradeLlamaServer: vi.fn(async () => ({ success: true, note: 'updated' })),
 }));
 
 // The launcher's curated presets (and their weights' on-disk state) ride along
@@ -672,6 +680,26 @@ describe('llama-server routes', () => {
     });
   });
 
+  it('GET /api/local-llm/llama-server/status includes llama.cpp update metadata', async () => {
+    const { getLlamaServerUpdateStatus } = await import('../services/llamaServerManager.js');
+    getLlamaServerUpdateStatus.mockResolvedValueOnce({
+      version: '0.1.1-dev',
+      latestVersion: '0.3.0',
+      updateAvailable: true,
+      canUpgrade: true,
+      downloadUrl: 'https://github.com/ggml-org/llama.cpp/releases',
+    });
+
+    const res = await request(makeApp()).get('/api/local-llm/llama-server/status');
+
+    expect(res.body).toMatchObject({
+      version: '0.1.1-dev',
+      latestVersion: '0.3.0',
+      updateAvailable: true,
+      canUpgrade: true,
+    });
+  });
+
   it('GET /api/local-llm/llama-server/status publishes the drafter-free spec types', async () => {
     // The card renders the picker from this list, so a launch with no drafter
     // GGUF (`ngram-map-k`) has to be reachable without the user knowing the
@@ -737,5 +765,21 @@ describe('llama-server routes', () => {
     const res = await request(makeApp()).post('/api/local-llm/llama-server/install');
     expect(res.status).toBe(200);
     expect(res.body).toEqual({ success: true, message: 'installed' });
+  });
+
+  it('POST /api/local-llm/llama-server/upgrade emits progress and returns the result', async () => {
+    const { upgradeLlamaServer } = await import('../services/llamaServerManager.js');
+    upgradeLlamaServer.mockResolvedValueOnce({ success: true, note: 'updated and restarted' });
+    const app = makeApp();
+
+    const res = await request(app).post('/api/local-llm/llama-server/upgrade');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ success: true, note: 'updated and restarted' });
+    expect(upgradeLlamaServer).toHaveBeenCalledWith({ onProgress: expect.any(Function) });
+    expect(app.get('io').emit).toHaveBeenCalledWith(
+      'localLlm:progress',
+      { event: 'complete', message: 'llama.cpp updated — updated and restarted' },
+    );
   });
 });

--- a/server/routes/localLlm.test.js
+++ b/server/routes/localLlm.test.js
@@ -680,7 +680,16 @@ describe('llama-server routes', () => {
     });
   });
 
-  it('GET /api/local-llm/llama-server/status includes llama.cpp update metadata', async () => {
+  it('GET /api/local-llm/llama-server/status keeps Homebrew probes out of lifecycle status', async () => {
+    const { getLlamaServerUpdateStatus } = await import('../services/llamaServerManager.js');
+    const res = await request(makeApp()).get('/api/local-llm/llama-server/status');
+
+    expect(res.status).toBe(200);
+    expect(getLlamaServerUpdateStatus).not.toHaveBeenCalled();
+    expect(res.body).not.toHaveProperty('updateAvailable');
+  });
+
+  it('GET /api/local-llm/llama-server/update-status returns llama.cpp update metadata', async () => {
     const { getLlamaServerUpdateStatus } = await import('../services/llamaServerManager.js');
     getLlamaServerUpdateStatus.mockResolvedValueOnce({
       version: '0.1.1-dev',
@@ -690,7 +699,7 @@ describe('llama-server routes', () => {
       downloadUrl: 'https://github.com/ggml-org/llama.cpp/releases',
     });
 
-    const res = await request(makeApp()).get('/api/local-llm/llama-server/status');
+    const res = await request(makeApp()).get('/api/local-llm/llama-server/update-status');
 
     expect(res.body).toMatchObject({
       version: '0.1.1-dev',

--- a/server/services/llamaServerManager.js
+++ b/server/services/llamaServerManager.js
@@ -6,7 +6,7 @@
  * managed as an optional PM2 process (`portos-llama-server`).
  */
 
-import { stat } from 'fs/promises';
+import { realpath, stat } from 'fs/promises';
 import { spawn } from '../lib/childProcess.js';
 import { commandExists } from '../lib/commandExists.js';
 import { findCommandOnPath, safeChildProcessEnv, safeChildProcessOptions } from '../lib/processEnv.js';
@@ -132,19 +132,45 @@ async function readBrewLlamaCppInfo() {
 
   return Promise.resolve()
     .then(() => JSON.parse(result.stdout))
-    .then((payload) => {
+    .then(async (payload) => {
       const formula = payload?.formulae?.find((entry) => entry?.name === LLAMA_CPP_FORMULA);
       const installed = formula?.installed?.[0];
       if (!installed) return null;
+      const prefixResult = await readCommandOutput(
+        'brew',
+        ['--prefix', LLAMA_CPP_FORMULA],
+        BREW_INFO_TIMEOUT_MS,
+      );
       return {
         installedVersion: String(installed.version || ''),
         latestVersion: formula?.versions?.stable ? String(formula.versions.stable) : null,
         outdated: formula.outdated === true,
         pinned: formula.pinned === true,
         linked: Boolean(formula.linked_keg),
+        prefix: prefixResult.error ? null : prefixResult.stdout.trim().split(/\r?\n/)[0] || null,
       };
     })
     .catch(() => null);
+}
+
+/**
+ * Confirm that the binary found on PATH resolves to Homebrew's linked keg.
+ *
+ * `brew info` reports whether the formula is linked, not which executable the
+ * current PATH resolves. A source build earlier on PATH can therefore coexist
+ * with a linked Homebrew formula; upgrading the formula in that state would
+ * leave the serving process on the old source build. Canonicalize both paths so
+ * the normal `/opt/homebrew/bin` and `/opt/homebrew/opt` symlinks compare as the
+ * same Cellar executable.
+ */
+async function isHomebrewLlamaServer(binaryPath, brewInfo) {
+  if (!binaryPath || !brewInfo?.prefix) return false;
+  const expectedPath = `${brewInfo.prefix}/bin/llama-server`;
+  const [activePath, homebrewPath] = await Promise.all([
+    realpath(binaryPath).catch(() => null),
+    realpath(expectedPath).catch(() => null),
+  ]);
+  return Boolean(activePath && homebrewPath && activePath === homebrewPath);
 }
 
 /**
@@ -379,11 +405,12 @@ export async function getLlamaServerUpdateStatus() {
     readLlamaServerVersion(binaryPath),
     readBrewLlamaCppInfo(),
   ]);
+  const homebrewBinary = await isHomebrewLlamaServer(binaryPath, brewInfo);
   return {
     version: version || brewInfo?.installedVersion || null,
     latestVersion: brewInfo?.latestVersion || null,
     updateAvailable: Boolean(brewInfo?.outdated),
-    canUpgrade: Boolean(brewInfo?.linked && !brewInfo.pinned),
+    canUpgrade: Boolean(brewInfo?.linked && !brewInfo.pinned && homebrewBinary),
     downloadUrl: LLAMA_CPP_DOWNLOAD_URL,
   };
 }
@@ -705,7 +732,13 @@ async function restartManagedLlamaServer(config, baseline) {
     console.error(`❌ llama-server: could not restore the previous configuration after update: ${err.message}`);
     return null;
   });
-  if (started) preTuningConfig = baseline;
+  if (!started) return null;
+  if (!started.online && !(await waitForEndpoint(started.endpoint))) {
+    console.error('❌ llama-server: restored process never answered after update');
+    await stopLlamaServer().catch(() => {});
+    return null;
+  }
+  preTuningConfig = baseline;
   return started;
 }
 
@@ -749,6 +782,15 @@ export async function upgradeLlamaServer({ onProgress = () => {} } = {}) {
       success: false,
       manualUpdateRequired: true,
       error: 'Homebrew has llama.cpp installed, but its keg is not linked to the llama-server on PATH. Link the formula manually before asking PortOS to update it.',
+    };
+  }
+
+  const binaryPath = resolveLlamaServerBinary();
+  if (!(await isHomebrewLlamaServer(binaryPath, brewInfo))) {
+    return {
+      success: false,
+      manualUpdateRequired: true,
+      error: `The active llama-server is not the linked Homebrew llama.cpp binary, so PortOS left it untouched. Update that installation manually: ${LLAMA_CPP_DOWNLOAD_URL}`,
     };
   }
 

--- a/server/services/llamaServerManager.js
+++ b/server/services/llamaServerManager.js
@@ -20,6 +20,8 @@ import { isPortInUse } from '../lib/platform.js';
 import { PORTS } from '../lib/ports.js';
 import { tuningSpecsFor } from '../lib/localModelTuning.js';
 import { ServerError } from '../lib/errorHandler.js';
+import { bufferedSpawn } from '../lib/bufferedSpawn.js';
+import { runStreamingCommand } from '../lib/streamingSpawn.js';
 import { execPm2, getAppStatusStrict, clearJlistCache, getSavedProcessNames } from './pm2.js';
 // `settings.js` is lazy-imported at its call sites below, never statically: it
 // eagerly resolves `fileUtils.PATHS` at module load, which drags PATHS into the
@@ -32,6 +34,11 @@ export { LLAMA_APP };
 
 const PROBE_TIMEOUT_MS = 1500;
 const STARTUP_WAIT_TIMEOUT_MS = 4000;
+const LLAMA_CPP_FORMULA = 'llama.cpp';
+const LLAMA_CPP_DOWNLOAD_URL = 'https://github.com/ggml-org/llama.cpp/releases';
+const VERSION_PROBE_TIMEOUT_MS = 5000;
+const BREW_INFO_TIMEOUT_MS = 15_000;
+const UPGRADE_TIMEOUT_MS = 30 * 60 * 1000;
 // `llama-server --help` is a fast local exec; this only bounds a wedged binary.
 const HELP_PROBE_TIMEOUT_MS = 5000;
 // llama.cpp's own in-place idle unload. See `supportsSleepIdle`.
@@ -77,6 +84,68 @@ let currentConfig = null;
 // cannot tell a PortOS tuning apart from the same flags typed by the user.
 let preTuningConfig = null;
 let lastExitError = null;
+
+/**
+ * Run a small local command and retain its output without throwing. Version and
+ * Homebrew metadata are optional decorations on status, so a missing/broken
+ * command must not take the runtime status endpoint down with it.
+ */
+async function readCommandOutput(command, args, timeoutMs) {
+  const result = await bufferedSpawn(command, args, { timeoutMs, shell: false });
+  return {
+    error: result.success
+      ? null
+      : result.error || new Error(result.timedOut ? `timed out after ${timeoutMs}ms` : `exited with code ${result.code}`),
+    stdout: result.stdout || '',
+    stderr: result.stderr || '',
+  };
+}
+
+/**
+ * Read the version printed by the installed llama-server binary. Different
+ * llama.cpp builds have used both `version: X` and `version X`, so accept both
+ * spellings while keeping the status field to the useful short version token.
+ */
+function parseLlamaServerVersion(output) {
+  const match = String(output || '').match(/\bversion\s*:?\s+([^\s(]+)/i);
+  return match?.[1]?.replace(/^v/, '') || null;
+}
+
+async function readLlamaServerVersion(binaryPath) {
+  const result = await readCommandOutput(binaryPath, ['--version'], VERSION_PROBE_TIMEOUT_MS);
+  return result.error ? null : parseLlamaServerVersion(`${result.stdout}\n${result.stderr}`);
+}
+
+/**
+ * Read Homebrew's formula metadata for the installed llama.cpp package.
+ * `outdated` is authoritative here: llama.cpp's installed Homebrew version is
+ * often a build number while the current formula uses a release version, so a
+ * generic semver comparison would report false positives.
+ */
+async function readBrewLlamaCppInfo() {
+  const result = await readCommandOutput(
+    'brew',
+    ['info', '--json=v2', '--formula', LLAMA_CPP_FORMULA],
+    BREW_INFO_TIMEOUT_MS,
+  );
+  if (result.error) return null;
+
+  return Promise.resolve()
+    .then(() => JSON.parse(result.stdout))
+    .then((payload) => {
+      const formula = payload?.formulae?.find((entry) => entry?.name === LLAMA_CPP_FORMULA);
+      const installed = formula?.installed?.[0];
+      if (!installed) return null;
+      return {
+        installedVersion: String(installed.version || ''),
+        latestVersion: formula?.versions?.stable ? String(formula.versions.stable) : null,
+        outdated: formula.outdated === true,
+        pinned: formula.pinned === true,
+        linked: Boolean(formula.linked_keg),
+      };
+    })
+    .catch(() => null);
+}
 
 /**
  * Probes whether an OpenAI-compatible endpoint responds at the given host/port.
@@ -285,6 +354,37 @@ export async function getLlamaServerStatus() {
     // process actually got is `config.sleepIdleMinutes` — they differ until the
     // next start, because this is a launch flag.
     idleMinutes: await configuredSleepIdleMinutes(),
+  };
+}
+
+/**
+ * Check whether the installed llama.cpp formula has a newer Homebrew build.
+ * This is kept separate from the lifecycle status probe because the latter is
+ * also used by performance/ownership paths that must remain disk-and-process
+ * local; the LLMs page calls this explicit update-information path.
+ */
+export async function getLlamaServerUpdateStatus() {
+  const binaryPath = resolveLlamaServerBinary();
+  if (!binaryPath) {
+    return {
+      version: null,
+      latestVersion: null,
+      updateAvailable: false,
+      canUpgrade: false,
+      downloadUrl: LLAMA_CPP_DOWNLOAD_URL,
+    };
+  }
+
+  const [version, brewInfo] = await Promise.all([
+    readLlamaServerVersion(binaryPath),
+    readBrewLlamaCppInfo(),
+  ]);
+  return {
+    version: version || brewInfo?.installedVersion || null,
+    latestVersion: brewInfo?.latestVersion || null,
+    updateAvailable: Boolean(brewInfo?.outdated),
+    canUpgrade: Boolean(brewInfo?.linked && !brewInfo.pinned),
+    downloadUrl: LLAMA_CPP_DOWNLOAD_URL,
   };
 }
 
@@ -593,6 +693,153 @@ export async function stopLlamaServer() {
  * just stopped.
  */
 const waitForPortRelease = daemon.waitForPortRelease;
+
+/**
+ * Put a managed server back after an upgrade attempt. The model may take longer
+ * than the normal port-release race, so wait before asking `startLlamaServer`
+ * to validate the preserved launch configuration.
+ */
+async function restartManagedLlamaServer(config, baseline) {
+  await waitForPortRelease(config.port ?? PORTS.LLAMA_SERVER);
+  const started = await startLlamaServer(config).catch((err) => {
+    console.error(`❌ llama-server: could not restore the previous configuration after update: ${err.message}`);
+    return null;
+  });
+  if (started) preTuningConfig = baseline;
+  return started;
+}
+
+async function upgradeFailureResult(message, managedConfig, baseline, updated = false) {
+  const restored = managedConfig ? await restartManagedLlamaServer(managedConfig, baseline) : null;
+  const restoreNote = managedConfig && !restored
+    ? ' PortOS could not restore the llama-server process.'
+    : '';
+  return {
+    success: false,
+    ...(updated ? { updated: true } : {}),
+    error: `${message}${restoreNote}`,
+  };
+}
+
+/**
+ * Upgrade a Homebrew-installed llama.cpp binary in place.
+ *
+ * A managed llama-server is stopped before Homebrew swaps the binary and then
+ * restarted with the exact launch configuration it was using. An external
+ * process is never stopped; changing the package only takes effect for it when
+ * its owner starts it again.
+ */
+export async function upgradeLlamaServer({ onProgress = () => {} } = {}) {
+  const brewInfo = await readBrewLlamaCppInfo();
+  if (!brewInfo) {
+    return {
+      success: false,
+      error: `llama.cpp is not installed through Homebrew, so PortOS cannot update it here. Install it with Homebrew or update your source build manually: ${LLAMA_CPP_DOWNLOAD_URL}`,
+    };
+  }
+  if (brewInfo.pinned) {
+    return {
+      success: false,
+      manualUpdateRequired: true,
+      error: 'llama.cpp is pinned in Homebrew. Unpin it before asking PortOS to update it.',
+    };
+  }
+  if (!brewInfo.linked) {
+    return {
+      success: false,
+      manualUpdateRequired: true,
+      error: 'Homebrew has llama.cpp installed, but its keg is not linked to the llama-server on PATH. Link the formula manually before asking PortOS to update it.',
+    };
+  }
+
+  const launch = await readLlamaServerLaunch();
+  if (launch.readFailed) {
+    return {
+      success: false,
+      error: 'PortOS could not read PM2 to determine whether it owns llama-server. Try the update again in a moment.',
+    };
+  }
+  if (launch.managed && !launch.config?.model) {
+    return {
+      success: false,
+      error: 'PortOS could not recover llama-server\'s launch configuration, so it left the running process untouched.',
+    };
+  }
+  const managedConfig = launch.managed ? launch.config : null;
+  const baseline = preTuningConfig;
+
+  if (managedConfig) {
+    onProgress({ event: 'progress', message: 'Stopping llama-server before updating…' });
+    const stopped = await stopLlamaServer();
+    if (!stopped.success) {
+      return {
+        success: false,
+        error: stopped.message || 'PortOS could not stop the managed llama-server before updating.',
+      };
+    }
+  }
+
+  onProgress({ event: 'progress', message: 'Updating llama.cpp via Homebrew…' });
+  const upgraded = await runStreamingCommand(
+    'brew',
+    ['upgrade', LLAMA_CPP_FORMULA],
+    (message) => onProgress({ event: 'progress', message }),
+    { timeoutMs: UPGRADE_TIMEOUT_MS },
+  );
+
+  if (!upgraded.success) {
+    return upgradeFailureResult(
+      `llama.cpp upgrade failed: ${upgraded.error || 'Homebrew reported an unknown error'}.`,
+      managedConfig,
+      baseline,
+    );
+  }
+
+  // Homebrew normally keeps a linked formula linked across an upgrade, but an
+  // unlinked keg should not leave the newly-upgraded runtime invisible to PATH.
+  if (!resolveLlamaServerBinary()) {
+    onProgress({ event: 'progress', message: 'llama.cpp upgraded but is not linked — linking…' });
+    const linked = await runStreamingCommand(
+      'brew',
+      ['link', '--overwrite', LLAMA_CPP_FORMULA],
+      (message) => onProgress({ event: 'progress', message }),
+      { timeoutMs: 60_000 },
+    );
+    if (!linked.success || !resolveLlamaServerBinary()) {
+      return upgradeFailureResult(
+        `llama.cpp was upgraded, but its llama-server binary is not on PATH${linked.error ? `: ${linked.error}` : '.'}`,
+        managedConfig,
+        baseline,
+        true,
+      );
+    }
+  }
+
+  // A new binary may gain support for a cached compatibility flag such as
+  // --sleep-idle-seconds. Re-probe it before the preserved launch line returns.
+  sleepIdleSupport.clear();
+
+  if (managedConfig) {
+    onProgress({ event: 'progress', message: 'Restarting llama-server with its previous settings…' });
+    const restarted = await restartManagedLlamaServer(managedConfig, baseline);
+    if (!restarted) {
+      return {
+        success: false,
+        updated: true,
+        error: 'llama.cpp was upgraded, but llama-server could not be restarted with its previous settings.',
+      };
+    }
+    return {
+      success: true,
+      note: 'Updated llama.cpp and restarted llama-server with its previous settings.',
+    };
+  }
+
+  return {
+    success: true,
+    note: 'Updated llama.cpp. The new binary will be used the next time llama-server starts.',
+  };
+}
 
 /**
  * Block until the endpoint answers, or the readiness budget elapses.

--- a/server/services/llamaServerManager.js
+++ b/server/services/llamaServerManager.js
@@ -728,7 +728,10 @@ const waitForPortRelease = daemon.waitForPortRelease;
  */
 async function restartManagedLlamaServer(config, baseline) {
   await waitForPortRelease(config.port ?? PORTS.LLAMA_SERVER);
-  const started = await startLlamaServer(config).catch((err) => {
+  // The recovered PM2 config carries the effective idle flag from the old
+  // process. Leave this field undefined so startLlamaServer reads the current
+  // saved setting when an upgrade is also the next launch.
+  const started = await startLlamaServer({ ...config, sleepIdleMinutes: undefined }).catch((err) => {
     console.error(`❌ llama-server: could not restore the previous configuration after update: ${err.message}`);
     return null;
   });

--- a/server/services/llamaServerManager.test.js
+++ b/server/services/llamaServerManager.test.js
@@ -682,6 +682,32 @@ describe('llamaServerManager', () => {
       expect(startCall).toContain('example-model');
     });
 
+    it('restarts a managed server with the current saved idle window', async () => {
+      const binaryPath = homebrewBinaryPath;
+      vi.spyOn(processEnv, 'findCommandOnPath').mockReturnValue(binaryPath);
+      stubBrewInfo();
+      pm2State = {
+        name: LLAMA_APP,
+        status: 'online',
+        pid: 321,
+        args: ['-m', modelPath, '--port', String(PORTS.LLAMA_SERVER), '--sleep-idle-seconds', '0'],
+      };
+      openAiModelsProbe.probeOpenAiModels.mockImplementation(async () => ({ reachable: pm2State?.status === 'online' }));
+      vi.spyOn(childProcess, 'execFile').mockImplementation((_bin, _args, _opts, cb) => {
+        cb(null, '--sleep-idle-seconds SECONDS', '');
+        return fakeSpawnProcess();
+      });
+      vi.spyOn(streamingSpawnModule, 'runStreamingCommand').mockResolvedValue({ success: true });
+      _resetLlamaServerStateForTests({ sleepIdleMinutes: 30 });
+
+      const result = await upgradeLlamaServer();
+
+      expect(result).toMatchObject({ success: true });
+      const startCall = execPm2Calls.find((args) => args[0] === 'start');
+      const idleFlagIndex = startCall.indexOf('--sleep-idle-seconds');
+      expect(startCall[idleFlagIndex + 1]).toBe('1800');
+    });
+
     it('refuses to update when PM2 ownership cannot be determined', async () => {
       vi.spyOn(processEnv, 'findCommandOnPath').mockReturnValue(homebrewBinaryPath);
       stubBrewInfo();

--- a/server/services/llamaServerManager.test.js
+++ b/server/services/llamaServerManager.test.js
@@ -23,7 +23,7 @@ import * as bufferedSpawnModule from '../lib/bufferedSpawn.js';
 import * as streamingSpawnModule from '../lib/streamingSpawn.js';
 import { PORTS } from '../lib/ports.js';
 import { EventEmitter } from 'events';
-import { mkdtemp, rm, writeFile } from 'fs/promises';
+import { mkdir, mkdtemp, rm, symlink, writeFile } from 'fs/promises';
 import { tmpdir } from 'os';
 import { join } from 'path';
 
@@ -59,6 +59,8 @@ describe('llamaServerManager', () => {
   let modelDir;
   let modelPath;
   let draftPath;
+  let homebrewBinaryPath;
+  let homebrewPrefix;
   let pm2State = null;
   let execPm2Calls = [];
   // Failed PM2 reads, on demand. `getAppStatusStrict` answers `null` for a read
@@ -74,6 +76,16 @@ describe('llamaServerManager', () => {
     draftPath = join(modelDir, 'draft.gguf');
     await writeFile(modelPath, 'gguf');
     await writeFile(draftPath, 'gguf');
+    const homebrewRoot = join(modelDir, 'homebrew');
+    const cellarRoot = join(homebrewRoot, 'Cellar', 'llama.cpp', 'build-100');
+    homebrewPrefix = join(homebrewRoot, 'opt', 'llama.cpp');
+    homebrewBinaryPath = join(homebrewRoot, 'bin', 'llama-server');
+    await mkdir(join(cellarRoot, 'bin'), { recursive: true });
+    await mkdir(join(homebrewRoot, 'bin'), { recursive: true });
+    await mkdir(join(homebrewRoot, 'opt'), { recursive: true });
+    await writeFile(join(cellarRoot, 'bin', 'llama-server'), 'binary');
+    await symlink(cellarRoot, homebrewPrefix);
+    await symlink(join(homebrewPrefix, 'bin', 'llama-server'), homebrewBinaryPath);
   });
 
   afterAll(async () => {
@@ -173,12 +185,14 @@ describe('llamaServerManager', () => {
   });
 
   it('reports the binary version and Homebrew update metadata', async () => {
-    const binaryPath = '/opt/homebrew/bin/llama-server';
+    const binaryPath = homebrewBinaryPath;
     vi.spyOn(processEnv, 'findCommandOnPath').mockReturnValue(binaryPath);
-    const buffered = vi.spyOn(bufferedSpawnModule, 'bufferedSpawn').mockImplementation(async (command) => ({
+    const buffered = vi.spyOn(bufferedSpawnModule, 'bufferedSpawn').mockImplementation(async (command, args) => ({
       success: true,
       code: 0,
-      stdout: command === 'brew' ? brewInfoJson() : 'version: 0.1.1-dev (build 100, commit abc123)',
+      stdout: command === 'brew' && args[0] === '--prefix'
+        ? `${homebrewPrefix}\n`
+        : command === 'brew' ? brewInfoJson() : 'version: 0.1.1-dev (build 100, commit abc123)',
       stderr: '',
       timedOut: false,
     }));
@@ -200,11 +214,13 @@ describe('llamaServerManager', () => {
   });
 
   it('does not offer an automatic update for a pinned Homebrew formula', async () => {
-    vi.spyOn(processEnv, 'findCommandOnPath').mockReturnValue('/opt/homebrew/bin/llama-server');
-    vi.spyOn(bufferedSpawnModule, 'bufferedSpawn').mockImplementation(async (command) => ({
+    vi.spyOn(processEnv, 'findCommandOnPath').mockReturnValue(homebrewBinaryPath);
+    vi.spyOn(bufferedSpawnModule, 'bufferedSpawn').mockImplementation(async (command, args) => ({
       success: true,
       code: 0,
-      stdout: command === 'brew' ? brewInfoJson({ pinned: true }) : 'version: 0.1.1-dev',
+      stdout: command === 'brew' && args[0] === '--prefix'
+        ? `${homebrewPrefix}\n`
+        : command === 'brew' ? brewInfoJson({ pinned: true }) : 'version: 0.1.1-dev',
       stderr: '',
       timedOut: false,
     }));
@@ -230,6 +246,26 @@ describe('llamaServerManager', () => {
       version: 'custom-build',
       latestVersion: null,
       updateAvailable: false,
+      canUpgrade: false,
+    });
+  });
+
+  it('keeps the Homebrew update manual when a source build is first on PATH', async () => {
+    vi.spyOn(processEnv, 'findCommandOnPath').mockReturnValue('/usr/local/bin/llama-server');
+    vi.spyOn(bufferedSpawnModule, 'bufferedSpawn').mockImplementation(async (command, args) => ({
+      success: true,
+      code: 0,
+      stdout: command === 'brew' && args[0] === '--prefix'
+        ? `${homebrewPrefix}\n`
+        : command === 'brew' ? brewInfoJson() : 'version: custom-build',
+      stderr: '',
+      timedOut: false,
+    }));
+
+    await expect(getLlamaServerUpdateStatus()).resolves.toMatchObject({
+      version: 'custom-build',
+      latestVersion: '0.3.0',
+      updateAvailable: true,
       canUpgrade: false,
     });
   });
@@ -592,16 +628,16 @@ describe('llamaServerManager', () => {
   });
 
   describe('upgradeLlamaServer', () => {
-    const stubBrewInfo = (options) => vi.spyOn(bufferedSpawnModule, 'bufferedSpawn').mockImplementation(async () => ({
+    const stubBrewInfo = (options) => vi.spyOn(bufferedSpawnModule, 'bufferedSpawn').mockImplementation(async (_command, args) => ({
       success: true,
       code: 0,
-      stdout: brewInfoJson(options),
+      stdout: args[0] === '--prefix' ? `${homebrewPrefix}\n` : brewInfoJson(options),
       stderr: '',
       timedOut: false,
     }));
 
     it('updates an idle installation through Homebrew without starting it', async () => {
-      vi.spyOn(processEnv, 'findCommandOnPath').mockReturnValue('/opt/homebrew/bin/llama-server');
+      vi.spyOn(processEnv, 'findCommandOnPath').mockReturnValue(homebrewBinaryPath);
       stubBrewInfo();
       const progress = vi.fn();
       const stream = vi.spyOn(streamingSpawnModule, 'runStreamingCommand').mockImplementation(async (_cmd, _args, onLine) => {
@@ -624,7 +660,7 @@ describe('llamaServerManager', () => {
     });
 
     it('restarts a managed server with its recovered launch configuration', async () => {
-      const binaryPath = '/opt/homebrew/bin/llama-server';
+      const binaryPath = homebrewBinaryPath;
       vi.spyOn(processEnv, 'findCommandOnPath').mockReturnValue(binaryPath);
       stubBrewInfo();
       pm2State = {
@@ -647,7 +683,7 @@ describe('llamaServerManager', () => {
     });
 
     it('refuses to update when PM2 ownership cannot be determined', async () => {
-      vi.spyOn(processEnv, 'findCommandOnPath').mockReturnValue('/opt/homebrew/bin/llama-server');
+      vi.spyOn(processEnv, 'findCommandOnPath').mockReturnValue(homebrewBinaryPath);
       stubBrewInfo();
       pm2Reads.failures = Infinity;
       const stream = vi.spyOn(streamingSpawnModule, 'runStreamingCommand');
@@ -657,6 +693,43 @@ describe('llamaServerManager', () => {
         error: expect.stringMatching(/could not read PM2/i),
       });
       expect(stream).not.toHaveBeenCalled();
+    });
+
+    it('refuses an automatic update when a source build owns the active binary', async () => {
+      vi.spyOn(processEnv, 'findCommandOnPath').mockReturnValue('/usr/local/bin/llama-server');
+      stubBrewInfo();
+      const stream = vi.spyOn(streamingSpawnModule, 'runStreamingCommand');
+
+      await expect(upgradeLlamaServer()).resolves.toMatchObject({
+        success: false,
+        manualUpdateRequired: true,
+        error: expect.stringMatching(/active llama-server is not the linked Homebrew/i),
+      });
+      expect(stream).not.toHaveBeenCalled();
+    });
+
+    it('does not report success when a managed restart never becomes ready', async () => {
+      const binaryPath = homebrewBinaryPath;
+      vi.spyOn(processEnv, 'findCommandOnPath').mockReturnValue(binaryPath);
+      stubBrewInfo();
+      pm2State = {
+        name: LLAMA_APP,
+        status: 'online',
+        pid: 321,
+        args: ['-m', modelPath, '--port', String(PORTS.LLAMA_SERVER), '--alias', 'example-model'],
+      };
+      openAiModelsProbe.probeOpenAiModels.mockResolvedValue({ reachable: false });
+      vi.spyOn(streamingSpawnModule, 'runStreamingCommand').mockResolvedValue({ success: true });
+      _resetLlamaServerStateForTests({ relaunchReadyTimeout: 0, pm2ReadRetryDelay: 0 });
+
+      const result = await upgradeLlamaServer();
+
+      expect(result).toMatchObject({
+        success: false,
+        updated: true,
+        error: expect.stringMatching(/could not be restarted/i),
+      });
+      expect(execPm2Calls.filter((args) => args[0] === 'delete').length).toBeGreaterThanOrEqual(2);
     });
   });
 

--- a/server/services/llamaServerManager.test.js
+++ b/server/services/llamaServerManager.test.js
@@ -8,6 +8,8 @@ import {
   captureLlamaServerConfig,
   restoreLlamaServerConfig,
   installLlamaServer,
+  getLlamaServerUpdateStatus,
+  upgradeLlamaServer,
   _resetLlamaServerStateForTests,
   LLAMA_APP,
 } from './llamaServerManager.js';
@@ -17,6 +19,8 @@ import * as childProcess from '../lib/childProcess.js';
 import * as platform from '../lib/platform.js';
 import * as openAiModelsProbe from '../lib/openAiModelsProbe.js';
 import * as pm2Module from './pm2.js';
+import * as bufferedSpawnModule from '../lib/bufferedSpawn.js';
+import * as streamingSpawnModule from '../lib/streamingSpawn.js';
 import { PORTS } from '../lib/ports.js';
 import { EventEmitter } from 'events';
 import { mkdtemp, rm, writeFile } from 'fs/promises';
@@ -37,6 +41,17 @@ function endProcess(child, code) {
   child.emit('exit', code);
   child.emit('close', code);
 }
+
+const brewInfoJson = ({ installedVersion = 'build-100', latestVersion = '0.3.0', outdated = true, pinned = false, linkedKeg = 'build-100' } = {}) => JSON.stringify({
+  formulae: [{
+    name: 'llama.cpp',
+    versions: { stable: latestVersion },
+    installed: [{ version: installedVersion }],
+    outdated,
+    pinned,
+    linked_keg: linkedKeg,
+  }],
+});
 
 describe('llamaServerManager', () => {
   // startLlamaServer refuses to spawn for a GGUF that is not on disk, so the
@@ -155,6 +170,68 @@ describe('llamaServerManager', () => {
     // a cold run right after `brew link` blew past commandExists' 5s bound and
     // reported an installed, working binary as missing.
     expect(execProbe).not.toHaveBeenCalled();
+  });
+
+  it('reports the binary version and Homebrew update metadata', async () => {
+    const binaryPath = '/opt/homebrew/bin/llama-server';
+    vi.spyOn(processEnv, 'findCommandOnPath').mockReturnValue(binaryPath);
+    const buffered = vi.spyOn(bufferedSpawnModule, 'bufferedSpawn').mockImplementation(async (command) => ({
+      success: true,
+      code: 0,
+      stdout: command === 'brew' ? brewInfoJson() : 'version: 0.1.1-dev (build 100, commit abc123)',
+      stderr: '',
+      timedOut: false,
+    }));
+
+    const status = await getLlamaServerUpdateStatus();
+
+    expect(status).toMatchObject({
+      version: '0.1.1-dev',
+      latestVersion: '0.3.0',
+      updateAvailable: true,
+      canUpgrade: true,
+    });
+    expect(buffered).toHaveBeenCalledWith(binaryPath, ['--version'], { timeoutMs: 5000, shell: false });
+    expect(buffered).toHaveBeenCalledWith(
+      'brew',
+      ['info', '--json=v2', '--formula', 'llama.cpp'],
+      { timeoutMs: 15_000, shell: false },
+    );
+  });
+
+  it('does not offer an automatic update for a pinned Homebrew formula', async () => {
+    vi.spyOn(processEnv, 'findCommandOnPath').mockReturnValue('/opt/homebrew/bin/llama-server');
+    vi.spyOn(bufferedSpawnModule, 'bufferedSpawn').mockImplementation(async (command) => ({
+      success: true,
+      code: 0,
+      stdout: command === 'brew' ? brewInfoJson({ pinned: true }) : 'version: 0.1.1-dev',
+      stderr: '',
+      timedOut: false,
+    }));
+
+    await expect(getLlamaServerUpdateStatus()).resolves.toMatchObject({
+      updateAvailable: true,
+      canUpgrade: false,
+      latestVersion: '0.3.0',
+    });
+  });
+
+  it('keeps a custom llama-server build updateable by manual means only', async () => {
+    vi.spyOn(processEnv, 'findCommandOnPath').mockReturnValue('/usr/local/bin/llama-server');
+    vi.spyOn(bufferedSpawnModule, 'bufferedSpawn').mockImplementation(async (command) => ({
+      success: command !== 'brew',
+      code: command === 'brew' ? 1 : 0,
+      stdout: command === 'brew' ? '' : 'version: custom-build',
+      stderr: command === 'brew' ? 'Error: No available formula' : '',
+      timedOut: false,
+    }));
+
+    await expect(getLlamaServerUpdateStatus()).resolves.toMatchObject({
+      version: 'custom-build',
+      latestVersion: null,
+      updateAvailable: false,
+      canUpgrade: false,
+    });
   });
 
   it('rejects start when binary is missing', async () => {
@@ -512,6 +589,75 @@ describe('llamaServerManager', () => {
     });
 
     await expect(installLlamaServer()).rejects.toThrow(/brew link --overwrite llama\.cpp/i);
+  });
+
+  describe('upgradeLlamaServer', () => {
+    const stubBrewInfo = (options) => vi.spyOn(bufferedSpawnModule, 'bufferedSpawn').mockImplementation(async () => ({
+      success: true,
+      code: 0,
+      stdout: brewInfoJson(options),
+      stderr: '',
+      timedOut: false,
+    }));
+
+    it('updates an idle installation through Homebrew without starting it', async () => {
+      vi.spyOn(processEnv, 'findCommandOnPath').mockReturnValue('/opt/homebrew/bin/llama-server');
+      stubBrewInfo();
+      const progress = vi.fn();
+      const stream = vi.spyOn(streamingSpawnModule, 'runStreamingCommand').mockImplementation(async (_cmd, _args, onLine) => {
+        onLine('Updated llama.cpp');
+        return { success: true };
+      });
+
+      const result = await upgradeLlamaServer({ onProgress: progress });
+
+      expect(result).toMatchObject({ success: true });
+      expect(stream).toHaveBeenCalledWith(
+        'brew',
+        ['upgrade', 'llama.cpp'],
+        expect.any(Function),
+        { timeoutMs: 30 * 60 * 1000 },
+      );
+      expect(progress).toHaveBeenCalledWith({ event: 'progress', message: 'Updating llama.cpp via Homebrew…' });
+      expect(progress).toHaveBeenCalledWith({ event: 'progress', message: 'Updated llama.cpp' });
+      expect(execPm2Calls.some((args) => args[0] === 'start' || args[0] === 'delete')).toBe(false);
+    });
+
+    it('restarts a managed server with its recovered launch configuration', async () => {
+      const binaryPath = '/opt/homebrew/bin/llama-server';
+      vi.spyOn(processEnv, 'findCommandOnPath').mockReturnValue(binaryPath);
+      stubBrewInfo();
+      pm2State = {
+        name: LLAMA_APP,
+        status: 'online',
+        pid: 321,
+        args: ['-m', modelPath, '--port', String(PORTS.LLAMA_SERVER), '--alias', 'example-model'],
+      };
+      openAiModelsProbe.probeOpenAiModels.mockImplementation(async () => ({ reachable: pm2State?.status === 'online' }));
+      vi.spyOn(streamingSpawnModule, 'runStreamingCommand').mockResolvedValue({ success: true });
+
+      const result = await upgradeLlamaServer();
+
+      expect(result).toMatchObject({ success: true });
+      expect(execPm2Calls.some((args) => args[0] === 'delete')).toBe(true);
+      const startCall = execPm2Calls.find((args) => args[0] === 'start');
+      expect(startCall).toContain(modelPath);
+      expect(startCall).toContain('--alias');
+      expect(startCall).toContain('example-model');
+    });
+
+    it('refuses to update when PM2 ownership cannot be determined', async () => {
+      vi.spyOn(processEnv, 'findCommandOnPath').mockReturnValue('/opt/homebrew/bin/llama-server');
+      stubBrewInfo();
+      pm2Reads.failures = Infinity;
+      const stream = vi.spyOn(streamingSpawnModule, 'runStreamingCommand');
+
+      await expect(upgradeLlamaServer()).resolves.toMatchObject({
+        success: false,
+        error: expect.stringMatching(/could not read PM2/i),
+      });
+      expect(stream).not.toHaveBeenCalled();
+    });
   });
 
   // ---- tuning relaunch ----------------------------------------------------


### PR DESCRIPTION
## Summary
- Surface llama.cpp installed/latest versions and Homebrew update availability on the Local LLMs page.
- Update linked Homebrew installations in place and restore PortOS-managed llama-server launch settings after the package swap.
- Keep externally managed, pinned, unlinked, and custom installations safe with a manual-update path.

## Test plan
- `server: npm test -- --run services/llamaServerManager.test.js -t "upgradeLlamaServer|reports the binary version|pinned Homebrew|custom llama-server"`
- `server: npm test -- --run routes/localLlm.test.js -t "llama-server"`
- `client: npm test -- --run src/components/settings/RuntimeServersCard.test.jsx src/components/settings/LocalLlmTab.test.jsx`
- `client: npm run lint`
- `npx biome check server/services/llamaServerManager.js server/services/llamaServerManager.test.js server/routes/localLlm.js server/routes/localLlm.test.js`