### PR TITLE
fix: retry transient API failures before streaming

### DIFF
--- a/server/lib/aiToolkit/internal/preHeaderRetry.js
+++ b/server/lib/aiToolkit/internal/preHeaderRetry.js
@@ -1,0 +1,80 @@
+const TRANSIENT_GATEWAY_STATUSES = new Set([502, 503, 504, 520, 521, 522, 523, 524]);
+const REPLAY_SAFE_TRANSPORT_CODES = new Set([
+  'ECONNREFUSED',
+  'ECONNRESET',
+  'EPIPE',
+  'ETIMEDOUT',
+  'UND_ERR_CONNECT_TIMEOUT',
+  'UND_ERR_SOCKET',
+]);
+
+export function isTransientGatewayStatus(status) {
+  return TRANSIENT_GATEWAY_STATUSES.has(Number(status));
+}
+
+export function isReplaySafeTransportError(error) {
+  const code = error?.code || error?.cause?.code;
+  return REPLAY_SAFE_TRANSPORT_CODES.has(code);
+}
+
+function abortError(signal) {
+  return signal?.reason instanceof Error
+    ? signal.reason
+    : new DOMException('The operation was aborted', 'AbortError');
+}
+
+function abortableDelay(ms, signal) {
+  if (signal?.aborted) return Promise.reject(abortError(signal));
+  return new Promise((resolve, reject) => {
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(abortError(signal));
+    };
+    const timer = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    signal?.addEventListener('abort', onAbort, { once: true });
+  });
+}
+
+/**
+ * Retry a streaming request only while it is still safe to replace the whole
+ * response: before the caller has accepted an OK response and begun reading
+ * its body. Final responses/errors are returned unchanged so existing provider
+ * classification and fallback behavior remain authoritative.
+ */
+export async function fetchWithPreHeaderRetry(fetchAttempt, {
+  signal,
+  maxAttempts = 3,
+  maxElapsedMs = 2000,
+  baseDelayMs = 100,
+  now = Date.now,
+  delay = abortableDelay,
+} = {}) {
+  const startedAt = now();
+
+  for (let attempt = 1; ; attempt += 1) {
+    try {
+      const response = await fetchAttempt();
+      const retryable = isTransientGatewayStatus(response?.status);
+      // An OK/non-retryable response is now the caller's stream to consume.
+      // Return it even if the signal raced with header delivery: the caller's
+      // reader owns partial-output handling from this boundary onward.
+      if (!retryable) return response;
+      if (signal?.aborted) throw abortError(signal);
+      const delayMs = baseDelayMs * (2 ** (attempt - 1));
+      const hasBudget = attempt < maxAttempts && now() - startedAt + delayMs <= maxElapsedMs;
+      if (!hasBudget) return response;
+
+      await Promise.resolve(response.body?.cancel?.()).catch(() => {});
+      await delay(delayMs, signal);
+    } catch (error) {
+      if (signal?.aborted) throw abortError(signal);
+      const delayMs = baseDelayMs * (2 ** (attempt - 1));
+      const hasBudget = attempt < maxAttempts && now() - startedAt + delayMs <= maxElapsedMs;
+      if (!isReplaySafeTransportError(error) || !hasBudget) throw error;
+      await delay(delayMs, signal);
+    }
+  }
+}

--- a/server/lib/aiToolkit/internal/preHeaderRetry.js
+++ b/server/lib/aiToolkit/internal/preHeaderRetry.js
@@ -13,8 +13,37 @@ export function isTransientGatewayStatus(status) {
 }
 
 export function isReplaySafeTransportError(error) {
-  const code = error?.code || error?.cause?.code;
-  return REPLAY_SAFE_TRANSPORT_CODES.has(code);
+  const seen = new Set();
+  let current = error;
+  for (let depth = 0; current && typeof current === 'object' && depth < 5; depth += 1) {
+    if (seen.has(current)) break;
+    seen.add(current);
+    if (REPLAY_SAFE_TRANSPORT_CODES.has(current.code)) return true;
+    current = current.cause;
+  }
+  return false;
+}
+
+function isLoopbackHost(hostname) {
+  const host = String(hostname || '').toLowerCase().replace(/^\[|\]$/g, '');
+  if (host === 'localhost' || host.endsWith('.localhost') || host === '::1' || host === '::' || host === '0.0.0.0') return true;
+  const octets = host.split('.');
+  return octets.length === 4
+    && Number(octets[0]) === 127
+    && octets.slice(1).every((octet) => /^\d+$/.test(octet) && Number(octet) <= 255);
+}
+
+/**
+ * Completion POSTs are not generally safe to replay: a proxy can return a
+ * transient error after the provider accepted the request, which would repeat
+ * a billable generation. PortOS's local, keyless inference daemons are the one
+ * bounded case where duplicate work cannot create an external charge. Keep
+ * this opt-in predicate beside the retry policy so every caller applies the
+ * same safety boundary.
+ */
+export function isReplaySafeLocalRequest({ endpoint, apiKey } = {}) {
+  if (apiKey || typeof endpoint !== 'string' || !URL.canParse(endpoint)) return false;
+  return isLoopbackHost(new URL(endpoint).hostname);
 }
 
 function abortError(signal) {
@@ -46,6 +75,7 @@ function abortableDelay(ms, signal) {
  */
 export async function fetchWithPreHeaderRetry(fetchAttempt, {
   signal,
+  allowReplay = false,
   maxAttempts = 3,
   maxElapsedMs = 2000,
   baseDelayMs = 100,
@@ -61,7 +91,7 @@ export async function fetchWithPreHeaderRetry(fetchAttempt, {
       // An OK/non-retryable response is now the caller's stream to consume.
       // Return it even if the signal raced with header delivery: the caller's
       // reader owns partial-output handling from this boundary onward.
-      if (!retryable) return response;
+      if (!allowReplay || !retryable) return response;
       if (signal?.aborted) throw abortError(signal);
       const delayMs = baseDelayMs * (2 ** (attempt - 1));
       const hasBudget = attempt < maxAttempts && now() - startedAt + delayMs <= maxElapsedMs;
@@ -73,7 +103,7 @@ export async function fetchWithPreHeaderRetry(fetchAttempt, {
       if (signal?.aborted) throw abortError(signal);
       const delayMs = baseDelayMs * (2 ** (attempt - 1));
       const hasBudget = attempt < maxAttempts && now() - startedAt + delayMs <= maxElapsedMs;
-      if (!isReplaySafeTransportError(error) || !hasBudget) throw error;
+      if (!allowReplay || !isReplaySafeTransportError(error) || !hasBudget) throw error;
       await delay(delayMs, signal);
     }
   }

--- a/server/lib/aiToolkit/internal/preHeaderRetry.test.js
+++ b/server/lib/aiToolkit/internal/preHeaderRetry.test.js
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  fetchWithPreHeaderRetry,
+  isReplaySafeTransportError,
+  isTransientGatewayStatus,
+} from './preHeaderRetry.js';
+
+const response = (status, cancel = vi.fn()) => ({ status, body: { cancel } });
+
+describe('pre-header retry policy', () => {
+  it('retries only the allowlisted gateway statuses and cancels failed bodies', async () => {
+    const failed = response(503);
+    const ok = response(200);
+    const fetchAttempt = vi.fn().mockResolvedValueOnce(failed).mockResolvedValueOnce(ok);
+
+    await expect(fetchWithPreHeaderRetry(fetchAttempt, { delay: vi.fn() })).resolves.toBe(ok);
+    expect(fetchAttempt).toHaveBeenCalledTimes(2);
+    expect(failed.body.cancel).toHaveBeenCalledOnce();
+    expect([400, 401, 429, 500].some(isTransientGatewayStatus)).toBe(false);
+    expect([502, 503, 504, 520, 521, 522, 523, 524].every(isTransientGatewayStatus)).toBe(true);
+  });
+
+  it('retries classified transport failures but not arbitrary errors', async () => {
+    const socketError = Object.assign(new TypeError('fetch failed'), { cause: { code: 'UND_ERR_SOCKET' } });
+    const ok = response(200);
+    const retrying = vi.fn().mockRejectedValueOnce(socketError).mockResolvedValueOnce(ok);
+
+    await expect(fetchWithPreHeaderRetry(retrying, { delay: vi.fn() })).resolves.toBe(ok);
+    expect(isReplaySafeTransportError(socketError)).toBe(true);
+
+    const unsafe = Object.assign(new Error('certificate rejected'), { code: 'CERT_HAS_EXPIRED' });
+    const noRetry = vi.fn().mockRejectedValue(unsafe);
+    await expect(fetchWithPreHeaderRetry(noRetry, { delay: vi.fn() })).rejects.toBe(unsafe);
+    expect(noRetry).toHaveBeenCalledOnce();
+  });
+
+  it('stops promptly when aborted during backoff', async () => {
+    const controller = new AbortController();
+    const fetchAttempt = vi.fn().mockResolvedValue(response(502));
+    const delay = vi.fn((_ms, signal) => new Promise((_resolve, reject) => {
+      signal.addEventListener('abort', () => reject(signal.reason), { once: true });
+    }));
+    const pending = fetchWithPreHeaderRetry(fetchAttempt, { signal: controller.signal, delay });
+
+    controller.abort(new Error('stopped'));
+    await expect(pending).rejects.toThrow('stopped');
+    expect(fetchAttempt).toHaveBeenCalledOnce();
+  });
+
+  it('returns the final retryable response intact when the attempt budget is exhausted', async () => {
+    const final = response(504);
+    const fetchAttempt = vi.fn().mockResolvedValue(final);
+
+    await expect(fetchWithPreHeaderRetry(fetchAttempt, { maxAttempts: 1 })).resolves.toBe(final);
+    expect(final.body.cancel).not.toHaveBeenCalled();
+  });
+});

--- a/server/lib/aiToolkit/internal/preHeaderRetry.test.js
+++ b/server/lib/aiToolkit/internal/preHeaderRetry.test.js
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   fetchWithPreHeaderRetry,
   isReplaySafeTransportError,
+  isReplaySafeLocalRequest,
   isTransientGatewayStatus,
 } from './preHeaderRetry.js';
 
@@ -13,7 +14,7 @@ describe('pre-header retry policy', () => {
     const ok = response(200);
     const fetchAttempt = vi.fn().mockResolvedValueOnce(failed).mockResolvedValueOnce(ok);
 
-    await expect(fetchWithPreHeaderRetry(fetchAttempt, { delay: vi.fn() })).resolves.toBe(ok);
+    await expect(fetchWithPreHeaderRetry(fetchAttempt, { allowReplay: true, delay: vi.fn() })).resolves.toBe(ok);
     expect(fetchAttempt).toHaveBeenCalledTimes(2);
     expect(failed.body.cancel).toHaveBeenCalledOnce();
     expect([400, 401, 429, 500].some(isTransientGatewayStatus)).toBe(false);
@@ -21,11 +22,13 @@ describe('pre-header retry policy', () => {
   });
 
   it('retries classified transport failures but not arbitrary errors', async () => {
-    const socketError = Object.assign(new TypeError('fetch failed'), { cause: { code: 'UND_ERR_SOCKET' } });
+    const socketError = Object.assign(new TypeError('fetch failed'), {
+      cause: { cause: { code: 'UND_ERR_SOCKET' } },
+    });
     const ok = response(200);
     const retrying = vi.fn().mockRejectedValueOnce(socketError).mockResolvedValueOnce(ok);
 
-    await expect(fetchWithPreHeaderRetry(retrying, { delay: vi.fn() })).resolves.toBe(ok);
+    await expect(fetchWithPreHeaderRetry(retrying, { allowReplay: true, delay: vi.fn() })).resolves.toBe(ok);
     expect(isReplaySafeTransportError(socketError)).toBe(true);
 
     const unsafe = Object.assign(new Error('certificate rejected'), { code: 'CERT_HAS_EXPIRED' });
@@ -34,13 +37,28 @@ describe('pre-header retry policy', () => {
     expect(noRetry).toHaveBeenCalledOnce();
   });
 
+  it('does not replay a completion unless the caller proves it is local and keyless', async () => {
+    const failed = response(503);
+    const fetchAttempt = vi.fn().mockResolvedValue(failed);
+
+    await expect(fetchWithPreHeaderRetry(fetchAttempt, { delay: vi.fn() })).resolves.toBe(failed);
+    expect(fetchAttempt).toHaveBeenCalledOnce();
+    expect(isReplaySafeLocalRequest({ endpoint: 'http://localhost:11434/v1' })).toBe(true);
+    expect(isReplaySafeLocalRequest({ endpoint: 'http://127.0.0.42:1234/v1' })).toBe(true);
+    expect(isReplaySafeLocalRequest({ endpoint: 'http://[::1]:1234/v1' })).toBe(true);
+    expect(isReplaySafeLocalRequest({ endpoint: 'http://0.0.0.0:1234/v1' })).toBe(true);
+    expect(isReplaySafeLocalRequest({ endpoint: 'http://[::]:1234/v1' })).toBe(true);
+    expect(isReplaySafeLocalRequest({ endpoint: 'https://api.example.com/v1' })).toBe(false);
+    expect(isReplaySafeLocalRequest({ endpoint: 'http://localhost:11434/v1', apiKey: 'secret' })).toBe(false);
+  });
+
   it('stops promptly when aborted during backoff', async () => {
     const controller = new AbortController();
     const fetchAttempt = vi.fn().mockResolvedValue(response(502));
     const delay = vi.fn((_ms, signal) => new Promise((_resolve, reject) => {
       signal.addEventListener('abort', () => reject(signal.reason), { once: true });
     }));
-    const pending = fetchWithPreHeaderRetry(fetchAttempt, { signal: controller.signal, delay });
+    const pending = fetchWithPreHeaderRetry(fetchAttempt, { allowReplay: true, signal: controller.signal, delay });
 
     controller.abort(new Error('stopped'));
     await expect(pending).rejects.toThrow('stopped');

--- a/server/lib/aiToolkit/runner.js
+++ b/server/lib/aiToolkit/runner.js
@@ -7,6 +7,7 @@ import { spawn, ChildProcess } from 'child_process';
 import { randomUUID } from 'crypto';
 import { analyzeError, analyzeHttpError, ERROR_CATEGORIES } from './errorDetection.js';
 import { apiGenerationOptions } from './internal/generationOptions.js';
+import { fetchWithPreHeaderRetry } from './internal/preHeaderRetry.js';
 
 // npm-installed CLI providers (claude, codex, opencode, …) are .cmd/.bat
 // shims on Windows; Node's spawn() can't execute those without going through
@@ -649,7 +650,7 @@ export function createRunnerService(config = {}) {
       const response = !endpointGuard.allowed
         ? { ok: false, error: `Endpoint blocked: ${endpointGuard.reason}`, status: 0 }
         : ready.success
-        ? await fetch(`${provider.endpoint}/chat/completions`, {
+        ? await fetchWithPreHeaderRetry(() => fetch(`${provider.endpoint}/chat/completions`, {
             method: 'POST',
             headers,
             signal: controller.signal,
@@ -664,7 +665,7 @@ export function createRunnerService(config = {}) {
               // OpenAI-style endpoints). Only sent when the provider opts in.
               ...(Number(provider.numCtx) > 0 ? { num_ctx: Number(provider.numCtx) } : {})
             })
-          }).catch(err => ({ ok: false, error: err.message, status: 0 }))
+          }), { signal: controller.signal }).catch(err => ({ ok: false, error: err.message, status: 0 }))
         : { ok: false, error: `Ollama is not running and PortOS could not start it: ${ready.error || 'unknown error'}`, status: 0 };
 
       if (!response.ok) {

--- a/server/lib/aiToolkit/runner.js
+++ b/server/lib/aiToolkit/runner.js
@@ -7,7 +7,7 @@ import { spawn, ChildProcess } from 'child_process';
 import { randomUUID } from 'crypto';
 import { analyzeError, analyzeHttpError, ERROR_CATEGORIES } from './errorDetection.js';
 import { apiGenerationOptions } from './internal/generationOptions.js';
-import { fetchWithPreHeaderRetry } from './internal/preHeaderRetry.js';
+import { fetchWithPreHeaderRetry, isReplaySafeLocalRequest } from './internal/preHeaderRetry.js';
 
 // npm-installed CLI providers (claude, codex, opencode, …) are .cmd/.bat
 // shims on Windows; Node's spawn() can't execute those without going through
@@ -665,7 +665,10 @@ export function createRunnerService(config = {}) {
               // OpenAI-style endpoints). Only sent when the provider opts in.
               ...(Number(provider.numCtx) > 0 ? { num_ctx: Number(provider.numCtx) } : {})
             })
-          }), { signal: controller.signal }).catch(err => ({ ok: false, error: err.message, status: 0 }))
+          }), {
+            signal: controller.signal,
+            allowReplay: isReplaySafeLocalRequest(provider),
+          }).catch(err => ({ ok: false, error: err.message, status: 0 }))
         : { ok: false, error: `Ollama is not running and PortOS could not start it: ${ready.error || 'unknown error'}`, status: 0 };
 
       if (!response.ok) {

--- a/server/lib/aiToolkit/runner.test.js
+++ b/server/lib/aiToolkit/runner.test.js
@@ -307,6 +307,41 @@ describe('AI Toolkit runner service', () => {
     expect('num_ctx' in JSON.parse(fetch.mock.calls[0][1].body)).toBe(false);
   });
 
+  it('retries a transient gateway response before the API stream starts', async () => {
+    const dataDir = await mkdtemp(join(tmpdir(), 'ai-toolkit-runner-'));
+    tempDirs.push(dataDir);
+    const cancel = vi.fn(async () => {});
+    const encoder = new TextEncoder();
+    const chunks = [encoder.encode('data: {"choices":[{"delta":{"content":"hi"}}]}\n')];
+    let index = 0;
+    const fetch = vi.fn()
+      .mockResolvedValueOnce({ ok: false, status: 503, body: { cancel } })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        body: { getReader: () => ({ read: async () => index < chunks.length
+          ? { done: false, value: chunks[index++] }
+          : { done: true } }) },
+      });
+    vi.stubGlobal('fetch', fetch);
+
+    const runner = createRunnerService({
+      dataDir,
+      hooks: { ensureProviderReady: async () => ({ success: true }) },
+    });
+    let done;
+    const completed = new Promise((resolve) => { done = resolve; });
+    await runner.executeApiRun({
+      runId: 'run-pre-header-retry', provider: runReady(), model: null,
+      prompt: 'hi', workspacePath: process.cwd(), screenshots: [],
+      onData: undefined, onComplete: (metadata) => done(metadata),
+    });
+
+    await expect(completed).resolves.toMatchObject({ success: true });
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(cancel).toHaveBeenCalledOnce();
+  });
+
   it('anchors relative screenshot refs under screenshotsDir so `../` traversal cannot escape it', async () => {
     const dataDir = await mkdtemp(join(tmpdir(), 'ai-toolkit-runner-'));
     const screenshotsDir = await mkdtemp(join(tmpdir(), 'ai-toolkit-shots-'));

--- a/server/lib/openAiChatStream.js
+++ b/server/lib/openAiChatStream.js
@@ -20,7 +20,7 @@
  */
 
 import { readResponseJson } from './readResponseJson.js';
-import { fetchWithPreHeaderRetry } from './aiToolkit/internal/preHeaderRetry.js';
+import { fetchWithPreHeaderRetry, isReplaySafeLocalRequest } from './aiToolkit/internal/preHeaderRetry.js';
 
 /**
  * Parse one OpenAI-style SSE `data:` line into its content/reasoning delta and,
@@ -256,7 +256,10 @@ export async function streamOpenAiChat({
       ...(withUsage ? { stream_options: { include_usage: true } } : {}),
       ...extraBody,
     }),
-  }), { signal }).catch((err) => ({ ok: false, status: 0, error: err.message }));
+  }), {
+    signal,
+    allowReplay: isReplaySafeLocalRequest({ endpoint, apiKey }),
+  }).catch((err) => ({ ok: false, status: 0, error: err.message }));
 
   let response = await post(includeUsage);
   // `stream_options` is standard OpenAI, but a stricter daemon (or an older

--- a/server/lib/openAiChatStream.js
+++ b/server/lib/openAiChatStream.js
@@ -20,6 +20,7 @@
  */
 
 import { readResponseJson } from './readResponseJson.js';
+import { fetchWithPreHeaderRetry } from './aiToolkit/internal/preHeaderRetry.js';
 
 /**
  * Parse one OpenAI-style SSE `data:` line into its content/reasoning delta and,
@@ -242,7 +243,7 @@ export async function streamOpenAiChat({
   // told us it does not understand the key.
   const includeUsage = typeof onStats === 'function' && !usageUnsupportedEndpoints.has(url);
 
-  const post = (withUsage) => fetch(url, {
+  const post = (withUsage) => fetchWithPreHeaderRetry(() => fetch(url, {
     method: 'POST',
     headers,
     signal,
@@ -255,7 +256,7 @@ export async function streamOpenAiChat({
       ...(withUsage ? { stream_options: { include_usage: true } } : {}),
       ...extraBody,
     }),
-  }).catch((err) => ({ ok: false, status: 0, error: err.message }));
+  }), { signal }).catch((err) => ({ ok: false, status: 0, error: err.message }));
 
   let response = await post(includeUsage);
   // `stream_options` is standard OpenAI, but a stricter daemon (or an older

--- a/server/lib/openAiChatStream.test.js
+++ b/server/lib/openAiChatStream.test.js
@@ -129,7 +129,7 @@ describe('streamOpenAiChat — pre-header retries', () => {
       });
 
     await expect(streamOpenAiChat({
-      endpoint: 'http://example.com/v1', model: 'example-model', messages: [],
+      endpoint: 'http://127.0.0.1:11434/v1', model: 'example-model', messages: [],
     })).resolves.toBe('ok');
     expect(global.fetch).toHaveBeenCalledTimes(2);
     expect(cancel).toHaveBeenCalledOnce();
@@ -152,7 +152,7 @@ describe('streamOpenAiChat — pre-header retries', () => {
     });
 
     const error = await streamOpenAiChat({
-      endpoint: 'http://example.com/v1', model: 'example-model', messages: [],
+      endpoint: 'http://127.0.0.1:11434/v1', model: 'example-model', messages: [],
     }).catch((err) => err);
     expect(error).toMatchObject({ message: 'socket reset', partialOutput: 'partial' });
     expect(global.fetch).toHaveBeenCalledOnce();

--- a/server/lib/openAiChatStream.test.js
+++ b/server/lib/openAiChatStream.test.js
@@ -17,6 +17,7 @@ import {
   parseOllamaStreamFrame,
   parseStreamFrame,
   resolvePartialOutput,
+  streamOpenAiChat,
   streamOllamaChat,
   toOllamaMessages,
 } from './openAiChatStream.js';
@@ -104,6 +105,59 @@ describe('resolvePartialOutput', () => {
   it('returns empty string when neither content nor reasoning streamed', () => {
     expect(resolvePartialOutput({ output: '', reasoning: '' })).toBe('');
     expect(resolvePartialOutput({})).toBe('');
+  });
+});
+
+describe('streamOpenAiChat — pre-header retries', () => {
+  it('retries an allowlisted gateway response before reading the stream', async () => {
+    const cancel = vi.fn(async () => {});
+    const chunk = new TextEncoder().encode('data: {"choices":[{"delta":{"content":"ok"}}]}\n');
+    let read = false;
+    global.fetch = vi.fn()
+      .mockResolvedValueOnce({ ok: false, status: 503, body: { cancel } })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        body: {
+          getReader: () => ({
+            read: vi.fn(async () => read
+              ? { done: true }
+              : (read = true, { done: false, value: chunk })),
+            cancel: vi.fn(async () => {}),
+          }),
+        },
+      });
+
+    await expect(streamOpenAiChat({
+      endpoint: 'http://example.com/v1', model: 'example-model', messages: [],
+    })).resolves.toBe('ok');
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+    expect(cancel).toHaveBeenCalledOnce();
+    delete global.fetch;
+  });
+
+  it('never replays a response after streamed output has begun', async () => {
+    const chunk = new TextEncoder().encode('data: {"choices":[{"delta":{"content":"partial"}}]}\n');
+    let reads = 0;
+    const reader = {
+      read: vi.fn(async () => {
+        reads += 1;
+        if (reads === 1) return { done: false, value: chunk };
+        throw Object.assign(new Error('socket reset'), { code: 'ECONNRESET' });
+      }),
+      cancel: vi.fn(async () => {}),
+    };
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true, status: 200, body: { getReader: () => reader },
+    });
+
+    const error = await streamOpenAiChat({
+      endpoint: 'http://example.com/v1', model: 'example-model', messages: [],
+    }).catch((err) => err);
+    expect(error).toMatchObject({ message: 'socket reset', partialOutput: 'partial' });
+    expect(global.fetch).toHaveBeenCalledOnce();
+    expect(reader.cancel).toHaveBeenCalledOnce();
+    delete global.fetch;
   });
 });
 


### PR DESCRIPTION
## Summary
- Retry replay-safe gateway and transport failures before a streaming response begins.
- Keep retries bounded, abort-aware, and shared by the toolkit runner and OpenAI chat stream.

Closes #5098

## Test plan
- `nvm exec 24.14.1 npm test` — server: 1,673 files passed; 34,822 tests passed; 19 skipped.
- `nvm exec 24.14.1 npm run lint` — client: 2,303 files checked.