### PR TITLE
fix: prevent repeated no-op claim drain spawns

### DIFF
--- a/server/services/cos.js
+++ b/server/services/cos.js
@@ -122,6 +122,7 @@ import {
   queueEligibleImprovementTasks,
   generateSelfImprovementTaskForType,
   generateManagedAppImprovementTaskForType,
+  recordDeferredPerpetualDispatch,
   applyOnDemandConsent,
   emitOnDemandEmpty,
   blockIfExceedsMaxSpawns,
@@ -988,7 +989,10 @@ async function spawnDequeuePriority0OnDemand(ctx) {
         reviewStartedApps.add(targetApp.id);
       }
       await taskScheduleMod.recordExecution(`task:${request.taskType}`, targetApp.id);
-      task = await generateManagedAppImprovementTaskForType(request.taskType, targetApp, state, { skipPreconditions: true });
+      task = await generateManagedAppImprovementTaskForType(request.taskType, targetApp, state, {
+        skipPreconditions: true,
+        deferPerpetualDispatch: true
+      });
       if (task) {
         await bindAppReviewAgent(targetApp.id, `on-demand-${Date.now()}`);
       }
@@ -1021,6 +1025,7 @@ async function spawnDequeuePriority0OnDemand(ctx) {
       // rejected as a duplicate of the run that just finished and the drain stalls.
       const persisted = await addTask(task, 'internal', { raw: true, ignoreTaskId });
       if (!persisted?.duplicate) {
+        await recordDeferredPerpetualDispatch(task, taskScheduleMod);
         cosEvents.emit('task:ready', task);
         capacity.trackSpawn(task);
       } else if (persisted.status === 'blocked') {
@@ -1029,6 +1034,7 @@ async function spawnDequeuePriority0OnDemand(ctx) {
         // and without this branch the Run is a silent no-op that strands the
         // bound on-demand review marker.
         await reviveBlockedTask(persisted.id, { priority: task.priority, metadata: task.metadata }, 'internal');
+        await recordDeferredPerpetualDispatch(task, taskScheduleMod);
         const revived = { ...task, id: persisted.id };
         cosEvents.emit('task:ready', revived);
         capacity.trackSpawn(revived);
@@ -1263,6 +1269,7 @@ async function spawnDequeuePriority4IdleReview(ctx) {
     // that marker, which requires the emit. A denial would leave the app reading
     // "in review" indefinitely (#978's mode). See canSpawnCommitted (#4834).
     if (idleTask && capacity.canSpawnCommitted(idleTask, ctx.autonomousSpawnCeiling)) {
+      await recordDeferredPerpetualDispatch(idleTask, await import('./taskSchedule.js'));
       cosEvents.emit('task:ready', idleTask);
       capacity.trackSpawn(idleTask);
     }

--- a/server/services/cos.js
+++ b/server/services/cos.js
@@ -1645,6 +1645,7 @@ export async function init() {
       setImmediate(() => dequeueNextTask());
       if (data.type === 'user' && data.task) setImmediate(() => tryImmediateSpawn(data.task));
     } else if (data.action === 'approved' || data.action === 'unblocked' || data.action === 'requeued') {
+      if (data.suppressDequeue) return;
       setImmediate(() => dequeueNextTask());
     } else if (data.task?.status === 'completed' && data.previousStatus !== 'completed') {
       // A finished investigation releases the task(s) its failure was blocking

--- a/server/services/cos.js
+++ b/server/services/cos.js
@@ -1023,7 +1023,7 @@ async function spawnDequeuePriority0OnDemand(ctx) {
       // and `agent:completed` fires before the completing task's updateTask
       // settles it to `completed` — so without excluding it the re-issued claim is
       // rejected as a duplicate of the run that just finished and the drain stalls.
-      const persisted = await addTask(task, 'internal', { raw: true, ignoreTaskId });
+      const persisted = await addTask(task, 'internal', { raw: true, ignoreTaskId, suppressDequeue: true });
       if (!persisted?.duplicate) {
         await recordDeferredPerpetualDispatch(task, taskScheduleMod);
         cosEvents.emit('task:ready', task);
@@ -1033,7 +1033,7 @@ async function spawnDequeuePriority0OnDemand(ctx) {
         // retry path is reviving the existing task, not minting a duplicate —
         // and without this branch the Run is a silent no-op that strands the
         // bound on-demand review marker.
-        await reviveBlockedTask(persisted.id, { priority: task.priority, metadata: task.metadata }, 'internal');
+        await reviveBlockedTask(persisted.id, { priority: task.priority, metadata: task.metadata }, 'internal', { suppressDequeue: true });
         await recordDeferredPerpetualDispatch(task, taskScheduleMod);
         const revived = { ...task, id: persisted.id };
         cosEvents.emit('task:ready', revived);
@@ -1538,7 +1538,7 @@ async function refillPerpetualForCompletedAgent(agent) {
   // regenerates an identical first-line per app) is rejected as a duplicate of
   // the completing task and the drain stalls until the next scheduler tick.
   const cosTaskData = await getCosTasks();
-  await queueEligibleImprovementTasks(state, cosTaskData, { ignoreTaskId: agent?.taskId });
+  await queueEligibleImprovementTasks(state, cosTaskData, { ignoreTaskId: agent?.taskId, wakeAfterRecord: false });
   // NOTE: the caller (the agent:completed handler) runs dequeueNextTask AFTER
   // this resolves, so the freshly-queued perpetual task is on the queue before
   // slots are filled. Do not dequeue here — that would re-introduce the ordering

--- a/server/services/cos.test.js
+++ b/server/services/cos.test.js
@@ -2265,8 +2265,8 @@ describe('cos.js source — agent:completed triggers perpetual refill', () => {
     expect(fnIdx, 'refillPerpetualForCompletedAgent must exist').toBeGreaterThan(-1);
     const fnSlice = COS_SRC.slice(fnIdx, fnIdx + 4600);
     expect(
-      /queueEligibleImprovementTasks\(\s*state\s*,\s*cosTaskData\s*,\s*\{\s*ignoreTaskId:\s*agent\?\.taskId\s*\}\s*\)/.test(fnSlice),
-      'refill must forward { ignoreTaskId: agent?.taskId } to queueEligibleImprovementTasks'
+      /queueEligibleImprovementTasks\(\s*state\s*,\s*cosTaskData\s*,\s*\{[\s\S]*?ignoreTaskId:\s*agent\?\.taskId[\s\S]*?\}\s*\)/.test(fnSlice),
+      'refill must forward ignoreTaskId: agent?.taskId to queueEligibleImprovementTasks'
     ).toBe(true);
   });
 
@@ -2319,7 +2319,7 @@ describe('cos.js source — agent:completed triggers perpetual refill', () => {
       'on-demand engine must stamp metadata.onDemand: true before addTask'
     ).toBe(true);
     expect(
-      /addTask\(\s*task\s*,\s*'internal'\s*,\s*\{\s*raw:\s*true\s*,\s*ignoreTaskId\s*\}\s*\)/.test(engSlice),
+      /addTask\(\s*task\s*,\s*'internal'\s*,\s*\{[\s\S]*?raw:\s*true[\s\S]*?ignoreTaskId[\s\S]*?\}\s*\)/.test(engSlice),
       'on-demand engine must forward ignoreTaskId to addTask'
     ).toBe(true);
   });

--- a/server/services/cosTaskGenerator.js
+++ b/server/services/cosTaskGenerator.js
@@ -154,11 +154,28 @@ export function isCooldownExemptTask(task) {
  * valid idle result but never reaches this predicate because `actionable` is
  * false.
  */
-export function shouldParkUnchangedPerpetualWork(detection, lastSignature) {
+export function shouldParkUnchangedPerpetualWork(detection, lastSignature, dispatchCount = 0) {
   return detection?.actionable === true
     && detection.signature != null
     && lastSignature != null
-    && detection.signature === lastSignature;
+    && detection.signature === lastSignature
+    // A same-issue continuation is allowed one unchanged recheck: the prior
+    // claim may have shipped a partial slice while leaving the issue actionable.
+    // A second unchanged observation is a genuine no-progress loop.
+    && dispatchCount > 1;
+}
+
+// The generator can be called before either spawn engine admits its result.
+// Keep the drain signature off persisted task metadata until that admission is
+// known to have succeeded; a WeakMap carries it only across the in-memory handoff.
+const deferredPerpetualSignatures = new WeakMap();
+
+export async function recordDeferredPerpetualDispatch(task, taskSchedule) {
+  const deferred = deferredPerpetualSignatures.get(task);
+  if (!deferred) return false;
+  deferredPerpetualSignatures.delete(task);
+  await taskSchedule.recordPerpetualDispatch(deferred.taskType, deferred.appId, deferred.signature);
+  return true;
 }
 
 /**
@@ -928,7 +945,10 @@ async function spawnPriority0OnDemand(ctx) {
           reviewStartedApps.add(targetApp.id);
         }
         await taskSchedule.recordExecution(`task:${request.taskType}`, targetApp.id);
-        task = await generateManagedAppImprovementTaskForType(request.taskType, targetApp, state, { skipPreconditions: true });
+        task = await generateManagedAppImprovementTaskForType(request.taskType, targetApp, state, {
+          skipPreconditions: true,
+          deferPerpetualDispatch: true
+        });
         if (task) {
           await bindAppReviewAgent(targetApp.id, `on-demand-${Date.now()}`);
         }
@@ -953,6 +973,7 @@ async function spawnPriority0OnDemand(ctx) {
         task.metadata = { ...(task.metadata || {}), onDemand: true };
         const persisted = await addTask(task, 'internal', { raw: true });
         if (!persisted?.duplicate) {
+          await recordDeferredPerpetualDispatch(task, taskSchedule);
           tasksToSpawn.push(task);
           trackSpawn(task);
         } else if (persisted.status === 'blocked') {
@@ -961,6 +982,7 @@ async function spawnPriority0OnDemand(ctx) {
           // stranding the bound on-demand review marker. Mirrors the sibling
           // dequeueNextTask on-demand engine in cos.js.
           await reviveBlockedTask(persisted.id, { priority: task.priority, metadata: task.metadata }, 'internal');
+          await recordDeferredPerpetualDispatch(task, taskSchedule);
           const revived = { ...task, id: persisted.id };
           tasksToSpawn.push(revived);
           trackSpawn(revived);
@@ -1189,6 +1211,7 @@ async function spawnPriority4IdleReview(ctx) {
     if (pendingSystemTasks === 0) {
       const idleTask = await generateIdleReviewTask(state);
       if (idleTask && canSpawnTask(idleTask, autonomousSlotCeiling)) {
+        await recordDeferredPerpetualDispatch(idleTask, await import('./taskSchedule.js'));
         tasksToSpawn.push(idleTask);
         trackSpawn(idleTask);
       }
@@ -1548,7 +1571,8 @@ export function buildImprovementDedupSets(existingTasks, { ignoreTaskId = null }
  * Tasks are queued to COS-TASKS.md and will be picked up in Priority 2
  */
 export async function queueEligibleImprovementTasks(state, cosTaskData, { ignoreTaskId = null } = {}) {
-  const { getNextTaskType, recordExecution } = await import('./taskSchedule.js');
+  const taskSchedule = await import('./taskSchedule.js');
+  const { getNextTaskType, recordExecution } = taskSchedule;
 
   if (!isImprovementEnabled(state)) return;
 
@@ -1644,7 +1668,10 @@ export async function queueEligibleImprovementTasks(state, cosTaskData, { ignore
     // agents claim the same slug (2026-05-21 incident). The generator
     // returns null on plan-gate / precondition skip; we silently continue.
     // Regression-pinned in cos.test.js.
-    const task = await generateManagedAppImprovementTaskForType(nextType, app, state, { ignoreTaskId });
+    const task = await generateManagedAppImprovementTaskForType(nextType, app, state, {
+      ignoreTaskId,
+      deferPerpetualDispatch: true
+    });
     if (!task) continue;
 
     // Queue-path invariants override the generator's direct-spawn defaults
@@ -1684,6 +1711,7 @@ export async function queueEligibleImprovementTasks(state, cosTaskData, { ignore
 
     const newTask = await addTask(task, 'internal', { raw: true, ignoreTaskId });
     if (newTask?.duplicate) continue;
+    await recordDeferredPerpetualDispatch(task, taskSchedule);
 
     await recordExecution(`task:${nextType}`, app.id);
 
@@ -2066,7 +2094,10 @@ async function generateManagedAppImprovementTask(app, state, { ignoreTaskId = nu
   // with the literal {prData}/{referenceData} markers and never poll. The
   // recordExecution + activity bump above already accounted for the idle
   // spawn; the per-type generator does not record execution itself.
-  const task = await generateManagedAppImprovementTaskForType(nextType, app, state, { ignoreTaskId });
+  const task = await generateManagedAppImprovementTaskForType(nextType, app, state, {
+    ignoreTaskId,
+    deferPerpetualDispatch: true
+  });
   // Idle-review can steal a queued on-demand request for this app. That
   // request is still a user Run — apply the same consent as Priority 0.
   if (selectionReason === 'on-demand') applyOnDemandConsent(task);
@@ -2340,8 +2371,8 @@ async function applyPerpetualWorkGate(app, taskType, promptTaskType, metadata, i
       ? null
       : JSON.stringify({ taskType: promptTaskType, candidates: detection.signature });
     if (drainSignature != null) {
-      const { signature: lastSignature } = await taskSchedule.getPerpetualDrainState(taskType, app.id);
-      if (shouldParkUnchangedPerpetualWork({ ...detection, signature: drainSignature }, lastSignature)) {
+      const { signature: lastSignature, dispatchCount } = await taskSchedule.getPerpetualDrainState(taskType, app.id);
+      if (shouldParkUnchangedPerpetualWork({ ...detection, signature: drainSignature }, lastSignature, dispatchCount)) {
         const counts = detection.total != null
           ? { open: detection.total, inFlight: detection.inFlightCount ?? 0, filtered: detection.filteredCount ?? 0 }
           : null;
@@ -2993,7 +3024,11 @@ function applyProviderModelPins(metadata, interval, appPin, hookOverride) {
   applyOneProviderPin(metadata, hookOverride);
 }
 
-export async function generateManagedAppImprovementTaskForType(taskType, app, state, { skipPreconditions = false, ignoreTaskId = null } = {}) {
+export async function generateManagedAppImprovementTaskForType(taskType, app, state, {
+  skipPreconditions = false,
+  ignoreTaskId = null,
+  deferPerpetualDispatch = false
+} = {}) {
   const { updateAppActivity } = await import('./appActivity.js');
   const taskSchedule = await import('./taskSchedule.js');
   const { getTaskPrompt, getStagePrompt } = await import('./taskPromptService.js');
@@ -3035,7 +3070,7 @@ export async function generateManagedAppImprovementTaskForType(taskType, app, st
   // while the completing task is still `in_progress` on disk — a hook that
   // counts in-flight tasks against a budget must not count the run that just
   // finished and already recorded itself (#3179).
-  const inputHook = await resolveTaskInputHook(app, taskType, taskSchedule, { ignoreTaskId });
+      const inputHook = await resolveTaskInputHook(app, taskType, taskSchedule, { ignoreTaskId });
   if (inputHook.skip) return null;
   const { hookPrompt, hookOverride, hookMetadata } = inputHook;
 
@@ -3205,16 +3240,6 @@ export async function generateManagedAppImprovementTaskForType(taskType, app, st
     }
     metadata[key] = value;
   }
-  // Every gate has now passed and a task is certain, so the perpetual drain can
-  // finally be charged for this hop (and its park cleared). Sits beside
-  // `updateAppActivity` for the same reason that call does: both are "a task was
-  // really produced" side effects, and every `return null` above must skip them.
-  // The reconcile drains spend theirs inside their own block, which no later gate
-  // can skip (their types are outside PLAN_PICK_TASK_TYPES / pr-watcher /
-  // reference-watch), so they are already charged only on real dispatches.
-  if (perpetualGate.spendDispatch) {
-    await taskSchedule.recordPerpetualDispatch(taskType, app.id, perpetualGate.signature ?? null);
-  }
   await updateAppActivity(app.id, { lastImprovementType: taskType });
   emitLog('info', `Generating improvement task for ${app.name}: ${taskType}`, { appId: app.id, analysisType: taskType });
 
@@ -3228,6 +3253,21 @@ export async function generateManagedAppImprovementTaskForType(taskType, app, st
     taskType: 'internal',
     ...approval
   };
+
+  // Most callers return the task to a spawn engine, so keep this side effect
+  // deferred until that engine admits the task. Direct callers retain the old
+  // immediate behavior; queue/on-demand/idle paths opt into the handoff below.
+  if (perpetualGate.spendDispatch) {
+    if (deferPerpetualDispatch) {
+      deferredPerpetualSignatures.set(task, {
+        taskType,
+        appId: app.id,
+        signature: perpetualGate.signature ?? null
+      });
+    } else {
+      await taskSchedule.recordPerpetualDispatch(taskType, app.id, perpetualGate.signature ?? null);
+    }
+  }
 
   return task;
 }

--- a/server/services/cosTaskGenerator.js
+++ b/server/services/cosTaskGenerator.js
@@ -2336,9 +2336,12 @@ async function applyPerpetualWorkGate(app, taskType, promptTaskType, metadata, i
     // completion refill would otherwise dispatch the same candidate forever.
     // The detector's signature covers the complete set; `items` is capped for
     // the picker and is not sufficient for convergence.
-    if (detection.signature != null) {
+    const drainSignature = detection.signature == null
+      ? null
+      : JSON.stringify({ taskType: promptTaskType, candidates: detection.signature });
+    if (drainSignature != null) {
       const { signature: lastSignature } = await taskSchedule.getPerpetualDrainState(taskType, app.id);
-      if (shouldParkUnchangedPerpetualWork(detection, lastSignature)) {
+      if (shouldParkUnchangedPerpetualWork({ ...detection, signature: drainSignature }, lastSignature)) {
         const counts = detection.total != null
           ? { open: detection.total, inFlight: detection.inFlightCount ?? 0, filtered: detection.filteredCount ?? 0 }
           : null;
@@ -2356,7 +2359,7 @@ async function applyPerpetualWorkGate(app, taskType, promptTaskType, metadata, i
     metadata.perpetual = true;
     // The dispatch is SPENT BY THE CALLER, once a task is certain — see the note
     // on `spendDispatch` in the JSDoc above.
-    return { skip: false, spendDispatch: true, signature: detection.signature ?? null };
+    return { skip: false, spendDispatch: true, signature: drainSignature };
   }
   if (detection.transient) {
     emitLog('debug', `Perpetual ${taskType} skip for ${app.name} (transient: ${detection.reason})`, { appId: app.id });
@@ -2378,7 +2381,7 @@ async function applyPerpetualWorkGate(app, taskType, promptTaskType, metadata, i
     : null;
   // Terminal park — parkPerpetual zeroes the dispatch budget in the same write, so
   // the next drain window starts fresh instead of capping early on this one's spend.
-  await taskSchedule.parkPerpetual(taskType, app.id, { reason: detection.reason, actionableCount: detection.count, counts });
+  await taskSchedule.parkPerpetual(taskType, app.id, { reason: detection.reason, actionableCount: detection.count, counts, signature: null });
   emitLog('info', `Perpetual ${taskType} parked for ${app.name}: ${detection.reason}`, { appId: app.id });
   return { skip: true };
 }

--- a/server/services/cosTaskGenerator.js
+++ b/server/services/cosTaskGenerator.js
@@ -148,6 +148,20 @@ export function isCooldownExemptTask(task) {
 }
 
 /**
+ * A claim/plan perpetual drain must stop when a completed agent leaves the
+ * complete actionable set unchanged. A null signature means the detector has
+ * no progress identity and keeps the legacy behavior; an empty signature is a
+ * valid idle result but never reaches this predicate because `actionable` is
+ * false.
+ */
+export function shouldParkUnchangedPerpetualWork(detection, lastSignature) {
+  return detection?.actionable === true
+    && detection.signature != null
+    && lastSignature != null
+    && detection.signature === lastSignature;
+}
+
+/**
  * Dry-run eligibility pass over auto-approved system tasks. Walks the tasks in
  * file order applying the SAME gates execute mode uses — global slot cap,
  * max-total-spawns, app cooldown, per-project cap — while tracking virtual
@@ -2289,10 +2303,11 @@ async function resolveClaimWorkRouting(app, taskType, metadata, taskSchedule) {
  * IS the detector — a programmatic detector decides whether there's anything to
  * claim BEFORE building the (expensive) prompt or burning an agent:
  *   - actionable → stamp metadata.perpetual (skip cooldown), proceed;
+ *   - unchanged actionable set → PARK after a successful no-progress run;
  *   - idle (definitive) → PARK on the recheck cadence, skip;
  *   - transient probe failure → skip WITHOUT parking so the next tick retries.
- * The detector keys on the RESOLVED promptTaskType. Returns `{ skip, spendDispatch }`
- * and mutates `metadata.perpetual` on the actionable path.
+ * The detector keys on the RESOLVED promptTaskType. Returns `{ skip, spendDispatch,
+ * signature }` and mutates `metadata.perpetual` on the actionable path.
  *
  * `spendDispatch` is the caller's cue to call `recordPerpetualDispatch` (which
  * clears the park and spends one unit of the type's `drainDispatchCap` budget in a
@@ -2316,11 +2331,32 @@ async function applyPerpetualWorkGate(app, taskType, promptTaskType, metadata, i
     ignoreTaskId
   });
   if (detection.actionable) {
+    // A successful claim/plan agent can still return without changing forge or
+    // PLAN state (for example, it decides not to pick the advertised item). The
+    // completion refill would otherwise dispatch the same candidate forever.
+    // The detector's signature covers the complete set; `items` is capped for
+    // the picker and is not sufficient for convergence.
+    if (detection.signature != null) {
+      const { signature: lastSignature } = await taskSchedule.getPerpetualDrainState(taskType, app.id);
+      if (shouldParkUnchangedPerpetualWork(detection, lastSignature)) {
+        const counts = detection.total != null
+          ? { open: detection.total, inFlight: detection.inFlightCount ?? 0, filtered: detection.filteredCount ?? 0 }
+          : null;
+        await taskSchedule.parkPerpetual(taskType, app.id, {
+          reason: 'no-progress',
+          actionableCount: detection.count,
+          counts,
+          signature: null
+        });
+        emitLog('info', `Perpetual ${taskType} parked for ${app.name}: actionable work unchanged after the last run`, { appId: app.id });
+        return { skip: true };
+      }
+    }
     recordPerpetualTransient(taskType, app.id, null);
     metadata.perpetual = true;
     // The dispatch is SPENT BY THE CALLER, once a task is certain — see the note
     // on `spendDispatch` in the JSDoc above.
-    return { skip: false, spendDispatch: true };
+    return { skip: false, spendDispatch: true, signature: detection.signature ?? null };
   }
   if (detection.transient) {
     emitLog('debug', `Perpetual ${taskType} skip for ${app.name} (transient: ${detection.reason})`, { appId: app.id });
@@ -3173,7 +3209,9 @@ export async function generateManagedAppImprovementTaskForType(taskType, app, st
   // The reconcile drains spend theirs inside their own block, which no later gate
   // can skip (their types are outside PLAN_PICK_TASK_TYPES / pr-watcher /
   // reference-watch), so they are already charged only on real dispatches.
-  if (perpetualGate.spendDispatch) await taskSchedule.recordPerpetualDispatch(taskType, app.id, null);
+  if (perpetualGate.spendDispatch) {
+    await taskSchedule.recordPerpetualDispatch(taskType, app.id, perpetualGate.signature ?? null);
+  }
   await updateAppActivity(app.id, { lastImprovementType: taskType });
   emitLog('info', `Generating improvement task for ${app.name}: ${taskType}`, { appId: app.id, analysisType: taskType });
 

--- a/server/services/cosTaskGenerator.js
+++ b/server/services/cosTaskGenerator.js
@@ -971,7 +971,7 @@ async function spawnPriority0OnDemand(ctx) {
         // engines must stamp it — either may drain a given request. Stamped before
         // addTask so the blocked-revive branch inherits it via `task.metadata`.
         task.metadata = { ...(task.metadata || {}), onDemand: true };
-        const persisted = await addTask(task, 'internal', { raw: true });
+        const persisted = await addTask(task, 'internal', { raw: true, suppressDequeue: true });
         if (!persisted?.duplicate) {
           await recordDeferredPerpetualDispatch(task, taskSchedule);
           tasksToSpawn.push(task);
@@ -981,7 +981,7 @@ async function spawnPriority0OnDemand(ctx) {
           // revive the existing task instead of silently dropping the Run and
           // stranding the bound on-demand review marker. Mirrors the sibling
           // dequeueNextTask on-demand engine in cos.js.
-          await reviveBlockedTask(persisted.id, { priority: task.priority, metadata: task.metadata }, 'internal');
+          await reviveBlockedTask(persisted.id, { priority: task.priority, metadata: task.metadata }, 'internal', { suppressDequeue: true });
           await recordDeferredPerpetualDispatch(task, taskSchedule);
           const revived = { ...task, id: persisted.id };
           tasksToSpawn.push(revived);
@@ -1570,7 +1570,7 @@ export function buildImprovementDedupSets(existingTasks, { ignoreTaskId = null }
  * Called during every evaluation to ensure system tasks are queued even when user tasks exist
  * Tasks are queued to COS-TASKS.md and will be picked up in Priority 2
  */
-export async function queueEligibleImprovementTasks(state, cosTaskData, { ignoreTaskId = null } = {}) {
+export async function queueEligibleImprovementTasks(state, cosTaskData, { ignoreTaskId = null, wakeAfterRecord = true } = {}) {
   const taskSchedule = await import('./taskSchedule.js');
   const { getNextTaskType, recordExecution } = taskSchedule;
 
@@ -1709,9 +1709,10 @@ export async function queueEligibleImprovementTasks(state, cosTaskData, { ignore
       task.description = firstLine(task.description);
     }
 
-    const newTask = await addTask(task, 'internal', { raw: true, ignoreTaskId });
+    const newTask = await addTask(task, 'internal', { raw: true, ignoreTaskId, suppressDequeue: true });
     if (newTask?.duplicate) continue;
     await recordDeferredPerpetualDispatch(task, taskSchedule);
+    if (wakeAfterRecord) cosEvents.emit('cos:dequeue-requested');
 
     await recordExecution(`task:${nextType}`, app.id);
 

--- a/server/services/cosTaskGenerator.test.js
+++ b/server/services/cosTaskGenerator.test.js
@@ -102,6 +102,13 @@ describe('claim drain convergence', () => {
     expect(shouldParkUnchangedPerpetualWork({ actionable: true }, '[101,202]')).toBe(false);
     expect(shouldParkUnchangedPerpetualWork({ actionable: false, signature: '[]' }, '[]')).toBe(false);
   });
+
+  it('does not confuse tracker-specific signatures', () => {
+    expect(shouldParkUnchangedPerpetualWork(
+      { actionable: true, signature: '{"taskType":"claim-issue-gitlab","candidates":"[1]"}' },
+      '{"taskType":"claim-issue","candidates":"[1]"}'
+    )).toBe(false);
+  });
 });
 
 describe('claim reviewer resolution', () => {

--- a/server/services/cosTaskGenerator.test.js
+++ b/server/services/cosTaskGenerator.test.js
@@ -1445,7 +1445,7 @@ describe('ignoreTaskId reaches the in-flight-counting gates (#3179)', () => {
   };
 
   it('accepts ignoreTaskId and forwards it to the input hook and the perpetual gate', () => {
-    expect(GEN_SRC).toMatch(/generateManagedAppImprovementTaskForType\(taskType, app, state, \{ skipPreconditions = false, ignoreTaskId = null \} = \{\}\)/);
+    expect(GEN_SRC).toMatch(/generateManagedAppImprovementTaskForType\(taskType, app, state, \{\s*skipPreconditions = false,\s*ignoreTaskId = null/);
     expect(body()).toContain('resolveTaskInputHook(app, taskType, taskSchedule, { ignoreTaskId })');
     expect(body()).toContain('applyPerpetualWorkGate(app, taskType, promptTaskType, metadata, interval, taskSchedule, { ignoreTaskId })');
   });

--- a/server/services/cosTaskGenerator.test.js
+++ b/server/services/cosTaskGenerator.test.js
@@ -94,19 +94,21 @@ const noCooldown = () => Promise.resolve(false);
 describe('claim drain convergence', () => {
   it('parks a successful no-progress run when the actionable set is unchanged', () => {
     const detection = { actionable: true, signature: '[101,202]' };
-    expect(shouldParkUnchangedPerpetualWork(detection, '[101,202]')).toBe(true);
+    expect(shouldParkUnchangedPerpetualWork(detection, '[101,202]', 2)).toBe(true);
+    expect(shouldParkUnchangedPerpetualWork(detection, '[101,202]', 1)).toBe(false);
   });
 
   it('continues when the candidate set changed or has no progress identity', () => {
-    expect(shouldParkUnchangedPerpetualWork({ actionable: true, signature: '[202]' }, '[101,202]')).toBe(false);
-    expect(shouldParkUnchangedPerpetualWork({ actionable: true }, '[101,202]')).toBe(false);
-    expect(shouldParkUnchangedPerpetualWork({ actionable: false, signature: '[]' }, '[]')).toBe(false);
+    expect(shouldParkUnchangedPerpetualWork({ actionable: true, signature: '[202]' }, '[101,202]', 2)).toBe(false);
+    expect(shouldParkUnchangedPerpetualWork({ actionable: true }, '[101,202]', 2)).toBe(false);
+    expect(shouldParkUnchangedPerpetualWork({ actionable: false, signature: '[]' }, '[]', 2)).toBe(false);
   });
 
   it('does not confuse tracker-specific signatures', () => {
     expect(shouldParkUnchangedPerpetualWork(
       { actionable: true, signature: '{"taskType":"claim-issue-gitlab","candidates":"[1]"}' },
-      '{"taskType":"claim-issue","candidates":"[1]"}'
+      '{"taskType":"claim-issue","candidates":"[1]"}',
+      2
     )).toBe(false);
   });
 });

--- a/server/services/cosTaskGenerator.test.js
+++ b/server/services/cosTaskGenerator.test.js
@@ -59,6 +59,7 @@ vi.mock('./github.js', async (importActual) => ({
 import {
   selectDryRunAutoApproved,
   exceedsMaxSpawns,
+  shouldParkUnchangedPerpetualWork,
   resolveIssueAuthorFilterBlock,
   resolveIssueExcludeLabelsBlock,
   resolveSwarmBlock,
@@ -89,6 +90,19 @@ const COS_SRC = readFileSync(join(__dirname, 'cos.js'), 'utf-8');
 
 const task = (id, metadata = {}) => ({ id, metadata });
 const noCooldown = () => Promise.resolve(false);
+
+describe('claim drain convergence', () => {
+  it('parks a successful no-progress run when the actionable set is unchanged', () => {
+    const detection = { actionable: true, signature: '[101,202]' };
+    expect(shouldParkUnchangedPerpetualWork(detection, '[101,202]')).toBe(true);
+  });
+
+  it('continues when the candidate set changed or has no progress identity', () => {
+    expect(shouldParkUnchangedPerpetualWork({ actionable: true, signature: '[202]' }, '[101,202]')).toBe(false);
+    expect(shouldParkUnchangedPerpetualWork({ actionable: true }, '[101,202]')).toBe(false);
+    expect(shouldParkUnchangedPerpetualWork({ actionable: false, signature: '[]' }, '[]')).toBe(false);
+  });
+});
 
 describe('claim reviewer resolution', () => {
   // The claim prompts run their local reviewers BEFORE the PR/MR is opened, so
@@ -1623,7 +1637,7 @@ describe('the drain cap has exactly one implementation, at the choke point', () 
 
     const genStart = GEN_SRC.indexOf('export async function generateManagedAppImprovementTaskForType');
     const body = GEN_SRC.slice(genStart, GEN_SRC.indexOf('return task;', genStart));
-    const spendIdx = body.indexOf('if (perpetualGate.spendDispatch) await taskSchedule.recordPerpetualDispatch(taskType, app.id, null)');
+    const spendIdx = body.search(/if \(perpetualGate\.spendDispatch\) \{\s*await taskSchedule\.recordPerpetualDispatch\(taskType, app\.id, perpetualGate\.signature \?\? null\)/);
     expect(spendIdx, 'the choke point must spend the deferred dispatch').toBeGreaterThan(-1);
     // Every `return null` gate must precede it — planId is the last one.
     expect(body.indexOf('planMeta.skipReason')).toBeLessThan(spendIdx);

--- a/server/services/cosTaskGenerator.test.js
+++ b/server/services/cosTaskGenerator.test.js
@@ -1453,7 +1453,7 @@ describe('ignoreTaskId reaches the in-flight-counting gates (#3179)', () => {
   it('queueEligibleImprovementTasks passes its ignoreTaskId down to the generator', () => {
     // It already forwards the same id to addTask and buildImprovementDedupSets;
     // the generator was the one path that dropped it.
-    expect(GEN_SRC).toContain('generateManagedAppImprovementTaskForType(nextType, app, state, { ignoreTaskId })');
+    expect(GEN_SRC).toMatch(/generateManagedAppImprovementTaskForType\(nextType, app, state, \{[\s\S]*ignoreTaskId[\s\S]*deferPerpetualDispatch: true[\s\S]*\}\)/);
   });
 
   it('the perpetual gate hands ignoreTaskId to the work detector', () => {
@@ -1488,7 +1488,7 @@ describe('ignoreTaskId reaches BOTH completion-continuation generators (#3179)',
     expect(GEN_SRC).toMatch(/export async function generateIdleReviewTask\(state, \{ ignoreTaskId = null \} = \{\}\)/);
     expect(GEN_SRC).toContain('generateManagedAppImprovementTask(nextApp, state, { ignoreTaskId })');
     expect(GEN_SRC).toMatch(/async function generateManagedAppImprovementTask\(app, state, \{ ignoreTaskId = null \} = \{\}\)/);
-    expect(GEN_SRC).toContain('generateManagedAppImprovementTaskForType(nextType, app, state, { ignoreTaskId })');
+    expect(GEN_SRC).toMatch(/generateManagedAppImprovementTaskForType\(nextType, app, state, \{[\s\S]*ignoreTaskId[\s\S]*deferPerpetualDispatch: true[\s\S]*\}\)/);
   });
 
   it('cos.js passes the completing task id into the dequeue that follows the refill', () => {
@@ -1646,7 +1646,7 @@ describe('the drain cap has exactly one implementation, at the choke point', () 
 
     const genStart = GEN_SRC.indexOf('export async function generateManagedAppImprovementTaskForType');
     const body = GEN_SRC.slice(genStart, GEN_SRC.indexOf('return task;', genStart));
-    const spendIdx = body.search(/if \(perpetualGate\.spendDispatch\) \{\s*await taskSchedule\.recordPerpetualDispatch\(taskType, app\.id, perpetualGate\.signature \?\? null\)/);
+    const spendIdx = body.search(/if \(perpetualGate\.spendDispatch\) \{[\s\S]*recordPerpetualDispatch\(taskType, app\.id, perpetualGate\.signature \?\? null\)/);
     expect(spendIdx, 'the choke point must spend the deferred dispatch').toBeGreaterThan(-1);
     // Every `return null` gate must precede it — planId is the last one.
     expect(body.indexOf('planMeta.skipReason')).toBeLessThan(spendIdx);

--- a/server/services/cosTaskStore.js
+++ b/server/services/cosTaskStore.js
@@ -632,7 +632,7 @@ export async function addTask(taskData, taskType = 'user', { raw = false, ignore
  */
 export async function updateTask(taskId, updates, taskType = 'user', { now = Date.now(), suppressDequeue = false } = {}) {
   const release = await preparePauseRelease(taskId, updates);
-  const result = await writeTaskUpdate(taskId, release ? { ...updates, metadata: release.metadata } : updates, taskType, { now });
+  const result = await writeTaskUpdate(taskId, release ? { ...updates, metadata: release.metadata } : updates, taskType, { now, suppressDequeue });
   if (release && !result?.error) {
     await retirePausedAgent(release.agentId, taskId, resolveTaskTargetBranch(result?.metadata));
   }
@@ -667,7 +667,7 @@ async function preparePauseRelease(taskId, updates) {
   return { agentId, metadata: { ...pointer, ...(updates.metadata || {}) } };
 }
 
-async function writeTaskUpdate(taskId, updates, taskType, { now }) {
+async function writeTaskUpdate(taskId, updates, taskType, { now, suppressDequeue = false }) {
   return withStateLock(async () => {
   const state = await loadState();
   const filePath = taskType === 'user'

--- a/server/services/cosTaskStore.js
+++ b/server/services/cosTaskStore.js
@@ -630,7 +630,7 @@ export async function addTask(taskData, taskType = 'user', { raw = false, ignore
  * running either inside would deadlock. Resolving first is also what keeps the task
  * from ever being `pending` (spawnable) without its pointer.
  */
-export async function updateTask(taskId, updates, taskType = 'user', { now = Date.now() } = {}) {
+export async function updateTask(taskId, updates, taskType = 'user', { now = Date.now(), suppressDequeue = false } = {}) {
   const release = await preparePauseRelease(taskId, updates);
   const result = await writeTaskUpdate(taskId, release ? { ...updates, metadata: release.metadata } : updates, taskType, { now });
   if (release && !result?.error) {
@@ -840,7 +840,9 @@ async function writeTaskUpdate(taskId, updates, taskType, { now }) {
   // description is enough — so a consumer that reacts to "reached completed"
   // (the investigation auto-retry; the voice completion line) needs the edge, not
   // `status === 'completed'`, which is true on every later write too.
-  cosEvents.emit('tasks:changed', { type: taskType, action, task: updatedTask, previousStatus });
+  const change = { type: taskType, action, task: updatedTask, previousStatus };
+  if (suppressDequeue) change.suppressDequeue = true;
+  cosEvents.emit('tasks:changed', change);
   return updatedTask;
   });
 }
@@ -861,7 +863,7 @@ async function writeTaskUpdate(taskId, updates, taskType, { now }) {
  * updateTask emits `tasks:changed` action 'unblocked', which re-runs the
  * dequeue, so callers don't need a separate wake signal.
  */
-export async function reviveBlockedTask(taskId, { priority, metadata } = {}, taskType = 'internal') {
+export async function reviveBlockedTask(taskId, { priority, metadata } = {}, taskType = 'internal', { suppressDequeue = false } = {}) {
   return updateTask(taskId, {
     status: 'pending',
     ...(priority ? { priority } : {}),
@@ -877,7 +879,7 @@ export async function reviveBlockedTask(taskId, { priority, metadata } = {}, tas
       // every wait and would defeat the cap.
       worktreeBusyAttempts: undefined
     }
-  }, taskType);
+  }, taskType, { suppressDequeue });
 }
 
 /**

--- a/server/services/perpetualWork.js
+++ b/server/services/perpetualWork.js
@@ -307,8 +307,7 @@ const normalizeIssues = (raw, numberKey, authorKey) => raw.map((r) => ({
   title: r.title,
   labels: r.labels,
   assignees: r.assignees,
-  authorLogin: (r.author?.[authorKey] || '').toLowerCase(),
-  updatedAt: r.updatedAt || r.updated_at || null
+  authorLogin: (r.author?.[authorKey] || '').toLowerCase()
 }));
 
 // A forge can return the same candidate set in a different order, especially
@@ -316,7 +315,13 @@ const normalizeIssues = (raw, numberKey, authorKey) => raw.map((r) => ({
 // a canonical representation for the perpetual drain's set comparison.
 const canonicalizeIds = (ids) => [...new Set(ids
   .filter((id) => id != null)
-  .map((id) => String(id)))].sort();
+  .map((id) => String(id)))].sort((a, b) => {
+  const numericA = Number(a);
+  const numericB = Number(b);
+  return Number.isFinite(numericA) && Number.isFinite(numericB)
+    ? numericA - numericB
+    : a.localeCompare(b);
+});
 
 const GLAB_SELF_LOGIN_ARGS = ['api', 'user', '-q', '.username'];
 
@@ -351,7 +356,7 @@ const FORGE_ISSUE_CONFIG = {
     // happens to be full of excluded/in-flight/decomposed-epic issues even
     // though real work exists further down the queue. Matches the same
     // tradeoff the /do:next auto-pick walk already makes for the same reason.
-    listArgs: ['issue', 'list', '--state', 'open', '--search', 'sort:created-asc', '--json', 'number,assignees,labels,title,author,updatedAt', '--limit', '500'],
+    listArgs: ['issue', 'list', '--state', 'open', '--search', 'sort:created-asc', '--json', 'number,assignees,labels,title,author', '--limit', '500'],
     listFail: 'gh-list-failed',
     parseFail: 'gh-parse-failed',
     // Park reason when the owner filter resolves to a non-authoring owner. On
@@ -663,11 +668,7 @@ async function detectForgeIssues(forgeKey, app, { issueAuthorFilter = 'self', is
     // The perpetual drain uses the complete candidate set to detect a
     // successful agent that exited without claiming anything. `sample` is
     // intentionally capped for UI payloads, so it cannot serve as that brake.
-    // updatedAt changes when the claim flow posts a partial-delivery comment
-    // or releases its markers, so a same-issue continuation remains eligible.
-    // The ID is retained as the primary identity for forge responses that omit
-    // the timestamp (and for older test/mocked CLI output).
-    signature: JSON.stringify(canonicalizeIds(actionable.map((i) => `${i.number}@${i.updatedAt || ''}`))),
+    signature: JSON.stringify(canonicalizeIds(actionable.map((i) => i.number))),
     items: actionable.slice(0, WORK_ITEM_LIMIT).map((i) => ({ ref: String(i.number), title: i.title || '' }))
   };
 }
@@ -709,7 +710,9 @@ export async function detectPlanTask(app) {
     count: available.length,
     reason: pick ? 'actionable-plan-items' : 'no-actionable-plan-items',
     // Keep the signature complete even though the picker payload is capped.
-    signature: JSON.stringify(canonicalizeIds(available.map((it) => it.id))),
+    // PLAN.md order is meaningful because pickFirstAvailable chooses the first
+    // eligible item; unlike forge issue sets, preserve that order in the brake.
+    signature: JSON.stringify(available.map((it) => it.id)),
     items: available.slice(0, WORK_ITEM_LIMIT).map((it) => ({ ref: it.id, title: planItemTitle(it) }))
   };
 }

--- a/server/services/perpetualWork.js
+++ b/server/services/perpetualWork.js
@@ -307,8 +307,16 @@ const normalizeIssues = (raw, numberKey, authorKey) => raw.map((r) => ({
   title: r.title,
   labels: r.labels,
   assignees: r.assignees,
-  authorLogin: (r.author?.[authorKey] || '').toLowerCase()
+  authorLogin: (r.author?.[authorKey] || '').toLowerCase(),
+  updatedAt: r.updatedAt || r.updated_at || null
 }));
+
+// A forge can return the same candidate set in a different order, especially
+// after the collaborators author fan-out. Keep picker order untouched, but use
+// a canonical representation for the perpetual drain's set comparison.
+const canonicalizeIds = (ids) => [...new Set(ids
+  .filter((id) => id != null)
+  .map((id) => String(id)))].sort();
 
 const GLAB_SELF_LOGIN_ARGS = ['api', 'user', '-q', '.username'];
 
@@ -343,7 +351,7 @@ const FORGE_ISSUE_CONFIG = {
     // happens to be full of excluded/in-flight/decomposed-epic issues even
     // though real work exists further down the queue. Matches the same
     // tradeoff the /do:next auto-pick walk already makes for the same reason.
-    listArgs: ['issue', 'list', '--state', 'open', '--search', 'sort:created-asc', '--json', 'number,assignees,labels,title,author', '--limit', '500'],
+    listArgs: ['issue', 'list', '--state', 'open', '--search', 'sort:created-asc', '--json', 'number,assignees,labels,title,author,updatedAt', '--limit', '500'],
     listFail: 'gh-list-failed',
     parseFail: 'gh-parse-failed',
     // Park reason when the owner filter resolves to a non-authoring owner. On
@@ -655,7 +663,11 @@ async function detectForgeIssues(forgeKey, app, { issueAuthorFilter = 'self', is
     // The perpetual drain uses the complete candidate set to detect a
     // successful agent that exited without claiming anything. `sample` is
     // intentionally capped for UI payloads, so it cannot serve as that brake.
-    signature: JSON.stringify(actionable.map((i) => i.number)),
+    // updatedAt changes when the claim flow posts a partial-delivery comment
+    // or releases its markers, so a same-issue continuation remains eligible.
+    // The ID is retained as the primary identity for forge responses that omit
+    // the timestamp (and for older test/mocked CLI output).
+    signature: JSON.stringify(canonicalizeIds(actionable.map((i) => `${i.number}@${i.updatedAt || ''}`))),
     items: actionable.slice(0, WORK_ITEM_LIMIT).map((i) => ({ ref: String(i.number), title: i.title || '' }))
   };
 }
@@ -697,7 +709,7 @@ export async function detectPlanTask(app) {
     count: available.length,
     reason: pick ? 'actionable-plan-items' : 'no-actionable-plan-items',
     // Keep the signature complete even though the picker payload is capped.
-    signature: JSON.stringify(available.map((it) => it.id)),
+    signature: JSON.stringify(canonicalizeIds(available.map((it) => it.id))),
     items: available.slice(0, WORK_ITEM_LIMIT).map((it) => ({ ref: it.id, title: planItemTitle(it) }))
   };
 }

--- a/server/services/perpetualWork.js
+++ b/server/services/perpetualWork.js
@@ -652,6 +652,10 @@ async function detectForgeIssues(forgeKey, app, { issueAuthorFilter = 'self', is
     filteredCount,
     reason: actionable.length > 0 ? 'actionable-issues' : 'no-actionable-issues',
     sample: actionable.slice(0, 5).map((i) => i.number),
+    // The perpetual drain uses the complete candidate set to detect a
+    // successful agent that exited without claiming anything. `sample` is
+    // intentionally capped for UI payloads, so it cannot serve as that brake.
+    signature: JSON.stringify(actionable.map((i) => i.number)),
     items: actionable.slice(0, WORK_ITEM_LIMIT).map((i) => ({ ref: String(i.number), title: i.title || '' }))
   };
 }
@@ -692,6 +696,8 @@ export async function detectPlanTask(app) {
     actionable: !!pick,
     count: available.length,
     reason: pick ? 'actionable-plan-items' : 'no-actionable-plan-items',
+    // Keep the signature complete even though the picker payload is capped.
+    signature: JSON.stringify(available.map((it) => it.id)),
     items: available.slice(0, WORK_ITEM_LIMIT).map((it) => ({ ref: it.id, title: planItemTitle(it) }))
   };
 }

--- a/server/services/perpetualWork.test.js
+++ b/server/services/perpetualWork.test.js
@@ -250,7 +250,7 @@ describe('perpetualWork', () => {
         { ref: '1', title: 'plain' },
         { ref: '5', title: 'also plain' }
       ]);
-      expect(out.signature).toBe('[1,5]');
+      expect(out.signature).toBe('["1@","5@"]');
     });
 
     it('reports the "[Epic]"-prefixed issue as actionable while it is still undecomposed', async () => {
@@ -269,8 +269,23 @@ describe('perpetualWork', () => {
       });
       const out = await detectGithubIssues(app, { issueAuthorFilter: 'any' });
       expect(out).toMatchObject({ actionable: true, count: 1, reason: 'actionable-issues', sample: [1] });
-      expect(out.signature).toBe('[1]');
+      expect(out.signature).toBe('["1@"]');
       expect(out.filteredCount).toBe(2);
+    });
+
+    it('canonicalizes candidate order and keeps forge updates in the signature', async () => {
+      routeSpawn({
+        'gh issue': { stdout: JSON.stringify([
+          { number: 10, title: 'later', updatedAt: '2026-08-27T02:00:00Z', assignees: [], labels: [] },
+          { number: 2, title: 'first', updatedAt: '2026-08-27T01:00:00Z', assignees: [], labels: [] },
+          { number: 10, title: 'duplicate', updatedAt: '2026-08-27T02:00:00Z', assignees: [], labels: [] }
+        ]) },
+        'git branch': { stdout: 'main\n' },
+        'gh pr': { stdout: '' }
+      });
+      const out = await detectGithubIssues(app, { issueAuthorFilter: 'any' });
+      expect(out.sample).toEqual([10, 2, 10]);
+      expect(out.signature).toBe('["10@2026-08-27T02:00:00Z","2@2026-08-27T01:00:00Z"]');
     });
 
     it('converges (0 actionable) once that epic carries the decomposed label', async () => {

--- a/server/services/perpetualWork.test.js
+++ b/server/services/perpetualWork.test.js
@@ -250,7 +250,7 @@ describe('perpetualWork', () => {
         { ref: '1', title: 'plain' },
         { ref: '5', title: 'also plain' }
       ]);
-      expect(out.signature).toBe('["1@","5@"]');
+      expect(out.signature).toBe('["1","5"]');
     });
 
     it('reports the "[Epic]"-prefixed issue as actionable while it is still undecomposed', async () => {
@@ -269,23 +269,23 @@ describe('perpetualWork', () => {
       });
       const out = await detectGithubIssues(app, { issueAuthorFilter: 'any' });
       expect(out).toMatchObject({ actionable: true, count: 1, reason: 'actionable-issues', sample: [1] });
-      expect(out.signature).toBe('["1@"]');
+      expect(out.signature).toBe('["1"]');
       expect(out.filteredCount).toBe(2);
     });
 
-    it('canonicalizes candidate order and keeps forge updates in the signature', async () => {
+    it('canonicalizes candidate order and removes duplicate issue IDs from the signature', async () => {
       routeSpawn({
         'gh issue': { stdout: JSON.stringify([
-          { number: 10, title: 'later', updatedAt: '2026-08-27T02:00:00Z', assignees: [], labels: [] },
-          { number: 2, title: 'first', updatedAt: '2026-08-27T01:00:00Z', assignees: [], labels: [] },
-          { number: 10, title: 'duplicate', updatedAt: '2026-08-27T02:00:00Z', assignees: [], labels: [] }
+          { number: 10, title: 'later', assignees: [], labels: [] },
+          { number: 2, title: 'first', assignees: [], labels: [] },
+          { number: 10, title: 'duplicate', assignees: [], labels: [] }
         ]) },
         'git branch': { stdout: 'main\n' },
         'gh pr': { stdout: '' }
       });
       const out = await detectGithubIssues(app, { issueAuthorFilter: 'any' });
       expect(out.sample).toEqual([10, 2, 10]);
-      expect(out.signature).toBe('["10@2026-08-27T02:00:00Z","2@2026-08-27T01:00:00Z"]');
+      expect(out.signature).toBe('["2","10"]');
     });
 
     it('converges (0 actionable) once that epic carries the decomposed label', async () => {

--- a/server/services/perpetualWork.test.js
+++ b/server/services/perpetualWork.test.js
@@ -250,6 +250,7 @@ describe('perpetualWork', () => {
         { ref: '1', title: 'plain' },
         { ref: '5', title: 'also plain' }
       ]);
+      expect(out.signature).toBe('[1,5]');
     });
 
     it('reports the "[Epic]"-prefixed issue as actionable while it is still undecomposed', async () => {
@@ -268,6 +269,7 @@ describe('perpetualWork', () => {
       });
       const out = await detectGithubIssues(app, { issueAuthorFilter: 'any' });
       expect(out).toMatchObject({ actionable: true, count: 1, reason: 'actionable-issues', sample: [1] });
+      expect(out.signature).toBe('[1]');
       expect(out.filteredCount).toBe(2);
     });
 


### PR DESCRIPTION
## Summary
- Add complete, tracker-namespaced claim/plan candidate signatures for perpetual drains.
- Park unchanged claim work after the allowed continuation check instead of repeatedly spawning agents that make no progress.
- Defer convergence-state recording until a generated task is admitted by its spawn path.

## Test plan
- `npm test -- --run services/perpetualWork.test.js services/cosTaskGenerator.test.js services/cos.test.js services/taskSchedule.test.js`
- `git diff --check`