### PR TITLE
refactor(dashboard): remove unreferenced WIDTH_CLASS export (#5199)

### DIFF
--- a/client/src/components/dashboard/widgetRegistry.jsx
+++ b/client/src/components/dashboard/widgetRegistry.jsx
@@ -89,13 +89,6 @@ export const FALLBACK_LAYOUT = Object.freeze({
   widgets: ['apps', 'cos', 'upcoming-tasks', 'system-health'],
 });
 
-export const WIDTH_CLASS = {
-  full:    'col-span-12',
-  half:    'col-span-12 md:col-span-6',
-  third:   'col-span-12 md:col-span-6 lg:col-span-4',
-  quarter: 'col-span-12 sm:col-span-6 lg:col-span-3',
-};
-
 // Width keyword → 12-column grid units. Used when synthesizing a default
 // grid for a layout that hasn't been positionally edited yet.
 export const WIDTH_TO_COLS = {

--- a/client/src/components/dashboard/widgetRegistry.test.jsx
+++ b/client/src/components/dashboard/widgetRegistry.test.jsx
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import * as widgetRegistry from './widgetRegistry.jsx';
+
+describe('widgetRegistry', () => {
+  it('exports WIDGETS and WIDGETS_BY_ID', () => {
+    expect(Array.isArray(widgetRegistry.WIDGETS)).toBe(true);
+    expect(widgetRegistry.WIDGETS.length).toBeGreaterThan(0);
+    expect(widgetRegistry.WIDGETS_BY_ID).toBeDefined();
+
+    for (const widget of widgetRegistry.WIDGETS) {
+      expect(widget.id).toBeDefined();
+      expect(widget.label).toBeDefined();
+      expect(widget.Component).toBeDefined();
+      expect(widget.width).toBeDefined();
+      expect(widgetRegistry.WIDGETS_BY_ID[widget.id]).toBe(widget);
+    }
+  });
+
+  it('exports FALLBACK_LAYOUT with expected shape', () => {
+    expect(widgetRegistry.FALLBACK_LAYOUT).toEqual({
+      id: '_fallback',
+      name: 'Default (offline)',
+      builtIn: true,
+      widgets: ['apps', 'cos', 'upcoming-tasks', 'system-health'],
+    });
+  });
+
+  it('exports grid conversion constants', () => {
+    expect(widgetRegistry.WIDTH_TO_COLS).toEqual({
+      full: 12,
+      half: 6,
+      third: 4,
+      quarter: 3,
+    });
+    expect(widgetRegistry.GRID_COLS).toBe(12);
+    expect(widgetRegistry.GRID_DEFAULT_H).toBe(4);
+  });
+
+  it('does not export deprecated WIDTH_CLASS', () => {
+    expect(widgetRegistry.WIDTH_CLASS).toBeUndefined();
+  });
+});

--- a/client/src/components/dashboard/widgetRegistry.test.jsx
+++ b/client/src/components/dashboard/widgetRegistry.test.jsx
@@ -11,18 +11,21 @@ describe('widgetRegistry', () => {
       expect(widget.id).toBeDefined();
       expect(widget.label).toBeDefined();
       expect(widget.Component).toBeDefined();
-      expect(widget.width).toBeDefined();
+      expect(Object.keys(widgetRegistry.WIDTH_TO_COLS)).toContain(widget.width);
       expect(widgetRegistry.WIDGETS_BY_ID[widget.id]).toBe(widget);
     }
   });
 
-  it('exports FALLBACK_LAYOUT with expected shape', () => {
+  it('exports FALLBACK_LAYOUT with expected shape and registered widgets', () => {
     expect(widgetRegistry.FALLBACK_LAYOUT).toEqual({
       id: '_fallback',
       name: 'Default (offline)',
       builtIn: true,
       widgets: ['apps', 'cos', 'upcoming-tasks', 'system-health'],
     });
+    for (const id of widgetRegistry.FALLBACK_LAYOUT.widgets) {
+      expect(widgetRegistry.WIDGETS_BY_ID[id]).toBeDefined();
+    }
   });
 
   it('exports grid conversion constants', () => {


### PR DESCRIPTION
### Summary
Removes the deprecated and unreferenced `WIDTH_CLASS` map export from `client/src/components/dashboard/widgetRegistry.jsx` and adds unit tests covering `widgetRegistry.jsx` invariants.

### Changes
- `client/src/components/dashboard/widgetRegistry.jsx`: Removed `WIDTH_CLASS` export.
- `client/src/components/dashboard/widgetRegistry.test.jsx`: Added unit tests verifying registered widgets, lookup map, fallback layout integrity, and grid conversion constants.

### Test Plan
- Run client test suite (`cd client && npm test`) - 795 test files passed (10067 tests).
- Run client linter (`cd client && npm run lint`) - Biome checked 2321 files with 0 errors/warnings.

Closes #5199