### PR TITLE
fix: preserve iterable peer headers (#5133)

### DIFF
--- a/server/lib/peerHttpClient.js
+++ b/server/lib/peerHttpClient.js
@@ -77,7 +77,7 @@ export async function peerFetch(url, options = {}, peer = null) {
 
 function normalizeHeaders(headers) {
   if (!headers) return {};
-  if (typeof headers[Symbol.iterator] === 'function') return Object.fromEntries(headers);
+  if (typeof headers[Symbol.iterator] === 'function') return Object.fromEntries(new Headers(headers));
   return { ...headers };
 }
 

--- a/server/lib/peerHttpClient.js
+++ b/server/lib/peerHttpClient.js
@@ -64,7 +64,7 @@ export function __resetSelfInstanceIdForTests() {
  * keep working.
  */
 export async function peerFetch(url, options = {}, peer = null) {
-  const callerHeaders = options.headers || {};
+  const callerHeaders = normalizeHeaders(options.headers);
   const finalOptions = {
     ...options,
     headers: {
@@ -73,6 +73,12 @@ export async function peerFetch(url, options = {}, peer = null) {
     },
   };
   return url.startsWith('https://') ? httpsFetch(url, finalOptions) : fetch(url, finalOptions);
+}
+
+function normalizeHeaders(headers) {
+  if (!headers) return {};
+  if (typeof headers[Symbol.iterator] === 'function') return Object.fromEntries(headers);
+  return { ...headers };
 }
 
 /**

--- a/server/lib/peerHttpClient.test.js
+++ b/server/lib/peerHttpClient.test.js
@@ -77,6 +77,26 @@ describe('peerHttpClient', () => {
       expect(sent).toEqual(['authorization']);
     });
 
+    it('preserves a Headers instance while dropping the overridden Basic credential', async () => {
+      await peerFetch('http://peer.example/x', {
+        headers: new Headers({ Authorization: 'Bearer t', 'X-Request-Id': 'request-1' }),
+      }, { auth: { password: 'pw' } });
+      const sent = Object.keys(calls[0].options.headers).filter((k) => k.toLowerCase() === 'authorization');
+      expect(sent).toEqual(['authorization']);
+      expect(calls[0].options.headers.authorization).toBe('Bearer t');
+      expect(calls[0].options.headers['x-request-id']).toBe('request-1');
+    });
+
+    it('preserves Map headers while dropping overridden injected headers', async () => {
+      await peerFetch('http://peer.example/x', {
+        headers: new Map([['x-portos-instance-id', 'explicit'], ['X-Request-Id', 'request-1']]),
+      });
+      const sent = Object.keys(calls[0].options.headers).filter((k) => k.toLowerCase() === 'x-portos-instance-id');
+      expect(sent).toEqual(['x-portos-instance-id']);
+      expect(calls[0].options.headers['x-portos-instance-id']).toBe('explicit');
+      expect(calls[0].options.headers['X-Request-Id']).toBe('request-1');
+    });
+
     it('omits the header entirely when this install has no identity yet', async () => {
       selfInstanceId = 'unknown';
       __resetSelfInstanceIdForTests();

--- a/server/lib/peerHttpClient.test.js
+++ b/server/lib/peerHttpClient.test.js
@@ -94,7 +94,14 @@ describe('peerHttpClient', () => {
       const sent = Object.keys(calls[0].options.headers).filter((k) => k.toLowerCase() === 'x-portos-instance-id');
       expect(sent).toEqual(['x-portos-instance-id']);
       expect(calls[0].options.headers['x-portos-instance-id']).toBe('explicit');
-      expect(calls[0].options.headers['X-Request-Id']).toBe('request-1');
+      expect(calls[0].options.headers['x-request-id']).toBe('request-1');
+    });
+
+    it('preserves duplicate values from iterable header pairs', async () => {
+      await peerFetch('http://peer.example/x', {
+        headers: [['Accept', 'application/json'], ['Accept', 'text/plain']],
+      });
+      expect(calls[0].options.headers.accept).toBe('application/json, text/plain');
     });
 
     it('omits the header entirely when this install has no identity yet', async () => {


### PR DESCRIPTION
## Summary

- normalize `Headers`, `Map`, and iterable header inputs before combining caller and peer-injected headers
- preserve caller authorization precedence without emitting duplicate `Authorization` headers
- retain duplicate values from iterable header pairs using the platform `Headers` semantics

## Test plan

- `cd server && npm test -- --run lib/peerHttpClient.test.js`
- `git diff --check origin/main...HEAD`

Closes #5133
