### PR TITLE
fix: derive Spotify redirects from Tailscale host (#5321)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,15 +43,14 @@ PGPASSWORD=portos
 # HOST=0.0.0.0
 
 # Public-facing hostname baked into OAuth redirect URIs for Google Calendar/Gmail
-# (googleAuth.js) and Spotify (spotifyAuth.js). Defaults to "localhost". Set this to
-# the host the OAuth provider will redirect back to (e.g. your Tailscale MagicDNS name)
-# so the callback URL matches what you registered in the provider dashboard.
+# (googleAuth.js) and Spotify (spotifyAuth.js). Google and Spotify default to
+# "localhost"; Spotify otherwise auto-detects the active Tailscale hostname and
+# HTTPS state. Set this explicit override when the provider must use another host.
 # PUBLIC_HOST=host-example.ts.net
 
 # Explicit override for the Spotify OAuth redirect URI (spotifyAuth.js). When set, it is
-# used verbatim instead of the auto-derived http://PUBLIC_HOST:PORT/api/spotify/oauth/callback.
-# It must match the redirect URI registered in the Spotify dashboard byte-for-byte
-# (use this when your public URL is HTTPS or differs from the auto-derived form).
+# used verbatim instead of PUBLIC_HOST or the active Tailscale hostname/HTTPS state.
+# It must match the redirect URI registered in the Spotify dashboard byte-for-byte.
 # SPOTIFY_REDIRECT_URI=https://host-example.ts.net:5555/api/spotify/oauth/callback
 
 # OpenClaw integration (configured via Settings UI; env overrides take precedence)

--- a/server/services/loras.test.js
+++ b/server/services/loras.test.js
@@ -1091,10 +1091,11 @@ describe('LoRA key layout', () => {
     });
     const list = await lorasService.listLoras();
     expect(list.find((l) => l.filename === 'lora-comfy.safetensors').keyLayout).toBe('comfyui');
-    // Sidecar write is fire-and-forget; let the microtask queue drain.
-    await new Promise((r) => setTimeout(r, 10));
-    const sidecar = JSON.parse(await fs.readFile(join(tmpLoras, 'lora-comfy.safetensors.metadata.json'), 'utf-8'));
-    expect(sidecar.keyLayout).toBe('comfyui');
+    // Sidecar write is fire-and-forget; wait for it to complete.
+    await vi.waitFor(async () => {
+      const sidecar = JSON.parse(await fs.readFile(join(tmpLoras, 'lora-comfy.safetensors.metadata.json'), 'utf-8'));
+      expect(sidecar.keyLayout).toBe('comfyui');
+    });
   });
 
   it('prefers the stored sidecar layout over re-reading the header', async () => {

--- a/server/services/spotifyAuth.js
+++ b/server/services/spotifyAuth.js
@@ -24,6 +24,8 @@
 import { dataPath, ensureDir, atomicWrite, tryReadFile } from '../lib/fileUtils.js';
 import { ServerError } from '../lib/errorHandler.js';
 import { fetchWithTimeout } from '../lib/fetchWithTimeout.js';
+import { getSelfHost } from '../lib/peerSelfHost.js';
+import { getHttpsEnabledAtBoot } from '../lib/httpsState.js';
 
 // Cap on each token-endpoint round-trip so a hung accounts.spotify.com can't
 // stall an OAuth callback or a history-sync refresh indefinitely.
@@ -52,9 +54,15 @@ const ACCOUNTS_BASE = 'https://accounts.spotify.com';
  */
 export function getRedirectUri() {
   if (process.env.SPOTIFY_REDIRECT_URI) return process.env.SPOTIFY_REDIRECT_URI;
-  const host = process.env.PUBLIC_HOST || 'localhost';
   const port = process.env.PORT || 5555;
-  return `http://${host}:${port}/api/spotify/oauth/callback`;
+  if (process.env.PUBLIC_HOST) {
+    return `http://${process.env.PUBLIC_HOST}:${port}/api/spotify/oauth/callback`;
+  }
+  const detectedHost = getSelfHost();
+  const host = detectedHost && !/^(undefined|null)\b/i.test(detectedHost) ? detectedHost : null;
+  if (!host) return `http://localhost:${port}/api/spotify/oauth/callback`;
+  const scheme = getHttpsEnabledAtBoot().value ? 'https' : 'http';
+  return `${scheme}://${host}:${port}/api/spotify/oauth/callback`;
 }
 
 /**

--- a/server/services/spotifyAuth.test.js
+++ b/server/services/spotifyAuth.test.js
@@ -5,6 +5,8 @@ const mocks = {
   atomicWrite: vi.fn(async () => {}),
   tryReadFile: vi.fn(async () => null),
   fetchWithTimeout: vi.fn(),
+  getSelfHost: vi.fn(),
+  getHttpsEnabledAtBoot: vi.fn(),
 };
 
 vi.mock('../lib/fileUtils.js', () => ({
@@ -18,7 +20,15 @@ vi.mock('../lib/fetchWithTimeout.js', () => ({
   fetchWithTimeout: (...args) => mocks.fetchWithTimeout(...args),
 }));
 
-import { isTokenExpired, withExpiry, getRedirectUri, getAccessToken } from './spotifyAuth.js';
+vi.mock('../lib/peerSelfHost.js', () => ({
+  getSelfHost: (...args) => mocks.getSelfHost(...args),
+}));
+
+vi.mock('../lib/httpsState.js', () => ({
+  getHttpsEnabledAtBoot: (...args) => mocks.getHttpsEnabledAtBoot(...args),
+}));
+
+import { isTokenExpired, withExpiry, getRedirectUri, getAuthStatus, getAccessToken } from './spotifyAuth.js';
 
 describe('spotifyAuth pure helpers', () => {
   describe('withExpiry', () => {
@@ -61,6 +71,8 @@ describe('spotifyAuth pure helpers', () => {
     const savedEnv = { ...process.env };
     afterEach(() => {
       process.env = { ...savedEnv };
+      mocks.getSelfHost.mockReset().mockReturnValue(null);
+      mocks.getHttpsEnabledAtBoot.mockReset().mockReturnValue({ value: false });
     });
 
     it('honors an explicit SPOTIFY_REDIRECT_URI override', () => {
@@ -73,6 +85,56 @@ describe('spotifyAuth pure helpers', () => {
       process.env.PUBLIC_HOST = 'myhost';
       process.env.PORT = '5555';
       expect(getRedirectUri()).toBe('http://myhost:5555/api/spotify/oauth/callback');
+    });
+
+    it('uses the active Tailscale host and HTTPS state when no override is configured', () => {
+      delete process.env.SPOTIFY_REDIRECT_URI;
+      delete process.env.PUBLIC_HOST;
+      process.env.PORT = '5555';
+      mocks.getSelfHost.mockReturnValue('host-example.ts.net');
+      mocks.getHttpsEnabledAtBoot.mockReturnValue({ value: true });
+
+      expect(getRedirectUri()).toBe('https://host-example.ts.net:5555/api/spotify/oauth/callback');
+    });
+
+    it('uses HTTP for an auto-detected host when HTTPS is disabled', () => {
+      delete process.env.SPOTIFY_REDIRECT_URI;
+      delete process.env.PUBLIC_HOST;
+      process.env.PORT = '5555';
+      mocks.getSelfHost.mockReturnValue('host-example.ts.net');
+      mocks.getHttpsEnabledAtBoot.mockReturnValue({ value: false });
+
+      expect(getRedirectUri()).toBe('http://host-example.ts.net:5555/api/spotify/oauth/callback');
+    });
+
+    it('falls back to localhost when no host is auto-detected', () => {
+      delete process.env.SPOTIFY_REDIRECT_URI;
+      delete process.env.PUBLIC_HOST;
+      process.env.PORT = '5555';
+      mocks.getSelfHost.mockReturnValue(null);
+
+      expect(getRedirectUri()).toBe('http://localhost:5555/api/spotify/oauth/callback');
+    });
+
+    it('falls back to localhost when certificate metadata has an invalid hostname', () => {
+      delete process.env.SPOTIFY_REDIRECT_URI;
+      delete process.env.PUBLIC_HOST;
+      process.env.PORT = '5555';
+      mocks.getSelfHost.mockReturnValue('undefined.example-tailnet.ts.net');
+
+      expect(getRedirectUri()).toBe('http://localhost:5555/api/spotify/oauth/callback');
+    });
+
+    it('surfaces the derived URI in auth status', async () => {
+      delete process.env.SPOTIFY_REDIRECT_URI;
+      delete process.env.PUBLIC_HOST;
+      process.env.PORT = '5555';
+      mocks.getSelfHost.mockReturnValue('host-example.ts.net');
+      mocks.getHttpsEnabledAtBoot.mockReturnValue({ value: true });
+
+      await expect(getAuthStatus()).resolves.toMatchObject({
+        redirectUri: 'https://host-example.ts.net:5555/api/spotify/oauth/callback',
+      });
     });
   });
 });


### PR DESCRIPTION
## Summary

- Derive Spotify OAuth callback host and scheme from active Tailscale HTTPS state when no explicit override is configured.
- Preserve `SPOTIFY_REDIRECT_URI`, `PUBLIC_HOST`, and localhost fallback precedence.
- Reject invalid certificate-metadata placeholder hosts and document the derived behavior.

## Tests

- `cd server && npm test -- --run services/spotifyAuth.test.js`

Closes #5321
