### PR TITLE
fix: report a missing TUI binary instead of filing an anonymous provider investigation

### DIFF
--- a/server/services/autoFixer.js
+++ b/server/services/autoFixer.js
@@ -536,7 +536,10 @@ async function createAIProviderInvestigationTask(error) {
   const context = buildAIProviderErrorContext(error, diagnostics);
 
   const taskData = {
-    description: `Investigate AI provider failure: ${ctx.provider} (${ctx.model})`,
+    // Mirror the `|| 'Unknown'` fallbacks buildAIProviderErrorContext already
+    // applies to the body. Without them an unattributable failure filed a task
+    // titled "Investigate AI provider failure: undefined (undefined)".
+    description: `Investigate AI provider failure: ${ctx.provider || 'Unknown provider'} (${ctx.model || 'unknown model'})`,
     priority: 'MEDIUM',
     context,
     diagnostics,

--- a/server/services/autoFixer.test.js
+++ b/server/services/autoFixer.test.js
@@ -232,6 +232,32 @@ describe('autoFixer — defer + noteFallbackHandled', () => {
     clearPendingAutoFixTasks();
   });
 
+  // The body built by buildAIProviderErrorContext has always fallen back to
+  // 'Unknown'/'N/A'; the title did not, so a failure that reached the hook with
+  // no attribution filed a task literally called
+  // "Investigate AI provider failure: undefined (undefined)".
+  it('never titles a task with a literal undefined provider or model', async () => {
+    clearPendingAutoFixTasks();
+    cos.isRunning.mockReturnValue(false);
+
+    // Emitted raw, not through emitProviderFailure — that helper defaults
+    // provider/model, which is exactly the attribution this case lacks.
+    errorEvents.emit('error', {
+      code: 'AI_PROVIDER_EXECUTION_FAILED',
+      message: 'AI provider undefined execution failed: TUI exited with code 1',
+      severity: 'error',
+      canAutoFix: true,
+      timestamp: Date.now(),
+      context: { exitCode: 1, duration: 86, errorDetails: 'TUI exited with code 1' },
+    });
+    await vi.advanceTimersByTimeAsync(5500);
+
+    const pending = getPendingAutoFixTasks();
+    expect(pending).toHaveLength(1);
+    expect(pending[0].description).not.toMatch(/undefined/);
+    clearPendingAutoFixTasks();
+  });
+
   it('clears the dedupe entry when deferred task creation fails so future failures can still raise tasks', async () => {
     // Simulate addTask rejecting (e.g. PLAN.md write error). Without the
     // dedupe-clear in the catch arm, the next identical failure would be

--- a/server/services/localModelAgentBenchmark.js
+++ b/server/services/localModelAgentBenchmark.js
@@ -137,6 +137,13 @@ export async function runOpenCodeAgentBenchmark({ backend, modelId, timeoutMs = 
         timeout: timeoutMs,
         label: `local-model-benchmark:${backend}`,
         guard: true,
+        // This run is a PROBE — measuring whether a local model can drive an
+        // agentic task is the whole point, so "it couldn't" is the result, and
+        // it is already reported in `error` below. Left reporting, every failed
+        // benchmark also queued a CoS "Investigate AI provider failure" task
+        // against a provider nobody claimed was healthy — and pointed it at a
+        // run record this function's `finally` had already deleted.
+        reportFailure: false,
         onComplete: resolve,
       }).catch((err) => resolve({ success: false, exitCode: 1, error: err?.message || 'OpenCode TUI failed' }));
     });

--- a/server/services/localModelAgentBenchmark.test.js
+++ b/server/services/localModelAgentBenchmark.test.js
@@ -75,6 +75,22 @@ describe('runOpenCodeAgentBenchmark', () => {
     }));
   });
 
+  // A benchmark probes whether a local model can drive an agentic task at all,
+  // so "it couldn't" is the measurement — reported in `error` below — not a
+  // provider incident. Reporting it fired the host's onRunFailed hook, and
+  // autoFixer queued a CoS "Investigate AI provider failure" task per failed
+  // benchmark run, pointing at a run record `finally` had already deleted.
+  it('runs as a probe so a failed benchmark does not queue a provider investigation', async () => {
+    executeTuiRun.mockImplementation(async ({ onComplete }) => {
+      onComplete({ success: false, exitCode: 1, error: 'TUI exited with code 1', duration: 86 });
+    });
+
+    const result = await runOpenCodeAgentBenchmark({ backend: 'llama', modelId: 'dflash' });
+
+    expect(executeTuiRun.mock.calls[0][0]).toEqual(expect.objectContaining({ reportFailure: false }));
+    expect(result).toMatchObject({ completed: false, exitCode: 1, error: 'TUI exited with code 1' });
+  });
+
   it('accepts the Claude Ollama TUI as a separate local harness target', async () => {
     getProviderById.mockResolvedValue({
       id: 'claude-ollama-tui',

--- a/server/services/runner.js
+++ b/server/services/runner.js
@@ -91,9 +91,19 @@ export function getRunsPath() {
  * the file is written, so caller-specific fields like `completionReason`
  * (TUI) survive to disk and show up on /runs replay.
  *
+ * `identity` (optional `{ providerId, providerName, model }`) fills ONLY keys
+ * the stored metadata doesn't already carry — for a caller that spawns against
+ * a synthesized run id instead of a toolkit `createRun` record. `extras` still
+ * overwrites, so the two are not interchangeable.
+ *
+ * `reportFailure: false` finalizes the record but skips the `onRunFailed` hook,
+ * for a run that is a deliberate PROBE of a provider rather than work the user
+ * asked for. Same reasoning as the `canceled` branch below: the failure is the
+ * caller's measurement, not evidence that a configured provider is broken.
+ *
  * @returns the merged metadata object (also written to disk).
  */
-export async function finalizeRunRecord({ runId, output, exitCode, success, error, startTime, extras }) {
+export async function finalizeRunRecord({ runId, output, exitCode, success, error, startTime, extras, identity, reportFailure = true }) {
   const toolkit = requireToolkit();
   const runDir = join(getRunsPath(), runId);
   const outputPath = join(runDir, 'output.txt');
@@ -104,6 +114,18 @@ export async function finalizeRunRecord({ runId, output, exitCode, success, erro
   const metadataStr = await readFile(metadataPath, 'utf-8').catch(() => '{}');
   let metadata = {};
   try { metadata = JSON.parse(metadataStr); } catch { console.log('⚠️ Corrupted metadata for run, using fresh'); }
+  // A caller that never went through toolkit `createRun` — or whose run record
+  // was lost — leaves `{}` here, and the completion fields below then describe a
+  // run with no id, provider or model. That anonymous record still reaches the
+  // `onRunFailed` hook, which published an investigation task literally titled
+  // "Investigate AI provider failure: undefined (undefined)" and keyed its
+  // dedupe + circuit breaker on `undefined-undefined` — one bucket every such
+  // failure collapses into, suppressing unrelated real ones for the window.
+  // Backfill what the caller already handed us.
+  if (!metadata.id) metadata.id = runId;
+  for (const [key, value] of Object.entries(identity || {})) {
+    if (metadata[key] === undefined && value !== undefined) metadata[key] = value;
+  }
   metadata.endTime = new Date().toISOString();
   metadata.duration = Date.now() - startTime;
   metadata.exitCode = exitCode;
@@ -142,11 +164,36 @@ export async function finalizeRunRecord({ runId, output, exitCode, success, erro
   // already persisted by this point, so a failing hook must not un-finalize it.
   if (success) {
     safeSettle(() => runnerConfig.hooks?.onRunCompleted?.(metadata, output), 'onRunCompleted');
-  } else if (!canceled) {
+  } else if (!canceled && reportFailure) {
     safeSettle(() => runnerConfig.hooks?.onRunFailed?.(metadata, metadata.error, output), 'onRunFailed');
   }
 
   return metadata;
+}
+
+/**
+ * Report a PRE-SPAWN failure through the run record instead of throwing.
+ *
+ * Extracted from `resolveRunCwd` below so every "we can't even start this run"
+ * check shares one settlement path. Both spawning runners invoke their executor
+ * WITHOUT awaiting it (the /runs route never does), so a bare throw surfaces
+ * only as an unhandled rejection and the UI shows the run hanging forever.
+ *
+ * @returns the finalized metadata (also handed to `onComplete`).
+ */
+export async function failRunRecord({ runId, error, exitCode = null, startTime = Date.now(), onData, onComplete, identity, reportFailure = true }) {
+  const message = `❌ ${error}`;
+  // Settle the caller's callbacks through the same guard the close handler
+  // uses. A throwing (or rejecting) onComplete here would reject the caller
+  // AFTER the failed run was already persisted — and since /runs never awaits
+  // its executor, that lands as the unhandled rejection + hung-looking run
+  // this helper exists to prevent.
+  safeSettle(() => onData?.(message), 'onData');
+  const failure = await finalizeRunRecord({
+    runId, output: message, exitCode, success: false, error, startTime, identity, reportFailure,
+  });
+  safeSettle(() => onComplete?.(failure), 'onComplete');
+  return failure;
 }
 
 /**
@@ -163,21 +210,13 @@ export async function finalizeRunRecord({ runId, output, exitCode, success, erro
  * @returns {Promise<{cwd: string, failure?: undefined} | {cwd?: undefined, failure: object}>}
  *   `cwd` on success; `failure` (the finalized metadata) when the workspace is unusable.
  */
-export async function resolveRunCwd({ runId, workspacePath, label, startTime = Date.now(), onData, onComplete }) {
+export async function resolveRunCwd({ runId, workspacePath, label, startTime = Date.now(), onData, onComplete, identity, reportFailure = true }) {
   try {
     return { cwd: resolveSpawnCwd(workspacePath, PATHS.root, label) };
   } catch (err) {
-    const message = `❌ ${err.message}`;
-    // Settle the caller's callbacks through the same guard the close handler
-    // uses. A throwing (or rejecting) onComplete here would reject
-    // resolveRunCwd itself AFTER the failed run was already persisted — and
-    // since /runs never awaits its executor, that lands as the unhandled
-    // rejection + hung-looking run this helper exists to prevent.
-    safeSettle(() => onData?.(message), 'onData');
-    const failure = await finalizeRunRecord({
-      runId, output: message, exitCode: null, success: false, error: err.message, startTime,
+    const failure = await failRunRecord({
+      runId, error: err.message, exitCode: null, startTime, onData, onComplete, identity, reportFailure,
     });
-    safeSettle(() => onComplete?.(failure), 'onComplete');
     return { failure };
   }
 }

--- a/server/services/runner.test.js
+++ b/server/services/runner.test.js
@@ -165,6 +165,115 @@ describe('finalizeRunRecord — authoritative timeout classification', () => {
     expect(errorDetection.analyzeError).not.toHaveBeenCalled();
     expect(onRunFailed).not.toHaveBeenCalled();
   });
+
+  // A caller that synthesizes its own run id instead of going through toolkit
+  // `createRun` (the local-model benchmark) leaves no metadata.json to merge
+  // into, so the record described a run with no id, provider or model. That
+  // anonymous record still reached onRunFailed, and autoFixer filed
+  // "Investigate AI provider failure: undefined (undefined)" against it —
+  // keying its dedupe and circuit breaker on `undefined-undefined`.
+  it('attributes a failure with no stored metadata to the run and provider it was given', async () => {
+    const onRunFailed = vi.fn();
+    setAIToolkit(fakeToolkit(), { dataDir: '/tmp/test-runner', hooks: { onRunFailed } });
+
+    const metadata = await finalizeRunRecord({
+      runId: 'run-no-record',
+      output: '',
+      exitCode: 1,
+      success: false,
+      error: 'TUI exited with code 1',
+      startTime: Date.now(),
+      identity: { providerId: 'opencode-llama-tui', providerName: 'OpenCode', model: 'dflash' },
+    });
+
+    expect(metadata).toMatchObject({
+      id: 'run-no-record',
+      providerId: 'opencode-llama-tui',
+      providerName: 'OpenCode',
+      model: 'dflash',
+    });
+    expect(onRunFailed).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'run-no-record', providerName: 'OpenCode', model: 'dflash' }),
+      'TUI exited with code 1',
+      '',
+    );
+  });
+
+  it('never lets identity overwrite what the stored run record already says', async () => {
+    readFile.mockResolvedValueOnce(JSON.stringify({
+      id: 'run-real', providerId: 'claude-cli', providerName: 'Claude Code', model: 'claude-opus-5',
+    }));
+
+    const metadata = await finalizeRunRecord({
+      runId: 'run-real',
+      output: '',
+      exitCode: 1,
+      success: false,
+      error: 'boom',
+      startTime: Date.now(),
+      identity: { providerId: 'wrong', providerName: 'Wrong', model: 'wrong-model' },
+    });
+
+    expect(metadata).toMatchObject({
+      id: 'run-real', providerId: 'claude-cli', providerName: 'Claude Code', model: 'claude-opus-5',
+    });
+  });
+
+  // A benchmark deliberately probes a model that may not work at all — that is
+  // the measurement, not evidence a configured provider broke. Escalating it
+  // queued a CoS investigation task per failed benchmark run.
+  it('finalizes a probe run without firing the provider-failure hook', async () => {
+    const onRunFailed = vi.fn();
+    setAIToolkit(fakeToolkit(), { dataDir: '/tmp/test-runner', hooks: { onRunFailed } });
+
+    const metadata = await finalizeRunRecord({
+      runId: 'run-probe',
+      output: '',
+      exitCode: 1,
+      success: false,
+      error: 'TUI exited with code 1',
+      startTime: Date.now(),
+      reportFailure: false,
+    });
+
+    expect(metadata).toMatchObject({ success: false, exitCode: 1, error: 'TUI exited with code 1' });
+    expect(onRunFailed).not.toHaveBeenCalled();
+  });
+});
+
+describe('failRunRecord — pre-spawn failures reach the caller', () => {
+  it('streams the reason, persists the record, and settles onComplete', async () => {
+    const onData = vi.fn();
+    const onComplete = vi.fn();
+
+    const failure = await runner.failRunRecord({
+      runId: 'run-no-binary',
+      error: 'TUI command not found: opencode',
+      exitCode: 127,
+      startTime: Date.now(),
+      onData,
+      onComplete,
+      identity: { providerName: 'OpenCode' },
+    });
+
+    expect(onData).toHaveBeenCalledWith('\u274c TUI command not found: opencode');
+    expect(failure).toMatchObject({
+      id: 'run-no-binary',
+      success: false,
+      exitCode: 127,
+      error: 'TUI command not found: opencode',
+      providerName: 'OpenCode',
+    });
+    expect(onComplete).toHaveBeenCalledWith(failure);
+  });
+
+  it('does not let a throwing onComplete escape and strand the run', async () => {
+    await expect(runner.failRunRecord({
+      runId: 'run-throwing-callback',
+      error: 'nope',
+      onComplete: () => { throw new Error('callback blew up'); },
+    })).resolves.toMatchObject({ success: false });
+  });
 });
 
 describe('patchRunMetadata — serialized merges', () => {

--- a/server/services/tuiPromptRunner.js
+++ b/server/services/tuiPromptRunner.js
@@ -45,9 +45,10 @@ import {
   createTerminalModelErrorDetector,
   createTerminalRequestTimeoutDetector,
 } from '../lib/aiToolkit/errorDetection.js';
-import { getRunsPath, finalizeRunRecord, emitRunStarted, registerActiveRun, unregisterActiveRun, consumeRunStopRequested, resolveRunCwd } from './runner.js';
+import { getRunsPath, finalizeRunRecord, failRunRecord, emitRunStarted, registerActiveRun, unregisterActiveRun, consumeRunStopRequested, resolveRunCwd } from './runner.js';
 import { registerExternalSession, unregisterExternalSession, isExternalSessionAttached, pasteToSession } from './shell.js';
 import { isHostShuttingDown } from '../lib/hostShutdown.js';
+import { findCommandOnPath } from '../lib/processEnv.js';
 import {
   DEFAULT_TUI_PROMPT_DELAY_MS,
   PASTE_MARKER_POLL_MS,
@@ -141,9 +142,13 @@ const PTY_ROWS = 50;
  *   Shell page's session tab; falls back to `command · model` when absent.
  * @param {boolean} [options.guard=false] — prepend the PM2 guard shim for an
  *   autonomous task that must not be able to kill the shared PortOS daemon.
+ * @param {boolean} [options.reportFailure=true] — fire the host's `onRunFailed`
+ *   hook when the run fails. Pass `false` for a deliberate PROBE of a provider
+ *   (the local-model benchmark): its failure is the caller's measurement, which
+ *   it reports itself, not a provider incident for the autofixer to escalate.
  * @returns {Promise<void>}
  */
-export async function executeTuiRun({ runId, provider, prompt, workspacePath, onData, onComplete, timeout, idleMs, label, guard = false }) {
+export async function executeTuiRun({ runId, provider, prompt, workspacePath, onData, onComplete, timeout, idleMs, label, guard = false, reportFailure = true }) {
   if (!provider || typeof provider !== 'object') {
     throw new Error('executeTuiRun: provider is required');
   }
@@ -170,11 +175,21 @@ export async function executeTuiRun({ runId, provider, prompt, workspacePath, on
   const runDir = join(getRunsPath(), runId);
   await ensureDir(runDir);
 
+  // Who this run is, for a finalize that finds no `createRun` metadata on disk
+  // to merge into. Mirrors `emitRunStarted`'s naming so the started and failed
+  // events describe the same run — they used to disagree, and the failure event
+  // was the anonymous one.
+  const runIdentity = {
+    providerId: provider.id,
+    providerName: provider.name || provider.id,
+    model: provider.defaultModel,
+  };
+
   // Logs the effective cwd, and rejects a workspace that was requested but is
   // missing on disk instead of silently spawning in the PortOS root (#3180).
   // Sequenced after ensureDir so finalizeRunRecord has a run dir to write into.
   const { cwd: workingDir, failure } = await resolveRunCwd({
-    runId, workspacePath, label: `TUI run ${runId}`, onData, onComplete,
+    runId, workspacePath, label: `TUI run ${runId}`, onData, onComplete, identity: runIdentity, reportFailure,
   });
   if (failure) return failure;
 
@@ -224,6 +239,26 @@ ${prompt}`;
     guard,
     extra: { TERM: 'xterm-256color', COLORTERM: 'truecolor' },
   });
+
+  // A PTY has no shell to print "command not found": node-pty forks, `execvp`
+  // fails in the child, and the child exits 1 with an EMPTY screen. So the
+  // output-driven `detectMissingTuiBinary` probe further down can never fire on
+  // this path, and the run finalized as a bare `TUI exited with code 1` — no
+  // provider, no cause, nothing to act on. Resolve against the CHILD's PATH
+  // (`childEnv`, since a provider may override PATH with only its own bin dir)
+  // and report the real reason with the 127 that probe already uses.
+  if (!findCommandOnPath(command, { env: childEnv, cwd: workingDir })) {
+    return failRunRecord({
+      runId,
+      error: `TUI command not found: ${command}`,
+      exitCode: 127,
+      startTime: Date.now(),
+      onData,
+      onComplete,
+      identity: runIdentity,
+      reportFailure,
+    });
+  }
 
   let ptyProcess;
   try {
@@ -413,6 +448,8 @@ ${prompt}`;
         // set post-write and never made it to disk → /runs replay missed it).
         const metadata = await finalizeRunRecord({
           runId, output: responseText, exitCode, success, error, startTime,
+          identity: runIdentity,
+          reportFailure,
           extras: {
             completionReason: reason,
             usedResponseFile,

--- a/server/services/tuiPromptRunner.test.js
+++ b/server/services/tuiPromptRunner.test.js
@@ -15,15 +15,27 @@ const TEST_WORKSPACE = process.cwd();
 // serves seeded response files from memory — see below). Mocks live
 // inside vi.hoisted so the vi.mock factories (which are themselves hoisted
 // to the top of the file) can reference them.
-const { ptyInstances, ptySpawnMock, runnerMocks, shellMocks, runsTmpDirRef, responseFiles } = vi.hoisted(() => ({
+const { ptyInstances, ptySpawnMock, runnerMocks, shellMocks, runsTmpDirRef, responseFiles, processEnvMocks } = vi.hoisted(() => ({
   ptyInstances: [],
   ptySpawnMock: vi.fn(),
+  // The pre-spawn binary probe. Defaults to "resolved" so every other test in
+  // this file exercises the spawn path regardless of which agent CLIs happen to
+  // be installed on the host running the suite.
+  processEnvMocks: {
+    findCommandOnPath: vi.fn((name) => `/usr/local/bin/${name}`),
+  },
   runsTmpDirRef: { current: null },
   // Absolute response-file path → contents, for the runs driven under fake
   // timers (see the fileUtils mock below).
   responseFiles: new Map(),
   runnerMocks: {
     finalizeRunRecord: vi.fn(),
+    failRunRecord: vi.fn(async ({ runId, error, exitCode, onData, onComplete }) => {
+      const failure = { id: runId, success: false, exitCode, error };
+      onData?.(`\u274c ${error}`);
+      onComplete?.(failure);
+      return failure;
+    }),
     emitRunStarted: vi.fn(),
     registerActiveRun: vi.fn(),
     unregisterActiveRun: vi.fn(),
@@ -60,6 +72,10 @@ runnerMocks.getRunsPath.mockImplementation(() => runsTmpDirRef.current);
 vi.mock('node-pty', () => ({ spawn: (...args) => ptySpawnMock(...args) }));
 vi.mock('./runner.js', () => runnerMocks);
 vi.mock('./shell.js', () => shellMocks);
+vi.mock('../lib/processEnv.js', async () => {
+  const actual = await vi.importActual('../lib/processEnv.js');
+  return { ...actual, findCommandOnPath: (...args) => processEnvMocks.findCommandOnPath(...args) };
+});
 vi.mock('../lib/fileUtils.js', async () => {
   const actual = await vi.importActual('../lib/fileUtils.js');
   // Imported here rather than relied on from the module scope: vi.mock
@@ -337,6 +353,9 @@ describe('executeTuiRun', () => {
     runnerMocks.consumeRunStopRequested.mockReset();
     runnerMocks.consumeRunStopRequested.mockReturnValue(false);
     runnerMocks.getRunsPath.mockClear();
+    runnerMocks.failRunRecord.mockClear();
+    processEnvMocks.findCommandOnPath.mockReset();
+    processEnvMocks.findCommandOnPath.mockImplementation((name) => `/usr/local/bin/${name}`);
     resetHostShutdownFlagForTests();
     shellMocks.registerExternalSession.mockClear();
     shellMocks.unregisterExternalSession.mockClear();
@@ -371,6 +390,56 @@ describe('executeTuiRun', () => {
       const provider = { id: 'claude', type: 'tui', command: 'echo' };
       await expect(executeTuiRun({ runId: 'run-x', provider, prompt: 12345, workspacePath: '/tmp' }))
         .rejects.toThrow(/non-empty string/);
+    });
+  });
+
+  describe('missing TUI binary', () => {
+    // A PTY has no shell to say "command not found": node-pty's child fails
+    // `execvp` and exits 1 with an EMPTY screen, so the output-driven
+    // `detectMissingTuiBinary` probe never fires. Before the pre-spawn check,
+    // an uninstalled CLI finalized as a bare "TUI exited with code 1" with no
+    // provider attached — which is exactly what queued a CoS task titled
+    // "Investigate AI provider failure: undefined (undefined)".
+    it('reports the real cause through the run record instead of spawning', async () => {
+      processEnvMocks.findCommandOnPath.mockReturnValue(null);
+      const provider = { id: 'opencode-llama-tui', name: 'OpenCode', type: 'tui', command: 'opencode', defaultModel: 'dflash' };
+      const onComplete = vi.fn();
+
+      await executeTuiRun({ runId: 'run-missing', provider, prompt: 'do thing', workspacePath: TEST_WORKSPACE, onComplete });
+
+      expect(ptySpawnMock).not.toHaveBeenCalled();
+      expect(runnerMocks.failRunRecord).toHaveBeenCalledWith(expect.objectContaining({
+        runId: 'run-missing',
+        error: 'TUI command not found: opencode',
+        exitCode: 127,
+        identity: { providerId: 'opencode-llama-tui', providerName: 'OpenCode', model: 'dflash' },
+      }));
+      expect(onComplete).toHaveBeenCalledWith(expect.objectContaining({ success: false, exitCode: 127 }));
+    });
+
+    it('probes the child PATH, not the server PATH — a provider may override it', async () => {
+      processEnvMocks.findCommandOnPath.mockReturnValue(null);
+      const provider = {
+        id: 'codex', name: 'Codex', type: 'tui', command: 'codex',
+        envVars: { PATH: '/opt/only-my-bin' },
+      };
+
+      await executeTuiRun({ runId: 'run-path', provider, prompt: 'do thing', workspacePath: TEST_WORKSPACE });
+
+      expect(processEnvMocks.findCommandOnPath).toHaveBeenCalledWith('codex', expect.objectContaining({
+        env: expect.objectContaining({ PATH: expect.stringContaining('/opt/only-my-bin') }),
+      }));
+    });
+
+    it('leaves failure reporting on by default and off for a probe run', async () => {
+      processEnvMocks.findCommandOnPath.mockReturnValue(null);
+      const provider = { id: 'opencode-llama-tui', name: 'OpenCode', type: 'tui', command: 'opencode' };
+
+      await executeTuiRun({ runId: 'run-default', provider, prompt: 'p', workspacePath: TEST_WORKSPACE });
+      expect(runnerMocks.failRunRecord).toHaveBeenLastCalledWith(expect.objectContaining({ reportFailure: true }));
+
+      await executeTuiRun({ runId: 'run-probe', provider, prompt: 'p', workspacePath: TEST_WORKSPACE, reportFailure: false });
+      expect(runnerMocks.failRunRecord).toHaveBeenLastCalledWith(expect.objectContaining({ reportFailure: false }));
     });
   });
 


### PR DESCRIPTION
A local-model benchmark against an OpenCode provider queued a CoS task titled `Investigate AI provider failure: undefined (undefined)` — no run id, no provider, no model, exit 1 after 86ms. Four defects lined up behind it.

## Summary

1. **`opencode` was not installed.** A PTY has no shell to print "command not found" — node-pty forks, `execvp` fails, the child exits 1 with an *empty* screen — so the output-driven `detectMissingTuiBinary` probe could never fire and the run finalized as a bare `TUI exited with code 1`. `executeTuiRun` now resolves the command against the **child's** PATH (a provider may override it) before spawning, and reports the real reason with the same 127 that probe already uses.

2. **The failure record had no identity.** `finalizeRunRecord` reads `metadata.json` off disk, and the benchmark spawns against a synthesized run id rather than a toolkit `createRun` record — so the absent file left `{}` and the record described a run with no id, provider or model. It now backfills the run id it was handed, plus an optional caller-supplied `identity` that fills only keys the stored record does not already carry.

3. **A benchmark is a probe, not an incident.** Measuring whether a local model can drive an agentic task is the whole point, so "it couldn't" is the measurement — already reported in the API response. It now finalizes its run record without firing the provider-failure hook, the same way a cancellation does. Escalating it filed one investigation task per failed benchmark, pointed at a run record the benchmark's own `finally` had already deleted.

4. **The task title had no fallbacks.** `autoFixer` built the title without the `|| 'Unknown'` guards its body already has, so an unattributed failure produced the literal `undefined (undefined)`. It also keyed dedupe and the circuit breaker on `undefined-undefined`, collapsing every such failure into one bucket and suppressing unrelated real ones for the window.

Also extracts `failRunRecord` from `resolveRunCwd` so both pre-spawn checks share one settlement path — the executors are invoked without being awaited, so a bare throw surfaces as an unhandled rejection and a run that hangs forever.

## Test plan

- `server/services/runner.test.js` — identity backfill reaches `onRunFailed`; stored metadata always wins over `identity`; a probe run finalizes without the hook; `failRunRecord` streams, persists, settles, and contains a throwing `onComplete`.
- `server/services/tuiPromptRunner.test.js` — a missing binary reports 127 without spawning, probes the child PATH rather than the server PATH, and honors `reportFailure`.
- `server/services/localModelAgentBenchmark.test.js` — the benchmark runs as a probe and still reports the failure in its own result.
- `server/services/autoFixer.test.js` — a task is never titled with a literal `undefined`.

Every new guard test was verified to go red against the unfixed code and green with it. Full server suite: 35,153 passing. The one failure on this host (`routes/settings.test.js`) reproduces on clean `main` and is filed separately as #5288.