### PR TITLE
Answer the user's own inbound FaceTime Audio call

### DIFF
--- a/client/src/components/cos/tabs/MindTab.jsx
+++ b/client/src/components/cos/tabs/MindTab.jsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useSearchParams } from 'react-router';
-import { ArrowUp, Brain, Check, CirclePause, CirclePlay, Cpu, Database, Eraser, ImagePlus, MessageCircle, RefreshCw, Settings2, Square, StickyNote, Upload, Wrench, X } from 'lucide-react';
+import { ArrowUp, Brain, Check, CirclePause, CirclePlay, Cpu, Database, Eraser, ImagePlus, MessageCircle, PhoneCall, PhoneOff, RefreshCw, Settings2, Square, StickyNote, Upload, Wrench, X } from 'lucide-react';
 import { Link } from 'react-router';
 import useMounted from '../../../hooks/useMounted';
 import { useSocket } from '../../../hooks/useSocket';
@@ -178,6 +178,11 @@ export default function MindTab() {
   const [visibility, setVisibility] = useState(null);
   const [visibilityError, setVisibilityError] = useState(null);
   const [visibilityLoading, setVisibilityLoading] = useState(true);
+  // FaceTime Audio call state — broadcast from callSession.js regardless of
+  // which tab (if any) is the call host, so this chip shows/hides even when
+  // the audio itself is carried by /voice/call-host in another tab.
+  const [callState, setCallState] = useState(null);
+  const [hangingUp, setHangingUp] = useState(false);
   const cursorRef = useRef(null);
   const loadPendingRef = useRef(false);
   const deferredLoadRef = useRef(false);
@@ -335,6 +340,23 @@ export default function MindTab() {
       socket.off('cos:mind:status', refresh);
     };
   }, [loadHistory, loadRuntime, loadVisibility, socket]);
+
+  useEffect(() => {
+    const onCallState = (snapshot) => setCallState(snapshot?.error ? null : snapshot);
+    socket.on('voice:call:state', onCallState);
+    return () => socket.off('voice:call:state', onCallState);
+  }, [socket]);
+
+  // No ack — the chip's own next `voice:call:state` broadcast (active: false)
+  // is the actual confirmation, same as the call-host page's own hangup.
+  const hangUpCall = useCallback(() => {
+    setHangingUp(true);
+    socket.emit('voice:call:hangup');
+  }, [socket]);
+
+  useEffect(() => {
+    if (!callState?.active) setHangingUp(false);
+  }, [callState?.active]);
 
   useEffect(() => {
     if (!stickToBottomRef.current || !messageListRef.current) return;
@@ -607,6 +629,26 @@ export default function MindTab() {
           }} />
         </div>
       </header>
+
+      {callState?.active && (
+        <Banner
+          tone="info"
+          icon={PhoneCall}
+          title="On a FaceTime Audio call"
+          actions={
+            <button
+              type="button"
+              onClick={hangUpCall}
+              disabled={hangingUp}
+              className="flex min-h-[36px] items-center gap-1.5 rounded border border-port-border px-3 text-xs text-port-text hover:bg-port-border/50 disabled:opacity-50"
+            >
+              <PhoneOff size={14} aria-hidden="true" />{hangingUp ? 'Hanging up…' : 'Hang up'}
+            </button>
+          }
+        >
+          {callState.turns > 0 ? `${callState.turns} turn${callState.turns === 1 ? '' : 's'} so far.` : 'Just connected.'}
+        </Banner>
+      )}
 
       {gap && <Banner tone="warning" title="History gap detected">The saved cursor is no longer retained. The visible trace was reloaded from the newest bounded snapshot.</Banner>}
       {loadError && <Banner tone="error" title="Conversation unavailable">{loadError}. Existing messages are preserved; retry when the connection recovers.</Banner>}

--- a/client/src/components/cos/tabs/MindTab.test.jsx
+++ b/client/src/components/cos/tabs/MindTab.test.jsx
@@ -32,6 +32,7 @@ const socket = vi.hoisted(() => {
   return {
     on: vi.fn((event, handler) => handlers.set(event, handler)),
     off: vi.fn((event) => handlers.delete(event)),
+    emit: vi.fn(),
     emitServer: (event, data) => handlers.get(event)?.(data),
     reset: () => handlers.clear(),
   };
@@ -625,5 +626,35 @@ describe('MindTab', () => {
     await user.click(screen.getByRole('tab', { name: 'Context' }));
 
     expect(await screen.findByText('# Context with new memory')).toBeInTheDocument();
+  });
+
+  it('shows the active-call chip from a broadcast state even when this tab is not the call host, and hangs it up', async () => {
+    renderTab();
+    await screen.findByText('Review the next bounded slice.');
+    expect(screen.queryByText('On a FaceTime Audio call')).not.toBeInTheDocument();
+
+    await act(async () => {
+      socket.emitServer('voice:call:state', { state: 'listening', active: true, hostAttached: true, turns: 2 });
+    });
+    expect(await screen.findByText('On a FaceTime Audio call')).toBeInTheDocument();
+    expect(screen.getByText('2 turns so far.')).toBeInTheDocument();
+
+    await userEvent.setup().click(screen.getByRole('button', { name: /Hang up/ }));
+    expect(socket.emit).toHaveBeenCalledWith('voice:call:hangup');
+
+    await act(async () => {
+      socket.emitServer('voice:call:state', { state: 'idle', active: false, hostAttached: false, turns: 0 });
+    });
+    expect(screen.queryByText('On a FaceTime Audio call')).not.toBeInTheDocument();
+  });
+
+  it('ignores an errored call-state broadcast rather than showing a stale chip', async () => {
+    renderTab();
+    await screen.findByText('Review the next bounded slice.');
+
+    await act(async () => {
+      socket.emitServer('voice:call:state', { error: 'host-taken', active: false, hostAttached: false, state: 'idle' });
+    });
+    expect(screen.queryByText('On a FaceTime Audio call')).not.toBeInTheDocument();
   });
 });

--- a/client/src/components/settings/VoiceTab.jsx
+++ b/client/src/components/settings/VoiceTab.jsx
@@ -368,6 +368,26 @@ export function VoiceTab() {
           <button type="button" onClick={refreshFaceTime} className="px-3 py-2 rounded bg-port-bg border border-port-border text-sm text-white">Check setup</button>
         </div>
         <div className="border-t border-port-border pt-3 space-y-2">
+          <h4 className="text-sm font-semibold text-white">Answer my calls</h4>
+          <label className="flex items-start gap-3 cursor-pointer">
+            <input
+              id="facetime-auto-answer"
+              type="checkbox"
+              checked={facetime.autoAnswer === true}
+              onChange={(e) => patch('facetime.autoAnswer', e.target.checked)}
+              disabled={faceTimeDirty}
+              className="w-4 h-4 mt-0.5 shrink-0"
+            />
+            <div className="min-w-0 flex-1">
+              <span className="text-sm text-white">Automatically answer incoming calls</span>
+              <p className="text-xs text-gray-500">
+                Only calls from your own configured handle are ever answered — every other caller is left ringing. Needs the <Link to="/voice/call-host" className="text-port-accent underline">call host</Link> tab open on this Mac; without it, an authorized call rings unanswered and a notification tells you why.
+              </p>
+            </div>
+          </label>
+        </div>
+
+        <div className="border-t border-port-border pt-3 space-y-2">
           <h4 className="text-sm font-semibold text-white">Call me when it matters</h4>
           <label className="flex items-start gap-3 cursor-pointer">
             <input

--- a/docs/features/voice.md
+++ b/docs/features/voice.md
@@ -75,6 +75,27 @@ cannot reset them. Escalation additionally fires only for a `critical`
 notification that is *still unread* after `escalateAfterMinutes`. See
 [Chief of Staff enhancement → Persistent Mind phone calls](./cos-enhancement.md#persistent-mind-phone-calls).
 
+**Calling PortOS back.** Turn on **Automatically answer incoming calls** in
+Settings → Voice → FaceTime Audio (`facetime.autoAnswer`, off by default) to
+call the Mac from your phone or watch and talk to your Chief of Staff. Fail
+closed by construction: the helper's `answer` command presses only the
+Notification Center action naming your own configured identity — a call from
+any other handle is left ringing, and PortOS never logs anything that would
+name who it was. Answering also needs the **call host** tab open and attached
+on this Mac (same tab the outbound bridge uses); without it, an authorized
+call rings unanswered and a `medium` notification records the miss instead of
+silently dropping it. Quiet hours change only the greeting's tone, never
+whether the call is picked up — you placed it, so PortOS answers at any hour.
+Once answered, the call runs exactly like an outbound one: whisper STT →
+voice LLM/persona → Kokoro/Piper TTS, the same silence/max-duration/hangup
+rules, and a transcript in the daily journal. If the Persistent Mind is
+running, the call carries its persona and context and the transcript is
+handed back to it as a message on hangup, continuing the same conversation on
+its next wake; if the mind isn't running, it's the plain voice persona, same
+as the widget. The Mind tab shows an active-call chip with a **Hang up**
+button (`voice:call:hangup`) for either direction, from any tab — not just
+the one carrying the audio.
+
 ### Meeting capture
 
 The call-host page's second mode: **/voice/call-host?mode=capture** (or the
@@ -223,8 +244,10 @@ Barge-in works by aborting the shared `AbortController` tied to the current turn
 
 Socket events are documented in `server/sockets/voice.js` — including the
 call-host bridge (`voice:call:attach` / `voice:call:audio` / `voice:call:detach`
-inbound, `voice:call:state` / `voice:call:tts` outbound) and meeting capture,
-which reuses the same `voice:call:audio` PCM frames (`voice:capture:start` /
+/ `voice:call:hangup` inbound, `voice:call:state` / `voice:call:tts` outbound —
+`voice:call:state` broadcasts to every connected tab, not just the call host,
+so the Mind tab's active-call chip stays in sync) and meeting capture, which
+reuses the same `voice:call:audio` PCM frames (`voice:capture:start` /
 `voice:capture:stop` inbound, `voice:capture:state` outbound).
 
 ## Troubleshooting

--- a/server/lib/apiRouteCatalog.generated.json
+++ b/server/lib/apiRouteCatalog.generated.json
@@ -22183,7 +22183,7 @@
       "sources": [
         {
           "source": "server/routes/voice.js",
-          "line": 133
+          "line": 134
         }
       ]
     },
@@ -22194,7 +22194,7 @@
       "sources": [
         {
           "source": "server/routes/voice.js",
-          "line": 138
+          "line": 139
         }
       ]
     },
@@ -22205,7 +22205,7 @@
       "sources": [
         {
           "source": "server/routes/voice.js",
-          "line": 184
+          "line": 185
         }
       ]
     },
@@ -22216,7 +22216,7 @@
       "sources": [
         {
           "source": "server/routes/voice.js",
-          "line": 204
+          "line": 205
         }
       ]
     },
@@ -22260,7 +22260,7 @@
       "sources": [
         {
           "source": "server/routes/voice.js",
-          "line": 256
+          "line": 257
         }
       ]
     },
@@ -22271,7 +22271,7 @@
       "sources": [
         {
           "source": "server/routes/voice.js",
-          "line": 167
+          "line": 168
         }
       ]
     },
@@ -22282,7 +22282,7 @@
       "sources": [
         {
           "source": "server/routes/voice.js",
-          "line": 217
+          "line": 218
         }
       ]
     },
@@ -22293,7 +22293,7 @@
       "sources": [
         {
           "source": "server/routes/voice.js",
-          "line": 282
+          "line": 283
         }
       ]
     },
@@ -22304,7 +22304,7 @@
       "sources": [
         {
           "source": "server/routes/voice.js",
-          "line": 294
+          "line": 295
         }
       ]
     },
@@ -22315,7 +22315,7 @@
       "sources": [
         {
           "source": "server/routes/voice.js",
-          "line": 198
+          "line": 199
         }
       ]
     },
@@ -22326,7 +22326,7 @@
       "sources": [
         {
           "source": "server/routes/voice.js",
-          "line": 306
+          "line": 307
         }
       ]
     },

--- a/server/lib/socketEventCatalog.generated.json
+++ b/server/lib/socketEventCatalog.generated.json
@@ -67,7 +67,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 418
+          "line": 434
         }
       ]
     },
@@ -80,7 +80,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 425
+          "line": 441
         }
       ]
     },
@@ -93,7 +93,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 426
+          "line": 442
         }
       ]
     },
@@ -119,7 +119,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 415
+          "line": 431
         }
       ]
     },
@@ -132,7 +132,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 421
+          "line": 437
         }
       ]
     },
@@ -145,7 +145,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 422
+          "line": 438
         }
       ]
     },
@@ -163,7 +163,7 @@
         {
           "direction": "client-to-server",
           "source": "server/services/socket.js",
-          "line": 123
+          "line": 124
         }
       ]
     },
@@ -176,7 +176,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 123
+          "line": 124
         }
       ]
     },
@@ -189,7 +189,7 @@
         {
           "direction": "client-to-server",
           "source": "server/services/socket.js",
-          "line": 123
+          "line": 124
         }
       ]
     },
@@ -202,7 +202,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 123
+          "line": 124
         }
       ]
     },
@@ -225,7 +225,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 288
+          "line": 304
         }
       ]
     },
@@ -601,7 +601,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 392
+          "line": 408
         }
       ]
     },
@@ -614,7 +614,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 580
+          "line": 596
         }
       ]
     },
@@ -627,7 +627,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 583
+          "line": 599
         }
       ]
     },
@@ -640,7 +640,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 577
+          "line": 593
         }
       ]
     },
@@ -653,7 +653,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 574
+          "line": 590
         }
       ]
     },
@@ -720,7 +720,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 433
+          "line": 449
         }
       ]
     },
@@ -738,7 +738,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 107
+          "line": 108
         }
       ]
     },
@@ -939,7 +939,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 250
+          "line": 266
         }
       ]
     },
@@ -999,7 +999,7 @@
         {
           "direction": "server-to-client",
           "source": "client/src/components/cos/tabs/MindTab.jsx",
-          "line": 329
+          "line": 334
         },
         {
           "direction": "server-to-client",
@@ -1101,7 +1101,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 333
+          "line": 349
         }
       ]
     },
@@ -1150,7 +1150,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 331
+          "line": 347
         }
       ]
     },
@@ -1179,7 +1179,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 332
+          "line": 348
         }
       ]
     },
@@ -1218,7 +1218,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 329
+          "line": 345
         }
       ]
     },
@@ -1247,7 +1247,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 330
+          "line": 346
         }
       ]
     },
@@ -1260,7 +1260,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 348
+          "line": 364
         }
       ]
     },
@@ -1278,7 +1278,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 353
+          "line": 369
         }
       ]
     },
@@ -1301,7 +1301,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 354
+          "line": 370
         }
       ]
     },
@@ -1324,7 +1324,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 352
+          "line": 368
         }
       ]
     },
@@ -1342,7 +1342,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 344
+          "line": 360
         }
       ]
     },
@@ -1355,7 +1355,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 345
+          "line": 361
         }
       ]
     },
@@ -1378,7 +1378,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 316
+          "line": 332
         }
       ]
     },
@@ -1391,7 +1391,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 341
+          "line": 357
         }
       ]
     },
@@ -1404,7 +1404,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 337
+          "line": 353
         }
       ]
     },
@@ -1417,7 +1417,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 339
+          "line": 355
         }
       ]
     },
@@ -1430,7 +1430,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 340
+          "line": 356
         }
       ]
     },
@@ -1443,7 +1443,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 338
+          "line": 354
         }
       ]
     },
@@ -1456,12 +1456,12 @@
         {
           "direction": "server-to-client",
           "source": "client/src/components/cos/tabs/MindTab.jsx",
-          "line": 330
+          "line": 335
         },
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 215
+          "line": 217
         }
       ]
     },
@@ -1474,12 +1474,12 @@
         {
           "direction": "server-to-client",
           "source": "client/src/components/cos/tabs/MindTab.jsx",
-          "line": 331
+          "line": 336
         },
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 334
+          "line": 350
         }
       ]
     },
@@ -1497,7 +1497,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 363
+          "line": 379
         }
       ]
     },
@@ -1520,7 +1520,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 313
+          "line": 329
         }
       ]
     },
@@ -1569,7 +1569,7 @@
         {
           "direction": "client-to-server",
           "source": "server/services/socket.js",
-          "line": 120
+          "line": 121
         }
       ]
     },
@@ -1582,7 +1582,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 120
+          "line": 121
         }
       ]
     },
@@ -1595,7 +1595,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 349
+          "line": 365
         }
       ]
     },
@@ -1623,7 +1623,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 322
+          "line": 338
         }
       ]
     },
@@ -1646,7 +1646,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 326
+          "line": 342
         }
       ]
     },
@@ -1659,7 +1659,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 324
+          "line": 340
         }
       ]
     },
@@ -1687,7 +1687,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 323
+          "line": 339
         }
       ]
     },
@@ -1710,7 +1710,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 325
+          "line": 341
         }
       ]
     },
@@ -1723,7 +1723,7 @@
         {
           "direction": "client-to-server",
           "source": "server/services/socket.js",
-          "line": 120
+          "line": 121
         }
       ]
     },
@@ -1736,7 +1736,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 120
+          "line": 121
         }
       ]
     },
@@ -1749,7 +1749,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 357
+          "line": 373
         }
       ]
     },
@@ -1762,7 +1762,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 358
+          "line": 374
         }
       ]
     },
@@ -1911,12 +1911,12 @@
         {
           "direction": "client-to-server",
           "source": "server/services/socket.js",
-          "line": 152
+          "line": 153
         },
         {
           "direction": "client-to-server",
           "source": "server/sockets/voice.js",
-          "line": 617
+          "line": 631
         }
       ]
     },
@@ -1952,7 +1952,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 377
+          "line": 393
         }
       ]
     },
@@ -1965,7 +1965,7 @@
         {
           "direction": "server-to-client",
           "source": "server/lib/errorHandler.js",
-          "line": 318
+          "line": 325
         }
       ]
     },
@@ -1983,7 +1983,7 @@
         {
           "direction": "client-to-server",
           "source": "server/services/socket.js",
-          "line": 129
+          "line": 130
         }
       ]
     },
@@ -1996,7 +1996,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 146
+          "line": 147
         }
       ]
     },
@@ -2014,7 +2014,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 137
+          "line": 138
         }
       ]
     },
@@ -2050,7 +2050,7 @@
         {
           "direction": "client-to-server",
           "source": "server/services/socket.js",
-          "line": 121
+          "line": 122
         }
       ]
     },
@@ -2063,7 +2063,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 121
+          "line": 122
         }
       ]
     },
@@ -2081,7 +2081,7 @@
         {
           "direction": "client-to-server",
           "source": "server/services/socket.js",
-          "line": 121
+          "line": 122
         }
       ]
     },
@@ -2094,7 +2094,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 121
+          "line": 122
         }
       ]
     },
@@ -2204,7 +2204,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 549
+          "line": 565
         }
       ]
     },
@@ -2242,7 +2242,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 552
+          "line": 568
         }
       ]
     },
@@ -2275,7 +2275,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 546
+          "line": 562
         }
       ]
     },
@@ -2308,7 +2308,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 543
+          "line": 559
         }
       ]
     },
@@ -2326,12 +2326,12 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 114
+          "line": 115
         },
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 241
+          "line": 257
         }
       ]
     },
@@ -2349,7 +2349,7 @@
         {
           "direction": "client-to-server",
           "source": "server/services/socket.js",
-          "line": 112
+          "line": 113
         }
       ]
     },
@@ -2367,7 +2367,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 481
+          "line": 497
         }
       ]
     },
@@ -2385,7 +2385,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 480
+          "line": 496
         }
       ]
     },
@@ -2403,7 +2403,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 478
+          "line": 494
         }
       ]
     },
@@ -2421,7 +2421,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 479
+          "line": 495
         }
       ]
     },
@@ -2439,7 +2439,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 477
+          "line": 493
         }
       ]
     },
@@ -2462,7 +2462,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 466
+          "line": 482
         }
       ]
     },
@@ -2480,7 +2480,7 @@
         {
           "direction": "client-to-server",
           "source": "server/services/socket.js",
-          "line": 124
+          "line": 125
         }
       ]
     },
@@ -2493,7 +2493,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 124
+          "line": 125
         }
       ]
     },
@@ -2511,7 +2511,7 @@
         {
           "direction": "client-to-server",
           "source": "server/services/socket.js",
-          "line": 124
+          "line": 125
         }
       ]
     },
@@ -2524,7 +2524,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 124
+          "line": 125
         }
       ]
     },
@@ -2778,7 +2778,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 525
+          "line": 541
         }
       ]
     },
@@ -2791,7 +2791,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 528
+          "line": 544
         }
       ]
     },
@@ -2809,7 +2809,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 531
+          "line": 547
         }
       ]
     },
@@ -2827,7 +2827,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 532
+          "line": 548
         }
       ]
     },
@@ -2845,7 +2845,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 530
+          "line": 546
         }
       ]
     },
@@ -2863,7 +2863,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 533
+          "line": 549
         }
       ]
     },
@@ -2876,7 +2876,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 527
+          "line": 543
         }
       ]
     },
@@ -2889,7 +2889,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 526
+          "line": 542
         }
       ]
     },
@@ -2902,7 +2902,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 529
+          "line": 545
         }
       ]
     },
@@ -2920,7 +2920,7 @@
         {
           "direction": "client-to-server",
           "source": "server/services/socket.js",
-          "line": 125
+          "line": 126
         }
       ]
     },
@@ -2933,7 +2933,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 125
+          "line": 126
         }
       ]
     },
@@ -2951,7 +2951,7 @@
         {
           "direction": "client-to-server",
           "source": "server/services/socket.js",
-          "line": 125
+          "line": 126
         }
       ]
     },
@@ -2964,7 +2964,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 125
+          "line": 126
         }
       ]
     },
@@ -3182,7 +3182,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 444
+          "line": 460
         }
       ]
     },
@@ -3200,7 +3200,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 441
+          "line": 457
         }
       ]
     },
@@ -3218,7 +3218,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 445
+          "line": 461
         }
       ]
     },
@@ -3236,7 +3236,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 446
+          "line": 462
         }
       ]
     },
@@ -3254,7 +3254,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 442
+          "line": 458
         }
       ]
     },
@@ -3272,7 +3272,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 451
+          "line": 467
         }
       ]
     },
@@ -3290,7 +3290,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 453
+          "line": 469
         }
       ]
     },
@@ -3308,7 +3308,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 452
+          "line": 468
         }
       ]
     },
@@ -3326,7 +3326,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 440
+          "line": 456
         }
       ]
     },
@@ -3344,7 +3344,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 443
+          "line": 459
         }
       ]
     },
@@ -3375,7 +3375,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 273
+          "line": 289
         }
       ]
     },
@@ -3388,7 +3388,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 279
+          "line": 295
         }
       ]
     },
@@ -3406,7 +3406,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 402
+          "line": 418
         }
       ]
     },
@@ -3429,7 +3429,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 406
+          "line": 422
         }
       ]
     },
@@ -3452,7 +3452,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 405
+          "line": 421
         }
       ]
     },
@@ -3470,7 +3470,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 403
+          "line": 419
         }
       ]
     },
@@ -3493,7 +3493,7 @@
         {
           "direction": "client-to-server",
           "source": "server/services/socket.js",
-          "line": 122
+          "line": 123
         }
       ]
     },
@@ -3506,7 +3506,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 122
+          "line": 123
         }
       ]
     },
@@ -3519,7 +3519,7 @@
         {
           "direction": "client-to-server",
           "source": "server/services/socket.js",
-          "line": 122
+          "line": 123
         }
       ]
     },
@@ -3532,7 +3532,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 122
+          "line": 123
         }
       ]
     },
@@ -3550,7 +3550,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 404
+          "line": 420
         }
       ]
     },
@@ -3640,7 +3640,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 507
+          "line": 523
         }
       ]
     },
@@ -3653,7 +3653,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 512
+          "line": 528
         }
       ]
     },
@@ -3766,7 +3766,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 490
+          "line": 506
         }
       ]
     },
@@ -3789,7 +3789,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 496
+          "line": 512
         }
       ]
     },
@@ -3812,7 +3812,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 493
+          "line": 509
         }
       ]
     },
@@ -4400,7 +4400,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 471
+          "line": 487
         }
       ]
     },
@@ -4418,7 +4418,7 @@
         {
           "direction": "server-to-client",
           "source": "server/lib/errorHandler.js",
-          "line": 330
+          "line": 337
         }
       ]
     },
@@ -4493,7 +4493,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 562
+          "line": 578
         }
       ]
     },
@@ -4506,7 +4506,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 565
+          "line": 581
         }
       ]
     },
@@ -4519,7 +4519,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 559
+          "line": 575
         }
       ]
     },
@@ -4532,7 +4532,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 556
+          "line": 572
         }
       ]
     },
@@ -4550,7 +4550,7 @@
         {
           "direction": "client-to-server",
           "source": "server/sockets/voice.js",
-          "line": 468
+          "line": 469
         }
       ]
     },
@@ -4568,7 +4568,7 @@
         {
           "direction": "client-to-server",
           "source": "server/sockets/voice.js",
-          "line": 495
+          "line": 496
         }
       ]
     },
@@ -4591,7 +4591,25 @@
         {
           "direction": "client-to-server",
           "source": "server/sockets/voice.js",
-          "line": 534
+          "line": 535
+        }
+      ]
+    },
+    {
+      "event": "voice:call:hangup",
+      "directions": [
+        "client-to-server"
+      ],
+      "sources": [
+        {
+          "direction": "client-to-server",
+          "source": "client/src/components/cos/tabs/MindTab.jsx",
+          "line": 354
+        },
+        {
+          "direction": "client-to-server",
+          "source": "server/sockets/voice.js",
+          "line": 545
         }
       ]
     },
@@ -4603,23 +4621,33 @@
       "sources": [
         {
           "direction": "server-to-client",
+          "source": "client/src/components/cos/tabs/MindTab.jsx",
+          "line": 346
+        },
+        {
+          "direction": "server-to-client",
           "source": "client/src/pages/VoiceCallHost.jsx",
           "line": 248
         },
         {
           "direction": "server-to-client",
-          "source": "server/sockets/voice.js",
-          "line": 424
+          "source": "server/services/socket.js",
+          "line": 230
         },
         {
           "direction": "server-to-client",
           "source": "server/sockets/voice.js",
-          "line": 476
+          "line": 425
         },
         {
           "direction": "server-to-client",
           "source": "server/sockets/voice.js",
-          "line": 483
+          "line": 477
+        },
+        {
+          "direction": "server-to-client",
+          "source": "server/sockets/voice.js",
+          "line": 484
         }
       ]
     },
@@ -4637,12 +4665,12 @@
         {
           "direction": "server-to-client",
           "source": "server/sockets/voice.js",
-          "line": 415
+          "line": 416
         },
         {
           "direction": "server-to-client",
           "source": "server/sockets/voice.js",
-          "line": 451
+          "line": 452
         }
       ]
     },
@@ -4660,7 +4688,7 @@
         {
           "direction": "client-to-server",
           "source": "server/sockets/voice.js",
-          "line": 572
+          "line": 586
         }
       ]
     },
@@ -4678,22 +4706,22 @@
         {
           "direction": "server-to-client",
           "source": "server/sockets/voice.js",
-          "line": 548
+          "line": 562
         },
         {
           "direction": "server-to-client",
           "source": "server/sockets/voice.js",
-          "line": 576
+          "line": 590
         },
         {
           "direction": "server-to-client",
           "source": "server/sockets/voice.js",
-          "line": 581
+          "line": 595
         },
         {
           "direction": "server-to-client",
           "source": "server/sockets/voice.js",
-          "line": 586
+          "line": 600
         }
       ]
     },
@@ -4716,7 +4744,7 @@
         {
           "direction": "client-to-server",
           "source": "server/sockets/voice.js",
-          "line": 599
+          "line": 613
         }
       ]
     },
@@ -4734,17 +4762,17 @@
         {
           "direction": "server-to-client",
           "source": "server/sockets/voice.js",
-          "line": 261
+          "line": 262
         },
         {
           "direction": "server-to-client",
           "source": "server/sockets/voice.js",
-          "line": 285
+          "line": 286
         },
         {
           "direction": "server-to-client",
           "source": "server/sockets/voice.js",
-          "line": 290
+          "line": 291
         }
       ]
     },
@@ -4767,7 +4795,7 @@
         {
           "direction": "client-to-server",
           "source": "server/sockets/voice.js",
-          "line": 278
+          "line": 279
         }
       ]
     },
@@ -4785,82 +4813,82 @@
         {
           "direction": "server-to-client",
           "source": "server/sockets/voice.js",
-          "line": 169
+          "line": 170
         },
         {
           "direction": "server-to-client",
           "source": "server/sockets/voice.js",
-          "line": 182
+          "line": 183
         },
         {
           "direction": "server-to-client",
           "source": "server/sockets/voice.js",
-          "line": 191
+          "line": 192
         },
         {
           "direction": "server-to-client",
           "source": "server/sockets/voice.js",
-          "line": 196
+          "line": 197
         },
         {
           "direction": "server-to-client",
           "source": "server/sockets/voice.js",
-          "line": 200
+          "line": 201
         },
         {
           "direction": "server-to-client",
           "source": "server/sockets/voice.js",
-          "line": 216
+          "line": 217
         },
         {
           "direction": "server-to-client",
           "source": "server/sockets/voice.js",
-          "line": 225
+          "line": 226
         },
         {
           "direction": "server-to-client",
           "source": "server/sockets/voice.js",
-          "line": 230
+          "line": 231
         },
         {
           "direction": "server-to-client",
           "source": "server/sockets/voice.js",
-          "line": 234
+          "line": 235
         },
         {
           "direction": "server-to-client",
           "source": "server/sockets/voice.js",
-          "line": 240
+          "line": 241
         },
         {
           "direction": "server-to-client",
           "source": "server/sockets/voice.js",
-          "line": 293
+          "line": 294
         },
         {
           "direction": "server-to-client",
           "source": "server/sockets/voice.js",
-          "line": 461
+          "line": 462
         },
         {
           "direction": "server-to-client",
           "source": "server/sockets/voice.js",
-          "line": 491
+          "line": 492
         },
         {
           "direction": "server-to-client",
           "source": "server/sockets/voice.js",
-          "line": 559
+          "line": 573
         },
         {
           "direction": "server-to-client",
           "source": "server/sockets/voice.js",
-          "line": 595
+          "line": 609
         },
         {
           "direction": "server-to-client",
           "source": "server/sockets/voice.js",
-          "line": 613
+          "line": 627
         }
       ]
     },
@@ -4878,17 +4906,17 @@
         {
           "direction": "server-to-client",
           "source": "server/sockets/voice.js",
-          "line": 170
+          "line": 171
         },
         {
           "direction": "server-to-client",
           "source": "server/sockets/voice.js",
-          "line": 250
+          "line": 251
         },
         {
           "direction": "server-to-client",
           "source": "server/sockets/voice.js",
-          "line": 262
+          "line": 263
         }
       ]
     },
@@ -4922,12 +4950,12 @@
         {
           "direction": "client-to-server",
           "source": "server/sockets/voice.js",
-          "line": 244
+          "line": 245
         },
         {
           "direction": "server-to-client",
           "source": "server/sockets/voice.js",
-          "line": 514
+          "line": 515
         }
       ]
     },
@@ -4945,7 +4973,7 @@
         {
           "direction": "client-to-server",
           "source": "server/sockets/voice.js",
-          "line": 378
+          "line": 379
         }
       ]
     },
@@ -4963,7 +4991,7 @@
         {
           "direction": "client-to-server",
           "source": "server/sockets/voice.js",
-          "line": 386
+          "line": 387
         }
       ]
     },
@@ -5012,7 +5040,7 @@
         {
           "direction": "client-to-server",
           "source": "server/sockets/voice.js",
-          "line": 253
+          "line": 254
         }
       ]
     },
@@ -5030,7 +5058,7 @@
         {
           "direction": "client-to-server",
           "source": "server/sockets/voice.js",
-          "line": 338
+          "line": 339
         }
       ]
     },
@@ -5066,7 +5094,7 @@
         {
           "direction": "client-to-server",
           "source": "server/sockets/voice.js",
-          "line": 220
+          "line": 221
         }
       ]
     },
@@ -5115,7 +5143,7 @@
         {
           "direction": "client-to-server",
           "source": "server/sockets/voice.js",
-          "line": 186
+          "line": 187
         }
       ]
     },
@@ -5133,7 +5161,7 @@
         {
           "direction": "client-to-server",
           "source": "server/sockets/voice.js",
-          "line": 301
+          "line": 302
         }
       ]
     },
@@ -5164,7 +5192,7 @@
         {
           "direction": "client-to-server",
           "source": "server/sockets/voice.js",
-          "line": 356
+          "line": 357
         }
       ]
     },
@@ -5182,14 +5210,14 @@
         {
           "direction": "server-to-client",
           "source": "server/services/socket.js",
-          "line": 261
+          "line": 277
         }
       ]
     }
   ],
   "stats": {
-    "events": 262,
-    "clientToServer": 62,
+    "events": 263,
+    "clientToServer": 63,
     "serverToClient": 209,
     "bidirectional": 9,
     "sourceFiles": 104

--- a/server/routes/voice.js
+++ b/server/routes/voice.js
@@ -48,6 +48,7 @@ const voiceConfigPatchSchema = z.object({
     blackHole16chLabel: z.string().trim().min(1).max(120).optional(),
     escalateCritical: z.boolean().optional(),
     escalateAfterMinutes: z.number().int().min(1).max(1440).optional(),
+    autoAnswer: z.boolean().optional(),
   }).partial().optional(),
   stt: z.object({
     engine: z.enum(['whisper', 'web-speech']).optional(),

--- a/server/routes/voice.test.js
+++ b/server/routes/voice.test.js
@@ -144,6 +144,24 @@ describe('Voice Routes', () => {
       expect(config.updateVoiceConfig).toHaveBeenCalledWith(patch);
     });
 
+    it('accepts a facetime.autoAnswer patch', async () => {
+      config.updateVoiceConfig.mockResolvedValue({ ...DEFAULT_CFG });
+      bootstrap.reconcile.mockResolvedValue({ skipped: true });
+      const patch = { facetime: { autoAnswer: true } };
+      const res = await request(buildApp()).put('/api/voice/config').send(patch);
+      expect(res.status).toBe(200);
+      expect(config.updateVoiceConfig).toHaveBeenCalledWith(patch);
+    });
+
+    it('rejects a non-boolean facetime.autoAnswer', async () => {
+      const res = await request(buildApp())
+        .put('/api/voice/config')
+        .send({ facetime: { autoAnswer: 'yes' } });
+      expect(res.status).toBe(400);
+      expect(res.body.code).toBe('VALIDATION_ERROR');
+      expect(config.updateVoiceConfig).not.toHaveBeenCalled();
+    });
+
     it('rejects out-of-range fastPath.browser params', async () => {
       const res = await request(buildApp())
         .put('/api/voice/config')

--- a/server/services/persistentMindCallCapability.js
+++ b/server/services/persistentMindCallCapability.js
@@ -76,14 +76,16 @@ const trimmedIdentity = (config) => ({
 });
 
 /**
- * Render the bounded briefing the call runs with, so the voice on the phone is
- * continuous with the mind rather than a stranger who happens to share a voice.
+ * Render the bounded briefing a call runs with, so the voice on the phone is
+ * continuous with the mind rather than a stranger who happens to share a
+ * voice. `intro` sets the scene (outbound vs inbound) — everything else is
+ * shared between the two directions.
  *
  * Deliberately built without a summarizer: this runs on the mind's own turn,
  * and a call must never trigger an extra provider round the user did not ask
  * for. An unsummarized older history simply reads as unavailable.
  */
-async function buildCallContext(reason) {
+async function buildCallContext(intro) {
   const root = await loadState();
   const prompt = normalizePersistentMindPrompt(root.config?.persistentMindPrompt);
   const memories = await readPersistentMindMemories(PERSISTENT_MIND_ID);
@@ -94,11 +96,17 @@ async function buildCallContext(reason) {
     memories,
     maxChars: CALL_CONTEXT_MAX_CHARS,
   });
-  return [
-    'You are speaking on a phone call that you placed to the user. Keep it short, say why you called, and let them talk.',
-    `# Why you called\n${reason}`,
-    context.text,
-  ].join('\n\n').slice(0, CALL_CONTEXT_MAX_CHARS * 2);
+  return [intro, context.text].join('\n\n').slice(0, CALL_CONTEXT_MAX_CHARS * 2);
+}
+
+/**
+ * The inbound counterpart of the briefing above — used when the user calls
+ * PortOS back and the incoming-call watcher (`callSession.js#pollIncoming`)
+ * answers with the Persistent Mind running. No `reason` exists for a call the
+ * mind did not decide to place, so the intro just orients it to the situation.
+ */
+export async function buildInboundCallContext() {
+  return buildCallContext('You are on a phone call the user placed to reach you directly (they called you, not the other way around). Keep it short, greet them, and let them talk.');
 }
 
 /**
@@ -241,7 +249,9 @@ export async function requestUserCall({
   const verdict = persistentMindCallRateVerdict(root.persistentMind, now, PERSISTENT_MIND_CALL_LIMITS);
   if (!verdict.ok) return finish(suppressed(verdict.reason, { retryAt: verdict.retryAt }));
 
-  const context = await buildCallContext(request.reason).catch((error) => {
+  const context = await buildCallContext(
+    `You are speaking on a phone call that you placed to the user. Keep it short, say why you called, and let them talk.\n\n# Why you called\n${request.reason}`,
+  ).catch((error) => {
     // A briefing that could not be assembled is not a reason to leave the user
     // uncalled; the opening line alone still carries the message.
     console.error(`❌ mind call: context assembly failed: ${error.message}`);

--- a/server/services/socket.js
+++ b/server/services/socket.js
@@ -25,6 +25,7 @@ import { videoGenEvents } from './videoGen/events.js';
 import { audioGenEvents } from './audioGen/events.js';
 import { aiStatusEvents } from './aiStatusEvents.js';
 import { wireProactiveTriggers } from './voice/proactiveTriggers.js';
+import { callStateEvents } from './voice/callSession.js';
 import {
   validateSocketData,
   errorRecoverSchema
@@ -206,6 +207,7 @@ function setupEventForwarding() {
   setupMusicVideoEventForwarding();
   setupProactiveSpeechForwarding();
   setupPersistentMindEventForwarding();
+  setupCallStateEventForwarding();
 }
 
 let persistentMindEventForwardingSetup = false;
@@ -213,6 +215,20 @@ function setupPersistentMindEventForwarding() {
   if (persistentMindEventForwardingSetup) return;
   persistentMindEventForwardingSetup = true;
   runEventLogEvents.on('mind:event', (event) => broadcastToCos('cos:mind:event', event));
+}
+
+// The call-host tab already gets `voice:call:state` directly from its own
+// socket handler (server/sockets/voice.js — it drives that socket's opening-
+// line delivery too). This is the read-only fan-out to every OTHER tab, so a
+// view like the Mind tab's active-call chip can show/hide without being the
+// tab carrying the audio.
+let callStateForwardingSetup = false;
+function setupCallStateEventForwarding() {
+  if (callStateForwardingSetup) return;
+  callStateForwardingSetup = true;
+  callStateEvents.on('state', (snapshot) => {
+    if (ioInstance) ioInstance.emit('voice:call:state', snapshot);
+  });
 }
 
 export function initSocket(io) {

--- a/server/services/voice/callSession.js
+++ b/server/services/voice/callSession.js
@@ -6,7 +6,7 @@
  * call is up, whether anyone can hear it, when to give up, and what is written
  * down afterwards.
  *
- * Three deliberate constraints:
+ * Four deliberate constraints:
  *
  * - **One call, one host.** A second call-host tab is refused rather than
  *   allowed to double-answer, mirroring the single-attach shell-session
@@ -18,11 +18,24 @@
  * - **Only text is kept.** The transcript goes to the daily journal like any
  *   other voice turn. The audio is never persisted, and the configured handle
  *   never appears in what is written down.
+ * - **Answering is fail-closed, and reading is not answering.** The incoming
+ *   watcher (`pollIncoming`) is only ever armed while a call-host tab is
+ *   attached (`attachHost`/`detachHost`), so it never runs unobserved. Within
+ *   a tick, `probe()` is a safe read — it never presses anything, and the
+ *   native helper reports nothing distinguishing "no call" from "a caller who
+ *   is not the configured identity" (fail-closed at the helper boundary), so
+ *   this module never learns an unauthorized caller exists and never logs
+ *   one. Only `answer()` — the press — is additionally gated on the host
+ *   being attached *at press time*, because answering a call nobody can hear
+ *   is worse than missing it.
  */
 
 import { appendJournal, getToday } from '../brainJournal.js';
 import * as facetimeBridge from './facetimeBridge.js';
 import { getVoiceConfig } from './config.js';
+import { getLocalMinutes, isWithinQuietHours } from './proactiveSpeech.js';
+import { addNotification, NOTIFICATION_TYPES, PRIORITY_LEVELS } from '../notifications.js';
+import { EventEmitter } from 'events';
 
 export const CALL_STATES = ['idle', 'dialing', 'connected', 'listening', 'speaking', 'ended'];
 export const PROBE_INTERVAL_MS = 2_000;
@@ -37,13 +50,19 @@ const initialState = () => ({
   lastVoiceAt: null,
   endedReason: null,
   transcript: [],
-  // Set only for a call PortOS placed on its own initiative. `origin` decides
-  // whether the transcript is handed back to the persistent mind afterwards;
-  // `openingLine` is what the call host speaks the moment the far end picks up
-  // (consumed once, so a state re-emit cannot make it say it twice).
+  // 'user' — PortOS placed this call on request. 'mind' — the Persistent Mind
+  // placed it (voice.call-user). 'inbound' — the user called PortOS and the
+  // autoAnswer watcher answered it. `origin` decides whether the transcript
+  // is handed back to the persistent mind afterwards; `openingLine` is what
+  // the call host speaks the moment the far end picks up (consumed once, so a
+  // state re-emit cannot make it say it twice).
   origin: 'user',
   openingLine: '',
   context: null,
+  // Only meaningful for `origin === 'inbound'`: whether the Persistent Mind
+  // was running at the moment the call was answered. Captured once so a mind
+  // that starts or stops mid-call cannot flip the hangup handoff decision.
+  mindEnabled: false,
 });
 
 let session = initialState();
@@ -51,21 +70,56 @@ let host = null;
 let timer = null;
 let listener = null;
 
+// Broadcast sink for anything other than the call-host socket — the Mind tab
+// wants to show an active-call chip regardless of which tab is carrying the
+// audio. `listener` above stays a single slot owned by the attached host
+// (it also drives that socket's opening-line delivery); this is a plain
+// multi-subscriber event, mirroring `notificationEvents` in notifications.js.
+export const callStateEvents = new EventEmitter();
+
 // Injectable so the state machine can be driven with stubs and fake timers
 // instead of a real helper and a real call.
 // Imported lazily: the persistent-mind supervisor pulls in a large service
-// graph, and a call the mind did not place never needs it.
+// graph, and a call the mind did not place — or answer — never needs it.
 const enqueueMindMessage = async (text) => {
   const { enqueuePersistentMindMessage } = await import('../persistentMindSupervisor.js');
   return enqueuePersistentMindMessage({ text });
 };
 
+const isMindEnabled = async () => {
+  const { getPersistentMindState } = await import('../persistentMindSupervisor.js');
+  const state = await getPersistentMindState();
+  return Boolean(state?.enabled);
+};
+
+const buildInboundContext = async () => {
+  const { buildInboundCallContext } = await import('../persistentMindCallCapability.js');
+  return buildInboundCallContext();
+};
+
+const MISSED_CALL_TITLES = {
+  'no-host': 'Missed call from you — the call host was not attached',
+  'helper-failed': 'Missed call from you — the FaceTime helper failed to answer',
+};
+
+const notifyMissedCall = async (reason) => addNotification({
+  type: NOTIFICATION_TYPES.AGENT_WARNING,
+  title: MISSED_CALL_TITLES[reason] || 'Missed call from you',
+  description: 'An incoming call from your configured identity rang and PortOS could not answer it automatically.',
+  priority: PRIORITY_LEVELS.MEDIUM,
+  metadata: { source: 'voice-facetime-incoming', reason },
+});
+
 const defaultDeps = () => ({
   probe: facetimeBridge.probe,
   call: facetimeBridge.call,
+  answer: facetimeBridge.answer,
   hangup: facetimeBridge.hangup,
   appendJournal,
   enqueueMindMessage,
+  isMindEnabled,
+  buildInboundContext,
+  notifyMissedCall,
   now: Date.now,
 });
 
@@ -94,6 +148,7 @@ const emitState = () => {
   } catch (error) {
     console.error(`❌ voice call: state listener failed: ${error.message}`);
   }
+  callStateEvents.emit('state', snapshot);
   return snapshot;
 };
 
@@ -133,6 +188,9 @@ export function attachHost(socket) {
   if (host && host !== socket && host.connected !== false) return { ok: false, reason: 'host-taken' };
   host = socket;
   console.log(`📞 voice call: host attached (${socket?.id ?? 'socket'})`);
+  // Arm the incoming-call watcher now that something could carry the audio.
+  // Idempotent on a reconnect of the same socket.
+  startIncomingWatcher();
   return { ok: true, state: emitState() };
 }
 
@@ -140,6 +198,8 @@ export async function detachHost(socket) {
   if (host !== socket) return publicState();
   host = null;
   console.log('📞 voice call: host detached');
+  // Never poll for an incoming call with nothing attached to carry it.
+  stopIncomingWatcher();
   // Losing the host loses the audio path, so an in-flight call is ended rather
   // than left running deaf.
   if (publicState().active) return endCall('host-detached');
@@ -200,6 +260,168 @@ const startPolling = () => {
   }, PROBE_INTERVAL_MS);
   timer.unref?.();
 };
+
+// ---------------------------------------------------------------------------
+// Incoming watcher — armed only while a call-host tab is attached (see
+// attachHost/detachHost above). Separate timer from the active-call poll
+// above: this one runs while the session is *idle*, watching for a call
+// PortOS did not place.
+// ---------------------------------------------------------------------------
+
+let incomingTimer = null;
+// Edge-detected so a ring that keeps being reported "authorized" for several
+// ticks in a row (waiting on a slow answer, or unanswerable because the host
+// went away) produces exactly one notification/answer attempt per ring, not
+// one every 2 seconds for as long as it rings.
+let incomingRingActive = false;
+
+const stopIncomingWatcher = () => {
+  if (incomingTimer) clearInterval(incomingTimer);
+  incomingTimer = null;
+  incomingRingActive = false;
+};
+
+const startIncomingWatcher = () => {
+  stopIncomingWatcher();
+  incomingTimer = setInterval(() => {
+    pollIncoming().catch((error) => console.error(`❌ voice call: incoming poll failed: ${error.message}`));
+  }, PROBE_INTERVAL_MS);
+  incomingTimer.unref?.();
+};
+
+const recordMissedCall = async (reason) => {
+  try {
+    await deps.notifyMissedCall(reason);
+  } catch (error) {
+    console.error(`❌ voice call: missed-call notification failed: ${error.message}`);
+  }
+};
+
+/**
+ * Compute the greeting an answered call opens with. Quiet hours change the
+ * style only, per the decided approach — they never decide whether to
+ * answer; the user placed the call, so PortOS answers at any hour.
+ */
+async function buildInboundGreeting(config) {
+  const persona = config?.llm?.personality?.name?.trim() || 'PortOS';
+  const quietHours = config?.llm?.proactive?.quietHours;
+  let quiet = false;
+  if (quietHours?.enabled) {
+    const nowMinutes = await getLocalMinutes();
+    quiet = isWithinQuietHours({ start: quietHours.start, end: quietHours.end, nowMinutes });
+  }
+  return quiet
+    ? `Hi, this is ${persona}. It's late, so I'll keep this brief — go ahead.`
+    : `Hi, this is ${persona}. Go ahead.`;
+}
+
+/**
+ * Take over the session for a call the helper just answered on our behalf.
+ * Skips `dialing` entirely — the helper already reports the call live — and
+ * reuses the same `listening` transition the outbound flow drives the
+ * opening-line delivery from (see `deliverOpeningLine` in sockets/voice.js).
+ */
+async function beginAnsweredCall(config) {
+  const greeting = await buildInboundGreeting(config);
+
+  let mindEnabled = false;
+  try {
+    mindEnabled = await deps.isMindEnabled();
+  } catch (error) {
+    console.error(`❌ voice call: mind status check failed: ${error.message}`);
+  }
+
+  let context = null;
+  if (mindEnabled) {
+    context = await deps.buildInboundContext().catch((error) => {
+      // A briefing that failed to assemble is not a reason to leave the call
+      // unanswered — the plain persona still carries the conversation.
+      console.error(`❌ voice call: inbound context assembly failed: ${error.message}`);
+      return null;
+    });
+  }
+
+  session = {
+    ...initialState(),
+    state: 'connected',
+    startedAt: deps.now(),
+    lastVoiceAt: deps.now(),
+    origin: 'inbound',
+    openingLine: greeting,
+    context,
+    mindEnabled,
+  };
+  emitState();
+  setState('listening');
+  startPolling();
+}
+
+/**
+ * One incoming-watch tick. Exported so a test can drive it directly, exactly
+ * like `pollCall` — including with `host` unset, which the production timer
+ * itself never does (see attachHost/detachHost), but which is exactly the
+ * "no host attached" failure mode `pollIncoming` still has to handle
+ * defensively (a host that detaches in the gap between this tick starting
+ * and the answer attempt landing is a real, if narrow, race).
+ */
+export async function pollIncoming() {
+  const config = await getVoiceConfig();
+  if (!config?.facetime?.autoAnswer) {
+    incomingRingActive = false;
+    return { checked: false, reason: 'auto-answer-off' };
+  }
+  if (publicState().active) return { checked: false, reason: 'call-in-progress' };
+
+  let observed = null;
+  try {
+    observed = await deps.probe();
+  } catch (error) {
+    // Mirrors pollCall: a probe that cannot answer is unknown, not evidence
+    // of anything — and never carries caller identity, so this is safe to log.
+    console.error(`❌ voice call: incoming probe failed: ${error.message}`);
+    return { checked: false, reason: 'probe-failed' };
+  }
+
+  // The helper reports nothing distinguishing "no call" from "a caller who is
+  // not the configured identity" — fail-closed at the helper boundary. Reused
+  // here: `authorized` on an idle-session probe means "the ringing caller
+  // matches the configured identity", never "no call at all".
+  const ringing = Boolean(observed?.authorized) && observed?.state === 'dialing';
+  if (!ringing) {
+    incomingRingActive = false;
+    return { checked: true, incoming: false };
+  }
+  if (incomingRingActive) return { checked: true, incoming: true, deduped: true };
+  incomingRingActive = true;
+
+  if (!host) {
+    await recordMissedCall('no-host');
+    return { checked: true, incoming: true, answered: false, reason: 'no-host' };
+  }
+
+  let result = null;
+  try {
+    result = await deps.answer();
+  } catch (error) {
+    console.error(`❌ voice call: incoming answer failed: ${error.message}`);
+    await recordMissedCall('helper-failed');
+    return { checked: true, incoming: true, answered: false, reason: 'helper-failed' };
+  }
+  if (!result?.ok) {
+    await recordMissedCall('helper-failed');
+    return { checked: true, incoming: true, answered: false, reason: 'helper-failed' };
+  }
+
+  // Reset the edge detector now: once answered, `publicState().active` short-
+  // circuits every tick for the rest of the call (see the top of this
+  // function), so the "ring stopped" branch above never runs again to clear
+  // it — leaving it stuck `true` would make the *next* genuine incoming call,
+  // after this one ends, look like a duplicate of this one and be silently
+  // skipped forever.
+  incomingRingActive = false;
+  await beginAnsweredCall(config);
+  return { checked: true, incoming: true, answered: true };
+}
 
 /**
  * Place a call. Fails closed when nothing can carry the audio.
@@ -268,6 +490,7 @@ export async function endCall(reason = 'ended') {
   stopPolling();
   const transcript = session.transcript;
   const origin = session.origin;
+  const mindEnabled = session.mindEnabled;
   session.endedReason = reason;
   setState('ended');
 
@@ -294,10 +517,18 @@ export async function endCall(reason = 'ended') {
   // thing — including after a call nobody picked up, which is exactly when an
   // empty transcript would otherwise leave it uninformed. Best-effort for the
   // same reason the journal append is.
-  if (origin === 'mind') {
+  //
+  // An answered inbound call gets the same handoff, but only when the mind
+  // was actually running when it was answered — an inbound call answered
+  // with the mind off ran the plain voice persona, and telling a mind that
+  // never took part about a conversation it did not have would be noise, not
+  // continuity.
+  const handToMind = origin === 'mind' || (origin === 'inbound' && mindEnabled);
+  if (handToMind) {
+    const verb = origin === 'mind' ? 'placed' : 'answered';
     try {
       await deps.enqueueMindMessage(
-        `Outcome of the FaceTime Audio call you placed (ended: ${reason}):\n${
+        `Outcome of the FaceTime Audio call you ${verb} (ended: ${reason}):\n${
           transcript.length ? renderTranscript(transcript) : 'The call ended with nothing said.'
         }`.slice(0, MIND_TRANSCRIPT_MAX_CHARS),
       );
@@ -313,8 +544,10 @@ export async function endCall(reason = 'ended') {
 /** Test helper — drop all state between cases. */
 export const __resetCallSession = () => {
   stopPolling();
+  stopIncomingWatcher();
   session = initialState();
   host = null;
   listener = null;
+  callStateEvents.removeAllListeners();
   __setCallSessionDeps();
 };

--- a/server/services/voice/callSession.test.js
+++ b/server/services/voice/callSession.test.js
@@ -6,15 +6,32 @@ vi.mock('./config.js', () => ({ getVoiceConfig: vi.fn() }));
 // appendJournal's isIsoDate() guard silently rejected, so no transcript was ever
 // written. The mock has to match the real signature for the assertion to mean anything.
 vi.mock('../brainJournal.js', () => ({ appendJournal: vi.fn(), getToday: async () => '2026-08-29' }));
-vi.mock('./facetimeBridge.js', () => ({ probe: vi.fn(), call: vi.fn(), hangup: vi.fn() }));
+vi.mock('./facetimeBridge.js', () => ({ probe: vi.fn(), call: vi.fn(), answer: vi.fn(), hangup: vi.fn() }));
+vi.mock('../notifications.js', () => ({
+  addNotification: vi.fn().mockResolvedValue({ id: 'notif-1' }),
+  NOTIFICATION_TYPES: { AGENT_WARNING: 'agent_warning' },
+  PRIORITY_LEVELS: { LOW: 'low', MEDIUM: 'medium', HIGH: 'high', CRITICAL: 'critical' },
+}));
+// Real proactiveSpeech.js pulls in tts.js (Kokoro/Piper), which reads
+// voiceHome() at module-load time — importing it for real here would need the
+// whole TTS engine graph booted just to compute a quiet-hours boolean. Only
+// the wall clock behind isWithinQuietHours is injected; the predicate itself
+// is the real one so the overnight-wrap logic is genuinely exercised.
+vi.mock('./proactiveSpeech.js', async () => ({
+  isWithinQuietHours: (await import('../../lib/timezone.js')).isWithinTimeWindow,
+  getLocalMinutes: vi.fn(async () => 12 * 60),
+}));
 
 import { getVoiceConfig } from './config.js';
+import { addNotification } from '../notifications.js';
+import { getLocalMinutes } from './proactiveSpeech.js';
 import {
   PROBE_INTERVAL_MS,
   SILENCE_HANGUP_MS,
   __resetCallSession,
   __setCallSessionDeps,
   attachHost,
+  callStateEvents,
   detachHost,
   endCall,
   getCallContext,
@@ -22,6 +39,7 @@ import {
   markSpeaking,
   noteCallerSpeech,
   pollCall,
+  pollIncoming,
   recordTurn,
   setCallStateListener,
   startCall,
@@ -33,27 +51,35 @@ const socket = (id = 'host-1') => ({ id, connected: true, emit: vi.fn() });
 let clock;
 let probe;
 let call;
+let answer;
 let hangup;
 let appendJournal;
 let enqueueMindMessage;
+let isMindEnabled;
+let buildInboundContext;
 
 const install = (overrides = {}) => {
   clock = 1_000_000;
   probe = vi.fn().mockResolvedValue({ state: 'connected' });
   call = vi.fn().mockResolvedValue({ state: 'dialing' });
+  answer = vi.fn().mockResolvedValue({ ok: true, command: 'answer', state: 'connected', authorized: true, action: 'press-notification-action', message: 'Answered', errorCode: null });
   hangup = vi.fn().mockResolvedValue({ state: 'ended' });
   appendJournal = vi.fn().mockResolvedValue({});
   enqueueMindMessage = vi.fn().mockResolvedValue({ success: true });
-  __setCallSessionDeps({ probe, call, hangup, appendJournal, enqueueMindMessage, now: () => clock, ...overrides });
+  isMindEnabled = vi.fn().mockResolvedValue(false);
+  buildInboundContext = vi.fn().mockResolvedValue('# Persistent mind identity');
+  __setCallSessionDeps({ probe, call, answer, hangup, appendJournal, enqueueMindMessage, isMindEnabled, buildInboundContext, now: () => clock, ...overrides });
 };
 
 beforeEach(() => {
   __resetCallSession();
   install();
   getVoiceConfig.mockResolvedValue({ facetime: { maxCallMinutes: 15 } });
+  getLocalMinutes.mockResolvedValue(12 * 60);
+  addNotification.mockClear();
 });
 
-afterEach(() => { __resetCallSession(); });
+afterEach(() => { __resetCallSession(); vi.useRealTimers(); });
 
 describe('FaceTime call session', () => {
   it('refuses to dial without an attached call host', async () => {
@@ -341,5 +367,182 @@ describe('FaceTime call session', () => {
 
     expect(getCallState()).toMatchObject({ state: 'idle', active: false });
     consoleError.mockRestore();
+  });
+
+  it('broadcasts every state change on callStateEvents, for a tab that is not the call host', async () => {
+    const states = [];
+    callStateEvents.on('state', (snapshot) => states.push(snapshot.state));
+    attachHost(socket());
+    await startCall();
+    await endCall('remote-hangup');
+
+    expect(states).toContain('dialing');
+    expect(states).toContain('ended');
+  });
+});
+
+describe('FaceTime incoming-call watcher', () => {
+  it('never reads the helper while autoAnswer is off, even with a host attached', async () => {
+    getVoiceConfig.mockResolvedValue({ facetime: { maxCallMinutes: 15, autoAnswer: false } });
+    attachHost(socket());
+
+    expect(await pollIncoming()).toEqual({ checked: false, reason: 'auto-answer-off' });
+    expect(probe).not.toHaveBeenCalled();
+  });
+
+  it('answers an authorized incoming call, speaks a greeting, and runs it like any other call', async () => {
+    getVoiceConfig.mockResolvedValue({ facetime: { maxCallMinutes: 15, autoAnswer: true }, llm: { personality: { name: 'Alfred' } } });
+    probe.mockResolvedValue({ state: 'dialing', authorized: true });
+    attachHost(socket());
+
+    const result = await pollIncoming();
+
+    expect(result).toMatchObject({ incoming: true, answered: true });
+    expect(answer).toHaveBeenCalledTimes(1);
+    expect(getCallState()).toMatchObject({ state: 'listening', active: true });
+    expect(takeCallOpeningLine()).toBe("Hi, this is Alfred. Go ahead.");
+    expect(addNotification).not.toHaveBeenCalled();
+  });
+
+  it('leaves a call from any other handle ringing and logs nothing that names them', async () => {
+    getVoiceConfig.mockResolvedValue({ facetime: { maxCallMinutes: 15, autoAnswer: true } });
+    // The helper reports nothing distinguishing "no call" from "an
+    // unauthorized caller" — fail-closed at the helper boundary. This is the
+    // only shape an unmatched caller can produce.
+    probe.mockResolvedValue({ state: 'idle', authorized: false });
+    attachHost(socket());
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const result = await pollIncoming();
+
+    expect(result).toEqual({ checked: true, incoming: false });
+    expect(answer).not.toHaveBeenCalled();
+    expect(addNotification).not.toHaveBeenCalled();
+    expect(consoleError).not.toHaveBeenCalled();
+    consoleError.mockRestore();
+  });
+
+  it('answers at any hour, but a quiet-hours greeting is softer, never withheld', async () => {
+    getVoiceConfig.mockResolvedValue({
+      facetime: { maxCallMinutes: 15, autoAnswer: true },
+      llm: { personality: { name: 'Alfred' }, proactive: { quietHours: { enabled: true, start: '22:00', end: '07:00' } } },
+    });
+    getLocalMinutes.mockResolvedValue(3 * 60); // 3am — inside the overnight window
+    probe.mockResolvedValue({ state: 'dialing', authorized: true });
+    attachHost(socket());
+
+    const result = await pollIncoming();
+
+    expect(result).toMatchObject({ answered: true });
+    expect(answer).toHaveBeenCalledTimes(1);
+    expect(takeCallOpeningLine()).toMatch(/it's late/i);
+  });
+
+  it('records a missed call, and never presses answer, when no host is attached', async () => {
+    getVoiceConfig.mockResolvedValue({ facetime: { maxCallMinutes: 15, autoAnswer: true } });
+    probe.mockResolvedValue({ state: 'dialing', authorized: true });
+    // No attachHost() in this test — the production timer would never reach
+    // here with `host` unset (see attachHost/detachHost), but a host that
+    // detaches between this tick starting and the answer landing is a real
+    // race, and pollIncoming has to be correct standalone regardless.
+
+    const result = await pollIncoming();
+
+    expect(result).toEqual({ checked: true, incoming: true, answered: false, reason: 'no-host' });
+    expect(answer).not.toHaveBeenCalled();
+    expect(addNotification).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'agent_warning',
+      title: 'Missed call from you — the call host was not attached',
+      priority: 'medium',
+    }));
+    expect(getCallState()).toMatchObject({ state: 'idle', active: false });
+  });
+
+  it('records a missed call when the helper fails to press an authorized ring', async () => {
+    getVoiceConfig.mockResolvedValue({ facetime: { maxCallMinutes: 15, autoAnswer: true } });
+    probe.mockResolvedValue({ state: 'dialing', authorized: true });
+    answer.mockRejectedValue(new Error('AX press failed'));
+    attachHost(socket());
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const result = await pollIncoming();
+
+    expect(result).toEqual({ checked: true, incoming: true, answered: false, reason: 'helper-failed' });
+    expect(addNotification).toHaveBeenCalledWith(expect.objectContaining({
+      title: 'Missed call from you — the FaceTime helper failed to answer',
+    }));
+    consoleError.mockRestore();
+  });
+
+  it('notifies once per ring, not once per 2-second tick, while it keeps ringing unanswered', async () => {
+    getVoiceConfig.mockResolvedValue({ facetime: { maxCallMinutes: 15, autoAnswer: true } });
+    probe.mockResolvedValue({ state: 'dialing', authorized: true });
+    // host stays unattached for all three ticks.
+
+    await pollIncoming();
+    await pollIncoming();
+    await pollIncoming();
+
+    expect(addNotification).toHaveBeenCalledTimes(1);
+  });
+
+  it('is ready to notify again for the next ring once the first one stops', async () => {
+    getVoiceConfig.mockResolvedValue({ facetime: { maxCallMinutes: 15, autoAnswer: true } });
+    probe.mockResolvedValue({ state: 'dialing', authorized: true });
+
+    await pollIncoming();
+    expect(addNotification).toHaveBeenCalledTimes(1);
+
+    probe.mockResolvedValue({ state: 'idle', authorized: false }); // ring stopped
+    await pollIncoming();
+    probe.mockResolvedValue({ state: 'dialing', authorized: true }); // a second call rings
+    await pollIncoming();
+
+    expect(addNotification).toHaveBeenCalledTimes(2);
+  });
+
+  it('hands an answered call to the mind on hangup only when the mind was running when it answered', async () => {
+    getVoiceConfig.mockResolvedValue({ facetime: { maxCallMinutes: 15, autoAnswer: true } });
+    probe.mockResolvedValue({ state: 'dialing', authorized: true });
+    isMindEnabled.mockResolvedValue(true);
+    attachHost(socket());
+    await pollIncoming();
+    recordTurn('caller', 'Hey, it is me.');
+
+    await endCall('remote-hangup');
+
+    expect(buildInboundContext).toHaveBeenCalledTimes(1);
+    expect(enqueueMindMessage).toHaveBeenCalledTimes(1);
+    expect(enqueueMindMessage.mock.calls[0][0]).toContain('you answered');
+  });
+
+  it('runs the plain persona with no mind handoff when the mind was not running', async () => {
+    getVoiceConfig.mockResolvedValue({ facetime: { maxCallMinutes: 15, autoAnswer: true } });
+    probe.mockResolvedValue({ state: 'dialing', authorized: true });
+    isMindEnabled.mockResolvedValue(false);
+    attachHost(socket());
+    await pollIncoming();
+    recordTurn('caller', 'Hey, it is me.');
+
+    await endCall('remote-hangup');
+
+    expect(buildInboundContext).not.toHaveBeenCalled();
+    expect(enqueueMindMessage).not.toHaveBeenCalled();
+  });
+
+  it('polls the helper only while a call-host tab is attached, and stops on detach', async () => {
+    vi.useFakeTimers();
+    getVoiceConfig.mockResolvedValue({ facetime: { maxCallMinutes: 15, autoAnswer: true } });
+    probe.mockResolvedValue({ state: 'idle', authorized: false });
+    const host = socket();
+
+    attachHost(host);
+    await vi.advanceTimersByTimeAsync(PROBE_INTERVAL_MS * 2);
+    expect(probe.mock.calls.length).toBeGreaterThanOrEqual(2);
+
+    await detachHost(host);
+    probe.mockClear();
+    await vi.advanceTimersByTimeAsync(PROBE_INTERVAL_MS * 3);
+    expect(probe).not.toHaveBeenCalled();
   });
 });

--- a/server/services/voice/config.js
+++ b/server/services/voice/config.js
@@ -30,6 +30,12 @@ export const VOICE_DEFAULTS = Object.freeze({
     // by itself make an install start ringing the user.
     escalateCritical: false,
     escalateAfterMinutes: 10,
+    // Answer an inbound call from the configured identity automatically. OFF
+    // by default — same reasoning as escalateCritical: enabling the feature
+    // must never by itself make the Mac start picking up calls. The watcher
+    // that acts on this also requires a call-host tab attached (see
+    // callSession.js) — this flag alone changes nothing without one.
+    autoAnswer: false,
   },
 
   stt: {

--- a/server/services/voice/facetimeBridge.test.js
+++ b/server/services/voice/facetimeBridge.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { CALL_AUDIO_DEVICE_RATE, checkAudioDevice, checkSetup, facetimeControlResultSchema } from './facetimeBridge.js';
+import { CALL_AUDIO_DEVICE_RATE, FACETIME_COMMANDS, checkAudioDevice, checkSetup, facetimeControlResultSchema } from './facetimeBridge.js';
 
 const device = (overrides = {}) => ({
   name: 'BlackHole 16ch',
@@ -62,6 +62,40 @@ describe('FaceTime Audio control protocol', () => {
     const { run } = await import('./facetimeBridge.js');
     await expect(run('probe', { facetime: { targetHandle: '', targetName: '' } }))
       .rejects.toThrow();
+  });
+
+  describe('answer command (phase 4 — inbound)', () => {
+    it('is one of the commands the strict helper contract accepts', () => {
+      expect(FACETIME_COMMANDS).toContain('answer');
+    });
+
+    it('accepts the same strict result contract answer/hangup share with probe/call', () => {
+      const result = facetimeControlResultSchema.safeParse({
+        ok: true, command: 'answer', state: 'connected', authorized: true,
+        action: 'press-notification-action', message: 'Answered the incoming call', errorCode: null,
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects an answer result naming a caller — the contract has no field for one', () => {
+      // The whole point of the fail-closed helper boundary: there is no way
+      // to report who called, so a leak would have to smuggle it through an
+      // existing field, and the schema being `.strict()` with a fixed field
+      // set means nothing extra fits.
+      const result = facetimeControlResultSchema.safeParse({
+        ok: true, command: 'answer', state: 'connected', authorized: true,
+        action: 'press-notification-action', message: 'Answered the incoming call', errorCode: null,
+        callerIdentity: 'private@example.com',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('is exposed and, like every other command, refuses to run when identity is not configured', async () => {
+      const { answer, run } = await import('./facetimeBridge.js');
+      expect(typeof answer).toBe('function');
+      await expect(run('answer', { facetime: { targetHandle: '', targetName: '' } }))
+        .rejects.toThrow();
+    });
   });
 });
 

--- a/server/sockets/voice.js
+++ b/server/sockets/voice.js
@@ -10,7 +10,7 @@
 //           | voice:screenshot:request
 //           | voice:speak | voice:output:primary | voice:output:detached
 // Call host (FaceTime Audio bridge):
-// Inbound:  voice:call:attach | voice:call:audio | voice:call:detach
+// Inbound:  voice:call:attach | voice:call:audio | voice:call:detach | voice:call:hangup
 // Outbound: voice:call:state | voice:call:tts
 // Meeting capture (same page, same audio bridge, no LLM — STT only):
 // Inbound:  voice:capture:start | voice:call:audio | voice:capture:stop
@@ -31,6 +31,7 @@ import { CALL_AUDIO_SAMPLE_RATE, createCallEndpointer, pcmToFloat } from '../ser
 import {
   attachHost,
   detachHost,
+  endCall,
   getCallContext,
   getCallHost,
   isCallActive,
@@ -534,6 +535,19 @@ export const registerVoiceHandlers = (socket) => {
   socket.on('voice:call:detach', async () => {
     call.endpointer = null;
     emitCallState(await detachHost(socket));
+  });
+
+  // Hang up the active call from any tab, not just the one carrying the
+  // audio — the Mind tab's "Hang up" button is not the call host. Routed
+  // through endCall() (not a raw facetimeBridge.hangup()) so the session is
+  // cleaned up the same way any other end-of-call is: journal write, mind
+  // handoff, state reset. A no-op when nothing is active.
+  socket.on('voice:call:hangup', async () => {
+    try {
+      if (isCallActive()) await endCall('user-hangup');
+    } catch (err) {
+      console.error(`❌ voice:call:hangup failed: ${err.message}`);
+    }
   });
 
   // ---------------------------------------------------------------------------

--- a/server/sockets/voice.test.js
+++ b/server/sockets/voice.test.js
@@ -32,6 +32,7 @@ const {
   attachHost: attachCallHost,
   __resetCallSession,
   __setCallSessionDeps,
+  getCallState,
   pollCall,
   startCall,
 } = await import('../services/voice/callSession.js');
@@ -325,6 +326,44 @@ describe('call host opening line', () => {
     await flush();
 
     expect(host.emitted.filter((e) => e.event === 'voice:call:tts')).toHaveLength(0);
+  });
+});
+
+describe('voice:call:hangup', () => {
+  beforeEach(() => {
+    __resetCallSession();
+    __setCallSessionDeps({
+      probe: vi.fn(async () => ({ state: 'connected' })),
+      call: vi.fn(async () => ({ state: 'dialing' })),
+      hangup: vi.fn(async () => ({ state: 'ended' })),
+      appendJournal: vi.fn(async () => ({})),
+      enqueueMindMessage: vi.fn(async () => ({})),
+    });
+  });
+
+  it('ends the active call from any connected socket, not just the one carrying the audio', async () => {
+    // The Mind tab's hang-up button is not the call-host tab — this is the
+    // socket path it uses instead of a raw facetimeBridge.hangup() call, so
+    // the session is cleaned up (journal, mind handoff, state reset) the same
+    // way any other end-of-call is.
+    const host = makeFakeSocket();
+    registerVoiceHandlers(host);
+    await host.fire('voice:call:attach');
+    await startCall();
+    expect(getCallState().active).toBe(true);
+
+    const mindTab = makeFakeSocket();
+    registerVoiceHandlers(mindTab);
+    await mindTab.fire('voice:call:hangup');
+
+    expect(getCallState().active).toBe(false);
+  });
+
+  it('is a no-op when nothing is active', async () => {
+    const socket = makeFakeSocket();
+    registerVoiceHandlers(socket);
+    await expect(socket.fire('voice:call:hangup')).resolves.not.toThrow();
+    expect(getCallState().active).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

- Adds `facetime.autoAnswer` (default off). With it on and a call-host tab attached, `callSession.js`'s new incoming watcher answers a call from the user's own configured identity and runs it through the existing voice pipeline (whisper STT → voice LLM/persona → Kokoro/Piper TTS), exactly like an outbound call.
- Fail-closed at the helper boundary: `facetimeBridge.answer()` reports nothing distinguishing "no call" from "an unauthorized caller," so this module never learns an unauthorized caller exists and never logs one — a call from any other handle is simply left ringing.
- Reading the helper (`probe`) each tick is safe and runs while the watcher is armed; the press (`answer`) is additionally gated on the call-host tab being attached *at press time* — answering a call nobody can hear is worse than missing it.
- An authorized call that rings with no host attached, or one the helper fails to press, raises a `medium` `agent_warning` notification (deduped once per ring, not once per 2-second tick) instead of silently dropping it.
- Quiet hours only soften the greeting's wording; they never decide whether to answer.
- When the Persistent Mind is running at answer time, the call carries its persona/context and the transcript is handed back to it as a message on hangup, mirroring how an outbound mind-placed call already works; when it isn't running, the call runs the plain voice persona like the widget.
- New `voice:call:hangup` socket event, routed through `endCall()` (not a raw `facetimeBridge.hangup()`) so the session's journal write and mind handoff run the same as any other end-of-call — usable from any tab, not just the call host.
- `voice:call:state` now also broadcasts to every connected tab via a new `callStateEvents` emitter (the call-host socket still gets its own direct emit, which drives opening-line delivery). The Mind tab shows an active-call chip with a **Hang up** button driven by this broadcast.
- Settings → Voice → FaceTime Audio gets an **Automatically answer incoming calls** toggle with the plain-language rule.

## Test plan

- `cd server && npx vitest run services/voice/callSession.test.js services/voice/facetimeBridge.test.js sockets/voice.test.js routes/voice.test.js services/persistentMindCallCapability.test.js` — watcher tests use an injected `probe`/`answer` stub and fake timers (armed-only-while-attached, dedup, mind handoff, quiet-hours greeting, no-log-on-unauthorized).
- `cd client && npx vitest run src/components/cos/tabs/MindTab.test.jsx` — active-call chip appears from a broadcast even when this tab isn't the call host, and hang up emits `voice:call:hangup`.
- Full suites green: `server && npx vitest run` (35549 passed), `client && npx vitest run` (10262 passed), `npm run lint`, `npm run build`.
- Regenerated `server/lib/apiRouteCatalog.generated.json` and `server/lib/socketEventCatalog.generated.json`.

Closes #5310
Part of #5306