### PR TITLE
ci: run related tests once across all runner CPUs

### DIFF
--- a/client/vitest.config.js
+++ b/client/vitest.config.js
@@ -6,7 +6,10 @@ import { vitestCiPool } from '../scripts/vitestCiPool.js';
 export default defineConfig({
   plugins: [react()],
   test: {
-    ...vitestCiPool(),
+    // Four jsdom workers exhausted Testing Library's existing 3s async budget
+    // on the public runner before ChiefOfStaff's config panel settled. Keep the
+    // proven two-worker client cap; the Node/server runner uses all four CPUs.
+    ...vitestCiPool({ maxWorkers: 2 }),
     environment: 'jsdom',
     globals: true,
     setupFiles: ['./src/test/setup.js'],

--- a/docs/GITHUB_ACTIONS.md
+++ b/docs/GITHUB_ACTIONS.md
@@ -32,8 +32,8 @@ A release therefore pays for one full run (on its PR), not three.
 PRs into `main` use `scripts/ci-test-plan.js` to classify the changed files
 before installing dependencies. Directory-scoped features run their server and
 client feature tests; flat modules fall back to Vitest's import-graph-aware
-`related` mode, fed only the changed behavioral source paths. The planner
-deliberately chooses full CI for shared
+`related` mode, fed the changed behavioral source paths plus the planner's
+explicit test files. The planner deliberately chooses full CI for shared
 composition roots, test configuration, dependency manifests, workflow changes,
 unknown artifacts, or wide diffs.
 
@@ -61,13 +61,15 @@ being registered, either in `ALWAYS_RUN_TESTS` or in its own
 
 ### Vitest runner tuning
 
-On GitHub Actions, `CI=true` caps each Vitest runner at `maxWorkers: 2`
+On GitHub Actions, `CI=true` caps the server Vitest runner at `maxWorkers: 4`
 (`scripts/vitestCiPool.js`, spread into `server/vitest.config.js` and
-`client/vitest.config.js`). Standard hosted runners are 2 vCPU / 7GB;
+`client/vitest.config.js`). Standard Linux runners for public repositories are
+[4 vCPU / 16GB](https://docs.github.com/en/actions/reference/runners/github-hosted-runners);
 uncapped forks oversubscribe those cores during transform. Local `npm test`
-is unbounded. File-level parallelism stays on for unit tests so the two
-workers stay busy; the DB suite already serializes files because those tests
-share one Postgres.
+is unbounded. The jsdom-heavy client retains its proven two-worker override:
+four workers made its async rendering assertions timing-dependent under CI
+contention. File-level parallelism stays on; the DB suite already serializes
+files because those tests share one Postgres.
 
 Each test job restores Vite/Vitest transform artifacts
 (`node_modules/.vite`, `node_modules/.vitest`) **after** the install — `npm ci`
@@ -230,8 +232,10 @@ The selected work is split across parallel jobs:
   see "Reusing the release PR's CI run" below.
 
 Targeted `files` plans run the planner's exact test files once. `related` plans
-run `vitest related` directly against changed behavioral source paths, then run
-the cheap structural/repository contracts that cannot be found through imports.
+run `vitest related` once with changed behavioral source paths and the cheap
+structural/repository contract files as inputs. Vitest treats a test-file input
+as directly selected, so contracts and changed tests share the import-graph run
+without being repeated in a second process.
 There is no buffered discovery pass: the old `vitest list --changed` path could
 spend minutes printing every test name, overflow Node's buffer, discard the
 result, and rerun the same graph.

--- a/scripts/run-ci-tests.js
+++ b/scripts/run-ci-tests.js
@@ -21,6 +21,10 @@ export function toRunnerPath(scope, path) {
   return `../${path}`;
 }
 
+export function relatedInputs(sourceFiles, selectedFiles) {
+  return [...new Set([...sourceFiles, ...selectedFiles])];
+}
+
 export function recordVitestDuration(scope, label, startedAt) {
   const seconds = ((Date.now() - startedAt) / 1000).toFixed(1);
   const line = `⏱ ${scope} ${label}: ${seconds}s`;
@@ -92,15 +96,17 @@ function main() {
   // The old discovery pass took 282 seconds on PR #5296, overflowed Node's
   // spawnSync buffer, discarded its work, then reran the same graph. `related`
   // builds that graph once and immediately executes it.
-  const relatedStatus = spawnNpm(scope, 'test:ci:related', sourceFiles, 'source-related tests');
-  if (relatedStatus !== 0) process.exit(relatedStatus);
-
-  // Structural and repository-wide guards do not import the source they scan,
-  // so the import graph cannot discover them. They are deliberately cheap and
-  // run once after the related set.
-  process.exit(selectedFiles.length
-    ? spawnNpm(scope, 'test:ci', selectedFiles, 'explicit contract guards')
-    : 0);
+  // A test file passed to `vitest related` is itself selected, so changed tests
+  // and structural guards can share the source graph's one Vitest invocation.
+  // Running them in a second exact-file process repeated any changed test that
+  // already imported the source; on PR #5299 that rebuilt the atlas twice and
+  // added 27.5 seconds after the related run had already passed it.
+  process.exit(spawnNpm(
+    scope,
+    'test:ci:related',
+    relatedInputs(sourceFiles, selectedFiles),
+    'related and contract tests',
+  ));
 }
 
 if (isDirectlyInvoked(import.meta.url)) main();

--- a/scripts/run-ci-tests.test.js
+++ b/scripts/run-ci-tests.test.js
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 
 import {
   recordVitestDuration,
+  relatedInputs,
   requiresSourceFiles,
   toRunnerPath,
 } from './run-ci-tests.js';
@@ -45,5 +46,18 @@ describe('requiresSourceFiles', () => {
     expect(requiresSourceFiles('related', ['server/services/auth.js'])).toBe(false);
     expect(requiresSourceFiles('files', [])).toBe(false);
     expect(requiresSourceFiles('full', [])).toBe(false);
+  });
+});
+
+describe('relatedInputs', () => {
+  it('runs source-related tests and explicit guards in one deduplicated invocation', () => {
+    expect(relatedInputs(
+      ['./services/auth.js', './services/auth.test.js'],
+      ['./services/auth.test.js', '../scripts/repo-scan-guards.test.js'],
+    )).toEqual([
+      './services/auth.js',
+      './services/auth.test.js',
+      '../scripts/repo-scan-guards.test.js',
+    ]);
   });
 });

--- a/scripts/vitestCiPool.js
+++ b/scripts/vitestCiPool.js
@@ -1,15 +1,16 @@
 /**
- * Vitest worker caps for GitHub Actions. Standard hosted runners are 2 vCPU /
- * 7GB; uncapped forks oversubscribe those cores during transform and swap.
+ * Vitest worker caps for GitHub Actions. Standard Linux runners for public
+ * repositories are 4 vCPU / 16GB; uncapped forks oversubscribe those cores
+ * during transform and swap.
  * Local `npm test` stays unbounded so a developer machine can use every core.
  *
- * fileParallelism stays at Vitest's default (true): two workers stay busy on
+ * fileParallelism stays at Vitest's default (true): four workers stay busy on
  * independent files. The DB suite already serializes files because those
  * tests share one Postgres.
  *
  * Vitest 4 exposes `maxWorkers` only — there is no `minWorkers` / `minThreads`.
  */
-export function vitestCiPool() {
+export function vitestCiPool({ maxWorkers = 4 } = {}) {
   if (!process.env.CI) return {};
-  return { maxWorkers: 2 };
+  return { maxWorkers };
 }

--- a/scripts/vitestCiPool.test.js
+++ b/scripts/vitestCiPool.test.js
@@ -15,13 +15,18 @@ describe('vitestCiPool', () => {
     expect(vitestCiPool()).toEqual({});
   });
 
-  it('caps workers at 2 on CI', () => {
+  it('matches the four CPUs on public GitHub-hosted runners', () => {
     process.env.CI = 'true';
-    expect(vitestCiPool()).toEqual({ maxWorkers: 2 });
+    expect(vitestCiPool()).toEqual({ maxWorkers: 4 });
   });
 
   it('treats CI=1 as CI', () => {
     process.env.CI = '1';
-    expect(vitestCiPool()).toEqual({ maxWorkers: 2 });
+    expect(vitestCiPool()).toEqual({ maxWorkers: 4 });
+  });
+
+  it('allows a workspace to retain a lower evidence-based cap', () => {
+    process.env.CI = 'true';
+    expect(vitestCiPool({ maxWorkers: 2 })).toEqual({ maxWorkers: 2 });
   });
 });


### PR DESCRIPTION
## Summary

- run source-related tests, changed tests, and structural contract guards in one `vitest related` invocation
- remove the second exact-file phase that repeated changed suites already selected through the import graph
- raise the CI Vitest cap from two to four workers to match the current 4-vCPU public GitHub-hosted runners
- document the single-pass selector behavior and current runner specification

The exact #5299 selection previously spent 205.0 seconds in the related run and another 27.5 seconds rerunning explicit files, including the atlas suite. The new combined selection ran all 409 files and 11,619 tests once locally in 73.9 seconds. A controlled full-server run under `CI=1` improved from 261.3 seconds at two workers to 161.0 seconds at four workers with identical pass/skip counts.

## Test plan

- `PORTOS_TEST_QUIET=1 PGPASSWORD=portos npm test --prefix server -- --run ../scripts/run-ci-tests.test.js ../scripts/vitestCiPool.test.js ../scripts/ci-test-plan.test.js`
- `CI=1 PORTOS_TEST_QUIET=1 PGPASSWORD=portos npm test --prefix server`
- exact #5299-shaped `CI_TEST_MODE=related` run through `scripts/run-ci-tests.js`
- `CI=1 npm test --prefix client`
- `npm run build --prefix client`
- `git diff --check`