### PR TITLE
feat: add non-worktree task completion choice

### DIFF
--- a/client/src/components/cos/TaskAddForm.jsx
+++ b/client/src/components/cos/TaskAddForm.jsx
@@ -53,6 +53,7 @@ export default function TaskAddForm({ providers, apps, onTaskAdded, compact = fa
   // An app that explicitly pins either flag false still wins — see the
   // app-defaults effect below, which distinguishes absent from `false`.
   const [useWorktree, setUseWorktree] = useState(true);
+  const [whenDone, setWhenDone] = useState('leave-uncommitted');
   const [openPR, setOpenPR] = useState(true);
   const [simplify, setSimplify] = useState(true);
   const [planOnly, setPlanOnly] = useState(false);
@@ -508,6 +509,7 @@ export default function TaskAddForm({ providers, apps, onTaskAdded, compact = fa
       slashdoArgs: planOnly ? '--yes' : undefined,
       createJiraTicket: planOnly ? false : createJiraTicket,
       useWorktree: planOnly ? false : useWorktree,
+      whenDone: planOnly || useWorktree ? undefined : whenDone,
       openPR: planOnly ? false : useWorktree && openPR,
       simplify: planOnly ? false : simplify,
       // Omitted entirely when no template pinned a posture — sending `undefined`
@@ -785,6 +787,15 @@ export default function TaskAddForm({ providers, apps, onTaskAdded, compact = fa
                   Worktree
                 </span>
               </label>
+              {!useWorktree && (
+                <label htmlFor="task-when-done" className="flex items-center gap-2 py-1 basis-full sm:basis-auto">
+                  <span className="text-sm text-gray-400">When done</span>
+                  <select id="task-when-done" value={whenDone} onChange={(e) => setWhenDone(e.target.value)} className="min-w-52 rounded border border-port-border bg-port-bg px-2 py-1 text-sm text-white focus:border-port-accent focus:outline-hidden">
+                    <option value="leave-uncommitted">Leave code uncommitted</option>
+                    <option value="commit-push">Commit and push to default branch</option>
+                  </select>
+                </label>
+              )}
               <label className="flex items-center gap-2 cursor-pointer select-none whitespace-nowrap py-1">
                 <input
                   type="checkbox"

--- a/client/src/components/cos/TaskAddForm.test.jsx
+++ b/client/src/components/cos/TaskAddForm.test.jsx
@@ -195,6 +195,21 @@ describe('TaskAddForm responsive layout', () => {
     });
   });
 
+  it('offers and submits the non-worktree completion choice', async () => {
+    const user = userEvent.setup();
+    api.addCosTask.mockResolvedValue({ success: true });
+    render(<TaskAddForm providers={[]} apps={[]} onTaskAdded={vi.fn()} />);
+
+    await user.click(worktreeToggle());
+    expect(screen.getByLabelText('When done')).toHaveValue('leave-uncommitted');
+    await user.selectOptions(screen.getByLabelText('When done'), 'commit-push');
+    await user.type(screen.getByPlaceholderText('Task description *'), 'Update default branch');
+    await user.click(screen.getByRole('button', { name: /^Add$/ }));
+
+    await waitFor(() => expect(api.addCosTask).toHaveBeenCalled());
+    expect(api.addCosTask.mock.calls.at(-1)[0]).toMatchObject({ useWorktree: false, whenDone: 'commit-push' });
+  });
+
   it.each([
     ['PLAN.md', 'plan', 'plan'],
     ['JIRA', 'jira', 'jira'],

--- a/server/lib/cosValidation.js
+++ b/server/lib/cosValidation.js
@@ -1262,6 +1262,7 @@ export const createCosTaskSchema = z.object({
     v => v === 'true' ? true : v === 'false' ? false : v,
     z.boolean().optional()
   ),
+  whenDone: z.enum(['commit-push', 'leave-uncommitted']).optional(),
   // Read-only planning mode: investigate the codebase and file the issue, but
   // do not start implementation delivery. The task store expands this into
   // the safe no-worktree/no-PR/no-simplify posture before persistence.
@@ -1912,6 +1913,10 @@ export function sanitizeTaskMetadata(raw) {
   }
   if (Object.prototype.hasOwnProperty.call(raw, 'reviewerApplies') && typeof raw.reviewerApplies === 'boolean') {
     clean.reviewerApplies = raw.reviewerApplies;
+    hasKeys = true;
+  }
+  if (Object.prototype.hasOwnProperty.call(raw, 'whenDone') && ['commit-push', 'leave-uncommitted'].includes(raw.whenDone)) {
+    clean.whenDone = raw.whenDone;
     hasKeys = true;
   }
   // `prAuthorFilter` gates pr-watcher dispatch on PR authorship — constrained

--- a/server/lib/cosValidation.test.js
+++ b/server/lib/cosValidation.test.js
@@ -199,6 +199,16 @@ describe('cosValidation plan-only task mode', () => {
 
 });
 
+describe('cosValidation non-worktree completion choice', () => {
+  it('accepts the supported completion choices and preserves them through metadata sanitization', () => {
+    expect(createCosTaskSchema.parse({ description: 'x', whenDone: 'commit-push' }).whenDone).toBe('commit-push');
+    expect(createCosTaskSchema.parse({ description: 'x', whenDone: 'leave-uncommitted' }).whenDone).toBe('leave-uncommitted');
+    expect(createCosTaskSchema.safeParse({ description: 'x', whenDone: 'later' }).success).toBe(false);
+    expect(sanitizeTaskMetadata({ whenDone: 'commit-push' })).toEqual({ whenDone: 'commit-push' });
+    expect(sanitizeTaskMetadata({ whenDone: 'later' })).toBeNull();
+  });
+});
+
 describe('cosValidation reviewer CLI binaries', () => {
   // The bug this exists to prevent: `antigravity` is the stored, federated
   // reviewer identity, but the shipped executable is `agy` — no `antigravity`

--- a/server/services/agentPromptBuilder.js
+++ b/server/services/agentPromptBuilder.js
@@ -320,6 +320,7 @@ export async function buildAgentPrompt(task, config, workspaceDir, worktreeInfo 
 
   // Build worktree context section if applicable
   const willOpenPR = isTruthyMetaFn(task.metadata?.openPR);
+  const whenDone = task.metadata?.whenDone === 'commit-push' ? 'commit-push' : 'leave-uncommitted';
   const claimFlow = isClaimFlowTask(task, isTruthyMetaFn);
   const prCompletion = resolvePrCompletion(task.metadata);
   // A discard (reasoning-only) worktree: the agent reasons in it but it's thrown
@@ -659,7 +660,7 @@ ${skillSection ? `## Task-Type Skill Guidelines\n\n${skillSection}\n` : ''}${too
 - Never update the PortOS changelog (\`.changelog/\`) for work on managed apps — the PortOS changelog tracks PortOS core changes only
 ${(() => {
   const bullet = buildCompletionGuidelineBullet({
-    isReadOnly: isTruthyMetaFn(task.metadata?.readOnly),
+    isReadOnly: isTruthyMetaFn(task.metadata?.readOnly), whenDone,
     isTui, tuiCompletionCommand, slashdoFree: isTui && !canRunSlashCommands,
     worktreeInfo, willOpenPR, prCompletion, discardWorktree, noCodeOutput, noChangeSuccess,
     leavePrOpen: leavesPrForHuman(task),

--- a/server/services/cosTaskStore.js
+++ b/server/services/cosTaskStore.js
@@ -388,7 +388,7 @@ export async function addTask(taskData, taskType = 'user', { raw = false, ignore
     // always wins, and internal/system tasks (autopilot, self-improvement) keep
     // their existing auto-merge behavior so automation isn't silently gated on a
     // human merging a PR.
-    else if (taskData.useWorktree === true && taskType === 'user') metadata.openPR = true;
+    else if (taskData.openPR === undefined && taskData.useWorktree === true && taskType === 'user') metadata.openPR = true;
     // Claim prompts own their forge lifecycle in a separately-created
     // claim/<item> worktree. Keep this marker independent from openPR: false is
     // still required to stop CoS from provisioning a second worktree.

--- a/server/services/cosTaskStore.js
+++ b/server/services/cosTaskStore.js
@@ -379,6 +379,7 @@ export async function addTask(taskData, taskType = 'user', { raw = false, ignore
     else if (taskData.useWorktree === false) metadata.useWorktree = false;
     if (taskData.openPR === true) metadata.openPR = true;
     else if (taskData.openPR === false) metadata.openPR = false;
+    if (taskData.whenDone === 'commit-push' || taskData.whenDone === 'leave-uncommitted') metadata.whenDone = taskData.whenDone;
     // Default a worktree-isolated USER task to opening a PR rather than
     // auto-merging straight to the default branch — an unreviewed agent commit
     // landing on main is the more dangerous default (see the local-model eval

--- a/server/services/cosTaskStore.test.js
+++ b/server/services/cosTaskStore.test.js
@@ -857,6 +857,11 @@ describe('cosTaskStore.addTask', () => {
     expect(task.metadata.prCompletion).toBe('leave-open');
   });
 
+  it('persists the non-worktree completion choice', async () => {
+    const task = await addTask({ description: 'commit in place', useWorktree: false, whenDone: 'commit-push' }, 'user');
+    expect(task.metadata.whenDone).toBe('commit-push');
+  });
+
   it('defaults a worktree USER task to openPR:true when openPR is unspecified', async () => {
     const task = await addTask({ description: 'wt default pr', useWorktree: true }, 'user');
     expect(task.metadata.useWorktree).toBe(true);

--- a/server/services/promptSections/completion.js
+++ b/server/services/promptSections/completion.js
@@ -44,7 +44,7 @@ function withNoChangeAuditGuidance(guidance, noChangeSuccess) {
 export function buildCompletionGuidelineBullet({
   isReadOnly, isTui, tuiCompletionCommand, slashdoFree = false,
   worktreeInfo, willOpenPR, prCompletion = PR_COMPLETIONS.MERGE_ON_GREEN, discardWorktree = false, noCodeOutput = false,
-  leavePrOpen = false, isPrFollowUp = false, claimFlow = false, noChangeSuccess = false, whenDone = 'leave-uncommitted',
+  leavePrOpen = false, isPrFollowUp = false, claimFlow = false, noChangeSuccess = false, whenDone = null,
 }) {
   // A PR follow-up (review-loop or merge-only) already carries its own PRIMARY
   // OBJECTIVE section with the full procedure, and its cleanup runs with
@@ -100,7 +100,7 @@ export function buildCompletionGuidelineBullet({
   if (worktreeInfo) {
     return withNoChangeAuditGuidance('Your worktree branch will be automatically merged back to the source branch when your task completes — do NOT open a PR.', noChangeSuccess);
   }
-  return whenDone === 'commit-push'
+  return whenDone === null ? null : whenDone === 'commit-push'
     ? 'Commit and push your changes to the default branch (see Git Hygiene below).'
     : 'Leave your code changes uncommitted in the default branch; do not commit or push.';
 }

--- a/server/services/promptSections/completion.js
+++ b/server/services/promptSections/completion.js
@@ -44,7 +44,7 @@ function withNoChangeAuditGuidance(guidance, noChangeSuccess) {
 export function buildCompletionGuidelineBullet({
   isReadOnly, isTui, tuiCompletionCommand, slashdoFree = false,
   worktreeInfo, willOpenPR, prCompletion = PR_COMPLETIONS.MERGE_ON_GREEN, discardWorktree = false, noCodeOutput = false,
-  leavePrOpen = false, isPrFollowUp = false, claimFlow = false, noChangeSuccess = false,
+  leavePrOpen = false, isPrFollowUp = false, claimFlow = false, noChangeSuccess = false, whenDone = 'leave-uncommitted',
 }) {
   // A PR follow-up (review-loop or merge-only) already carries its own PRIMARY
   // OBJECTIVE section with the full procedure, and its cleanup runs with
@@ -100,7 +100,9 @@ export function buildCompletionGuidelineBullet({
   if (worktreeInfo) {
     return withNoChangeAuditGuidance('Your worktree branch will be automatically merged back to the source branch when your task completes — do NOT open a PR.', noChangeSuccess);
   }
-  return null;
+  return whenDone === 'commit-push'
+    ? 'Commit and push your changes to the default branch (see Git Hygiene below).'
+    : 'Leave your code changes uncommitted in the default branch; do not commit or push.';
 }
 
 // One-line worktree note for a discard (reasoning-only) task, replacing the


### PR DESCRIPTION
## Summary
- Add a When done selector for tasks that run without an isolated worktree.
- Persist the choice and instruct agents to either leave changes uncommitted or commit and push to the default branch.

## Test plan
- npm test -- --run src/components/cos/TaskAddForm.test.jsx