### PR TITLE
fix: load Accelerando from reachable author endpoint

### DIFF
--- a/client/src/pages/RapidReader.test.jsx
+++ b/client/src/pages/RapidReader.test.jsx
@@ -3,7 +3,7 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 const api = vi.hoisted(() => ({
   ACCELERANDO_LICENSE_URL: 'https://creativecommons.org/licenses/by-nc-nd/2.5/',
-  ACCELERANDO_SOURCE_PAGE_URL: 'https://www.antipope.org/charlie/blog-static/fiction/accelerando/accelerando-intro.html',
+  ACCELERANDO_SOURCE_PAGE_URL: 'http://www.antipope.org/charlie/blog-static/fiction/accelerando/accelerando-intro.html',
   getAccelerandoBook: vi.fn(),
 }));
 
@@ -30,7 +30,7 @@ describe('RapidReader Accelerando loader', () => {
     expect(api.getAccelerandoBook).not.toHaveBeenCalled();
     expect(screen.getByRole('link', { name: /author's page/i })).toHaveAttribute(
       'href',
-      'https://www.antipope.org/charlie/blog-static/fiction/accelerando/accelerando-intro.html',
+      'http://www.antipope.org/charlie/blog-static/fiction/accelerando/accelerando-intro.html',
     );
     expect(screen.getByRole('link', { name: 'CC BY-NC-ND 2.5' })).toHaveAttribute(
       'href',

--- a/client/src/services/apiRapidReader.js
+++ b/client/src/services/apiRapidReader.js
@@ -1,6 +1,6 @@
 import { request } from './apiCore.js';
 
-export const ACCELERANDO_SOURCE_PAGE_URL = 'https://www.antipope.org/charlie/blog-static/fiction/accelerando/accelerando-intro.html';
+export const ACCELERANDO_SOURCE_PAGE_URL = 'http://www.antipope.org/charlie/blog-static/fiction/accelerando/accelerando-intro.html';
 export const ACCELERANDO_LICENSE_URL = 'https://creativecommons.org/licenses/by-nc-nd/2.5/';
 
 export const getAccelerandoBook = (options) => request('/rapid-reader/accelerando', options);

--- a/server/services/rapidReader.js
+++ b/server/services/rapidReader.js
@@ -8,8 +8,8 @@ export const ACCELERANDO_BOOK = Object.freeze({
   id: 'accelerando',
   title: 'Accelerando',
   author: 'Charles Stross',
-  sourceUrl: 'https://www.antipope.org/charlie/blog-static/fiction/accelerando/accelerando.html',
-  sourcePageUrl: 'https://www.antipope.org/charlie/blog-static/fiction/accelerando/accelerando-intro.html',
+  sourceUrl: 'http://www.antipope.org/charlie/blog-static/fiction/accelerando/accelerando.html',
+  sourcePageUrl: 'http://www.antipope.org/charlie/blog-static/fiction/accelerando/accelerando-intro.html',
   licenseName: 'CC BY-NC-ND 2.5',
   licenseUrl: 'https://creativecommons.org/licenses/by-nc-nd/2.5/',
 });

--- a/server/services/rapidReader.test.js
+++ b/server/services/rapidReader.test.js
@@ -69,6 +69,7 @@ describe('getAccelerandoBook', () => {
       id: 'accelerando',
       title: 'Accelerando',
       author: 'Charles Stross',
+      sourceUrl: 'http://www.antipope.org/charlie/blog-static/fiction/accelerando/accelerando.html',
       licenseName: 'CC BY-NC-ND 2.5',
       licenseUrl: 'https://creativecommons.org/licenses/by-nc-nd/2.5/',
       cached: false,


### PR DESCRIPTION
## Summary

- Update the Rapid Reader Accelerando source and author-page URLs to the working official endpoint so the book can be downloaded when requested.
- Keep the server metadata and client link aligned, with regression coverage for the source URL.

## Test plan

- npm test --prefix server -- --run services/rapidReader.test.js lib/safeUrlFetch.test.js
- npm test --prefix client -- --run src/pages/RapidReader.test.jsx
- npm run build