### PR TITLE
refactor: reuse streak glyph helper (#5198)

### DIFF
--- a/client/src/components/dashboard/builtins/ActivityStreakWidget.jsx
+++ b/client/src/components/dashboard/builtins/ActivityStreakWidget.jsx
@@ -1,3 +1,5 @@
+import { streakGlyph } from '../../../lib/streakGlyph.js';
+
 export default function ActivityStreakWidget({ dashboardState }) {
   const { usage } = dashboardState;
   if (!usage) return null;
@@ -5,7 +7,7 @@ export default function ActivityStreakWidget({ dashboardState }) {
     <div className="bg-port-card border border-port-border rounded-xl p-4">
       <div className="flex items-center gap-3 mb-3">
         <div className="text-2xl" aria-hidden="true">
-          {usage.currentStreak >= 7 ? '🔥' : usage.currentStreak >= 3 ? '⚡' : '✨'}
+          {streakGlyph(usage.currentStreak)}
         </div>
         <div>
           <div className="text-xl font-bold text-white">


### PR DESCRIPTION
## Summary

- reuse the canonical `streakGlyph` helper in the Activity Streak dashboard widget
- remove the duplicate inline threshold logic so streak glyph changes stay consistent across the app

## Test plan

- `npm run build --prefix client`
- `npm test` *(broad suite has an unrelated existing `lib/auditCatalog.test.js` failure: missing scheduled counterpart for `api-contract-audit`; 35,010 tests passed)*
- `npm test --prefix client` *(broad client suite has three unrelated existing failures in accessibility, Quota Burn, and POST drill configuration tests; 10,067 tests passed)*

Closes #5198
