### PR TITLE
fix: guard goal progress and todo submissions

### DIFF
--- a/client/src/components/goals/GoalDetailPanel.jsx
+++ b/client/src/components/goals/GoalDetailPanel.jsx
@@ -136,6 +136,7 @@ export default function GoalDetailPanel({ goal, allGoals, onClose, onRefresh }) 
             setNewTodoPriority={s.setNewTodoPriority}
             newTodoEstimate={s.newTodoEstimate}
             setNewTodoEstimate={s.setNewTodoEstimate}
+            todoSubmitting={s.todoSubmitting}
             handleAddTodo={s.handleAddTodo}
             handleToggleTodo={s.handleToggleTodo}
             handleDeleteTodo={s.handleDeleteTodo}
@@ -244,6 +245,7 @@ export default function GoalDetailPanel({ goal, allGoals, onClose, onRefresh }) 
             setShowProgressForm={s.setShowProgressForm}
             progressForm={s.progressForm}
             setProgressForm={s.setProgressForm}
+            progressSubmitting={s.progressSubmitting}
             handleAddProgress={s.handleAddProgress}
             resetProgressForm={s.resetProgressForm}
             handleDeleteProgress={s.handleDeleteProgress}

--- a/client/src/components/goals/GoalProgressLog.jsx
+++ b/client/src/components/goals/GoalProgressLog.jsx
@@ -4,7 +4,7 @@ import InlineConfirmRow from '../ui/InlineConfirmRow';
 import { useConfirmDelete } from '../../hooks/useConfirmDelete';
 
 export default function GoalProgressLog({
-  goal, showProgressForm, setShowProgressForm, progressForm, setProgressForm,
+  goal, showProgressForm, setShowProgressForm, progressForm, setProgressForm, progressSubmitting,
   handleAddProgress, resetProgressForm, handleDeleteProgress
 }) {
   const { isConfirming, requestDelete, cancelDelete, confirmDelete } = useConfirmDelete();
@@ -63,7 +63,7 @@ export default function GoalProgressLog({
           <div className="flex gap-1">
             <button
               onClick={handleAddProgress}
-              disabled={!progressForm.note.trim()}
+              disabled={progressSubmitting || !progressForm.note.trim()}
               className="px-2 py-1 text-xs rounded bg-port-accent text-white disabled:opacity-50"
             >
               Log

--- a/client/src/components/goals/GoalTodoList.jsx
+++ b/client/src/components/goals/GoalTodoList.jsx
@@ -5,7 +5,7 @@ import { PRIORITY_BADGE } from './goalConstants';
 
 export default function GoalTodoList({
   goal, newTodoTitle, setNewTodoTitle, newTodoPriority, setNewTodoPriority,
-  newTodoEstimate, setNewTodoEstimate, handleAddTodo, handleToggleTodo, handleDeleteTodo
+  newTodoEstimate, setNewTodoEstimate, todoSubmitting, handleAddTodo, handleToggleTodo, handleDeleteTodo
 }) {
   const { isConfirming, requestDelete, cancelDelete, confirmDelete } = useConfirmDelete();
   return (
@@ -72,14 +72,14 @@ export default function GoalTodoList({
             type="text"
             value={newTodoTitle}
             onChange={e => setNewTodoTitle(e.target.value)}
-            onKeyDown={e => e.key === 'Enter' && handleAddTodo()}
+            onKeyDown={e => e.key === 'Enter' && !todoSubmitting && handleAddTodo()}
             placeholder="Add todo..."
             aria-label="New todo title"
             className="flex-1 bg-port-bg border border-port-border rounded px-2 py-1 text-xs text-white"
           />
           <button
             onClick={handleAddTodo}
-            disabled={!newTodoTitle.trim()}
+            disabled={todoSubmitting || !newTodoTitle.trim()}
             className="px-2 py-1 text-xs rounded bg-port-accent/20 text-port-accent disabled:opacity-50"
           >
             Add

--- a/client/src/hooks/useGoalDetail.js
+++ b/client/src/hooks/useGoalDetail.js
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import * as api from '../services/api';
 import { MAX_TAGS, MAX_TAG_LENGTH } from '../components/goals/goalConstants';
 
@@ -15,12 +15,16 @@ export function useGoalDetail({ goal, allGoals, onClose, onRefresh }) {
   const [showProgressForm, setShowProgressForm] = useState(false);
   const todayISO = new Date().toISOString().slice(0, 10);
   const [progressForm, setProgressForm] = useState({ date: todayISO, note: '', durationMinutes: '' });
+  const [progressSubmitting, setProgressSubmitting] = useState(false);
+  const progressSubmittingRef = useRef(false);
   const [subcalendars, setSubcalendars] = useState([]);
   const [selectedCalendar, setSelectedCalendar] = useState('');
   const [calendarMatchPattern, setCalendarMatchPattern] = useState('');
   const [newTodoTitle, setNewTodoTitle] = useState('');
   const [newTodoPriority, setNewTodoPriority] = useState('medium');
   const [newTodoEstimate, setNewTodoEstimate] = useState('');
+  const [todoSubmitting, setTodoSubmitting] = useState(false);
+  const todoSubmittingRef = useRef(false);
   // Plan & scheduling state
   const [planOpen, setPlanOpen] = useState(false);
   const [generatingPhases, setGeneratingPhases] = useState(false);
@@ -232,15 +236,24 @@ export function useGoalDetail({ goal, allGoals, onClose, onRefresh }) {
   };
 
   const handleAddProgress = async () => {
-    if (!progressForm.note.trim() || !progressForm.date) return;
-    await api.addGoalProgress(goal.id, {
-      date: progressForm.date,
-      note: progressForm.note,
-      ...(progressForm.durationMinutes ? { durationMinutes: parseInt(progressForm.durationMinutes, 10) } : {})
-    });
-    setProgressForm({ date: todayISO, note: '', durationMinutes: '' });
-    setShowProgressForm(false);
-    onRefresh();
+    if (progressSubmittingRef.current || !progressForm.note.trim() || !progressForm.date) return;
+    progressSubmittingRef.current = true;
+    setProgressSubmitting(true);
+    try {
+      await api.addGoalProgress(goal.id, {
+        date: progressForm.date,
+        note: progressForm.note,
+        ...(progressForm.durationMinutes ? { durationMinutes: parseInt(progressForm.durationMinutes, 10) } : {})
+      });
+      setProgressForm({ date: todayISO, note: '', durationMinutes: '' });
+      setShowProgressForm(false);
+      onRefresh();
+    } catch {
+      // Keep the form intact so the user can retry. The request helper owns the toast.
+    } finally {
+      progressSubmittingRef.current = false;
+      setProgressSubmitting(false);
+    }
   };
 
   const resetProgressForm = () => {
@@ -295,16 +308,25 @@ export function useGoalDetail({ goal, allGoals, onClose, onRefresh }) {
   };
 
   const handleAddTodo = async () => {
-    if (!newTodoTitle.trim()) return;
-    await api.addGoalTodo(goal.id, {
-      title: newTodoTitle,
-      priority: newTodoPriority,
-      ...(newTodoEstimate ? { estimateMinutes: parseInt(newTodoEstimate, 10) } : {})
-    });
-    setNewTodoTitle('');
-    setNewTodoPriority('medium');
-    setNewTodoEstimate('');
-    onRefresh();
+    if (todoSubmittingRef.current || !newTodoTitle.trim()) return;
+    todoSubmittingRef.current = true;
+    setTodoSubmitting(true);
+    try {
+      await api.addGoalTodo(goal.id, {
+        title: newTodoTitle,
+        priority: newTodoPriority,
+        ...(newTodoEstimate ? { estimateMinutes: parseInt(newTodoEstimate, 10) } : {})
+      });
+      setNewTodoTitle('');
+      setNewTodoPriority('medium');
+      setNewTodoEstimate('');
+      onRefresh();
+    } catch {
+      // Keep the form intact so the user can retry. The request helper owns the toast.
+    } finally {
+      todoSubmittingRef.current = false;
+      setTodoSubmitting(false);
+    }
   };
 
   const handleToggleTodo = async (todo) => {
@@ -367,12 +389,14 @@ export function useGoalDetail({ goal, allGoals, onClose, onRefresh }) {
     selectedActivity, setSelectedActivity,
     showProgressForm, setShowProgressForm,
     progressForm, setProgressForm,
+    progressSubmitting,
     subcalendars,
     selectedCalendar, setSelectedCalendar,
     calendarMatchPattern, setCalendarMatchPattern,
     newTodoTitle, setNewTodoTitle,
     newTodoPriority, setNewTodoPriority,
     newTodoEstimate, setNewTodoEstimate,
+    todoSubmitting,
     planOpen, setPlanOpen,
     generatingPhases,
     proposedPhases, setProposedPhases,

--- a/client/src/hooks/useGoalDetail.test.jsx
+++ b/client/src/hooks/useGoalDetail.test.jsx
@@ -9,6 +9,8 @@ const rescheduleGoalTimeBlocks = vi.fn(() => Promise.resolve({}));
 const checkInGoal = vi.fn(() => Promise.resolve({ id: 'check-in-1' }));
 const updateGoalProgress = vi.fn(() => Promise.resolve({}));
 const updateGoal = vi.fn(() => Promise.resolve({}));
+const addGoalProgress = vi.fn(() => Promise.resolve({}));
+const addGoalTodo = vi.fn(() => Promise.resolve({}));
 
 vi.mock('../services/api', () => ({
   getActivities: (...args) => getActivities(...args),
@@ -18,7 +20,9 @@ vi.mock('../services/api', () => ({
   rescheduleGoalTimeBlocks: (...args) => rescheduleGoalTimeBlocks(...args),
   checkInGoal: (...args) => checkInGoal(...args),
   updateGoalProgress: (...args) => updateGoalProgress(...args),
-  updateGoal: (...args) => updateGoal(...args)
+  updateGoal: (...args) => updateGoal(...args),
+  addGoalProgress: (...args) => addGoalProgress(...args),
+  addGoalTodo: (...args) => addGoalTodo(...args)
 }));
 
 const { useGoalDetail } = await import('./useGoalDetail');
@@ -298,5 +302,54 @@ describe('useGoalDetail handleProgressChange', () => {
     await act(async () => {
       await expect(result.current.handleProgressChange(85)).resolves.toBe(false);
     });
+  });
+});
+
+describe('useGoalDetail creation actions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getActivities.mockResolvedValue([]);
+    getCalendarAccounts.mockResolvedValue([]);
+    addGoalProgress.mockResolvedValue({});
+    addGoalTodo.mockResolvedValue({});
+  });
+
+  it('gates duplicate progress submissions and refreshes after success', async () => {
+    let release;
+    addGoalProgress.mockReturnValue(new Promise(resolve => { release = resolve; }));
+    const { result, onRefresh } = renderGoalDetail();
+    act(() => { result.current.setProgressForm({ date: '2026-08-27', note: 'Shipped it', durationMinutes: '' }); });
+    let first;
+    act(() => { first = result.current.handleAddProgress(); });
+    expect(result.current.progressSubmitting).toBe(true);
+    await act(async () => { await result.current.handleAddProgress(); });
+    expect(addGoalProgress).toHaveBeenCalledTimes(1);
+    await act(async () => { release({}); await first; });
+    expect(result.current.progressSubmitting).toBe(false);
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves progress input and skips refresh after failure', async () => {
+    addGoalProgress.mockRejectedValue(new Error('server exploded'));
+    const { result, onRefresh } = renderGoalDetail();
+    act(() => { result.current.setProgressForm({ date: '2026-08-27', note: 'Retry me', durationMinutes: '5' }); });
+    await act(async () => { await result.current.handleAddProgress(); });
+    expect(result.current.progressForm.note).toBe('Retry me');
+    expect(result.current.progressSubmitting).toBe(false);
+    expect(onRefresh).not.toHaveBeenCalled();
+  });
+
+  it('gates duplicate todo submissions and preserves input after failure', async () => {
+    let release;
+    addGoalTodo.mockReturnValue(new Promise(resolve => { release = resolve; }));
+    const { result } = renderGoalDetail();
+    act(() => { result.current.setNewTodoTitle('Follow up'); });
+    let first;
+    act(() => { first = result.current.handleAddTodo(); });
+    expect(result.current.todoSubmitting).toBe(true);
+    await act(async () => { await result.current.handleAddTodo(); });
+    expect(addGoalTodo).toHaveBeenCalledTimes(1);
+    await act(async () => { release({}); await first; });
+    expect(result.current.todoSubmitting).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- Add pending submission guards for goal progress logs and todo creation.
- Preserve form values on failed requests and refresh only after successful creation.

## Test plan

- `npm test -- --run src/hooks/useGoalDetail.test.jsx`
- Related goal component tests and client build pass.

Closes #5204
