### PR TITLE
stop a test forking a real PM2 daemon per run (38 GB leaked), and bound every pm2 app's memory

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,11 @@ PGPASSWORD=portos
 # session / heavy SSE load doesn't cause spurious restarts (e.g. 32G on 128 GB).
 # PORTOS_SERVER_MAX_MEMORY=32G
 
+# Same ceiling for the Vite dev server (portos-ui). Default 1G — a dev server that
+# transforms modules on demand should sit well under that; raise it only if a huge
+# client tree makes Vite restart during normal editing.
+# PORTOS_UI_MAX_MEMORY=2G
+
 # Override the base URLs advertised to clients (auto-derived from PORTOS_HOST/PORT if unset)
 # PORTOS_API_URL=https://my-machine.ts.net:5555
 # PORTOS_UI_URL=https://my-machine.ts.net:5555

--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -12,19 +12,22 @@ const BASE_ENV = {
 };
 
 // Read a couple of machine-local settings from .env (pm2 doesn't auto-load it
-// here): PGMODE → PostgreSQL port; PORTOS_SERVER_MAX_MEMORY → the restart ceiling
-// below. An explicit process.env wins over the .env file so a one-off shell
-// override still works.
+// here): PGMODE → PostgreSQL port; PORTOS_SERVER_MAX_MEMORY / PORTOS_UI_MAX_MEMORY
+// → the restart ceilings below. An explicit process.env wins over the .env file
+// so a one-off shell override still works.
 const fs = require('fs');
 const envFile = path.join(__dirname, '.env');
 let pgMode = 'docker';
-let envMaxMemory = null;
+let envServerMaxMemory = null;
+let envUiMaxMemory = null;
 try {
   const envContent = fs.readFileSync(envFile, 'utf8');
   const modeMatch = envContent.match(/^PGMODE=(\w+)/m);
   if (modeMatch) pgMode = modeMatch[1];
   const memMatch = envContent.match(/^PORTOS_SERVER_MAX_MEMORY=(\S+)/m);
-  if (memMatch) envMaxMemory = memMatch[1];
+  if (memMatch) envServerMaxMemory = memMatch[1];
+  const uiMemMatch = envContent.match(/^PORTOS_UI_MAX_MEMORY=(\S+)/m);
+  if (uiMemMatch) envUiMaxMemory = uiMemMatch[1];
 } catch { /* no .env file — default to docker */ }
 
 // pm2 restarts portos-server when its RSS crosses this — originally a memory-leak
@@ -35,7 +38,61 @@ try {
 // streams and long jobs. (Training is no longer collateral damage from these
 // restarts — it's spawned detached into its own process group — but fewer
 // restarts is still better.)
-const SERVER_MAX_MEMORY = process.env.PORTOS_SERVER_MAX_MEMORY || envMaxMemory || '4G';
+const SERVER_MAX_MEMORY = process.env.PORTOS_SERVER_MAX_MEMORY || envServerMaxMemory || '4G';
+
+// Same idea for the Vite dev server. It had NO ceiling at all and was observed at
+// 2.7 GB after 18h of uptime — a dev server that only transforms modules on
+// demand has no business holding gigabytes.
+const UI_MAX_MEMORY = process.env.PORTOS_UI_MAX_MEMORY || envUiMaxMemory || '1G';
+
+// The support daemons (autofixer, its UI, the browser bridge) idle around 45 MB.
+// A ceiling an order of magnitude above that never fires in normal operation and
+// still catches a runaway.
+const HELPER_MAX_MEMORY = '512M';
+
+// The CoS runner supervises long-lived agent CLI children; the ceiling covers the
+// runner itself, not the agents (they are separate processes with their own RSS).
+const COS_MAX_MEMORY = '2G';
+
+const MEMORY_UNIT_MB = { K: 1 / 1024, M: 1, G: 1024 };
+
+/**
+ * Parse a pm2 memory spec ('512M', '4G', '1024') to megabytes.
+ * pm2 itself defaults a bare number to bytes, but every spec here carries a unit
+ * and an unrecognized one returns null so `heapCapArgs` degrades to "no cap"
+ * rather than silently inventing a wrong one.
+ */
+function memorySpecToMB(spec) {
+  const match = String(spec).trim().match(/^(\d+(?:\.\d+)?)\s*([KMG])B?$/i);
+  if (!match) return null;
+  return Math.round(Number(match[1]) * MEMORY_UNIT_MB[match[2].toUpperCase()]);
+}
+
+/**
+ * V8's old-space cap for a pm2 app, as `node_args`.
+ *
+ * WHY: without an explicit cap, V8 sizes the heap limit from physical memory and
+ * lands at ~4 GB on any workstation. That is at or above every ceiling below, so
+ * the process reaches `max_memory_restart` and gets KILLED before V8 ever feels
+ * enough pressure to run the full compacting GC that would have reclaimed the
+ * garbage. Capping the heap under the pm2 ceiling inverts that race: V8 collects,
+ * RSS settles, and the restart stays a genuine last resort instead of the normal
+ * way memory is reclaimed — which matters because a restart drops in-flight SSE
+ * streams and long jobs.
+ *
+ * 75% leaves room for the non-heap RSS (native buffers, sharp, the module code
+ * itself) under the same ceiling.
+ *
+ * `node_args` rather than `NODE_OPTIONS` on purpose: NODE_OPTIONS is inherited by
+ * every child process, so it would also shrink the heap of the agent CLIs, build
+ * steps, and media tooling portos-server spawns. `node_args` applies to the
+ * interpreter pm2 launches and stops there.
+ */
+function heapCapArgs(restartSpec) {
+  const ceilingMB = memorySpecToMB(restartSpec);
+  if (!ceilingMB) return [];
+  return [`--max-old-space-size=${Math.max(256, Math.floor(ceilingMB * 0.75))}`];
+}
 
 const PORTS = {
   API: 5555,           // Express API server (HTTPS when Tailscale cert is active)
@@ -113,6 +170,7 @@ module.exports = {
       // `'**/.cache/**'`, `'**/portos-stepwise-*/**'`) to `ignore_watch`.
       watch: false,
       max_memory_restart: SERVER_MAX_MEMORY,
+      node_args: heapCapArgs(SERVER_MAX_MEMORY),
       // PM2's default kill_timeout (1600ms) is shorter than the server's own
       // GRACEFUL_SHUTDOWN_TIMEOUT_MS (10s) force-exit in server/index.js, so if
       // shutdown ever stalls, PM2 would SIGKILL the process before its graceful
@@ -152,7 +210,8 @@ module.exports = {
       max_restarts: 5,
       min_uptime: '30s',
       restart_delay: 10000,
-      max_memory_restart: '2G',
+      max_memory_restart: COS_MAX_MEMORY,
+      node_args: heapCapArgs(COS_MAX_MEMORY),
       // Important: This process manages long-running agent processes
       // Keep kill_timeout high to allow graceful shutdown of agents
       kill_timeout: 30000
@@ -168,7 +227,15 @@ module.exports = {
         ...BASE_ENV,
         VITE_PORT: PORTS.UI
       },
-      watch: false
+      watch: false,
+      // Vite's dev server keeps a module graph, a transform cache, and per-client
+      // HMR bookkeeping that all grow with session length, and it never releases
+      // them on its own. With the default (physical-memory-derived) heap limit it
+      // was measured at 2.7 GB after 18h. The heap cap makes V8 actually collect;
+      // the ceiling restarts a dev server that still runs away. A restart here is
+      // cheap — the browser reconnects and Vite re-warms its transform cache.
+      max_memory_restart: UI_MAX_MEMORY,
+      node_args: heapCapArgs(UI_MAX_MEMORY)
     },
     {
       name: 'portos-autofixer',
@@ -186,7 +253,9 @@ module.exports = {
       autorestart: true,
       max_restarts: 10,
       min_uptime: '10s',
-      restart_delay: 5000
+      restart_delay: 5000,
+      max_memory_restart: HELPER_MAX_MEMORY,
+      node_args: heapCapArgs(HELPER_MAX_MEMORY)
     },
     {
       name: 'portos-autofixer-ui',
@@ -203,7 +272,9 @@ module.exports = {
       autorestart: true,
       max_restarts: 10,
       min_uptime: '10s',
-      restart_delay: 5000
+      restart_delay: 5000,
+      max_memory_restart: HELPER_MAX_MEMORY,
+      node_args: heapCapArgs(HELPER_MAX_MEMORY)
     },
     {
       name: 'portos-browser',
@@ -224,7 +295,9 @@ module.exports = {
       autorestart: true,
       max_restarts: 10,
       min_uptime: '10s',
-      restart_delay: 5000
+      restart_delay: 5000,
+      max_memory_restart: HELPER_MAX_MEMORY,
+      node_args: heapCapArgs(HELPER_MAX_MEMORY)
     }
   ]
 };

--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -55,15 +55,22 @@ const COS_MAX_MEMORY = '2G';
 const MEMORY_UNIT_MB = { K: 1 / 1024, M: 1, G: 1024 };
 
 /**
- * Parse a pm2 memory spec ('512M', '4G', '1024') to megabytes.
- * pm2 itself defaults a bare number to bytes, but every spec here carries a unit
- * and an unrecognized one returns null so `memoryLimits` degrades to "no cap"
- * rather than silently inventing a wrong one.
+ * Parse a pm2 memory spec to megabytes: '512M', '4G', or a bare '4294967296'.
+ *
+ * The bare form is BYTES — that is pm2's own rule for an unsuffixed value, and
+ * PORTOS_SERVER_MAX_MEMORY / PORTOS_UI_MAX_MEMORY are user-set, so a machine that
+ * already spells its ceiling in bytes must still get a heap cap. Dropping to "no
+ * cap" there would leave exactly the configuration this policy exists to fix: an
+ * RSS ceiling with nothing making V8 collect beneath it.
+ *
+ * An unrecognized spec returns null so `memoryLimits` degrades to "no cap" rather
+ * than silently inventing a wrong one.
  */
 function memorySpecToMB(spec) {
-  const match = String(spec).trim().match(/^(\d+(?:\.\d+)?)\s*([KMG])B?$/i);
+  const match = String(spec).trim().match(/^(\d+(?:\.\d+)?)\s*([KMG])?B?$/i);
   if (!match) return null;
-  return Math.round(Number(match[1]) * MEMORY_UNIT_MB[match[2].toUpperCase()]);
+  const unitMB = match[2] ? MEMORY_UNIT_MB[match[2].toUpperCase()] : 1 / (1024 * 1024);
+  return Math.round(Number(match[1]) * unitMB);
 }
 
 /**

--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -17,17 +17,15 @@ const BASE_ENV = {
 // so a one-off shell override still works.
 const fs = require('fs');
 const envFile = path.join(__dirname, '.env');
+const readEnvValue = (content, key) => content.match(new RegExp(`^${key}=(\\S+)`, 'm'))?.[1] ?? null;
 let pgMode = 'docker';
 let envServerMaxMemory = null;
 let envUiMaxMemory = null;
 try {
   const envContent = fs.readFileSync(envFile, 'utf8');
-  const modeMatch = envContent.match(/^PGMODE=(\w+)/m);
-  if (modeMatch) pgMode = modeMatch[1];
-  const memMatch = envContent.match(/^PORTOS_SERVER_MAX_MEMORY=(\S+)/m);
-  if (memMatch) envServerMaxMemory = memMatch[1];
-  const uiMemMatch = envContent.match(/^PORTOS_UI_MAX_MEMORY=(\S+)/m);
-  if (uiMemMatch) envUiMaxMemory = uiMemMatch[1];
+  pgMode = readEnvValue(envContent, 'PGMODE') || pgMode;
+  envServerMaxMemory = readEnvValue(envContent, 'PORTOS_SERVER_MAX_MEMORY');
+  envUiMaxMemory = readEnvValue(envContent, 'PORTOS_UI_MAX_MEMORY');
 } catch { /* no .env file — default to docker */ }
 
 // pm2 restarts portos-server when its RSS crosses this — originally a memory-leak
@@ -59,7 +57,7 @@ const MEMORY_UNIT_MB = { K: 1 / 1024, M: 1, G: 1024 };
 /**
  * Parse a pm2 memory spec ('512M', '4G', '1024') to megabytes.
  * pm2 itself defaults a bare number to bytes, but every spec here carries a unit
- * and an unrecognized one returns null so `heapCapArgs` degrades to "no cap"
+ * and an unrecognized one returns null so `memoryLimits` degrades to "no cap"
  * rather than silently inventing a wrong one.
  */
 function memorySpecToMB(spec) {
@@ -69,29 +67,41 @@ function memorySpecToMB(spec) {
 }
 
 /**
- * V8's old-space cap for a pm2 app, as `node_args`.
+ * Both memory bounds for a pm2 app: the RSS ceiling pm2 restarts at, and V8's
+ * old-space cap underneath it.
  *
- * WHY: without an explicit cap, V8 sizes the heap limit from physical memory and
- * lands at ~4 GB on any workstation. That is at or above every ceiling below, so
- * the process reaches `max_memory_restart` and gets KILLED before V8 ever feels
- * enough pressure to run the full compacting GC that would have reclaimed the
- * garbage. Capping the heap under the pm2 ceiling inverts that race: V8 collects,
- * RSS settles, and the restart stays a genuine last resort instead of the normal
- * way memory is reclaimed — which matters because a restart drops in-flight SSE
- * streams and long jobs.
+ * WHY the cap: without an explicit one, V8 sizes the heap limit from physical
+ * memory and lands at ~4 GB on any workstation. That is at or above every ceiling
+ * below, so the process reaches `max_memory_restart` and gets KILLED before V8
+ * ever feels enough pressure to run the full compacting GC that would have
+ * reclaimed the garbage. Capping the heap under the pm2 ceiling inverts that
+ * race: V8 collects, RSS settles, and the restart stays a genuine last resort
+ * instead of the normal way memory is reclaimed — which matters because a restart
+ * drops in-flight SSE streams and long jobs.
  *
- * 75% leaves room for the non-heap RSS (native buffers, sharp, the module code
- * itself) under the same ceiling.
+ * `ratio` is the gap left for the RSS that `--max-old-space-size` does NOT count:
+ * Buffers over 8 KB and ArrayBuffer backing stores are external, not old space.
+ * The default 0.75 suits a process whose bytes are mostly JS objects. Give a
+ * lower ratio to anything that moves large native buffers — portos-server runs
+ * sharp/libvips (a single 4096² RGBA `.raw().toBuffer()` is 64 MB) and decodes
+ * audio into Float32Arrays, so a heap sitting legally at its cap could still push
+ * RSS past the ceiling and get killed, i.e. the very race this exists to prevent.
  *
  * `node_args` rather than `NODE_OPTIONS` on purpose: NODE_OPTIONS is inherited by
  * every child process, so it would also shrink the heap of the agent CLIs, build
  * steps, and media tooling portos-server spawns. `node_args` applies to the
- * interpreter pm2 launches and stops there.
+ * interpreter pm2 launches and stops there. (pm2 also re-exports it into the
+ * app's own env, so `INHERITED_PM2_CONFIG_KEYS` in server/services/pm2.js strips
+ * it before PortOS shells out to `pm2 start` for a managed app.)
  */
-function heapCapArgs(restartSpec) {
+function memoryLimits(restartSpec, ratio = 0.75) {
   const ceilingMB = memorySpecToMB(restartSpec);
-  if (!ceilingMB) return [];
-  return [`--max-old-space-size=${Math.max(256, Math.floor(ceilingMB * 0.75))}`];
+  return {
+    max_memory_restart: restartSpec,
+    // No floor: a floor could raise the cap to or above a small user-set ceiling
+    // and invert the whole policy. ratio < 1 keeps the cap strictly below it.
+    node_args: ceilingMB ? [`--max-old-space-size=${Math.floor(ceilingMB * ratio)}`] : []
+  };
 }
 
 const PORTS = {
@@ -169,8 +179,10 @@ module.exports = {
       // and add `'**/data/**'` (plus `'**/node_modules'`, `'**/logs/**'`,
       // `'**/.cache/**'`, `'**/portos-stepwise-*/**'`) to `ignore_watch`.
       watch: false,
-      max_memory_restart: SERVER_MAX_MEMORY,
-      node_args: heapCapArgs(SERVER_MAX_MEMORY),
+      // 0.60, not the 0.75 default: sharp/libvips raw buffers and decoded audio
+      // are external memory the heap cap does not count, so portos-server needs a
+      // wider external margin under the same ceiling than a plain JS service.
+      ...memoryLimits(SERVER_MAX_MEMORY, 0.60),
       // PM2's default kill_timeout (1600ms) is shorter than the server's own
       // GRACEFUL_SHUTDOWN_TIMEOUT_MS (10s) force-exit in server/index.js, so if
       // shutdown ever stalls, PM2 would SIGKILL the process before its graceful
@@ -210,8 +222,7 @@ module.exports = {
       max_restarts: 5,
       min_uptime: '30s',
       restart_delay: 10000,
-      max_memory_restart: COS_MAX_MEMORY,
-      node_args: heapCapArgs(COS_MAX_MEMORY),
+      ...memoryLimits(COS_MAX_MEMORY),
       // Important: This process manages long-running agent processes
       // Keep kill_timeout high to allow graceful shutdown of agents
       kill_timeout: 30000
@@ -220,6 +231,10 @@ module.exports = {
       name: 'portos-ui',
       script: path.join(__dirname, 'client', 'node_modules', 'vite', 'bin', 'vite.js'),
       cwd: path.join(__dirname, 'client'),
+      // Explicit, unlike the inferred-from-.js default the other apps could rely
+      // on: this is the one script PortOS does not own, so pin the interpreter
+      // that node_args attach to rather than let a Vite release change it.
+      interpreter: 'node',
       log_date_format: LOG_DATE_FORMAT,
       windowsHide: IS_WIN,
       args: `--host 0.0.0.0 --port ${PORTS.UI}`,
@@ -229,13 +244,22 @@ module.exports = {
       },
       watch: false,
       // Vite's dev server keeps a module graph, a transform cache, and per-client
-      // HMR bookkeeping that all grow with session length, and it never releases
-      // them on its own. With the default (physical-memory-derived) heap limit it
-      // was measured at 2.7 GB after 18h. The heap cap makes V8 actually collect;
-      // the ceiling restarts a dev server that still runs away. A restart here is
-      // cheap — the browser reconnects and Vite re-warms its transform cache.
-      max_memory_restart: UI_MAX_MEMORY,
-      node_args: heapCapArgs(UI_MAX_MEMORY)
+      // HMR bookkeeping that all grow with session length and that it never
+      // releases on its own; with the default (physical-memory-derived) heap limit
+      // it was measured at 2.7 GB after 18h. The heap cap reaches the JS half of
+      // that — Vite 8 bundles through rolldown, whose own allocations are native
+      // and counted only by the RSS ceiling, so both bounds are load-bearing here.
+      //
+      // A restart is cheap (the browser reconnects, Vite re-warms its transform
+      // cache) but not free, and this is the one app that otherwise inherits pm2's
+      // `restart_delay: 0`. The damping below turns a mis-sized ceiling into slow
+      // churn instead of a tight crash loop; raise PORTOS_UI_MAX_MEMORY if a large
+      // client tree makes it fire during normal editing.
+      autorestart: true,
+      max_restarts: 10,
+      min_uptime: '60s',
+      restart_delay: 15000,
+      ...memoryLimits(UI_MAX_MEMORY)
     },
     {
       name: 'portos-autofixer',
@@ -254,8 +278,7 @@ module.exports = {
       max_restarts: 10,
       min_uptime: '10s',
       restart_delay: 5000,
-      max_memory_restart: HELPER_MAX_MEMORY,
-      node_args: heapCapArgs(HELPER_MAX_MEMORY)
+      ...memoryLimits(HELPER_MAX_MEMORY)
     },
     {
       name: 'portos-autofixer-ui',
@@ -273,8 +296,7 @@ module.exports = {
       max_restarts: 10,
       min_uptime: '10s',
       restart_delay: 5000,
-      max_memory_restart: HELPER_MAX_MEMORY,
-      node_args: heapCapArgs(HELPER_MAX_MEMORY)
+      ...memoryLimits(HELPER_MAX_MEMORY)
     },
     {
       name: 'portos-browser',
@@ -296,8 +318,7 @@ module.exports = {
       max_restarts: 10,
       min_uptime: '10s',
       restart_delay: 5000,
-      max_memory_restart: HELPER_MAX_MEMORY,
-      node_args: heapCapArgs(HELPER_MAX_MEMORY)
+      ...memoryLimits(HELPER_MAX_MEMORY)
     }
   ]
 };

--- a/scripts/ecosystem-memory-bounds.test.js
+++ b/scripts/ecosystem-memory-bounds.test.js
@@ -17,7 +17,7 @@ import path from 'path';
  * uptime — the regression these assertions exist to prevent.
  */
 const require = createRequire(import.meta.url);
-const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const { apps } = require(path.join(repoRoot, 'ecosystem.config.cjs'));
 
 const UNIT_MB = { K: 1 / 1024, M: 1, G: 1024 };
@@ -31,21 +31,38 @@ const heapCapMB = (app) => {
   return flag ? Number(flag.split('=')[1]) : null;
 };
 
+const APP_CASES = apps.map((app) => [app.name, app]);
+
+// pm2 also manages python/go/docker/static apps, and `--max-old-space-size` is
+// meaningless for those — scope the heap-cap assertion to the Node-interpreted
+// entries so a future non-Node app doesn't force the guard to be deleted.
+const NODE_APP_CASES = APP_CASES.filter(([, app]) =>
+  app.interpreter === 'node' || (!app.interpreter && /\.[cm]?js$/i.test(app.script)));
+
 describe('ecosystem.config.cjs memory bounds', () => {
-  it.each(apps.map((app) => [app.name, app]))('%s declares a restart ceiling', (_name, app) => {
+  it('recognizes every app as Node-interpreted (update the filter if that changes)', () => {
+    expect(NODE_APP_CASES).toHaveLength(APP_CASES.length);
+  });
+
+  it.each(APP_CASES)('%s declares a restart ceiling', (_name, app) => {
     expect(toMB(app.max_memory_restart)).toBeGreaterThan(0);
   });
 
-  it.each(apps.map((app) => [app.name, app]))('%s caps V8 below that ceiling', (_name, app) => {
+  it.each(NODE_APP_CASES)('%s caps V8 below a declared restart ceiling', (_name, app) => {
+    const ceiling = toMB(app.max_memory_restart);
     const cap = heapCapMB(app);
     expect(cap).toBeGreaterThan(0);
     // Strictly below, so V8 collects first and pm2 restarts only as a last resort.
-    expect(cap).toBeLessThan(toMB(app.max_memory_restart));
+    // This is also what a `Math.max(...)` floor on the cap would break: at a small
+    // user-set ceiling the floor could raise the cap to or past it.
+    expect(cap).toBeLessThan(ceiling);
   });
 
-  // A heap cap must never reach the child processes portos-server spawns (agent
-  // CLIs, builds, media tooling) — NODE_OPTIONS is inherited, `node_args` is not.
-  it.each(apps.map((app) => [app.name, app]))('%s sets the cap via node_args, not NODE_OPTIONS', (_name, app) => {
+  // A heap cap must never reach the child processes these apps spawn (agent CLIs,
+  // builds, media tooling) — NODE_OPTIONS is inherited by children, node_args is
+  // not. server/services/pm2.js additionally strips the `node_args` key pm2
+  // re-exports into the app's own environment.
+  it.each(NODE_APP_CASES)('%s sets the cap via node_args, not NODE_OPTIONS', (_name, app) => {
     expect(app.env?.NODE_OPTIONS ?? '').not.toContain('max-old-space-size');
   });
 });

--- a/scripts/ecosystem-memory-bounds.test.js
+++ b/scripts/ecosystem-memory-bounds.test.js
@@ -18,12 +18,17 @@ import path from 'path';
  */
 const require = createRequire(import.meta.url);
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
-const { apps } = require(path.join(repoRoot, 'ecosystem.config.cjs'));
+const configPath = path.join(repoRoot, 'ecosystem.config.cjs');
+const { apps } = require(configPath);
 
+// Deliberately a SECOND implementation of the config's own parser, not an import
+// of it: a guard that reuses the parser under test agrees with itself and can no
+// longer fail. A bare number is bytes, per pm2.
 const UNIT_MB = { K: 1 / 1024, M: 1, G: 1024 };
 const toMB = (spec) => {
-  const match = String(spec).trim().match(/^(\d+(?:\.\d+)?)\s*([KMG])B?$/i);
-  return match ? Number(match[1]) * UNIT_MB[match[2].toUpperCase()] : null;
+  const match = String(spec).trim().match(/^(\d+(?:\.\d+)?)\s*([KMG])?B?$/i);
+  if (!match) return null;
+  return Number(match[1]) * (match[2] ? UNIT_MB[match[2].toUpperCase()] : 1 / (1024 * 1024));
 };
 
 const heapCapMB = (app) => {
@@ -56,6 +61,30 @@ describe('ecosystem.config.cjs memory bounds', () => {
     // This is also what a `Math.max(...)` floor on the cap would break: at a small
     // user-set ceiling the floor could raise the cap to or past it.
     expect(cap).toBeLessThan(ceiling);
+  });
+
+  // The ceilings are user-overridable via env, and pm2 accepts a BARE NUMBER as
+  // bytes — the form a machine that tuned this before the heap cap existed is
+  // most likely to already have. A parser that only understood '4G' returned no
+  // cap there, leaving precisely the un-collected-heap-under-an-RSS-ceiling setup
+  // this policy exists to fix. Asserted through a real config load rather than
+  // against the parser directly, so it observes what pm2 would actually receive.
+  it('still caps V8 when the ceiling is spelled in pm2 bare bytes', () => {
+    const previous = process.env.PORTOS_SERVER_MAX_MEMORY;
+    process.env.PORTOS_SERVER_MAX_MEMORY = '4294967296'; // 4 GB, in bytes
+    try {
+      delete require.cache[require.resolve(configPath)];
+      const server = require(configPath).apps.find((a) => a.name === 'portos-server');
+      expect(server.max_memory_restart).toBe('4294967296');
+      expect(heapCapMB(server)).toBeGreaterThan(0);
+      expect(heapCapMB(server)).toBeLessThan(4096);
+    } finally {
+      if (previous === undefined) delete process.env.PORTOS_SERVER_MAX_MEMORY;
+      else process.env.PORTOS_SERVER_MAX_MEMORY = previous;
+      // Drop the env-poisoned module so the shared `apps` above stays authoritative
+      // for any later require of the config in this process.
+      delete require.cache[require.resolve(configPath)];
+    }
   });
 
   // A heap cap must never reach the child processes these apps spawn (agent CLIs,

--- a/server/lib/ecosystemMemory.test.js
+++ b/server/lib/ecosystemMemory.test.js
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'module';
+import { fileURLToPath } from 'url';
+import path from 'path';
+
+/**
+ * Every pm2 app needs BOTH memory bounds, and they have to be in the right order.
+ *
+ * `max_memory_restart` alone is not a memory policy — it is only the kill switch.
+ * Node sizes V8's heap limit from physical memory (~4 GB on any workstation), so
+ * without an explicit `--max-old-space-size` the process hits the pm2 ceiling
+ * before V8 ever runs the full compacting GC that would have reclaimed the
+ * garbage: the restart becomes the routine way memory is freed, and every restart
+ * drops in-flight SSE streams and long jobs.
+ *
+ * portos-ui shipped with neither bound and was measured at 2.7 GB after 18h of
+ * uptime — the regression these assertions exist to prevent.
+ */
+const require = createRequire(import.meta.url);
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const { apps } = require(path.join(repoRoot, 'ecosystem.config.cjs'));
+
+const UNIT_MB = { K: 1 / 1024, M: 1, G: 1024 };
+const toMB = (spec) => {
+  const match = String(spec).trim().match(/^(\d+(?:\.\d+)?)\s*([KMG])B?$/i);
+  return match ? Number(match[1]) * UNIT_MB[match[2].toUpperCase()] : null;
+};
+
+const heapCapMB = (app) => {
+  const flag = (app.node_args || []).find((a) => a.startsWith('--max-old-space-size='));
+  return flag ? Number(flag.split('=')[1]) : null;
+};
+
+describe('ecosystem.config.cjs memory bounds', () => {
+  it.each(apps.map((app) => [app.name, app]))('%s declares a restart ceiling', (_name, app) => {
+    expect(toMB(app.max_memory_restart)).toBeGreaterThan(0);
+  });
+
+  it.each(apps.map((app) => [app.name, app]))('%s caps V8 below that ceiling', (_name, app) => {
+    const cap = heapCapMB(app);
+    expect(cap).toBeGreaterThan(0);
+    // Strictly below, so V8 collects first and pm2 restarts only as a last resort.
+    expect(cap).toBeLessThan(toMB(app.max_memory_restart));
+  });
+
+  // A heap cap must never reach the child processes portos-server spawns (agent
+  // CLIs, builds, media tooling) — NODE_OPTIONS is inherited, `node_args` is not.
+  it.each(apps.map((app) => [app.name, app]))('%s sets the cap via node_args, not NODE_OPTIONS', (_name, app) => {
+    expect(app.env?.NODE_OPTIONS ?? '').not.toContain('max-old-space-size');
+  });
+});

--- a/server/services/llamaServerManager.test.js
+++ b/server/services/llamaServerManager.test.js
@@ -125,6 +125,12 @@ describe('llamaServerManager', () => {
     vi.spyOn(openAiModelsProbe, 'probeOpenAiModels')
       .mockImplementation(async () => ({ reachable: pm2State?.status === 'online', models: [] }));
 
+    // `createDaemonWatcher` reads the saved boot list on every status read, and
+    // the dump is a real file on the developer's machine — pin it so these tests
+    // are about this code, not their PM2 state. (Its twin in
+    // mtplxServerManager.test.js pins it for the same reason.)
+    vi.spyOn(pm2Module, 'getSavedProcessNames').mockResolvedValue([]);
+
     vi.spyOn(pm2Module, 'execPm2').mockImplementation(async (args) => {
       execPm2Calls.push(args);
       const action = args[0];

--- a/server/services/pm2.js
+++ b/server/services/pm2.js
@@ -53,8 +53,13 @@ function isJsScript(script) {
  * fires regardless of `--no-autorestart`) killed the 25GB model process seconds
  * after every successful load, forever. `exec_mode` and `watch` leak the same
  * way — verified by starting a process with each key set in the environment.
+ *
+ * `node_args` joins them for the same reason: portos-server carries its own V8
+ * heap cap (ecosystem.config.cjs), and leaking that into a `pm2 start` would cap
+ * every app PortOS launches at portos-server's ceiling — including an app whose
+ * whole job is to hold more than that.
  */
-const INHERITED_PM2_CONFIG_KEYS = ['max_memory_restart', 'exec_mode', 'watch'];
+const INHERITED_PM2_CONFIG_KEYS = ['max_memory_restart', 'exec_mode', 'watch', 'node_args'];
 
 /** Drop the PM2 config keys PM2 injected into our own environment. */
 function withoutInheritedPm2Config(env) {
@@ -100,6 +105,18 @@ export function spawnPm2(pm2Args, opts = {}) {
 /**
  * Execute a PM2 CLI command and return stdout/stderr as a promise.
  * Drop-in replacement for execAsync('pm2 ...') that bypasses pm2.cmd on Windows.
+ *
+ * TESTING — `vi.spyOn(pm2Module, 'execPm2')` is NOT enough on its own. It
+ * intercepts callers in OTHER modules (mtplxServerManager, llamaServerManager),
+ * but every export in THIS file that calls `execPm2`/`spawnPm2` reads the local
+ * binding and runs the real implementation regardless of the spy — silently, with
+ * the test still passing. `pm2.savedProcesses.test.js` relied on that and really
+ * ran `pm2 save`, and PM2 forked a God Daemon per test that outlived the suite:
+ * 641 orphans holding 38 GB accumulated on one dev machine before anyone noticed.
+ * A test that calls into this module must mock the spawn seam instead —
+ * `vi.mock('../lib/childProcess.js', … spawn: mockSpawn)`, as pm2.launch.test.js
+ * and pm2.savedProcesses.test.js do — and assert the mock was reached.
+ *
  * @param {string[]} pm2Args PM2 CLI arguments (e.g. ['jlist'])
  * @param {object} opts Spawn options (env, cwd, etc.)
  * @returns {Promise<{stdout: string, stderr: string}>}

--- a/server/services/pm2.launch.test.js
+++ b/server/services/pm2.launch.test.js
@@ -83,6 +83,9 @@ describe('PM2 command launch interpreters', () => {
       vi.stubEnv('max_memory_restart', '4294967296');
       vi.stubEnv('exec_mode', 'cluster_mode');
       vi.stubEnv('watch', 'true');
+      // portos-server carries its own V8 heap cap; inherited, it would cap every
+      // app PortOS launches — including one whose job is to hold more than that.
+      vi.stubEnv('node_args', '--max-old-space-size=3072');
 
       await execPm2(['start', '/usr/local/bin/llama-server', '--name', 'portos-llama-server']);
 
@@ -90,6 +93,7 @@ describe('PM2 command launch interpreters', () => {
       expect(spawnOpts.env).not.toHaveProperty('max_memory_restart');
       expect(spawnOpts.env).not.toHaveProperty('exec_mode');
       expect(spawnOpts.env).not.toHaveProperty('watch');
+      expect(spawnOpts.env).not.toHaveProperty('node_args');
       expect(spawnOpts.env.PATH).toBe(process.env.PATH);
     });
 

--- a/server/services/pm2.savedProcesses.test.js
+++ b/server/services/pm2.savedProcesses.test.js
@@ -105,10 +105,7 @@ describe('saveProcessList exclusions', () => {
   const seedDump = (names) =>
     writeFile(join(home, 'dump.pm2'), JSON.stringify(names.map((name) => ({ name, script: `/bin/${name}` }))));
 
-  // Regression guard for the daemon leak described at the top of this file. If a
-  // future refactor moves `pm2 save` off the mocked `spawn` seam, this assertion
-  // fails loudly here instead of quietly forking a real PM2 God Daemon per test
-  // that survives the run forever.
+  // Regression guard for the daemon leak described at the top of this file.
   it('runs `pm2 save` through the stubbed spawn seam, never a real subprocess', async () => {
     await seedDump(['portos-server']);
 

--- a/server/services/pm2.savedProcesses.test.js
+++ b/server/services/pm2.savedProcesses.test.js
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { EventEmitter } from 'events';
 import { mkdtemp, rm, writeFile } from 'fs/promises';
 import { tmpdir } from 'os';
 import { join } from 'path';
@@ -7,8 +8,31 @@ import { join } from 'path';
 // call is made). Mocked to keep the import side-effect-free in CI.
 vi.mock('pm2', () => ({ default: { connect: vi.fn(), list: vi.fn(), disconnect: vi.fn() } }));
 
+// `saveProcessList` runs `pm2 save` through pm2.js's OWN `execPm2`, and an
+// intra-module call reads the local binding — a `vi.spyOn(pm2Module, 'execPm2')`
+// never intercepts it (that only works for the cross-module callers in
+// mtplxServerManager / llamaServerManager). This test used to rely on that spy,
+// so every run really launched `pm2 save` against the throwaway PM2_HOME below,
+// and PM2 answered by forking a God Daemon that outlived the suite. Those
+// daemons never exit: 641 of them (38 GB of RSS) had accumulated on the dev
+// machine that reported this. Mocking the spawn seam — the same one
+// pm2.launch.test.js uses — is what actually keeps the subprocess out.
+const mockSpawn = vi.hoisted(() => vi.fn());
+vi.mock('../lib/childProcess.js', async (importOriginal) => ({
+  ...(await importOriginal()),
+  spawn: mockSpawn,
+}));
+
 import { getSavedProcessNames, saveProcessList } from './pm2.js';
-import * as pm2Module from './pm2.js';
+
+// Fake child_process.spawn result: closes with exit code 0 on the next tick.
+function fakeChild() {
+  const child = new EventEmitter();
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  queueMicrotask(() => child.emit('close', 0));
+  return child;
+}
 
 /**
  * `getSavedProcessNames` reads `$PM2_HOME/dump.pm2` — the list a boot-time
@@ -68,18 +92,33 @@ describe('saveProcessList exclusions', () => {
 
   beforeEach(async () => {
     home = await mkdtemp(join(tmpdir(), 'portos-pm2-home-'));
-    // `pm2 save` itself is the real subprocess; the dump it would have written
-    // is seeded per test so the filtering is what's under assertion.
-    vi.spyOn(pm2Module, 'execPm2').mockResolvedValue({ stdout: '', stderr: '' });
+    // `pm2 save` is stubbed out at the spawn seam; the dump it would have
+    // written is seeded per test so the filtering is what's under assertion.
+    mockSpawn.mockReset();
+    mockSpawn.mockImplementation(() => fakeChild());
   });
 
   afterEach(async () => {
-    vi.restoreAllMocks();
     await rm(home, { recursive: true, force: true });
   });
 
   const seedDump = (names) =>
     writeFile(join(home, 'dump.pm2'), JSON.stringify(names.map((name) => ({ name, script: `/bin/${name}` }))));
+
+  // Regression guard for the daemon leak described at the top of this file. If a
+  // future refactor moves `pm2 save` off the mocked `spawn` seam, this assertion
+  // fails loudly here instead of quietly forking a real PM2 God Daemon per test
+  // that survives the run forever.
+  it('runs `pm2 save` through the stubbed spawn seam, never a real subprocess', async () => {
+    await seedDump(['portos-server']);
+
+    await saveProcessList(home);
+
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
+    const [, args, opts] = mockSpawn.mock.calls[0];
+    expect(args.at(-1)).toBe('save');
+    expect(opts.env.PM2_HOME).toBe(home);
+  });
 
   it('drops an excluded app from the dump and leaves the rest', async () => {
     await seedDump(['portos-server', 'portos-llama-server', 'portos-mtplx']);


### PR DESCRIPTION
## Summary

Chasing "why is the Vite dev server holding 2.7 GB?" turned up a much larger leak that isn't in the product at all, plus a real gap in how the pm2 apps are bounded.

**The big one — 641 orphaned PM2 daemons holding 38 GB.** `saveProcessList` calls `pm2.js`'s own `execPm2`, and an intra-module call reads the module-local binding, so the test's `vi.spyOn(pm2Module, 'execPm2')` never intercepted it. Every run really executed `pm2 save` against a throwaway `PM2_HOME`, and PM2 answered by forking a God Daemon that outlived the suite. They never exit, so they accumulate across every full-suite run — 641 of them (38.3 GB resident) had piled up on one dev machine. The test now mocks the `spawn` seam the module actually imports (the pattern `pm2.launch.test.js` already uses) and asserts the call went through it, so a future refactor that moves the seam fails loudly instead of silently spawning processes again.

Verified: with the fix, a suite run spawns zero new daemons; other checkouts still running the old test spawned five during the same session.

**A ceiling alone was not a memory policy.** `portos-ui` had no `max_memory_restart` and no heap cap at all; the three helper daemons had no ceiling either. And a ceiling without a heap cap doesn't do what it looks like: Node sizes V8's heap limit from physical memory (~4 GB on a workstation), which is at or above every ceiling here — so a process reaches `max_memory_restart` and gets killed *before* V8 ever runs the compacting GC that would have reclaimed the garbage. The restart becomes the routine way memory is freed, and each one drops in-flight SSE streams and long jobs.

Every app now pairs a ceiling with `--max-old-space-size` beneath it, passed via `node_args` rather than `NODE_OPTIONS` so it can't shrink the heap of the agent CLIs and media tooling `portos-server` spawns:

| app | ceiling | heap cap |
| --- | --- | --- |
| portos-server | 4G | 2457 MB (0.60 — sharp/libvips raw buffers are external memory the cap doesn't count) |
| portos-cos | 2G | 1536 MB |
| portos-ui | 1G (new, `PORTOS_UI_MAX_MEMORY`) | 768 MB |
| portos-autofixer / -ui / -browser | 512M (new) | 384 MB |

`portos-ui` also gains restart damping — it was the only app inheriting pm2's `restart_delay: 0`, so a mis-sized ceiling would crash-loop and re-transform the whole client each cycle.

### Two things review caught that are worth calling out

- **`node_args` had to join `INHERITED_PM2_CONFIG_KEYS`.** PM2 exports a managed process's config into its environment and the CLI reads it back as config, outranking flags — the mechanism that once fed portos-server's 4G ceiling to a loaded 25 GB llama-server and killed it seconds after every load. Unstripped, portos-server's new heap cap would reach every app PortOS launches.
- **pm2 treats a bare `max_memory_restart` as bytes.** A machine that already spells its ceiling `4294967296` parsed to null and got no cap at all — leaving exactly the un-collected-heap-under-an-RSS-ceiling setup this change exists to fix.

## Test plan

- Full server suite green: 1707 files / 35,258 tests, 0 failures.
- New `scripts/ecosystem-memory-bounds.test.js` asserts every app declares a ceiling, caps V8 strictly below it, sets the cap via `node_args` (never `NODE_OPTIONS`), and still caps when the ceiling is in bare bytes — asserted through a real config load, so it observes what pm2 would receive.
- New guard in `pm2.savedProcesses.test.js` asserts `pm2 save` reached the mocked spawn seam with the throwaway `PM2_HOME`, which is the leak itself.
- `pm2.launch.test.js` extended to assert `node_args` is stripped from the spawn env.
- Confirmed empirically that a suite run adds zero PM2 daemons (before: four to five per run).