### PR TITLE
fix: clarify brain search clear button labels

### DIFF
--- a/client/src/components/brain/tabs/MemoryTab.jsx
+++ b/client/src/components/brain/tabs/MemoryTab.jsx
@@ -818,7 +818,7 @@ export default function MemoryTab({ onRefresh }) {
         {searchQuery && (
           <button
             onClick={() => setSearchQuery('')}
-            aria-label="Close"
+            aria-label="Clear search"
             className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500 hover:text-white min-h-[44px] min-w-[44px] flex items-center justify-center"
           >
             <X size={14} />

--- a/client/src/components/brain/tabs/NotesTab.jsx
+++ b/client/src/components/brain/tabs/NotesTab.jsx
@@ -315,7 +315,7 @@ export default function NotesTab() {
             {searchQuery && (
               <button
                 onClick={clearSearch}
-                aria-label="Close"
+                aria-label="Clear search"
                 className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-500 hover:text-white min-h-[44px] min-w-[44px] flex items-center justify-center"
               >
                 <X size={14} />
@@ -1068,4 +1068,3 @@ function renderInline(text, onLinkClick) {
 
   return parts;
 }
-

--- a/client/src/components/brain/tabs/NotesTab.test.jsx
+++ b/client/src/components/brain/tabs/NotesTab.test.jsx
@@ -118,9 +118,7 @@ describe('NotesTab header touch targets', () => {
     // only thing labelled "Close" — assert that, or a second Close button
     // appearing later would silently redirect this assertion at the wrong
     // element and make it pass for the wrong reason.
-    const closeButtons = screen.getAllByRole('button', { name: 'Close' });
-    expect(closeButtons).toHaveLength(1);
-    const [clear] = closeButtons;
+    const clear = screen.getByRole('button', { name: 'Clear search' });
 
     // The clear button is absolutely positioned at `right-2` (8px) and is 44px
     // wide, so the input needs >= 52px of right padding or the typed text runs


### PR DESCRIPTION
## Summary
- Clarify the accessible name of Notes and Memory search clear buttons.
- Update the NotesTab accessibility test to follow the renamed control.

## Test plan
- `git diff --check`
- Client Vitest attempted; dependencies are unavailable in the worktree.

Closes #5222