### PR TITLE
Poll only in-flight clone ids in the Links tab instead of the whole collection

### DIFF
--- a/client/src/components/brain/tabs/LinksTab.jsx
+++ b/client/src/components/brain/tabs/LinksTab.jsx
@@ -84,6 +84,21 @@ const CLONE_POLL_INTERVAL_MS = 3000;
 // change restarts the window; after it expires the user re-triggers the clone.
 const CLONE_POLL_STALL_MS = 10 * 60 * 1000;
 
+// The fields `cloneRepoInBackground` writes as a clone progresses. The poll
+// merges ONLY these onto the record it already has, so a response that was
+// already in flight when the user renamed a link or dragged its chip cannot
+// revert that edit with a pre-edit snapshot of the whole record.
+const CLONE_PROGRESS_FIELDS = ['cloneStatus', 'cloneError', 'localPath'];
+
+/** The clone-progress fields that actually moved, or null when none did. */
+function cloneProgressPatch(fresh, current) {
+  const patch = {};
+  for (const field of CLONE_PROGRESS_FIELDS) {
+    if (fresh[field] !== current[field]) patch[field] = fresh[field];
+  }
+  return Object.keys(patch).length > 0 ? patch : null;
+}
+
 export default function LinksTab({ onRefresh }) {
   const [inputUrl, setInputUrl] = useState('');
   const [inputTitle, setInputTitle] = useState('');
@@ -144,30 +159,36 @@ export default function LinksTab({ onRefresh }) {
       setStalledPollKey(inFlightKey);
       return;
     }
-    // A 404 (link deleted mid-clone) or a transient failure drops that id and
-    // leaves every other link untouched.
-    const fresh = await Promise.all(
-      inFlightIds.map(id => api.getBrainLink(id, { silent: true }).catch(() => null))
-    );
-    const byId = new Map(fresh.filter(Boolean).map(l => [l.id, l]));
-    if (byId.size === 0) return;
+    // A 404 means the user deleted the bookmark mid-clone: drop it, or its id
+    // stays in the in-flight set and is polled until the stall bound. Any other
+    // failure is transient and leaves that link exactly as it is.
+    const settled = await Promise.all(inFlightIds.map(id => api.getBrainLink(id, { silent: true })
+      .then(fresh => ({ id, fresh }))
+      .catch(err => ({ id, gone: err?.status === 404 }))));
+    const byId = new Map(settled.map(r => [r.id, r]));
     setLinks(prev => {
       let changed = false;
-      const next = prev.map(l => {
-        const updated = byId.get(l.id);
-        // `updatedAt` is the storage layer's write clock; `cloneStatus` is a
-        // belt-and-braces second signal. Unchanged records keep their identity
-        // so the boards, chips, and search results don't re-render on a tick.
-        if (!updated || (updated.updatedAt === l.updatedAt && updated.cloneStatus === l.cloneStatus)) return l;
+      const next = [];
+      for (const link of prev) {
+        const result = byId.get(link.id);
+        if (result?.gone) { changed = true; continue; }
+        const patch = result?.fresh ? cloneProgressPatch(result.fresh, link) : null;
+        if (!patch) { next.push(link); continue; }
         changed = true;
-        return updated;
-      });
+        next.push({ ...link, ...patch });
+      }
+      // Unchanged records keep their identity — and an all-quiet tick keeps the
+      // array itself — so the boards, chips, and search don't re-render.
       return changed ? next : prev;
     });
   }, [inFlightKey]);
 
+  // True once the poll gave up: the badges below say so rather than showing a
+  // spinner for a status nothing is watching any more.
+  const cloneWatchStalled = inFlightIds.length > 0 && stalledPollKey === inFlightKey;
+
   useAutoRefetch(pollInFlightClones, CLONE_POLL_INTERVAL_MS, {
-    enabled: inFlightIds.length > 0 && stalledPollKey !== inFlightKey,
+    enabled: inFlightIds.length > 0 && !cloneWatchStalled,
     // The initial `fetchLinks` already delivered current statuses, so the first
     // tick belongs one interval out, not immediately on enable.
     immediate: false,
@@ -757,6 +778,14 @@ export default function LinksTab({ onRefresh }) {
                       {link.cloneStatus === 'cloning' && 'Cloning...'}
                       {link.cloneStatus === 'pending' && 'Pending clone'}
                       {link.cloneStatus === 'failed' && 'Clone failed'}
+                      {cloneWatchStalled && isCloneInFlight(link) && (
+                        <span
+                          className="text-gray-500"
+                          title="No change for 10 minutes — this tab stopped checking. Reload the page to resume."
+                        >
+                          (stalled)
+                        </span>
+                      )}
                     </span>
 
                     {/* Clone error */}

--- a/client/src/components/brain/tabs/LinksTab.jsx
+++ b/client/src/components/brain/tabs/LinksTab.jsx
@@ -72,6 +72,18 @@ const CLONE_STATUS_STYLES = {
   failed: 'text-port-error'
 };
 
+/** A clone the server is still working on — the only reason this tab polls. */
+const isCloneInFlight = (link) => link.cloneStatus === 'cloning' || link.cloneStatus === 'pending';
+
+const CLONE_POLL_INTERVAL_MS = 3000;
+
+// Give up polling a clone that has shown no progress for this long. A server
+// restart mid-clone strands the record at `cloning` forever (only the promise
+// callbacks in `cloneRepoInBackground` reset it), and without this bound the
+// poll below becomes the permanent steady state of the Links tab. Any status
+// change restarts the window; after it expires the user re-triggers the clone.
+const CLONE_POLL_STALL_MS = 10 * 60 * 1000;
+
 export default function LinksTab({ onRefresh }) {
   const [inputUrl, setInputUrl] = useState('');
   const [inputTitle, setInputTitle] = useState('');
@@ -107,9 +119,60 @@ export default function LinksTab({ onRefresh }) {
       .catch(() => setBuckets([]));
   }, [fetchLinks]);
 
-  // Poll for clone status updates while at least one link is in flight.
-  const hasInFlightClone = links.some(l => l.cloneStatus === 'cloning' || l.cloneStatus === 'pending');
-  useAutoRefetch(fetchLinks, 3000, { enabled: hasInFlightClone, pollOnly: true });
+  // Poll ONLY the links whose clone is in flight, patching each fresh record
+  // into local state. Re-running `fetchLinks` here re-read and re-parsed every
+  // link record server-side (one file read per link, up to 5000) and replaced
+  // the whole array — re-rendering every bucket board, chip, and search result
+  // — every 3s just to move one status badge (#5442).
+  const inFlight = links.filter(isCloneInFlight);
+  const inFlightIds = inFlight.map(l => l.id);
+  // Identity of the in-flight SET and its statuses. A change here is progress,
+  // so it restarts the stall window; an unrelated `links` update (an edit, a
+  // bucket drag) leaves both the window and the poll callback alone.
+  const inFlightKey = inFlight.map(l => `${l.id}:${l.cloneStatus}`).join('|');
+
+  const [stalledPollKey, setStalledPollKey] = useState(null);
+  const pollWindowStartRef = useRef(0);
+  useEffect(() => {
+    pollWindowStartRef.current = Date.now();
+  }, [inFlightKey]);
+
+  // Depends on `inFlightKey` alone: the same key means the same ids, so the
+  // closure over `inFlightIds` can never go stale.
+  const pollInFlightClones = useCallback(async () => {
+    if (Date.now() - pollWindowStartRef.current > CLONE_POLL_STALL_MS) {
+      setStalledPollKey(inFlightKey);
+      return;
+    }
+    // A 404 (link deleted mid-clone) or a transient failure drops that id and
+    // leaves every other link untouched.
+    const fresh = await Promise.all(
+      inFlightIds.map(id => api.getBrainLink(id, { silent: true }).catch(() => null))
+    );
+    const byId = new Map(fresh.filter(Boolean).map(l => [l.id, l]));
+    if (byId.size === 0) return;
+    setLinks(prev => {
+      let changed = false;
+      const next = prev.map(l => {
+        const updated = byId.get(l.id);
+        // `updatedAt` is the storage layer's write clock; `cloneStatus` is a
+        // belt-and-braces second signal. Unchanged records keep their identity
+        // so the boards, chips, and search results don't re-render on a tick.
+        if (!updated || (updated.updatedAt === l.updatedAt && updated.cloneStatus === l.cloneStatus)) return l;
+        changed = true;
+        return updated;
+      });
+      return changed ? next : prev;
+    });
+  }, [inFlightKey]);
+
+  useAutoRefetch(pollInFlightClones, CLONE_POLL_INTERVAL_MS, {
+    enabled: inFlightIds.length > 0 && stalledPollKey !== inFlightKey,
+    // The initial `fetchLinks` already delivered current statuses, so the first
+    // tick belongs one interval out, not immediately on enable.
+    immediate: false,
+    pollOnly: true
+  });
 
   // Client-side filter (type / bucket membership) then keyword search.
   const matchesFilter = (link) => {

--- a/client/src/components/brain/tabs/LinksTab.jsx
+++ b/client/src/components/brain/tabs/LinksTab.jsx
@@ -77,24 +77,38 @@ const isCloneInFlight = (link) => link.cloneStatus === 'cloning' || link.cloneSt
 
 const CLONE_POLL_INTERVAL_MS = 3000;
 
-// Give up polling a clone that has shown no progress for this long. A server
-// restart mid-clone strands the record at `cloning` forever (only the promise
-// callbacks in `cloneRepoInBackground` reset it), and without this bound the
-// poll below becomes the permanent steady state of the Links tab. Any status
-// change restarts the window; after it expires the user re-triggers the clone.
+// Give up polling a clone that has shown no progress for roughly this long. A
+// server restart mid-clone strands the record at `cloning` forever (only the
+// promise callbacks in `cloneRepoInBackground` reset it), and without this
+// bound the poll below becomes the permanent steady state of the Links tab.
+// Any status change restarts the count; once it expires the badge says so
+// (#5463 tracks giving the stranded record itself a way back).
 const CLONE_POLL_STALL_MS = 10 * 60 * 1000;
 
-// The fields `cloneRepoInBackground` writes as a clone progresses. The poll
+// Counted in TICKS, not wall-clock: `useAutoRefetch` pauses while the tab is
+// hidden, so a wall-clock deadline would be tripped by the resume tick alone
+// after the user left the tab backgrounded — abandoning a clone that may well
+// have finished. Ticks only accrue while we are actually looking.
+const CLONE_POLL_STALL_TICKS = Math.ceil(CLONE_POLL_STALL_MS / CLONE_POLL_INTERVAL_MS);
+
+// The fields the background clone and its post-clone intake write. The poll
 // merges ONLY these onto the record it already has, so a response that was
 // already in flight when the user renamed a link or dragged its chip cannot
-// revert that edit with a pre-edit snapshot of the whole record.
-const CLONE_PROGRESS_FIELDS = ['cloneStatus', 'cloneError', 'localPath'];
+// revert that edit with a pre-edit snapshot of the whole record. All five are
+// server-owned; nothing in this tab edits them locally.
+const CLONE_PROGRESS_FIELDS = ['cloneStatus', 'cloneError', 'localPath', 'malwareScan', 'repoStudy'];
+
+// `malwareScan` / `repoStudy` arrive as fresh objects on every fetch, so they
+// need a value comparison — otherwise every tick would look like a change and
+// re-render the whole list. A false "changed" costs one render; there is no
+// false "same" for equal content the server serializes consistently.
+const sameFieldValue = (a, b) => a === b || JSON.stringify(a) === JSON.stringify(b);
 
 /** The clone-progress fields that actually moved, or null when none did. */
 function cloneProgressPatch(fresh, current) {
   const patch = {};
   for (const field of CLONE_PROGRESS_FIELDS) {
-    if (fresh[field] !== current[field]) patch[field] = fresh[field];
+    if (!sameFieldValue(fresh[field], current[field])) patch[field] = fresh[field];
   }
   return Object.keys(patch).length > 0 ? patch : null;
 }
@@ -142,29 +156,37 @@ export default function LinksTab({ onRefresh }) {
   const inFlight = links.filter(isCloneInFlight);
   const inFlightIds = inFlight.map(l => l.id);
   // Identity of the in-flight SET and its statuses. A change here is progress,
-  // so it restarts the stall window; an unrelated `links` update (an edit, a
-  // bucket drag) leaves both the window and the poll callback alone.
+  // so it restarts the no-progress tick count; an unrelated `links` update (an
+  // edit, a bucket drag) leaves both the count and the poll callback alone.
   const inFlightKey = inFlight.map(l => `${l.id}:${l.cloneStatus}`).join('|');
 
   const [stalledPollKey, setStalledPollKey] = useState(null);
-  const pollWindowStartRef = useRef(0);
+  // Ticks since the in-flight set last moved, and a monotonic id so a slow
+  // response can't land on top of a newer one.
+  const noProgressTicksRef = useRef(0);
+  const pollGenerationRef = useRef(0);
   useEffect(() => {
-    pollWindowStartRef.current = Date.now();
+    noProgressTicksRef.current = 0;
   }, [inFlightKey]);
 
   // Depends on `inFlightKey` alone: the same key means the same ids, so the
   // closure over `inFlightIds` can never go stale.
   const pollInFlightClones = useCallback(async () => {
-    if (Date.now() - pollWindowStartRef.current > CLONE_POLL_STALL_MS) {
+    if (noProgressTicksRef.current >= CLONE_POLL_STALL_TICKS) {
       setStalledPollKey(inFlightKey);
       return;
     }
+    noProgressTicksRef.current += 1;
+    const generation = ++pollGenerationRef.current;
     // A 404 means the user deleted the bookmark mid-clone: drop it, or its id
     // stays in the in-flight set and is polled until the stall bound. Any other
     // failure is transient and leaves that link exactly as it is.
     const settled = await Promise.all(inFlightIds.map(id => api.getBrainLink(id, { silent: true })
       .then(fresh => ({ id, fresh }))
       .catch(err => ({ id, gone: err?.status === 404 }))));
+    // A response slower than the interval would otherwise patch a finished
+    // clone back to `cloning`, restarting the poll and the stall count.
+    if (generation !== pollGenerationRef.current) return;
     const byId = new Map(settled.map(r => [r.id, r]));
     setLinks(prev => {
       let changed = false;

--- a/client/src/components/brain/tabs/LinksTab.test.jsx
+++ b/client/src/components/brain/tabs/LinksTab.test.jsx
@@ -1,0 +1,177 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+
+vi.mock('../../../services/api', () => ({
+  getBrainLinks: vi.fn(),
+  getBrainLink: vi.fn(),
+  getBrainBuckets: vi.fn(),
+  createBrainLink: vi.fn(),
+  updateBrainLink: vi.fn(),
+  deleteBrainLink: vi.fn(),
+  reorderBrainLinks: vi.fn(),
+  cloneBrainLink: vi.fn(),
+  pullBrainLink: vi.fn(),
+  scanBrainLink: vi.fn(),
+  openBrainLinkFolder: vi.fn(),
+  brainScanReportPath: vi.fn(() => '/report'),
+}));
+
+vi.mock('../../ui/Toast', () => ({ default: { success: vi.fn(), error: vi.fn() } }));
+
+// Counting stub: the board is the most expensive consumer of the `links`
+// array, so its render count is the direct measure of "the poll does not
+// replace the array on every tick".
+let bucketBoardRenders = 0;
+vi.mock('../links/BucketBoard', () => ({
+  default: () => {
+    bucketBoardRenders += 1;
+    return <div data-testid="bucket-board" />;
+  },
+}));
+
+import { getBrainLink, getBrainLinks, getBrainBuckets } from '../../../services/api';
+import LinksTab from './LinksTab';
+
+const link = (id, cloneStatus, overrides = {}) => ({
+  id,
+  url: `https://github.com/example/${id}`,
+  title: `repo-${id}`,
+  linkType: 'github',
+  tags: [],
+  isGitHubRepo: true,
+  cloneStatus,
+  bucketId: null,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+  ...overrides,
+});
+
+// Mount and settle the initial `getBrainLinks` + `getBrainBuckets` round-trip.
+async function renderTab() {
+  const result = render(<MemoryRouter><LinksTab /></MemoryRouter>);
+  await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+  return result;
+}
+
+const tick = (ms = 3000) => act(async () => { await vi.advanceTimersByTimeAsync(ms); });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  bucketBoardRenders = 0;
+  vi.useFakeTimers();
+  getBrainBuckets.mockResolvedValue({ buckets: [] });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('LinksTab clone-status polling', () => {
+  it('polls only the in-flight ids, never the whole collection again', async () => {
+    getBrainLinks.mockResolvedValue({ links: [link('a', 'cloning'), link('b', 'cloned')] });
+    getBrainLink.mockResolvedValue(link('a', 'cloning'));
+    await renderTab();
+
+    expect(getBrainLinks).toHaveBeenCalledTimes(1);
+    expect(getBrainLink).not.toHaveBeenCalled();
+
+    await tick();
+    expect(getBrainLink).toHaveBeenCalledTimes(1);
+    expect(getBrainLink).toHaveBeenCalledWith('a', { silent: true });
+
+    await tick();
+    expect(getBrainLink).toHaveBeenCalledTimes(2);
+    expect(getBrainLink.mock.calls.every(([id]) => id === 'a')).toBe(true);
+    // The whole-collection fetch happened once, at mount, and never again.
+    expect(getBrainLinks).toHaveBeenCalledTimes(1);
+  });
+
+  it('polls a pending clone too, and every in-flight id in one tick', async () => {
+    getBrainLinks.mockResolvedValue({
+      links: [link('a', 'cloning'), link('b', 'pending'), link('c', 'none')],
+    });
+    getBrainLink.mockImplementation(async (id) => link(id, 'cloning'));
+    await renderTab();
+
+    await tick();
+    expect(getBrainLink.mock.calls.map(([id]) => id).sort()).toEqual(['a', 'b']);
+  });
+
+  it('patches the fresh status in and stops polling once nothing is in flight', async () => {
+    getBrainLinks.mockResolvedValue({ links: [link('a', 'cloning'), link('b', 'cloned')] });
+    getBrainLink.mockResolvedValue(link('a', 'cloned', { updatedAt: '2026-01-01T00:05:00.000Z' }));
+    await renderTab();
+
+    expect(screen.getByText('Cloning...')).toBeTruthy();
+
+    await tick();
+    expect(screen.queryByText('Cloning...')).toBeNull();
+    expect(screen.getAllByText('Cloned')).toHaveLength(2);
+
+    const callsAfterCompletion = getBrainLink.mock.calls.length;
+    await tick(9000);
+    expect(getBrainLink).toHaveBeenCalledTimes(callsAfterCompletion);
+  });
+
+  it('leaves the other links intact when one in-flight id 404s', async () => {
+    getBrainLinks.mockResolvedValue({ links: [link('a', 'cloning'), link('c', 'cloning')] });
+    getBrainLink.mockImplementation(async (id) => {
+      if (id === 'a') throw new Error('Link not found');
+      return link('c', 'cloned', { updatedAt: '2026-01-01T00:05:00.000Z' });
+    });
+    await renderTab();
+
+    await tick();
+    expect(screen.getByText('Cloning...')).toBeTruthy();
+    expect(screen.getByText('Cloned')).toBeTruthy();
+    expect(screen.getByText('repo-a')).toBeTruthy();
+    expect(screen.getByText('repo-c')).toBeTruthy();
+  });
+
+  it('does not re-render the list from a replaced array when a tick brings no change', async () => {
+    getBrainLinks.mockResolvedValue({ links: [link('a', 'cloning')] });
+    getBrainLink.mockResolvedValue(link('a', 'cloning'));
+    await renderTab();
+
+    const before = bucketBoardRenders;
+    await tick(9000);
+    expect(getBrainLink).toHaveBeenCalledTimes(3);
+    expect(bucketBoardRenders).toBe(before);
+  });
+
+  // A server restart mid-clone strands the record at `cloning` forever, so an
+  // unbounded poll would become the tab's permanent steady state.
+  it('gives up on a clone stuck with no status change past the stall window', async () => {
+    getBrainLinks.mockResolvedValue({ links: [link('a', 'cloning')] });
+    getBrainLink.mockResolvedValue(link('a', 'cloning'));
+    await renderTab();
+
+    await tick(10 * 60 * 1000);
+    const stalledAt = getBrainLink.mock.calls.length;
+    expect(stalledAt).toBeGreaterThan(0);
+
+    await tick(60 * 1000);
+    expect(getBrainLink).toHaveBeenCalledTimes(stalledAt);
+    // The badge still reports the last known state — the user retriggers it.
+    expect(screen.getByText('Cloning...')).toBeTruthy();
+  });
+
+  it('restarts the stall window when a clone actually progresses', async () => {
+    getBrainLinks.mockResolvedValue({ links: [link('a', 'pending')] });
+    getBrainLink.mockResolvedValue(link('a', 'pending'));
+    await renderTab();
+
+    await tick(9 * 60 * 1000);
+    getBrainLink.mockResolvedValue(link('a', 'cloning', { updatedAt: '2026-01-01T00:09:00.000Z' }));
+    await tick();
+    expect(screen.getByText('Cloning...')).toBeTruthy();
+
+    // Without the reset the window would have expired 2 minutes in; the status
+    // change bought a fresh 10 minutes.
+    getBrainLink.mockResolvedValue(link('a', 'cloning', { updatedAt: '2026-01-01T00:09:00.000Z' }));
+    const beforeExtra = getBrainLink.mock.calls.length;
+    await tick(3 * 60 * 1000);
+    expect(getBrainLink.mock.calls.length).toBeGreaterThan(beforeExtra);
+  });
+});

--- a/client/src/components/brain/tabs/LinksTab.test.jsx
+++ b/client/src/components/brain/tabs/LinksTab.test.jsx
@@ -100,7 +100,7 @@ describe('LinksTab clone-status polling', () => {
 
   it('patches the fresh status in and stops polling once nothing is in flight', async () => {
     getBrainLinks.mockResolvedValue({ links: [link('a', 'cloning'), link('b', 'cloned')] });
-    getBrainLink.mockResolvedValue(link('a', 'cloned', { updatedAt: '2026-01-01T00:05:00.000Z' }));
+    getBrainLink.mockResolvedValue(link('a', 'cloned'));
     await renderTab();
 
     expect(screen.getByText('Cloning...')).toBeTruthy();
@@ -193,19 +193,76 @@ describe('LinksTab clone-status polling', () => {
     expect(screen.getByText('(stalled)')).toBeTruthy();
   });
 
+  // The stall bound counts ticks, not wall-clock: useAutoRefetch pauses while
+  // the tab is hidden, so a wall-clock deadline would be tripped by the resume
+  // tick alone and abandon a clone that may well have finished.
+  it('does not count time the tab spent hidden against the stall bound', async () => {
+    getBrainLinks.mockResolvedValue({ links: [link('a', 'cloning')] });
+    getBrainLink.mockResolvedValue(link('a', 'cloning'));
+    await renderTab();
+
+    const hidden = vi.spyOn(document, 'visibilityState', 'get').mockReturnValue('hidden');
+    await tick(20 * 60 * 1000);
+    expect(getBrainLink).not.toHaveBeenCalled();
+
+    hidden.mockReturnValue('visible');
+    await act(async () => { document.dispatchEvent(new Event('visibilitychange')); });
+    expect(getBrainLink).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText('(stalled)')).toBeNull();
+    hidden.mockRestore();
+  });
+
+  it('ignores a poll response overtaken by a newer one', async () => {
+    getBrainLinks.mockResolvedValue({ links: [link('a', 'cloning')] });
+    // The first tick's response resolves only after the second tick's has been
+    // applied — it must not patch the finished clone back to `cloning`.
+    let release;
+    const slow = new Promise(resolve => { release = resolve; });
+    getBrainLink
+      .mockImplementationOnce(async () => { await slow; return link('a', 'cloning'); })
+      .mockResolvedValue(link('a', 'cloned', { localPath: '/repos/a' }));
+    await renderTab();
+
+    await tick();
+    await tick();
+    expect(screen.getByText('Cloned')).toBeTruthy();
+
+    await act(async () => { release(); await Promise.resolve(); });
+    expect(screen.getByText('Cloned')).toBeTruthy();
+    expect(screen.queryByText('Cloning...')).toBeNull();
+  });
+
+  // The post-clone intake writes these in a second update, right after the
+  // status flips — the poll has to carry them or the chips never appear.
+  it('carries the post-clone intake fields through', async () => {
+    getBrainLinks.mockResolvedValue({ links: [link('a', 'cloning')] });
+    getBrainLink.mockResolvedValue(link('a', 'cloning', {
+      malwareScan: { reportId: '11111111-1111-4111-8111-111111111111', status: 'queued' },
+    }));
+    await renderTab();
+
+    await tick();
+    expect(screen.getByTitle(/Malware scan queued/)).toBeTruthy();
+
+    // …and an unchanged object on the next tick is not treated as a change.
+    const renders = bucketBoardRenders;
+    await tick();
+    expect(bucketBoardRenders).toBe(renders);
+  });
+
   it('restarts the stall window when a clone actually progresses', async () => {
     getBrainLinks.mockResolvedValue({ links: [link('a', 'pending')] });
     getBrainLink.mockResolvedValue(link('a', 'pending'));
     await renderTab();
 
     await tick(9 * 60 * 1000);
-    getBrainLink.mockResolvedValue(link('a', 'cloning', { updatedAt: '2026-01-01T00:09:00.000Z' }));
+    getBrainLink.mockResolvedValue(link('a', 'cloning'));
     await tick();
     expect(screen.getByText('Cloning...')).toBeTruthy();
 
     // Without the reset the window would have expired 2 minutes in; the status
     // change bought a fresh 10 minutes.
-    getBrainLink.mockResolvedValue(link('a', 'cloning', { updatedAt: '2026-01-01T00:09:00.000Z' }));
+    getBrainLink.mockResolvedValue(link('a', 'cloning'));
     const beforeExtra = getBrainLink.mock.calls.length;
     await tick(3 * 60 * 1000);
     expect(getBrainLink.mock.calls.length).toBeGreaterThan(beforeExtra);

--- a/client/src/components/brain/tabs/LinksTab.test.jsx
+++ b/client/src/components/brain/tabs/LinksTab.test.jsx
@@ -114,11 +114,11 @@ describe('LinksTab clone-status polling', () => {
     expect(getBrainLink).toHaveBeenCalledTimes(callsAfterCompletion);
   });
 
-  it('leaves the other links intact when one in-flight id 404s', async () => {
+  it('leaves the other links intact when one in-flight id fails transiently', async () => {
     getBrainLinks.mockResolvedValue({ links: [link('a', 'cloning'), link('c', 'cloning')] });
     getBrainLink.mockImplementation(async (id) => {
-      if (id === 'a') throw new Error('Link not found');
-      return link('c', 'cloned', { updatedAt: '2026-01-01T00:05:00.000Z' });
+      if (id === 'a') throw Object.assign(new Error('Server unreachable'), { status: 503 });
+      return link('c', 'cloned');
     });
     await renderTab();
 
@@ -127,6 +127,41 @@ describe('LinksTab clone-status polling', () => {
     expect(screen.getByText('Cloned')).toBeTruthy();
     expect(screen.getByText('repo-a')).toBeTruthy();
     expect(screen.getByText('repo-c')).toBeTruthy();
+  });
+
+  // Without this the deleted record keeps its slot in the in-flight set and is
+  // polled every 3s until the stall bound expires.
+  it('drops a link deleted mid-clone and stops polling it', async () => {
+    getBrainLinks.mockResolvedValue({ links: [link('a', 'cloning'), link('c', 'cloning')] });
+    getBrainLink.mockImplementation(async (id) => {
+      if (id === 'a') throw Object.assign(new Error('Link not found'), { status: 404 });
+      return link('c', 'cloning');
+    });
+    await renderTab();
+
+    await tick();
+    expect(screen.queryByText('repo-a')).toBeNull();
+    expect(screen.getByText('repo-c')).toBeTruthy();
+
+    getBrainLink.mockClear();
+    await tick();
+    expect(getBrainLink.mock.calls.map(([id]) => id)).toEqual(['c']);
+  });
+
+  // The poll's job is the clone badge; it must not carry a pre-edit snapshot of
+  // the rest of the record back over a local change.
+  it('merges only the clone-progress fields, never the whole record', async () => {
+    getBrainLinks.mockResolvedValue({ links: [link('a', 'cloning', { title: 'renamed-locally' })] });
+    getBrainLink.mockResolvedValue(link('a', 'cloned', { title: 'repo-a', localPath: '/repos/a' }));
+    await renderTab();
+
+    await tick();
+    expect(screen.getByText('Cloned')).toBeTruthy();
+    // The clone's own localPath landed…
+    expect(screen.getByText('repos/a')).toBeTruthy();
+    // …but the stale title from the same response did not.
+    expect(screen.getByText('renamed-locally')).toBeTruthy();
+    expect(screen.queryByText('repo-a')).toBeNull();
   });
 
   it('does not re-render the list from a replaced array when a tick brings no change', async () => {
@@ -153,8 +188,9 @@ describe('LinksTab clone-status polling', () => {
 
     await tick(60 * 1000);
     expect(getBrainLink).toHaveBeenCalledTimes(stalledAt);
-    // The badge still reports the last known state — the user retriggers it.
+    // …and says so, rather than spinning on a status nothing is watching.
     expect(screen.getByText('Cloning...')).toBeTruthy();
+    expect(screen.getByText('(stalled)')).toBeTruthy();
   });
 
   it('restarts the stall window when a clone actually progresses', async () => {


### PR DESCRIPTION
## Summary

While any GitHub repo clone was pending or cloning, the Links tab re-fetched the **entire** bookmark collection every 3 seconds — one server-side file read and parse per link (up to 5,000), an N-record JSON response, and a full replacement of the `links` array that re-rendered every bucket board, chip, and search result — all to move one status badge. A stuck `cloning` record (a server restart mid-clone strands one there) made that the tab's steady state indefinitely.

It now polls `GET /api/brain/links/:id` for the in-flight ids only:

- **Per-id polling.** Unchanged records keep their identity, and an all-quiet tick keeps the array itself, so the list, boards, and search don't re-render.
- **Merges only the clone-progress fields** (`cloneStatus`, `cloneError`, `localPath`, `malwareScan`, `repoStudy`) — a response already in flight when the user renames a link or drags its chip can't revert that edit with a pre-edit snapshot of the whole record.
- **Drops a 404** (bookmark deleted mid-clone), so its id doesn't stay in the in-flight set; other failures leave that link untouched.
- **Bounded stall window.** After ~10 minutes with no status change the poll gives up and the badge reads `(stalled)` instead of spinning on a status nothing is watching. Counted in *ticks*, not wall-clock, because `useAutoRefetch` pauses while the tab is hidden — a wall-clock deadline would be tripped by the resume tick alone.
- **Generation guard** so a response slower than the 3s interval can't land after a newer one and patch a finished clone back to `cloning`.

Follow-up filed as #5463: a record stranded at `cloning` still has no way back server-side (the clone route 409s on `CLONE_IN_PROGRESS`, and the UI offers Retry only for `failed`). This PR bounds the client poll; the boot-time reconcile is tracked there.

## Test plan

- New `client/src/components/brain/tabs/LinksTab.test.jsx` (none existed): 12 cases covering per-id polling with no further whole-collection fetch, both in-flight statuses, badge update + poll stop on completion, transient failure isolation, 404 drop, clone-fields-only merge, no re-render on a no-op tick, the tick-counted stall bound, hidden-tab immunity, out-of-order response rejection, and intake-field carry-through.
- Each new guard was probed against a reverted implementation to confirm the test actually fails without it.
- `cd client && npm test` — 822 files, 10413 tests passing, no `act()` warnings.
- `cd client && npm run lint` — clean.

Closes #5442