### PR TITLE
fix: expose advanced cron toggle state (#5130)

### DIFF
--- a/client/src/components/CronSchedulePicker.jsx
+++ b/client/src/components/CronSchedulePicker.jsx
@@ -143,6 +143,7 @@ function TimeInput({ value, onChange, label = 'Time of day' }) {
 }
 
 function CronExpressionPicker({ value, onChange, className, showAdvanced, showSummary, cronAriaLabel, onCronKeyDown }) {
+  const advancedContainerId = useId();
   const expr = typeof value === 'string' ? value : '';
   const parsed = parseCronToRecurrence(expr);
   const simple = parsed?.frequency === 'daily' || parsed?.frequency === 'weekly';
@@ -172,11 +173,13 @@ function CronExpressionPicker({ value, onChange, className, showAdvanced, showSu
           <button
             type="button"
             onClick={() => setAdvanced(current => !current)}
+            aria-expanded={advanced}
+            aria-controls={advancedContainerId}
             className="text-xs text-gray-500 underline decoration-dotted hover:text-gray-300"
           >
             {advanced ? 'Hide advanced' : 'Advanced cron'}
           </button>
-          {advanced && (
+          <div id={advancedContainerId} hidden={!advanced}>
             <div className="flex flex-wrap items-center gap-2">
               <input
                 type="text"
@@ -200,7 +203,7 @@ function CronExpressionPicker({ value, onChange, className, showAdvanced, showSu
                 {CRON_PRESETS.map(preset => <option key={preset.value} value={preset.value}>{preset.label}</option>)}
               </select>
             </div>
-          )}
+          </div>
         </>
       )}
     </div>

--- a/client/src/components/CronSchedulePicker.test.jsx
+++ b/client/src/components/CronSchedulePicker.test.jsx
@@ -5,6 +5,22 @@ import CronSchedulePicker from './CronSchedulePicker.jsx';
 describe('CronSchedulePicker', () => {
   afterEach(() => vi.useRealTimers());
 
+  it('exposes the advanced cron panel state and relationship', () => {
+    render(<CronSchedulePicker value="0 7 * * *" onChange={vi.fn()} />);
+
+    const toggle = screen.getByRole('button', { name: 'Hide advanced' });
+    const advancedPanel = document.getElementById(toggle.getAttribute('aria-controls'));
+
+    expect(toggle).toHaveAttribute('aria-expanded', 'true');
+    expect(toggle).toHaveAttribute('aria-controls', advancedPanel.id);
+
+    fireEvent.click(toggle);
+
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    expect(toggle).toHaveAttribute('aria-controls', advancedPanel.id);
+    expect(advancedPanel).toHaveAttribute('hidden');
+  });
+
   it('edits an arbitrary weekly interval without losing the weekday', () => {
     const onChange = vi.fn();
     render(


### PR DESCRIPTION
## Summary

- expose the advanced cron disclosure state with `aria-expanded`
- connect the toggle to a stable, always-valid advanced panel ID
- retain the collapsed panel with native `hidden` semantics so the ID relationship remains valid

## Test plan

- `CronSchedulePicker.test.jsx` (5 tests)
- Biome lint on the changed component and test
- Codex local review (`gpt-5.6-luna`, max effort, two rounds); both findings addressed

Closes #5130
