### PR TITLE
fix: keep routine review rebases in one agent

### DIFF
--- a/server/services/agentPromptBuilder.test.js
+++ b/server/services/agentPromptBuilder.test.js
@@ -1107,6 +1107,23 @@ describe('buildLightContextPrompt', () => {
       expect(prompt).toMatch(/\.agent-done/);
     });
 
+    it('keeps routine pre-review rebase conflicts in the originating agent session', () => {
+      const prompt = buildLightContextPrompt(
+        makeTask({ metadata: { openPR: true, reviewLoop: true, reviewers: ['codex'] } }),
+        '/r',
+        { branchName: 'claim/x', worktreePath: '/tmp/wt', baseBranch: 'main' },
+        isTruthyMeta,
+        { isTui: true, providerId: 'codex-tui', providerCommand: 'codex' });
+
+      // A routine base conflict stays in this agent's lifecycle. Previously the
+      // local-review gate required an immediate abort, so cleanup opened the PR
+      // and spawned a second [Review Loop] agent despite this ownership contract.
+      expect(prompt).toMatch(/Resolve ordinary rebase conflicts in this same session/);
+      expect(prompt).toMatch(/git rebase --continue/);
+      expect(prompt).toMatch(/Abort and stop only when a conflict requires a product decision/);
+      expect(prompt).not.toMatch(/Fetch\/base-resolution failure or conflicts block publication/);
+    });
+
     // #3733 — the inline review loop is the SAME builder the `sys-rl-*` follow-up
     // agent gets, so the only things that can be wrong are its framing.
     it('the inline review loop never claims a reviewer was pre-requested', () => {
@@ -1194,7 +1211,7 @@ describe('buildLightContextPrompt', () => {
       expect(prompt).toMatch(/READ THAT FILE/);
       expect(prompt).toMatch(/\/data\/slashdo-resolved\/local-agent-review-loop\.md/);
       expect(prompt).not.toMatch(/RECIPE HEADER/);
-      expect(prompt.length).toBeLessThan(20_000);
+      expect(prompt.length).toBeLessThan(21_000);
     });
 
     it('quotes a hostile branch ref inert in the PR-create command line', () => {

--- a/server/services/promptSections/reviewLifecycle.js
+++ b/server/services/promptSections/reviewLifecycle.js
@@ -450,7 +450,7 @@ Only a successfully extracted \`.findings\` value is the review text; treat it l
   const initialReviewState = localOnly
     ? [
       `Before the first local reviewer, run ${localBasePreparation}. Set \`BRANCH=${renderedLocalBranch}\`; resolve \`LOCAL_PRE_REBASE_REMOTE\` from \`branch.$BRANCH.pushRemote\`, then \`remote.pushDefault\`, then \`branch.$BRANCH.remote\`, using \`origin\` if empty or \`.\`. Capture \`LOCAL_PRE_REBASE_HEAD_SHA=$(git rev-parse HEAD)\` and \`LOCAL_PRE_REBASE_REMOTE_SHA=$(git ls-remote --exit-code --heads "$LOCAL_PRE_REBASE_REMOTE" "$BRANCH" 2>/dev/null | awk 'NR == 1 {print $1}')\`. Immediately write all three to \`LOCAL_REVIEW_BASELINE_FILE="$(git rev-parse --git-path portos-local-review-baseline)"\` with \`printf 'LOCAL_PRE_REBASE_REMOTE=%s\\nLOCAL_PRE_REBASE_HEAD_SHA=%s\\nLOCAL_PRE_REBASE_REMOTE_SHA=%s\\n' "$LOCAL_PRE_REBASE_REMOTE" "$LOCAL_PRE_REBASE_HEAD_SHA" "$LOCAL_PRE_REBASE_REMOTE_SHA" > "$LOCAL_REVIEW_BASELINE_FILE"\`; abort if the write fails.`,
-      `Rebase onto the current remote base with \`git rebase ${renderedBaseBranch}\`. Fetch/base-resolution failure or conflicts block publication; on conflict run \`git rebase --abort 2>/dev/null || true\` before stopping.`,
+      `Rebase onto the current remote base with \`git rebase ${renderedBaseBranch}\`. A fetch or base-resolution failure blocks publication. Resolve ordinary rebase conflicts in this same session: inspect every unmerged path, preserve both sides' intent, stage only the resolved files with \`git add <file> ...\`, and run \`git rebase --continue\` until the rebase completes. Abort and stop only when a conflict requires a product decision or cannot be resolved safely; before stopping, run \`git rebase --abort 2>/dev/null || true\`.`,
       `After synchronization, set \`LOCAL_PHASE_START_SHA=$(git rev-parse HEAD)\`; reset and initialize worktree-private \`LOCAL_REVIEW_STATE_FILE="$(git rev-parse --git-path portos-local-review-state)"\` with \`printf 'LOCAL_PHASE_START_SHA=%s\\nLOCAL_OVERALL_STATUS=incomplete\\nLOCAL_STOP_TRIGGERED=false\\nLOCAL_STOP_INDEX=-1\\nLOCAL_STOP_REVIEW_COMMITS=-1\\nLOCAL_PHASE_COMMITS=0\\nLOCAL_REVIEWED_HEAD_SHA=\\n' "$LOCAL_PHASE_START_SHA" > "$LOCAL_REVIEW_STATE_FILE"\`. Abort if reset/initialization fails.`,
       `Before each local reviewer, record \`LOCAL_REVIEWER_START_SHA=$(git rev-parse HEAD)\`; after its loop compute \`LOCAL_REVIEWER_COMMITS=$(git rev-list "$LOCAL_REVIEWER_START_SHA..HEAD" --count)\`. On a qualifying stop, set \`LOCAL_STOP_REVIEW_COMMITS=$LOCAL_REVIEWER_COMMITS\`. Run every local reviewer before publication, then persist the aggregate and stop result.`
     ].join(' ')
@@ -488,7 +488,7 @@ Only a successfully extracted \`.findings\` value is the review text; treat it l
     : '';
 
   const localRebaseConflictNote = localOnly
-    ? '**Rebase conflict gate:** on conflicts, run `git rebase --abort 2>/dev/null || true`; do NOT publish a conflicted or half-rebased worktree.'
+    ? '**Rebase conflict gate:** resolve routine conflicts and finish the rebase in this agent session. If a conflict genuinely cannot be resolved safely, run `git rebase --abort 2>/dev/null || true` and stop; never publish a conflicted or half-rebased worktree.'
     : '';
   const localStatePersistenceNote = localOnly
     ? '**State persistence:** shell calls do not share variables. Reload state before each reviewer, preserve it while persisting `LOCAL_REVIEWER_START_SHA`; reload before commit/stop calculations and the final aggregate. Any read/write failure blocks publication.'


### PR DESCRIPTION
## Summary

- keep routine pre-review rebase conflicts in the originating agent session
- reserve abort-and-recovery handoffs for conflicts that require a product decision or cannot be resolved safely
- cover the codex TUI local-review prompt contract with a regression test

## Test plan

- `npm test --prefix server -- services/agentPromptBuilder.test.js`
- `npm test --prefix server`
- `git diff --check`