### PR TITLE
fix: serialize autobiography file mutations (#5197)

### DIFF
--- a/server/services/autobiography.js
+++ b/server/services/autobiography.js
@@ -9,6 +9,7 @@
 
 import { join } from 'path';
 import { v4 as uuidv4 } from '../lib/uuid.js';
+import { createFileWriteQueue } from '../lib/fileWriteQueue.js';
 import { atomicWrite, ensureDir, PATHS, readJSONFile } from '../lib/fileUtils.js';
 import { recordTombstone } from '../lib/tombstones.js';
 import { addNotification, NOTIFICATION_TYPES, exists as notificationExists } from './notifications.js';
@@ -18,6 +19,8 @@ import { callProviderAISimple, parseLLMJSON } from './aiProvider.js';
 const DATA_DIR = join(PATHS.digitalTwin, 'autobiography');
 const STORIES_FILE = join(DATA_DIR, 'stories.json');
 const CONFIG_FILE = join(DATA_DIR, 'config.json');
+const queueStoriesWrite = createFileWriteQueue();
+const queueConfigWrite = createFileWriteQueue();
 
 // Thematic prompt bank organized by life themes
 const PROMPT_THEMES = [
@@ -212,47 +215,49 @@ export function getThemes() {
  * @param {string} [excludePromptId] - Prompt ID to exclude (used by skip to avoid returning the same prompt)
  */
 export async function getNextPrompt(excludePromptId) {
-  const data = await loadStories();
-  const usedPrompts = data.usedPrompts || [];
+  return queueStoriesWrite(async () => {
+    const data = await loadStories();
+    const usedPrompts = data.usedPrompts || [];
 
-  // Build flat list of all prompts with IDs
-  const allPrompts = PROMPT_THEMES.flatMap(theme =>
-    theme.prompts.map((text, idx) => ({
-      id: `${theme.id}-${idx}`,
-      themeId: theme.id,
-      themeLabel: theme.label,
-      text
-    }))
-  );
+    // Build flat list of all prompts with IDs
+    const allPrompts = PROMPT_THEMES.flatMap(theme =>
+      theme.prompts.map((text, idx) => ({
+        id: `${theme.id}-${idx}`,
+        themeId: theme.id,
+        themeLabel: theme.label,
+        text
+      }))
+    );
 
-  // Filter out used prompts
-  let available = allPrompts.filter(p => !usedPrompts.includes(p.id));
+    // Filter out used prompts
+    let available = allPrompts.filter(p => !usedPrompts.includes(p.id));
 
-  // If all prompts used, reset and start over
-  if (available.length === 0) {
-    data.usedPrompts = [];
-    await saveStories(data);
-    available = allPrompts;
-  }
-
-  // Exclude the currently displayed prompt so skip returns a different one
-  if (excludePromptId) {
-    const filtered = available.filter(p => p.id !== excludePromptId);
-    if (filtered.length > 0) {
-      available = filtered;
+    // If all prompts used, reset and start over
+    if (available.length === 0) {
+      data.usedPrompts = [];
+      await saveStories(data);
+      available = allPrompts;
     }
-  }
 
-  // Pick from the least-used theme to keep balance
-  const themeCounts = {};
-  for (const story of data.stories) {
-    themeCounts[story.themeId] = (themeCounts[story.themeId] || 0) + 1;
-  }
+    // Exclude the currently displayed prompt so skip returns a different one
+    if (excludePromptId) {
+      const filtered = available.filter(p => p.id !== excludePromptId);
+      if (filtered.length > 0) {
+        available = filtered;
+      }
+    }
 
-  // Sort available prompts by theme usage (least written first)
-  available.sort((a, b) => (themeCounts[a.themeId] || 0) - (themeCounts[b.themeId] || 0));
+    // Pick from the least-used theme to keep balance
+    const themeCounts = {};
+    for (const story of data.stories) {
+      themeCounts[story.themeId] = (themeCounts[story.themeId] || 0) + 1;
+    }
 
-  return available[0];
+    // Sort available prompts by theme usage (least written first)
+    available.sort((a, b) => (themeCounts[a.themeId] || 0) - (themeCounts[b.themeId] || 0));
+
+    return available[0];
+  });
 }
 
 /**
@@ -277,56 +282,60 @@ export function getPromptById(promptId) {
  * Save a story for a given prompt
  */
 export async function saveStory({ promptId, content, parentStoryId, customPromptText }) {
-  const data = await loadStories();
-  const prompt = getPromptById(promptId);
+  return queueStoriesWrite(async () => {
+    const data = await loadStories();
+    const prompt = getPromptById(promptId);
 
-  // For follow-up stories, use custom prompt text from the follow-up question
-  const isFollowUp = !!parentStoryId;
-  const parentStory = isFollowUp ? data.stories.find(s => s.id === parentStoryId) : null;
+    // For follow-up stories, use custom prompt text from the follow-up question
+    const isFollowUp = !!parentStoryId;
+    const parentStory = isFollowUp ? data.stories.find(s => s.id === parentStoryId) : null;
 
-  const story = {
-    id: uuidv4(),
-    promptId: isFollowUp ? `followup-${parentStoryId}` : promptId,
-    themeId: isFollowUp ? (parentStory?.themeId || 'unknown') : (prompt?.themeId || 'unknown'),
-    themeLabel: isFollowUp ? (parentStory?.themeLabel || 'Unknown') : (prompt?.themeLabel || 'Unknown'),
-    promptText: customPromptText || prompt?.text || '',
-    content,
-    wordCount: content.split(/\s+/).filter(Boolean).length,
-    createdAt: new Date().toISOString(),
-    ...(parentStoryId && { parentStoryId })
-  };
+    const story = {
+      id: uuidv4(),
+      promptId: isFollowUp ? `followup-${parentStoryId}` : promptId,
+      themeId: isFollowUp ? (parentStory?.themeId || 'unknown') : (prompt?.themeId || 'unknown'),
+      themeLabel: isFollowUp ? (parentStory?.themeLabel || 'Unknown') : (prompt?.themeLabel || 'Unknown'),
+      promptText: customPromptText || prompt?.text || '',
+      content,
+      wordCount: content.split(/\s+/).filter(Boolean).length,
+      createdAt: new Date().toISOString(),
+      ...(parentStoryId && { parentStoryId })
+    };
 
-  data.stories.push(story);
+    data.stories.push(story);
 
-  // Mark prompt as used
-  if (!data.usedPrompts) data.usedPrompts = [];
-  if (!data.usedPrompts.includes(promptId)) {
-    data.usedPrompts.push(promptId);
-  }
+    // Mark prompt as used
+    if (!data.usedPrompts) data.usedPrompts = [];
+    if (!data.usedPrompts.includes(promptId)) {
+      data.usedPrompts.push(promptId);
+    }
 
-  await saveStories(data);
-  console.log(`📖 Autobiography story saved: ${story.themeLabel} (${story.wordCount} words)`);
+    await saveStories(data);
+    console.log(`📖 Autobiography story saved: ${story.themeLabel} (${story.wordCount} words)`);
 
-  return story;
+    return story;
+  });
 }
 
 /**
  * Update an existing story
  */
 export async function updateStory(storyId, content) {
-  const data = await loadStories();
-  const story = data.stories.find(s => s.id === storyId);
+  return queueStoriesWrite(async () => {
+    const data = await loadStories();
+    const story = data.stories.find(s => s.id === storyId);
 
-  if (!story) return null;
+    if (!story) return null;
 
-  story.content = content;
-  story.wordCount = content.split(/\s+/).filter(Boolean).length;
-  story.updatedAt = new Date().toISOString();
+    story.content = content;
+    story.wordCount = content.split(/\s+/).filter(Boolean).length;
+    story.updatedAt = new Date().toISOString();
 
-  await saveStories(data);
-  console.log(`📖 Autobiography story updated: ${story.themeLabel} (${story.wordCount} words)`);
+    await saveStories(data);
+    console.log(`📖 Autobiography story updated: ${story.themeLabel} (${story.wordCount} words)`);
 
-  return story;
+    return story;
+  });
 }
 
 /**
@@ -341,16 +350,18 @@ export async function updateStory(storyId, content) {
  * carries the same id on every peer.
  */
 export async function deleteStory(storyId) {
-  const data = await loadStories();
-  const idx = data.stories.findIndex(s => s.id === storyId);
-  if (idx === -1) return null;
+  return queueStoriesWrite(async () => {
+    const data = await loadStories();
+    const idx = data.stories.findIndex(s => s.id === storyId);
+    if (idx === -1) return null;
 
-  const removed = data.stories.splice(idx, 1)[0];
-  data.deletedStories = recordTombstone(data.deletedStories, removed.id, { keyField: 'id' });
-  await saveStories(data);
-  console.log(`📖 Autobiography story deleted: ${removed.themeLabel}`);
+    const removed = data.stories.splice(idx, 1)[0];
+    data.deletedStories = recordTombstone(data.deletedStories, removed.id, { keyField: 'id' });
+    await saveStories(data);
+    console.log(`📖 Autobiography story deleted: ${removed.themeLabel}`);
 
-  return removed;
+    return removed;
+  });
 }
 
 /**
@@ -415,11 +426,13 @@ export async function getConfig() {
  * Update configuration
  */
 export async function updateConfig(updates) {
-  const config = await loadConfig();
-  const updated = { ...config, ...updates };
-  await saveConfig(updated);
-  console.log(`📖 Autobiography config updated: interval=${updated.intervalHours}h, enabled=${updated.enabled}`);
-  return updated;
+  return queueConfigWrite(async () => {
+    const config = await loadConfig();
+    const updated = { ...config, ...updates };
+    await saveConfig(updated);
+    console.log(`📖 Autobiography config updated: interval=${updated.intervalHours}h, enabled=${updated.enabled}`);
+    return updated;
+  });
 }
 
 /**
@@ -509,14 +522,24 @@ Return a JSON array of exactly 3 strings, nothing else. Example:
     return { error: 'Failed to parse follow-up questions from AI response' };
   }
 
-  // Store follow-ups on the story
-  story.followUpPrompts = followUps.slice(0, 3);
-  story.followUpsGeneratedAt = new Date().toISOString();
-  await saveStories(data);
+  // Re-read inside the file queue so a story mutation that completed while the
+  // provider was running is preserved in the write-back.
+  const storedFollowUps = await queueStoriesWrite(async () => {
+    const currentData = await loadStories();
+    const currentStory = currentData.stories.find(s => s.id === storyId);
+    if (!currentStory) return null;
+
+    currentStory.followUpPrompts = followUps.slice(0, 3);
+    currentStory.followUpsGeneratedAt = new Date().toISOString();
+    await saveStories(currentData);
+    return currentStory.followUpPrompts;
+  });
+
+  if (!storedFollowUps) return { error: 'Story not found' };
 
   console.log(`📖 Autobiography follow-ups generated for story ${storyId}: ${followUps.length} questions`);
 
-  return { followUps: story.followUpPrompts };
+  return { followUps: storedFollowUps };
 }
 
 /**
@@ -653,9 +676,12 @@ export async function checkAndPrompt() {
     }
   });
 
-  config.lastPromptAt = new Date().toISOString();
-  config.lastPromptId = prompt.id;
-  await saveConfig(config);
+  await queueConfigWrite(async () => {
+    const currentConfig = await loadConfig();
+    currentConfig.lastPromptAt = new Date().toISOString();
+    currentConfig.lastPromptId = prompt.id;
+    await saveConfig(currentConfig);
+  });
 
   console.log(`📖 Autobiography prompt sent: ${prompt.themeLabel} - ${prompt.text.substring(0, 50)}...`);
 

--- a/server/services/autobiography.js
+++ b/server/services/autobiography.js
@@ -9,9 +9,12 @@
 
 import { join } from 'path';
 import { v4 as uuidv4 } from '../lib/uuid.js';
-import { createFileWriteQueue } from '../lib/fileWriteQueue.js';
 import { atomicWrite, ensureDir, PATHS, readJSONFile } from '../lib/fileUtils.js';
 import { recordTombstone } from '../lib/tombstones.js';
+import {
+  queueAutobiographyConfigWrite,
+  queueAutobiographyStoriesWrite
+} from './autobiographyFileQueues.js';
 import { addNotification, NOTIFICATION_TYPES, exists as notificationExists } from './notifications.js';
 import { getActiveProvider, getProviderById } from './providers.js';
 import { callProviderAISimple, parseLLMJSON } from './aiProvider.js';
@@ -19,8 +22,6 @@ import { callProviderAISimple, parseLLMJSON } from './aiProvider.js';
 const DATA_DIR = join(PATHS.digitalTwin, 'autobiography');
 const STORIES_FILE = join(DATA_DIR, 'stories.json');
 const CONFIG_FILE = join(DATA_DIR, 'config.json');
-const queueStoriesWrite = createFileWriteQueue();
-const queueConfigWrite = createFileWriteQueue();
 
 // Thematic prompt bank organized by life themes
 const PROMPT_THEMES = [
@@ -215,7 +216,7 @@ export function getThemes() {
  * @param {string} [excludePromptId] - Prompt ID to exclude (used by skip to avoid returning the same prompt)
  */
 export async function getNextPrompt(excludePromptId) {
-  return queueStoriesWrite(async () => {
+  return queueAutobiographyStoriesWrite(async () => {
     const data = await loadStories();
     const usedPrompts = data.usedPrompts || [];
 
@@ -282,7 +283,7 @@ export function getPromptById(promptId) {
  * Save a story for a given prompt
  */
 export async function saveStory({ promptId, content, parentStoryId, customPromptText }) {
-  return queueStoriesWrite(async () => {
+  return queueAutobiographyStoriesWrite(async () => {
     const data = await loadStories();
     const prompt = getPromptById(promptId);
 
@@ -321,7 +322,7 @@ export async function saveStory({ promptId, content, parentStoryId, customPrompt
  * Update an existing story
  */
 export async function updateStory(storyId, content) {
-  return queueStoriesWrite(async () => {
+  return queueAutobiographyStoriesWrite(async () => {
     const data = await loadStories();
     const story = data.stories.find(s => s.id === storyId);
 
@@ -350,7 +351,7 @@ export async function updateStory(storyId, content) {
  * carries the same id on every peer.
  */
 export async function deleteStory(storyId) {
-  return queueStoriesWrite(async () => {
+  return queueAutobiographyStoriesWrite(async () => {
     const data = await loadStories();
     const idx = data.stories.findIndex(s => s.id === storyId);
     if (idx === -1) return null;
@@ -426,7 +427,7 @@ export async function getConfig() {
  * Update configuration
  */
 export async function updateConfig(updates) {
-  return queueConfigWrite(async () => {
+  return queueAutobiographyConfigWrite(async () => {
     const config = await loadConfig();
     const updated = { ...config, ...updates };
     await saveConfig(updated);
@@ -524,7 +525,7 @@ Return a JSON array of exactly 3 strings, nothing else. Example:
 
   // Re-read inside the file queue so a story mutation that completed while the
   // provider was running is preserved in the write-back.
-  const storedFollowUps = await queueStoriesWrite(async () => {
+  const storedFollowUps = await queueAutobiographyStoriesWrite(async () => {
     const currentData = await loadStories();
     const currentStory = currentData.stories.find(s => s.id === storyId);
     if (!currentStory) return null;
@@ -639,51 +640,50 @@ Rules:
  * Called by the autonomous job system or can be triggered manually.
  */
 export async function checkAndPrompt() {
-  const config = await loadConfig();
+  return queueAutobiographyConfigWrite(async () => {
+    const config = await loadConfig();
 
-  if (!config.enabled) {
-    return { prompted: false, reason: 'disabled' };
-  }
-
-  const now = Date.now();
-  const intervalMs = (config.intervalHours || 24) * 60 * 60 * 1000;
-  const lastPromptTime = config.lastPromptAt ? new Date(config.lastPromptAt).getTime() : 0;
-
-  if (now - lastPromptTime < intervalMs) {
-    return { prompted: false, reason: 'not_due' };
-  }
-
-  // Check if there's already an unread autobiography notification
-  const alreadyNotified = await notificationExists(
-    NOTIFICATION_TYPES.AUTOBIOGRAPHY_PROMPT
-  );
-
-  if (alreadyNotified) {
-    return { prompted: false, reason: 'pending_notification' };
-  }
-
-  const prompt = await getNextPrompt();
-
-  await addNotification({
-    type: NOTIFICATION_TYPES.AUTOBIOGRAPHY_PROMPT,
-    title: '5-Minute Story Time',
-    description: `${prompt.themeLabel}: ${prompt.text}`,
-    priority: 'low',
-    link: `/digital-twin/autobiography?prompt=${prompt.id}`,
-    metadata: {
-      promptId: prompt.id,
-      themeId: prompt.themeId
+    if (!config.enabled) {
+      return { prompted: false, reason: 'disabled' };
     }
+
+    const now = Date.now();
+    const intervalMs = (config.intervalHours || 24) * 60 * 60 * 1000;
+    const lastPromptTime = config.lastPromptAt ? new Date(config.lastPromptAt).getTime() : 0;
+
+    if (now - lastPromptTime < intervalMs) {
+      return { prompted: false, reason: 'not_due' };
+    }
+
+    // Check if there's already an unread autobiography notification
+    const alreadyNotified = await notificationExists(
+      NOTIFICATION_TYPES.AUTOBIOGRAPHY_PROMPT
+    );
+
+    if (alreadyNotified) {
+      return { prompted: false, reason: 'pending_notification' };
+    }
+
+    const prompt = await getNextPrompt();
+
+    await addNotification({
+      type: NOTIFICATION_TYPES.AUTOBIOGRAPHY_PROMPT,
+      title: '5-Minute Story Time',
+      description: `${prompt.themeLabel}: ${prompt.text}`,
+      priority: 'low',
+      link: `/digital-twin/autobiography?prompt=${prompt.id}`,
+      metadata: {
+        promptId: prompt.id,
+        themeId: prompt.themeId
+      }
+    });
+
+    config.lastPromptAt = new Date().toISOString();
+    config.lastPromptId = prompt.id;
+    await saveConfig(config);
+
+    console.log(`📖 Autobiography prompt sent: ${prompt.themeLabel} - ${prompt.text.substring(0, 50)}...`);
+
+    return { prompted: true, prompt };
   });
-
-  await queueConfigWrite(async () => {
-    const currentConfig = await loadConfig();
-    currentConfig.lastPromptAt = new Date().toISOString();
-    currentConfig.lastPromptId = prompt.id;
-    await saveConfig(currentConfig);
-  });
-
-  console.log(`📖 Autobiography prompt sent: ${prompt.themeLabel} - ${prompt.text.substring(0, 50)}...`);
-
-  return { prompted: true, prompt };
 }

--- a/server/services/autobiography.test.js
+++ b/server/services/autobiography.test.js
@@ -111,6 +111,27 @@ const setupMocks = (storiesData, configData) => {
   });
 };
 
+const setupPersistentMocks = (storiesData, configData) => {
+  let storedStories = JSON.parse(JSON.stringify(storiesData));
+  let storedConfig = JSON.parse(JSON.stringify(configData));
+
+  readFile.mockImplementation(async (filePath) => JSON.stringify(
+    filePath.includes('config.json') ? storedConfig : storedStories
+  ));
+  writeFile.mockImplementation(async (filePath, content) => {
+    if (filePath.includes('config.json')) {
+      storedConfig = JSON.parse(content);
+    } else {
+      storedStories = JSON.parse(content);
+    }
+  });
+
+  return {
+    getConfig: () => storedConfig,
+    getStories: () => storedStories
+  };
+};
+
 describe('Autobiography - getThemes', () => {
   it('should return all 12 themes with prompt counts', () => {
     const themes = getThemes();
@@ -406,6 +427,53 @@ describe('Autobiography - deleteStory', () => {
     const result = await deleteStory('nonexistent');
 
     expect(result).toBeNull();
+  });
+});
+
+describe('Autobiography - concurrent mutations', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    uuidCounter = 0;
+  });
+
+  it('preserves stories and tombstones across concurrent story operations', async () => {
+    const allPromptIds = getThemes().flatMap(theme =>
+      Array.from({ length: theme.promptCount }, (_, i) => `${theme.id}-${i}`)
+    );
+    const persisted = setupPersistentMocks(makeStoriesData({
+      stories: [
+        { id: 'delete-me', themeId: 'family', themeLabel: 'Family', content: 'Old story' }
+      ],
+      usedPrompts: allPromptIds,
+      deletedStories: [{ id: 'previous-delete', deletedAt: '2026-01-01T00:00:00.000Z' }]
+    }), makeConfigData());
+
+    await Promise.all([
+      saveStory({ promptId: 'childhood-0', content: 'A newly preserved story.' }),
+      deleteStory('delete-me'),
+      getNextPrompt()
+    ]);
+
+    const stored = persisted.getStories();
+    expect(stored.stories.map(story => story.id)).toEqual(['test-uuid-1']);
+    expect(stored.deletedStories.map(tombstone => tombstone.id)).toEqual(
+      expect.arrayContaining(['delete-me', 'previous-delete'])
+    );
+    expect(stored.usedPrompts).toEqual([]);
+  });
+
+  it('merges concurrent config updates against the latest write', async () => {
+    const persisted = setupPersistentMocks(makeStoriesData(), makeConfigData());
+
+    await Promise.all([
+      updateConfig({ intervalHours: 48 }),
+      updateConfig({ enabled: false })
+    ]);
+
+    expect(persisted.getConfig()).toMatchObject({
+      intervalHours: 48,
+      enabled: false
+    });
   });
 });
 

--- a/server/services/autobiography.test.js
+++ b/server/services/autobiography.test.js
@@ -672,6 +672,17 @@ describe('Autobiography - checkAndPrompt', () => {
     expect(notification.metadata).not.toHaveProperty('type');
   });
 
+  it('creates only one notification across concurrent due checks', async () => {
+    const oldTime = new Date(Date.now() - 48 * 60 * 60 * 1000).toISOString();
+    setupPersistentMocks(makeStoriesData(), makeConfigData({ lastPromptAt: oldTime }));
+
+    const results = await Promise.all([checkAndPrompt(), checkAndPrompt()]);
+
+    expect(results.filter(result => result.prompted)).toHaveLength(1);
+    expect(results.filter(result => result.reason === 'not_due')).toHaveLength(1);
+    expect(mockAddNotification).toHaveBeenCalledTimes(1);
+  });
+
   it('should prompt when lastPromptAt is null (first time)', async () => {
     setupMocks(makeStoriesData(), makeConfigData({ lastPromptAt: null }));
 

--- a/server/services/autobiography.tombstone.test.js
+++ b/server/services/autobiography.tombstone.test.js
@@ -118,6 +118,19 @@ describe('autobiography story tombstones (#3531)', () => {
     ]));
     expect((await getStories()).map((s) => s.id)).toEqual(['peer-story-1']);
   });
+
+  it('preserves local and peer stories when their writes start concurrently', async () => {
+    await Promise.all([
+      newStory('A local memory.'),
+      applyDigitalTwinRemote(peerSnapshotWith([
+        { id: 'peer-story-1', themeId: 'family', content: 'A peer memory.', createdAt: '2026-01-01T00:00:00.000Z' },
+      ])),
+    ]);
+
+    const stories = await getStories();
+    expect(stories).toHaveLength(2);
+    expect(stories.map((story) => story.id)).toContain('peer-story-1');
+  });
 });
 
 describe('mergeAutobiographyStories tombstones (#3531)', () => {

--- a/server/services/autobiographyFileQueues.js
+++ b/server/services/autobiographyFileQueues.js
@@ -1,0 +1,6 @@
+import { createFileWriteQueue } from '../lib/fileWriteQueue.js';
+
+// These files have writers in both autobiography.js and digital-twin-sync.js.
+// Sharing the tails keeps every read-modify-write cycle ordered across services.
+export const queueAutobiographyStoriesWrite = createFileWriteQueue();
+export const queueAutobiographyConfigWrite = createFileWriteQueue();

--- a/server/services/digital-twin-sync.js
+++ b/server/services/digital-twin-sync.js
@@ -63,6 +63,7 @@ import { atomicWrite, readJSONFile, ensureDir, PATHS } from '../lib/fileUtils.js
 import { canonicalStringify, isPlainObject } from '../lib/objects.js';
 import { normalizeTombstones, mergeTombstones, isTombstoned, pruneTombstones, tombstonesEqual } from '../lib/tombstones.js';
 import { compareNewerWins } from '../lib/lwwTimestamp.js';
+import { queueAutobiographyStoriesWrite } from './autobiographyFileQueues.js';
 
 const DIR = PATHS.digitalTwin;
 const IDENTITY_FILE = join(DIR, 'identity.json');
@@ -943,7 +944,9 @@ export async function applyDigitalTwinRemote(remoteData) {
 
   if (isPlainObject(remoteData.autobiography)) {
     // stories only — config (prompt schedule) is intentionally machine-local.
-    count += await applyMerge(AUTOBIO_STORIES_FILE, remoteData.autobiography.stories, mergeAutobiographyStories, { dir: AUTOBIO_DIR });
+    count += await queueAutobiographyStoriesWrite(() =>
+      applyMerge(AUTOBIO_STORIES_FILE, remoteData.autobiography.stories, mergeAutobiographyStories, { dir: AUTOBIO_DIR })
+    );
   }
 
   count += await applySocialAccounts(remoteData.socialAccounts);


### PR DESCRIPTION
## Summary

- serialize autobiography story and configuration read-modify-write cycles
- share the story write queue with federation merges so local and peer changes are preserved
- prevent concurrent prompt checks from creating duplicate notifications

## Test plan

- `nvm exec 24.14.1 npm test -- autobiography.test.js autobiography.tombstone.test.js digital-twin-sync.test.js fileWriteQueue.test.js` (140 passed)
- full server suite before review: 35,010 passed; one unrelated audit-catalog assertion and two unrelated TRELLIS normal-bake timeouts failed
- local Codex review with `gpt-5.6-luna` at high reasoning; both findings addressed

Closes #5197
