### PR TITLE
fix: serialize LoRA deletion with sidecar writes (#5137)

### DIFF
--- a/server/services/loraTraining/index.js
+++ b/server/services/loraTraining/index.js
@@ -27,6 +27,7 @@ import { killWithEscalation } from '../../lib/killWithEscalation.js';
 import { getImageModels } from '../../lib/mediaModels.js';
 import { resolveFlux2Python, isFlux2VenvHealthy, resolveMfluxPython } from '../../lib/pythonSetup.js';
 import { getSettings } from '../settings.js';
+import { writeLoraSidecar } from '../loras.js';
 import { enqueueJob, getJob, mediaJobEvents } from '../mediaJobQueue/index.js';
 import { updateDataset } from '../loraDatasets.js';
 import { trainingEvents } from './events.js';
@@ -1044,7 +1045,7 @@ async function registerTrainedLora({
   const sidecar = buildTrainedSidecar({
     run, result, filename, previewImageUrl, sizeBytes, selectedStep, autoSelected,
   });
-  await atomicWrite(`${dest}.metadata.json`, JSON.stringify(sidecar, null, 2) + '\n');
+  await writeLoraSidecar(filename, sidecar);
   return { sizeBytes, sidecar };
 }
 

--- a/server/services/loras.js
+++ b/server/services/loras.js
@@ -295,18 +295,34 @@ export const getLora = async (filename) => {
 export const deleteLora = async (filename) => {
   assertSafeLoraFilename(filename);
   const filePath = join(PATHS.loras, filename);
-  if (!existsSync(filePath)) {
-    throw new ServerError(`LoRA not found: ${filename}`, { status: 404, code: 'NOT_FOUND' });
-  }
-  const s = await stat(filePath).catch(() => null);
-  if (!s || !s.isFile()) {
-    throw new ServerError(
-      `Cannot delete "${filename}": not a regular file`,
-      { status: 400, code: 'INVALID_LORA_FILE' },
+  await queueSidecarWrite(filename, async () => {
+    if (!existsSync(filePath)) {
+      throw new ServerError(`LoRA not found: ${filename}`, { status: 404, code: 'NOT_FOUND' });
+    }
+    const s = await stat(filePath).catch(() => null);
+    if (!s || !s.isFile()) {
+      throw new ServerError(
+        `Cannot delete "${filename}": not a regular file`,
+        { status: 400, code: 'INVALID_LORA_FILE' },
+      );
+    }
+
+    // Capture metadata before removing it so a later model-unlink failure can
+    // restore the usable pair. readFile also fails before model removal when a
+    // malformed sidecar is a directory or otherwise unreadable.
+    const metadataPath = sidecarPath(filename);
+    const metadata = await readFile(metadataPath).then(
+      (contents) => contents,
+      (err) => (err.code === 'ENOENT' ? null : Promise.reject(err)),
     );
-  }
-  await rm(filePath, { force: true });
-  await removeSidecar(filename);
+    if (metadata !== null) await rm(metadataPath);
+    const modelRemovalError = await rm(filePath).then(() => null, (err) => err);
+    if (modelRemovalError) {
+      if (metadata !== null) await atomicWrite(metadataPath, metadata);
+      throw modelRemovalError;
+    }
+    invalidateLoraMetadataCache(filename);
+  });
   console.log(`🗑️ Deleted LoRA: ${filename}`);
   return { ok: true, filename };
 };
@@ -327,37 +343,33 @@ export const deleteLora = async (filename) => {
 const queueSidecarWrite = createKeyedFileWriteQueue();
 
 // Replace a sidecar wholesale (the install paths), serialized against patches.
-const writeSidecar = (filename, sidecar) => queueSidecarWrite(filename, async () => {
+export const writeLoraSidecar = (filename, sidecar) => queueSidecarWrite(filename, async () => {
+  if (!existsSync(join(PATHS.loras, filename))) {
+    throw new ServerError(`LoRA not found: ${filename}`, { status: 404, code: 'NOT_FOUND' });
+  }
   await atomicWrite(sidecarPath(filename), JSON.stringify(sidecar, null, 2) + '\n');
-  invalidateLoraMetadataCache(filename);
-});
-
-// Remove a sidecar, serialized so a queued patch can't recreate it after the
-// LoRA is gone.
-const removeSidecar = (filename) => queueSidecarWrite(filename, async () => {
-  await rm(sidecarPath(filename), { force: true });
   invalidateLoraMetadataCache(filename);
 });
 
 export const patchLoraSidecar = async (filename, patch) => {
   assertSafeLoraFilename(filename);
   const filePath = join(PATHS.loras, filename);
-  if (!existsSync(filePath)) {
-    throw new ServerError(`LoRA not found: ${filename}`, { status: 404, code: 'NOT_FOUND' });
-  }
-  // Match getLora/deleteLora: refuse non-regular files (directory named
-  // foo.safetensors, dangling symlink, etc.) so we don't quietly create a
-  // sidecar for an entry that listLoras() will then filter out.
-  const s = await stat(filePath).catch(() => null);
-  if (!s || !s.isFile()) {
-    throw new ServerError(
-      `Cannot patch "${filename}": not a regular file`,
-      { status: 400, code: 'INVALID_LORA_FILE' },
-    );
-  }
   // The read has to be INSIDE the queued cycle — reading before joining the
   // queue would merge against a snapshot the previous write already superseded.
   return queueSidecarWrite(filename, async () => {
+    if (!existsSync(filePath)) {
+      throw new ServerError(`LoRA not found: ${filename}`, { status: 404, code: 'NOT_FOUND' });
+    }
+    // Match getLora/deleteLora: refuse non-regular files (directory named
+    // foo.safetensors, dangling symlink, etc.) so we don't quietly create a
+    // sidecar for an entry that listLoras() will then filter out.
+    const s = await stat(filePath).catch(() => null);
+    if (!s || !s.isFile()) {
+      throw new ServerError(
+        `Cannot patch "${filename}": not a regular file`,
+        { status: 400, code: 'INVALID_LORA_FILE' },
+      );
+    }
     const current = (await readSidecar(filename)) || { filename };
     const next = { ...current, ...patch, filename };
     await atomicWrite(sidecarPath(filename), JSON.stringify(next, null, 2) + '\n');
@@ -625,7 +637,7 @@ const performCivitaiInstall = async (input, { modelId, versionId, fetchImpl }) =
   await verifyDownloadedLora(destPath, { expectedSha256: file?.hashes?.SHA256 || null, source: 'civitai' });
 
   const sidecar = await withKeyLayout(buildSidecar({ model, version, file, filename }), destPath);
-  await writeSidecar(filename, sidecar);
+  await writeLoraSidecar(filename, sidecar);
   console.log(`✅ Installed Civitai LoRA: ${filename} [layout=${sidecar.keyLayout || 'unknown'}]`);
   return sidecar;
 };
@@ -733,7 +745,7 @@ export const installFromHuggingface = async (input, { fetchImpl = fetch, onProgr
     buildHfLoraSidecar({ repo, revision, file, model, family, filename, fluxVariant }),
     destPath,
   );
-  await writeSidecar(filename, sidecar);
+  await writeLoraSidecar(filename, sidecar);
   console.log(`✅ Installed HuggingFace LoRA: ${filename} [layout=${sidecar.keyLayout || 'unknown'}]`);
   return sidecar;
 };

--- a/server/services/loras.test.js
+++ b/server/services/loras.test.js
@@ -23,6 +23,7 @@ let tmpRoot;
 let tmpLoras;
 let lorasService;
 let civitaiLib;
+let atomicWriteHook;
 
 beforeEach(async () => {
   tmpRoot = mkdtempSync(join(tmpdir(), 'portos-loras-test-'));
@@ -34,6 +35,9 @@ beforeEach(async () => {
     return {
       ...actual,
       PATHS: { ...actual.PATHS, loras: tmpLoras },
+      atomicWrite: (...args) => atomicWriteHook
+        ? atomicWriteHook(actual.atomicWrite, ...args)
+        : actual.atomicWrite(...args),
     };
   });
   // Stub settings so resolveCivitaiKey doesn't read the real data/settings.json.
@@ -45,6 +49,7 @@ beforeEach(async () => {
 });
 
 afterEach(() => {
+  atomicWriteHook = null;
   vi.doUnmock('../lib/fileUtils.js');
   vi.doUnmock('./settings.js');
   rmSync(tmpRoot, { recursive: true, force: true });
@@ -355,6 +360,19 @@ describe('deleteLora', () => {
     expect(existsSync(join(tmpLoras, 'lora-x.safetensors'))).toBe(false);
     expect(existsSync(join(tmpLoras, 'lora-x.safetensors.metadata.json'))).toBe(false);
   });
+  it('keeps the model when sidecar removal fails', async () => {
+    const fs = await import('fs/promises');
+    await fs.mkdir(tmpLoras, { recursive: true });
+    const filePath = join(tmpLoras, 'cleanup-fails.safetensors');
+    const sidecar = `${filePath}.metadata.json`;
+    await fs.writeFile(filePath, 'weights');
+    await fs.mkdir(sidecar);
+    await fs.writeFile(join(sidecar, 'locked'), 'metadata');
+
+    await expect(lorasService.deleteLora('cleanup-fails.safetensors')).rejects.toThrow();
+    expect(existsSync(filePath)).toBe(true);
+    expect(existsSync(sidecar)).toBe(true);
+  });
   it('invalidates cached metadata before the same filename is reused', async () => {
     const fs = await import('fs/promises');
     await fs.mkdir(tmpLoras, { recursive: true });
@@ -424,6 +442,37 @@ describe('patchLoraSidecar', () => {
     expect(patched.recommendedScale).toBe(0.5);
     expect(patched.name).toBe('Custom');
     expect(JSON.parse(readFileSync(join(tmpLoras, 'lora-y.safetensors.metadata.json'), 'utf-8')).name).toBe('Custom');
+  });
+  it('does not recreate a sidecar when deletion wins the write queue', async () => {
+    const fs = await import('fs/promises');
+    await fs.mkdir(tmpLoras, { recursive: true });
+    const filePath = join(tmpLoras, 'delete-race.safetensors');
+    const sidecar = `${filePath}.metadata.json`;
+    await fs.writeFile(filePath, 'weights');
+
+    let releaseWrite;
+    let markWriteStarted;
+    const writeStarted = new Promise((resolve) => { markWriteStarted = resolve; });
+    const writeReleased = new Promise((resolve) => { releaseWrite = resolve; });
+    atomicWriteHook = async (atomicWrite, ...args) => {
+      markWriteStarted();
+      await writeReleased;
+      return atomicWrite(...args);
+    };
+
+    const firstPatch = lorasService.patchLoraSidecar('delete-race.safetensors', { name: 'Before delete' });
+    await writeStarted;
+    const deletion = lorasService.deleteLora('delete-race.safetensors');
+    const latePatch = lorasService.patchLoraSidecar('delete-race.safetensors', { name: 'After delete' });
+
+    releaseWrite();
+    await firstPatch;
+    await deletion;
+    const err = await latePatch.catch((error) => error);
+    expect(err.status).toBe(404);
+    expect(err.code).toBe('NOT_FOUND');
+    expect(existsSync(filePath)).toBe(false);
+    expect(existsSync(sidecar)).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary
Serializes LoRA deletion with active sidecar writes to prevent race conditions during deletion operations.

## Test plan
- Run `server/services/loras.test.js`
- Verified clean rebase on latest main