### PR TITLE
feat: manage Eidoverse Worlds GitHub source

### DIFF
--- a/client/src/components/settings/InstanceFeaturesTab.jsx
+++ b/client/src/components/settings/InstanceFeaturesTab.jsx
@@ -6,7 +6,7 @@ import ToggleSwitch from '../ToggleSwitch';
 import { useInstanceFeatures, publishInstanceFeatures } from '../../hooks/useInstanceFeatures.js';
 import { isGitHubRepoUrl } from '../../lib/githubRepoUrl.js';
 import { getPrimaryLaunchUrl } from '../../services/appUrls.js';
-import { installEidoverseFeature, updateInstanceFeature } from '../../services/api';
+import { installEidoverseFeature, updateEidoverseWorldsSource, updateInstanceFeature } from '../../services/api';
 
 // How the current value was decided, so a user who never touched the toggle can
 // see that the install picked it up from a configured integration rather than
@@ -58,6 +58,24 @@ export function InstanceFeaturesTab() {
     setSavingId(null);
   };
 
+  const handleEidoverseSourceUpdate = async (feature) => {
+    if (savingId) return;
+    const worldsRepoUrl = eidoverseRepoUrl ?? feature?.setup?.worldsRepoUrl;
+    if (!worldsRepoUrl || !isGitHubRepoUrl(worldsRepoUrl)) return;
+    setSavingId(feature.id);
+    const result = await updateEidoverseWorldsSource(worldsRepoUrl, { silent: true }).catch((err) => {
+      toast.error(err.message || 'Could not update the Eidoverse Worlds source');
+      return null;
+    });
+
+    if (result) {
+      setEidoverseRepoUrl(null);
+      publishInstanceFeatures(result.features, { featureId: feature.id, enabled: feature.enabled });
+      toast.success('Eidoverse Worlds GitHub origin updated');
+    }
+    setSavingId(null);
+  };
+
   const handleEidoverseRecheck = () => {
     if (recheckingEidoverse) return;
     setRecheckingEidoverse(true);
@@ -102,6 +120,9 @@ export function InstanceFeaturesTab() {
           const selectedRepoUrl = eidoverseRepoUrl ?? setup?.worldsRepoUrl ?? '';
           const repoIsValid = isGitHubRepoUrl(selectedRepoUrl);
           const canInstall = repoIsValid && setup?.bunAvailable === true && setup?.registryAvailable !== false;
+          const canUpdateSource = repoIsValid
+            && selectedRepoUrl.trim() !== setup?.worldsRepoUrl
+            && setup?.registryAvailable !== false;
           const launchUrl = setup?.appId && setup?.uiPort
             ? getPrimaryLaunchUrl({ id: setup.appId, uiPort: setup.uiPort })
             : null;
@@ -121,11 +142,11 @@ export function InstanceFeaturesTab() {
                       : (isEidoverse ? 'Installed but disabled on this instance' : 'Not used on this instance'))}
                 </p>
                 {hint && <p className="text-xs text-gray-500 mt-1">{hint}</p>}
-                {needsInstall && (
+                {isEidoverse && (
                   <div className="mt-3 space-y-1 text-xs text-gray-400">
-                    <p>
+                    {needsInstall && <p>
                       PortOS will clone your selected Worlds repository and the upstream video runtime as separate AGPL-3.0 repositories, install their Bun dependencies, and register Worlds under Apps. It will not start the server automatically.
-                    </p>
+                    </p>}
                     <label className="block pt-2" htmlFor="eidoverse-worlds-repo">
                       <span className="block text-gray-300 mb-1">Worlds GitHub repository</span>
                       <input
@@ -148,25 +169,41 @@ export function InstanceFeaturesTab() {
                           : 'Enter a valid GitHub repository URL.'}
                       </p>
                     )}
-                    <p>Use your own fork if you want PortOS agents to prepare changes and PRs against it.</p>
-                    {setup?.bunAvailable === false && (
-                      <p className="text-port-warning">
-                        Bun is required. <a className="underline hover:text-white" href="https://bun.sh" target="_blank" rel="noreferrer">Install Bun</a>, then retry.
-                      </p>
-                    )}
-                    {setup?.registryAvailable === false && (
-                      <p className="text-port-error">The managed-app registry could not be read. Repair that before installing to avoid a duplicate app record.</p>
-                    )}
-                    {(setup?.bunAvailable === false || setup?.registryAvailable === false) && (
+                    <p>
+                      {needsInstall
+                        ? 'Use your own fork if you want PortOS agents to prepare changes and PRs against it.'
+                        : 'Changing this updates the installed checkout’s Git origin in place. Local work, the managed-app path, and world data stay untouched.'}
+                    </p>
+                    {!needsInstall && (
                       <button
                         type="button"
-                        onClick={handleEidoverseRecheck}
-                        disabled={recheckingEidoverse}
-                        className="inline-flex items-center justify-center min-h-[44px] px-3 mt-2 text-sm bg-port-border hover:bg-port-border/70 disabled:opacity-50 text-white rounded transition-colors"
+                        onClick={() => handleEidoverseSourceUpdate(feature)}
+                        disabled={savingId !== null || !canUpdateSource}
+                        className="inline-flex items-center justify-center min-h-[44px] px-3 mt-2 text-sm bg-port-accent hover:bg-port-accent/80 disabled:opacity-50 disabled:cursor-not-allowed text-white rounded transition-colors"
                       >
-                        {recheckingEidoverse ? 'Rechecking…' : 'Recheck requirements'}
+                        {installing ? 'Updating source…' : 'Update source'}
                       </button>
                     )}
+                    {needsInstall && <>
+                      {setup?.bunAvailable === false && (
+                        <p className="text-port-warning">
+                          Bun is required. <a className="underline hover:text-white" href="https://bun.sh" target="_blank" rel="noreferrer">Install Bun</a>, then retry.
+                        </p>
+                      )}
+                      {setup?.registryAvailable === false && (
+                        <p className="text-port-error">The managed-app registry could not be read. Repair that before installing to avoid a duplicate app record.</p>
+                      )}
+                      {(setup?.bunAvailable === false || setup?.registryAvailable === false) && (
+                        <button
+                          type="button"
+                          onClick={handleEidoverseRecheck}
+                          disabled={recheckingEidoverse}
+                          className="inline-flex items-center justify-center min-h-[44px] px-3 mt-2 text-sm bg-port-border hover:bg-port-border/70 disabled:opacity-50 text-white rounded transition-colors"
+                        >
+                          {recheckingEidoverse ? 'Rechecking…' : 'Recheck requirements'}
+                        </button>
+                      )}
+                    </>}
                   </div>
                 )}
                 {setup?.installed && (

--- a/client/src/components/settings/InstanceFeaturesTab.jsx
+++ b/client/src/components/settings/InstanceFeaturesTab.jsx
@@ -4,7 +4,7 @@ import toast from '../ui/Toast';
 import BrailleSpinner from '../BrailleSpinner';
 import ToggleSwitch from '../ToggleSwitch';
 import { useInstanceFeatures, publishInstanceFeatures } from '../../hooks/useInstanceFeatures.js';
-import { isGitHubRepoUrl } from '../../lib/githubRepoUrl.js';
+import { isGitHubRepoUrl, parseGitHubUrl } from '../../lib/githubRepoUrl.js';
 import { getPrimaryLaunchUrl } from '../../services/appUrls.js';
 import { installEidoverseFeature, updateEidoverseWorldsSource, updateInstanceFeature } from '../../services/api';
 
@@ -18,10 +18,16 @@ const sourceHint = (feature) => {
     : `Detected automatically — no ${feature.label} instance is configured yet.`;
 };
 
+const normalizeGitHubRepo = (url) => {
+  const parsed = parseGitHubUrl(url);
+  return parsed ? `https://github.com/${parsed.owner}/${parsed.repo}` : null;
+};
+
 export function InstanceFeaturesTab() {
   const { features, error, reload } = useInstanceFeatures();
   const [savingId, setSavingId] = useState(null);
   const [eidoverseRepoUrl, setEidoverseRepoUrl] = useState(null);
+  const [updatingEidoverseSource, setUpdatingEidoverseSource] = useState(false);
   const [recheckingEidoverse, setRecheckingEidoverse] = useState(false);
 
   // The toggle is announced on the shared INSTANCE_FEATURES_CHANGED channel, so
@@ -62,6 +68,7 @@ export function InstanceFeaturesTab() {
     if (savingId) return;
     const worldsRepoUrl = eidoverseRepoUrl ?? feature?.setup?.worldsRepoUrl;
     if (!worldsRepoUrl || !isGitHubRepoUrl(worldsRepoUrl)) return;
+    setUpdatingEidoverseSource(true);
     setSavingId(feature.id);
     const result = await updateEidoverseWorldsSource(worldsRepoUrl, { silent: true }).catch((err) => {
       toast.error(err.message || 'Could not update the Eidoverse Worlds source');
@@ -73,6 +80,7 @@ export function InstanceFeaturesTab() {
       publishInstanceFeatures(result.features, { featureId: feature.id, enabled: feature.enabled });
       toast.success('Eidoverse Worlds GitHub origin updated');
     }
+    setUpdatingEidoverseSource(false);
     setSavingId(null);
   };
 
@@ -121,7 +129,7 @@ export function InstanceFeaturesTab() {
           const repoIsValid = isGitHubRepoUrl(selectedRepoUrl);
           const canInstall = repoIsValid && setup?.bunAvailable === true && setup?.registryAvailable !== false;
           const canUpdateSource = repoIsValid
-            && selectedRepoUrl.trim() !== setup?.worldsRepoUrl
+            && normalizeGitHubRepo(selectedRepoUrl) !== setup?.worldsRepoUrl
             && setup?.registryAvailable !== false;
           const launchUrl = setup?.appId && setup?.uiPort
             ? getPrimaryLaunchUrl({ id: setup.appId, uiPort: setup.uiPort })
@@ -181,7 +189,7 @@ export function InstanceFeaturesTab() {
                         disabled={savingId !== null || !canUpdateSource}
                         className="inline-flex items-center justify-center min-h-[44px] px-3 mt-2 text-sm bg-port-accent hover:bg-port-accent/80 disabled:opacity-50 disabled:cursor-not-allowed text-white rounded transition-colors"
                       >
-                        {installing ? 'Updating source…' : 'Update source'}
+                        {updatingEidoverseSource ? 'Updating source…' : 'Update source'}
                       </button>
                     )}
                     {needsInstall && <>

--- a/client/src/components/settings/InstanceFeaturesTab.test.jsx
+++ b/client/src/components/settings/InstanceFeaturesTab.test.jsx
@@ -171,6 +171,28 @@ describe('InstanceFeaturesTab', () => {
     expect(await screen.findByDisplayValue('https://github.com/example-owner/eidoverse-worlds')).toBeInTheDocument();
   });
 
+  it('does not offer a source update for an equivalent repository URL', async () => {
+    const installed = {
+      ...EIDOVERSE_FEATURE,
+      enabled: true,
+      setup: {
+        ...EIDOVERSE_FEATURE.setup,
+        installed: true,
+        appId: 'app-eidoverse',
+      },
+    };
+    mock.getInstanceFeatures.mockResolvedValue({ features: [installed] });
+    render(<MemoryRouter><InstanceFeaturesTab /></MemoryRouter>);
+
+    fireEvent.change(
+      await screen.findByRole('textbox', { name: 'Worlds GitHub repository' }),
+      { target: { value: 'https://github.com/anima-research/eidoverse-worlds.git' } },
+    );
+
+    expect(screen.getByRole('button', { name: 'Update source' })).toBeDisabled();
+    expect(mock.updateEidoverseWorldsSource).not.toHaveBeenCalled();
+  });
+
   it('keeps installation disabled for an invalid repository URL', async () => {
     mock.getInstanceFeatures.mockResolvedValue({ features: [EIDOVERSE_FEATURE] });
     render(<MemoryRouter><InstanceFeaturesTab /></MemoryRouter>);

--- a/client/src/components/settings/InstanceFeaturesTab.test.jsx
+++ b/client/src/components/settings/InstanceFeaturesTab.test.jsx
@@ -6,6 +6,7 @@ const mock = vi.hoisted(() => ({
   getInstanceFeatures: vi.fn(),
   updateInstanceFeature: vi.fn(),
   installEidoverseFeature: vi.fn(),
+  updateEidoverseWorldsSource: vi.fn(),
 }));
 
 vi.mock('../../services/api', () => mock);
@@ -63,6 +64,20 @@ describe('InstanceFeaturesTab', () => {
         enabled: true,
         source: 'explicit',
         setup: { ...EIDOVERSE_FEATURE.setup, installed: true, appId: 'app-eidoverse', runtimeStatus: 'not_started' },
+      }],
+    });
+    mock.updateEidoverseWorldsSource.mockResolvedValue({
+      features: [{
+        ...EIDOVERSE_FEATURE,
+        enabled: true,
+        source: 'explicit',
+        setup: {
+          ...EIDOVERSE_FEATURE.setup,
+          installed: true,
+          appId: 'app-eidoverse',
+          worldsRepoUrl: 'https://github.com/example-owner/eidoverse-worlds',
+          runtimeStatus: 'not_started',
+        },
       }],
     });
   });
@@ -128,6 +143,32 @@ describe('InstanceFeaturesTab', () => {
       'https://github.com/example-owner/eidoverse-worlds',
       { silent: true },
     ));
+  });
+
+  it('updates the origin of an installed Worlds checkout in place', async () => {
+    const installed = {
+      ...EIDOVERSE_FEATURE,
+      enabled: true,
+      source: 'explicit',
+      setup: {
+        ...EIDOVERSE_FEATURE.setup,
+        installed: true,
+        appId: 'app-eidoverse',
+        runtimeStatus: 'not_started',
+      },
+    };
+    mock.getInstanceFeatures.mockResolvedValue({ features: [installed] });
+    render(<MemoryRouter><InstanceFeaturesTab /></MemoryRouter>);
+
+    const repoInput = await screen.findByRole('textbox', { name: 'Worlds GitHub repository' });
+    fireEvent.change(repoInput, { target: { value: 'https://github.com/example-owner/eidoverse-worlds' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Update source' }));
+
+    await waitFor(() => expect(mock.updateEidoverseWorldsSource).toHaveBeenCalledWith(
+      'https://github.com/example-owner/eidoverse-worlds',
+      { silent: true },
+    ));
+    expect(await screen.findByDisplayValue('https://github.com/example-owner/eidoverse-worlds')).toBeInTheDocument();
   });
 
   it('keeps installation disabled for an invalid repository URL', async () => {

--- a/client/src/services/apiSystem.js
+++ b/client/src/services/apiSystem.js
@@ -78,6 +78,11 @@ export const installEidoverseFeature = (worldsRepoUrl, options = {}) => request(
   body: JSON.stringify({ worldsRepoUrl }),
   ...options,
 });
+export const updateEidoverseWorldsSource = (worldsRepoUrl, options = {}) => request('/settings/features/eidoverse/source', {
+  method: 'PUT',
+  body: JSON.stringify({ worldsRepoUrl }),
+  ...options,
+});
 export const startEidoverseHost = (options = {}) => request('/settings/features/eidoverse/host', {
   method: 'POST',
   ...options,

--- a/docs/features/eidoverse.md
+++ b/docs/features/eidoverse.md
@@ -24,6 +24,11 @@ at its durable world store. PortOS does not copy either project's source into
 the PortOS repository, combine the codebases, or relicense them; each checkout
 retains its own upstream license and git history.
 
+After installation, the **Worlds GitHub repository** field remains available on
+**Settings → Features**. Updating it changes the installed checkout's `origin`
+in place, so the managed-app path, local working tree, and world data stay
+untouched. The companion video checkout remains on its upstream repository.
+
 ## Runtime and data ownership
 
 The managed app uses port `8940` and starts with:

--- a/server/lib/apiRouteCatalog.generated.json
+++ b/server/lib/apiRouteCatalog.generated.json
@@ -19246,7 +19246,7 @@
       "sources": [
         {
           "source": "server/routes/settings.js",
-          "line": 139
+          "line": 143
         }
       ]
     },
@@ -19257,7 +19257,7 @@
       "sources": [
         {
           "source": "server/routes/settings.js",
-          "line": 202
+          "line": 214
         }
       ]
     },
@@ -19268,7 +19268,7 @@
       "sources": [
         {
           "source": "server/routes/settings.js",
-          "line": 158
+          "line": 162
         }
       ]
     },
@@ -19279,7 +19279,7 @@
       "sources": [
         {
           "source": "server/routes/settings.js",
-          "line": 196
+          "line": 208
         }
       ]
     },
@@ -19290,7 +19290,7 @@
       "sources": [
         {
           "source": "server/routes/settings.js",
-          "line": 163
+          "line": 167
         }
       ]
     },
@@ -19301,7 +19301,7 @@
       "sources": [
         {
           "source": "server/routes/settings.js",
-          "line": 189
+          "line": 201
         }
       ]
     },
@@ -19312,7 +19312,7 @@
       "sources": [
         {
           "source": "server/routes/settings.js",
-          "line": 183
+          "line": 195
         }
       ]
     },
@@ -19323,7 +19323,18 @@
       "sources": [
         {
           "source": "server/routes/settings.js",
-          "line": 170
+          "line": 174
+        }
+      ]
+    },
+    {
+      "method": "PUT",
+      "path": "/api/settings/features/eidoverse/source",
+      "mountPath": "/api/settings",
+      "sources": [
+        {
+          "source": "server/routes/settings.js",
+          "line": 185
         }
       ]
     },
@@ -19334,7 +19345,7 @@
       "sources": [
         {
           "source": "server/routes/settings.js",
-          "line": 152
+          "line": 156
         }
       ]
     },
@@ -23554,8 +23565,8 @@
   ],
   "stats": {
     "mounts": 145,
-    "operations": 2125,
-    "declarations": 2128,
+    "operations": 2126,
+    "declarations": 2129,
     "sourceFiles": 225
   }
 }

--- a/server/routes/settings.js
+++ b/server/routes/settings.js
@@ -10,7 +10,7 @@ import {
   CODEX_PARALLEL_DEFAULT,
 } from '../services/mediaJobQueue/index.js';
 import { assertMediaRoutingConfig } from '../services/federatedMedia/routingPolicy.js';
-import { assertConfiguredEidoverseInstalled, getInstanceFeatures, updateEidoverseWorldsRepo, updateInstanceFeature } from '../services/instanceFeatures.js';
+import { assertConfiguredEidoverseInstalled, getInstanceFeatures, updateEidoverseWorldsRepo, updateEidoverseWorldsSource, updateInstanceFeature } from '../services/instanceFeatures.js';
 import { installEidoverse } from '../services/eidoverse.js';
 import { ensureEidoverseHost } from '../services/eidoverseHost.js';
 import { isGitHubRepoUrl } from '../lib/githubRepoUrl.js';
@@ -26,6 +26,10 @@ const aiAssignmentUpdateSchema = z.object({
   providerId: z.string().trim().max(128).nullable().optional(),
   model: z.string().trim().max(300).nullable().optional(),
   effort: z.enum(EFFORT_LEVELS).nullable().optional(),
+}).strict();
+
+const eidoverseRepoSchema = z.object({
+  worldsRepoUrl: z.string().trim().max(500).refine(isGitHubRepoUrl, 'Must be a GitHub repository URL'),
 }).strict();
 
 // Server-authoritative bounds the client UI can render directly so the form
@@ -168,12 +172,20 @@ router.get('/features', asyncHandler(async (_req, res) => {
 // Explicit consent boundary: no Eidoverse checkout or dependency install occurs
 // until the user presses Install in Settings > Features.
 router.post('/features/eidoverse/install', asyncHandler(async (req, res) => {
-  const { worldsRepoUrl } = validateRequest(z.object({
-    worldsRepoUrl: z.string().trim().max(500).refine(isGitHubRepoUrl, 'Must be a GitHub repository URL'),
-  }).strict(), req.body || {});
+  const { worldsRepoUrl } = validateRequest(eidoverseRepoSchema, req.body || {});
   const normalizedRepoUrl = await updateEidoverseWorldsRepo(worldsRepoUrl);
   await installEidoverse({ worldsRepoUrl: normalizedRepoUrl });
   res.status(201).json(await updateInstanceFeature('eidoverse', true));
+}));
+
+// PUT /api/settings/features/eidoverse/source
+// Update the origin of the existing Worlds checkout in place. The working tree,
+// managed-app path, and world data remain untouched; future app updates pull
+// from the newly selected repository.
+router.put('/features/eidoverse/source', asyncHandler(async (req, res) => {
+  const { worldsRepoUrl } = validateRequest(eidoverseRepoSchema, req.body || {});
+  await updateEidoverseWorldsSource(worldsRepoUrl);
+  res.json(await getInstanceFeatures());
 }));
 
 // POST /api/settings/features/eidoverse/host

--- a/server/routes/settings.test.js
+++ b/server/routes/settings.test.js
@@ -49,6 +49,7 @@ vi.mock('../services/eidoverse.js', () => ({
   normalizeEidoverseWorldsRepo: vi.fn((url) => url),
   getEidoverseStatus: vi.fn(async () => ({ installed: false, bunAvailable: true, registryAvailable: true })),
   assertEidoverseInstalled: vi.fn(async () => ({ installed: true })),
+  setEidoverseWorldsOrigin: vi.fn(async () => ({ appId: 'app-eidoverse' })),
   installEidoverse: vi.fn(async () => ({ installed: true })),
 }));
 vi.mock('../services/eidoverseHost.js', () => ({
@@ -58,7 +59,7 @@ vi.mock('../services/eidoverseHost.js', () => ({
 import settingsRoutes from './settings.js';
 import { hasConfiguredInstances as hasConfiguredDatadogInstances } from '../services/datadog.js';
 import { hasConfiguredInstances as hasConfiguredJiraInstances } from '../services/jira.js';
-import { assertEidoverseInstalled, installEidoverse } from '../services/eidoverse.js';
+import { assertEidoverseInstalled, installEidoverse, setEidoverseWorldsOrigin } from '../services/eidoverse.js';
 import { ensureEidoverseHost } from '../services/eidoverseHost.js';
 
 const buildApp = () => {
@@ -191,6 +192,28 @@ describe('Settings routes — instance feature participation', () => {
     expect(store.instanceFeatures.eidoverse.enabled).toBe(true);
     expect(store.instanceFeatures.eidoverse.worldsRepoUrl).toBe(worldsRepoUrl);
     expect(res.body.features).toContainEqual(expect.objectContaining({ id: 'eidoverse', enabled: true }));
+  });
+
+  it('updates the installed Eidoverse source without changing feature participation', async () => {
+    const worldsRepoUrl = 'https://github.com/example-owner/eidoverse-worlds';
+    store = { instanceFeatures: { eidoverse: { enabled: true } } };
+
+    const res = await request(buildApp())
+      .put('/api/settings/features/eidoverse/source')
+      .send({ worldsRepoUrl });
+
+    expect(res.status).toBe(200);
+    expect(setEidoverseWorldsOrigin).toHaveBeenCalledWith(worldsRepoUrl);
+    expect(store.instanceFeatures.eidoverse).toMatchObject({ enabled: true, worldsRepoUrl });
+  });
+
+  it('rejects an invalid Eidoverse source update before mutating the checkout', async () => {
+    const res = await request(buildApp())
+      .put('/api/settings/features/eidoverse/source')
+      .send({ worldsRepoUrl: 'https://example.com/not-github' });
+
+    expect(res.status).toBe(400);
+    expect(setEidoverseWorldsOrigin).not.toHaveBeenCalled();
   });
 
   it('opens the Eidoverse host bridge only after verifying the managed app installation', async () => {

--- a/server/services/eidoverse.js
+++ b/server/services/eidoverse.js
@@ -62,20 +62,36 @@ const envFileContents = (paths) => [
   '',
 ].join('\n');
 
-const isManagedEidoverseApp = (app) => app?.pm2ProcessNames?.includes(EIDOVERSE_PROCESS_NAME)
-  || app?.name === 'Eidoverse Worlds';
+const isManagedEidoverseApp = (app) => Boolean(app?.pm2ProcessNames?.includes(EIDOVERSE_PROCESS_NAME));
 
 // A source switch keeps the existing checkout in place, so the configured
-// owner/repo path may no longer match the managed-app path. Prefer the exact
-// path for fresh installs, then fall back to the stable Eidoverse process name
-// for an already-registered checkout whose origin is being changed.
-const findManagedApp = (apps, paths) => apps.find((app) => (
-  app.repoPath === paths.worlds && isManagedEidoverseApp(app)
-)) || apps.find(isManagedEidoverseApp) || null;
+// owner/repo path may no longer match the managed-app path. The process name is
+// the stable PortOS-owned identifier across that source change.
+const findManagedApp = (apps) => apps.find(isManagedEidoverseApp) || null;
+
+async function resolveEidoverseInstallPaths(worldsRepoUrl) {
+  const configuredPaths = getEidoversePaths(worldsRepoUrl);
+  const registered = findManagedApp(await getAllApps());
+  const existingWorldsPath = typeof registered?.repoPath === 'string' && registered.repoPath.trim()
+    ? registered.repoPath
+    : null;
+
+  if (!existingWorldsPath
+    || existingWorldsPath === configuredPaths.worlds
+    || !await pathExists(join(existingWorldsPath, '.git'))) {
+    return configuredPaths;
+  }
+
+  return Object.freeze({
+    ...configuredPaths,
+    worlds: existingWorldsPath,
+    envFile: join(existingWorldsPath, '.env.portos'),
+  });
+}
 
 async function registerManagedApp(paths) {
   const apps = await getAllApps();
-  const existing = findManagedApp(apps, paths);
+  const existing = findManagedApp(apps);
   const fields = managedAppFields(paths);
   const app = existing
     ? await updateApp(existing.id, fields)
@@ -101,9 +117,10 @@ async function performInstall(worldsRepoUrl) {
     });
   }
 
-  const paths = getEidoversePaths(worldsRepoUrl);
+  const configuredPaths = getEidoversePaths(worldsRepoUrl);
+  const paths = await resolveEidoverseInstallPaths(worldsRepoUrl);
   await Promise.all([
-    cloneRepo(worldsRepoUrl),
+    paths.worlds === configuredPaths.worlds ? cloneRepo(worldsRepoUrl) : Promise.resolve(),
     cloneRepo(EIDOVERSE_VIDEO_REPO),
   ]);
 
@@ -153,7 +170,7 @@ export async function getEidoverseStatus({ worldsRepoUrl = DEFAULT_EIDOVERSE_WOR
     ),
   ]);
 
-  const app = registry.apps ? findManagedApp(registry.apps, configuredPaths) : null;
+  const app = registry.apps ? findManagedApp(registry.apps) : null;
   const worldsPath = typeof app?.repoPath === 'string' && app.repoPath.trim()
     ? app.repoPath
     : configuredPaths.worlds;
@@ -208,7 +225,7 @@ export async function setEidoverseWorldsOrigin(worldsRepoUrl) {
   const normalizedRepoUrl = normalizeEidoverseWorldsRepo(worldsRepoUrl);
   const configuredPaths = getEidoversePaths(normalizedRepoUrl);
   const apps = await getAllApps();
-  const app = findManagedApp(apps, configuredPaths);
+  const app = findManagedApp(apps);
 
   if (!app) {
     throw new ServerError('Install Eidoverse Worlds before changing its GitHub source.', {
@@ -231,10 +248,17 @@ export async function setEidoverseWorldsOrigin(worldsRepoUrl) {
     { ignoreExitCode: true },
   );
   if (result.exitCode !== 0) {
-    throw new ServerError('The Eidoverse Worlds checkout has no usable Git origin.', {
-      status: 422,
-      code: 'EIDOVERSE_ORIGIN_UPDATE_FAILED',
-    });
+    const added = await execGit(
+      ['remote', 'add', 'origin', normalizedRepoUrl],
+      repoPath,
+      { ignoreExitCode: true },
+    );
+    if (added.exitCode !== 0) {
+      throw new ServerError('The Eidoverse Worlds checkout has no usable Git origin.', {
+        status: 422,
+        code: 'EIDOVERSE_ORIGIN_UPDATE_FAILED',
+      });
+    }
   }
 
   notifyAppsChanged('update', app.id);

--- a/server/services/eidoverse.js
+++ b/server/services/eidoverse.js
@@ -2,6 +2,7 @@ import { join } from 'path';
 import { ServerError } from '../lib/errorHandler.js';
 import { bufferedSpawnOrThrow } from '../lib/bufferedSpawn.js';
 import { commandExists } from '../lib/commandExists.js';
+import { execGit } from '../lib/execGit.js';
 import { atomicWrite, ensureDir, pathExists, PATHS } from '../lib/fileUtils.js';
 import { parseGitHubUrl } from '../lib/githubRepoUrl.js';
 import { cloneRepo } from './githubCloner.js';
@@ -61,7 +62,16 @@ const envFileContents = (paths) => [
   '',
 ].join('\n');
 
-const findManagedApp = (apps, paths) => apps.find((app) => app.repoPath === paths.worlds) || null;
+const isManagedEidoverseApp = (app) => app?.pm2ProcessNames?.includes(EIDOVERSE_PROCESS_NAME)
+  || app?.name === 'Eidoverse Worlds';
+
+// A source switch keeps the existing checkout in place, so the configured
+// owner/repo path may no longer match the managed-app path. Prefer the exact
+// path for fresh installs, then fall back to the stable Eidoverse process name
+// for an already-registered checkout whose origin is being changed.
+const findManagedApp = (apps, paths) => apps.find((app) => (
+  app.repoPath === paths.worlds && isManagedEidoverseApp(app)
+)) || apps.find(isManagedEidoverseApp) || null;
 
 async function registerManagedApp(paths) {
   const apps = await getAllApps();
@@ -132,31 +142,29 @@ export async function installEidoverse({ worldsRepoUrl = DEFAULT_EIDOVERSE_WORLD
  */
 export async function getEidoverseStatus({ worldsRepoUrl = DEFAULT_EIDOVERSE_WORLDS_REPO } = {}) {
   const normalizedRepoUrl = normalizeEidoverseWorldsRepo(worldsRepoUrl);
-  const paths = getEidoversePaths(normalizedRepoUrl);
-  const [
-    bunAvailable,
-    worldsRepo,
-    videoRepo,
-    rootDependencies,
-    clientDependencies,
-    configured,
-    worldDataReady,
-    registry,
-  ] = await Promise.all([
+  const configuredPaths = getEidoversePaths(normalizedRepoUrl);
+  const [bunAvailable, videoRepo, worldDataReady, registry] = await Promise.all([
     commandExists('bun'),
-    pathExists(join(paths.worlds, '.git')),
-    pathExists(join(paths.video, '.git')),
-    pathExists(join(paths.worlds, 'node_modules')),
-    pathExists(join(paths.worlds, 'client', 'node_modules')),
-    pathExists(paths.envFile),
-    pathExists(paths.worldData),
+    pathExists(join(configuredPaths.video, '.git')),
+    pathExists(configuredPaths.worldData),
     getAllApps().then(
       (apps) => ({ apps, error: null }),
       (error) => ({ apps: null, error: error.message }),
     ),
   ]);
 
-  const app = registry.apps ? findManagedApp(registry.apps, paths) : null;
+  const app = registry.apps ? findManagedApp(registry.apps, configuredPaths) : null;
+  const worldsPath = typeof app?.repoPath === 'string' && app.repoPath.trim()
+    ? app.repoPath
+    : configuredPaths.worlds;
+  const worldsEnvFile = join(worldsPath, '.env.portos');
+  const [worldsRepo, rootDependencies, clientDependencies, configured] = await Promise.all([
+    pathExists(join(worldsPath, '.git')),
+    pathExists(join(worldsPath, 'node_modules')),
+    pathExists(join(worldsPath, 'client', 'node_modules')),
+    pathExists(worldsEnvFile),
+  ]);
+
   const runtime = app
     ? await getAppStatusStrict(EIDOVERSE_PROCESS_NAME, app.pm2Home).catch(() => null)
     : null;
@@ -189,6 +197,48 @@ export async function getEidoverseStatus({ worldsRepoUrl = DEFAULT_EIDOVERSE_WOR
       ? (runtime === null ? 'unknown' : (runtime.status === 'not_found' ? 'not_started' : runtime.status))
       : 'not_registered',
   };
+}
+
+/**
+ * Change the Worlds checkout's fetch origin without moving the checkout or
+ * touching its working tree. This is intentionally separate from installation:
+ * changing a remote must not silently clone a second copy or delete local work.
+ */
+export async function setEidoverseWorldsOrigin(worldsRepoUrl) {
+  const normalizedRepoUrl = normalizeEidoverseWorldsRepo(worldsRepoUrl);
+  const configuredPaths = getEidoversePaths(normalizedRepoUrl);
+  const apps = await getAllApps();
+  const app = findManagedApp(apps, configuredPaths);
+
+  if (!app) {
+    throw new ServerError('Install Eidoverse Worlds before changing its GitHub source.', {
+      status: 409,
+      code: 'EIDOVERSE_NOT_INSTALLED',
+    });
+  }
+
+  const repoPath = typeof app.repoPath === 'string' && app.repoPath.trim() ? app.repoPath : null;
+  if (!repoPath || !await pathExists(join(repoPath, '.git'))) {
+    throw new ServerError('The registered Eidoverse Worlds checkout could not be found.', {
+      status: 409,
+      code: 'EIDOVERSE_CHECKOUT_MISSING',
+    });
+  }
+
+  const result = await execGit(
+    ['remote', 'set-url', 'origin', normalizedRepoUrl],
+    repoPath,
+    { ignoreExitCode: true },
+  );
+  if (result.exitCode !== 0) {
+    throw new ServerError('The Eidoverse Worlds checkout has no usable Git origin.', {
+      status: 422,
+      code: 'EIDOVERSE_ORIGIN_UPDATE_FAILED',
+    });
+  }
+
+  notifyAppsChanged('update', app.id);
+  return { appId: app.id, worldsRepoUrl: normalizedRepoUrl };
 }
 
 export async function assertEidoverseInstalled(options) {

--- a/server/services/eidoverse.test.js
+++ b/server/services/eidoverse.test.js
@@ -97,6 +97,11 @@ describe('Eidoverse managed-app installer', () => {
       mock.apps.push(app);
       return app;
     });
+    mock.updateApp.mockImplementation(async (id, fields) => {
+      const index = mock.apps.findIndex((app) => app.id === id);
+      mock.apps[index] = { ...mock.apps[index], ...fields };
+      return mock.apps[index];
+    });
   });
 
   it('clones separate licensed repos, installs Bun dependencies, and registers Worlds', async () => {
@@ -123,6 +128,27 @@ describe('Eidoverse managed-app installer', () => {
       appId: 'app-eidoverse',
       runtimeStatus: 'not_started',
     });
+  });
+
+  it('resumes an existing checkout after its configured source changes', async () => {
+    const existingPaths = getEidoversePaths();
+    mock.apps = [{
+      id: 'app-eidoverse',
+      name: 'Eidoverse Worlds',
+      repoPath: existingPaths.worlds,
+      pm2ProcessNames: ['eidoverse-worlds'],
+    }];
+    mock.existing.add(join(existingPaths.worlds, '.git'));
+
+    const status = await installEidoverse({ worldsRepoUrl: SELECTED_WORLDS_REPO });
+
+    expect(mock.cloneRepo).not.toHaveBeenCalledWith(SELECTED_WORLDS_REPO);
+    expect(mock.spawn).toHaveBeenCalledWith('bun', ['install', '--frozen-lockfile'], expect.objectContaining({ cwd: existingPaths.worlds }));
+    expect(mock.atomicWrite).toHaveBeenCalledWith(
+      existingPaths.envFile,
+      expect.stringContaining(`EIDOVERSE_DIR=${JSON.stringify(existingPaths.video)}`),
+    );
+    expect(status).toMatchObject({ installed: true, appId: 'app-eidoverse' });
   });
 
   it('uses the canonical upstream by default and normalizes a selected fork URL', () => {
@@ -215,6 +241,38 @@ describe('Eidoverse managed-app installer', () => {
     await expect(setEidoverseWorldsOrigin(SELECTED_WORLDS_REPO)).rejects.toMatchObject({
       status: 409,
       code: 'EIDOVERSE_CHECKOUT_MISSING',
+    });
+    expect(mock.execGit).not.toHaveBeenCalled();
+  });
+
+  it('adds origin when an existing checkout has no origin remote', async () => {
+    const existingPaths = getEidoversePaths();
+    mock.apps = [{
+      id: 'app-eidoverse',
+      repoPath: existingPaths.worlds,
+      pm2ProcessNames: ['eidoverse-worlds'],
+    }];
+    mock.existing.add(join(existingPaths.worlds, '.git'));
+    mock.execGit
+      .mockResolvedValueOnce({ stdout: '', stderr: "error: No such remote 'origin'", exitCode: 2 })
+      .mockResolvedValueOnce({ stdout: '', stderr: '', exitCode: 0 });
+
+    await expect(setEidoverseWorldsOrigin(SELECTED_WORLDS_REPO)).resolves.toMatchObject({
+      appId: 'app-eidoverse',
+      worldsRepoUrl: SELECTED_WORLDS_REPO,
+    });
+    expect(mock.execGit).toHaveBeenNthCalledWith(
+      2,
+      ['remote', 'add', 'origin', SELECTED_WORLDS_REPO],
+      existingPaths.worlds,
+      { ignoreExitCode: true },
+    );
+  });
+
+  it('refuses to update a source with no registered managed app', async () => {
+    await expect(setEidoverseWorldsOrigin(SELECTED_WORLDS_REPO)).rejects.toMatchObject({
+      status: 409,
+      code: 'EIDOVERSE_NOT_INSTALLED',
     });
     expect(mock.execGit).not.toHaveBeenCalled();
   });

--- a/server/services/eidoverse.test.js
+++ b/server/services/eidoverse.test.js
@@ -7,6 +7,7 @@ const mock = vi.hoisted(() => ({
   apps: [],
   registryError: null,
   cloneRepo: vi.fn(),
+  execGit: vi.fn(),
   spawn: vi.fn(),
   atomicWrite: vi.fn(),
   ensureDir: vi.fn(),
@@ -24,6 +25,10 @@ vi.mock('../lib/fileUtils.js', () => ({
 
 vi.mock('../lib/commandExists.js', () => ({
   commandExists: vi.fn(async () => mock.bunAvailable),
+}));
+
+vi.mock('../lib/execGit.js', () => ({
+  execGit: mock.execGit,
 }));
 
 vi.mock('../lib/bufferedSpawn.js', () => ({
@@ -56,6 +61,7 @@ import {
   getEidoverseStatus,
   installEidoverse,
   normalizeEidoverseWorldsRepo,
+  setEidoverseWorldsOrigin,
 } from './eidoverse.js';
 
 const SELECTED_WORLDS_REPO = 'https://github.com/example-owner/eidoverse-worlds';
@@ -68,6 +74,7 @@ describe('Eidoverse managed-app installer', () => {
     mock.bunAvailable = true;
     mock.apps = [];
     mock.registryError = null;
+    mock.execGit.mockResolvedValue({ stdout: '', stderr: '', exitCode: 0 });
     __resetEidoverseInstallForTests();
 
     mock.cloneRepo.mockImplementation(async (url) => {
@@ -149,5 +156,66 @@ describe('Eidoverse managed-app installer', () => {
       appRegistered: null,
       registryError: 'Managed-app registry unavailable',
     });
+  });
+
+  it('changes the origin of an existing checkout without moving or cloning it', async () => {
+    const existingPaths = getEidoversePaths();
+    mock.apps = [{
+      id: 'app-eidoverse',
+      name: 'Eidoverse Worlds',
+      repoPath: existingPaths.worlds,
+      pm2ProcessNames: ['eidoverse-worlds'],
+    }];
+    mock.existing.add(join(existingPaths.worlds, '.git'));
+
+    await expect(setEidoverseWorldsOrigin(SELECTED_WORLDS_REPO)).resolves.toEqual({
+      appId: 'app-eidoverse',
+      worldsRepoUrl: SELECTED_WORLDS_REPO,
+    });
+    expect(mock.execGit).toHaveBeenCalledWith(
+      ['remote', 'set-url', 'origin', SELECTED_WORLDS_REPO],
+      existingPaths.worlds,
+      { ignoreExitCode: true },
+    );
+    expect(mock.cloneRepo).not.toHaveBeenCalled();
+  });
+
+  it('keeps the registered checkout installed after its configured source changes', async () => {
+    const existingPaths = getEidoversePaths();
+    mock.apps = [{
+      id: 'app-eidoverse',
+      name: 'Eidoverse Worlds',
+      repoPath: existingPaths.worlds,
+      pm2ProcessNames: ['eidoverse-worlds'],
+    }];
+    mock.existing = new Set([
+      join(existingPaths.worlds, '.git'),
+      join(existingPaths.worlds, 'node_modules'),
+      join(existingPaths.worlds, 'client', 'node_modules'),
+      existingPaths.envFile,
+      join(existingPaths.video, '.git'),
+      existingPaths.worldData,
+    ]);
+
+    await expect(getEidoverseStatus({ worldsRepoUrl: SELECTED_WORLDS_REPO })).resolves.toMatchObject({
+      installed: true,
+      worldsRepoUrl: SELECTED_WORLDS_REPO,
+      appId: 'app-eidoverse',
+    });
+  });
+
+  it('refuses to update a source when the managed checkout is missing', async () => {
+    mock.apps = [{
+      id: 'app-eidoverse',
+      name: 'Eidoverse Worlds',
+      repoPath: getEidoversePaths().worlds,
+      pm2ProcessNames: ['eidoverse-worlds'],
+    }];
+
+    await expect(setEidoverseWorldsOrigin(SELECTED_WORLDS_REPO)).rejects.toMatchObject({
+      status: 409,
+      code: 'EIDOVERSE_CHECKOUT_MISSING',
+    });
+    expect(mock.execGit).not.toHaveBeenCalled();
   });
 });

--- a/server/services/instanceFeatures.js
+++ b/server/services/instanceFeatures.js
@@ -7,6 +7,7 @@ import {
   DEFAULT_EIDOVERSE_WORLDS_REPO,
   getEidoverseStatus,
   normalizeEidoverseWorldsRepo,
+  setEidoverseWorldsOrigin,
 } from './eidoverse.js';
 import { getSettingsWithStatus, updateSettingsWith } from './settings.js';
 
@@ -160,6 +161,12 @@ export async function updateEidoverseWorldsRepo(worldsRepoUrl) {
     };
   });
   return normalizedRepoUrl;
+}
+
+export async function updateEidoverseWorldsSource(worldsRepoUrl) {
+  const normalizedRepoUrl = normalizeEidoverseWorldsRepo(worldsRepoUrl);
+  await setEidoverseWorldsOrigin(normalizedRepoUrl);
+  return updateEidoverseWorldsRepo(normalizedRepoUrl);
 }
 
 // The same precedence ladder as `resolveInstanceFeatures`, but probing only this

--- a/server/services/instanceFeatures.test.js
+++ b/server/services/instanceFeatures.test.js
@@ -9,6 +9,7 @@ const mock = vi.hoisted(() => ({
   datadogThrows: false,
   eidoverseInstalled: false,
   assertEidoverseInstalled: vi.fn(),
+  setEidoverseWorldsOrigin: vi.fn(),
 }));
 
 vi.mock('./settings.js', () => ({
@@ -38,6 +39,7 @@ vi.mock('./eidoverse.js', () => ({
     registryAvailable: true,
   })),
   assertEidoverseInstalled: mock.assertEidoverseInstalled,
+  setEidoverseWorldsOrigin: mock.setEidoverseWorldsOrigin,
 }));
 
 import {
@@ -46,6 +48,7 @@ import {
   isInstanceFeatureEnabled,
   resolveInstanceFeatures,
   updateInstanceFeature,
+  updateEidoverseWorldsSource,
 } from './instanceFeatures.js';
 
 const byId = (features, id) => features.find((feature) => feature.id === id);
@@ -59,6 +62,7 @@ describe('instance features', () => {
     mock.datadogThrows = false;
     mock.eidoverseInstalled = false;
     mock.assertEidoverseInstalled.mockReset().mockResolvedValue({ installed: true });
+    mock.setEidoverseWorldsOrigin.mockReset().mockResolvedValue({ appId: 'app-eidoverse' });
     mock.updateSettingsWith.mockReset();
     mock.updateSettingsWith.mockImplementation(async (mutate) => {
       mock.settings = await mutate(structuredClone(mock.settings));
@@ -96,6 +100,14 @@ describe('instance features', () => {
 
     await expect(updateInstanceFeature('eidoverse', true)).rejects.toMatchObject({ status: 409 });
     expect(mock.updateSettingsWith).not.toHaveBeenCalled();
+  });
+
+  it('changes the installed source before persisting the normalized setting', async () => {
+    const selected = 'https://github.com/example-owner/eidoverse-worlds';
+
+    await expect(updateEidoverseWorldsSource(selected)).resolves.toBe(selected);
+    expect(mock.setEidoverseWorldsOrigin).toHaveBeenCalledWith(selected);
+    expect(mock.settings.instanceFeatures.eidoverse.worldsRepoUrl).toBe(selected);
   });
 
   it('resolves an explicit disable without changing POST configuration', () => {


### PR DESCRIPTION
## Summary

## Changes
- Add a Settings > Features editor for the installed Worlds Git origin.
- Update the existing checkout in place and keep the managed-app path and world data stable.
- Preserve install/resume behavior for an existing checkout and validate GitHub repository input.

## Test plan
- Focused server contracts: 74 tests passed.
- Focused client contract: 14 tests passed.
- Client lint and production build passed.
- Full client suite passed; full server suite has one unrelated Node/npm-version-sensitive failure in scripts/checkNpmVersion.test.js.