### PR TITLE
fix: serialize journal settings updates (#5196)

### DIFF
--- a/server/services/brainJournal.js
+++ b/server/services/brainJournal.js
@@ -25,6 +25,7 @@
 import { join } from 'path';
 import { atomicWrite, ensureDir, readJSONFile, PATHS } from '../lib/fileUtils.js';
 import { createMutex } from '../lib/asyncMutex.js';
+import { createFileWriteQueue } from '../lib/fileWriteQueue.js';
 import { ServerError } from '../lib/errorHandler.js';
 import { replaceMarkedSection } from '../lib/markedSection.js';
 import * as brainStorage from './brainStorage.js';
@@ -51,6 +52,8 @@ const DEFAULT_SETTINGS = {
   autoSync: true,
 };
 
+const queueSettingsWrite = createFileWriteQueue();
+
 // ─── Settings ──────────────────────────────────────────────────────────────
 
 export async function getSettings() {
@@ -60,10 +63,12 @@ export async function getSettings() {
 }
 
 export async function updateSettings(partial) {
-  const current = await getSettings();
-  const next = { ...current, ...partial };
-  await atomicWrite(SETTINGS_FILE, next);
-  return next;
+  return queueSettingsWrite(async () => {
+    const current = await getSettings();
+    const next = { ...current, ...partial };
+    await atomicWrite(SETTINGS_FILE, next);
+    return next;
+  });
 }
 
 // ─── Store ─────────────────────────────────────────────────────────────────

--- a/server/services/brainJournal.test.js
+++ b/server/services/brainJournal.test.js
@@ -112,6 +112,26 @@ describe('brainJournal', () => {
     });
   });
 
+  describe('settings', () => {
+    it('serializes concurrent patches so each update sees the latest settings', async () => {
+      const [vaultUpdate, folderUpdate] = await Promise.all([
+        journal.updateSettings({ obsidianVaultId: 'vault-1' }),
+        journal.updateSettings({ obsidianFolder: 'Journal' }),
+      ]);
+
+      expect(vaultUpdate).toMatchObject({ obsidianVaultId: 'vault-1' });
+      expect(folderUpdate).toMatchObject({
+        obsidianVaultId: 'vault-1',
+        obsidianFolder: 'Journal',
+      });
+      expect(await journal.getSettings()).toEqual({
+        obsidianVaultId: 'vault-1',
+        obsidianFolder: 'Journal',
+        autoSync: true,
+      });
+    });
+  });
+
   describe('getJournal / listJournals', () => {
     it('returns null for missing dates', async () => {
       expect(await journal.getJournal('2026-01-01')).toBeNull();


### PR DESCRIPTION
## Summary

- serialize Daily Log settings read-modify-write cycles through the shared file-write queue
- preserve disjoint fields when settings patches arrive concurrently
- cover concurrent settings updates with a focused regression test

## Test plan

- `nvm exec 24.14.1 npm test -- brainJournal.test.js` (server; 29 passed)
- `npm test -- --run lib/fileWriteQueue.test.js` (server; 8 passed, reviewer verification)
- mandatory Codex review: CLEAN

Closes #5196
