### PR TITLE
fix: contain FableLoom graph media previews

### DIFF
--- a/client/src/components/fableloom/LoomCanvas.jsx
+++ b/client/src/components/fableloom/LoomCanvas.jsx
@@ -259,7 +259,7 @@ export default function LoomCanvas({
                   width={nodeW - 16}
                   height={nodeH - 48}
                 >
-                  <div className="h-full" xmlns="http://www.w3.org/1999/xhtml">
+                  <div className="h-full w-full min-w-0 overflow-hidden" xmlns="http://www.w3.org/1999/xhtml">
                     <LoomSceneMedia
                       node={node}
                       jobs={mediaJobs[node.id]}

--- a/client/src/components/fableloom/LoomCanvas.test.jsx
+++ b/client/src/components/fableloom/LoomCanvas.test.jsx
@@ -136,8 +136,12 @@ describe('LoomCanvas', () => {
     );
 
     const preview = screen.getByAltText('The Gate image generation preview').parentElement;
+    const mediaHost = screen.getByLabelText('Scene: The Gate').querySelector('foreignObject > div');
+    expect(mediaHost).toHaveClass('h-full', 'w-full', 'min-w-0', 'overflow-hidden');
     expect(preview).toHaveClass('grid');
+    expect(preview).toHaveClass('min-w-0');
     expect(preview).not.toHaveClass('relative');
+    expect(screen.getByAltText('The Gate image generation preview')).toHaveClass('block', 'min-w-0');
     expect(screen.getByText('Generating image 42%')).not.toHaveClass('absolute');
 
     rerender(

--- a/client/src/components/fableloom/LoomSceneMedia.jsx
+++ b/client/src/components/fableloom/LoomSceneMedia.jsx
@@ -80,21 +80,21 @@ export default function LoomSceneMedia({
   // the SVG origin. Compact media lives in that exact shape, so overlap its
   // preview/status with one grid cell instead of relative/absolute positioning.
   const previewClass = compact
-    ? 'grid flex-1 min-h-0 overflow-hidden rounded border border-port-border bg-port-bg'
+    ? 'grid flex-1 min-h-0 min-w-0 overflow-hidden rounded border border-port-border bg-port-bg'
     : 'relative min-h-0 overflow-hidden rounded border border-port-border bg-port-bg aspect-video max-h-56';
-  const previewItemClass = compact ? 'col-start-1 row-start-1 min-h-0' : '';
+  const previewItemClass = compact ? 'col-start-1 row-start-1 min-h-0 min-w-0' : '';
   const noticePositionClass = compact
     ? 'col-start-1 row-start-1 self-end'
     : 'absolute inset-x-0 bottom-0';
 
   return (
-    <div className={compact ? 'flex h-full min-h-0 flex-col gap-1' : 'space-y-2'}>
+    <div className={compact ? 'flex h-full w-full min-h-0 min-w-0 flex-col gap-1' : 'space-y-2'}>
       <div className={previewClass}>
         {showFinalVideo ? (
           <video
             src={`/data/videos/${encodeURIComponent(node.videoHistoryId)}.mp4`}
             aria-label={`${title} video preview`}
-            className={`${previewItemClass} h-full w-full object-cover`}
+            className={`${previewItemClass} block h-full w-full object-cover`}
             controls={!compact}
             autoPlay={compact}
             muted={compact}
@@ -108,13 +108,13 @@ export default function LoomSceneMedia({
           <img
             src={`data:image/png;base64,${liveFrame}`}
             alt={`${title} ${activeKind} generation preview`}
-            className={`${previewItemClass} h-full w-full object-cover`}
+            className={`${previewItemClass} block h-full w-full object-cover`}
           />
         ) : showStill ? (
           <MediaImage
             src={`/data/images/${node.image}`}
             alt={`${title} image preview`}
-            className={`${previewItemClass} h-full w-full object-cover`}
+            className={`${previewItemClass} block h-full w-full object-cover`}
           />
         ) : showSpinner ? (
           <div className={`${previewItemClass} grid h-full min-h-16 place-items-center text-port-accent`}>


### PR DESCRIPTION
## Summary
- Constrain FableLoom graph media hosts and preview layers to the SVG node bounds.
- Keep compact preview layering static for WebKit while preventing intrinsic media sizing from escaping the node.

## Test plan
- `npm --prefix client test -- --run src/components/fableloom`
- `npm --prefix client run build`
- `npm exec -- biome lint --error-on-warnings src/components/fableloom/LoomCanvas.jsx src/components/fableloom/LoomSceneMedia.jsx src/components/fableloom/LoomCanvas.test.jsx` (from `client/`)