### PR TITLE
feat(quota-burn): make configured jobs collapsible and filter preset additions

### DIFF
--- a/client/src/components/quotaBurn/FamilyCard.jsx
+++ b/client/src/components/quotaBurn/FamilyCard.jsx
@@ -7,12 +7,13 @@
  * runner evaluates, so the card can't disagree with what actually happens.
  */
 
+import { useState } from 'react';
 import { AlertTriangle, Ban, ChevronDown, ChevronRight, Flame, Plus, RotateCcw } from 'lucide-react';
 import Banner from '../ui/Banner';
 import BrailleSpinner from '../BrailleSpinner';
 import JobRow from './JobRow';
 import PresetPicker from './PresetPicker';
-import { dispatchCapInput, isUnlimitedDispatchCap, jobFromPreset, quotaBurnJobIsSpent, UNLIMITED_DISPATCHES } from '../../lib/quotaBurnPatch';
+import { dispatchCapInput, getAvailablePresetsForJobs, isUnlimitedDispatchCap, jobFromPreset, quotaBurnJobIsSpent, UNLIMITED_DISPATCHES } from '../../lib/quotaBurnPatch';
 import { formatDateTime } from '../../utils/formatters';
 import { NumberField } from './fields';
 
@@ -22,6 +23,7 @@ export default function FamilyCard({
 }) {
   const jobs = config.jobs || [];
   const hasEnabledJobs = jobs.some((job) => job.enabled !== false);
+  const [expandedJobIds, setExpandedJobIds] = useState(() => new Set());
   // Pending counts and `run once` completions stay on the STATUS side and are
   // passed to JobRow as their own props — merging them into the job objects
   // would mean stripping them back off before every save (the PUT schema is
@@ -60,27 +62,52 @@ export default function FamilyCard({
     while (taken.has(`${base}-${suffix}`)) suffix += 1;
     return `${base}-${suffix}`;
   };
-  const addJob = () => patchJobs([...jobs, {
-    id: nextJobId(),
-    enabled: true,
-    label: '',
-    jobType: catalog.jobTypes[0].id,
-    model: null,
-    providerId: null,
-    runOnce: false,
-    params: {},
-  }]);
+  const addJob = () => {
+    const id = nextJobId();
+    patchJobs([...jobs, {
+      id,
+      enabled: true,
+      label: '',
+      jobType: catalog.jobTypes[0].id,
+      model: null,
+      providerId: null,
+      runOnce: false,
+      params: {},
+    }]);
+    setExpandedJobIds((prev) => new Set(prev).add(id));
+  };
   // A preset job inherits the app the plan is already pointed at, when the plan
   // is unambiguous about it — otherwise a one-click "add a UX audit" lands as a
   // step that cannot run until the user notices the unset app picker. Derived at
   // click time, not per render: the page polls while any family is pending.
   const addPresetJob = (preset) => {
     const targetedAppIds = [...new Set(jobs.map((job) => job.params?.appId).filter(Boolean))];
+    const id = nextJobId();
     patchJobs([...jobs, jobFromPreset(preset, {
-      id: nextJobId(),
+      id,
       appId: targetedAppIds.length === 1 ? targetedAppIds[0] : null,
     })]);
+    setExpandedJobIds((prev) => new Set(prev).add(id));
   };
+
+  const allExpanded = jobs.length > 0 && jobs.every((job) => expandedJobIds.has(job.id));
+  const toggleAllJobs = () => {
+    if (allExpanded) {
+      setExpandedJobIds(new Set());
+    } else {
+      setExpandedJobIds(new Set(jobs.map((job) => job.id)));
+    }
+  };
+  const toggleJobExpand = (jobId) => {
+    setExpandedJobIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(jobId)) next.delete(jobId);
+      else next.add(jobId);
+      return next;
+    });
+  };
+
+  const availablePresets = getAvailablePresetsForJobs(catalog.presets, jobs);
 
   return (
     <div className="rounded border border-port-border bg-port-card/40">
@@ -210,6 +237,16 @@ export default function FamilyCard({
             <div className="flex flex-wrap items-center justify-between gap-2">
               <h3 className="text-xs uppercase tracking-wide text-gray-400">Burn plan — runs in order</h3>
               <div className="flex items-center gap-3">
+                {jobs.length > 0 && (
+                  <button
+                    type="button"
+                    className="inline-flex items-center gap-1 text-xs text-gray-300 hover:text-white"
+                    onClick={toggleAllJobs}
+                  >
+                    {allExpanded ? <ChevronDown size={13} /> : <ChevronRight size={13} />}
+                    {allExpanded ? 'Collapse all' : 'Expand all'}
+                  </button>
+                )}
                 {/* Re-arming step by step is the wrong shape for the case this
                     exists to serve: a plan configured as a one-shot SERIES,
                     which the user wants to run again as a series. Not confirmed
@@ -228,7 +265,7 @@ export default function FamilyCard({
                 )}
                 <button
                   type="button"
-                  className="inline-flex items-center gap-1 text-xs text-port-accent hover:underline disabled:opacity-40"
+                  className="inline-flex items-center gap-1 text-port-accent hover:underline disabled:opacity-40"
                   disabled={!canAddJob}
                   title={canAddJob ? 'Add a job to this plan' : 'Job catalog unavailable — retry the catalog load above'}
                   onClick={addJob}
@@ -241,7 +278,7 @@ export default function FamilyCard({
               <PresetPicker
                 id={`burn-${familyId}-preset`}
                 label="Add a preset job"
-                presets={catalog.presets}
+                presets={availablePresets}
                 onPick={addPresetJob}
                 hint="Single-focus audits that read the code, file GitHub issues, and change nothing — safe work for an unattended window."
               />
@@ -259,6 +296,8 @@ export default function FamilyCard({
                 pending={statusById.get(job.id)?.pending ?? null}
                 ranAt={statusById.get(job.id)?.ranAt ?? null}
                 actionsBusy={actionsBusy}
+                expanded={expandedJobIds.has(job.id)}
+                onToggleExpand={() => toggleJobExpand(job.id)}
                 onChange={(next) => changeJob(index, next)}
                 onMove={moveJob}
                 onRemove={(i) => patchJobs(jobs.filter((_, x) => x !== i))}
@@ -272,3 +311,4 @@ export default function FamilyCard({
     </div>
   );
 }
+

--- a/client/src/components/quotaBurn/JobRow.jsx
+++ b/client/src/components/quotaBurn/JobRow.jsx
@@ -7,7 +7,7 @@
  */
 
 import { useEffect, useState } from 'react';
-import { ArrowDown, ArrowUp, CheckCircle2, Play, RotateCcw, Trash2 } from 'lucide-react';
+import { ArrowDown, ArrowUp, CheckCircle2, ChevronDown, ChevronRight, Play, RotateCcw, Trash2 } from 'lucide-react';
 import ConfirmButtonPair from '../ui/ConfirmButtonPair';
 import InlineConfirmRow from '../ui/InlineConfirmRow';
 import JobParamField from './JobParamField';
@@ -18,8 +18,13 @@ import { inputClass } from './fields';
 
 export default function JobRow({
   job, index, total, catalog, pending, ranAt, actionsBusy,
+  expanded = false, onToggleExpand,
   onChange, onMove, onRemove, onRun, onRearm,
 }) {
+  const [localExpanded, setLocalExpanded] = useState(false);
+  const isExpanded = onToggleExpand !== undefined ? expanded : localExpanded;
+  const toggleExpand = onToggleExpand || (() => setLocalExpanded((prev) => !prev));
+
   // Two-click arm on delete (the repo's inline-confirm convention). A job holds
   // the family's whole free-text work prompt and nothing else stores it — a
   // stray click on the trash icon would drop it from the persisted plan with no
@@ -67,6 +72,15 @@ export default function JobRow({
     // eight steps ran together as one undifferentiated block.
     <div className="rounded border border-port-border/70 bg-port-bg p-3 space-y-3">
       <div className="flex flex-wrap items-center gap-2">
+        <button
+          type="button"
+          className="p-1 text-gray-400 hover:text-white"
+          onClick={toggleExpand}
+          aria-label={isExpanded ? `Collapse step ${index + 1}` : `Expand step ${index + 1}`}
+          title={isExpanded ? 'Collapse step' : 'Expand step'}
+        >
+          {isExpanded ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+        </button>
         <input
           id={`${idPrefix}-enabled`}
           type="checkbox"
@@ -81,6 +95,13 @@ export default function JobRow({
           aria-label={`Name for step ${index + 1}`}
           onChange={(event) => onChange({ ...job, label: event.target.value })}
         />
+        {!isExpanded && (
+          <span className="text-xs text-gray-400 truncate max-w-xs">
+            {spec?.label || job.jobType}
+            {job.model ? ` · ${job.model}` : ''}
+            {job.runOnce ? ' · run once' : ''}
+          </span>
+        )}
         <div className="flex items-center gap-1">
           <button type="button" className="p-1 text-gray-400 hover:text-white disabled:opacity-30" disabled={index === 0} onClick={() => onMove(index, -1)} aria-label={`Move step ${index + 1} earlier`}><ArrowUp size={14} /></button>
           <button type="button" className="p-1 text-gray-400 hover:text-white disabled:opacity-30" disabled={index === total - 1} onClick={() => onMove(index, 1)} aria-label={`Move step ${index + 1} later`}><ArrowDown size={14} /></button>
@@ -116,93 +137,98 @@ export default function JobRow({
         </div>
       </div>
 
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-        <label htmlFor={`${idPrefix}-type`} className="block text-xs text-gray-400">
-          Job type
-          <select
-            id={`${idPrefix}-type`}
-            className={inputClass}
-            value={job.jobType}
-            // Params are CARRIED, not cleared. Each job type reads only its own
-            // keys (the server's normalizer keeps any scalar), so a stray click
-            // through the type picker no longer silently destroys a long work
-            // prompt — switching back restores it.
-            onChange={(event) => onChange({ ...job, jobType: event.target.value })}
-          >
-            {catalog.jobTypes.map((type) => <option key={type.id} value={type.id}>{type.label}</option>)}
-          </select>
-        </label>
-        <label htmlFor={`${idPrefix}-model`} className="block text-xs text-gray-400">
-          Model (optional)
-          <input
-            id={`${idPrefix}-model`}
-            className={inputClass}
-            value={job.model || ''}
-            placeholder="provider default"
-            onChange={(event) => onChange({ ...job, model: event.target.value || null })}
-          />
-        </label>
-        {/* The repeat/one-shot choice. The plan is a rotation the runner walks
-            lap after lap while the window still has quota, which is right for a
-            standing audit and wrong for work that only needs doing once — that
-            was simply re-done every lap. */}
-        <div className="text-xs text-gray-400">
-          <div className="flex items-center gap-2 mt-1">
-            <input
-              id={`${idPrefix}-run-once`}
-              type="checkbox"
-              checked={job.runOnce === true}
-              onChange={(event) => onChange({ ...job, runOnce: event.target.checked })}
+      {isExpanded && (
+        <>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <label htmlFor={`${idPrefix}-type`} className="block text-xs text-gray-400">
+              Job type
+              <select
+                id={`${idPrefix}-type`}
+                className={inputClass}
+                value={job.jobType}
+                // Params are CARRIED, not cleared. Each job type reads only its own
+                // keys (the server's normalizer keeps any scalar), so a stray click
+                // through the type picker no longer silently destroys a long work
+                // prompt — switching back restores it.
+                onChange={(event) => onChange({ ...job, jobType: event.target.value })}
+              >
+                {catalog.jobTypes.map((type) => <option key={type.id} value={type.id}>{type.label}</option>)}
+              </select>
+            </label>
+            <label htmlFor={`${idPrefix}-model`} className="block text-xs text-gray-400">
+              Model (optional)
+              <input
+                id={`${idPrefix}-model`}
+                className={inputClass}
+                value={job.model || ''}
+                placeholder="provider default"
+                onChange={(event) => onChange({ ...job, model: event.target.value || null })}
+              />
+            </label>
+            {/* The repeat/one-shot choice. The plan is a rotation the runner walks
+                lap after lap while the window still has quota, which is right for a
+                standing audit and wrong for work that only needs doing once — that
+                was simply re-done every lap. */}
+            <div className="text-xs text-gray-400">
+              <div className="flex items-center gap-2 mt-1">
+                <input
+                  id={`${idPrefix}-run-once`}
+                  type="checkbox"
+                  checked={job.runOnce === true}
+                  onChange={(event) => onChange({ ...job, runOnce: event.target.checked })}
+                />
+                <label htmlFor={`${idPrefix}-run-once`}>Run once</label>
+              </div>
+              <p className="text-[11px] text-gray-500 mt-1">
+                {job.runOnce
+                  ? 'Dispatches once, then drops out of the rotation until you re-arm it.'
+                  : 'Repeats every lap of the plan while the window still has quota.'}
+              </p>
+            </div>
+            <PresetPicker
+              id={`${idPrefix}-preset`}
+              label="Start from a preset (optional)"
+              presets={catalog.presets}
+              // Deliberately NOT filtered to this row's current job type. Filtering
+              // hid the control entirely on a non-agent row, so converting an
+              // existing step into an audit meant deleting and re-adding it — and
+              // the conversion is safe: params carry across the type switch and
+              // existing prompt text is confirmed before it is replaced.
+              hint="Fills the work prompt below with a ready-made single-focus audit that files issues and changes no code."
+              value={matchedPreset?.id || ''}
+              // Re-picking the preset the row already matches is a no-op, so it
+              // needs no "replace your text?" confirm — the text IS the preset's.
+              onPick={(preset) => (hasPromptText && preset.id !== matchedPreset?.id
+                ? setPendingPreset(preset)
+                : applyPreset(preset))}
             />
-            <label htmlFor={`${idPrefix}-run-once`}>Run once</label>
+            {(spec?.params || []).map((descriptor) => (
+              <JobParamField
+                key={descriptor.key}
+                descriptor={descriptor}
+                value={job.params?.[descriptor.key]}
+                options={optionsFor(descriptor)}
+                idPrefix={idPrefix}
+                onChange={setParam}
+              />
+            ))}
           </div>
-          <p className="text-[11px] text-gray-500 mt-1">
-            {job.runOnce
-              ? 'Dispatches once, then drops out of the rotation until you re-arm it.'
-              : 'Repeats every lap of the plan while the window still has quota.'}
-          </p>
-        </div>
-        <PresetPicker
-          id={`${idPrefix}-preset`}
-          label="Start from a preset (optional)"
-          presets={catalog.presets}
-          // Deliberately NOT filtered to this row's current job type. Filtering
-          // hid the control entirely on a non-agent row, so converting an
-          // existing step into an audit meant deleting and re-adding it — and
-          // the conversion is safe: params carry across the type switch and
-          // existing prompt text is confirmed before it is replaced.
-          hint="Fills the work prompt below with a ready-made single-focus audit that files issues and changes no code."
-          value={matchedPreset?.id || ''}
-          // Re-picking the preset the row already matches is a no-op, so it
-          // needs no "replace your text?" confirm — the text IS the preset's.
-          onPick={(preset) => (hasPromptText && preset.id !== matchedPreset?.id
-            ? setPendingPreset(preset)
-            : applyPreset(preset))}
-        />
-        {(spec?.params || []).map((descriptor) => (
-          <JobParamField
-            key={descriptor.key}
-            descriptor={descriptor}
-            value={job.params?.[descriptor.key]}
-            options={optionsFor(descriptor)}
-            idPrefix={idPrefix}
-            onChange={setParam}
-          />
-        ))}
-      </div>
 
-      {pendingPreset && (
-        <InlineConfirmRow
-          tone="warning"
-          question={`Replace this step's work prompt with the “${pendingPreset.label}” preset? Your current text is discarded.`}
-          confirmText="Replace"
-          cancelText="Keep mine"
-          onConfirm={() => applyPreset(pendingPreset)}
-          onCancel={() => setPendingPreset(null)}
-        />
+          {pendingPreset && (
+            <InlineConfirmRow
+              tone="warning"
+              question={`Replace this step's work prompt with the “${pendingPreset.label}” preset? Your current text is discarded.`}
+              confirmText="Replace"
+              cancelText="Keep mine"
+              onConfirm={() => applyPreset(pendingPreset)}
+              onCancel={() => setPendingPreset(null)}
+            />
+          )}
+
+          {spec?.description && <p className="text-[11px] text-gray-500">{spec.description}</p>}
+        </>
       )}
 
-      {spec?.description && <p className="text-[11px] text-gray-500">{spec.description}</p>}
       {/* A spent step is not probed server-side (its count would never be acted
           on), so this REPLACES the pending line rather than sitting beside it —
           "Idle — no pending work" would otherwise be the only thing a finished
@@ -230,3 +256,4 @@ export default function JobRow({
     </div>
   );
 }
+

--- a/client/src/lib/quotaBurnPatch.js
+++ b/client/src/lib/quotaBurnPatch.js
@@ -87,6 +87,30 @@ export function jobFromPreset(preset, { id, appId = null } = {}) {
 export const quotaBurnJobIsSpent = (job, ranAt) => Boolean(job?.runOnce && ranAt);
 
 /**
+ * Whether a preset is already represented in a family's jobs list.
+ * Matched by comparing the trimmed prompt text (or jobType + label for non-prompt presets).
+ */
+export function isPresetInJobs(preset, jobs = []) {
+  if (!preset) return false;
+  const presetPrompt = String(preset.params?.prompt || '').trim();
+  if (presetPrompt) {
+    return (jobs || []).some(
+      (job) => String(job?.params?.prompt || '').trim() === presetPrompt,
+    );
+  }
+  return (jobs || []).some(
+    (job) => job?.jobType === preset.jobType && job?.label === preset.label,
+  );
+}
+
+/**
+ * Filter catalog presets to only those not currently in the given jobs list.
+ */
+export function getAvailablePresetsForJobs(presets = [], jobs = []) {
+  return (presets || []).filter((preset) => !isPresetInJobs(preset, jobs));
+}
+
+/**
  * `QUOTA_BURN_UNLIMITED_DISPATCHES` in `server/lib/quotaBurnConfig.js`: the
  * `maxDispatchesPerWindow` value that means the window is not counted at all,
  * and the default. Mirrored (not imported) for the same reason the merge above
@@ -107,3 +131,4 @@ export const isUnlimitedDispatchCap = (cap) => Number(cap) < 0;
  * that body with it. -1 is the natural continuation of "fewer restrictions".
  */
 export const dispatchCapInput = (value) => (value < 1 ? UNLIMITED_DISPATCHES : value);
+

--- a/client/src/lib/quotaBurnPatch.test.js
+++ b/client/src/lib/quotaBurnPatch.test.js
@@ -2,6 +2,8 @@ import { describe, it, expect } from 'vitest';
 import {
   applyQuotaBurnPreset,
   dispatchCapInput,
+  getAvailablePresetsForJobs,
+  isPresetInJobs,
   isUnlimitedDispatchCap,
   jobFromPreset,
   mergeQuotaBurnPatch,
@@ -140,4 +142,42 @@ describe('dispatch cap helpers', () => {
     expect(dispatchCapInput(50)).toBe(50);
   });
 });
+
+describe('isPresetInJobs and getAvailablePresetsForJobs', () => {
+  const p1 = { id: 'ux-audit', label: 'UX issues', jobType: 'agent-prompt', params: { prompt: 'Audit UX.' } };
+  const p2 = { id: 'a11y-audit', label: 'A11y issues', jobType: 'agent-prompt', params: { prompt: 'Audit A11y.' } };
+  const p3 = { id: 'perf-audit', label: 'Perf issues', jobType: 'agent-prompt', params: { prompt: 'Audit Perf.' } };
+
+  it('matches a preset in jobs by prompt text', () => {
+    const jobs = [{ id: 'j1', params: { prompt: 'Audit UX.' } }];
+    expect(isPresetInJobs(p1, jobs)).toBe(true);
+    expect(isPresetInJobs(p2, jobs)).toBe(false);
+  });
+
+  it('filters presets to only those not already in jobs', () => {
+    const jobs = [{ id: 'j1', params: { prompt: 'Audit UX.' } }];
+    const available = getAvailablePresetsForJobs([p1, p2, p3], jobs);
+    expect(available).toEqual([p2, p3]);
+  });
+
+  it('returns all presets when jobs list is empty', () => {
+    expect(getAvailablePresetsForJobs([p1, p2], [])).toEqual([p1, p2]);
+  });
+
+  it('returns empty list when all presets are in jobs', () => {
+    const jobs = [
+      { id: 'j1', params: { prompt: 'Audit UX.' } },
+      { id: 'j2', params: { prompt: 'Audit A11y.' } },
+    ];
+    expect(getAvailablePresetsForJobs([p1, p2], jobs)).toEqual([]);
+  });
+
+  it('handles null/undefined gracefully', () => {
+    expect(isPresetInJobs(null, [])).toBe(false);
+    expect(getAvailablePresetsForJobs(null, null)).toEqual([]);
+  });
+});
+
 // @vitest-environment node
+
+

--- a/client/src/pages/QuotaBurn.test.jsx
+++ b/client/src/pages/QuotaBurn.test.jsx
@@ -265,6 +265,7 @@ describe('QuotaBurn page', () => {
   it('asks before a preset overwrites a work prompt the user already wrote', async () => {
     const user = userEvent.setup();
     renderPage('/devtools/quota-burn/grok');
+    await user.click(await screen.findByLabelText('Expand step 1'));
     await user.selectOptions(await screen.findByLabelText('Job type'), 'agent-prompt');
     const promptBox = screen.getByLabelText('Work prompt');
     await user.type(promptBox, 'my own prompt');
@@ -287,6 +288,7 @@ describe('QuotaBurn page', () => {
     // disk records a preset id), so it stays honest across an edit.
     const user = userEvent.setup();
     renderPage('/devtools/quota-burn/grok');
+    await user.click(await screen.findByLabelText('Expand step 1'));
     await user.selectOptions(await screen.findByLabelText('Job type'), 'agent-prompt');
     const picker = screen.getByLabelText(/Start from a preset/);
     expect(picker).toHaveValue('');
@@ -306,6 +308,7 @@ describe('QuotaBurn page', () => {
     // hand-written prompt with no confirmation and no undo.
     const user = userEvent.setup();
     renderPage('/devtools/quota-burn/grok');
+    await user.click(await screen.findByLabelText('Expand step 1'));
     await user.selectOptions(await screen.findByLabelText('Job type'), 'agent-prompt');
     await user.type(screen.getByLabelText('Work prompt'), 'keep me');
     await user.selectOptions(screen.getByLabelText('Job type'), 'universe-bible-images');
@@ -352,6 +355,7 @@ describe('QuotaBurn run-once steps', () => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
     const user = setupSaveUser();
     renderPage('/devtools/quota-burn/grok');
+    await user.click(await screen.findByLabelText('Expand step 1'));
     await user.click(await screen.findByLabelText('Run once'));
     await flushSave();
     expect(api.saveQuotaBurn).toHaveBeenCalled();
@@ -791,3 +795,130 @@ describe('QuotaBurn save races', () => {
     }
   });
 });
+
+describe('QuotaBurn collapsible jobs', () => {
+  it('renders configured jobs in a collapsed state by default with summary details', async () => {
+    renderPage('/devtools/quota-burn/grok');
+    expect(await screen.findByDisplayValue('Bible images')).toBeInTheDocument();
+    // Compact summary badge shows job type
+    expect(screen.getByText(/Universe bible images/)).toBeInTheDocument();
+    // Inner fields are collapsed
+    expect(screen.queryByLabelText('Job type')).not.toBeInTheDocument();
+    expect(screen.getByLabelText('Expand step 1')).toBeInTheDocument();
+  });
+
+  it('expands and collapses a single job using its chevron toggle', async () => {
+    const user = userEvent.setup();
+    renderPage('/devtools/quota-burn/grok');
+    const toggle = await screen.findByLabelText('Expand step 1');
+    await user.click(toggle);
+
+    // Now expanded: shows inner fields
+    expect(await screen.findByLabelText('Job type')).toBeInTheDocument();
+    expect(screen.getByLabelText('Collapse step 1')).toBeInTheDocument();
+
+    // Click again to collapse
+    await user.click(screen.getByLabelText('Collapse step 1'));
+    expect(screen.queryByLabelText('Job type')).not.toBeInTheDocument();
+    expect(screen.getByLabelText('Expand step 1')).toBeInTheDocument();
+  });
+
+  it('expands all and collapses all jobs via header control', async () => {
+    const twoJobConfig = {
+      ...config,
+      families: {
+        ...config.families,
+        grok: {
+          ...config.families.grok,
+          jobs: [
+            { id: 'j1', enabled: true, label: 'Job 1', jobType: 'universe-bible-images', params: {} },
+            { id: 'j2', enabled: true, label: 'Job 2', jobType: 'agent-prompt', params: {} },
+          ],
+        },
+      },
+    };
+    api.getQuotaBurn.mockResolvedValue({ config: twoJobConfig, status });
+    const user = userEvent.setup();
+    renderPage('/devtools/quota-burn/grok');
+
+    expect(await screen.findByRole('button', { name: /Expand all/i })).toBeInTheDocument();
+    expect(screen.queryByLabelText('Collapse step 1')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Collapse step 2')).not.toBeInTheDocument();
+
+    // Expand all
+    await user.click(screen.getByRole('button', { name: /Expand all/i }));
+    expect(screen.getByLabelText('Collapse step 1')).toBeInTheDocument();
+    expect(screen.getByLabelText('Collapse step 2')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Collapse all/i })).toBeInTheDocument();
+
+    // Collapse all
+    await user.click(screen.getByRole('button', { name: /Collapse all/i }));
+    expect(screen.queryByLabelText('Collapse step 1')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Collapse step 2')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Expand all/i })).toBeInTheDocument();
+  });
+
+  it('automatically expands newly added jobs for editing', async () => {
+    const user = userEvent.setup();
+    renderPage('/devtools/quota-burn/grok');
+    await user.click(await screen.findByRole('button', { name: /Add job/i }));
+    expect(await screen.findByLabelText('Collapse step 2')).toBeInTheDocument();
+  });
+});
+
+describe('QuotaBurn preset addition filtering', () => {
+  const multiPresetCatalog = {
+    ...catalog,
+    presets: [
+      { id: 'ux-audit', label: 'UX issues', summary: 'Audit UI.', jobType: 'agent-prompt', params: { prompt: 'Prompt 1' } },
+      { id: 'a11y-audit', label: 'A11y issues', summary: 'Audit A11y.', jobType: 'agent-prompt', params: { prompt: 'Prompt 2' } },
+    ],
+  };
+
+  it('filters preset addition dropdown to only presets not already in the family', async () => {
+    const grokWithUx = {
+      ...config,
+      families: {
+        ...config.families,
+        grok: {
+          ...config.families.grok,
+          jobs: [
+            { id: 'j1', enabled: true, label: 'UX issues', jobType: 'agent-prompt', params: { prompt: 'Prompt 1' } },
+          ],
+        },
+      },
+    };
+    api.getQuotaBurn.mockResolvedValue({ config: grokWithUx, status });
+    api.getQuotaBurnCatalog.mockResolvedValue(multiPresetCatalog);
+
+    renderPage('/devtools/quota-burn/grok');
+    const select = await screen.findByLabelText(/Add a preset job/);
+    const options = Array.from(select.querySelectorAll('option')).map((o) => o.value);
+
+    // 'ux-audit' is already in the list, so only '' (placeholder) and 'a11y-audit' should be available
+    expect(options).toEqual(['', 'a11y-audit']);
+  });
+
+  it('hides preset addition picker when all catalog presets are in the jobs list', async () => {
+    const grokWithAll = {
+      ...config,
+      families: {
+        ...config.families,
+        grok: {
+          ...config.families.grok,
+          jobs: [
+            { id: 'j1', enabled: true, label: 'UX issues', jobType: 'agent-prompt', params: { prompt: 'Prompt 1' } },
+            { id: 'j2', enabled: true, label: 'A11y issues', jobType: 'agent-prompt', params: { prompt: 'Prompt 2' } },
+          ],
+        },
+      },
+    };
+    api.getQuotaBurn.mockResolvedValue({ config: grokWithAll, status });
+    api.getQuotaBurnCatalog.mockResolvedValue(multiPresetCatalog);
+
+    renderPage('/devtools/quota-burn/grok');
+    expect(await screen.findByDisplayValue('UX issues')).toBeInTheDocument();
+    expect(screen.queryByLabelText(/Add a preset job/)).not.toBeInTheDocument();
+  });
+});
+


### PR DESCRIPTION
## Summary
- Make configured jobs collapsible on the Quota Burn configuration page with an expand/collapse toggle per job row and a summary badge showing the configured type, model, and one-shot status when collapsed.
- Add an 'Expand all / Collapse all' toggle button in the 'Burn plan — runs in order' section header.
- Automatically expand newly added jobs (both blank and from presets) for editing.
- Filter the preset addition dropdown (`PresetPicker`) using `getAvailablePresetsForJobs` so that presets already configured in the family's job list are omitted from the preset addition picker.

## Changes
- `client/src/lib/quotaBurnPatch.js`: export `isPresetInJobs` and `getAvailablePresetsForJobs`
- `client/src/lib/quotaBurnPatch.test.js`: unit tests for preset matching and filtering
- `client/src/components/quotaBurn/JobRow.jsx`: collapsible job row with chevron toggle, compact summary badge, and accessible labels
- `client/src/components/quotaBurn/FamilyCard.jsx`: manage expanded job IDs state, expand/collapse all toggle, filter available presets for preset addition
- `client/src/pages/QuotaBurn.test.jsx`: integration tests for collapsible jobs, header controls, auto-expansion, and preset addition filtering