### PR TITLE
fix: show submitted CoS tasks immediately

### DIFF
--- a/client/src/components/cos/TaskAddForm.jsx
+++ b/client/src/components/cos/TaskAddForm.jsx
@@ -562,7 +562,11 @@ export default function TaskAddForm({ providers, apps, onTaskAdded, compact = fa
     setAttachments([]);
 
     toast.success('Task added');
-    onTaskAdded?.();
+    // The POST returns the persisted task, so let queue views render that
+    // confirmed record immediately instead of waiting for the next socket
+    // delivery or polling refresh. The position is not persisted on a task,
+    // but the receiving list needs it to mirror this form's insertion choice.
+    onTaskAdded?.(result, { position: addToTop ? 'top' : 'bottom' });
   };
 
   // Compact mode: single row with description + app + add, expandable

--- a/client/src/components/cos/TaskAddForm.test.jsx
+++ b/client/src/components/cos/TaskAddForm.test.jsx
@@ -88,6 +88,19 @@ describe('TaskAddForm responsive layout', () => {
     expect(localStorage.getItem('portos-cos-task-description-draft')).toBeNull();
   });
 
+  it('passes the persisted task to queue views immediately after submission', async () => {
+    const user = userEvent.setup();
+    const onTaskAdded = vi.fn();
+    const task = { id: 'task-new', description: 'Appear immediately', status: 'pending', metadata: {} };
+    api.addCosTask.mockResolvedValue(task);
+    render(<TaskAddForm providers={[]} apps={[]} onTaskAdded={onTaskAdded} />);
+
+    await user.type(screen.getByPlaceholderText('Task description *'), task.description);
+    await user.click(screen.getByRole('button', { name: /^Add$/ }));
+
+    await waitFor(() => expect(onTaskAdded).toHaveBeenCalledWith(task, { position: 'bottom' }));
+  });
+
   it('keeps the description draft when submission fails', async () => {
     const user = userEvent.setup();
     api.addCosTask.mockRejectedValue(new Error('Unable to add task'));

--- a/client/src/components/cos/tabs/TasksTab.jsx
+++ b/client/src/components/cos/tabs/TasksTab.jsx
@@ -38,7 +38,7 @@ function SectionGlyph({ status }) {
   return <MicroGlyph variant={spec.variant} state={spec.state} animated={spec.animated} size={13} />;
 }
 
-export default function TasksTab({ tasks, agents = [], onRefresh, providers, apps }) {
+export default function TasksTab({ tasks, agents = [], onRefresh, onTaskAdded, providers, apps }) {
   const [searchParams] = useSearchParams();
   const [userTasksLocal, setUserTasksLocal] = useState([]);
   const [durations, setDurations] = useState(null);
@@ -195,6 +195,14 @@ export default function TasksTab({ tasks, agents = [], onRefresh, providers, app
     }
   };
 
+  const handleTaskAdded = useCallback((task, options) => {
+    onTaskAdded?.(task, options);
+    // Keep the established authoritative refresh for agent/status data. The
+    // parent has already inserted the task above, so this can never make a
+    // successful submission appear to disappear while the refresh is pending.
+    onRefresh();
+  }, [onRefresh, onTaskAdded]);
+
   return (
     <div className="space-y-6">
       {/* User Tasks */}
@@ -220,7 +228,7 @@ export default function TasksTab({ tasks, agents = [], onRefresh, providers, app
         </div>
 
         {/* Add Task Form */}
-        <TaskAddForm providers={providers} apps={apps} onTaskAdded={onRefresh} />
+        <TaskAddForm providers={providers} apps={apps} onTaskAdded={handleTaskAdded} />
 
         {/* User Tasks Sections */}
         {pendingUserTasksLocal.length === 0 && activeUserTasksLocal.length === 0 && blockedUserTasksLocal.length === 0 && completedUserTasksLocal.length === 0 ? (

--- a/client/src/pages/ChiefOfStaff.jsx
+++ b/client/src/pages/ChiefOfStaff.jsx
@@ -563,6 +563,37 @@ export default function ChiefOfStaff() {
     });
   };
 
+  // A successful task POST returns the persisted task synchronously. Insert it
+  // into the queue right away so the user gets a durable pending indication
+  // before the scheduler's socket updates report its active transition.
+  const handleUserTaskAdded = useCallback((task, { position = 'bottom' } = {}) => {
+    if (!task?.id) return;
+    // A full-data read started before the POST resolved carries a queue snapshot
+    // that cannot contain this task. Retire it before inserting the confirmed
+    // record, just as fetchQueue does for socket-driven updates.
+    queueSeqRef.current += 1;
+    setTasks(prev => {
+      const current = prev.user?.tasks || [];
+      if (current.some(existing => existing.id === task.id)) return prev;
+      const nextTasks = position === 'top' ? [task, ...current] : [...current, task];
+      const grouped = {
+        pending: nextTasks.filter(item => item.status === 'pending'),
+        in_progress: nextTasks.filter(item => item.status === 'in_progress'),
+        challenged: nextTasks.filter(item => item.status === 'challenged'),
+        blocked: nextTasks.filter(item => item.status === 'blocked'),
+        completed: nextTasks.filter(item => item.status === 'completed'),
+      };
+      return {
+        ...prev,
+        user: {
+          ...(prev.user || { exists: true, type: 'user' }),
+          tasks: nextTasks,
+          grouped,
+        },
+      };
+    });
+  }, []);
+
   const handleHealthCheck = async () => {
     setAgentState('investigating');
     setStatusMessage("Running system health check...");
@@ -1080,7 +1111,7 @@ export default function ChiefOfStaff() {
                 tabs that don't surface this data. */}
             <ActionableInsightsBanner insights={insights} onTaskUnblocked={handleTaskUnblocked} onRefresh={fetchData} />
             <QuickSummary />
-            <TasksTab tasks={tasks} agents={agents} onRefresh={fetchData} providers={providers} apps={apps} />
+            <TasksTab tasks={tasks} agents={agents} onRefresh={fetchData} onTaskAdded={handleUserTaskAdded} providers={providers} apps={apps} />
           </div>
         )}
         {activeTab === 'agents' && (

--- a/client/src/pages/ChiefOfStaff.test.jsx
+++ b/client/src/pages/ChiefOfStaff.test.jsx
@@ -37,7 +37,11 @@ vi.mock('../components/ui/Toast', () => ({ default: toast }));
 vi.mock('../services/socket', () => ({ default: socketStub }));
 // TaskAddForm drags in the reviewer/model picker plumbing (local-LLM status,
 // prompt templates) that the task-event tests below have no stake in.
-vi.mock('../components/cos/TaskAddForm', () => ({ default: () => null }));
+vi.mock('../components/cos/TaskAddForm', () => ({
+  default: ({ onTaskAdded }) => <button type="button" onClick={() => onTaskAdded?.({
+    id: 'task-immediate', description: 'Appears without a refresh', status: 'pending', metadata: {},
+  }, { position: 'bottom' })}>Add test task</button>,
+}));
 // ConfigTab's provider/model hook fetches over the network — stub it.
 vi.mock('../hooks/useProviderModels', () => ({
   default: () => ({
@@ -531,6 +535,16 @@ describe('ChiefOfStaff task-change subscriptions', () => {
     expect(await screen.findByText('Example scheduled task')).toBeInTheDocument();
     // The event carries the whole list, so it must not cost a round trip.
     expect(api.getCosTasks.mock.calls.length).toBe(before);
+  });
+
+  it('renders a submitted user task before the follow-up refresh resolves', async () => {
+    renderTasksTab();
+    await screen.findByRole('button', { name: 'Add test task' });
+    api.getCosTasks.mockReturnValue(new Promise(() => {}));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add test task' }));
+
+    expect(await screen.findByText('Appears without a refresh')).toBeInTheDocument();
   });
 
   it('coalesces a burst of task-store changes into a single refetch', async () => {


### PR DESCRIPTION
## Summary
- Render a server-confirmed user task in the CoS queue immediately after submission.
- Preserve requested queue placement and prevent older queue reads from overwriting the new row.

## Test plan
- `cd client && npm test -- --run src/components/cos/TaskAddForm.test.jsx src/pages/ChiefOfStaff.test.jsx`