### PR TITLE
feat: expand digit span results by default

### DIFF
--- a/client/src/components/meatspace/post/PostSessionResults.jsx
+++ b/client/src/components/meatspace/post/PostSessionResults.jsx
@@ -18,6 +18,7 @@ export default function PostSessionResults({ session, conditions = {}, onSaved, 
         isTraining={isTraining}
         plan={sessionPlan}
         actualDurationMs={savedSession?.actualDurationMs}
+        initialExpandedDrill={drillResults?.findIndex(result => result.type === 'digit-span') ?? -1}
       />
 
       {benchmark && (

--- a/client/src/components/meatspace/post/PostSessionResults.test.jsx
+++ b/client/src/components/meatspace/post/PostSessionResults.test.jsx
@@ -41,6 +41,26 @@ function renderResults(overrides = {}) {
 }
 
 describe('PostSessionResults drill breakdown', () => {
+  it('opens a digit-span drill review by default', () => {
+    const { container } = renderResults({
+      drillResults: [{
+        type: 'digit-span',
+        score: 80,
+        questions: [{ prompt: '123', expected: '123', answered: '123', correct: true, responseMs: 800 }],
+      }],
+    });
+
+    expect(within(container.querySelector('table')).getAllByText('123')).not.toHaveLength(0);
+    expect(container.querySelector('.lucide-chevron-up')).toBeInTheDocument();
+  });
+
+  it('leaves non-digit-span drills collapsed by default', () => {
+    const { container } = renderResults();
+
+    expect(container.querySelector('table')).not.toBeInTheDocument();
+    expect(container.querySelectorAll('.lucide-chevron-down')).toHaveLength(2);
+  });
+
   it('renders a chevron on every drill row — including non-LLM ones (regression: dead expand affordance)', () => {
     const { container } = renderResults();
     // Both rows start collapsed, so both show ChevronDown. Previously this

--- a/client/src/components/meatspace/post/PostSessionSummary.jsx
+++ b/client/src/components/meatspace/post/PostSessionSummary.jsx
@@ -19,8 +19,8 @@ function fillBlankAttempts(questions) {
 // History render identically. `drillResults` is the live hook's results array
 // OR a saved session's `tasks` array (same task shape); `sessionScore` is the
 // blended session score.
-export default function PostSessionSummary({ drillResults = [], sessionScore = 0, isTraining = false, plan = null, actualDurationMs = null }) {
-  const [expandedDrill, setExpandedDrill] = useState(null);
+export default function PostSessionSummary({ drillResults = [], sessionScore = 0, isTraining = false, plan = null, actualDurationMs = null, initialExpandedDrill = null }) {
+  const [expandedDrill, setExpandedDrill] = useState(initialExpandedDrill);
 
   const scoreColor = sessionScore >= 80 ? 'text-port-success' :
     sessionScore >= 50 ? 'text-port-warning' : 'text-port-error';


### PR DESCRIPTION
## Summary
- Expand the digit-span drill review automatically on the POST results screen.
- Keep other drill types and saved-session detail views collapsed by default.

## Test plan
- npm test -- --run src/components/meatspace/post/PostSessionResults.test.jsx src/components/meatspace/post/PostSessionDetail.test.jsx