### PR TITLE
Show Rapid Reader remaining time as a live H:MM:SS countdown

### DIFF
--- a/client/src/components/RapidReader.jsx
+++ b/client/src/components/RapidReader.jsx
@@ -4,6 +4,7 @@ import Modal from './ui/Modal';
 import useKeyCapture from '../hooks/useKeyCapture';
 import { noPointerFocusSurfaceProps } from '../lib/a11yKeyboard';
 import { rapidReaderWords } from '../lib/rapidReaderPosition';
+import { formatCountdown } from '../utils/formatters';
 
 // Optimal Recognition Point — the focal letter the eye lands on. Spritz-style:
 // shorter words use a left-shifted ORP, longer words shift right. Returns the
@@ -142,8 +143,11 @@ export default function RapidReader({
   const changeChunkSize = (next) => { setChunkSize(next); onChunkSizeChange?.(next); };
 
   const progress = totalWords ? (Math.min(totalWords, wordIndex + current.wordCount) / totalWords) * 100 : 0;
-  const elapsedSec = Math.round(((wordIndex + 1) * 60) / Math.max(60, wpm));
-  const totalSec = Math.round((totalWords * 60) / Math.max(60, wpm));
+  // Time left to finish, derived from the live `wpm` so it re-renders the moment
+  // the slider or the +/- hotkeys change speed. The words still to come are the
+  // ones after the chunk on screen.
+  const remainingWords = Math.max(0, totalWords - wordIndex - current.wordCount);
+  const remainingSec = (remainingWords * 60) / Math.max(60, wpm);
 
   if (!totalWords) {
     return (
@@ -280,7 +284,7 @@ export default function RapidReader({
             </button>
           </div>
           <span className="font-mono text-gray-500">
-            {Math.min(wordIndex + 1, totalWords)}/{totalWords} words · {elapsedSec}s/{totalSec}s
+            {Math.min(wordIndex + 1, totalWords)}/{totalWords} words · {formatCountdown(remainingSec)} left
           </span>
         </div>
       </div>

--- a/client/src/components/RapidReader.test.jsx
+++ b/client/src/components/RapidReader.test.jsx
@@ -115,3 +115,26 @@ describe('RapidReader keyboard transport', () => {
     expect(voiceHotkey()).not.toHaveBeenCalled();
   });
 });
+
+describe('RapidReader remaining-time readout', () => {
+  installVoiceHotkeySpy();
+
+  const wordsText = (count) => Array.from({ length: count }, (_, i) => `w${i}`).join(' ');
+
+  it('counts down the words still to come and re-derives it when WPM changes', () => {
+    // 600 words at 300 WPM: 599 left after the on-screen chunk → 119.8s → "02:00".
+    const { container } = render(<RapidReader text={wordsText(600)} wpm={300} />);
+    expect(container.textContent).toContain('1/600 words · 02:00 left');
+
+    // The `-` hotkey drops WPM by 25, so the same remainder takes longer.
+    act(() => { fireEvent.keyDown(document.body, { key: '-' }); });
+
+    expect(container.textContent).toContain('1/600 words · 02:11 left');
+  });
+
+  it('renders an over-an-hour remainder as H:MM:SS', () => {
+    // 3700 words at 60 WPM: 3699 left → 3699s → "1:01:39".
+    const { container } = render(<RapidReader text={wordsText(3700)} wpm={60} />);
+    expect(container.textContent).toContain('1:01:39 left');
+  });
+});

--- a/client/src/utils/formatters.js
+++ b/client/src/utils/formatters.js
@@ -506,14 +506,17 @@ export function countWords(text) {
 }
 
 /**
- * Format a number of seconds as MM:SS (e.g. 75 → "01:15"). Used for sprint
- * timers and other countdowns. Negative values clamp to 0.
+ * Format a number of seconds as MM:SS (e.g. 75 → "01:15"), or H:MM:SS once the
+ * total reaches an hour (e.g. 3661 → "1:01:01"). Used for sprint timers and
+ * other countdowns. Negative and non-finite values clamp to 0.
  */
 export function formatCountdown(seconds) {
-  const safe = Math.max(0, Math.round(seconds));
-  const m = Math.floor(safe / 60);
+  const safe = Number.isFinite(seconds) ? Math.max(0, Math.round(seconds)) : 0;
+  const h = Math.floor(safe / 3600);
+  const m = Math.floor((safe % 3600) / 60);
   const s = safe % 60;
-  return `${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
+  const mmss = `${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
+  return h > 0 ? `${h}:${mmss}` : mmss;
 }
 
 /**

--- a/client/src/utils/formatters.test.js
+++ b/client/src/utils/formatters.test.js
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   clamp, formatContextLength, formatDurationMin, formatDurationMs, formatEventDateTime, timeAgo, formatAgeDays,
-  formatCooldown, recommendedRamGb, parseTimeoutMs, formatDurationSec, middleTruncate,
+  formatCooldown, formatCountdown, recommendedRamGb, parseTimeoutMs, formatDurationSec, middleTruncate,
   formatWeight, formatPercent, formatUsd, formatBytes,
   formatDateNumeric, formatTimeOfDaySeconds, formatClockTime, formatWeekdayDate,
   formatMonthDay, formatMonthYear, formatWeekdayShort, formatWeekdayTime, formatDateFull, formatDateShort, formatDateTime,
@@ -609,3 +609,23 @@ describe('canonical date/time formatters (#3870)', () => {
   });
 });
 // @vitest-environment node
+
+describe('formatCountdown', () => {
+  it('renders sub-hour durations as MM:SS', () => {
+    expect(formatCountdown(0)).toBe('00:00');
+    expect(formatCountdown(75)).toBe('01:15');
+    expect(formatCountdown(3599)).toBe('59:59');
+  });
+
+  it('adds an hour bucket once the total reaches an hour', () => {
+    expect(formatCountdown(3600)).toBe('1:00:00');
+    expect(formatCountdown(3661)).toBe('1:01:01');
+    expect(formatCountdown(36000)).toBe('10:00:00');
+  });
+
+  it('clamps negative and non-finite input to zero', () => {
+    expect(formatCountdown(-10)).toBe('00:00');
+    expect(formatCountdown(NaN)).toBe('00:00');
+    expect(formatCountdown(undefined)).toBe('00:00');
+  });
+});


### PR DESCRIPTION
## Summary

- The Rapid Reader controls bar showed elapsed/total as raw seconds (`34s/411s`), which runs into four-digit counts on a long document at a slow WPM. It now shows **how much time is left**, as `MM:SS` — or `H:MM:SS` past an hour.
- The countdown is derived from the live `wpm` state, so the WPM slider and the `+`/`-` hotkeys update it immediately; no new effect or state.
- `formatCountdown` in `client/src/utils/formatters.js` gains an hour bucket (`3661` → `1:01:01`) and keeps its existing `MM:SS` output under an hour, so the Writers' Room sprint timer (`ExercisePanel.jsx`) renders exactly as before. It also now clamps non-finite input to `00:00` alongside the existing negative clamp.

Out of scope (per the issue): the static pre-start estimate on `client/src/pages/RapidReader.jsx`, and any change to the reading-speed / `delayFor` logic.

## Test plan

- `client/src/utils/formatters.test.js` — new `formatCountdown` describe: sub-hour `MM:SS`, the hour bucket at 3600/3661/36000, and the negative/non-finite clamp.
- `client/src/components/RapidReader.test.jsx` — new describe: the countdown renders next to the word fraction, re-derives when the `-` hotkey changes WPM, and renders an over-an-hour remainder as `H:MM:SS`.
- `cd client && npx vitest run src/utils/formatters.test.js src/components/RapidReader.test.jsx` → 105 passed.

Closes #5314
