### PR TITLE
fix: clarify Persistent Mind context tab

### DIFF
--- a/client/src/components/cos/tabs/MindTab.jsx
+++ b/client/src/components/cos/tabs/MindTab.jsx
@@ -23,7 +23,7 @@ const MAX_VISIBLE_EVENTS = PAGE_LIMIT * MAX_BACKFILL_PAGES;
 const MIND_VIEWS = new Set(['conversation', 'context', 'setup']);
 const MIND_TABS = [
   { id: 'conversation', label: 'Chat', icon: MessageCircle },
-  { id: 'context', label: 'Memory', icon: Brain },
+  { id: 'context', label: 'Context', icon: Brain },
   { id: 'setup', label: 'Settings', icon: Settings2 },
 ];
 

--- a/client/src/components/cos/tabs/MindTab.test.jsx
+++ b/client/src/components/cos/tabs/MindTab.test.jsx
@@ -404,6 +404,8 @@ describe('MindTab', () => {
 
   it('loads the editable effective context from the URL-backed context view', async () => {
     renderTab('/cos/mind?view=context');
+    expect(screen.getByRole('tab', { name: 'Context' })).toHaveAttribute('aria-selected', 'true');
+    expect(screen.queryByRole('tab', { name: 'Memory' })).not.toBeInTheDocument();
     expect(await screen.findByRole('heading', { name: 'Identity and operating prompt' })).toBeInTheDocument();
     expect(screen.getByLabelText('Identity')).toHaveValue('Resident mind');
     expect(screen.getByText('# Effective context')).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- Rename the Persistent Mind `Memory` sub-tab to `Context` so it reflects its prompt, context, visibility, and runtime information.
- Preserve the existing URL-backed `view=context` route and distinguish this view from Chief of Staff > Memory.

## Test plan
- `cd client && npm test -- --run src/components/cos/tabs/MindTab.test.jsx`
- `cd client && npm run lint`
- `cd client && npm run build`
