### PR TITLE
feat: add IdeaLoom list editing panel (#5337)

### DIFF
--- a/client/src/components/brain/IdeaLoomLists.jsx
+++ b/client/src/components/brain/IdeaLoomLists.jsx
@@ -1,0 +1,141 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useSearchParams } from 'react-router';
+import { ArrowDown, ArrowUp, CheckCircle2, Plus, Save, Trash2, X } from 'lucide-react';
+import * as api from '../../services/api';
+import toast from '../ui/Toast';
+import InlineConfirmRow from '../ui/InlineConfirmRow';
+import { useConfirmDelete } from '../../hooks/useConfirmDelete';
+
+const emptyList = () => ({ title: '', prompt: '', category: '', help: '', status: 'draft', ideas: [] });
+
+// The dedicated Ideas page owns both models, but this panel intentionally only
+// speaks the machine-local IdeaLoom list API. Native Brain ideas stay separate.
+export default function IdeaLoomLists() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const selectedId = searchParams.get('list');
+  const [lists, setLists] = useState([]);
+  const [settings, setSettings] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [draft, setDraft] = useState(null);
+  const [ideaText, setIdeaText] = useState('');
+  const { isConfirming, requestDelete, cancelDelete, confirmDelete } = useConfirmDelete();
+
+  const select = useCallback((id) => {
+    setSearchParams((current) => {
+      const next = new URLSearchParams(current);
+      if (id) next.set('list', id);
+      else next.delete('list');
+      return next;
+    });
+  }, [setSearchParams]);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    const [nextLists, nextSettings] = await Promise.all([
+      api.getIdeaLoomLists({ silent: true }),
+      api.getIdeaLoomSettings({ silent: true }),
+    ]).catch((error) => {
+      toast.error(error.message || 'Failed to load IdeaLoom lists');
+      return [[], null];
+    });
+    setLists(Array.isArray(nextLists?.lists) ? nextLists.lists : (Array.isArray(nextLists) ? nextLists : []));
+    setSettings(nextSettings?.settings || nextSettings);
+    setLoading(false);
+  }, []);
+
+  useEffect(() => { load(); }, [load]);
+
+  const selected = useMemo(() => lists.find((list) => list.id === selectedId) || null, [lists, selectedId]);
+  useEffect(() => {
+    if (selected) setDraft({ ...selected, ideas: [...(selected.ideas || [])] });
+  }, [selected]);
+
+  const save = async () => {
+    if (!draft?.title?.trim()) {
+      toast.error('A list title is required');
+      return;
+    }
+    const body = { ...draft, title: draft.title.trim(), ideas: (draft.ideas || []).map((idea) => idea.trim()).filter(Boolean) };
+    const result = await (draft.id
+      ? api.updateIdeaLoomList(draft.id, body, { silent: true })
+      : api.createIdeaLoomList(body, { silent: true })
+    ).catch((error) => { toast.error(error.message || 'Failed to save IdeaLoom list'); return null; });
+    if (!result) return;
+    const saved = result.list || result;
+    setLists((current) => draft.id
+      ? current.map((list) => list.id === saved.id ? saved : list)
+      : [...current, saved]);
+    setDraft({ ...saved, ideas: [...(saved.ideas || [])] });
+    select(saved.id);
+    toast.success(draft.id ? 'List saved' : 'List created');
+  };
+
+  const remove = async (id) => {
+    const result = await api.deleteIdeaLoomList(id, { silent: true }).catch((error) => {
+      toast.error(error.message || 'Failed to delete IdeaLoom list');
+      return false;
+    });
+    if (result === false) return;
+    setLists((current) => current.filter((list) => list.id !== id));
+    setDraft(null);
+    if (selectedId === id) select(null);
+    toast.success('List deleted');
+  };
+
+  const updateDraft = (field, value) => setDraft((current) => ({ ...current, [field]: value }));
+  const moveIdea = (index, offset) => setDraft((current) => {
+    const ideas = [...current.ideas];
+    const target = index + offset;
+    if (target < 0 || target >= ideas.length) return current;
+    [ideas[index], ideas[target]] = [ideas[target], ideas[index]];
+    return { ...current, ideas };
+  });
+  const addIdea = () => {
+    if (!ideaText.trim()) return;
+    updateDraft('ideas', [...(draft?.ideas || []), ideaText.trim()]);
+    setIdeaText('');
+  };
+
+  if (loading) return <p className="py-8 text-center text-gray-500">Loading IdeaLoom lists…</p>;
+
+  return (
+    <section className="grid gap-4 lg:grid-cols-[minmax(14rem,20rem)_1fr]" aria-label="IdeaLoom lists">
+      <aside className="rounded-lg border border-port-border bg-port-card p-3">
+        <div className="mb-3 flex items-center justify-between gap-2">
+          <div><h2 className="font-medium text-white">IdeaLoom lists</h2><p className="text-xs text-gray-500">Separate from native Brain ideas</p></div>
+          <button type="button" onClick={() => { setDraft(emptyList()); select(null); }} className="min-h-[44px] rounded px-3 text-sm text-port-accent hover:bg-port-accent/10" aria-label="Create IdeaLoom list"><Plus size={16} /></button>
+        </div>
+        {!settings?.enabled && <p className="mb-3 rounded bg-port-warning/10 p-2 text-xs text-port-warning">Vault sync is disabled. Local lists remain available.</p>}
+        <div className="space-y-1">
+          {lists.map((list) => <button key={list.id} type="button" onClick={() => select(list.id)} className={`w-full rounded p-3 text-left ${selected?.id === list.id ? 'bg-port-accent/20 text-white' : 'text-gray-300 hover:bg-port-border/50'}`}>
+            <span className="block truncate text-sm font-medium">{list.title}</span><span className="text-xs text-gray-500">{list.status === 'completed' ? 'Completed' : 'Draft'} · {(list.ideas || []).length} ideas</span>
+          </button>)}
+          {!lists.length && <p className="py-5 text-center text-sm text-gray-500">No IdeaLoom lists yet.</p>}
+        </div>
+      </aside>
+
+      <div className="rounded-lg border border-port-border bg-port-card p-4">
+        {!draft ? <p className="py-10 text-center text-gray-500">Choose a list or create one to edit its ordered ideas.</p> : <>
+          <div className="mb-4 flex items-center justify-between gap-2"><h2 className="font-medium text-white">{draft.id ? 'Edit list' : 'New list'}</h2>{draft.id && <button type="button" onClick={() => requestDelete(draft.id)} className="min-h-[44px] px-2 text-port-error" aria-label="Delete list"><Trash2 size={16} /></button>}</div>
+          {draft.id && isConfirming(draft.id) && <InlineConfirmRow question="Delete this list and its ideas?" confirmTitle="Delete list" cancelTitle="Cancel" onConfirm={() => confirmDelete(() => remove(draft.id))} onCancel={cancelDelete} />}
+          <div className="grid gap-3 sm:grid-cols-2">
+            <Field label="Title" value={draft.title} onChange={(value) => updateDraft('title', value)} required />
+            <Field label="Category" value={draft.category || ''} onChange={(value) => updateDraft('category', value)} />
+            <Field label="Prompt" value={draft.prompt || ''} onChange={(value) => updateDraft('prompt', value)} className="sm:col-span-2" />
+            <Field label="Help" value={draft.help || ''} onChange={(value) => updateDraft('help', value)} className="sm:col-span-2" />
+            <label className="text-sm text-gray-300" htmlFor="idealoom-status">Status<select id="idealoom-status" value={draft.status || 'draft'} onChange={(event) => updateDraft('status', event.target.value)} className="mt-1 block min-h-[44px] w-full rounded border border-port-border bg-port-bg px-3 text-white"><option value="draft">Draft</option><option value="completed">Completed</option></select></label>
+          </div>
+          <div className="mt-5"><h3 className="mb-2 text-sm font-medium text-white">Ordered ideas</h3><div className="space-y-2">{(draft.ideas || []).map((idea, index) => <div className="flex items-center gap-1" key={`${index}-${idea}`}><span className="w-6 text-right text-xs text-gray-500">{index + 1}.</span><input value={idea} onChange={(event) => { const ideas = [...draft.ideas]; ideas[index] = event.target.value; updateDraft('ideas', ideas); }} aria-label={`Idea ${index + 1}`} className="min-h-[44px] min-w-0 flex-1 rounded border border-port-border bg-port-bg px-3 text-sm text-white" /><button type="button" onClick={() => moveIdea(index, -1)} disabled={index === 0} className="min-h-[44px] min-w-[44px] text-gray-400 disabled:opacity-30" aria-label={`Move idea ${index + 1} up`}><ArrowUp size={16} /></button><button type="button" onClick={() => moveIdea(index, 1)} disabled={index === draft.ideas.length - 1} className="min-h-[44px] min-w-[44px] text-gray-400 disabled:opacity-30" aria-label={`Move idea ${index + 1} down`}><ArrowDown size={16} /></button><button type="button" onClick={() => updateDraft('ideas', draft.ideas.filter((_, itemIndex) => itemIndex !== index))} className="min-h-[44px] min-w-[44px] text-gray-400 hover:text-port-error" aria-label={`Remove idea ${index + 1}`}><X size={16} /></button></div>)}</div>
+            <div className="mt-2 flex gap-2"><input value={ideaText} onChange={(event) => setIdeaText(event.target.value)} onKeyDown={(event) => { if (event.key === 'Enter') { event.preventDefault(); addIdea(); } }} aria-label="New idea" placeholder="Add an idea" className="min-h-[44px] min-w-0 flex-1 rounded border border-port-border bg-port-bg px-3 text-sm text-white" /><button type="button" onClick={addIdea} aria-label="Add idea" className="min-h-[44px] rounded px-3 text-port-accent hover:bg-port-accent/10"><Plus size={16} /></button></div>
+          </div>
+          <div className="mt-5 flex flex-wrap gap-2"><button type="button" onClick={save} className="flex min-h-[44px] items-center gap-2 rounded bg-port-accent/20 px-3 text-sm text-port-accent hover:bg-port-accent/30"><Save size={16} />Save list</button>{draft.id && <button type="button" onClick={() => updateDraft('status', draft.status === 'completed' ? 'draft' : 'completed')} className="flex min-h-[44px] items-center gap-2 rounded px-3 text-sm text-gray-300 hover:bg-port-border/50"><CheckCircle2 size={16} />Mark {draft.status === 'completed' ? 'draft' : 'completed'}</button>}</div>
+        </>}
+      </div>
+    </section>
+  );
+}
+
+function Field({ label, value, onChange, required, className = '' }) {
+  const id = `idealoom-${label.toLowerCase().replaceAll(' ', '-')}`;
+  return <label className={`text-sm text-gray-300 ${className}`} htmlFor={id}>{label}{required && <span className="text-port-error"> *</span>}<input id={id} value={value} onChange={(event) => onChange(event.target.value)} required={required} className="mt-1 block min-h-[44px] w-full rounded border border-port-border bg-port-bg px-3 text-white" /></label>;
+}

--- a/client/src/components/brain/IdeaLoomLists.test.jsx
+++ b/client/src/components/brain/IdeaLoomLists.test.jsx
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, useLocation } from 'react-router';
+
+vi.mock('../../services/api', () => ({
+  getIdeaLoomLists: vi.fn(), getIdeaLoomSettings: vi.fn(),
+  createIdeaLoomList: vi.fn(), updateIdeaLoomList: vi.fn(), deleteIdeaLoomList: vi.fn(),
+}));
+vi.mock('../ui/Toast', () => ({ default: { error: vi.fn(), success: vi.fn() } }));
+
+import * as api from '../../services/api';
+import IdeaLoomLists from './IdeaLoomLists';
+
+function Location() {
+  return <output data-testid="location">{useLocation().search}</output>;
+}
+
+function renderPanel() {
+  return render(<MemoryRouter initialEntries={['/brain/ideas']}><IdeaLoomLists /><Location /></MemoryRouter>);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  api.getIdeaLoomLists.mockResolvedValue([]);
+  api.getIdeaLoomSettings.mockResolvedValue({ enabled: false });
+});
+
+describe('IdeaLoomLists', () => {
+  it('keeps local list editing available while vault sync is disabled', async () => {
+    api.createIdeaLoomList.mockResolvedValue({ id: 'list-1', title: 'Launch ideas', status: 'draft', ideas: ['One'] });
+    renderPanel();
+
+    expect(await screen.findByText('Vault sync is disabled. Local lists remain available.')).toBeTruthy();
+    fireEvent.click(screen.getByLabelText('Create IdeaLoom list'));
+    fireEvent.change(screen.getByLabelText(/Title/), { target: { value: 'Launch ideas' } });
+    fireEvent.change(screen.getByLabelText('New idea'), { target: { value: 'One' } });
+    fireEvent.click(screen.getByLabelText('Add idea'));
+    fireEvent.click(screen.getByText('Save list'));
+
+    await waitFor(() => expect(api.createIdeaLoomList).toHaveBeenCalledWith(expect.objectContaining({ title: 'Launch ideas', ideas: ['One'] }), { silent: true }));
+    await waitFor(() => expect(screen.getByTestId('location').textContent).toBe('?list=list-1'));
+  });
+
+  it('reorders a selected list locally before saving its ordered items', async () => {
+    api.getIdeaLoomLists.mockResolvedValue([{ id: 'list-1', title: 'Launch ideas', status: 'draft', ideas: ['First', 'Second'] }]);
+    api.updateIdeaLoomList.mockResolvedValue({ id: 'list-1', title: 'Launch ideas', status: 'draft', ideas: ['Second', 'First'] });
+    renderPanel();
+
+    fireEvent.click(await screen.findByText('Launch ideas'));
+    await screen.findByLabelText('Move idea 2 up');
+    fireEvent.click(screen.getByLabelText('Move idea 2 up'));
+    fireEvent.click(screen.getByText('Save list'));
+
+    await waitFor(() => expect(api.updateIdeaLoomList).toHaveBeenCalledWith('list-1', expect.objectContaining({ ideas: ['Second', 'First'] }), { silent: true }));
+    expect(screen.getByTestId('location').textContent).toBe('?list=list-1');
+  });
+});

--- a/client/src/services/apiBrain.js
+++ b/client/src/services/apiBrain.js
@@ -112,6 +112,24 @@ export const updateBrainIdea = (id, data, options = {}) => request(`/brain/ideas
 });
 export const deleteBrainIdea = (id, options = {}) => request(`/brain/ideas/${id}`, { method: 'DELETE', ...options });
 
+// Brain - machine-local IdeaLoom lists. These deliberately use a separate
+// endpoint and record shape from native Brain ideas: list ordering and sync
+// metadata must never be flattened into the federated idea model.
+export const getIdeaLoomSettings = (options = {}) => request('/brain/ideas/idealoom/settings', options);
+export const updateIdeaLoomSettings = (data, options = {}) => request('/brain/ideas/idealoom/settings', {
+  method: 'PUT', body: JSON.stringify(data), ...options
+});
+export const getIdeaLoomLists = (options = {}) => request('/brain/ideas/idealoom/lists', options);
+export const createIdeaLoomList = (data, options = {}) => request('/brain/ideas/idealoom/lists', {
+  method: 'POST', body: JSON.stringify(data), ...options
+});
+export const updateIdeaLoomList = (id, data, options = {}) => request(`/brain/ideas/idealoom/lists/${id}`, {
+  method: 'PUT', body: JSON.stringify(data), ...options
+});
+export const deleteIdeaLoomList = (id, options = {}) => request(`/brain/ideas/idealoom/lists/${id}`, {
+  method: 'DELETE', ...options
+});
+
 // Brain - Admin
 export const getBrainAdmin = (filters) => {
   const params = new URLSearchParams();


### PR DESCRIPTION
## Summary
Adds the IdeaLoom list editing and reordering panel component in the client (`IdeaLoomLists.jsx`) along with API client methods in `apiBrain.js`.

## Test plan
- Run IdeaLoom list client tests (`cd client && npm test -- src/components/brain/IdeaLoomLists.test.jsx`)
- Run client services tests (`cd client && npm test -- src/services/`)
- Run client lint (`cd client && npm run lint`)