### PR TITLE
feat: draft complete FableLoom series plans with AI

### DIFF
--- a/client/src/components/fableloom/LoomSeriesPlan.jsx
+++ b/client/src/components/fableloom/LoomSeriesPlan.jsx
@@ -13,7 +13,9 @@ import ProviderModelSelector from '../ProviderModelSelector';
 import { useAsyncAction } from '../../hooks/useAsyncAction';
 import useProviderModels from '../../hooks/useProviderModels';
 import useUnsavedChangesGuard from '../../hooks/useUnsavedChangesGuard';
-import { feedbackLoomSeriesPlan, reviewLoomSeriesPlan, updateLoom } from '../../services/api';
+import {
+  feedbackLoomSeriesPlan, generateLoomSeriesPlan, reviewLoomSeriesPlan, updateLoom,
+} from '../../services/api';
 import { uuidv4 } from '../../lib/uuid.js';
 import { effectiveModelFor, effortAwareModelOptions } from '../../utils/providers';
 import LoomEpisodeFeedback from './LoomEpisodeFeedback';
@@ -194,6 +196,13 @@ function SeriesAiEditor({ loom, dirty, onLoomUpdate }) {
     setAnalysis(result.analysis);
   }, { errorMessage: 'Series analysis failed' });
 
+  const [generatePlan, generating] = useAsyncAction(async () => {
+    const result = await generateLoomSeriesPlan(loom.id, routeBody, { silent: true });
+    onLoomUpdate(result.loom);
+    setAnalysis(null);
+    toast.success('Full series plan drafted');
+  }, { errorMessage: 'Series-plan drafting failed' });
+
   const [applyFeedback, applying] = useAsyncAction(async () => {
     const result = await feedbackLoomSeriesPlan(loom.id, { feedback: feedback.trim(), ...routeBody }, { silent: true });
     onLoomUpdate(result.loom);
@@ -202,7 +211,10 @@ function SeriesAiEditor({ loom, dirty, onLoomUpdate }) {
     toast.success(result.changes?.[0] || 'Series plan updated');
   }, { errorMessage: 'Series-plan feedback failed' });
 
-  const busy = reviewing || applying;
+  const busy = generating || reviewing || applying;
+  const hasPlan = !!loom.seriesPlan?.storyArc?.trim()
+    || !!loom.seriesPlan?.plotPoints?.length
+    || !!loom.seriesPlan?.sideQuests?.length;
   return (
     <div className="rounded-lg border border-port-border bg-port-card p-4 space-y-4">
       <div>
@@ -231,6 +243,21 @@ function SeriesAiEditor({ loom, dirty, onLoomUpdate }) {
       {selectedProvider ? (
         <p className="text-xs text-port-text-muted">
           These actions will use {selectedProvider.name}{effectiveModelFor(selectedProvider, route.model) ? ` (${effectiveModelFor(selectedProvider, route.model)})` : ''}.
+        </p>
+      ) : null}
+      <button
+        type="button"
+        onClick={generatePlan}
+        disabled={busy || dirty}
+        className="flex items-center justify-center gap-2 w-full px-3 py-2 rounded bg-port-accent text-white text-sm disabled:opacity-50"
+      >
+        {generating ? <Loader2 size={14} className="animate-spin" /> : <Sparkles size={14} />}
+        {generating ? 'Drafting full plan…' : hasPlan ? 'Regenerate full plan' : 'Draft full plan'}
+      </button>
+      {hasPlan ? (
+        <p className="text-xs text-port-text-muted">
+          Regenerating replaces the saved arc, plot points, and side quests. Episode titles,
+          synopses, scenes, and paths stay untouched.
         </p>
       ) : null}
       <div className="flex flex-wrap gap-2">

--- a/client/src/components/fableloom/LoomSeriesPlan.jsx
+++ b/client/src/components/fableloom/LoomSeriesPlan.jsx
@@ -6,11 +6,13 @@
 
 import { useEffect, useRef, useState } from 'react';
 import { BrainCircuit, ChevronDown, ChevronUp, Loader2, MessageSquareText, Plus, Save, Sparkles, Trash2 } from 'lucide-react';
+import ConfirmButtonPair from '../ui/ConfirmButtonPair';
 import toast from '../ui/Toast';
 import { FormField } from '../ui/FormField.jsx';
 import UnsavedChangesConfirm from '../ui/UnsavedChangesConfirm.jsx';
 import ProviderModelSelector from '../ProviderModelSelector';
 import { useAsyncAction } from '../../hooks/useAsyncAction';
+import { useConfirmDelete } from '../../hooks/useConfirmDelete';
 import useProviderModels from '../../hooks/useProviderModels';
 import useUnsavedChangesGuard from '../../hooks/useUnsavedChangesGuard';
 import {
@@ -88,6 +90,16 @@ export default function LoomSeriesPlan({ loom, onLoomUpdate }) {
     setDirty(revisionRef.current > submittedRevision);
     toast.success('Series plan saved');
   }, { errorMessage: 'Could not save series plan' });
+
+  // AI generation/feedback replaces the saved series plan as one server-owned
+  // result. Make that response authoritative over any typing that happened
+  // while the provider call was in flight; otherwise the revision guard would
+  // keep the stale local plan on screen and a later Save would undo the AI run.
+  const adoptServerPlan = (updated) => {
+    revisionRef.current = 0;
+    savedRevisionRef.current = 0;
+    onLoomUpdate(updated);
+  };
 
   const episodeOptions = loom.episodes.map((episode) => ({
     id: episode.id,
@@ -171,7 +183,7 @@ export default function LoomSeriesPlan({ loom, onLoomUpdate }) {
           onMove={(index, direction) => moveItem('sideQuests', index, direction)}
         />
 
-        <SeriesAiEditor loom={loom} dirty={dirty} onLoomUpdate={onLoomUpdate} />
+        <SeriesAiEditor loom={loom} dirty={dirty} onLoomUpdate={adoptServerPlan} />
 
         <WholeEpisodeEditor loom={loom} dirty={dirty} onLoomUpdate={onLoomUpdate} />
       </div>
@@ -183,6 +195,7 @@ function SeriesAiEditor({ loom, dirty, onLoomUpdate }) {
   const [feedback, setFeedback] = useState('');
   const [analysis, setAnalysis] = useState(null);
   const [route, setRoute] = useState({ providerId: '', model: '', effort: '' });
+  const regenerateConfirm = useConfirmDelete();
   const { providers, loading } = useProviderModels({ allowDefault: true, silent: true, withEffort: true });
   const selectedProvider = providers.find((provider) => provider.id === route.providerId);
   const routeBody = {
@@ -215,6 +228,10 @@ function SeriesAiEditor({ loom, dirty, onLoomUpdate }) {
   const hasPlan = !!loom.seriesPlan?.storyArc?.trim()
     || !!loom.seriesPlan?.plotPoints?.length
     || !!loom.seriesPlan?.sideQuests?.length;
+  const confirmRegeneration = () => {
+    regenerateConfirm.cancelDelete();
+    if (!dirty && !busy) generatePlan();
+  };
   return (
     <div className="rounded-lg border border-port-border bg-port-card p-4 space-y-4">
       <div>
@@ -245,15 +262,28 @@ function SeriesAiEditor({ loom, dirty, onLoomUpdate }) {
           These actions will use {selectedProvider.name}{effectiveModelFor(selectedProvider, route.model) ? ` (${effectiveModelFor(selectedProvider, route.model)})` : ''}.
         </p>
       ) : null}
-      <button
-        type="button"
-        onClick={generatePlan}
-        disabled={busy || dirty}
-        className="flex items-center justify-center gap-2 w-full px-3 py-2 rounded bg-port-accent text-white text-sm disabled:opacity-50"
-      >
-        {generating ? <Loader2 size={14} className="animate-spin" /> : <Sparkles size={14} />}
-        {generating ? 'Drafting full plan…' : hasPlan ? 'Regenerate full plan' : 'Draft full plan'}
-      </button>
+      {hasPlan && regenerateConfirm.isConfirming('series-plan') ? (
+        <ConfirmButtonPair
+          prompt="Replace the saved plan?"
+          confirmText="Regenerate"
+          confirmIcon={Sparkles}
+          onConfirm={confirmRegeneration}
+          onCancel={regenerateConfirm.cancelDelete}
+          tone="warning"
+          className="justify-end"
+          largeTouchTargets
+        />
+      ) : (
+        <button
+          type="button"
+          onClick={() => (hasPlan ? regenerateConfirm.requestDelete('series-plan') : generatePlan())}
+          disabled={busy || dirty}
+          className="flex items-center justify-center gap-2 w-full px-3 py-2 rounded bg-port-accent text-white text-sm disabled:opacity-50"
+        >
+          {generating ? <Loader2 size={14} className="animate-spin" /> : <Sparkles size={14} />}
+          {generating ? 'Drafting full plan…' : hasPlan ? 'Regenerate full plan' : 'Draft full plan'}
+        </button>
+      )}
       {hasPlan ? (
         <p className="text-xs text-port-text-muted">
           Regenerating replaces the saved arc, plot points, and side quests. Episode titles,

--- a/client/src/components/fableloom/LoomSeriesPlan.test.jsx
+++ b/client/src/components/fableloom/LoomSeriesPlan.test.jsx
@@ -88,11 +88,36 @@ describe('LoomSeriesPlan', () => {
     renderPlan({ loom: loom(), onLoomUpdate });
 
     fireEvent.click(screen.getByRole('button', { name: /regenerate full plan/i }));
+    expect(api.generateLoomSeriesPlan).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole('button', { name: /^regenerate$/i }));
 
     await waitFor(() => expect(api.generateLoomSeriesPlan).toHaveBeenCalledWith(
       'loom-1', {}, { silent: true },
     ));
     expect(onLoomUpdate).toHaveBeenCalledWith(generated);
+  });
+
+  it('adopts a generated plan over typing performed while the provider call is in flight', async () => {
+    let finishDraft;
+    api.generateLoomSeriesPlan.mockImplementation(() => new Promise((resolve) => { finishDraft = resolve; }));
+    render(<RouterProvider router={createMemoryRouter([
+      { path: '/', element: <StatefulPlan initial={loom()} /> },
+    ], { initialEntries: ['/'] })} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /regenerate full plan/i }));
+    fireEvent.click(screen.getByRole('button', { name: /^regenerate$/i }));
+    fireEvent.change(screen.getByRole('textbox', { name: /story arc/i }), {
+      target: { value: 'Typing that should not undo the requested regeneration.' },
+    });
+    const generated = loom({ seriesPlan: {
+      storyArc: 'The generated arc wins.',
+      plotPoints: [],
+      sideQuests: [],
+    } });
+    finishDraft({ loom: generated, runId: 'run-draft' });
+
+    await waitFor(() => expect(screen.getByRole('textbox', { name: /story arc/i })).toHaveValue('The generated arc wins.'));
+    expect(screen.getByRole('button', { name: /save plan/i })).toBeDisabled();
   });
 
   it('keeps typing performed while a save response is in flight', async () => {

--- a/client/src/components/fableloom/LoomSeriesPlan.test.jsx
+++ b/client/src/components/fableloom/LoomSeriesPlan.test.jsx
@@ -5,6 +5,7 @@ import { useState } from 'react';
 
 vi.mock('../../services/api', () => ({
   feedbackLoomSeriesPlan: vi.fn(),
+  generateLoomSeriesPlan: vi.fn(),
   reviewLoomSeriesPlan: vi.fn(),
   updateLoom: vi.fn(),
 }));
@@ -72,6 +73,26 @@ describe('LoomSeriesPlan', () => {
     expect(await screen.findByText('The spine works.')).toBeInTheDocument();
     expect(screen.getByText('Move the reversal into episode 3')).toBeInTheDocument();
     expect(screen.getByText('Episode feedback for Pilot')).toBeInTheDocument();
+  });
+
+  it('regenerates the whole saved scaffold through the selected AI route without touching episodes locally', async () => {
+    const onLoomUpdate = vi.fn();
+    const generated = loom({
+      seriesPlan: {
+        storyArc: 'A generated arc.',
+        plotPoints: [{ id: 'plot-new', title: 'New turn', description: 'The cost lands.', episodeId: 'ep-1' }],
+        sideQuests: [{ id: 'quest-new', title: 'Lost map', description: 'Find it.', status: 'planned', startEpisodeId: 'ep-1', endEpisodeId: null }],
+      },
+    });
+    api.generateLoomSeriesPlan.mockResolvedValue({ loom: generated, runId: 'run-draft' });
+    renderPlan({ loom: loom(), onLoomUpdate });
+
+    fireEvent.click(screen.getByRole('button', { name: /regenerate full plan/i }));
+
+    await waitFor(() => expect(api.generateLoomSeriesPlan).toHaveBeenCalledWith(
+      'loom-1', {}, { silent: true },
+    ));
+    expect(onLoomUpdate).toHaveBeenCalledWith(generated);
   });
 
   it('keeps typing performed while a save response is in flight', async () => {

--- a/client/src/pages/FableLoom.jsx
+++ b/client/src/pages/FableLoom.jsx
@@ -9,18 +9,22 @@
 
 import { useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router';
-import { Plus, Trash2, Waypoints } from 'lucide-react';
+import { Plus, Sparkles, Trash2, Waypoints } from 'lucide-react';
+import ProviderModelSelector from '../components/ProviderModelSelector';
 import ConfirmButtonPair from '../components/ui/ConfirmButtonPair';
 import { FormField } from '../components/ui/FormField.jsx';
 import PageSkeleton from '../components/ui/PageSkeleton';
 import Pill from '../components/ui/Pill';
 import { useAsyncAction } from '../hooks/useAsyncAction';
 import { useConfirmDelete } from '../hooks/useConfirmDelete';
+import useProviderModels from '../hooks/useProviderModels';
+import toast from '../components/ui/Toast';
 import { timeAgo } from '../utils/formatters';
+import { effectiveModelFor, effortAwareModelOptions } from '../utils/providers';
 import { fieldClass, labelClass } from '../components/fableloom/fieldStyles';
 import { LOOM_FORMATS, isTeleplayFormat, loomFormatLabel } from '../components/fableloom/loomFormats';
 import {
-  createLoom, deleteLoom, listLooms, listPipelineSeries, listUniverses,
+  createLoom, deleteLoom, generateLoomSeriesPlan, listLooms, listPipelineSeries, listUniverses,
 } from '../services/api';
 
 const emptyForm = () => ({ name: '', logline: '', premise: '', styleNotes: '', format: 'prose', universeId: '', seriesId: '' });
@@ -32,6 +36,10 @@ export default function FableLoom() {
   const [series, setSeries] = useState([]);
   const [showForm, setShowForm] = useState(false);
   const [form, setForm] = useState(emptyForm());
+  const [planRoute, setPlanRoute] = useState({ providerId: '', model: '', effort: '' });
+  const { providers, loading: providersLoading } = useProviderModels({
+    allowDefault: true, enabled: showForm, silent: true, withEffort: true,
+  });
   const del = useConfirmDelete();
 
   useEffect(() => {
@@ -43,7 +51,14 @@ export default function FableLoom() {
   const universeNames = useMemo(() => new Map(universes.map((u) => [u.id, u.name])), [universes]);
   const seriesNames = useMemo(() => new Map(series.map((s) => [s.id, s.name])), [series]);
 
-  const [runCreate, creating] = useAsyncAction(async () => {
+  const planProvider = providers.find((provider) => provider.id === planRoute.providerId);
+  const planRouteBody = {
+    ...(planRoute.providerId ? { providerId: planRoute.providerId } : {}),
+    ...(planRoute.model ? { model: planRoute.model } : {}),
+    ...(planRoute.effort ? { effort: planRoute.effort } : {}),
+  };
+
+  const [runCreate, creating] = useAsyncAction(async (draftPlan = false) => {
     const loom = await createLoom({
       name: form.name.trim(),
       logline: form.logline,
@@ -53,13 +68,21 @@ export default function FableLoom() {
       universeId: form.universeId || null,
       seriesId: form.seriesId || null,
     }, { silent: true });
+    if (draftPlan) {
+      const generated = await generateLoomSeriesPlan(loom.id, planRouteBody, { silent: true })
+        .catch((error) => {
+          toast.error(`Loom created, but plan drafting failed: ${error.message}`);
+          return null;
+        });
+      if (generated) toast.success('Loom created with a full series-plan draft');
+    }
     navigate(`/fableloom/${loom.id}/plan`);
   }, { errorMessage: 'Could not create the loom' });
 
   const handleCreate = (event) => {
     event.preventDefault();
     if (!form.name.trim() || creating) return;
-    runCreate();
+    runCreate(event.nativeEvent.submitter?.value === 'draft');
   };
 
   const handleDelete = async (id) => {
@@ -157,13 +180,54 @@ export default function FableLoom() {
               placeholder="e.g. painterly, muted palette, storybook illustration"
             />
           </FormField>
-          <div className="flex justify-end">
+          <section className="border-t border-port-border pt-3 space-y-2">
+            <div>
+              <h3 className="text-sm font-semibold flex items-center gap-1.5">
+                <Sparkles size={14} className="text-port-accent" /> AI series-plan draft
+              </h3>
+              <p className="text-xs text-port-text-muted mt-1">
+                Optionally draft the complete arc, ordered plot points, and side quests from
+                these story details and the linked universe canon.
+              </p>
+            </div>
+            <ProviderModelSelector
+              providers={providers}
+              selectedProviderId={planRoute.providerId}
+              selectedModel={planRoute.model}
+              availableModels={effortAwareModelOptions(planProvider, planRoute.model)}
+              onProviderChange={(providerId) => setPlanRoute({ providerId, model: '', effort: '' })}
+              onModelChange={(model) => setPlanRoute((current) => ({ ...current, model }))}
+              effort={planRoute.effort}
+              onEffortChange={(effort) => setPlanRoute((current) => ({ ...current, effort }))}
+              label="Plan AI provider"
+              disabled={creating || providersLoading}
+              modelDisabled={creating || providersLoading}
+              emptyProviderOption="Default (series-plan stage or active provider)"
+              emptyModelOption="Default model"
+              alwaysShowModel={!!planRoute.providerId}
+            />
+            {planProvider ? (
+              <p className="text-xs text-port-text-muted">
+                The draft will use {planProvider.name}{effectiveModelFor(planProvider, planRoute.model) ? ` (${effectiveModelFor(planProvider, planRoute.model)})` : ''}.
+              </p>
+            ) : null}
+          </section>
+          <div className="flex flex-col-reverse sm:flex-row sm:justify-end gap-2">
             <button
               type="submit"
+              value="empty"
               disabled={creating || !form.name.trim()}
-              className="px-4 py-2 rounded bg-port-accent text-white text-sm disabled:opacity-50"
+              className="px-4 py-2 rounded border border-port-border text-sm hover:border-port-accent disabled:opacity-50"
             >
               {creating ? 'Creating…' : 'Create loom'}
+            </button>
+            <button
+              type="submit"
+              value="draft"
+              disabled={creating || providersLoading || !form.name.trim()}
+              className="flex items-center justify-center gap-1.5 px-4 py-2 rounded bg-port-accent text-white text-sm disabled:opacity-50"
+            >
+              <Sparkles size={14} /> {creating ? 'Creating…' : 'Create & draft plan'}
             </button>
           </div>
         </form>

--- a/client/src/pages/FableLoom.test.jsx
+++ b/client/src/pages/FableLoom.test.jsx
@@ -7,6 +7,8 @@ vi.mock('../services/api', () => ({
   listLooms: vi.fn(),
   createLoom: vi.fn(),
   deleteLoom: vi.fn(),
+  generateLoomSeriesPlan: vi.fn(),
+  getProviders: vi.fn(),
   listUniverses: vi.fn(),
   listPipelineSeries: vi.fn(),
 }));
@@ -42,6 +44,13 @@ beforeEach(() => {
   api.listLooms.mockResolvedValue(looms);
   api.listUniverses.mockResolvedValue([{ id: 'uni-1', name: 'Aria Verse' }]);
   api.listPipelineSeries.mockResolvedValue([]);
+  api.getProviders.mockResolvedValue({
+    activeProvider: 'codex',
+    providers: [{
+      id: 'codex', name: 'Codex', enabled: true, command: 'codex',
+      defaultModel: 'gpt-5.6', models: ['gpt-5.6'],
+    }],
+  });
 });
 
 describe('FableLoom index', () => {
@@ -72,6 +81,26 @@ describe('FableLoom index', () => {
 
     await waitFor(() => expect(api.createLoom).toHaveBeenCalledWith({
       name: 'Gate of Ash', logline: '', premise: '', styleNotes: '', format: 'prose', universeId: null, seriesId: null,
+    }, { silent: true }));
+    expect(navigate).toHaveBeenCalledWith('/fableloom/loom-9/plan');
+  });
+
+  it('creates and drafts the full plan with the chosen provider, model, and effort', async () => {
+    api.createLoom.mockResolvedValue({ id: 'loom-9' });
+    api.generateLoomSeriesPlan.mockResolvedValue({ loom: { id: 'loom-9' }, runId: 'run-draft' });
+    const user = userEvent.setup();
+    renderPage();
+    await waitFor(() => expect(screen.getByText('The Hollow Crown')).toBeInTheDocument());
+
+    await user.click(screen.getByRole('button', { name: /New loom/ }));
+    await user.type(screen.getByLabelText('Name'), 'Gate of Ash');
+    await user.selectOptions(await screen.findByLabelText('Plan AI provider'), 'codex');
+    await user.selectOptions(screen.getByLabelText('Model'), 'gpt-5.6');
+    await user.selectOptions(screen.getByLabelText('Thinking effort'), 'high');
+    await user.click(screen.getByRole('button', { name: /Create & draft plan/ }));
+
+    await waitFor(() => expect(api.generateLoomSeriesPlan).toHaveBeenCalledWith('loom-9', {
+      providerId: 'codex', model: 'gpt-5.6', effort: 'high',
     }, { silent: true }));
     expect(navigate).toHaveBeenCalledWith('/fableloom/loom-9/plan');
   });

--- a/client/src/pages/FableLoom.test.jsx
+++ b/client/src/pages/FableLoom.test.jsx
@@ -83,6 +83,7 @@ describe('FableLoom index', () => {
       name: 'Gate of Ash', logline: '', premise: '', styleNotes: '', format: 'prose', universeId: null, seriesId: null,
     }, { silent: true }));
     expect(navigate).toHaveBeenCalledWith('/fableloom/loom-9/plan');
+    expect(api.generateLoomSeriesPlan).not.toHaveBeenCalled();
   });
 
   it('creates and drafts the full plan with the chosen provider, model, and effort', async () => {

--- a/client/src/services/apiFableLoom.js
+++ b/client/src/services/apiFableLoom.js
@@ -24,6 +24,9 @@ export const deleteLoom = (id, options = {}) => request(loomPath(id), {
   method: 'DELETE', ...options,
 });
 
+export const generateLoomSeriesPlan = (id, body = {}, options = {}) => request(loomPath(id, '/plan/generate'), {
+  method: 'POST', body: JSON.stringify(body), ...options,
+});
 export const reviewLoomSeriesPlan = (id, body = {}, options = {}) => request(loomPath(id, '/plan/review'), {
   method: 'POST', body: JSON.stringify(body), ...options,
 });

--- a/client/src/services/apiFableLoom.test.js
+++ b/client/src/services/apiFableLoom.test.js
@@ -43,7 +43,12 @@ describe('apiFableLoom', () => {
     });
   });
 
-  it('posts series-plan analysis and feedback', async () => {
+  it('posts series-plan generation, analysis, and feedback', async () => {
+    await api.generateLoomSeriesPlan('loom-1', { providerId: 'writer', effort: 'high' }, { silent: true });
+    expect(request).toHaveBeenCalledWith('/fableloom/loom-1/plan/generate', {
+      method: 'POST', body: JSON.stringify({ providerId: 'writer', effort: 'high' }), silent: true,
+    });
+
     await api.reviewLoomSeriesPlan('loom/1', { providerId: 'writer' }, { silent: true });
     expect(request).toHaveBeenCalledWith('/fableloom/loom%2F1/plan/review', {
       method: 'POST', body: JSON.stringify({ providerId: 'writer' }), silent: true,

--- a/data.reference/prompts/stage-config.json
+++ b/data.reference/prompts/stage-config.json
@@ -1003,6 +1003,13 @@
       "returnsJson": true,
       "variables": []
     },
+    "fableloom-generate-series-plan": {
+      "name": "FableLoom — Draft Series Plan",
+      "description": "Drafts a complete series-level scaffold from the loom title, logline, premise, linked-universe canon, and episode outline. Returns a full story arc plus ordered plot points and side quests without changing episode scene graphs.",
+      "model": "heavy",
+      "returnsJson": true,
+      "variables": []
+    },
     "fableloom-feedback-episode": {
       "name": "FableLoom — Apply Episode Feedback",
       "description": "Applies one conversational author instruction to an existing branching-narrative episode. Returns sparse patches for episode metadata, existing scene content, and existing path labels/details while preserving scene and path ids.",

--- a/data.reference/prompts/stages/fableloom-generate-series-plan.md
+++ b/data.reference/prompts/stages/fableloom-generate-series-plan.md
@@ -1,0 +1,38 @@
+# FableLoom — Draft Series Plan
+
+You are the series architect for an interactive branching story. Draft the complete series-level scaffold from the author's story details, linked-universe canon, episode outline, and any useful ideas in the current plan. Do not write episode scenes or change episode records.
+
+## Story
+
+{{storyContext}}
+
+## World canon
+
+{{canonDigest}}
+
+## Current plan and episode outline
+
+{{seriesPlanJson}}
+
+## Planning contract
+
+- Write a clear beginning-to-end `storyArc`: protagonist pressure, escalation, irreversible midpoint, climax, resolution, and thematic movement. Account for meaningful local branches while keeping the series-level promises and payoffs legible.
+- Draft 6–12 ordered `plotPoints`. Each is a tentpole beat with a concise title and a description of what happens, why it matters, and what changes.
+- Draft 2–5 `sideQuests`. Each supporting thread needs a purpose, escalation, and payoff that strengthens the main arc rather than distracting from it.
+- Episode references must use an exact episode id from the supplied outline. Use `null` when no fitting episode exists yet; never invent an episode id.
+- Side-quest status is one of `idea`, `planned`, `active`, or `resolved`. A new scaffold normally uses `planned`.
+- Replace the planning scaffold only. Do not return scene prose, graph nodes, transitions, new episodes, or ids for plan items; the server mints plan-item ids.
+
+Return ONLY valid JSON matching this shape:
+
+```json
+{
+  "storyArc": "complete dramatic arc",
+  "plotPoints": [
+    { "title": "tentpole beat", "description": "what happens, why it matters, and what changes", "episodeId": "episode id or null" }
+  ],
+  "sideQuests": [
+    { "title": "supporting thread", "description": "purpose, escalation, and payoff", "status": "planned", "startEpisodeId": "episode id or null", "endEpisodeId": "episode id or null" }
+  ]
+}
+```

--- a/docs/features/fableloom.md
+++ b/docs/features/fableloom.md
@@ -112,6 +112,7 @@ in the request body beats both.
 
 | Stage | What it does |
 |---|---|
+| `fableloom-generate-series-plan` | Drafts the full series arc, ordered plot points, and side quests from the loom metadata, linked-universe canon, and episode outline. |
 | `fableloom-weave-episode` | Generates a full episode graph (scenes, intents, triggers, endings) from the loom premise + episode synopsis + linked-universe canon. |
 | `fableloom-branch-node` | Grows N new intent-labeled branches out of one scene. |
 | `fableloom-play-turn` | Resolves one reader message: `move` through a matched transition or `stay` with in-world narration. |

--- a/scripts/migrations/309-fableloom-generate-series-plan-stage.js
+++ b/scripts/migrations/309-fableloom-generate-series-plan-stage.js
@@ -1,0 +1,5 @@
+/** Seed the FableLoom full-series-plan generation stage into existing installs. */
+
+import { makeSeedMigration } from './_seedStageHelpers.js';
+
+export default makeSeedMigration('fableloom-generate-series-plan');

--- a/scripts/migrations/309-fableloom-generate-series-plan-stage.test.js
+++ b/scripts/migrations/309-fableloom-generate-series-plan-stage.test.js
@@ -1,0 +1,12 @@
+import { describe } from 'vitest';
+
+import migration from './309-fableloom-generate-series-plan-stage.js';
+import { runSeedStageMigrationTests } from './_seedStageTestHelpers.js';
+
+describe('migration 309 — seed the FableLoom series-plan generation stage', () => {
+  runSeedStageMigrationTests({
+    migration,
+    stages: ['fableloom-generate-series-plan'],
+    prefix: 'migration-309-',
+  });
+});

--- a/server/lib/apiRouteCatalog.generated.json
+++ b/server/lib/apiRouteCatalog.generated.json
@@ -2437,6 +2437,83 @@
       ]
     },
     {
+      "method": "GET",
+      "path": "/api/brain/ideas/idealoom/lists",
+      "mountPath": "/api/brain",
+      "sources": [
+        {
+          "source": "server/routes/brainIdeaLoom.js",
+          "line": 21
+        }
+      ]
+    },
+    {
+      "method": "POST",
+      "path": "/api/brain/ideas/idealoom/lists",
+      "mountPath": "/api/brain",
+      "sources": [
+        {
+          "source": "server/routes/brainIdeaLoom.js",
+          "line": 25
+        }
+      ]
+    },
+    {
+      "method": "DELETE",
+      "path": "/api/brain/ideas/idealoom/lists/:id",
+      "mountPath": "/api/brain",
+      "sources": [
+        {
+          "source": "server/routes/brainIdeaLoom.js",
+          "line": 43
+        }
+      ]
+    },
+    {
+      "method": "GET",
+      "path": "/api/brain/ideas/idealoom/lists/:id",
+      "mountPath": "/api/brain",
+      "sources": [
+        {
+          "source": "server/routes/brainIdeaLoom.js",
+          "line": 30
+        }
+      ]
+    },
+    {
+      "method": "PUT",
+      "path": "/api/brain/ideas/idealoom/lists/:id",
+      "mountPath": "/api/brain",
+      "sources": [
+        {
+          "source": "server/routes/brainIdeaLoom.js",
+          "line": 36
+        }
+      ]
+    },
+    {
+      "method": "GET",
+      "path": "/api/brain/ideas/idealoom/settings",
+      "mountPath": "/api/brain",
+      "sources": [
+        {
+          "source": "server/routes/brainIdeaLoom.js",
+          "line": 12
+        }
+      ]
+    },
+    {
+      "method": "PUT",
+      "path": "/api/brain/ideas/idealoom/settings",
+      "mountPath": "/api/brain",
+      "sources": [
+        {
+          "source": "server/routes/brainIdeaLoom.js",
+          "line": 16
+        }
+      ]
+    },
+    {
       "method": "POST",
       "path": "/api/brain/import/chatgpt",
       "mountPath": "/api/brain/import",
@@ -8625,7 +8702,7 @@
       "sources": [
         {
           "source": "server/routes/fableLoom.js",
-          "line": 66
+          "line": 68
         }
       ]
     },
@@ -8636,7 +8713,7 @@
       "sources": [
         {
           "source": "server/routes/fableLoom.js",
-          "line": 73
+          "line": 75
         }
       ]
     },
@@ -8647,7 +8724,7 @@
       "sources": [
         {
           "source": "server/routes/fableLoom.js",
-          "line": 89
+          "line": 91
         }
       ]
     },
@@ -8658,7 +8735,7 @@
       "sources": [
         {
           "source": "server/routes/fableLoom.js",
-          "line": 78
+          "line": 80
         }
       ]
     },
@@ -8669,7 +8746,7 @@
       "sources": [
         {
           "source": "server/routes/fableLoom.js",
-          "line": 84
+          "line": 86
         }
       ]
     },
@@ -8680,7 +8757,7 @@
       "sources": [
         {
           "source": "server/routes/fableLoom.js",
-          "line": 108
+          "line": 115
         }
       ]
     },
@@ -8691,7 +8768,7 @@
       "sources": [
         {
           "source": "server/routes/fableLoom.js",
-          "line": 118
+          "line": 125
         }
       ]
     },
@@ -8702,7 +8779,7 @@
       "sources": [
         {
           "source": "server/routes/fableLoom.js",
-          "line": 113
+          "line": 120
         }
       ]
     },
@@ -8713,7 +8790,7 @@
       "sources": [
         {
           "source": "server/routes/fableLoom.js",
-          "line": 193
+          "line": 200
         }
       ]
     },
@@ -8724,7 +8801,7 @@
       "sources": [
         {
           "source": "server/routes/fableLoom.js",
-          "line": 132
+          "line": 139
         }
       ]
     },
@@ -8735,7 +8812,7 @@
       "sources": [
         {
           "source": "server/routes/fableLoom.js",
-          "line": 142
+          "line": 149
         }
       ]
     },
@@ -8746,7 +8823,7 @@
       "sources": [
         {
           "source": "server/routes/fableLoom.js",
-          "line": 137
+          "line": 144
         }
       ]
     },
@@ -8757,7 +8834,7 @@
       "sources": [
         {
           "source": "server/routes/fableLoom.js",
-          "line": 180
+          "line": 187
         }
       ]
     },
@@ -8768,7 +8845,7 @@
       "sources": [
         {
           "source": "server/routes/fableLoom.js",
-          "line": 155
+          "line": 162
         }
       ]
     },
@@ -8779,7 +8856,7 @@
       "sources": [
         {
           "source": "server/routes/fableLoom.js",
-          "line": 167
+          "line": 174
         }
       ]
     },
@@ -8790,7 +8867,7 @@
       "sources": [
         {
           "source": "server/routes/fableLoom.js",
-          "line": 160
+          "line": 167
         }
       ]
     },
@@ -8801,7 +8878,7 @@
       "sources": [
         {
           "source": "server/routes/fableLoom.js",
-          "line": 198
+          "line": 205
         }
       ]
     },
@@ -8812,7 +8889,7 @@
       "sources": [
         {
           "source": "server/routes/fableLoom.js",
-          "line": 209
+          "line": 216
         }
       ]
     },
@@ -8823,7 +8900,7 @@
       "sources": [
         {
           "source": "server/routes/fableLoom.js",
-          "line": 185
+          "line": 192
         }
       ]
     },
@@ -8834,7 +8911,7 @@
       "sources": [
         {
           "source": "server/routes/fableLoom.js",
-          "line": 123
+          "line": 130
         }
       ]
     },
@@ -8845,7 +8922,7 @@
       "sources": [
         {
           "source": "server/routes/fableLoom.js",
-          "line": 175
+          "line": 182
         }
       ]
     },
@@ -8856,7 +8933,18 @@
       "sources": [
         {
           "source": "server/routes/fableLoom.js",
-          "line": 101
+          "line": 108
+        }
+      ]
+    },
+    {
+      "method": "POST",
+      "path": "/api/fableloom/:id/plan/generate",
+      "mountPath": "/api/fableloom",
+      "sources": [
+        {
+          "source": "server/routes/fableLoom.js",
+          "line": 98
         }
       ]
     },
@@ -8867,7 +8955,7 @@
       "sources": [
         {
           "source": "server/routes/fableLoom.js",
-          "line": 96
+          "line": 103
         }
       ]
     },
@@ -22982,8 +23070,8 @@
   ],
   "stats": {
     "mounts": 145,
-    "operations": 2072,
-    "declarations": 2075,
-    "sourceFiles": 224
+    "operations": 2081,
+    "declarations": 2084,
+    "sourceFiles": 225
   }
 }

--- a/server/lib/fableLoomValidation.js
+++ b/server/lib/fableLoomValidation.js
@@ -186,6 +186,8 @@ export const feedbackSchema = z.object({
 
 export const seriesPlanReviewSchema = z.object({ ...llmPickFields });
 
+export const seriesPlanGenerateSchema = z.object({ ...llmPickFields });
+
 export const seriesPlanFeedbackSchema = z.object({
   feedback: z.string().trim().min(1).max(LOOM_LIMITS.FEEDBACK_MAX),
   ...llmPickFields,

--- a/server/lib/promptStageCallSites.generated.json
+++ b/server/lib/promptStageCallSites.generated.json
@@ -40,6 +40,9 @@
   "fableloom-feedback-series-plan": [
     "server/services/fableLoom/weave.js"
   ],
+  "fableloom-generate-series-plan": [
+    "server/services/fableLoom/weave.js"
+  ],
   "fableloom-play-turn": [
     "server/services/fableLoom/weave.js"
   ],

--- a/server/routes/fableLoom.js
+++ b/server/routes/fableLoom.js
@@ -25,6 +25,7 @@ import {
   reformatSchema,
   reviewSchema,
   seriesPlanFeedbackSchema,
+  seriesPlanGenerateSchema,
   seriesPlanReviewSchema,
   transitionCreateSchema,
   transitionPatchSchema,
@@ -43,6 +44,7 @@ import {
   deleteNodeTransition,
   feedbackEpisode,
   feedbackSeriesPlan,
+  generateSeriesPlan,
   getLoom,
   listLoomSummaries,
   playTurn,
@@ -92,6 +94,11 @@ router.delete('/:id', asyncHandler(async (req, res) => {
 }));
 
 // --- Series plan ------------------------------------------------------------
+
+router.post('/:id/plan/generate', asyncHandler(async (req, res) => {
+  const input = validateRequest(seriesPlanGenerateSchema, req.body);
+  res.json(await generateSeriesPlan(req.params.id, input));
+}));
 
 router.post('/:id/plan/review', asyncHandler(async (req, res) => {
   const input = validateRequest(seriesPlanReviewSchema, req.body);

--- a/server/routes/fableLoom.test.js
+++ b/server/routes/fableLoom.test.js
@@ -15,6 +15,7 @@ vi.mock('../services/fableLoom/index.js', () => ({
   deleteNodeTransition: vi.fn(),
   feedbackEpisode: vi.fn(),
   feedbackSeriesPlan: vi.fn(),
+  generateSeriesPlan: vi.fn(),
   getLoom: vi.fn(),
   listLoomSummaries: vi.fn(async () => []),
   playTurn: vi.fn(),
@@ -97,7 +98,16 @@ describe('FableLoom routes', () => {
     expect(fableLoom.updateLoom).toHaveBeenCalledWith('loom-1', { name: 'Y' });
   });
 
-  it('reviews and conversationally edits the series plan', async () => {
+  it('generates, reviews, and conversationally edits the series plan', async () => {
+    fableLoom.generateSeriesPlan.mockResolvedValueOnce({ loom: { id: 'loom-1' }, runId: 'run-draft' });
+    const generated = await request(makeApp())
+      .post('/api/fableloom/loom-1/plan/generate')
+      .send({ providerId: 'writer', model: 'large', effort: 'high' });
+    expect(generated.status).toBe(200);
+    expect(fableLoom.generateSeriesPlan).toHaveBeenCalledWith('loom-1', {
+      providerId: 'writer', model: 'large', effort: 'high',
+    });
+
     fableLoom.reviewSeriesPlan.mockResolvedValueOnce({ analysis: { summary: 'Coherent.' } });
     const reviewed = await request(makeApp())
       .post('/api/fableloom/loom-1/plan/review')

--- a/server/services/fableLoom/README.md
+++ b/server/services/fableLoom/README.md
@@ -8,7 +8,7 @@ intent to a transition and moves them through the graph until an ending.
 | Module | Purpose |
 |---|---|
 | `records.js` | Sanitizer + CRUD for looms/episodes/nodes; transitions are addressable one at a time (`addNodeTransition` / `updateNodeTransition` / `deleteNodeTransition`) as well as replaceable as a whole array via the node patch; `attachNodeImage` and `attachNodeVideo` for media-job hooks. |
-| `weave.js` | AI ops via `runStagedLLM`: `weaveEpisode` (full graph), `branchNode` (grow paths), `feedbackEpisode` (apply a conversational sparse patch to one episode), `reviewEpisode` (critique + deterministic analysis), `playTurn` (reader intent → transition; a tapped path resolves off the graph with NO LLM call), `reformatEpisodeScenes` (rewrite ONE episode's scenes into another format; the loom's format pin lands only once every episode is converted). |
+| `weave.js` | AI ops via `runStagedLLM`: `generateSeriesPlan` (full arc / plot-point / side-quest scaffold), `weaveEpisode` (full graph), `branchNode` (grow paths), `feedbackEpisode` (apply a conversational sparse patch to one episode), `reviewEpisode` (critique + deterministic analysis), `playTurn` (reader intent → transition; a tapped path resolves off the graph with NO LLM call), `reformatEpisodeScenes` (rewrite ONE episode's scenes into another format; the loom's format pin lands only once every episode is converted). |
 | `formats.js` | Scene formats (`prose` / `teleplay`) and the prompt contracts each generative stage renders for them. |
 | `store.js` | PostgreSQL/file backend facade (`fableloom_stories`; collectionStore escape hatch for tests). |
 | `db.js` | PostgreSQL leaf I/O. |

--- a/server/services/fableLoom/index.js
+++ b/server/services/fableLoom/index.js
@@ -28,6 +28,7 @@ export {
   buildCanonDigest,
   feedbackEpisode,
   feedbackSeriesPlan,
+  generateSeriesPlan,
   mapGeneratedGraph,
   playTurn,
   publicNode,

--- a/server/services/fableLoom/weave.js
+++ b/server/services/fableLoom/weave.js
@@ -119,6 +119,19 @@ const seriesPlanDigest = (loom) => JSON.stringify({
   })),
 }, null, 2);
 
+// A full-plan draft replaces the whole scaffold after a potentially slow
+// provider call. Capture every authored input the stage read so a save made
+// while that call is in flight cannot be overwritten by a stale response.
+const seriesPlanGenerationFingerprint = (loom) => JSON.stringify({
+  name: loom.name,
+  logline: loom.logline,
+  premise: loom.premise,
+  format: loom.format,
+  universeId: loom.universeId,
+  seriesPlan: loom.seriesPlan,
+  episodes: loom.episodes.map(({ id, number, title, synopsis }) => ({ id, number, title, synopsis })),
+});
+
 // --- Weave: generate a full episode graph -----------------------------------
 
 // Raw generated node fields, passed through for the sanitizer to trim/cap.
@@ -393,13 +406,53 @@ export async function feedbackEpisode(loomId, episodeId, {
   };
 }
 
-// --- Series plan: holistic guidance and conversational editing --------------
+// --- Series plan: generation, holistic guidance, and conversational editing --
 
 const analysisStrings = (value) => (Array.isArray(value) ? value : [])
   .filter((item) => typeof item === 'string')
   .map((item) => trimTo(item, 1000))
   .filter(Boolean)
   .slice(0, 12);
+
+/**
+ * Draft the complete series-level scaffold from the story metadata, linked
+ * universe canon, current episode outline, and any useful ideas already in the
+ * plan. This intentionally replaces only `seriesPlan`; episode records and
+ * scene graphs remain untouched.
+ */
+export async function generateSeriesPlan(loomId, { providerId, model, effort } = {}) {
+  const loom = await requireLoom(loomId);
+  const sourceFingerprint = seriesPlanGenerationFingerprint(loom);
+  const canonDigest = await buildCanonDigest(loom);
+  const { content, runId } = await runStagedLLM('fableloom-generate-series-plan', {
+    storyContext: storyContext(loom),
+    canonDigest: canonDigest || '(none — invent only what the premise needs)',
+    seriesPlanJson: seriesPlanDigest(loom),
+  }, llmOptions({ providerId, model, effort }, 'fableloom-generate-series-plan'));
+
+  const storyArc = isStr(content?.storyArc) ? content.storyArc : '';
+  const isUsablePlanItem = (item) => item && typeof item === 'object'
+    && ((isStr(item.title) && item.title.trim()) || (isStr(item.description) && item.description.trim()));
+  const plotPoints = (Array.isArray(content?.plotPoints) ? content.plotPoints : [])
+    .filter(isUsablePlanItem);
+  const sideQuests = (Array.isArray(content?.sideQuests) ? content.sideQuests : [])
+    .filter(isUsablePlanItem);
+  if (!storyArc.trim() || !plotPoints.length || !sideQuests.length) {
+    throw aiShapeError('The model did not return a complete series-plan scaffold');
+  }
+
+  const updated = await mutateLoom(loomId, (current) => {
+    if (seriesPlanGenerationFingerprint(current) !== sourceFingerprint) {
+      throw new ServerError('The story changed while its plan was being drafted', {
+        status: 409,
+        code: 'LOOM_CHANGED_DURING_GENERATION',
+      });
+    }
+    current.seriesPlan = { storyArc, plotPoints, sideQuests };
+    return current;
+  });
+  return { loom: updated, runId };
+}
 
 /** Read-only story-editor pass over the arc, tentpole beats, side quests, and episode outline. */
 export async function reviewSeriesPlan(loomId, { providerId, model, effort } = {}) {

--- a/server/services/fableLoom/weave.test.js
+++ b/server/services/fableLoom/weave.test.js
@@ -25,7 +25,7 @@ vi.mock('../pipeline/series.js', () => ({ getSeries: getSeriesMock }));
 const { createLoom, addEpisode, addNode, mutateLoom, updateLoom, updateNode, getLoom } = await import('./records.js');
 const { _resetFableLoomBackend } = await import('./store.js');
 const {
-  branchNode, buildCanonDigest, feedbackEpisode, feedbackSeriesPlan, mapGeneratedGraph, playTurn,
+  branchNode, buildCanonDigest, feedbackEpisode, feedbackSeriesPlan, generateSeriesPlan, mapGeneratedGraph, playTurn,
   reformatEpisodeScenes, reviewEpisode, reviewSeriesPlan, weaveEpisode,
 } = await import('./weave.js');
 
@@ -586,6 +586,83 @@ describe('buildCanonDigest', () => {
 });
 
 describe('series plan AI', () => {
+  it('drafts and persists a complete scaffold while preserving episode records', async () => {
+    const { loomId, episodeId } = await setup();
+    getUniverseMock.mockResolvedValueOnce({
+      characters: [{ name: 'Mara', description: 'a courier who fears command' }],
+    });
+    runStagedLLM.mockResolvedValueOnce({
+      content: {
+        storyArc: 'Mara accepts responsibility for the city she once fled.',
+        plotPoints: [
+          { title: 'The summons', description: 'The crown chooses Mara.', episodeId },
+          { title: 'The false road', description: 'A tempting escape closes.', episodeId: 'invented-episode' },
+        ],
+        sideQuests: [{
+          title: 'The missing map', description: 'A rival becomes an ally.', status: 'planned',
+          startEpisodeId: episodeId, endEpisodeId: null,
+        }],
+      },
+      runId: 'run-draft',
+    });
+
+    const result = await generateSeriesPlan(loomId, {
+      providerId: 'writer', model: 'large', effort: 'high',
+    });
+
+    expect(result.runId).toBe('run-draft');
+    expect(result.loom.seriesPlan.storyArc).toContain('accepts responsibility');
+    expect(result.loom.seriesPlan.plotPoints).toHaveLength(2);
+    expect(result.loom.seriesPlan.plotPoints.every((item) => item.id.startsWith('plot-'))).toBe(true);
+    expect(result.loom.seriesPlan.plotPoints[1].episodeId).toBeNull();
+    expect(result.loom.seriesPlan.sideQuests[0]).toMatchObject({
+      title: 'The missing map', startEpisodeId: episodeId,
+    });
+    expect(result.loom.episodes).toHaveLength(1);
+    expect(result.loom.episodes[0]).toMatchObject({ id: episodeId, title: 'Pilot', synopsis: 'A crown wakes.' });
+    expect(runStagedLLM).toHaveBeenCalledWith('fableloom-generate-series-plan', expect.objectContaining({
+      storyContext: expect.stringContaining('The Hollow Crown'),
+      canonDigest: expect.stringContaining('Mara'),
+      seriesPlanJson: expect.stringContaining(episodeId),
+    }), expect.objectContaining({
+      providerOverride: 'writer', modelOverride: 'large', effortOverride: 'high',
+    }));
+  });
+
+  it('rejects an incomplete generated scaffold without replacing the saved plan', async () => {
+    const { loomId } = await setup();
+    await updateLoom(loomId, { seriesPlan: {
+      storyArc: 'Saved arc', plotPoints: [], sideQuests: [],
+    } });
+    runStagedLLM.mockResolvedValueOnce({
+      content: { storyArc: 'Partial arc', plotPoints: [{ title: 'A beat' }], sideQuests: [] },
+    });
+
+    await expect(generateSeriesPlan(loomId)).rejects.toMatchObject({ code: 'AI_RESPONSE_INVALID' });
+    expect((await getLoom(loomId)).seriesPlan.storyArc).toBe('Saved arc');
+  });
+
+  it('does not overwrite story inputs saved while the provider call is in flight', async () => {
+    const { loomId } = await setup();
+    let finishDraft;
+    runStagedLLM.mockImplementationOnce(() => new Promise((resolve) => { finishDraft = resolve; }));
+    const generation = generateSeriesPlan(loomId);
+    await vi.waitFor(() => expect(runStagedLLM).toHaveBeenCalledOnce());
+    await updateLoom(loomId, { premise: 'A newer premise saved during the draft.' });
+    finishDraft({
+      content: {
+        storyArc: 'A stale arc.',
+        plotPoints: [{ title: 'Old beat', description: 'Based on stale context.' }],
+        sideQuests: [{ title: 'Old thread', description: 'Also stale.' }],
+      },
+    });
+
+    await expect(generation).rejects.toMatchObject({ code: 'LOOM_CHANGED_DURING_GENERATION' });
+    const current = await getLoom(loomId);
+    expect(current.premise).toBe('A newer premise saved during the draft.');
+    expect(current.seriesPlan.storyArc).toBe('');
+  });
+
   it('returns normalized holistic analysis without mutating the loom', async () => {
     const { loomId } = await setup();
     runStagedLLM.mockResolvedValueOnce({


### PR DESCRIPTION
## Summary
- Add an explicit Create & draft plan flow to FableLoom with provider, model, and effort controls.
- Generate a complete series arc, plot-point beats, and side-quest scaffolding from the loom and linked universe while preserving episode graphs.
- Support guarded regeneration from the plan editor, reject stale provider responses, and seed the new prompt stage for upgrades.

## Test plan
- `npm run build`
- `npm test` (35,362 server tests and 10,171 client tests passed)
- Focused FableLoom server/client tests and scoped Biome lint