### PR TITLE
fix: enable persistent mind on explicit start

### DIFF
--- a/server/routes/cosMindRoutes.test.js
+++ b/server/routes/cosMindRoutes.test.js
@@ -140,10 +140,10 @@ describe('persistent mind routes', () => {
   });
 
   it('fails visibly when the supervisor refuses a lifecycle transition', async () => {
-    mocks.startPersistentMind.mockResolvedValue({ success: false, error: 'Persistent mind is disabled' });
+    mocks.startPersistentMind.mockResolvedValue({ success: false, error: 'Lifecycle transition refused' });
     const res = await post('/mind/start');
     expect(res.status).toBe(409);
-    expect(res.body.error).toBe('Persistent mind is disabled');
+    expect(res.body.error).toBe('Lifecycle transition refused');
   });
 
   it('requires explicit approval before promoting a redacted event summary', async () => {

--- a/server/services/cosState.js
+++ b/server/services/cosState.js
@@ -64,7 +64,7 @@ export const DEFAULT_CONFIG = {
   // opt-in also admits those loop/storm investigations unattended.
   autoApproveInvestigations: false,
   // Persisting a profile is not consent to wake the mind. Fresh and upgraded
-  // installs stay disabled until the user explicitly enables and starts it.
+  // installs stay disabled until the user explicitly starts it.
   persistentMindProfile: createDefaultPersistentMindProfile(),
   // Per-domain autonomy guardrails (#711). Each domain is off | dry-run | execute.
   // Default is `execute` for every domain, reproducing pre-#711 behavior so no

--- a/server/services/persistentMindSupervisor.js
+++ b/server/services/persistentMindSupervisor.js
@@ -653,11 +653,11 @@ export async function setPersistentMindEnabled(enabled) {
 
 export async function startPersistentMind() {
   const result = await mutateMindState((mind) => {
-    if (!mind.enabled) return { mind, value: { success: false, error: 'Persistent mind is disabled' } };
     if (mind.started) return { mind, value: { success: true, alreadyStarted: true } };
     return {
       mind: {
         ...mind,
+        enabled: true,
         started: true,
         status: 'waiting',
         pauseReason: null,

--- a/server/services/persistentMindSupervisor.test.js
+++ b/server/services/persistentMindSupervisor.test.js
@@ -109,14 +109,15 @@ describe('persistent mind supervisor', () => {
     supervisor.__resetPersistentMindSupervisorForTests();
   });
 
-  it('is silent on boot and refuses start until explicitly enabled', async () => {
+  it('is silent on boot and enables the runtime only when explicitly started', async () => {
     const prepare = vi.fn();
     const run = vi.fn();
     await supervisor.registerPersistentMindTurnAdapter({ prepare, run });
 
     await supervisor.initializePersistentMindSupervisor();
     expect(mock.scheduled.size).toBe(0);
-    expect(await supervisor.startPersistentMind()).toEqual({ success: false, error: 'Persistent mind is disabled' });
+    expect(await supervisor.startPersistentMind()).toEqual({ success: true, alreadyStarted: false });
+    expect(mock.root.persistentMind).toMatchObject({ enabled: true, started: true, status: 'waiting' });
     expect(prepare).not.toHaveBeenCalled();
     expect(run).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary
- atomically enable the persistent mind runtime when the user explicitly starts it
- preserve silent, disabled boot behavior and keep provider-profile saves non-starting
- update lifecycle coverage and state documentation for the corrected transition

## Test plan
- `cd server && npm test -- persistentMindSupervisor.test.js cosMindRoutes.test.js`
- `cd server && npm test`