### PR TITLE
fix: scope canon usage issue scans

### DIFF
--- a/server/services/canonUsage.js
+++ b/server/services/canonUsage.js
@@ -86,12 +86,15 @@ export async function getUniverseCanonUsage(universeId) {
   // Per (kind, entryId) → Map(seriesId → { seriesName, issueIds: Set })
   const tally = { characters: new Map(), places: new Map(), objects: new Map() };
 
-  // Pre-load ALL issues once and group by seriesId to avoid an N+1 query
-  // (one listIssues call per series previously). listAllIssues is UNCAPPED —
-  // listIssues({}) slices at 1000 total and would silently drop the tail on
-  // large installs. Filter to only the series linked to this universe.
+  // Pre-load linked-series issues in one indexed, uncapped query. This avoids
+  // both the old N+1 shape (one listIssues call per series) and loading every
+  // unrelated issue in the install. Run history is irrelevant to the prose
+  // matcher, so strip it before the aggregation retains these records.
   const linkedSeriesIds = new Set(linkedSeries.map((s) => s.id));
-  const allIssues = await listAllIssues();
+  const allIssues = await listAllIssues({
+    seriesIds: [...linkedSeriesIds],
+    withHistory: false,
+  });
   const issuesBySeriesId = new Map();
   for (const issue of allIssues) {
     if (!linkedSeriesIds.has(issue.seriesId)) continue;

--- a/server/services/canonUsage.test.js
+++ b/server/services/canonUsage.test.js
@@ -21,12 +21,13 @@ vi.mock('./pipeline/series.js', () => ({
 }));
 
 vi.mock('./pipeline/issues.js', () => ({
-  // canonUsage calls listAllIssues() once to pre-load every issue (UNCAPPED —
-  // listIssues({}) slices at 1000 total), so flatten the per-series map and
-  // annotate each issue with its seriesId.
-  listAllIssues: vi.fn(async () => {
+  // canonUsage calls listAllIssues() once with all linked series ids (UNCAPPED
+  // and one query), so mirror that filtering over the in-memory fixtures.
+  listAllIssues: vi.fn(async ({ seriesIds } = {}) => {
+    const wanted = Array.isArray(seriesIds) ? new Set(seriesIds) : null;
     const all = [];
     for (const [sid, issues] of mockIssuesBySeries) {
+      if (wanted && !wanted.has(sid)) continue;
       for (const issue of issues) {
         all.push({ ...issue, seriesId: sid });
       }
@@ -124,10 +125,7 @@ describe('canonUsage — getUniverseCanonUsage entry rows', () => {
       .rejects.toMatchObject({ status: 404, code: 'UNIVERSE_NOT_FOUND' });
   });
 
-  it('calls listAllIssues exactly once regardless of how many series are linked (N+1 guard)', async () => {
-    // Three series linked to the universe. The pre-load-all-issues fix means
-    // canonUsage must call listAllIssues() once, not once-per-series. A
-    // regression to the old per-series loop would call it 3 times here.
+  it('loads only linked-series issues in one history-free call (N+1 and scope guard)', async () => {
     mockUniverses.set('uni-1', {
       id: 'uni-1',
       characters: [{ id: 'c1', name: 'Lyra' }],
@@ -142,10 +140,15 @@ describe('canonUsage — getUniverseCanonUsage entry rows', () => {
     mockIssuesBySeries.set('ser-1', [{ id: 'i1', stages: { prose: { output: 'Lyra walks.' } } }]);
     mockIssuesBySeries.set('ser-2', [{ id: 'i2', stages: { prose: { output: 'Lyra runs.' } } }]);
     mockIssuesBySeries.set('ser-3', [{ id: 'i3', stages: { prose: { output: 'Lyra flies.' } } }]);
+    mockIssuesBySeries.set('ser-other', [{ id: 'i4', stages: { prose: { output: 'Lyra hides.' } } }]);
 
     await getUniverseCanonUsage('uni-1');
 
     expect(listAllIssues).toHaveBeenCalledTimes(1);
+    expect(listAllIssues).toHaveBeenCalledWith({
+      seriesIds: ['ser-1', 'ser-2', 'ser-3'],
+      withHistory: false,
+    });
   });
 
   it('sorts per-entry rows by issueCount desc with alpha tiebreaker on seriesName', async () => {

--- a/server/services/pipeline/issueCrud.js
+++ b/server/services/pipeline/issueCrud.js
@@ -89,9 +89,15 @@ export async function listIssueIds({ includeDeleted = false } = {}) {
  * @param {object} [options]
  * @param {boolean} [options.includeDeleted=false]
  * @param {boolean} [options.withHistory=true] - false strips per-stage run history
+ * @param {string[]} [options.seriesIds] - scopes the uncapped read to these series
  */
-export async function listAllIssues({ includeDeleted = false, withHistory = true } = {}) {
-  const { issues } = await readState();
+export async function listAllIssues({ includeDeleted = false, withHistory = true, seriesIds = null } = {}) {
+  const scopedSeriesIds = Array.isArray(seriesIds)
+    ? [...new Set(seriesIds.filter((id) => typeof id === 'string' && id))]
+    : null;
+  const issues = scopedSeriesIds
+    ? await store().loadAllForSeriesIds(scopedSeriesIds)
+    : (await readState()).issues;
   const live = includeDeleted ? issues : issues.filter((i) => !i.deleted);
   return withHistory ? live : live.map(stripRunHistoryFromIssue);
 }

--- a/server/services/pipeline/issues.test.js
+++ b/server/services/pipeline/issues.test.js
@@ -1275,6 +1275,18 @@ describe('pipeline issues service', () => {
         const leanRec = lean.find((i) => i.id === a.id);
         expect(leanRec).toBeTruthy();
       });
+
+      it('scopes an uncapped read to several series without including others', async () => {
+        const a = await svc.createIssue({ seriesId: 'ser-scope-a', title: 'A' });
+        const b = await svc.createIssue({ seriesId: 'ser-scope-b', title: 'B' });
+        await svc.createIssue({ seriesId: 'ser-scope-other', title: 'Other' });
+        const scoped = await svc.listAllIssues({
+          seriesIds: ['ser-scope-a', 'ser-scope-b', 'ser-scope-a'],
+          withHistory: false,
+        });
+        expect(scoped.map((i) => i.id).sort()).toEqual([a.id, b.id].sort());
+        expect(await svc.listAllIssues({ seriesIds: [] })).toEqual([]);
+      });
     });
 
     describe('listIssuesForSeries (#1469)', () => {

--- a/server/services/pipeline/issuesStore/db.js
+++ b/server/services/pipeline/issuesStore/db.js
@@ -57,6 +57,20 @@ export async function listRawBySeries(seriesId) {
 }
 
 /**
+ * Raw `data` JSONB for several series in one indexed query. Callers that need
+ * an uncapped cross-series scan use this instead of loading the whole table or
+ * issuing one query per series.
+ */
+export async function listRawBySeriesIds(seriesIds) {
+  if (seriesIds.length === 0) return [];
+  const { rows } = await query(
+    `SELECT data FROM pipeline_issues WHERE series_id = ANY($1::text[])`,
+    [seriesIds],
+  );
+  return rows.map((r) => r.data);
+}
+
+/**
  * Upsert one record. `data` is written verbatim (lossless); the typed mirror
  * columns are bind-sanitized so a hand-edited/legacy record can't make the
  * write throw. `created_at` preserved on conflict.

--- a/server/services/pipeline/issuesStore/db.test.js
+++ b/server/services/pipeline/issuesStore/db.test.js
@@ -77,6 +77,15 @@ describe.skipIf(!dbReady)('pipeline issues DB adapter round-trip', () => {
     expect(ordered.map((r) => r.id)).toEqual(['iss-a', 'iss-b']);
   });
 
+  it('listRawBySeriesIds returns only the requested series', async () => {
+    await db.writeRaw('iss-1', I('iss-1', { seriesId: 'ser-1' }));
+    await db.writeRaw('iss-2', I('iss-2', { seriesId: 'ser-2' }));
+    await db.writeRaw('iss-3', I('iss-3', { seriesId: 'ser-3' }));
+    expect((await db.listRawBySeriesIds(['ser-1', 'ser-3'])).map((r) => r.id).sort())
+      .toEqual(['iss-1', 'iss-3']);
+    expect(await db.listRawBySeriesIds([])).toEqual([]);
+  });
+
   it('listIds returns live, tombstoned, and ephemeral ids alike', async () => {
     await db.writeRaw('iss-live', I('iss-live'));
     await db.writeRaw('iss-dead', I('iss-dead', { deleted: true, deletedAt: '2026-02-02T00:00:00.000Z' }));

--- a/server/services/pipeline/issuesStore/store.js
+++ b/server/services/pipeline/issuesStore/store.js
@@ -73,6 +73,15 @@ function makeFileBackend(dir, sanitizeRecord) {
       const records = await Promise.all(ids.map((id) => cs.loadOneRaw(id)));
       return records.filter((r) => r != null && r.seriesId === seriesId);
     },
+    // One full scan for a set of series. This is the dev/test-only backend;
+    // production uses the indexed multi-series PostgreSQL query below.
+    listRawBySeriesIds: async (seriesIds) => {
+      if (seriesIds.length === 0) return [];
+      const wanted = new Set(seriesIds);
+      const ids = await cs.listIds();
+      const records = await Promise.all(ids.map((id) => cs.loadOneRaw(id)));
+      return records.filter((r) => r != null && wanted.has(r.seriesId));
+    },
     writeRaw: (id, record) => cs.saveOneNow(id, record),
     deleteRaw: (id) => cs.deleteOneNow(id),
     verify: () => cs.verifySchemaVersion(),
@@ -89,6 +98,7 @@ function makePgBackend(db, sanitizeRecord) {
     listIds: db.listIds,
     listRaw: db.listRaw,
     listRawBySeries: db.listRawBySeries,
+    listRawBySeriesIds: db.listRawBySeriesIds,
     writeRaw: db.writeRaw,
     deleteRaw: db.deleteRaw,
     verify: async () => ({ ok: true, type: 'pipelineIssues', onDisk: null, expected: null,
@@ -149,6 +159,10 @@ function createFacade({ dir, sanitizeRecord }) {
     },
     loadAllForSeries: async (seriesId) => {
       const raw = await (await getBackend()).listRawBySeries(seriesId);
+      return raw.map((r) => sanitizer(r)).filter((r) => r != null);
+    },
+    loadAllForSeriesIds: async (seriesIds) => {
+      const raw = await (await getBackend()).listRawBySeriesIds(seriesIds);
       return raw.map((r) => sanitizer(r)).filter((r) => r != null);
     },
 

--- a/server/services/pipeline/issuesStore/store.test.js
+++ b/server/services/pipeline/issuesStore/store.test.js
@@ -58,6 +58,17 @@ describe('pipeline issues store facade — file backend', () => {
     expect(await s.loadAllForSeries('ser-missing')).toEqual([]);
   });
 
+  it('loadAllForSeriesIds returns several requested series in one scan', async () => {
+    const s = getIssuesStore(passthroughSanitize);
+    await s.saveOneNow('iss-1', { id: 'iss-1', seriesId: 'ser-1', title: 'One' });
+    await s.saveOneNow('iss-2', { id: 'iss-2', seriesId: 'ser-2', title: 'Two' });
+    await s.saveOneNow('iss-3', { id: 'iss-3', seriesId: 'ser-3', title: 'Three' });
+    const selected = await s.loadAllForSeriesIds(['ser-1', 'ser-3']);
+    expect(selected.map((r) => r.id).sort()).toEqual(['iss-1', 'iss-3']);
+    expect(selected.every((r) => r._sanitized === true)).toBe(true);
+    expect(await s.loadAllForSeriesIds([])).toEqual([]);
+  });
+
   it('listIds({ includeDeleted: false }) drops tombstones; default keeps them (#2540)', async () => {
     const s = getIssuesStore(passthroughSanitize);
     await s.saveOneNow('iss-live', { id: 'iss-live', seriesId: 'ser-1', title: 'Live' });


### PR DESCRIPTION
## Summary
- Scope Universe Canon usage scans to the series linked to the selected universe.
- Fetch those series through one indexed PostgreSQL query and omit unused run-history data from aggregation.
- Preserve the uncapped, single-query contract across PostgreSQL and the test-only file backend.

## Test plan
- `cd server && npm test -- services/canonUsage.test.js services/pipeline/issuesStore/store.test.js services/pipeline/issues.test.js` (154 passed)
- `cd server && npm run test:db -- services/pipeline/issuesStore/db.test.js` (8 passed)
- `cd server && npm test` (35,750 passed, 19 skipped; one unrelated failure in `scripts/checkNpmVersion.test.js` under local Node 26/npm 11)