### PR TITLE
fix: wrap feature agent metadata on mobile (#5192)

### DIFF
--- a/client/src/components/feature-agents/FeatureAgentCard.jsx
+++ b/client/src/components/feature-agents/FeatureAgentCard.jsx
@@ -27,7 +27,7 @@ export default function FeatureAgentCard({ agent, onStart, onPause, onResume, on
         </div>
       </div>
 
-      <div className="flex items-center gap-4 text-xs text-gray-500 mb-3">
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-gray-500 mb-3">
         <span>Runs: {agent.runCount || 0}</span>
         <span>Last: {timeAgo(agent.lastRunAt)}</span>
         <span>{SCHEDULE_LABELS[agent.schedule?.mode] || 'Continuous'}</span>


### PR DESCRIPTION
## Summary
- Allow FeatureAgentCard metadata to wrap cleanly on narrow viewports.

## Test plan
- `git diff --check`
- Client Vitest/lint unavailable in fresh worktree because dependencies are not installed.

Closes #5192