### PR TITLE
fix: show keyboard focus on BrainGraph type filters (#5221)

### DIFF
--- a/client/src/components/brain/tabs/BrainGraph.jsx
+++ b/client/src/components/brain/tabs/BrainGraph.jsx
@@ -566,10 +566,10 @@ export default function BrainGraph() {
                   type="checkbox"
                   checked={typeFilters[type]}
                   onChange={() => toggleType(type)}
-                  className="sr-only"
+                  className="peer sr-only"
                 />
                 <span
-                  className={`inline-block w-3 h-3 rounded-sm border-2 transition-colors ${
+                  className={`inline-block w-3 h-3 rounded-sm border-2 transition-colors peer-focus-visible:ring-2 peer-focus-visible:ring-port-accent peer-focus-visible:ring-offset-1 peer-focus-visible:ring-offset-port-bg ${
                     typeFilters[type] ? 'border-transparent' : 'border-gray-600 bg-transparent'
                   }`}
                   style={typeFilters[type] ? { backgroundColor: BRAIN_TYPE_HEX[type] } : undefined}

--- a/client/src/components/brain/tabs/BrainGraph.test.jsx
+++ b/client/src/components/brain/tabs/BrainGraph.test.jsx
@@ -123,6 +123,29 @@ describe('legend disclosure', () => {
   });
 });
 
+describe('type filters', () => {
+  it('shows a keyboard focus ring and toggles with Space', async () => {
+    const user = userEvent.setup();
+    await renderGraph();
+
+    const checkbox = screen.getByRole('checkbox', { name: 'Ideas' });
+    const swatch = checkbox.nextElementSibling;
+
+    expect(checkbox).toHaveClass('peer', 'sr-only');
+    expect(swatch).toHaveClass(
+      'peer-focus-visible:ring-2',
+      'peer-focus-visible:ring-port-accent',
+      'peer-focus-visible:ring-offset-1',
+      'peer-focus-visible:ring-offset-port-bg',
+    );
+
+    expect(checkbox).toBeChecked();
+    checkbox.focus();
+    await user.keyboard(' ');
+    expect(checkbox).not.toBeChecked();
+  });
+});
+
 describe('detail panel', () => {
   // Tapping a node needs a WebGL raycast, so reach the panel the way a user on
   // a phone can: search → focus a node → tap one of its connections. That also

--- a/client/src/components/brain/tabs/BrainGraph.test.jsx
+++ b/client/src/components/brain/tabs/BrainGraph.test.jsx
@@ -138,6 +138,7 @@ describe('type filters', () => {
       'peer-focus-visible:ring-offset-1',
       'peer-focus-visible:ring-offset-port-bg',
     );
+    expect(swatch.className).not.toMatch(/(^|\s)ring-/);
 
     expect(checkbox).toBeChecked();
     checkbox.focus();


### PR DESCRIPTION
## Summary
- Add a keyboard-only focus ring to BrainGraph type filter checkboxes.
- Preserve the existing checkbox and Space-key filtering behavior.
- Add regression coverage for the focus utility contract and keyboard toggling.

## Test plan
- `npm test -- BrainGraph.test.jsx`
- `npm run lint`
- `npm run build`

Closes #5221