### PR TITLE
fix: support current YouTube playlist cards

### DIFF
--- a/server/services/youtubePlaylists.js
+++ b/server/services/youtubePlaylists.js
@@ -61,16 +61,19 @@ function buildPlaylistsExtractionScript() {
       const abs = (href) => { try { return new URL(href, location.origin).href; } catch { return href || null; } };
       const seen = new Set();
       const playlists = [];
-      const collect = () => Array.from(document.querySelectorAll('ytd-playlist-renderer, ytd-grid-playlist-renderer, ytd-playlist-card-renderer')).map((card) => {
+      // YouTube has shipped both the older playlist renderers and its newer
+      // rich-grid/lockup cards. Keep the selectors together so a frontend
+      // rollout does not make a valid signed-in library look empty.
+      const collect = () => Array.from(document.querySelectorAll('ytd-playlist-renderer, ytd-grid-playlist-renderer, ytd-playlist-card-renderer, ytd-rich-item-renderer, ytd-rich-grid-media, yt-lockup-view-model')).map((card) => {
         const link = Array.from(card.querySelectorAll('a[href*="list="]'))[0];
         const url = link ? abs(link.getAttribute('href')) : null;
         let id = null;
         try { id = url ? new URL(url).searchParams.get('list') : null; } catch {}
-        const titleEl = card.querySelector('a#video-title, #video-title, #video-title-link');
+        const titleEl = card.querySelector('a#video-title, a#video-title-link, a.yt-lockup-metadata-view-model__title, #video-title');
         const image = card.querySelector('img');
         const text = (card.textContent || '').replace(/\\s+/g, ' ').trim();
         const count = text.match(/([\\d,]+)\\s+videos?/i);
-        return { id, name: (titleEl?.textContent || link?.textContent || '').trim(), videoCount: count ? Number(count[1].replace(/,/g, '')) : null, thumbnail: image?.src || image?.getAttribute('data-thumb') || null };
+        return { id, name: (titleEl?.textContent || titleEl?.getAttribute('title') || link?.textContent || '').trim(), videoCount: count ? Number(count[1].replace(/,/g, '')) : null, thumbnail: image?.src || image?.getAttribute('data-thumb') || null };
       });
       const append = (items) => items.forEach((item) => {
         if (item.id && !seen.has(item.id)) { seen.add(item.id); playlists.push(item); }
@@ -102,15 +105,18 @@ function buildPlaylistVideosExtractionScript() {
       const abs = (href) => { try { return new URL(href, location.origin).href; } catch { return href || null; } };
       const seen = new Set();
       const videos = [];
-      const collect = () => Array.from(document.querySelectorAll('ytd-playlist-video-renderer, ytd-playlist-panel-video-renderer, ytd-grid-video-renderer')).map((row) => {
-        const titleEl = row.querySelector('a#video-title, a#video-title-link');
-        const url = titleEl ? abs(titleEl.getAttribute('href')) : null;
+      // Playlist pages can render the same video rows as either legacy rows
+      // or rich-grid/lockup cards, depending on the active YouTube frontend.
+      const collect = () => Array.from(document.querySelectorAll('ytd-playlist-video-renderer, ytd-playlist-panel-video-renderer, ytd-grid-video-renderer, ytd-rich-item-renderer, ytd-rich-grid-media, yt-lockup-view-model')).map((row) => {
+        const titleEl = row.querySelector('a#video-title, a#video-title-link, a.yt-lockup-metadata-view-model__title, #video-title');
+        const videoLink = titleEl || row.querySelector('a[href*="watch?v="]');
+        const url = videoLink ? abs(videoLink.getAttribute('href')) : null;
         let id = null;
         try { id = url ? new URL(url).searchParams.get('v') : null; } catch {}
         const channelEl = row.querySelector('#byline a, ytd-channel-name a, #channel-name a');
         const image = row.querySelector('img');
         const durationEl = row.querySelector('ytd-thumbnail-overlay-time-status-renderer span, #text.ytd-thumbnail-overlay-time-status-renderer');
-        return { id, title: (titleEl?.textContent || '').trim(), channel: (channelEl?.textContent || '').trim() || null, thumbnail: image?.src || image?.getAttribute('data-thumb') || null, duration: (durationEl?.textContent || '').trim() || null };
+        return { id, title: (titleEl?.textContent || titleEl?.getAttribute('title') || '').trim(), channel: (channelEl?.textContent || '').trim() || null, thumbnail: image?.src || image?.getAttribute('data-thumb') || null, duration: (durationEl?.textContent || '').trim() || null };
       });
       const append = (items) => items.forEach((item) => {
         if (item.id && !seen.has(item.id)) { seen.add(item.id); videos.push(item); }

--- a/server/services/youtubePlaylists.test.js
+++ b/server/services/youtubePlaylists.test.js
@@ -47,6 +47,9 @@ describe('syncYoutubePlaylists', () => {
     expect(result).toMatchObject({ ok: true, playlistCount: 1, videoCount: 1, scanned: 1, failed: 0 });
     expect(mocks.findOrOpenPage).toHaveBeenCalledWith('https://www.youtube.com/feed/playlists');
     expect(mocks.evaluateOnPage.mock.calls[0][1]).toContain('/accounts\\.google\\.com|\\/ServiceLogin/i');
+    expect(mocks.evaluateOnPage.mock.calls[0][1]).toContain('ytd-rich-item-renderer');
+    expect(mocks.evaluateOnPage.mock.calls[0][1]).toContain('yt-lockup-view-model');
+    expect(mocks.evaluateOnPage.mock.calls[2][1]).toContain('ytd-rich-grid-media');
     expect(mocks.atomicWrite).toHaveBeenCalledWith('/tmp/youtube/playlists.json', expect.objectContaining({ schemaVersion: 1 }));
   });
 


### PR DESCRIPTION
## Summary
- support YouTube’s current rich-grid and lockup playlist/video card elements
- retain legacy selectors and fall back to direct watch links/title attributes
- add focused coverage for the new extraction selectors

## Verification
- `npm test --prefix server -- services/youtubePlaylists.test.js` (11 tests passed)