### PR TITLE
feat: submit persistent mind chat with Enter

### DIFF
--- a/client/src/components/cos/tabs/MindTab.jsx
+++ b/client/src/components/cos/tabs/MindTab.jsx
@@ -315,6 +315,11 @@ export default function MindTab() {
     setMessageText(next);
   };
 
+  const handleMessageKeyDown = (event) => {
+    if (event.key !== 'Enter' || event.altKey || event.nativeEvent.isComposing) return;
+    void submitMessage(event);
+  };
+
   const changeAnnotationText = (next) => {
     if (annotationError) {
       annotationDraftIdRef.current = null;
@@ -525,7 +530,7 @@ export default function MindTab() {
             {submitError && <p role="alert" className="mt-2 text-sm text-port-error">{submitError} — Retry uses the same id, so it will not duplicate the input.</p>}
             <div className="flex items-end gap-2 rounded-[1.35rem] border border-port-border bg-port-bg p-1.5 pl-3 focus-within:border-port-accent/70 focus-within:ring-1 focus-within:ring-port-accent/30">
               <label htmlFor="mind-input-text" className="sr-only">Message</label>
-              <textarea id="mind-input-text" value={messageText} onChange={(event) => changeMessageText(event.target.value)} maxLength={8000} rows={1} className="min-h-[36px] max-h-32 flex-1 resize-y bg-transparent py-2 text-sm leading-5 text-port-text outline-none placeholder:text-port-text-muted" placeholder="Message Persistent Mind" />
+              <textarea id="mind-input-text" value={messageText} onChange={(event) => changeMessageText(event.target.value)} onKeyDown={handleMessageKeyDown} maxLength={8000} rows={1} className="min-h-[36px] max-h-32 flex-1 resize-y bg-transparent py-2 text-sm leading-5 text-port-text outline-none placeholder:text-port-text-muted" placeholder="Message Persistent Mind" />
               <button type="submit" disabled={!messageText.trim() || submitting} aria-label={submitting ? 'Sending message' : submitError ? 'Retry' : 'Send message'} className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-port-accent text-white transition-colors hover:bg-port-accent/85 disabled:cursor-not-allowed disabled:bg-port-border disabled:text-port-text-muted">
                 {submitting ? <RefreshCw size={17} className="animate-spin" aria-hidden="true" /> : <ArrowUp size={19} strokeWidth={2.5} aria-hidden="true" />}
               </button>

--- a/client/src/components/cos/tabs/MindTab.jsx
+++ b/client/src/components/cos/tabs/MindTab.jsx
@@ -316,7 +316,7 @@ export default function MindTab() {
   };
 
   const handleMessageKeyDown = (event) => {
-    if (event.key !== 'Enter' || event.altKey || event.nativeEvent.isComposing) return;
+    if (event.key !== 'Enter' || event.altKey || event.nativeEvent.isComposing || event.keyCode === 229) return;
     void submitMessage(event);
   };
 

--- a/client/src/components/cos/tabs/MindTab.test.jsx
+++ b/client/src/components/cos/tabs/MindTab.test.jsx
@@ -282,6 +282,19 @@ describe('MindTab', () => {
     ));
   });
 
+  it('does not submit an IME composition commit key', async () => {
+    const user = userEvent.setup();
+    renderTab();
+    await screen.findByText('Review the next bounded slice.');
+    const message = screen.getByLabelText('Message');
+
+    await user.type(message, 'Composing text');
+    fireEvent(message, createEvent.keyDown(message, { key: 'Enter', keyCode: 229 }));
+
+    expect(api.sendPersistentMindMessage).not.toHaveBeenCalled();
+    expect(message).toHaveValue('Composing text');
+  });
+
   it('mints a new id when failed text is edited into a different submission', async () => {
     const user = userEvent.setup();
     api.sendPersistentMindMessage.mockRejectedValueOnce(new Error('Connection lost'));

--- a/client/src/components/cos/tabs/MindTab.test.jsx
+++ b/client/src/components/cos/tabs/MindTab.test.jsx
@@ -1,6 +1,6 @@
 import { act } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { render, screen, waitFor, within } from '@testing-library/react';
+import { createEvent, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router';
 
@@ -258,6 +258,28 @@ describe('MindTab', () => {
     await waitFor(() => expect(api.sendPersistentMindMessage).toHaveBeenCalledTimes(2));
     const firstId = api.sendPersistentMindMessage.mock.calls[0][0].id;
     expect(api.sendPersistentMindMessage.mock.calls[1][0].id).toBe(firstId);
+  });
+
+  it('sends on Enter while preserving a newline for Option+Enter', async () => {
+    const user = userEvent.setup();
+    renderTab();
+    await screen.findByText('Review the next bounded slice.');
+    const message = screen.getByLabelText('Message');
+
+    await user.type(message, 'First line');
+    const optionEnter = createEvent.keyDown(message, { key: 'Enter', altKey: true });
+    fireEvent(message, optionEnter);
+    expect(optionEnter.defaultPrevented).toBe(false);
+    expect(api.sendPersistentMindMessage).not.toHaveBeenCalled();
+
+    await user.clear(message);
+    await user.type(message, 'First line\nSecond line');
+    expect(message).toHaveValue('First line\nSecond line');
+    await user.keyboard('{Enter}');
+    await waitFor(() => expect(api.sendPersistentMindMessage).toHaveBeenCalledWith(
+      { id: expect.stringMatching(/^message-/), text: 'First line\nSecond line' },
+      { silent: true },
+    ));
   });
 
   it('mints a new id when failed text is edited into a different submission', async () => {


### PR DESCRIPTION
## Summary
- Submit the CoS persistent mind chat when the user presses Enter.
- Preserve native Option/Alt+Enter multiline editing and guard IME composition commit keys.

## Test plan
- `npm test --prefix client -- --run src/components/cos/tabs/MindTab.test.jsx` (17 passed)
- `npm run lint --prefix client` (clean)
- Full client test/build attempts were blocked by host filesystem `ENOSPC` while Vite wrote temporary/output files.