### PR TITLE
Distinguish a user-pinned scheduled-task prompt from a legacy mis-flag

### DIFF
--- a/server/lib/apiRouteCatalog.generated.json
+++ b/server/lib/apiRouteCatalog.generated.json
@@ -6018,7 +6018,7 @@
       "sources": [
         {
           "source": "server/routes/cosScheduleRoutes.js",
-          "line": 95
+          "line": 107
         }
       ]
     },
@@ -6029,7 +6029,7 @@
       "sources": [
         {
           "source": "server/routes/cosScheduleRoutes.js",
-          "line": 129
+          "line": 141
         }
       ]
     },
@@ -6040,7 +6040,7 @@
       "sources": [
         {
           "source": "server/routes/cosScheduleRoutes.js",
-          "line": 135
+          "line": 147
         }
       ]
     },
@@ -6051,7 +6051,7 @@
       "sources": [
         {
           "source": "server/routes/cosScheduleRoutes.js",
-          "line": 219
+          "line": 231
         }
       ]
     },
@@ -6062,7 +6062,7 @@
       "sources": [
         {
           "source": "server/routes/cosScheduleRoutes.js",
-          "line": 157
+          "line": 169
         }
       ]
     },
@@ -6073,7 +6073,7 @@
       "sources": [
         {
           "source": "server/routes/cosScheduleRoutes.js",
-          "line": 163
+          "line": 175
         }
       ]
     },
@@ -6084,7 +6084,7 @@
       "sources": [
         {
           "source": "server/routes/cosScheduleRoutes.js",
-          "line": 173
+          "line": 185
         }
       ]
     },
@@ -6095,7 +6095,7 @@
       "sources": [
         {
           "source": "server/routes/cosScheduleRoutes.js",
-          "line": 108
+          "line": 120
         }
       ]
     },
@@ -6106,7 +6106,7 @@
       "sources": [
         {
           "source": "server/routes/cosScheduleRoutes.js",
-          "line": 116
+          "line": 128
         }
       ]
     },
@@ -6117,7 +6117,7 @@
       "sources": [
         {
           "source": "server/routes/cosScheduleRoutes.js",
-          "line": 188
+          "line": 200
         }
       ]
     },
@@ -6128,7 +6128,7 @@
       "sources": [
         {
           "source": "server/routes/cosScheduleRoutes.js",
-          "line": 194
+          "line": 206
         }
       ]
     },
@@ -6139,7 +6139,7 @@
       "sources": [
         {
           "source": "server/routes/cosScheduleRoutes.js",
-          "line": 209
+          "line": 221
         }
       ]
     },
@@ -6150,7 +6150,7 @@
       "sources": [
         {
           "source": "server/routes/cosScheduleRoutes.js",
-          "line": 142
+          "line": 154
         }
       ]
     },
@@ -6491,7 +6491,7 @@
       "sources": [
         {
           "source": "server/routes/cosScheduleRoutes.js",
-          "line": 101
+          "line": 113
         }
       ]
     },

--- a/server/lib/cosValidation.js
+++ b/server/lib/cosValidation.js
@@ -1428,6 +1428,25 @@ export const createLoopSchema = z.object({
 });
 
 // =============================================================================
+// TASK SCHEDULE SCHEMAS
+// =============================================================================
+
+// Provenance of a schedule config's stored prompt. `promptCustomized` alone cannot
+// tell a deliberate user pin from a flag the legacy migration inferred, so the
+// self-heal in taskScheduleStore.js reads this instead (#5432):
+//   'user'            — written by updateTaskInterval from an explicit prompt write.
+//   'legacy-inferred' — written by the legacy migration's "differs from every known
+//                       shipped default" branch.
+// Absent/null is pre-existing state and is treated as 'legacy-inferred', so an
+// install upgrading into this keeps today's self-heal behavior. Additive and
+// absent-tolerant, so no migration is required.
+export const PROMPT_SOURCES = ['user', 'legacy-inferred'];
+
+// Empty string from a client clears the provenance rather than 400ing, matching
+// the clearable-null convention the other schedule overrides use.
+export const promptSourceSchema = z.preprocess(emptyToNull, z.enum(PROMPT_SOURCES).nullable().optional());
+
+// =============================================================================
 // COS JOB SCHEMAS
 // =============================================================================
 

--- a/server/routes/cosScheduleRoutes.js
+++ b/server/routes/cosScheduleRoutes.js
@@ -7,6 +7,7 @@ import { z } from 'zod';
 import * as taskSchedule from '../services/taskSchedule.js';
 import { asyncHandler, ServerError } from '../lib/errorHandler.js';
 import { sanitizeTaskMetadata, taskDataInputsSchema, validateRequest, parsePagination } from '../lib/validation.js';
+import { promptSourceSchema, PROMPT_SOURCES } from '../lib/cosValidation.js';
 import { EFFORT_LEVELS } from '../lib/providerModels.js';
 
 const templateTaskSchema = z.object({
@@ -24,7 +25,11 @@ const SCHEDULE_FIELDS = ['type', 'enabled', 'intervalMs', 'cronExpression', 'pro
   // Perpetual (drain-until-done) recheck cadence: after a perpetual task drains
   // its backlog and parks, it re-probes its work-detector on this cadence.
   // `recheckCron` (5-field) takes precedence over `recheckIntervalMs`.
-  'recheckCron', 'recheckIntervalMs'];
+  'recheckCron', 'recheckIntervalMs',
+  // Provenance of the stored prompt ('user' | 'legacy-inferred' | null). An
+  // explicit prompt write re-stamps it below in updateTaskInterval, so a body
+  // carrying it only matters when the prompt itself is not being changed.
+  'promptSource'];
 
 /**
  * Pick only defined values from body for schedule settings updates
@@ -73,6 +78,13 @@ function pickScheduleSettings(body) {
       throw new ServerError('dataInputs must contain only registered task data input ids', { status: 400, code: 'VALIDATION_ERROR' });
     }
     settings.dataInputs = parsed.data;
+  }
+  if (settings.promptSource !== undefined) {
+    const parsed = promptSourceSchema.safeParse(settings.promptSource);
+    if (!parsed.success) {
+      throw new ServerError(`promptSource must be one of ${PROMPT_SOURCES.join(', ')} or null`, { status: 400, code: 'VALIDATION_ERROR' });
+    }
+    settings.promptSource = parsed.data ?? null;
   }
   if (settings.effort !== undefined && settings.effort !== null && !EFFORT_LEVELS.includes(settings.effort)) {
     throw new ServerError(`effort must be one of ${EFFORT_LEVELS.join(', ')} or null`, { status: 400, code: 'VALIDATION_ERROR' });

--- a/server/routes/cosScheduleRoutes.test.js
+++ b/server/routes/cosScheduleRoutes.test.js
@@ -177,9 +177,11 @@ describe('CoS Schedule Routes', () => {
       expect(taskSchedule.updateTaskInterval).not.toHaveBeenCalled();
     });
 
-    // promptSource carries the stored prompt's provenance (#5432). It must reach
-    // updateTaskInterval, or a PUT that round-trips a task config would strip a
-    // user's pin and hand the prompt back to the auto-upgrade.
+    // promptSource carries the stored prompt's provenance (#5432). An explicit
+    // prompt write stamps it server-side, so the allowlist entry exists for the
+    // writes that carry provenance WITHOUT a prompt — restoring a saved config,
+    // or releasing a pin back to the auto-upgrade path without clearing the body.
+    // The enum is validated here so neither can persist an unrecognized value.
     it('forwards a valid promptSource', async () => {
       taskSchedule.updateTaskInterval.mockResolvedValue({ type: 'weekly' });
 

--- a/server/routes/cosScheduleRoutes.test.js
+++ b/server/routes/cosScheduleRoutes.test.js
@@ -176,6 +176,44 @@ describe('CoS Schedule Routes', () => {
       expect(response.status).toBe(400);
       expect(taskSchedule.updateTaskInterval).not.toHaveBeenCalled();
     });
+
+    // promptSource carries the stored prompt's provenance (#5432). It must reach
+    // updateTaskInterval, or a PUT that round-trips a task config would strip a
+    // user's pin and hand the prompt back to the auto-upgrade.
+    it('forwards a valid promptSource', async () => {
+      taskSchedule.updateTaskInterval.mockResolvedValue({ type: 'weekly' });
+
+      const response = await request(app)
+        .put('/api/cos/schedule/task/documentation')
+        .send({ promptSource: 'user' });
+
+      expect(response.status).toBe(200);
+      expect(taskSchedule.updateTaskInterval).toHaveBeenCalledWith('documentation', expect.objectContaining({
+        promptSource: 'user'
+      }));
+    });
+
+    it('normalizes an empty promptSource to null', async () => {
+      taskSchedule.updateTaskInterval.mockResolvedValue({ type: 'weekly' });
+
+      const response = await request(app)
+        .put('/api/cos/schedule/task/documentation')
+        .send({ promptSource: '' });
+
+      expect(response.status).toBe(200);
+      expect(taskSchedule.updateTaskInterval).toHaveBeenCalledWith('documentation', expect.objectContaining({
+        promptSource: null
+      }));
+    });
+
+    it('rejects an unknown promptSource', async () => {
+      const response = await request(app)
+        .put('/api/cos/schedule/task/documentation')
+        .send({ promptSource: 'made-up' });
+
+      expect(response.status).toBe(400);
+      expect(taskSchedule.updateTaskInterval).not.toHaveBeenCalled();
+    });
   });
 
   describe('GET /api/cos/schedule/due', () => {

--- a/server/services/taskSchedule.js
+++ b/server/services/taskSchedule.js
@@ -161,8 +161,15 @@ export async function updateTaskInterval(taskType, settings) {
     }
     // If user is setting a custom prompt, mark it so auto-upgrade won't overwrite it.
     // If user clears the prompt (null), remove the customized flag to resume defaults.
+    //
+    // `promptSource` records that this write was an EXPLICIT user action, which is
+    // what the store's self-heal reads to leave the pin alone (#5432). Without it,
+    // pasting an older SHIPPED body into Settings → Scheduled Tasks was un-pinnable:
+    // the self-heal saw a body matching a retired default, cleared the flag on the
+    // next load, and the next PROMPT_VERSIONS bump overwrote the chosen text.
     if ('prompt' in settings) {
       settings.promptCustomized = settings.prompt != null;
+      settings.promptSource = settings.prompt != null ? 'user' : null;
     }
 
     schedule.tasks[taskType] = {

--- a/server/services/taskSchedule.js
+++ b/server/services/taskSchedule.js
@@ -162,14 +162,21 @@ export async function updateTaskInterval(taskType, settings) {
     // If user is setting a custom prompt, mark it so auto-upgrade won't overwrite it.
     // If user clears the prompt (null), remove the customized flag to resume defaults.
     //
-    // `promptSource` records that this write was an EXPLICIT user action, which is
-    // what the store's self-heal reads to leave the pin alone (#5432). Without it,
-    // pasting an older SHIPPED body into Settings → Scheduled Tasks was un-pinnable:
-    // the self-heal saw a body matching a retired default, cleared the flag on the
-    // next load, and the next PROMPT_VERSIONS bump overwrote the chosen text.
+    // `promptSource: 'user'` records that this write was an EXPLICIT user action,
+    // which is what the store's self-heal reads to leave the pin alone (#5432).
+    // Without it, pasting an older SHIPPED body into Settings → Scheduled Tasks was
+    // un-pinnable: the self-heal saw a body matching a retired default, cleared the
+    // flag on the next load, and the next PROMPT_VERSIONS bump overwrote the text.
+    //
+    // A body identical to the CURRENT default is not a pin. The editor prefills its
+    // textarea from the stored prompt, so re-saving an untouched default would
+    // otherwise stamp a permanent pin and freeze that type off every future prompt
+    // upgrade — which is exactly the mis-flag the self-heal existed to undo, now
+    // beyond its reach. Retired shipped bodies still pin: that is the #5432 case.
     if ('prompt' in settings) {
-      settings.promptCustomized = settings.prompt != null;
-      settings.promptSource = settings.prompt != null ? 'user' : null;
+      settings.promptCustomized = settings.prompt != null
+        && settings.prompt !== DEFAULT_TASK_PROMPTS[taskType];
+      settings.promptSource = settings.promptCustomized ? 'user' : null;
     }
 
     schedule.tasks[taskType] = {

--- a/server/services/taskSchedule.test.js
+++ b/server/services/taskSchedule.test.js
@@ -427,6 +427,108 @@ describe('taskSchedule', () => {
     })
   })
 
+  describe('promptSource provenance (issue #5432)', () => {
+    // The self-heal above clears promptCustomized whenever the stored prompt
+    // byte-matches ANY shipped default (current or retired). That is right for a
+    // flag the legacy migration guessed at, but it cannot tell that apart from a
+    // user who deliberately pasted an older SHIPPED body into Settings →
+    // Scheduled Tasks — that pin was cleared on the next load and the next
+    // PROMPT_VERSIONS bump silently overwrote their chosen text. promptSource
+    // records which of the two wrote the flag.
+    const portosDocPrompt = PREVIOUS_DEFAULT_PROMPTS['documentation'].find((p) => p.includes('PortOS'))
+
+    const loadDocumentation = async (config) => {
+      mockSchedule({
+        tasks: { 'documentation': { type: 'once', enabled: false, providerId: null, model: null, ...config } }
+      })
+      return (await loadSchedule()).tasks['documentation']
+    }
+
+    it('keeps a user-pinned retired default pinned instead of self-healing it', async () => {
+      const task = await loadDocumentation({
+        prompt: portosDocPrompt,
+        promptVersion: 1,
+        promptCustomized: true,
+        promptSource: 'user'
+      })
+      expect(task.promptCustomized).toBe(true)
+      expect(task.prompt).toBe(portosDocPrompt)
+    })
+
+    it('still self-heals a legacy-inferred flag on a retired default', async () => {
+      const task = await loadDocumentation({
+        prompt: portosDocPrompt,
+        promptVersion: 1,
+        promptCustomized: true,
+        promptSource: 'legacy-inferred'
+      })
+      expect(task.promptCustomized).toBe(false)
+      expect(task.prompt).toBe(DEFAULT_TASK_PROMPTS['documentation'])
+    })
+
+    // Every install that upgrades into this field carries no promptSource at all.
+    // Absent must keep behaving exactly as it does today, or the upgrade itself
+    // would freeze thousands of mis-flagged prompts on their retired bodies.
+    it('treats an absent promptSource as legacy-inferred (self-heals, as today)', async () => {
+      const task = await loadDocumentation({
+        prompt: portosDocPrompt,
+        promptVersion: 1,
+        promptCustomized: true
+      })
+      expect(task.promptSource).toBeUndefined()
+      expect(task.promptCustomized).toBe(false)
+      expect(task.prompt).toBe(DEFAULT_TASK_PROMPTS['documentation'])
+    })
+
+    it('stamps legacy-inferred when the legacy migration flags an unrecognized body', async () => {
+      const custom = 'A documentation prompt that matches no shipped default at all.'
+      // No promptVersion → the legacy-migration branch runs.
+      const task = await loadDocumentation({ prompt: custom })
+      expect(task.promptCustomized).toBe(true)
+      expect(task.promptSource).toBe('legacy-inferred')
+    })
+
+    it('drops a stale promptSource when the config has no prompt to pin', async () => {
+      const task = await loadDocumentation({ prompt: null, promptSource: 'user' })
+      expect(task.prompt).toBe(DEFAULT_TASK_PROMPTS['documentation'])
+      expect(task.promptSource).toBeNull()
+    })
+
+    it('survives a PROMPT_VERSIONS bump when the pin is user-sourced', async () => {
+      const original = PROMPT_VERSIONS['documentation']
+      PROMPT_VERSIONS['documentation'] = original + 1
+      try {
+        const task = await loadDocumentation({
+          prompt: portosDocPrompt,
+          promptVersion: original,
+          promptCustomized: true,
+          promptSource: 'user'
+        })
+        expect(task.prompt).toBe(portosDocPrompt)
+        expect(task.promptVersion).toBe(original)
+      } finally {
+        PROMPT_VERSIONS['documentation'] = original
+      }
+    })
+
+    it('upgrades the same body across a bump when the pin is legacy-inferred', async () => {
+      const original = PROMPT_VERSIONS['documentation']
+      PROMPT_VERSIONS['documentation'] = original + 1
+      try {
+        const task = await loadDocumentation({
+          prompt: portosDocPrompt,
+          promptVersion: original,
+          promptCustomized: true,
+          promptSource: 'legacy-inferred'
+        })
+        expect(task.prompt).toBe(DEFAULT_TASK_PROMPTS['documentation'])
+        expect(task.promptVersion).toBe(original + 1)
+      } finally {
+        PROMPT_VERSIONS['documentation'] = original
+      }
+    })
+  })
+
   describe('pre-unification prompt generations (self- + app-improvement split)', () => {
     // Before the two improvement schedules were unified, every basic task
     // shipped up to two bodies with different headers — `[Self-Improvement] …`
@@ -612,6 +714,37 @@ describe('taskSchedule', () => {
         prompt: null
       })
       expect(result.promptCustomized).toBe(false)
+    })
+
+    // An explicit prompt write is the ONE source of a 'user' pin (#5432) — it is
+    // what makes the store's self-heal leave a retired-but-deliberate body alone.
+    it('should stamp promptSource "user" when a custom prompt is written', async () => {
+      const result = await updateTaskInterval('security', {
+        prompt: 'Custom security audit prompt'
+      })
+      expect(result.promptSource).toBe('user')
+    })
+
+    it('should clear promptSource when the prompt is set to null', async () => {
+      const result = await updateTaskInterval('security', {
+        prompt: null
+      })
+      expect(result.promptSource).toBeNull()
+    })
+
+    it('should preserve an existing pin when the write does not touch the prompt', async () => {
+      mockSchedule({
+        tasks: {
+          'security': {
+            type: 'weekly', enabled: false, providerId: null, model: null,
+            prompt: 'A pinned body that matches no shipped default.',
+            promptVersion: 2, promptCustomized: true, promptSource: 'user'
+          }
+        }
+      })
+      const result = await updateTaskInterval('security', { enabled: true })
+      expect(result.promptSource).toBe('user')
+      expect(result.promptCustomized).toBe(true)
     })
 
     it('should create new task entry for unknown type', async () => {

--- a/server/services/taskSchedule.test.js
+++ b/server/services/taskSchedule.test.js
@@ -725,6 +725,26 @@ describe('taskSchedule', () => {
       expect(result.promptSource).toBe('user')
     })
 
+    // The prompt editor prefills from the stored body, so "open, click Save" sends
+    // back the CURRENT default verbatim. That must not pin — a pin is checked by
+    // the self-heal only when its provenance is inferred, so a 'user' stamp here
+    // would freeze the type off every future prompt upgrade with no way back.
+    it('should not pin a prompt that is byte-identical to the current default', async () => {
+      const result = await updateTaskInterval('security', {
+        prompt: DEFAULT_TASK_PROMPTS['security']
+      })
+      expect(result.promptCustomized).toBe(false)
+      expect(result.promptSource).toBeNull()
+    })
+
+    // A RETIRED shipped body IS a deliberate choice — the #5432 case.
+    it('should pin a retired shipped default written by the user', async () => {
+      const retired = PREVIOUS_DEFAULT_PROMPTS['security'][0]
+      const result = await updateTaskInterval('security', { prompt: retired })
+      expect(result.promptCustomized).toBe(true)
+      expect(result.promptSource).toBe('user')
+    })
+
     it('should clear promptSource when the prompt is set to null', async () => {
       const result = await updateTaskInterval('security', {
         prompt: null

--- a/server/services/taskScheduleStore.js
+++ b/server/services/taskScheduleStore.js
@@ -199,6 +199,9 @@ async function readSchedule() {
       // No prompt set — initialize with current default and version
       config.prompt = DEFAULT_TASK_PROMPTS[taskType];
       config.promptVersion = PROMPT_VERSIONS[taskType] || 1;
+      // A prompt-less config pins nothing, so drop any stale provenance rather
+      // than let it freeze the freshly-installed default off the upgrade path.
+      if (config.promptSource) config.promptSource = null;
       needsSave = true;
     } else {
       // Legacy migration: infer customization when promptVersion is missing
@@ -216,8 +219,12 @@ async function readSchedule() {
           config.promptVersion = 1;
           needsSave = true;
         } else {
-          // Prompt differs from all known defaults — treat as user-customized
+          // Prompt differs from all known defaults — treat as user-customized.
+          // Stamp the provenance as INFERRED, not 'user': this branch is a guess
+          // made from a body we don't recognize, so the self-heal below must stay
+          // free to undo it once the body turns out to be a retired default.
           config.promptCustomized = true;
+          config.promptSource = 'legacy-inferred';
           config.promptVersion = PROMPT_VERSIONS[taskType] || 1;
           needsSave = true;
         }
@@ -241,7 +248,17 @@ async function readSchedule() {
       // forever, now un-flagged so nothing else notices. Reset the version to 1
       // whenever the body is a prior default rather than the current one, which
       // is the same stamp the version-inference branch above applies.
-      if (config.promptCustomized && promptMatchesShippedDefault(config.prompt, taskType)) {
+      //
+      // Gated on provenance (#5432): a user who deliberately pastes an older
+      // SHIPPED body into Settings → Scheduled Tasks also byte-matches a shipped
+      // default, and clearing THAT flag would let the next PROMPT_VERSIONS bump
+      // overwrite their chosen text. `promptSource === 'user'` marks an explicit
+      // write through updateTaskInterval and is left alone; 'legacy-inferred' and
+      // absent (every install upgrading into this field) self-heal exactly as
+      // they do today.
+      if (config.promptSource !== 'user'
+        && config.promptCustomized
+        && promptMatchesShippedDefault(config.prompt, taskType)) {
         config.promptCustomized = false;
         if (config.prompt !== DEFAULT_TASK_PROMPTS[taskType]) config.promptVersion = 1;
         needsSave = true;


### PR DESCRIPTION
## Summary

- The schedule store's self-heal cleared `promptCustomized` whenever the stored prompt byte-matched a shipped default (current or retired). Correct for a flag the legacy migration inferred; wrong for a deliberate pin — a user who pasted an older shipped body into **Settings → Scheduled Tasks** had it cleared on the next load, and the next `PROMPT_VERSIONS` bump silently replaced their text.
- Records provenance instead of relying on the boolean: `updateTaskInterval` stamps `promptSource: 'user'` on an explicit prompt write, the legacy-migration branch stamps `'legacy-inferred'`, and the self-heal now skips a config whose source is `'user'`.
- **Absent is treated as `'legacy-inferred'`**, so every install upgrading into the field keeps today's behavior — additive and absent-tolerant, no migration needed.
- A body byte-identical to the *current* default is explicitly **not** a pin. The editor prefills from the stored prompt, so "open, click Save" would otherwise stamp a permanent pin and freeze that type off every future prompt upgrade. Retired shipped bodies still pin — that is the case this issue is about.
- `promptSource` rides the schedule-config Zod schema (`server/lib/cosValidation.js`) and the update route's `SCHEDULE_FIELDS` allowlist, validated as an enum so no unrecognized value can persist.
- `server/lib/apiRouteCatalog.generated.json` is regenerated (line-number drift from the route edit).

Non-goals from the issue respected: no changes to `PREVIOUS_DEFAULT_PROMPTS` or `promptMatchesShippedDefault`, no "reset to shipped default" UI, no rework of the self-heal's `promptVersion` stamping.

## Test plan

- `cd server && npm test` — full suite green (1760 files, 35897 tests).
- New coverage in `server/services/taskSchedule.test.js`:
  - a user-pinned retired default stays pinned; a `legacy-inferred` one still self-heals
  - an **absent** `promptSource` self-heals exactly as today
  - the legacy-migration branch stamps `'legacy-inferred'`
  - a user pin survives a simulated `PROMPT_VERSIONS` bump; a legacy-inferred one still upgrades
  - `updateTaskInterval` stamps `'user'` for a custom body and for a retired shipped body, but **not** for the current default; clears it on `prompt: null`; leaves an existing pin alone when the write doesn't touch the prompt
  - a stale `promptSource` is dropped when the config has no prompt to pin
- New coverage in `server/routes/cosScheduleRoutes.test.js`: a valid `promptSource` is forwarded, `''` normalizes to `null`, an unknown value 400s.

Closes #5432
