### PR TITLE
feat: persist user task description drafts

### DIFF
--- a/client/src/components/cos/TaskAddForm.jsx
+++ b/client/src/components/cos/TaskAddForm.jsx
@@ -18,9 +18,15 @@ import useReviewerModelOptions from '../../hooks/useReviewerModelOptions';
 import useAssignableInstances from '../../hooks/useAssignableInstances';
 import { reviewerModelsFromDefaults, reviewerEffortsFromDefaults } from '../../lib/reviewerModels';
 import { PORTOS_APP_ID } from '../../lib/appIdentity';
+import { safeReadStorage, safeRemoveStorage, safeWriteStorage } from '../../lib/safeStorage';
+
+const TASK_DESCRIPTION_DRAFT_KEY = 'portos-cos-task-description-draft';
 
 export default function TaskAddForm({ providers, apps, onTaskAdded, compact = false, defaultExpanded = false, defaultApp = '' }) {
-  const [newTask, setNewTask] = useState({ description: '', model: '', provider: '', effort: '', temperature: '', thinking: '', app: defaultApp });
+  const [newTask, setNewTask] = useState(() => ({
+    description: safeReadStorage(TASK_DESCRIPTION_DRAFT_KEY) || '',
+    model: '', provider: '', effort: '', temperature: '', thinking: '', app: defaultApp
+  }));
   const [addToTop, setAddToTop] = useState(false);
   const [enhancePrompt, setEnhancePrompt] = useState(false);
   const [isEnhancing, setIsEnhancing] = useState(false);
@@ -74,6 +80,14 @@ export default function TaskAddForm({ providers, apps, onTaskAdded, compact = fa
   // run-shape toggles, so the app-defaults effect skips the single run that
   // change triggers. See that effect for why.
   const templateAppChangeRef = useRef(false);
+
+  useEffect(() => {
+    if (newTask.description) {
+      safeWriteStorage(TASK_DESCRIPTION_DRAFT_KEY, newTask.description);
+    } else {
+      safeRemoveStorage(TASK_DESCRIPTION_DRAFT_KEY);
+    }
+  }, [newTask.description]);
 
   // Fetch templates
   useEffect(() => {
@@ -503,6 +517,7 @@ export default function TaskAddForm({ providers, apps, onTaskAdded, compact = fa
 
     // Only clear form inputs after successful submission
     setNewTask(t => ({ ...t, description: '' }));
+    safeRemoveStorage(TASK_DESCRIPTION_DRAFT_KEY);
     setSlashdoCommand(planOnly ? 'plan-task' : '');
     // targetInstanceId deliberately SURVIVES the clear, like app/model/provider
     // and the worktree toggles: it is a run setting, and someone queueing work

--- a/client/src/components/cos/TaskAddForm.jsx
+++ b/client/src/components/cos/TaskAddForm.jsx
@@ -21,12 +21,13 @@ import { PORTOS_APP_ID } from '../../lib/appIdentity';
 import { safeReadJsonStorage, safeReadStorage, safeRemoveStorage, safeWriteJsonStorage } from '../../lib/safeStorage';
 
 const TASK_DESCRIPTION_DRAFT_KEY = 'portos-cos-task-description-draft';
+const INVALID_DRAFT = Symbol('invalid task description draft');
 
 const readTaskDescriptionDraft = (defaultApp) => {
   const raw = safeReadStorage(TASK_DESCRIPTION_DRAFT_KEY);
   if (raw === null) return { description: '', app: defaultApp };
-  const draft = safeReadJsonStorage(TASK_DESCRIPTION_DRAFT_KEY, undefined);
-  if (draft === undefined) return { description: raw, app: defaultApp };
+  const draft = safeReadJsonStorage(TASK_DESCRIPTION_DRAFT_KEY, INVALID_DRAFT);
+  if (draft === INVALID_DRAFT) return { description: raw, app: defaultApp };
   if (typeof draft === 'string') return { description: draft, app: defaultApp };
   if (!draft || typeof draft !== 'object' || Array.isArray(draft)) return { description: '', app: defaultApp };
   return {
@@ -36,11 +37,12 @@ const readTaskDescriptionDraft = (defaultApp) => {
 };
 
 export default function TaskAddForm({ providers, apps, onTaskAdded, compact = false, defaultExpanded = false, defaultApp = '' }) {
+  const [initialDraft] = useState(() => readTaskDescriptionDraft(defaultApp));
   const [newTask, setNewTask] = useState(() => {
-    const draft = readTaskDescriptionDraft(defaultApp);
     return {
-      description: draft.description,
-      model: '', provider: '', effort: '', temperature: '', thinking: '', app: draft.app
+      description: initialDraft.description,
+      model: '', provider: '', effort: '', temperature: '', thinking: '',
+      app: apps?.some(app => app.id === initialDraft.app) ? initialDraft.app : defaultApp
     };
   });
   const [addToTop, setAddToTop] = useState(false);
@@ -107,6 +109,13 @@ export default function TaskAddForm({ providers, apps, onTaskAdded, compact = fa
       safeRemoveStorage(TASK_DESCRIPTION_DRAFT_KEY);
     }
   }, [newTask.app, newTask.description]);
+
+  useEffect(() => {
+    if (!initialDraft.app || !apps?.length || newTask.app === initialDraft.app) return;
+    if (apps.some(app => app.id === initialDraft.app)) {
+      setNewTask(task => ({ ...task, app: initialDraft.app }));
+    }
+  }, [apps, initialDraft.app, newTask.app]);
 
   useEffect(() => {
     if (!newTask.app || !apps?.length || apps.some(app => app.id === newTask.app)) return;

--- a/client/src/components/cos/TaskAddForm.jsx
+++ b/client/src/components/cos/TaskAddForm.jsx
@@ -18,15 +18,31 @@ import useReviewerModelOptions from '../../hooks/useReviewerModelOptions';
 import useAssignableInstances from '../../hooks/useAssignableInstances';
 import { reviewerModelsFromDefaults, reviewerEffortsFromDefaults } from '../../lib/reviewerModels';
 import { PORTOS_APP_ID } from '../../lib/appIdentity';
-import { safeReadStorage, safeRemoveStorage, safeWriteStorage } from '../../lib/safeStorage';
+import { safeReadJsonStorage, safeReadStorage, safeRemoveStorage, safeWriteJsonStorage } from '../../lib/safeStorage';
 
 const TASK_DESCRIPTION_DRAFT_KEY = 'portos-cos-task-description-draft';
 
+const readTaskDescriptionDraft = (defaultApp) => {
+  const raw = safeReadStorage(TASK_DESCRIPTION_DRAFT_KEY);
+  if (raw === null) return { description: '', app: defaultApp };
+  const draft = safeReadJsonStorage(TASK_DESCRIPTION_DRAFT_KEY, undefined);
+  if (draft === undefined) return { description: raw, app: defaultApp };
+  if (typeof draft === 'string') return { description: draft, app: defaultApp };
+  if (!draft || typeof draft !== 'object' || Array.isArray(draft)) return { description: '', app: defaultApp };
+  return {
+    description: typeof draft.description === 'string' ? draft.description : '',
+    app: typeof draft.app === 'string' && draft.app ? draft.app : defaultApp,
+  };
+};
+
 export default function TaskAddForm({ providers, apps, onTaskAdded, compact = false, defaultExpanded = false, defaultApp = '' }) {
-  const [newTask, setNewTask] = useState(() => ({
-    description: safeReadStorage(TASK_DESCRIPTION_DRAFT_KEY) || '',
-    model: '', provider: '', effort: '', temperature: '', thinking: '', app: defaultApp
-  }));
+  const [newTask, setNewTask] = useState(() => {
+    const draft = readTaskDescriptionDraft(defaultApp);
+    return {
+      description: draft.description,
+      model: '', provider: '', effort: '', temperature: '', thinking: '', app: draft.app
+    };
+  });
   const [addToTop, setAddToTop] = useState(false);
   const [enhancePrompt, setEnhancePrompt] = useState(false);
   const [isEnhancing, setIsEnhancing] = useState(false);
@@ -83,11 +99,19 @@ export default function TaskAddForm({ providers, apps, onTaskAdded, compact = fa
 
   useEffect(() => {
     if (newTask.description) {
-      safeWriteStorage(TASK_DESCRIPTION_DRAFT_KEY, newTask.description);
+      safeWriteJsonStorage(TASK_DESCRIPTION_DRAFT_KEY, {
+        description: newTask.description,
+        app: newTask.app || null,
+      });
     } else {
       safeRemoveStorage(TASK_DESCRIPTION_DRAFT_KEY);
     }
-  }, [newTask.description]);
+  }, [newTask.app, newTask.description]);
+
+  useEffect(() => {
+    if (!newTask.app || !apps?.length || apps.some(app => app.id === newTask.app)) return;
+    setNewTask(task => ({ ...task, app: defaultApp }));
+  }, [apps, defaultApp, newTask.app]);
 
   // Fetch templates
   useEffect(() => {

--- a/client/src/components/cos/TaskAddForm.test.jsx
+++ b/client/src/components/cos/TaskAddForm.test.jsx
@@ -62,18 +62,26 @@ describe('TaskAddForm responsive layout', () => {
   it('restores the description draft and clears it after a successful submit', async () => {
     const user = userEvent.setup();
     const description = 'Keep this task after an accidental navigation';
-    localStorage.setItem('portos-cos-task-description-draft', description);
+    localStorage.setItem('portos-cos-task-description-draft', JSON.stringify({ description, app: 'draft-app' }));
     api.addCosTask.mockResolvedValue({ success: true });
 
-    const { unmount } = render(<TaskAddForm providers={[]} apps={[]} onTaskAdded={vi.fn()} />);
+    const apps = [
+      { id: 'draft-app', name: 'Draft App', repoPath: 'example.com/draft' },
+      { id: 'current-app', name: 'Current App', repoPath: 'example.com/current' },
+    ];
+    const { unmount } = render(<TaskAddForm providers={[]} apps={apps} defaultApp="current-app" onTaskAdded={vi.fn()} />);
     expect(screen.getByPlaceholderText('Task description *')).toHaveValue(description);
+    expect(screen.getByLabelText('Target application')).toHaveValue('draft-app');
 
     unmount();
-    render(<TaskAddForm providers={[]} apps={[]} onTaskAdded={vi.fn()} />);
+    render(<TaskAddForm providers={[]} apps={apps} defaultApp="current-app" onTaskAdded={vi.fn()} />);
     const descriptionInput = screen.getByPlaceholderText('Task description *');
     await user.click(descriptionInput);
     await user.type(descriptionInput, ' with more detail');
-    expect(localStorage.getItem('portos-cos-task-description-draft')).toBe(`${description} with more detail`);
+    expect(JSON.parse(localStorage.getItem('portos-cos-task-description-draft'))).toEqual({
+      description: `${description} with more detail`,
+      app: 'draft-app',
+    });
 
     await user.click(screen.getByRole('button', { name: /^Add$/ }));
     await waitFor(() => expect(api.addCosTask).toHaveBeenCalled());
@@ -91,7 +99,10 @@ describe('TaskAddForm responsive layout', () => {
 
     await waitFor(() => expect(api.addCosTask).toHaveBeenCalled());
     expect(descriptionInput).toHaveValue('Retry this task');
-    expect(localStorage.getItem('portos-cos-task-description-draft')).toBe('Retry this task');
+    expect(JSON.parse(localStorage.getItem('portos-cos-task-description-draft'))).toEqual({
+      description: 'Retry this task',
+      app: null,
+    });
   });
 
   it('sends OpenCode Ollama thinking, effort, and temperature overrides with the task', async () => {

--- a/client/src/components/cos/TaskAddForm.test.jsx
+++ b/client/src/components/cos/TaskAddForm.test.jsx
@@ -59,6 +59,41 @@ describe('TaskAddForm responsive layout', () => {
     expect(options).not.toHaveClass('grid-cols-2');
   });
 
+  it('restores the description draft and clears it after a successful submit', async () => {
+    const user = userEvent.setup();
+    const description = 'Keep this task after an accidental navigation';
+    localStorage.setItem('portos-cos-task-description-draft', description);
+    api.addCosTask.mockResolvedValue({ success: true });
+
+    const { unmount } = render(<TaskAddForm providers={[]} apps={[]} onTaskAdded={vi.fn()} />);
+    expect(screen.getByPlaceholderText('Task description *')).toHaveValue(description);
+
+    unmount();
+    render(<TaskAddForm providers={[]} apps={[]} onTaskAdded={vi.fn()} />);
+    const descriptionInput = screen.getByPlaceholderText('Task description *');
+    await user.click(descriptionInput);
+    await user.type(descriptionInput, ' with more detail');
+    expect(localStorage.getItem('portos-cos-task-description-draft')).toBe(`${description} with more detail`);
+
+    await user.click(screen.getByRole('button', { name: /^Add$/ }));
+    await waitFor(() => expect(api.addCosTask).toHaveBeenCalled());
+    expect(localStorage.getItem('portos-cos-task-description-draft')).toBeNull();
+  });
+
+  it('keeps the description draft when submission fails', async () => {
+    const user = userEvent.setup();
+    api.addCosTask.mockRejectedValue(new Error('Unable to add task'));
+    render(<TaskAddForm providers={[]} apps={[]} onTaskAdded={vi.fn()} />);
+
+    const descriptionInput = screen.getByPlaceholderText('Task description *');
+    await user.type(descriptionInput, 'Retry this task');
+    await user.click(screen.getByRole('button', { name: /^Add$/ }));
+
+    await waitFor(() => expect(api.addCosTask).toHaveBeenCalled());
+    expect(descriptionInput).toHaveValue('Retry this task');
+    expect(localStorage.getItem('portos-cos-task-description-draft')).toBe('Retry this task');
+  });
+
   it('sends OpenCode Ollama thinking, effort, and temperature overrides with the task', async () => {
     const user = userEvent.setup();
     api.addCosTask.mockResolvedValue({ success: true });

--- a/client/src/components/cos/TaskAddForm.test.jsx
+++ b/client/src/components/cos/TaskAddForm.test.jsx
@@ -105,6 +105,27 @@ describe('TaskAddForm responsive layout', () => {
     });
   });
 
+  it('does not submit a stale restored app while app options are unavailable', async () => {
+    const user = userEvent.setup();
+    localStorage.setItem('portos-cos-task-description-draft', JSON.stringify({
+      description: 'Use the current app safely',
+      app: 'stale-app',
+    }));
+    api.addCosTask.mockResolvedValue({ success: true });
+    render(<TaskAddForm providers={[]} apps={[]} defaultApp="current-app" onTaskAdded={vi.fn()} />);
+
+    await user.click(screen.getByRole('button', { name: /^Add$/ }));
+    await waitFor(() => expect(api.addCosTask).toHaveBeenCalled());
+    expect(api.addCosTask.mock.calls[0][0].app).toBe('current-app');
+  });
+
+  it('restores a plain-text draft from the previous storage format', async () => {
+    localStorage.setItem('portos-cos-task-description-draft', 'Legacy task draft');
+    render(<TaskAddForm providers={[]} apps={[]} onTaskAdded={vi.fn()} />);
+
+    await waitFor(() => expect(screen.getByPlaceholderText('Task description *')).toHaveValue('Legacy task draft'));
+  });
+
   it('sends OpenCode Ollama thinking, effort, and temperature overrides with the task', async () => {
     const user = userEvent.setup();
     api.addCosTask.mockResolvedValue({ success: true });


### PR DESCRIPTION
## Summary
- Persist the user task description draft in guarded localStorage.
- Restore the draft when the task form mounts and clear it only after successful submission.
- Keep failed submissions recoverable with focused component coverage.

## Test plan
- npm test -- --run src/components/cos/TaskAddForm.test.jsx (client)
- npm run lint (client)
- npm run build (client)