### PR TITLE
fix: hide disabled model source warnings

### DIFF
--- a/client/src/components/models/ModelsPanel.jsx
+++ b/client/src/components/models/ModelsPanel.jsx
@@ -49,12 +49,13 @@ export default function ModelsPanel({ report, loading, onRunReport, cleanup }) {
       normalizeLmStudioRepo(model.id),
     ]).filter(Boolean)),
   }), [residency]);
+  const disabledSources = new Set(report?.disabledSources || []);
   const modelSourceErrors = (report?.sourceErrors || []).filter((source) => (
     source.startsWith('ollama')
     || source.startsWith('lmstudio')
     || source === 'huggingface'
     || source === 'loras'
-  ));
+  ) && ![...disabledSources].some((backend) => source === backend || source.startsWith(`${backend}-`)));
 
   return (
     <div className="space-y-4">

--- a/client/src/components/models/ModelsPanel.test.jsx
+++ b/client/src/components/models/ModelsPanel.test.jsx
@@ -75,4 +75,25 @@ describe('ModelsPanel live residency', () => {
     expect(screen.getByText('status unknown')).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Remove Example model' })).not.toBeInTheDocument();
   });
+
+  it('hides unavailable sources the user intentionally disabled', () => {
+    render(
+      <MemoryRouter>
+        <ModelsPanel
+          report={{
+            ...report,
+            sourceErrors: ['lmstudio-backend', 'ollama-backend'],
+            disabledSources: ['lmstudio'],
+          }}
+          loading={false}
+          onRunReport={vi.fn()}
+          cleanup={cleanup}
+        />
+      </MemoryRouter>,
+    );
+
+    const warning = screen.getByText(/Some model sources are unavailable:/);
+    expect(warning.textContent).toContain('ollama-backend');
+    expect(warning.textContent).not.toContain('lmstudio-backend');
+  });
 });

--- a/server/services/systemResources.js
+++ b/server/services/systemResources.js
@@ -22,6 +22,7 @@ import * as ollamaManager from './ollamaManager.js';
 import * as lmStudioManager from './lmStudioManager.js';
 import { listJobs } from './mediaJobQueue/index.js';
 import * as cos from './cos.js';
+import { getSettings } from './settings.js';
 
 export const REPORT_CACHE_TTL_MS = 30_000;
 
@@ -366,6 +367,7 @@ export async function buildSystemResourceReport() {
     lmStudioStored,
     lmStudioLoaded,
     lmStudioBytes,
+    settings,
     npmCacheBytes,
     dependencySizes,
     browserDownloadsBytes,
@@ -388,6 +390,7 @@ export async function buildSystemResourceReport() {
     lmStudioManager.listStoredModels().catch(() => null),
     lmStudioManager.getLoadedModels(true).catch(() => null),
     lmStudioManager.getModelsDir().then((path) => dirSize(path, { strict: true })).catch(() => null),
+    getSettings().catch(() => null),
     dirSize(npmCachePath, { strict: true }).catch(() => null),
     Promise.all(dependencyPaths.map((path) => dirSize(path, { strict: true }).catch(() => null))),
     dirSize(PATHS.browserDownloads, { strict: true }).catch(() => null),
@@ -407,6 +410,10 @@ export async function buildSystemResourceReport() {
   const lmStudioListError = lmStudioModels == null
     ? 'LM Studio model inventory failed'
     : lmStudioManager.getLastListError();
+  const disabledSources = [
+    ...(settings?.localLlm?.ollama?.disabled ? ['ollama'] : []),
+    ...(settings?.localLlm?.lmstudio?.disabled ? ['lmstudio'] : []),
+  ];
   const downloadedModels = downloadedModelInventory({
     hf,
     loraStorage,
@@ -542,6 +549,7 @@ export async function buildSystemResourceReport() {
     queues: { media: mediaQueue, agents: agentQueue },
     cleanupCandidates,
     sourceErrors,
+    disabledSources,
   };
 }
 

--- a/server/services/systemResources.test.js
+++ b/server/services/systemResources.test.js
@@ -84,6 +84,9 @@ vi.mock('./cos.js', () => ({
   })),
   getStatus: vi.fn(async () => ({ running: true, paused: false, activeAgents: 0, pausedAgents: 0 })),
 }));
+vi.mock('./settings.js', () => ({
+  getSettings: vi.fn(async () => ({})),
+}));
 
 const promptRunner = await import('./promptRunner.js');
 const fsPromises = await import('fs/promises');
@@ -94,6 +97,7 @@ const mediaModelStorage = await import('./mediaModelStorage.js');
 const ollamaManager = await import('./ollamaManager.js');
 const lmStudioManager = await import('./lmStudioManager.js');
 const cos = await import('./cos.js');
+const settings = await import('./settings.js');
 const {
   buildCleanupCandidates,
   buildSystemResourceReport,
@@ -120,6 +124,7 @@ describe('system resource reporting', () => {
     lmStudioManager.getLoadedModels.mockResolvedValue([]);
     lmStudioManager.getLastLoadedModelsError.mockReturnValue(null);
     lmStudioManager.getLastListError.mockReturnValue(null);
+    settings.getSettings.mockResolvedValue({});
   });
 
   it('combines storage, model residency, and live queue summaries', async () => {
@@ -172,6 +177,26 @@ describe('system resource reporting', () => {
     expect(model).toMatchObject({ name: 'Example', residencyUnknown: true });
     expect(candidate).toMatchObject({ busy: true, manualOnly: true, action: null });
     expect(report.sourceErrors).toEqual(expect.arrayContaining(['ollama-backend', 'ollama-residency']));
+  });
+
+  it('exposes disabled local backends separately from the full source error list', async () => {
+    settings.getSettings.mockResolvedValue({ localLlm: { lmstudio: { disabled: true } } });
+    lmStudioManager.checkLMStudioAvailable.mockResolvedValue(false);
+    lmStudioManager.getAvailableModels.mockRejectedValueOnce(new Error('backend unavailable'));
+    lmStudioManager.listStoredModels.mockRejectedValueOnce(new Error('inventory unavailable'));
+    lmStudioManager.getLoadedModels.mockRejectedValueOnce(new Error('residency unavailable'));
+    lmStudioManager.getLastLoadedModelsError.mockReturnValue('residency unavailable');
+    lmStudioManager.getLastListError.mockReturnValue('inventory unavailable');
+
+    const report = await buildSystemResourceReport();
+
+    expect(report.disabledSources).toEqual(['lmstudio']);
+    expect(report.sourceErrors).toEqual(expect.arrayContaining([
+      'lmstudio-backend',
+      'lmstudio-inventory',
+      'lmstudio-catalog',
+      'lmstudio-residency',
+    ]));
   });
 
   it('aggregates LM Studio quantizations into one folder-scoped cleanup row', async () => {


### PR DESCRIPTION
## Summary
- Carry local LLM disabled preferences with the system resource report.
- Hide unavailable Ollama/LM Studio warnings for backends intentionally disabled by the user on Models Status.
- Preserve the full diagnostic source list and existing fail-closed cleanup behavior.

## Test plan
- `npm test -- --run services/systemResources.test.js` (server)
- `npm test -- --run src/components/models/ModelsPanel.test.jsx` (client)
- `npx biome lint --error-on-warnings src/components/models/ModelsPanel.jsx src/components/models/ModelsPanel.test.jsx` (client)