### PR TITLE
fix: verify Windows image execution markers

### DIFF
--- a/scripts/image_execution_marker.test.js
+++ b/scripts/image_execution_marker.test.js
@@ -1,23 +1,36 @@
-import { execFileSync } from 'child_process';
+import { spawnSync } from 'child_process';
 import { fileURLToPath } from 'url';
 import { dirname } from 'path';
 import { describe, expect, it } from 'vitest';
+import { parseImageExecutionMarker } from '../server/services/imageGen/local.js';
 
 const scriptsDir = dirname(fileURLToPath(import.meta.url));
 
 describe('local image execution marker', () => {
-  const buildMarker = (requestedDevice, effectiveDevice, placement) => {
+  const emitMarker = (requestedDevice, effectiveDevice, placement) => {
     const program = [
-      'import json, sys',
+      'import sys',
       `sys.path.insert(0, ${JSON.stringify(scriptsDir)})`,
-      'from _runner_common import build_image_execution_marker',
-      `print(json.dumps(build_image_execution_marker('diffusers-image', ${JSON.stringify(requestedDevice)}, ${JSON.stringify(effectiveDevice)}, ${JSON.stringify(placement)}, [])))`,
+      'from _runner_common import emit_image_execution_marker',
+      `emit_image_execution_marker('diffusers-image', ${JSON.stringify(requestedDevice)}, ${JSON.stringify(effectiveDevice)}, ${JSON.stringify(placement)}, [])`,
     ].join('; ');
-    return JSON.parse(execFileSync('python3', ['-c', program], { encoding: 'utf8' }));
+    const result = spawnSync('python3', ['-c', program], { encoding: 'utf8' });
+    expect(result.status).toBe(0);
+    const marker = result.stderr.trim().split('\n').find((line) => line.startsWith('IMAGE_EXECUTION:'));
+    expect(marker).toBeDefined();
+    return marker;
   };
 
-  it('records the Windows split CUDA placement as confirmed', () => {
-    expect(buildMarker('cuda', 'cuda', 'cuda+offload')).toMatchObject({
+  it('round-trips confirmed Windows CUDA placements through the server parser', () => {
+    expect(parseImageExecutionMarker(emitMarker('cuda', 'cuda', 'cuda'))).toMatchObject({
+      state: 'confirmed',
+      requestedDevice: 'cuda',
+      effectiveDevice: 'cuda',
+      placement: 'cuda',
+      cpuFallback: false,
+      runtime: { runtime: 'diffusers-image', versions: {} },
+    });
+    expect(parseImageExecutionMarker(emitMarker('cuda', 'cuda', 'cuda+offload'))).toMatchObject({
       state: 'confirmed',
       requestedDevice: 'cuda',
       effectiveDevice: 'cuda',
@@ -26,25 +39,18 @@ describe('local image execution marker', () => {
       runtime: { runtime: 'diffusers-image', versions: {} },
     });
   });
-  it('records a CPU fallback as degraded without host or prompt data', () => {
-    const program = [
-      'import json, sys',
-      `sys.path.insert(0, ${JSON.stringify(scriptsDir)})`,
-      'from _runner_common import build_image_execution_marker',
-      "print(json.dumps(build_image_execution_marker('flux2', 'cuda', 'cpu', 'cpu', [])))",
-    ].join('; ');
-    const marker = JSON.parse(execFileSync('python3', ['-c', program], { encoding: 'utf8' }));
+  it('round-trips a Windows CPU fallback as degraded without host or prompt data', () => {
+    const parsed = parseImageExecutionMarker(emitMarker('cuda', 'cpu', 'cpu'));
 
-    expect(marker).toMatchObject({
-      version: 1,
+    expect(parsed).toMatchObject({
       state: 'degraded',
       requestedDevice: 'cuda',
       effectiveDevice: 'cpu',
       placement: 'cpu',
       cpuFallback: true,
-      runtime: { runtime: 'flux2', versions: {} },
+      runtime: { runtime: 'diffusers-image', versions: {} },
     });
-    expect(marker).not.toHaveProperty('prompt');
-    expect(marker).not.toHaveProperty('path');
+    expect(parsed).not.toHaveProperty('prompt');
+    expect(parsed).not.toHaveProperty('path');
   });
 });

--- a/scripts/image_execution_marker.test.js
+++ b/scripts/image_execution_marker.test.js
@@ -6,6 +6,26 @@ import { describe, expect, it } from 'vitest';
 const scriptsDir = dirname(fileURLToPath(import.meta.url));
 
 describe('local image execution marker', () => {
+  const buildMarker = (requestedDevice, effectiveDevice, placement) => {
+    const program = [
+      'import json, sys',
+      `sys.path.insert(0, ${JSON.stringify(scriptsDir)})`,
+      'from _runner_common import build_image_execution_marker',
+      `print(json.dumps(build_image_execution_marker('diffusers-image', ${JSON.stringify(requestedDevice)}, ${JSON.stringify(effectiveDevice)}, ${JSON.stringify(placement)}, [])))`,
+    ].join('; ');
+    return JSON.parse(execFileSync('python3', ['-c', program], { encoding: 'utf8' }));
+  };
+
+  it('records the Windows split CUDA placement as confirmed', () => {
+    expect(buildMarker('cuda', 'cuda', 'cuda+offload')).toMatchObject({
+      state: 'confirmed',
+      requestedDevice: 'cuda',
+      effectiveDevice: 'cuda',
+      placement: 'cuda+offload',
+      cpuFallback: false,
+      runtime: { runtime: 'diffusers-image', versions: {} },
+    });
+  });
   it('records a CPU fallback as degraded without host or prompt data', () => {
     const program = [
       'import json, sys',

--- a/scripts/imagine_win.py
+++ b/scripts/imagine_win.py
@@ -22,6 +22,8 @@ from transformers import (
     T5Config, T5EncoderModel, T5TokenizerFast,
 )
 
+from _runner_common import emit_image_execution_marker
+
 # ---------------------------------------------------------------------------
 # Paths
 # ---------------------------------------------------------------------------
@@ -182,6 +184,18 @@ def main():
     generator = torch.Generator('cuda').manual_seed(args.seed) if args.seed is not None else None
 
     pipe = build_pipeline(flux_key, hf_cache, dtype)
+
+    # The transformer and CLIP run on CUDA while T5 is intentionally kept on
+    # CPU to fit the Windows pipeline in available VRAM.  Emit this evidence
+    # only after placement is complete so the gallery can distinguish the
+    # split CUDA path from an unmarked legacy runner or a CPU fallback.
+    emit_image_execution_marker(
+        'diffusers-image',
+        'cuda',
+        'cuda',
+        'cuda+offload',
+        ['torch', 'diffusers', 'transformers', 'accelerate'],
+    )
 
     log(f'STATUS:Generating image ({args.width}x{args.height}, {args.steps} steps)...')
 


### PR DESCRIPTION
## Summary
- Emit a sanitized execution marker after the Windows image pipeline has completed device placement.
- Cover confirmed CUDA, CUDA-offload, and CPU-fallback states through the server parser.

## Test plan
- `cd server && nvm exec 24.14.1 npm test`
- `cd client && nvm exec 24.14.1 npm test`
- `cd client && nvm exec 24.14.1 npm run lint`

Closes #5102