### PR TITLE
fix: pin NODE_ENV=production for the client build so we stop shipping development React

### DIFF
--- a/client/vite.buildEnv.js
+++ b/client/vite.buildEnv.js
@@ -1,0 +1,36 @@
+/**
+ * Which `NODE_ENV` a Vite invocation must run under.
+ *
+ * Vite only defaults `NODE_ENV` to `production` for a build when it is UNSET —
+ * `resolveConfig()` does `if (!isNodeEnvSet) process.env.NODE_ENV = defaultNodeEnv`
+ * — so an inherited value wins. PortOS runs under PM2 with
+ * `NODE_ENV=development` (ecosystem.config.cjs), and the client build is
+ * reached from inside that process tree on the paths that matter most:
+ * `npm start`, the self-updater (docs/SELF_UPDATE.md), and CoS agents. Every one
+ * of those produced a `dist/` compiled as development, which makes the CJS entry
+ * of react/react-dom resolve to their DEVELOPMENT builds.
+ *
+ * That is not a cosmetic difference:
+ *   - `vendor-react` goes from ~284 kB to ~488 kB on the critical path;
+ *   - every render pays the dev build's validation and warning machinery, and
+ *     users get dev-only warnings in their console;
+ *   - `<React.StrictMode>` (src/main.jsx) starts DOUBLE-INVOKING effects in the
+ *     shipped app, so any mount effect with a side effect fires twice — one
+ *     visit to /music persisted TWO empty "Untitled music draft" tracks, which
+ *     then sync out to federated peers.
+ *
+ * `serve` keeps whatever it inherited: the dev server genuinely wants the dev
+ * builds, and their warnings are the point.
+ *
+ * Kept dependency-free and OUTSIDE `src/` on purpose — vite.config.js imports it
+ * to set `process.env.NODE_ENV` before Vite derives `isProduction`, its
+ * `process.env.NODE_ENV` define, and the plugin JSX runtime from it, while
+ * scripts/clientBuildEnv.test.js imports it under the server's node runner,
+ * which has none of the client's dependencies installed.
+ *
+ * @param {'build'|'serve'} command - Vite's resolved command.
+ * @param {string|undefined} ambientNodeEnv - `process.env.NODE_ENV` as inherited.
+ * @returns {string} the NODE_ENV the invocation must run under.
+ */
+export const resolveBundleNodeEnv = (command, ambientNodeEnv) =>
+  (command === 'build' ? 'production' : (ambientNodeEnv || 'development'));

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -5,6 +5,8 @@ import { readFileSync, existsSync } from 'fs';
 import { execFileSync } from 'child_process';
 import { resolve } from 'path';
 
+import { resolveBundleNodeEnv } from './vite.buildEnv.js';
+
 const ANALYZE_BUNDLE = process.env.ANALYZE === 'true';
 const CONFIG_DIR = import.meta.dirname;
 
@@ -85,7 +87,16 @@ function buildStamp() {
 const CERT_PATH = resolve(CONFIG_DIR, '..', 'data', 'certs', 'cert.pem');
 const API_SCHEME = existsSync(CERT_PATH) ? 'https' : 'http';
 
-export default defineConfig(({ mode }) => {
+export default defineConfig(({ command, mode }) => {
+  // Pin the build's NODE_ENV before Vite reads it. resolveConfig() only defaults
+  // it to 'production' when it is UNSET, and PortOS reaches this build from
+  // inside a PM2 tree carrying NODE_ENV=development — which Vite would then
+  // inline, shipping the DEVELOPMENT react/react-dom to every user. The config
+  // file is loaded BEFORE Vite derives `isProduction`, its
+  // `process.env.NODE_ENV` define, and the plugin JSX runtime, so all three
+  // agree on the value set here. See client/vite.buildEnv.js.
+  process.env.NODE_ENV = resolveBundleNodeEnv(command, process.env.NODE_ENV);
+
   const env = loadEnv(mode, process.cwd(), 'VITE_');
   const API_HOST = env.VITE_API_HOST || 'localhost';
   const API_TARGET = `${API_SCHEME}://${API_HOST}:5555`;

--- a/scripts/clientBuildEnv.test.js
+++ b/scripts/clientBuildEnv.test.js
@@ -1,0 +1,70 @@
+/**
+ * Guard for the client bundle's compile-time NODE_ENV.
+ *
+ * PortOS builds the client from inside a PM2 tree that exports
+ * NODE_ENV=development, and Vite inherits that rather than defaulting a build to
+ * production. The result shipped for real: the deployed `dist/` carried the
+ * DEVELOPMENT react/react-dom — 488 kB of vendor-react instead of 284 kB, plus
+ * StrictMode double-invoking every mount effect in production (one visit to
+ * /music persisted two empty draft tracks).
+ *
+ * Nothing near the build fails when this regresses — the bundle is merely
+ * bigger, slower, and double-firing — so the invariant is pinned here. Lives in
+ * `scripts/` and reads vite.config.js as TEXT for the same reason
+ * dev-proxy-drift.test.js does: importing it would pull in the client's
+ * dependencies, which the server's node runner does not have.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+// Dependency-free by construction — see the module's own header.
+import { resolveBundleNodeEnv } from '../client/vite.buildEnv.js';
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const viteConfig = readFileSync(join(REPO_ROOT, 'client', 'vite.config.js'), 'utf8');
+
+describe('resolveBundleNodeEnv', () => {
+  it('forces production for a build even when the environment says development', () => {
+    // The actual PortOS case: PM2 exports NODE_ENV=development and `npm start`
+    // (and the self-updater) build from inside that process tree.
+    expect(resolveBundleNodeEnv('build', 'development')).toBe('production');
+  });
+
+  it('forces production for a build under any other inherited value', () => {
+    expect(resolveBundleNodeEnv('build', undefined)).toBe('production');
+    expect(resolveBundleNodeEnv('build', '')).toBe('production');
+    expect(resolveBundleNodeEnv('build', 'test')).toBe('production');
+    expect(resolveBundleNodeEnv('build', 'production')).toBe('production');
+  });
+
+  it('leaves the dev server on development', () => {
+    // `vite serve` genuinely wants the dev builds — their warnings are the point.
+    expect(resolveBundleNodeEnv('serve', 'development')).toBe('development');
+    expect(resolveBundleNodeEnv('serve', undefined)).toBe('development');
+  });
+});
+
+describe('client/vite.config.js', () => {
+  it('applies the resolved value to process.env.NODE_ENV', () => {
+    // A helper nothing assigns from is a helper that fixes nothing: Vite reads
+    // process.env.NODE_ENV (not our return value) to derive isProduction, the
+    // `process.env.NODE_ENV` define, and the plugin's JSX runtime.
+    expect(viteConfig).toMatch(
+      /process\.env\.NODE_ENV\s*=\s*resolveBundleNodeEnv\(\s*command\s*,\s*process\.env\.NODE_ENV\s*\)/,
+    );
+    expect(viteConfig).toContain("from './vite.buildEnv.js'");
+  });
+
+  it('assigns before loadEnv, so the config file wins over the inherited value', () => {
+    // Vite loads this config file BEFORE it derives isProduction — but only the
+    // statements that actually run first inside the factory beat the rest of the
+    // config. Pin the ordering rather than trusting the diff to preserve it.
+    const assignAt = viteConfig.indexOf('process.env.NODE_ENV = resolveBundleNodeEnv(');
+    const loadEnvAt = viteConfig.indexOf('loadEnv(');
+    expect(assignAt).toBeGreaterThan(-1);
+    expect(loadEnvAt).toBeGreaterThan(-1);
+    expect(assignAt).toBeLessThan(loadEnvAt);
+  });
+});


### PR DESCRIPTION
## Summary

The deployed client bundle was compiled as **development**, so every PortOS install has been serving the development builds of `react` and `react-dom`.

Vite only defaults `NODE_ENV` to `production` for a build when it is **unset** (`resolveConfig`: `if (!isNodeEnvSet) process.env.NODE_ENV = defaultNodeEnv`), so an inherited value wins. PortOS runs under PM2 with `NODE_ENV=development` (`ecosystem.config.cjs:10`) and reaches `vite build` from inside that process tree — `npm start`, the self-updater (`update.sh:306`), and CoS agents. Confirmed against the bundle a live install is actually serving.

Costs, all measured on this repo:

- `vendor-react` is **488 kB instead of 284 kB** on the critical path (+72%; 90 kB gzipped), and every render pays the dev build's validation and warning machinery.
- Dev-only React warnings reach real users' consoles.
- `<React.StrictMode>` (`client/src/main.jsx`) **double-invokes effects in the shipped app**, so any mount effect with a side effect fires twice. Measured in a browser against the built bundle: one page load of `/music` issued two `POST /api/tracks` and persisted two empty `Untitled music draft` records — which then sync out to federated peers. After the fix that same load issues one.

The config file is loaded *before* Vite derives `isProduction`, its `process.env.NODE_ENV` define, and the plugin JSX runtime, so assigning `process.env.NODE_ENV` as the factory's first statement makes all three agree. Setting only the `define` is **not** enough — it desyncs the JSX transform, which still emits `jsxDEV` against a production `react/jsx-runtime` (the app fails to boot with `jsxDEV is not a function`). `vite serve` keeps whatever it inherited; the dev server wants the dev builds.

## Test plan

- `scripts/clientBuildEnv.test.js` (new) pins the resolution and the wiring: production is forced for `build` under any inherited value, `serve` is left alone, and `vite.config.js` actually assigns the result to `process.env.NODE_ENV` before `loadEnv`. It reads the config as text and imports a dependency-free helper, following `scripts/dev-proxy-drift.test.js` — the server's node runner has none of the client's dependencies.
- `NODE_ENV=development npm run build --prefix client` now emits `vendor-react` at 284 kB with `Minified React error` and zero dev-warning strings, and no `jsxDEV` in the entry chunk — byte-identical output to an explicit `NODE_ENV=production` build.
- Browser verification against a locally served build (isolated instance, own data root + `portos_test`): swept ~90 routes for console errors, exceptions and failed requests; `/music` draft creation goes 2 → 1; no new errors anywhere.
- `cd server && npm test` — 1752 files, 35756 tests, green.
- `cd client && npm test` — 10307 passed. One unrelated pre-existing flake in `GitTab.test.jsx` (a `waitFor` timing race under the loaded parallel run); passes in isolation, and client vitest uses `client/vitest.config.js`, not the file changed here.
- `npm run lint --prefix client` clean.
- `vite serve` still emits `jsxDEV` (dev builds unchanged).