### PR TITLE
feat: add FableLoom episode outline view

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -519,6 +519,7 @@ export default function App() {
           <Route path="importer" element={<Importer />} />
           <Route path="fableloom" element={<FableLoom />} />
           <Route path="fableloom/:loomId" element={<FableLoomStory />} />
+          <Route path="fableloom/:loomId/:episodeId/outline" element={<FableLoomStory view="outline" />} />
           <Route path="fableloom/:loomId/:episodeId" element={<FableLoomStory />} />
           <Route path="fableloom/:loomId/:episodeId/:nodeId" element={<FableLoomStory />} />
           <Route path="start-story" element={<StartStory />} />

--- a/client/src/components/fableloom/LoomEpisodeOutline.jsx
+++ b/client/src/components/fableloom/LoomEpisodeOutline.jsx
@@ -1,0 +1,198 @@
+/**
+ * FableLoom episode outline — a text-first reading order for an episode graph.
+ *
+ * Reachable scenes are ordered breadth-first from the opening scene so the
+ * outline follows the same progression as the graph layout. Every scene keeps
+ * its authored prose and intent paths visible; selecting a path returns to the
+ * visual editor with that scene selected.
+ */
+
+import { useMemo } from 'react';
+import { ArrowRight, Flag, Play, Waypoints } from 'lucide-react';
+import { sceneProseClass } from './fieldStyles';
+
+const asArray = (value) => (Array.isArray(value) ? value : []);
+
+const orderEpisodeNodes = (episode) => {
+  const nodes = asArray(episode?.nodes);
+  const byId = new Map(nodes.map((node) => [node.id, node]));
+  const ordered = [];
+  const visited = new Set();
+  const queue = byId.has(episode?.startNodeId) ? [episode.startNodeId] : [];
+  let queueIndex = 0;
+
+  while (queueIndex < queue.length) {
+    const nodeId = queue[queueIndex];
+    queueIndex += 1;
+    if (visited.has(nodeId)) continue;
+    visited.add(nodeId);
+    const node = byId.get(nodeId);
+    if (!node) continue;
+    ordered.push(node);
+    for (const transition of asArray(node.transitions)) {
+      if (byId.has(transition?.targetNodeId) && !visited.has(transition.targetNodeId)) {
+        queue.push(transition.targetNodeId);
+      }
+    }
+  }
+
+  return {
+    reachable: ordered,
+    unreachable: nodes.filter((node) => !visited.has(node.id)),
+    byId,
+  };
+};
+
+function SceneBlock({ node, number, episode, format, byId, onSelectNode }) {
+  const isStart = node.id === episode.startNodeId;
+  const transitions = asArray(node.transitions);
+
+  return (
+    <li className="relative pl-8 sm:pl-10" data-testid={`outline-scene-${node.id}`}>
+      <span className="absolute left-0 top-1 flex h-6 w-6 items-center justify-center rounded-full border border-port-border bg-port-card text-[10px] font-semibold text-port-text-muted sm:h-7 sm:w-7">
+        {number}
+      </span>
+      <article className="rounded-lg border border-port-border bg-port-card p-4 space-y-3">
+        <header className="flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <h3 className="font-semibold text-port-text break-words">{node.title || 'Untitled scene'}</h3>
+            <div className="mt-1 flex flex-wrap items-center gap-2 text-[11px] text-port-text-muted">
+              {isStart && <span className="inline-flex items-center gap-1 text-port-accent"><Play size={11} /> Opening</span>}
+              {node.isEnding && (
+                <span className="inline-flex items-center gap-1 text-port-success">
+                  <Flag size={11} /> {node.endingLabel || 'Ending'}
+                </span>
+              )}
+            </div>
+          </div>
+          <span className="shrink-0 text-[11px] text-port-text-muted">Scene {number}</span>
+        </header>
+
+        {node.prose?.trim() ? (
+          <div className={`${sceneProseClass(format)} text-port-text`}>
+            {node.prose}
+          </div>
+        ) : (
+          <p className="text-sm italic text-port-text-muted">No scene text yet.</p>
+        )}
+
+        {transitions.length > 0 && (
+          <div className="border-t border-port-border pt-3">
+            <h4 className="mb-2 text-[11px] font-semibold uppercase tracking-wide text-port-text-muted">Reader paths</h4>
+            <ul className="space-y-1.5">
+              {transitions.map((transition) => {
+                const target = byId.get(transition.targetNodeId);
+                return (
+                  <li key={transition.id || `${node.id}-${transition.targetNodeId}-${transition.intent}`} className="flex items-start gap-2 text-xs">
+                    <ArrowRight size={13} className="mt-0.5 shrink-0 text-port-accent" />
+                    <span className="min-w-0">
+                      <span className="font-medium">{transition.intent || 'Unlabeled path'}</span>
+                      {transition.description && <span className="text-port-text-muted"> — {transition.description}</span>}
+                      {' '}
+                      {target ? (
+                        <button
+                          type="button"
+                          onClick={() => onSelectNode?.(target.id)}
+                          className="text-port-accent hover:underline"
+                        >
+                          Scene {target.number}: {target.title || 'Untitled scene'}
+                        </button>
+                      ) : (
+                        <span className="text-port-error">Missing scene</span>
+                      )}
+                    </span>
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        )}
+      </article>
+    </li>
+  );
+}
+
+export default function LoomEpisodeOutline({ loom, episode, onSelectNode }) {
+  const { reachable, unreachable, byId } = useMemo(() => orderEpisodeNodes(episode), [episode]);
+  const nodes = asArray(episode?.nodes);
+  const endingCount = nodes.filter((node) => node.isEnding).length;
+  const numberedNodes = useMemo(() => {
+    const numbers = new Map();
+    [...reachable, ...unreachable].forEach((node, index) => numbers.set(node.id, index + 1));
+    return numbers;
+  }, [reachable, unreachable]);
+
+  const numberedById = useMemo(
+    () => new Map([...byId].map(([id, node]) => [id, { ...node, number: numberedNodes.get(id) }])),
+    [byId, numberedNodes],
+  );
+
+  if (!reachable.length && !unreachable.length) {
+    return (
+      <section className="flex-1 overflow-y-auto p-4 md:p-6" aria-label="Episode outline">
+        <div className="mx-auto grid min-h-full max-w-4xl place-items-center text-center">
+          <div>
+            <Waypoints size={32} className="mx-auto mb-3 text-port-text-muted" />
+            <h2 className="font-semibold">No scenes yet</h2>
+            <p className="mt-1 text-sm text-port-text-muted">Add a scene or weave this episode to start its outline.</p>
+          </div>
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section className="flex-1 overflow-y-auto p-4 md:p-6" aria-label="Episode outline">
+      <div className="mx-auto max-w-4xl space-y-6">
+        <header>
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <p className="text-xs font-medium uppercase tracking-wide text-port-accent">{loom.name}</p>
+              <h2 className="mt-1 text-xl font-semibold">{episode.title || 'Untitled episode'}</h2>
+            </div>
+            <span className="shrink-0 text-xs text-port-text-muted">
+              {nodes.length} scene{nodes.length === 1 ? '' : 's'} · {endingCount} ending{endingCount === 1 ? '' : 's'}
+            </span>
+          </div>
+          {episode.synopsis && <p className="mt-2 max-w-3xl text-sm text-port-text-muted">{episode.synopsis}</p>}
+        </header>
+
+        <ol className="space-y-4 border-l border-port-border pl-0">
+          {reachable.map((node) => (
+            <SceneBlock
+              key={node.id}
+              node={node}
+              number={numberedNodes.get(node.id)}
+              episode={episode}
+              format={loom.format}
+              byId={numberedById}
+              onSelectNode={onSelectNode}
+            />
+          ))}
+        </ol>
+
+        {unreachable.length > 0 && (
+          <section className="rounded-lg border border-port-warning/40 bg-port-warning/5 p-4" aria-label="Unreachable scenes">
+            <div className="mb-3">
+              <h3 className="font-semibold">Unreachable scenes</h3>
+              <p className="mt-1 text-xs text-port-text-muted">These scenes are saved in the episode but cannot be reached from its opening scene.</p>
+            </div>
+            <ol className="space-y-4 border-l border-port-border pl-0">
+              {unreachable.map((node) => (
+                <SceneBlock
+                  key={node.id}
+                  node={node}
+                  number={numberedNodes.get(node.id)}
+                  episode={episode}
+                  format={loom.format}
+                  byId={numberedById}
+                  onSelectNode={onSelectNode}
+                />
+              ))}
+            </ol>
+          </section>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/client/src/components/fableloom/LoomEpisodeOutline.test.jsx
+++ b/client/src/components/fableloom/LoomEpisodeOutline.test.jsx
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import LoomEpisodeOutline from './LoomEpisodeOutline';
+
+const episode = {
+  id: 'ep-1',
+  title: 'The First Door',
+  synopsis: 'A choice waits in the dark.',
+  format: 'prose',
+  startNodeId: 'node-1',
+  nodes: [
+    {
+      id: 'node-1',
+      title: 'Threshold',
+      prose: 'You stand before the first door.',
+      transitions: [{ id: 'tr-1', intent: 'Open it', description: 'Face what waits inside.', targetNodeId: 'node-2' }],
+    },
+    { id: 'node-2', title: 'The Chamber', prose: 'A blue light fills the room.', isEnding: true, endingLabel: 'Awakened', transitions: [] },
+    { id: 'node-3', title: 'Forgotten Hall', prose: 'Dust gathers here.', transitions: [] },
+  ],
+};
+
+describe('LoomEpisodeOutline', () => {
+  it('shows scenes in story order with authored text, paths, and unreachable scenes', () => {
+    render(<LoomEpisodeOutline loom={{ name: 'Example Loom', format: 'prose' }} episode={episode} />);
+
+    expect(screen.getByRole('heading', { name: 'The First Door' })).toBeInTheDocument();
+    expect(screen.getByText('You stand before the first door.')).toBeInTheDocument();
+    expect(screen.getByText('Open it')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Scene 2: The Chamber/ })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Unreachable scenes' })).toBeInTheDocument();
+    expect(screen.getByText('Forgotten Hall')).toBeInTheDocument();
+    expect(screen.getByText('Awakened')).toBeInTheDocument();
+  });
+
+  it('returns to the visual editor when a path destination is selected', async () => {
+    const onSelectNode = vi.fn();
+    const user = userEvent.setup();
+    render(<LoomEpisodeOutline loom={{ name: 'Example Loom', format: 'prose' }} episode={episode} onSelectNode={onSelectNode} />);
+
+    await user.click(screen.getByRole('button', { name: /Scene 2: The Chamber/ }));
+    expect(onSelectNode).toHaveBeenCalledWith('node-2');
+  });
+
+  it('explains when an episode has no scenes', () => {
+    render(<LoomEpisodeOutline loom={{ name: 'Example Loom', format: 'prose' }} episode={{ ...episode, nodes: [], startNodeId: null }} />);
+
+    expect(screen.getByRole('heading', { name: 'No scenes yet' })).toBeInTheDocument();
+  });
+});

--- a/client/src/pages/FableLoomStory.jsx
+++ b/client/src/pages/FableLoomStory.jsx
@@ -2,7 +2,8 @@
  * FableLoom editor — the full-bleed visual workspace for one loom.
  *
  * URL is the source of truth: /fableloom/:loomId/plan is the series workspace;
- * /fableloom/:loomId/:episodeId/:nodeId? selects an episode and scene, and the
+ * /fableloom/:loomId/:episodeId selects an episode, /outline switches that
+ * episode to its text outline, and /:nodeId selects a scene in the graph. The
  * play drawer rides ?play=1.
  * Left: the scene-graph canvas (stacks top-to-bottom under the `lg` rail
  * breakpoint). Right rail: the selected scene's editor, or the
@@ -13,7 +14,7 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import { Link, Navigate, useNavigate, useParams, useSearchParams } from 'react-router';
-import { ArrowLeft, BookOpenText, Loader2, Plus, Settings, Sparkles, Trash2, Waypoints, Workflow as WorkflowIcon } from 'lucide-react';
+import { ArrowLeft, BookOpenText, ListTree, Loader2, Plus, Settings, Sparkles, Trash2, Waypoints, Workflow as WorkflowIcon } from 'lucide-react';
 import toast from '../components/ui/Toast';
 import Drawer from '../components/Drawer';
 import ConfirmButtonPair from '../components/ui/ConfirmButtonPair';
@@ -24,6 +25,7 @@ import { useAsyncAction } from '../hooks/useAsyncAction';
 import { useConfirmDelete } from '../hooks/useConfirmDelete';
 import useContainerWidth from '../hooks/useContainerWidth';
 import LoomCanvas from '../components/fableloom/LoomCanvas';
+import LoomEpisodeOutline from '../components/fableloom/LoomEpisodeOutline';
 import LoomEpisodeFeedback from '../components/fableloom/LoomEpisodeFeedback';
 import LoomNodeEditor from '../components/fableloom/LoomNodeEditor';
 import LoomPlayPanel from '../components/fableloom/LoomPlayPanel';
@@ -37,7 +39,7 @@ import {
   updateLoomEpisode, updateLoomNode, weaveLoomEpisode,
 } from '../services/api';
 
-export default function FableLoomStory() {
+export default function FableLoomStory({ view = 'graph' }) {
   const { loomId, episodeId, nodeId } = useParams();
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
@@ -51,6 +53,7 @@ export default function FableLoomStory() {
   const [settingsOpen, setSettingsOpen] = useState(false);
   const playOpen = searchParams.get('play') === '1';
   const seriesPlanOpen = episodeId === 'plan';
+  const outlineOpen = view === 'outline';
   // Orientation keys off the PAGE, not the canvas. The canvas is the leftover
   // after the 380px rail on `lg+`, so measuring it would stack a laptop graph
   // while the rail is still beside it.
@@ -244,6 +247,19 @@ export default function FableLoomStory() {
           >
             + Episode
           </button>
+          {episode && (
+            <TabPills
+              variant="pills"
+              size="xs"
+              ariaLabel="Episode view"
+              tabs={[
+                { id: 'graph', label: 'Graph', icon: Waypoints },
+                { id: 'outline', label: 'Outline', icon: ListTree },
+              ]}
+              activeTab={outlineOpen ? 'outline' : 'graph'}
+              onChange={(id) => navigate(id === 'outline' ? `${episodePath(episode.id)}/outline` : episodePath(episode.id))}
+            />
+          )}
         </div>
       </header>
 
@@ -265,6 +281,12 @@ export default function FableLoomStory() {
             </button>
           </div>
         </div>
+      ) : outlineOpen ? (
+        <LoomEpisodeOutline
+          loom={loom}
+          episode={episode}
+          onSelectNode={(id) => navigate(episodePath(episode.id, id))}
+        />
       ) : (
         <div className="flex-1 min-h-0 flex flex-col lg:flex-row">
           <section className="flex-1 min-h-[55vh] lg:min-h-0 min-w-0 relative">

--- a/client/src/pages/FableLoomStory.test.jsx
+++ b/client/src/pages/FableLoomStory.test.jsx
@@ -17,6 +17,7 @@ vi.mock('../services/api', () => ({
 // The graph canvas and the rails are irrelevant to the header — stub them so
 // the suite exercises the loom → series backlink and nothing else.
 vi.mock('../components/fableloom/LoomCanvas', () => ({ default: () => <div /> }));
+vi.mock('../components/fableloom/LoomEpisodeOutline', () => ({ default: ({ episode }) => <div data-testid="episode-outline">{episode.title}</div> }));
 vi.mock('../components/fableloom/LoomNodeEditor', () => ({ default: () => <div /> }));
 vi.mock('../components/fableloom/LoomPlayPanel', () => ({ default: () => <div /> }));
 vi.mock('../components/fableloom/LoomSettingsDrawer', () => ({ default: () => <div /> }));
@@ -33,6 +34,18 @@ const loom = (fields = {}) => ({
   universeId: null,
   seriesId: null,
   episodes: [],
+  ...fields,
+});
+
+const episode = (fields = {}) => ({
+  id: 'ep-1',
+  number: 1,
+  title: 'The First Door',
+  synopsis: 'A choice waits in the dark.',
+  startNodeId: 'node-1',
+  nodes: [
+    { id: 'node-1', title: 'Threshold', prose: 'You stand before the first door.', transitions: [] },
+  ],
   ...fields,
 });
 
@@ -95,5 +108,21 @@ describe('FableLoomStory series backlink', () => {
     );
     expect(await screen.findByText('Series planning workspace')).toBeInTheDocument();
     expect(screen.getByRole('tab', { name: 'Series plan' })).toBeInTheDocument();
+  });
+});
+
+describe('FableLoomStory episode outline route', () => {
+  it('renders the outline view at its dedicated URL without mounting the graph editor', async () => {
+    api.getLoom.mockResolvedValue(loom({ episodes: [episode()] }));
+    render(
+      <MemoryRouter initialEntries={['/fableloom/loom-1/ep-1/outline']}>
+        <Routes>
+          <Route path="/fableloom/:loomId/:episodeId/outline" element={<FableLoomStory view="outline" />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByTestId('episode-outline')).toHaveTextContent('The First Door');
+    expect(screen.getByRole('tab', { name: 'Outline' })).toHaveAttribute('aria-selected', 'true');
   });
 });

--- a/docs/features/fableloom.md
+++ b/docs/features/fableloom.md
@@ -30,6 +30,10 @@ answers in-world without leaving the scene when nothing matches.
   intent paths, scene image) sits beside the canvas on large screens and
   below it on small ones, with a path strip for inbound/outbound intents
   when the graph is stacked. `?play=1` opens the reader drawer.
+- **`/fableloom/:loomId/:episodeId/outline`** — a text-first episode outline:
+  reachable scenes appear in story order with their authored prose, endings,
+  and reader paths. Unreachable scenes remain visible in a separate section,
+  and path destinations return to the matching scene in the visual editor.
 - **Play drawer** — the reader chat. Sessions are client-side state
   (restart is free; nothing persists server-side).
 - **Story settings drawer** — scene format (plus the rewrite pass), and the


### PR DESCRIPTION
## Summary

- Add a dedicated text-first outline view for each FableLoom episode.
- Show scenes in opening-scene order with authored prose, endings, and reader paths.
- Keep unreachable scenes visible and provide graph/outline navigation from the episode header.

## Test plan

- `npm test -- --run src/components/fableloom/LoomEpisodeOutline.test.jsx src/pages/FableLoomStory.test.jsx`
- `npm test`
- `npm run build`