### PR TITLE
fix(videoGen): make FastMetal render progress accurate

### DIFF
--- a/scripts/generate_fastvideo.py
+++ b/scripts/generate_fastvideo.py
@@ -31,7 +31,7 @@ def translate_line(line: str) -> str:
         cur, total = int(step_match.group(1)), int(step_match.group(2))
         return f"STAGE:fastvideo:step:{cur}:{total}:denoising step {cur}/{total}"
     if _PERCENT_PATTERN.search(line):
-        return f"STATUS:FastVideo startup progress: {line}"
+        return f"STATUS:FastVideo: {line}"
     if "loading" in line.lower() or "encoding" in line.lower():
         return f"STATUS:{line}"
     return line
@@ -107,7 +107,8 @@ def main() -> int:
         "--width", str(args.width),
         "--height", str(args.height),
         "--num-frames", str(args.num_frames),
-        "--num-inference-steps", str(args.steps),
+        "--fps", str(args.fps),
+        "--seed", str(args.seed),
         "--output-path", str(args.output),
     ]
     if args.fast:

--- a/scripts/generate_fastvideo.py
+++ b/scripts/generate_fastvideo.py
@@ -18,6 +18,25 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 from _runner_common import emit_runtime_fingerprint, establish_process_group  # noqa: E402
 
 
+_DENOISE_STEP_PATTERN = re.compile(
+    r'\bdenois(?:e|ing)\s+step\s*(\d+)\s*/\s*(\d+)\b', re.IGNORECASE,
+)
+_PERCENT_PATTERN = re.compile(r'\d+%')
+
+
+def translate_line(line: str) -> str:
+    """Translate one upstream output line into PortOS's progress protocol."""
+    step_match = _DENOISE_STEP_PATTERN.search(line)
+    if step_match:
+        cur, total = int(step_match.group(1)), int(step_match.group(2))
+        return f"STAGE:fastvideo:step:{cur}:{total}:denoising step {cur}/{total}"
+    if _PERCENT_PATTERN.search(line):
+        return f"STATUS:FastVideo startup progress: {line}"
+    if "loading" in line.lower() or "encoding" in line.lower():
+        return f"STATUS:{line}"
+    return line
+
+
 def parse_args() -> argparse.Namespace:
     p = argparse.ArgumentParser(description="PortOS FastVideo MLX helper")
     p.add_argument("--repo-dir", default=None, help="Path to cloned FastVideo repo")
@@ -88,6 +107,7 @@ def main() -> int:
         "--width", str(args.width),
         "--height", str(args.height),
         "--num-frames", str(args.num_frames),
+        "--num-inference-steps", str(args.steps),
         "--output-path", str(args.output),
     ]
     if args.fast:
@@ -115,28 +135,16 @@ def main() -> int:
     )
 
     assert proc.stdout is not None
-    # Parse output lines and map to STAGE: / STATUS: protocols
-    step_pattern = re.compile(r'(?:step|Step)\s*(\d+)[/:](\d+)', re.IGNORECASE)
-    percent_pattern = re.compile(r'(\d+)%')
-
+    # Parse output lines and map to STAGE: / STATUS: protocols. Only the
+    # upstream denoising-step message represents render progress. Startup
+    # model-loading bars also contain percentages (often ending at 100%) and
+    # must remain status output or the generic server parser will report them
+    # as completed rendering.
     for raw in proc.stdout:
         line = raw.rstrip()
         if not line:
             continue
-
-        step_match = step_pattern.search(line)
-        if step_match:
-            cur, total = int(step_match.group(1)), int(step_match.group(2))
-            print(f"STAGE:fastvideo:step:{cur}:{total}:denoising step {cur}/{total}", file=sys.stderr, flush=True)
-        else:
-            pct_match = percent_pattern.search(line)
-            if pct_match:
-                pct = int(pct_match.group(1))
-                print(f"STAGE:fastvideo:step:{pct}:100:generating {pct}%", file=sys.stderr, flush=True)
-            elif "loading" in line.lower() or "encoding" in line.lower():
-                print(f"STATUS:{line}", file=sys.stderr, flush=True)
-            else:
-                print(line, file=sys.stderr, flush=True)
+        print(translate_line(line), file=sys.stderr, flush=True)
 
     return_code = proc.wait()
     if return_code != 0:

--- a/scripts/generate_fastvideo.py
+++ b/scripts/generate_fastvideo.py
@@ -107,6 +107,7 @@ def main() -> int:
         "--width", str(args.width),
         "--height", str(args.height),
         "--num-frames", str(args.num_frames),
+        "--num-inference-steps", str(args.steps),
         "--fps", str(args.fps),
         "--seed", str(args.seed),
         "--output-path", str(args.output),

--- a/scripts/generate_fastvideo.test.js
+++ b/scripts/generate_fastvideo.test.js
@@ -1,0 +1,46 @@
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { resolveTestPython } from '../server/lib/testHelper.js';
+
+const script = join(dirname(fileURLToPath(import.meta.url)), 'generate_fastvideo.py');
+const pyBin = resolveTestPython();
+const runPython = (source) => execFileSync(pyBin, ['-c', source, script], { encoding: 'utf8' });
+
+const importRunner = [
+  'import importlib.util, sys',
+  'from pathlib import Path',
+  'script = Path(sys.argv[1])',
+  'spec = importlib.util.spec_from_file_location("generate_fastvideo", script)',
+  'runner = importlib.util.module_from_spec(spec)',
+  'spec.loader.exec_module(runner)',
+].join('\n');
+
+describe.skipIf(!pyBin)('generate_fastvideo.py', () => {
+  it('reports only denoising steps as render progress', () => {
+    const output = runPython(`${importRunner}\n${[
+      'print(runner.translate_line("Loading checkpoint: 100%|##########| 10/10"))',
+      'print(runner.translate_line("denoise step 1/3 complete"))',
+      'print(runner.translate_line("denoising step 3 / 3 complete"))',
+    ].join('\n')}`);
+
+    expect(output.trim().split('\n')).toEqual([
+      'STATUS:FastVideo startup progress: Loading checkpoint: 100%|##########| 10/10',
+      'STAGE:fastvideo:step:1:3:denoising step 1/3',
+      'STAGE:fastvideo:step:3:3:denoising step 3/3',
+    ]);
+  });
+
+  it('does not treat an unrelated step or percentage as render completion', () => {
+    const output = runPython(`${importRunner}\n${[
+      'print(runner.translate_line("Loading pipeline step 3/3"))',
+      'print(runner.translate_line("100%|##########| 1/1"))',
+    ].join('\n')}`);
+
+    expect(output.trim().split('\n')).toEqual([
+      'STATUS:Loading pipeline step 3/3',
+      'STATUS:FastVideo startup progress: 100%|##########| 1/1',
+    ]);
+  });
+});

--- a/scripts/generate_fastvideo.test.js
+++ b/scripts/generate_fastvideo.test.js
@@ -7,6 +7,7 @@ import { resolveTestPython } from '../server/lib/testHelper.js';
 const script = join(dirname(fileURLToPath(import.meta.url)), 'generate_fastvideo.py');
 const pyBin = resolveTestPython();
 const runPython = (source) => execFileSync(pyBin, ['-c', source, script], { encoding: 'utf8' });
+const lines = (output) => output.trim().split('\n').map((line) => line.trimEnd());
 
 const importRunner = [
   'import importlib.util, sys',
@@ -25,7 +26,7 @@ describe.skipIf(!pyBin)('generate_fastvideo.py', () => {
       'print(runner.translate_line("denoising step 3 / 3 complete"))',
     ].join('\n')}`);
 
-    expect(output.trim().split('\n')).toEqual([
+    expect(lines(output)).toEqual([
       'STATUS:FastVideo: Loading checkpoint: 100%|##########| 10/10',
       'STAGE:fastvideo:step:1:3:denoising step 1/3',
       'STAGE:fastvideo:step:3:3:denoising step 3/3',
@@ -38,7 +39,7 @@ describe.skipIf(!pyBin)('generate_fastvideo.py', () => {
       'print(runner.translate_line("100%|##########| 1/1"))',
     ].join('\n')}`);
 
-    expect(output.trim().split('\n')).toEqual([
+    expect(lines(output)).toEqual([
       'STATUS:Loading pipeline step 3/3',
       'STATUS:FastVideo: 100%|##########| 1/1',
     ]);

--- a/scripts/generate_fastvideo.test.js
+++ b/scripts/generate_fastvideo.test.js
@@ -26,7 +26,7 @@ describe.skipIf(!pyBin)('generate_fastvideo.py', () => {
     ].join('\n')}`);
 
     expect(output.trim().split('\n')).toEqual([
-      'STATUS:FastVideo startup progress: Loading checkpoint: 100%|##########| 10/10',
+      'STATUS:FastVideo: Loading checkpoint: 100%|##########| 10/10',
       'STAGE:fastvideo:step:1:3:denoising step 1/3',
       'STAGE:fastvideo:step:3:3:denoising step 3/3',
     ]);
@@ -40,7 +40,7 @@ describe.skipIf(!pyBin)('generate_fastvideo.py', () => {
 
     expect(output.trim().split('\n')).toEqual([
       'STATUS:Loading pipeline step 3/3',
-      'STATUS:FastVideo startup progress: 100%|##########| 1/1',
+      'STATUS:FastVideo: 100%|##########| 1/1',
     ]);
   });
 });


### PR DESCRIPTION
## Summary

- Prevent FastVideo startup percentage bars from being reported as completed renders.
- Preserve explicit denoising-step progress and forward the requested seed/FPS to the upstream runner.

## Test plan

- npm test -- --run ../scripts/generate_fastvideo.test.js services/videoGen/generateVideoHelpers.test.js (server)
- python3 -m py_compile scripts/generate_fastvideo.py