### PR TITLE
fix: batch run usage disk writes (#5126)

### DIFF
--- a/server/services/usage.js
+++ b/server/services/usage.js
@@ -482,8 +482,7 @@ export async function recordSession(providerId, providerName, model) {
  * tokens, estimated" so every existing caller — and the
  * `POST /api/usage/messages` route — keeps its current behavior.
  */
-export async function recordMessages(providerId, model, messageCount, outputTokens = 0, inputTokens = 0, extra = {}) {
-  if (!usageData) await loadUsage();
+function applyMessageUsage(providerId, model, messageCount, outputTokens = 0, inputTokens = 0, extra = {}) {
   const provider = normalizeProvider(providerId);
   const cacheReadTokens = Math.max(0, extra?.cacheReadTokens || 0);
   const cacheWriteTokens = Math.max(0, extra?.cacheWriteTokens || 0);
@@ -535,7 +534,11 @@ export async function recordMessages(providerId, model, messageCount, outputToke
   const providerDay = providerDayBucket(day, provider.id, providerName);
   bumpDayBucket(providerDay);
   if (model) bumpDayBucket(modelDayBucket(providerDay, model));
+}
 
+export async function recordMessages(providerId, model, messageCount, outputTokens = 0, inputTokens = 0, extra = {}) {
+  if (!usageData) await loadUsage();
+  applyMessageUsage(providerId, model, messageCount, outputTokens, inputTokens, extra);
   await saveUsage();
 }
 
@@ -561,27 +564,32 @@ export async function recordMessages(providerId, model, messageCount, outputToke
  */
 export async function recordRunUsage(record) {
   // A single run can produce several records when its session switched models
-  // mid-flight (see usageReconciler.reconcileRunUsage) — record each so every
-  // model's tokens are priced at that model's own rate.
-  if (Array.isArray(record)) {
-    for (const entry of record) await recordRunUsage(entry);
-    return;
+  // mid-flight (see usageReconciler.reconcileRunUsage). Apply the full batch
+  // in memory before saving so every model is priced independently without
+  // rewriting the complete usage file once per entry.
+  const records = Array.isArray(record) ? record.flat(Infinity) : [record];
+  if (records.length === 0) return;
+  if (!usageData) await loadUsage();
+
+  for (const entry of records) {
+    const {
+      providerId = null,
+      model = null,
+      messages = 1,
+      tokensIn = 0,
+      tokensOut = 0,
+      cacheReadTokens = 0,
+      cacheWriteTokens = 0,
+      source = 'estimate'
+    } = entry || {};
+    applyMessageUsage(providerId, model, messages, tokensOut, tokensIn, {
+      cacheReadTokens,
+      cacheWriteTokens,
+      source
+    });
   }
-  const {
-    providerId = null,
-    model = null,
-    messages = 1,
-    tokensIn = 0,
-    tokensOut = 0,
-    cacheReadTokens = 0,
-    cacheWriteTokens = 0,
-    source = 'estimate'
-  } = record || {};
-  await recordMessages(providerId, model, messages, tokensOut, tokensIn, {
-    cacheReadTokens,
-    cacheWriteTokens,
-    source
-  });
+
+  await saveUsage();
 }
 
 /**

--- a/server/services/usage.test.js
+++ b/server/services/usage.test.js
@@ -908,6 +908,57 @@ describe('usage.js — cache tiers and measured/estimate provenance (#3124 Phase
     expect(getUsage().totalTokens.input).toBe(1500 + 3_500_000 + 280_000);
   });
 
+  it('records a multi-model run with one atomic write', async () => {
+    readJSONFile.mockResolvedValueOnce(makeUsage({}, {
+      byModel: {
+        'claude-opus-5': { sessions: 1, messages: 0, tokens: 0 },
+        'claude-sonnet-5': { sessions: 1, messages: 0, tokens: 0 }
+      }
+    }));
+    await loadUsage();
+    vi.clearAllMocks();
+
+    await recordRunUsage([
+      {
+        providerId: 'claude-code',
+        model: 'claude-opus-5',
+        messages: 2,
+        tokensIn: 100,
+        tokensOut: 20,
+        source: 'measured'
+      },
+      {
+        providerId: 'claude-code',
+        model: 'claude-sonnet-5',
+        messages: 3,
+        tokensIn: 200,
+        tokensOut: 30,
+        cacheReadTokens: 400,
+        source: 'estimate'
+      }
+    ]);
+
+    expect(atomicWrite).toHaveBeenCalledTimes(1);
+    expect(getUsage()).toMatchObject({
+      totalMessages: 5,
+      totalTokens: { input: 700, output: 50 },
+      byProvider: {
+        'claude-code': { messages: 5, tokens: 50 }
+      },
+      byModel: {
+        'claude-opus-5': { messages: 2, tokens: 20 },
+        'claude-sonnet-5': { messages: 3, tokens: 30 }
+      }
+    });
+    expect(getUsage().dailyActivity[today].byProvider['claude-code']).toMatchObject({
+      messages: 5,
+      tokensIn: 300,
+      tokensOut: 50,
+      cacheReadTokens: 400,
+      source: 'mixed'
+    });
+  });
+
   it('defaults recordMessages to an estimate source with no cache tokens', async () => {
     readJSONFile.mockResolvedValueOnce(makeUsage({}));
     await loadUsage();


### PR DESCRIPTION
## Summary

- batch recordRunUsage array payloads in memory before persisting usage data
- preserve token, message, provider, model, cache-token, and provenance accounting for every batch entry
- add regression coverage proving a multi-model batch performs one atomic write

## Test plan

- cd server && npm test -- --run services/usage.test.js services/usageReconciler.test.js services/usageReconciler.property.test.js (114 passed)
- git diff --check

Closes #5126
