### PR TITLE
fix: respect reduced motion in BrainGraph

### DIFF
--- a/client/src/components/brain/tabs/BrainGraph.jsx
+++ b/client/src/components/brain/tabs/BrainGraph.jsx
@@ -54,6 +54,14 @@ const isCanvasGesture = (e) => e.target?.tagName === 'CANVAS';
 // constant the two silently drift apart.
 const TOOLTIP_WIDTH = 320;
 
+// The force layout is settled before the scene renders, so reduced-motion
+// users can see it immediately at rest. Keep the canvas on demand and turn
+// off OrbitControls' inertia too, preventing movement after an interaction.
+export const graphMotionSettings = (reducedMotion) => ({
+  frameloop: reducedMotion ? 'demand' : 'always',
+  enableDamping: !reducedMotion
+});
+
 // Per-type API getters for detail panel
 const TYPE_GETTERS = {
   people: api.getBrainPerson,
@@ -124,7 +132,7 @@ function GraphEdges({ simEdges, selectedId }) {
 // move over the canvas WHILE A NODE IS HOVERED (it tracks the tooltip position),
 // and every prop here is already identity-stable across that render — so without
 // memo each move reconciles a <mesh> per node for nothing.
-const GraphScene = memo(function GraphScene({ graph, selectedId, adjacentIds, onSelect, onFocus, onHover, pickRef, touchGestureRef }) {
+const GraphScene = memo(function GraphScene({ graph, selectedId, adjacentIds, onSelect, onFocus, onHover, pickRef, touchGestureRef, reducedMotion }) {
   const sphereGeo = useMemo(() => new THREE.SphereGeometry(1, 16, 12), []);
   const { camera, size } = useThree();
 
@@ -205,7 +213,7 @@ const GraphScene = memo(function GraphScene({ graph, selectedId, adjacentIds, on
         </mesh>
       )}
 
-      <OrbitControls enableDamping dampingFactor={0.05} minDistance={10} maxDistance={200} />
+      <OrbitControls enableDamping={!reducedMotion} dampingFactor={0.05} minDistance={10} maxDistance={200} />
     </>
   );
 });
@@ -233,6 +241,10 @@ export default function BrainGraph() {
   const [typeFilters, setTypeFilters] = useState(() =>
     Object.fromEntries(BRAIN_TYPES.map(t => [t, true]))
   );
+  const [reducedMotion, setReducedMotion] = useState(() =>
+    window.matchMedia?.('(prefers-reduced-motion: reduce)').matches ?? false
+  );
+  const motionSettings = graphMotionSettings(reducedMotion);
 
   const graphRef = useRef(null);
   const dragStartRef = useRef(null);
@@ -241,6 +253,15 @@ export default function BrainGraph() {
   // True while the in-flight gesture came from a finger, so the mesh raycast
   // and onPointerMissed can stand down for the threshold pick below.
   const touchGestureRef = useRef(false);
+
+  useEffect(() => {
+    const media = window.matchMedia?.('(prefers-reduced-motion: reduce)');
+    if (!media) return undefined;
+    const updatePreference = () => setReducedMotion(media.matches);
+    updatePreference();
+    media.addEventListener?.('change', updatePreference);
+    return () => media.removeEventListener?.('change', updatePreference);
+  }, []);
 
   const focusId = currentFocusId(focusTrail);
 
@@ -633,6 +654,7 @@ export default function BrainGraph() {
         {graph && (
           <Canvas
             camera={{ position: [0, 0, 80], fov: 50 }}
+            frameloop={motionSettings.frameloop}
             dpr={[1, 1.5]}
             style={{ background: 'rgb(var(--port-bg))' }}
             gl={{ antialias: true }}
@@ -647,6 +669,7 @@ export default function BrainGraph() {
               onHover={handleHover}
               pickRef={pickRef}
               touchGestureRef={touchGestureRef}
+              reducedMotion={reducedMotion}
             />
           </Canvas>
         )}

--- a/client/src/components/brain/tabs/BrainGraph.test.jsx
+++ b/client/src/components/brain/tabs/BrainGraph.test.jsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -8,7 +8,7 @@ import userEvent from '@testing-library/user-event';
 // <bufferGeometry>/<mesh> as unknown DOM elements, and the r3f refs they hand
 // back are HTMLElements without the three.js geometry API.
 vi.mock('@react-three/fiber', () => ({
-  Canvas: () => <div data-testid="graph-canvas" />,
+  Canvas: ({ frameloop }) => <div data-testid="graph-canvas" data-frameloop={frameloop} />,
   // GraphScene reads the live camera through this; it is never rendered here,
   // but the named import has to resolve.
   useThree: () => ({ camera: null, size: { width: 0, height: 0 } }),
@@ -41,7 +41,7 @@ vi.mock('../../../services/api', () => ({
 import * as api from '../../../services/api';
 import { chipColors, parseColor } from '../../../lib/chipContrast';
 import { BRAIN_TYPE_HEX } from '../constants';
-import BrainGraph, { recordBody } from './BrainGraph';
+import BrainGraph, { graphMotionSettings, recordBody } from './BrainGraph';
 
 const GRAPH = {
   hasEmbeddings: true,
@@ -58,6 +58,8 @@ const renderGraph = async () => {
   await act(async () => {});
 };
 
+const originalMatchMedia = window.matchMedia;
+
 beforeEach(() => {
   vi.clearAllMocks();
   api.getBrainGraph.mockResolvedValue(GRAPH);
@@ -70,6 +72,33 @@ beforeEach(() => {
     api.getBrainPerson, api.getBrainProject, api.getBrainIdea, api.getBrainAdminItem,
     api.getBrainMemory, api.getBrainGoal, api.getBrainJournalEntry, api.getSong,
   ]) getter.mockResolvedValue(null);
+});
+
+afterEach(() => {
+  window.matchMedia = originalMatchMedia;
+});
+
+describe('reduced motion', () => {
+  it('reads the system preference and renders the canvas on demand', async () => {
+    window.matchMedia = vi.fn(() => ({
+      matches: true,
+      addEventListener() {},
+      removeEventListener() {}
+    }));
+
+    await renderGraph();
+
+    expect(window.matchMedia).toHaveBeenCalledWith('(prefers-reduced-motion: reduce)');
+    expect(screen.getByTestId('graph-canvas')).toHaveAttribute('data-frameloop', 'demand');
+  });
+
+  it('stops the canvas render loop and OrbitControls inertia when motion is reduced', () => {
+    expect(graphMotionSettings(true)).toEqual({ frameloop: 'demand', enableDamping: false });
+  });
+
+  it('keeps animated rendering and controls for users without the preference', () => {
+    expect(graphMotionSettings(false)).toEqual({ frameloop: 'always', enableDamping: true });
+  });
 });
 
 // The legend is ten rows tall and sits over the canvas, which blankets a


### PR DESCRIPTION
## Summary

- Honor the system reduced-motion preference in BrainGraph.
- Stop the continuous Three.js render loop and OrbitControls inertia for reduced-motion users while retaining normal interactive rendering otherwise.

## Test plan

- `cd client && npm test -- --run src/components/brain/tabs/BrainGraph.test.jsx`
- `cd client && npm run lint`

Closes #5225
