### PR TITLE
fix: use FableLoom scenes as video prompts

### DIFF
--- a/client/src/components/fableloom/LoomNodeEditor.jsx
+++ b/client/src/components/fableloom/LoomNodeEditor.jsx
@@ -1,7 +1,8 @@
 /**
  * FableLoom scene editor — the side panel for the selected node: title/prose,
- * ending flag + label, the intent-transition list, scene image/video prompts
- * and previews via the shared local media lanes, and the AI branch action.
+ * ending flag + label, the intent-transition list, scene image prompt and
+ * image/video previews via the shared local media lanes, and the AI branch
+ * action. The authored scene text is the video prompt.
  *
  * Fields save on blur (silent PATCH, skipped when unchanged; the server
  * returns the full loom, which the parent folds into state). Paths save one
@@ -55,7 +56,6 @@ export default function LoomNodeEditor({ loom, episode, node, onLoomUpdate, onCl
       title: node.title || '',
       prose: node.prose || '',
       imagePrompt: node.imagePrompt || '',
-      videoPrompt: node.videoPrompt || '',
       isEnding: !!node.isEnding,
       endingLabel: node.endingLabel || '',
       transitions: (node.transitions || []).map(toRow),
@@ -170,15 +170,14 @@ export default function LoomNodeEditor({ loom, episode, node, onLoomUpdate, onCl
   }, { errorMessage: 'Could not queue the render' });
 
   const [runGenerateVideo, videoRendering] = useAsyncAction(async () => {
-    const prompt = form.videoPrompt.trim() || form.imagePrompt.trim();
+    const prompt = form.prose.trim();
     if (!prompt) {
-      toast.error('Write a video or image prompt first');
+      toast.error('Write the scene first');
       return;
     }
-    // Keep the motion prompt independently editable, while allowing existing
-    // image-only scenes to render a useful first clip without a migration or a
-    // second required authoring step. A rendered still seeds image-to-video.
-    await saveField('videoPrompt', form.videoPrompt.trim());
+    // The authored scene is already the complete generation prompt, especially
+    // for teleplays where sluglines, action, and dialogue carry the full beat.
+    // An existing rendered still seeds image-to-video when one is available.
     await generateVideo({
       prompt: loom.styleNotes ? `${prompt}\n\nStyle: ${loom.styleNotes}` : prompt,
       backend: 'local',
@@ -319,15 +318,7 @@ export default function LoomNodeEditor({ loom, episode, node, onLoomUpdate, onCl
             Generate video
           </button>
         </div>
-        <textarea
-          rows={2}
-          className={fieldClass}
-          placeholder="Motion prompt (falls back to the image prompt)"
-          aria-label="Video prompt"
-          value={form.videoPrompt}
-          onChange={(e) => setForm((p) => ({ ...p, videoPrompt: e.target.value }))}
-          onBlur={() => saveField('videoPrompt', form.videoPrompt)}
-        />
+        <p className="text-xs text-port-text-muted">Uses the scene above as the video prompt.</p>
         {node.videoHistoryId && (
           <video
             controls

--- a/client/src/components/fableloom/LoomNodeEditor.test.jsx
+++ b/client/src/components/fableloom/LoomNodeEditor.test.jsx
@@ -19,11 +19,15 @@ import {
 } from '../../services/api';
 import LoomNodeEditor from './LoomNodeEditor';
 
-const loom = { id: 'loom-1', name: 'Example Story', format: 'prose', styleNotes: '' };
+const loom = { id: 'loom-1', name: 'Example Story', format: 'teleplay', styleNotes: '' };
+const scene = 'EXT. ANCIENT GATE - NIGHT\n\nThe gate groans open.';
 
 // One scene with a single existing path, plus a second scene to point at.
 const makeNodes = (transitions) => ([
-  { id: 'n1', title: 'The Gate', prose: 'You stand before it.', image: 'scene.png', imagePrompt: 'an ancient gate', videoPrompt: 'the gate slowly opens', transitions },
+  {
+    id: 'n1', title: 'The Gate', prose: scene, image: 'scene.png',
+    imagePrompt: 'an ancient gate', videoPrompt: 'legacy motion prompt', transitions,
+  },
   { id: 'n2', title: 'Inside', prose: 'Torchlight.', transitions: [] },
 ]);
 
@@ -108,16 +112,18 @@ describe('LoomNodeEditor paths', () => {
 });
 
 describe('LoomNodeEditor scene media', () => {
-  it('queues a local video from the scene prompt and rendered still', async () => {
+  it('queues a local video from the teleplay scene and rendered still', async () => {
     const user = userEvent.setup();
     generateVideo.mockResolvedValue({ jobId: 'video-1', status: 'queued' });
     renderEditor();
 
+    expect(screen.queryByLabelText('Video prompt')).not.toBeInTheDocument();
+    expect(screen.getByText('Uses the scene above as the video prompt.')).toBeInTheDocument();
     await user.click(screen.getByRole('button', { name: 'Generate video' }));
 
     await waitFor(() => expect(generateVideo).toHaveBeenCalledTimes(1));
     expect(generateVideo).toHaveBeenCalledWith({
-      prompt: 'the gate slowly opens',
+      prompt: scene,
       backend: 'local',
       mode: 'image',
       sourceImageFile: 'scene.png',
@@ -126,11 +132,11 @@ describe('LoomNodeEditor scene media', () => {
     });
   });
 
-  it('falls back to the image prompt for a scene without a video prompt', async () => {
+  it('uses the scene for text-to-video when no rendered still exists', async () => {
     const user = userEvent.setup();
     generateVideo.mockResolvedValue({ jobId: 'video-2', status: 'queued' });
     const nodes = makeNodes([]).map((node) => node.id === 'n1'
-      ? { ...node, imagePrompt: 'a lantern in fog', image: null, videoPrompt: '' }
+      ? { ...node, image: null }
       : node);
     render(
       <LoomNodeEditor
@@ -146,7 +152,7 @@ describe('LoomNodeEditor scene media', () => {
 
     await waitFor(() => expect(generateVideo).toHaveBeenCalledTimes(1));
     expect(generateVideo).toHaveBeenCalledWith(expect.objectContaining({
-      prompt: 'a lantern in fog', backend: 'local', mode: 'text', fableLoom: expect.any(String),
+      prompt: scene, backend: 'local', mode: 'text', fableLoom: expect.any(String),
     }));
     expect(generateVideo.mock.calls[0][0]).not.toHaveProperty('sourceImageFile');
   });

--- a/docs/features/fableloom.md
+++ b/docs/features/fableloom.md
@@ -135,12 +135,14 @@ the node durably — even if the editor unmounted mid-render — with
 newest-render-wins per node. The loom's `styleNotes` are appended to the
 prompt for a consistent look.
 
-Each node also carries an optional `videoPrompt` and `videoHistoryId`. **Generate
-video** posts to the shared local `/api/video-gen` queue with the same
-destination tag. If the node already has a rendered image, it is sent as the
-video's first-frame conditioning image; otherwise the render is text-to-video.
-The completion hook (`server/services/fableLoomSceneVideoHook.js`) files the
-finished history id onto the node durably, with newest-render-wins per node.
+**Generate video** uses the authored scene text itself as the prompt and posts
+to the shared local `/api/video-gen` queue with the same destination tag. If the
+node already has a rendered image, it is sent as the video's first-frame
+conditioning image; otherwise the render is text-to-video. The completion hook
+(`server/services/fableLoomSceneVideoHook.js`) files the finished
+`videoHistoryId` onto the node durably, with newest-render-wins per node. The
+legacy `videoPrompt` record field remains accepted for compatibility with older
+clients, but the editor no longer asks authors to maintain a duplicate prompt.
 
 ## Storage
 

--- a/server/services/fableLoom/records.js
+++ b/server/services/fableLoom/records.js
@@ -3,11 +3,12 @@
  * transitions.
  *
  * A loom is a branching-narrative story: episodes hold a directed graph of
- * scene nodes; each node carries prose, image/video prompts and rendered media,
- * plus a list of intent-triggered transitions the play LLM matches free-text
- * reader input against. All ids are server-minted. Every write funnels through
- * `mutateLoom` (per-record write queue + full re-sanitize), so a malformed
- * mutation can never persist.
+ * scene nodes; each node carries prose, an image prompt, rendered media, and a
+ * list of intent-triggered transitions the play LLM matches against free-text
+ * reader input. Legacy video prompts remain sanitized for compatibility, while
+ * current clients use the scene text itself. All ids are server-minted. Every
+ * write funnels through `mutateLoom` (per-record write queue + full re-sanitize),
+ * so a malformed mutation can never persist.
  */
 
 import { randomUUID } from 'crypto';


### PR DESCRIPTION
## Summary
- use the authored FableLoom scene text as the video-generation prompt
- remove the redundant video prompt textarea while preserving legacy record compatibility
- keep rendered stills as optional image-to-video conditioning

## Test plan
- `cd client && npm test -- src/components/fableloom src/pages/FableLoom.test.jsx src/pages/FableLoomStory.test.jsx`
- `cd client && npm run lint -- src/components/fableloom/LoomNodeEditor.jsx src/components/fableloom/LoomNodeEditor.test.jsx`
- `cd client && npm run build`