### PR TITLE
feat: preselect loaded local rhetoric evaluator models

### DIFF
--- a/client/src/components/meatspace/post/RhetoricTrainer.jsx
+++ b/client/src/components/meatspace/post/RhetoricTrainer.jsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { ArrowLeft, CheckCircle, ChevronRight, Feather, Lightbulb, Repeat2, RotateCcw, Save, Sparkles, Timer } from 'lucide-react';
 import { evaluateRhetoricAttempt, getLoadedLlmModels, submitTrainingEntry, updatePostConfig } from '../../../services/api';
 import useProviderModels from '../../../hooks/useProviderModels';
-import { mergeModelLists } from '../../../utils/providers';
+import { isEmbeddingModel, isOllamaBackedProvider, localBackendForProvider, mergeModelLists } from '../../../utils/providers';
 import ProviderModelSelector from '../../ProviderModelSelector';
 import toast from '../../ui/Toast';
 import { uuidv4 } from '../../../lib/uuid';
@@ -92,21 +92,50 @@ const LOCAL_MODEL_BACKENDS = [
   { id: 'ollama', label: 'Ollama' },
   { id: 'lmstudio', label: 'LM Studio' },
 ];
+const EMBEDDING_CAPABILITIES = new Set(['embedding', 'embeddings']);
+
+const isGenerationLoadedModel = (model) => {
+  const type = typeof model?.type === 'string' ? model.type.toLowerCase() : '';
+  if (EMBEDDING_CAPABILITIES.has(type)) return false;
+  if (Array.isArray(model?.capabilities) && model.capabilities.length > 0) {
+    return !model.capabilities.some((capability) => EMBEDDING_CAPABILITIES.has(String(capability).toLowerCase()));
+  }
+  if (type) return true;
+  return !isEmbeddingModel(model?.id || model?.name || '');
+};
 
 const normalizeLoadedLocalModels = (status, sourceErrors = []) => LOCAL_MODEL_BACKENDS.flatMap(({ id: backend, label }) => (
   !sourceErrors.includes(backend) && Array.isArray(status?.[backend])
     ? status[backend]
       .filter((model) => typeof model?.id === 'string' && model.id.trim())
-      .map((model) => ({ backend, backendLabel: label, id: model.id, name: model.name || model.id }))
+      .map((model) => ({
+        backend,
+        backendLabel: label,
+        id: model.id,
+        name: model.name || model.id,
+        type: model.type,
+        capabilities: model.capabilities,
+      }))
     : []
 ));
 
+const backendForProvider = (provider) => (
+  isOllamaBackedProvider(provider) ? 'ollama' : localBackendForProvider(provider)
+);
+
 const pickLoadedEvaluatorModel = (models, providers, activeProviderId, sourceErrors) => {
   const available = models.filter((model) => (
-    !sourceErrors.includes(model.backend) && providers.some((provider) => provider.id === model.backend)
+    !sourceErrors.includes(model.backend)
+    && isGenerationLoadedModel(model)
+    && providers.some((provider) => backendForProvider(provider) === model.backend)
   ));
-  const active = available.find((model) => model.backend === activeProviderId);
-  return active || available[0] || null;
+  const activeBackend = backendForProvider(providers.find((provider) => provider.id === activeProviderId));
+  const selected = available.find((model) => model.backend === activeBackend) || available[0] || null;
+  if (!selected) return null;
+  const provider = providers.find((candidate) => (
+    candidate.id === activeProviderId && backendForProvider(candidate) === selected.backend
+  )) || providers.find((candidate) => backendForProvider(candidate) === selected.backend);
+  return provider ? { ...selected, providerId: provider.id } : null;
 };
 
 function EvaluatorReport({ results, enabled }) {
@@ -281,13 +310,13 @@ export default function RhetoricTrainer({ mode, onSelectMode, onExitMode, onBack
     setSelectedProviderId: setEvaluatorProviderId,
     setSelectedModel: setEvaluatorModel,
   } = useProviderModels({ filter: evaluatorProviderFilter, allowDefault: true, silent: true, withEffort: true });
-  const configReady = config !== null;
+  const evaluatorBackend = backendForProvider(providers.find((provider) => provider.id === evaluatorProviderId));
   const evaluatorAvailableModels = useMemo(() => mergeModelLists(
     evaluatorModels,
     localModelStatus.models
-      .filter((model) => model.backend === evaluatorProviderId)
+      .filter((model) => model.backend === evaluatorBackend && isGenerationLoadedModel(model))
       .map((model) => model.id),
-  ), [evaluatorModels, evaluatorProviderId, localModelStatus.models]);
+  ), [evaluatorBackend, evaluatorModels, localModelStatus.models]);
   const roundStart = useRef(Date.now());
   const promptStart = useRef(Date.now());
   const roundIdRef = useRef(newRoundId());
@@ -318,7 +347,7 @@ export default function RhetoricTrainer({ mode, onSelectMode, onExitMode, onBack
   }, [savedEvaluator.enabled, savedEvaluator.providerId, savedEvaluator.model, savedEvaluator.effort]);
 
   useEffect(() => {
-    if (selectedMode || !configReady) return undefined;
+    if (selectedMode) return undefined;
     let canceled = false;
     setLocalModelStatus({ state: 'loading', models: [], sourceErrors: [] });
     getLoadedLlmModels({ silent: true })
@@ -340,12 +369,11 @@ export default function RhetoricTrainer({ mode, onSelectMode, onExitMode, onBack
         if (!canceled) setLocalModelStatus({ state: 'unavailable', models: [], sourceErrors: LOCAL_MODEL_BACKENDS.map(({ id }) => id) });
       });
     return () => { canceled = true; };
-  }, [configReady, selectedMode?.id]);
+  }, [selectedMode?.id]);
 
   useEffect(() => {
     if (
       selectedMode
-      || !configReady
       || localModelStatus.state !== 'ready'
       || evaluatorSelectionTouchedRef.current
       || evaluatorAutoSelectionRef.current
@@ -359,10 +387,9 @@ export default function RhetoricTrainer({ mode, onSelectMode, onExitMode, onBack
     );
     if (!loaded) return;
     evaluatorAutoSelectionRef.current = true;
-    setEvaluatorProviderId(loaded.backend);
+    setEvaluatorProviderId(loaded.providerId);
     setEvaluatorModel(loaded.id);
   }, [
-    configReady,
     evaluatorActiveProviderId,
     localModelStatus,
     providers,

--- a/client/src/components/meatspace/post/RhetoricTrainer.jsx
+++ b/client/src/components/meatspace/post/RhetoricTrainer.jsx
@@ -1,7 +1,8 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { ArrowLeft, CheckCircle, ChevronRight, Feather, Lightbulb, Repeat2, RotateCcw, Save, Sparkles, Timer } from 'lucide-react';
-import { evaluateRhetoricAttempt, submitTrainingEntry, updatePostConfig } from '../../../services/api';
+import { evaluateRhetoricAttempt, getLoadedLlmModels, submitTrainingEntry, updatePostConfig } from '../../../services/api';
 import useProviderModels from '../../../hooks/useProviderModels';
+import { mergeModelLists } from '../../../utils/providers';
 import ProviderModelSelector from '../../ProviderModelSelector';
 import toast from '../../ui/Toast';
 import { uuidv4 } from '../../../lib/uuid';
@@ -87,6 +88,26 @@ export const RHETORIC_MODES = [
 const modeFor = (id) => RHETORIC_MODES.find((mode) => mode.id === id) || null;
 const newRoundId = () => uuidv4();
 const evaluatorProviderFilter = (provider) => provider?.enabled !== false;
+const LOCAL_MODEL_BACKENDS = [
+  { id: 'ollama', label: 'Ollama' },
+  { id: 'lmstudio', label: 'LM Studio' },
+];
+
+const normalizeLoadedLocalModels = (status, sourceErrors = []) => LOCAL_MODEL_BACKENDS.flatMap(({ id: backend, label }) => (
+  !sourceErrors.includes(backend) && Array.isArray(status?.[backend])
+    ? status[backend]
+      .filter((model) => typeof model?.id === 'string' && model.id.trim())
+      .map((model) => ({ backend, backendLabel: label, id: model.id, name: model.name || model.id }))
+    : []
+));
+
+const pickLoadedEvaluatorModel = (models, providers, activeProviderId, sourceErrors) => {
+  const available = models.filter((model) => (
+    !sourceErrors.includes(model.backend) && providers.some((provider) => provider.id === model.backend)
+  ));
+  const active = available.find((model) => model.backend === activeProviderId);
+  return active || available[0] || null;
+};
 
 function EvaluatorReport({ results, enabled }) {
   if (!enabled) return null;
@@ -154,6 +175,7 @@ function RhetoricEvaluatorConfig({
   saving,
   error,
   onSave,
+  localModelStatus,
 }) {
   const saved = config?.rhetoricEvaluator?.enabled === true;
   return (
@@ -180,6 +202,28 @@ function RhetoricEvaluatorConfig({
           <span className="block text-xs text-gray-500 mt-0.5">Off by default. Saving this setting is the consent gate for background provider calls.</span>
         </span>
       </label>
+      {localModelStatus.state === 'loading' && (
+        <p className="text-xs text-gray-500" role="status">Checking which local models are loaded…</p>
+      )}
+      {localModelStatus.models.length > 0 && (
+        <div className="rounded-lg border border-port-accent/30 bg-port-accent/5 px-3 py-2.5" role="status">
+          <div className="text-xs font-medium text-port-accent">Loaded local models</div>
+          <div className="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-xs text-gray-300">
+            {localModelStatus.models.map((model) => (
+              <span key={`${model.backend}:${model.id}`}>{model.name} · {model.backendLabel}</span>
+            ))}
+          </div>
+          <p className="mt-1 text-[11px] text-gray-500">A loaded model is preselected when there is no saved evaluator choice, avoiding a cold start.</p>
+        </div>
+      )}
+      {localModelStatus.state === 'ready' && localModelStatus.models.length === 0 && localModelStatus.sourceErrors.length === 0 && (
+        <p className="text-xs text-gray-500">No local models are loaded right now. Selecting one later may require a cold start.</p>
+      )}
+      {localModelStatus.sourceErrors.length > 0 && (
+        <p className="text-xs text-amber-400" role="status">
+          Couldn&apos;t verify residency for {localModelStatus.sourceErrors.map((backend) => LOCAL_MODEL_BACKENDS.find((entry) => entry.id === backend)?.label || backend).join(', ')}. Loaded-model information may be partial.
+        </p>
+      )}
       <ProviderModelSelector
         providers={providers}
         selectedProviderId={providerId}
@@ -221,17 +265,29 @@ export default function RhetoricTrainer({ mode, onSelectMode, onExitMode, onBack
   const [saving, setSaving] = useState(false);
   const [evaluatorSaving, setEvaluatorSaving] = useState(false);
   const [evaluatorSaveError, setEvaluatorSaveError] = useState('');
+  const [localModelStatus, setLocalModelStatus] = useState({ state: 'loading', models: [], sourceErrors: [] });
   const savedEvaluator = config?.rhetoricEvaluator || {};
+  const hasSavedEvaluatorChoice = savedEvaluator.providerId != null || savedEvaluator.model != null;
   const [evaluatorEnabled, setEvaluatorEnabled] = useState(savedEvaluator.enabled === true);
   const [evaluatorEffort, setEvaluatorEffort] = useState(savedEvaluator.effort || '');
+  const evaluatorSelectionTouchedRef = useRef(false);
+  const evaluatorAutoSelectionRef = useRef(false);
   const {
     providers,
+    activeProviderId: evaluatorActiveProviderId,
     selectedProviderId: evaluatorProviderId,
     selectedModel: evaluatorModel,
     availableModels: evaluatorModels,
     setSelectedProviderId: setEvaluatorProviderId,
     setSelectedModel: setEvaluatorModel,
   } = useProviderModels({ filter: evaluatorProviderFilter, allowDefault: true, silent: true, withEffort: true });
+  const configReady = config !== null;
+  const evaluatorAvailableModels = useMemo(() => mergeModelLists(
+    evaluatorModels,
+    localModelStatus.models
+      .filter((model) => model.backend === evaluatorProviderId)
+      .map((model) => model.id),
+  ), [evaluatorModels, evaluatorProviderId, localModelStatus.models]);
   const roundStart = useRef(Date.now());
   const promptStart = useRef(Date.now());
   const roundIdRef = useRef(newRoundId());
@@ -260,6 +316,61 @@ export default function RhetoricTrainer({ mode, onSelectMode, onExitMode, onBack
     setEvaluatorModel(savedEvaluator.model || '');
     setEvaluatorEffort(savedEvaluator.effort || '');
   }, [savedEvaluator.enabled, savedEvaluator.providerId, savedEvaluator.model, savedEvaluator.effort]);
+
+  useEffect(() => {
+    if (selectedMode || !configReady) return undefined;
+    let canceled = false;
+    setLocalModelStatus({ state: 'loading', models: [], sourceErrors: [] });
+    getLoadedLlmModels({ silent: true })
+      .then((status) => {
+        if (canceled) return;
+        const listsValid = LOCAL_MODEL_BACKENDS.every(({ id }) => Array.isArray(status?.[id]));
+        const sourceErrors = Array.isArray(status?.sourceErrors)
+          ? status.sourceErrors.filter((backend) => LOCAL_MODEL_BACKENDS.some((entry) => entry.id === backend))
+          : [];
+        setLocalModelStatus({
+          state: listsValid ? 'ready' : 'unavailable',
+          models: normalizeLoadedLocalModels(status, sourceErrors),
+          sourceErrors: sourceErrors.length > 0
+            ? sourceErrors
+            : (listsValid ? [] : LOCAL_MODEL_BACKENDS.map(({ id }) => id)),
+        });
+      })
+      .catch(() => {
+        if (!canceled) setLocalModelStatus({ state: 'unavailable', models: [], sourceErrors: LOCAL_MODEL_BACKENDS.map(({ id }) => id) });
+      });
+    return () => { canceled = true; };
+  }, [configReady, selectedMode?.id]);
+
+  useEffect(() => {
+    if (
+      selectedMode
+      || !configReady
+      || localModelStatus.state !== 'ready'
+      || evaluatorSelectionTouchedRef.current
+      || evaluatorAutoSelectionRef.current
+      || hasSavedEvaluatorChoice
+    ) return;
+    const loaded = pickLoadedEvaluatorModel(
+      localModelStatus.models,
+      providers,
+      evaluatorActiveProviderId,
+      localModelStatus.sourceErrors,
+    );
+    if (!loaded) return;
+    evaluatorAutoSelectionRef.current = true;
+    setEvaluatorProviderId(loaded.backend);
+    setEvaluatorModel(loaded.id);
+  }, [
+    configReady,
+    evaluatorActiveProviderId,
+    localModelStatus,
+    providers,
+    hasSavedEvaluatorChoice,
+    selectedMode,
+    setEvaluatorModel,
+    setEvaluatorProviderId,
+  ]);
 
   const prompt = selectedMode?.prompts[promptIndex];
   const completed = results.length;
@@ -413,15 +524,23 @@ export default function RhetoricTrainer({ mode, onSelectMode, onExitMode, onBack
           providerId={evaluatorProviderId}
           model={evaluatorModel}
           effort={evaluatorEffort}
-          availableModels={evaluatorModels}
+          availableModels={evaluatorAvailableModels}
           enabled={evaluatorEnabled}
-          onProviderChange={(value) => { setEvaluatorProviderId(value); setEvaluatorEffort(''); }}
-          onModelChange={setEvaluatorModel}
+          onProviderChange={(value) => {
+            evaluatorSelectionTouchedRef.current = true;
+            setEvaluatorProviderId(value);
+            setEvaluatorEffort('');
+          }}
+          onModelChange={(value) => {
+            evaluatorSelectionTouchedRef.current = true;
+            setEvaluatorModel(value);
+          }}
           onEffortChange={setEvaluatorEffort}
           onEnabledChange={setEvaluatorEnabled}
           saving={evaluatorSaving}
           error={evaluatorSaveError}
           onSave={saveEvaluator}
+          localModelStatus={localModelStatus}
         />
         <div className="grid gap-4 sm:grid-cols-2">
           {RHETORIC_MODES.map((entry) => {

--- a/client/src/components/meatspace/post/RhetoricTrainer.jsx
+++ b/client/src/components/meatspace/post/RhetoricTrainer.jsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { ArrowLeft, CheckCircle, ChevronRight, Feather, Lightbulb, Repeat2, RotateCcw, Save, Sparkles, Timer } from 'lucide-react';
 import { evaluateRhetoricAttempt, getLoadedLlmModels, submitTrainingEntry, updatePostConfig } from '../../../services/api';
 import useProviderModels from '../../../hooks/useProviderModels';
-import { isEmbeddingModel, isOllamaBackedProvider, localBackendForProvider, mergeModelLists } from '../../../utils/providers';
+import { isEmbeddingModel, isLocalEndpoint, isLocalInstanceProvider, isOllamaBackedProvider, localBackendForProvider, mergeModelLists } from '../../../utils/providers';
 import ProviderModelSelector from '../../ProviderModelSelector';
 import toast from '../../ui/Toast';
 import { uuidv4 } from '../../../lib/uuid';
@@ -119,9 +119,26 @@ const normalizeLoadedLocalModels = (status, sourceErrors = []) => LOCAL_MODEL_BA
     : []
 ));
 
-const backendForProvider = (provider) => (
-  isOllamaBackedProvider(provider) ? 'ollama' : localBackendForProvider(provider)
-);
+const configuredProviderEndpoints = (provider) => {
+  const endpoints = [];
+  if (typeof provider?.endpoint === 'string' && provider.endpoint.trim()) endpoints.push(provider.endpoint);
+  const anthropicBaseUrl = provider?.envVars?.ANTHROPIC_BASE_URL;
+  if (typeof anthropicBaseUrl === 'string' && anthropicBaseUrl.trim()) endpoints.push(anthropicBaseUrl);
+  const openCodeConfig = provider?.envVars?.OPENCODE_CONFIG_CONTENT;
+  if (typeof openCodeConfig === 'string' && openCodeConfig.trim()) {
+    const openCodeEndpoints = [...openCodeConfig.matchAll(/"baseURL"\s*:\s*"([^"]+)"/g)].map((match) => match[1]);
+    if (openCodeEndpoints.length === 0) return null;
+    endpoints.push(...openCodeEndpoints);
+  }
+  return endpoints;
+};
+
+const backendForProvider = (provider) => {
+  if (!provider || !isLocalInstanceProvider(provider)) return null;
+  const endpoints = configuredProviderEndpoints(provider);
+  if (!endpoints || endpoints.some((endpoint) => !isLocalEndpoint(endpoint))) return null;
+  return isOllamaBackedProvider(provider) ? 'ollama' : localBackendForProvider(provider);
+};
 
 const pickLoadedEvaluatorModel = (models, providers, activeProviderId, sourceErrors) => {
   const available = models.filter((model) => (
@@ -341,10 +358,15 @@ export default function RhetoricTrainer({ mode, onSelectMode, onExitMode, onBack
 
   useEffect(() => {
     setEvaluatorEnabled(savedEvaluator.enabled === true);
-    setEvaluatorProviderId(savedEvaluator.providerId || '');
-    setEvaluatorModel(savedEvaluator.model || '');
+    if (
+      !evaluatorSelectionTouchedRef.current
+      && (hasSavedEvaluatorChoice || !evaluatorAutoSelectionRef.current)
+    ) {
+      setEvaluatorProviderId(savedEvaluator.providerId || '');
+      setEvaluatorModel(savedEvaluator.model || '');
+    }
     setEvaluatorEffort(savedEvaluator.effort || '');
-  }, [savedEvaluator.enabled, savedEvaluator.providerId, savedEvaluator.model, savedEvaluator.effort]);
+  }, [hasSavedEvaluatorChoice, savedEvaluator.enabled, savedEvaluator.providerId, savedEvaluator.model, savedEvaluator.effort]);
 
   useEffect(() => {
     if (selectedMode) return undefined;

--- a/client/src/components/meatspace/post/RhetoricTrainer.test.jsx
+++ b/client/src/components/meatspace/post/RhetoricTrainer.test.jsx
@@ -15,6 +15,7 @@ describe('RhetoricTrainer', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    evaluateRhetoricAttempt.mockReset();
     getLoadedLlmModels.mockResolvedValue({ ollama: [], lmstudio: [], sourceErrors: [] });
     getProviders.mockResolvedValue({ providers: [] });
     submitTrainingEntry.mockResolvedValue();
@@ -85,6 +86,64 @@ describe('RhetoricTrainer', () => {
     expect(await screen.findByText('Loaded local models')).toBeInTheDocument();
     expect(screen.getByText(/Couldn't verify residency for LM Studio/)).toBeInTheDocument();
     expect(screen.queryByText(/No local models are loaded/)).not.toBeInTheDocument();
+  });
+
+  it('does not preselect embedding-only resident models', async () => {
+    getLoadedLlmModels.mockResolvedValueOnce({
+      ollama: [{ id: 'nomic-embed-text:latest', name: 'nomic-embed-text:latest' }],
+      lmstudio: [{ id: 'example-embed', name: 'example-embed', type: 'embeddings' }],
+      sourceErrors: [],
+    });
+    getProviders.mockResolvedValueOnce({
+      activeProvider: 'ollama',
+      providers: [{ id: 'ollama', name: 'Ollama', enabled: true, models: [] }],
+    });
+
+    render(<RhetoricTrainer {...props} config={{ rhetoricEvaluator: { enabled: false } }} />);
+
+    expect(await screen.findByText('Loaded local models')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByLabelText('Provider')).toHaveValue('');
+      expect(screen.getByLabelText('Model')).toHaveValue('');
+    });
+    expect(screen.queryByRole('option', { name: 'nomic-embed-text:latest' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('option', { name: 'example-embed' })).not.toBeInTheDocument();
+  });
+
+  it('maps an Ollama-backed wrapper provider to resident Ollama models', async () => {
+    getLoadedLlmModels.mockResolvedValueOnce({
+      ollama: [{ id: 'example-rhetoric:latest', name: 'example-rhetoric:latest' }],
+      lmstudio: [],
+      sourceErrors: [],
+    });
+    getProviders.mockResolvedValueOnce({
+      activeProvider: 'opencode-ollama-tui',
+      providers: [{ id: 'opencode-ollama-tui', name: 'OpenCode Ollama TUI', enabled: true, models: [], ollamaBacked: true }],
+    });
+
+    render(<RhetoricTrainer {...props} config={{ rhetoricEvaluator: { enabled: false } }} />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Provider')).toHaveValue('opencode-ollama-tui');
+      expect(screen.getByLabelText('Model')).toHaveValue('example-rhetoric:latest');
+    });
+  });
+
+  it('checks local residency when POST config is unavailable', async () => {
+    getLoadedLlmModels.mockResolvedValueOnce({
+      ollama: [{ id: 'example-rhetoric:latest', name: 'example-rhetoric:latest' }],
+      lmstudio: [],
+      sourceErrors: [],
+    });
+    getProviders.mockResolvedValueOnce({
+      activeProvider: 'ollama',
+      providers: [{ id: 'ollama', name: 'Ollama', enabled: true, models: [] }],
+    });
+
+    render(<RhetoricTrainer {...props} config={null} />);
+
+    expect(await screen.findByText('Loaded local models')).toBeInTheDocument();
+    expect(getLoadedLlmModels).toHaveBeenCalledWith({ silent: true });
   });
 
   it('shows the rhetoric exercise choices', async () => {

--- a/client/src/components/meatspace/post/RhetoricTrainer.test.jsx
+++ b/client/src/components/meatspace/post/RhetoricTrainer.test.jsx
@@ -129,7 +129,7 @@ describe('RhetoricTrainer', () => {
     });
   });
 
-  it('checks local residency when POST config is unavailable', async () => {
+  it('checks local residency when POST config is unavailable and preserves it through hydration', async () => {
     getLoadedLlmModels.mockResolvedValueOnce({
       ollama: [{ id: 'example-rhetoric:latest', name: 'example-rhetoric:latest' }],
       lmstudio: [],
@@ -140,10 +140,42 @@ describe('RhetoricTrainer', () => {
       providers: [{ id: 'ollama', name: 'Ollama', enabled: true, models: [] }],
     });
 
-    render(<RhetoricTrainer {...props} config={null} />);
+    const view = render(<RhetoricTrainer {...props} config={null} />);
 
     expect(await screen.findByText('Loaded local models')).toBeInTheDocument();
     expect(getLoadedLlmModels).toHaveBeenCalledWith({ silent: true });
+    await waitFor(() => {
+      expect(screen.getByLabelText('Provider')).toHaveValue('ollama');
+      expect(screen.getByLabelText('Model')).toHaveValue('example-rhetoric:latest');
+    });
+
+    view.rerender(<RhetoricTrainer {...props} config={{ rhetoricEvaluator: { enabled: false } }} />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Provider')).toHaveValue('ollama');
+      expect(screen.getByLabelText('Model')).toHaveValue('example-rhetoric:latest');
+    });
+  });
+
+  it('does not use local residency for a remote Ollama provider', async () => {
+    getLoadedLlmModels.mockResolvedValueOnce({
+      ollama: [{ id: 'example-rhetoric:latest', name: 'example-rhetoric:latest' }],
+      lmstudio: [],
+      sourceErrors: [],
+    });
+    getProviders.mockResolvedValueOnce({
+      activeProvider: 'remote-ollama',
+      providers: [{ id: 'remote-ollama', name: 'Remote Ollama', endpoint: 'http://192.0.2.10:11434/v1', enabled: true, models: [] }],
+    });
+
+    render(<RhetoricTrainer {...props} config={{ rhetoricEvaluator: { enabled: false } }} />);
+
+    expect(await screen.findByText('Loaded local models')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByLabelText('Provider')).toHaveValue('');
+      expect(screen.getByLabelText('Model')).toHaveValue('');
+    });
+    expect(screen.queryByRole('option', { name: 'example-rhetoric:latest' })).not.toBeInTheDocument();
   });
 
   it('shows the rhetoric exercise choices', async () => {

--- a/client/src/components/meatspace/post/RhetoricTrainer.test.jsx
+++ b/client/src/components/meatspace/post/RhetoricTrainer.test.jsx
@@ -1,16 +1,91 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import RhetoricTrainer from './RhetoricTrainer';
-import { evaluateRhetoricAttempt, submitTrainingEntry } from '../../../services/api';
+import { evaluateRhetoricAttempt, getLoadedLlmModels, getProviders, submitTrainingEntry } from '../../../services/api';
 
 vi.mock('../../../services/api', () => ({
   evaluateRhetoricAttempt: vi.fn(),
+  getLoadedLlmModels: vi.fn(() => Promise.resolve({ ollama: [], lmstudio: [], sourceErrors: [] })),
   getProviders: vi.fn(() => Promise.resolve({ providers: [] })),
   submitTrainingEntry: vi.fn(() => Promise.resolve()),
 }));
 
 describe('RhetoricTrainer', () => {
   const props = { onBack: vi.fn(), onSelectMode: vi.fn(), onExitMode: vi.fn(), onContinue: vi.fn() };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getLoadedLlmModels.mockResolvedValue({ ollama: [], lmstudio: [], sourceErrors: [] });
+    getProviders.mockResolvedValue({ providers: [] });
+    submitTrainingEntry.mockResolvedValue();
+  });
+
+  it('shows loaded local models and preselects a resident model when no choice is saved', async () => {
+    getLoadedLlmModels.mockResolvedValueOnce({
+      ollama: [{ id: 'example-rhetoric:latest', name: 'example-rhetoric:latest' }],
+      lmstudio: [],
+      sourceErrors: [],
+    });
+    getProviders.mockResolvedValueOnce({
+      activeProvider: 'example-cloud',
+      providers: [
+        { id: 'example-cloud', name: 'Example Cloud', enabled: true, models: ['example-cloud-model'] },
+        { id: 'ollama', name: 'Ollama', enabled: true, models: [] },
+      ],
+    });
+
+    render(<RhetoricTrainer {...props} config={{ rhetoricEvaluator: { enabled: false } }} />);
+
+    expect(await screen.findByText('Loaded local models')).toBeInTheDocument();
+    expect(screen.getByText('example-rhetoric:latest · Ollama')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByLabelText('Provider')).toHaveValue('ollama');
+      expect(screen.getByLabelText('Model')).toHaveValue('example-rhetoric:latest');
+    });
+  });
+
+  it('preserves a saved evaluator choice when a local model is loaded', async () => {
+    getLoadedLlmModels.mockResolvedValueOnce({
+      ollama: [{ id: 'example-rhetoric:latest', name: 'example-rhetoric:latest' }],
+      lmstudio: [],
+      sourceErrors: [],
+    });
+    getProviders.mockResolvedValueOnce({
+      activeProvider: 'ollama',
+      providers: [
+        { id: 'example-cloud', name: 'Example Cloud', enabled: true, models: ['example-cloud-model'] },
+        { id: 'ollama', name: 'Ollama', enabled: true, models: [] },
+      ],
+    });
+
+    render(<RhetoricTrainer
+      {...props}
+      config={{ rhetoricEvaluator: { enabled: true, providerId: 'example-cloud', model: 'example-cloud-model' } }}
+    />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Provider')).toHaveValue('example-cloud');
+      expect(screen.getByLabelText('Model')).toHaveValue('example-cloud-model');
+    });
+  });
+
+  it('shows partial residency status without claiming no local models are loaded', async () => {
+    getLoadedLlmModels.mockResolvedValueOnce({
+      ollama: [{ id: 'example-rhetoric:latest', name: 'example-rhetoric:latest' }],
+      lmstudio: [],
+      sourceErrors: ['lmstudio'],
+    });
+    getProviders.mockResolvedValueOnce({
+      activeProvider: 'ollama',
+      providers: [{ id: 'ollama', name: 'Ollama', enabled: true, models: [] }],
+    });
+
+    render(<RhetoricTrainer {...props} config={{ rhetoricEvaluator: { enabled: false } }} />);
+
+    expect(await screen.findByText('Loaded local models')).toBeInTheDocument();
+    expect(screen.getByText(/Couldn't verify residency for LM Studio/)).toBeInTheDocument();
+    expect(screen.queryByText(/No local models are loaded/)).not.toBeInTheDocument();
+  });
 
   it('shows the rhetoric exercise choices', async () => {
     render(<RhetoricTrainer {...props} />);


### PR DESCRIPTION
## Summary
- Show live Ollama and LM Studio resident models in POST rhetoric's optional AI evaluator.
- Preselect a resident generation-capable local model when no evaluator choice is saved, while preserving saved/manual/remote-provider semantics and excluding embedding-only models.

## Test plan
- `npm test` (client)
- `npm run lint` (client)
- `npm run build` (client)