### PR TITLE
feat: clarify persistent mind workspace access

### DIFF
--- a/client/src/components/cos/PersistentMindTaskAccessControls.jsx
+++ b/client/src/components/cos/PersistentMindTaskAccessControls.jsx
@@ -7,6 +7,7 @@ const normalizeCapabilities = (value) => ({
   createTasks: value?.createTasks === true,
   readPortos: value?.readPortos === true,
   writePortos: value?.writePortos === true,
+  ...(Array.isArray(value?.allowedAppIds) ? { allowedAppIds: [...new Set(value.allowedAppIds)] } : {}),
 });
 
 const OPTIONS = [
@@ -29,6 +30,7 @@ const OPTIONS = [
 
 export default function PersistentMindTaskAccessControls({
   capabilities,
+  taskCatalog,
   disabled = false,
   onSaved,
   onSavingChange,
@@ -36,10 +38,12 @@ export default function PersistentMindTaskAccessControls({
   const idPrefix = useId();
   const [draft, setDraft] = useState(() => normalizeCapabilities(capabilities));
   const [saving, setSaving] = useState(false);
+  const taskApps = Array.isArray(taskCatalog?.apps) ? taskCatalog.apps : [];
+  const allowedAppIds = Array.isArray(draft.allowedAppIds) ? draft.allowedAppIds : null;
 
   useEffect(() => {
     if (!saving) setDraft(normalizeCapabilities(capabilities));
-  }, [capabilities?.schemaVersion, capabilities?.createTasks, capabilities?.readPortos, capabilities?.writePortos, saving]);
+  }, [capabilities?.schemaVersion, capabilities?.createTasks, capabilities?.readPortos, capabilities?.writePortos, capabilities?.allowedAppIds?.join('\0'), saving]);
 
   const save = async (key, enabled) => {
     const previous = draft;
@@ -52,6 +56,29 @@ export default function PersistentMindTaskAccessControls({
       onSaved?.(next);
       const option = OPTIONS.find((candidate) => candidate.key === key);
       toast.success(`${option?.label || 'Capability'} ${enabled ? 'enabled' : 'disabled'}`);
+    } catch (error) {
+      setDraft(previous);
+      toast.error(error.message);
+    } finally {
+      setSaving(false);
+      onSavingChange?.(false);
+    }
+  };
+
+  const saveAllowedAppIds = async (appId, enabled) => {
+    const current = allowedAppIds || taskApps.map((app) => app.id);
+    const next = enabled
+      ? [...new Set([...current, appId])]
+      : current.filter((id) => id !== appId);
+    const previous = draft;
+    const nextCapabilities = { ...draft, allowedAppIds: next };
+    setDraft(nextCapabilities);
+    setSaving(true);
+    onSavingChange?.(true);
+    try {
+      await api.updateCosConfig({ persistentMindCapabilities: nextCapabilities }, { silent: true });
+      onSaved?.(nextCapabilities);
+      toast.success(`${taskApps.find((app) => app.id === appId)?.name || 'Managed app'} task access ${enabled ? 'enabled' : 'disabled'}`);
     } catch (error) {
       setDraft(previous);
       toast.error(error.message);
@@ -82,6 +109,41 @@ export default function PersistentMindTaskAccessControls({
           </div>
         );
       })}
+      {taskCatalog && (
+        <div className="border-t border-port-border pt-4">
+          <div>
+            <p className="text-sm text-port-text">Managed app access</p>
+            <p className="mt-0.5 text-xs text-port-text-muted">Choose which configured apps the task grant may target. Existing installs start with every runnable app allowed.</p>
+          </div>
+          {taskApps.length > 0 ? (
+            <div className="mt-3 space-y-3">
+              {taskApps.map((app) => {
+                const id = `${idPrefix}-app-${app.id}`;
+                const checked = allowedAppIds ? allowedAppIds.includes(app.id) : app.granted !== false;
+                return (
+                  <div key={app.id} className="flex items-start justify-between gap-4">
+                    <div>
+                      <label htmlFor={id} className="text-sm text-port-text">{app.name}</label>
+                      <p className="mt-0.5 text-xs text-port-text-muted">{app.planOnly ? 'Implementation or Plan & File Issue' : 'Implementation delivery'}</p>
+                    </div>
+                    <input
+                      id={id}
+                      type="checkbox"
+                      checked={checked}
+                      disabled={disabled || saving || !draft.createTasks}
+                      onChange={(event) => saveAllowedAppIds(app.id, event.target.checked)}
+                      className="mt-1 h-4 w-4 accent-port-accent disabled:opacity-50"
+                    />
+                  </div>
+                );
+              })}
+            </div>
+          ) : (
+            <p className="mt-3 rounded border border-dashed border-port-border p-3 text-xs text-port-text-muted">No runnable managed apps are currently configured.</p>
+          )}
+          {!draft.createTasks && <p className="mt-3 text-xs text-port-text-muted">Enable the task capability above before selecting managed apps.</p>}
+        </div>
+      )}
       <div className="rounded border border-port-border bg-port-bg/40 px-3 py-2 text-xs text-port-text-muted">
         <p className="font-medium text-port-text">Typed authority only</p>
         <p className="mt-1">Every tool has a closed input schema, explicit side-effect policy, stable request id, and normalized result. Raw PortOS routes are never accepted as tool arguments.</p>

--- a/client/src/components/cos/PersistentMindVisibilityPanel.jsx
+++ b/client/src/components/cos/PersistentMindVisibilityPanel.jsx
@@ -1,4 +1,5 @@
-import { CheckCircle2, CircleAlert, CircleHelp, RefreshCw } from 'lucide-react';
+import { CheckCircle2, CircleAlert, CircleHelp, ExternalLink, RefreshCw, Settings2 } from 'lucide-react';
+import { Link } from 'react-router';
 import { formatDateTime } from '../../utils/formatters.js';
 
 const readinessLabel = (readiness) => {
@@ -20,6 +21,18 @@ const ReadinessIcon = ({ readiness }) => {
   if (readiness === 'unknown') return <CircleHelp size={15} aria-hidden="true" />;
   return <CircleAlert size={15} aria-hidden="true" />;
 };
+
+const REPAIR_ACTIONS = Object.freeze({
+  dependencies: { label: 'Open app settings', href: (appId) => `/apps/${encodeURIComponent(appId)}/overview?edit=1&appTab=general` },
+  engines: { label: 'Open app settings', href: (appId) => `/apps/${encodeURIComponent(appId)}/overview?edit=1&appTab=general` },
+  submodules: { label: 'Manage submodules', href: (appId) => `/apps/${encodeURIComponent(appId)}/submodules` },
+  forge: { label: 'Open app Git settings', href: (appId) => `/apps/${encodeURIComponent(appId)}/git` },
+  reviewers: { label: 'Manage reviewers', href: () => '/settings/code-reviewers' },
+  preflight: { label: 'Open app settings', href: (appId) => `/apps/${encodeURIComponent(appId)}/overview?edit=1&appTab=general` },
+});
+
+const blockingWarnings = (preflight) => (Array.isArray(preflight?.warnings) ? preflight.warnings : [])
+  .filter((warning) => warning?.severity !== 'advisory' && REPAIR_ACTIONS[warning?.check]);
 
 const checkLabel = (preflight, check) => {
   const hasWorkspace = Array.isArray(preflight.workspaces) && preflight.workspaces.length > 0;
@@ -61,11 +74,26 @@ export default function PersistentMindVisibilityPanel({ visibility, error, loadi
         {visibility?.truncated && <span className="text-port-warning">Some checks were bounded before completion.</span>}
       </div>
 
+      {readiness === 'blocked' && (
+        <div role="alert" className="mt-3 flex flex-col gap-2 rounded border border-port-error/40 bg-port-error/10 p-3 text-xs text-port-text sm:flex-row sm:items-center sm:justify-between">
+          <p><span className="font-semibold text-port-error">Delegated work is blocked.</span> Repair a required check below, or change the mind&apos;s managed-app permissions.</p>
+          <div className="flex shrink-0 flex-wrap gap-2">
+            <Link to="/cos/tools" className="inline-flex items-center gap-1 rounded border border-port-accent px-2.5 py-1.5 font-medium text-port-accent hover:bg-port-accent/10">
+              <Settings2 size={13} aria-hidden="true" /> Manage permissions
+            </Link>
+            <Link to="/apps" className="inline-flex items-center gap-1 rounded border border-port-border px-2.5 py-1.5 font-medium text-port-text-muted hover:border-port-accent hover:text-port-accent">
+              Managed apps <ExternalLink size={13} aria-hidden="true" />
+            </Link>
+          </div>
+        </div>
+      )}
+
       {workspaces.length > 0 ? (
         <div className="mt-3 grid gap-2 md:grid-cols-2">
           {workspaces.map((workspace) => {
             const workspaceReadiness = workspace.readiness || 'unknown';
             const preflight = workspace.preflight || {};
+            const repairs = blockingWarnings(preflight);
             return (
               <article key={workspace.appId || workspace.appName} className="rounded border border-port-border/80 p-3" aria-label={`${workspace.appName || 'Workspace'} preflight`}>
                 <div className="flex items-center justify-between gap-2">
@@ -81,7 +109,24 @@ export default function PersistentMindVisibilityPanel({ visibility, error, loadi
                   ))}
                 </div>
                 {(workspaceReadiness === 'blocked' || workspaceReadiness === 'unknown') && (
-                  <p className="mt-2 text-xs text-port-warning">{workspaceReadiness === 'blocked' ? 'A required workspace check must be repaired before this task can run.' : 'A workspace probe could not complete. Refresh or repair the unavailable check before requiring it.'}</p>
+                  <div className="mt-2 rounded border border-port-warning/30 bg-port-warning/10 p-2 text-xs text-port-warning">
+                    <p>{workspaceReadiness === 'blocked' ? 'A required workspace check must be repaired before this task can run.' : 'A workspace probe could not complete. Refresh or repair the unavailable check before requiring it.'}</p>
+                    {repairs.length > 0 && (
+                      <ul className="mt-2 space-y-1.5">
+                        {repairs.map((warning) => {
+                          const action = REPAIR_ACTIONS[warning.check];
+                          return (
+                            <li key={warning.code} className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between sm:gap-2">
+                              <span>{warning.message}</span>
+                              <Link to={action.href(workspace.appId)} className="inline-flex shrink-0 items-center gap-1 font-medium text-port-accent hover:underline">
+                                {action.label} <ExternalLink size={12} aria-hidden="true" />
+                              </Link>
+                            </li>
+                          );
+                        })}
+                      </ul>
+                    )}
+                  </div>
                 )}
               </article>
             );

--- a/client/src/components/cos/PersistentMindVisibilityPanel.test.jsx
+++ b/client/src/components/cos/PersistentMindVisibilityPanel.test.jsx
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import PersistentMindVisibilityPanel from './PersistentMindVisibilityPanel';
+
+const renderPanel = (visibility) => render(
+  <MemoryRouter>
+    <PersistentMindVisibilityPanel visibility={visibility} loading={false} onRefresh={vi.fn()} />
+  </MemoryRouter>,
+);
+
+const blockedVisibility = (overrides = {}) => ({
+  capturedAt: '2026-08-27T12:00:00.000Z',
+  freshness: { state: 'fresh' },
+  readiness: 'blocked',
+  workspaces: [{
+    appId: 'example-app',
+    appName: 'Example App',
+    readiness: 'blocked',
+    preflight: {
+      warnings: [
+        { code: 'workspace-engines-unavailable', check: 'engines', severity: 'warning', message: 'The required engine is incompatible.' },
+        { code: 'workspace-reviewers-unavailable', check: 'reviewers', severity: 'warning', message: 'A required reviewer is unavailable.' },
+      ],
+    },
+  }],
+  ...overrides,
+});
+
+describe('PersistentMindVisibilityPanel', () => {
+  it('turns a blocked snapshot into direct repair and permission actions', () => {
+    renderPanel(blockedVisibility());
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Delegated work is blocked');
+    expect(screen.getByRole('link', { name: /manage permissions/i })).toHaveAttribute('href', '/cos/tools');
+    expect(screen.getByRole('link', { name: /managed apps/i })).toHaveAttribute('href', '/apps');
+    expect(screen.getByRole('link', { name: /manage reviewers/i })).toHaveAttribute('href', '/settings/code-reviewers');
+    expect(screen.getByRole('link', { name: /open app settings/i })).toHaveAttribute('href', '/apps/example-app/overview?edit=1&appTab=general');
+  });
+
+  it('links submodule blockers to the affected app instead of hiding the cause', () => {
+    renderPanel(blockedVisibility({
+      workspaces: [{
+        appId: 'example-app',
+        appName: 'Example App',
+        readiness: 'blocked',
+        preflight: {
+          warnings: [{ code: 'workspace-submodules-unavailable', check: 'submodules', severity: 'warning', message: 'Submodules need initialization.' }],
+        },
+      }],
+    }));
+
+    expect(screen.getByRole('link', { name: /manage submodules/i })).toHaveAttribute('href', '/apps/example-app/submodules');
+  });
+
+  it('does not present repair actions for a ready workspace', () => {
+    renderPanel({
+      ...blockedVisibility(),
+      readiness: 'ready',
+      workspaces: [{
+        appId: 'example-app',
+        appName: 'Example App',
+        readiness: 'ready',
+        preflight: { warnings: [] },
+      }],
+    });
+
+    expect(screen.queryByRole('link', { name: /manage permissions/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /open app settings/i })).not.toBeInTheDocument();
+  });
+});

--- a/client/src/pages/PersistentMindTools.jsx
+++ b/client/src/pages/PersistentMindTools.jsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { CheckCircle2, LockKeyhole, RefreshCw, ShieldCheck } from 'lucide-react';
+import { Link } from 'react-router';
 import * as api from '../services/api';
 import BrailleSpinner from '../components/BrailleSpinner';
 import Banner from '../components/ui/Banner';

--- a/client/src/pages/PersistentMindTools.jsx
+++ b/client/src/pages/PersistentMindTools.jsx
@@ -40,7 +40,13 @@ export default function PersistentMindTools({ onCapabilitiesChange, onSavingChan
     setData((current) => current ? {
       ...current,
       capabilities,
-      taskCatalog: capabilities.createTasks ? current.taskCatalog : null,
+      taskCatalog: capabilities.createTasks && current.taskCatalog ? {
+        ...current.taskCatalog,
+        apps: (current.taskCatalog.apps || []).map((app) => ({
+          ...app,
+          granted: Array.isArray(capabilities.allowedAppIds) ? capabilities.allowedAppIds.includes(app.id) : true,
+        })),
+      } : null,
       tools: (current.tools || []).map((tool) => ({
         ...tool,
         granted: capabilities[tool.capability] === true,
@@ -81,6 +87,7 @@ export default function PersistentMindTools({ onCapabilitiesChange, onSavingChan
                 <div className="mt-4">
                   <PersistentMindTaskAccessControls
                     capabilities={data.capabilities}
+                    taskCatalog={taskCatalog}
                     onSaved={updateCapabilities}
                     onSavingChange={onSavingChange}
                   />
@@ -90,14 +97,15 @@ export default function PersistentMindTools({ onCapabilitiesChange, onSavingChan
               {taskCatalog && (
                 <section aria-labelledby="task-catalog-heading" className="rounded border border-port-border bg-port-card p-4">
                   <h2 id="task-catalog-heading" className="text-sm font-semibold uppercase tracking-wide text-port-text-muted">Available task filing choices</h2>
-                  <p className="mt-1 text-sm text-port-text-muted">These are the current choices the mind receives when it uses the typed task action. Repository paths and credentials are never included.</p>
+                  <p className="mt-1 text-sm text-port-text-muted">These are the current choices the mind receives when it uses the typed task action. Repository paths and credentials are never included. Use Managed app access above to change which apps are authorized.</p>
                   <div className="mt-4 grid gap-4 lg:grid-cols-2">
                     <div>
                       <h3 className="text-xs font-semibold uppercase tracking-wide text-port-text-muted">Target apps</h3>
                       <ul className="mt-2 space-y-2 text-sm text-port-text">
                         {(taskCatalog.apps || []).map((app) => (
                           <li key={app.id} className="rounded border border-port-border px-3 py-2">
-                            <span>{app.name}</span>
+                            <Link to={`/apps/${encodeURIComponent(app.id)}/automation`} className="text-port-accent hover:underline">{app.name}</Link>
+                            <span className={`ml-2 rounded-full border px-2 py-0.5 text-[11px] ${app.granted === false ? 'border-port-border text-port-text-muted' : 'border-port-success/40 text-port-success'}`}>{app.granted === false ? 'Not authorized' : 'Authorized'}</span>
                             <span className="ml-2 text-xs text-port-text-muted">{app.planOnly ? 'Implementation or Plan & File Issue' : 'Implementation delivery'}</span>
                           </li>
                         ))}

--- a/client/src/pages/PersistentMindTools.test.jsx
+++ b/client/src/pages/PersistentMindTools.test.jsx
@@ -79,9 +79,42 @@ describe('PersistentMindTools', () => {
     expect(await screen.findByText(/persistent-mind capabilities granted/)).toHaveTextContent('1 of 1');
     expect(screen.getByText('Granted')).toBeInTheDocument();
     expect(await screen.findByText('Available task filing choices')).toBeInTheDocument();
-    expect(screen.getByText(/Implementation or Plan & File Issue/)).toBeInTheDocument();
+    expect(screen.getAllByText(/Implementation or Plan & File Issue/)).not.toHaveLength(0);
     expect(screen.getByText('gpt-5 · low, high')).toBeInTheDocument();
     expect(api.getPersistentMindTools).toHaveBeenCalledTimes(2);
+  });
+
+  it('lets the user narrow task access to individual managed apps', async () => {
+    const user = userEvent.setup();
+    api.getPersistentMindTools.mockResolvedValueOnce(response({
+      capabilities: { schemaVersion: 2, createTasks: true, readPortos: false, writePortos: false },
+      tools: [{ ...response().tools[0], granted: true }],
+      taskCatalog: {
+        apps: [
+          { id: 'example-app', name: 'Example App', planOnly: false, granted: true },
+          { id: 'second-app', name: 'Second App', planOnly: true, granted: true },
+        ],
+        providers: [],
+      },
+    }));
+    renderPage();
+
+    const secondApp = await screen.findByRole('checkbox', { name: 'Second App' });
+    expect(secondApp).toBeChecked();
+    await user.click(secondApp);
+
+    await waitFor(() => expect(api.updateCosConfig).toHaveBeenCalledWith(
+      { persistentMindCapabilities: {
+        schemaVersion: 2,
+        createTasks: true,
+        readPortos: false,
+        writePortos: false,
+        allowedAppIds: ['example-app'],
+      } },
+      { silent: true },
+    ));
+    expect(secondApp).not.toBeChecked();
+    expect(screen.getByRole('link', { name: 'Example App' })).toHaveAttribute('href', '/apps/example-app/automation');
   });
 
   it('does not let a stale catalog refresh restore a revoked grant', async () => {

--- a/server/lib/persistentMindCapabilities.js
+++ b/server/lib/persistentMindCapabilities.js
@@ -73,6 +73,7 @@ export const PERSISTENT_MIND_TASK_LIMITS = Object.freeze({
   descriptionChars: 500,
   promptChars: 12_000,
   appIdChars: 128,
+  maxAllowedAppIds: 50,
   providerIdChars: 100,
   modelChars: 200,
 });
@@ -91,6 +92,11 @@ export const PERSISTENT_MIND_VALIDATION_CHECKS = Object.freeze([
 export const persistentMindCapabilitiesSchema = portosSemanticToolGrantsSchema.extend({
   schemaVersion: z.literal(PERSISTENT_MIND_CAPABILITIES_SCHEMA_VERSION).optional(),
   createTasks: z.boolean().optional(),
+  // Omitted preserves the legacy grant to every runnable managed app. An
+  // explicit list lets the user narrow that grant without changing the typed
+  // task capability itself.
+  allowedAppIds: z.array(z.string().trim().min(1).max(PERSISTENT_MIND_TASK_LIMITS.appIdChars))
+    .max(PERSISTENT_MIND_TASK_LIMITS.maxAllowedAppIds).optional(),
 });
 
 export const persistentMindTaskRequestSchema = z.object({
@@ -138,10 +144,19 @@ export function createDefaultPersistentMindCapabilities() {
 export function normalizePersistentMindCapabilities(raw) {
   const source = raw && typeof raw === 'object' && !Array.isArray(raw) ? raw : {};
   const semanticGrants = normalizePortosSemanticToolGrants(source);
+  const allowedAppIds = Array.isArray(source.allowedAppIds)
+    ? [...new Set(source.allowedAppIds
+      .filter((id) => typeof id === 'string')
+      .map((id) => id.trim())
+      .filter(Boolean)
+      .filter((id) => id.length <= PERSISTENT_MIND_TASK_LIMITS.appIdChars))]
+      .slice(0, PERSISTENT_MIND_TASK_LIMITS.maxAllowedAppIds)
+    : undefined;
   return {
     schemaVersion: PERSISTENT_MIND_CAPABILITIES_SCHEMA_VERSION,
     createTasks: source.createTasks === true,
     ...semanticGrants,
+    ...(allowedAppIds !== undefined ? { allowedAppIds } : {}),
   };
 }
 

--- a/server/lib/persistentMindCapabilities.test.js
+++ b/server/lib/persistentMindCapabilities.test.js
@@ -25,9 +25,17 @@ describe('persistent mind capabilities', () => {
 
   it('validates and merges the explicit task-creation grant', () => {
     expect(persistentMindCapabilitiesSchema.safeParse({ createTasks: true, readPortos: true, writePortos: false }).success).toBe(true);
+    expect(persistentMindCapabilitiesSchema.safeParse({ allowedAppIds: ['example-app', 'second-app'] }).success).toBe(true);
+    expect(persistentMindCapabilitiesSchema.safeParse({ allowedAppIds: Array.from({ length: 51 }, (_, index) => `app-${index}`) }).success).toBe(false);
     expect(persistentMindCapabilitiesSchema.safeParse({ createTasks: true, shell: true }).success).toBe(false);
     expect(mergePersistentMindCapabilities({ createTasks: false }, { createTasks: true }))
       .toMatchObject({ createTasks: true, readPortos: false, writePortos: false });
+  });
+
+  it('preserves legacy all-app access while normalizing an explicit app allowlist', () => {
+    expect(normalizePersistentMindCapabilities({ createTasks: true })).not.toHaveProperty('allowedAppIds');
+    expect(normalizePersistentMindCapabilities({ allowedAppIds: [' example-app ', 'example-app', '', 'second-app'] }))
+      .toMatchObject({ allowedAppIds: ['example-app', 'second-app'] });
   });
 
   it('accepts only bounded typed task requests and known PR dispositions', () => {

--- a/server/routes/cosMindRoutes.js
+++ b/server/routes/cosMindRoutes.js
@@ -207,7 +207,16 @@ router.get('/mind/context', asyncHandler(async (_req, res) => {
 router.get('/mind/tools', asyncHandler(async (_req, res) => {
   const root = await loadState();
   const capabilities = normalizePersistentMindCapabilities(root.config?.persistentMindCapabilities);
-  const taskCatalog = capabilities.createTasks ? await readPersistentMindTaskCatalog() : null;
+  const taskCatalog = capabilities.createTasks
+    ? await readPersistentMindTaskCatalog({ includeAllApps: true })
+    : null;
+  if (taskCatalog && Array.isArray(taskCatalog.apps)) {
+    const allowed = Array.isArray(capabilities.allowedAppIds) ? new Set(capabilities.allowedAppIds) : null;
+    taskCatalog.apps = taskCatalog.apps.map((app) => ({
+      ...app,
+      granted: !allowed || allowed.has(app.id),
+    }));
+  }
   res.json({
     schemaVersion: PERSISTENT_MIND_CAPABILITIES_SCHEMA_VERSION,
     capabilities,

--- a/server/routes/cosMindRoutes.test.js
+++ b/server/routes/cosMindRoutes.test.js
@@ -216,6 +216,22 @@ describe('persistent mind routes', () => {
     ]));
   });
 
+  it('marks revoked managed apps without removing them from the settings inventory', async () => {
+    mocks.loadState.mockResolvedValue({ config: {
+      persistentMindCapabilities: { schemaVersion: 2, createTasks: true, allowedAppIds: [] },
+    } });
+    mocks.readPersistentMindTaskCatalog.mockResolvedValue({
+      apps: [{ id: 'demo-app', name: 'Demo App', planOnly: true }],
+      providers: [],
+    });
+
+    const res = await get('/mind/tools');
+
+    expect(res.status).toBe(200);
+    expect(res.body.taskCatalog.apps).toEqual([{ id: 'demo-app', name: 'Demo App', planOnly: true, granted: false }]);
+    expect(mocks.readPersistentMindTaskCatalog).toHaveBeenCalledWith({ includeAllApps: true });
+  });
+
   it('exposes live context, system, inference, and model-residency telemetry', async () => {
     mocks.getPersistentMindState.mockResolvedValue({
       enabled: true,

--- a/server/services/persistentMindAdapter.js
+++ b/server/services/persistentMindAdapter.js
@@ -331,7 +331,9 @@ export function createPersistentMindTurnAdapter() {
         prompt,
         provider,
       });
-      const taskCatalog = taskAccess.createTasks ? await readPersistentMindTaskCatalog() : undefined;
+      const taskCatalog = taskAccess.createTasks
+        ? await readPersistentMindTaskCatalog({ allowedAppIds: taskAccess.allowedAppIds })
+        : undefined;
       const taskCapabilityPrompt = buildPersistentMindTaskCapabilityPrompt({
         enabled: taskAccess.createTasks,
         catalog: taskCatalog,

--- a/server/services/persistentMindTaskCapability.js
+++ b/server/services/persistentMindTaskCapability.js
@@ -114,7 +114,7 @@ const appCatalogEntry = async (app) => {
   };
 };
 
-export async function readPersistentMindTaskCatalog() {
+export async function readPersistentMindTaskCatalog({ allowedAppIds = null, includeAllApps = false } = {}) {
   const [apps, providers] = await Promise.all([getActiveApps(), listProviders()]);
   const runnableApps = apps
     .filter((app) => isRunnableApp(app) && typeof app?.id === 'string' && app.id
@@ -125,8 +125,12 @@ export async function readPersistentMindTaskCatalog() {
     candidates,
     deferCwdDependent: true,
   });
+  const appCatalog = await Promise.all(runnableApps.map(appCatalogEntry));
+  const allowed = Array.isArray(allowedAppIds) ? new Set(allowedAppIds) : null;
   return {
-    apps: await Promise.all(runnableApps.map(appCatalogEntry)),
+    // The tools settings page needs to see revoked apps so it can restore them;
+    // the model-facing catalog remains narrowed to the granted set.
+    apps: includeAllApps || !allowed ? appCatalog : appCatalog.filter((app) => allowed.has(app.id)),
     providers: candidates
       .filter((provider) => readiness[provider.id]?.status === 'ready')
       .map(providerCatalogEntry),
@@ -261,7 +265,10 @@ const validateChoice = async (request, apps, providers) => {
   return { app, provider, preflight, readiness };
 };
 
-async function queueOneTask({ request, taskId, apps }) {
+async function queueOneTask({ request, taskId, apps, allowedAppIds }) {
+  if (Array.isArray(allowedAppIds) && !allowedAppIds.includes(request.appId)) {
+    return { success: false, error: `Managed app '${request.appId}' is not authorized for Persistent Mind tasks; update Persistent Mind Tools permissions` };
+  }
   const existing = await getTaskById(taskId);
   if (existing) return { success: true, duplicate: true, task: existing };
   const providers = await listProviders();
@@ -325,7 +332,8 @@ export async function executePersistentMindTaskRequests({
   if (requests.length === 0) return [];
 
   const [root, apps] = await Promise.all([loadState(), getActiveApps()]);
-  const enabled = normalizePersistentMindCapabilities(root.config?.persistentMindCapabilities).createTasks;
+  const taskAccess = normalizePersistentMindCapabilities(root.config?.persistentMindCapabilities);
+  const enabled = taskAccess.createTasks;
   const record = typeof recordCapabilityEvent === 'function'
     ? recordCapabilityEvent
     : () => Promise.resolve();
@@ -359,7 +367,7 @@ export async function executePersistentMindTaskRequests({
       ? { success: false, error: 'Persistent mind turn was interrupted before task creation' }
       : enabled
       ? await Promise.resolve()
-        .then(() => queueOneTask({ request, taskId, apps }))
+        .then(() => queueOneTask({ request, taskId, apps, allowedAppIds: taskAccess.allowedAppIds }))
         .then((value) => value, (error) => ({ success: false, error: boundedError(error) }))
       : { success: false, error: 'Persistent mind task creation access is disabled' };
     const displayText = outcome.success

--- a/server/services/persistentMindTaskCapability.test.js
+++ b/server/services/persistentMindTaskCapability.test.js
@@ -111,6 +111,16 @@ describe('persistent mind CoS-task capability', () => {
     expect(prompt).not.toContain('command');
   });
 
+  it('filters the model-facing catalog while retaining all apps for the settings inventory', async () => {
+    mocks.apps.push({ id: 'second-app', name: 'Second App', repoPath: '/example/second-app' });
+
+    const filtered = await readPersistentMindTaskCatalog({ allowedAppIds: ['portos'] });
+    const inventory = await readPersistentMindTaskCatalog({ allowedAppIds: ['portos'], includeAllApps: true });
+
+    expect(filtered.apps.map((app) => app.id)).toEqual(['portos']);
+    expect(inventory.apps.map((app) => app.id)).toEqual(['portos', 'second-app']);
+  });
+
   it('omits blocked and unknown providers while publishing bounded reason-code aggregates', async () => {
     mocks.providers.push(
       { id: 'claude', name: 'Claude', type: 'cli', enabled: true, command: 'claude' },
@@ -239,6 +249,18 @@ describe('persistent mind CoS-task capability', () => {
     expect(result).toMatchObject({ success: false, error: expect.stringContaining('disabled') });
     expect(mocks.addTask).not.toHaveBeenCalled();
     expect(recordCapabilityEvent).toHaveBeenCalledTimes(2);
+  });
+
+  it('rejects a task targeting an app outside the explicit allowlist', async () => {
+    mocks.root.config.persistentMindCapabilities.allowedAppIds = [];
+    const [result] = await executePersistentMindTaskRequests({
+      taskRequests: [taskRequest()],
+      turnId: 'turn-revoked-app',
+      wake: { kind: 'message', message: { id: 'message-revoked-app' } },
+    });
+
+    expect(result).toMatchObject({ success: false, error: expect.stringContaining('not authorized') });
+    expect(mocks.addTask).not.toHaveBeenCalled();
   });
 
   it('allows an explicit provider-default model choice', async () => {


### PR DESCRIPTION
## Summary
- Add direct repair links to Persistent Mind environment blockers.
- Add per-managed-app authorization controls for typed CoS task creation while preserving existing opt-in authority.

## Test plan
- `npm test -- --run src/components/cos/PersistentMindVisibilityPanel.test.jsx src/pages/PersistentMindTools.test.jsx` (client)
- `npm test -- --run lib/persistentMindCapabilities.test.js services/persistentMindTaskCapability.test.js routes/cosMindRoutes.test.js` (server)
- `npm run build` (client)