### PR TITLE
fix: allow manual quota burn retriggers

### DIFF
--- a/client/src/components/quotaBurn/FamilyCard.jsx
+++ b/client/src/components/quotaBurn/FamilyCard.jsx
@@ -21,6 +21,7 @@ export default function FamilyCard({
   onToggleExpand, onPatch, onRunFamily, onRunJob, onRearm, onRetryCatalog,
 }) {
   const jobs = config.jobs || [];
+  const hasEnabledJobs = jobs.some((job) => job.enabled !== false);
   // Pending counts and `run once` completions stay on the STATUS side and are
   // passed to JobRow as their own props — merging them into the job objects
   // would mean stripping them back off before every save (the PUT schema is
@@ -142,9 +143,9 @@ export default function FamilyCard({
           <button
             type="button"
             className="text-xs text-port-accent hover:underline disabled:opacity-40"
-            disabled={actionsBusy || !status?.willBurn}
+            disabled={actionsBusy || !hasEnabledJobs}
             onClick={() => onRunFamily(familyId)}
-            title={status?.willBurn ? 'Run this family\'s next job now' : 'This family has no burnable window right now'}
+            title={hasEnabledJobs ? 'Force-run this family\'s next available job now' : 'Add an enabled job before running this family'}
           >
             Burn now
           </button>

--- a/client/src/pages/QuotaBurn.jsx
+++ b/client/src/pages/QuotaBurn.jsx
@@ -521,7 +521,7 @@ export default function QuotaBurn() {
             actionsBusy={unsaved || running}
             onToggleExpand={(id) => navigate(expanded === id ? '/devtools/quota-burn' : `/devtools/quota-burn/${id}`)}
             onPatch={(patch) => patchFamily(familyId, patch)}
-            onRunFamily={(id) => run({ familyId: id }, 'Burn')}
+            onRunFamily={(id) => run({ familyId: id, force: true }, 'Burn')}
             onRunJob={(id, job) => run({ familyId: id, jobId: job.id, force: true }, 'Job run')}
             onRearm={rearm}
           />

--- a/client/src/pages/QuotaBurn.test.jsx
+++ b/client/src/pages/QuotaBurn.test.jsx
@@ -225,6 +225,23 @@ describe('QuotaBurn page', () => {
     ));
   });
 
+  it('keeps the family Burn now action available after its automatic window closes', async () => {
+    const user = userEvent.setup();
+    const gatedStatus = {
+      ...status,
+      families: [{ ...status.families[0], willBurn: false, skipReason: 'dispatch cap reached (5/5)' }, status.families[1]],
+    };
+    api.getQuotaBurn.mockResolvedValue({ config, status: gatedStatus });
+    renderPage('/devtools/quota-burn/grok');
+
+    const burnButton = await screen.findByTitle('Force-run this family\'s next available job now');
+    expect(burnButton).toBeEnabled();
+    await user.click(burnButton);
+    await waitFor(() => expect(api.runQuotaBurn).toHaveBeenCalledWith(
+      { familyId: 'grok', force: true }, { silent: true },
+    ));
+  });
+
   it('adds a fully-configured job from a preset, inheriting the plan\'s app', async () => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
     const user = setupSaveUser();

--- a/client/src/services/apiQuotaBurn.js
+++ b/client/src/services/apiQuotaBurn.js
@@ -19,8 +19,8 @@ export const saveQuotaBurn = (patch, options) => request('/quota-burn', {
   ...options,
 });
 
-// Evaluate now. `{ familyId, jobId, force }` runs one named job past the
-// window/reserve/cap gates; no body behaves like a scheduled tick.
+// Evaluate now. `{ familyId, jobId, force }` runs a family or named job past
+// the window/reserve/cap gates; no body behaves like a scheduled tick.
 export const runQuotaBurn = (body = {}, options) => request('/quota-burn/run', {
   method: 'POST',
   body: JSON.stringify(body),

--- a/server/routes/quotaBurn.js
+++ b/server/routes/quotaBurn.js
@@ -63,7 +63,7 @@ router.put('/', asyncHandler(async (req, res) => {
 
 // POST /api/quota-burn/run — evaluate now. With no body it behaves like a
 // scheduled tick that ignores the master switch. `{ familyId, jobId, force }`
-// runs one named job immediately, past the window/reserve/cap gates.
+// runs a family or one named job immediately, past the window/reserve/cap gates.
 router.post('/run', asyncHandler(async (req, res) => {
   const { familyId = null, jobId = null, force = false } = validateRequest(quotaBurnRunSchema, req.body || {});
   if (force && !familyId) {

--- a/server/services/quotaBurnRunner.js
+++ b/server/services/quotaBurnRunner.js
@@ -156,8 +156,9 @@ async function dispatchFromCandidate(candidate, { jobId = null, force = false, a
 /**
  * One evaluation. `trigger` is recorded in the run log so the page can tell a
  * scheduled tick from a "Run now". A manual trigger ignores the master
- * `enabled` switch (the user just clicked the button) but respects every quota
- * gate — the reset window, the reserve, and the per-window dispatch cap.
+ * `enabled` switch (the user just clicked the button); an explicit `force`
+ * request also bypasses the reset window, reserve, dispatch cap, and denial
+ * gates.
  */
 export async function runQuotaBurnCycle(options = {}) {
   if (running) {
@@ -291,10 +292,11 @@ async function evaluate({ trigger = 'scheduled', familyId = null, jobId = null, 
   // walk straight past `maxDispatchesPerWindow` and spend quota the user already
   // spent (#4115). Same posture as the provider-quota read above: skip the cycle.
   if (!dispatches) return finish({ dispatched: false, reason: 'dispatch ledger read failed' });
-  // `force` is the page's per-job "Run now" — the window/reserve/cap/denial gates
-  // that bound UNATTENDED burns don't apply to a run the user just asked for. It
-  // goes through the same selection, so the candidate still carries the family's
-  // real card and limit; it only comes back `charge: false`.
+  // `force` is the page's explicit family/job "Run now" — the
+  // window/reserve/cap/denial gates that bound UNATTENDED burns don't apply to a
+  // run the user just asked for. It goes through the same selection, so the
+  // candidate still carries the family's real card and limit; it only comes
+  // back `charge: false`.
   const candidates = selectBurnCandidates(quotas, config, {
     dispatches, blocks, completions, bypassGatesFor: force ? familyId : null,
   }).filter((candidate) => !familyId || candidate.family.id === familyId);

--- a/server/services/quotaBurnRunner.test.js
+++ b/server/services/quotaBurnRunner.test.js
@@ -207,6 +207,15 @@ describe('runQuotaBurnCycle', () => {
     expect(state.recorded).toEqual([]);
   });
 
+  it('force-runs a family plan after its automatic window closes', async () => {
+    state.config = plan({ families: { grok: { enabled: true, resetWithinHours: 0, jobs: [{ id: 'second', enabled: true, jobType: 'agent-prompt' }] } } });
+    state.pending = { second: { count: 1 } };
+    const result = await runQuotaBurnCycle({ trigger: 'manual', familyId: 'grok', force: true });
+    expect(result.dispatched).toBe(true);
+    expect(state.ran).toEqual([{ jobId: 'second', familyId: 'grok', charge: false }]);
+    expect(state.recorded).toEqual([]);
+  });
+
   it('burns EVERY eligible family in one cycle, not just the soonest to reset', async () => {
     // Families don't share a budget — each draws down its own window against its
     // own reserve and cap. Stopping the cycle at the first dispatch meant the


### PR DESCRIPTION
## Summary

Allow the Quota Burn family-level Burn now action to be used after automatic quota gates close by routing it through the existing explicit force-run path. Keep the scheduled eligibility and plan configuration safeguards intact.

## Test plan

- npm test -- --run pages/QuotaBurn.test.jsx (client)
- npm test -- --run services/quotaBurnRunner.test.js (server)