### PR TITLE
fix: restore scrolling in FableLoom episode rail

### DIFF
--- a/client/src/pages/FableLoomStory.jsx
+++ b/client/src/pages/FableLoomStory.jsx
@@ -608,7 +608,7 @@ export default function FableLoomStory({ view = 'graph' }) {
             aria-label={node ? `${node.title || 'Scene'} details` : 'Episode validation'}
             className={node
               ? 'absolute inset-x-0 bottom-0 z-20 flex h-[calc(100%_-_0.75rem)] max-h-dvh-cap flex-col overflow-hidden rounded-t-2xl border border-b-0 border-port-border bg-port-card shadow-2xl motion-safe:animate-in motion-safe:slide-in-from-bottom-4 motion-safe:duration-200 lg:static lg:h-auto lg:max-h-none lg:w-[380px] lg:shrink-0 lg:rounded-none lg:border-y-0 lg:border-r-0 lg:border-l'
-              : 'max-h-dvh-cap overflow-hidden border-t border-port-border lg:max-h-none lg:w-[380px] lg:shrink-0 lg:border-t-0 lg:border-l'}
+              : 'flex max-h-dvh-cap flex-col overflow-hidden border-t border-port-border lg:max-h-none lg:w-[380px] lg:shrink-0 lg:border-t-0 lg:border-l'}
             style={node
               ? { '--dvh-cap': '78vh', '--dvh-cap-dynamic': '78dvh' }
               : { '--dvh-cap': '45vh', '--dvh-cap-dynamic': '45dvh' }}

--- a/client/src/pages/FableLoomStory.test.jsx
+++ b/client/src/pages/FableLoomStory.test.jsx
@@ -244,6 +244,17 @@ describe('FableLoomStory episode expansion safety', () => {
   });
 });
 
+describe('FableLoomStory episode rail layout', () => {
+  it('keeps the episode rail content independently scrollable when no scene is selected', async () => {
+    api.getLoom.mockResolvedValue(loom({ episodes: [episode()] }));
+    renderEditor('/fableloom/loom-1/ep-1');
+
+    const rail = await screen.findByTestId('loom-validation-rail');
+    expect(rail).toHaveClass('flex', 'flex-col', 'overflow-hidden');
+    expect(rail.firstElementChild).toHaveClass('min-h-0', 'flex-1', 'overflow-y-auto');
+  });
+});
+
 describe('FableLoomStory mobile scene details', () => {
   it('opens the selected scene in a slide-up sheet and closes back to the graph', async () => {
     const user = userEvent.setup();


### PR DESCRIPTION
## Summary
- make the unselected FableLoom episode rail a bounded flex column so its existing inner scroller can reach all validation and production content
- add a page-level regression for the complete rail scroll chain

## Test plan
- `cd client && npm test -- src/pages/FableLoomStory.test.jsx`
- `cd client && npx biome lint --error-on-warnings src/pages/FableLoomStory.jsx src/pages/FableLoomStory.test.jsx`
- `cd client && npm run build`