### PR TITLE
feat: host Eidoverse Worlds inside PortOS

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -23,6 +23,7 @@ const AgentsPage = lazyWithReload(() => import('./pages/DevTools').then(m => ({ 
 const DataDog = lazyWithReload(() => import('./pages/DataDog'));
 const FlowsDoc = lazyWithReload(() => import('./pages/FlowsDoc'));
 const GitHub = lazyWithReload(() => import('./pages/GitHub'));
+const Eidoverse = lazyWithReload(() => import('./pages/Eidoverse'));
 const OpenWorld = lazyWithReload(() => import('./pages/OpenWorld'));
 const AppDetail = lazyWithReload(() => import('./pages/AppDetail'));
 const FeatureAgents = lazyWithReload(() => import('./pages/FeatureAgents'));
@@ -276,6 +277,7 @@ export default function App() {
           <Route path="devtools/video-download" element={<VideoDownloaderPage />} />
           <Route path="devtools/processes" element={<ProcessesPage />} />
           <Route path="devtools/agents" element={<AgentsPage />} />
+          <Route path="eidoverse" element={<Eidoverse />} />
           <Route path="ai" element={<AIProviders />} />
           {/* The provider editor is a deep-linkable slide-in over the same page:
               /ai/new creates, /ai/edit/:providerId edits. The id sits under its

--- a/client/src/components/Layout.jsx
+++ b/client/src/components/Layout.jsx
@@ -48,6 +48,7 @@ import {
   Globe,
   Newspaper,
   Globe2,
+  Orbit,
   Ticket,
   Network,
   Flame,
@@ -166,6 +167,7 @@ import * as api from '../services/api';
 export const NAV_PRESENTATION = {
   '/': { icon: Home, single: true },
   '/review': { icon: ClipboardList, single: true },
+  '/eidoverse': { icon: Orbit, single: true },
   '/openworld': { icon: Globe2, single: true },
   '/apps': { icon: Package, dynamic: 'apps' },
   '/brain/config': { icon: Settings },
@@ -400,7 +402,7 @@ const sectionNavItem = (section) => {
   return { label: section, feature: sharedFeature, children, ...SECTION_PRESENTATION[section] };
 };
 
-const mainRows = ['/', '/review', '/openworld'].map(navRowForPath);
+const mainRows = ['/', '/review', '/eidoverse', '/openworld'].map(navRowForPath);
 const appsCommand = navRowForPath('/apps');
 const goalsRow = navRowForPath('/goals/list');
 const sectionRows = Object.fromEntries(SECTION_ORDER.map((section) => [section, sectionNavItem(section)]));
@@ -527,6 +529,7 @@ export function SingleNavRow({ item, collapsed, active, badgeCount, pinned, onTo
 // regex — see `isFullWidthRoute` below.
 const EXACT_FULL_WIDTH_PATHS = [
   '/character',
+  '/eidoverse',
   '/ai',
   // Data Manager is a bordered title bar over a `flex-1 overflow-auto` body,
   // so it owns its own scroll. EXACT, not a prefix — a `/data` prefix would

--- a/client/src/components/Layout.test.jsx
+++ b/client/src/components/Layout.test.jsx
@@ -60,6 +60,7 @@ const allFeaturesOn = () => [
   { id: 'post', label: 'POST', enabled: true },
   { id: 'datadog', label: 'DataDog', enabled: true },
   { id: 'jira', label: 'JIRA', enabled: true },
+  { id: 'eidoverse', label: 'Eidoverse Worlds', enabled: true },
   { id: 'gsd', label: 'GSD', enabled: true },
   { id: 'openclaw', label: 'OpenClaw', enabled: true },
   { id: 'health', label: 'Health tracking', enabled: true },
@@ -245,6 +246,18 @@ describe('Layout — instance feature gating', () => {
     expect(screen.getByRole('link', { name: 'Features' })).toHaveAttribute('href', '/settings/features');
   });
 
+  it('shows and hides Eidoverse with its instance feature flag', async () => {
+    await renderLayout('/eidoverse');
+    expect(screen.getByRole('link', { name: 'Eidoverse' })).toHaveAttribute('href', '/eidoverse');
+
+    featureMock.features = allFeaturesOn()
+      .map((feature) => feature.id === 'eidoverse' ? { ...feature, enabled: false } : feature);
+    act(() => window.dispatchEvent(new CustomEvent(INSTANCE_FEATURES_CHANGED, {
+      detail: { features: featureMock.features },
+    })));
+    expect(screen.queryByRole('link', { name: 'Eidoverse' })).toBeNull();
+  });
+
   it('shows and hides OpenClaw with its instance feature flag', async () => {
     await renderLayout('/openclaw');
     expect(screen.getByRole('link', { name: 'OpenClaw' })).toHaveAttribute('href', '/openclaw');
@@ -418,6 +431,7 @@ describe('Layout — isFullWidthRoute classification', () => {
     ['/ask', true], ['/ask/1', true], ['/asking', false],
     ['/timeline', true], ['/timeline/2026-08-12', true],
     ['/tribe', true], ['/rapid-reader', true], ['/openclaw', true],
+    ['/eidoverse', true], ['/eidoverse/world', false],
     // Index page stays padded+scrolling; only the DETAIL route is full-width.
     ['/catalog', false], ['/catalog/book/1', true],
     ['/universes', false], ['/universes/u1', true],

--- a/client/src/pages/Apps.jsx
+++ b/client/src/pages/Apps.jsx
@@ -14,6 +14,7 @@ import { useAppOperation } from '../hooks/useAppOperation';
 import useUrlParams from '../hooks/useUrlParams';
 import * as api from '../services/api';
 import socket from '../services/socket';
+import { getLaunchUrls } from '../services/appUrls';
 import { NON_PM2_TYPES, isStandardizable, getAppTypeLabel } from '../components/apps/constants';
 import { formatBytes } from '../utils/formatters';
 
@@ -103,6 +104,10 @@ export default function Apps() {
     const result = await api.launchNativeApp(app.id).catch(() => null);
     setNativeLaunchLoading(prev => ({ ...prev, [app.id]: false }));
     if (result?.success) toast.success(`${app.nativeLaunch.label} is running`);
+  };
+
+  const handleWebLaunch = (url) => {
+    if (url) window.open(url, '_blank');
   };
 
   const handleUpdate = (app) => startUpdate(app.id, app.name);
@@ -292,6 +297,8 @@ export default function Apps() {
             const rowOperating = !!rowOperation && !rowOperation.completed && !rowOperation.error;
             const busyElsewhere = isOperating && !rowOperating;
             const busyReason = `${(liveOperation && operationName(liveOperation)) || 'Another app'} is ${liveOperation?.type === 'standardize' ? 'being standardized' : 'updating'}`;
+            const launchUrls = getLaunchUrls(app);
+            const primaryLaunchUrl = launchUrls.https || launchUrls.http;
             return (
             <div
               key={app.id}
@@ -423,11 +430,11 @@ export default function Apps() {
                     )}
 
                     {/* Launch buttons grouped together */}
-                    {(app.nativeLaunch || (app.overallStatus === 'online' && (app.uiPort || app.devUiPort))) && (
+                    {(app.nativeLaunch || (app.overallStatus === 'online' && (primaryLaunchUrl || launchUrls.dev))) && (
                       <div className="inline-flex rounded-lg overflow-hidden border border-port-border divide-x divide-port-border">
-                        {app.overallStatus === 'online' && app.uiPort && (
+                        {app.overallStatus === 'online' && primaryLaunchUrl && (
                           <button
-                            onClick={() => window.open(`${window.location.protocol}//${window.location.hostname}:${app.uiPort}`, '_blank')}
+                            onClick={() => handleWebLaunch(primaryLaunchUrl)}
                             className="px-3 py-1.5 min-h-[40px] sm:min-h-0 bg-port-accent/20 text-port-accent enabled:hover:bg-port-accent/30 transition-colors flex items-center gap-1"
                             aria-label={`Launch ${app.name} UI`}
                           >
@@ -435,9 +442,9 @@ export default function Apps() {
                             <span className="text-xs">Launch</span>
                           </button>
                         )}
-                        {app.overallStatus === 'online' && app.devUiPort && (
+                        {app.overallStatus === 'online' && launchUrls.dev && (
                           <button
-                            onClick={() => window.open(`${window.location.protocol}//${window.location.hostname}:${app.devUiPort}`, '_blank')}
+                            onClick={() => handleWebLaunch(launchUrls.dev)}
                             className="px-3 py-1.5 min-h-[40px] sm:min-h-0 bg-port-warning/20 text-port-warning enabled:hover:bg-port-warning/30 transition-colors flex items-center gap-1"
                             aria-label={`Launch ${app.name} Dev UI`}
                           >

--- a/client/src/pages/Apps.test.jsx
+++ b/client/src/pages/Apps.test.jsx
@@ -16,6 +16,16 @@ const APPS = [
   },
 ];
 
+const launchUrlMock = vi.hoisted(() => ({
+  getLaunchUrls: vi.fn((app) => ({
+    https: null,
+    http: app.uiPort ? `http://host-alpha.example-tailnet.ts.net:${app.uiPort}` : null,
+    dev: app.devUiPort ? `http://host-alpha.example-tailnet.ts.net:${app.devUiPort}` : null,
+  })),
+}));
+
+vi.mock('../services/appUrls', () => launchUrlMock);
+
 vi.mock('../services/api', () => ({
   PORTOS_APP_ID: 'portos-default',
   getApps: vi.fn(() => Promise.resolve(APPS)),
@@ -186,6 +196,19 @@ describe('Apps row action hierarchy', () => {
 
     await act(async () => { resolveBuild({ success: true }); });
     await waitFor(() => expect(screen.getByRole('button', { name: 'Build production UI: npm run build' })).toBeEnabled());
+  });
+
+  it('opens a plain-HTTP managed app without inheriting PortOS HTTPS', async () => {
+    api.getApps.mockResolvedValue([{ ...APPS[0], uiPort: 8940 }]);
+    const open = vi.spyOn(window, 'open').mockImplementation(() => null);
+    const user = userEvent.setup();
+
+    await renderApps();
+    await user.click(screen.getByRole('button', { name: 'Launch Example App UI' }));
+
+    expect(open).toHaveBeenCalledWith('http://host-alpha.example-tailnet.ts.net:8940', '_blank');
+    expect(launchUrlMock.getLaunchUrls).toHaveBeenCalledWith(expect.objectContaining({ id: 'app-alpha', uiPort: 8940 }));
+    open.mockRestore();
   });
 });
 

--- a/client/src/pages/Eidoverse.jsx
+++ b/client/src/pages/Eidoverse.jsx
@@ -1,0 +1,179 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { ExternalLink, Orbit, RotateCcw, Settings } from 'lucide-react';
+import { Link } from 'react-router';
+import PageHeader from '../components/PageHeader';
+import BrailleSpinner from '../components/BrailleSpinner';
+import {
+  getApp,
+  getInstanceFeatures,
+  startApp,
+  startEidoverseHost,
+} from '../services/api';
+
+const silent = { silent: true };
+const RUNNING_STATUSES = new Set(['online', 'launching', 'unknown']);
+
+const failedStart = (result) => Object.values(result?.results || {})
+  .find((entry) => entry?.success === false);
+
+export const hostUrlFor = (host, setup, location = window.location) => {
+  if (location.protocol === 'https:') {
+    if (host.protocol !== 'https') {
+      throw new Error('PortOS is using HTTPS, but the Eidoverse host could not load the shared certificate.');
+    }
+    return `https://${location.hostname}:${host.port}/`;
+  }
+  return `http://${location.hostname}:${setup.uiPort}/`;
+};
+
+export default function Eidoverse() {
+  const requestGeneration = useRef(0);
+  const [phase, setPhase] = useState('loading');
+  const [error, setError] = useState('');
+  const [hostUrl, setHostUrl] = useState('');
+  const [appId, setAppId] = useState(null);
+
+  const prepare = useCallback(() => {
+    const generation = ++requestGeneration.current;
+    const isCurrent = () => requestGeneration.current === generation;
+    const updatePhase = (next) => { if (isCurrent()) setPhase(next); };
+
+    setPhase('loading');
+    setError('');
+    setHostUrl('');
+
+    const load = async () => {
+      const featureState = await getInstanceFeatures(silent);
+      const feature = featureState.features?.find((entry) => entry.id === 'eidoverse');
+      const setup = feature?.setup;
+      if (!setup?.installed) return { phase: 'setup', appId: setup?.appId || null };
+      if (!setup.appId) throw new Error('Eidoverse is installed but its managed-app record is unavailable.');
+
+      const app = await getApp(setup.appId, silent);
+      if (!RUNNING_STATUSES.has(app.overallStatus)) {
+        updatePhase('starting');
+        const result = await startApp(setup.appId, silent);
+        const failure = failedStart(result);
+        if (failure) throw new Error(failure.error || 'PortOS could not start Eidoverse Worlds.');
+      }
+
+      updatePhase('connecting');
+      const host = await startEidoverseHost(silent);
+      if (!host?.running) throw new Error('The Eidoverse host did not start.');
+      return {
+        phase: 'ready',
+        appId: setup.appId,
+        hostUrl: hostUrlFor(host, setup),
+      };
+    };
+
+    load().then((result) => {
+      if (!isCurrent()) return;
+      setPhase(result.phase);
+      setAppId(result.appId);
+      setHostUrl(result.hostUrl || '');
+    }, (reason) => {
+      if (!isCurrent()) return;
+      setPhase('error');
+      setError(reason?.message || 'Eidoverse Worlds could not be loaded.');
+    });
+  }, []);
+
+  useEffect(() => {
+    prepare();
+    return () => { requestGeneration.current += 1; };
+  }, [prepare]);
+
+  const actions = (
+    <>
+      {hostUrl && (
+        <a
+          href={hostUrl}
+          target="_blank"
+          rel="noreferrer"
+          className="inline-flex min-h-[40px] items-center gap-1.5 rounded-lg border border-port-border px-3 py-1.5 text-sm text-gray-200 transition-colors hover:border-port-accent hover:text-white"
+        >
+          <ExternalLink size={15} aria-hidden="true" />
+          Open full screen
+        </a>
+      )}
+      {appId && (
+        <Link
+          to={`/apps/${appId}/overview`}
+          className="inline-flex min-h-[40px] items-center gap-1.5 rounded-lg border border-port-border px-3 py-1.5 text-sm text-gray-200 transition-colors hover:border-port-accent hover:text-white"
+        >
+          <Settings size={15} aria-hidden="true" />
+          Manage app
+        </Link>
+      )}
+    </>
+  );
+
+  return (
+    <div className="flex h-full min-h-0 flex-col bg-black">
+      <PageHeader
+        icon={Orbit}
+        title="Eidoverse Worlds"
+        subtitle="A shared 3D world for you and your agents"
+        actions={actions}
+        className="bg-port-bg"
+      />
+
+      {phase === 'ready' && (
+        <iframe
+          src={hostUrl}
+          title="Eidoverse Worlds"
+          className="min-h-0 w-full flex-1 border-0 bg-black"
+          allow="camera; microphone; fullscreen; gamepad; xr-spatial-tracking"
+          allowFullScreen
+        />
+      )}
+
+      {['loading', 'starting', 'connecting'].includes(phase) && (
+        <div className="flex flex-1 items-center justify-center p-6" role="status">
+          <BrailleSpinner
+            text={phase === 'starting'
+              ? 'Starting Eidoverse Worlds'
+              : (phase === 'connecting' ? 'Connecting to Eidoverse Worlds' : 'Loading Eidoverse Worlds')}
+          />
+        </div>
+      )}
+
+      {phase === 'setup' && (
+        <div className="flex flex-1 items-center justify-center p-6">
+          <section className="max-w-lg rounded-xl border border-port-border bg-port-card p-6 text-center">
+            <Orbit className="mx-auto mb-3 h-10 w-10 text-port-accent" aria-hidden="true" />
+            <h2 className="text-lg font-semibold text-white">Install Eidoverse Worlds</h2>
+            <p className="mt-2 text-sm text-gray-400">
+              Install and enable the managed app from PortOS Features before opening this world.
+            </p>
+            <Link
+              to="/settings/features"
+              className="mt-5 inline-flex min-h-[44px] items-center gap-2 rounded-lg bg-port-accent px-4 py-2 text-sm font-medium text-black transition-opacity hover:opacity-90"
+            >
+              <Settings size={16} aria-hidden="true" />
+              Open Features
+            </Link>
+          </section>
+        </div>
+      )}
+
+      {phase === 'error' && (
+        <div className="flex flex-1 items-center justify-center p-6">
+          <section className="max-w-lg rounded-xl border border-port-error/50 bg-port-card p-6 text-center" role="alert">
+            <h2 className="text-lg font-semibold text-white">Eidoverse Worlds did not load</h2>
+            <p className="mt-2 text-sm text-port-error">{error}</p>
+            <button
+              type="button"
+              onClick={prepare}
+              className="mt-5 inline-flex min-h-[44px] items-center gap-2 rounded-lg bg-port-accent px-4 py-2 text-sm font-medium text-black transition-opacity hover:opacity-90"
+            >
+              <RotateCcw size={16} aria-hidden="true" />
+              Retry
+            </button>
+          </section>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/pages/Eidoverse.test.jsx
+++ b/client/src/pages/Eidoverse.test.jsx
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router';
+
+vi.mock('../services/api', () => ({
+  getApp: vi.fn(),
+  getInstanceFeatures: vi.fn(),
+  startApp: vi.fn(),
+  startEidoverseHost: vi.fn(),
+}));
+
+import * as api from '../services/api';
+import Eidoverse, { hostUrlFor } from './Eidoverse';
+
+const setup = {
+  installed: true,
+  appId: 'app-eidoverse',
+  uiPort: 8940,
+  runtimeStatus: 'online',
+};
+
+const featureResponse = (overrides = {}) => ({
+  features: [{
+    id: 'eidoverse',
+    enabled: false,
+    setup: { ...setup, ...overrides },
+  }],
+});
+
+const renderPage = () => render(
+  <MemoryRouter initialEntries={['/eidoverse']}>
+    <Eidoverse />
+  </MemoryRouter>,
+);
+
+describe('Eidoverse hosted page', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    api.getInstanceFeatures.mockResolvedValue(featureResponse());
+    api.getApp.mockResolvedValue({ id: setup.appId, overallStatus: 'online' });
+    api.startApp.mockResolvedValue({ success: true, results: {} });
+    api.startEidoverseHost.mockResolvedValue({ running: true, protocol: 'http', port: 5563 });
+  });
+
+  it('loads the installed managed app even when the optional nav entry is disabled', async () => {
+    renderPage();
+
+    const frame = await screen.findByTitle('Eidoverse Worlds');
+    expect(frame).toHaveAttribute('src', `http://${window.location.hostname}:8940/`);
+    expect(api.getApp).toHaveBeenCalledWith('app-eidoverse', { silent: true });
+    expect(api.startApp).not.toHaveBeenCalled();
+    expect(api.startEidoverseHost).toHaveBeenCalledWith({ silent: true });
+    expect(screen.getByRole('link', { name: 'Manage app' })).toHaveAttribute('href', '/apps/app-eidoverse/overview');
+  });
+
+  it('starts a stopped managed app before connecting the hosted page', async () => {
+    api.getApp.mockResolvedValue({ id: setup.appId, overallStatus: 'stopped' });
+    renderPage();
+
+    await screen.findByTitle('Eidoverse Worlds');
+    expect(api.startApp).toHaveBeenCalledWith('app-eidoverse', { silent: true });
+    expect(api.startEidoverseHost).toHaveBeenCalledAfter(api.startApp);
+  });
+
+  it('sends an uninstalled user to the existing Features setup', async () => {
+    api.getInstanceFeatures.mockResolvedValue(featureResponse({ installed: false, appId: null }));
+    renderPage();
+
+    const setupLink = await screen.findByRole('link', { name: 'Open Features' });
+    expect(setupLink).toHaveAttribute('href', '/settings/features');
+    expect(api.getApp).not.toHaveBeenCalled();
+    expect(api.startEidoverseHost).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a managed-app start failure and retries on demand', async () => {
+    api.getApp.mockResolvedValue({ id: setup.appId, overallStatus: 'stopped' });
+    api.startApp
+      .mockResolvedValueOnce({ success: true, results: { eidoverse: { success: false, error: 'Example startup failure' } } })
+      .mockResolvedValueOnce({ success: true, results: { eidoverse: { success: true } } });
+    const user = userEvent.setup();
+    renderPage();
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Example startup failure');
+    await user.click(screen.getByRole('button', { name: 'Retry' }));
+
+    await screen.findByTitle('Eidoverse Worlds');
+    expect(api.startApp).toHaveBeenCalledTimes(2);
+  });
+
+  it('uses the PortOS TLS bridge for an HTTPS MagicDNS page', () => {
+    expect(hostUrlFor(
+      { running: true, protocol: 'https', port: 5563 },
+      setup,
+      { protocol: 'https:', hostname: 'host-alpha.example-tailnet.ts.net' },
+    )).toBe('https://host-alpha.example-tailnet.ts.net:5563/');
+    expect(() => hostUrlFor(
+      { running: true, protocol: 'http', port: 5563 },
+      setup,
+      { protocol: 'https:', hostname: 'host-alpha.example-tailnet.ts.net' },
+    )).toThrow(/shared certificate/);
+  });
+
+  it('shows bridge readiness errors instead of mounting a dead iframe', async () => {
+    api.startEidoverseHost.mockRejectedValue(new Error('Eidoverse Worlds did not become ready in time.'));
+    renderPage();
+
+    await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent('did not become ready'));
+    expect(screen.queryByTitle('Eidoverse Worlds')).toBeNull();
+  });
+});

--- a/client/src/services/apiApps.js
+++ b/client/src/services/apiApps.js
@@ -3,7 +3,7 @@ import { request, API_BASE } from './apiCore.js';
 
 // Apps
 export const getApps = (options) => request('/apps', options);
-export const getApp = (id) => request(`/apps/${id}`);
+export const getApp = (id, options) => request(`/apps/${id}`, options);
 // Reverse lookup (#2991): sprite records whose publishBinding.appId targets this
 // app. Read-only; the caller owns a .catch fallback, so default to silent.
 export const getAppSpriteBindings = (id, options) =>

--- a/client/src/services/apiSystem.js
+++ b/client/src/services/apiSystem.js
@@ -78,6 +78,10 @@ export const installEidoverseFeature = (worldsRepoUrl, options = {}) => request(
   body: JSON.stringify({ worldsRepoUrl }),
   ...options,
 });
+export const startEidoverseHost = (options = {}) => request('/settings/features/eidoverse/host', {
+  method: 'POST',
+  ...options,
+});
 export const updateSettings = (data, options) => request('/settings', {
   method: 'PUT',
   body: JSON.stringify(data),

--- a/docs/PORTS.md
+++ b/docs/PORTS.md
@@ -35,6 +35,7 @@ Common port labels:
 | 5560 | portos-autofixer-ui | ui | Autofixer web UI |
 | 5561 | portos-db (Docker container) | - | Infrastructure dependency: PostgreSQL Docker container provisioned by `scripts/setup-db.js` / Docker Compose (not a PM2 process in `server/services/apps.js`; native mode uses system pg on 5432). |
 | 5562 | portos-whisper | whisper-server | Loopback whisper.cpp speech-to-text server. |
+| 5563 | portos-server | eidoverse-host | Optional HTTPS/WebSocket bridge for the embedded Eidoverse Worlds page. Starts on demand and forwards to the managed app on loopback `:8940`. |
 | 5568 | portos-llama-server | - | Loopback llama.cpp speculative-decoding server. Optional PM2 process, started/stopped from Models → LLMs. |
 | 8000 | portos-mtplx | - | Loopback MTPLX OpenAI-compatible API (upstream's own default, kept so the shipped provider presets match). Optional PM2 process, started/stopped from Models → LLMs. See [features/mtplx.md](./features/mtplx.md). |
 | 18020 | vLLM (Docker) | - | Loopback vLLM Qwen3.8-27B / DFlash 2 container on an RTX 3090 host. Operator-started (`docker compose --profile single up -d`) — PortOS never brings it up on boot. See [features/qwen38-rtx3090.md](./features/qwen38-rtx3090.md). |
@@ -127,7 +128,7 @@ PortOS automatically detects ports from env vars:
 | Range | Purpose |
 |-------|---------|
 | 5553-5561 | PortOS core services (includes the `:5553` loopback mirror and the `portos-db` Docker container on `:5561`) |
-| 5562-5569 | Reserved for PortOS extensions (5568 is the managed llama-server default) |
+| 5562-5569 | Reserved for PortOS extensions (5563 hosts Eidoverse on demand; 5568 is the managed llama-server default) |
 | 5570-5599 | User applications |
 
 PostgreSQL in native mode listens on the system default `:5432`, outside these ranges. Two third-party

--- a/docs/features/eidoverse.md
+++ b/docs/features/eidoverse.md
@@ -33,9 +33,17 @@ bun --env-file=.env.portos server/server.ts
 ```
 
 Installation does not start the server. Start, stop, logs, updates, and launch
-links remain visible on the normal managed-app screen. Managed updates pull both
-the selected Worlds checkout and its companion video runtime before using Bun's
-frozen lockfile rather than npm.
+links remain visible on the normal managed-app screen. Plain-HTTP managed apps
+keep an `http://` launch URL even when PortOS itself is open over HTTPS, so the
+Apps launch action works from a Tailscale MagicDNS session. Managed updates pull
+both the selected Worlds checkout and its companion video runtime before using
+Bun's frozen lockfile rather than npm.
+
+When the feature is enabled, **Eidoverse** appears beside OpenWorld in PortOS's
+primary navigation. Opening it starts the managed app when needed and embeds its
+web client in a full-width PortOS page. OpenWorld remains available during this
+evaluation; replacing or redirecting it is a separate product decision after
+the Eidoverse integration proves the required behavior.
 
 Durable Eidoverse world logs live at `data/eidoverse/worlds`. This is
 machine-local `file-primary` data: PortOS backups include it, but PortOS does
@@ -55,9 +63,17 @@ an empty join token; do not expose this configuration to the public internet.
 An instance that needs a broader trust model should configure Eidoverse access
 control in that project before starting it.
 
+Eidoverse itself remains a plain-HTTP service on `:8940`. For an HTTPS PortOS
+session, the embedded page lazily opens a PortOS-owned HTTPS/WebSocket bridge on
+`:5563`, using the same machine certificate as `:5555` and forwarding to
+`127.0.0.1:8940`. This avoids browser mixed-content rejection while leaving both
+external repositories unchanged. The bridge starts only when the page is
+opened, waits for the managed app to answer before mounting the iframe, and
+returns an explicit unavailable state when the runtime does not become ready.
+
 ## PortOS bridge boundary
 
-This slice establishes installation and runtime management only. Persistent
-Mind presence, agent identity, and dynamic PortOS buildings/assets should be
-implemented as explicit adapters across the two projects' public protocols.
-They must remain opt-in and must not cause provider calls at PortOS boot.
+The hosted UI and runtime management do not yet bridge Persistent Mind presence,
+agent identity, or dynamic PortOS buildings/assets. Those should be implemented
+as explicit adapters across the two projects' public protocols. They must remain
+opt-in and must not cause provider calls at PortOS boot.

--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -121,6 +121,7 @@ const PORTS = {
   AUTOFIXER_UI: 5560,  // Autofixer UI
   POSTGRES_DOCKER: 5561, // PostgreSQL Docker container (host port mapping)
   WHISPER: 5562,       // Loopback whisper.cpp speech-to-text server
+  EIDOVERSE_HOST: 5563, // Optional HTTPS/WebSocket bridge to Eidoverse Worlds on :8940
   LLAMA_SERVER: 5568,  // Loopback llama.cpp speculative-decoding server
   VLLM_QWEN: 18020,    // Loopback vLLM Qwen3.8-27B (DFlash 2) container — started by the operator, never by PortOS
   SGLANG_QWEN: 18021,  // Loopback SGLang Qwen3.8-27B container (Hopper/Blackwell) — started by the operator, never by PortOS

--- a/server/lib/apiRouteCatalog.generated.json
+++ b/server/lib/apiRouteCatalog.generated.json
@@ -19246,7 +19246,7 @@
       "sources": [
         {
           "source": "server/routes/settings.js",
-          "line": 138
+          "line": 139
         }
       ]
     },
@@ -19257,7 +19257,7 @@
       "sources": [
         {
           "source": "server/routes/settings.js",
-          "line": 192
+          "line": 202
         }
       ]
     },
@@ -19268,7 +19268,7 @@
       "sources": [
         {
           "source": "server/routes/settings.js",
-          "line": 157
+          "line": 158
         }
       ]
     },
@@ -19279,7 +19279,7 @@
       "sources": [
         {
           "source": "server/routes/settings.js",
-          "line": 186
+          "line": 196
         }
       ]
     },
@@ -19290,7 +19290,7 @@
       "sources": [
         {
           "source": "server/routes/settings.js",
-          "line": 162
+          "line": 163
         }
       ]
     },
@@ -19301,7 +19301,18 @@
       "sources": [
         {
           "source": "server/routes/settings.js",
-          "line": 179
+          "line": 189
+        }
+      ]
+    },
+    {
+      "method": "POST",
+      "path": "/api/settings/features/eidoverse/host",
+      "mountPath": "/api/settings",
+      "sources": [
+        {
+          "source": "server/routes/settings.js",
+          "line": 183
         }
       ]
     },
@@ -19312,7 +19323,7 @@
       "sources": [
         {
           "source": "server/routes/settings.js",
-          "line": 169
+          "line": 170
         }
       ]
     },
@@ -19323,7 +19334,7 @@
       "sources": [
         {
           "source": "server/routes/settings.js",
-          "line": 151
+          "line": 152
         }
       ]
     },
@@ -23543,8 +23554,8 @@
   ],
   "stats": {
     "mounts": 145,
-    "operations": 2124,
-    "declarations": 2127,
+    "operations": 2125,
+    "declarations": 2128,
     "sourceFiles": 225
   }
 }

--- a/server/lib/navManifest.js
+++ b/server/lib/navManifest.js
@@ -68,6 +68,7 @@ export const SECTION_FEATURE = new Map([
 const RAW_NAV_COMMANDS = [
   { id: 'nav.dashboard', path: '/', label: 'Dashboard', section: 'Main', aliases: ['dashboard', 'home'], keywords: ['overview', 'start'] },
   { id: 'nav.review-hub', path: '/review', label: 'Review Hub', section: 'Main', aliases: ['review', 'review-hub'] },
+  { id: 'nav.eidoverse', path: '/eidoverse', label: 'Eidoverse', section: 'Main', feature: 'eidoverse', aliases: ['eidoverse', 'eidoverse-worlds', 'worlds'], keywords: ['3d', 'world', 'agents', 'spatial', 'managed app'] },
   { id: 'nav.cybercity', path: '/openworld', label: 'OpenWorld', section: 'Main', previousPaths: ['/city'], aliases: ['openworld', 'open world', 'open-world', 'city'], keywords: ['3d', 'visualization', 'game', 'map', 'explore'] },
   { id: 'nav.cybercity.settings', path: '/openworld/settings', label: 'OpenWorld Settings', section: 'Main', aliases: ['openworld settings', 'open world settings', 'world settings', 'city settings', 'city-settings', 'openworld-config'], keywords: ['openworld', 'settings', '3d', 'configure', 'world style', 'low poly'] },
   ...OPEN_WORLD_REGION_COMMANDS,

--- a/server/lib/navManifest.test.js
+++ b/server/lib/navManifest.test.js
@@ -192,6 +192,11 @@ describe('nav contract — instance-feature gating', () => {
     expect(byId['nav.cos.gsd']).toBe('gsd');
   });
 
+  it('gates the Eidoverse host page on its installed feature', () => {
+    const command = NAV_COMMANDS.find((entry) => entry.id === 'nav.eidoverse');
+    expect(command).toMatchObject({ path: '/eidoverse', feature: 'eidoverse' });
+  });
+
   it('gates the complete Health section and MortalLoom settings', () => {
     const byId = Object.fromEntries(NAV_COMMANDS.map((c) => [c.id, c.feature]));
     expect([...SECTION_FEATURE]).toContainEqual(['Health', 'health']);

--- a/server/lib/ports.js
+++ b/server/lib/ports.js
@@ -16,6 +16,7 @@ export const PORTS = {
   AUTOFIXER_UI: 5560, // Autofixer UI
   POSTGRES_DOCKER: 5561, // PostgreSQL Docker container (host port mapping)
   WHISPER: 5562,    // Loopback whisper.cpp speech-to-text server
+  EIDOVERSE_HOST: 5563, // Optional HTTPS/WebSocket bridge to Eidoverse Worlds on :8940
   LLAMA_SERVER: 5568, // Loopback llama.cpp speculative-decoding server
   VLLM_QWEN: 18020, // Loopback vLLM Qwen3.8-27B (DFlash 2) container — operator-started, never by PortOS
   SGLANG_QWEN: 18021, // Loopback SGLang Qwen3.8-27B container (Hopper/Blackwell) — operator-started, never by PortOS

--- a/server/lib/socketEventCatalog.generated.json
+++ b/server/lib/socketEventCatalog.generated.json
@@ -591,7 +591,7 @@
         {
           "direction": "server-to-client",
           "source": "client/src/pages/Apps.jsx",
-          "line": 64
+          "line": 65
         },
         {
           "direction": "server-to-client",

--- a/server/routes/settings.js
+++ b/server/routes/settings.js
@@ -10,8 +10,9 @@ import {
   CODEX_PARALLEL_DEFAULT,
 } from '../services/mediaJobQueue/index.js';
 import { assertMediaRoutingConfig } from '../services/federatedMedia/routingPolicy.js';
-import { getInstanceFeatures, updateEidoverseWorldsRepo, updateInstanceFeature } from '../services/instanceFeatures.js';
+import { assertConfiguredEidoverseInstalled, getInstanceFeatures, updateEidoverseWorldsRepo, updateInstanceFeature } from '../services/instanceFeatures.js';
 import { installEidoverse } from '../services/eidoverse.js';
+import { ensureEidoverseHost } from '../services/eidoverseHost.js';
 import { isGitHubRepoUrl } from '../lib/githubRepoUrl.js';
 import { asyncHandler } from '../lib/errorHandler.js';
 import { isPlainObject } from '../lib/objects.js';
@@ -173,6 +174,15 @@ router.post('/features/eidoverse/install', asyncHandler(async (req, res) => {
   const normalizedRepoUrl = await updateEidoverseWorldsRepo(worldsRepoUrl);
   await installEidoverse({ worldsRepoUrl: normalizedRepoUrl });
   res.status(201).json(await updateInstanceFeature('eidoverse', true));
+}));
+
+// POST /api/settings/features/eidoverse/host
+// Lazily opens PortOS's TLS/WebSocket bridge. The external runtime stays a
+// separately managed app; this listener only makes its existing web UI safe to
+// embed when PortOS itself was opened over HTTPS.
+router.post('/features/eidoverse/host', asyncHandler(async (_req, res) => {
+  await assertConfiguredEidoverseInstalled();
+  res.json(await ensureEidoverseHost());
 }));
 
 // PUT /api/settings/features/:featureId

--- a/server/routes/settings.test.js
+++ b/server/routes/settings.test.js
@@ -51,11 +51,15 @@ vi.mock('../services/eidoverse.js', () => ({
   assertEidoverseInstalled: vi.fn(async () => ({ installed: true })),
   installEidoverse: vi.fn(async () => ({ installed: true })),
 }));
+vi.mock('../services/eidoverseHost.js', () => ({
+  ensureEidoverseHost: vi.fn(async () => ({ running: true, protocol: 'https', port: 5563 })),
+}));
 
 import settingsRoutes from './settings.js';
 import { hasConfiguredInstances as hasConfiguredDatadogInstances } from '../services/datadog.js';
 import { hasConfiguredInstances as hasConfiguredJiraInstances } from '../services/jira.js';
-import { installEidoverse } from '../services/eidoverse.js';
+import { assertEidoverseInstalled, installEidoverse } from '../services/eidoverse.js';
+import { ensureEidoverseHost } from '../services/eidoverseHost.js';
 
 const buildApp = () => {
   const app = express();
@@ -187,6 +191,15 @@ describe('Settings routes — instance feature participation', () => {
     expect(store.instanceFeatures.eidoverse.enabled).toBe(true);
     expect(store.instanceFeatures.eidoverse.worldsRepoUrl).toBe(worldsRepoUrl);
     expect(res.body.features).toContainEqual(expect.objectContaining({ id: 'eidoverse', enabled: true }));
+  });
+
+  it('opens the Eidoverse host bridge only after verifying the managed app installation', async () => {
+    const res = await request(buildApp()).post('/api/settings/features/eidoverse/host');
+
+    expect(res.status).toBe(200);
+    expect(assertEidoverseInstalled).toHaveBeenCalledOnce();
+    expect(ensureEidoverseHost).toHaveBeenCalledOnce();
+    expect(res.body).toEqual({ running: true, protocol: 'https', port: 5563 });
   });
 
   it('rejects a non-GitHub Worlds repository', async () => {

--- a/server/services/eidoverseHost.js
+++ b/server/services/eidoverseHost.js
@@ -1,0 +1,215 @@
+import { request as httpRequest } from 'node:http';
+import { createConnection } from 'node:net';
+import { createTailscaleServers, watchCertReload } from '../../lib/tailscale-https.js';
+import { certPaths } from '../../lib/certPaths.js';
+import { PATHS } from '../lib/fileUtils.js';
+import { PORTS } from '../lib/ports.js';
+import { ServerError } from '../lib/errorHandler.js';
+import { EIDOVERSE_PORT } from './eidoverse.js';
+
+const BAD_GATEWAY_BODY = 'Eidoverse Worlds is not running.';
+const FORWARDED_HEADER_NAMES = new Set(['host', 'x-forwarded-host', 'x-forwarded-proto']);
+
+const targetAuthority = (host, port) => `${host}:${port}`;
+
+const forwardedHeaders = (req, protocol, targetHost, targetPort) => ({
+  ...req.headers,
+  host: targetAuthority(targetHost, targetPort),
+  'x-forwarded-host': req.headers.host || '',
+  'x-forwarded-proto': protocol,
+});
+
+const writeBadGateway = (res) => {
+  if (res.headersSent) {
+    res.destroy();
+    return;
+  }
+  res.writeHead(502, {
+    'content-type': 'text/plain; charset=utf-8',
+    'content-length': Buffer.byteLength(BAD_GATEWAY_BODY),
+  });
+  res.end(BAD_GATEWAY_BODY);
+};
+
+const websocketRequestHead = (req, protocol, targetHost, targetPort) => {
+  const headers = [];
+  for (let index = 0; index < req.rawHeaders.length; index += 2) {
+    const name = req.rawHeaders[index];
+    if (!FORWARDED_HEADER_NAMES.has(name.toLowerCase())) {
+      headers.push(`${name}: ${req.rawHeaders[index + 1]}`);
+    }
+  }
+  headers.push(`Host: ${targetAuthority(targetHost, targetPort)}`);
+  headers.push(`X-Forwarded-Host: ${req.headers.host || ''}`);
+  headers.push(`X-Forwarded-Proto: ${protocol}`);
+  return `${req.method} ${req.url} HTTP/${req.httpVersion}\r\n${headers.join('\r\n')}\r\n\r\n`;
+};
+
+/**
+ * Create the lazy Eidoverse HTTPS bridge. The target is fixed at construction
+ * time, so this is not a general-purpose proxy. No listener is opened until
+ * `start()` is called by the user-facing Eidoverse page.
+ */
+export function createEidoverseHost({
+  targetHost = '127.0.0.1',
+  targetPort = EIDOVERSE_PORT,
+  listenHost = '0.0.0.0',
+  listenPort = PORTS.EIDOVERSE_HOST,
+  certDir = certPaths(PATHS.data).dir,
+} = {}) {
+  let server = null;
+  let httpsEnabled = false;
+  let startInFlight = null;
+  let stopCertWatch = () => {};
+  const sockets = new Set();
+
+  const trackSocket = (rawSocket) => {
+    if (sockets.has(rawSocket)) return rawSocket;
+    sockets.add(rawSocket);
+    rawSocket.once('close', () => sockets.delete(rawSocket));
+    return rawSocket;
+  };
+
+  const protocol = () => (httpsEnabled ? 'https' : 'http');
+
+  const status = () => {
+    const address = server?.address();
+    return {
+      running: Boolean(server?.listening),
+      protocol: protocol(),
+      port: address && typeof address === 'object' ? address.port : listenPort,
+    };
+  };
+
+  const handleHttp = (req, res) => {
+    const upstream = httpRequest({
+      hostname: targetHost,
+      port: targetPort,
+      method: req.method,
+      path: req.url,
+      headers: forwardedHeaders(req, protocol(), targetHost, targetPort),
+    }, (upstreamResponse) => {
+      res.writeHead(upstreamResponse.statusCode || 502, upstreamResponse.headers);
+      upstreamResponse.once('error', () => res.destroy());
+      upstreamResponse.pipe(res);
+    });
+    upstream.once('error', () => writeBadGateway(res));
+    req.once('aborted', () => upstream.destroy());
+    req.pipe(upstream);
+  };
+
+  const handleUpgrade = (req, clientSocket, head) => {
+    trackSocket(clientSocket);
+    const upstreamSocket = trackSocket(createConnection({ host: targetHost, port: targetPort }));
+    let connected = false;
+
+    upstreamSocket.once('connect', () => {
+      connected = true;
+      upstreamSocket.write(websocketRequestHead(req, protocol(), targetHost, targetPort));
+      if (head.length > 0) upstreamSocket.write(head);
+      clientSocket.pipe(upstreamSocket).pipe(clientSocket);
+    });
+
+    upstreamSocket.on('error', () => {
+      if (connected) {
+        clientSocket.destroy();
+        return;
+      }
+      if (!clientSocket.destroyed) {
+        clientSocket.end(
+          `HTTP/1.1 502 Bad Gateway\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Length: ${Buffer.byteLength(BAD_GATEWAY_BODY)}\r\nConnection: close\r\n\r\n${BAD_GATEWAY_BODY}`,
+        );
+      }
+    });
+    clientSocket.once('error', () => upstreamSocket.destroy());
+    clientSocket.once('close', () => upstreamSocket.destroy());
+  };
+
+  const targetIsReady = () => new Promise((resolve) => {
+    const probe = httpRequest({ hostname: targetHost, port: targetPort, path: '/', method: 'GET' }, (response) => {
+      response.resume();
+      resolve(true);
+    });
+    probe.setTimeout(500, () => {
+      probe.destroy();
+      resolve(false);
+    });
+    probe.once('error', () => resolve(false));
+    probe.end();
+  });
+
+  const waitUntilReady = async ({ attempts = 20, intervalMs = 250 } = {}) => {
+    for (let attempt = 0; attempt < attempts; attempt += 1) {
+      if (await targetIsReady()) return status();
+      if (attempt < attempts - 1) {
+        await new Promise((resolve) => setTimeout(resolve, intervalMs));
+      }
+    }
+    throw new ServerError('Eidoverse Worlds did not become ready in time.', {
+      status: 503,
+      code: 'EIDOVERSE_NOT_READY',
+    });
+  };
+
+  const start = () => {
+    if (server?.listening) return Promise.resolve(status());
+    if (startInFlight) return startInFlight;
+
+    const created = createTailscaleServers(handleHttp, { certDir, httpMirror: false });
+    server = created.server;
+    httpsEnabled = created.httpsEnabled;
+    server.on('connection', trackSocket);
+    server.on('upgrade', handleUpgrade);
+
+    const attempt = new Promise((resolve, reject) => {
+      const handleListenError = (error) => reject(error);
+      server.once('error', handleListenError);
+      server.listen(listenPort, listenHost, () => {
+        server.off('error', handleListenError);
+        server.on('error', (error) => console.error(`❌ Eidoverse host failed: ${error.message}`));
+        stopCertWatch = httpsEnabled ? watchCertReload(server, certDir) : () => {};
+        console.log(`🌐 Eidoverse host listening on ${protocol()}://${listenHost}:${status().port}`);
+        resolve(status());
+      });
+    });
+
+    startInFlight = attempt
+      .catch((error) => {
+        server?.close();
+        server = null;
+        httpsEnabled = false;
+        throw error;
+      })
+      .finally(() => {
+        startInFlight = null;
+      });
+    return startInFlight;
+  };
+
+  const close = async () => {
+    stopCertWatch();
+    stopCertWatch = () => {};
+    sockets.forEach((socket) => socket.destroy());
+    if (!server?.listening) {
+      server = null;
+      httpsEnabled = false;
+      return;
+    }
+    const activeServer = server;
+    server = null;
+    httpsEnabled = false;
+    await new Promise((resolve, reject) => {
+      activeServer.close((error) => (error ? reject(error) : resolve()));
+    });
+  };
+
+  return Object.freeze({ start, close, status, waitUntilReady });
+}
+
+let eidoverseHost = null;
+
+export async function ensureEidoverseHost() {
+  eidoverseHost ||= createEidoverseHost();
+  await eidoverseHost.start();
+  return eidoverseHost.waitUntilReady();
+}

--- a/server/services/eidoverseHost.test.js
+++ b/server/services/eidoverseHost.test.js
@@ -1,0 +1,112 @@
+import { once } from 'node:events';
+import { createServer } from 'node:http';
+import { afterEach, describe, expect, it } from 'vitest';
+import { WebSocket, WebSocketServer } from 'ws';
+import { createEidoverseHost } from './eidoverseHost.js';
+
+const bridges = [];
+const upstreamServers = [];
+const webSocketServers = [];
+const webSocketClients = [];
+
+const listen = async (server) => {
+  server.listen(0, '127.0.0.1');
+  await once(server, 'listening');
+  upstreamServers.push(server);
+  return server.address().port;
+};
+
+const closeServer = (server) => new Promise((resolve, reject) => {
+  server.close((error) => (error ? reject(error) : resolve()));
+});
+
+afterEach(async () => {
+  webSocketClients.splice(0).forEach((client) => client.terminate());
+  await Promise.all(bridges.splice(0).map((bridge) => bridge.close()));
+  await Promise.all(webSocketServers.splice(0).map((server) => new Promise((resolve) => server.close(resolve))));
+  await Promise.all(upstreamServers.splice(0).map(closeServer));
+});
+
+describe('Eidoverse host bridge', () => {
+  it('forwards HTTP responses and the browser-facing scheme to the managed app', async () => {
+    const upstreamPort = await listen(createServer((req, res) => {
+      const forwardedScheme = req.headers['x-forwarded-proto'];
+      res.writeHead(201, {
+        'content-type': 'application/json',
+        ...(forwardedScheme ? { 'x-forwarded-proto-seen': forwardedScheme } : {}),
+      });
+      res.end(JSON.stringify({ path: req.url, host: req.headers.host }));
+    }));
+    const bridge = createEidoverseHost({
+      targetPort: upstreamPort,
+      listenHost: '127.0.0.1',
+      listenPort: 0,
+      certDir: null,
+    });
+    bridges.push(bridge);
+
+    const host = await bridge.start();
+    expect(await bridge.waitUntilReady({ attempts: 1 })).toEqual(host);
+    const response = await fetch(`http://127.0.0.1:${host.port}/worlds/example?mode=join`);
+
+    expect(response.status).toBe(201);
+    expect(response.headers.get('x-forwarded-proto-seen')).toBe('http');
+    expect(await response.json()).toEqual({
+      path: '/worlds/example?mode=join',
+      host: `127.0.0.1:${upstreamPort}`,
+    });
+    expect(host).toEqual({ running: true, protocol: 'http', port: expect.any(Number) });
+  });
+
+  it('returns an honest 502 when Eidoverse is not listening', async () => {
+    const reserved = createServer();
+    const unusedPort = await listen(reserved);
+    upstreamServers.pop();
+    await closeServer(reserved);
+    const bridge = createEidoverseHost({
+      targetPort: unusedPort,
+      listenHost: '127.0.0.1',
+      listenPort: 0,
+      certDir: null,
+    });
+    bridges.push(bridge);
+
+    const host = await bridge.start();
+    const response = await fetch(`http://127.0.0.1:${host.port}/`);
+
+    expect(response.status).toBe(502);
+    expect(await response.text()).toBe('Eidoverse Worlds is not running.');
+  });
+
+  it('passes the Eidoverse WebSocket exchange through the same host', async () => {
+    const upstream = createServer();
+    const webSocketServer = new WebSocketServer({ server: upstream });
+    webSocketServers.push(webSocketServer);
+    webSocketServer.on('connection', (socket, req) => {
+      socket.on('message', (message) => socket.send(`echo:${message}`));
+      socket.send(`scheme:${req.headers['x-forwarded-proto']}`);
+    });
+    const upstreamPort = await listen(upstream);
+    const bridge = createEidoverseHost({
+      targetPort: upstreamPort,
+      listenHost: '127.0.0.1',
+      listenPort: 0,
+      certDir: null,
+    });
+    bridges.push(bridge);
+
+    const host = await bridge.start();
+    const client = new WebSocket(`ws://127.0.0.1:${host.port}/ws`);
+    webSocketClients.push(client);
+    const firstMessage = once(client, 'message');
+    await once(client, 'open');
+    expect(String((await firstMessage)[0])).toBe('scheme:http');
+
+    const echo = once(client, 'message');
+    client.send('hello');
+    expect(String((await echo)[0])).toBe('echo:hello');
+    client.close();
+    await once(client, 'close');
+    webSocketClients.pop();
+  });
+});

--- a/server/services/instanceFeatures.js
+++ b/server/services/instanceFeatures.js
@@ -126,6 +126,11 @@ const configuredEidoverseRepo = (settings) => {
     : DEFAULT_EIDOVERSE_WORLDS_REPO;
 };
 
+export async function assertConfiguredEidoverseInstalled() {
+  const { settings } = await getSettingsWithStatus();
+  return assertEidoverseInstalled({ worldsRepoUrl: configuredEidoverseRepo(settings) });
+}
+
 const attachSetupStatus = async (features, settings) => {
   const eidoverse = await getEidoverseStatus({ worldsRepoUrl: configuredEidoverseRepo(settings) });
   return features.map((feature) => (
@@ -176,8 +181,7 @@ export async function updateInstanceFeature(featureId, enabled) {
     throw new ServerError(`Unknown instance feature: ${featureId}`, { status: 404, code: 'NOT_FOUND' });
   }
   if (featureId === 'eidoverse' && enabled) {
-    const { settings } = await getSettingsWithStatus();
-    await assertEidoverseInstalled({ worldsRepoUrl: configuredEidoverseRepo(settings) });
+    await assertConfiguredEidoverseInstalled();
   }
 
   const settings = await updateSettingsWith((current) => {


### PR DESCRIPTION
## Summary
- add a feature-gated Eidoverse page that starts and embeds its managed app
- terminate HTTPS and WebSockets through an on-demand PortOS bridge for MagicDNS sessions
- make managed-app launch links use each listener scheme

## Test plan
- npm test
- npm run lint --prefix client
- npm run build --prefix client
- generated API and Socket.IO catalog freshness tests