### PR TITLE
feat(openworld): add drifting cloud banks

### DIFF
--- a/client/src/components/openworld/OpenWorldClouds.jsx
+++ b/client/src/components/openworld/OpenWorldClouds.jsx
@@ -1,0 +1,107 @@
+import { useLayoutEffect, useMemo, useRef } from 'react';
+import { useFrame } from '@react-three/fiber';
+import * as THREE from 'three';
+import { mixHex, openWorldDayMix, seededRand } from './openWorldConstants';
+import { useOpenWorldPalette } from './OpenWorldPaletteContext';
+
+const CLOUD_BANK_SPAN = 620;
+const CLOUD_BANK_COPIES = [-CLOUD_BANK_SPAN, 0, CLOUD_BANK_SPAN];
+const CLOUD_DRIFT_SPEED = 0.75;
+const cloudTransform = new THREE.Object3D();
+
+function clusterCount(settings) {
+  if (settings?.effectiveTier === 'low') return 4;
+  if (settings?.effectiveTier === 'medium') return 7;
+  if (settings?.effectiveTier === 'ultra') return 13;
+  return 10;
+}
+
+function createCloudPuffs(count) {
+  const rand = seededRand(7421);
+  const puffs = [];
+
+  for (let cluster = 0; cluster < count; cluster += 1) {
+    const center = {
+      x: -CLOUD_BANK_SPAN / 2 + rand() * CLOUD_BANK_SPAN,
+      y: 38 + rand() * 36,
+      z: -250 + rand() * 500,
+    };
+    const puffCount = 3 + Math.floor(rand() * 3);
+    const clusterScale = 2.4 + rand() * 3.4;
+
+    for (let puff = 0; puff < puffCount; puff += 1) {
+      const centerPuff = puff === 0;
+      const angle = rand() * Math.PI * 2;
+      const spread = centerPuff ? 0 : (0.7 + rand() * 1.45) * clusterScale;
+      const scale = clusterScale * (centerPuff ? 1 : 0.52 + rand() * 0.44);
+      puffs.push({
+        position: [
+          center.x + Math.cos(angle) * spread,
+          center.y + (centerPuff ? 0.8 : (rand() - 0.58) * clusterScale * 0.44),
+          center.z + Math.sin(angle) * spread * 0.58,
+        ],
+        rotation: [rand() * 0.22, rand() * Math.PI * 2, rand() * 0.16],
+        scale: [scale * (1.25 + rand() * 0.5), scale * (0.48 + rand() * 0.24), scale],
+      });
+    }
+  }
+
+  return puffs;
+}
+
+function writeCloudMatrices(mesh, puffs) {
+  if (!mesh || typeof mesh.setMatrixAt !== 'function') return;
+  puffs.forEach((puff, index) => {
+    cloudTransform.position.set(...puff.position);
+    cloudTransform.rotation.set(...puff.rotation);
+    cloudTransform.scale.set(...puff.scale);
+    cloudTransform.updateMatrix();
+    mesh.setMatrixAt(index, cloudTransform.matrix);
+  });
+  mesh.instanceMatrix.needsUpdate = true;
+  mesh.computeBoundingSphere?.();
+}
+
+export default function OpenWorldClouds({ settings }) {
+  const { accent, lowPoly, surface } = useOpenWorldPalette();
+  const driftRef = useRef();
+  const meshRefs = useRef([]);
+  const puffs = useMemo(() => createCloudPuffs(clusterCount(settings)), [settings?.effectiveTier]);
+  const dayMix = openWorldDayMix(settings);
+  const cloudColor = mixHex(mixHex('#8290a6', accent, 0.08), '#f7fbff', 0.68 + dayMix * 0.22);
+
+  useLayoutEffect(() => {
+    meshRefs.current.forEach((mesh) => writeCloudMatrices(mesh, puffs));
+  }, [puffs]);
+
+  useFrame(({ clock }) => {
+    if (!driftRef.current || !lowPoly) return;
+    driftRef.current.position.x = (clock.getElapsedTime() * CLOUD_DRIFT_SPEED) % CLOUD_BANK_SPAN;
+  });
+
+  if (!lowPoly) return null;
+
+  return (
+    <group ref={driftRef}>
+      {CLOUD_BANK_COPIES.map((offset, index) => (
+        <instancedMesh
+          key={offset}
+          ref={(mesh) => { meshRefs.current[index] = mesh; }}
+          args={[undefined, undefined, puffs.length]}
+          position={[offset, 0, 0]}
+        >
+          <icosahedronGeometry args={[1, 1]} />
+          <meshStandardMaterial
+            {...surface}
+            color={cloudColor}
+            roughness={1}
+            metalness={0}
+            transparent
+            opacity={0.74}
+            depthWrite={false}
+          />
+        </instancedMesh>
+      ))}
+    </group>
+  );
+}

--- a/client/src/components/openworld/OpenWorldClouds.test.jsx
+++ b/client/src/components/openworld/OpenWorldClouds.test.jsx
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+
+const palette = vi.hoisted(() => ({ lowPoly: true }));
+
+vi.mock('@react-three/fiber', () => ({ useFrame: () => {} }));
+vi.mock('./OpenWorldPaletteContext', () => ({
+  useOpenWorldPalette: () => ({
+    accent: '#22d3ee',
+    lowPoly: palette.lowPoly,
+    surface: { flatShading: true },
+  }),
+}));
+
+import OpenWorldClouds from './OpenWorldClouds';
+
+describe('OpenWorldClouds', () => {
+  beforeEach(() => {
+    palette.lowPoly = true;
+  });
+
+  it('renders a repeating instanced cloud bank in the bright low-poly world', () => {
+    const { container } = render(<OpenWorldClouds settings={{ effectiveTier: 'high' }} />);
+    expect(container.getElementsByTagName('instancedMesh')).toHaveLength(3);
+  });
+
+  it('keeps the cloud bank out of the cyber world', () => {
+    palette.lowPoly = false;
+    const { container } = render(<OpenWorldClouds settings={{ effectiveTier: 'high' }} />);
+    expect(container.getElementsByTagName('instancedMesh')).toHaveLength(0);
+  });
+
+  it('retains a signature cloud bank on the adaptive low tier', () => {
+    const { container } = render(<OpenWorldClouds settings={{ effectiveTier: 'low' }} />);
+    expect(container.getElementsByTagName('instancedMesh')).toHaveLength(3);
+  });
+});

--- a/client/src/components/openworld/OpenWorldScene.jsx
+++ b/client/src/components/openworld/OpenWorldScene.jsx
@@ -37,6 +37,7 @@ import OpenWorldSignalBeacons from './OpenWorldSignalBeacons';
 import OpenWorldSky from './OpenWorldSky';
 import OpenWorldGalaxySky from './OpenWorldGalaxySky';
 import OpenWorldLandscape from './OpenWorldLandscape';
+import OpenWorldClouds from './OpenWorldClouds';
 import OpenWorldNature from './OpenWorldNature';
 import OpenWorldGrass from './OpenWorldGrass';
 import OpenWorldWater from './OpenWorldWater';
@@ -385,6 +386,7 @@ function OpenWorldScene({
           would recompile every lit material 1.2s into each load. */}
       <OpenWorldLights settings={renderSettings} lightingTier={settings?.effectiveTier} />
       <OpenWorldLandscape settings={renderSettings} />
+      {palette?.lowPoly && <OpenWorldClouds settings={renderSettings} />}
       <OpenWorldNature settings={renderSettings} />
       <OpenWorldGrass settings={renderSettings} />
       <OpenWorldWater settings={renderSettings} />

--- a/docs/features/openworld.md
+++ b/docs/features/openworld.md
@@ -235,8 +235,9 @@ exercised by the suite instead of bit-rotting behind a default nobody selects.
 
 The style change keeps the operational geometry and live data mappings stable while changing
 their material language. The Vibes pass now adds grounded nature patches, a varied plaza grove,
-and planter-framed warp pads; the shared app-building grammar remains intentionally recognizable
-across both styles so a status means the same thing in either world.
+planter-framed warp pads, and a deterministic drifting cloud bank that scales with the adaptive
+render tier; the shared app-building grammar remains intentionally recognizable across both
+styles so a status means the same thing in either world.
 
 ## Critical Files
 


### PR DESCRIPTION
## Summary
- Adds deterministic drifting cloud banks to OpenWorld in low-poly mode via instanced mesh rendering (`OpenWorldClouds.jsx`)
- Cloud cluster count scales dynamically with adaptive quality tier (low, medium, high, ultra)
- Updates documentation and adds component unit tests

## Test plan
- Unit tests: `npm test -- src/components/openworld/OpenWorldClouds.test.jsx` passes (3/3 tests)
- OpenWorld suite: `npm test -- src/components/openworld/` passes (19 files, 158 tests)
- Lint: `npm run lint` passes with 0 errors/warnings