### PR TITLE
fix: restore FableLoom mobile scene previews and details

### DIFF
--- a/client/src/components/fableloom/LoomCanvas.jsx
+++ b/client/src/components/fableloom/LoomCanvas.jsx
@@ -45,8 +45,10 @@ export default function LoomCanvas({
   // An in-flight drag lives entirely outside React state: the dragged <g>'s
   // transform is mutated directly per pointermove, and the position commits
   // once on release. Routing it through setState re-rendered every node card
-  // (each with a foreignObject subtree) ~60×/s. Edges catch up on release.
+  // (each with a foreignObject media surface) ~60×/s. Edges catch up on release.
   const dragRef = useRef(null);
+  const cardRefs = useRef(new Map());
+  const mediaRefs = useRef(new Map());
   const [measureRef, measuredWidth] = useContainerWidth();
   const viewportWidth = viewportWidthProp ?? measuredWidth;
   const markerId = useId().replace(/:/g, '');
@@ -78,7 +80,8 @@ export default function LoomCanvas({
     const start = positions[node.id] || { x: 0, y: 0 };
     dragRef.current = {
       id: node.id,
-      el: event.currentTarget,
+      cardEl: cardRefs.current.get(node.id),
+      mediaEl: mediaRefs.current.get(node.id),
       startX: event.clientX,
       startY: event.clientY,
       originX: start.x,
@@ -98,7 +101,11 @@ export default function LoomCanvas({
     drag.moved = true;
     drag.x = Math.max(0, drag.originX + dx);
     drag.y = Math.max(0, drag.originY + dy);
-    drag.el.setAttribute('transform', `translate(${drag.x}, ${drag.y})`);
+    drag.cardEl?.setAttribute('transform', `translate(${drag.x}, ${drag.y})`);
+    // Media foreignObjects are deliberately NOT children of the transformed
+    // card group. Move their absolute coordinates in lockstep while dragging.
+    drag.mediaEl?.setAttribute('x', drag.x + 8);
+    drag.mediaEl?.setAttribute('y', drag.y + 24);
   };
 
   const handlePointerUp = () => {
@@ -106,7 +113,8 @@ export default function LoomCanvas({
     dragRef.current = null;
     if (!drag) return;
     if (drag.moved) {
-      drag.el.dataset.loomDragged = '1';
+      if (drag.cardEl) drag.cardEl.dataset.loomDragged = '1';
+      if (drag.mediaEl) drag.mediaEl.dataset.loomDragged = '1';
       onMoveNode?.(drag.id, { x: Math.round(drag.x), y: Math.round(drag.y) });
     }
   };
@@ -223,6 +231,10 @@ export default function LoomCanvas({
             return (
               <g
                 key={node.id}
+                ref={(element) => {
+                  if (element) cardRefs.current.set(node.id, element);
+                  else cardRefs.current.delete(node.id);
+                }}
                 data-node-id={node.id}
                 transform={`translate(${pos.x}, ${pos.y})`}
                 className={stacked ? 'cursor-pointer' : 'cursor-grab'}
@@ -253,24 +265,6 @@ export default function LoomCanvas({
                 <text x={10} y={17} className="fill-port-text text-[11px] font-semibold pointer-events-none">
                   {truncate(node.title || 'Untitled scene', titleMax)}
                 </text>
-                <foreignObject
-                  x={8}
-                  y={24}
-                  width={nodeW - 16}
-                  height={nodeH - 48}
-                >
-                  <div className="h-full w-full min-w-0 overflow-hidden" xmlns="http://www.w3.org/1999/xhtml">
-                    <LoomSceneMedia
-                      node={node}
-                      jobs={mediaJobs[node.id]}
-                      onGenerateImage={onGenerateImage}
-                      onGenerateVideo={onGenerateVideo}
-                      compact
-                      generationDisabled={generationDisabled}
-                      generationDisabledReason={generationDisabledReason}
-                    />
-                  </div>
-                </foreignObject>
                 <g transform={`translate(10, ${nodeH - 16})`} className="pointer-events-none">
                   {isStart && (
                     <g>
@@ -300,6 +294,46 @@ export default function LoomCanvas({
                   </text>
                 )}
               </g>
+            );
+          })}
+        </g>
+        {/* WebKit/iOS paints HTML inside a foreignObject at the wrong place
+            when an ancestor SVG group is transformed. Keep each media surface
+            at the SVG root and give it already-resolved canvas coordinates so
+            images and videos stay inside their scene card on every engine. */}
+        <g>
+          {nodes.map((node) => {
+            const pos = positions[node.id];
+            if (!pos) return null;
+            return (
+              <foreignObject
+                key={node.id}
+                ref={(element) => {
+                  if (element) mediaRefs.current.set(node.id, element);
+                  else mediaRefs.current.delete(node.id);
+                }}
+                data-node-media-id={node.id}
+                x={pos.x + 8}
+                y={pos.y + 24}
+                width={nodeW - 16}
+                height={nodeH - 48}
+                onPointerDown={(event) => handlePointerDown(event, node)}
+                onPointerMove={handlePointerMove}
+                onPointerUp={handlePointerUp}
+                onClick={(event) => handleNodeActivate(event, node.id)}
+              >
+                <div className="h-full w-full min-w-0 overflow-hidden" xmlns="http://www.w3.org/1999/xhtml">
+                  <LoomSceneMedia
+                    node={node}
+                    jobs={mediaJobs[node.id]}
+                    onGenerateImage={onGenerateImage}
+                    onGenerateVideo={onGenerateVideo}
+                    compact
+                    generationDisabled={generationDisabled}
+                    generationDisabledReason={generationDisabledReason}
+                  />
+                </div>
+              </foreignObject>
             );
           })}
         </g>

--- a/client/src/components/fableloom/LoomCanvas.test.jsx
+++ b/client/src/components/fableloom/LoomCanvas.test.jsx
@@ -123,7 +123,7 @@ describe('LoomCanvas', () => {
     expect(screen.getAllByRole('button', { name: 'Generate image' })[0]).toBeEnabled();
   });
 
-  it('keeps compact preview layers statically positioned inside the SVG node for WebKit', () => {
+  it('uses absolute SVG coordinates for compact media so WebKit keeps it inside the card', () => {
     const { rerender } = render(
       <LoomCanvas
         episode={episode()}
@@ -136,7 +136,13 @@ describe('LoomCanvas', () => {
     );
 
     const preview = screen.getByAltText('The Gate image generation preview').parentElement;
-    const mediaHost = screen.getByLabelText('Scene: The Gate').querySelector('foreignObject > div');
+    const sceneCard = screen.getByLabelText('Scene: The Gate');
+    const mediaSurface = document.querySelector('[data-node-media-id="n1"]');
+    const mediaHost = mediaSurface.querySelector('div');
+    const [, cardX, cardY] = /translate\(([^,]+), ([^)]+)\)/.exec(sceneCard.getAttribute('transform'));
+    expect(sceneCard).not.toContainElement(mediaSurface);
+    expect(mediaSurface).toHaveAttribute('x', String(Number(cardX) + 8));
+    expect(mediaSurface).toHaveAttribute('y', String(Number(cardY) + 24));
     expect(mediaHost).toHaveClass('h-full', 'w-full', 'min-w-0', 'overflow-hidden');
     expect(preview).toHaveClass('grid');
     expect(preview).toHaveClass('min-w-0');

--- a/client/src/components/fableloom/LoomSceneMedia.jsx
+++ b/client/src/components/fableloom/LoomSceneMedia.jsx
@@ -76,9 +76,9 @@ export default function LoomSceneMedia({
   const buttonClass = compact
     ? 'inline-flex min-w-0 items-center justify-center gap-1 rounded border border-port-border bg-port-bg/80 px-1.5 py-1 text-[9px] text-port-text hover:border-port-accent hover:text-port-accent disabled:opacity-45'
     : 'inline-flex items-center justify-center gap-1.5 rounded border border-port-border px-2.5 py-1.5 text-xs text-port-text hover:border-port-accent hover:text-port-accent disabled:opacity-45';
-  // WebKit paints positioned HTML inside a transformed SVG foreignObject at
-  // the SVG origin. Compact media lives in that exact shape, so overlap its
-  // preview/status with one grid cell instead of relative/absolute positioning.
+  // Compact media still lives inside an SVG foreignObject. Keep its overlapping
+  // preview/status layers in one grid cell: WebKit handles that more reliably
+  // than positioned HTML descendants, while the canvas owns card coordinates.
   const previewClass = compact
     ? 'grid flex-1 min-h-0 min-w-0 overflow-hidden rounded border border-port-border bg-port-bg'
     : 'relative min-h-0 overflow-hidden rounded border border-port-border bg-port-bg aspect-video max-h-56';

--- a/client/src/pages/FableLoomStory.jsx
+++ b/client/src/pages/FableLoomStory.jsx
@@ -7,14 +7,13 @@
  * play drawer rides ?play=1.
  * Left: the scene-graph canvas (stacks top-to-bottom under the `lg` rail
  * breakpoint). Right rail: the selected scene's editor, or the
- * structure/review panel when nothing is selected. On small screens the
- * rail sits under the canvas and is height-capped so the graph stays the
- * thing you scroll.
+ * structure/review panel when nothing is selected. On small screens a
+ * selected scene slides up over the graph as a dismissible details sheet.
  */
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Link, Navigate, useNavigate, useParams, useSearchParams } from 'react-router';
-import { ArrowLeft, BookOpenText, ListTree, Loader2, Plus, Settings, Sparkles, Trash2, Waypoints, Workflow as WorkflowIcon } from 'lucide-react';
+import { ArrowLeft, BookOpenText, ListTree, Loader2, Plus, Settings, Sparkles, Trash2, Waypoints, Workflow as WorkflowIcon, X } from 'lucide-react';
 import toast from '../components/ui/Toast';
 import Drawer from '../components/Drawer';
 import ConfirmButtonPair from '../components/ui/ConfirmButtonPair';
@@ -320,6 +319,9 @@ export default function FableLoomStory({ view = 'graph' }) {
   const selectNode = (id) => {
     navigate(episodePath(episodeId, id) + (playOpen ? '?play=1' : ''));
   };
+  const clearNodeSelection = () => {
+    navigate(episodePath(episodeId) + (playOpen ? '?play=1' : ''));
+  };
 
   const setPlayOpen = (open) => {
     setSearchParams((prev) => {
@@ -524,7 +526,7 @@ export default function FableLoomStory({ view = 'graph' }) {
           onSelectNode={(id) => navigate(episodePath(episode.id, id))}
         />
       ) : (
-        <div className="flex-1 min-h-0 flex flex-col lg:flex-row">
+        <div className="relative flex-1 min-h-0 flex flex-col lg:flex-row">
           <section className="flex-1 min-h-[55vh] lg:min-h-0 min-w-0 relative">
             {episode.nodes.length ? (
               <LoomCanvas
@@ -565,37 +567,66 @@ export default function FableLoomStory({ view = 'graph' }) {
               </div>
             )}
           </section>
+          {node && (
+            <button
+              type="button"
+              aria-label="Return to graph"
+              onClick={clearNodeSelection}
+              className="absolute inset-0 z-10 bg-black/45 lg:hidden"
+            />
+          )}
           <aside
-            className="lg:w-[380px] lg:shrink-0 max-h-dvh-cap lg:max-h-none border-t lg:border-t-0 lg:border-l border-port-border overflow-y-auto"
-            style={{ '--dvh-cap': '45vh', '--dvh-cap-dynamic': '45dvh' }}
+            data-testid={node ? 'scene-details-sheet' : 'loom-validation-rail'}
+            aria-label={node ? `${node.title || 'Scene'} details` : 'Episode validation'}
+            className={node
+              ? 'absolute inset-x-0 bottom-0 z-20 flex h-[calc(100%_-_0.75rem)] max-h-dvh-cap flex-col overflow-hidden rounded-t-2xl border border-b-0 border-port-border bg-port-card shadow-2xl motion-safe:animate-in motion-safe:slide-in-from-bottom-4 motion-safe:duration-200 lg:static lg:h-auto lg:max-h-none lg:w-[380px] lg:shrink-0 lg:rounded-none lg:border-y-0 lg:border-r-0 lg:border-l'
+              : 'max-h-dvh-cap overflow-hidden border-t border-port-border lg:max-h-none lg:w-[380px] lg:shrink-0 lg:border-t-0 lg:border-l'}
+            style={node
+              ? { '--dvh-cap': '78vh', '--dvh-cap-dynamic': '78dvh' }
+              : { '--dvh-cap': '45vh', '--dvh-cap-dynamic': '45dvh' }}
           >
-            {node ? (
-              <LoomNodeEditor
-                key={node.id}
-                loom={loom}
-                episode={episode}
-                node={node}
-                universe={linkedUniverse}
-                onLoomUpdate={setLoom}
-                onClearSelection={() => navigate(episodePath(episode.id))}
-                mediaJobs={mediaJobs[node.id]}
-                onGenerateImage={queueSceneImage}
-                onGenerateVideo={queueSceneVideo}
-                generationDisabled={styleContextLoading || styleContextUnavailable}
-                generationDisabledReason={generationDisabledReason}
-                onMakeStart={node.id !== episode.startNodeId ? async () => {
-                  const updated = await updateLoomEpisode(loomId, episode.id, { startNodeId: node.id })
-                    .catch(() => null);
-                  if (updated) setLoom(updated);
-                } : null}
-              />
-            ) : (
-              <LoomValidationPanel
-                loom={loom}
-                episode={episode}
-                onSelectNode={selectNode}
-              />
+            {node && (
+              <div className="relative flex shrink-0 items-center justify-center border-b border-port-border px-4 py-2 lg:hidden">
+                <span className="h-1 w-10 rounded-full bg-port-border" aria-hidden="true" />
+                <button
+                  type="button"
+                  onClick={clearNodeSelection}
+                  aria-label="Close scene details"
+                  className="absolute right-2 top-1/2 flex min-h-[44px] min-w-[44px] -translate-y-1/2 items-center justify-center rounded-lg text-port-text-muted hover:bg-port-border/50 hover:text-port-text"
+                >
+                  <X size={18} />
+                </button>
+              </div>
             )}
+            <div className="min-h-0 flex-1 overflow-y-auto">
+              {node ? (
+                <LoomNodeEditor
+                  key={node.id}
+                  loom={loom}
+                  episode={episode}
+                  node={node}
+                  universe={linkedUniverse}
+                  onLoomUpdate={setLoom}
+                  onClearSelection={clearNodeSelection}
+                  mediaJobs={mediaJobs[node.id]}
+                  onGenerateImage={queueSceneImage}
+                  onGenerateVideo={queueSceneVideo}
+                  generationDisabled={styleContextLoading || styleContextUnavailable}
+                  generationDisabledReason={generationDisabledReason}
+                  onMakeStart={node.id !== episode.startNodeId ? async () => {
+                    const updated = await updateLoomEpisode(loomId, episode.id, { startNodeId: node.id })
+                      .catch(() => null);
+                    if (updated) setLoom(updated);
+                  } : null}
+                />
+              ) : (
+                <LoomValidationPanel
+                  loom={loom}
+                  episode={episode}
+                  onSelectNode={selectNode}
+                />
+              )}
+            </div>
           </aside>
         </div>
       )}

--- a/client/src/pages/FableLoomStory.test.jsx
+++ b/client/src/pages/FableLoomStory.test.jsx
@@ -66,11 +66,13 @@ vi.mock('../components/fableloom/LoomMediaJobWatchers', () => ({
   },
 }));
 vi.mock('../components/fableloom/LoomEpisodeOutline', () => ({ default: ({ episode }) => <div data-testid="episode-outline">{episode.title}</div> }));
-vi.mock('../components/fableloom/LoomNodeEditor', () => ({ default: () => <div /> }));
+vi.mock('../components/fableloom/LoomNodeEditor', () => ({
+  default: ({ node }) => <div>Editing scene: {node.title}</div>,
+}));
 vi.mock('../components/fableloom/LoomPlayPanel', () => ({ default: () => <div /> }));
 vi.mock('../components/fableloom/LoomSettingsDrawer', () => ({ default: () => <div /> }));
 vi.mock('../components/fableloom/LoomSeriesPlan', () => ({ default: () => <div>Series planning workspace</div> }));
-vi.mock('../components/fableloom/LoomValidationPanel', () => ({ default: () => <div /> }));
+vi.mock('../components/fableloom/LoomValidationPanel', () => ({ default: () => <div>Episode validation</div> }));
 
 import * as api from '../services/api';
 import FableLoomStory from './FableLoomStory';
@@ -97,11 +99,12 @@ const episode = (fields = {}) => ({
   ...fields,
 });
 
-const renderEditor = () => render(
-  <MemoryRouter initialEntries={['/fableloom/loom-1']}>
+const renderEditor = (initialEntry = '/fableloom/loom-1') => render(
+  <MemoryRouter initialEntries={[initialEntry]}>
     <Routes>
       <Route path="/fableloom/:loomId" element={<FableLoomStory />} />
       <Route path="/fableloom/:loomId/:episodeId" element={<FableLoomStory />} />
+      <Route path="/fableloom/:loomId/:episodeId/:nodeId" element={<FableLoomStory />} />
     </Routes>
   </MemoryRouter>,
 );
@@ -191,6 +194,24 @@ describe('FableLoomStory episode outline route', () => {
 
     expect(await screen.findByTestId('episode-outline')).toHaveTextContent('The First Door');
     expect(screen.getByRole('tab', { name: 'Outline' })).toHaveAttribute('aria-selected', 'true');
+  });
+});
+
+describe('FableLoomStory mobile scene details', () => {
+  it('opens the selected scene in a slide-up sheet and closes back to the graph', async () => {
+    const user = userEvent.setup();
+    api.getLoom.mockResolvedValue(loom({ episodes: [episode()] }));
+    renderEditor('/fableloom/loom-1/ep-1/node-1');
+
+    const sheet = await screen.findByTestId('scene-details-sheet');
+    expect(sheet).toHaveClass('absolute', 'bottom-0', 'rounded-t-2xl', 'lg:static');
+    expect(screen.getByText('Editing scene: Threshold')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Close scene details' }));
+
+    await waitFor(() => expect(screen.queryByTestId('scene-details-sheet')).not.toBeInTheDocument());
+    expect(screen.getByTestId('loom-validation-rail')).toBeInTheDocument();
+    expect(screen.getByText('Episode validation')).toBeInTheDocument();
   });
 });
 


### PR DESCRIPTION
## Summary

- render scene image and video preview surfaces at root SVG coordinates so iOS and WebKit paint them reliably inside graph cards
- keep preview surfaces synchronized with node dragging and preserve existing media controls
- present selected scene details as a dismissible mobile bottom sheet while retaining the desktop editor rail
- add regression coverage for preview positioning, dragging, and closing the mobile sheet

## Testing

- cd client && npm test -- --run src/components/fableloom src/pages/FableLoomStory.test.jsx (14 files, 88 tests passed)
- cd client && npm run build
- git diff --check origin/main...HEAD