### PR TITLE
test: prove mind visibility projection is privacy-safe and federation-free

### DIFF
--- a/server/services/persistentMindVisibility.test.js
+++ b/server/services/persistentMindVisibility.test.js
@@ -1,3 +1,4 @@
+import { readFile } from 'fs/promises';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
@@ -101,5 +102,104 @@ describe('persistent mind visibility', () => {
     expect(visibility.truncated).toBe(true);
     expect(visibility.characterBudget).toMatchObject({ maxChars: 20_000, truncated: true });
     expect(JSON.stringify(visibility).length).toBeLessThanOrEqual(21_000);
+  });
+
+  // #5154 privacy contract. Every forbidden value below is fed in through a
+  // DIFFERENT input surface (config, live records, error text, prompt, provider
+  // credentials, runtime probe, app registry) so a projection that starts
+  // spreading a whole source object fails here rather than in production.
+  it('never projects identity, secrets, network addresses, paths, or live-record contents', async () => {
+    mocks.inspectRuntime.mockResolvedValue({
+      inference: { active: false, residency: { status: 'provider-managed' }, endpoint: 'http://192.0.2.10:11434' },
+      context: { chars: 100, maxChars: 1_000, approximateTokens: 25, summaryState: 'current', lastMessage: 'private live record' },
+      system: { memory: { usagePercent: 40 }, hostname: 'private-hostname' },
+    });
+
+    const visibility = await readPersistentMindVisibility({
+      root: {
+        config: {
+          persistentMindCapabilities: { createTasks: true },
+          domainAutonomy: { cos: 'execute' },
+          secret: 'private-config-value',
+          pgPassword: 'private-db-password',
+        },
+        queuedTasks: [{ prompt: 'private live record' }],
+      },
+      state: { agents: {}, status: 'idle', lastError: 'private-token' },
+      profile: { providerId: 'example-provider', model: 'example-model' },
+      prompt: { identity: 'Private Person', instructions: 'Read /Users/private-user/private-file' },
+      provider: { id: 'example-provider', type: 'api', apiKey: 'private-api-key', endpoint: 'http://192.0.2.10:1234/v1' },
+      apps: [{ id: 'example-app', name: 'Example App', repoPath: '/private/example-app', remote: 'git@example.com:acme/private.git' }],
+      now: 1_000,
+    });
+
+    const serialized = JSON.stringify(visibility);
+    const prompt = buildPersistentMindVisibilityPrompt(visibility);
+    for (const forbidden of [
+      'private-config-value', 'private-db-password', 'private live record', 'private-token',
+      'Private Person', '/Users/private-user', 'private-api-key', '192.0.2.10',
+      'private-hostname', '/private/example-app', 'git@',
+    ]) {
+      expect(serialized).not.toContain(forbidden);
+      expect(prompt).not.toContain(forbidden);
+    }
+  });
+
+  // #5154: "unknown" must mean "the probe did not answer", never "the probe
+  // answered nothing". Collapsing the two would let the mind read a failed
+  // health check as a clean empty one.
+  it('keeps failed probes distinct from a legitimately empty projection', async () => {
+    mocks.readPreflights.mockResolvedValue([]);
+    const empty = await readPersistentMindVisibility({ apps: [], now: 1_000 });
+    expect(empty.sections).toMatchObject({ runtime: { freshness: 'fresh' }, workspace: { freshness: 'fresh' } });
+    expect(empty.workspaces).toEqual([]);
+    expect(empty.runtime.status).toBe('ready');
+    expect(empty.readiness).toBe('ready');
+    expect(empty.reasonCodes).toEqual([]);
+
+    mocks.inspectRuntime.mockRejectedValue(new Error('runtime probe failed'));
+    mocks.readPreflights.mockRejectedValue(new Error('preflight probe failed'));
+    const failed = await readPersistentMindVisibility({ apps: [], now: 1_000 });
+    expect(failed.sections).toMatchObject({ runtime: { freshness: 'unknown' }, workspace: { freshness: 'unknown' } });
+    expect(failed.runtime).toMatchObject({ status: 'unknown', context: { pressure: 'unknown' }, model: { residency: 'unknown' } });
+    expect(failed.readiness).toBe('unknown');
+    expect(failed.health).toMatchObject({ system: 'unknown', provider: 'unknown', database: 'unknown', forge: 'unknown' });
+    expect(failed.reasonCodes).toEqual(expect.arrayContaining(['runtime-unknown', 'workspace-unknown']));
+  });
+
+  it('collects read-only, makes no provider inference call, and never enters a federation payload', async () => {
+    const root = { config: { persistentMindCapabilities: { createTasks: true }, domainAutonomy: { cos: 'execute' } } };
+    const state = { agents: {}, status: 'idle' };
+    const rootBefore = structuredClone(root);
+    const stateBefore = structuredClone(state);
+    await readPersistentMindVisibility({ root, state, apps: [], now: 1_000 });
+    expect(root).toEqual(rootBefore);
+    expect(state).toEqual(stateBefore);
+    expect(mocks.readPreflights).toHaveBeenCalledWith([], expect.objectContaining({ force: false }));
+
+    // Deliberately an exact allowlist, not a denylist: the read-only and
+    // no-inference guarantees hold only while this module depends on nothing
+    // but these five readers. Adding a dependency should fail here and force a
+    // re-read of the privacy contract above - especially an LLM runner, which
+    // would turn a diagnostic read into a billed provider call.
+    const source = await readFile(new URL('./persistentMindVisibility.js', import.meta.url), 'utf8');
+    const imports = [...source.matchAll(/^import[^;]*?from '([^']+)';/gm)].map(([, id]) => id);
+    expect(imports.sort()).toEqual([
+      '../lib/domainAutonomy.js',
+      '../lib/persistentMindCapabilities.js',
+      './apps.js',
+      './persistentMindRuntime.js',
+      './persistentMindWorkspacePreflight.js',
+    ]);
+
+    // Privacy records stay machine-local: the projection must not be reachable
+    // from any outbound federation path.
+    const federation = await Promise.all([
+      './sharing/peerSyncPush.js',
+      './sharing/peerCosSync.js',
+      './sharing/peerSyncShared.js',
+      '../routes/peerSync.js',
+    ].map((rel) => readFile(new URL(rel, import.meta.url), 'utf8')));
+    expect(federation.join('\n')).not.toMatch(/persistentMindVisibility|mindVisibility/i);
   });
 });


### PR DESCRIPTION
## Summary

Closes #5154.

The persistent-mind visibility service shipped with #5156 and already covers most of #5154: `readPersistentMindVisibility` produces one versioned, bounded projection, and the turn prompt, `GET /api/cos/mind/visibility`, and the **Environment visibility** panel all render that same result. The two acceptance criteria that were never met are the guard tests — the privacy contract in the service's own doc comment was a promise nothing enforced.

This adds them:

- **Privacy fixture** — forbidden identity, secret, network, path, and live-record values are fed in through seven distinct input surfaces (config, queued records, error text, prompt identity, provider credentials, the runtime probe, the app registry) and asserted absent from both the serialized projection and the rendered prompt. A projection that starts spreading a whole source object fails here rather than in production.
- **Failed vs. empty** — a rejected runtime/preflight read must surface `unknown` plus a reason code, never the `ready`/empty shape a successful zero-workspace read produces. This is the "preserve unknown, failed, stale, and legitimately empty as distinct states" constraint from the issue.
- **Read-only, no inference, no federation** — inputs are asserted unmutated, the module is pinned to an exact import allowlist (so adding any dependency, an LLM runner above all, fails the test and forces a re-read of the privacy contract), and the outbound federation modules are asserted never to reference the projection.

The stale `claim/issue-5154` branch held a parallel, superseded implementation of the same service against a different API; it is not merged here.

## Test plan

- `server/services/persistentMindVisibility.test.js` — 5 passing (2 existing, 3 new).
- Persistent-mind services + `routes/cosMindRoutes.test.js` — 10 files, 106 passing.
- Full server suite green.
- Each new test was re-run against a deliberately broken service (leaked provider secret, collapsed failure state, extra import) and confirmed to fail — none is vacuous.
