### PR TITLE
Keep the LTX-2.5 image-to-video anchor through every ancestral denoise step

### DIFF
--- a/scripts/generate_ltx2.py
+++ b/scripts/generate_ltx2.py
@@ -1245,23 +1245,42 @@ def _import_ancestral_sampler():
     return samplers
 
 
-def _sampler_preserves_conditioned_tokens(samplers) -> bool:
-    """Does the pin's own ancestral loop re-apply the mask AFTER the ancestral step?
+def _ancestral_loop_source(samplers) -> str | None:
+    """The pin's ancestral loop as source text, or None when it cannot be read.
 
-    Read off the loop's source rather than inferred from a version string,
-    because the whole problem is that PortOS does not control which commit is
-    checked out. The window starts at the LAST `ancestral_euler_step(` call, so
-    the `apply_denoise_mask` every pin runs on x0 *before* the step cannot be
-    mistaken for the post-renoise one the invariant needs. A source-less
-    sampler (a C extension, a pin shipped as a .pyc) reads as "not proven",
-    which routes to the hook rather than to trust.
+    Every verdict below is read off this rather than inferred from a version
+    string, because the whole problem is that PortOS does not control which
+    commit is checked out. A source-less sampler (a C extension, a pin shipped
+    as a .pyc) yields None and is REFUSED — the invariant cannot be proven, and
+    the hook below cannot be proven to reach the loop either.
     """
     try:
-        source = inspect.getsource(samplers.ancestral_denoise_loop)
+        return inspect.getsource(samplers.ancestral_denoise_loop)
     except (OSError, TypeError):
-        return False
-    _, marker, tail = source.rpartition("ancestral_euler_step(")
+        return None
+
+
+def _sampler_preserves_conditioned_tokens(loop_source: str) -> bool:
+    """Does the pin's own ancestral loop re-apply the mask AFTER the ancestral step?
+
+    The window starts at the LAST `ancestral_euler_step(` call, so the
+    `apply_denoise_mask` every pin runs on x0 *before* the step cannot be
+    mistaken for the post-renoise one the invariant needs.
+    """
+    _, marker, tail = loop_source.rpartition("ancestral_euler_step(")
     return bool(marker) and "apply_denoise_mask" in tail
+
+
+def _hook_can_reach_loop(loop_source: str) -> bool:
+    """Does the loop route its conditioning through the seam the hook wraps?
+
+    The hook learns each latent's (clean, mask) pair by wrapping the module-level
+    `apply_denoise_mask` the loop calls on x0. A fork that inlines that blend, or
+    reaches it through a module reference, never trips the recorder — the hook
+    would install, report success, and preserve nothing. So the call has to be
+    visible in the loop before the hook is allowed to claim the invariant.
+    """
+    return "apply_denoise_mask" in loop_source
 
 
 def _install_ancestral_anchor_hook(samplers) -> bool:
@@ -1280,11 +1299,9 @@ def _install_ancestral_anchor_hook(samplers) -> bool:
     Pairs are keyed by latent SHAPE rather than by call order, so an extra model
     call, a reordered loop, or a pipeline that denoises video only still lands on
     the right mask. Two latents sharing a shape WITHIN one step (video and audio
-    of equal token count) is the one case a shape cannot disambiguate, so that
-    key is dropped and those steps keep the pin's own behavior — never a wrong
-    mask. Restating the same shape in a LATER step is the ordinary case (stage 2
-    of a two-stage render rebuilds its latent state) and simply replaces the
-    record.
+    of equal token count) is the one case a shape cannot disambiguate, so those
+    steps keep the pin's own behavior — never a wrong mask — and only for as long
+    as the collision lasts.
     """
     try:
         from ltx_core_mlx.conditioning.types.latent_cond import apply_denoise_mask
@@ -1293,10 +1310,11 @@ def _install_ancestral_anchor_hook(samplers) -> bool:
     if getattr(samplers.ancestral_euler_step, "_portos_anchor_hook", False):
         return True
 
-    original_apply = samplers.apply_denoise_mask
+    original_apply = getattr(samplers, "apply_denoise_mask", None)
+    if original_apply is None:
+        return False
     original_step = samplers.ancestral_euler_step
     conditioning: dict = {}
-    ambiguous: set = set()
     steps_taken = [0]
 
     def _key(latent):
@@ -1308,10 +1326,19 @@ def _install_ancestral_anchor_hook(samplers) -> bool:
         key = _key(clean_latent)
         if key is not None:
             prior = conditioning.get(key)
-            same_step = prior is not None and prior[2] == steps_taken[0]
-            if same_step and (prior[0] is not clean_latent or prior[1] is not denoise_mask):
-                ambiguous.add(key)
-            conditioning[key] = (clean_latent, denoise_mask, steps_taken[0])
+            # Ambiguity is a property of THIS batch of records, not of the shape
+            # forever: two latents of equal token count inside one step cannot be
+            # told apart, but the same shape restated in a later step (stage 2
+            # rebuilding its latent state) is an ordinary replacement.
+            same_batch = prior is not None and prior["batch"] == steps_taken[0]
+            collides = same_batch and (
+                prior["clean"] is not clean_latent or prior["mask"] is not denoise_mask
+                or prior["ambiguous"]
+            )
+            conditioning[key] = {
+                "clean": clean_latent, "mask": denoise_mask,
+                "batch": steps_taken[0], "ambiguous": collides,
+            }
         return original_apply(x0, clean_latent, denoise_mask)
 
     @functools.wraps(original_step)
@@ -1319,12 +1346,10 @@ def _install_ancestral_anchor_hook(samplers) -> bool:
         result = original_step(sample, denoised, *args, **kwargs)
         key = _key(sample)
         steps_taken[0] += 1
-        if key is None or key in ambiguous:
+        record = conditioning.get(key) if key is not None else None
+        if record is None or record["ambiguous"]:
             return result
-        pair = conditioning.get(key)
-        if pair is None:
-            return result
-        clean_latent, denoise_mask = pair[0], pair[1]
+        clean_latent, denoise_mask = record["clean"], record["mask"]
         # The step returns float32 while the latent state is held in the model
         # dtype; match the result so the blend does not silently upcast the
         # whole latent. A pin (or a test double) whose arrays carry no dtype
@@ -1357,15 +1382,17 @@ def enforce_i2v_anchor_invariant(args) -> str:
     samplers = _import_ancestral_sampler()
     if samplers is None:
         return "not-required"
-    if _sampler_preserves_conditioned_tokens(samplers):
-        return "native"
-    if _install_ancestral_anchor_hook(samplers):
-        emit_status("Preserving the frame-one anchor across the ancestral denoise")
-        return "hook"
+    loop_source = _ancestral_loop_source(samplers)
+    if loop_source is not None:
+        if _sampler_preserves_conditioned_tokens(loop_source):
+            return "native"
+        if _hook_can_reach_loop(loop_source) and _install_ancestral_anchor_hook(samplers):
+            emit_status("Preserving the frame-one anchor across the ancestral denoise")
+            return "hook"
     raise SystemExit(
         "This ltx runtime samples image-to-video with the ancestral (SDE) Euler "
         "loop but neither preserves the conditioned frame across its steps nor "
-        "exposes ltx_core_mlx's apply_denoise_mask for PortOS to preserve it — "
+        "routes its conditioning through a seam PortOS can preserve it at — "
         "the render would drift off the supplied image. Re-run "
         "scripts/setup-image-video.sh to restore the pinned LTX-2.5 checkout."
     )

--- a/scripts/generate_ltx2.py
+++ b/scripts/generate_ltx2.py
@@ -1200,6 +1200,177 @@ def _image_conditioning_kwargs(generate_and_save, image: str | None,
     return {"image": image}
 
 
+# --- I2V anchor preservation across an ancestral (SDE) denoise -----------------
+#
+# LTX-2.5 samples distilled stage 1 with the ancestral (SDE) Euler loop, which
+# renoises the WHOLE latent after every step. The conditioned tokens — the
+# frame-0 rows an image-to-video render pins to the supplied picture — live in
+# that same latent, so a loop that does not re-apply the conditioning mask AFTER
+# the renoise leaves the anchor clean only on the terminal step. The clip that
+# comes out is plausible and coherent; it just isn't the picture the user handed
+# in, and nothing in the output says so.
+#
+# PortOS does not own the pin, so the invariant is enforced rather than assumed:
+#
+#   1. a pin whose own ancestral loop re-applies the mask after the renoise is
+#      used as-is ("native");
+#   2. a pin that does not gets a clean-room hook at the sampler seam — the same
+#      re-application, expressed through the pin's OWN `apply_denoise_mask`, and
+#      idempotent, so it cannot fight a loop that already does it ("hook"); and
+#   3. a pin that exposes neither is REFUSED before any weights load, because
+#      the alternative is silently shipping an unanchored clip.
+#
+# Scoped to `--mode image`: that is the only mode whose whole promise is "the
+# reference IS frame one" (lib/videoReferenceModes.js). T2V has a uniform mask
+# and nothing to preserve, and the FFLF/extend/a2v pipelines are left byte-
+# identical — this seam is not on their path unless they route through the same
+# ancestral loop, which they do not on any pin PortOS ships.
+
+
+def _import_ancestral_sampler():
+    """The installed pin's sampler module, or None when it has no ancestral loop.
+
+    A pin without `ancestral_euler_step` / `ancestral_denoise_loop` never injects
+    noise mid-denoise (plain Euler), so the anchor holds by construction and
+    there is nothing here to enforce — that is the LTX-2.3 pin, and why this
+    returns a sentinel rather than raising.
+    """
+    try:
+        from ltx_pipelines_mlx.utils import samplers
+    except ImportError:
+        return None
+    if not all(hasattr(samplers, name)
+               for name in ("ancestral_euler_step", "ancestral_denoise_loop")):
+        return None
+    return samplers
+
+
+def _sampler_preserves_conditioned_tokens(samplers) -> bool:
+    """Does the pin's own ancestral loop re-apply the mask AFTER the ancestral step?
+
+    Read off the loop's source rather than inferred from a version string,
+    because the whole problem is that PortOS does not control which commit is
+    checked out. The window starts at the LAST `ancestral_euler_step(` call, so
+    the `apply_denoise_mask` every pin runs on x0 *before* the step cannot be
+    mistaken for the post-renoise one the invariant needs. A source-less
+    sampler (a C extension, a pin shipped as a .pyc) reads as "not proven",
+    which routes to the hook rather than to trust.
+    """
+    try:
+        source = inspect.getsource(samplers.ancestral_denoise_loop)
+    except (OSError, TypeError):
+        return False
+    _, marker, tail = source.rpartition("ancestral_euler_step(")
+    return bool(marker) and "apply_denoise_mask" in tail
+
+
+def _install_ancestral_anchor_hook(samplers) -> bool:
+    """Clean-room compatibility hook at the sampler seam. True when installed.
+
+    Two module-global wrappers, both inside the pin's own `samplers` module, so
+    they take effect no matter which module imported the loop by name:
+
+      - `apply_denoise_mask` — the loop already calls it once per latent per step
+        to pin x0 to the clean tokens. Wrapping it RECORDS the (clean, mask) pair
+        for each latent; the return value is the pin's own, untouched.
+      - `ancestral_euler_step` — after the pin's step (Euler + renoise) returns,
+        the recorded pair for that latent is applied again, which is exactly the
+        reference `post_process_latent` the broken pins are missing.
+
+    Pairs are keyed by latent SHAPE rather than by call order, so an extra model
+    call, a reordered loop, or a pipeline that denoises video only still lands on
+    the right mask. Two latents sharing a shape WITHIN one step (video and audio
+    of equal token count) is the one case a shape cannot disambiguate, so that
+    key is dropped and those steps keep the pin's own behavior — never a wrong
+    mask. Restating the same shape in a LATER step is the ordinary case (stage 2
+    of a two-stage render rebuilds its latent state) and simply replaces the
+    record.
+    """
+    try:
+        from ltx_core_mlx.conditioning.types.latent_cond import apply_denoise_mask
+    except ImportError:
+        return False
+    if getattr(samplers.ancestral_euler_step, "_portos_anchor_hook", False):
+        return True
+
+    original_apply = samplers.apply_denoise_mask
+    original_step = samplers.ancestral_euler_step
+    conditioning: dict = {}
+    ambiguous: set = set()
+    steps_taken = [0]
+
+    def _key(latent):
+        shape = getattr(latent, "shape", None)
+        return None if shape is None else tuple(shape)
+
+    @functools.wraps(original_apply)
+    def recording_apply_denoise_mask(x0, clean_latent, denoise_mask):
+        key = _key(clean_latent)
+        if key is not None:
+            prior = conditioning.get(key)
+            same_step = prior is not None and prior[2] == steps_taken[0]
+            if same_step and (prior[0] is not clean_latent or prior[1] is not denoise_mask):
+                ambiguous.add(key)
+            conditioning[key] = (clean_latent, denoise_mask, steps_taken[0])
+        return original_apply(x0, clean_latent, denoise_mask)
+
+    @functools.wraps(original_step)
+    def anchor_preserving_ancestral_euler_step(sample, denoised, *args, **kwargs):
+        result = original_step(sample, denoised, *args, **kwargs)
+        key = _key(sample)
+        steps_taken[0] += 1
+        if key is None or key in ambiguous:
+            return result
+        pair = conditioning.get(key)
+        if pair is None:
+            return result
+        clean_latent, denoise_mask = pair[0], pair[1]
+        # The step returns float32 while the latent state is held in the model
+        # dtype; match the result so the blend does not silently upcast the
+        # whole latent. A pin (or a test double) whose arrays carry no dtype
+        # skips the cast rather than guessing one.
+        dtype = getattr(result, "dtype", None)
+        if dtype is not None:
+            clean_latent = clean_latent.astype(dtype)
+            denoise_mask = denoise_mask.astype(dtype)
+        return apply_denoise_mask(result, clean_latent, denoise_mask)
+
+    anchor_preserving_ancestral_euler_step._portos_anchor_hook = True
+    samplers.apply_denoise_mask = recording_apply_denoise_mask
+    samplers.ancestral_euler_step = anchor_preserving_ancestral_euler_step
+    return True
+
+
+def enforce_i2v_anchor_invariant(args) -> str:
+    """Guarantee the frame-0 anchor survives every denoise step, or refuse to render.
+
+    Returns which mechanism is carrying the invariant — "not-required" (no
+    ancestral sampler on this pin, or not an anchored I2V render), "native" (the
+    pin's own loop), or "hook" (the compatibility hook above). Raises SystemExit
+    when the installed pin has the ancestral sampler but can supply neither.
+
+    Called from main() BEFORE any pipeline is constructed, so a refusal costs the
+    user a second rather than a full model load.
+    """
+    if args.mode != "image" or not args.image:
+        return "not-required"
+    samplers = _import_ancestral_sampler()
+    if samplers is None:
+        return "not-required"
+    if _sampler_preserves_conditioned_tokens(samplers):
+        return "native"
+    if _install_ancestral_anchor_hook(samplers):
+        emit_status("Preserving the frame-one anchor across the ancestral denoise")
+        return "hook"
+    raise SystemExit(
+        "This ltx runtime samples image-to-video with the ancestral (SDE) Euler "
+        "loop but neither preserves the conditioned frame across its steps nor "
+        "exposes ltx_core_mlx's apply_denoise_mask for PortOS to preserve it — "
+        "the render would drift off the supplied image. Re-run "
+        "scripts/setup-image-video.sh to restore the pinned LTX-2.5 checkout."
+    )
+
+
 def _one_stage_kwargs(args: argparse.Namespace, **extra) -> dict:
     """Shared generate_and_save kwargs for the one-stage text/image runners.
 
@@ -1882,6 +2053,10 @@ def main() -> NoReturn:
     configure_gemma_max_length(args.gemma_max_length)
     install_prompt_encode_markers()
     configure_mlx_cache(args)
+    # Frame-one anchor contract (#5422). Runs before any pipeline is built so a
+    # pin that cannot hold the anchor through an ancestral denoise refuses in a
+    # second rather than after a full model load.
+    enforce_i2v_anchor_invariant(args)
 
     runners = {
         "text": run_text,

--- a/scripts/generate_ltx2.test.js
+++ b/scripts/generate_ltx2.test.js
@@ -1062,7 +1062,7 @@ describe.skipIf(!pyBin)('generate_ltx2.py MLX allocator-cache policy', () => {
       '',
     ].join('\n');
 
-    const samplersPy = ({ ancestral = true, nativeReapply = false } = {}) => {
+    const samplersPy = ({ ancestral = true, nativeReapply = false, inlineBlend = false } = {}) => {
       const lines = [
         'from ltx_core_mlx.conditioning.types.latent_cond import LatentState, Vec, apply_denoise_mask',
         '',
@@ -1085,12 +1085,24 @@ describe.skipIf(!pyBin)('generate_ltx2.py MLX allocator-cache policy', () => {
         '    return Vec(stepped)',
         '',
         '',
+        ...(inlineBlend ? [
+          'def _blend(x0, state):',
+          '    return Vec(v * m + c * (1.0 - m) for v, c, m in',
+          '               zip(x0, state.clean_latent, state.denoise_mask))',
+          '',
+          '',
+        ] : []),
         'def ancestral_denoise_loop(model, video_state, audio_state, sigmas, observer=None):',
         '    video_x, audio_x = video_state.latent, audio_state.latent',
         '    for step, (sigma, sigma_next) in enumerate(zip(sigmas[:-1], sigmas[1:])):',
         '        video_x0, audio_x0 = model(video_x, audio_x, sigma)',
-        '        video_x0 = apply_denoise_mask(video_x0, video_state.clean_latent, video_state.denoise_mask)',
-        '        audio_x0 = apply_denoise_mask(audio_x0, audio_state.clean_latent, audio_state.denoise_mask)',
+        ...(inlineBlend ? [
+          '        video_x0 = _blend(video_x0, video_state)',
+          '        audio_x0 = _blend(audio_x0, audio_state)',
+        ] : [
+          '        video_x0 = apply_denoise_mask(video_x0, video_state.clean_latent, video_state.denoise_mask)',
+          '        audio_x0 = apply_denoise_mask(audio_x0, audio_state.clean_latent, audio_state.denoise_mask)',
+        ]),
         '        if sigma_next == 0:',
         '            video_x, audio_x = video_x0, audio_x0',
         '            break',
@@ -1269,6 +1281,25 @@ describe.skipIf(!pyBin)('generate_ltx2.py MLX allocator-cache policy', () => {
       ]);
       expect(result.mechanism).toBe('not-required');
       expect(result.untouched).toBe(true);
+    });
+
+    // The hook learns each latent's conditioning by wrapping the loop's own
+    // apply_denoise_mask call. A fork that inlines that blend never trips the
+    // recorder, so installing would report success and preserve nothing —
+    // worse than refusing, because the status line reads as a guarantee.
+    it('refuses a pin whose loop never crosses the seam the hook wraps', () => {
+      const output = runPython(`${importRunner}\n${[
+        'from types import SimpleNamespace',
+        ...installFakePin({ inlineBlend: true }),
+        IMAGE_ARGS,
+        'try:',
+        '    runner.enforce_i2v_anchor_invariant(args)',
+        'except SystemExit as exc:',
+        '    print(str(exc))',
+        'else:',
+        '    raise AssertionError("a pin the hook cannot reach was accepted")',
+      ].join('\n')}`);
+      expect(output).toMatch(/ancestral \(SDE\) Euler/);
     });
 
     // Fail closed: a pin that renoises the anchor away and gives PortOS no way

--- a/scripts/generate_ltx2.test.js
+++ b/scripts/generate_ltx2.test.js
@@ -1028,4 +1028,268 @@ describe.skipIf(!pyBin)('generate_ltx2.py MLX allocator-cache policy', () => {
     ].join('\n')}`);
     expect(out.trim().split(/\r?\n/).map((l) => l.trimEnd())).toEqual(['None', '2048']);
   });
+
+  // ── Frame-one anchor across an ancestral (SDE) denoise (#5422) ─────────────
+  // LTX-2.5 samples distilled stage 1 with the ancestral Euler loop, which
+  // renoises the whole latent every step. A pin that does not re-apply the
+  // conditioning mask AFTER that renoise leaves the anchor clean only on the
+  // terminal step, so the clip is plausible but unrelated to the supplied
+  // image. These cases run a REAL miniature ancestral loop — a pure-Python
+  // stand-in for the pinned sampler, imported from a temp package rather than
+  // planted in sys.modules, because the native-preservation probe reads the
+  // loop's source and source only exists for a module loaded from a file.
+  describe('i2v anchor invariant', () => {
+    // 4 video tokens, token 0 conditioned on the supplied image (mask 0 =
+    // preserve) and held at 7.0; 3 audio tokens, fully generated (uniform
+    // mask) — the T2V-shaped control that must come out byte-identical.
+    const LATENT_COND_PY = [
+      'class Vec(list):',
+      '    """A latent with a shape, so the hook can key conditioning by it."""',
+      '    @property',
+      '    def shape(self):',
+      '        return (len(self),)',
+      '',
+      '',
+      'class LatentState:',
+      '    def __init__(self, latent, clean_latent, denoise_mask):',
+      '        self.latent = latent',
+      '        self.clean_latent = clean_latent',
+      '        self.denoise_mask = denoise_mask',
+      '',
+      '',
+      'def apply_denoise_mask(x0, clean_latent, denoise_mask):',
+      '    return Vec(v * m + c * (1.0 - m) for v, c, m in zip(x0, clean_latent, denoise_mask))',
+      '',
+    ].join('\n');
+
+    const samplersPy = ({ ancestral = true, nativeReapply = false } = {}) => {
+      const lines = [
+        'from ltx_core_mlx.conditioning.types.latent_cond import LatentState, Vec, apply_denoise_mask',
+        '',
+        '',
+        'def euler_step(sample, denoised, sigma, sigma_next):',
+        '    ratio = sigma_next / sigma',
+        '    return Vec(ratio * s + (1.0 - ratio) * d for s, d in zip(sample, denoised))',
+        '',
+      ];
+      if (!ancestral) return lines.join('\n');
+      return lines.concat([
+        '',
+        'def ancestral_euler_step(sample, denoised, sigma, sigma_next, noise=None, eta=1.0):',
+        '    if sigma_next == 0:',
+        '        return Vec(denoised)',
+        '    ratio = sigma_next / sigma',
+        '    stepped = [ratio * s + (1.0 - ratio) * d for s, d in zip(sample, denoised)]',
+        '    if eta > 0 and noise is not None:',
+        '        stepped = [v + eta * sigma_next * n for v, n in zip(stepped, noise)]',
+        '    return Vec(stepped)',
+        '',
+        '',
+        'def ancestral_denoise_loop(model, video_state, audio_state, sigmas, observer=None):',
+        '    video_x, audio_x = video_state.latent, audio_state.latent',
+        '    for step, (sigma, sigma_next) in enumerate(zip(sigmas[:-1], sigmas[1:])):',
+        '        video_x0, audio_x0 = model(video_x, audio_x, sigma)',
+        '        video_x0 = apply_denoise_mask(video_x0, video_state.clean_latent, video_state.denoise_mask)',
+        '        audio_x0 = apply_denoise_mask(audio_x0, audio_state.clean_latent, audio_state.denoise_mask)',
+        '        if sigma_next == 0:',
+        '            video_x, audio_x = video_x0, audio_x0',
+        '            break',
+        '        noise_v = Vec((step + 1) * 0.5 for _ in video_x)',
+        '        noise_a = Vec((step + 1) * 0.25 for _ in audio_x)',
+        '        video_x = ancestral_euler_step(video_x, video_x0, sigma, sigma_next, noise_v)',
+        '        audio_x = ancestral_euler_step(audio_x, audio_x0, sigma, sigma_next, noise_a)',
+        ...(nativeReapply ? [
+          '        video_x = apply_denoise_mask(video_x, video_state.clean_latent, video_state.denoise_mask)',
+          '        audio_x = apply_denoise_mask(audio_x, audio_state.clean_latent, audio_state.denoise_mask)',
+        ] : []),
+        '        if observer is not None:',
+        '            observer(step, video_x, audio_x)',
+        '    return video_x, audio_x',
+        '',
+      ]).join('\n');
+    };
+
+    const installFakePin = (opts = {}) => [
+      'import sys, tempfile',
+      'from pathlib import Path',
+      'root = Path(tempfile.mkdtemp())',
+      'for pkg in ("ltx_core_mlx", "ltx_core_mlx/conditioning", "ltx_core_mlx/conditioning/types",',
+      '            "ltx_pipelines_mlx", "ltx_pipelines_mlx/utils"):',
+      '    (root / pkg).mkdir(parents=True, exist_ok=True)',
+      '    (root / pkg / "__init__.py").write_text("")',
+      `(root / "ltx_core_mlx/conditioning/types/latent_cond.py").write_text(${JSON.stringify(LATENT_COND_PY)})`,
+      `(root / "ltx_pipelines_mlx/utils/samplers.py").write_text(${JSON.stringify(samplersPy(opts))})`,
+      'sys.path.insert(0, str(root))',
+      'for name in [m for m in sys.modules if m.startswith(("ltx_core_mlx", "ltx_pipelines_mlx"))]:',
+      '    sys.modules.pop(name, None)',
+    ];
+
+    // The render the invariant is about: --mode image with a source image.
+    const IMAGE_ARGS = 'args = SimpleNamespace(mode="image", image="/tmp/frame-one.png")';
+
+    // A model that predicts 0.0 everywhere, so any token the mask does NOT pin
+    // moves and any token it DOES pin can only move via the renoise — which is
+    // exactly the drift under test.
+    const RUN_LOOP = [
+      'from ltx_pipelines_mlx.utils import samplers',
+      'from ltx_core_mlx.conditioning.types.latent_cond import LatentState, Vec',
+      'video = LatentState(Vec([7.0, 1.0, 1.0, 1.0]), Vec([7.0, 0.0, 0.0, 0.0]), Vec([0.0, 1.0, 1.0, 1.0]))',
+      'audio = LatentState(Vec([0.2, 0.2, 0.2]), Vec([0.0, 0.0, 0.0]), Vec([1.0, 1.0, 1.0]))',
+      'def model(v, a, sigma):',
+      '    return (Vec(0.0 for _ in v), Vec(0.0 for _ in a))',
+      'anchors, audio_trace = [], []',
+      'def observer(step, video_x, audio_x):',
+      '    anchors.append(round(video_x[0], 6))',
+      '    audio_trace.append([round(t, 6) for t in audio_x])',
+      'samplers.ancestral_denoise_loop(model, video, audio, [1.0, 0.6, 0.3, 0.0], observer=observer)',
+    ];
+
+    const runAnchor = (body) => JSON.parse(runPython(`${importRunner}\n${[
+      'from types import SimpleNamespace',
+      ...body,
+    ].join('\n')}`));
+
+    it('keeps the anchor exactly clean at every step on a pin that renoises it away', () => {
+      const result = runAnchor([
+        ...installFakePin(),
+        IMAGE_ARGS,
+        'import contextlib, io, json',
+        'err = io.StringIO()',
+        'with contextlib.redirect_stderr(err):',
+        '    mechanism = runner.enforce_i2v_anchor_invariant(args)',
+        ...RUN_LOOP,
+        'print(json.dumps({"mechanism": mechanism, "anchors": anchors, "audio": audio_trace,',
+        '                  "status": err.getvalue().strip()}))',
+      ]);
+      expect(result.mechanism).toBe('hook');
+      // Two nonterminal steps; the terminal one is not observed because the
+      // loop breaks on it — and a terminal-only match is precisely the bug.
+      expect(result.anchors).toEqual([7, 7]);
+      expect(result.status).toMatch(/STATUS:.*frame-one anchor/i);
+    });
+
+    // main() calls this once, but a second install must not nest the wrappers:
+    // a nested recorder would keep re-recording its own wrapper output and the
+    // seam would drift from the one function the invariant is proven against.
+    it('installs the hook at most once', () => {
+      const result = runAnchor([
+        ...installFakePin(),
+        IMAGE_ARGS,
+        "import contextlib, io, json",
+        "with contextlib.redirect_stderr(io.StringIO()):",
+        "    first = runner.enforce_i2v_anchor_invariant(args)",
+        "    second = runner.enforce_i2v_anchor_invariant(args)",
+        "from ltx_pipelines_mlx.utils import samplers",
+        "nested = getattr(samplers.ancestral_euler_step.__wrapped__, \"__wrapped__\", None) is not None",
+        ...RUN_LOOP,
+        'print(json.dumps({"first": first, "second": second, "nested": nested, "anchors": anchors}))',
+      ]);
+      expect([result.first, result.second]).toEqual(['hook', 'hook']);
+      expect(result.nested).toBe(false);
+      expect(result.anchors).toEqual([7, 7]);
+    });
+
+    // Without the hook the same loop drifts — otherwise the case above would
+    // pass against a sampler that never had the defect.
+    it('drifts off the anchor when nothing enforces the invariant', () => {
+      const result = runAnchor([
+        ...installFakePin(),
+        'import json',
+        ...RUN_LOOP,
+        'print(json.dumps({"anchors": anchors, "audio": audio_trace}))',
+      ]);
+      expect(result.anchors[0]).not.toBe(7);
+      expect(result.anchors[1]).not.toBe(7);
+    });
+
+    // The generated (uniform-mask) latent is what a T2V render is made of
+    // end to end: the hook must not perturb a single token of it.
+    it('leaves a fully generated latent byte-identical', () => {
+      const [hooked, plain] = [true, false].map((enforce) => runAnchor([
+        ...installFakePin(),
+        IMAGE_ARGS,
+        'import contextlib, io, json',
+        ...(enforce ? [
+          'with contextlib.redirect_stderr(io.StringIO()):',
+          '    runner.enforce_i2v_anchor_invariant(args)',
+        ] : []),
+        ...RUN_LOOP,
+        'print(json.dumps({"audio": audio_trace}))',
+      ]));
+      expect(hooked.audio).toEqual(plain.audio);
+    });
+
+    // A pin that already re-applies the mask after its own renoise is used as
+    // it ships — no wrapper, so nothing PortOS wrote can drift from upstream.
+    it('uses a pin that already preserves conditioned tokens, unpatched', () => {
+      const result = runAnchor([
+        ...installFakePin({ nativeReapply: true }),
+        IMAGE_ARGS,
+        'import json',
+        'mechanism = runner.enforce_i2v_anchor_invariant(args)',
+        'from ltx_pipelines_mlx.utils import samplers',
+        'patched = [f.__name__ for f in (samplers.ancestral_euler_step, samplers.apply_denoise_mask)',
+        '           if getattr(f, "__wrapped__", None) is not None]',
+        ...RUN_LOOP,
+        'print(json.dumps({"mechanism": mechanism, "patched": patched, "anchors": anchors}))',
+      ]);
+      expect(result.mechanism).toBe('native');
+      expect(result.patched).toEqual([]);
+      expect(result.anchors).toEqual([7, 7]);
+    });
+
+    // The LTX-2.3 pin: plain Euler, no mid-denoise renoise, so the anchor holds
+    // by construction and its sampler must be left exactly as it was.
+    it('is not required on a pin with no ancestral sampler', () => {
+      const result = runAnchor([
+        ...installFakePin({ ancestral: false }),
+        IMAGE_ARGS,
+        'import json',
+        'from ltx_pipelines_mlx.utils import samplers',
+        'before = samplers.euler_step',
+        'mechanism = runner.enforce_i2v_anchor_invariant(args)',
+        'print(json.dumps({"mechanism": mechanism, "untouched": samplers.euler_step is before}))',
+      ]);
+      expect(result.mechanism).toBe('not-required');
+      expect(result.untouched).toBe(true);
+    });
+
+    // Every other mode keeps the argv-for-argv behavior it had before this
+    // contract existed — the seam is not even probed.
+    it.each(['text', 'fflf', 'extend', 'a2v', 'ic'])('leaves --mode %s alone', (mode) => {
+      const result = runAnchor([
+        ...installFakePin(),
+        `args = SimpleNamespace(mode=${JSON.stringify(mode)}, image="/tmp/frame-one.png")`,
+        'import json',
+        'from ltx_pipelines_mlx.utils import samplers',
+        'before = (samplers.ancestral_euler_step, samplers.apply_denoise_mask)',
+        'mechanism = runner.enforce_i2v_anchor_invariant(args)',
+        'after = (samplers.ancestral_euler_step, samplers.apply_denoise_mask)',
+        'print(json.dumps({"mechanism": mechanism, "untouched": before == after}))',
+      ]);
+      expect(result.mechanism).toBe('not-required');
+      expect(result.untouched).toBe(true);
+    });
+
+    // Fail closed: a pin that renoises the anchor away and gives PortOS no way
+    // to put it back must refuse, not render something that looks fine.
+    it('refuses an anchored render the pin cannot hold', () => {
+      const output = runPython(`${importRunner}\n${[
+        'from types import SimpleNamespace',
+        ...installFakePin(),
+        'import sys',
+        'from ltx_pipelines_mlx.utils import samplers  # noqa: F401 — import before hiding the core',
+        'sys.modules["ltx_core_mlx.conditioning.types.latent_cond"] = None',
+        IMAGE_ARGS,
+        'try:',
+        '    runner.enforce_i2v_anchor_invariant(args)',
+        'except SystemExit as exc:',
+        '    print(str(exc))',
+        'else:',
+        '    raise AssertionError("an unpreservable pin was accepted")',
+      ].join('\n')}`);
+      expect(output).toMatch(/ancestral \(SDE\) Euler/);
+      expect(output).toMatch(/setup-image-video\.sh/);
+    });
+  });
 });

--- a/scripts/setup-image-video.sh
+++ b/scripts/setup-image-video.sh
@@ -330,6 +330,17 @@ if [[ "$INSTALL_LTX25" == "1" ]]; then
     echo "❌ INSTALL_LTX25=1 requires git." >&2
     exit 1
   fi
+  # VERIFIED PIN — image-to-video frame-one anchor (#5422). This fork samples
+  # distilled stage 1 with the ancestral (SDE) Euler loop, which renoises the
+  # whole latent every step. This revision's `ancestral_denoise_loop`
+  # (packages/ltx-pipelines-mlx/.../utils/samplers.py) re-applies the
+  # conditioning mask AFTER that renoise, so the frame-0 tokens stay equal to
+  # the supplied image at every step rather than only the last. A revision that
+  # does not renders a coherent clip unrelated to the picture the user handed
+  # in. Moving this pin means re-reading that loop and moving
+  # `i2vAnchorVerifiedRevision` in server/services/videoGen/runtimes.js with it
+  # (runtimes.test.js fails until both agree); scripts/generate_ltx2.py also
+  # checks the LIVE checkout at render time and refuses rather than drifting.
   LTX25_PIN="${LTX25_PIN:-57952288076766abe27dda3a774b2c24f7346977}"
   LTX25_DIR="${HOME}/.portos/ltx-2.5-mlx"
   LTX25_PY="${LTX25_DIR}/.venv/bin/python3"

--- a/scripts/setup-image-video.test.js
+++ b/scripts/setup-image-video.test.js
@@ -4,6 +4,7 @@ import { tmpdir } from 'os';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 import { afterEach, describe, expect, it } from 'vitest';
+import { BYOV_RUNTIME_INFO } from '../server/services/videoGen/runtimes.js';
 
 const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 const SETUP_SCRIPT = join(REPO_ROOT, 'scripts', 'setup-image-video.sh');
@@ -157,4 +158,27 @@ describe('setup-image-video clone/fetch progress reporting', () => {
 
     expect(silentFetches).toEqual([]);
   });
+});
+
+// The pin the installer checks out and the revision the server verifies a
+// checkout against are the SAME fact written in two languages. When they drift,
+// every install silently provisions a runtime the server then reports as stale —
+// and for LTX-2.5 the drifted revision is also the one whose sampler nobody read
+// for the i2v frame-one anchor (#5422).
+describe('pinned runtime revisions', () => {
+  const pinned = Object.values(BYOV_RUNTIME_INFO)
+    .filter((info) => info.pinEnvVar && info.expectedRevision);
+
+  it('covers every runtime the registry pins', () => {
+    expect(pinned.map((info) => info.id).sort()).toEqual(
+      expect.arrayContaining(['ltx25', 'minimax_h3', 'wan22']));
+  });
+
+  it.each(pinned.map((info) => [info.id, info]))(
+    'installs %s at the revision the registry verifies', (_id, info) => {
+      const shellDefault = source.match(
+        new RegExp(`^\\s*${info.pinEnvVar}="\\$\\{${info.pinEnvVar}:-([^}"]+)\\}"`, 'm'),
+      )?.[1];
+      expect(shellDefault).toBe(info.expectedRevision);
+    });
 });

--- a/server/services/videoGen/runtimes.js
+++ b/server/services/videoGen/runtimes.js
@@ -222,6 +222,15 @@ export const BYOV_RUNTIME_INFO = Object.freeze({
     pinEnvVar: 'LTX25_PIN',
     importProbe: 'import ltx_pipelines_mlx',
     fingerprintPackages: ['ltx_pipelines_mlx', 'ltx_core_mlx', 'mlx', 'mlx_metal'],
+    // The revision whose ancestral (SDE) Euler loop was READ and confirmed to
+    // re-apply the conditioning mask after its renoise — the invariant an
+    // image-to-video render depends on to keep frame one equal to the supplied
+    // picture at every step, not only the last (#5422). This is deliberately a
+    // literal rather than a reference to LTX25_EXPECTED_REVISION: bumping the
+    // pin without re-reading that loop turns runtimes.test.js red, which is the
+    // whole point. scripts/generate_ltx2.py enforces the invariant against the
+    // LIVE pin regardless, and refuses the render when it cannot.
+    i2vAnchorVerifiedRevision: '57952288076766abe27dda3a774b2c24f7346977',
   },
   fastvideo: {
     id: 'fastvideo',

--- a/server/services/videoGen/runtimes.test.js
+++ b/server/services/videoGen/runtimes.test.js
@@ -24,7 +24,7 @@ import {
   byovRuntimeLoraCapable, invalidateByovLoraCapabilityCache, invalidateByovReadyCache,
   isByovRuntimeReady, isPinnedSourceStatusClean, modelAnchorsLastFrame,
   resolveByovRuntimeLoraCapable, runtimeIsCacheOnly, runtimeNeedsProcessGroupKill,
-  routesToWindowsHelper,
+  routesToWindowsHelper, LTX25_EXPECTED_REVISION,
 } from './runtimes.js';
 
 const REVISION = 'fcd9e9b79a1d6018d91ac477c0968de1fa067e49';
@@ -426,5 +426,25 @@ describe('runtime execution flags', () => {
     expect(runtimeNeedsProcessGroupKill('minimax_h3_cuda')).toBe(true);
     expect(runtimeNeedsProcessGroupKill('ltx2')).toBe(false);
     expect(runtimeNeedsProcessGroupKill('nope')).toBe(false);
+  });
+});
+
+// A pin bump is where the frame-one anchor silently breaks: the LTX-2.5 fork
+// samples image-to-video with the ancestral (SDE) Euler loop, and a revision
+// whose loop does not re-apply the conditioning mask after its renoise renders a
+// coherent clip that has nothing to do with the supplied image (#5422). The
+// helper enforces the invariant against the live pin at render time; this is the
+// tripwire that makes a reviewer look BEFORE that reaches a user machine.
+describe('LTX-2.5 i2v anchor pin verification', () => {
+  it('pins a revision whose ancestral sampler was read for anchor preservation', () => {
+    expect(BYOV_RUNTIME_INFO.ltx25.i2vAnchorVerifiedRevision).toBe(LTX25_EXPECTED_REVISION);
+  });
+
+  // Nothing else declares it, so the field never reads as "verified" for a
+  // runtime whose sampler was never inspected.
+  it('claims verification for no other runtime', () => {
+    const claimed = Object.values(BYOV_RUNTIME_INFO)
+      .filter((info) => info.i2vAnchorVerifiedRevision).map((info) => info.id);
+    expect(claimed).toEqual(['ltx25']);
   });
 });


### PR DESCRIPTION
## Summary

LTX-2.5 samples distilled stage 1 with the ancestral (SDE) Euler loop, which renoises the whole latent after every step. The conditioned frame-0 tokens — the rows an image-to-video render pins to the supplied picture — live in that latent, so a pin that does not re-apply the conditioning mask *after* the renoise leaves the anchor clean only on the terminal step. The clip that comes out is coherent and has nothing to do with the image the user handed in, and nothing in the output says so.

PortOS does not own the pin, so `scripts/generate_ltx2.py` now enforces the invariant against the **live checkout**, before any weights load:

- a pin whose own ancestral loop re-applies the mask after the renoise is used as-is (`native`);
- a pin that does not gets a clean-room hook at the sampler seam — the same re-application, expressed through the pin's own `apply_denoise_mask`, idempotent, keyed by latent shape (`hook`); and
- a pin that offers neither — no ancestral-loop source to read, or a loop that never routes conditioning through that seam — **refuses the render** rather than shipping an unanchored clip.

Scoped to `--mode image`. T2V, FFLF, extend, a2v and every plain-Euler pin are byte-identical, and argv is unchanged for every render.

`server/services/videoGen/runtimes.js` records the revision whose sampler was actually read (`i2vAnchorVerifiedRevision`), so a pin bump that skips re-verification turns `runtimes.test.js` red. `scripts/setup-image-video.sh` carries the same fact where the pin is set, and a new drift case ties every `*_PIN` shell default to the registry's `expectedRevision`.

**Boundary:** no LTX-2.5 render was executed and no weights were downloaded. What is proven here is the PortOS-side contract — the probe, the hook, the fail-closed path — plus the verdict the helper returns against the two runtimes already installed.

Closes #5422

## Test plan

- `cd server && npx vitest run` — full server suite green (1760 files, 35901 tests). Suite globs `../scripts`, so the helper cases run here.
- New in `scripts/generate_ltx2.test.js` (13 cases): a real miniature ancestral loop, imported from a temp package so the source probe has source to read. Covers the anchor staying exactly clean at **every nonterminal** step under the hook; the same loop **drifting** with nothing installed (so the case above cannot pass against a sampler that never had the defect); a fully generated latent coming out byte-identical; a natively-preserving pin used unpatched; a plain-Euler pin left untouched; every non-`image` mode left untouched; at-most-once installation; and two fail-closed refusals — a pin with no reachable seam, and a loop that inlines the blend.
- Each new guard was mutation-checked: removing the hook's patch, the idempotence guard, the seam gate, or drifting the shell pin each turns exactly the intended case red.
- Verified against the two installed checkouts (no weights loaded): the pinned LTX-2.5 fork reports `native`, the LTX-2.3 pin reports `not-required`.
- `bash -n scripts/setup-image-video.sh`.
