### PR TITLE
fix: guard managed app pull request route

### DIFF
--- a/server/routes/apps/index.test.js
+++ b/server/routes/apps/index.test.js
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import express from 'express';
+import { request } from '../../lib/testHelper.js';
+
+// Keep this an assembly test: the domain route tests mount their sub-router
+// directly, so they cannot catch a missing router.use() in this barrel.
+const { passThrough } = vi.hoisted(() => ({
+  passThrough: (_req, _res, next) => next(),
+}));
+vi.mock('./crud.js', () => ({ default: passThrough }));
+vi.mock('./lifecycle.js', () => ({ default: passThrough }));
+vi.mock('./viteTls.js', () => ({ default: passThrough }));
+vi.mock('./xcode.js', () => ({ default: passThrough }));
+vi.mock('./icons.js', () => ({ default: passThrough }));
+vi.mock('./taskTypes.js', () => ({ default: passThrough }));
+vi.mock('./issues.js', () => ({ default: passThrough }));
+vi.mock('./launch.js', () => ({ default: passThrough }));
+vi.mock('./documents.js', () => ({ default: passThrough }));
+vi.mock('./agents.js', () => ({ default: passThrough }));
+vi.mock('./spriteBindings.js', () => ({ default: passThrough }));
+vi.mock('../../services/apps.js', () => ({
+  getAppById: vi.fn(),
+}));
+
+import appsRoutes from './index.js';
+import * as appsService from '../../services/apps.js';
+
+describe('apps route assembly', () => {
+  let app;
+
+  beforeEach(() => {
+    app = express();
+    app.use('/api/apps', appsRoutes);
+    vi.clearAllMocks();
+    appsService.getAppById.mockResolvedValue(null);
+  });
+
+  it('mounts the pull-request route through the apps barrel', async () => {
+    const response = await request(app).get('/api/apps/app-999/pull-requests');
+
+    expect(response.status).toBe(404);
+    expect(response.body).toMatchObject({ error: 'App not found', code: 'NOT_FOUND' });
+    expect(appsService.getAppById).toHaveBeenCalledWith('app-999');
+  });
+});

--- a/server/routes/apps/index.test.js
+++ b/server/routes/apps/index.test.js
@@ -18,7 +18,8 @@ vi.mock('./launch.js', () => ({ default: passThrough }));
 vi.mock('./documents.js', () => ({ default: passThrough }));
 vi.mock('./agents.js', () => ({ default: passThrough }));
 vi.mock('./spriteBindings.js', () => ({ default: passThrough }));
-vi.mock('../../services/apps.js', () => ({
+vi.mock('../../services/apps.js', async (importOriginal) => ({
+  ...(await importOriginal()),
   getAppById: vi.fn(),
 }));
 


### PR DESCRIPTION
## Summary
- Add an apps-router assembly regression test for the managed app pull-request endpoint.
- Confirm the live 404 was caused by a stale server process and refresh the process so the existing route is loaded.

## Test plan
- npm exec vitest run routes/apps/index.test.js routes/apps/pullRequests.test.js services/appPullRequests.test.js (server)
- npm exec vitest run src/components/apps/tabs/PullRequestsTab.test.jsx (client)
- npm run build (client)
- Live GET against a repo-backed managed app returned 200 with pull-request payload fields after server restart.