### PR TITLE
feat: use shared AI selectors for feature agents

### DIFF
--- a/client/src/components/feature-agents/ConfigTab.jsx
+++ b/client/src/components/feature-agents/ConfigTab.jsx
@@ -3,6 +3,8 @@ import { Save } from 'lucide-react';
 import toast from '../ui/Toast';
 import { FormField } from '../ui/FormField';
 import * as api from '../../services/api';
+import useProviderModels from '../../hooks/useProviderModels';
+import AgentJobProviderFields from '../cos/AgentJobProviderFields';
 
 function ArrayInput({ label, value, onChange, placeholder }) {
   const [text, setText] = useState((value || []).join('\n'));
@@ -32,6 +34,11 @@ function ArrayInput({ label, value, onChange, placeholder }) {
 }
 
 export default function ConfigTab({ agent, isCreate, apps, onSave }) {
+  const { providers, activeProviderId } = useProviderModels({
+    allowDefault: true,
+    silent: true,
+    withEffort: true
+  });
   const [form, setForm] = useState({
     name: '',
     description: '',
@@ -42,6 +49,7 @@ export default function ConfigTab({ agent, isCreate, apps, onSave }) {
     constraints: [],
     providerId: '',
     model: '',
+    effort: '',
     autonomyLevel: 'assistant',
     priority: 'MEDIUM'
   });
@@ -59,6 +67,7 @@ export default function ConfigTab({ agent, isCreate, apps, onSave }) {
         constraints: agent.constraints || [],
         providerId: agent.providerId || '',
         model: agent.model || '',
+        effort: agent.effort || '',
         autonomyLevel: agent.autonomyLevel || 'assistant',
         priority: agent.priority || 'MEDIUM'
       });
@@ -74,6 +83,10 @@ export default function ConfigTab({ agent, isCreate, apps, onSave }) {
     });
   }, []);
 
+  const setAiProvider = useCallback((patch) => {
+    setForm(prev => ({ ...prev, ...patch }));
+  }, []);
+
   const handleSubmit = async (e) => {
     e.preventDefault();
     setSaving(true);
@@ -81,18 +94,19 @@ export default function ConfigTab({ agent, isCreate, apps, onSave }) {
     const payload = {
       ...form,
       providerId: form.providerId || null,
-      model: form.model || null
+      model: form.model || null,
+      effort: form.effort || null
     };
 
     if (isCreate) {
-      const created = await api.createFeatureAgent(payload).catch(() => null);
+      const created = await api.createFeatureAgent(payload, { silent: true }).catch(() => null);
       setSaving(false);
       if (created) {
         toast.success('Feature agent created');
         onSave?.(created);
       }
     } else {
-      const updated = await api.updateFeatureAgent(agent.id, payload).catch(() => null);
+      const updated = await api.updateFeatureAgent(agent.id, payload, { silent: true }).catch(() => null);
       setSaving(false);
       if (updated) {
         toast.success('Config saved');
@@ -178,15 +192,14 @@ export default function ConfigTab({ agent, isCreate, apps, onSave }) {
 
       {/* AI Provider Override */}
       <div className="bg-port-card border border-port-border rounded-xl p-5 space-y-4">
-        <h3 className="text-sm font-medium text-gray-400 uppercase tracking-wider">AI Provider (optional override)</h3>
-        <div className="grid grid-cols-2 gap-4">
-          <FormField label="Provider ID">
-            <input value={form.providerId || ''} onChange={e => set('providerId', e.target.value)} className={inputCls} placeholder="Leave empty for default" />
-          </FormField>
-          <FormField label="Model">
-            <input value={form.model || ''} onChange={e => set('model', e.target.value)} className={inputCls} placeholder="Leave empty for default" />
-          </FormField>
-        </div>
+        <h3 className="text-sm font-medium text-gray-400 uppercase tracking-wider">AI Provider Override</h3>
+        <AgentJobProviderFields
+          data={{ providerId: form.providerId, model: form.model, effort: form.effort }}
+          providers={providers}
+          activeProviderId={activeProviderId}
+          onChange={setAiProvider}
+        />
+        <p className="text-xs text-gray-500">Leave the provider at the active default unless this agent should always use a specific coding provider, model, or reasoning effort.</p>
       </div>
 
       <div className="flex justify-end">

--- a/client/src/components/feature-agents/ConfigTab.test.jsx
+++ b/client/src/components/feature-agents/ConfigTab.test.jsx
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+const api = vi.hoisted(() => ({
+  createFeatureAgent: vi.fn(),
+  getToolUseModels: vi.fn(),
+}));
+const providerHook = vi.hoisted(() => ({
+  providers: [{
+    id: 'codex',
+    name: 'Codex',
+    type: 'cli',
+    enabled: true,
+    defaultModel: 'gpt-5',
+    models: ['gpt-5'],
+  }],
+  activeProviderId: 'codex',
+}));
+
+vi.mock('../../services/api', () => api);
+vi.mock('../../services/apiLocalLlm', () => ({ getToolUseModels: api.getToolUseModels }));
+vi.mock('../../hooks/useProviderModels', () => ({ default: () => providerHook }));
+vi.mock('../ui/Toast', () => ({ default: { success: vi.fn(), error: vi.fn() } }));
+
+import ConfigTab from './ConfigTab.jsx';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  api.getToolUseModels.mockResolvedValue({ models: [] });
+  api.createFeatureAgent.mockResolvedValue({ id: 'fa-example' });
+});
+
+describe('Feature agent AI provider controls', () => {
+  it('uses the shared provider/model/effort selectors and persists their choices', async () => {
+    render(<ConfigTab isCreate apps={[{ id: 'app-example', name: 'Example App' }]} />);
+
+    expect(screen.queryByLabelText('Provider ID')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Model')).toBeInTheDocument();
+    expect(screen.getByLabelText('Provider')).toHaveValue('');
+
+    fireEvent.change(screen.getByLabelText('Provider'), { target: { value: 'codex' } });
+    fireEvent.change(screen.getByLabelText('Model'), { target: { value: 'gpt-5' } });
+    fireEvent.change(screen.getByLabelText('Thinking effort'), { target: { value: 'high' } });
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Example Agent' } });
+    fireEvent.change(screen.getByLabelText('Description'), { target: { value: 'Improve the example app' } });
+    fireEvent.change(screen.getByLabelText('App'), { target: { value: 'app-example' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Create Agent' }));
+
+    await waitFor(() => expect(api.createFeatureAgent).toHaveBeenCalledWith(expect.objectContaining({
+      providerId: 'codex',
+      model: 'gpt-5',
+      effort: 'high',
+    }), { silent: true }));
+  });
+});

--- a/client/src/services/apiAgents.js
+++ b/client/src/services/apiAgents.js
@@ -355,13 +355,15 @@ export const getCosWorkflow = (hours = 24) => request(`/cos/workflow?hours=${hou
 // Feature Agents
 export const getFeatureAgents = () => request('/feature-agents');
 export const getFeatureAgent = (id) => request(`/feature-agents/${id}`);
-export const createFeatureAgent = (data) => request('/feature-agents', {
+export const createFeatureAgent = (data, options = {}) => request('/feature-agents', {
   method: 'POST',
-  body: JSON.stringify(data)
+  body: JSON.stringify(data),
+  ...options
 });
-export const updateFeatureAgent = (id, data) => request(`/feature-agents/${id}`, {
+export const updateFeatureAgent = (id, data, options = {}) => request(`/feature-agents/${id}`, {
   method: 'PUT',
-  body: JSON.stringify(data)
+  body: JSON.stringify(data),
+  ...options
 });
 export const deleteFeatureAgent = (id, options = {}) => request(`/feature-agents/${id}`, { method: 'DELETE', ...options });
 export const startFeatureAgent = (id, options = {}) => request(`/feature-agents/${id}/start`, { method: 'POST', ...options });

--- a/server/lib/agentValidation.js
+++ b/server/lib/agentValidation.js
@@ -10,6 +10,7 @@
  */
 import { z } from 'zod';
 import { partialWithoutDefaults } from './zodCompat.js';
+import { EFFORT_LEVELS } from './providerModels.js';
 
 // =============================================================================
 // AGENT PERSONALITY SCHEMAS
@@ -338,6 +339,7 @@ export const featureAgentSchema = z.object({
   constraints: z.array(z.string()).default([]),
   providerId: z.string().optional().nullable(),
   model: z.string().optional().nullable(),
+  effort: z.preprocess((value) => (value === '' ? undefined : value), z.enum(EFFORT_LEVELS).nullable().optional()),
   autonomyLevel: featureAgentAutonomySchema.default('assistant'),
   priority: featureAgentPrioritySchema.default('MEDIUM')
 });
@@ -357,6 +359,7 @@ export const featureAgentUpdateSchema = z.object({
   constraints: z.array(z.string()).optional(),
   providerId: z.string().optional().nullable(),
   model: z.string().optional().nullable(),
+  effort: z.preprocess((value) => (value === '' ? undefined : value), z.enum(EFFORT_LEVELS).nullable().optional()),
   autonomyLevel: featureAgentAutonomySchema.optional(),
   priority: featureAgentPrioritySchema.optional()
 });

--- a/server/lib/validation.test.js
+++ b/server/lib/validation.test.js
@@ -839,6 +839,11 @@ describe('validation.js', () => {
       const result = featureAgentSchema.safeParse({ ...validAgent, priority: 'INVALID' });
       expect(result.success).toBe(false);
     });
+
+    it('should validate an optional reasoning effort', () => {
+      expect(featureAgentSchema.safeParse({ ...validAgent, effort: 'high' }).success).toBe(true);
+      expect(featureAgentSchema.safeParse({ ...validAgent, effort: 'bogus' }).success).toBe(false);
+    });
   });
 
   describe('featureAgentUpdateSchema (deepPartial)', () => {

--- a/server/services/featureAgents.js
+++ b/server/services/featureAgents.js
@@ -359,7 +359,8 @@ export function generateTaskFromFeatureAgent(agent) {
       featureAgentRun: true,
       app: agent.appId,
       provider: agent.providerId || undefined,
-      model: agent.model || undefined
+      model: agent.model || undefined,
+      effort: agent.effort || undefined
     }
   };
 }

--- a/server/services/featureAgents.test.js
+++ b/server/services/featureAgents.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { calculateBackoff } from './featureAgents.js';
+import { calculateBackoff, generateTaskFromFeatureAgent } from './featureAgents.js';
 
 /**
  * Tests for feature agents pure logic.
@@ -146,24 +146,6 @@ describe('Feature Agent State Transitions', () => {
 });
 
 describe('Feature Agent Task Generation', () => {
-  function generateTaskFromFeatureAgent(agent) {
-    return {
-      id: `fa-run-${agent.id}-${Date.now()}`,
-      description: `[Feature Agent] ${agent.name}: ${agent.description}`,
-      priority: agent.priority || 'MEDIUM',
-      status: 'pending',
-      taskType: 'internal',
-      approvalRequired: false,
-      metadata: {
-        featureAgentId: agent.id,
-        featureAgentRun: true,
-        app: agent.appId,
-        provider: agent.providerId || undefined,
-        model: agent.model || undefined
-      }
-    };
-  }
-
   const agent = {
     id: 'fa-abc123',
     name: 'UI Agent',
@@ -171,7 +153,8 @@ describe('Feature Agent Task Generation', () => {
     priority: 'HIGH',
     appId: 'app-001',
     providerId: 'prov-1',
-    model: 'opus'
+    model: 'opus',
+    effort: 'high'
   };
 
   it('should generate task with correct metadata', () => {
@@ -179,6 +162,7 @@ describe('Feature Agent Task Generation', () => {
     expect(task.metadata.featureAgentId).toBe('fa-abc123');
     expect(task.metadata.featureAgentRun).toBe(true);
     expect(task.metadata.app).toBe('app-001');
+    expect(task.metadata.effort).toBe('high');
   });
 
   it('should use agent priority', () => {


### PR DESCRIPTION
## Summary
- replace free-text provider and model inputs in the feature-agent form with the shared provider/model/effort selector
- persist optional reasoning effort through feature-agent validation and generated CoS task metadata
- add focused client and server regression coverage

## Test plan
- npm test -- --run src/components/feature-agents/ConfigTab.test.jsx src/components/cos/AgentJobProviderFields.test.jsx (client)
- npm test -- --run services/featureAgents.test.js lib/validation.test.js (server)
- npm run lint -- --no-errors-on-unmatched (client)
- npm run build (client)