### PR TITLE
feat: give Persistent Mind full task filing parity

### DIFF
--- a/client/src/components/cos/PersistentMindTaskAccessControls.jsx
+++ b/client/src/components/cos/PersistentMindTaskAccessControls.jsx
@@ -61,6 +61,7 @@ export default function PersistentMindTaskAccessControls({
       <div className="rounded border border-port-border bg-port-bg/40 px-3 py-2 text-xs text-port-text-muted">
         <p className="font-medium text-port-text">The mind chooses per task</p>
         <p className="mt-1">Target app · AI provider · model · thinking effort · priority</p>
+        <p className="mt-1">Mode: implement and ship · or Plan &amp; File Issue for GitHub/GitLab apps</p>
         <p className="mt-1">Landing gate: code review then merge · merge when CI is green · leave open for human review</p>
       </div>
       <p className="text-xs text-port-text-muted">

--- a/client/src/pages/PersistentMindTools.jsx
+++ b/client/src/pages/PersistentMindTools.jsx
@@ -28,15 +28,20 @@ export default function PersistentMindTools() {
   }, [load]);
 
   const tools = Array.isArray(data?.tools) ? data.tools : [];
+  const taskCatalog = data?.taskCatalog;
   const grantedCount = tools.filter((tool) => tool.granted === true).length;
-  const updateCapabilities = (capabilities) => setData((current) => current ? {
-    ...current,
-    capabilities,
-    tools: (current.tools || []).map((tool) => ({
-      ...tool,
-      granted: capabilities[tool.capability] === true,
-    })),
-  } : current);
+  const updateCapabilities = (capabilities) => {
+    setData((current) => current ? {
+      ...current,
+      capabilities,
+      taskCatalog: capabilities.createTasks ? current.taskCatalog : null,
+      tools: (current.tools || []).map((tool) => ({
+        ...tool,
+        granted: capabilities[tool.capability] === true,
+      })),
+    } : current);
+    if (capabilities.createTasks && !data?.taskCatalog) load();
+  };
 
   return (
     <div className="flex h-full min-h-0 flex-col">
@@ -75,6 +80,41 @@ export default function PersistentMindTools() {
                   </button>
                 </div>
               </section>
+
+              {taskCatalog && (
+                <section aria-labelledby="task-catalog-heading" className="rounded border border-port-border bg-port-card p-4">
+                  <h2 id="task-catalog-heading" className="text-sm font-semibold uppercase tracking-wide text-port-text-muted">Available task filing choices</h2>
+                  <p className="mt-1 text-sm text-port-text-muted">These are the current choices the mind receives when it uses the typed task action. Repository paths and credentials are never included.</p>
+                  <div className="mt-4 grid gap-4 lg:grid-cols-2">
+                    <div>
+                      <h3 className="text-xs font-semibold uppercase tracking-wide text-port-text-muted">Target apps</h3>
+                      <ul className="mt-2 space-y-2 text-sm text-port-text">
+                        {(taskCatalog.apps || []).map((app) => (
+                          <li key={app.id} className="rounded border border-port-border px-3 py-2">
+                            <span>{app.name}</span>
+                            <span className="ml-2 text-xs text-port-text-muted">{app.planOnly ? 'Implementation or Plan & File Issue' : 'Implementation delivery'}</span>
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                    <div>
+                      <h3 className="text-xs font-semibold uppercase tracking-wide text-port-text-muted">Coding providers, models, and effort</h3>
+                      <ul className="mt-2 space-y-2 text-sm text-port-text">
+                        {(taskCatalog.providers || []).map((provider) => (
+                          <li key={provider.id} className="rounded border border-port-border px-3 py-2">
+                            <div>{provider.name}</div>
+                            {provider.models?.length ? provider.models.map((model) => (
+                              <div key={model.id} className="mt-1 text-xs text-port-text-muted">
+                                {model.id} · {model.efforts?.length ? model.efforts.join(', ') : 'provider default effort'}
+                              </div>
+                            )) : <div className="mt-1 text-xs text-port-text-muted">Provider default model and effort</div>}
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  </div>
+                </section>
+              )}
 
               <section aria-labelledby="tools-heading" className="space-y-3">
                 <h2 id="tools-heading" className="text-sm font-semibold uppercase tracking-wide text-port-text-muted">Granted capabilities</h2>

--- a/client/src/pages/PersistentMindTools.jsx
+++ b/client/src/pages/PersistentMindTools.jsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { ArrowLeft, CheckCircle2, LockKeyhole, RefreshCw, ShieldCheck, Wrench } from 'lucide-react';
 import { Link } from 'react-router';
 import * as api from '../services/api';
@@ -11,16 +11,23 @@ export default function PersistentMindTools() {
   const [data, setData] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
+  const requestVersion = useRef(0);
 
   const load = useCallback(() => {
+    const version = ++requestVersion.current;
     setLoading(true);
     api.getPersistentMindTools({ silent: true })
       .then((response) => {
+        if (version !== requestVersion.current) return;
         setData(response);
         setError(null);
       })
-      .catch((requestError) => setError(requestError?.message || 'Could not load persistent mind tools'))
-      .finally(() => setLoading(false));
+      .catch((requestError) => {
+        if (version === requestVersion.current) setError(requestError?.message || 'Could not load persistent mind tools');
+      })
+      .finally(() => {
+        if (version === requestVersion.current) setLoading(false);
+      });
   }, []);
 
   useEffect(() => {
@@ -31,6 +38,7 @@ export default function PersistentMindTools() {
   const taskCatalog = data?.taskCatalog;
   const grantedCount = tools.filter((tool) => tool.granted === true).length;
   const updateCapabilities = (capabilities) => {
+    requestVersion.current += 1;
     setData((current) => current ? {
       ...current,
       capabilities,
@@ -41,6 +49,7 @@ export default function PersistentMindTools() {
       })),
     } : current);
     if (capabilities.createTasks && !data?.taskCatalog) load();
+    else if (!capabilities.createTasks) setLoading(false);
   };
 
   return (

--- a/client/src/pages/PersistentMindTools.test.jsx
+++ b/client/src/pages/PersistentMindTools.test.jsx
@@ -84,6 +84,33 @@ describe('PersistentMindTools', () => {
     expect(api.getPersistentMindTools).toHaveBeenCalledTimes(2);
   });
 
+  it('does not let a stale catalog refresh restore a revoked grant', async () => {
+    const user = userEvent.setup();
+    let resolveCatalog;
+    api.getPersistentMindTools
+      .mockResolvedValueOnce(response())
+      .mockImplementationOnce(() => new Promise((resolve) => {
+        resolveCatalog = resolve;
+      }));
+    renderPage();
+
+    const toggle = await screen.findByRole('checkbox', { name: 'Allow mind to queue CoS agent tasks' });
+    await user.click(toggle);
+    await waitFor(() => expect(api.getPersistentMindTools).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(toggle).toBeChecked());
+
+    await user.click(toggle);
+    await waitFor(() => expect(toggle).not.toBeChecked());
+    resolveCatalog(response({
+      capabilities: { schemaVersion: 1, createTasks: true },
+      tools: [{ ...response().tools[0], granted: true }],
+      taskCatalog: { apps: [{ id: 'stale-app', name: 'Stale App', planOnly: false }], providers: [] },
+    }));
+
+    await waitFor(() => expect(toggle).not.toBeChecked());
+    expect(screen.queryByText('Available task filing choices')).not.toBeInTheDocument();
+  });
+
   it('keeps the failure visible instead of presenting an empty inventory', async () => {
     api.getPersistentMindTools.mockRejectedValue(new Error('Server unreachable'));
     renderPage();

--- a/client/src/pages/PersistentMindTools.test.jsx
+++ b/client/src/pages/PersistentMindTools.test.jsx
@@ -29,6 +29,7 @@ const response = (overrides = {}) => ({
     guardrails: ['Up to five requests per turn'],
   }],
   boundaries: ['No arbitrary shell or file-system access'],
+  taskCatalog: null,
   ...overrides,
 });
 
@@ -54,8 +55,18 @@ describe('PersistentMindTools', () => {
     expect(screen.getByText('Off by default')).toBeInTheDocument();
   });
 
-  it('edits the typed task grant and updates the inventory without a refetch', async () => {
+  it('edits the typed task grant and refreshes the newly available catalog', async () => {
     const user = userEvent.setup();
+    api.getPersistentMindTools
+      .mockResolvedValueOnce(response())
+      .mockResolvedValueOnce(response({
+        capabilities: { schemaVersion: 1, createTasks: true },
+        tools: [{ ...response().tools[0], granted: true }],
+        taskCatalog: {
+          apps: [{ id: 'example-app', name: 'Example App', planOnly: true }],
+          providers: [{ id: 'codex', name: 'Codex', type: 'cli', models: [{ id: 'gpt-5', efforts: ['low', 'high'] }] }],
+        },
+      }));
     renderPage();
 
     const toggle = await screen.findByRole('checkbox', { name: 'Allow mind to queue CoS agent tasks' });
@@ -67,6 +78,10 @@ describe('PersistentMindTools', () => {
     ));
     expect(await screen.findByText(/persistent-mind capabilities granted/)).toHaveTextContent('1 of 1');
     expect(screen.getByText('Granted')).toBeInTheDocument();
+    expect(await screen.findByText('Available task filing choices')).toBeInTheDocument();
+    expect(screen.getByText(/Implementation or Plan & File Issue/)).toBeInTheDocument();
+    expect(screen.getByText('gpt-5 · low, high')).toBeInTheDocument();
+    expect(api.getPersistentMindTools).toHaveBeenCalledTimes(2);
   });
 
   it('keeps the failure visible instead of presenting an empty inventory', async () => {

--- a/docs/features/cos-enhancement.md
+++ b/docs/features/cos-enhancement.md
@@ -109,6 +109,29 @@ Comprehensive upgrade from reactive task executor to proactive autonomous agent 
 3. **Self-Modification**: Full autonomy - COS can change its own base thinking model without user approval
 4. **Failure Investigation**: Unattended by default - an `[Auto] Investigate agent failure` task runs without approval, because an isolated agent failure is exactly the work CoS exists to diagnose for itself. Approval is reserved for a failure *loop*, where another unattended agent would only repeat what already didn't work: the same cause investigated again within 24h (`repeat-fingerprint`), or the circuit-breaker hour already one slot from its cap (`failure-storm`). The reason is stamped on the task as the producer-agnostic `metadata.approvalReason` (`investigation-loop:<signal>`), which the Tasks UI turns into a hint on the APPROVE button. See `resolveInvestigationApproval` in `server/services/agentErrorAnalysis.js`.
 
+## Persistent Mind task filing
+
+The Persistent Mind has one explicit, default-off typed action, `cos.create-task`.
+When the grant is enabled, each wake receives a bounded server-built catalog of
+runnable apps and enabled CLI/TUI coding providers. The catalog includes each
+provider's selectable models and effort levels, and marks apps whose effective
+work tracker supports the issue-only **Plan & File Issue** workflow.
+
+The mind may select the provider, model, effort, priority, delivery mode, and PR
+completion policy per request. Implementation mode requires one of
+`review-then-merge`, `merge-on-green`, or `leave-open`; plan-only mode is only
+valid for GitHub/GitLab apps and is normalized to the existing unattended
+`plan-task --yes` no-code/no-PR contract. The queue path revalidates every choice
+after inference, so stale prompts, disabled providers, invented model ids, and
+unsupported trackers fail closed.
+
+`GET /api/cos/mind/tools` returns the authority inventory and, when task access is
+granted, the same redacted task catalog used in the mind prompt. This keeps the
+Mind Tools UI and the model-facing contract discoverable without granting the
+mind arbitrary shell, filesystem, or general API access. Broader PortOS APIs
+remain governed by their own authenticated route contracts and are not silently
+made callable by enabling task filing.
+
 ## Test Coverage
 
 | Test File | Module |

--- a/server/lib/persistentMindCapabilities.js
+++ b/server/lib/persistentMindCapabilities.js
@@ -25,8 +25,9 @@ export const PERSISTENT_MIND_TOOL_CATALOG = Object.freeze([
     defaultEnabled: false,
     guardrails: [
       'Up to five requests per turn',
-      'Configured app, provider, model, effort, and completion policy are re-validated before queueing',
-      'Work runs through the normal isolated-worktree, autonomy, budget, review, CI, and PR gates',
+      'Configured app, provider, model, effort, mode, and completion policy are re-validated before queueing',
+      'Implementation work runs through the normal isolated-worktree, autonomy, budget, review, CI, and PR gates',
+      'Plan & File Issue requests use the existing issue-only planning contract',
     ],
   }),
 ]);
@@ -61,8 +62,24 @@ export const persistentMindTaskRequestSchema = z.object({
   // providers whose CLI owns model selection and publishes no concrete ids.
   model: z.string().trim().max(PERSISTENT_MIND_TASK_LIMITS.modelChars),
   effort: z.union([z.literal(''), z.enum(EFFORT_LEVELS)]).optional().default(''),
-  prCompletion: z.enum(PR_COMPLETION_VALUES),
-}).strict();
+  // `planOnly` is the User Task form's issue-only mode. It deliberately does
+  // not require a PR disposition because the task store forces the
+  // no-worktree/no-PR posture for it. Implementation tasks still must choose a
+  // disposition so the mind cannot silently inherit a different landing gate.
+  // Keep absence meaningful for replay compatibility: adding a default here
+  // would change the canonical fingerprint of an older implementation request
+  // and could queue it twice after an install upgrades.
+  planOnly: z.boolean().optional(),
+  prCompletion: z.enum(PR_COMPLETION_VALUES).optional(),
+}).strict().superRefine((value, context) => {
+  if (!value.planOnly && !value.prCompletion) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['prCompletion'],
+      message: 'Implementation tasks require a PR completion policy',
+    });
+  }
+});
 
 export function createDefaultPersistentMindCapabilities() {
   return {

--- a/server/lib/persistentMindCapabilities.test.js
+++ b/server/lib/persistentMindCapabilities.test.js
@@ -43,4 +43,18 @@ describe('persistent mind capabilities', () => {
     expect(persistentMindTaskRequestSchema.safeParse({ ...task, prCompletion: 'merge-now' }).success).toBe(false);
     expect(persistentMindTaskRequestSchema.safeParse({ ...task, priority: 'URGENT' }).success).toBe(false);
   });
+
+  it('allows plan-and-file requests without a PR disposition', () => {
+    const task = {
+      description: 'File an issue for the missing export contract',
+      prompt: 'Inspect the repository and file one actionable issue without editing code.',
+      appId: 'portos',
+      providerId: 'codex',
+      model: '',
+      effort: '',
+      planOnly: true,
+    };
+    expect(persistentMindTaskRequestSchema.safeParse(task).success).toBe(true);
+    expect(persistentMindTaskRequestSchema.safeParse({ ...task, planOnly: false }).success).toBe(false);
+  });
 });

--- a/server/routes/cosMindRoutes.js
+++ b/server/routes/cosMindRoutes.js
@@ -33,6 +33,7 @@ import {
 } from '../services/persistentMindContext.js';
 import { getProviderById } from '../services/providers.js';
 import { persistentMindHarnessInfo } from '../services/persistentMindAdapter.js';
+import { readPersistentMindTaskCatalog } from '../services/persistentMindTaskCapability.js';
 import { inspectPersistentMindRuntime } from '../services/persistentMindRuntime.js';
 import {
   enqueuePersistentMindMessage,
@@ -165,10 +166,12 @@ router.get('/mind/context', asyncHandler(async (_req, res) => {
 router.get('/mind/tools', asyncHandler(async (_req, res) => {
   const root = await loadState();
   const capabilities = normalizePersistentMindCapabilities(root.config?.persistentMindCapabilities);
+  const taskCatalog = capabilities.createTasks ? await readPersistentMindTaskCatalog() : null;
   res.json({
     schemaVersion: PERSISTENT_MIND_CAPABILITIES_SCHEMA_VERSION,
     capabilities,
     boundaries: PERSISTENT_MIND_TOOL_BOUNDARIES,
+    taskCatalog,
     tools: PERSISTENT_MIND_TOOL_CATALOG.map((tool) => ({
       ...tool,
       granted: capabilities[tool.capability] === true,

--- a/server/routes/cosMindRoutes.test.js
+++ b/server/routes/cosMindRoutes.test.js
@@ -22,6 +22,7 @@ const mocks = vi.hoisted(() => ({
   resumePersistentMind: vi.fn(),
   stopPersistentMind: vi.fn(),
   inspectPersistentMindRuntime: vi.fn(),
+  readPersistentMindTaskCatalog: vi.fn(),
 }));
 
 vi.mock('../services/agentRunEventLog.js', () => ({
@@ -46,6 +47,9 @@ vi.mock('../services/persistentMindAdapter.js', () => ({
     recommendation: provider?.type === 'api' ? 'recommended' : 'supported',
     detail: 'Structured provider harness.',
   }),
+}));
+vi.mock('../services/persistentMindTaskCapability.js', () => ({
+  readPersistentMindTaskCatalog: mocks.readPersistentMindTaskCatalog,
 }));
 vi.mock('../services/persistentMindSupervisor.js', () => ({
   getPersistentMindState: mocks.getPersistentMindState,
@@ -113,6 +117,10 @@ describe('persistent mind routes', () => {
       context: { chars: 9, maxChars: 32000, approximateTokens: 3, summaryState: 'empty', memoryCount: 1 },
       system: { memory: { total: 100, used: 40, free: 60, usagePercent: 40 } },
     });
+    mocks.readPersistentMindTaskCatalog.mockResolvedValue({
+      apps: [{ id: 'demo-app', name: 'Demo App', planOnly: true }],
+      providers: [{ id: 'codex', name: 'Codex', type: 'cli', models: [{ id: 'gpt-5', efforts: ['low', 'high'] }] }],
+    });
   });
 
   it('serves a bounded cursor snapshot with only the safe profile fields', async () => {
@@ -164,6 +172,10 @@ describe('persistent mind routes', () => {
         granted: true,
         defaultEnabled: false,
       })],
+      taskCatalog: {
+        apps: [{ id: 'demo-app', planOnly: true }],
+        providers: [{ id: 'codex' }],
+      },
     });
     expect(res.body.tools[0].guardrails).toEqual(expect.arrayContaining([
       expect.stringMatching(/isolated-worktree/i),

--- a/server/services/persistentMindAdapter.js
+++ b/server/services/persistentMindAdapter.js
@@ -109,7 +109,7 @@ Return ONLY one JSON object with this shape:
   "thinkingSummary": "A concise, user-visible working note explaining what you considered and why. Do not reveal hidden chain-of-thought.",
   "message": "The conversational reply. Required for a human message; optional for a self-directed wake.",
   "memoryCandidates": [{ "content": "A durable fact worth remembering", "summary": "Short label", "type": "fact", "category": "other", "tags": ["optional"] }],
-  "taskRequests": [{ "description": "Concise queue label", "prompt": "Complete instructions for the agent", "priority": "MEDIUM", "appId": "configured-app-id", "providerId": "configured-provider-id", "model": "configured-model-id-or-empty-for-default", "effort": "high", "prCompletion": "review-then-merge" }],
+  "taskRequests": [{ "description": "Concise queue label", "prompt": "Complete instructions for the agent", "priority": "MEDIUM", "appId": "configured-app-id", "providerId": "configured-provider-id", "model": "configured-model-id-or-empty-for-default", "effort": "high", "planOnly": false, "prCompletion": "review-then-merge" }],
   "selfWake": { "reason": "Why another wake would be useful", "delayMinutes": 60 }
 }
 Use empty arrays when there is no durable memory candidate or task request, and null when no earlier follow-up is needed. Memory candidates are durable memories to save automatically; only include information that is worth retaining. Typed CoS task creation is the only action capability in this lane and is available only when the capability section says ON. This lane still cannot mutate files directly, call arbitrary tools, contact people, or perform other external actions.`;

--- a/server/services/persistentMindTaskCapability.js
+++ b/server/services/persistentMindTaskCapability.js
@@ -17,7 +17,7 @@ import { canonicalStringify } from '../lib/objects.js';
 import { antigravityBaseModels, effortLevelsForProvider, filterSelectableModels } from '../lib/providerModels.js';
 import { PR_COMPLETIONS } from '../lib/prDisposition.js';
 import { sha256Text } from '../lib/fileUtils.js';
-import { getActiveApps } from './apps.js';
+import { getActiveApps, getAppWorkTracker } from './apps.js';
 import { loadState } from './cosState.js';
 import { addTask, getTaskById } from './cosTaskStore.js';
 import { listProviders } from './providers.js';
@@ -27,6 +27,7 @@ const MAX_CATALOG_PROVIDERS = 50;
 const MAX_CATALOG_MODELS = 60;
 const MAX_CATALOG_PROMPT_CHARS = 16_000;
 const MAX_CATALOG_APP_PROMPT_CHARS = 4_000;
+const ISSUE_TRACKERS = new Set(['github', 'gitlab']);
 
 const isRunnableApp = (app) => typeof app?.repoPath === 'string' && app.repoPath.trim().length > 0;
 const isRunnableAgentProvider = (provider) => provider?.enabled !== false
@@ -58,14 +59,23 @@ const providerCatalogEntry = (provider) => {
   };
 };
 
+const appCatalogEntry = async (app) => {
+  const tracker = await getAppWorkTracker(app.id);
+  return {
+    id: app.id,
+    name: String(app.name || app.id).slice(0, 100),
+    planOnly: ISSUE_TRACKERS.has(tracker?.resolved),
+  };
+};
+
 export async function readPersistentMindTaskCatalog() {
   const [apps, providers] = await Promise.all([getActiveApps(), listProviders()]);
+  const runnableApps = apps
+    .filter((app) => isRunnableApp(app) && typeof app?.id === 'string' && app.id
+      && app.id.length <= PERSISTENT_MIND_TASK_LIMITS.appIdChars)
+    .slice(0, MAX_CATALOG_APPS);
   return {
-    apps: apps
-      .filter((app) => isRunnableApp(app) && typeof app?.id === 'string' && app.id
-        && app.id.length <= PERSISTENT_MIND_TASK_LIMITS.appIdChars)
-      .slice(0, MAX_CATALOG_APPS)
-      .map((app) => ({ id: app.id, name: String(app.name || app.id).slice(0, 100) })),
+    apps: await Promise.all(runnableApps.map(appCatalogEntry)),
     providers: providers
       .filter((provider) => isRunnableAgentProvider(provider)
         && typeof provider?.id === 'string' && provider.id
@@ -109,12 +119,17 @@ Task creation access is OFF. Return an empty taskRequests array. You may recomme
   }
   const promptCatalog = boundedPromptCatalog(catalog);
   return `# CoS agent task capability
-Task creation access is ON. You may request up to ${PERSISTENT_MIND_TASK_LIMITS.maxPerTurn} internal CoS agent tasks when the current wake calls for concrete delegated work. Each task runs in an isolated worktree, opens a pull request, and is auto-approved into the normal CoS scheduler. The scheduler still enforces capacity, autonomy, and budget gates.
+Task creation access is ON. You may request up to ${PERSISTENT_MIND_TASK_LIMITS.maxPerTurn} internal CoS agent tasks when the current wake calls for concrete delegated work. Implementation tasks run in an isolated worktree, open a pull request, and are auto-approved into the normal CoS scheduler. Plan-only tasks use the issue-only planning contract described below. The scheduler still enforces capacity, autonomy, and budget gates.
 
 For each task, choose one configured app, provider, model (or "" for the provider's configured default), supported effort (or "" for the provider default), and exactly one PR completion policy:
 - "review-then-merge": run the configured code-review loop, then merge only when its gate passes.
 - "merge-on-green": skip code review and merge after CI is green.
 - "leave-open": open the PR and wait for a human to review and merge it.
+Set 'planOnly' to true to use the issue-only "Plan & File Issue" mode, but only
+for an app whose catalog entry has 'planOnly: true'; that mode investigates the
+repository and files one GitHub/GitLab issue without editing code or opening a
+PR. In plan-only mode, 'prCompletion' may be omitted. Otherwise set
+'planOnly' to false and choose one PR completion policy.
 
 Configured choices (ids are authoritative; do not invent ids):
 ${JSON.stringify(promptCatalog)}
@@ -134,7 +149,7 @@ const taskIdFor = (wakeId, fingerprint) => (
 
 const boundedError = (error) => String(error?.message || error || 'Task creation failed').slice(0, 300);
 
-const validateChoice = (request, apps, providers) => {
+const validateChoice = async (request, apps, providers) => {
   const app = apps.find((candidate) => candidate.id === request.appId && isRunnableApp(candidate));
   if (!app) return { error: `App '${request.appId}' has no configured repository` };
   const provider = providers.find((candidate) => (
@@ -149,14 +164,21 @@ const validateChoice = (request, apps, providers) => {
   if (request.effort && !efforts.includes(request.effort)) {
     return { error: `Effort '${request.effort}' is not supported by provider '${request.providerId}'` };
   }
+  if (request.planOnly) {
+    const tracker = await getAppWorkTracker(request.appId);
+    if (!ISSUE_TRACKERS.has(tracker?.resolved)) {
+      return { error: `Plan-and-file tasks require a GitHub or GitLab issue tracker for app '${request.appId}'` };
+    }
+  }
   return { app, provider };
 };
 
 async function queueOneTask({ request, taskId, apps, providers }) {
   const existing = await getTaskById(taskId);
   if (existing) return { success: true, duplicate: true, task: existing };
-  const choice = validateChoice(request, apps, providers);
+  const choice = await validateChoice(request, apps, providers);
   if (choice.error) return { success: false, error: choice.error };
+  const planOnly = request.planOnly === true;
   const task = await addTask({
     id: taskId,
     description: request.description,
@@ -166,11 +188,15 @@ async function queueOneTask({ request, taskId, apps, providers }) {
     provider: request.providerId,
     model: request.model || undefined,
     effort: request.effort || undefined,
-    useWorktree: true,
-    openPR: true,
-    prCompletion: request.prCompletion,
-    simplify: true,
-    worktreeChangesExpected: true,
+    ...(planOnly ? {
+      planOnly: true,
+    } : {
+      useWorktree: true,
+      openPR: true,
+      prCompletion: request.prCompletion,
+      simplify: true,
+      worktreeChangesExpected: true,
+    }),
     approvalRequired: false,
   }, 'internal');
   return { success: true, duplicate: task.duplicate === true, task };
@@ -182,7 +208,8 @@ const eventDataFor = (request, outcome, displayText) => ({
   providerId: request.providerId,
   model: request.model || null,
   effort: request.effort || null,
-  prCompletion: request.prCompletion,
+  planOnly: request.planOnly === true,
+  prCompletion: request.prCompletion || null,
   ...(outcome ? {
     success: outcome.success === true,
     duplicate: outcome.duplicate === true,

--- a/server/services/persistentMindTaskCapability.js
+++ b/server/services/persistentMindTaskCapability.js
@@ -17,6 +17,7 @@ import { canonicalStringify } from '../lib/objects.js';
 import { antigravityBaseModels, effortLevelsForProvider, filterSelectableModels } from '../lib/providerModels.js';
 import { PR_COMPLETIONS } from '../lib/prDisposition.js';
 import { sha256Text } from '../lib/fileUtils.js';
+import { resolveAppWorkTracker } from '../lib/workTracker.js';
 import { getActiveApps, getAppWorkTracker } from './apps.js';
 import { loadState } from './cosState.js';
 import { addTask, getTaskById } from './cosTaskStore.js';
@@ -27,7 +28,9 @@ const MAX_CATALOG_PROVIDERS = 50;
 const MAX_CATALOG_MODELS = 60;
 const MAX_CATALOG_PROMPT_CHARS = 16_000;
 const MAX_CATALOG_APP_PROMPT_CHARS = 4_000;
+const APP_TRACKER_CACHE_TTL_MS = 30_000;
 const ISSUE_TRACKERS = new Set(['github', 'gitlab']);
+const appTrackerCache = new Map();
 
 const isRunnableApp = (app) => typeof app?.repoPath === 'string' && app.repoPath.trim().length > 0;
 const isRunnableAgentProvider = (provider) => provider?.enabled !== false
@@ -59,8 +62,17 @@ const providerCatalogEntry = (provider) => {
   };
 };
 
+const catalogTrackerFor = (app) => {
+  const key = `${app.id}\0${app.repoPath}\0${app.workTracker || 'auto'}`;
+  const cached = appTrackerCache.get(key);
+  if (cached && cached.expiresAt > Date.now()) return cached.promise;
+  const promise = resolveAppWorkTracker(app);
+  appTrackerCache.set(key, { expiresAt: Date.now() + APP_TRACKER_CACHE_TTL_MS, promise });
+  return promise;
+};
+
 const appCatalogEntry = async (app) => {
-  const tracker = await getAppWorkTracker(app.id);
+  const tracker = await catalogTrackerFor(app);
   return {
     id: app.id,
     name: String(app.name || app.id).slice(0, 100),

--- a/server/services/persistentMindTaskCapability.test.js
+++ b/server/services/persistentMindTaskCapability.test.js
@@ -104,6 +104,14 @@ describe('persistent mind CoS-task capability', () => {
     expect(prompt).toContain('provider-0');
   });
 
+  it('reuses tracker resolution for repeated catalog reads', async () => {
+    mocks.apps = [{ id: 'cached-app', name: 'Cached App', repoPath: '/example/cached-app' }];
+    await readPersistentMindTaskCatalog();
+    await readPersistentMindTaskCatalog();
+
+    expect(mocks.resolveAppWorkTracker).toHaveBeenCalledTimes(1);
+  });
+
   it('queues an auto-approved isolated task with the chosen run and PR policy', async () => {
     const recordCapabilityEvent = vi.fn(async () => true);
     const results = await executePersistentMindTaskRequests({

--- a/server/services/persistentMindTaskCapability.test.js
+++ b/server/services/persistentMindTaskCapability.test.js
@@ -10,9 +10,13 @@ const mocks = vi.hoisted(() => ({
   existing: null,
   addTask: vi.fn(),
   getTaskById: vi.fn(),
+  getAppWorkTracker: vi.fn(),
 }));
 
-vi.mock('./apps.js', () => ({ getActiveApps: vi.fn(async () => mocks.apps) }));
+vi.mock('./apps.js', () => ({
+  getActiveApps: vi.fn(async () => mocks.apps),
+  getAppWorkTracker: (...args) => mocks.getAppWorkTracker(...args),
+}));
 vi.mock('./cosState.js', () => ({ loadState: vi.fn(async () => mocks.root) }));
 vi.mock('./cosTaskStore.js', () => ({
   addTask: (...args) => mocks.addTask(...args),
@@ -47,6 +51,7 @@ beforeEach(() => {
     defaultModel: 'gpt-5', models: ['gpt-5', 'gpt-5-mini'],
   }];
   mocks.existing = null;
+  mocks.getAppWorkTracker.mockResolvedValue({ resolved: 'plan' });
   mocks.getTaskById.mockImplementation(async () => mocks.existing);
   mocks.addTask.mockResolvedValue({ id: 'sys-mind-stable', status: 'pending', autoApproved: true });
 });
@@ -57,7 +62,7 @@ describe('persistent mind CoS-task capability', () => {
     mocks.providers.push({ id: 'api-only', name: 'API Only', type: 'api', enabled: true });
     const catalog = await readPersistentMindTaskCatalog();
     expect(catalog).toEqual({
-      apps: [{ id: 'portos', name: 'PortOS' }],
+      apps: [{ id: 'portos', name: 'PortOS', planOnly: false }],
       providers: [{
         id: 'codex', name: 'Codex', type: 'cli',
         models: [
@@ -70,6 +75,8 @@ describe('persistent mind CoS-task capability', () => {
     expect(prompt).toContain('"review-then-merge"');
     expect(prompt).toContain('"merge-on-green"');
     expect(prompt).toContain('"leave-open"');
+    expect(prompt).toContain('Plan & File Issue');
+    expect(prompt).toContain('planOnly');
     expect(prompt).not.toContain('command');
   });
 
@@ -109,6 +116,32 @@ describe('persistent mind CoS-task capability', () => {
       simplify: true, approvalRequired: false,
     }), 'internal');
     expect(recordCapabilityEvent.mock.calls.map(([event]) => event.kind)).toEqual(['request', 'result']);
+  });
+
+  it('queues plan-and-file mode only for an app with an issue tracker', async () => {
+    mocks.getAppWorkTracker.mockResolvedValue({ resolved: 'github' });
+    const results = await executePersistentMindTaskRequests({
+      taskRequests: [taskRequest({ planOnly: true, prCompletion: undefined })],
+      turnId: 'turn-plan-only',
+      wake: { kind: 'message', message: { id: 'message-plan-only' } },
+    });
+
+    expect(results).toMatchObject([{ success: true }]);
+    expect(mocks.addTask).toHaveBeenCalledWith(expect.objectContaining({ planOnly: true }), 'internal');
+    expect(mocks.addTask.mock.calls[0][0]).not.toHaveProperty('openPR');
+    expect(mocks.addTask.mock.calls[0][0]).not.toHaveProperty('prCompletion');
+  });
+
+  it('rejects plan-and-file mode for PLAN.md apps before queueing', async () => {
+    mocks.getAppWorkTracker.mockResolvedValue({ resolved: 'plan' });
+    const [result] = await executePersistentMindTaskRequests({
+      taskRequests: [taskRequest({ planOnly: true, prCompletion: undefined })],
+      turnId: 'turn-plan-tracker',
+      wake: { kind: 'message', message: { id: 'message-plan-tracker' } },
+    });
+
+    expect(result).toMatchObject({ success: false, error: expect.stringContaining('GitHub or GitLab') });
+    expect(mocks.addTask).not.toHaveBeenCalled();
   });
 
   it('fails closed when access is revoked after inference', async () => {

--- a/server/services/persistentMindTaskCapability.test.js
+++ b/server/services/persistentMindTaskCapability.test.js
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => ({
   addTask: vi.fn(),
   getTaskById: vi.fn(),
   getAppWorkTracker: vi.fn(),
+  resolveAppWorkTracker: vi.fn(),
 }));
 
 vi.mock('./apps.js', () => ({
@@ -23,6 +24,9 @@ vi.mock('./cosTaskStore.js', () => ({
   getTaskById: (...args) => mocks.getTaskById(...args),
 }));
 vi.mock('./providers.js', () => ({ listProviders: vi.fn(async () => mocks.providers) }));
+vi.mock('../lib/workTracker.js', () => ({
+  resolveAppWorkTracker: (...args) => mocks.resolveAppWorkTracker(...args),
+}));
 
 const {
   buildPersistentMindTaskCapabilityPrompt,
@@ -52,6 +56,7 @@ beforeEach(() => {
   }];
   mocks.existing = null;
   mocks.getAppWorkTracker.mockResolvedValue({ resolved: 'plan' });
+  mocks.resolveAppWorkTracker.mockResolvedValue({ resolved: 'plan' });
   mocks.getTaskById.mockImplementation(async () => mocks.existing);
   mocks.addTask.mockResolvedValue({ id: 'sys-mind-stable', status: 'pending', autoApproved: true });
 });


### PR DESCRIPTION
## Summary
- Give the Persistent Mind typed task action full User Task filing parity for provider, model, effort, priority, delivery mode, and PR completion policy.
- Add validated GitHub/GitLab-only Plan & File Issue mode and expose a redacted live task catalog through the Mind Tools API and UI.
- Keep arbitrary PortOS APIs, shell, filesystem, and credentials outside the mind authority while documenting the typed contract.

## Test plan
- npm test --prefix server -- --run lib/persistentMindCapabilities.test.js services/persistentMindTaskCapability.test.js routes/cosMindRoutes.test.js services/persistentMindAdapter.test.js
- npm test --prefix client
- npm run build --prefix client
- npm run lint --prefix client