### PR TITLE
fix: start new FableLoom stories in series planning

### DIFF
--- a/client/src/pages/FableLoom.jsx
+++ b/client/src/pages/FableLoom.jsx
@@ -53,7 +53,7 @@ export default function FableLoom() {
       universeId: form.universeId || null,
       seriesId: form.seriesId || null,
     }, { silent: true });
-    navigate(`/fableloom/${loom.id}`);
+    navigate(`/fableloom/${loom.id}/plan`);
   }, { errorMessage: 'Could not create the loom' });
 
   const handleCreate = (event) => {
@@ -175,7 +175,7 @@ export default function FableLoom() {
         <div className="text-center py-16 border border-dashed border-port-border rounded-lg">
           <Waypoints size={32} className="mx-auto text-port-text-muted mb-3" />
           <p className="text-sm text-port-text-muted">
-            No branching narratives yet. Create a loom, link a universe, and weave your first episode.
+            No branching narratives yet. Create a loom, shape its series plan, then weave its episodes.
           </p>
         </div>
       ) : (

--- a/client/src/pages/FableLoom.test.jsx
+++ b/client/src/pages/FableLoom.test.jsx
@@ -73,7 +73,7 @@ describe('FableLoom index', () => {
     await waitFor(() => expect(api.createLoom).toHaveBeenCalledWith({
       name: 'Gate of Ash', logline: '', premise: '', styleNotes: '', format: 'prose', universeId: null, seriesId: null,
     }, { silent: true }));
-    expect(navigate).toHaveBeenCalledWith('/fableloom/loom-9');
+    expect(navigate).toHaveBeenCalledWith('/fableloom/loom-9/plan');
   });
 
   it('deletes a loom after inline confirmation', async () => {

--- a/client/src/pages/FableLoomStory.jsx
+++ b/client/src/pages/FableLoomStory.jsx
@@ -161,8 +161,12 @@ export default function FableLoomStory({ view = 'graph' }) {
     return <PageSkeleton label="Loading loom" fullHeight padded sidebar={false} />;
   }
 
-  // Route normalization: no/stale episode id → first episode (or stay bare
-  // when the loom has none yet). The reserved `plan` id is the series view.
+  // Route normalization: a loom without episodes starts in series planning;
+  // an established loom opens its first episode. The reserved `plan` id is
+  // the series view.
+  if (!episodeId && !loom.episodes.length) {
+    return <Navigate to={`${basePath}/plan`} replace />;
+  }
   if (!seriesPlanOpen && !episode && loom.episodes.length) {
     return <Navigate to={episodePath(loom.episodes[0].id)} replace />;
   }

--- a/client/src/pages/FableLoomStory.test.jsx
+++ b/client/src/pages/FableLoomStory.test.jsx
@@ -53,6 +53,7 @@ const renderEditor = () => render(
   <MemoryRouter initialEntries={['/fableloom/loom-1']}>
     <Routes>
       <Route path="/fableloom/:loomId" element={<FableLoomStory />} />
+      <Route path="/fableloom/:loomId/:episodeId" element={<FableLoomStory />} />
     </Routes>
   </MemoryRouter>,
 );
@@ -62,7 +63,24 @@ beforeEach(() => {
   api.getLoom.mockResolvedValue(loom());
 });
 
-describe('FableLoomStory series backlink', () => {
+describe('FableLoomStory navigation and series backlink', () => {
+  it('opens an empty loom in the series plan before asking for episodes', async () => {
+    renderEditor();
+
+    expect(await screen.findByText('Series planning workspace')).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Series plan' })).toHaveAttribute('aria-selected', 'true');
+    expect(screen.queryByRole('button', { name: 'Add the first episode' })).toBeNull();
+  });
+
+  it('still opens the first episode for an established loom', async () => {
+    api.getLoom.mockResolvedValue(loom({ episodes: [episode()] }));
+    renderEditor();
+
+    expect(await screen.findByRole('tab', { name: '1. The First Door' }))
+      .toHaveAttribute('aria-selected', 'true');
+    expect(screen.queryByText('Series planning workspace')).toBeNull();
+  });
+
   it('links back to the series a loom is soft-linked to', async () => {
     api.getLoom.mockResolvedValue(loom({ seriesId: 'ser-1' }));
     api.getPipelineSeries.mockResolvedValue({ id: 'ser-1', name: 'Example Series' });


### PR DESCRIPTION
## Summary

- open newly created FableLoom stories directly in the series-planning workspace
- route older empty looms to story-arc, plot-point, and side-quest planning before episode creation
- preserve first-episode navigation for established looms

## Test plan

- `cd client && npm test -- --run src/pages/FableLoom.test.jsx src/pages/FableLoomStory.test.jsx src/components/fableloom/LoomSeriesPlan.test.jsx src/services/apiFableLoom.test.js` (26 tests)