### PR TITLE
refactor(dashboard): remove unneeded export from placeNewWidget (#5200)

### DIFF
--- a/client/src/components/dashboard/DashboardGrid.jsx
+++ b/client/src/components/dashboard/DashboardGrid.jsx
@@ -296,7 +296,7 @@ function DragHandle({ kind, item, onPointerDown, onClick, handleProps }) {
 // Auto-place a new widget at the end of the reading sequence, left-aligned.
 // Used when LayoutEditor adds a widget to a layout without specifying a
 // position. The pack decides where "the end" actually renders.
-export function placeNewWidget(items, widgetId) {
+function placeNewWidget(items, widgetId) {
   const meta = WIDGETS_BY_ID[widgetId];
   const w = WIDTH_TO_COLS[meta?.width] ?? 4;
   const h = meta?.defaultH ?? GRID_DEFAULT_H;


### PR DESCRIPTION
## Summary
Removes the unused `export` keyword from internal helper `placeNewWidget` in `client/src/components/dashboard/DashboardGrid.jsx`.

`placeNewWidget` is only used internally by `reconcileGrid` within `DashboardGrid.jsx` and is not imported by any external consumer or test.

## Test Plan
- Ran `npx vitest run src/components/dashboard/` (all 7 test files, 88 tests pass).
- Passed local reviewer pass (`codex`, `claude`).

Closes #5200