### PR TITLE
fix: quiet federated media status probes

### DIFF
--- a/server/lib/apiRouteCatalog.generated.json
+++ b/server/lib/apiRouteCatalog.generated.json
@@ -9120,7 +9120,7 @@
       "sources": [
         {
           "source": "server/routes/federatedMedia.js",
-          "line": 66
+          "line": 70
         }
       ]
     },
@@ -9131,7 +9131,7 @@
       "sources": [
         {
           "source": "server/routes/federatedMedia.js",
-          "line": 79
+          "line": 83
         }
       ]
     },
@@ -9142,7 +9142,7 @@
       "sources": [
         {
           "source": "server/routes/federatedMedia.js",
-          "line": 85
+          "line": 89
         }
       ]
     },
@@ -9153,7 +9153,7 @@
       "sources": [
         {
           "source": "server/routes/federatedMedia.js",
-          "line": 96
+          "line": 100
         }
       ]
     },
@@ -9164,7 +9164,7 @@
       "sources": [
         {
           "source": "server/routes/federatedMedia.js",
-          "line": 102
+          "line": 106
         }
       ]
     },
@@ -9175,7 +9175,7 @@
       "sources": [
         {
           "source": "server/routes/federatedMedia.js",
-          "line": 108
+          "line": 112
         }
       ]
     },

--- a/server/lib/errorHandler.js
+++ b/server/lib/errorHandler.js
@@ -59,6 +59,13 @@ export class ServerError extends Error {
     this.code = options.code || getErrorCode(this.status);
     this.timestamp = Date.now();
     this.context = options.context || {};
+    // Most errors use one message everywhere. A federation boundary may need a
+    // locally-actionable message (for logs/socket toasts) while returning a
+    // less identifying message to the HTTP caller; keep that distinction on
+    // the shared envelope instead of hand-rolling a route response.
+    this.responseMessage = typeof options.responseMessage === 'string' && options.responseMessage
+      ? options.responseMessage
+      : null;
     this.severity = options.severity || 'error'; // error, critical, warning
     this.canAutoFix = options.canAutoFix || false;
   }
@@ -152,7 +159,7 @@ export function asyncHandler(fn) {
  */
 export function buildErrorEnvelope(error, safeContext) {
   return {
-    error: error.message,
+    error: error.responseMessage || error.message,
     code: error.code,
     timestamp: error.timestamp,
     ...(safeContext && Object.keys(safeContext).length > 0 && { context: safeContext })

--- a/server/lib/errorHandler.test.js
+++ b/server/lib/errorHandler.test.js
@@ -37,6 +37,7 @@ describe('errorHandler.js', () => {
       expect(error.canAutoFix).toBe(false);
       expect(error.timestamp).toBeDefined();
       expect(error.context).toEqual({});
+      expect(error.responseMessage).toBeNull();
     });
 
     it('should create error with custom options', () => {
@@ -45,13 +46,15 @@ describe('errorHandler.js', () => {
         code: 'NOT_FOUND',
         severity: 'warning',
         canAutoFix: true,
-        context: { resource: 'user' }
+        context: { resource: 'user' },
+        responseMessage: 'Resource not found',
       });
       expect(error.status).toBe(404);
       expect(error.code).toBe('NOT_FOUND');
       expect(error.severity).toBe('warning');
       expect(error.canAutoFix).toBe(true);
       expect(error.context).toEqual({ resource: 'user' });
+      expect(error.responseMessage).toBe('Resource not found');
     });
 
     it('should derive code from status when no explicit code is passed', () => {
@@ -513,12 +516,18 @@ describe('errorHandler.js', () => {
       errorEvents.on('error', listener);
       sendErrorResponse(
         res,
-        new ServerError('boom', { status: 400, context: { modelId: 'm', apiKey: 'secret' } }),
+        new ServerError('boom for local peer', {
+          status: 400,
+          context: { modelId: 'm', apiKey: 'secret' },
+          responseMessage: 'Request failed',
+        }),
         { io }
       );
 
       const payload = io.emit.mock.calls.find(([event]) => event === 'error:occurred')[1];
+      expect(payload.message).toBe('boom for local peer');
       expect(payload.context).toEqual({ modelId: 'm' });
+      expect(res.json.mock.calls[0][0].error).toBe('Request failed');
       expect(res.json.mock.calls[0][0].context).toEqual({ modelId: 'm' });
       errorEvents.off('error', listener);
     });
@@ -528,6 +537,21 @@ describe('errorHandler.js', () => {
     it('omits context when the sanitized context is empty', () => {
       const body = buildErrorEnvelope(new ServerError('nope', { status: 400 }), {});
       expect(body).toEqual({ error: 'nope', code: 'BAD_REQUEST', timestamp: expect.any(Number) });
+    });
+
+    it('can keep a detailed local message out of the HTTP response', () => {
+      const error = new ServerError('Disabled for peer "Example Peer"', {
+        status: 503,
+        code: 'MEDIA_PROVIDER_DISABLED',
+        responseMessage: 'Federated media provider is disabled',
+      });
+
+      expect(buildErrorEnvelope(error, {})).toEqual({
+        error: 'Federated media provider is disabled',
+        code: 'MEDIA_PROVIDER_DISABLED',
+        timestamp: expect.any(Number),
+      });
+      expect(error.message).toContain('Example Peer');
     });
   });
 });

--- a/server/routes/federatedMedia.js
+++ b/server/routes/federatedMedia.js
@@ -51,7 +51,11 @@ const assetAuth = asyncHandler(async (req, _res, next) => {
 const assetBody = raw({ type: FEDERATED_MEDIA_ASSET_MIME_TYPES, limit: FEDERATED_MEDIA_ASSET_MAX_BYTES });
 
 router.get('/status', asyncHandler(async (req, res) => {
-  const { config } = await authorizeFederatedMediaPeer(req);
+  // Capacity discovery is a periodic control-plane probe. A disabled provider,
+  // stale credential, or retired peer must still get a typed HTTP response for
+  // the consumer's readiness UI, but should not become a red error toast on the
+  // provider every time the peer poller runs.
+  const { config } = await authorizeFederatedMediaPeer(req, { statusProbe: true });
   const { kinds: kindsParam } = validateRequest(federatedMediaStatusQuerySchema, req.query);
   const kinds = normalizeRequestedMediaKinds(kindsParam);
   res.json(await getFederatedMediaProviderStatus(config, { kinds }));

--- a/server/routes/federatedMedia.test.js
+++ b/server/routes/federatedMedia.test.js
@@ -208,6 +208,7 @@ describe('federated media routes', () => {
 
   it('defaults GET /status to the audio-only kinds an unopted-in caller understands', async () => {
     await request(buildApp()).get('/api/federation/media/v1/status');
+    expect(provider.authorize).toHaveBeenCalledWith(expect.anything(), { statusProbe: true });
     expect(provider.status).toHaveBeenCalledWith(expect.anything(), { kinds: ['audio'] });
   });
 

--- a/server/services/federatedMediaProvider.js
+++ b/server/services/federatedMediaProvider.js
@@ -319,10 +319,11 @@ export function normalizeFederatedMediaProviderConfig(settings) {
  * global error-toast channel. Job/asset requests keep normal error severity.
  */
 export async function authorizeFederatedMediaPeer(req, { statusProbe = false } = {}) {
-  const deny = (message, code, status = 503) => {
+  const deny = (message, code, status = 503, { responseMessage } = {}) => {
     throw new ServerError(message, {
       status,
       code,
+      ...(responseMessage ? { responseMessage } : {}),
       ...(statusProbe ? { severity: 'warning' } : {}),
     });
   };
@@ -347,13 +348,13 @@ export async function authorizeFederatedMediaPeer(req, { statusProbe = false } =
   }
   const config = normalizeFederatedMediaProviderConfig(await getSettings());
   if (!config.enabled) {
-    const peerLabel = typeof peer.name === 'string' && peer.name.trim()
-      ? `peer "${peer.name.trim()}"`
-      : 'the requesting peer';
+    const peerName = typeof peer.name === 'string' ? peer.name.trim().replace(/\s+/g, ' ') : '';
+    const peerLabel = peerName ? `peer "${peerName}"` : `peer ${callerId.slice(0, 8)}…`;
     deny(
-      `Federated media provider is disabled for ${peerLabel}`,
+      `Federated media provider is disabled — refused request from ${peerLabel}`,
       'MEDIA_PROVIDER_DISABLED',
       503,
+      { responseMessage: 'Federated media provider is disabled' },
     );
   }
   return { callerId, config };

--- a/server/services/federatedMediaProvider.js
+++ b/server/services/federatedMediaProvider.js
@@ -313,22 +313,48 @@ export function normalizeFederatedMediaProviderConfig(settings) {
  * The provider is stricter than ordinary federation reads: it never inherits
  * authGate's auth-off bypass and never accepts a browser session. A verified
  * Basic credential plus a registered, enabled caller is required every time.
+ * Status discovery is expected to encounter disabled or misconfigured peers,
+ * so callers can mark those denials as warnings: the HTTP response still tells
+ * the consumer exactly why discovery failed, but it stays off this provider's
+ * global error-toast channel. Job/asset requests keep normal error severity.
  */
-export async function authorizeFederatedMediaPeer(req) {
-  const config = normalizeFederatedMediaProviderConfig(await getSettings());
-  if (!config.enabled) {
-    unavailable('Federated media provider is disabled', 'MEDIA_PROVIDER_DISABLED');
-  }
+export async function authorizeFederatedMediaPeer(req, { statusProbe = false } = {}) {
+  const deny = (message, code, status = 503) => {
+    throw new ServerError(message, {
+      status,
+      code,
+      ...(statusProbe ? { severity: 'warning' } : {}),
+    });
+  };
   if (req.portosAuthContext?.method !== 'basic' || req.portosAuthContext?.authenticated !== true) {
-    unavailable('Verified peer Basic authentication is required', 'MEDIA_PROVIDER_PEER_AUTH_REQUIRED', 403);
+    deny(
+      'Verified peer Basic authentication is required',
+      'MEDIA_PROVIDER_PEER_AUTH_REQUIRED',
+      403,
+    );
   }
   const callerId = readCallerInstanceId(req);
   if (!callerId) {
-    unavailable('A peer instance id is required', 'MEDIA_PROVIDER_PEER_ID_REQUIRED', 403);
+    deny('A peer instance id is required', 'MEDIA_PROVIDER_PEER_ID_REQUIRED', 403);
   }
   const peer = await findPeerById(callerId);
   if (!peer || peer.enabled === false) {
-    unavailable('The caller is not an enabled registered peer', 'MEDIA_PROVIDER_PEER_FORBIDDEN', 403);
+    deny(
+      'The caller is not an enabled registered peer',
+      'MEDIA_PROVIDER_PEER_FORBIDDEN',
+      403,
+    );
+  }
+  const config = normalizeFederatedMediaProviderConfig(await getSettings());
+  if (!config.enabled) {
+    const peerLabel = typeof peer.name === 'string' && peer.name.trim()
+      ? `peer "${peer.name.trim()}"`
+      : 'the requesting peer';
+    deny(
+      `Federated media provider is disabled for ${peerLabel}`,
+      'MEDIA_PROVIDER_DISABLED',
+      503,
+    );
   }
   return { callerId, config };
 }

--- a/server/services/federatedMediaProvider.test.js
+++ b/server/services/federatedMediaProvider.test.js
@@ -211,13 +211,28 @@ describe('federated media provider authorization', () => {
       status: 503,
       code: 'MEDIA_PROVIDER_DISABLED',
       severity: 'warning',
-      message: 'Federated media provider is disabled for peer "Example Peer"',
+      message: 'Federated media provider is disabled — refused request from peer "Example Peer"',
+      responseMessage: 'Federated media provider is disabled',
     });
     await expect(authorizeFederatedMediaPeer(req)).rejects.toMatchObject({
       status: 503,
       code: 'MEDIA_PROVIDER_DISABLED',
       severity: 'error',
-      message: 'Federated media provider is disabled for peer "Example Peer"',
+      message: 'Federated media provider is disabled — refused request from peer "Example Peer"',
+      responseMessage: 'Federated media provider is disabled',
+    });
+
+    // Provider config stays hidden until the caller proves both its credential
+    // and registered peer identity, even when the provider is disabled.
+    await expect(authorizeFederatedMediaPeer({
+      ...req,
+      portosAuthContext: { enabled: true, authenticated: false, method: null },
+    })).rejects.toMatchObject({
+      status: 403, code: 'MEDIA_PROVIDER_PEER_AUTH_REQUIRED',
+    });
+    state.peer = null;
+    await expect(authorizeFederatedMediaPeer(req)).rejects.toMatchObject({
+      status: 403, code: 'MEDIA_PROVIDER_PEER_FORBIDDEN',
     });
   });
 });

--- a/server/services/federatedMediaProvider.test.js
+++ b/server/services/federatedMediaProvider.test.js
@@ -152,7 +152,7 @@ function readyEngine(overrides = {}) {
 beforeEach(() => {
   vi.clearAllMocks();
   state.settings = { federation: { mediaProvider: config() } };
-  state.peer = { instanceId: 'peer-example', enabled: true };
+  state.peer = { instanceId: 'peer-example', name: 'Example Peer', enabled: true };
   state.jobs = [];
   state.nextId = 1;
   state.capabilities = { engines: [readyEngine()], defaultEngine: 'musicgen' };
@@ -176,6 +176,9 @@ describe('federated media provider authorization', () => {
     await expect(authorizeFederatedMediaPeer(baseReq)).rejects.toMatchObject({
       status: 403, code: 'MEDIA_PROVIDER_PEER_AUTH_REQUIRED',
     });
+    await expect(authorizeFederatedMediaPeer(baseReq, { statusProbe: true })).rejects.toMatchObject({
+      status: 403, code: 'MEDIA_PROVIDER_PEER_AUTH_REQUIRED', severity: 'warning',
+    });
     await expect(authorizeFederatedMediaPeer({
       ...baseReq,
       portosAuthContext: { enabled: true, authenticated: true, method: 'session' },
@@ -194,6 +197,27 @@ describe('federated media provider authorization', () => {
     state.peer.enabled = false;
     await expect(authorizeFederatedMediaPeer(req)).rejects.toMatchObject({
       status: 403, code: 'MEDIA_PROVIDER_PEER_FORBIDDEN',
+    });
+  });
+
+  it('keeps periodic disabled-provider discovery quiet while naming real job callers', async () => {
+    state.settings = { federation: { mediaProvider: { ...config(), enabled: false } } };
+    const req = {
+      headers: { 'x-portos-instance-id': 'peer-example' },
+      portosAuthContext: { enabled: true, authenticated: true, method: 'basic' },
+    };
+
+    await expect(authorizeFederatedMediaPeer(req, { statusProbe: true })).rejects.toMatchObject({
+      status: 503,
+      code: 'MEDIA_PROVIDER_DISABLED',
+      severity: 'warning',
+      message: 'Federated media provider is disabled for peer "Example Peer"',
+    });
+    await expect(authorizeFederatedMediaPeer(req)).rejects.toMatchObject({
+      status: 503,
+      code: 'MEDIA_PROVIDER_DISABLED',
+      severity: 'error',
+      message: 'Federated media provider is disabled for peer "Example Peer"',
     });
   });
 });


### PR DESCRIPTION
## Summary
- Treat periodic federated media status discovery failures as quiet control-plane responses.
- Authenticate and resolve peers before disclosing provider state, while naming the peer locally when real work is rejected.
- Separate local diagnostics from federation response text and add regression coverage.

## Test plan
- cd server && npm test -- --run lib/errorHandler.test.js services/federatedMediaProvider.test.js services/federatedMediaConsumer.test.js services/instances.test.js routes/federatedMedia.test.js ../scripts/generate-api-route-catalog.test.js
- cd server && npm test -- --exclude ../scripts/checkNpmVersion.test.js --silent=passed-only --reporter=default (35,418 passed; the omitted environment guard requires the repository npm 12 toolchain while this host currently provides npm 11)