### PR TITLE
feat(repo-study): focus intake studies on product features

### DIFF
--- a/client/src/components/brain/RepoIntakeOptions.jsx
+++ b/client/src/components/brain/RepoIntakeOptions.jsx
@@ -22,7 +22,7 @@ export const REPO_INTAKE_OPTIONS = [
     key: 'learn',
     label: 'Study for app ideas',
     Icon: Lightbulb,
-    hint: 'An agent reads the clone for implementation ideas worth adopting and files the good ones as issues. Clean-room — it never copies code.',
+    hint: 'An agent studies the clone as a product — its features and design — and files the feature ideas and enhancements worth adopting as issues. Clean-room — it never copies code.',
   },
 ];
 

--- a/server/lib/repoIntakeActions.js
+++ b/server/lib/repoIntakeActions.js
@@ -5,7 +5,7 @@
  * write path and from the Zod schemas.
  *
  * `malwareScan` → the read-only `/do:scan` audit of the clone.
- * `learn`       → a `repo-study` review: read the clone for ideas worth adopting
+ * `learn`       → a `repo-study` review: read the clone for feature/design ideas worth adopting
  *                 into PortOS and file them in the work tracker (clean-room).
  */
 

--- a/server/services/repoIntake.js
+++ b/server/services/repoIntake.js
@@ -7,9 +7,12 @@
  *
  *   - `malwareScan` → the read-only `/do:scan` audit, identical to the Links
  *     tab's per-link Scan button (both go through `queueMalwareScan` here).
- *   - `learn`       → a `repo-study` review: read the clone as a source of IDEAS
- *     for PortOS and file the adoptable ones into PortOS's configured work
- *     tracker. Clean-room — propose reimplementation, never copy upstream code.
+ *   - `learn`       → a `repo-study` review: read the clone as a PRODUCT — its
+ *     features, design, and user-facing behavior — and file the feature ideas
+ *     and enhancements PortOS should adopt into its configured work tracker.
+ *     Code organization and other meta-programming observations are out of
+ *     scope (that is what `reference-watch` and the code-quality audits are
+ *     for). Clean-room — propose reimplementation, never copy upstream code.
  *     Its optional provider/model/effort pins travel with the stored request.
  *
  * Both are queued only AFTER the clone succeeds (there is nothing to read
@@ -19,6 +22,7 @@
 
 import { randomUUID } from 'crypto';
 import { existsSync } from 'fs';
+import { join } from 'path';
 import * as cos from './cos.js';
 import { getAppById, PORTOS_APP_ID } from './apps.js';
 import { prepareScanReportDirectory, reportPathForId } from './malwareScanReports.js';
@@ -99,15 +103,34 @@ Use that path as SCAN_DIR. Adhere to every Operational Invariant in the workflow
   };
 }
 
+/** The target app's user-facing feature inventory, when it keeps one (PortOS: docs/features/product-surfaces.md). */
+export const FEATURE_MAP_RELATIVE_PATH = 'docs/features/product-surfaces.md';
+
+/**
+ * Resolve the target app's feature map for the study brief — the file the
+ * agent reads to place the studied repo against EVERY feature the app already
+ * has (a three.js demo lands on the 3D/OpenWorld surface, a chat bot on voice
+ * or the Chief of Staff), instead of only the features it happens to grep for.
+ * Null when the app does not keep one; the brief then falls back to README,
+ * docs, and navigation.
+ */
+export const resolveFeatureMapPath = (repoPath) => {
+  const candidate = join(repoPath, FEATURE_MAP_RELATIVE_PATH);
+  return existsSync(candidate) ? candidate : null;
+};
+
 /**
  * Build the `repo-study` agent context. Kept separate from the queueing so the
  * wording is assertable without going through the task store.
  */
-export function buildRepoStudyContext(link, { appName, repoPath, trackerInstructions, studyContext }) {
+export function buildRepoStudyContext(link, { appName, repoPath, trackerInstructions, studyContext, featureMapPath = null }) {
   const requesterContext = typeof studyContext === 'string' && studyContext.trim()
     ? `\n## Additional context from the requester\n\n${studyContext.trim()}\n`
     : '';
-  return `A GitHub repository was captured into the Brain and cloned locally. Study it as a source of IDEAS for ${appName} and record the adoptable ones in the work tracker.${requesterContext}
+  const featureMapInstruction = featureMapPath
+    ? `Read \`${featureMapPath}\` — ${appName}'s user-facing feature inventory — in full before you judge anything.`
+    : `${appName} keeps no single feature inventory; build one from its README, \`docs/\`, and navigation/route definitions under \`${repoPath}\` before you judge anything.`;
+  return `A GitHub repository was captured into the Brain and cloned locally. Study it as a PRODUCT — what it lets its users do, how it is designed, and what it does well — and record the feature ideas and enhancements ${appName} should adopt in the work tracker.${requesterContext}
 
 ## The repository under study
 
@@ -122,15 +145,25 @@ export function buildRepoStudyContext(link, { appName, repoPath, trackerInstruct
 - **Clean-room.** Do NOT copy source, config, prose, or assets out of the clone into ${appName}. Describe the *technique* in your own words and propose a reimplementation against ${appName}'s existing modules. If an idea can only be had by copying, drop it.
 - **License first.** Read the repo's LICENSE before proposing anything. Name the license in every proposal. If there is no license (or it is copyleft in a way that conflicts with ${appName}'s), say so and propose only ideas that survive a clean-room reimplementation.
 
-## What to look for
+## First: what is this repo, and where does it land in ${appName}?
 
-Read the repo's README, its entry points, and the modules that implement its distinctive behavior. For each thing it does notably well, ask whether ${appName} would be better with an equivalent:
+1. **State the repo's purpose** in two or three sentences: who it is for, what problem it solves, and the handful of capabilities that define it. Read the README, docs, and entry points; skim \`git log\` for what its authors have been investing in.
+2. **Map it onto ${appName}'s whole feature set — not just the surfaces you happened to grep.** ${featureMapInstruction} Then name the one or two ${appName} features the repo's domain belongs to, and treat those as the primary lens for the rest of the study. Examples of the mapping you are expected to make: a three.js game, scene, or visual-rendering demo belongs to the 3D / OpenWorld surface; a chat or voice bot belongs to the voice stack or the Chief of Staff; a note-taking or knowledge tool belongs to the Brain; a story, comic, or media generator belongs to the Create suite. A repo whose domain maps to NO existing feature is itself a finding — say which new surface it would justify, or that it does not fit ${appName} at all.
+3. **Only then** walk the repo's features one by one against the mapped ${appName} feature(s), using the checklist below.
 
-1. **Features ${appName} lacks** that fit its existing surfaces (a page, a service, a CoS task type, a provider).
-2. **Better implementations of things ${appName} already does** — a sharper algorithm, a cheaper data layout, a failure mode handled that ${appName} doesn't handle.
-3. **Non-obvious operational lessons** — a guard, a migration strategy, a rate-limit or retry shape worth mirroring.
+## What to look for — features and design, not engineering hygiene
 
-Ground every proposal in ${appName}'s actual code: grep \`${repoPath}\` to confirm the gap is real before filing. An idea ${appName} already implements is not a proposal. Prefer 2–5 well-argued items over a long shallow list; filing nothing is a legitimate outcome — say so in your final summary.
+Read the modules that implement the repo's distinctive user-facing behavior, not just its README. For each capability it has, ask whether ${appName} would be better with an equivalent:
+
+1. **New features ${appName} lacks** — a capability, workflow, or integration its users would value, mapped onto ${appName}'s existing surfaces (a page, a service, a CoS task type, a provider, a voice/agent capability). Say which surface, and whether it warrants an opt-in feature flag.
+2. **Enhancements to features ${appName} already has** — where the upstream's version of a similar feature is richer, safer for the user, or handles a real-world case ${appName}'s does not. Name the ${appName} feature being enhanced.
+3. **Design ideas** — a UX pattern, a safety/consent model, a fail-closed behavior, or a setup/onboarding flow that would make an existing ${appName} feature better for the person using it.
+
+**Out of scope:** code organization, module layout, build tooling, test strategy, process-spawn plumbing, and other internal engineering or meta-programming observations. Do not file those, even when they are good — they change nothing the user can see or do. An engineering technique is worth filing ONLY when it is the enabling piece of a feature you are proposing, and then it goes inside that feature's proposal, not as its own item.
+
+Ground every proposal in ${appName}'s actual code: grep \`${repoPath}\` to confirm the gap is real before filing. A feature ${appName} already has is not a proposal. Prefer 2–5 well-argued items over a long shallow list; filing nothing is a legitimate outcome — say so in your final summary.
+
+**Large features:** when an idea needs several independently shippable steps (a feature flag, a native/OS integration, a new agent capability, a UI), file ONE epic that states the user-facing outcome and the recommended defaults, plus one ready-to-work issue per phase that references the epic — never one monolithic item and never a bare list of steps in chat.
 
 ## Where to record proposals
 
@@ -176,6 +209,7 @@ export async function queueRepoStudy(link, targetAppId = PORTOS_APP_ID, studyCon
           .replace(/\{appName\}/g, () => app.name)
           .replace(/\{repoPath\}/g, () => app.repoPath),
         studyContext,
+        featureMapPath: resolveFeatureMapPath(app.repoPath),
       }),
       // The deliverable is tracker items, not code — the agent reads PortOS and
       // the clone, then files. No worktree, no PR, no review loop.

--- a/server/services/repoIntake.test.js
+++ b/server/services/repoIntake.test.js
@@ -132,6 +132,16 @@ describe('queueRepoStudy', () => {
   // ledger (agentFinalization.js), which auto-parks and notifies. A hand-queued
   // repo study has no schedule to park, so it must reach the no-commit gate via
   // `workTracker` instead — see taskTypeHooks.js#isTrackerFilingDispatch.
+  it('points the brief at the app\'s feature map when the repo keeps one, else asks for one to be built', async () => {
+    await queueRepoStudy(LINK);
+    expect(addTask.mock.calls[0][0].context).toContain('Read `/srv/portos/docs/features/product-surfaces.md`');
+
+    // Only the clone exists; the app has no product-surfaces map.
+    existsSync.mockImplementation((path) => path === LINK.localPath);
+    await queueRepoStudy(LINK);
+    expect(addTask.mock.calls[1][0].context).toMatch(/keeps no single feature inventory; build one/);
+  });
+
   it('does not masquerade as a scheduled task type', async () => {
     await queueRepoStudy(LINK);
     expect(addTask.mock.calls[0][0].analysisType).toBeUndefined();
@@ -188,6 +198,38 @@ describe('buildRepoStudyContext', () => {
     expect(body).toMatch(/Never execute anything from the clone/);
     expect(body).toMatch(/Never edit the clone/);
     expect(body).toContain(LINK.localPath);
+  });
+
+  it('frames the study around features and design, with engineering hygiene out of scope', () => {
+    const body = context();
+    // The brief must ask for product-level ideas — a study that only reports
+    // module layout / spawn plumbing / build tooling is the failure mode this
+    // pins (#5301–#5304 were all of that shape).
+    expect(body).toMatch(/Study it as a PRODUCT/);
+    expect(body).toMatch(/New features PortOS lacks/);
+    expect(body).toMatch(/Enhancements to features PortOS already has/);
+    expect(body).toMatch(/\*\*Out of scope:\*\* code organization, module layout, build tooling/);
+    expect(body).toMatch(/file ONE epic .* plus one ready-to-work issue per phase/);
+  });
+
+  it('makes the agent state the repo purpose and map it onto the whole feature inventory first', () => {
+    const body = context();
+    expect(body).toMatch(/## First: what is this repo, and where does it land in PortOS\?/);
+    expect(body).toMatch(/State the repo's purpose/);
+    expect(body).toMatch(/three\.js game, scene, or visual-rendering demo belongs to the 3D \/ OpenWorld surface/);
+    // No feature map supplied → the brief tells the agent to build one.
+    expect(body).toMatch(/keeps no single feature inventory; build one from its README/);
+  });
+
+  it('points the agent at the feature map when the target app keeps one', () => {
+    const body = buildRepoStudyContext(LINK, {
+      appName: 'PortOS',
+      repoPath: '/srv/portos',
+      trackerInstructions: 'FILE HERE',
+      featureMapPath: '/srv/portos/docs/features/product-surfaces.md',
+    });
+    expect(body).toContain('Read `/srv/portos/docs/features/product-surfaces.md` — PortOS\'s user-facing feature inventory — in full');
+    expect(body).not.toMatch(/keeps no single feature inventory/);
   });
 
   it('states the clean-room and license rules the proposals depend on', () => {


### PR DESCRIPTION
## Summary

- frame repo studies around the source product purpose, user-facing features, and design
- map each source repository onto the target app feature inventory before proposing work
- exclude standalone engineering-hygiene findings and split large feature proposals into an epic plus phases
- update the Brain capture hint to match the new study contract

## Tests

- `cd server && npm test -- repoIntake.test.js repoIntakeActions.mirror.test.js`