### PR TITLE
feat: add health tracking feature flag

### DIFF
--- a/client/src/components/Layout.test.jsx
+++ b/client/src/components/Layout.test.jsx
@@ -53,7 +53,7 @@ vi.mock('../services/socket', () => ({
 
 // --- API: every sidebar fetch resolves empty so the dynamic sections stay bare
 //     and the single rows are the only top-level leaves under test. ---
-// Instance features gate sidebar rows (POST / DataDog / JIRA / GSD / OpenClaw). Default every
+// Instance features gate sidebar rows (Health / POST / DataDog / JIRA / GSD / OpenClaw). Default every
 // feature ON so these tests see the full sidebar; the gating itself is covered
 // by 'Layout — instance feature gating' below.
 const allFeaturesOn = () => [
@@ -62,6 +62,7 @@ const allFeaturesOn = () => [
   { id: 'jira', label: 'JIRA', enabled: true },
   { id: 'gsd', label: 'GSD', enabled: true },
   { id: 'openclaw', label: 'OpenClaw', enabled: true },
+  { id: 'health', label: 'Health tracking', enabled: true },
 ];
 const featureMock = vi.hoisted(() => ({ features: null }));
 
@@ -257,6 +258,15 @@ describe('Layout — instance feature gating', () => {
 
     expect(screen.queryByRole('button', { name: 'POST' })).toBeNull();
     expect(screen.getByRole('link', { name: 'DataDog' })).toBeTruthy();
+  });
+
+  it('drops the whole Health section when health tracking is off', async () => {
+    featureMock.features = allFeaturesOn()
+      .map((f) => (f.id === 'health' ? { ...f, enabled: false } : f));
+
+    await renderLayout('/devtools/flows');
+
+    expect(screen.queryByRole('button', { name: 'Health' })).toBeNull();
   });
 
   it('shows everything when the feature list cannot be read', async () => {

--- a/client/src/components/settings/SettingsTabsHeader.jsx
+++ b/client/src/components/settings/SettingsTabsHeader.jsx
@@ -18,7 +18,7 @@ export const TABS = [
   { id: 'database', label: 'Database', to: '/settings/database' },
   { id: 'features', label: 'Features', to: '/settings/features' },
   { id: 'general', label: 'General', to: '/settings/general' },
-  { id: 'mortalloom', label: 'MortalLoom', to: '/settings/mortalloom' },
+  { id: 'mortalloom', label: 'MortalLoom', to: '/settings/mortalloom', feature: 'health' },
   { id: 'openclaw', label: 'OpenClaw', to: '/openclaw', feature: 'openclaw' },
   { id: 'prompts', label: 'Prompts', to: '/prompts' },
   { id: 'providers', label: 'Providers', to: '/ai' },

--- a/client/src/pages/Settings.tabs.test.jsx
+++ b/client/src/pages/Settings.tabs.test.jsx
@@ -59,3 +59,10 @@ describe('Settings — Instance Features tab', () => {
     expect(screen.queryByTestId('general-tab')).toBeNull();
   });
 });
+
+describe('Settings — MortalLoom tab', () => {
+  it('marks MortalLoom as part of the health-tracking feature', () => {
+    const tab = TABS.find(t => t.id === 'mortalloom');
+    expect(tab).toMatchObject({ to: '/settings/mortalloom', feature: 'health' });
+  });
+});

--- a/server/lib/instanceFeatureRegistry.js
+++ b/server/lib/instanceFeatureRegistry.js
@@ -50,6 +50,14 @@ export const INSTANCE_FEATURES = Object.freeze([
     // OpenClaw; an explicit Settings > Features toggle remains authoritative.
     defaultEnabled: true,
   }),
+  Object.freeze({
+    id: 'health',
+    label: 'Health tracking',
+    description: 'Personal health tracking, MeatSpace records, and MortalLoom iCloud sync.',
+    // Health and MortalLoom were previously always visible. Keep existing
+    // installs on that behavior until the user explicitly changes the flag.
+    defaultEnabled: true,
+  }),
 ]);
 
 export const INSTANCE_FEATURE_IDS = Object.freeze(INSTANCE_FEATURES.map((feature) => feature.id));

--- a/server/lib/instanceFeatureRegistry.test.js
+++ b/server/lib/instanceFeatureRegistry.test.js
@@ -18,6 +18,13 @@ describe('instance feature registry', () => {
     expect(APP_FEATURE_IDS.every((id) => INSTANCE_FEATURE_IDS.includes(id))).toBe(true);
     expect(new Set(APP_FEATURE_IDS).size).toBe(APP_FEATURE_IDS.length);
   });
+
+  it('keeps health tracking enabled by default for existing installs', () => {
+    expect(INSTANCE_FEATURES.find((feature) => feature.id === 'health')).toMatchObject({
+      label: 'Health tracking',
+      defaultEnabled: true,
+    });
+  });
 });
 
 describe('countConfiguredInstances', () => {

--- a/server/lib/navManifest.js
+++ b/server/lib/navManifest.js
@@ -60,7 +60,10 @@ const OPEN_WORLD_REGION_COMMANDS = [
 // server/lib/instanceFeatureRegistry.js — navManifest.test.js fails on both
 // kinds of drift, because a stale key here would silently un-gate a section
 // with every other assertion still green.
-export const SECTION_FEATURE = new Map([['POST', 'post']]);
+export const SECTION_FEATURE = new Map([
+  ['Health', 'health'],
+  ['POST', 'post'],
+]);
 
 const RAW_NAV_COMMANDS = [
   { id: 'nav.dashboard', path: '/', label: 'Dashboard', section: 'Main', aliases: ['dashboard', 'home'], keywords: ['overview', 'start'] },
@@ -314,7 +317,7 @@ const RAW_NAV_COMMANDS = [
   // resolving after the fold.
   { id: 'nav.models.status', path: '/models/status', label: 'Status', section: 'Models', previousPaths: ['/system-resources/models'], aliases: ['model-status', 'models-status', 'memory-management', 'resident-models', 'model-resources', 'loaded-models', 'downloaded-models', 'model-memory'], keywords: ['memory', 'resident', 'loaded', 'unload', 'ram', 'vram', 'free memory', 'what is loaded', 'ollama', 'lm studio', 'hugging face', 'lora', 'delete model', 'disk'] },
   { id: 'nav.settings.local-llm-playground', path: '/local-llm/playground', label: 'Playground', section: 'Models', aliases: ['llm-playground', 'playground', 'model-playground', 'compare-models'], keywords: ['ollama', 'lm studio', 'compare', 'benchmark', 'chat', 'test model', 'ttft', 'tokens per second', 'local llm'] },
-  { id: 'nav.settings.mortalloom', path: '/settings/mortalloom', label: 'MortalLoom', section: 'Settings', aliases: ['settings-mortalloom', 'mortalloom'] },
+  { id: 'nav.settings.mortalloom', path: '/settings/mortalloom', label: 'MortalLoom', section: 'Settings', feature: 'health', aliases: ['settings-mortalloom', 'mortalloom'] },
   { id: 'nav.settings.openclaw', path: '/openclaw', label: 'OpenClaw', section: 'Settings', feature: 'openclaw', aliases: ['openclaw', 'settings-openclaw'], keywords: ['operator', 'chat', 'agent', 'runtime', 'sessions', 'streaming'] },
   { id: 'nav.settings.security', path: '/settings/security', label: 'Security', section: 'Settings', aliases: ['settings-security', 'login-password', 'auth-password', 'password-settings'], keywords: ['password', 'login', 'auth', 'sign-in', 'lock', 'tailnet', 'sidecar'] },
   { id: 'nav.settings.sharing', path: '/settings/sharing', label: 'Sharing', section: 'Settings', aliases: ['settings-sharing', 'sharing-settings'], keywords: ['display name', 'bio', 'attribution', 'identity', 'source'] },

--- a/server/lib/navManifest.test.js
+++ b/server/lib/navManifest.test.js
@@ -177,6 +177,13 @@ describe('nav contract — instance-feature gating', () => {
     expect(byId['nav.cos.gsd']).toBe('gsd');
   });
 
+  it('gates the complete Health section and MortalLoom settings', () => {
+    const byId = Object.fromEntries(NAV_COMMANDS.map((c) => [c.id, c.feature]));
+    expect([...SECTION_FEATURE]).toContainEqual(['Health', 'health']);
+    expect(NAV_COMMANDS.filter((c) => c.section === 'Health').every((c) => c.feature === 'health')).toBe(true);
+    expect(byId['nav.settings.mortalloom']).toBe('health');
+  });
+
   it('leaves ungated pages untagged', () => {
     const gated = NAV_COMMANDS.filter((c) => c.feature).map((c) => c.id);
     expect(gated).toContain('nav.devtools.jira');

--- a/server/routes/settings.test.js
+++ b/server/routes/settings.test.js
@@ -111,6 +111,7 @@ describe('Settings routes — instance feature participation', () => {
     // available unless the install explicitly opts out.
     expect(res.body.features).toContainEqual(expect.objectContaining({ id: 'gsd', enabled: true }));
     expect(res.body.features).toContainEqual(expect.objectContaining({ id: 'openclaw', enabled: true }));
+    expect(res.body.features).toContainEqual(expect.objectContaining({ id: 'health', enabled: true }));
   });
 
   it('updates one feature without replacing unrelated settings', async () => {

--- a/server/services/instanceFeatures.test.js
+++ b/server/services/instanceFeatures.test.js
@@ -171,7 +171,7 @@ describe('instance features', () => {
 
     const { features } = await getInstanceFeatures();
     expect(Object.fromEntries(features.map((f) => [f.id, f.enabled])))
-      .toEqual({ post: true, datadog: true, jira: false, gsd: true, openclaw: true });
+      .toEqual({ post: true, datadog: true, jira: false, gsd: true, openclaw: true, health: true });
   });
 
   it('rejects an unknown feature id', async () => {


### PR DESCRIPTION
## Summary
- Add an install-wide Health tracking feature flag to Settings > Features.
- Gate the Health sidebar section, MortalLoom navigation, and MortalLoom Settings tab from the shared feature registry.
- Preserve existing behavior by default and keep direct routes available.

## Test plan
- `npx vitest run lib/instanceFeatureRegistry.test.js lib/navManifest.test.js routes/settings.test.js` (server)
- `npx vitest run src/components/Layout.test.jsx src/pages/Settings.tabs.test.jsx` (client)