### PR TITLE
feat: show FableLoom AI run progress and shell access

### DIFF
--- a/client/src/components/fableloom/LoomAiRunStatus.jsx
+++ b/client/src/components/fableloom/LoomAiRunStatus.jsx
@@ -1,0 +1,47 @@
+import { CheckCircle2, ExternalLink, Loader2, XCircle } from 'lucide-react';
+import { Link } from 'react-router';
+
+const TERMINAL_PHASES = new Set(['complete', 'error']);
+
+const phaseLabel = (run) => {
+  if (run.phase === 'start') return 'Starting AI…';
+  if (run.phase === 'running') return run.message || 'AI is working…';
+  if (run.phase === 'ready') return run.message || 'TUI run is ready';
+  if (run.phase === 'applying') return run.message || 'Applying AI changes…';
+  if (run.phase === 'complete') return run.message || 'AI update complete';
+  if (run.phase === 'error') return run.message || 'AI update failed';
+  return run.message || 'AI operation in progress…';
+};
+
+export default function LoomAiRunStatus({ run }) {
+  if (!run) return null;
+  const terminal = TERMINAL_PHASES.has(run.phase);
+  const failed = run.phase === 'error';
+  const canOpenShell = run.shellReady && run.runId && !terminal;
+  const Icon = failed ? XCircle : terminal ? CheckCircle2 : Loader2;
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className={`rounded border px-3 py-2 text-xs flex flex-wrap items-center gap-x-2 gap-y-1 ${
+        failed
+          ? 'border-port-error/40 text-port-error'
+          : terminal
+            ? 'border-port-success/40 text-port-success'
+            : 'border-port-accent/30 text-port-text-muted'
+      }`}
+    >
+      <Icon size={14} className={!terminal ? 'animate-spin' : ''} />
+      <span className="min-w-0 flex-1">{phaseLabel(run)}</span>
+      {run.providerName ? <span className="text-port-text-muted">{run.providerName}{run.model ? ` · ${run.model}` : ''}</span> : null}
+      {canOpenShell ? (
+        <Link
+          to={`/shell/${encodeURIComponent(run.runId)}`}
+          className="inline-flex items-center gap-1 text-port-accent hover:underline font-medium"
+        >
+          <ExternalLink size={12} /> Open shell
+        </Link>
+      ) : null}
+    </div>
+  );
+}

--- a/client/src/components/fableloom/LoomAiRunStatus.test.jsx
+++ b/client/src/components/fableloom/LoomAiRunStatus.test.jsx
@@ -1,0 +1,34 @@
+import { MemoryRouter } from 'react-router';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import LoomAiRunStatus from './LoomAiRunStatus';
+
+describe('LoomAiRunStatus', () => {
+  it('offers the live TUI run through the existing Shell route', () => {
+    render(
+      <MemoryRouter>
+        <LoomAiRunStatus run={{
+          phase: 'ready',
+          message: 'TUI run is ready',
+          runId: 'run-tui-1',
+          providerName: 'Codex TUI',
+          model: 'gpt-test',
+          shellReady: true,
+        }} />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole('link', { name: /open shell/i })).toHaveAttribute('href', '/shell/run-tui-1');
+  });
+
+  it('keeps a completed operation visible without offering a released shell session', () => {
+    render(
+      <MemoryRouter>
+        <LoomAiRunStatus run={{ phase: 'complete', message: 'AI response ready', runId: 'run-tui-1', shellReady: false }} />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole('status')).toHaveTextContent('AI response ready');
+    expect(screen.queryByRole('link', { name: /open shell/i })).toBeNull();
+  });
+});

--- a/client/src/components/fableloom/LoomEpisodeFeedback.jsx
+++ b/client/src/components/fableloom/LoomEpisodeFeedback.jsx
@@ -4,10 +4,12 @@ import ProviderModelSelector from '../ProviderModelSelector';
 import { FormField } from '../ui/FormField.jsx';
 import toast from '../ui/Toast';
 import { useAsyncAction } from '../../hooks/useAsyncAction';
+import useFableLoomAiRun from '../../hooks/useFableLoomAiRun';
 import useProviderModels from '../../hooks/useProviderModels';
 import { feedbackLoomEpisode } from '../../services/api';
 import { effectiveModelFor, effortAwareModelOptions } from '../../utils/providers';
 import { fieldClass, labelClass } from './fieldStyles';
+import LoomAiRunStatus from './LoomAiRunStatus';
 
 /**
  * Conversational editor for one episode. The route selection is deliberately
@@ -26,6 +28,7 @@ export default function LoomEpisodeFeedback({
 }) {
   const [feedback, setFeedback] = useState('');
   const [route, setRoute] = useState({ providerId: '', model: '', effort: '' });
+  const { run: aiRun, begin: beginAiRun, fail: failAiRun } = useFableLoomAiRun();
   const { providers, loading: providersLoading } = useProviderModels({
     allowDefault: true,
     silent: true,
@@ -41,13 +44,18 @@ export default function LoomEpisodeFeedback({
   }, [episode.id]);
 
   const [runFeedback, submitting] = useAsyncAction(async () => {
+    const operationId = beginAiRun();
     onFeedbackStarted?.();
     const result = await feedbackLoomEpisode(loom.id, episode.id, {
       feedback: feedback.trim(),
+      operationId,
       ...(route.providerId ? { providerId: route.providerId } : {}),
       ...(route.model ? { model: route.model } : {}),
       ...(route.effort ? { effort: route.effort } : {}),
-    }, { silent: true });
+    }, { silent: true }).catch((error) => {
+      failAiRun(error.message);
+      throw error;
+    });
     onLoomUpdate(result.loom);
     setFeedback('');
     toast.success(result.changedScenes
@@ -115,6 +123,7 @@ export default function LoomEpisodeFeedback({
         {submitting ? <Loader2 size={14} className="animate-spin" /> : <Sparkles size={14} />}
         {submitting ? 'Updating episode…' : 'Apply AI feedback'}
       </button>
+      <LoomAiRunStatus run={aiRun} />
     </section>
   );
 }

--- a/client/src/components/fableloom/LoomEpisodeFeedback.test.jsx
+++ b/client/src/components/fableloom/LoomEpisodeFeedback.test.jsx
@@ -6,6 +6,9 @@ vi.mock('../../services/api', () => ({
   feedbackLoomEpisode: vi.fn(),
   getProviders: vi.fn(),
 }));
+vi.mock('../../services/socket', () => ({
+  default: { on: vi.fn(), off: vi.fn() },
+}));
 
 import * as api from '../../services/api';
 import LoomEpisodeFeedback from './LoomEpisodeFeedback';
@@ -52,7 +55,10 @@ describe('LoomEpisodeFeedback', () => {
     await waitFor(() => expect(api.feedbackLoomEpisode).toHaveBeenCalledWith(
       'loom-1',
       'ep-1',
-      { feedback: 'Make the opening urgent.', providerId: 'codex', model: 'gpt-5', effort: 'high' },
+      expect.objectContaining({
+        feedback: 'Make the opening urgent.', providerId: 'codex', model: 'gpt-5', effort: 'high',
+        operationId: expect.any(String),
+      }),
       { silent: true },
     ));
     expect(onFeedbackStarted).toHaveBeenCalledTimes(1);

--- a/client/src/components/fableloom/LoomSeriesPlan.jsx
+++ b/client/src/components/fableloom/LoomSeriesPlan.jsx
@@ -211,7 +211,9 @@ function SeriesAiEditor({ loom, dirty, onLoomUpdate }) {
   const [analysis, setAnalysis] = useState(null);
   const [route, setRoute] = useState({ providerId: '', model: '', effort: '' });
   const regenerateConfirm = useConfirmDelete();
-  const { run: aiRun, begin: beginAiRun, fail: failAiRun } = useFableLoomAiRun();
+  const reviewRun = useFableLoomAiRun();
+  const generateRun = useFableLoomAiRun();
+  const feedbackRun = useFableLoomAiRun();
   const { providers, loading } = useProviderModels({ allowDefault: true, silent: true, withEffort: true });
   const selectedProvider = providers.find((provider) => provider.id === route.providerId);
   const routeBody = {
@@ -221,26 +223,26 @@ function SeriesAiEditor({ loom, dirty, onLoomUpdate }) {
   };
 
   const [runReview, reviewing] = useAsyncAction(async () => {
-    const operationId = beginAiRun();
+    const operationId = reviewRun.begin();
     const result = await reviewLoomSeriesPlan(loom.id, { ...routeBody, operationId }, { silent: true })
-      .catch((error) => { failAiRun(error.message); throw error; });
+      .catch((error) => { reviewRun.fail(error.message); throw error; });
     setAnalysis(result.analysis);
   }, { errorMessage: 'Series analysis failed' });
 
   const [generatePlan, generating] = useAsyncAction(async () => {
-    const operationId = beginAiRun();
+    const operationId = generateRun.begin();
     const result = await generateLoomSeriesPlan(loom.id, { ...routeBody, operationId }, { silent: true })
-      .catch((error) => { failAiRun(error.message); throw error; });
+      .catch((error) => { generateRun.fail(error.message); throw error; });
     onLoomUpdate(result.loom);
     setAnalysis(null);
     toast.success('Full series plan drafted');
   }, { errorMessage: 'Series-plan drafting failed' });
 
   const [applyFeedback, applying] = useAsyncAction(async () => {
-    const operationId = beginAiRun();
+    const operationId = feedbackRun.begin();
     const result = await feedbackLoomSeriesPlan(loom.id, {
       feedback: feedback.trim(), ...routeBody, operationId,
-    }, { silent: true }).catch((error) => { failAiRun(error.message); throw error; });
+    }, { silent: true }).catch((error) => { feedbackRun.fail(error.message); throw error; });
     onLoomUpdate(result.loom);
     setFeedback('');
     setAnalysis(null);
@@ -307,6 +309,7 @@ function SeriesAiEditor({ loom, dirty, onLoomUpdate }) {
           {generating ? 'Drafting full plan…' : hasPlan ? 'Regenerate full plan' : 'Draft full plan'}
         </button>
       )}
+      <LoomAiRunStatus run={generateRun.run} />
       {hasPlan ? (
         <p className="text-xs text-port-text-muted">
           Regenerating replaces the saved arc, plot points, and side quests. Episode titles,
@@ -324,6 +327,7 @@ function SeriesAiEditor({ loom, dirty, onLoomUpdate }) {
           {reviewing ? 'Analyzing…' : 'Analyze series'}
         </button>
       </div>
+      <LoomAiRunStatus run={reviewRun.run} />
       <FormField
         label="Edit outline & plot points"
         hint="Ask the AI to refine or restructure plot points, story beats, or side quests across the entire series."
@@ -347,7 +351,7 @@ function SeriesAiEditor({ loom, dirty, onLoomUpdate }) {
         {applying ? <Loader2 size={14} className="animate-spin" /> : <Sparkles size={14} />}
         {applying ? 'Updating series plan…' : 'Apply guidance to plan'}
       </button>
-      <LoomAiRunStatus run={aiRun} />
+      <LoomAiRunStatus run={feedbackRun.run} />
       {dirty ? <p className="text-xs text-port-warning">Save the plan before running AI so it reads the edits on screen.</p> : null}
       {analysis ? <SeriesAnalysis analysis={analysis} /> : null}
     </div>

--- a/client/src/components/fableloom/LoomSeriesPlan.jsx
+++ b/client/src/components/fableloom/LoomSeriesPlan.jsx
@@ -13,6 +13,7 @@ import UnsavedChangesConfirm from '../ui/UnsavedChangesConfirm.jsx';
 import ProviderModelSelector from '../ProviderModelSelector';
 import { useAsyncAction } from '../../hooks/useAsyncAction';
 import { useConfirmDelete } from '../../hooks/useConfirmDelete';
+import useFableLoomAiRun from '../../hooks/useFableLoomAiRun';
 import useProviderModels from '../../hooks/useProviderModels';
 import useUnsavedChangesGuard from '../../hooks/useUnsavedChangesGuard';
 import {
@@ -21,6 +22,7 @@ import {
 import { uuidv4 } from '../../lib/uuid.js';
 import { effectiveModelFor, effortAwareModelOptions } from '../../utils/providers';
 import { fieldClass, labelClass } from './fieldStyles';
+import LoomAiRunStatus from './LoomAiRunStatus';
 
 const newItemId = (prefix) => `${prefix}-${uuidv4()}`;
 
@@ -209,6 +211,7 @@ function SeriesAiEditor({ loom, dirty, onLoomUpdate }) {
   const [analysis, setAnalysis] = useState(null);
   const [route, setRoute] = useState({ providerId: '', model: '', effort: '' });
   const regenerateConfirm = useConfirmDelete();
+  const { run: aiRun, begin: beginAiRun, fail: failAiRun } = useFableLoomAiRun();
   const { providers, loading } = useProviderModels({ allowDefault: true, silent: true, withEffort: true });
   const selectedProvider = providers.find((provider) => provider.id === route.providerId);
   const routeBody = {
@@ -218,19 +221,26 @@ function SeriesAiEditor({ loom, dirty, onLoomUpdate }) {
   };
 
   const [runReview, reviewing] = useAsyncAction(async () => {
-    const result = await reviewLoomSeriesPlan(loom.id, routeBody, { silent: true });
+    const operationId = beginAiRun();
+    const result = await reviewLoomSeriesPlan(loom.id, { ...routeBody, operationId }, { silent: true })
+      .catch((error) => { failAiRun(error.message); throw error; });
     setAnalysis(result.analysis);
   }, { errorMessage: 'Series analysis failed' });
 
   const [generatePlan, generating] = useAsyncAction(async () => {
-    const result = await generateLoomSeriesPlan(loom.id, routeBody, { silent: true });
+    const operationId = beginAiRun();
+    const result = await generateLoomSeriesPlan(loom.id, { ...routeBody, operationId }, { silent: true })
+      .catch((error) => { failAiRun(error.message); throw error; });
     onLoomUpdate(result.loom);
     setAnalysis(null);
     toast.success('Full series plan drafted');
   }, { errorMessage: 'Series-plan drafting failed' });
 
   const [applyFeedback, applying] = useAsyncAction(async () => {
-    const result = await feedbackLoomSeriesPlan(loom.id, { feedback: feedback.trim(), ...routeBody }, { silent: true });
+    const operationId = beginAiRun();
+    const result = await feedbackLoomSeriesPlan(loom.id, {
+      feedback: feedback.trim(), ...routeBody, operationId,
+    }, { silent: true }).catch((error) => { failAiRun(error.message); throw error; });
     onLoomUpdate(result.loom);
     setFeedback('');
     setAnalysis(null);
@@ -337,6 +347,7 @@ function SeriesAiEditor({ loom, dirty, onLoomUpdate }) {
         {applying ? <Loader2 size={14} className="animate-spin" /> : <Sparkles size={14} />}
         {applying ? 'Updating series plan…' : 'Apply guidance to plan'}
       </button>
+      <LoomAiRunStatus run={aiRun} />
       {dirty ? <p className="text-xs text-port-warning">Save the plan before running AI so it reads the edits on screen.</p> : null}
       {analysis ? <SeriesAnalysis analysis={analysis} /> : null}
     </div>

--- a/client/src/components/fableloom/LoomSeriesPlan.test.jsx
+++ b/client/src/components/fableloom/LoomSeriesPlan.test.jsx
@@ -10,6 +10,9 @@ vi.mock('../../services/api', () => ({
   updateLoom: vi.fn(),
 }));
 vi.mock('../../hooks/useProviderModels', () => ({ default: () => ({ providers: [], loading: false }) }));
+vi.mock('../../services/socket', () => ({
+  default: { on: vi.fn(), off: vi.fn() },
+}));
 vi.mock('../ProviderModelSelector', () => ({ default: () => <div>AI route picker</div> }));
 
 import * as api from '../../services/api';
@@ -92,7 +95,10 @@ describe('LoomSeriesPlan', () => {
 
     await waitFor(() => expect(api.feedbackLoomSeriesPlan).toHaveBeenCalledWith(
       'loom-1',
-      { feedback: 'Move the turn to episode 1 and raise stakes.' },
+      expect.objectContaining({
+        feedback: 'Move the turn to episode 1 and raise stakes.',
+        operationId: expect.any(String),
+      }),
       { silent: true },
     ));
     expect(onLoomUpdate).toHaveBeenCalledWith(updated);
@@ -115,7 +121,7 @@ describe('LoomSeriesPlan', () => {
     fireEvent.click(screen.getByRole('button', { name: /^regenerate$/i }));
 
     await waitFor(() => expect(api.generateLoomSeriesPlan).toHaveBeenCalledWith(
-      'loom-1', {}, { silent: true },
+      'loom-1', { operationId: expect.any(String) }, { silent: true },
     ));
     expect(onLoomUpdate).toHaveBeenCalledWith(generated);
   });

--- a/client/src/hooks/README.md
+++ b/client/src/hooks/README.md
@@ -22,6 +22,7 @@ grep -i "what you want to do" client/src/hooks/README.md
 | `useNotifications` | Generic toast dispatch + socket-subscribed notification list. | You need to read / dispatch the global notification stream. |
 | `useErrorNotifications` | Subscribes to server error events and shows toasts. | Wire once high in the tree to surface server errors. |
 | `useAIStatusNotifications` | Subscribes to AI operation status events. | Wire once to surface AI run lifecycle as toasts. |
+| `useFableLoomAiRun` | Tracks one FableLoom AI operation, including the attachable shell handoff for TUI providers. | FableLoom series or episode AI actions. |
 | `useAgentFeedbackToast` | Agent completion toast with thumbs-up/down UI. | Show actionable agent-run completion feedback. |
 | `useOnDemandTaskToast` | Toasts when a user-triggered on-demand task run found no work (parked). | Wire once high in the tree so an explicit "Run" that parks isn't a silent no-op. |
 | `useEngagementReminderToast` | Polls deterministic POST/creative-feedback actions and shows each reminder once per browser tab/day with a deep link. | Wire once high in the tree so daily actions remain visible outside the dashboard. |

--- a/client/src/hooks/index.js
+++ b/client/src/hooks/index.js
@@ -25,6 +25,7 @@ export { default as useColorMatch } from './useColorMatch.js';
 export { default as useContainerWidth } from './useContainerWidth.js';
 export { default as useEscapeKey } from './useEscapeKey.js';
 export { default as useFieldDraft } from './useFieldDraft.js';
+export { default as useFableLoomAiRun } from './useFableLoomAiRun.js';
 export { default as useFocusTrap } from './useFocusTrap.js';
 export { default as useNoteSave } from './useNoteSave.js';
 export { default as useHoverTooltip } from './useHoverTooltip.js';

--- a/client/src/hooks/useAIStatusNotifications.js
+++ b/client/src/hooks/useAIStatusNotifications.js
@@ -136,6 +136,7 @@ export function useAIStatusNotifications() {
     };
 
     const handleStatus = (event) => {
+      if (event.localOnly) return;
       const state = opsRef.current.get(event.id) || { silent: !!event.silent, opened: false };
       opsRef.current.set(event.id, state);
 

--- a/client/src/hooks/useFableLoomAiRun.js
+++ b/client/src/hooks/useFableLoomAiRun.js
@@ -1,0 +1,35 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { uuidv4 } from '../lib/uuid.js';
+import socket from '../services/socket';
+
+// A FableLoom operation is keyed by a caller-owned id rather than by the run
+// id: the run id does not exist until the server has created it, and a completed
+// operation may already have released its shell session.
+export default function useFableLoomAiRun() {
+  const [run, setRun] = useState(null);
+  const operationIdRef = useRef(null);
+
+  useEffect(() => {
+    const handleStatus = (event) => {
+      if (!event?.operationId || event.operationId !== operationIdRef.current) return;
+      setRun((current) => ({ ...(current || {}), ...event }));
+    };
+    socket.on('ai:status', handleStatus);
+    return () => socket.off('ai:status', handleStatus);
+  }, []);
+
+  const begin = useCallback(() => {
+    const operationId = uuidv4();
+    operationIdRef.current = operationId;
+    setRun({ operationId, phase: 'start', message: 'Starting AI…' });
+    return operationId;
+  }, []);
+
+  const fail = useCallback((message) => {
+    setRun((current) => current
+      ? { ...current, phase: 'error', message: message || 'AI operation failed', shellReady: false }
+      : current);
+  }, []);
+
+  return { run, begin, fail };
+}

--- a/client/src/hooks/useFableLoomAiRun.test.jsx
+++ b/client/src/hooks/useFableLoomAiRun.test.jsx
@@ -1,0 +1,48 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const handlers = new Set();
+vi.mock('../services/socket', () => ({
+  default: {
+    on: (event, handler) => { if (event === 'ai:status') handlers.add(handler); },
+    off: (event, handler) => { if (event === 'ai:status') handlers.delete(handler); },
+  },
+}));
+
+import useFableLoomAiRun from './useFableLoomAiRun.js';
+
+const emit = (event) => handlers.forEach((handler) => handler(event));
+
+beforeEach(() => handlers.clear());
+
+describe('useFableLoomAiRun', () => {
+  it('ignores stale operation events and exposes a ready shell handoff', () => {
+    const { result } = renderHook(() => useFableLoomAiRun());
+    let operationId;
+    act(() => { operationId = result.current.begin(); });
+
+    act(() => emit({ operationId: 'stale-operation', phase: 'running', message: 'Wrong run' }));
+    expect(result.current.run.message).toBe('Starting AI…');
+
+    act(() => emit({
+      operationId,
+      phase: 'ready',
+      runId: 'run-tui-1',
+      providerType: 'tui',
+      providerName: 'Codex TUI',
+      model: 'gpt-test',
+      shellReady: true,
+      message: 'TUI run is ready',
+    }));
+    expect(result.current.run).toMatchObject({
+      operationId, runId: 'run-tui-1', phase: 'ready', shellReady: true,
+    });
+  });
+
+  it('marks a client-side request failure as terminal', () => {
+    const { result } = renderHook(() => useFableLoomAiRun());
+    act(() => { result.current.begin(); });
+    act(() => { result.current.fail('Provider unavailable'); });
+    expect(result.current.run).toMatchObject({ phase: 'error', message: 'Provider unavailable', shellReady: false });
+  });
+});

--- a/client/src/pages/FableLoomStory.jsx
+++ b/client/src/pages/FableLoomStory.jsx
@@ -23,6 +23,7 @@ import PageSkeleton from '../components/ui/PageSkeleton';
 import TabPills from '../components/ui/TabPills';
 import { useAsyncAction } from '../hooks/useAsyncAction';
 import { useConfirmDelete } from '../hooks/useConfirmDelete';
+import useFableLoomAiRun from '../hooks/useFableLoomAiRun';
 import useContainerWidth from '../hooks/useContainerWidth';
 import LoomCanvas from '../components/fableloom/LoomCanvas';
 import LoomEpisodeOutline from '../components/fableloom/LoomEpisodeOutline';
@@ -33,6 +34,7 @@ import LoomPlayPanel from '../components/fableloom/LoomPlayPanel';
 import LoomSettingsDrawer from '../components/fableloom/LoomSettingsDrawer';
 import LoomSeriesPlan from '../components/fableloom/LoomSeriesPlan';
 import LoomValidationPanel from '../components/fableloom/LoomValidationPanel';
+import LoomAiRunStatus from '../components/fableloom/LoomAiRunStatus';
 import { fieldClass, labelClass } from '../components/fableloom/fieldStyles';
 import {
   buildFableLoomImageRequest, buildFableLoomVideoRequest,
@@ -640,6 +642,7 @@ function EpisodeSetupDrawer({ open, onClose, loom, episode, onLoomUpdate, onFeed
   // in-flight meta saves per the client save-gating convention.
   const [metaSaving, setMetaSaving] = useState(0);
   const [feedbackRunning, setFeedbackRunning] = useState(false);
+  const { run: aiRun, begin: beginAiRun, fail: failAiRun } = useFableLoomAiRun();
   const del = useConfirmDelete();
   const hasScenes = episode.nodes.length > 0;
 
@@ -660,10 +663,15 @@ function EpisodeSetupDrawer({ open, onClose, loom, episode, onLoomUpdate, onFeed
   };
 
   const [runWeave, weaving] = useAsyncAction(async () => {
+    const operationId = beginAiRun();
     const result = await weaveLoomEpisode(loom.id, episode.id, {
       guidance: form.guidance,
       replace: hasScenes,
-    }, { silent: true });
+      operationId,
+    }, { silent: true }).catch((error) => {
+      failAiRun(error.message);
+      throw error;
+    });
     onLoomUpdate(result.loom);
     toast.success('Episode woven');
     onClose();
@@ -729,6 +737,7 @@ function EpisodeSetupDrawer({ open, onClose, loom, episode, onLoomUpdate, onFeed
             {weaving ? <Loader2 size={14} className="animate-spin" /> : <Sparkles size={14} />}
             {weaving ? 'Weaving…' : hasScenes ? 'Reweave episode' : 'Weave episode'}
           </button>
+          <LoomAiRunStatus run={aiRun} />
         </div>
 
         <LoomEpisodeFeedback

--- a/server/lib/fableLoomValidation.js
+++ b/server/lib/fableLoomValidation.js
@@ -212,20 +212,21 @@ export const nodePatchSchema = z.object(nodeFields);
 
 // A per-call pick carries the same three dimensions as the saved pin.
 const llmPickFields = llmRoutePinSchema.shape;
+const aiRunFields = { ...llmPickFields, operationId: z.string().uuid().optional() };
 
 export const weaveSchema = z.object({
   guidance: z.string().max(4000).optional(),
   replace: z.boolean().optional(),
-  ...llmPickFields,
+  ...aiRunFields,
 });
 
 export const branchSchema = z.object({
   guidance: z.string().max(4000).optional(),
   branchCount: z.number().int().min(1).max(4).optional(),
-  ...llmPickFields,
+  ...aiRunFields,
 });
 
-export const reviewSchema = z.object({ ...llmPickFields });
+export const reviewSchema = z.object({ ...aiRunFields });
 
 // A turn is EITHER a reader's free text (matched to a path by the play stage)
 // or a path the reader took outright — a tapped choice needs no intent
@@ -238,7 +239,7 @@ export const playTurnSchema = z.object({
     role: z.enum(['reader', 'narrator']),
     text: z.string().max(4000),
   })).max(50).optional(),
-  ...llmPickFields,
+  ...aiRunFields,
 }).refine((body) => body.message || body.transitionId, {
   message: 'A play turn needs either a message or a transitionId',
   path: ['message'],
@@ -246,21 +247,21 @@ export const playTurnSchema = z.object({
 
 export const reformatSchema = z.object({
   format,
-  ...llmPickFields,
+  ...aiRunFields,
 });
 
 export const feedbackSchema = z.object({
   feedback: z.string().trim().min(1).max(LOOM_LIMITS.FEEDBACK_MAX),
-  ...llmPickFields,
+  ...aiRunFields,
 });
 
-export const seriesPlanReviewSchema = z.object({ ...llmPickFields });
+export const seriesPlanReviewSchema = z.object({ ...aiRunFields });
 
-export const seriesPlanGenerateSchema = z.object({ ...llmPickFields });
+export const seriesPlanGenerateSchema = z.object({ ...aiRunFields });
 
 export const seriesPlanFeedbackSchema = z.object({
   feedback: z.string().trim().min(1).max(LOOM_LIMITS.FEEDBACK_MAX),
-  ...llmPickFields,
+  ...aiRunFields,
 });
 
 export const hostedSessionCreateSchema = z.object({
@@ -275,4 +276,3 @@ export const hostedSessionPatchSchema = z.object({
   playbackPhase: z.enum(['entry', 'hold', 'exit', 'ended']).optional(),
   activeHoldIndex: z.number().int().min(0).max(10).optional(),
 });
-

--- a/server/services/aiStatusEvents.js
+++ b/server/services/aiStatusEvents.js
@@ -40,6 +40,8 @@ const ICONS = {
  * @param {string} [init.model]
  * @param {string} [init.appId]         — managed-app id this call works on behalf of
  * @param {string} [init.workspacePath] — CoS-agent workspace this call works on behalf of
+ * @param {string} [init.operationId]   — caller-owned id for correlating a UI operation
+ * @param {boolean} [init.localOnly]   — keep the event off the global AI toast surface
  * @param {boolean} [init.background]    — this call is part of an UNATTENDED job (a
  *   scheduled/autopilot task the user isn't watching), NOT merely display-silent.
  *   Distinct from `silent` (which only suppresses the start toast — user-triggered
@@ -62,6 +64,8 @@ export function startAIOp(init) {
     model: init.model,
     appId: init.appId,
     workspacePath: init.workspacePath,
+    operationId: init.operationId,
+    localOnly: !!init.localOnly,
     silent: !!init.silent,
     background: !!init.background
   };

--- a/server/services/aiStatusEvents.test.js
+++ b/server/services/aiStatusEvents.test.js
@@ -33,6 +33,22 @@ describe('startAIOp building-association fields', () => {
     expect(events.map(e => e.phase)).toEqual(['start', 'model:loading', 'complete']);
   });
 
+  it('propagates an operation id and local-only marker onto every phase event', () => {
+    const events = captureEvents(() => {
+      const op = startAIOp({
+        op: 'fableloom-feedback-episode',
+        label: 'Updating episode',
+        operationId: 'op-42',
+        localOnly: true,
+      });
+      op.update('running', 'Working…');
+      op.complete('Ready');
+    });
+
+    expect(events).toHaveLength(3);
+    expect(events.every((event) => event.operationId === 'op-42' && event.localOnly)).toBe(true);
+  });
+
   it('leaves appId/workspacePath undefined for unassociated internal ops', () => {
     const [start] = captureEvents(() => {
       startAIOp({ op: 'taste-summary', label: 'Summarizing taste' });

--- a/server/services/fableLoom/weave.js
+++ b/server/services/fableLoom/weave.js
@@ -14,6 +14,7 @@
 
 import { randomUUID } from 'crypto';
 import { ServerError } from '../../lib/errorHandler.js';
+import { startAIOp } from '../aiStatusEvents.js';
 import { runStagedLLM } from '../stageRunner.js';
 import { isStr, trimTo } from '../../lib/storyBible.js';
 import { resolveLlmRoutePin } from '../../lib/llmRoutePin.js';
@@ -59,6 +60,51 @@ const llmOptions = ({ providerId, model, effort } = {}, source) => ({
   ...(model ? { modelOverride: model } : {}),
   ...(effort ? { effortOverride: effort } : {}),
 });
+
+// FableLoom edits are one HTTP request but can spend minutes inside a TUI. The
+// operation id is minted by the requesting view, so status frames cannot be
+// mistaken for a different loom or a stale run in another tab. The normal
+// `ai:status` channel carries these frames; `localOnly` keeps the global toast
+// surface from duplicating the drawer's inline status and error message.
+const runLoomAi = (stage, variables, route, { action, label, source }) => {
+  const status = route.operationId
+    ? startAIOp({
+      op: `fableloom-${action}`,
+      label,
+      operationId: route.operationId,
+      localOnly: true,
+      silent: true,
+    })
+    : null;
+  const options = llmOptions(route, source);
+  if (status) {
+    options.onRunCreated = (runId, meta = {}) => status.update(
+      'running',
+      `${label} is running…`,
+      { ...meta, runId },
+    );
+    options.onRunReady = (meta = {}) => status.update(
+      'ready',
+      'TUI run is ready — open Shell to watch and interact',
+      meta,
+    );
+    options.onRunSettled = (runId) => status.update(
+      'applying',
+      'AI response received — applying changes…',
+      { runId },
+    );
+  }
+  return runStagedLLM(stage, variables, options).then((result) => {
+    status?.complete('AI response ready', { runId: result.runId, shellReady: false });
+    return result;
+  }, (error) => {
+    status?.error(
+      error?.message || 'AI operation failed',
+      error?.runId ? { runId: error.runId } : {},
+    );
+    throw error;
+  });
+};
 
 /**
  * Routing for a play turn: an explicit per-call pick beats the loom's saved
@@ -206,7 +252,7 @@ export function mapGeneratedGraph(parsed) {
 }
 
 export async function weaveEpisode(loomId, episodeId, {
-  guidance = '', replace = false, providerId, model, effort,
+  guidance = '', replace = false, providerId, model, effort, operationId,
 } = {}) {
   const loom = await requireLoom(loomId);
   const episode = findEpisode(loom, episodeId);
@@ -214,7 +260,7 @@ export async function weaveEpisode(loomId, episodeId, {
     throw new ServerError('Episode already has scenes — pass replace to regenerate', { status: 409, code: 'EPISODE_NOT_EMPTY' });
   }
   const canonDigest = await buildCanonDigest(loom);
-  const { content, runId } = await runStagedLLM('fableloom-weave-episode', {
+  const { content, runId } = await runLoomAi('fableloom-weave-episode', {
     storyContext: storyContext(loom, episode),
     canonDigest: canonDigest || '(none — invent what the story needs)',
     guidance: guidance || '(none)',
@@ -224,7 +270,9 @@ export async function weaveEpisode(loomId, episodeId, {
     cameraMovementCatalog: fableLoomCameraMovementCatalogForPrompt(),
     sceneFormatContract: sceneFormatContract(loom.format),
     participationContract: audienceContract(loom, episode),
-  }, llmOptions({ providerId, model, effort }, 'fableloom-weave'));
+  }, { providerId, model, effort, operationId }, {
+    action: 'weave-episode', label: 'Weaving episode', source: 'fableloom-weave',
+  });
 
   const { nodes, startNodeId } = mapGeneratedGraph(content);
   if (loom.participationMode === 'helper') {
@@ -258,7 +306,7 @@ export async function weaveEpisode(loomId, episodeId, {
 // --- Branch: grow new paths out of one scene --------------------------------
 
 export async function branchNode(loomId, episodeId, nodeId, {
-  guidance = '', branchCount, providerId, model, effort,
+  guidance = '', branchCount, providerId, model, effort, operationId,
 } = {}) {
   const loom = await requireLoom(loomId);
   const episode = findEpisode(loom, episodeId);
@@ -272,7 +320,7 @@ export async function branchNode(loomId, episodeId, nodeId, {
   const count = clamp(branchCount, 1, 4, 2);
 
   const canonDigest = await buildCanonDigest(loom);
-  const { content, runId } = await runStagedLLM('fableloom-branch-node', {
+  const { content, runId } = await runLoomAi('fableloom-branch-node', {
     storyContext: storyContext(loom, episode),
     canonDigest: canonDigest || '(none — invent what the story needs)',
     graphDigest: describeGraphForPrompt(episode, {
@@ -286,7 +334,9 @@ export async function branchNode(loomId, episodeId, nodeId, {
     guidance: guidance || '(none)',
     sceneFormatContract: sceneFormatContract(loom.format),
     participationContract: audienceContract(loom, episode),
-  }, llmOptions({ providerId, model, effort }, 'fableloom-branch'));
+  }, { providerId, model, effort, operationId }, {
+    action: 'branch-node', label: 'Growing scene branches', source: 'fableloom-branch',
+  });
 
   const branches = Array.isArray(content?.branches)
     ? content.branches.filter((b) => b && typeof b === 'object' && b.node && typeof b.node === 'object').slice(0, count)
@@ -328,20 +378,22 @@ export async function branchNode(loomId, episodeId, nodeId, {
 
 const REVIEW_SEVERITIES = new Set(['high', 'medium', 'low']);
 
-export async function reviewEpisode(loomId, episodeId, { providerId, model, effort } = {}) {
+export async function reviewEpisode(loomId, episodeId, { providerId, model, effort, operationId } = {}) {
   const loom = await requireLoom(loomId);
   const episode = findEpisode(loom, episodeId);
   const structural = analyzeEpisodeGraph(episode, {
     participationMode: loom.participationMode,
     requireAudienceIntroduction: requiresAudienceIntroduction(loom, episode),
   });
-  const { content, runId } = await runStagedLLM('fableloom-review', {
+  const { content, runId } = await runLoomAi('fableloom-review', {
     storyContext: storyContext(loom, episode),
     graphDigest: describeGraphForPrompt(episode, { participationMode: loom.participationMode }),
     structuralDigest: structural.issues.length
       ? structural.issues.map((i) => `- [${i.severity}] ${i.message}`).join('\n')
       : '(no structural issues)',
-  }, llmOptions({ providerId, model, effort }, 'fableloom-review'));
+  }, { providerId, model, effort, operationId }, {
+    action: 'review-episode', label: 'Reviewing episode', source: 'fableloom-review',
+  });
 
   const nodeIds = new Set(episode.nodes.map((n) => n.id));
   const findings = (Array.isArray(content?.findings) ? content.findings : [])
@@ -442,7 +494,7 @@ const normalizeFeedbackPatch = (content, episode) => {
  * records need to be added or removed.
  */
 export async function feedbackEpisode(loomId, episodeId, {
-  feedback, providerId, model, effort,
+  feedback, providerId, model, effort, operationId,
 } = {}) {
   const instruction = trimTo(feedback, LOOM_LIMITS.FEEDBACK_MAX);
   if (!instruction) {
@@ -451,7 +503,7 @@ export async function feedbackEpisode(loomId, episodeId, {
   const loom = await requireLoom(loomId);
   const episode = findEpisode(loom, episodeId);
   const canonDigest = await buildCanonDigest(loom);
-  const { content, runId } = await runStagedLLM('fableloom-feedback-episode', {
+  const { content, runId } = await runLoomAi('fableloom-feedback-episode', {
     storyContext: storyContext(loom, episode),
     canonDigest: canonDigest || '(none)',
     graphDigest: describeGraphForPrompt(episode, {
@@ -460,7 +512,9 @@ export async function feedbackEpisode(loomId, episodeId, {
     }),
     cameraMovementCatalog: fableLoomCameraMovementCatalogForPrompt(),
     feedback: instruction,
-  }, llmOptions({ providerId, model, effort }, 'fableloom-feedback'));
+  }, { providerId, model, effort, operationId }, {
+    action: 'feedback-episode', label: 'Updating episode', source: 'fableloom-feedback',
+  });
 
   const { episodePatch, scenePatches } = normalizeFeedbackPatch(content, episode);
   const updated = await mutateLoom(loomId, (current) => {
@@ -507,15 +561,17 @@ const analysisStrings = (value) => (Array.isArray(value) ? value : [])
  * plan. This intentionally replaces only `seriesPlan`; episode records and
  * scene graphs remain untouched.
  */
-export async function generateSeriesPlan(loomId, { providerId, model, effort } = {}) {
+export async function generateSeriesPlan(loomId, { providerId, model, effort, operationId } = {}) {
   const loom = await requireLoom(loomId);
   const sourceFingerprint = seriesPlanGenerationFingerprint(loom);
   const canonDigest = await buildCanonDigest(loom);
-  const { content, runId } = await runStagedLLM('fableloom-generate-series-plan', {
+  const { content, runId } = await runLoomAi('fableloom-generate-series-plan', {
     storyContext: storyContext(loom),
     canonDigest: canonDigest || '(none — invent only what the premise needs)',
     seriesPlanJson: seriesPlanDigest(loom),
-  }, llmOptions({ providerId, model, effort }, 'fableloom-generate-series-plan'));
+  }, { providerId, model, effort, operationId }, {
+    action: 'generate-series-plan', label: 'Drafting series plan', source: 'fableloom-generate-series-plan',
+  });
 
   const storyArc = isStr(content?.storyArc) ? content.storyArc : '';
   const isUsablePlanItem = (item) => item && typeof item === 'object'
@@ -542,14 +598,16 @@ export async function generateSeriesPlan(loomId, { providerId, model, effort } =
 }
 
 /** Read-only story-editor pass over the arc, tentpole beats, side quests, and episode outline. */
-export async function reviewSeriesPlan(loomId, { providerId, model, effort } = {}) {
+export async function reviewSeriesPlan(loomId, { providerId, model, effort, operationId } = {}) {
   const loom = await requireLoom(loomId);
   const canonDigest = await buildCanonDigest(loom);
-  const { content, runId } = await runStagedLLM('fableloom-review-series-plan', {
+  const { content, runId } = await runLoomAi('fableloom-review-series-plan', {
     storyContext: storyContext(loom),
     canonDigest: canonDigest || '(none)',
     seriesPlanJson: seriesPlanDigest(loom),
-  }, llmOptions({ providerId, model, effort }, 'fableloom-review-series-plan'));
+  }, { providerId, model, effort, operationId }, {
+    action: 'review-series-plan', label: 'Reviewing series plan', source: 'fableloom-review-series-plan',
+  });
   const analysis = {
     summary: trimTo(content?.summary, 2000),
     strengths: analysisStrings(content?.strengths),
@@ -567,7 +625,7 @@ export async function reviewSeriesPlan(loomId, { providerId, model, effort } = {
 
 /** Apply one author instruction to the series-level plan without touching episode scene graphs. */
 export async function feedbackSeriesPlan(loomId, {
-  feedback, providerId, model, effort,
+  feedback, providerId, model, effort, operationId,
 } = {}) {
   const instruction = trimTo(feedback, LOOM_LIMITS.FEEDBACK_MAX);
   if (!instruction) {
@@ -575,12 +633,14 @@ export async function feedbackSeriesPlan(loomId, {
   }
   const loom = await requireLoom(loomId);
   const canonDigest = await buildCanonDigest(loom);
-  const { content, runId } = await runStagedLLM('fableloom-feedback-series-plan', {
+  const { content, runId } = await runLoomAi('fableloom-feedback-series-plan', {
     storyContext: storyContext(loom),
     canonDigest: canonDigest || '(none)',
     seriesPlanJson: seriesPlanDigest(loom),
     feedback: instruction,
-  }, llmOptions({ providerId, model, effort }, 'fableloom-feedback-series-plan'));
+  }, { providerId, model, effort, operationId }, {
+    action: 'feedback-series-plan', label: 'Updating series plan', source: 'fableloom-feedback-series-plan',
+  });
 
   if (!content || typeof content !== 'object') {
     throw aiShapeError('The model returned no series-plan edits');
@@ -793,7 +853,7 @@ const unconvertedSceneCount = (loom, target) => loom.episodes.reduce(
  * browser closed mid-walk can't leave the loom pinned to a format half its
  * scenes are not in.
  */
-export async function reformatEpisodeScenes(loomId, episodeId, { format, providerId, model, effort } = {}) {
+export async function reformatEpisodeScenes(loomId, episodeId, { format, providerId, model, effort, operationId } = {}) {
   const target = asLoomFormat(format);
   const loom = await requireLoom(loomId);
   const episode = findEpisode(loom, episodeId);
@@ -806,7 +866,7 @@ export async function reformatEpisodeScenes(loomId, episodeId, { format, provide
   for (let i = 0; i < nodes.length && chunks < REFORMAT_CHUNKS_MAX; i += REFORMAT_CHUNK) {
     const batch = nodes.slice(i, i + REFORMAT_CHUNK);
     chunks += 1;
-    const { content, runId } = await runStagedLLM('fableloom-reformat-scenes', {
+    const { content, runId } = await runLoomAi('fableloom-reformat-scenes', {
       // The TARGET format, not the loom's current one: the pin is written
       // last, so passing `loom` would assert the source format as fact in
       // the same prompt that asks for the target — and would render
@@ -816,7 +876,9 @@ export async function reformatEpisodeScenes(loomId, episodeId, { format, provide
       formatLabel: loomFormatLabel(target),
       sceneFormatContract: sceneFormatContract(target),
       scenesJson: JSON.stringify(batch.map((n) => ({ id: n.id, title: n.title, prose: n.prose })), null, 2),
-    }, llmOptions({ providerId, model, effort }, 'fableloom-reformat'));
+    }, { providerId, model, effort, operationId }, {
+      action: 'reformat-scenes', label: 'Reformatting scenes', source: 'fableloom-reformat',
+    });
     if (runId) runIds.push(runId);
 
     // Only ids from THIS batch count. A model that invents an id, echoes a

--- a/server/services/fableLoom/weave.js
+++ b/server/services/fableLoom/weave.js
@@ -66,8 +66,7 @@ const llmOptions = ({ providerId, model, effort } = {}, source) => ({
 // mistaken for a different loom or a stale run in another tab. The normal
 // `ai:status` channel carries these frames; `localOnly` keeps the global toast
 // surface from duplicating the drawer's inline status and error message.
-const runLoomAi = (stage, variables, route, { action, label, source }) => {
-  const status = route.operationId
+const createLoomAiStatus = (route, { action, label }) => route.operationId
     ? startAIOp({
       op: `fableloom-${action}`,
       label,
@@ -75,13 +74,18 @@ const runLoomAi = (stage, variables, route, { action, label, source }) => {
       localOnly: true,
       silent: true,
     })
-    : null;
+  : null;
+
+const runLoomAi = (stage, variables, route, {
+  action, label, source, status: existingStatus = null, complete = true,
+}) => {
+  const status = existingStatus || createLoomAiStatus(route, { action, label });
   const options = llmOptions(route, source);
   if (status) {
     options.onRunCreated = (runId, meta = {}) => status.update(
       'running',
       `${label} is running…`,
-      { ...meta, runId },
+      { ...meta, runId, shellReady: false },
     );
     options.onRunReady = (meta = {}) => status.update(
       'ready',
@@ -95,7 +99,7 @@ const runLoomAi = (stage, variables, route, { action, label, source }) => {
     );
   }
   return runStagedLLM(stage, variables, options).then((result) => {
-    status?.complete('AI response ready', { runId: result.runId, shellReady: false });
+    if (complete) status?.complete('AI response ready', { runId: result.runId, shellReady: false });
     return result;
   }, (error) => {
     status?.error(
@@ -860,6 +864,10 @@ export async function reformatEpisodeScenes(loomId, episodeId, { format, provide
   const canonDigest = await buildCanonDigest(loom);
   const runIds = [];
   const nodes = episode.nodes.filter((n) => needsReformat(n, target));
+  const status = createLoomAiStatus(
+    { operationId, providerId, model, effort },
+    { action: 'reformat-scenes', label: 'Reformatting scenes' },
+  );
   let rewritten = 0;
   let chunks = 0;
 
@@ -877,7 +885,7 @@ export async function reformatEpisodeScenes(loomId, episodeId, { format, provide
       sceneFormatContract: sceneFormatContract(target),
       scenesJson: JSON.stringify(batch.map((n) => ({ id: n.id, title: n.title, prose: n.prose })), null, 2),
     }, { providerId, model, effort, operationId }, {
-      action: 'reformat-scenes', label: 'Reformatting scenes', source: 'fableloom-reformat',
+      action: 'reformat-scenes', label: 'Reformatting scenes', source: 'fableloom-reformat', status, complete: false,
     });
     if (runId) runIds.push(runId);
 
@@ -905,6 +913,8 @@ export async function reformatEpisodeScenes(loomId, episodeId, { format, provide
     });
     rewritten += byId.size;
   }
+
+  status?.complete('AI response ready', { runId: runIds.at(-1), shellReady: false });
 
   // An episode with nothing to rewrite is a no-op, not a failure — the client
   // walks every episode, and the pin below is still the point. Only an episode

--- a/server/services/fableLoom/weave.test.js
+++ b/server/services/fableLoom/weave.test.js
@@ -24,6 +24,7 @@ vi.mock('../pipeline/series.js', () => ({ getSeries: getSeriesMock }));
 
 const { createLoom, addEpisode, addNode, mutateLoom, updateLoom, updateNode, getLoom } = await import('./records.js');
 const { _resetFableLoomBackend } = await import('./store.js');
+const { aiStatusEvents } = await import('../aiStatusEvents.js');
 const {
   branchNode, buildCanonDigest, feedbackEpisode, feedbackSeriesPlan, generateSeriesPlan, mapGeneratedGraph, playTurn,
   reformatEpisodeScenes, reviewEpisode, reviewSeriesPlan, weaveEpisode,
@@ -233,6 +234,34 @@ describe('reviewEpisode', () => {
 });
 
 describe('feedbackEpisode', () => {
+  it('reports the provider and shell lifecycle for an in-page operation', async () => {
+    const { loomId, episodeId } = await setup();
+    const events = [];
+    const handle = (event) => events.push(event);
+    aiStatusEvents.on('status', handle);
+    runStagedLLM.mockImplementation(async (_stage, _variables, options) => {
+      options.onRunCreated('run-feedback', {
+        providerId: 'codex-tui', providerName: 'Codex TUI', model: 'gpt-test', providerType: 'tui',
+      });
+      options.onRunReady({
+        runId: 'run-feedback', providerId: 'codex-tui', providerName: 'Codex TUI',
+        model: 'gpt-test', providerType: 'tui', shellReady: true,
+      });
+      options.onRunSettled('run-feedback');
+      return { content: { title: 'Revised' }, runId: 'run-feedback' };
+    });
+
+    await feedbackEpisode(loomId, episodeId, {
+      feedback: 'Revise the title.', operationId: '00000000-0000-4000-8000-000000000042',
+    });
+    aiStatusEvents.off('status', handle);
+
+    expect(events.map((event) => event.phase)).toEqual(['start', 'running', 'ready', 'applying', 'complete']);
+    expect(events.find((event) => event.phase === 'ready')).toMatchObject({
+      runId: 'run-feedback', shellReady: true, operationId: '00000000-0000-4000-8000-000000000042',
+    });
+  });
+
   it('applies sparse metadata, scene, and existing-path edits without changing ids', async () => {
     const { loomId, episodeId } = await setup();
     let updated = await addNode(loomId, episodeId, { title: 'The Gate', prose: 'You wait.' });

--- a/server/services/promptRunner.js
+++ b/server/services/promptRunner.js
@@ -524,9 +524,11 @@ export function assertVisionRunUsedImages(result, requestedProvider) {
  *   `text` value — callers receive the full buffered text either way.
  *   For TUI providers the stripped chunks are emitted; the final `text`
  *   is the cleaned response with the prompt-echo elided.
- * @param {(runId:string)=>void} [args.onRunCreated] — called immediately after
+ * @param {(runId:string,meta:object)=>void} [args.onRunCreated] — called immediately after
  *   each concrete primary/correction/fallback run id is known. Observational;
  *   callback errors are logged and ignored.
+ * @param {(meta:object)=>void} [args.onRunReady] — called when an interactive
+ *   TUI run has been registered as an attachable shell session.
  * @param {(runId:string)=>void} [args.onRunSettled] — called when that concrete
  *   attempt resolves or rejects. Observational; callback errors are ignored.
  * @param {string[]} [args.screenshots] — image paths for a vision/multimodal
@@ -1148,6 +1150,7 @@ async function executeProviderRunOnce({
   runId: callerRunId,
   onData: onDataCallback,
   onRunCreated,
+  onRunReady,
   onRunSettled,
   timeout: timeoutOverride,
   cwd: cwdOverride,
@@ -1229,7 +1232,15 @@ async function executeProviderRunOnce({
   // caller-supplied primary run AND for every fresh correction/fallback run.
   // Hook failures are observational only and must not break provider work.
   if (typeof onRunCreated === 'function') {
-    try { onRunCreated(runId); } catch (err) {
+    try {
+      onRunCreated(runId, {
+        runId,
+        providerId: effectiveProvider.id,
+        providerName: effectiveProvider.name || effectiveProvider.id,
+        model: effectiveModel,
+        providerType: effectiveProvider.type,
+      });
+    } catch (err) {
       console.error(`❌ run lifecycle start hook failed: ${err.message}`);
     }
   }
@@ -1389,7 +1400,7 @@ async function executeProviderRunOnce({
     } else if (effectiveProvider.type === PROVIDER_TYPES.TUI) {
       // `source` (e.g. 'pipeline-manuscript-completeness') labels the live,
       // interactive view this TUI run surfaces in the Shell page.
-      executeTuiRun({ runId, provider: providerForRun, prompt, workspacePath: effectiveCwd, onData, onComplete, timeout: effectiveTimeout, label: source }).catch(safeReject);
+      executeTuiRun({ runId, provider: providerForRun, prompt, workspacePath: effectiveCwd, onData, onComplete, onReady: onRunReady, timeout: effectiveTimeout, label: source }).catch(safeReject);
     } else {
       safeReject(new Error(`Unsupported provider type: ${effectiveProvider.type}`));
     }

--- a/server/services/promptRunner.test.js
+++ b/server/services/promptRunner.test.js
@@ -176,6 +176,37 @@ describe('promptRunner — happy paths', () => {
     expect(events).toEqual(['created:run-xyz', 'execute:run-xyz', 'settled:run-xyz']);
   });
 
+  it('forwards the attachable-shell readiness callback for TUI providers', async () => {
+    const onRunReady = vi.fn();
+    tuiRunner.executeTuiRun.mockImplementation(async ({ runId, provider, onReady, onComplete }) => {
+      onReady?.({
+        runId,
+        providerId: provider.id,
+        providerName: provider.name || provider.id,
+        model: provider.defaultModel,
+        providerType: provider.type,
+        shellReady: true,
+      });
+      onComplete({ success: true });
+    });
+
+    await runPromptThroughProvider({
+      provider: tuiProvider({ name: 'Codex TUI' }),
+      prompt: 'p',
+      source: 'test',
+      onRunReady,
+    });
+
+    expect(onRunReady).toHaveBeenCalledWith({
+      runId: 'run-xyz',
+      providerId: 'claude-code-tui',
+      providerName: 'Codex TUI',
+      model: 'm-default',
+      providerType: 'tui',
+      shellReady: true,
+    });
+  });
+
   it('forwards screenshots to executeApiRun for a vision/multimodal call', async () => {
     runner.executeApiRun.mockImplementation(async ({ onComplete }) => onComplete({ success: true }));
 

--- a/server/services/stageRunner.js
+++ b/server/services/stageRunner.js
@@ -654,6 +654,7 @@ async function executeStagePrompt({ stage, label, prompt, options }) {
     // effort control, so no capability check is needed here.
     effort: effectiveEffort,
     onRunCreated: options.onRunCreated,
+    onRunReady: options.onRunReady,
     onRunSettled: options.onRunSettled,
   });
   const { text } = runResult2;

--- a/server/services/tuiPromptRunner.js
+++ b/server/services/tuiPromptRunner.js
@@ -148,7 +148,7 @@ const PTY_ROWS = 50;
  *   it reports itself, not a provider incident for the autofixer to escalate.
  * @returns {Promise<void>}
  */
-export async function executeTuiRun({ runId, provider, prompt, workspacePath, onData, onComplete, timeout, idleMs, label, guard = false, reportFailure = true }) {
+export async function executeTuiRun({ runId, provider, prompt, workspacePath, onData, onComplete, onReady, timeout, idleMs, label, guard = false, reportFailure = true }) {
   if (!provider || typeof provider !== 'object') {
     throw new Error('executeTuiRun: provider is required');
   }
@@ -301,6 +301,18 @@ ${prompt}`;
     cwd: workingDir,
     kind: 'tui-run',
   });
+  try {
+    onReady?.({
+      runId,
+      providerId: provider.id,
+      providerName: provider.name || provider.id,
+      model: provider.defaultModel,
+      providerType: provider.type,
+      shellReady: true,
+    });
+  } catch (err) {
+    console.error(`❌ TUI ready hook failed: ${err.message}`);
+  }
 
   const startTime = Date.now();
   let outputBuffer = '';

--- a/server/services/tuiPromptRunner.test.js
+++ b/server/services/tuiPromptRunner.test.js
@@ -510,9 +510,10 @@ describe('executeTuiRun', () => {
 
     it('registers a read-only Shell view (labelled by source) and tears it down on finish', async () => {
       const provider = { id: 'claude', type: 'tui', command: 'claude', defaultModel: 'claude-fable-5' };
+      const onReady = vi.fn();
       const promise = executeTuiRun({
         runId: 'run-view', provider, prompt: 'review this manuscript', workspacePath: TEST_WORKSPACE,
-        label: 'pipeline-manuscript-completeness',
+        label: 'pipeline-manuscript-completeness', onReady,
       });
       await flushAsync();
 
@@ -525,6 +526,14 @@ describe('executeTuiRun', () => {
           cwd: TEST_WORKSPACE,
         }),
       );
+      expect(onReady).toHaveBeenCalledWith({
+        runId: 'run-view',
+        providerId: 'claude',
+        providerName: 'claude',
+        model: 'claude-fable-5',
+        providerType: 'tui',
+        shellReady: true,
+      });
       expect(shellMocks.unregisterExternalSession).not.toHaveBeenCalled();
 
       ptyInstances[0].emitExit({ exitCode: 0 });


### PR DESCRIPTION
## Summary
- Add live status phases for FableLoom series and episode AI actions.
- Surface the selected provider/model and link active shell TUI runs into the existing Shell view.
- Keep status correlated to the initiating drawer and preserve a single lifecycle for multi-chunk work.

## Test plan
- `npm run lint --prefix client`
- `npm run build --prefix client`
- Focused FableLoom client Vitest suites
- Focused FableLoom/provider/TUI server Vitest suites