### PR TITLE
fix: trap command palette focus (#5128)

### DIFF
--- a/client/src/components/CmdKSearch.jsx
+++ b/client/src/components/CmdKSearch.jsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom';
 import { useLocation, useNavigate } from 'react-router';
 import { Brain, Cpu, Package, History, HeartPulse, Search, Loader2, Navigation, Play, LayoutGrid, BookMarked } from 'lucide-react';
 import { useCmdKSearch } from '../hooks/useCmdKSearch';
+import useFocusTrap from '../hooks/useFocusTrap.js';
 import { useInstanceFeatures } from '../hooks/useInstanceFeatures.js';
 import { useScrollLock } from '../hooks/useScrollLock';
 import { search, getPaletteManifest, runPaletteAction, getDashboardLayouts, setActiveDashboardLayout, listCatalogIngredients } from '../services/api';
@@ -68,6 +69,7 @@ export default function CmdKSearch() {
   const navigate = useNavigate();
   const location = useLocation();
   const inputRef = useRef(null);
+  const modalRef = useRef(null);
 
   const [query, setQuery] = useState('');
   const [manifest, setManifest] = useState(null);
@@ -80,10 +82,7 @@ export default function CmdKSearch() {
   const [recentPaths, setRecentPaths] = useState([]);
   const resultRefs = useRef([]);
 
-  useEffect(() => {
-    if (open) inputRef.current?.focus();
-  }, [open]);
-
+  useFocusTrap(open, modalRef, { initialFocusRef: inputRef });
   useScrollLock(open);
 
   // Layout records every route visit in the shared sidebar working set. Refresh
@@ -378,7 +377,13 @@ export default function CmdKSearch() {
         aria-hidden="true"
       />
 
-      <div className="relative w-full max-w-3xl mx-4 bg-port-card rounded-xl border border-port-border shadow-2xl overflow-hidden">
+      <div
+        ref={modalRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Command palette"
+        className="relative w-full max-w-3xl mx-4 bg-port-card rounded-xl border border-port-border shadow-2xl overflow-hidden"
+      >
         <div className="flex items-center gap-3 px-4 py-4 border-b border-port-border">
           <Search size={18} className="text-gray-400 shrink-0" />
           <input

--- a/client/src/components/CmdKSearch.test.jsx
+++ b/client/src/components/CmdKSearch.test.jsx
@@ -51,6 +51,36 @@ beforeEach(() => {
   HTMLElement.prototype.scrollIntoView = vi.fn();
 });
 
+describe('CmdKSearch dialog accessibility', () => {
+  it('traps focus inside the modal and restores it to the opener on close', async () => {
+    render(
+      <MemoryRouter>
+        <button type="button">Open palette shortcut</button>
+        <CmdKSearch />
+      </MemoryRouter>,
+    );
+
+    const opener = screen.getByRole('button', { name: 'Open palette shortcut' });
+    opener.focus();
+    fireEvent.keyDown(document, { key: 'k', metaKey: true });
+
+    const dialog = await screen.findByRole('dialog', { name: 'Command palette' });
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
+
+    const input = within(dialog).getByRole('textbox', { name: 'Command palette' });
+    expect(input).toHaveFocus();
+
+    fireEvent.keyDown(input, { key: 'Tab' });
+    expect(input).toHaveFocus();
+    fireEvent.keyDown(input, { key: 'Tab', shiftKey: true });
+    expect(input).toHaveFocus();
+
+    fireEvent.keyDown(input, { key: 'Escape' });
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+    expect(opener).toHaveFocus();
+  });
+});
+
 describe('CmdKSearch recent destinations', () => {
   it('leads with shared nav history, resolves deep links, and fills with non-duplicate defaults', async () => {
     localStorage.setItem(RECENT_KEY, JSON.stringify([
@@ -96,7 +126,7 @@ describe('CmdKSearch instance feature gating', () => {
       </MemoryRouter>,
     );
     fireEvent.keyDown(document, { key: 'k', metaKey: true });
-    const input = await screen.findByLabelText('Command palette');
+    const input = await screen.findByRole('textbox', { name: 'Command palette' });
     fireEvent.change(input, { target: { value: query } });
     await act(async () => {});
   };


### PR DESCRIPTION
## Summary

- announce the command palette as a modal dialog to assistive technology
- keep Tab and Shift+Tab focus inside the palette and restore focus on close
- cover dialog semantics, focus containment, and focus restoration with a regression test

## Test plan

- `cd client && npm test -- --run src/components/CmdKSearch.test.jsx src/a11yConventions.test.js`
- `cd client && npx vitest run --configLoader runner src/a11yConventions.test.js src/hooks/useFocusTrap.test.jsx src/components/CmdKSearch.test.jsx`
- `cd client && npx biome check --error-on-warnings src/components/CmdKSearch.jsx src/components/CmdKSearch.test.jsx`

Closes #5128
