### PR TITLE
fix: announce YouTube ingest progress (#5131)

### DIFF
--- a/client/src/components/QuickBrainCapture.jsx
+++ b/client/src/components/QuickBrainCapture.jsx
@@ -266,8 +266,15 @@ export default function QuickBrainCapture() {
       {ingest.active && (
         <div className="mt-3 flex items-center gap-2 text-xs text-gray-400">
           <Film size={14} className="text-red-400 shrink-0" />
-          <span className="capitalize">{ingest.stage || 'starting'}…</span>
-          <div className="flex-1 h-1.5 bg-port-bg rounded-full overflow-hidden">
+          <span aria-live="polite" className="capitalize">{ingest.stage || 'starting'}…</span>
+          <div
+            role="progressbar"
+            aria-label="YouTube video ingest progress"
+            aria-valuenow={Math.round(ingest.percent)}
+            aria-valuemin={0}
+            aria-valuemax={100}
+            className="flex-1 h-1.5 bg-port-bg rounded-full overflow-hidden"
+          >
             <div className="h-full bg-port-accent transition-all" style={{ width: `${ingest.percent}%` }} />
           </div>
           <button

--- a/client/src/components/QuickBrainCapture.jsx
+++ b/client/src/components/QuickBrainCapture.jsx
@@ -8,6 +8,7 @@ import { parseBareUrl } from '../lib/bareUrl';
 import { readClipboard } from '../lib/clipboard';
 import { INGEST_OPTIONS, defaultIngestOptions, ingestOptionsFromSettings, isYoutubeVideoUrl } from '../lib/youtubeUrl';
 import RepoIntakeOptions from './brain/RepoIntakeOptions';
+import ProgressBar from './ui/ProgressBar';
 import ToggleChip from './ui/ToggleChip';
 
 export default function QuickBrainCapture() {
@@ -267,16 +268,11 @@ export default function QuickBrainCapture() {
         <div className="mt-3 flex items-center gap-2 text-xs text-gray-400">
           <Film size={14} className="text-red-400 shrink-0" />
           <span aria-live="polite" className="capitalize">{ingest.stage || 'starting'}…</span>
-          <div
-            role="progressbar"
-            aria-label="YouTube video ingest progress"
-            aria-valuenow={Math.round(ingest.percent)}
-            aria-valuemin={0}
-            aria-valuemax={100}
-            className="flex-1 h-1.5 bg-port-bg rounded-full overflow-hidden"
-          >
-            <div className="h-full bg-port-accent transition-all" style={{ width: `${ingest.percent}%` }} />
-          </div>
+          <ProgressBar
+            percent={ingest.percent}
+            label="YouTube video ingest progress"
+            className="flex-1"
+          />
           <button
             type="button"
             onClick={ingest.cancel}

--- a/client/src/components/QuickBrainCapture.test.jsx
+++ b/client/src/components/QuickBrainCapture.test.jsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
 
 vi.mock('../services/api', () => ({
@@ -27,7 +27,13 @@ vi.mock('./ui/Toast', () => ({
 // under test without inventing a fake transport — no test here drives frames.
 class StubEventSource {
   static CLOSED = 2;
-  constructor(url) { this.url = url; this.readyState = 0; }
+  static instances = [];
+  constructor(url) {
+    this.url = url;
+    this.readyState = 0;
+    StubEventSource.instances.push(this);
+  }
+  emit(frame) { this.onmessage?.({ data: JSON.stringify(frame) }); }
   close() { this.readyState = StubEventSource.CLOSED; }
 }
 globalThis.EventSource = StubEventSource;
@@ -59,6 +65,7 @@ const openAdvanced = async () => {
 describe('QuickBrainCapture', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    StubEventSource.instances = [];
     localStorage.clear();
     captureBrainThought.mockResolvedValue({ message: 'Saved to Links!' });
     getYoutubeIngestSettings.mockResolvedValue({
@@ -356,6 +363,15 @@ describe('QuickBrainCapture', () => {
       expect(progress).toHaveAttribute('aria-valuemin', '0');
       expect(progress).toHaveAttribute('aria-valuemax', '100');
       expect(screen.getByText('starting…')).toHaveAttribute('aria-live', 'polite');
+
+      await waitFor(() => expect(StubEventSource.instances).toHaveLength(1));
+      act(() => StubEventSource.instances[0].emit({ type: 'progress', stage: 'video', percent: 47.6 }));
+      await waitFor(() => expect(progress).toHaveAttribute('aria-valuenow', '48'));
+      expect(screen.getByText('video…')).toHaveAttribute('aria-live', 'polite');
+
+      act(() => StubEventSource.instances[0].emit({ type: 'metadata', title: 'Example Video' }));
+      await waitFor(() => expect(progress).toHaveAttribute('aria-valuenow', '48'));
+      expect(screen.getByText('video…')).toBeInTheDocument();
     });
 
     it('does not fetch ingest settings until a YouTube URL is typed', () => {

--- a/client/src/components/QuickBrainCapture.test.jsx
+++ b/client/src/components/QuickBrainCapture.test.jsx
@@ -345,6 +345,19 @@ describe('QuickBrainCapture', () => {
       expect(startYoutubeIngest.mock.calls[0][0]).toMatchObject({ ingestAudio: true, captureTranscript: true });
     });
 
+    it('exposes ingest progress and stage updates to assistive technology', async () => {
+      renderWidget();
+      type(YT);
+      await waitFor(() => expect(getYoutubeIngestSettings).toHaveBeenCalled());
+      fireEvent.click(screen.getByLabelText('Capture'));
+
+      const progress = await screen.findByRole('progressbar', { name: 'YouTube video ingest progress' });
+      expect(progress).toHaveAttribute('aria-valuenow', '0');
+      expect(progress).toHaveAttribute('aria-valuemin', '0');
+      expect(progress).toHaveAttribute('aria-valuemax', '100');
+      expect(screen.getByText('starting…')).toHaveAttribute('aria-live', 'polite');
+    });
+
     it('does not fetch ingest settings until a YouTube URL is typed', () => {
       renderWidget();
       type('just a thought');

--- a/client/src/components/QuickBrainCapture.test.jsx
+++ b/client/src/components/QuickBrainCapture.test.jsx
@@ -23,8 +23,8 @@ vi.mock('./ui/Toast', () => ({
 }));
 
 // jsdom has no EventSource, and once a kickoff resolves the real
-// useSseProgress subscribes to one. A do-nothing stub keeps the hook wiring
-// under test without inventing a fake transport — no test here drives frames.
+// useSseProgress subscribes to one. This controllable stub lets the accessibility
+// coverage drive realistic progress frames without opening a network transport.
 class StubEventSource {
   static CLOSED = 2;
   static instances = [];
@@ -34,6 +34,10 @@ class StubEventSource {
     StubEventSource.instances.push(this);
   }
   emit(frame) { this.onmessage?.({ data: JSON.stringify(frame) }); }
+  fail() {
+    this.readyState = StubEventSource.CLOSED;
+    this.onerror?.();
+  }
   close() { this.readyState = StubEventSource.CLOSED; }
 }
 globalThis.EventSource = StubEventSource;
@@ -372,6 +376,17 @@ describe('QuickBrainCapture', () => {
       act(() => StubEventSource.instances[0].emit({ type: 'metadata', title: 'Example Video' }));
       await waitFor(() => expect(progress).toHaveAttribute('aria-valuenow', '48'));
       expect(screen.getByText('video…')).toBeInTheDocument();
+
+      act(() => StubEventSource.instances[0].fail());
+      await waitFor(() => expect(screen.queryByRole('progressbar')).not.toBeInTheDocument());
+
+      startYoutubeIngest.mockResolvedValueOnce({ jobId: 'job-2' });
+      type(YT);
+      fireEvent.click(screen.getByLabelText('Capture'));
+
+      const retryProgress = await screen.findByRole('progressbar', { name: 'YouTube video ingest progress' });
+      expect(retryProgress).toHaveAttribute('aria-valuenow', '0');
+      expect(screen.getByText('starting…')).toHaveAttribute('aria-live', 'polite');
     });
 
     it('does not fetch ingest settings until a YouTube URL is typed', () => {

--- a/client/src/hooks/useSseJobSlot.js
+++ b/client/src/hooks/useSseJobSlot.js
@@ -64,8 +64,14 @@ export default function useSseJobSlot({
   // Metadata and warning frames intentionally omit progress fields. Preserve the
   // last announced values across those sparse frames instead of flashing 0% /
   // "starting" between real progress updates.
+  //
+  // `latestUrl` is only a STALE-FRAME guard: the real hook sets it alongside
+  // `latest`, so a mismatch means the frame belongs to a previous job. An absent
+  // `latestUrl` means "unknown", not "mismatched" — treating it as a mismatch
+  // would silently freeze progress for any consumer whose SSE seam is stubbed.
   useEffect(() => {
-    if (!job || !latest || sse.latestUrl !== jobUrl) return;
+    if (!job || !latest) return;
+    if (sse.latestUrl && sse.latestUrl !== jobUrl) return;
     setProgress((prev) => ({
       percent: Number.isFinite(latest.percent) ? Math.round(latest.percent) : prev.percent,
       stage: typeof latest.stage === 'string' && latest.stage ? latest.stage : prev.stage,

--- a/client/src/hooks/useSseJobSlot.js
+++ b/client/src/hooks/useSseJobSlot.js
@@ -57,19 +57,20 @@ export default function useSseJobSlot({
   const [job, setJob] = useState(null); // { jobId, context }
   const [pending, setPending] = useState(false);
   const [progress, setProgress] = useState({ percent: 0, stage: null });
-  const sse = useSseProgress(job ? eventsUrl(job.jobId) : null);
+  const jobUrl = job ? eventsUrl(job.jobId) : null;
+  const sse = useSseProgress(jobUrl);
   const latest = sse.latest;
 
   // Metadata and warning frames intentionally omit progress fields. Preserve the
   // last announced values across those sparse frames instead of flashing 0% /
   // "starting" between real progress updates.
   useEffect(() => {
-    if (!job || !latest) return;
+    if (!job || !latest || sse.latestUrl !== jobUrl) return;
     setProgress((prev) => ({
       percent: Number.isFinite(latest.percent) ? Math.round(latest.percent) : prev.percent,
       stage: typeof latest.stage === 'string' && latest.stage ? latest.stage : prev.stage,
     }));
-  }, [latest, job]);
+  }, [latest, job, jobUrl, sse.latestUrl]);
 
   useEffect(() => {
     if (!job || !latest) return;

--- a/client/src/hooks/useSseJobSlot.js
+++ b/client/src/hooks/useSseJobSlot.js
@@ -56,10 +56,20 @@ export default function useSseJobSlot({
 } = {}) {
   const [job, setJob] = useState(null); // { jobId, context }
   const [pending, setPending] = useState(false);
+  const [progress, setProgress] = useState({ percent: 0, stage: null });
   const sse = useSseProgress(job ? eventsUrl(job.jobId) : null);
   const latest = sse.latest;
-  const percent = Math.round(latest?.percent ?? 0);
-  const stage = latest?.stage ?? null;
+
+  // Metadata and warning frames intentionally omit progress fields. Preserve the
+  // last announced values across those sparse frames instead of flashing 0% /
+  // "starting" between real progress updates.
+  useEffect(() => {
+    if (!job || !latest) return;
+    setProgress((prev) => ({
+      percent: Number.isFinite(latest.percent) ? Math.round(latest.percent) : prev.percent,
+      stage: typeof latest.stage === 'string' && latest.stage ? latest.stage : prev.stage,
+    }));
+  }, [latest, job]);
 
   useEffect(() => {
     if (!job || !latest) return;
@@ -91,6 +101,7 @@ export default function useSseJobSlot({
     const arg = trimStartArg ? (startArg ?? '').trim() : startArg;
     if (trimStartArg && !arg) return;
     if (job || pending) return;
+    setProgress({ percent: 0, stage: null });
     setPending(true);
     startRequest(arg)
       .then(({ jobId }) => {
@@ -111,8 +122,8 @@ export default function useSseJobSlot({
 
   return {
     active: pending || !!job,
-    percent,
-    stage,
+    percent: progress.percent,
+    stage: progress.stage,
     context: job?.context ?? null,
     start,
     cancel,

--- a/client/src/hooks/useSseProgress.js
+++ b/client/src/hooks/useSseProgress.js
@@ -25,6 +25,7 @@ export const isTerminalSseFrame = (frame) => TERMINAL_TYPES.has(frame?.type);
 export function useSseProgress(url, { enabled = true } = {}) {
   const [frames, setFrames] = useState([]);
   const [latest, setLatest] = useState(null);
+  const [latestUrl, setLatestUrl] = useState(null);
   const [isOpen, setIsOpen] = useState(false);
   // `closed` flips true when the stream ends for ANY reason — a terminal frame
   // OR a connection failure/404 (e.g. the server pruned a fast-completing job
@@ -42,10 +43,12 @@ export function useSseProgress(url, { enabled = true } = {}) {
       // subscribe, tearing down the new stream before it can deliver progress.
       setIsOpen(false);
       setClosed(false);
+      setLatestUrl(null);
       return undefined;
     }
     setFrames([]);
     setLatest(null);
+    setLatestUrl(null);
     setIsOpen(false);
     setClosed(false);
 
@@ -62,6 +65,7 @@ export function useSseProgress(url, { enabled = true } = {}) {
       }
       setFrames((prev) => [...prev, data]);
       setLatest(data);
+      setLatestUrl(url);
       if (TERMINAL_TYPES.has(data?.type)) {
         es.close();
         setIsOpen(false); // the connection is now closed — keep isOpen honest
@@ -85,5 +89,5 @@ export function useSseProgress(url, { enabled = true } = {}) {
     };
   }, [url, enabled]);
 
-  return { frames, latest, isOpen, closed, close: () => esRef.current?.close() };
+  return { frames, latest, latestUrl, isOpen, closed, close: () => esRef.current?.close() };
 }

--- a/client/src/hooks/useSseProgress.test.jsx
+++ b/client/src/hooks/useSseProgress.test.jsx
@@ -27,6 +27,7 @@ describe('useSseProgress', () => {
     });
     expect(result.current.frames).toHaveLength(2);
     expect(result.current.latest).toEqual({ type: 'progress', progress: 0.5 });
+    expect(result.current.latestUrl).toBe('/x');
     expect(result.current.closed).toBe(false);
   });
 
@@ -57,6 +58,7 @@ describe('useSseProgress', () => {
     rerender({ url: '/b' });
     expect(result.current.closed).toBe(false);
     expect(result.current.frames).toHaveLength(0);
+    expect(result.current.latestUrl).toBeNull();
     expect(last().url).toBe('/b');
   });
 
@@ -73,6 +75,7 @@ describe('useSseProgress', () => {
     rerender({ url: null });
     expect(result.current.closed).toBe(false);
     expect(result.current.latest).toEqual({ type: 'error', error: 'boom' });
+    expect(result.current.latestUrl).toBeNull();
   });
 
   it('isTerminalSseFrame matches the terminal set and rejects others', () => {


### PR DESCRIPTION
## Summary

- expose YouTube ingest completion as a labeled ARIA progress bar
- announce stage changes through a polite live region
- preserve progress across sparse SSE frames while isolating retries from stale job state
- cover live progress, sparse metadata, and retry reset behavior

## Test plan

- `cd client && npm test -- --run src/components/QuickBrainCapture.test.jsx src/hooks/useSseProgress.test.jsx`
- `cd client && npm run lint`

Closes #5131
