### PR TITLE
fix: improve mobile FableLoom scene controls

### DIFF
--- a/client/src/components/fableloom/LoomNodeEditor.jsx
+++ b/client/src/components/fableloom/LoomNodeEditor.jsx
@@ -252,12 +252,17 @@ export default function LoomNodeEditor({
           )}
         </div>
         {del.isConfirming(node.id) ? (
-          <ConfirmButtonPair prompt="Delete scene?" onConfirm={handleDelete} onCancel={del.cancelDelete} />
+          <ConfirmButtonPair
+            prompt="Delete scene?"
+            onConfirm={() => del.confirmDelete(handleDelete)}
+            onCancel={del.cancelDelete}
+            largeTouchTargets
+          />
         ) : (
           <button
             type="button"
             onClick={() => del.requestDelete(node.id)}
-            className="text-port-text-muted hover:text-port-error"
+            className="flex min-h-[44px] min-w-[44px] items-center justify-center rounded-lg text-port-text-muted hover:bg-port-error/10 hover:text-port-error"
             aria-label="Delete scene"
           >
             <Trash2 size={16} />

--- a/client/src/components/fableloom/LoomNodeEditor.test.jsx
+++ b/client/src/components/fableloom/LoomNodeEditor.test.jsx
@@ -12,7 +12,7 @@ vi.mock('../../services/api', () => ({
 }));
 
 import {
-  addLoomTransition, branchLoomNode, deleteLoomTransition, updateLoomNode, updateLoomTransition,
+  addLoomTransition, branchLoomNode, deleteLoomNode, deleteLoomTransition, updateLoomNode, updateLoomTransition,
 } from '../../services/api';
 import LoomNodeEditor from './LoomNodeEditor';
 
@@ -79,6 +79,34 @@ const renderHelperEditor = () => {
 beforeEach(() => vi.clearAllMocks());
 
 describe('LoomNodeEditor paths', () => {
+  it('requires confirmation before deleting a scene', async () => {
+    const user = userEvent.setup();
+    const onClearSelection = vi.fn();
+    const nodes = makeNodes([]);
+    deleteLoomNode.mockResolvedValue({ id: 'loom-1' });
+    render(
+      <LoomNodeEditor
+        loom={loom}
+        episode={{ id: 'ep-1', startNodeId: 'n1', nodes }}
+        node={nodes[0]}
+        onLoomUpdate={vi.fn()}
+        onClearSelection={onClearSelection}
+      />,
+    );
+
+    const trash = screen.getByRole('button', { name: 'Delete scene' });
+    expect(trash).toHaveClass('min-h-[44px]', 'min-w-[44px]');
+    await user.click(trash);
+
+    expect(deleteLoomNode).not.toHaveBeenCalled();
+    expect(screen.getByRole('group')).toHaveTextContent('Delete scene?');
+
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+
+    await waitFor(() => expect(deleteLoomNode).toHaveBeenCalledWith('loom-1', 'ep-1', 'n1'));
+    expect(onClearSelection).toHaveBeenCalledTimes(1);
+  });
+
   it('creates a path server-side first, so the new row already carries its id', async () => {
     const user = userEvent.setup();
     const minted = { id: 'tr-9', targetNodeId: 'n2', intent: '', triggers: [], description: '' };
@@ -314,4 +342,3 @@ describe('LoomNodeEditor scene media', () => {
     expect(screen.getByText(/Tip: Render dialogue separately/)).toBeInTheDocument();
   });
 });
-

--- a/client/src/pages/FableLoomStory.jsx
+++ b/client/src/pages/FableLoomStory.jsx
@@ -586,15 +586,15 @@ export default function FableLoomStory({ view = 'graph' }) {
               : { '--dvh-cap': '45vh', '--dvh-cap-dynamic': '45dvh' }}
           >
             {node && (
-              <div className="relative flex shrink-0 items-center justify-center border-b border-port-border px-4 py-2 lg:hidden">
+              <div className="relative flex min-h-[4.5rem] shrink-0 items-center justify-center border-b border-port-border px-4 py-3 lg:hidden">
                 <span className="h-1 w-10 rounded-full bg-port-border" aria-hidden="true" />
                 <button
                   type="button"
                   onClick={clearNodeSelection}
                   aria-label="Close scene details"
-                  className="absolute right-2 top-1/2 flex min-h-[44px] min-w-[44px] -translate-y-1/2 items-center justify-center rounded-lg text-port-text-muted hover:bg-port-border/50 hover:text-port-text"
+                  className="absolute right-3 top-1/2 flex min-h-[56px] min-w-[56px] -translate-y-1/2 items-center justify-center rounded-xl text-port-text-muted hover:bg-port-border/50 hover:text-port-text"
                 >
-                  <X size={18} />
+                  <X size={24} />
                 </button>
               </div>
             )}

--- a/client/src/pages/FableLoomStory.test.jsx
+++ b/client/src/pages/FableLoomStory.test.jsx
@@ -207,7 +207,9 @@ describe('FableLoomStory mobile scene details', () => {
     expect(sheet).toHaveClass('absolute', 'bottom-0', 'rounded-t-2xl', 'lg:static');
     expect(screen.getByText('Editing scene: Threshold')).toBeInTheDocument();
 
-    await user.click(screen.getByRole('button', { name: 'Close scene details' }));
+    const close = screen.getByRole('button', { name: 'Close scene details' });
+    expect(close).toHaveClass('min-h-[56px]', 'min-w-[56px]');
+    await user.click(close);
 
     await waitFor(() => expect(screen.queryByTestId('scene-details-sheet')).not.toBeInTheDocument());
     expect(screen.getByTestId('loom-validation-rail')).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- Increase and visually isolate the mobile scene-details close control.
- Require confirmation before deleting a FableLoom scene and enlarge its touch targets.

## Test plan
- npm run lint (client)
- npm test (client)