### PR TITLE
fix: avoid negative Basic auth cache entries

### DIFF
--- a/server/services/authGate.js
+++ b/server/services/authGate.js
@@ -29,22 +29,28 @@ const PUBLIC_API_PATHS = new Set([
 // future routes that live outside `/api`.
 const GATED_NON_API_PREFIXES = ['/sdapi/'];
 
-// Short-lived cache for Basic-auth scrypt results so probe cycles (3 parallel
-// HTTP requests every 30s) don't re-run scrypt each time. Keyed by sha256 of
-// the password so the plaintext never lives in the Map. Flushed on any
-// settings write (covers password rotation).
+// Short-lived cache for successful Basic-auth scrypt results so probe cycles
+// (3 parallel HTTP requests every 30s) don't re-run scrypt each time. Failed
+// results are deliberately not cached so a corrected credential is retried
+// immediately. Keyed by sha256 so plaintext never lives in the Map. Flushed
+// on any settings write (covers password rotation).
 const basicAuthCache = new Map();
 const BASIC_AUTH_CACHE_TTL_MS = 60_000;
 settingsEvents.on('settings:updated', () => basicAuthCache.clear());
 
 const verifyBasicPassword = async (password) => {
+  if (typeof password !== 'string' || password.length === 0) return false;
   const key = createHash('sha256').update(password).digest('hex');
   const cached = basicAuthCache.get(key);
   if (cached && cached.expiresAt > Date.now()) return cached.ok;
   const ok = await verifyPassword(password);
-  basicAuthCache.set(key, { ok, expiresAt: Date.now() + BASIC_AUTH_CACHE_TTL_MS });
+  if (ok) {
+    basicAuthCache.set(key, { ok: true, expiresAt: Date.now() + BASIC_AUTH_CACHE_TTL_MS });
+  }
   return ok;
 };
+
+export const __testing = { verifyBasicPassword };
 
 const isPublicPath = (path) => {
   if (PUBLIC_API_PATHS.has(path)) return true;

--- a/server/services/authGate.test.js
+++ b/server/services/authGate.test.js
@@ -1,5 +1,5 @@
 import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
-import { writeFileSync, rmSync } from 'fs';
+import { readFileSync, writeFileSync, rmSync } from 'fs';
 import { join } from 'path';
 import { mockPathsDataRoot } from '../lib/mockPathsDataRoot.js';
 import { bindSettingsFile } from '../lib/settingsTestUtil.js';
@@ -425,6 +425,35 @@ describe('authGate HTTP Basic auth (peer federation)', () => {
     expect(result.called).toBe(false);
     expect(result.res.statusCode).toBe(401);
   });
+
+  it('does not cache failed password verification', async () => {
+    const auth = await import('./auth.js');
+    await auth.setPassword({ newPassword: 'future-secret' });
+    const futureSettings = JSON.parse(readFileSync(join(tempRoot, 'settings.json'), 'utf-8'));
+    await auth.setPassword({
+      newPassword: 'current-secret',
+      currentPassword: 'future-secret',
+    });
+    const { __testing } = await import('./authGate.js');
+
+    expect(await __testing.verifyBasicPassword('future-secret')).toBe(false);
+
+    // Replace the backing credential without emitting settings:updated. A failed
+    // verification must not shadow the now-valid password for the cache TTL.
+    await mergeSettingsFile({ secrets: futureSettings.secrets });
+    expect(await __testing.verifyBasicPassword('future-secret')).toBe(true);
+  });
+
+  it.each([null, undefined, 123, {}, []])(
+    'rejects malformed Basic password value %j without throwing',
+    async (password) => {
+      const auth = await import('./auth.js');
+      await auth.setPassword({ newPassword: 'peer-secret' });
+      const { __testing } = await import('./authGate.js');
+
+      await expect(__testing.verifyBasicPassword(password)).resolves.toBe(false);
+    },
+  );
 });
 
 describe('socketAuthGate middleware', () => {


### PR DESCRIPTION
## Summary

- cache only successful HTTP Basic password verifications so corrected credentials are retried immediately
- reject empty or non-string Basic password values before hashing
- cover negative-cache retry and malformed-value behavior with regression tests

## Test plan

- `cd server && npm test -- --run services/authGate.test.js` (40 passed)
- `codex review --base origin/main` with `gpt-5.6-luna`, reasoning effort `max` (clean)

Closes #5135
