### PR TITLE
feat(quota-burn): add audit presets and standard model/effort pickers

### DIFF
--- a/client/src/components/quotaBurn/FamilyCard.jsx
+++ b/client/src/components/quotaBurn/FamilyCard.jsx
@@ -71,6 +71,7 @@ export default function FamilyCard({
       jobType: catalog.jobTypes[0].id,
       model: null,
       providerId: null,
+      effort: null,
       runOnce: false,
       params: {},
     }]);
@@ -290,6 +291,7 @@ export default function FamilyCard({
               <JobRow
                 key={job.id}
                 job={job}
+                familyId={familyId}
                 index={index}
                 total={jobs.length}
                 catalog={catalog}

--- a/client/src/components/quotaBurn/JobRow.jsx
+++ b/client/src/components/quotaBurn/JobRow.jsx
@@ -12,12 +12,15 @@ import ConfirmButtonPair from '../ui/ConfirmButtonPair';
 import InlineConfirmRow from '../ui/InlineConfirmRow';
 import JobParamField from './JobParamField';
 import PresetPicker from './PresetPicker';
+import EffortSelect from '../cos/EffortSelect';
 import { applyQuotaBurnPreset, quotaBurnJobIsSpent } from '../../lib/quotaBurnPatch';
 import { timeAgo } from '../../utils/formatters';
+import { commandBasename, effortAwareModelOptions, effortLevelsForProvider, effortSurvivingModel } from '../../utils/providers';
 import { inputClass } from './fields';
 
 export default function JobRow({
   job, index, total, catalog, pending, ranAt, actionsBusy,
+  familyId,
   expanded = false, onToggleExpand,
   onChange, onMove, onRemove, onRun, onRearm,
 }) {
@@ -65,6 +68,38 @@ export default function JobRow({
     imageMode: catalog.imageModes,
   })[descriptor.kind];
 
+  // Resolve the provider for this family/job to provide model options and effort support
+  const familyProviders = (catalog.providers || []).filter((provider) =>
+    provider?.enabled !== false &&
+    provider?.ollamaBacked !== true && provider?.mtplxBacked !== true &&
+    provider?.llamaBacked !== true && provider?.vllmBacked !== true &&
+    provider?.sglangBacked !== true &&
+    (provider?.type === 'cli' || provider?.type === 'tui') &&
+    (commandBasename(provider?.command) === familyId ||
+     String(provider?.id || '').toLowerCase().includes(familyId || '') ||
+     (familyId === 'agy' && String(provider?.id || '').toLowerCase().includes('antigravity')))
+  );
+
+  const selectedProvider = (job.providerId && familyProviders.find((p) => p.id === job.providerId))
+    || (job.providerId && (catalog.providers || []).find((p) => p.id === job.providerId))
+    || familyProviders.find((p) => p.type === (job.jobType === 'agent-prompt' ? 'tui' : 'cli'))
+    || familyProviders[0]
+    || null;
+
+  const availableModels = selectedProvider ? effortAwareModelOptions(selectedProvider, job.model) : [];
+  const effortLevels = selectedProvider ? effortLevelsForProvider(selectedProvider, job.model) : null;
+  const showEffort = Boolean(effortLevels && effortLevels.length > 0);
+
+  const handleModelChange = (modelVal) => {
+    const nextModel = modelVal || null;
+    let nextEffort = job.effort || null;
+    if (job.effort && selectedProvider) {
+      const surviving = effortSurvivingModel(selectedProvider, nextModel, job.effort);
+      nextEffort = surviving || null;
+    }
+    onChange({ ...job, model: nextModel, effort: nextEffort });
+  };
+
   return (
     // `bg-port-bg`, not `bg-port-bg/40`: a step sits INSIDE the family card, so
     // it reads as a sunken well only if it carries the page color at full
@@ -99,6 +134,7 @@ export default function JobRow({
           <span className="text-xs text-gray-400 truncate max-w-xs">
             {spec?.label || job.jobType}
             {job.model ? ` · ${job.model}` : ''}
+            {job.effort ? ` · ${job.effort}` : ''}
             {job.runOnce ? ' · run once' : ''}
           </span>
         )}
@@ -157,14 +193,36 @@ export default function JobRow({
             </label>
             <label htmlFor={`${idPrefix}-model`} className="block text-xs text-gray-400">
               Model (optional)
-              <input
+              <select
                 id={`${idPrefix}-model`}
                 className={inputClass}
                 value={job.model || ''}
-                placeholder="provider default"
-                onChange={(event) => onChange({ ...job, model: event.target.value || null })}
-              />
+                onChange={(event) => handleModelChange(event.target.value)}
+              >
+                <option value="">Default model</option>
+                {availableModels.map((m) => {
+                  const val = typeof m === 'string' ? m : m.id;
+                  const lbl = typeof m === 'string' ? m : (m.name || m.id);
+                  return <option key={val} value={val}>{lbl}</option>;
+                })}
+                {job.model && !availableModels.some((m) => (typeof m === 'string' ? m : m.id) === job.model) && (
+                  <option value={job.model}>{job.model}</option>
+                )}
+              </select>
             </label>
+            {showEffort && (
+              <label htmlFor={`${idPrefix}-effort`} className="block text-xs text-gray-400">
+                Thinking effort (optional)
+                <EffortSelect
+                  id={`${idPrefix}-effort`}
+                  provider={selectedProvider}
+                  model={job.model}
+                  value={job.effort || ''}
+                  onChange={(effort) => onChange({ ...job, effort: effort || null })}
+                  className={inputClass}
+                />
+              </label>
+            )}
             {/* The repeat/one-shot choice. The plan is a rotation the runner walks
                 lap after lap while the window still has quota, which is right for a
                 standing audit and wrong for work that only needs doing once — that

--- a/client/src/lib/quotaBurnPatch.js
+++ b/client/src/lib/quotaBurnPatch.js
@@ -61,7 +61,7 @@ export function applyQuotaBurnPreset(job, preset) {
  */
 export function jobFromPreset(preset, { id, appId = null } = {}) {
   return applyQuotaBurnPreset({
-    id, enabled: true, label: '', jobType: preset.jobType, model: null, providerId: null,
+    id, enabled: true, label: '', jobType: preset.jobType, model: null, providerId: null, effort: null,
     // Standing work, matching a hand-added step: an audit dimension is worth
     // re-running as the code changes.
     runOnce: false,

--- a/client/src/lib/quotaBurnPatch.test.js
+++ b/client/src/lib/quotaBurnPatch.test.js
@@ -112,7 +112,7 @@ describe('applyQuotaBurnPreset', () => {
 describe('jobFromPreset', () => {
   it('mints a runnable job with the caller\'s id and app', () => {
     expect(jobFromPreset(preset, { id: 'job-x', appId: 'a1' })).toEqual({
-      id: 'job-x', enabled: true, label: 'UX issues', jobType: 'agent-prompt', model: null, providerId: null,
+      id: 'job-x', enabled: true, label: 'UX issues', jobType: 'agent-prompt', model: null, providerId: null, effort: null,
       // Standing work: an audit dimension is worth re-running as the code moves.
       runOnce: false,
       params: { ...preset.params, appId: 'a1' },

--- a/client/src/pages/QuotaBurn.jsx
+++ b/client/src/pages/QuotaBurn.jsx
@@ -37,7 +37,7 @@ export const SAVE_DEBOUNCE_MS = 500;
 // is a 10-20s PTY spawn, so this is a handful of polls, not a busy loop.
 const PENDING_POLL_MS = 4000;
 
-const EMPTY_CATALOG = { jobTypes: [], apps: [], universes: [], imageModes: [] };
+const EMPTY_CATALOG = { jobTypes: [], apps: [], universes: [], imageModes: [], providers: [] };
 
 // Where a patch the server never accepted waits for the next visit. Session
 // scope, not local: this is a crash buffer for the current tab, and a patch

--- a/client/src/pages/QuotaBurn.test.jsx
+++ b/client/src/pages/QuotaBurn.test.jsx
@@ -920,5 +920,98 @@ describe('QuotaBurn preset addition filtering', () => {
     expect(await screen.findByDisplayValue('UX issues')).toBeInTheDocument();
     expect(screen.queryByLabelText(/Add a preset job/)).not.toBeInTheDocument();
   });
+
+  it('renders standard model select and effort picker for effort-capable providers', async () => {
+    const claudeProviderCatalog = {
+      ...catalog,
+      providers: [
+        {
+          id: 'claude-code',
+          name: 'Claude Code',
+          type: 'tui',
+          command: 'claude',
+          models: [{ id: 'claude-sonnet-4', name: 'Claude Sonnet 4' }, { id: 'claude-opus-4', name: 'Claude Opus 4' }],
+        },
+      ],
+    };
+    const claudeConfig = {
+      ...config,
+      families: {
+        ...config.families,
+        claude: {
+          enabled: true,
+          resetWithinHours: 24,
+          reservePercent: 0,
+          maxDispatchesPerWindow: 5,
+          priority: 0,
+          jobs: [
+            { id: 'j1', enabled: true, label: 'Audit UI', jobType: 'agent-prompt', model: 'claude-sonnet-4', effort: 'high', params: { appId: 'a1', prompt: 'audit' } },
+          ],
+        },
+      },
+    };
+    api.getQuotaBurn.mockResolvedValue({ config: claudeConfig, status });
+    api.getQuotaBurnCatalog.mockResolvedValue(claudeProviderCatalog);
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const user = setupSaveUser();
+
+    renderPage('/devtools/quota-burn/claude');
+    await user.click(await screen.findByLabelText('Expand step 1'));
+
+    const modelSelect = await screen.findByLabelText('Model (optional)');
+    expect(modelSelect).toBeInTheDocument();
+    expect(modelSelect.tagName).toBe('SELECT');
+    expect(modelSelect).toHaveValue('claude-sonnet-4');
+
+    const effortSelect = screen.getByLabelText('Thinking effort');
+    expect(effortSelect).toBeInTheDocument();
+    expect(effortSelect.tagName).toBe('SELECT');
+    expect(effortSelect).toHaveValue('high');
+
+    // Change effort to medium and verify auto-save
+    await user.selectOptions(effortSelect, 'medium');
+    await flushSave();
+    expect(api.saveQuotaBurn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        families: expect.objectContaining({
+          claude: expect.objectContaining({
+            jobs: [
+              expect.objectContaining({
+                id: 'j1',
+                model: 'claude-sonnet-4',
+                effort: 'medium',
+              }),
+            ],
+          }),
+        }),
+      }),
+      expect.anything(),
+    );
+  });
+
+  it('displays model and effort in collapsed step summary badge', async () => {
+    const claudeConfig = {
+      ...config,
+      families: {
+        ...config.families,
+        claude: {
+          enabled: true,
+          resetWithinHours: 24,
+          reservePercent: 0,
+          maxDispatchesPerWindow: 5,
+          priority: 0,
+          jobs: [
+            { id: 'j1', enabled: true, label: '', jobType: 'agent-prompt', model: 'claude-sonnet-4', effort: 'high', params: { appId: 'a1', prompt: 'audit' } },
+          ],
+        },
+      },
+    };
+    api.getQuotaBurn.mockResolvedValue({ config: claudeConfig, status });
+    api.getQuotaBurnCatalog.mockResolvedValue(catalog);
+
+    renderPage('/devtools/quota-burn/claude');
+    expect(await screen.findByText(/Agent prompt · claude-sonnet-4 · high/)).toBeInTheDocument();
+  });
 });
+
 

--- a/client/src/utils/providers.js
+++ b/client/src/utils/providers.js
@@ -70,7 +70,7 @@ export const knownModelContextWindow = (model) => {
 // import server-side modules. Strip the directory + a Windows `.exe` suffix so a
 // path-configured command (/opt/homebrew/bin/grok) matches the bare vendor name.
 // Keep in lockstep with the server helper (only `.exe` is stripped, not `.cmd`).
-const commandBasename = (command) =>
+export const commandBasename = (command) =>
   typeof command === 'string' && command !== ''
     ? command.split(/[\\/]/).pop().toLowerCase().replace(/\.exe$/, '')
     : '';

--- a/server/lib/quotaBurnConfig.js
+++ b/server/lib/quotaBurnConfig.js
@@ -256,6 +256,7 @@ export function normalizeQuotaBurnJob(raw, index = 0) {
     jobType,
     model: nullableString(raw.model, BOUNDS.labelLength.max),
     providerId: nullableString(raw.providerId, BOUNDS.labelLength.max),
+    effort: nullableString(raw.effort, BOUNDS.labelLength.max),
     // Opt-IN, and absent reads as `false`, so every plan written before this
     // field existed keeps repeating exactly as it did. See `jobIsSpent`.
     runOnce: raw.runOnce === true,

--- a/server/lib/quotaBurnConfig.test.js
+++ b/server/lib/quotaBurnConfig.test.js
@@ -93,6 +93,13 @@ describe('normalizeQuotaBurnJob', () => {
     expect(normalizeQuotaBurnJob({ jobType: 'agent-prompt', runOnce: 'yes' }).runOnce).toBe(false);
     expect(normalizeQuotaBurnJob({ jobType: 'agent-prompt', runOnce: true }).runOnce).toBe(true);
   });
+
+  it('normalizes effort and model strings', () => {
+    expect(normalizeQuotaBurnJob({ jobType: 'agent-prompt', model: '  claude-sonnet-4  ', effort: '  high  ' }))
+      .toMatchObject({ model: 'claude-sonnet-4', effort: 'high' });
+    expect(normalizeQuotaBurnJob({ jobType: 'agent-prompt', model: '', effort: '' }))
+      .toMatchObject({ model: null, effort: null });
+  });
 });
 
 describe('jobIsSpent', () => {

--- a/server/lib/quotaBurnPresets.js
+++ b/server/lib/quotaBurnPresets.js
@@ -482,6 +482,126 @@ What is worth filing:
 Every finding needs a plausible attacker or accident story that ends in real
 harm. "Best practice says otherwise" is not one.`,
   }),
+
+  auditPreset({
+    id: 'api-contract-audit',
+    label: 'API & route contracts',
+    summary: 'Endpoint validation, status codes, query/param types, and error payloads.',
+    labels: '`bug`, `area:api`, `plan`',
+    dedupeSearch: 'api route contract validation status code',
+    mission: `
+# API contract audit — file issues, change nothing
+
+Audit this application's API endpoints and route handlers for contract drift,
+validation gaps, and error traps, and file them as GitHub issues. No code changes.
+
+Trace client callers to server routes and schemas:
+
+- **Unvalidated inputs** — endpoints reading \`req.body\`/\`query\`/\`params\` directly
+  without a validation schema, allowing malformed types into domain logic.
+- **Client/server drift** — client services sending unused fields, routes
+  expecting omitted properties, or callers expecting unreturned responses.
+- **Status and envelope errors** — 200 responses returning \`{ error }\`, raw 500s
+  for bad client input, or bare strings instead of \`{ error: message }\`.
+- **Async traps** — route handlers missing \`asyncHandler\`, where a rejected
+  promise hangs the request socket.
+- **Loose schemas** — validation schemas allowing unbounded strings (missing
+  \`.max()\`), arbitrary keys (missing \`.strict()\`), or unvalidated enums.
+- **HTTP method mismatch** — mutations on \`GET\` or non-idempotent updates.
+
+For each finding, cite the caller and route (\`path/to/file.js:LINE\`), the
+invalid shape, and the concrete failure that occurs.`,
+  }),
+
+  auditPreset({
+    id: 'react-lifecycle-audit',
+    label: 'React lifecycle & state',
+    summary: 'Stale closures, effect cleanups, state sync, and unmount safety in UI code.',
+    labels: '`bug`, `area:ui`, `plan`',
+    dedupeSearch: 'react lifecycle effect cleanup state closure',
+    mission: `
+# React lifecycle audit — file issues, change nothing
+
+Audit React components, custom hooks, and state lifecycles for memory leaks,
+stale closures, and race conditions, and file them as GitHub issues. No code changes.
+
+Inspect UI components and hooks:
+
+- **Missing effect teardowns** — \`useEffect\` listeners (\`window\`/\`document\`),
+  timers, sockets, or observers without cleanup functions on unmount.
+- **Stale closures** — callbacks and timers capturing state/props without
+  up-to-date refs or dependencies, operating on stale data.
+- **Unmounted state updates** — async operations setting state after unmount
+  or when superseded by a newer request.
+- **Derived state anti-patterns** — mirroring props in local state synced via
+  \`useEffect\`, causing visual flashes and desync instead of \`useMemo\`.
+- **Render-time side-effects** — mutating refs or triggering side-effects during
+  render rather than in effects/handlers.
+- **Broken dependencies** — missing dependencies causing stale reads, or inline
+  object literals triggering runaway render loops.
+
+Trace the sequence of user interactions and state transitions that triggers
+each defect.`,
+  }),
+
+  auditPreset({
+    id: 'observability-audit',
+    label: 'Logging & observability',
+    summary: 'Silent failure swallowing, missing error logs, log noise, and diagnostic gaps.',
+    labels: '`code-quality`, `plan`',
+    dedupeSearch: 'logging observability telemetry diagnostics',
+    mission: `
+# Observability audit — file issues, change nothing
+
+Audit how this application logs events, reports runtime failures, and surfaces
+diagnostics, and file the gaps as GitHub issues. No code changes this run.
+
+Trace error handling and log statements:
+
+- **Silent failure swallowing** — \`catch\` blocks discarding errors with no
+  logging or telemetry, hiding failures in production.
+- **Log noise & console spam** — polling loops, socket frames, or hot render
+  paths emitting lines on every tick, burying actionable errors.
+- **Missing error context** — errors logged with only \`err.message\` while
+  omitting task IDs, universe IDs, route paths, or stack traces.
+- **Inconsistent log levels** — fatal runtime errors logged as \`console.log\`
+  instead of \`console.error\` / structured error loggers.
+- **Uninstrumented workflows** — multi-step background pipelines or agent
+  transitions with no progress logging, leaving stuck jobs invisible.
+
+For each finding, cite the catch block or uninstrumented workflow and explain
+what operational blindspot it creates.`,
+  }),
+
+  auditPreset({
+    id: 'copy-audit',
+    label: 'Copy & text clarity',
+    summary: 'Jargon, misleading labels, confusing error text, and missing pluralization.',
+    labels: '`ux`, `plan`',
+    dedupeSearch: 'copy text clarity phrasing wording',
+    mission: `
+# Copy clarity audit — file issues, change nothing
+
+Audit user-facing copy, labels, tooltips, dialogs, and error messages for
+clarity, accuracy, and consistency, and file them as GitHub issues. No code changes.
+
+Review user-facing UI text:
+
+- **Internal jargon** — technical variable names, database keys, or protocol
+  details leaking into UI labels where domain terms belong.
+- **Ambiguous action labels** — generic "OK"/"Submit" on destructive actions
+  instead of explicit verbs ("Delete", "Discard"), or misleading "Cancel" buttons.
+- **Dead-end error messages** — "Failed" or "Invalid request" without explaining
+  what was wrong or how the user can resolve it.
+- **Broken pluralization** — "1 items", "0 files deleted", or "found 1 results"
+  missing singular/plural branching.
+- **Inconsistent terminology** — the same entity or action named differently
+  across tabs, dialogs, and navigation.
+- **Clipped labels** — text containers with fixed widths cutting off words.
+
+Provide the exact current string, where it appears (\`file.jsx:LINE\`), and the
+proposed replacement text with rationale.`,
+  }),
 ]);
 
 /** Look up a preset by id. Returns `null` for an unknown id — never throws. */

--- a/server/lib/quotaBurnValidation.js
+++ b/server/lib/quotaBurnValidation.js
@@ -36,6 +36,7 @@ const quotaBurnJobSchema = z.object({
   jobType: z.enum(QUOTA_BURN_JOB_TYPES),
   model: z.string().max(B.labelLength.max).nullable().optional(),
   providerId: z.string().max(B.labelLength.max).nullable().optional(),
+  effort: z.string().max(B.labelLength.max).nullable().optional(),
   // One-shot work: dispatch this step at most once, then drop it out of the
   // rotation until the user re-arms it. Absent reads as `false`, so plans
   // written before this field keep repeating.

--- a/server/routes/quotaBurn.js
+++ b/server/routes/quotaBurn.js
@@ -15,6 +15,7 @@ import { saveQuotaBurnConfig } from '../services/quotaBurnStore.js';
 import { getQuotaBurnStatus, runQuotaBurnCycle } from '../services/quotaBurnRunner.js';
 import { getActiveApps } from '../services/apps.js';
 import { listUniverseNames } from '../services/universeBuilder.js';
+import { listProviders } from '../services/providers.js';
 
 const router = Router();
 
@@ -32,12 +33,13 @@ router.get('/', asyncHandler(async (req, res) => {
 // pickers in one round trip: job types + their param descriptors, the family
 // list, and the app/universe/render-backend options those params select from.
 router.get('/catalog', asyncHandler(async (_req, res) => {
-  const [apps, universes] = await Promise.all([
+  const [apps, universes, providers] = await Promise.all([
     getActiveApps(),
     // The `{ id, name }` projection, NOT listUniverses() — the picker needs a
     // label, not every bible on the install. A missing/empty universe store must
     // not 500 the config page either; the universe job just has nothing to pick.
     listUniverseNames().catch(() => []),
+    listProviders().catch(() => []),
   ]);
   res.json({
     jobTypes: QUOTA_BURN_JOB_CATALOG,
@@ -50,6 +52,7 @@ router.get('/catalog', asyncHandler(async (_req, res) => {
     // Exactly the modes the media job queue can dispatch — the burn job enqueues
     // through it, so a backend added there appears in this picker for free.
     imageModes: QUEUEABLE_IMAGE_MODES,
+    providers: providers || [],
   });
 }));
 

--- a/server/routes/quotaBurn.test.js
+++ b/server/routes/quotaBurn.test.js
@@ -14,12 +14,14 @@ vi.mock('../services/quotaBurnRunner.js', () => ({
 vi.mock('../services/quotaBurnCompletions.js', () => ({ clearQuotaBurnJobCompletion: vi.fn() }));
 vi.mock('../services/apps.js', () => ({ getActiveApps: vi.fn() }));
 vi.mock('../services/universeBuilder.js', () => ({ listUniverseNames: vi.fn() }));
+vi.mock('../services/providers.js', () => ({ listProviders: vi.fn() }));
 
 import { clearQuotaBurnJobCompletion } from '../services/quotaBurnCompletions.js';
 import { getQuotaBurnConfig, saveQuotaBurnConfig } from '../services/quotaBurnStore.js';
 import { getQuotaBurnStatus, runQuotaBurnCycle } from '../services/quotaBurnRunner.js';
 import { getActiveApps } from '../services/apps.js';
 import { listUniverseNames } from '../services/universeBuilder.js';
+import { listProviders } from '../services/providers.js';
 import quotaBurnRoutes from './quotaBurn.js';
 
 const buildApp = () => {
@@ -38,6 +40,7 @@ beforeEach(() => {
   });
   getActiveApps.mockResolvedValue([{ id: 'a1', name: 'App One', secret: 'do-not-leak' }]);
   listUniverseNames.mockResolvedValue([{ id: 'u1', name: 'Example Universe' }]);
+  listProviders.mockResolvedValue([{ id: 'claude-code', name: 'Claude Code', type: 'cli' }]);
 });
 
 describe('GET /api/quota-burn', () => {
@@ -60,11 +63,12 @@ describe('GET /api/quota-burn', () => {
 });
 
 describe('GET /api/quota-burn/catalog', () => {
-  it('projects apps and universes down to id + name', async () => {
+  it('projects apps, universes, and providers', async () => {
     const res = await request(buildApp()).get('/api/quota-burn/catalog');
     expect(res.status).toBe(200);
     expect(res.body.apps).toEqual([{ id: 'a1', name: 'App One' }]);
     expect(res.body.universes).toEqual([{ id: 'u1', name: 'Example Universe' }]);
+    expect(res.body.providers).toEqual([{ id: 'claude-code', name: 'Claude Code', type: 'cli' }]);
     expect(res.body.jobTypes.map((type) => type.id)).toContain('universe-bible-images');
   });
 

--- a/server/services/pipeline/refineHelpers.js
+++ b/server/services/pipeline/refineHelpers.js
@@ -16,6 +16,7 @@ export async function runPromptRefineRaw({
   const result = await runStagedLLM(templateName, variables, {
     providerOverride: options.providerId,
     modelOverride: options.model,
+    effortOverride: options.effort,
     returnsJson: true,
     source,
   });

--- a/server/services/quotaBurnJobs/agentPrompt.js
+++ b/server/services/quotaBurnJobs/agentPrompt.js
@@ -90,6 +90,7 @@ export async function run({ params, job, family, candidate, context } = {}) {
     context: renderBurnPrompt({ family, candidate, prompt }),
     provider: provider.id,
     model: job?.model || undefined,
+    effort: job?.effort || undefined,
     useWorktree: params?.useWorktree !== false,
     // A job that lands no code can never produce a PR. Leaving `openPR: true`
     // on it (the param's default, one checkbox away) makes the spawner expect a
@@ -136,6 +137,6 @@ export async function run({ params, job, family, candidate, context } = {}) {
   return {
     dispatched: true,
     summary: `Queued "${label}" in ${app.name} via ${provider.id}`,
-    detail: { taskId: task.id, appId: app.id, providerId: provider.id, model: job?.model || null },
+    detail: { taskId: task.id, appId: app.id, providerId: provider.id, model: job?.model || null, effort: job?.effort || null },
   };
 }

--- a/server/services/quotaBurnJobs/agentPrompt.test.js
+++ b/server/services/quotaBurnJobs/agentPrompt.test.js
@@ -39,12 +39,13 @@ describe('countPending', () => {
 });
 
 describe('run', () => {
-  it('queues an internal task pinned to the family provider', async () => {
-    const result = await run({ params: { appId: 'app-1', prompt: 'Do the thing' }, job: { id: 'j1', label: 'Nightly', model: 'grok-4' }, family, candidate });
+  it('queues an internal task pinned to the family provider, model, and effort', async () => {
+    const result = await run({ params: { appId: 'app-1', prompt: 'Do the thing' }, job: { id: 'j1', label: 'Nightly', model: 'grok-4', effort: 'high' }, family, candidate });
     expect(result.dispatched).toBe(true);
+    expect(result.detail.effort).toBe('high');
     expect(state.added[0].type).toBe('internal');
     expect(state.added[0].task).toMatchObject({
-      app: 'app-1', provider: 'grok-cli', model: 'grok-4', useWorktree: true, openPR: true, simplify: true, reviewLoop: false,
+      app: 'app-1', provider: 'grok-cli', model: 'grok-4', effort: 'high', useWorktree: true, openPR: true, simplify: true, reviewLoop: false,
     });
     expect(state.added[0].task.context).toContain('Do the thing');
   });

--- a/server/services/quotaBurnJobs/universeBibleDescribe.js
+++ b/server/services/quotaBurnJobs/universeBibleDescribe.js
@@ -165,7 +165,7 @@ export async function run({ params, job, family, context, force = false } = {}) 
   const { picked, total, max, depth } = collected;
   if (!picked) return { dispatched: false, reason: 'every bible entry is already described' };
 
-  const options = { providerId: provider.id, model: job?.model || undefined };
+  const options = { providerId: provider.id, model: job?.model || undefined, effort: job?.effort || undefined };
   const outcome = { described: 0, fields: 0, skipped: 0, failed: 0 };
   const failures = [];
   for (const row of picked.rows) {
@@ -207,6 +207,7 @@ export async function run({ params, job, family, context, force = false } = {}) 
       universeId: picked.universeId,
       providerId: provider.id,
       model: job?.model || null,
+      effort: job?.effort || null,
       depth,
       ...outcome,
       failures,

--- a/server/services/universeCanonExpandRunner.js
+++ b/server/services/universeCanonExpandRunner.js
@@ -64,7 +64,7 @@ export async function runCanonEntryExpand({
   const { content, rationale, runId, providerId, model } = await runPromptRefineRaw({
     templateName,
     variables: buildVariables({ universe, target, peers: list.filter((_, i) => i !== idx) }),
-    options: { providerId: options.providerId, model: options.model },
+    options: { providerId: options.providerId, model: options.model, effort: options.effort },
     source: templateName,
     logTag: null,
     emptyError,


### PR DESCRIPTION
## Summary
- **New Quota Burn Audit Presets**: Added four new high-signal, single-focus audit presets to `server/lib/quotaBurnPresets.js` (`api-contract-audit`, `react-lifecycle-audit`, `observability-audit`, `copy-audit`) that file structured, decision-complete GitHub issues and change no code.
- **Standard Model & Effort Selection**: Replaced the freeform `Model (optional)` text input with standard Model dropdowns (`<select>`) and the `EffortSelect` thinking-effort picker for effort-capable providers (Claude, Codex, Antigravity).
- **Backend Schema & Runner Support**: Added `effort` normalization, validation, and execution pass-through to `normalizeQuotaBurnJob`, `quotaBurnJobSchema`, `agentPrompt.js`, `universeBibleDescribe.js`, and `universeCanonExpandRunner.js`. Included providers in `/api/quota-burn/catalog`.
- **Tests**: Added comprehensive unit tests in server and client suites verifying preset integrity, effort validation, model/effort dropdown rendering, and auto-save behavior.