### PR TITLE
fix: confirm catalog relation removal (#5206)

### DIFF
--- a/client/src/pages/CatalogIngredient.jsx
+++ b/client/src/pages/CatalogIngredient.jsx
@@ -11,6 +11,7 @@ import { Sparkles, Save, Trash2, ArrowLeft, Loader2, ExternalLink, Plus, X, Hist
 import toast from '../components/ui/Toast';
 import FilePickerButton from '../components/ui/FilePickerButton';
 import Modal from '../components/ui/Modal.jsx';
+import ConfirmButtonPair from '../components/ui/ConfirmButtonPair.jsx';
 import {
   getCatalogIngredientDetails,
   updateCatalogIngredient,
@@ -818,6 +819,8 @@ function ReferenceSheetPanel({ payload, universeRef }) {
 function RelationsPanel({ record, relations, onAdd, onRemove }) {
   const [pickerOpen, setPickerOpen] = useState(false);
   const [kind, setKind] = useState(RELATION_KINDS[0].id);
+  const [armedRelation, setArmedRelation] = useState(null);
+  const [removingRelation, setRemovingRelation] = useState(null);
   const outbound = Array.isArray(relations.outbound) ? relations.outbound : [];
   const inbound = Array.isArray(relations.inbound) ? relations.inbound : [];
 
@@ -861,17 +864,38 @@ function RelationsPanel({ record, relations, onAdd, onRemove }) {
             <div>
               <div className="text-[10px] uppercase tracking-wider text-gray-500 mb-1.5">Outbound</div>
               <ul className="space-y-1.5">
-                {outbound.map((r) => (
-                  <li key={`${r.toId}-${r.kind}`} className="flex items-center gap-2 flex-wrap">
-                    <span className="text-xs text-gray-400">{getRelationKind(r.kind)?.label || r.kind}</span>
-                    {chip(r.other)}
-                    <button type="button" onClick={() => onRemove(r.toId, r.kind)}
-                      aria-label={`Remove relation to ${r.other?.name || r.toId}`}
-                      className="text-gray-500 hover:text-port-error">
-                      <X size={12} aria-hidden="true" />
-                    </button>
-                  </li>
-                ))}
+                {outbound.map((r) => {
+                  const relationKey = `${r.toId}-${r.kind}`;
+                  const relationName = r.other?.name || r.toId;
+                  return (
+                    <li key={relationKey} className="flex items-center gap-2 flex-wrap">
+                      <span className="text-xs text-gray-400">{getRelationKind(r.kind)?.label || r.kind}</span>
+                      {chip(r.other)}
+                      {armedRelation === relationKey ? (
+                        <ConfirmButtonPair
+                          prompt="Remove?"
+                          confirmText="Remove"
+                          busyText="Removing"
+                          busy={removingRelation === relationKey}
+                          ariaLabel={`Confirm removal of relation to ${relationName}`}
+                          onCancel={() => setArmedRelation(null)}
+                          onConfirm={async () => {
+                            setRemovingRelation(relationKey);
+                            await onRemove(r.toId, r.kind);
+                            setRemovingRelation(null);
+                            setArmedRelation(null);
+                          }}
+                        />
+                      ) : (
+                        <button type="button" onClick={() => setArmedRelation(relationKey)}
+                          aria-label={`Remove relation to ${relationName}`}
+                          className="text-gray-500 hover:text-port-error">
+                          <X size={12} aria-hidden="true" />
+                        </button>
+                      )}
+                    </li>
+                  );
+                })}
               </ul>
             </div>
           )}

--- a/client/src/pages/CatalogIngredient.test.jsx
+++ b/client/src/pages/CatalogIngredient.test.jsx
@@ -100,7 +100,7 @@ vi.mock('../components/TagPicker', () => ({ default: () => <div data-testid="tag
 vi.mock('../components/ui/Toast', () => ({ default: { success: vi.fn(), error: vi.fn(), info: vi.fn() } }));
 
 import CatalogIngredient, { buildGenerationPromptSeed } from './CatalogIngredient';
-import { getCatalogIngredientDetails } from '../services/apiCatalog';
+import { getCatalogIngredientDetails, unlinkCatalogIngredientRelation } from '../services/apiCatalog';
 
 const renderPage = () => render(<MemoryRouter><CatalogIngredient /></MemoryRouter>);
 
@@ -109,6 +109,41 @@ beforeEach(() => {
 });
 
 describe('CatalogIngredient — character sheet', () => {
+  it('requires confirmation before removing an outbound relation', async () => {
+    unlinkCatalogIngredientRelation.mockResolvedValue({});
+    getCatalogIngredientDetails.mockImplementation(async () => ({
+      ...detailsOf(CHAR_FIXTURE),
+      relations: {
+        outbound: [{
+          fromId: CHAR_FIXTURE.id,
+          toId: 'cat-place-1',
+          kind: 'lives-at',
+          other: { id: 'cat-place-1', name: 'Example Place', type: 'place' },
+        }],
+        inbound: [],
+      },
+    }));
+    renderPage();
+
+    const removeButton = await screen.findByRole('button', { name: 'Remove relation to Example Place' });
+    fireEvent.click(removeButton);
+    expect(unlinkCatalogIngredientRelation).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(unlinkCatalogIngredientRelation).not.toHaveBeenCalled();
+    expect(screen.getByRole('button', { name: 'Remove relation to Example Place' })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove relation to Example Place' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Remove' }));
+
+    await waitFor(() => expect(unlinkCatalogIngredientRelation).toHaveBeenCalledWith(
+      CHAR_FIXTURE.id,
+      { toId: 'cat-place-1', kind: 'lives-at' },
+      { silent: true },
+    ));
+    await waitFor(() => expect(screen.queryByText('Example Place')).toBeNull());
+  });
+
   it('renders grouped sheet sections with the enriched canon scalar fields', async () => {
     renderPage();
     await waitFor(() => expect(screen.getByDisplayValue('Sharp eyes, ink-stained cuffs.')).toBeTruthy());


### PR DESCRIPTION
## Summary

- require an explicit inline confirmation before unlinking an outbound catalog relation
- keep cancel non-destructive and disable both confirmation controls while removal is in flight
- cover arm, cancel, confirm, API payload, and reactive row removal behavior

## Test plan

- `cd client && npm test -- --run src/pages/CatalogIngredient.test.jsx`
- `cd client && npx biome lint --error-on-warnings src/pages/CatalogIngredient.jsx src/pages/CatalogIngredient.test.jsx`
- `cd client && npm run build`

Closes #5206
