### PR TITLE
fix: classify all audit tasks in workflow graph

### DIFF
--- a/server/services/workflow.js
+++ b/server/services/workflow.js
@@ -76,7 +76,13 @@ export const WORKFLOW_STAGES = [
       'typing',
       'ui-bugs',
       'mobile-responsive',
-      'ux'
+      'ux',
+      'data-safety',
+      'simplify',
+      'api-contract',
+      'react-lifecycle',
+      'observability',
+      'copy'
     ],
     jobIds: ['job-wiki-maintenance', 'job-refresh-local-llm-catalog', 'job-refresh-cli-provider-catalogs']
   },

--- a/server/services/workflow.test.js
+++ b/server/services/workflow.test.js
@@ -18,6 +18,7 @@ const { getScheduleStatus } = await import('./taskSchedule.js');
 const { getAllJobs } = await import('./autonomousJobs.js');
 const { checkJobGate, hasGate, getRegisteredGates } = await import('./jobGates.js');
 const { getWorkflowGraph, projectWorkflowTimeline, WORKFLOW_STAGES } = await import('./workflow.js');
+const { AUDIT_TASK_TYPES } = await import('../lib/auditCatalog.js');
 
 const STAGE_IDS = WORKFLOW_STAGES.map(s => s.id);
 
@@ -62,6 +63,11 @@ describe('WORKFLOW_STAGES contract', () => {
         seen.add(t);
       }
     }
+  });
+
+  it('places every audit task type in the audit stage', () => {
+    const audit = WORKFLOW_STAGES.find(s => s.id === 'audit');
+    expect([...AUDIT_TASK_TYPES].filter(type => !audit.taskTypes.includes(type))).toEqual([]);
   });
 
   it('does not place the same job id in two stages', () => {


### PR DESCRIPTION
## Summary
- Classify all six scheduled audit task types under the Audit workflow stage.
- Add a regression guard tied to the audit catalog so new audit types cannot silently fall through to Ambient.

## Test plan
- `npx vitest run services/workflow.test.js`
- `npm test -- workflow.test.js ../lib/auditCatalog.test.js`

Closes #5244