### PR TITLE
fix: prevent duplicate goal edit saves

### DIFF
--- a/client/src/components/goals/GoalDetailPanel.jsx
+++ b/client/src/components/goals/GoalDetailPanel.jsx
@@ -99,6 +99,7 @@ export default function GoalDetailPanel({ goal, allGoals, onClose, onRefresh }) 
           toggleFeatureArea={s.toggleFeatureArea}
           parentOptions={parentOptions}
           saveEdit={s.saveEdit}
+          saving={s.saving}
           onCancel={() => s.setEditing(false)}
         />
       ) : (

--- a/client/src/components/goals/GoalEditForm.jsx
+++ b/client/src/components/goals/GoalEditForm.jsx
@@ -19,7 +19,7 @@ const AREA_ICONS = {
 
 export default function GoalEditForm({
   form, setForm, tagInput, setTagInput, addTag, removeTag,
-  toggleFeatureArea, parentOptions, saveEdit, onCancel
+  toggleFeatureArea, parentOptions, saveEdit, saving, onCancel
 }) {
   const selectedAreas = form.featureAreas || [];
   const { features, error } = useInstanceFeatures();
@@ -239,8 +239,8 @@ export default function GoalEditForm({
         )}
       </div>
       <div className="flex gap-2">
-        <button onClick={saveEdit} className="px-3 py-1.5 text-sm rounded bg-port-accent text-white hover:bg-port-accent/80">
-          Save
+        <button onClick={saveEdit} disabled={saving} className="px-3 py-1.5 text-sm rounded bg-port-accent text-white hover:bg-port-accent/80 disabled:opacity-50">
+          {saving ? 'Saving…' : 'Save'}
         </button>
         <button onClick={onCancel} className="px-3 py-1.5 text-sm rounded bg-port-border text-gray-300">
           Cancel

--- a/client/src/hooks/useGoalDetail.js
+++ b/client/src/hooks/useGoalDetail.js
@@ -6,6 +6,7 @@ import { MAX_TAGS, MAX_TAG_LENGTH } from '../components/goals/goalConstants';
 // thin composition shell; behavior is identical to the prior inline logic.
 export function useGoalDetail({ goal, allGoals, onClose, onRefresh }) {
   const [editing, setEditing] = useState(false);
+  const [saving, setSaving] = useState(false);
   const [form, setForm] = useState({});
   const [tagInput, setTagInput] = useState('');
   const [newMilestone, setNewMilestone] = useState({ title: '', targetDate: '' });
@@ -68,6 +69,7 @@ export function useGoalDetail({ goal, allGoals, onClose, onRefresh }) {
   };
 
   const saveEdit = async () => {
+    if (saving) return;
     // featureAreas handling (issue #2679):
     //  - When the user did NOT touch the selector, OMIT featureAreas from the
     //    PATCH. The whole editor sends a startEdit snapshot, so re-sending an
@@ -96,7 +98,14 @@ export function useGoalDetail({ goal, allGoals, onClose, onRefresh }) {
     if (featureAreasChanged) {
       payload.featureAreas = current;
     }
-    await api.updateGoal(goal.id, payload);
+    setSaving(true);
+    try {
+      await api.updateGoal(goal.id, payload);
+    } catch {
+      return;
+    } finally {
+      setSaving(false);
+    }
     setEditing(false);
     onRefresh();
   };
@@ -350,7 +359,7 @@ export function useGoalDetail({ goal, allGoals, onClose, onRefresh }) {
   };
 
   return {
-    editing, setEditing,
+    editing, setEditing, saving,
     form, setForm,
     tagInput, setTagInput,
     newMilestone, setNewMilestone,

--- a/client/src/hooks/useGoalDetail.test.jsx
+++ b/client/src/hooks/useGoalDetail.test.jsx
@@ -8,6 +8,7 @@ const removeGoalSchedule = vi.fn(() => Promise.resolve({}));
 const rescheduleGoalTimeBlocks = vi.fn(() => Promise.resolve({}));
 const checkInGoal = vi.fn(() => Promise.resolve({ id: 'check-in-1' }));
 const updateGoalProgress = vi.fn(() => Promise.resolve({}));
+const updateGoal = vi.fn(() => Promise.resolve({}));
 
 vi.mock('../services/api', () => ({
   getActivities: (...args) => getActivities(...args),
@@ -16,7 +17,8 @@ vi.mock('../services/api', () => ({
   removeGoalSchedule: (...args) => removeGoalSchedule(...args),
   rescheduleGoalTimeBlocks: (...args) => rescheduleGoalTimeBlocks(...args),
   checkInGoal: (...args) => checkInGoal(...args),
-  updateGoalProgress: (...args) => updateGoalProgress(...args)
+  updateGoalProgress: (...args) => updateGoalProgress(...args),
+  updateGoal: (...args) => updateGoal(...args)
 }));
 
 const { useGoalDetail } = await import('./useGoalDetail');
@@ -34,6 +36,39 @@ const SCHEDULING_ACTIONS = [
   ['handleRemoveSchedule', () => removeGoalSchedule],
   ['handleReschedule', () => rescheduleGoalTimeBlocks]
 ];
+
+describe('useGoalDetail saveEdit', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    updateGoal.mockResolvedValue({});
+  });
+
+  it('gates duplicate saves while the update is in flight', async () => {
+    let release;
+    updateGoal.mockReturnValue(new Promise(resolve => { release = resolve; }));
+    const { result } = renderGoalDetail();
+    act(() => { result.current.startEdit(); });
+    let first;
+    act(() => { first = result.current.saveEdit(); });
+    expect(result.current.saving).toBe(true);
+    await act(async () => { await result.current.saveEdit(); });
+    expect(updateGoal).toHaveBeenCalledTimes(1);
+    await act(async () => { release({}); await first; });
+    expect(result.current.saving).toBe(false);
+  });
+
+  it('keeps edit mode and form data when saving fails', async () => {
+    updateGoal.mockRejectedValue(new Error('server exploded'));
+    const { result, onRefresh } = renderGoalDetail();
+    act(() => { result.current.startEdit(); });
+    const originalForm = result.current.form;
+    await act(async () => { await result.current.saveEdit(); });
+    expect(result.current.saving).toBe(false);
+    expect(result.current.editing).toBe(true);
+    expect(result.current.form).toEqual(originalForm);
+    expect(onRefresh).not.toHaveBeenCalled();
+  });
+});
 
 describe('useGoalDetail scheduling actions', () => {
   beforeEach(() => {


### PR DESCRIPTION
## Summary
- gate goal edits while the update request is in flight
- preserve edit state and user input when saving fails

## Test plan
- npm test -- --run src/components/goals/GoalDetailPanel.test.jsx src/hooks/useGoalDetail.test.jsx

Closes #5203