### PR TITLE
Add authenticated VNC remote desktop bridge

### DIFF
--- a/docs/COMPANION_APP_API.md
+++ b/docs/COMPANION_APP_API.md
@@ -107,7 +107,29 @@ builds on:
 | `POST` | `/api/instances/peers/:id/sync` | Trigger a sync with a peer. |
 | `GET` | `/api/instances/peers/:id/query?path=/api/…` | Proxy a request through a peer. |
 
-## 4. Quick actions, brain capture & daily log — the palette bridge
+## 4. Remote desktop
+
+Remote desktop is deliberately stricter than the rest of the companion API: it
+requires the PortOS instance password gate to be enabled even though ordinary
+API routes support the default passwordless tailnet posture.
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET` | `/api/remote-desktop/status` | Report whether a VNC server is reachable on loopback, whether PortOS auth is enabled, and the host setup command. |
+| `POST` | `/api/remote-desktop/sessions` | Create a five-minute, single-purpose viewer URL. Returns `{ viewerPath, expiresAt }`. |
+
+The native client authenticates the session request with its saved instance
+password, then opens `viewerPath` in an embedded browser. The viewer loads the
+vendored noVNC module and connects to `/remote-desktop/ws?token=…`. That
+WebSocket is a byte-for-byte RFB bridge to `127.0.0.1:5900` (or the fixed
+`PORTOS_VNC_PORT` configured for the server process); neither the HTTP request
+nor the token can select an arbitrary TCP destination.
+
+The separate VNC password is entered inside the viewer and is never returned to
+PortOS's REST API or stored by the companion. See [REMOTE_DESKTOP.md](./REMOTE_DESKTOP.md)
+for setup and the complete security contract.
+
+## 5. Quick actions, brain capture & daily log — the palette bridge
 
 Non-DOM voice/palette actions are dispatchable over plain HTTP via the command
 palette bridge (`server/routes/palette.js`) — the app drives these directly and
@@ -157,7 +179,7 @@ are **not** interchangeable with these routes — pick per your need:
   `{ date, entry }`. Use it for a **typed** entry (`source: "text"`) or when you need
   the structured `entry` back.
 
-## 5. MeatSpace POST training & testing
+## 6. MeatSpace POST training & testing
 
 `/api/meatspace/post/*` (`server/routes/meatspacePostRoutes.js`). These are the
 read/write endpoints for POST config, sessions, and progress on a single instance.
@@ -185,7 +207,7 @@ those ids in one transaction and returns success only after the full batch is
 durable. Use `/sessions` only for scored tests, keeping training evidence out of
 benchmark history.
 
-## 6. iCloud-JSON sync precedent (POST-progress reconciliation)
+## 7. iCloud-JSON sync precedent (POST-progress reconciliation)
 
 The working reference for "iOS app writes an iCloud JSON file, PortOS ingests it"
 is MortalLoom (`server/routes/mortalloom.js`, `server/services/mortalLoomStore.js`):
@@ -197,7 +219,7 @@ is MortalLoom (`server/routes/mortalloom.js`, `server/services/mortalLoomStore.j
 A POST-progress iCloud reconciliation endpoint would need an explicit privacy
 design before it can mirror this precedent. Until then there is no cross-instance
 POST reconciliation — a companion app reads and writes each instance's
-`/api/meatspace/post/*` routes directly (see the note in §5).
+`/api/meatspace/post/*` routes directly (see the note in §6).
 
 ## Deferred follow-ups (filed separately)
 

--- a/docs/DEPS.md
+++ b/docs/DEPS.md
@@ -22,6 +22,7 @@ Before removing a Tier 3 candidate, run a transitive-dep check (`npm ls <pkg>`).
 | **Root devDeps** | | | | |
 | `pm2` | 1 | KEEP | top-level scripts | Process manager, foundational. Pinned `7.0.3` (aligned with server pin) |
 | **Server deps** | | | | |
+| `@novnc/novnc` | 1 | KEEP | PortDeck remote desktop viewer | Mature RFB/VNC protocol implementation; replacing it would require owning multiple security types and framebuffer encodings |
 | `@googleapis/calendar` | 1 | KEEP | Calendar integration | Scoped official Google SDK (replaced monolithic `googleapis`) |
 | `@googleapis/gmail` | 1 | KEEP | Messages/Gmail integration | Scoped official Google SDK |
 | `express` | 1 | KEEP | `server/index.js` + routes | Framework |
@@ -35,6 +36,7 @@ Before removing a Tier 3 candidate, run a transitive-dep check (`npm ls <pkg>`).
 | `socket.io` | 1 | KEEP | realtime | Foundational |
 | `socket.io-client` | 1 | KEEP | server-to-client | Paired with socket.io |
 | `undici` | 1 | KEEP | HTTP client | Node core team project |
+| `ws` | 1 | KEEP | remote desktop + browser WebSockets | Foundational WebSocket transport; also used transitively by Socket.IO |
 | `zod` | 1 | KEEP | input validation | Widely-audited |
 | **Server devDeps** | | | | |
 | `vitest` | 1 | KEEP | test runner | |

--- a/docs/DEPS.md
+++ b/docs/DEPS.md
@@ -3,7 +3,7 @@
 Living reference of every third-party dependency in PortOS, why it's kept, and what the current verdict is. Updated by `/do:depfree` runs.
 
 **Last audited:** 2026-08-04 (scoped audit of the `keyv`/`cacheable` supply-chain compromise); prior follow-up 2026-07-14 (issue #2547), prior full audit 2026-04-28 (default mode), tables corrected 2026-07-01 during a docs audit.
-**Verdict:** All dependencies justified. The 2026-08-04 audit replaced the entire `eslint` stack with `@biomejs/biome`, dropping 110 net client packages including the `file-entry-cache → flat-cache → keyv` chain named in the August 2026 Shai-Hulud npm compromise (PortOS held safe versions throughout — see the detailed finding below). The same pass closed a latent hole where `ignore-scripts=true` was only active for repo-root installs, not for any workspace install or CI. Since the last full audit: `sax` was removed (replaced with an owned parser, issue #1824), `portos-ai-toolkit` was vendored in-tree (`server/lib/aiToolkit/`), and monolithic `googleapis` was replaced with scoped `@googleapis/*` packages. The 2026-07-14 follow-up bumped `kokoro-js` to its latest patch `1.2.1` (still on maintenance watch — no publish since 2025-05) and aligned the dual `pm2` pins (root + server both `7.0.3`).
+**Verdict:** All dependencies justified. The 2026-08-04 audit replaced the entire `eslint` stack with `@biomejs/biome`, dropping 110 net client packages including the `file-entry-cache → flat-cache → keyv` chain named in the August 2026 Shai-Hulud npm compromise (PortOS held safe versions throughout — see the detailed finding below). The same pass closed a latent hole where `ignore-scripts=true` was only active for repo-root installs, not for any workspace install or CI. Since the last full audit: `sax` was removed (replaced with an owned parser, issue #1824), `portos-ai-toolkit` was vendored in-tree (`server/lib/aiToolkit/`), and monolithic `googleapis` was replaced with scoped `@googleapis/*` packages. The 2026-07-14 follow-up bumped `kokoro-js` to its latest patch `1.2.1` (still on maintenance watch — no publish since 2025-05) and aligned the dual `pm2` pins (root + server both `7.0.4`).
 
 ## Audit Methodology
 
@@ -20,7 +20,7 @@ Before removing a Tier 3 candidate, run a transitive-dep check (`npm ls <pkg>`).
 | Package | Tier | Verdict | Where Used | Notes |
 |---------|------|---------|------------|-------|
 | **Root devDeps** | | | | |
-| `pm2` | 1 | KEEP | top-level scripts | Process manager, foundational. Pinned `7.0.3` (aligned with server pin) |
+| `pm2` | 1 | KEEP | top-level scripts | Process manager, foundational. Pinned `7.0.4` (aligned with server pin) |
 | **Server deps** | | | | |
 | `@novnc/novnc` | 1 | KEEP | PortDeck remote desktop viewer | Mature RFB/VNC protocol implementation; replacing it would require owning multiple security types and framebuffer encodings |
 | `@googleapis/calendar` | 1 | KEEP | Calendar integration | Scoped official Google SDK (replaced monolithic `googleapis`) |
@@ -31,7 +31,7 @@ Before removing a Tier 3 candidate, run a transitive-dep check (`npm ls <pkg>`).
 | `node-pty` | 1 | KEEP | shell/terminal services | Native PTY binding (N-API) |
 | `pdf-lib` | 1 | KEEP | PDF generation/manipulation | |
 | `pg` | 1 | KEEP | Postgres access | Official `pg` driver |
-| `pm2` | 1 | KEEP | app lifecycle | Process manager. Pinned `7.0.3` (aligned with root pin) |
+| `pm2` | 1 | KEEP | app lifecycle | Process manager. Pinned `7.0.4` (aligned with root pin) |
 | `sharp` | 1 | KEEP | image processing | Native, widely-audited |
 | `socket.io` | 1 | KEEP | realtime | Foundational |
 | `socket.io-client` | 1 | KEEP | server-to-client | Paired with socket.io |

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@ Index of everything under `docs/`. Start with the [root README](../README.md) fo
 | [ARCHITECTURE.md](./ARCHITECTURE.md) | System design: React client, Express server, PM2 satellites, PostgreSQL + `data/` files |
 | [API.md](./API.md) | REST endpoints, complete route-domain index, Socket.IO events |
 | [COMPANION_APP_API.md](./COMPANION_APP_API.md) | PortDeck native iOS companion client discovery and HTTP API contract |
+| [REMOTE_DESKTOP.md](./REMOTE_DESKTOP.md) | PortDeck VNC broker security, host setup, and session flow |
 | [FEDERATED_MEDIA_PROVIDERS.md](./FEDERATED_MEDIA_PROVIDERS.md) | Authenticated, capacity-aware peer audio provider wire contract and setup |
 | [STORAGE.md](./STORAGE.md) | Storage classification contract — PostgreSQL vs filesystem, new-data-store checklist |
 | [BACKUP.md](./BACKUP.md) | Filesystem snapshots + PostgreSQL dumps, restore semantics |

--- a/docs/REMOTE_DESKTOP.md
+++ b/docs/REMOTE_DESKTOP.md
@@ -1,0 +1,28 @@
+# PortDeck remote desktop
+
+PortDeck can view and control a PortOS machine through a VNC server running on that same machine. PortOS brokers the RFB connection through the instance's existing HTTP(S) endpoint, so the iOS app does not need direct access to a separate VNC address.
+
+## Security model
+
+- Remote desktop sessions require PortOS instance authentication to be enabled. PortDeck uses the instance password already stored in its Keychain to request a short-lived, single-purpose viewer URL.
+- The broker connects only to `127.0.0.1`. A request cannot choose another VNC host or turn PortOS into a general TCP proxy.
+- The VNC password is entered in the viewer, is passed to the local VNC server through the RFB connection, and is not stored by PortDeck or PortOS.
+- The viewer token expires after five minutes if unused. A connected session may remain active for up to eight hours.
+- Prefer a Tailscale HTTPS endpoint. Tailscale still encrypts traffic when PortOS uses HTTP, but HTTPS also protects the browser-to-PortOS hop at the application layer.
+
+VNC grants control of the currently logged-in desktop. Use a unique VNC password that is different from both the macOS login password and the PortOS instance password. Apply Tailscale ACLs and the host firewall as appropriate; enabling a platform VNC server may make its own port available on additional interfaces independently of the PortOS loopback broker.
+
+## One-time host setup
+
+Run this on each PortOS machine:
+
+```bash
+npm run setup:remote-desktop
+```
+
+On macOS, the helper opens **System Settings → General → Sharing**. Enable **Remote Management**, open its Info panel, and enable **VNC viewers may control screen with password**. Modern macOS requires this user-approved System Settings action for full control; PortOS does not install a privileged launch daemon or try to bypass it.
+
+On Linux or Windows, install a VNC server and bind it to loopback port 5900. To use another local port, set `PORTOS_VNC_PORT` for the PortOS server process and restart PortOS.
+
+Re-run the setup command to verify that the VNC server is reachable on loopback. In PortDeck, open the instance, choose **Remote Desktop**, and enter the separate VNC password.
+

--- a/docs/REMOTE_DESKTOP.md
+++ b/docs/REMOTE_DESKTOP.md
@@ -7,7 +7,7 @@ PortDeck can view and control a PortOS machine through a VNC server running on t
 - Remote desktop sessions require PortOS instance authentication to be enabled. PortDeck uses the instance password already stored in its Keychain to request a short-lived, single-purpose viewer URL.
 - The broker connects only to `127.0.0.1`. A request cannot choose another VNC host or turn PortOS into a general TCP proxy.
 - The VNC password is entered in the viewer, is passed to the local VNC server through the RFB connection, and is not stored by PortDeck or PortOS.
-- The viewer token expires after five minutes if unused. A connected session may remain active for up to eight hours.
+- The viewer token expires after five minutes if unused. Once activated, it supports reconnects until a fixed eight-hour deadline and allows only one connection at a time.
 - Prefer a Tailscale HTTPS endpoint. Tailscale still encrypts traffic when PortOS uses HTTP, but HTTPS also protects the browser-to-PortOS hop at the application layer.
 
 VNC grants control of the currently logged-in desktop. Use a unique VNC password that is different from both the macOS login password and the PortOS instance password. Apply Tailscale ACLs and the host firewall as appropriate; enabling a platform VNC server may make its own port available on additional interfaces independently of the PortOS loopback broker.
@@ -25,4 +25,3 @@ On macOS, the helper opens **System Settings → General → Sharing**. Enable *
 On Linux or Windows, install a VNC server and bind it to loopback port 5900. To use another local port, set `PORTOS_VNC_PORT` for the PortOS server process and restart PortOS.
 
 Re-run the setup command to verify that the VNC server is reachable on loopback. In PortDeck, open the instance, choose **Remote Desktop**, and enter the separate VNC password.
-

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "test:db": "npm run test:db --prefix server",
     "setup:llm": "node scripts/setup-llm.js",
     "setup:browser": "node scripts/setup-browser.js",
+    "setup:remote-desktop": "node scripts/setup-remote-desktop.js",
     "fix:windows-console": "node scripts/fix-windows-console.js",
     "setup:cert": "node scripts/setup-cert.js",
     "setup:ghostty": "node scripts/setup-ghostty.js",

--- a/scripts/setup-remote-desktop.js
+++ b/scripts/setup-remote-desktop.js
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+
+import { createConnection } from 'node:net';
+import { platform } from 'node:os';
+import { spawnSync } from 'node:child_process';
+
+const portValue = Number.parseInt(process.env.PORTOS_VNC_PORT ?? '5900', 10);
+const port = Number.isInteger(portValue) && portValue > 0 && portValue <= 65_535 ? portValue : 5900;
+
+const probe = () => new Promise((resolve) => {
+  const socket = createConnection({ host: '127.0.0.1', port });
+  let settled = false;
+  const finish = (reachable) => {
+    if (settled) return;
+    settled = true;
+    socket.destroy();
+    resolve(reachable);
+  };
+  socket.setTimeout(1000);
+  socket.once('connect', () => finish(true));
+  socket.once('timeout', () => finish(false));
+  socket.once('error', () => finish(false));
+});
+
+if (await probe()) {
+  console.log(`✅ A VNC server is reachable on 127.0.0.1:${port}. PortOS remote desktop is ready.`);
+  process.exit(0);
+}
+
+console.log(`🖥️  No VNC server is reachable on 127.0.0.1:${port}.`);
+if (platform() === 'darwin') {
+  console.log('   In System Settings → General → Sharing, enable Remote Management.');
+  console.log('   Open its Info panel, enable “VNC viewers may control screen with password,” and choose a unique VNC password.');
+  console.log('   Do not reuse your macOS login password or PortOS instance password.');
+  if (process.stdin.isTTY && process.stdout.isTTY) {
+    spawnSync('open', ['x-apple.systempreferences:com.apple.Sharing-Settings.extension'], { stdio: 'ignore' });
+    console.log('   System Settings has been opened. Re-run this command after saving the setting.');
+  }
+} else {
+  console.log(`   Install and start a VNC server bound to loopback port ${port}.`);
+  console.log('   Set PORTOS_VNC_PORT if your local server uses a different port, then restart PortOS.');
+}
+process.exitCode = 1;

--- a/server/index.js
+++ b/server/index.js
@@ -152,7 +152,10 @@ import roundsRoutes from './routes/rounds.js';
 import midiRuntimeRoutes from './routes/midiRuntime.js';
 import peerSyncRoutes from './routes/peerSync.js';
 import askRoutes from './routes/ask.js';
+import remoteDesktopRoutes from './routes/remoteDesktop.js';
+import remoteDesktopViewerRoutes from './routes/remoteDesktopViewer.js';
 import { initSocket } from './services/socket.js';
+import { remoteDesktopBroker } from './services/remoteDesktop.js';
 import { bootstrapServices, runBootSequence, registerShutdownHandlers } from './services/bootstrap.js';
 import { errorMiddleware } from './lib/errorHandler.js';
 import { setHttpsEnabledAtBoot } from './lib/httpsState.js';
@@ -182,6 +185,13 @@ const io = new Server(httpServer, {
   },
   path: '/socket.io'
 });
+
+// noVNC uses a standards-based WebSocket rather than Socket.IO. The broker
+// accepts only short-lived session tokens issued by the authenticated API and
+// forwards them to a VNC server on loopback; port 5900 is never selected from
+// request input. Mount the HTTPS server and its optional loopback HTTP mirror.
+remoteDesktopBroker.mountWebSocket(httpServer);
+remoteDesktopBroker.mountWebSocket(localHttpServer);
 
 // Auth gate for Socket.IO — when settings.secrets.auth.enabled is true the
 // handshake must carry a valid token cookie or Authorization: Bearer header
@@ -236,6 +246,11 @@ app.use(authGate);
 app.use(express.json({ limit: JSON_BODY_LIMIT }));
 app.use(express.urlencoded({ limit: JSON_BODY_LIMIT, extended: true }));
 
+// The viewer and vendored noVNC modules are outside /api so WKWebView can load
+// them without persisting the user's PortOS password. The viewer URL itself is
+// gated by the one-purpose session token created below.
+app.use('/remote-desktop', remoteDesktopViewerRoutes);
+
 // API Routes
 app.use('/api/auth', authRoutes);
 app.use('/api/alerts', alertsRoutes);
@@ -243,6 +258,7 @@ app.use('/api/avatar', avatarRoutes);
 app.use('/api/system', systemHealthRoutes);
 app.use('/api/system/capabilities', systemCapabilitiesRoutes);
 app.use('/api/system-resources', systemResourcesRoutes);
+app.use('/api/remote-desktop', remoteDesktopRoutes);
 app.use('/api/capabilities', capabilitiesRoutes);
 app.use('/api/agent-context', agentContextMcpRoutes);
 app.use('/api/apps', appsRoutes);

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@googleapis/calendar": "^16.0.0",
         "@googleapis/gmail": "^18.0.0",
+        "@novnc/novnc": "1.7.0",
         "chokidar": "5.0.0",
         "express": "5.2.1",
         "google-auth-library": "^11.0.2",
@@ -688,6 +689,12 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@novnc/novnc": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@novnc/novnc/-/novnc-1.7.0.tgz",
+      "integrity": "sha512-ucEJOx4T2avIRCleodk7YobZj5O2Ga2AeLfQ69A/yjG9HHba2+PDgwSkN3FttrmG+70ZGx21sElNFouK13RzyA==",
+      "license": "MPL-2.0"
     },
     "node_modules/@oxc-project/types": {
       "version": "0.146.0",

--- a/server/package.json
+++ b/server/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@googleapis/calendar": "^16.0.0",
     "@googleapis/gmail": "^18.0.0",
+    "@novnc/novnc": "1.7.0",
     "chokidar": "5.0.0",
     "express": "5.2.1",
     "google-auth-library": "^11.0.2",

--- a/server/routes/remoteDesktop.js
+++ b/server/routes/remoteDesktop.js
@@ -1,0 +1,32 @@
+import express from 'express';
+import { asyncHandler, createServiceErrorMapper, ServerError } from '../lib/errorHandler.js';
+import { remoteDesktopBroker } from '../services/remoteDesktop.js';
+
+const router = express.Router();
+const mapServiceError = createServiceErrorMapper({ VNC_NOT_CONFIGURED: 409 });
+
+router.get('/status', asyncHandler(async (req, res) => {
+  const brokerStatus = await remoteDesktopBroker.status();
+  const authEnabled = req.portosAuthContext?.enabled === true;
+  res.json({
+    ...brokerStatus,
+    available: brokerStatus.configured && authEnabled,
+    requiresPortOSAuth: !authEnabled,
+    setupCommand: 'npm run setup:remote-desktop',
+  });
+}));
+
+router.post('/sessions', asyncHandler(async (req, res) => {
+  if (req.portosAuthContext?.enabled !== true || req.portosAuthContext?.authenticated !== true) {
+    throw new ServerError('Set an instance password in PortOS before enabling remote desktop sessions.', {
+      status: 409,
+      code: 'REMOTE_DESKTOP_REQUIRES_AUTH',
+      severity: 'warning',
+    });
+  }
+  const session = await remoteDesktopBroker.createSession()
+    .catch((err) => { throw mapServiceError(err); });
+  res.status(201).json(session);
+}));
+
+export default router;

--- a/server/routes/remoteDesktop.test.js
+++ b/server/routes/remoteDesktop.test.js
@@ -1,0 +1,97 @@
+import express from 'express';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const broker = vi.hoisted(() => ({
+  createSession: vi.fn(),
+  status: vi.fn(),
+}));
+
+vi.mock('../services/remoteDesktop.js', () => ({ remoteDesktopBroker: broker }));
+
+const { default: remoteDesktopRoutes } = await import('./remoteDesktop.js');
+const { errorMiddleware } = await import('../lib/errorHandler.js');
+
+const createApp = (authContext) => {
+  const app = express();
+  app.use((req, _res, next) => {
+    req.portosAuthContext = authContext;
+    next();
+  });
+  app.use('/api/remote-desktop', remoteDesktopRoutes);
+  app.use(errorMiddleware);
+  return app;
+};
+
+const fetchApp = async (app, path, options = {}) => {
+  const server = await new Promise((resolve) => {
+    const listening = app.listen(0, '127.0.0.1', () => resolve(listening));
+  });
+  const { port } = server.address();
+  const response = await fetch(`http://127.0.0.1:${port}${path}`, options);
+  const body = await response.json();
+  await new Promise((resolve) => server.close(resolve));
+  return { body, status: response.status };
+};
+
+beforeEach(() => {
+  broker.createSession.mockReset();
+  broker.status.mockReset();
+  broker.status.mockResolvedValue({ configured: true, platform: 'darwin', port: 5900, supported: true });
+  broker.createSession.mockResolvedValue({
+    viewerPath: '/remote-desktop?token=fake-session-token-value-for-tests',
+    expiresAt: '2030-01-01T00:00:00.000Z',
+  });
+});
+
+describe('remote desktop routes', () => {
+  it('reports that PortOS auth is required when the instance password is off', async () => {
+    const response = await fetchApp(
+      createApp({ enabled: false, authenticated: false }),
+      '/api/remote-desktop/status',
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({ available: false, configured: true, requiresPortOSAuth: true });
+  });
+
+  it('creates a viewer session for an authenticated instance', async () => {
+    const response = await fetchApp(
+      createApp({ enabled: true, authenticated: true }),
+      '/api/remote-desktop/sessions',
+      { method: 'POST' },
+    );
+
+    expect(response.status).toBe(201);
+    expect(response.body.viewerPath).toContain('/remote-desktop?token=');
+  });
+
+  it('refuses to create a session when instance authentication is disabled', async () => {
+    const response = await fetchApp(
+      createApp({ enabled: false, authenticated: false }),
+      '/api/remote-desktop/sessions',
+      { method: 'POST' },
+    );
+
+    expect(response.status).toBe(409);
+    expect(response.body.code).toBe('REMOTE_DESKTOP_REQUIRES_AUTH');
+    expect(broker.createSession).not.toHaveBeenCalled();
+  });
+
+  it('maps a missing loopback VNC server to the documented setup error', async () => {
+    broker.createSession.mockRejectedValue(Object.assign(new Error('VNC is not configured'), {
+      code: 'VNC_NOT_CONFIGURED',
+    }));
+
+    const response = await fetchApp(
+      createApp({ enabled: true, authenticated: true }),
+      '/api/remote-desktop/sessions',
+      { method: 'POST' },
+    );
+
+    expect(response.status).toBe(409);
+    expect(response.body).toMatchObject({
+      error: 'VNC is not configured',
+      code: 'VNC_NOT_CONFIGURED',
+    });
+  });
+});

--- a/server/routes/remoteDesktopViewer.js
+++ b/server/routes/remoteDesktopViewer.js
@@ -1,0 +1,29 @@
+import express from 'express';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { remoteDesktopBroker } from '../services/remoteDesktop.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const viewerTemplate = readFileSync(join(__dirname, '..', 'views', 'remote-desktop.html'), 'utf8');
+const vendorRoot = join(__dirname, '..', 'node_modules', '@novnc', 'novnc');
+const router = express.Router();
+
+router.use('/vendor', express.static(vendorRoot, {
+  index: false,
+  immutable: true,
+  maxAge: '1y',
+}));
+
+router.get('/', (req, res) => {
+  const token = req.query.token;
+  if (!remoteDesktopBroker.hasSession(token)) {
+    res.status(401).type('text/plain').send('This remote desktop link is invalid or expired. Return to PortDeck and start a new session.');
+    return;
+  }
+  res.set('Cache-Control', 'no-store');
+  res.set('Referrer-Policy', 'no-referrer');
+  res.type('html').send(viewerTemplate.replaceAll('__REMOTE_DESKTOP_TOKEN__', token));
+});
+
+export default router;

--- a/server/services/remoteDesktop.js
+++ b/server/services/remoteDesktop.js
@@ -66,7 +66,7 @@ export const createRemoteDesktopBroker = ({
     deleteExpiredSessions();
     const token = randomBytes(TOKEN_BYTES).toString('base64url');
     const expiresAt = now() + SESSION_TTL_MS;
-    sessions.set(token, { connected: false, expiresAt });
+    sessions.set(token, { activated: false, connected: false, expiresAt });
     return {
       viewerPath: `/remote-desktop?token=${encodeURIComponent(token)}`,
       expiresAt: new Date(expiresAt).toISOString(),
@@ -77,7 +77,7 @@ export const createRemoteDesktopBroker = ({
     if (typeof token !== 'string' || token.length < 32) return null;
     const session = sessions.get(token);
     if (!session) return null;
-    if (session.expiresAt <= now() && !session.connected) {
+    if (session.expiresAt <= now()) {
       sessions.delete(token);
       return null;
     }
@@ -89,13 +89,19 @@ export const createRemoteDesktopBroker = ({
   const claimSession = (token) => {
     const session = readSession(token);
     if (!session || session.connected) return null;
+    if (!session.activated) {
+      session.activated = true;
+      session.expiresAt = now() + connectedSessionTtlMs;
+    }
     session.connected = true;
-    session.expiresAt = now() + connectedSessionTtlMs;
     return session;
   };
 
   const releaseSession = (token) => {
-    sessions.delete(token);
+    const session = sessions.get(token);
+    if (!session) return;
+    session.connected = false;
+    if (session.expiresAt <= now()) sessions.delete(token);
   };
 
   const mountWebSocket = (httpServer) => {
@@ -114,23 +120,29 @@ export const createRemoteDesktopBroker = ({
         return;
       }
       const token = url.searchParams.get('token');
-      if (!claimSession(token)) {
+      const session = claimSession(token);
+      if (!session) {
         socket.write('HTTP/1.1 401 Unauthorized\r\nConnection: close\r\n\r\n');
         socket.destroy();
         return;
       }
-      wss.handleUpgrade(request, socket, head, (webSocket) => {
-        wss.emit('connection', webSocket, request, token);
-      });
+      try {
+        wss.handleUpgrade(request, socket, head, (webSocket) => {
+          wss.emit('connection', webSocket, request, token, session.expiresAt);
+        });
+      } catch {
+        releaseSession(token);
+        socket.destroy();
+      }
     });
 
-    wss.on('connection', (webSocket, _request, token) => {
+    wss.on('connection', (webSocket, _request, token, expiresAt) => {
       const vncSocket = connect({ host, port });
       const webSocketStream = createWebSocketStream(webSocket, { encoding: null });
       let cleanedUp = false;
       const expiryTimer = setTimeout(() => {
         webSocket.close(1000, 'Remote desktop session expired');
-      }, connectedSessionTtlMs);
+      }, Math.max(1, expiresAt - now()));
       expiryTimer.unref?.();
       const cleanup = () => {
         if (cleanedUp) return;

--- a/server/services/remoteDesktop.js
+++ b/server/services/remoteDesktop.js
@@ -1,0 +1,155 @@
+import { randomBytes } from 'node:crypto';
+import { createConnection } from 'node:net';
+import { platform } from 'node:os';
+import { createWebSocketStream, WebSocketServer } from 'ws';
+
+const LOOPBACK_HOST = '127.0.0.1';
+const DEFAULT_VNC_PORT = 5900;
+const PROBE_TIMEOUT_MS = 750;
+const SESSION_TTL_MS = 5 * 60 * 1000;
+const CONNECTED_SESSION_TTL_MS = 8 * 60 * 60 * 1000;
+const TOKEN_BYTES = 32;
+
+const parseVncPort = (value) => {
+  const port = Number.parseInt(value ?? '', 10);
+  return Number.isInteger(port) && port > 0 && port <= 65_535 ? port : DEFAULT_VNC_PORT;
+};
+
+const codedError = (message, code) => Object.assign(new Error(message), { code });
+
+export const createRemoteDesktopBroker = ({
+  host = LOOPBACK_HOST,
+  port = parseVncPort(process.env.PORTOS_VNC_PORT),
+  now = () => Date.now(),
+  connect = createConnection,
+  connectedSessionTtlMs = CONNECTED_SESSION_TTL_MS,
+} = {}) => {
+  const sessions = new Map();
+  const mountedServers = new WeakSet();
+
+  const deleteExpiredSessions = () => {
+    const cutoff = now();
+    for (const [token, session] of sessions) {
+      if (session.expiresAt <= cutoff && !session.connected) sessions.delete(token);
+    }
+  };
+
+  const probe = () => new Promise((resolve) => {
+    const socket = connect({ host, port });
+    let settled = false;
+    const finish = (reachable) => {
+      if (settled) return;
+      settled = true;
+      socket.destroy();
+      resolve(reachable);
+    };
+    socket.setTimeout(PROBE_TIMEOUT_MS);
+    socket.once('connect', () => finish(true));
+    socket.once('timeout', () => finish(false));
+    socket.once('error', () => finish(false));
+  });
+
+  const status = async () => ({
+    supported: true,
+    configured: await probe(),
+    platform: platform(),
+    port,
+  });
+
+  const createSession = async () => {
+    if (!await probe()) {
+      throw codedError(
+        `No VNC server is reachable on loopback port ${port}. Run npm run setup:remote-desktop on the PortOS machine.`,
+        'VNC_NOT_CONFIGURED',
+      );
+    }
+    deleteExpiredSessions();
+    const token = randomBytes(TOKEN_BYTES).toString('base64url');
+    const expiresAt = now() + SESSION_TTL_MS;
+    sessions.set(token, { connected: false, expiresAt });
+    return {
+      viewerPath: `/remote-desktop?token=${encodeURIComponent(token)}`,
+      expiresAt: new Date(expiresAt).toISOString(),
+    };
+  };
+
+  const readSession = (token) => {
+    if (typeof token !== 'string' || token.length < 32) return null;
+    const session = sessions.get(token);
+    if (!session) return null;
+    if (session.expiresAt <= now() && !session.connected) {
+      sessions.delete(token);
+      return null;
+    }
+    return session;
+  };
+
+  const hasSession = (token) => readSession(token) !== null;
+
+  const claimSession = (token) => {
+    const session = readSession(token);
+    if (!session || session.connected) return null;
+    session.connected = true;
+    session.expiresAt = now() + connectedSessionTtlMs;
+    return session;
+  };
+
+  const releaseSession = (token) => {
+    sessions.delete(token);
+  };
+
+  const mountWebSocket = (httpServer) => {
+    if (!httpServer || mountedServers.has(httpServer)) return;
+    mountedServers.add(httpServer);
+    const wss = new WebSocketServer({ noServer: true });
+
+    httpServer.on('upgrade', (request, socket, head) => {
+      if (request.url?.split('?', 1)[0] !== '/remote-desktop/ws') return;
+      let url;
+      try {
+        url = new URL(request.url, 'http://portos.invalid');
+      } catch {
+        socket.write('HTTP/1.1 400 Bad Request\r\nConnection: close\r\n\r\n');
+        socket.destroy();
+        return;
+      }
+      const token = url.searchParams.get('token');
+      if (!claimSession(token)) {
+        socket.write('HTTP/1.1 401 Unauthorized\r\nConnection: close\r\n\r\n');
+        socket.destroy();
+        return;
+      }
+      wss.handleUpgrade(request, socket, head, (webSocket) => {
+        wss.emit('connection', webSocket, request, token);
+      });
+    });
+
+    wss.on('connection', (webSocket, _request, token) => {
+      const vncSocket = connect({ host, port });
+      const webSocketStream = createWebSocketStream(webSocket, { encoding: null });
+      let cleanedUp = false;
+      const expiryTimer = setTimeout(() => {
+        webSocket.close(1000, 'Remote desktop session expired');
+      }, connectedSessionTtlMs);
+      expiryTimer.unref?.();
+      const cleanup = () => {
+        if (cleanedUp) return;
+        cleanedUp = true;
+        clearTimeout(expiryTimer);
+        releaseSession(token);
+        vncSocket.destroy();
+        webSocketStream.destroy();
+      };
+      vncSocket.once('connect', () => {
+        vncSocket.pipe(webSocketStream).pipe(vncSocket);
+      });
+      vncSocket.once('error', () => webSocket.close(1011, 'VNC server unavailable'));
+      webSocket.once('close', cleanup);
+      webSocketStream.once('error', cleanup);
+    });
+  };
+
+  return { createSession, hasSession, mountWebSocket, status };
+};
+
+export const remoteDesktopBroker = createRemoteDesktopBroker();

--- a/server/services/remoteDesktop.test.js
+++ b/server/services/remoteDesktop.test.js
@@ -1,0 +1,101 @@
+import { createServer } from 'node:net';
+import { createServer as createHttpServer } from 'node:http';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { WebSocket } from 'ws';
+import { createRemoteDesktopBroker } from './remoteDesktop.js';
+
+const servers = [];
+
+const listen = async () => {
+  const server = createServer();
+  servers.push(server);
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  return server.address().port;
+};
+
+afterEach(async () => {
+  await Promise.all(servers.splice(0).map((server) => new Promise((resolve) => server.close(resolve))));
+});
+
+describe('remote desktop broker', () => {
+  it('reports whether a loopback VNC server is configured', async () => {
+    const port = await listen();
+    const broker = createRemoteDesktopBroker({ port });
+
+    await expect(broker.status()).resolves.toMatchObject({ configured: true, port });
+  });
+
+  it('issues short-lived viewer paths only after a successful VNC probe', async () => {
+    const port = await listen();
+    const broker = createRemoteDesktopBroker({ port, now: () => 1_000 });
+
+    const session = await broker.createSession();
+
+    expect(session.viewerPath).toMatch(/^\/remote-desktop\?token=[A-Za-z0-9_-]+$/);
+    expect(session.expiresAt).toBe(new Date(1_000 + 5 * 60 * 1000).toISOString());
+    const token = new URL(session.viewerPath, 'http://portos.invalid').searchParams.get('token');
+    expect(broker.hasSession(token)).toBe(true);
+    expect(broker.hasSession('not-a-session-token')).toBe(false);
+  });
+
+  it('refuses sessions when no loopback VNC server is listening', async () => {
+    const temporaryServer = createServer();
+    await new Promise((resolve) => temporaryServer.listen(0, '127.0.0.1', resolve));
+    const port = temporaryServer.address().port;
+    await new Promise((resolve) => temporaryServer.close(resolve));
+
+    const broker = createRemoteDesktopBroker({ port });
+    await expect(broker.createSession()).rejects.toMatchObject({ code: 'VNC_NOT_CONFIGURED' });
+  });
+
+  it('bridges binary WebSocket frames to the loopback VNC socket', async () => {
+    const vncServer = createServer((socket) => socket.pipe(socket));
+    servers.push(vncServer);
+    await new Promise((resolve) => vncServer.listen(0, '127.0.0.1', resolve));
+    const broker = createRemoteDesktopBroker({ port: vncServer.address().port });
+    const session = await broker.createSession();
+    const token = new URL(session.viewerPath, 'http://portos.invalid').searchParams.get('token');
+    const httpServer = createHttpServer();
+    broker.mountWebSocket(httpServer);
+    await new Promise((resolve) => httpServer.listen(0, '127.0.0.1', resolve));
+    const client = new WebSocket(`ws://127.0.0.1:${httpServer.address().port}/remote-desktop/ws?token=${token}`);
+    await new Promise((resolve, reject) => {
+      client.once('open', resolve);
+      client.once('error', reject);
+    });
+
+    const echoed = new Promise((resolve) => client.once('message', resolve));
+    client.send(Buffer.from('RFB 003.008\n'));
+
+    expect(Buffer.from(await echoed).toString()).toBe('RFB 003.008\n');
+    client.close();
+    await new Promise((resolve) => client.once('close', resolve));
+    await vi.waitFor(() => expect(broker.hasSession(token)).toBe(false));
+    await new Promise((resolve) => httpServer.close(resolve));
+  });
+
+  it('closes an active connection when its maximum session lifetime elapses', async () => {
+    const vncServer = createServer((socket) => socket.pipe(socket));
+    servers.push(vncServer);
+    await new Promise((resolve) => vncServer.listen(0, '127.0.0.1', resolve));
+    const broker = createRemoteDesktopBroker({
+      port: vncServer.address().port,
+      connectedSessionTtlMs: 25,
+    });
+    const session = await broker.createSession();
+    const token = new URL(session.viewerPath, 'http://portos.invalid').searchParams.get('token');
+    const httpServer = createHttpServer();
+    broker.mountWebSocket(httpServer);
+    await new Promise((resolve) => httpServer.listen(0, '127.0.0.1', resolve));
+    const client = new WebSocket(`ws://127.0.0.1:${httpServer.address().port}/remote-desktop/ws?token=${token}`);
+
+    const close = new Promise((resolve, reject) => {
+      client.once('close', resolve);
+      client.once('error', reject);
+    });
+    await close;
+
+    await vi.waitFor(() => expect(broker.hasSession(token)).toBe(false));
+    await new Promise((resolve) => httpServer.close(resolve));
+  });
+});

--- a/server/services/remoteDesktop.test.js
+++ b/server/services/remoteDesktop.test.js
@@ -70,7 +70,15 @@ describe('remote desktop broker', () => {
     expect(Buffer.from(await echoed).toString()).toBe('RFB 003.008\n');
     client.close();
     await new Promise((resolve) => client.once('close', resolve));
-    await vi.waitFor(() => expect(broker.hasSession(token)).toBe(false));
+    await vi.waitFor(() => expect(broker.hasSession(token)).toBe(true));
+
+    const reconnected = new WebSocket(`ws://127.0.0.1:${httpServer.address().port}/remote-desktop/ws?token=${token}`);
+    await new Promise((resolve, reject) => {
+      reconnected.once('open', resolve);
+      reconnected.once('error', reject);
+    });
+    reconnected.close();
+    await new Promise((resolve) => reconnected.once('close', resolve));
     await new Promise((resolve) => httpServer.close(resolve));
   });
 

--- a/server/views/remote-desktop.html
+++ b/server/views/remote-desktop.html
@@ -1,0 +1,153 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1,maximum-scale=1,viewport-fit=cover">
+  <meta name="referrer" content="no-referrer">
+  <title>PortOS Remote Desktop</title>
+  <style>
+    :root { color-scheme: dark; font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", sans-serif; }
+    * { box-sizing: border-box; }
+    html, body { width: 100%; height: 100%; margin: 0; overflow: hidden; background: #080b12; }
+    #screen { position: fixed; inset: 0 0 calc(52px + env(safe-area-inset-bottom)); background: #080b12; }
+    #toolbar { position: fixed; z-index: 5; left: 0; right: 0; bottom: 0; min-height: calc(52px + env(safe-area-inset-bottom)); padding: 7px 8px calc(7px + env(safe-area-inset-bottom)); display: flex; align-items: center; gap: 7px; overflow-x: auto; background: rgba(16, 21, 32, .96); border-top: 1px solid #293148; }
+    button, input { font: inherit; }
+    button { min-width: 42px; height: 36px; padding: 0 11px; border: 1px solid #3a4665; border-radius: 9px; color: #f5f7ff; background: #222b40; font-weight: 600; }
+    button:active, button.active { background: #536dfe; border-color: #7890ff; }
+    #status { margin-right: auto; white-space: nowrap; color: #aeb9d4; font-size: 13px; }
+    #gate { position: fixed; z-index: 10; inset: 0; display: grid; place-items: center; padding: 24px; background: radial-gradient(circle at top, #1d2947, #080b12 65%); }
+    #gate[hidden] { display: none; }
+    .card { width: min(420px, 100%); padding: 24px; border: 1px solid #34405e; border-radius: 18px; background: rgba(20, 26, 40, .97); box-shadow: 0 24px 80px #0008; }
+    h1 { margin: 0 0 8px; font-size: 24px; }
+    p { margin: 0 0 18px; color: #b6bfd2; line-height: 1.45; }
+    label { display: block; margin-bottom: 7px; font-size: 13px; color: #cbd3e5; }
+    #password { width: 100%; height: 46px; padding: 0 13px; border: 1px solid #43506f; border-radius: 10px; color: white; background: #0e1421; }
+    #connect { width: 100%; height: 46px; margin-top: 12px; background: #536dfe; border-color: #7890ff; }
+    #error { min-height: 20px; margin: 10px 0 0; color: #ff9b9b; font-size: 13px; }
+    #keyboardSink { position: fixed; z-index: 4; left: 50%; bottom: 0; width: 2px; height: 2px; opacity: .01; resize: none; }
+  </style>
+</head>
+<body>
+  <div id="screen" aria-label="Remote desktop canvas"></div>
+  <div id="toolbar" hidden>
+    <span id="status">Connecting…</span>
+    <button id="keyboard" type="button" aria-label="Show keyboard">⌨︎</button>
+    <button data-modifier="MetaLeft" data-keysym="65511" type="button">⌘</button>
+    <button data-modifier="ControlLeft" data-keysym="65507" type="button">Ctrl</button>
+    <button data-modifier="AltLeft" data-keysym="65513" type="button">Opt</button>
+    <button data-key="Tab" data-keysym="65289" type="button">Tab</button>
+    <button data-key="Escape" data-keysym="65307" type="button">Esc</button>
+    <button id="cad" type="button">Ctrl Alt Del</button>
+    <button id="disconnect" type="button">Close</button>
+  </div>
+  <textarea id="keyboardSink" autocapitalize="none" autocomplete="off" autocorrect="off" spellcheck="false" aria-label="Remote keyboard input"></textarea>
+  <div id="gate">
+    <form class="card" id="credentials">
+      <h1>Remote Desktop</h1>
+      <p>Enter the VNC password configured on this PortOS machine. It is used only for this PortOS connection and is not stored by PortDeck.</p>
+      <label for="password">VNC password</label>
+      <input id="password" type="password" autocomplete="off" required>
+      <button id="connect" type="submit">Connect</button>
+      <div id="error" role="alert"></div>
+    </form>
+  </div>
+  <script type="module">
+    import RFB from '/remote-desktop/vendor/core/rfb.js';
+
+    const token = '__REMOTE_DESKTOP_TOKEN__';
+    const scheme = location.protocol === 'https:' ? 'wss' : 'ws';
+    const wsURL = `${scheme}://${location.host}/remote-desktop/ws?token=${encodeURIComponent(token)}`;
+    const screen = document.querySelector('#screen');
+    const gate = document.querySelector('#gate');
+    const form = document.querySelector('#credentials');
+    const password = document.querySelector('#password');
+    const error = document.querySelector('#error');
+    const toolbar = document.querySelector('#toolbar');
+    const status = document.querySelector('#status');
+    const sink = document.querySelector('#keyboardSink');
+    const heldModifiers = new Map();
+    let rfb;
+
+    const connect = () => {
+      error.textContent = '';
+      status.textContent = 'Connecting…';
+      toolbar.hidden = false;
+      rfb = new RFB(screen, wsURL, { credentials: { password: password.value } });
+      rfb.scaleViewport = true;
+      rfb.resizeSession = true;
+      rfb.showDotCursor = true;
+      rfb.qualityLevel = 7;
+      rfb.compressionLevel = 6;
+      rfb.addEventListener('connect', () => {
+        gate.hidden = true;
+        status.textContent = 'Connected';
+        password.value = '';
+      });
+      rfb.addEventListener('credentialsrequired', () => {
+        gate.hidden = false;
+        password.focus();
+      });
+      rfb.addEventListener('securityfailure', (event) => {
+        gate.hidden = false;
+        error.textContent = event.detail?.reason || 'The VNC server rejected the password.';
+        password.select();
+      });
+      rfb.addEventListener('disconnect', (event) => {
+        releaseModifiers();
+        rfb = undefined;
+        status.textContent = 'Disconnected';
+        gate.hidden = false;
+        error.textContent = event.detail?.clean ? 'Session ended.' : 'The remote desktop connection was lost. Return to PortDeck and start a new session.';
+      });
+    };
+
+    const releaseModifiers = () => {
+      for (const [code, keysym] of heldModifiers) rfb?.sendKey(keysym, code, false);
+      heldModifiers.clear();
+      document.querySelectorAll('[data-modifier]').forEach((button) => button.classList.remove('active'));
+    };
+
+    const unicodeKeysym = (character) => {
+      const codePoint = character.codePointAt(0);
+      return codePoint <= 0xff ? codePoint : (0x01000000 | codePoint);
+    };
+
+    const sendText = (text) => {
+      for (const character of text) rfb?.sendKey(unicodeKeysym(character));
+      releaseModifiers();
+    };
+
+    form.addEventListener('submit', (event) => {
+      event.preventDefault();
+      if (rfb) rfb.sendCredentials({ password: password.value });
+      else connect();
+    });
+    document.querySelector('#keyboard').addEventListener('click', () => sink.focus());
+    document.querySelector('#disconnect').addEventListener('click', () => rfb?.disconnect());
+    document.querySelector('#cad').addEventListener('click', () => rfb?.sendCtrlAltDel());
+    document.querySelectorAll('[data-modifier]').forEach((button) => button.addEventListener('click', () => {
+      const code = button.dataset.modifier;
+      const keysym = Number(button.dataset.keysym);
+      const down = !heldModifiers.has(code);
+      rfb?.sendKey(keysym, code, down);
+      if (down) heldModifiers.set(code, keysym); else heldModifiers.delete(code);
+      button.classList.toggle('active', down);
+    }));
+    document.querySelectorAll('[data-key]').forEach((button) => button.addEventListener('click', () => {
+      rfb?.sendKey(Number(button.dataset.keysym), button.dataset.key);
+      releaseModifiers();
+    }));
+    sink.addEventListener('input', () => {
+      if (sink.value) sendText(sink.value);
+      sink.value = '';
+    });
+    sink.addEventListener('keydown', (event) => {
+      const special = { Backspace: 65288, Enter: 65293, Tab: 65289, Escape: 65307, ArrowLeft: 65361, ArrowUp: 65362, ArrowRight: 65363, ArrowDown: 65364 };
+      if (!special[event.key]) return;
+      event.preventDefault();
+      rfb?.sendKey(special[event.key], event.code || event.key);
+      releaseModifiers();
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- add authenticated remote-desktop status/session endpoints and a loopback-only WebSocket-to-RFB bridge
- serve a mobile noVNC viewer with touch, keyboard, modifier, Ctrl-Alt-Delete, and disconnect controls
- add a host setup/verification helper, operator and companion API documentation, and an exact noVNC dependency pin
- support password-retry reconnects while enforcing one connection at a time and a fixed active-session deadline

Supports the PortOS side of #2678.

## Security

- requires existing PortOS instance authentication before issuing a viewer session
- connects only to the configured loopback VNC port; clients cannot select a host or general proxy target
- uses a random token that expires after five minutes unused, permits one active connection, and cannot be extended past the fixed eight-hour active deadline
- passes the separate VNC password through the RFB connection without storing it in PortDeck or PortOS

## Testing

- `cd server && npx vitest run services/remoteDesktop.test.js routes/remoteDesktop.test.js dependency-overrides.test.js` (11 passed)
- `cd server && npm audit --omit=dev` (0 vulnerabilities)
- `cd server && npm ls @novnc/novnc ws`
- `node --check scripts/setup-remote-desktop.js`
- `git diff --check`

## Environment note

The repository-wide root `npm test` was not treated as a clean local signal because this checkout is running npm 11.12.1 while the repository requires npm 12 or newer. The focused server suites covering this change pass.
