### PR TITLE
fix: prebundle Recharts for lazy MeatSpace tabs

### DIFF
--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -104,6 +104,12 @@ export default defineConfig(({ mode }) => {
         template: 'treemap',
       }),
     ].filter(Boolean),
+    // Recharts is imported by lazy-loaded pages. Its published ESM files use
+    // bare es-toolkit/compat/* imports, so prebundle it before a lazy tab can
+    // expose those specifiers directly to the browser.
+    optimizeDeps: {
+      include: ['recharts']
+    },
     server: {
       host: '0.0.0.0',
       port: 5554,

--- a/server/lib/apiRouteCatalog.generated.json
+++ b/server/lib/apiRouteCatalog.generated.json
@@ -5567,7 +5567,7 @@
       "sources": [
         {
           "source": "server/routes/cosMindRoutes.js",
-          "line": 150
+          "line": 151
         }
       ]
     },
@@ -5578,7 +5578,7 @@
       "sources": [
         {
           "source": "server/routes/cosMindRoutes.js",
-          "line": 268
+          "line": 271
         }
       ]
     },
@@ -5589,7 +5589,7 @@
       "sources": [
         {
           "source": "server/routes/cosMindRoutes.js",
-          "line": 253
+          "line": 256
         }
       ]
     },
@@ -5600,7 +5600,7 @@
       "sources": [
         {
           "source": "server/routes/cosMindRoutes.js",
-          "line": 258
+          "line": 261
         }
       ]
     },
@@ -5611,7 +5611,7 @@
       "sources": [
         {
           "source": "server/routes/cosMindRoutes.js",
-          "line": 177
+          "line": 180
         }
       ]
     },
@@ -5622,7 +5622,7 @@
       "sources": [
         {
           "source": "server/routes/cosMindRoutes.js",
-          "line": 294
+          "line": 297
         }
       ]
     },
@@ -5633,7 +5633,7 @@
       "sources": [
         {
           "source": "server/routes/cosMindRoutes.js",
-          "line": 307
+          "line": 310
         }
       ]
     },
@@ -5644,7 +5644,7 @@
       "sources": [
         {
           "source": "server/routes/cosMindRoutes.js",
-          "line": 239
+          "line": 242
         }
       ]
     },
@@ -5655,7 +5655,7 @@
       "sources": [
         {
           "source": "server/routes/cosMindRoutes.js",
-          "line": 245
+          "line": 248
         }
       ]
     },
@@ -5666,7 +5666,7 @@
       "sources": [
         {
           "source": "server/routes/cosMindRoutes.js",
-          "line": 263
+          "line": 266
         }
       ]
     },
@@ -5677,7 +5677,7 @@
       "sources": [
         {
           "source": "server/routes/cosMindRoutes.js",
-          "line": 280
+          "line": 283
         }
       ]
     },
@@ -5688,7 +5688,7 @@
       "sources": [
         {
           "source": "server/routes/cosMindRoutes.js",
-          "line": 286
+          "line": 289
         }
       ]
     },
@@ -5699,7 +5699,7 @@
       "sources": [
         {
           "source": "server/routes/cosMindRoutes.js",
-          "line": 220
+          "line": 223
         }
       ]
     },
@@ -5710,7 +5710,7 @@
       "sources": [
         {
           "source": "server/routes/cosMindRoutes.js",
-          "line": 276
+          "line": 279
         }
       ]
     },
@@ -5721,7 +5721,7 @@
       "sources": [
         {
           "source": "server/routes/cosMindRoutes.js",
-          "line": 290
+          "line": 293
         }
       ]
     },
@@ -5732,7 +5732,7 @@
       "sources": [
         {
           "source": "server/routes/cosMindRoutes.js",
-          "line": 204
+          "line": 207
         }
       ]
     },
@@ -5743,7 +5743,7 @@
       "sources": [
         {
           "source": "server/routes/cosMindRoutes.js",
-          "line": 229
+          "line": 232
         }
       ]
     },
@@ -21303,7 +21303,7 @@
       "sources": [
         {
           "source": "server/routes/update.js",
-          "line": 71
+          "line": 104
         }
       ]
     },
@@ -21314,7 +21314,7 @@
       "sources": [
         {
           "source": "server/routes/update.js",
-          "line": 146
+          "line": 179
         }
       ]
     },
@@ -21325,7 +21325,7 @@
       "sources": [
         {
           "source": "server/routes/update.js",
-          "line": 85
+          "line": 118
         }
       ]
     },
@@ -21336,7 +21336,7 @@
       "sources": [
         {
           "source": "server/routes/update.js",
-          "line": 77
+          "line": 110
         }
       ]
     },
@@ -21347,7 +21347,7 @@
       "sources": [
         {
           "source": "server/routes/update.js",
-          "line": 64
+          "line": 94
         }
       ]
     },
@@ -21358,7 +21358,7 @@
       "sources": [
         {
           "source": "server/routes/update.js",
-          "line": 96
+          "line": 129
         }
       ]
     },

--- a/server/lib/socketEventCatalog.generated.json
+++ b/server/lib/socketEventCatalog.generated.json
@@ -934,7 +934,7 @@
         {
           "direction": "server-to-client",
           "source": "client/src/pages/CatalogIngest.jsx",
-          "line": 144
+          "line": 146
         },
         {
           "direction": "server-to-client",
@@ -999,7 +999,7 @@
         {
           "direction": "server-to-client",
           "source": "client/src/components/cos/tabs/MindTab.jsx",
-          "line": 285
+          "line": 311
         },
         {
           "direction": "server-to-client",
@@ -1456,7 +1456,7 @@
         {
           "direction": "server-to-client",
           "source": "client/src/components/cos/tabs/MindTab.jsx",
-          "line": 286
+          "line": 312
         },
         {
           "direction": "server-to-client",
@@ -1474,7 +1474,7 @@
         {
           "direction": "server-to-client",
           "source": "client/src/components/cos/tabs/MindTab.jsx",
-          "line": 287
+          "line": 313
         },
         {
           "direction": "server-to-client",
@@ -3658,7 +3658,7 @@
         {
           "direction": "server-to-client",
           "source": "server/routes/update.js",
-          "line": 262
+          "line": 309
         }
       ]
     },
@@ -3676,12 +3676,12 @@
         {
           "direction": "server-to-client",
           "source": "server/routes/update.js",
-          "line": 264
+          "line": 311
         },
         {
           "direction": "server-to-client",
           "source": "server/routes/update.js",
-          "line": 269
+          "line": 316
         }
       ]
     },
@@ -3699,7 +3699,7 @@
         {
           "direction": "server-to-client",
           "source": "server/routes/update.js",
-          "line": 237
+          "line": 284
         }
       ]
     },


### PR DESCRIPTION
## Summary
- Explicitly prebundle Recharts in Vite dependency optimization.
- Prevent lazy MeatSpace chart tabs from exposing Recharts' bare `es-toolkit/compat/*` imports to the browser.

## Test plan
- `cd client && npm run lint`
- `cd client && npm test -- src/services/apiMeatspace.test.js`
- `cd client && npm run build`