### PR TITLE
fix: make IdeaLoom list deletion actually delete, and pin its federation boundary

### DIFF
--- a/server/lib/apiRouteCatalog.generated.json
+++ b/server/lib/apiRouteCatalog.generated.json
@@ -10011,7 +10011,7 @@
       "sources": [
         {
           "source": "server/routes/imageGen.js",
-          "line": 736
+          "line": 746
         }
       ]
     },
@@ -10022,7 +10022,7 @@
       "sources": [
         {
           "source": "server/routes/imageGen.js",
-          "line": 760
+          "line": 770
         }
       ]
     },
@@ -10033,7 +10033,7 @@
       "sources": [
         {
           "source": "server/routes/imageGen.js",
-          "line": 755
+          "line": 765
         }
       ]
     },
@@ -10044,7 +10044,7 @@
       "sources": [
         {
           "source": "server/routes/imageGen.js",
-          "line": 789
+          "line": 799
         }
       ]
     },
@@ -10055,7 +10055,7 @@
       "sources": [
         {
           "source": "server/routes/imageGen.js",
-          "line": 774
+          "line": 784
         }
       ]
     },
@@ -10066,7 +10066,7 @@
       "sources": [
         {
           "source": "server/routes/imageGen.js",
-          "line": 751
+          "line": 761
         }
       ]
     },
@@ -10077,7 +10077,7 @@
       "sources": [
         {
           "source": "server/routes/imageGen.js",
-          "line": 679
+          "line": 689
         }
       ]
     },
@@ -10088,7 +10088,7 @@
       "sources": [
         {
           "source": "server/routes/imageGen.js",
-          "line": 330
+          "line": 331
         }
       ]
     },
@@ -10099,7 +10099,7 @@
       "sources": [
         {
           "source": "server/routes/imageGen.js",
-          "line": 334
+          "line": 335
         }
       ]
     },
@@ -10110,7 +10110,7 @@
       "sources": [
         {
           "source": "server/routes/imageGen.js",
-          "line": 547
+          "line": 557
         }
       ]
     },
@@ -10121,7 +10121,7 @@
       "sources": [
         {
           "source": "server/routes/imageGen.js",
-          "line": 685
+          "line": 695
         }
       ]
     },
@@ -10132,7 +10132,7 @@
       "sources": [
         {
           "source": "server/routes/imageGen.js",
-          "line": 670
+          "line": 680
         }
       ]
     },
@@ -10143,7 +10143,7 @@
       "sources": [
         {
           "source": "server/routes/imageGen.js",
-          "line": 380
+          "line": 381
         }
       ]
     },
@@ -10154,7 +10154,7 @@
       "sources": [
         {
           "source": "server/routes/imageGen.js",
-          "line": 666
+          "line": 676
         }
       ]
     },
@@ -10165,7 +10165,7 @@
       "sources": [
         {
           "source": "server/routes/imageGen.js",
-          "line": 569
+          "line": 579
         }
       ]
     },
@@ -10176,7 +10176,7 @@
       "sources": [
         {
           "source": "server/routes/imageGen.js",
-          "line": 647
+          "line": 657
         }
       ]
     },
@@ -10187,7 +10187,7 @@
       "sources": [
         {
           "source": "server/routes/imageGen.js",
-          "line": 628
+          "line": 638
         }
       ]
     },
@@ -10198,7 +10198,7 @@
       "sources": [
         {
           "source": "server/routes/imageGen.js",
-          "line": 580
+          "line": 590
         }
       ]
     },
@@ -10209,7 +10209,7 @@
       "sources": [
         {
           "source": "server/routes/imageGen.js",
-          "line": 608
+          "line": 618
         }
       ]
     },
@@ -10220,7 +10220,7 @@
       "sources": [
         {
           "source": "server/routes/imageGen.js",
-          "line": 347
+          "line": 348
         }
       ]
     },
@@ -10330,7 +10330,7 @@
       "sources": [
         {
           "source": "server/routes/imageGen.js",
-          "line": 316
+          "line": 317
         }
       ]
     },
@@ -10341,7 +10341,7 @@
       "sources": [
         {
           "source": "server/routes/imageGen.js",
-          "line": 59
+          "line": 60
         }
       ]
     },
@@ -10352,7 +10352,7 @@
       "sources": [
         {
           "source": "server/routes/imageGen.js",
-          "line": 563
+          "line": 573
         }
       ]
     },

--- a/server/routes/brain.test.js
+++ b/server/routes/brain.test.js
@@ -163,6 +163,7 @@ describe('Brain Routes', () => {
   });
 
   describe('IdeaLoom local lists', () => {
+    const LIST_ID = 'c17c0284-b7de-4db6-a09c-7f735f0fd501';
     const listInput = {
       prompt: 'Find practical improvements', title: 'Practical improvements',
       category: 'product', ideas: ['Improve empty states']
@@ -177,7 +178,7 @@ describe('Brain Routes', () => {
     });
 
     it('validates local list CRUD input and preserves native Brain ideas', async () => {
-      ideaLoomLists.createList.mockResolvedValue({ id: 'c17c0284-b7de-4db6-a09c-7f735f0fd501', ...listInput, status: 'draft' });
+      ideaLoomLists.createList.mockResolvedValue({ id: LIST_ID, ...listInput, status: 'draft' });
       const created = await request(app).post('/api/brain/ideas/idealoom/lists').send(listInput);
       expect(created.status).toBe(201);
       expect(ideaLoomLists.createList).toHaveBeenCalledWith({ ...listInput, status: 'draft' });
@@ -185,6 +186,50 @@ describe('Brain Routes', () => {
 
       const rejected = await request(app).post('/api/brain/ideas/idealoom/lists').send({ ...listInput, ideas: [''] });
       expect(rejected.status).toBe(400);
+    });
+
+    it('reads, updates and deletes a list by id', async () => {
+      const stored = { id: LIST_ID, ...listInput, status: 'draft' };
+
+      ideaLoomLists.getList.mockResolvedValue(stored);
+      const read = await request(app).get(`/api/brain/ideas/idealoom/lists/${LIST_ID}`);
+      expect(read.status).toBe(200);
+      expect(read.body).toEqual(stored);
+      expect(ideaLoomLists.getList).toHaveBeenCalledWith(LIST_ID);
+      expect(brainService.getIdeaById).not.toHaveBeenCalled();
+
+      ideaLoomLists.updateList.mockResolvedValue({ ...stored, title: 'Renamed' });
+      const updated = await request(app)
+        .put(`/api/brain/ideas/idealoom/lists/${LIST_ID}`)
+        .send({ title: 'Renamed' });
+      expect(updated.status).toBe(200);
+      expect(ideaLoomLists.updateList).toHaveBeenCalledWith(LIST_ID, { title: 'Renamed' });
+      expect(brainService.updateIdea).not.toHaveBeenCalled();
+
+      // deleteList resolving true is what makes this a 204 rather than a 404 —
+      // the service must report whether the record actually existed.
+      ideaLoomLists.deleteList.mockResolvedValue(true);
+      const removed = await request(app).delete(`/api/brain/ideas/idealoom/lists/${LIST_ID}`);
+      expect(removed.status).toBe(204);
+      expect(ideaLoomLists.deleteList).toHaveBeenCalledWith(LIST_ID);
+      expect(brainService.deleteIdea).not.toHaveBeenCalled();
+    });
+
+    it('answers 404 for an unknown id on every id-addressed route', async () => {
+      ideaLoomLists.getList.mockResolvedValue(null);
+      ideaLoomLists.updateList.mockResolvedValue(null);
+      ideaLoomLists.deleteList.mockResolvedValue(false);
+
+      // The service is mocked here, so this pins the ROUTE contract: a falsy
+      // service result becomes a 404 on every id-addressed verb, for a
+      // well-formed id and a malformed one alike. That the service itself
+      // returns falsy for a bad id is covered against the live store in
+      // services/idealoomLists.test.js.
+      for (const id of [LIST_ID, 'not-a-uuid']) {
+        expect((await request(app).get(`/api/brain/ideas/idealoom/lists/${id}`)).status).toBe(404);
+        expect((await request(app).put(`/api/brain/ideas/idealoom/lists/${id}`).send({ title: 'x' })).status).toBe(404);
+        expect((await request(app).delete(`/api/brain/ideas/idealoom/lists/${id}`)).status).toBe(404);
+      }
     });
   });
 

--- a/server/services/idealoomLists.boundary.test.js
+++ b/server/services/idealoomLists.boundary.test.js
@@ -1,0 +1,151 @@
+/**
+ * Federation boundary for machine-local IdeaLoom lists (#5361).
+ *
+ * #5336 required that no IdeaLoom list payload or vault metadata participates
+ * in Brain federation, reconcile, or the memory bridge — the machine-local rule
+ * from docs/decisions/2026-08-08-privacy-records-machine-local.md. Today that
+ * holds only STRUCTURALLY: idealoomLists.js builds its own collectionStore
+ * outside BRAIN_ENTITY_TYPES, and every federation path derives from that list
+ * (or the bridge's own TYPE_MAP). Nothing fails if a later slice registers an
+ * IdeaLoom type in either one, which is exactly the regression the ADR forbids
+ * — and #5338/#5339 are about to hang vault paths and note content hashes off
+ * these records, so the blast radius becomes real PII-adjacent local state.
+ *
+ * These drive the REAL modules over a temp data root rather than asserting on
+ * mock calls, so the guarantee is proven end to end rather than restated.
+ */
+
+import { describe, it, expect, afterAll, vi } from 'vitest';
+import { mkdtempSync, rmSync, existsSync, readdirSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { makePathsProxy } from '../lib/mockPathsDataRoot.js';
+
+// Allocated lazily on the first PATHS read: brainStorage's module graph reads
+// PATHS.brain at import time, before any top-level assignment would run.
+var tempRoot; // eslint-disable-line no-var
+function getTempRoot() {
+  if (!tempRoot) tempRoot = mkdtempSync(join(tmpdir(), 'idealoom-boundary-test-'));
+  return tempRoot;
+}
+
+vi.mock('../lib/fileUtils.js', async () => {
+  const actual = await vi.importActual('../lib/fileUtils.js');
+  return makePathsProxy(actual, { dataRoot: () => getTempRoot() });
+});
+
+vi.mock('./instances.js', () => ({
+  getInstanceId: () => Promise.resolve('local-instance'),
+}));
+
+import * as lists from './idealoomLists.js';
+import * as brainStorage from './brainStorage.js';
+import { brainEvents } from './brainStorage.js';
+import * as brainReconcile from './brainReconcile.js';
+import * as brainSync from './brainSync.js';
+import { CONTENT_COMPOSERS, brainRecordToMemory } from './brainMemoryBridge.js';
+
+afterAll(() => { if (tempRoot) rmSync(tempRoot, { recursive: true, force: true }); });
+
+const listStoreDir = () => lists.ideaLoomListStore().dir;
+const listStoreIds = () => (existsSync(listStoreDir())
+  ? readdirSync(listStoreDir()).filter((name) => name !== 'index.json')
+  : []);
+
+// A list carrying the vault-ish sync metadata #5338/#5339 will attach, so the
+// assertions below fail the moment ANY of it reaches a federation payload.
+const vaultList = {
+  prompt: 'Vault-conditioned prompt 8f2c1a',
+  title: 'Machine-local list 8f2c1a',
+  category: 'product',
+  status: 'draft',
+  ideas: ['Local idea 8f2c1a'],
+  sync: {
+    notePath: 'Idea Loom/machine-local-8f2c1a.md',
+    noteHash: 'e3b0c44298fc1c149afbf4c8996fb924',
+    vaultId: '2f7f2b1e-6a4a-4f3d-9c11-0d1f8b6a4c22',
+  },
+};
+
+// Every distinctive string that must never appear in a federated payload.
+const secrets = (list) => [
+  list.id, list.prompt, list.title, list.ideas[0],
+  vaultList.sync.notePath, vaultList.sync.noteHash, vaultList.sync.vaultId,
+];
+
+describe('IdeaLoom lists stay outside Brain federation', () => {
+  it('never appears in the reconcile snapshot that carries native Brain ideas', async () => {
+    const list = await lists.createList(vaultList);
+    const idea = await brainStorage.create('ideas', { title: 'Native federated idea' });
+
+    const snapshot = await brainReconcile.getBrainSnapshot();
+    expect(Object.keys(snapshot.records)).not.toContain('idealoom-lists');
+    // The native idea IS present, so an empty/failed snapshot can't pass this.
+    expect(snapshot.records.ideas[idea.id]).toMatchObject({ title: 'Native federated idea' });
+
+    const serialized = JSON.stringify(snapshot);
+    for (const secret of secrets(list)) expect(serialized).not.toContain(secret);
+  });
+
+  it('leaves the reconcile checksum byte-identical across list writes', async () => {
+    const before = await brainReconcile.getBrainChecksum();
+
+    const list = await lists.createList(vaultList);
+    await lists.updateList(list.id, { title: 'Renamed machine-local list' });
+    await lists.updateSettings({ autoSync: true });
+    // The checksum is cached until a brain mutation event fires, and IdeaLoom
+    // writes deliberately emit none — so force a rebuild. Without this the
+    // assertion would pass on a stale cache no matter what the list store did.
+    brainEvents.emit('record:changed');
+
+    expect(await brainReconcile.getBrainChecksum()).toBe(before);
+
+    // Bypass probe: a native Brain write MUST move the checksum, otherwise the
+    // equality above proves nothing about what the checksum covers.
+    await brainStorage.create('people', { name: 'Checksum probe' });
+    expect(await brainReconcile.getBrainChecksum()).not.toBe(before);
+  });
+
+  it('refuses a peer change addressed to the idealoom-lists type', async () => {
+    // Seed a local list first: comparing two empty directory listings would
+    // pass even if the store were never consulted.
+    await lists.createList(vaultList);
+    const idsBefore = listStoreIds();
+    expect(idsBefore.length).toBeGreaterThan(0);
+
+    const result = await brainSync.applyRemoteChanges([{
+      op: 'create',
+      type: 'idealoom-lists',
+      id: 'b9d3c0a1-4f52-4a6e-8d70-2c19f5b7ae31',
+      record: { ...vaultList, updatedAt: new Date().toISOString() },
+      originInstanceId: 'remote-instance',
+    }]);
+
+    expect(result).toMatchObject({ inserted: 0, updated: 0, deleted: 0, skipped: 1 });
+    expect(listStoreIds()).toEqual(idsBefore);
+  });
+
+  it('ignores an idealoom-lists key in a peer reconcile snapshot', async () => {
+    await lists.createList(vaultList);
+    const idsBefore = listStoreIds();
+    expect(idsBefore.length).toBeGreaterThan(0);
+
+    const applied = await brainReconcile.applyBrainSnapshot({
+      records: {
+        'idealoom-lists': {
+          'b9d3c0a1-4f52-4a6e-8d70-2c19f5b7ae31': { ...vaultList, updatedAt: new Date().toISOString() },
+        },
+      },
+    });
+
+    expect(applied).toMatchObject({ inserted: 0, updated: 0, deleted: 0, skipped: 0 });
+    expect(listStoreIds()).toEqual(idsBefore);
+  });
+
+  it('cannot be bridged into the CoS memory system', async () => {
+    const list = await lists.createList(vaultList);
+
+    expect(CONTENT_COMPOSERS).not.toHaveProperty('idealoom-lists');
+    expect(brainRecordToMemory('idealoom-lists', list)).toBeNull();
+  });
+});

--- a/server/services/idealoomLists.js
+++ b/server/services/idealoomLists.js
@@ -92,5 +92,13 @@ export async function updateList(id, updates) {
 
 export async function deleteList(id) {
   if (!store.isValidId(id)) return false;
-  return store.deleteOne(id);
+  // deleteOne is idempotent and resolves to undefined, so it cannot tell the
+  // route whether anything was actually removed — returning it directly made
+  // every DELETE answer 404. Probe for the record inside the same per-id write
+  // queue as the removal so the existence check cannot race a concurrent write.
+  return store.queueRecordWrite(id, async () => {
+    if (!await store.loadOne(id)) return false;
+    await store.deleteOneNow(id);
+    return true;
+  });
 }

--- a/server/services/idealoomLists.test.js
+++ b/server/services/idealoomLists.test.js
@@ -19,6 +19,9 @@ import * as lists from './idealoomLists.js';
 
 afterAll(() => { if (tempRoot) rmSync(tempRoot, { recursive: true, force: true }); });
 
+// A well-formed UUID that is never created, for the not-found paths.
+const UNKNOWN_ID = 'a1f0c2d4-3b5e-4c7a-9d81-6e2f4b8c0a13';
+
 const draft = {
   prompt: 'Find small practical improvements',
   title: 'Practical improvements',
@@ -43,5 +46,35 @@ describe('IdeaLoom local lists', () => {
 
   it('updates integration settings without requiring a vault', async () => {
     expect(await lists.updateSettings({ autoSync: true })).toEqual({ enabled: false, obsidianVaultId: null, autoSync: true });
+  });
+
+  it('reads a single list back by id and reports an unknown id as missing', async () => {
+    const created = await lists.createList(draft);
+    expect(await lists.getList(created.id)).toEqual(created);
+    expect(await lists.getList(UNKNOWN_ID)).toBeNull();
+  });
+
+  it('deletes a list and reports whether anything was removed', async () => {
+    const created = await lists.createList(draft);
+
+    expect(await lists.deleteList(created.id)).toBe(true);
+    expect(await lists.getList(created.id)).toBeNull();
+    expect((await lists.listLists()).map(({ id }) => id)).not.toContain(created.id);
+
+    // Idempotent: a second delete removed nothing, so the route answers 404
+    // rather than a second 204. This is what a bare store.deleteOne() could not
+    // report — it resolves to undefined whether or not the record existed.
+    expect(await lists.deleteList(created.id)).toBe(false);
+    expect(await lists.deleteList(UNKNOWN_ID)).toBe(false);
+  });
+
+  it('rejects a malformed id on every id-addressed operation', async () => {
+    // The store would THROW on a non-UUID id; the service guards ahead of it so
+    // the routes can answer 404 instead of surfacing a 500.
+    for (const badId of ['not-a-uuid', '../escape', '__proto__']) {
+      expect(await lists.getList(badId)).toBeNull();
+      expect(await lists.updateList(badId, { title: 'Nope' })).toBeNull();
+      expect(await lists.deleteList(badId)).toBe(false);
+    }
   });
 });


### PR DESCRIPTION
## Summary

- **Fixes a real bug:** `DELETE /api/brain/ideas/idealoom/lists/:id` answered **404 for every list**, so the Brain IdeaLoom UI could never delete one — it toasted "Failed to delete IdeaLoom list" and left the row in place. `deleteList` returned `store.deleteOne(id)`, which resolves to `undefined` whether or not the record existed. It now probes for the record inside the same per-id write queue as the removal and returns a real boolean.
- **Adds the CRUD coverage #5336 implied but never wrote** — read-by-id, delete, the idempotent second delete, the malformed-id guards on all three id-addressed operations, and both 404 shapes at the route. That gap is exactly why the delete bug shipped.
- **Adds `server/services/idealoomLists.boundary.test.js`**, the missing proof that no IdeaLoom list payload or vault sync metadata crosses the Brain federation seam (ADR `docs/decisions/2026-08-08-privacy-records-machine-local.md`). It drives the *real* modules over a temp data root rather than asserting on mock calls:
  - the reconcile snapshot carries a native Brain idea but none of the list's id/prompt/note path;
  - `getBrainChecksum()` is byte-identical across list create/update/settings writes, with a forced cache invalidation plus a native-write bypass probe so it cannot pass vacuously;
  - `brainSync.applyRemoteChanges` and `brainReconcile.applyBrainSnapshot` both refuse an `idealoom-lists` payload and write nothing to the store;
  - the memory bridge has no mapping for the type, so `brainRecordToMemory` cannot bridge a list.

  Today those guarantees hold only *structurally* — nothing fails if a later slice registers an IdeaLoom type in `BRAIN_ENTITY_TYPES` or the bridge's `TYPE_MAP`. #5338/#5339 are about to hang vault paths and note content hashes off these records, so the boundary needed a test rather than a comment.

### Unrelated fix rolled in

The first commit regenerates `server/lib/apiRouteCatalog.generated.json`. `b9893531c` added image-generation routes without re-running `npm run generate:api-docs`, so `scripts/generate-api-route-catalog.test.js` has been **failing on `main`** since — it would have reddened this PR's CI. Regenerated by the script; no hand edits.

## Test plan

- `cd server && npx vitest run services/idealoomLists.test.js services/idealoomLists.boundary.test.js routes/brain.test.js` — 125 passed.
- **Bug confirmed:** reverting only the `deleteList` change fails the new `deletes a list and reports whether anything was removed` test with `expected undefined to be true`.
- **Non-vacuity confirmed:** each federation-refusal test seeds a real list first and asserts a non-empty store before the refusal, and each passes when run in isolation.
- `cd server && npm test` — full suite green (the two pre-existing route-catalog failures are resolved by the first commit).

Closes #5361
