### PR TITLE
fix: enlarge quota burn step touch targets (#5190)

### DIFF
--- a/client/src/components/quotaBurn/JobRow.jsx
+++ b/client/src/components/quotaBurn/JobRow.jsx
@@ -153,6 +153,7 @@ export default function JobRow({
                 cancelText="Cancel"
                 tone="warning"
                 ariaLabel={`Confirm running step ${index + 1} now`}
+                largeTouchTargets
                 onConfirm={() => { setRunArmed(false); onRun(job); }}
                 onCancel={() => setRunArmed(false)}
               />
@@ -168,6 +169,7 @@ export default function JobRow({
                 confirmIcon={Trash2}
                 cancelText="Cancel"
                 ariaLabel={`Confirm removing step ${index + 1}`}
+                largeTouchTargets
                 onConfirm={() => onRemove(index)}
                 onCancel={() => setArmed(false)}
               />

--- a/client/src/components/quotaBurn/JobRow.jsx
+++ b/client/src/components/quotaBurn/JobRow.jsx
@@ -51,6 +51,7 @@ export default function JobRow({
   const spec = catalog.jobTypes.find((type) => type.id === job.jobType);
   const idPrefix = `burn-job-${job.id}`;
   const spent = quotaBurnJobIsSpent(job, ranAt);
+  const actionButtonClass = 'inline-flex min-h-[44px] min-w-[44px] items-center justify-center';
   const setParam = (key, value) => onChange({ ...job, params: { ...job.params, [key]: value } });
   const promptText = String(job.params?.prompt || '').trim();
   const hasPromptText = Boolean(promptText);
@@ -138,38 +139,42 @@ export default function JobRow({
             {job.runOnce ? ' · run once' : ''}
           </span>
         )}
-        <div className="flex items-center gap-1">
-          <button type="button" className="p-1 text-gray-400 hover:text-white disabled:opacity-30" disabled={index === 0} onClick={() => onMove(index, -1)} aria-label={`Move step ${index + 1} earlier`}><ArrowUp size={14} /></button>
-          <button type="button" className="p-1 text-gray-400 hover:text-white disabled:opacity-30" disabled={index === total - 1} onClick={() => onMove(index, 1)} aria-label={`Move step ${index + 1} later`}><ArrowDown size={14} /></button>
-          {runArmed ? (
-            // `warning`, not `error`: forcing a run is expensive-but-safe, and
-            // it must not look identical to the delete confirm beside it.
-            <ConfirmButtonPair
-              prompt="Spend now?"
-              confirmText="Run"
-              confirmIcon={Play}
-              cancelText="Cancel"
-              tone="warning"
-              ariaLabel={`Confirm running step ${index + 1} now`}
-              onConfirm={() => { setRunArmed(false); onRun(job); }}
-              onCancel={() => setRunArmed(false)}
-            />
-          ) : (
-            <button type="button" className="p-1 text-port-accent hover:text-white disabled:opacity-30" disabled={actionsBusy} onClick={() => { setArmed(false); setRunArmed(true); }} aria-label={`Run step ${index + 1} now`} title="Run this job now, ignoring the reset window (asks to confirm)"><Play size={14} /></button>
-          )}
-          {armed ? (
-            <ConfirmButtonPair
-              prompt="Discards its prompt."
-              confirmText="Delete"
-              confirmIcon={Trash2}
-              cancelText="Cancel"
-              ariaLabel={`Confirm removing step ${index + 1}`}
-              onConfirm={() => onRemove(index)}
-              onCancel={() => setArmed(false)}
-            />
-          ) : (
-            <button type="button" className="p-1 text-red-400 hover:text-red-300 disabled:opacity-30" onClick={() => { setRunArmed(false); setArmed(true); }} aria-label={`Remove step ${index + 1}`}><Trash2 size={14} /></button>
-          )}
+        <div className="flex items-center">
+          <div className="flex items-center gap-1">
+            <button type="button" className={`${actionButtonClass} text-gray-400 hover:text-white disabled:opacity-30`} disabled={index === 0} onClick={() => onMove(index, -1)} aria-label={`Move step ${index + 1} earlier`}><ArrowUp size={14} /></button>
+            <button type="button" className={`${actionButtonClass} text-gray-400 hover:text-white disabled:opacity-30`} disabled={index === total - 1} onClick={() => onMove(index, 1)} aria-label={`Move step ${index + 1} later`}><ArrowDown size={14} /></button>
+            {runArmed ? (
+              // `warning`, not `error`: forcing a run is expensive-but-safe, and
+              // it must not look identical to the delete confirm beside it.
+              <ConfirmButtonPair
+                prompt="Spend now?"
+                confirmText="Run"
+                confirmIcon={Play}
+                cancelText="Cancel"
+                tone="warning"
+                ariaLabel={`Confirm running step ${index + 1} now`}
+                onConfirm={() => { setRunArmed(false); onRun(job); }}
+                onCancel={() => setRunArmed(false)}
+              />
+            ) : (
+              <button type="button" className={`${actionButtonClass} text-port-accent hover:text-white disabled:opacity-30`} disabled={actionsBusy} onClick={() => { setArmed(false); setRunArmed(true); }} aria-label={`Run step ${index + 1} now`} title="Run this job now, ignoring the reset window (asks to confirm)"><Play size={14} /></button>
+            )}
+          </div>
+          <div className="ml-2 border-l border-port-border/50 pl-2">
+            {armed ? (
+              <ConfirmButtonPair
+                prompt="Discards its prompt."
+                confirmText="Delete"
+                confirmIcon={Trash2}
+                cancelText="Cancel"
+                ariaLabel={`Confirm removing step ${index + 1}`}
+                onConfirm={() => onRemove(index)}
+                onCancel={() => setArmed(false)}
+              />
+            ) : (
+              <button type="button" className={`${actionButtonClass} text-red-400 hover:text-red-300 disabled:opacity-30`} onClick={() => { setRunArmed(false); setArmed(true); }} aria-label={`Remove step ${index + 1}`}><Trash2 size={14} /></button>
+            )}
+          </div>
         </div>
       </div>
 
@@ -314,4 +319,3 @@ export default function JobRow({
     </div>
   );
 }
-

--- a/client/src/components/ui/ConfirmButtonPair.jsx
+++ b/client/src/components/ui/ConfirmButtonPair.jsx
@@ -31,8 +31,12 @@ export default function ConfirmButtonPair({
   tone = 'error',
   ariaLabel,
   className = '',
+  largeTouchTargets = false,
 }) {
   const confirmTone = TONES[tone] || TONES.error;
+  const buttonSizeClass = largeTouchTargets
+    ? 'min-h-[44px] min-w-[44px] justify-center'
+    : 'min-h-[36px]';
   // While in-flight, the confirm icon becomes a spinner and both buttons
   // disable; the label additionally swaps to the in-flight word ("Deleting")
   // when a busyText is supplied, otherwise it stays put.
@@ -49,7 +53,7 @@ export default function ConfirmButtonPair({
         type="button"
         onClick={onConfirm}
         disabled={busy}
-        className={`inline-flex min-h-[36px] items-center gap-1 px-2 py-1 text-xs rounded transition-colors disabled:opacity-50 ${confirmTone}`}
+        className={`inline-flex ${buttonSizeClass} items-center gap-1 px-2 py-1 text-xs rounded transition-colors disabled:opacity-50 ${confirmTone}`}
       >
         {busy ? (
           <Loader2 size={12} className="animate-spin" />
@@ -62,7 +66,7 @@ export default function ConfirmButtonPair({
         type="button"
         onClick={onCancel}
         disabled={busy}
-        className="min-h-[36px] px-2 py-1 text-xs text-gray-400 hover:text-white transition-colors disabled:opacity-50"
+        className={`${buttonSizeClass} px-2 py-1 text-xs text-gray-400 hover:text-white transition-colors disabled:opacity-50`}
       >
         {cancelText}
       </button>

--- a/client/src/pages/QuotaBurn.test.jsx
+++ b/client/src/pages/QuotaBurn.test.jsx
@@ -214,6 +214,7 @@ describe('QuotaBurn page', () => {
   });
 
   it('keeps step actions touch-sized and separates delete from run', async () => {
+    const user = userEvent.setup();
     renderPage('/devtools/quota-burn/grok');
 
     const actions = await Promise.all([
@@ -229,6 +230,19 @@ describe('QuotaBurn page', () => {
     expect(screen.getByLabelText('Remove step 1').parentElement).toHaveClass(
       'ml-2', 'border-l', 'border-port-border/50', 'pl-2',
     );
+
+    await user.click(screen.getByLabelText('Run step 1 now'));
+    const runConfirm = screen.getByRole('group', { name: 'Confirm running step 1 now' });
+    Array.from(runConfirm.querySelectorAll('button')).forEach((action) => {
+      expect(action).toHaveClass('min-h-[44px]', 'min-w-[44px]');
+    });
+
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+    await user.click(screen.getByLabelText('Remove step 1'));
+    const removeConfirm = screen.getByRole('group', { name: 'Confirm removing step 1' });
+    Array.from(removeConfirm.querySelectorAll('button')).forEach((action) => {
+      expect(action).toHaveClass('min-h-[44px]', 'min-w-[44px]');
+    });
   });
 
   it('force-runs a single job from its row only after the arm click is confirmed', async () => {
@@ -1031,4 +1045,3 @@ describe('QuotaBurn preset addition filtering', () => {
     expect(await screen.findByText(/Agent prompt · claude-sonnet-4 · high/)).toBeInTheDocument();
   });
 });
-

--- a/client/src/pages/QuotaBurn.test.jsx
+++ b/client/src/pages/QuotaBurn.test.jsx
@@ -213,6 +213,24 @@ describe('QuotaBurn page', () => {
     expect(screen.getByText(/Ready — 4 bible entries have no image/)).toBeInTheDocument();
   });
 
+  it('keeps step actions touch-sized and separates delete from run', async () => {
+    renderPage('/devtools/quota-burn/grok');
+
+    const actions = await Promise.all([
+      screen.findByLabelText('Move step 1 earlier'),
+      screen.findByLabelText('Move step 1 later'),
+      screen.findByLabelText('Run step 1 now'),
+      screen.findByLabelText('Remove step 1'),
+    ]);
+    actions.forEach((action) => {
+      expect(action).toHaveClass('min-h-[44px]', 'min-w-[44px]');
+    });
+
+    expect(screen.getByLabelText('Remove step 1').parentElement).toHaveClass(
+      'ml-2', 'border-l', 'border-port-border/50', 'pl-2',
+    );
+  });
+
   it('force-runs a single job from its row only after the arm click is confirmed', async () => {
     const user = userEvent.setup();
     renderPage('/devtools/quota-burn/grok');
@@ -1013,5 +1031,4 @@ describe('QuotaBurn preset addition filtering', () => {
     expect(await screen.findByText(/Agent prompt · claude-sonnet-4 · high/)).toBeInTheDocument();
   });
 });
-
 


### PR DESCRIPTION
## Summary

- enlarge the quota-burn step move, run, and remove controls to 44px minimum touch targets
- visually separate the destructive remove action from the operational controls
- keep the armed run/remove confirmation controls touch-sized without changing other compact confirmation pairs

## Test plan

- `cd client && npm test -- src/pages/QuotaBurn.test.jsx`
- `cd client && npm test -- src/components/ui/ConfirmButtonPair.test.jsx`
- `cd client && npx biome lint --error-on-warnings src/components/ui/ConfirmButtonPair.jsx src/components/quotaBurn/JobRow.jsx src/pages/QuotaBurn.test.jsx`
- `cd client && npm run build`

Closes #5190
