### PR TITLE
fix: allow editing system task effort

### DIFF
--- a/client/src/components/cos/tabs/TaskItem.jsx
+++ b/client/src/components/cos/tabs/TaskItem.jsx
@@ -22,7 +22,7 @@ import {
 } from 'lucide-react';
 import toast from '../../ui/Toast';
 import * as api from '../../../services/api';
-import { filterSelectableModels } from '../../../utils/providers';
+import { effectiveModelFor, effortAwareModelOptions, effortSurvivingModel } from '../../../utils/providers';
 import { formatDurationMin, formatBytes } from '../../../utils/formatters';
 import ConfirmButtonPair from '../../ui/ConfirmButtonPair';
 import { useConfirmDelete } from '../../../hooks/useConfirmDelete';
@@ -30,6 +30,7 @@ import Modal from '../../ui/Modal';
 import CollapsibleText from '../../ui/CollapsibleText';
 import { extractCosTaskType } from '../../../lib/cosTaskType';
 import InstancePicker from '../InstancePicker';
+import EffortSelect from '../EffortSelect';
 
 const statusIcons = {
   pending: <Clock size={16} aria-hidden="true" className="text-yellow-500" />,
@@ -59,6 +60,7 @@ const getTaskEditData = (task) => ({
   context: task.metadata?.context || '',
   model: task.metadata?.model || '',
   provider: task.metadata?.provider || '',
+  effort: task.metadata?.effort || '',
   // '' = "Any instance" (#4520) — no pin, the opportunistic default.
   targetInstanceId: task.metadata?.targetInstanceId || ''
 });
@@ -121,6 +123,7 @@ export default function TaskItem({ task, isSystem, spawning = false, selected = 
   const taskContext = task.metadata?.context || '';
   const taskModel = task.metadata?.model || '';
   const taskProvider = task.metadata?.provider || '';
+  const taskEffort = task.metadata?.effort || '';
   const [editData, setEditData] = useState(() => getTaskEditData(task));
   const [showBlockedModal, setShowBlockedModal] = useState(false);
   const [blockedReason, setBlockedReason] = useState('');
@@ -144,11 +147,11 @@ export default function TaskItem({ task, isSystem, spawning = false, selected = 
   // whenever it is safe to do so, but never overwrite an active edit.
   useEffect(() => {
     if (!editing) setEditData(getTaskEditData(task));
-  }, [editing, task.id, task.description, taskPrompt, taskContext, taskModel, taskProvider, task]);
+  }, [editing, task.id, task.description, taskPrompt, taskContext, taskModel, taskProvider, taskEffort, task]);
 
   // Get models for selected provider in edit mode
   const editProvider = providers?.find(p => p.id === editData.provider);
-  const editModels = filterSelectableModels(editProvider?.models);
+  const editModels = effortAwareModelOptions(editProvider, editData.model);
 
   // Calculate duration estimate for pending tasks
   // Uses P80 estimate when available for more realistic time predictions
@@ -262,6 +265,7 @@ export default function TaskItem({ task, isSystem, spawning = false, selected = 
     editData.context !== (task.metadata?.context || '') ||
     editData.model !== (task.metadata?.model || '') ||
     editData.provider !== (task.metadata?.provider || '') ||
+    editData.effort !== (task.metadata?.effort || '') ||
     editData.targetInstanceId !== targetInstanceId;
 
   const handleCancelEdit = () => {
@@ -445,15 +449,15 @@ export default function TaskItem({ task, isSystem, spawning = false, selected = 
                 onChange={e => setEditData(d => ({ ...d, context: e.target.value }))}
                 className="w-full px-2 py-1 bg-port-bg border border-port-border rounded text-white text-sm font-mono resize-y overflow-auto"
               />
-              <div className="flex gap-2">
+              <div className="flex flex-col sm:flex-row gap-2">
                 <select
                   aria-label="Provider"
                   value={editData.provider}
-                  onChange={e => setEditData(d => ({ ...d, provider: e.target.value, model: '' }))}
-                  className="w-36 px-2 py-1 bg-port-bg border border-port-border rounded text-white text-sm"
+                  onChange={e => setEditData(d => ({ ...d, provider: e.target.value, model: '', effort: '' }))}
+                  className="w-full sm:w-36 px-2 py-1 bg-port-bg border border-port-border rounded text-white text-sm"
                 >
                   <option value="">Auto</option>
-                  {providers?.filter(p => p.enabled).map(p => (
+                  {providers?.filter(p => p.enabled !== false || p.id === editData.provider).map(p => (
                     <option key={p.id} value={p.id}>{p.name}</option>
                   ))}
                 </select>
@@ -461,7 +465,11 @@ export default function TaskItem({ task, isSystem, spawning = false, selected = 
                   <select
                     aria-label="Model"
                     value={editData.model}
-                    onChange={e => setEditData(d => ({ ...d, model: e.target.value }))}
+                    onChange={e => setEditData(d => ({
+                      ...d,
+                      model: e.target.value,
+                      effort: effortSurvivingModel(editProvider, e.target.value, d.effort)
+                    }))}
                     className="flex-1 px-2 py-1 bg-port-bg border border-port-border rounded text-white text-sm"
                   >
                     <option value="">Auto</option>
@@ -470,6 +478,13 @@ export default function TaskItem({ task, isSystem, spawning = false, selected = 
                     ))}
                   </select>
                 )}
+                <EffortSelect
+                  provider={editProvider}
+                  model={effectiveModelFor(editProvider, editData.model)}
+                  value={editData.effort}
+                  onChange={effort => setEditData(d => ({ ...d, effort }))}
+                  className="w-full sm:w-36 px-2 py-1 bg-port-bg border border-port-border rounded text-white text-sm"
+                />
               </div>
               {canPinInstance && (
                 <InstancePicker
@@ -531,8 +546,8 @@ export default function TaskItem({ task, isSystem, spawning = false, selected = 
                   className="text-sm text-gray-500 mt-1"
                 />
               )}
-              {(task.metadata?.model || task.metadata?.provider) && (
-                <div className="flex items-center gap-2 mt-1">
+              {(task.metadata?.model || task.metadata?.provider || task.metadata?.effort) && (
+                <div className="flex flex-wrap items-center gap-2 mt-1">
                   {task.metadata?.model && (
                     <span className="px-1.5 py-0.5 text-xs bg-port-accent-2/20 text-port-accent-2 rounded font-mono">
                       {task.metadata.model}
@@ -541,6 +556,11 @@ export default function TaskItem({ task, isSystem, spawning = false, selected = 
                   {task.metadata?.provider && (
                     <span className="px-1.5 py-0.5 text-xs bg-port-accent/20 text-port-accent rounded">
                       {task.metadata.provider}
+                    </span>
+                  )}
+                  {task.metadata?.effort && (
+                    <span className="px-1.5 py-0.5 text-xs bg-port-warning/20 text-port-warning rounded">
+                      {task.metadata.effort} effort
                     </span>
                   )}
                 </div>

--- a/client/src/components/cos/tabs/TaskItem.jsx
+++ b/client/src/components/cos/tabs/TaskItem.jsx
@@ -22,7 +22,7 @@ import {
 } from 'lucide-react';
 import toast from '../../ui/Toast';
 import * as api from '../../../services/api';
-import { effectiveModelFor, effortAwareModelOptions, effortSurvivingModel } from '../../../utils/providers';
+import { effectiveModelFor, effortAwareModelOptions, effortSurvivingModel, seedModelEffort } from '../../../utils/providers';
 import { formatDurationMin, formatBytes } from '../../../utils/formatters';
 import ConfirmButtonPair from '../../ui/ConfirmButtonPair';
 import { useConfirmDelete } from '../../../hooks/useConfirmDelete';
@@ -54,16 +54,27 @@ const APPROVAL_REASON_HINTS = {
   'config:requireApproval': 'Held for you: this scheduled task type has Require approval turned on.'
 };
 
-const getTaskEditData = (task) => ({
-  description: task.description,
-  prompt: task.metadata?.prompt || '',
-  context: task.metadata?.context || '',
-  model: task.metadata?.model || '',
-  provider: task.metadata?.provider || '',
-  effort: task.metadata?.effort || '',
-  // '' = "Any instance" (#4520) — no pin, the opportunistic default.
-  targetInstanceId: task.metadata?.targetInstanceId || ''
-});
+const getTaskEditData = (task, providers) => {
+  const provider = task.metadata?.provider || '';
+  // Tasks saved before Antigravity split model from effort carry a suffixed
+  // model id (`gemini-3.6-flash-high`). Seed both controls together so editing
+  // any other field cannot silently replace that tier with the provider default.
+  const seeded = seedModelEffort(
+    providers?.find(candidate => candidate.id === provider) || { id: provider },
+    task.metadata?.model,
+    task.metadata?.effort,
+  );
+  return {
+    description: task.description,
+    prompt: task.metadata?.prompt || '',
+    context: task.metadata?.context || '',
+    model: seeded.model,
+    provider,
+    effort: seeded.effort,
+    // '' = "Any instance" (#4520) — no pin, the opportunistic default.
+    targetInstanceId: task.metadata?.targetInstanceId || ''
+  };
+};
 
 export const taskRowId = (taskId, source) => `cos-task-${source}-${encodeURIComponent(taskId)}`;
 
@@ -124,7 +135,8 @@ export default function TaskItem({ task, isSystem, spawning = false, selected = 
   const taskModel = task.metadata?.model || '';
   const taskProvider = task.metadata?.provider || '';
   const taskEffort = task.metadata?.effort || '';
-  const [editData, setEditData] = useState(() => getTaskEditData(task));
+  const savedEditData = getTaskEditData(task, providers);
+  const [editData, setEditData] = useState(() => savedEditData);
   const [showBlockedModal, setShowBlockedModal] = useState(false);
   const [blockedReason, setBlockedReason] = useState('');
   const { isConfirming, requestDelete, cancelDelete, confirmDelete } = useConfirmDelete();
@@ -146,8 +158,8 @@ export default function TaskItem({ task, isSystem, spawning = false, selected = 
   // component stays mounted under the same task id. Keep the draft current
   // whenever it is safe to do so, but never overwrite an active edit.
   useEffect(() => {
-    if (!editing) setEditData(getTaskEditData(task));
-  }, [editing, task.id, task.description, taskPrompt, taskContext, taskModel, taskProvider, taskEffort, task]);
+    if (!editing) setEditData(getTaskEditData(task, providers));
+  }, [editing, task.id, task.description, taskPrompt, taskContext, taskModel, taskProvider, taskEffort, task, providers]);
 
   // Get models for selected provider in edit mode
   const editProvider = providers?.find(p => p.id === editData.provider);
@@ -260,13 +272,13 @@ export default function TaskItem({ task, isSystem, spawning = false, selected = 
   // (see the useState initializer above) — true only when the user actually
   // changed something, so an unmodified Cancel still discards with no friction.
   const hasUnsavedEdits =
-    editData.description !== task.description ||
-    (hasPromptField && editData.prompt !== (task.metadata?.prompt || '')) ||
-    editData.context !== (task.metadata?.context || '') ||
-    editData.model !== (task.metadata?.model || '') ||
-    editData.provider !== (task.metadata?.provider || '') ||
-    editData.effort !== (task.metadata?.effort || '') ||
-    editData.targetInstanceId !== targetInstanceId;
+    editData.description !== savedEditData.description ||
+    (hasPromptField && editData.prompt !== savedEditData.prompt) ||
+    editData.context !== savedEditData.context ||
+    editData.model !== savedEditData.model ||
+    editData.provider !== savedEditData.provider ||
+    editData.effort !== savedEditData.effort ||
+    editData.targetInstanceId !== savedEditData.targetInstanceId;
 
   const handleCancelEdit = () => {
     if (hasUnsavedEdits) {
@@ -281,7 +293,7 @@ export default function TaskItem({ task, isSystem, spawning = false, selected = 
   // again instead of the task's real values.
   const handleConfirmDiscard = () => {
     confirmDiscard(() => {
-      setEditData(getTaskEditData(task));
+      setEditData(getTaskEditData(task, providers));
       setEditing(false);
     });
   };

--- a/client/src/components/cos/tabs/TaskItem.test.jsx
+++ b/client/src/components/cos/tabs/TaskItem.test.jsx
@@ -86,6 +86,52 @@ describe('TaskItem task source', () => {
     ));
   });
 
+  it('shows and persists the selected thinking effort for an effort-capable provider', async () => {
+    const effortTask = {
+      ...task,
+      metadata: { ...task.metadata, effort: 'medium' },
+    };
+    render(<TaskItem task={effortTask} isSystem onRefresh={vi.fn()} providers={providers} />);
+
+    expect(screen.getByText('medium effort')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Edit task' }));
+
+    const effortSelect = screen.getByRole('combobox', { name: 'Thinking effort' });
+    expect(effortSelect).toHaveValue('medium');
+    fireEvent.change(effortSelect, { target: { value: 'xhigh' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => expect(api.updateCosTask).toHaveBeenCalledWith(
+      'sys-model-edit',
+      expect.objectContaining({
+        provider: 'codex-tui',
+        model: 'gpt-5.6-terra',
+        effort: 'xhigh',
+        type: 'internal',
+      }),
+      { silent: true },
+    ));
+  });
+
+  it('clears the model and effort when the provider changes', async () => {
+    const effortTask = {
+      ...task,
+      metadata: { ...task.metadata, effort: 'high' },
+    };
+    render(<TaskItem task={effortTask} isSystem onRefresh={vi.fn()} providers={providers} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit task' }));
+    fireEvent.change(screen.getByRole('combobox', { name: 'Provider' }), { target: { value: '' } });
+    expect(screen.queryByRole('combobox', { name: 'Thinking effort' })).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => expect(api.updateCosTask).toHaveBeenCalledWith(
+      'sys-model-edit',
+      expect.objectContaining({ provider: '', model: '', effort: '', type: 'internal' }),
+      { silent: true },
+    ));
+  });
+
   it('updates an approval-gated system task in the internal queue when changing status', async () => {
     render(<TaskItem task={{ ...task, approvalRequired: true }} isSystem onRefresh={vi.fn()} providers={providers} />);
 

--- a/client/src/components/cos/tabs/TaskItem.test.jsx
+++ b/client/src/components/cos/tabs/TaskItem.test.jsx
@@ -132,6 +132,45 @@ describe('TaskItem task source', () => {
     ));
   });
 
+  it('preserves effort encoded in a legacy Antigravity model pin', async () => {
+    const legacyTask = {
+      ...task,
+      metadata: {
+        provider: 'antigravity-tui',
+        model: 'gemini-3.6-flash-high',
+      },
+    };
+    const antigravityProviders = [{
+      id: 'antigravity-tui',
+      name: 'Antigravity TUI',
+      enabled: true,
+      models: ['gemini-3.6-flash-low', 'gemini-3.6-flash-medium', 'gemini-3.6-flash-high'],
+    }];
+    render(<TaskItem task={legacyTask} isSystem onRefresh={vi.fn()} providers={antigravityProviders} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit task' }));
+    expect(screen.getByRole('combobox', { name: 'Model' })).toHaveValue('gemini-3.6-flash');
+    expect(screen.getByRole('combobox', { name: 'Thinking effort' })).toHaveValue('high');
+
+    // Normalizing the two controls is not itself an edit, so Cancel stays
+    // immediate instead of asking the user to discard a change they never made.
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(screen.queryByRole('group', { name: 'Confirm discard task edits' })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit task' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    await waitFor(() => expect(api.updateCosTask).toHaveBeenCalledWith(
+      'sys-model-edit',
+      expect.objectContaining({
+        provider: 'antigravity-tui',
+        model: 'gemini-3.6-flash',
+        effort: 'high',
+        type: 'internal',
+      }),
+      { silent: true },
+    ));
+  });
+
   it('updates an approval-gated system task in the internal queue when changing status', async () => {
     render(<TaskItem task={{ ...task, approvalRequired: true }} isSystem onRefresh={vi.fn()} providers={providers} />);
 


### PR DESCRIPTION
## Summary

- Add an effort selector to the Pending System Tasks edit form beside provider and model.
- Preserve explicit effort values and legacy Antigravity model-tier pins while editing.

## Test plan
- `cd client && npx vitest run src/components/cos/tabs/TaskItem.test.jsx`
- `cd client && npm run lint`
- `cd client && npm run build`
- `cd client && npm test`