### PR TITLE
feat: configure persistent mind AI profile before start

### DIFF
--- a/client/src/components/cos/PersistentMindProfileControls.jsx
+++ b/client/src/components/cos/PersistentMindProfileControls.jsx
@@ -40,6 +40,11 @@ export default function PersistentMindProfileControls({
   const publishedProfileRef = useRef(draft);
   const pendingSavesRef = useRef(0);
 
+  // The provider hook memoizes its setters in production, but simple host-page
+  // test mocks may return fresh functions every render. This effect describes
+  // persisted profile changes only; depending on setter identity would turn
+  // its setDraft call into an unconditional render loop in those hosts.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
     const next = normalizeProfile(profile);
     draftRef.current = next;
@@ -54,8 +59,6 @@ export default function PersistentMindProfileControls({
     profile?.model,
     profile?.effort,
     profile?.thinkingInterface,
-    setSelectedProviderId,
-    setSelectedModel,
   ]);
 
   const save = async (patch) => {

--- a/client/src/components/cos/PersistentMindProfileControls.jsx
+++ b/client/src/components/cos/PersistentMindProfileControls.jsx
@@ -46,6 +46,11 @@ export default function PersistentMindProfileControls({
   // its setDraft call into an unconditional render loop in those hosts.
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
+    // A socket/manual history refresh can return the pre-PUT profile while an
+    // optimistic save is still in flight. Keep the draft authoritative until
+    // the request settles; onSaved publishes the successful snapshot, while
+    // the catch path restores the last known saved value.
+    if (pendingSavesRef.current > 0) return;
     const next = normalizeProfile(profile);
     draftRef.current = next;
     publishedProfileRef.current = next;

--- a/client/src/components/cos/PersistentMindProfileControls.jsx
+++ b/client/src/components/cos/PersistentMindProfileControls.jsx
@@ -1,0 +1,155 @@
+import { useEffect, useId, useRef, useState } from 'react';
+import useProviderModels from '../../hooks/useProviderModels';
+import * as api from '../../services/api';
+import ProviderModelSelector from '../ProviderModelSelector';
+import toast from '../ui/Toast';
+
+const DEFAULT_PROFILE = {
+  schemaVersion: 1,
+  enabled: false,
+  providerId: '',
+  model: '',
+  effort: '',
+  thinkingInterface: 'text',
+};
+
+const normalizeProfile = (profile) => ({
+  ...DEFAULT_PROFILE,
+  ...(profile || {}),
+  providerId: profile?.providerId || '',
+  model: profile?.model || '',
+  effort: profile?.effort || '',
+});
+
+export default function PersistentMindProfileControls({
+  profile,
+  disabled = false,
+  onSaved,
+  onSavingChange,
+}) {
+  const enabledId = useId();
+  const {
+    providers,
+    availableModels,
+    setSelectedProviderId,
+    setSelectedModel,
+  } = useProviderModels({ allowDefault: true, withEffort: true, silent: true });
+  const [draft, setDraft] = useState(() => normalizeProfile(profile));
+  const [saving, setSaving] = useState(false);
+  const draftRef = useRef(draft);
+  const publishedProfileRef = useRef(draft);
+  const pendingSavesRef = useRef(0);
+
+  useEffect(() => {
+    const next = normalizeProfile(profile);
+    draftRef.current = next;
+    publishedProfileRef.current = next;
+    setDraft(next);
+    setSelectedProviderId(next.providerId);
+    setSelectedModel(next.model);
+  }, [
+    profile?.schemaVersion,
+    profile?.enabled,
+    profile?.providerId,
+    profile?.model,
+    profile?.effort,
+    profile?.thinkingInterface,
+    setSelectedProviderId,
+    setSelectedModel,
+  ]);
+
+  const save = async (patch) => {
+    const current = draftRef.current;
+    const providerChanged = patch.providerId !== undefined && patch.providerId !== current.providerId;
+    const next = {
+      ...current,
+      ...patch,
+      ...(providerChanged && patch.model === undefined ? { model: '' } : {}),
+      ...(providerChanged && patch.effort === undefined ? { effort: '' } : {}),
+    };
+    const previous = current;
+    draftRef.current = next;
+    setDraft(next);
+    pendingSavesRef.current += 1;
+    if (pendingSavesRef.current === 1) {
+      setSaving(true);
+      onSavingChange?.(true);
+    }
+    try {
+      await api.updateCosConfig({ persistentMindProfile: next }, { silent: true });
+      toast.success('Persistent mind profile updated');
+      // A model change can synchronously clear an incompatible effort, creating
+      // two saves from one selection. Only publish the newest saved snapshot so
+      // the first response cannot reset the second optimistic update.
+      if (draftRef.current === next) {
+        publishedProfileRef.current = next;
+        onSaved?.(next);
+      }
+    } catch (error) {
+      if (draftRef.current === next) {
+        draftRef.current = previous;
+        setDraft(previous);
+        setSelectedProviderId(previous.providerId);
+        setSelectedModel(previous.model);
+        if (publishedProfileRef.current !== previous) {
+          publishedProfileRef.current = previous;
+          onSaved?.(previous);
+        }
+      }
+      toast.error(error.message);
+    } finally {
+      pendingSavesRef.current -= 1;
+      if (pendingSavesRef.current === 0) {
+        setSaving(false);
+        onSavingChange?.(false);
+      }
+    }
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <label htmlFor={enabledId} className="text-sm text-port-text">Enable persistent mind profile</label>
+          <p className="mt-0.5 text-xs text-port-text-muted">
+            Pins text reasoning to one AI provider and model. Saving this profile never starts a turn or downloads a model.
+          </p>
+        </div>
+        <input
+          id={enabledId}
+          type="checkbox"
+          checked={draft.enabled}
+          disabled={disabled || saving}
+          onChange={(event) => save({ enabled: event.target.checked })}
+          className="mt-1 h-4 w-4 accent-port-accent disabled:opacity-50"
+        />
+      </div>
+      <ProviderModelSelector
+        providers={providers}
+        selectedProviderId={draft.providerId}
+        selectedModel={draft.model}
+        availableModels={availableModels}
+        effort={draft.effort}
+        disabled={disabled || saving || !draft.enabled}
+        emptyProviderOption="Select an AI provider"
+        emptyModelOption="Select a model"
+        alwaysShowModel
+        layout="stacked"
+        label="AI provider"
+        onProviderChange={(providerId) => {
+          setSelectedProviderId(providerId);
+          setSelectedModel('');
+          save({ providerId });
+        }}
+        onModelChange={(model) => {
+          setSelectedModel(model);
+          save({ model });
+        }}
+        onEffortChange={(effort) => save({ effort })}
+      />
+      <p className="text-xs text-port-text-muted">
+        Thinking effort appears when the selected provider and model support it. File-changing work remains an explicit typed CoS task; an unavailable or invalid pin pauses the mind instead of falling back.
+      </p>
+    </div>
+  );
+}

--- a/client/src/components/cos/tabs/ConfigTab.jsx
+++ b/client/src/components/cos/tabs/ConfigTab.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { Settings, Activity, CheckCircle, FileText, X } from 'lucide-react';
 import toast from '../../ui/Toast';
 import * as api from '../../../services/api';
+import PersistentMindProfileControls from '../PersistentMindProfileControls';
 import ConfigRow from './ConfigRow';
 import { AUTONOMY_LEVELS, detectAutonomyLevel, AVATAR_STYLE_LABELS, AUTONOMY_DOMAINS, DOMAIN_AUTONOMY_MODES, getDomainMode, DOMAIN_BUDGET_FIELDS, getDomainBudget, normalizeBudgetLimit } from '../constants';
 import ProviderModelSelector from '../../ProviderModelSelector';
@@ -263,34 +264,10 @@ const getDefaultFormData = (config, avatarStyle) => ({
   avatarStyle: config?.avatarStyle || avatarStyle || 'svg'
 });
 
-const DEFAULT_PERSISTENT_MIND_PROFILE = {
-  schemaVersion: 1,
-  enabled: false,
-  providerId: '',
-  model: '',
-  effort: '',
-  thinkingInterface: 'text',
-};
-
-const mindProfileFromConfig = (config) => ({
-  ...DEFAULT_PERSISTENT_MIND_PROFILE,
-  ...(config?.persistentMindProfile || {}),
-});
-
 export default function ConfigTab({ config, onUpdate, onEvaluate, avatarStyle }) {
   const { providers, availableModels, setSelectedProviderId: setProviderHook, setSelectedModel: setModelHook, selectedProviderId: hookProviderId, selectedModel: hookModel } = useProviderModels();
-  const {
-    providers: mindProviders,
-    availableModels: mindModels,
-    setSelectedProviderId: setMindProviderHook,
-    setSelectedModel: setMindModelHook,
-    selectedProviderId: mindHookProviderId,
-    selectedModel: mindHookModel,
-  } = useProviderModels({ allowDefault: true, withEffort: true, silent: true });
   const [embeddingProviderId, setEmbeddingProviderId] = useState(config?.embeddingProviderId || 'lmstudio');
   const [embeddingModel, setEmbeddingModel] = useState(config?.embeddingModel || '');
-  const [mindProfile, setMindProfile] = useState(() => mindProfileFromConfig(config));
-  const [mindProfileSaving, setMindProfileSaving] = useState(false);
 
   // Sync local state when config prop updates
   useEffect(() => {
@@ -303,19 +280,6 @@ export default function ConfigTab({ config, onUpdate, onEvaluate, avatarStyle })
       setModelHook(config.embeddingModel);
     }
   }, [config?.embeddingProviderId, config?.embeddingModel, setProviderHook, setModelHook]);
-
-  // Only re-run when the persisted profile itself changes — not when the
-  // provider-model hook's setters are re-created. `useProviderModels`
-  // memoizes them, but a fresh object each render (as in a naive test
-  // mock) would otherwise turn this into an unconditional-setState loop,
-  // since `next` is a new object on every call.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  useEffect(() => {
-    const next = mindProfileFromConfig(config);
-    setMindProfile(next);
-    setMindProviderHook(next.providerId);
-    setMindModelHook(next.model);
-  }, [config?.persistentMindProfile]);
 
   const [editing, setEditing] = useState(false);
   const [formData, setFormData] = useState(() => getDefaultFormData(config, avatarStyle));
@@ -394,31 +358,6 @@ export default function ConfigTab({ config, onUpdate, onEvaluate, avatarStyle })
     }
   };
 
-  const saveMindProfile = async (patch) => {
-    const providerChanged = patch.providerId !== undefined && patch.providerId !== mindProfile.providerId;
-    const next = {
-      ...mindProfile,
-      ...patch,
-      ...(providerChanged && patch.model === undefined ? { model: '' } : {}),
-      ...(providerChanged && patch.effort === undefined ? { effort: '' } : {}),
-    };
-    const previous = mindProfile;
-    setMindProfile(next);
-    setMindProfileSaving(true);
-    try {
-      await api.updateCosConfig({ persistentMindProfile: next }, { silent: true });
-      toast.success('Persistent mind profile updated');
-      onUpdate();
-    } catch (err) {
-      setMindProfile(previous);
-      setMindProviderHook(previous.providerId);
-      setMindModelHook(previous.model);
-      toast.error(err.message);
-    } finally {
-      setMindProfileSaving(false);
-    }
-  };
-
   const handleSave = async () => {
     // Keep the user in edit mode on failure — only close the editor and toast
     // success once the config PUT actually resolves.
@@ -484,49 +423,8 @@ export default function ConfigTab({ config, onUpdate, onEvaluate, avatarStyle })
 
       <div>
         <h4 className="text-sm font-medium text-gray-400 mb-2">Persistent Mind</h4>
-        <div className="bg-port-card border border-port-border rounded-lg p-4 space-y-3">
-          <div className="flex items-start justify-between gap-4">
-            <div>
-              <label htmlFor="persistent-mind-enabled" className="text-sm text-gray-300">Enable persistent mind profile</label>
-              <p className="text-xs text-gray-600 mt-0.5">
-                Pins text reasoning to one provider and model. Saving this profile never starts a turn or downloads a model.
-              </p>
-            </div>
-            <input
-              id="persistent-mind-enabled"
-              type="checkbox"
-              checked={mindProfile.enabled}
-              disabled={mindProfileSaving}
-              onChange={(event) => saveMindProfile({ enabled: event.target.checked })}
-              className="mt-1 h-4 w-4 accent-port-accent disabled:opacity-50"
-            />
-          </div>
-          <ProviderModelSelector
-            providers={mindProviders}
-            selectedProviderId={mindProfile.providerId || mindHookProviderId}
-            selectedModel={mindProfile.model || mindHookModel}
-            availableModels={mindModels}
-            effort={mindProfile.effort}
-            disabled={mindProfileSaving || !mindProfile.enabled}
-            emptyProviderOption="Select a provider"
-            emptyModelOption="Select a model"
-            alwaysShowModel
-            layout="stacked"
-            label="Persistent mind provider"
-            onProviderChange={(providerId) => {
-              setMindProviderHook(providerId);
-              setMindModelHook('');
-              saveMindProfile({ providerId });
-            }}
-            onModelChange={(model) => {
-              setMindModelHook(model);
-              saveMindProfile({ model });
-            }}
-            onEffortChange={(effort) => saveMindProfile({ effort })}
-          />
-          <p className="text-xs text-gray-600">
-            Interface: text reasoning only. File-changing work remains an explicit typed CoS task with its own coding harness; an unavailable or invalid pin pauses the mind instead of falling back.
-          </p>
+        <div className="bg-port-card border border-port-border rounded-lg p-4">
+          <PersistentMindProfileControls profile={config?.persistentMindProfile} onSaved={onUpdate} />
         </div>
       </div>
 

--- a/client/src/components/cos/tabs/MindTab.jsx
+++ b/client/src/components/cos/tabs/MindTab.jsx
@@ -7,6 +7,7 @@ import * as api from '../../../services/api';
 import { formatDateTime } from '../../../utils/formatters';
 import BrailleSpinner from '../../BrailleSpinner';
 import Banner from '../../ui/Banner';
+import PersistentMindProfileControls from '../PersistentMindProfileControls';
 
 const PAGE_LIMIT = 200;
 const MAX_BACKFILL_PAGES = 5;
@@ -66,6 +67,7 @@ export default function MindTab() {
   const [lifecyclePending, setLifecyclePending] = useState(null);
   const [eventActionPending, setEventActionPending] = useState(null);
   const [lifecycleError, setLifecycleError] = useState(null);
+  const [profileSaving, setProfileSaving] = useState(false);
   const cursorRef = useRef(null);
   const loadPendingRef = useRef(false);
   const deferredLoadRef = useRef(false);
@@ -233,6 +235,7 @@ export default function MindTab() {
   const state = mind?.state;
   const selectedEvent = events?.find((event) => event.eventId === selectedEventId) || null;
   const isPaused = state?.status === 'paused';
+  const profileReady = Boolean(mind?.profile?.enabled && mind.profile.providerId && mind.profile.model);
 
   return (
     <section aria-labelledby="mind-heading" className="space-y-4">
@@ -247,13 +250,45 @@ export default function MindTab() {
           </p>
         </div>
         <div className="flex flex-wrap gap-2" role="group" aria-label="Persistent mind lifecycle">
-          {!state?.started && <ActionButton label="Start" icon={CirclePlay} pending={lifecyclePending === 'start'} onClick={() => runLifecycle('start')} />}
           {state?.started && !isPaused && <ActionButton label="Pause" icon={CirclePause} pending={lifecyclePending === 'pause'} onClick={() => runLifecycle('pause')} />}
           {state?.started && isPaused && <ActionButton label="Resume" icon={CirclePlay} pending={lifecyclePending === 'resume'} onClick={() => runLifecycle('resume')} />}
           {state?.started && <ActionButton label="Stop" icon={Square} pending={lifecyclePending === 'stop'} onClick={() => runLifecycle('stop')} />}
           <ActionButton label="Reload" icon={RefreshCw} pending={loading} onClick={() => loadHistory({ reset: true })} />
         </div>
       </header>
+
+      <section aria-labelledby="mind-profile-heading" className="rounded border border-port-border bg-port-card p-4">
+        <div className="mb-3">
+          <h3 id="mind-profile-heading" className="text-sm font-semibold text-port-text">AI profile</h3>
+          <p className="mt-1 text-xs text-port-text-muted">
+            Choose the provider, model, and model effort here before starting the persistent mind. Changes apply to its next wake.
+          </p>
+        </div>
+        <PersistentMindProfileControls
+          profile={mind?.profile}
+          disabled={!mind}
+          onSaved={(profile) => setMind((current) => current ? { ...current, profile } : current)}
+          onSavingChange={setProfileSaving}
+        />
+        {!state?.started && (
+          <div className="mt-4 flex flex-col gap-2 border-t border-port-border pt-4 sm:flex-row sm:items-center sm:justify-between">
+            <p className="text-xs text-port-text-muted">
+              {profileSaving
+                ? 'Saving the AI profile…'
+                : profileReady
+                  ? 'The saved AI profile is ready.'
+                  : 'Enable the profile and select both an AI provider and model to start.'}
+            </p>
+            <ActionButton
+              label="Start persistent mind"
+              icon={CirclePlay}
+              pending={lifecyclePending === 'start'}
+              disabled={loading || profileSaving || !profileReady}
+              onClick={() => runLifecycle('start')}
+            />
+          </div>
+        )}
+      </section>
 
       {gap && <Banner tone="warning" title="History gap detected">The saved cursor is no longer retained. The visible trace was reloaded from the newest bounded snapshot.</Banner>}
       {truncated && <Banner tone="info" title="Showing recent history">The initial trace shows the newest {PAGE_LIMIT} events; older retained events are not shown.</Banner>}

--- a/client/src/components/cos/tabs/MindTab.test.jsx
+++ b/client/src/components/cos/tabs/MindTab.test.jsx
@@ -14,6 +14,8 @@ const api = vi.hoisted(() => ({
   stopPersistentMind: vi.fn(),
   acknowledgePersistentMindEvent: vi.fn(),
   promotePersistentMindEvent: vi.fn(),
+  getProviders: vi.fn(),
+  updateCosConfig: vi.fn(),
 }));
 
 const socket = vi.hoisted(() => {
@@ -74,6 +76,19 @@ describe('MindTab', () => {
     api.stopPersistentMind.mockResolvedValue({ success: true });
     api.acknowledgePersistentMindEvent.mockResolvedValue({ success: true });
     api.promotePersistentMindEvent.mockResolvedValue({ success: true });
+    api.getProviders.mockResolvedValue({
+      activeProvider: 'codex',
+      providers: [{
+        id: 'codex',
+        name: 'Codex',
+        enabled: true,
+        type: 'cli',
+        command: 'codex',
+        defaultModel: 'gpt-5',
+        models: ['gpt-5', 'gpt-5-mini'],
+      }],
+    });
+    api.updateCosConfig.mockResolvedValue({ success: true });
   });
 
   it('restores the selected event from the URL and uses a responsive single DOM tree', async () => {
@@ -92,6 +107,7 @@ describe('MindTab', () => {
 
     expect(await screen.findByText('Conversation unavailable')).toBeInTheDocument();
     expect(screen.queryByText(/No conversation yet/)).not.toBeInTheDocument();
+    expect(screen.getByRole('checkbox', { name: 'Enable persistent mind profile' })).toBeDisabled();
   });
 
   it('deduplicates a socket-triggered cursor backfill', async () => {
@@ -130,6 +146,36 @@ describe('MindTab', () => {
     api.getPersistentMind.mockResolvedValue(response({ truncated: true }));
     renderTab();
     expect(await screen.findByText('Showing recent history')).toBeInTheDocument();
+  });
+
+  it('puts the AI profile controls before start and starts only after the profile save finishes', async () => {
+    const user = userEvent.setup();
+    let finishSave;
+    api.getPersistentMind.mockResolvedValue(response({
+      state: { enabled: true, started: false, status: 'idle', pauseReason: null },
+      profile: { enabled: true, providerId: 'codex', model: 'gpt-5', effort: 'high', thinkingInterface: 'text' },
+    }));
+    api.updateCosConfig.mockImplementation(() => new Promise((resolve) => { finishSave = resolve; }));
+    renderTab();
+
+    expect(await screen.findByRole('heading', { name: 'AI profile' })).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByLabelText('AI provider')).toHaveValue('codex'));
+    expect(screen.getByLabelText('Model')).toHaveValue('gpt-5');
+    expect(screen.getByLabelText('Thinking effort')).toHaveValue('high');
+    const start = screen.getByRole('button', { name: 'Start persistent mind' });
+
+    await user.selectOptions(screen.getByLabelText('Model'), 'gpt-5-mini');
+    expect(start).toBeDisabled();
+    expect(api.startPersistentMind).not.toHaveBeenCalled();
+    expect(api.updateCosConfig).toHaveBeenCalledWith(
+      { persistentMindProfile: expect.objectContaining({ providerId: 'codex', model: 'gpt-5-mini', effort: 'high' }) },
+      { silent: true },
+    );
+
+    finishSave({ success: true });
+    await waitFor(() => expect(start).toBeEnabled());
+    await user.click(start);
+    await waitFor(() => expect(api.startPersistentMind).toHaveBeenCalledTimes(1));
   });
 
   it('keeps a failed message for a visible idempotent retry', async () => {

--- a/client/src/components/cos/tabs/MindTab.test.jsx
+++ b/client/src/components/cos/tabs/MindTab.test.jsx
@@ -172,6 +172,11 @@ describe('MindTab', () => {
       { silent: true },
     );
 
+    await user.click(screen.getByRole('button', { name: 'Reload' }));
+    await waitFor(() => expect(api.getPersistentMind).toHaveBeenCalledTimes(2));
+    expect(screen.getByLabelText('Model')).toHaveValue('gpt-5-mini');
+    expect(start).toBeDisabled();
+
     finishSave({ success: true });
     await waitFor(() => expect(start).toBeEnabled());
     await user.click(start);


### PR DESCRIPTION
## Summary

- expose the persistent mind AI provider, model, and supported effort controls directly on the Mind page
- place Start after the saved profile controls and keep it disabled while settings are incomplete or saving
- reuse one profile editor across the Mind and Configuration tabs, including safe rollback and unavailable-profile handling

## Test plan

- `cd client && npm test -- --run src/components/cos/tabs/MindTab.test.jsx src/components/cos/tabs/ConfigTab.test.jsx`
- `cd client && npx biome lint --error-on-warnings src/components/cos/PersistentMindProfileControls.jsx src/components/cos/tabs/MindTab.jsx src/components/cos/tabs/MindTab.test.jsx src/components/cos/tabs/ConfigTab.jsx src/components/cos/tabs/ConfigTab.test.jsx`
- `cd client && npm run build`
- Full client suite: 9,955 tests passed before one unrelated Vitest worker exhausted an 8 GB heap; the changed suites pass independently.