### PR TITLE
docs: correct CoS goals file references (#5219)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -101,7 +101,8 @@ PortOS/
 │   ├── browser-config.json    # Browser CDP/health configuration
 │   ├── TASKS.md               # User task file
 │   ├── COS-TASKS.md           # System task file
-│   ├── COS-GOALS.md           # Mission and goals
+│   ├── GOALS.md               # Repository mission and goals
+│   ├── docs/GOALS_OPERATIONAL.md # Operational CoS goals
 │   ├── cos/                   # CoS state and agents
 │   │   ├── state.json         # Daemon state
 │   │   └── agents/            # Agent outputs

--- a/docs/features/identity-system.md
+++ b/docs/features/identity-system.md
@@ -15,7 +15,7 @@ Four separate workstreams converge on the same vision: a personal digital twin t
 | **Genome** | Fully implemented: 23andMe upload, 117 curated SNP markers across 32 categories, ClinVar integration, epigenetic tracking | `server/services/genome.js`, `GenomeTab.jsx`, `data/meatspace/genome.json` |
 | **Chronotype** | Implemented: `deriveChronotype()` combines the 5 sleep/circadian markers (CLOCK rs1801260, DEC2 rs57875989, PER2 rs35333999, CRY1 rs2287161, MTNR1B rs10830963) with `daily_routines` enrichment and writes `chronotype.json` | `server/services/identity/chronotype.js`, `identity.test.js`, `data/digital-twin/chronotype.json` |
 | **Aesthetic Taste** | P2 complete: Taste questionnaire with 5 sections (movies, music, visual_art, architecture, food), conversational Q&A, AI summary generation. Enrichment categories also feed taste data from book/movie/music lists | `TasteTab.jsx`, `taste-questionnaire.js`, `data/digital-twin/taste-profile.json` |
-| **Goal Tracking** | Partially exists: `COS-GOALS.md` for CoS missions, `TASKS.md` for user tasks, `EXISTENTIAL.md` soul doc | `data/COS-GOALS.md`, `data/TASKS.md`, `data/digital-twin/EXISTENTIAL.md` |
+| **Goal Tracking** | Partially exists: `GOALS.md` for repository mission and `docs/GOALS_OPERATIONAL.md` for operational CoS goals, `TASKS.md` for user tasks, `EXISTENTIAL.md` soul doc | `GOALS.md`, `docs/GOALS_OPERATIONAL.md`, `data/TASKS.md`, `data/digital-twin/EXISTENTIAL.md` |
 
 These should be unified under a single **Identity** architecture so the twin can reason across all dimensions (e.g., "your CLOCK gene says evening chronotype — schedule deep work after 8pm" or "given your longevity markers and age, here's how to prioritize your 10-year goals").
 


### PR DESCRIPTION
## Summary

- Correct the architecture tree to identify the repository and operational CoS goals documents.
- Update the identity-system goal-tracking references to the files that exist today.

## Test plan

- Confirmed both referenced files exist.
- Confirmed the stale `data/COS-GOALS.md` reference is absent from the changed documents.
- Ran `git diff --check`.

Closes #5219
