### PR TITLE
fix: compact automatic FableLoom transitions

### DIFF
--- a/client/src/components/fableloom/LoomCanvas.jsx
+++ b/client/src/components/fableloom/LoomCanvas.jsx
@@ -1,8 +1,9 @@
 /**
  * FableLoom canvas — the visual editor for one episode's scene graph.
  *
- * Renders scene nodes as SVG cards with intent-labeled transition edges —
- * placement, orientation, and orthogonal routing come from `layoutLoomGraph`.
+ * Renders scene nodes as SVG cards with intent-labeled decision edges and
+ * compact, unlabeled automatic cuts. Placement, orientation, and orthogonal
+ * routing come from `layoutLoomGraph`.
  * The canvas measures itself for card wrapping. Flow direction comes from
  * the parent when it knows the page breakpoint (editor rail beside vs
  * under); otherwise `pickLoomOrientation` keys off canvas width.
@@ -180,7 +181,7 @@ export default function LoomCanvas({
                     onSelectNode?.(edge.targetId);
                   }}
                 />
-                {edge.intent && (
+                {edge.intent && edge.showLabel !== false && (
                   <text
                     x={edge.labelX}
                     y={edge.labelY}

--- a/client/src/components/fableloom/LoomCanvas.test.jsx
+++ b/client/src/components/fableloom/LoomCanvas.test.jsx
@@ -23,6 +23,11 @@ const episode = () => ({
   ],
 });
 
+const sceneY = (name) => {
+  const transform = screen.getByLabelText(`Scene: ${name}`).getAttribute('transform');
+  return Number(/translate\([^,]+, ([^)]+)\)/.exec(transform)?.[1]);
+};
+
 describe('LoomCanvas', () => {
   it('renders scene cards with start/ending markers and edge intent labels', () => {
     render(<LoomCanvas episode={episode()} selectedNodeId={null} onSelectNode={() => {}} />);
@@ -32,6 +37,36 @@ describe('LoomCanvas', () => {
     expect(screen.getByText('Decision loop')).toBeInTheDocument();
     expect(screen.getByText('Within')).toBeInTheDocument();
     expect(screen.getByText('enter the gate')).toBeInTheDocument();
+  });
+
+  it('packs an automatic cut tightly and omits its redundant connection label', () => {
+    const automatic = episode();
+    automatic.nodes[0].playbackMode = 'cut';
+    automatic.nodes[0].transitions[0].intent = 'Continue';
+    const { rerender } = render(
+      <LoomCanvas
+        episode={automatic}
+        selectedNodeId={null}
+        onSelectNode={() => {}}
+        viewportWidth={390}
+      />,
+    );
+
+    const cutStartY = sceneY('The Gate');
+    const cutNextY = sceneY('Inside');
+    expect(screen.queryByText('Continue')).not.toBeInTheDocument();
+
+    rerender(
+      <LoomCanvas
+        episode={episode()}
+        selectedNodeId={null}
+        onSelectNode={() => {}}
+        viewportWidth={390}
+      />,
+    );
+    const decisionStartY = sceneY('The Gate');
+    const decisionNextY = sceneY('Inside');
+    expect(cutNextY - cutStartY).toBeLessThan(decisionNextY - decisionStartY);
   });
 
   it('keeps media controls in each visual node and gives a finished video preview precedence', () => {

--- a/client/src/lib/loomLayout.js
+++ b/client/src/lib/loomLayout.js
@@ -19,8 +19,9 @@
  * right-edge → left-edge cubic made parallel intents occupy the same curve.
  * Backward / same-layer edges drop into packed return lanes on the unused
  * side of the card band; skip-layer edges go around the other side so they
- * don't sweep through cards in between. Labels sit on the first stub, then
- * de-collide — see `routeLoomEdges`.
+ * don't sweep through cards in between. Decision labels sit on the first stub,
+ * then de-collide; automatic cuts use a compact, unlabeled connection — see
+ * `routeLoomEdges`.
  */
 
 export const LOOM_NODE_W = 200;
@@ -41,6 +42,9 @@ const MARGIN = 24;
 // Gap along the reading direction: enough for a 24-char label plus a vertical
 // (or horizontal, in tb) lane. Fan-out adds LANE_GAP per extra parallel edge.
 const BASE_FLOW_GAP = 148;
+// Automatic cuts carry no choice label, so they only need room for the arrow
+// and its generous pointer target rather than a full intent-text corridor.
+const COMPACT_FLOW_GAP = 48;
 const RANK_GAP = 48;
 const LANE_OFFSET = 36;
 const LANE_GAP = 18;
@@ -55,6 +59,11 @@ const MIN_NODE_W = 168;
 
 const asArray = (v) => (Array.isArray(v) ? v : []);
 const isFinitePos = (pos) => pos && Number.isFinite(pos.x) && Number.isFinite(pos.y);
+const isAutomaticContinuation = (node) => (
+  !node?.isEnding
+  && node?.playbackMode === 'cut'
+  && asArray(node?.transitions).length === 1
+);
 
 /** BFS layers from the start node, ordered to reduce edge crossings. */
 export function loomGraphLayers(episode) {
@@ -157,6 +166,20 @@ function flowGapFor(nodes) {
   return BASE_FLOW_GAP + Math.max(0, maxFanout(nodes) - 2) * LANE_GAP;
 }
 
+function layerFlowGaps(layers, byId, depthById, defaultGap) {
+  return layers.map((layer, depth) => {
+    const forwardSources = layer.flatMap((id) => {
+      const node = byId.get(id);
+      return asArray(node?.transitions)
+        .filter((transition) => depthById.get(transition?.targetNodeId) === depth + 1)
+        .map(() => node);
+    });
+    return forwardSources.length > 0 && forwardSources.every(isAutomaticContinuation)
+      ? COMPACT_FLOW_GAP
+      : defaultGap;
+  });
+}
+
 /**
  * Position every node and route every transition. Returns
  * `{ positions, edges, width, height, nodeW, nodeH, orientation }` —
@@ -177,7 +200,11 @@ export function layoutLoomGraph(episode, options = {}) {
     || pickLoomOrientation(options.viewportWidth, layers.length);
   const { nodeW, nodeH } = nodeMetrics(orientation, options.viewportWidth);
   const flowGap = flowGapFor(nodes);
+  const byId = new Map(nodes.map((node) => [node.id, node]));
   const posById = new Map(nodes.map((n) => [n.id, n.pos]));
+  const depthById = new Map();
+  layers.forEach((layer, depth) => layer.forEach((id) => depthById.set(id, depth)));
+  const flowGaps = layerFlowGaps(layers, byId, depthById, flowGap);
 
   const place = (originX, originY) => placeNodes(layers, {
     originX,
@@ -187,11 +214,10 @@ export function layoutLoomGraph(episode, options = {}) {
     orientation,
     viewportWidth: options.viewportWidth,
     flowGap,
+    flowGaps,
     rankGap: RANK_GAP,
     posById,
   });
-  const depthById = new Map();
-  layers.forEach((layer, depth) => layer.forEach((id) => depthById.set(id, depth)));
   const routeFor = (pos) => {
     const band = cardBand(pos, nodeW, nodeH, orientation);
     return routeLoomEdges(nodes, pos, band.max, {
@@ -244,18 +270,20 @@ export function layoutLoomGraph(episode, options = {}) {
 }
 
 function placeNodes(layers, {
-  originX, originY, nodeW, nodeH, orientation, viewportWidth, flowGap, rankGap, posById,
+  originX, originY, nodeW, nodeH, orientation, viewportWidth, flowGap, flowGaps, rankGap, posById,
 }) {
   const positions = {};
   const isLR = orientation === LOOM_ORIENTATION.LR;
   if (isLR) {
+    let x = originX;
     layers.forEach((layer, col) => {
       layer.forEach((id, row) => {
         const custom = posById.get(id);
         positions[id] = isFinitePos(custom)
           ? { x: custom.x, y: custom.y }
-          : { x: originX + col * (nodeW + flowGap), y: originY + row * (nodeH + rankGap) };
+          : { x, y: originY + row * (nodeH + rankGap) };
       });
+      x += nodeW + (flowGaps[col] ?? flowGap);
     });
     return positions;
   }
@@ -264,7 +292,7 @@ function placeNodes(layers, {
   const inner = Math.max(nodeW, (viewportWidth || (nodeW + originX * 2)) - originX * 2);
   const perRow = Math.max(1, Math.floor((inner + rankGap) / (nodeW + rankGap)));
   let y = originY;
-  for (const layer of layers) {
+  for (const [layerIndex, layer] of layers.entries()) {
     for (let i = 0; i < layer.length; i += perRow) {
       const row = layer.slice(i, i + perRow);
       const rowW = row.length * nodeW + (row.length - 1) * rankGap;
@@ -273,7 +301,7 @@ function placeNodes(layers, {
         positions[id] = { x: startX + ci * (nodeW + rankGap), y };
       });
       const lastInLayer = i + perRow >= layer.length;
-      y += nodeH + (lastInLayer ? flowGap : rankGap);
+      y += nodeH + (lastInLayer ? (flowGaps[layerIndex] ?? flowGap) : rankGap);
     }
   }
   return positions;
@@ -380,6 +408,7 @@ export function routeLoomEdges(nodes, positions, cardExtent, options = {}) {
       const back = !self && (byDepth
         ? toD <= fromD
         : (isLR ? to.x <= from.x : to.y <= from.y));
+      const automatic = !self && !skip && !back && isAutomaticContinuation(node);
       routes.push({
         id: tr.id,
         sourceId: node.id,
@@ -390,6 +419,7 @@ export function routeLoomEdges(nodes, positions, cardExtent, options = {}) {
         self,
         skip,
         back,
+        automatic,
         around: !self && (back || skip),
       });
     }
@@ -404,6 +434,7 @@ export function routeLoomEdges(nodes, positions, cardExtent, options = {}) {
     sourceId: route.sourceId,
     targetId: route.targetId,
     intent: route.intent,
+    showLabel: !route.automatic,
     ...loomEdgePath(route.from, route.to, {
       self: route.self,
       around: route.around,
@@ -549,7 +580,7 @@ export function placeEdgeLabels(edges, { obstacles = [] } = {}) {
   const placed = [];
   const halfWidth = (text) => (Math.min(text.length, LOOM_EDGE_LABEL_MAX) * LABEL_CHAR_W) / 2;
   for (const edge of [...edges].sort((a, b) => a.labelY - b.labelY || a.labelX - b.labelX)) {
-    if (!edge.intent) continue;
+    if (!edge.intent || edge.showLabel === false) continue;
     const half = halfWidth(edge.intent);
     const candidates = [edge.labelY];
     for (let row = 1; row <= LABEL_MAX_NUDGE_ROWS; row += 1) {


### PR DESCRIPTION
## Summary
- tighten single-transition automatic cuts in the FableLoom graph
- omit redundant connection labels for automatic cuts while preserving authored decision labels

## Test plan
- `cd client && npm test -- --run src/components/fableloom/LoomCanvas.test.jsx src/lib/loomLayout.test.js`
- `cd client && ./node_modules/.bin/biome lint --error-on-warnings src/components/fableloom/LoomCanvas.jsx src/components/fableloom/LoomCanvas.test.jsx src/lib/loomLayout.js`
- `cd client && npm run build`