### PR TITLE
feat: add dedicated Brain Ideas page (#5335)

### DIFF
--- a/client/src/components/Layout.jsx
+++ b/client/src/components/Layout.jsx
@@ -172,6 +172,7 @@ export const NAV_PRESENTATION = {
   '/brain/digest': { icon: Calendar },
   '/brain/feeds': { icon: Rss },
   '/brain/graph': { icon: Network },
+  '/brain/ideas': { icon: Lightbulb },
   '/brain/import': { icon: Upload },
   '/brain/inbox': { icon: MessageSquare },
   '/brain/links': { icon: Link2 },

--- a/client/src/components/brain/constants.js
+++ b/client/src/components/brain/constants.js
@@ -6,6 +6,7 @@ import { MessageSquare, Database, Calendar, Rss, Shield, Users, FolderKanban, Li
 // with no padding (the rest scroll inside a padded wrapper). See issue #1177.
 export const TABS = [
   { id: 'inbox', label: 'Inbox', icon: MessageSquare },
+  { id: 'ideas', label: 'Ideas', icon: Lightbulb },
   { id: 'daily-log', label: 'Daily Log', icon: NotebookPen, fullBleed: true },
   { id: 'links', label: 'Links', icon: Link2 },
   { id: 'memory', label: 'Memory', icon: Database },
@@ -26,7 +27,6 @@ export const FULL_BLEED_TAB_IDS = new Set(TABS.filter((t) => t.fullBleed).map((t
 // Memory sub-tabs for entity types (alphabetical)
 export const MEMORY_TABS = [
   { id: 'admin', label: 'Admin', icon: ClipboardList },
-  { id: 'ideas', label: 'Ideas', icon: Lightbulb },
   { id: 'memories', label: 'Memories', icon: BookOpen },
   { id: 'people', label: 'People', icon: Users },
   { id: 'projects', label: 'Projects', icon: FolderKanban }
@@ -159,4 +159,3 @@ export const BRAIN_TYPE_HEX = {
   journals: '#14b8a6',
   songs: '#f43f5e'
 };
-

--- a/client/src/components/brain/constants.test.js
+++ b/client/src/components/brain/constants.test.js
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest';
+import { MEMORY_TABS, TABS } from './constants';
+
+describe('Brain navigation', () => {
+  it('keeps native Ideas on its dedicated URL-backed Brain tab', () => {
+    expect(TABS.map(({ id }) => id)).toContain('ideas');
+    expect(MEMORY_TABS.map(({ id }) => id)).not.toContain('ideas');
+  });
+});

--- a/client/src/components/brain/tabs/MemoryTab.jsx
+++ b/client/src/components/brain/tabs/MemoryTab.jsx
@@ -50,9 +50,12 @@ export function transcriptTeaser(content, maxLen = 220) {
   return `${plain.slice(0, maxLen).trimEnd()}…`;
 }
 
-export default function MemoryTab({ onRefresh }) {
+// Ideas is a first-class Brain route, but it deliberately shares this native
+// record surface so CRUD, status completion, catalog handoff, embeddings, and
+// federation continue to use the same idea model and API.
+export default function MemoryTab({ onRefresh, fixedType = null }) {
   const navigate = useNavigate();
-  const [activeType, setActiveType] = useState('memories');
+  const [activeType, setActiveType] = useState(fixedType || 'memories');
   const [records, setRecords] = useState([]);
   const [loading, setLoading] = useState(true);
   const [editingId, setEditingId] = useState(null);
@@ -66,6 +69,10 @@ export default function MemoryTab({ onRefresh }) {
   const [viewerRecord, setViewerRecord] = useState(null);
   const [visibleCount, setVisibleCount] = useState(INITIAL_VISIBLE);
   const { isConfirming, requestDelete, cancelDelete, confirmDelete } = useConfirmDelete();
+
+  useEffect(() => {
+    if (fixedType) setActiveType(fixedType);
+  }, [fixedType]);
 
   const fetchRecords = useCallback(async () => {
     setLoading(true);
@@ -742,7 +749,7 @@ export default function MemoryTab({ onRefresh }) {
 
       {/* Type tabs */}
       <div className="flex items-center gap-2 flex-wrap">
-        {MEMORY_TABS.map((tab) => {
+        {!fixedType && MEMORY_TABS.map((tab) => {
           const Icon = tab.icon;
           const isActive = activeType === tab.id;
           const destInfo = DESTINATIONS[tab.id];

--- a/client/src/pages/Brain.jsx
+++ b/client/src/pages/Brain.jsx
@@ -65,6 +65,8 @@ export default function Brain() {
         return <LinksTab onRefresh={refetch} />;
       case 'memory':
         return <MemoryTab onRefresh={refetch} />;
+      case 'ideas':
+        return <MemoryTab onRefresh={refetch} fixedType="ideas" />;
       case 'notes':
         return <NotesTab onRefresh={refetch} />;
       case 'daily-log':

--- a/server/lib/navManifest.js
+++ b/server/lib/navManifest.js
@@ -132,6 +132,7 @@ const RAW_NAV_COMMANDS = [
   { id: 'nav.brain.digest', path: '/brain/digest', label: 'Digest', section: 'Brain', aliases: ['brain-digest'] },
   { id: 'nav.brain.feeds', path: '/brain/feeds', label: 'Feeds', section: 'Brain', aliases: ['brain-feeds', 'feeds', 'rss'], keywords: ['rss', 'subscriptions'] },
   { id: 'nav.brain.graph', path: '/brain/graph', label: 'Graph', section: 'Brain', aliases: ['brain-graph'] },
+  { id: 'nav.brain.ideas', path: '/brain/ideas', label: 'Ideas', section: 'Brain', aliases: ['brain-ideas', 'ideas'], keywords: ['brainstorm', 'creative', 'thought', 'concept'] },
   { id: 'nav.brain.import', path: '/brain/import', label: 'Import', section: 'Brain', aliases: ['brain-import', 'import-chatgpt', 'chatgpt-import'], keywords: ['chatgpt', 'openai', 'export', 'third-party'] },
   { id: 'nav.brain.links', path: '/brain/links', label: 'Links', section: 'Brain', aliases: ['brain-links'] },
   { id: 'nav.brain.memory', path: '/brain/memory', label: 'Memory', section: 'Brain', aliases: ['brain-memory', 'memory'] },


### PR DESCRIPTION
## Summary
Adds a dedicated Brain Ideas page and nav item so ideas have a first-class URL route and sidebar entry while sharing the native MemoryTab record surface.

## Test plan
- Run server navManifest tests (`npm test -- lib/navManifest.test.js`)
- Run client brain constants tests (`npm test -- src/components/brain/constants.test.js`)
- Run client lint (`npm run lint`)