### PR TITLE
fix: wake MTPLX before TUI runs

### DIFF
--- a/client/src/components/settings/LocalLlmTab.jsx
+++ b/client/src/components/settings/LocalLlmTab.jsx
@@ -505,9 +505,9 @@ export function LocalLlmTab() {
     () => installMtplx(),
     'MTPLX installed'
   ).then(loadMtplxStatus);
-  const runtimeStartMtplx = () => runAction(
+  const runtimeStartMtplx = (launch = {}) => runAction(
     'runtime-start-mtplx',
-    () => startMtplxServer(),
+    () => startMtplxServer(launch),
     (r) => r?.online ? 'MTPLX is running' : 'MTPLX is loading its checkpoint'
   ).then(loadMtplxStatus);
   // The card can start MTPLX explicitly from its cached checkpoint, and the
@@ -943,6 +943,7 @@ export function LocalLlmTab() {
         onConfigureLlama={() => scrollTo(llamaSectionRef)}
         onConfigureMtplx={() => scrollTo(mtplxSectionRef)}
         onInstallMtplx={runtimeInstallMtplx}
+        onStartMtplx={runtimeStartMtplx}
         onStopMtplx={runtimeStopMtplx}
         onSaveStartup={saveRuntimeStartup}
         onSaveIdleWindow={saveIdleWindow}

--- a/client/src/components/settings/LocalLlmTab.jsx
+++ b/client/src/components/settings/LocalLlmTab.jsx
@@ -11,7 +11,7 @@ import {
   getLocalLlmStatus, getLocalLlmCatalog, getLocalLlmHuggingFaceSearch, installLocalLlmModel,
   deleteLocalLlmModel, migrateLocalLlmBackend, installLocalLlmBackend, upgradeLocalLlmBackend, controlOllamaService,
   installAudioModel, patchSettingsSlice, getLlamaServerStatus, getLlamaServerUpdateStatus, startLlamaServer, stopLlamaServer, installLlamaServer, upgradeLlamaServer,
-  downloadSpecDecodeModel, cancelSpecDecodeModelDownload, controlLmStudioService, getMtplxServerStatus, stopMtplxServer, installMtplx,
+  downloadSpecDecodeModel, cancelSpecDecodeModelDownload, controlLmStudioService, getMtplxServerStatus, startMtplxServer, stopMtplxServer, installMtplx,
   searchMtplxModels, pullMtplxModel, removeMtplxModel,
   saveRuntimeStartupList
 } from '../../services/api';
@@ -505,8 +505,13 @@ export function LocalLlmTab() {
     () => installMtplx(),
     'MTPLX installed'
   ).then(loadMtplxStatus);
-  // MTPLX has no Start action: the first PortOS request routed to it starts it.
-  // What the card saves is the launch line that on-demand start will replay.
+  const runtimeStartMtplx = () => runAction(
+    'runtime-start-mtplx',
+    () => startMtplxServer(),
+    (r) => r?.online ? 'MTPLX is running' : 'MTPLX is loading its checkpoint'
+  ).then(loadMtplxStatus);
+  // The card can start MTPLX explicitly from its cached checkpoint, and the
+  // same launch configuration is replayed when a request wakes it on demand.
   const saveMtplxLaunch = (launch) => runAction(
     'runtime-save-mtplx-launch',
     () => patchSettingsSlice('localLlm.mtplx', { launch }),
@@ -1056,6 +1061,7 @@ export function LocalLlmTab() {
           actionInProgress={actionInProgress}
           onRefresh={loadMtplxStatus}
           onSaveLaunch={saveMtplxLaunch}
+          onStart={runtimeStartMtplx}
           onStop={runtimeStopMtplx}
           onInstall={runtimeInstallMtplx}
           onSearchModels={mtplxSearch}

--- a/client/src/components/settings/LocalLlmTab.test.jsx
+++ b/client/src/components/settings/LocalLlmTab.test.jsx
@@ -134,20 +134,21 @@ describe('LocalLlmTab runtime servers', () => {
     }
   });
 
-  // MTPLX starts on demand — the first request routed to it brings it up — so
-  // this surface offers Install and Configure, never Start.
-  it('offers no MTPLX Start on that surface', async () => {
-    const { getMtplxServerStatus } = await import('../../services/api');
+  // MTPLX starts on demand — the first request routed to it brings it up — and
+  // also offers an explicit start when its checkpoint is already cached.
+  it('offers MTPLX Start on the unified runtime surface', async () => {
+    const { getMtplxServerStatus, startMtplxServer } = await import('../../services/api');
     getMtplxServerStatus.mockResolvedValue({
       installed: true, running: false, supported: true, cachedModels: ['Example/Qwen-MTP'], endpoint: 'http://127.0.0.1:8000/v1',
     });
+    startMtplxServer.mockResolvedValue({ online: true });
 
     await renderTab();
     const card = screen.getByRole('heading', { name: 'Local Runtime Servers' }).closest('div.bg-port-card');
     const mtplxRow = within(card).getByText('MTPLX').closest('div.flex.flex-col');
 
-    expect(within(mtplxRow).queryByRole('button', { name: /^Start/ })).toBeNull();
-    expect(within(mtplxRow).getByText(/Starts on demand/)).toBeInTheDocument();
+    fireEvent.click(within(mtplxRow).getByRole('button', { name: /^Start/ }));
+    await waitFor(() => expect(startMtplxServer).toHaveBeenCalledWith({}));
   });
 
   it('saves an idle window through the settings slice for that runtime', async () => {

--- a/client/src/components/settings/MtplxServerCard.jsx
+++ b/client/src/components/settings/MtplxServerCard.jsx
@@ -25,6 +25,7 @@ export default function MtplxServerCard({
   actionInProgress,
   onRefresh,
   onSaveLaunch,
+  onStart,
   onStop,
   onInstall,
   onSearchModels,
@@ -156,11 +157,21 @@ export default function MtplxServerCard({
             <p className="text-xs text-gray-500">Couldn't read MTPLX's model cache ({status.cacheError}) — an on-demand start will fall through to MTPLX's own default checkpoint.</p>
           )}
           <p className="text-[11px] text-gray-500">
-            MTPLX starts on demand — the first PortOS request routed to it brings it up on these
-            options, and its idle window (set under Local Runtime Servers) stops it again to release
-            the checkpoint. There is no Start button because a manually-started server would only pin
-            those gigabytes ahead of a request that may never come.
+            MTPLX starts on demand when a request needs it. You can also start it now with the
+            cached checkpoint; its idle window (set under Local Runtime Servers) stops it again to
+            release the checkpoint. Neither path downloads weights without an explicit download.
           </p>
+          {!emptyCache && onStart && (
+            <button
+              onClick={() => onStart?.()}
+              disabled={busy}
+              className={`${btnClass} bg-port-success/20 hover:bg-port-success/30 text-port-success`}
+              title="Start MTPLX with the cached checkpoint; no weights are downloaded"
+            >
+              {actionInProgress === 'runtime-start-mtplx' ? <BrailleSpinner /> : <Terminal size={13} />}
+              Start MTPLX
+            </button>
+          )}
           <button
             onClick={() => onSaveLaunch({ model: model || null, ...(port ? { port: Number(port) } : {}) })}
             disabled={busy || emptyCache}

--- a/client/src/components/settings/MtplxServerCard.jsx
+++ b/client/src/components/settings/MtplxServerCard.jsx
@@ -163,7 +163,7 @@ export default function MtplxServerCard({
           </p>
           {!emptyCache && onStart && (
             <button
-              onClick={() => onStart?.()}
+              onClick={() => onStart({ model: model || null, ...(port ? { port: Number(port) } : {}) })}
               disabled={busy}
               className={`${btnClass} bg-port-success/20 hover:bg-port-success/30 text-port-success`}
               title="Start MTPLX with the cached checkpoint; no weights are downloaded"

--- a/client/src/components/settings/MtplxServerCard.test.jsx
+++ b/client/src/components/settings/MtplxServerCard.test.jsx
@@ -146,10 +146,12 @@ describe('MtplxServerCard', () => {
   });
 
   it('says MTPLX starts on demand while offering an explicit Start button', async () => {
-    const handlers = await renderCard({ installed: true, running: false, supported: true, cachedModels: ['Example/Qwen-MTP'] });
+    const handlers = await renderCard({ installed: true, running: false, supported: true, cachedModels: ['Example/Qwen-MTP', 'Example/Other-MTP'] });
     expect(screen.getByText(/starts on demand/i)).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText('Checkpoint'), { target: { value: 'Example/Other-MTP' } });
+    fireEvent.change(screen.getByLabelText('Port'), { target: { value: '8010' } });
     fireEvent.click(screen.getByRole('button', { name: /^Start MTPLX/ }));
-    expect(handlers.onStart).toHaveBeenCalledWith({ model: null });
+    expect(handlers.onStart).toHaveBeenCalledWith({ model: 'Example/Other-MTP', port: 8010 });
   });
 
   it('will not offer to stop a server started outside PortOS', async () => {

--- a/client/src/components/settings/MtplxServerCard.test.jsx
+++ b/client/src/components/settings/MtplxServerCard.test.jsx
@@ -149,7 +149,7 @@ describe('MtplxServerCard', () => {
     const handlers = await renderCard({ installed: true, running: false, supported: true, cachedModels: ['Example/Qwen-MTP'] });
     expect(screen.getByText(/starts on demand/i)).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: /^Start MTPLX/ }));
-    expect(handlers.onStart).toHaveBeenCalledWith();
+    expect(handlers.onStart).toHaveBeenCalledWith({ model: null });
   });
 
   it('will not offer to stop a server started outside PortOS', async () => {

--- a/client/src/components/settings/MtplxServerCard.test.jsx
+++ b/client/src/components/settings/MtplxServerCard.test.jsx
@@ -7,6 +7,7 @@ const renderCard = async (status, props = {}) => {
   const handlers = {
     onRefresh: vi.fn(),
     onSaveLaunch: vi.fn(),
+    onStart: vi.fn(),
     onStop: vi.fn(),
     onInstall: vi.fn(),
     // The checkpoint manager loads upstream's default listing on mount.
@@ -26,9 +27,8 @@ const renderCard = async (status, props = {}) => {
 };
 
 describe('MtplxServerCard', () => {
-  // MTPLX has no Start button: the first PortOS request routed to it starts it.
-  // What this card saves is the launch line that on-demand start replays, so the
-  // user's checkpoint choice survives a stop/start cycle they never see.
+  // The card saves the launch line used by both explicit and on-demand starts,
+  // so the user's checkpoint choice survives a stop/start cycle they never see.
   it('saves the cached checkpoint and port the user picked', async () => {
     const handlers = await renderCard({
       installed: true,
@@ -145,10 +145,11 @@ describe('MtplxServerCard', () => {
     expect(handlers.onSaveLaunch).toHaveBeenCalled();
   });
 
-  it('says MTPLX starts on demand, so the missing Start button reads as intent', async () => {
-    await renderCard({ installed: true, running: false, supported: true, cachedModels: ['Example/Qwen-MTP'] });
+  it('says MTPLX starts on demand while offering an explicit Start button', async () => {
+    const handlers = await renderCard({ installed: true, running: false, supported: true, cachedModels: ['Example/Qwen-MTP'] });
     expect(screen.getByText(/starts on demand/i)).toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: /^Start/ })).toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: /^Start MTPLX/ }));
+    expect(handlers.onStart).toHaveBeenCalledWith();
   });
 
   it('will not offer to stop a server started outside PortOS', async () => {

--- a/client/src/components/settings/RuntimeServersCard.jsx
+++ b/client/src/components/settings/RuntimeServersCard.jsx
@@ -285,6 +285,7 @@ export default function RuntimeServersCard({
   onConfigureLlama,
   onConfigureMtplx,
   onInstallMtplx,
+  onStartMtplx,
   onStopMtplx,
   onSaveStartup,
   onSaveIdleWindow,
@@ -335,17 +336,15 @@ export default function RuntimeServersCard({
       status: mtplxStatus,
       platformReason: mtplxStatus?.supported === false ? 'macOS with Apple Silicon only' : null,
       onInstall: onInstallMtplx,
-      // No Start button by design. MTPLX is lazily started by the first PortOS
-      // request routed to it and stopped again once its idle window elapses, so
-      // a manual Start would only pin 20GB ahead of a request that may never
-      // come. Install and Configure (download a checkpoint, set the launch
-      // options) are the two things that still need a human.
-      onStart: null,
+      // MTPLX can be started explicitly when a verified checkpoint is cached,
+      // and is still restarted automatically before a request after an idle
+      // release. Neither path downloads or guesses a model.
+      onStart: mtplxStatus?.cachedModels?.length ? onStartMtplx : null,
       onStop: onStopMtplx,
       startBlockedReason: mtplxStatus?.installed && !mtplxStatus?.running
         ? (mtplxStatus?.cachedModels?.length === 0 && !mtplxStatus?.cacheError
           ? 'No checkpoint yet — use Configure to download one'
-          : 'Starts on demand')
+          : null)
         : null,
       detail: mtplxStatus?.cachedModels?.length
         ? `${mtplxStatus.cachedModels.length} checkpoint${mtplxStatus.cachedModels.length === 1 ? '' : 's'} cached`

--- a/client/src/components/settings/RuntimeServersCard.test.jsx
+++ b/client/src/components/settings/RuntimeServersCard.test.jsx
@@ -19,6 +19,7 @@ const renderCard = (props = {}) => {
     onConfigureLlama: vi.fn(),
     onConfigureMtplx: vi.fn(),
     onInstallMtplx: vi.fn(),
+    onStartMtplx: vi.fn(),
     onSaveIdleWindow: vi.fn(),
     onStopMtplx: vi.fn(),
     onSaveStartup: vi.fn(),
@@ -124,16 +125,23 @@ describe('RuntimeServersCard', () => {
     );
   });
 
-  // MTPLX cannot unload its checkpoint in place, so PortOS stops the process
-  // when it goes idle and the next request starts it again. A manual Start would
-  // only pin 20GB ahead of a request that may never come.
-  it('offers no MTPLX Start — it starts on demand', () => {
-    renderCard({
+  // MTPLX can be started on demand or explicitly when a verified checkpoint is
+  // already cached. Neither path downloads weights.
+  it('offers MTPLX Start when a checkpoint is cached', () => {
+    const handlers = renderCard({
       mtplxStatus: { installed: true, running: false, supported: true, cachedModels: ['Example/Qwen-MTP'], endpoint: 'http://127.0.0.1:8000/v1' },
+    });
+    fireEvent.click(within(row('MTPLX')).getByRole('button', { name: /^Start/ }));
+    expect(handlers.onStartMtplx).toHaveBeenCalledWith();
+  });
+
+  it('keeps MTPLX Start unavailable when no checkpoint is cached', () => {
+    renderCard({
+      mtplxStatus: { installed: true, running: false, supported: true, cachedModels: [], endpoint: 'http://127.0.0.1:8000/v1' },
     });
     const mtplx = row('MTPLX');
     expect(within(mtplx).queryByRole('button', { name: /^Start/ })).toBeNull();
-    expect(within(mtplx).getByText(/Starts on demand/)).toBeInTheDocument();
+    expect(within(mtplx).getByText(/use Configure to download one/)).toBeInTheDocument();
   });
 
   // llama.cpp keeps its Stop: it is started explicitly from the launcher, and

--- a/server/services/localModelAgentBenchmark.js
+++ b/server/services/localModelAgentBenchmark.js
@@ -25,6 +25,7 @@ import { isClaudeCommand, isOpencodeCommand } from '../lib/providerModels.js';
 // different tool-call counts for the same run.
 import { summarizeOpenCodeEvents } from '../lib/opencodeStream.js';
 import { getProviderById } from './providers.js';
+import { ensureProviderReadyForExecution } from './providerExecutionReadiness.js';
 import { executeTuiRun } from './tuiPromptRunner.js';
 import { getRunsPath } from './runner.js';
 
@@ -124,6 +125,30 @@ export async function runOpenCodeAgentBenchmark({ backend, modelId, timeoutMs = 
   const startedAt = Date.now();
   const benchmarkFilePath = join(scratchDir, 'PORTOS_AGENT_BENCHMARK.txt');
   try {
+    // This benchmark uses the direct PTY runner instead of
+    // runPromptThroughProvider, so wake a stopped local daemon before spawning
+    // OpenCode. MTPLX releases its checkpoint after the idle window.
+    const ready = await ensureProviderReadyForExecution(provider);
+    if (!ready.success) {
+      return {
+        backend,
+        modelId,
+        providerId: target.providerId,
+        providerLabel: target.label,
+        measurementMode: 'pty-tui',
+        completed: false,
+        elapsedMs: Math.max(0, Date.now() - startedAt),
+        assistantChars: null,
+        outputTokens: null,
+        toolCalls: null,
+        taskCharsPerSecond: null,
+        taskTokensPerSecond: null,
+        exitCode: null,
+        timedOut: false,
+        error: ready.error || `${target.label} is not ready`,
+      };
+    }
+
     // The one-shot TUI runner owns PTY startup, prompt paste, trust dialogs,
     // response-file completion, cancellation and run-record cleanup semantics.
     // Clone only the model pin: the provider's endpoint, env and permissions

--- a/server/services/localModelAgentBenchmark.test.js
+++ b/server/services/localModelAgentBenchmark.test.js
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { join } from 'path';
 vi.mock('./providers.js', () => ({ getProviderById: vi.fn() }));
+vi.mock('./providerExecutionReadiness.js', () => ({ ensureProviderReadyForExecution: vi.fn().mockResolvedValue({ success: true }) }));
 vi.mock('./tuiPromptRunner.js', () => ({ executeTuiRun: vi.fn() }));
 vi.mock('./runner.js', () => ({ getRunsPath: vi.fn(() => '/tmp/portos-benchmark-runs') }));
 vi.mock('../lib/providerModels.js', () => ({
@@ -9,6 +10,7 @@ vi.mock('../lib/providerModels.js', () => ({
 }));
 
 import { getProviderById } from './providers.js';
+import { ensureProviderReadyForExecution } from './providerExecutionReadiness.js';
 import { executeTuiRun } from './tuiPromptRunner.js';
 import {
   buildOpenCodeAgentBenchmarkPrompt,
@@ -113,6 +115,25 @@ describe('runOpenCodeAgentBenchmark', () => {
       completed: true,
       measurementMode: 'pty-tui',
     });
+  });
+
+  it('wakes the MTPLX daemon before running its TUI benchmark', async () => {
+    getProviderById.mockResolvedValue({
+      id: 'opencode-mtplx-tui',
+      type: 'tui',
+      command: 'opencode',
+      args: [],
+      mtplxBacked: true,
+      endpoint: 'http://127.0.0.1:8000/v1',
+    });
+
+    await runOpenCodeAgentBenchmark({ backend: 'mtplx', modelId: 'mtplx-qwen38-27b-optimized-speed' });
+
+    expect(ensureProviderReadyForExecution).toHaveBeenCalledWith(expect.objectContaining({
+      id: 'opencode-mtplx-tui',
+      mtplxBacked: true,
+    }));
+    expect(executeTuiRun).toHaveBeenCalledTimes(1);
   });
 
   it('rejects a model outside the three explicit benchmark targets', async () => {

--- a/server/services/mtplxServerManager.js
+++ b/server/services/mtplxServerManager.js
@@ -841,7 +841,10 @@ export async function ensureMtplxRunning() {
  * it is this install's business.
  */
 export function isMtplxProvider(provider) {
-  if (!provider || provider.type !== 'api') return false;
+  // API providers reach MTPLX directly, while OpenCode TUI providers carry
+  // the same local endpoint and need the exact same lazy wake-up before the
+  // TUI is spawned.
+  if (!provider || !['api', 'tui'].includes(provider.type)) return false;
   if (!isLocalInstanceEndpoint(provider.endpoint)) return false;
   // `localRuntimeKind`, not `localBackendForProvider` — the latter only ever
   // answers 'ollama'/'lmstudio' (it maps those two catalog ports), so it reports

--- a/server/services/mtplxServerManager.test.js
+++ b/server/services/mtplxServerManager.test.js
@@ -679,6 +679,10 @@ describe('mtplxServerManager', () => {
     it('does not match a CLI provider', () => {
       expect(isMtplxProvider({ type: 'cli', endpoint: 'http://127.0.0.1:8000/v1', id: 'mtplx', mtplxBacked: true })).toBe(false);
     });
+
+    it('matches an MTPLX-backed TUI provider', () => {
+      expect(isMtplxProvider({ type: 'tui', endpoint: 'http://127.0.0.1:8000/v1', id: 'mtplx-tui', mtplxBacked: true })).toBe(true);
+    });
   });
 
   describe('ensureMtplxProviderReady', () => {

--- a/server/services/promptRunner.js
+++ b/server/services/promptRunner.js
@@ -26,7 +26,7 @@
  * stay honest about what the runner actually executed.
  */
 
-import { createRun, executeApiRun, executeCliRun, extractBakedModel, hasModelFlag, stopRun, patchRunMetadata } from './runner.js';
+import { createRun, executeApiRun, executeCliRun, extractBakedModel, hasModelFlag, stopRun, patchRunMetadata, finalizeRunRecord } from './runner.js';
 import { getActiveProvider, getProviderById, getAllProviders } from './providers.js';
 import { executeTuiRun } from './tuiPromptRunner.js';
 import { ServerError } from '../lib/errorHandler.js';
@@ -84,7 +84,9 @@ export function buildRequestCapabilities({ prompt, screenshots, outputReserveTok
 // regardless — and, if the backend is configured for parallelism
 // (OLLAMA_NUM_PARALLEL > 1), it loads N model contexts at once and can spike
 // VRAM into an OOM/thrash. Cloud HTTP and CLI/TUI providers have no such
-// constraint. So we cap concurrent IN-FLIGHT calls per LOCAL endpoint and queue
+// constraint. Local TUI providers still share this gate because their readiness
+// hook can start the same daemon before the PTY is spawned. So we cap concurrent
+// IN-FLIGHT calls per LOCAL endpoint and queue
 // the rest (FIFO). Default 1 (serialize); a beefy box can lift it with
 // LOCAL_LLM_MAX_CONCURRENCY. Keyed by endpoint so two distinct local servers
 // still run in parallel with each other.
@@ -120,11 +122,13 @@ function releaseLocalSlot(endpoint) {
   else gate.active = Math.max(0, gate.active - 1);
 }
 
-// Run `fn` under the local-endpoint gate when `provider` is a local API backend;
-// otherwise run it immediately (cloud / CLI / TUI are unconstrained).
+// Run `fn` under the local-endpoint gate when `provider` is a local API or TUI
+// backend; otherwise run it immediately (cloud / non-local CLI/TUI are
+// unconstrained).
 export async function withLocalConcurrencyGate(provider, fn) {
   const endpoint = provider?.endpoint;
-  if (!(provider?.type === PROVIDER_TYPES.API && isLocalEndpoint(endpoint))) return fn();
+  const isLocalProvider = provider?.type === PROVIDER_TYPES.API || provider?.type === PROVIDER_TYPES.TUI;
+  if (!(isLocalProvider && isLocalEndpoint(endpoint))) return fn();
   await acquireLocalSlot(endpoint);
   try {
     return await fn();
@@ -1254,7 +1258,16 @@ async function executeProviderRunOnce({
         error: err.message,
       }));
       if (!ready.success) {
-        const error = new Error(ready.error || 'Provider readiness check failed');
+        const message = ready.error || 'Provider readiness check failed';
+        await finalizeRunRecord({
+          runId,
+          output: '',
+          exitCode: 1,
+          success: false,
+          error: message,
+          startTime: Date.now(),
+        });
+        const error = new Error(message);
         error.effectiveProvider = effectiveProvider;
         error.effectiveModel = effectiveModel;
         throw error;

--- a/server/services/promptRunner.js
+++ b/server/services/promptRunner.js
@@ -1247,7 +1247,9 @@ async function executeProviderRunOnce({
   // (above) and any retry-fallback. This is the single chokepoint the
   // module comment promises: gating the *requested* provider at the call
   // site missed a remote/CLI primary that swaps/fails over to a local
-  // backend, defeating the VRAM/OOM serialization. No-op for cloud/CLI/TUI.
+  // backend, defeating the VRAM/OOM serialization. Non-local CLI/TUI providers
+  // remain unconstrained.
+  const attemptStartedAt = Date.now();
   return withLocalConcurrencyGate(effectiveProvider, async () => {
     // API providers run through the shared toolkit readiness hook. TUI
     // providers spawn OpenCode directly, so they need the same hook here or
@@ -1265,7 +1267,7 @@ async function executeProviderRunOnce({
           exitCode: 1,
           success: false,
           error: message,
-          startTime: Date.now(),
+          startTime: attemptStartedAt,
         });
         const error = new Error(message);
         error.effectiveProvider = effectiveProvider;

--- a/server/services/promptRunner.js
+++ b/server/services/promptRunner.js
@@ -39,6 +39,7 @@ import { createSingleFlight } from '../lib/singleFlight.js';
 import { extractJson } from '../lib/jsonExtract.js';
 import { isCreativeRunSource, withCreativeLatitude } from '../lib/creativeLatitude.js';
 import { DEFAULT_OUTPUT_RESERVE_TOKENS, estimateTokens } from '../lib/contextBudget.js';
+import { ensureProviderReadyForExecution } from './providerExecutionReadiness.js';
 
 // The fallback-lifecycle notifiers live in services/autoFixer.js, which
 // transitively pulls in services/cos.js (PM2 + fs + sockets). Importing it
@@ -1243,7 +1244,24 @@ async function executeProviderRunOnce({
   // module comment promises: gating the *requested* provider at the call
   // site missed a remote/CLI primary that swaps/fails over to a local
   // backend, defeating the VRAM/OOM serialization. No-op for cloud/CLI/TUI.
-  return withLocalConcurrencyGate(effectiveProvider, () => new Promise((resolve, reject) => {
+  return withLocalConcurrencyGate(effectiveProvider, async () => {
+    // API providers run through the shared toolkit readiness hook. TUI
+    // providers spawn OpenCode directly, so they need the same hook here or
+    // MTPLX remains stopped until after the TUI has already failed its request.
+    if (effectiveProvider.type === PROVIDER_TYPES.TUI) {
+      const ready = await ensureProviderReadyForExecution(effectiveProvider).catch((err) => ({
+        success: false,
+        error: err.message,
+      }));
+      if (!ready.success) {
+        const error = new Error(ready.error || 'Provider readiness check failed');
+        error.effectiveProvider = effectiveProvider;
+        error.effectiveModel = effectiveModel;
+        throw error;
+      }
+    }
+
+    return new Promise((resolve, reject) => {
     let text = '';
     let settled = false;
     let apiTimeoutHandle = null;
@@ -1360,7 +1378,8 @@ async function executeProviderRunOnce({
     } else {
       safeReject(new Error(`Unsupported provider type: ${effectiveProvider.type}`));
     }
-  })).finally(() => {
+    });
+  }).finally(() => {
     if (typeof onRunSettled !== 'function') return;
     try { onRunSettled(runId); } catch (err) {
       console.error(`❌ run lifecycle settle hook failed: ${err.message}`);

--- a/server/services/promptRunner.test.js
+++ b/server/services/promptRunner.test.js
@@ -27,6 +27,10 @@ vi.mock('./tuiPromptRunner.js', () => ({
   executeTuiRun: vi.fn(),
 }));
 
+vi.mock('./providerExecutionReadiness.js', () => ({
+  ensureProviderReadyForExecution: vi.fn().mockResolvedValue({ success: true }),
+}));
+
 // providers.js is a compatibility shim that throws when the toolkit hasn't
 // been initialized via setAIToolkit(). Mock it so the resolveProviderAndModel
 // tests can drive the active/by-id lookups directly. `getAllProviders` is
@@ -59,6 +63,7 @@ vi.mock('../lib/aiToolkitState.js', () => ({
 
 const runner = await import('./runner.js');
 const tuiRunner = await import('./tuiPromptRunner.js');
+const executionReadiness = await import('./providerExecutionReadiness.js');
 const providers = await import('./providers.js');
 const autoFixer = await import('./autoFixer.js');
 const toolkitState = await import('../lib/aiToolkitState.js');
@@ -642,6 +647,20 @@ describe('promptRunner — TUI provider routing', () => {
     expect(tuiRunner.executeTuiRun).toHaveBeenCalledTimes(1);
     expect(runner.executeCliRun).not.toHaveBeenCalled();
     expect(runner.executeApiRun).not.toHaveBeenCalled();
+  });
+
+  it('wakes an MTPLX-backed TUI before spawning OpenCode', async () => {
+    const provider = tuiProvider({
+      id: 'opencode-mtplx-tui',
+      mtplxBacked: true,
+      endpoint: 'http://127.0.0.1:8000/v1',
+    });
+    tuiRunner.executeTuiRun.mockImplementation(async ({ onComplete }) => onComplete({ success: true, text: 'ready' }));
+
+    await runPromptThroughProvider({ provider, prompt: 'p', source: 'test' });
+
+    expect(executionReadiness.ensureProviderReadyForExecution).toHaveBeenCalledWith(provider);
+    expect(tuiRunner.executeTuiRun).toHaveBeenCalledTimes(1);
   });
 
   it('passes cwd + timeout overrides through to executeTuiRun', async () => {

--- a/server/services/stageRunner.test.js
+++ b/server/services/stageRunner.test.js
@@ -724,6 +724,13 @@ describe('withLocalConcurrencyGate', () => {
     expect(state.peak).toBeGreaterThan(1);
   });
 
+  it('serializes concurrent TUI calls to a LOCAL endpoint', async () => {
+    const provider = { type: 'tui', endpoint: 'http://127.0.0.1:8000/v1' };
+    const { state, fn } = makeTracker();
+    await Promise.all(Array.from({ length: 4 }, () => withLocalConcurrencyGate(provider, fn)));
+    expect(state.peak).toBeLessThanOrEqual(LOCAL_LLM_MAX_CONCURRENCY);
+  });
+
   it('releases the slot even when the gated fn throws (no deadlock)', async () => {
     const provider = { type: 'api', endpoint: 'http://127.0.0.1:1234' };
     await expect(withLocalConcurrencyGate(provider, () => Promise.reject(new Error('boom')))).rejects.toThrow('boom');


### PR DESCRIPTION
## Summary
- Add clear in-app Start and Stop controls for cached MTPLX checkpoints in the Local Runtime Servers surfaces.
- Wake and serialize MTPLX before normal and benchmark TUI execution, with failed starts finalizing their run records.

## Test plan
- `npx vitest run services/mtplxServerManager.test.js services/promptRunner.test.js services/stageRunner.test.js services/localModelAgentBenchmark.test.js`
- `npx vitest run src/components/settings/ProviderReadiness.test.jsx src/components/settings/MtplxServerCard.test.jsx src/components/settings/RuntimeServersCard.test.jsx src/components/settings/LocalLlmTab.test.jsx`
- `npm run build` (client)