### PR TITLE
feat: add Persistent Mind image attachments (#5170)

### DIFF
--- a/client/src/components/cos/tabs/MindTab.jsx
+++ b/client/src/components/cos/tabs/MindTab.jsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useSearchParams } from 'react-router';
-import { ArrowUp, Brain, Check, CirclePause, CirclePlay, ExternalLink, MessageCircle, RefreshCw, Settings2, Square, StickyNote, Upload } from 'lucide-react';
+import { ArrowUp, Brain, Check, CirclePause, CirclePlay, ExternalLink, ImagePlus, MessageCircle, RefreshCw, Settings2, Square, StickyNote, Upload, X } from 'lucide-react';
 import { Link } from 'react-router';
 import useMounted from '../../../hooks/useMounted';
 import { useSocket } from '../../../hooks/useSocket';
@@ -10,16 +10,20 @@ import { formatDateTime } from '../../../utils/formatters';
 import BrailleSpinner from '../../BrailleSpinner';
 import Drawer from '../../Drawer';
 import Banner from '../../ui/Banner';
+import FilePickerButton from '../../ui/FilePickerButton';
 import TabPills from '../../ui/TabPills';
 import PersistentMindContextPanel from '../PersistentMindContextPanel';
 import PersistentMindProfileControls from '../PersistentMindProfileControls';
 import PersistentMindRuntimePanel, { PersistentMindThoughtStatus } from '../PersistentMindRuntimePanel';
 import PersistentMindTaskAccessControls from '../PersistentMindTaskAccessControls';
 import PersistentMindVisibilityPanel from '../PersistentMindVisibilityPanel';
+import { readFileAsBase64, UPLOAD_IMAGE_ACCEPT, validateImageFile } from '../../../utils/fileUpload';
 
 const PAGE_LIMIT = 200;
 const MAX_BACKFILL_PAGES = 5;
 const MAX_VISIBLE_EVENTS = PAGE_LIMIT * MAX_BACKFILL_PAGES;
+const MAX_MESSAGE_IMAGES = 8;
+const MAX_MESSAGE_IMAGE_BYTES = 10 * 1024 * 1024;
 const MIND_VIEWS = new Set(['conversation', 'context', 'setup']);
 const MIND_TABS = [
   { id: 'conversation', label: 'Chat', icon: MessageCircle },
@@ -63,6 +67,23 @@ const eventText = (event) => {
   }
   if (typeof data.status === 'string') return data.status;
   return null;
+};
+
+const safeMessageImages = (event) => (Array.isArray(event?.data?.images) ? event.data.images : [])
+  .filter((image) => (
+    typeof image?.attachmentId === 'string'
+    && typeof image?.path === 'string'
+    && image.path.startsWith('/api/screenshots/')
+    && typeof image?.originalName === 'string'
+  ))
+  .slice(0, MAX_MESSAGE_IMAGES);
+
+const imageCapability = (mind) => {
+  const capability = mind?.imageCapability;
+  const status = ['supported', 'unsupported', 'unknown'].includes(capability?.status)
+    ? capability.status
+    : 'unknown';
+  return { status, guidance: typeof capability?.guidance === 'string' ? capability.guidance : null };
 };
 
 const MindTypingIndicator = () => (
@@ -129,6 +150,9 @@ export default function MindTab() {
   const [gap, setGap] = useState(false);
   const [loading, setLoading] = useState(true);
   const [messageText, setMessageText] = useState('');
+  const [messageImages, setMessageImages] = useState([]);
+  const [messageImagesUploading, setMessageImagesUploading] = useState(false);
+  const [messageImageError, setMessageImageError] = useState(null);
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState(null);
   const [annotationText, setAnnotationText] = useState('');
@@ -157,6 +181,7 @@ export default function MindTab() {
   const visibilityLoadedRef = useRef(false);
   const runtimeMountedRef = useMounted();
   const messageDraftIdRef = useRef(null);
+  const messageDraftImagesRef = useRef(null);
   const annotationDraftIdRef = useRef(null);
   const messageListRef = useRef(null);
   const stickToBottomRef = useRef(true);
@@ -186,6 +211,7 @@ export default function MindTab() {
           state: response.state,
           profile: response.profile,
           capabilities: response.capabilities,
+          imageCapability: response.imageCapability,
           autonomyMode: response.autonomyMode,
         });
         page += 1;
@@ -303,7 +329,7 @@ export default function MindTab() {
     setAnnotationError(null);
   }, [selectedEventId]);
 
-  const appendLocalInput = ({ id, content, inputKind, targetEventId = null }) => {
+  const appendLocalInput = ({ id, content, inputKind, targetEventId = null, images = [] }) => {
     setEvents((previous) => {
       const sequence = Math.max(-1, ...(previous || []).map((item) => item.sequence || -1)) + 1;
       return mergeEvents(previous || [], [{
@@ -315,7 +341,7 @@ export default function MindTab() {
         at: new Date().toISOString(),
         data: {
           displayText: content,
-          ...(inputKind === 'message' ? { messageId: id } : { annotationId: id, targetEventId }),
+          ...(inputKind === 'message' ? { messageId: id, ...(images.length > 0 ? { images } : {}) } : { annotationId: id, targetEventId }),
         },
       }]);
     });
@@ -324,17 +350,21 @@ export default function MindTab() {
   const submitMessage = async (event) => {
     event.preventDefault();
     const trimmed = messageText.trim();
-    if (!trimmed || submitting) return;
+    if ((!trimmed && messageImages.length === 0) || submitting || messageImagesUploading) return;
     const id = messageDraftIdRef.current || mintId('message');
     messageDraftIdRef.current = id;
+    const images = messageDraftImagesRef.current || messageImages;
+    messageDraftImagesRef.current = images;
     setSubmitting(true);
     setSubmitError(null);
     try {
-      await api.sendPersistentMindMessage({ id, text: trimmed }, { silent: true });
+      await api.sendPersistentMindMessage({ id, text: trimmed, ...(images.length > 0 ? { images: images.map((image) => image.attachmentId) } : {}) }, { silent: true });
       stickToBottomRef.current = true;
-      appendLocalInput({ id, content: trimmed, inputKind: 'message' });
+      appendLocalInput({ id, content: trimmed, inputKind: 'message', images });
       setMessageText('');
+      setMessageImages([]);
       messageDraftIdRef.current = null;
+      messageDraftImagesRef.current = null;
       await loadHistory();
       stickToBottomRef.current = true;
       void loadRuntime();
@@ -369,9 +399,55 @@ export default function MindTab() {
   const changeMessageText = (next) => {
     if (submitError) {
       messageDraftIdRef.current = null;
+      messageDraftImagesRef.current = null;
       setSubmitError(null);
     }
     setMessageText(next);
+  };
+
+  const changeMessageImages = (next) => {
+    if (submitError) {
+      messageDraftIdRef.current = null;
+      messageDraftImagesRef.current = null;
+      setSubmitError(null);
+    }
+    setMessageImages(next);
+  };
+
+  const uploadMessageImages = async (files) => {
+    const selected = Array.from(files || []);
+    const room = MAX_MESSAGE_IMAGES - messageImages.length;
+    if (room <= 0 || selected.length === 0) return;
+    const uploads = selected.slice(0, room);
+    setMessageImagesUploading(true);
+    setMessageImageError(selected.length > room ? `Only ${room} more image${room === 1 ? '' : 's'} can be attached.` : null);
+    const accepted = [];
+    for (const file of uploads) {
+      const validationError = validateImageFile(file, MAX_MESSAGE_IMAGE_BYTES);
+      if (validationError) {
+        setMessageImageError(validationError);
+        continue;
+      }
+      try {
+        const data = await readFileAsBase64(file);
+        const attachment = await api.uploadPersistentMindAttachment({ filename: file.name, data }, { silent: true });
+        if (attachment?.attachmentId) accepted.push(attachment);
+      } catch (error) {
+        setMessageImageError(error?.message || `Could not upload ${file.name}`);
+      }
+    }
+    if (accepted.length > 0) changeMessageImages([...messageImages, ...accepted].slice(0, MAX_MESSAGE_IMAGES));
+    setMessageImagesUploading(false);
+  };
+
+  const removeMessageImage = async (image) => {
+    try {
+      await api.deletePersistentMindAttachment(image.attachmentId, { silent: true });
+      changeMessageImages(messageImages.filter((candidate) => candidate.attachmentId !== image.attachmentId));
+      setMessageImageError(null);
+    } catch (error) {
+      setMessageImageError(error?.message || `Could not remove ${image.originalName}`);
+    }
   };
 
   const handleMessageKeyDown = (event) => {
@@ -439,6 +515,8 @@ export default function MindTab() {
   const selectedEvent = events?.find((event) => event.eventId === selectedEventId) || null;
   const isPaused = state?.status === 'paused';
   const profileReady = Boolean(mind?.profile?.enabled && mind.profile.providerId && mind.profile.model);
+  const { status: imageCapabilityStatus, guidance: imageCapabilityGuidance } = imageCapability(mind);
+  const imageAttachmentsUnavailable = imageCapabilityStatus === 'unsupported';
   const setupSaving = profileSaving || taskAccessSaving;
   const conversationItems = buildConversationItems(events || [], showActivity);
   const changeView = (view) => setSearchParams((current) => {
@@ -600,10 +678,40 @@ export default function MindTab() {
 
           <form onSubmit={submitMessage} className="shrink-0 border-t border-port-border bg-port-card/95 px-2.5 pb-[max(0.65rem,env(safe-area-inset-bottom))] pt-2.5 sm:px-4">
             {submitError && <p role="alert" className="mt-2 text-sm text-port-error">{submitError} — Retry uses the same id, so it will not duplicate the input.</p>}
+            {messageImageError && <p role="alert" className="mt-2 text-sm text-port-error">{messageImageError}</p>}
+            {imageAttachmentsUnavailable && (
+              <p className="mt-2 text-xs text-port-text-muted">
+                Image attachments are unavailable for this Mind profile. {imageCapabilityGuidance || 'Choose a vision-capable provider or model in'}{' '}
+                <Link to="/settings?tab=providers" className="text-port-accent underline">Settings</Link>.
+              </p>
+            )}
+            {messageImages.length > 0 && (
+              <ul aria-label="Attached images" className="mt-2 flex flex-wrap gap-2">
+                {messageImages.map((image) => (
+                  <li key={image.attachmentId} className="relative h-16 w-16 overflow-hidden rounded-lg border border-port-border bg-port-bg">
+                    <MindImage image={image} className="h-full w-full object-cover" />
+                    <button type="button" onClick={() => void removeMessageImage(image)} disabled={submitting || messageImagesUploading} aria-label={`Remove ${image.originalName}`} className="absolute right-1 top-1 rounded-full bg-port-bg/90 p-1 text-port-text shadow disabled:opacity-50">
+                      <X size={12} aria-hidden="true" />
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
             <div className="flex items-end gap-2 rounded-[1.35rem] border border-port-border bg-port-bg p-1.5 pl-3 focus-within:border-port-accent/70 focus-within:ring-1 focus-within:ring-port-accent/30">
+              <FilePickerButton
+                accept={UPLOAD_IMAGE_ACCEPT}
+                multiple
+                onChange={(event) => uploadMessageImages(event.target.files)}
+                disabled={submitting || messageImagesUploading || imageAttachmentsUnavailable || messageImages.length >= MAX_MESSAGE_IMAGES}
+                ariaLabel="Attach images"
+                title={imageAttachmentsUnavailable ? 'Image attachments are unavailable for this profile' : 'Attach images'}
+                className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-port-text-muted hover:bg-port-border/50 hover:text-port-text"
+              >
+                {messageImagesUploading ? <RefreshCw size={17} className="animate-spin" aria-hidden="true" /> : <ImagePlus size={18} aria-hidden="true" />}
+              </FilePickerButton>
               <label htmlFor="mind-input-text" className="sr-only">Message</label>
               <textarea id="mind-input-text" value={messageText} onChange={(event) => changeMessageText(event.target.value)} onKeyDown={handleMessageKeyDown} maxLength={8000} rows={1} className="min-h-[36px] max-h-32 flex-1 resize-y bg-transparent py-2 text-sm leading-5 text-port-text outline-none placeholder:text-port-text-muted" placeholder="Message Persistent Mind" />
-              <button type="submit" disabled={!messageText.trim() || submitting} aria-label={submitting ? 'Sending message' : submitError ? 'Retry' : 'Send message'} className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-port-accent text-white transition-colors hover:bg-port-accent/85 disabled:cursor-not-allowed disabled:bg-port-border disabled:text-port-text-muted">
+              <button type="submit" disabled={(!messageText.trim() && messageImages.length === 0) || submitting || messageImagesUploading} aria-label={submitting ? 'Sending message' : submitError ? 'Retry' : 'Send message'} className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-port-accent text-white transition-colors hover:bg-port-accent/85 disabled:cursor-not-allowed disabled:bg-port-border disabled:text-port-text-muted">
                 {submitting ? <RefreshCw size={17} className="animate-spin" aria-hidden="true" /> : <ArrowUp size={19} strokeWidth={2.5} aria-hidden="true" />}
               </button>
             </div>
@@ -623,7 +731,9 @@ export default function MindTab() {
           <div className="space-y-5">
             <section aria-labelledby="mind-event-content-heading">
               <h3 id="mind-event-content-heading" className="text-xs font-semibold uppercase tracking-wide text-port-accent">Message</h3>
-              <p className="mt-2 whitespace-pre-wrap break-words text-sm text-port-text">{eventText(selectedEvent) || selectedEvent.kind}</p>
+              {eventText(selectedEvent) && <p className="mt-2 whitespace-pre-wrap break-words text-sm text-port-text">{eventText(selectedEvent)}</p>}
+              <MessageImages images={safeMessageImages(selectedEvent)} />
+              {!eventText(selectedEvent) && safeMessageImages(selectedEvent).length === 0 && <p className="mt-2 text-sm text-port-text">{selectedEvent.kind}</p>}
             </section>
 
             <section aria-labelledby="mind-event-metadata-heading" className="space-y-2 border-t border-port-border pt-4">
@@ -694,6 +804,7 @@ function ConversationItem({ event, thoughts, thoughtOnly, selectedEventId, onSel
         >
           {content}
         </button>
+        <MessageImages images={safeMessageImages(event)} compact />
         {thoughts.length > 0 && (
           <details className={`border-t ${outgoing ? 'border-white/20' : 'border-port-text/10'}`}>
             <summary className="cursor-pointer px-3.5 py-2 text-xs font-medium opacity-75 hover:opacity-100">
@@ -718,6 +829,28 @@ function ConversationItem({ event, thoughts, thoughtOnly, selectedEventId, onSel
       </div>
       <time className={`mt-1 px-2 text-[10px] text-port-text-muted ${outgoing ? 'text-right' : 'text-left'}`} dateTime={event.at}>{formatDateTime(event.at)}</time>
     </li>
+  );
+}
+
+function MindImage({ image, className = '' }) {
+  const [missing, setMissing] = useState(false);
+  if (missing || !image?.path) {
+    return <span role="img" aria-label={`${image?.originalName || 'Image'} is unavailable`} className={`flex items-center justify-center bg-port-bg p-1 text-center text-[10px] text-port-text-muted ${className}`}>Image unavailable</span>;
+  }
+  return <img src={image.path} alt={image.originalName || 'Attached image'} onError={() => setMissing(true)} className={className} />;
+}
+
+function MessageImages({ images, compact = false }) {
+  if (images.length === 0) return null;
+  return (
+    <ul aria-label={`${images.length} attached image${images.length === 1 ? '' : 's'}`} className={`flex flex-wrap gap-2 ${compact ? 'border-t border-white/20 px-3.5 py-2.5' : 'mt-3'}`}>
+      {images.map((image) => (
+        <li key={image.attachmentId} className={compact ? 'h-20 w-20 overflow-hidden rounded-lg bg-port-bg/20' : 'overflow-hidden rounded-lg border border-port-border bg-port-bg'}>
+          <MindImage image={image} className={compact ? 'h-full w-full object-cover' : 'max-h-64 max-w-full object-contain'} />
+          {!compact && <p className="border-t border-port-border px-2 py-1 text-xs text-port-text-muted">{image.originalName}</p>}
+        </li>
+      ))}
+    </ul>
   );
 }
 

--- a/client/src/components/cos/tabs/MindTab.test.jsx
+++ b/client/src/components/cos/tabs/MindTab.test.jsx
@@ -7,6 +7,8 @@ import { MemoryRouter } from 'react-router';
 const api = vi.hoisted(() => ({
   getPersistentMind: vi.fn(),
   sendPersistentMindMessage: vi.fn(),
+  uploadPersistentMindAttachment: vi.fn(),
+  deletePersistentMindAttachment: vi.fn(),
   addPersistentMindAnnotation: vi.fn(),
   startPersistentMind: vi.fn(),
   pausePersistentMind: vi.fn(),
@@ -80,6 +82,10 @@ describe('MindTab', () => {
     socket.reset();
     api.getPersistentMind.mockResolvedValue(response());
     api.sendPersistentMindMessage.mockResolvedValue({ success: true, duplicate: false });
+    api.uploadPersistentMindAttachment.mockResolvedValue({
+      attachmentId: 'attachment-1', filename: 'mind-attachment-1.png', path: '/api/screenshots/mind-attachment-1.png', originalName: 'diagram.png', mimeType: 'image/png', size: 4,
+    });
+    api.deletePersistentMindAttachment.mockResolvedValue({ success: true });
     api.addPersistentMindAnnotation.mockResolvedValue({ success: true, duplicate: false });
     api.startPersistentMind.mockResolvedValue({ success: true });
     api.pausePersistentMind.mockResolvedValue({ success: true });
@@ -303,6 +309,44 @@ describe('MindTab', () => {
       { id: expect.stringMatching(/^message-/), text: 'First line\nSecond line' },
       { silent: true },
     ));
+  });
+
+  it('uploads supported images, permits an image-only message, and deletes a removed upload', async () => {
+    const user = userEvent.setup();
+    renderTab();
+    await screen.findByText('Review the next bounded slice.');
+
+    const picker = screen.getByLabelText('Attach images');
+    await user.upload(picker, new File(['png'], 'diagram.png', { type: 'image/png' }));
+    await waitFor(() => expect(api.uploadPersistentMindAttachment).toHaveBeenCalledWith(
+      { filename: 'diagram.png', data: expect.any(String) }, { silent: true },
+    ));
+    expect(screen.getByRole('button', { name: 'Remove diagram.png' })).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Send message' }));
+    await waitFor(() => expect(api.sendPersistentMindMessage).toHaveBeenCalledWith(
+      { id: expect.stringMatching(/^message-/), text: '', images: ['attachment-1'] }, { silent: true },
+    ));
+
+    await user.upload(picker, new File(['png'], 'diagram.png', { type: 'image/png' }));
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Remove diagram.png' })).toBeInTheDocument());
+    await user.click(screen.getByRole('button', { name: 'Remove diagram.png' }));
+    await waitFor(() => expect(api.deletePersistentMindAttachment).toHaveBeenCalledWith('attachment-1', { silent: true }));
+  });
+
+  it('renders safe accepted image metadata and disables the image picker when unsupported', async () => {
+    api.getPersistentMind.mockResolvedValue(response({
+      imageCapability: { status: 'unsupported', guidance: 'Select a vision-capable model in Settings.' },
+      events: [event({ data: {
+        displayText: 'Please inspect this.',
+        images: [{ attachmentId: 'attachment-1', path: '/api/screenshots/mind-attachment-1.png', originalName: 'diagram.png', mimeType: 'image/png', size: 4 }],
+      } })],
+    }));
+    renderTab('/cos/mind?event=mind-message%3Amessage-1');
+
+    expect((await screen.findAllByAltText('diagram.png')).length).toBeGreaterThan(0);
+    expect(screen.getByLabelText('Attach images')).toBeDisabled();
+    expect(screen.getByText(/Image attachments are unavailable/)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Settings' })).toHaveAttribute('href', '/settings?tab=providers');
   });
 
   it('does not submit an IME composition commit key', async () => {

--- a/client/src/pages/CatalogIngredient.jsx
+++ b/client/src/pages/CatalogIngredient.jsx
@@ -12,6 +12,7 @@ import toast from '../components/ui/Toast';
 import FilePickerButton from '../components/ui/FilePickerButton';
 import Modal from '../components/ui/Modal.jsx';
 import ConfirmButtonPair from '../components/ui/ConfirmButtonPair.jsx';
+import UnsavedChangesConfirm from '../components/ui/UnsavedChangesConfirm.jsx';
 import {
   getCatalogIngredientDetails,
   updateCatalogIngredient,
@@ -40,6 +41,7 @@ import MediaImage from '../components/MediaImage';
 import CharacterLoraChip from '../components/loraTraining/CharacterLoraChip';
 import TagPicker from '../components/TagPicker';
 import GenericIngredientFields from '../components/GenericIngredientFields';
+import useUnsavedChangesGuard from '../hooks/useUnsavedChangesGuard';
 import { getCatalogType, CATALOG_BADGE_BY_ID, RELATION_KINDS, getRelationKind } from '../lib/catalogTypes';
 import { useCatalogTypes } from '../hooks/useCatalogTypes.jsx';
 import { timeAgo, formatDateTime } from '../utils/formatters';
@@ -109,6 +111,27 @@ export function buildGenerationPromptSeed(payload, typeDef, tags = []) {
   return seed.length > GENERATION_SEED_MAX
     ? `${seed.slice(0, GENERATION_SEED_MAX - 1).trimEnd()}…`
     : seed;
+}
+
+// Compare JSON-shaped editor values by value while ignoring object-key order.
+// A catalog payload can arrive from a peer with the same fields in a different
+// order; that is not an edit the user needs to save.
+function stableSerialize(value) {
+  return JSON.stringify(value, (_key, current) => {
+    if (!current || typeof current !== 'object' || Array.isArray(current)) return current;
+    return Object.keys(current).sort().reduce((sorted, key) => {
+      sorted[key] = current[key];
+      return sorted;
+    }, {});
+  });
+}
+
+function sameValue(left, right) {
+  return stableSerialize(left) === stableSerialize(right);
+}
+
+function ingredientPayload(value) {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value : {};
 }
 
 export default function CatalogIngredient() {
@@ -329,10 +352,23 @@ export default function CatalogIngredient() {
     });
     setSaving(false);
     if (!updated) return;
-    setRecord((prev) => ({ ...prev, ...updated }));
+    const persistedName = typeof updated.name === 'string' ? updated.name : trimmedName;
+    const persistedTags = Array.isArray(updated.tags) ? updated.tags : tags;
+    const persistedPayload = Object.hasOwn(updated, 'payload')
+      ? ingredientPayload(updated.payload)
+      : ingredientPayload(payload);
+    setRecord((prev) => ({
+      ...prev,
+      ...updated,
+      name: persistedName,
+      tags: persistedTags,
+      payload: persistedPayload,
+    }));
+    setName(persistedName);
     // The server normalizes tags through the canonical table (casing/whitespace
     // collapse), so reflect the persisted set back into the chips.
-    if (Array.isArray(updated.tags)) setTags(updated.tags);
+    setTags(persistedTags);
+    setPayload({ ...persistedPayload });
     toast.success('Saved');
     refreshRevisions();
   };
@@ -367,6 +403,19 @@ export default function CatalogIngredient() {
   const updatePayload = (key, value) => {
     setPayload((prev) => ({ ...prev, [key]: value }));
   };
+
+  const isDirty = Boolean(record && (
+    name !== (record.name || '')
+    || !sameValue(tags, Array.isArray(record.tags) ? record.tags : [])
+    || !sameValue(payload, ingredientPayload(record.payload))
+  ));
+  const routeGuard = useUnsavedChangesGuard(isDirty);
+  const discardAndExit = useCallback(() => {
+    // The parked route is leaving, so unmounting discards the local draft. Do
+    // not clear isDirty before proceeding: the shared guard auto-proceeds when
+    // a parked draft settles, which would race this explicit proceed call.
+    routeGuard.proceed();
+  }, [routeGuard]);
 
   if (loading || !record) {
     return (
@@ -413,6 +462,13 @@ export default function CatalogIngredient() {
 
   return (
     <section className="h-full overflow-y-auto p-4 md:p-6">
+      <UnsavedChangesConfirm
+        guard={routeGuard}
+        when={!saving}
+        question="Discard your unsaved changes to this ingredient?"
+        label={`Discard unsaved changes to ${record.name || 'this ingredient'}`}
+        onDiscard={discardAndExit}
+      />
       <div className="max-w-4xl mx-auto space-y-5">
         <header className="flex items-start justify-between gap-3 flex-wrap">
           <div className="flex items-start gap-3 min-w-0">
@@ -437,6 +493,7 @@ export default function CatalogIngredient() {
               className="inline-flex items-center gap-1.5 px-3 py-2 rounded-lg bg-port-accent hover:bg-port-accent/90 disabled:opacity-50 text-white text-sm font-medium">
               {saving ? <Loader2 size={14} className="animate-spin" /> : <Save size={14} />} Save
             </button>
+            {isDirty && <span className="text-xs text-port-warning" role="status">Unsaved changes</span>}
             {armedDelete ? (
               <span className="inline-flex items-center gap-1 text-sm">
                 <span className="text-gray-400 px-1">Delete this ingredient?</span>

--- a/client/src/pages/CatalogIngredient.test.jsx
+++ b/client/src/pages/CatalogIngredient.test.jsx
@@ -8,7 +8,7 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
-import { MemoryRouter } from 'react-router';
+import { createMemoryRouter, RouterProvider } from 'react-router';
 
 // Stable navigate mock — returning a fresh vi.fn() per call would change the
 // load effect's dependency identity every render and re-fire the fetch, which
@@ -96,16 +96,36 @@ vi.mock('../components/pipeline/MediaJobThumb', async () => {
 vi.mock('../services/apiImageVideo', () => ({ listImageGallery: vi.fn(async () => []) }));
 vi.mock('../components/IngredientPicker', () => ({ default: () => null }));
 vi.mock('../components/MediaImage', () => ({ default: ({ src, alt }) => <img src={src} alt={alt} /> }));
-vi.mock('../components/TagPicker', () => ({ default: () => <div data-testid="tag-picker" /> }));
+vi.mock('../components/loraTraining/CharacterLoraChip', () => ({ default: () => null }));
+vi.mock('../components/TagPicker', () => ({
+  default: ({ value = [], onChange }) => (
+    <button
+      type="button"
+      onClick={() => onChange(value.includes('example-tag')
+        ? value.filter((tag) => tag !== 'example-tag')
+        : [...value, 'example-tag'])}
+    >
+      Change tag
+    </button>
+  ),
+}));
 vi.mock('../components/ui/Toast', () => ({ default: { success: vi.fn(), error: vi.fn(), info: vi.fn() } }));
 
 import CatalogIngredient, { buildGenerationPromptSeed } from './CatalogIngredient';
-import { getCatalogIngredientDetails, unlinkCatalogIngredientRelation } from '../services/apiCatalog';
+import { getCatalogIngredientDetails, unlinkCatalogIngredientRelation, updateCatalogIngredient } from '../services/apiCatalog';
 
-const renderPage = () => render(<MemoryRouter><CatalogIngredient /></MemoryRouter>);
+const renderPage = (path = '/catalog/character/cat-chr-1') => {
+  const router = createMemoryRouter([
+    { path: '/catalog', element: <div>Catalog index</div> },
+    { path: '/catalog/:type/:id', element: <CatalogIngredient /> },
+  ], { initialEntries: [path] });
+  return { ...render(<RouterProvider router={router} />), router };
+};
 
 beforeEach(() => {
   getCatalogIngredientDetails.mockImplementation(async () => detailsOf(CHAR_FIXTURE));
+  updateCatalogIngredient.mockReset();
+  unlinkCatalogIngredientRelation.mockReset();
 });
 
 describe('CatalogIngredient — character sheet', () => {
@@ -142,6 +162,61 @@ describe('CatalogIngredient — character sheet', () => {
       { silent: true },
     ));
     await waitFor(() => expect(screen.queryByText('Example Place')).toBeNull());
+  });
+
+  describe('unsaved changes', () => {
+    it('tracks name, tags, and payload edits in the unsaved indicator', async () => {
+      renderPage();
+      const nameInput = await screen.findByLabelText('Name');
+      const descriptionInput = screen.getByDisplayValue('Sharp eyes, ink-stained cuffs.');
+      const tagButton = screen.getByRole('button', { name: 'Change tag' });
+
+      expect(screen.queryByText('Unsaved changes')).toBeNull();
+
+      fireEvent.change(nameInput, { target: { value: 'Edited ingredient' } });
+      expect(screen.getByText('Unsaved changes')).toBeTruthy();
+      fireEvent.change(nameInput, { target: { value: CHAR_FIXTURE.name } });
+      await waitFor(() => expect(screen.queryByText('Unsaved changes')).toBeNull());
+
+      fireEvent.click(tagButton);
+      expect(screen.getByText('Unsaved changes')).toBeTruthy();
+      fireEvent.click(tagButton);
+      await waitFor(() => expect(screen.queryByText('Unsaved changes')).toBeNull());
+
+      fireEvent.change(descriptionInput, { target: { value: 'Edited description' } });
+      expect(screen.getByText('Unsaved changes')).toBeTruthy();
+    });
+
+    it('confirms before the Back link discards dirty edits', async () => {
+      const { router } = renderPage();
+      const nameInput = await screen.findByLabelText('Name');
+      fireEvent.change(nameInput, { target: { value: 'Edited ingredient' } });
+
+      fireEvent.click(screen.getByRole('link', { name: /Back/ }));
+      expect(await screen.findByText('Discard your unsaved changes to this ingredient?')).toBeTruthy();
+      expect(screen.queryByText('Catalog index')).toBeNull();
+
+      fireEvent.click(screen.getByRole('button', { name: 'Keep editing' }));
+      await waitFor(() => expect(screen.queryByText('Discard your unsaved changes to this ingredient?')).toBeNull());
+      expect(router.state.location.pathname).toBe('/catalog/character/cat-chr-1');
+
+      fireEvent.click(screen.getByRole('link', { name: /Back/ }));
+      expect(await screen.findByText('Discard your unsaved changes to this ingredient?')).toBeTruthy();
+      fireEvent.click(screen.getByRole('button', { name: 'Discard' }));
+      expect(await screen.findByText('Catalog index')).toBeTruthy();
+    });
+
+    it('clears the unsaved indicator after a successful save', async () => {
+      updateCatalogIngredient.mockResolvedValue({ ...CHAR_FIXTURE, name: 'Saved ingredient' });
+      renderPage();
+      const nameInput = await screen.findByLabelText('Name');
+      fireEvent.change(nameInput, { target: { value: 'Saved ingredient' } });
+      expect(screen.getByText('Unsaved changes')).toBeTruthy();
+
+      fireEvent.click(screen.getByRole('button', { name: /^Save$/ }));
+      await waitFor(() => expect(updateCatalogIngredient).toHaveBeenCalled());
+      await waitFor(() => expect(screen.queryByText('Unsaved changes')).toBeNull());
+    });
   });
 
   it('renders grouped sheet sections with the enriched canon scalar fields', async () => {

--- a/client/src/services/apiAgents.js
+++ b/client/src/services/apiAgents.js
@@ -87,6 +87,10 @@ export const getPersistentMindVisibility = (options = {}) => {
 };
 export const sendPersistentMindMessage = (body, options = {}) =>
   request('/cos/mind/messages', { method: 'POST', body: JSON.stringify(body), ...options });
+export const uploadPersistentMindAttachment = (body, options = {}) =>
+  request('/cos/mind/attachments', { method: 'POST', body: JSON.stringify(body), ...options });
+export const deletePersistentMindAttachment = (attachmentId, options = {}) =>
+  request(`/cos/mind/attachments/${encodeURIComponent(attachmentId)}`, { method: 'DELETE', ...options });
 export const addPersistentMindAnnotation = (body, options = {}) =>
   request('/cos/mind/annotations', { method: 'POST', body: JSON.stringify(body), ...options });
 export const startPersistentMind = (options = {}) => request('/cos/mind/start', { method: 'POST', ...options });

--- a/server/routes/brain.test.js
+++ b/server/routes/brain.test.js
@@ -73,6 +73,7 @@ vi.mock('../services/brain.js', () => ({
   createBucket: vi.fn(),
   createBucketAppended: vi.fn(),
   updateBucket: vi.fn(),
+  reorderBuckets: vi.fn(),
   deleteBucket: vi.fn(),
   deleteBucketAndUnlinkChildren: vi.fn()
 }));
@@ -1450,19 +1451,23 @@ describe('Brain Routes', () => {
   });
 
   describe('POST /api/brain/buckets/reorder', () => {
-    it('persists order for each id in the given sequence', async () => {
+    it('persists order for all ids in one batch', async () => {
       const id3 = '33333333-3333-4333-8333-333333333333';
       const id1 = '11111111-1111-4111-8111-111111111111';
       const id2 = '22222222-2222-4222-8222-222222222222';
-      brainService.updateBucket.mockResolvedValue({});
+      brainService.reorderBuckets.mockResolvedValue([]);
       brainService.getBuckets.mockResolvedValue([]);
       const res = await request(app)
         .post('/api/brain/buckets/reorder')
         .send({ ids: [id3, id1, id2] });
       expect(res.status).toBe(200);
-      expect(brainService.updateBucket).toHaveBeenNthCalledWith(1, id3, { order: 0 });
-      expect(brainService.updateBucket).toHaveBeenNthCalledWith(2, id1, { order: 1 });
-      expect(brainService.updateBucket).toHaveBeenNthCalledWith(3, id2, { order: 2 });
+      expect(brainService.reorderBuckets).toHaveBeenCalledTimes(1);
+      expect(brainService.reorderBuckets).toHaveBeenCalledWith([
+        { id: id3, order: 0 },
+        { id: id1, order: 1 },
+        { id: id2, order: 2 },
+      ]);
+      expect(brainService.updateBucket).not.toHaveBeenCalled();
     });
   });
 

--- a/server/routes/brainLinks.js
+++ b/server/routes/brainLinks.js
@@ -316,9 +316,7 @@ router.post('/buckets', asyncHandler(async (req, res) => {
  */
 router.post('/buckets/reorder', asyncHandler(async (req, res) => {
   const { ids } = validateRequest(bucketReorderSchema, req.body);
-  for (let i = 0; i < ids.length; i++) {
-    await brainService.updateBucket(ids[i], { order: i });
-  }
+  await brainService.reorderBuckets(ids.map((id, order) => ({ id, order })));
   const buckets = await brainService.getBuckets();
   buckets.sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
   res.json({ buckets });

--- a/server/routes/brainLinks.test.js
+++ b/server/routes/brainLinks.test.js
@@ -28,6 +28,7 @@ vi.mock('../services/brain.js', () => ({
   getBucketById: vi.fn(),
   createBucketAppended: vi.fn(),
   updateBucket: vi.fn(),
+  reorderBuckets: vi.fn(),
   deleteBucketAndUnlinkChildren: vi.fn(),
 }));
 

--- a/server/services/brain.js
+++ b/server/services/brain.js
@@ -911,6 +911,7 @@ export const getBuckets = storage.getBuckets;
 export const getBucketById = storage.getBucketById;
 export const createBucket = storage.createBucket;
 export const updateBucket = storage.updateBucket;
+export const reorderBuckets = storage.reorderBuckets;
 export const deleteBucket = storage.deleteBucket;
 
 /**

--- a/server/services/brain.test.js
+++ b/server/services/brain.test.js
@@ -59,6 +59,7 @@ vi.mock('./brainStorage.js', () => {
     getBucketById: vi.fn(),
     createBucket: vi.fn(),
     updateBucket: vi.fn(),
+    reorderBuckets: vi.fn(),
     deleteBucket: vi.fn()
   };
 });
@@ -1402,6 +1403,11 @@ describe('brain service', () => {
     it('should re-export getSummary from storage', async () => {
       const { getSummary } = await import('./brain.js');
       expect(getSummary).toBe(storage.getSummary);
+    });
+
+    it('should re-export reorderBuckets from storage', async () => {
+      const { reorderBuckets } = await import('./brain.js');
+      expect(reorderBuckets).toBe(storage.reorderBuckets);
     });
   });
 

--- a/server/services/brainJournal.js
+++ b/server/services/brainJournal.js
@@ -127,6 +127,27 @@ async function saveObsidianLocation(date, { obsidianPath, obsidianVaultId }) {
   await atomicWrite(OBSIDIAN_LOCATIONS_FILE, map);
 }
 
+// Apply a bulk re-sync's changed locations in one sidecar write. Re-check each
+// record under the same mutex as individual writes so a day deleted while the
+// foreground re-sync was running cannot be resurrected in the local map.
+async function saveObsidianLocations(locations) {
+  if (!locations.size) return;
+  return storeMutex(async () => {
+    const map = { ...(await loadObsidianLocations()) };
+    let changed = false;
+    for (const [date, location] of locations) {
+      if (!(await brainStorage.getById('journals', date))) continue;
+      if (map[date]?.obsidianPath === location.obsidianPath && map[date]?.obsidianVaultId === location.obsidianVaultId) continue;
+      map[date] = location;
+      changed = true;
+    }
+    if (!changed) return;
+    obsidianLocationsCache = map;
+    obsidianLocationsCacheTime = Date.now();
+    await atomicWrite(OBSIDIAN_LOCATIONS_FILE, map);
+  });
+}
+
 // ── Synced journal entry store ───────────────────────────────────────────────
 
 // Daily Log entries are keyed by calendar date in the entity store, so the
@@ -442,7 +463,7 @@ function buildObsidianNotePath(settings, date) {
  * all entries now" action so users who turn off auto-sync can still trigger
  * a one-shot backfill.
  */
-export async function syncToObsidian(entry, { force = false } = {}) {
+export async function syncToObsidian(entry, { force = false, locationUpdates = null } = {}) {
   const settings = await getSettings();
   if (!settings.obsidianVaultId) return null;
   if (!force && !settings.autoSync) return null;
@@ -460,6 +481,10 @@ export async function syncToObsidian(entry, { force = false } = {}) {
   // a vault swap in Settings both need to update the store so a later
   // deleteJournal() unlinks the right file in the right vault.
   if (entry.obsidianPath !== notePath || entry.obsidianVaultId !== vaultId) {
+    if (locationUpdates) {
+      locationUpdates.set(entry.date, { obsidianPath: notePath, obsidianVaultId: vaultId });
+      return notePath;
+    }
     await persistObsidianLocation(entry.date, notePath, vaultId);
   }
   return notePath;
@@ -521,11 +546,12 @@ export async function resyncAllToObsidian() {
   let skipped = 0;
   let consecutiveSkips = 0;
   let stoppedEarly = false;
+  const locationUpdates = new Map();
   for (const entry of records) {
     // force:true so this bulk resync still writes even when the user has
     // turned off the per-write autoSync — they explicitly clicked "Re-sync
     // all entries now", which is the manual-sync escape hatch.
-    const path = await syncToObsidian(entry, { force: true }).catch(() => null);
+    const path = await syncToObsidian(entry, { force: true, locationUpdates }).catch(() => null);
     if (path) {
       synced += 1;
       consecutiveSkips = 0;
@@ -547,5 +573,6 @@ export async function resyncAllToObsidian() {
       break;
     }
   }
+  await saveObsidianLocations(locationUpdates);
   return { synced, skipped, stoppedEarly };
 }

--- a/server/services/brainJournal.test.js
+++ b/server/services/brainJournal.test.js
@@ -15,6 +15,7 @@ vi.mock('../lib/fileUtils.js', async () => {
   const actual = await vi.importActual('../lib/fileUtils.js');
   return {
     ...actual,
+    atomicWrite: vi.fn(actual.atomicWrite),
     PATHS: { ...actual.PATHS, brain: TEMP_ROOT },
   };
 });
@@ -84,6 +85,7 @@ vi.mock('./brainStorage.js', () => ({
 
 import * as journal from './brainJournal.js';
 import { brainEvents, getAll, getById } from './brainStorage.js';
+import { atomicWrite } from '../lib/fileUtils.js';
 import * as obsidian from './obsidian.js';
 
 // Pull the payload of the last emit of `name`, or undefined if it never fired.
@@ -445,6 +447,22 @@ describe('brainJournal', () => {
       // mirror per entry, which would double the call count. resyncAllToObsidian
       // passes force:true, so it still runs.
       await journal.updateSettings({ obsidianVaultId: 'v1', autoSync: false, obsidianFolder: 'Daily Log' });
+    });
+
+    it('writes all changed Obsidian locations in one sidecar save', async () => {
+      for (let i = 0; i < 3; i += 1) await journal.appendJournal(isoDay(i), `day ${i}`);
+      obsidian.upsertNote.mockResolvedValue('Daily Log/note.md');
+      atomicWrite.mockClear();
+
+      await journal.resyncAllToObsidian();
+
+      expect(atomicWrite).toHaveBeenCalledTimes(1);
+      const locations = await Promise.all([0, 1, 2].map((i) => journal.getJournal(isoDay(i))));
+      expect(locations.map(({ obsidianPath, obsidianVaultId }) => ({ obsidianPath, obsidianVaultId }))).toEqual([
+        { obsidianPath: 'Daily Log/2026-01-01.md', obsidianVaultId: 'v1' },
+        { obsidianPath: 'Daily Log/2026-01-02.md', obsidianVaultId: 'v1' },
+        { obsidianPath: 'Daily Log/2026-01-03.md', obsidianVaultId: 'v1' },
+      ]);
     });
 
     it('stops after a run of consecutive failures instead of grinding through every entry', async () => {

--- a/server/services/brainStorage.js
+++ b/server/services/brainStorage.js
@@ -644,6 +644,60 @@ export async function updateMany(type, updates) {
 }
 
 /**
+ * Apply a batch whose records can be persisted independently and whose sync
+ * entries should be appended together. Per-record queues still protect each
+ * record's read-modify-write, while Promise.allSettled lets successful writes
+ * reach the batch log before a failed sibling is surfaced to the caller.
+ */
+async function updateManyWithBatchLog(type, updates) {
+  const store = storeFor(type);
+  const results = await Promise.allSettled(updates.map(({ id, ...fields }) => {
+    if (!store.isValidId(id)) return null;
+    return store.queueRecordWrite(id, async () => {
+      const existing = await store.loadOne(id);
+      if (!existing || isTombstone(existing)) return null;
+
+      const record = {
+        ...existing,
+        ...fields,
+        // Preserve immutable fields, exactly as update() does.
+        originInstanceId: existing.originInstanceId,
+        createdAt: existing.createdAt,
+        updatedAt: now()
+      };
+
+      await store.saveOneNow(id, record);
+      return { id, record };
+    });
+  }));
+  const failures = results.filter(({ status }) => status === 'rejected');
+  const applied = results
+    .filter(({ status }) => status === 'fulfilled')
+    .map(({ value }) => value)
+    .filter(Boolean);
+
+  for (const { id, record } of applied) {
+    brainEvents.emit(`${type}:upserted`, { id, record: { id, ...record } });
+  }
+
+  if (applied.length > 0) {
+    await brainSyncLog.appendChanges(applied.map(({ id, record }) => ({
+      op: 'update',
+      type,
+      id,
+      record,
+      originInstanceId: record.originInstanceId,
+    }))).catch(err => console.error(`⚠️ Sync log batch append failed for ${type}: ${err.message}`));
+  }
+
+  if (failures.length > 0) throw failures[0].reason;
+  if (applied.length === 0) return [];
+
+  console.log(`🧠 Updated ${applied.length} ${type} records in one batch`);
+  return applied.map(({ id, record }) => ({ id, ...record }));
+}
+
+/**
  * Delete a record
  */
 export async function remove(type, id) {
@@ -1064,6 +1118,9 @@ export const getBuckets = (filters) => filters ? query('buckets', filters) : get
 export const getBucketById = (id) => getById('buckets', id);
 export const createBucket = (data) => create('buckets', data);
 export const updateBucket = (id, data) => update('buckets', id, data);
+// Bucket order changes are one user gesture; persist the independent records
+// together and append their federation entries with one sync-log write.
+export const reorderBuckets = (updates) => updateManyWithBatchLog('buckets', updates);
 export const deleteBucket = (id) => remove('buckets', id);
 
 // =============================================================================

--- a/server/services/brainStorage.test.js
+++ b/server/services/brainStorage.test.js
@@ -25,7 +25,16 @@ vi.mock('./instances.js', () => ({
   getInstanceId: () => Promise.resolve('local-instance'),
 }));
 
+vi.mock('./brainSyncLog.js', async () => {
+  const actual = await vi.importActual('./brainSyncLog.js');
+  return {
+    ...actual,
+    appendChanges: vi.fn(actual.appendChanges),
+  };
+});
+
 import * as brainStorage from './brainStorage.js';
+import * as brainSyncLog from './brainSyncLog.js';
 
 afterAll(() => { if (tempRoot) rmSync(tempRoot, { recursive: true, force: true }); });
 
@@ -294,6 +303,43 @@ describe('updateWith (locked read-modify-write)', () => {
     const stored = await brainStorage.getById('songs', created.id);
     expect(stored.title).toBe('Abort Song');
     expect(stored.updatedAt).toBe(created.updatedAt); // no write happened
+  });
+});
+
+describe('reorderBuckets (batched sync log)', () => {
+  it('writes all bucket orders and appends one sync-log batch', async () => {
+    const first = await brainStorage.create('buckets', { name: 'First', order: 0 });
+    const second = await brainStorage.create('buckets', { name: 'Second', order: 1 });
+    brainSyncLog.appendChanges.mockClear();
+
+    const reordered = await brainStorage.reorderBuckets([
+      { id: second.id, order: 0 },
+      { id: first.id, order: 1 },
+    ]);
+
+    expect(reordered.map(({ id, order }) => ({ id, order }))).toEqual([
+      { id: second.id, order: 0 },
+      { id: first.id, order: 1 },
+    ]);
+    expect(await brainStorage.getBucketById(first.id)).toMatchObject({ name: 'First', order: 1 });
+    expect(await brainStorage.getBucketById(second.id)).toMatchObject({ name: 'Second', order: 0 });
+    expect(brainSyncLog.appendChanges).toHaveBeenCalledTimes(1);
+    expect(brainSyncLog.appendChanges).toHaveBeenCalledWith([
+      expect.objectContaining({
+        op: 'update',
+        type: 'buckets',
+        id: second.id,
+        record: expect.objectContaining({ order: 0 }),
+        originInstanceId: 'local-instance',
+      }),
+      expect.objectContaining({
+        op: 'update',
+        type: 'buckets',
+        id: first.id,
+        record: expect.objectContaining({ order: 1 }),
+        originInstanceId: 'local-instance',
+      }),
+    ]);
   });
 });
 

--- a/server/services/persistentMindSupervisor.attachments.test.js
+++ b/server/services/persistentMindSupervisor.attachments.test.js
@@ -94,8 +94,8 @@ const uploadRecord = (overrides = {}) => ({
   originalName: 'diagram.png',
   mimeType: 'image/png',
   size: PNG.length,
-  uploadedAt: '2026-08-27T00:00:00.000Z',
-  expiresAt: '2026-08-28T00:00:00.000Z',
+  uploadedAt: new Date(Date.now() - 60_000).toISOString(),
+  expiresAt: new Date(Date.now() + 86_400_000).toISOString(),
   ...overrides,
 });
 
@@ -278,7 +278,7 @@ describe('persistent mind image attachment lifecycle', () => {
 
   it('cleans a pending upload whose stored bytes fail validation', async () => {
     mocks.root.persistentMind.pendingAttachments = [uploadRecord({ expiresAt: '2026-08-28T00:00:00.000Z' })];
-    mocks.detectImageFormat.mockReturnValue(null);
+    mocks.detectImageFormat.mockReturnValueOnce(null);
 
     await expect(supervisor.cleanupPersistentMindAttachments({ now: Date.parse('2026-08-27T00:00:00.000Z') }))
       .resolves.toMatchObject({ success: true, removed: 1, examined: 1 });


### PR DESCRIPTION
## Summary

- Add client UI and API methods for Persistent Mind image attachments (#5170).
- Support uploading, previewing, and removing image attachments in the mind chat composer.
- Render attached images in conversation items and the event details panel.
- Disable image attachments with helpful guidance when the active model lacks vision capabilities.
- Add comprehensive test coverage in `MindTab.test.jsx` and deflake timestamp assertions in `persistentMindSupervisor.attachments.test.js`.