### PR TITLE
fix: make the theme menu accessible (#5132)

### DIFF
--- a/client/src/components/Layout.jsx
+++ b/client/src/components/Layout.jsx
@@ -130,6 +130,7 @@ import { useSidebarSeries } from '../hooks/useSidebarSeries.js';
 import { useSidebarUniverses } from '../hooks/useSidebarUniverses.js';
 import { useThemeContext } from './ThemeContext';
 import NotificationDropdown from './NotificationDropdown';
+import ThemeSwitcher from './ThemeSwitcher';
 import VoiceToggleButton from './voice/VoiceToggleButton';
 import CmdKSearch from './CmdKSearch';
 import KeyboardHelp from './KeyboardHelp';
@@ -1280,6 +1281,7 @@ export default function Layout() {
                 <Monitor size={18} />
               </NavLink>
               <ThemeModeToggle />
+              <ThemeSwitcher className={collapsed ? 'lg:hidden' : ''} />
               <VoiceToggleButton className={collapsed ? 'lg:hidden' : ''} />
               <NotificationDropdown
                 notifications={notifications}
@@ -1400,6 +1402,7 @@ export default function Layout() {
               <Monitor size={18} />
             </NavLink>
             <ThemeModeToggle />
+            <ThemeSwitcher position="below" />
             <VoiceToggleButton />
           </div>
         </header>

--- a/client/src/components/ThemeSwitcher.jsx
+++ b/client/src/components/ThemeSwitcher.jsx
@@ -34,10 +34,10 @@ export default function ThemeSwitcher({ position = 'above', className = '' }) {
   useEscapeKey(open, () => close(true));
 
   useEffect(() => {
-    if (!open) return;
+    if (!open || !menuStyle) return;
     const selected = menuRef.current?.querySelector(`${ITEM_SELECTOR}[aria-checked="true"]`);
     (selected ?? menuRef.current?.querySelector(ITEM_SELECTOR))?.focus();
-  }, [open, menuRef]);
+  }, [open, menuRef, menuStyle]);
 
   const menuItems = () => Array.from(menuRef.current?.querySelectorAll(ITEM_SELECTOR) ?? []);
 

--- a/client/src/components/ThemeSwitcher.jsx
+++ b/client/src/components/ThemeSwitcher.jsx
@@ -42,6 +42,8 @@ export default function ThemeSwitcher({ position = 'above', className = '' }) {
       {open && createPortal(
         <div
           ref={menuRef}
+          role="menu"
+          aria-label="Interface theme"
           className="fixed max-w-[calc(100vw-1rem)] bg-port-card border border-port-border rounded-xl shadow-xl z-[100] p-2"
           style={{
             left: menuStyle?.left ?? `${VIEWPORT_PADDING}px`,
@@ -60,6 +62,8 @@ export default function ThemeSwitcher({ position = 'above', className = '' }) {
               return (
                 <button
                   key={option.id}
+                  role="menuitemradio"
+                  aria-checked={active}
                   onClick={() => { setTheme(option.id); setOpen(false); }}
                   className={`w-full flex items-center gap-3 px-2.5 py-2.5 rounded-lg text-sm transition-colors ${
                     active

--- a/client/src/components/ThemeSwitcher.jsx
+++ b/client/src/components/ThemeSwitcher.jsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { Check, Palette } from 'lucide-react';
 import { useThemeContext } from './ThemeContext';
@@ -8,6 +8,8 @@ import useClickOutside from '../hooks/useClickOutside.js';
 import useEscapeKey from '../hooks/useEscapeKey.js';
 
 const MENU_WIDTH = 288;
+const ITEM_SELECTOR = '[role="menuitemradio"]';
+const TABBABLE_SELECTOR = 'a[href],button:not(:disabled),input:not(:disabled),select:not(:disabled),textarea:not(:disabled),[tabindex]:not([tabindex="-1"])';
 
 export default function ThemeSwitcher({ position = 'above', className = '' }) {
   const { themeId, theme, themeList, setTheme } = useThemeContext();
@@ -19,21 +21,82 @@ export default function ThemeSwitcher({ position = 'above', className = '' }) {
     style: menuStyle,
   } = usePopoverPosition({ open, width: MENU_WIDTH, minWidth: 180, gap: 8, position });
 
+  const close = useCallback((refocus) => {
+    setOpen(false);
+    if (refocus) triggerRef.current?.focus();
+  }, [triggerRef]);
+
   // Close on outside-click / Escape — the popover-position hook owns placement
   // and reflow; this component still owns its own dismiss semantics. The menu is
   // portaled to <body>, so both the trigger container and the panel have to count
   // as "inside" — that's what the array form of useClickOutside is for.
   useClickOutside([containerRef, menuRef], open, () => setOpen(false));
-  useEscapeKey(open, () => setOpen(false));
+  useEscapeKey(open, () => close(true));
+
+  useEffect(() => {
+    if (!open) return;
+    const selected = menuRef.current?.querySelector(`${ITEM_SELECTOR}[aria-checked="true"]`);
+    (selected ?? menuRef.current?.querySelector(ITEM_SELECTOR))?.focus();
+  }, [open, menuRef]);
+
+  const menuItems = () => Array.from(menuRef.current?.querySelectorAll(ITEM_SELECTOR) ?? []);
+
+  const focusItem = (index) => {
+    const items = menuItems();
+    items[(index + items.length) % items.length]?.focus();
+  };
+
+  const moveFocus = (direction) => {
+    const items = menuItems();
+    const current = items.indexOf(document.activeElement);
+    focusItem(current === -1 ? (direction > 0 ? 0 : items.length - 1) : current + direction);
+  };
+
+  const focusPastTrigger = (backwards) => {
+    const trigger = triggerRef.current;
+    const items = Array.from(document.querySelectorAll(TABBABLE_SELECTOR))
+      .filter(element => !menuRef.current?.contains(element));
+    const triggerIndex = items.indexOf(trigger);
+    const next = triggerIndex === -1 ? null : items[triggerIndex + (backwards ? -1 : 1)];
+    (next ?? trigger)?.focus();
+  };
+
+  const handleMenuKeyDown = (event) => {
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      moveFocus(1);
+    } else if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      moveFocus(-1);
+    } else if (event.key === 'Home') {
+      event.preventDefault();
+      focusItem(0);
+    } else if (event.key === 'End') {
+      event.preventDefault();
+      focusItem(-1);
+    } else if (event.key === 'Tab') {
+      event.preventDefault();
+      focusPastTrigger(event.shiftKey);
+      setOpen(false);
+    }
+  };
 
   return (
     <div ref={containerRef} className={`relative ${className}`}>
       <button
+        type="button"
         ref={triggerRef}
         onClick={() => setOpen(!open)}
+        onKeyDown={(event) => {
+          if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+            event.preventDefault();
+            setOpen(true);
+          }
+        }}
         className="p-1.5 text-gray-500 hover:text-port-accent transition-colors"
         title="Switch theme"
         aria-label={`Switch theme. Current theme: ${theme?.label ?? 'Classic Midnight'}`}
+        aria-haspopup="menu"
         aria-expanded={open}
       >
         <Palette size={18} />
@@ -44,6 +107,7 @@ export default function ThemeSwitcher({ position = 'above', className = '' }) {
           ref={menuRef}
           role="menu"
           aria-label="Interface theme"
+          onKeyDown={handleMenuKeyDown}
           className="fixed max-w-[calc(100vw-1rem)] bg-port-card border border-port-border rounded-xl shadow-xl z-[100] p-2"
           style={{
             left: menuStyle?.left ?? `${VIEWPORT_PADDING}px`,
@@ -61,10 +125,11 @@ export default function ThemeSwitcher({ position = 'above', className = '' }) {
               const active = themeId === option.id;
               return (
                 <button
+                  type="button"
                   key={option.id}
                   role="menuitemradio"
                   aria-checked={active}
-                  onClick={() => { setTheme(option.id); setOpen(false); }}
+                  onClick={() => { setTheme(option.id); close(true); }}
                   className={`w-full flex items-center gap-3 px-2.5 py-2.5 rounded-lg text-sm transition-colors ${
                     active
                       ? 'bg-port-accent/10 text-port-accent'

--- a/client/src/components/ThemeSwitcher.test.jsx
+++ b/client/src/components/ThemeSwitcher.test.jsx
@@ -1,0 +1,42 @@
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import ThemeSwitcher from './ThemeSwitcher';
+
+vi.mock('./ThemeContext', () => ({
+  useThemeContext: () => ({
+    themeId: 'classic-midnight',
+    theme: { label: 'Classic Midnight' },
+    themeList: [
+      {
+        id: 'classic-midnight',
+        label: 'Classic Midnight',
+        shortLabel: 'Classic',
+        density: 'comfortable',
+        family: 'classic',
+        accent: '#2563eb',
+      },
+      {
+        id: 'blueprint-day',
+        label: 'Blueprint Day',
+        shortLabel: 'Blueprint',
+        density: 'compact',
+        family: 'blueprint',
+        accent: '#0ea5e9',
+      },
+    ],
+    setTheme: vi.fn(),
+  }),
+}));
+
+describe('ThemeSwitcher', () => {
+  it('exposes the current theme through accessible menu radio state', () => {
+    render(<ThemeSwitcher />);
+    fireEvent.click(screen.getByRole('button', { name: /Switch theme/ }));
+
+    const menu = screen.getByRole('menu', { name: 'Interface theme' });
+    expect(within(menu).getByRole('menuitemradio', { name: /Classic Midnight/ }))
+      .toHaveAttribute('aria-checked', 'true');
+    expect(within(menu).getByRole('menuitemradio', { name: /Blueprint Day/ }))
+      .toHaveAttribute('aria-checked', 'false');
+  });
+});

--- a/client/src/components/ThemeSwitcher.test.jsx
+++ b/client/src/components/ThemeSwitcher.test.jsx
@@ -36,6 +36,7 @@ describe('ThemeSwitcher', () => {
     const menu = screen.getByRole('menu', { name: 'Interface theme' });
     const active = within(menu).getByRole('menuitemradio', { name: /Classic Midnight/ });
     const inactive = within(menu).getByRole('menuitemradio', { name: /Blueprint Day/ });
+    expect(menu).toHaveStyle({ visibility: 'visible' });
     expect(active).toHaveAttribute('aria-checked', 'true');
     expect(inactive).toHaveAttribute('aria-checked', 'false');
     expect(active).toHaveFocus();

--- a/client/src/components/ThemeSwitcher.test.jsx
+++ b/client/src/components/ThemeSwitcher.test.jsx
@@ -34,9 +34,19 @@ describe('ThemeSwitcher', () => {
     fireEvent.click(screen.getByRole('button', { name: /Switch theme/ }));
 
     const menu = screen.getByRole('menu', { name: 'Interface theme' });
-    expect(within(menu).getByRole('menuitemradio', { name: /Classic Midnight/ }))
-      .toHaveAttribute('aria-checked', 'true');
-    expect(within(menu).getByRole('menuitemradio', { name: /Blueprint Day/ }))
-      .toHaveAttribute('aria-checked', 'false');
+    const active = within(menu).getByRole('menuitemradio', { name: /Classic Midnight/ });
+    const inactive = within(menu).getByRole('menuitemradio', { name: /Blueprint Day/ });
+    expect(active).toHaveAttribute('aria-checked', 'true');
+    expect(inactive).toHaveAttribute('aria-checked', 'false');
+    expect(active).toHaveFocus();
+
+    fireEvent.keyDown(active, { key: 'ArrowDown' });
+    expect(inactive).toHaveFocus();
+    fireEvent.keyDown(inactive, { key: 'ArrowUp' });
+    expect(active).toHaveFocus();
+
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Switch theme/ })).toHaveFocus();
   });
 });


### PR DESCRIPTION
## Summary

- expose theme choices as an accessible radio menu with current selection state
- provide complete keyboard focus and navigation behavior for the portaled menu
- restore the full theme picker to the desktop and mobile shell controls
- add regression coverage for ARIA state, visibility, and keyboard focus

## Test plan

- `cd client && npm test -- --run src/components/Layout.test.jsx src/a11yConventions.test.js src/components/ThemeSwitcher.test.jsx`
- `cd client && npx biome lint src/components/ThemeSwitcher.jsx src/components/ThemeSwitcher.test.jsx src/components/Layout.jsx --error-on-warnings`
- `cd client && npm run build`

Closes #5132
