### PR TITLE
docs: correct browser dependency architecture note (#5216)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -88,7 +88,7 @@ PortOS/
 │
 ├── browser/                   # portos-browser service
 │   ├── server.js              # Launches Chromium with CDP, runs health server
-│   └── package.json           # Playwright dependency
+│   └── package.json           # Zero third-party dependencies; Chrome launched via native child_process.spawn
 │
 ├── autofixer/                 # portos-autofixer service
 │   ├── server.js              # Crash detection daemon (polls PM2 every 15min)


### PR DESCRIPTION
## Summary

- correct the browser package entry in the architecture tree
- document that the browser workspace has no third-party dependencies
- identify native `child_process.spawn` as the Chrome launch mechanism

## Test plan

- `git diff --check`
- parse `browser/package.json` and assert its dependency map is empty
- verify `browser/server.js` imports native `child_process.spawn`
- verify `docs/ARCHITECTURE.md` carries the matching description

Closes #5216
