### PR TITLE
fix: make issue watcher reviews complete

### DIFF
--- a/server/services/agentFinalization.js
+++ b/server/services/agentFinalization.js
@@ -1070,6 +1070,32 @@ async function rescueTranscriptPayload({ agentId, taskType }) {
 }
 
 /**
+ * Accept a legacy hook payload written directly to the sentinel. The generic
+ * sentinel parser intentionally treats an object without `payload` as a plain
+ * summary, but older programmatic-I/O prompts (including issue-watcher's first
+ * version) told agents to write the hook payload at the top level. Only accept
+ * that shape when the task's own predicate confirms it, and never reinterpret a
+ * structured envelope or a plain-text summary as a bare payload.
+ */
+async function recoverBareSentinelPayload(contents, taskType) {
+  if (typeof contents !== 'string' || !isProgrammaticIoTaskType(taskType)) return null;
+  try {
+    const { safeJSONParse } = await import('../lib/fileUtils.js');
+    const candidate = safeJSONParse(contents, null, { allowArray: false, logError: false });
+    if (!candidate || typeof candidate !== 'object' || Array.isArray(candidate)
+      || Object.hasOwn(candidate, 'summary') || Object.hasOwn(candidate, 'payload')) return null;
+    const isPayload = await getTaskOutputPayloadPredicate(taskType);
+    return typeof isPayload === 'function' && isPayload(candidate) ? candidate : null;
+  } catch (err) {
+    // This is a completion boundary, outside the Express request lifecycle. A
+    // malformed legacy payload must leave the normal missing-payload verdict
+    // intact rather than aborting finalization.
+    emitLog('warn', `⚠️ Bare sentinel payload recovery failed for ${taskType}: ${err.message}`, { taskType });
+    return null;
+  }
+}
+
+/**
  * Read the finished agent's `.agent-done` payload and run the task type's
  * `processTaskOutput` hook, if it registers one. No-op for the vast majority of
  * task types (no hook). The hook receives `{ appId, success, payload, ... }` and
@@ -1103,6 +1129,15 @@ async function dispatchTaskOutputHook({ agentId, task, success, workspacePath, r
       if (salvaged.payload != null) {
         payload = salvaged.payload;
         emitLog('info', `Recovered structured .agent-done payload for ${agentId} (${taskType}) via lenient JSON extraction`, { agentId });
+      }
+    }
+    // Compatibility for programmatic-I/O prompts that predate the structured
+    // `{ summary, payload }` envelope and wrote the hook payload directly.
+    if (payload == null && contents != null) {
+      const bare = await recoverBareSentinelPayload(contents, taskType);
+      if (bare != null) {
+        payload = bare;
+        emitLog('info', `Recovered legacy bare .agent-done payload for ${agentId} (${taskType})`, { agentId });
       }
     }
     // No sentinel at all: the model may have PRINTED its deliverable into the

--- a/server/services/agentFinalization.transcriptRescue.test.js
+++ b/server/services/agentFinalization.transcriptRescue.test.js
@@ -158,6 +158,15 @@ describe('printed-payload transcript rescue (#3640)', () => {
     expect(hook).toHaveBeenCalledWith(expect.objectContaining({ payload: null }));
   });
 
+  it('accepts a legacy bare payload written to the sentinel when the hook predicate matches', async () => {
+    const bare = JSON.stringify({ analysis: 'quiet sentinel', proposal: null, pause: null });
+    const hook = await runDispatch({ transcript: printedTranscript(), sentinel: bare });
+
+    expect(hook).toHaveBeenCalledWith(expect.objectContaining({
+      payload: { analysis: 'quiet sentinel', proposal: null, pause: null },
+    }));
+  });
+
   it('accepts the documented envelope form when that is what was printed', async () => {
     const envelope = '{"summary": "no proposal", "payload": {"analysis": "quiet", "proposal": null}}';
     const hook = await runDispatch({ transcript: printedTranscript(envelope) });

--- a/server/services/agentManagement.js
+++ b/server/services/agentManagement.js
@@ -16,7 +16,7 @@ import { emitLog } from './cosEvents.js';
 // live", which is the thing this sequencing keeps removing.
 import { completeAgent, updateAgent, getAgents, getAgentRecord } from './cosAgentLifecycle.js';
 import { updateTask, addTask, getTaskById, reviveBlockedTask, evaluateTasks } from './cos.js';
-import { AGENT_PAUSED_CATEGORY, pauseMetadata, isAgentPausedTask, isResumablePausedTask, registerPauseReleaseAdapter } from '../lib/taskPauseHold.js';
+import { AGENT_PAUSED_CATEGORY, PAUSE_METADATA_KEYS, pauseMetadata, isAgentPausedTask, isResumablePausedTask, registerPauseReleaseAdapter } from '../lib/taskPauseHold.js';
 import { terminateAgentViaRunner, killAgentViaRunner, pauseAgentViaRunner, getAgentStatsFromRunner, getActiveAgentsFromRunner } from './cosRunnerClient.js';
 import { MAX_TOTAL_SPAWNS } from '../lib/validation.js';
 import { isInternalTaskId } from '../lib/taskParser.js';
@@ -26,7 +26,9 @@ import { activeAgents, runnerAgents, userTerminatedAgents, pausedAgents, useRunn
 // for handleOrphanedTask. Importing them from their own leaf modules is what
 // lets that edge be a plain static import instead of a dynamic-import dodge.
 import { cleanupAgentWorktree, resolveTaskResumePatch } from './agentWorktreeCleanup.js';
-import { isRetryHeld, clearedRetryHoldMetadata } from '../lib/taskRetryHold.js';
+import { RETRY_HOLD_KEY, RETRY_HOLD_SINCE_KEY, isRetryHeld, clearedRetryHoldMetadata } from '../lib/taskRetryHold.js';
+import { CLAIM_METADATA_KEYS } from './cosTaskClaim.js';
+import { REQUEUED_AT_KEY, LAST_SPAWNED_AT_KEY } from '../lib/taskRequeue.js';
 import { resolveTaskTargetBranch } from '../lib/taskTargetBranch.js';
 import { syncRunnerAgents } from './agentRunnerSync.js';
 import { flushRunnerOutputBatcher } from './agentRunnerOutputBatchers.js';
@@ -481,6 +483,20 @@ async function requeuePausedTask({ task, taskType, overrides }) {
   return { taskId: task.id, mode: 'requeued', branchName: resolveTaskTargetBranch(result?.metadata) };
 }
 
+// A replacement is a fresh task, but its task-type payload/configuration still
+// defines what the run must do. Preserve that durable contract while dropping
+// state owned by the spent task/run so the replacement gets a new retry budget,
+// lease, workspace pointer, and output-hook dispatch.
+const REPLACEMENT_RUNTIME_METADATA_KEYS = new Set([
+  'blockedReason', 'blockedCategory', 'blockedAt', 'blocker', 'failureCount',
+  'lastErrorCategory', 'lastFailureAt', 'cooldownUntil', 'totalSpawnCount',
+  'orphanRetryCount', 'lastOrphanedAt', 'lastOrphanedAgentId', 'worktreeBusyAttempts',
+  'lastSpawnedAt', 'interruptedByRestart', 'lastInterruptedAt', 'lastInterruptedAgentId',
+  'outputHookDispatchedAt', 'existingBranch', 'resumedFromAgentId', 'resumeWorktreePath',
+  REQUEUED_AT_KEY, RETRY_HOLD_KEY, RETRY_HOLD_SINCE_KEY,
+  ...PAUSE_METADATA_KEYS, ...CLAIM_METADATA_KEYS,
+]);
+
 /**
  * The fallback: the paused run's task is gone or completed, so queue the fresh task
  * the caller described instead. Same outcome the pre-fix client always took, kept
@@ -502,9 +518,12 @@ async function replacePausedTask({ agentId, task, taskType, overrides }) {
   // code the agent-facing payload lives there, and a replacement queued without
   // it would run with nothing but the one-line description.
   const { context, prompt, provider, model, effort, app } = task?.metadata || {};
+  const inheritedMetadata = { ...(task?.metadata || {}) };
+  for (const key of REPLACEMENT_RUNTIME_METADATA_KEYS) delete inheritedMetadata[key];
   const created = await addTask({
     description,
     context, prompt, provider, model, effort, app,
+    metadata: inheritedMetadata,
     ...resumeOverrideMetadata(overrides, context)
   }, taskType);
   if (created?.error) {

--- a/server/services/agentManagement.js
+++ b/server/services/agentManagement.js
@@ -491,8 +491,10 @@ const REPLACEMENT_RUNTIME_METADATA_KEYS = new Set([
   'blockedReason', 'blockedCategory', 'blockedAt', 'blocker', 'failureCount',
   'lastErrorCategory', 'lastFailureAt', 'cooldownUntil', 'totalSpawnCount',
   'orphanRetryCount', 'lastOrphanedAt', 'lastOrphanedAgentId', 'worktreeBusyAttempts',
-  'lastSpawnedAt', 'interruptedByRestart', 'lastInterruptedAt', 'lastInterruptedAgentId',
+  LAST_SPAWNED_AT_KEY, 'interruptedByRestart', 'lastInterruptedAt', 'lastInterruptedAgentId',
   'outputHookDispatchedAt', 'existingBranch', 'resumedFromAgentId', 'resumeWorktreePath',
+  'autoRetryCount', 'autoRetriedByInvestigation', 'autoRetriedAt', 'autoRetryExhaustedAt',
+  'resolution', 'autoExpiredReason', 'autoExpiredAt',
   REQUEUED_AT_KEY, RETRY_HOLD_KEY, RETRY_HOLD_SINCE_KEY,
   ...PAUSE_METADATA_KEYS, ...CLAIM_METADATA_KEYS,
 ]);

--- a/server/services/agentManagement.test.js
+++ b/server/services/agentManagement.test.js
@@ -911,6 +911,13 @@ describe('resumeAgent — requeues the paused agent\'s own task', () => {
         issueWatcher,
         outputHookDispatchedAt: '2026-08-30T00:00:00.000Z',
         totalSpawnCount: 3,
+        autoRetryCount: 2,
+        autoRetriedByInvestigation: 'sys-investigation',
+        autoRetriedAt: '2026-08-29T00:00:00.000Z',
+        autoRetryExhaustedAt: '2026-08-29T01:00:00.000Z',
+        resolution: 'auto-expired',
+        autoExpiredReason: 'investigation-resolved',
+        autoExpiredAt: '2026-08-29T02:00:00.000Z',
       },
     });
 
@@ -920,6 +927,10 @@ describe('resumeAgent — requeues the paused agent\'s own task', () => {
     expect(replacement.metadata).toMatchObject({ analysisType: 'issue-watcher', issueWatcher });
     expect(replacement.metadata).not.toHaveProperty('outputHookDispatchedAt');
     expect(replacement.metadata).not.toHaveProperty('totalSpawnCount');
+    for (const key of [
+      'autoRetryCount', 'autoRetriedByInvestigation', 'autoRetriedAt', 'autoRetryExhaustedAt',
+      'resolution', 'autoExpiredReason', 'autoExpiredAt',
+    ]) expect(replacement.metadata).not.toHaveProperty(key);
   });
 
   it('leaves a LATER agent\'s pause intact and creates nothing', async () => {

--- a/server/services/agentManagement.test.js
+++ b/server/services/agentManagement.test.js
@@ -896,6 +896,32 @@ describe('resumeAgent — requeues the paused agent\'s own task', () => {
     }), 'user');
   });
 
+  it('preserves the scheduled hook contract when replacing a spent task', async () => {
+    const issueWatcher = {
+      repoFullName: 'example/example',
+      issueComments: [],
+      pullRequests: [{ number: 7, headSha: 'a'.repeat(40) }],
+    };
+    getTaskById.mockResolvedValue({
+      ...PAUSED_TASK,
+      status: 'completed',
+      metadata: {
+        ...PAUSED_TASK.metadata,
+        analysisType: 'issue-watcher',
+        issueWatcher,
+        outputHookDispatchedAt: '2026-08-30T00:00:00.000Z',
+        totalSpawnCount: 3,
+      },
+    });
+
+    await resumeAgent('agent-paused-1', { description: '[Resume] Issue watcher' });
+
+    const [replacement] = addTask.mock.calls[0];
+    expect(replacement.metadata).toMatchObject({ analysisType: 'issue-watcher', issueWatcher });
+    expect(replacement.metadata).not.toHaveProperty('outputHookDispatchedAt');
+    expect(replacement.metadata).not.toHaveProperty('totalSpawnCount');
+  });
+
   it('leaves a LATER agent\'s pause intact and creates nothing', async () => {
     getTaskById.mockResolvedValue({
       ...PAUSED_TASK,

--- a/server/services/cosTaskStore.js
+++ b/server/services/cosTaskStore.js
@@ -325,8 +325,11 @@ export async function addTask(taskData, taskType = 'user', { raw = false, ignore
     // callers and for older clients that only send the plan-task command.
     const planOnly = taskData.planOnly === true || taskData.slashdoCommand === 'plan-task';
 
-    // Build metadata object
-    const metadata = {};
+    // Build metadata object. Internal producers such as resume replacement and
+    // GSD may provide a prebuilt metadata seed; copy it first so task-specific
+    // contracts survive a normal (non-raw) queue write. The explicit top-level
+    // fields below remain authoritative and overwrite any matching seed keys.
+    const metadata = isPlainObject(taskData.metadata) ? { ...taskData.metadata } : {};
     if (taskData.context) metadata.context = taskData.context;
     // The full agent-facing payload, when the producer names it explicitly
     // (#4153). Producers that still pass a multi-line `context` are classified

--- a/server/services/cosTaskStore.test.js
+++ b/server/services/cosTaskStore.test.js
@@ -337,6 +337,22 @@ describe('cosTaskStore.addTask', () => {
     expect(reloaded === true || reloaded === 'true').toBe(true);
   });
 
+  it('preserves a trusted metadata seed for replacement task contracts', async () => {
+    const issueWatcher = {
+      repoFullName: 'example/example',
+      issueComments: [],
+      pullRequests: [{ number: 7, headSha: 'a'.repeat(40) }],
+    };
+    const created = await addTask({
+      id: 'task-metadata-seed',
+      description: 'resume issue watcher',
+      metadata: { analysisType: 'issue-watcher', issueWatcher },
+    }, 'internal');
+
+    expect(created.metadata).toMatchObject({ analysisType: 'issue-watcher', issueWatcher });
+    expect((await getTaskById(created.id)).metadata).toMatchObject({ analysisType: 'issue-watcher', issueWatcher });
+  });
+
   it('marks explicitly dispatched tasks so the scheduler does not race their spawn', async () => {
     const task = await addTask({ description: 'run this now' }, 'internal', { suppressDequeue: true });
     const change = mock.events.find(e => e.name === 'tasks:changed' && e.payload.task?.id === task.id);

--- a/server/services/issueWatcher.js
+++ b/server/services/issueWatcher.js
@@ -667,7 +667,9 @@ export async function processTaskOutput({ appId, success, payload, task } = {}) 
       && !diffInsufficient
       && blockingFindings.length === 0;
     if (!canApprove) {
-      const summary = decision.summary || 'This change needs follow-up before it can merge.';
+      const downgraded = hasInvalidFinding && decision.verdict !== 'request_changes';
+      const summary = `${decision.summary || 'This change needs follow-up before it can merge.'}${
+        downgraded ? '\n\nPortOS could not anchor one or more reported findings to this diff, so the review is blocking until they are restated against exact added lines.' : ''}`;
       const shouldRequestChanges = decision.verdict === 'request_changes'
         || hasInvalidFinding
         || blockingFindings.length > 0;
@@ -680,11 +682,15 @@ export async function processTaskOutput({ appId, success, payload, task } = {}) 
       continue;
     }
 
+    const approveBody = decision.summary || 'Reviewed: no material issues found.';
     const approved = await submitReview(ctx, pr.number, {
-      body: decision.summary || 'Reviewed: no material issues found.',
+      body: approveBody,
       event: 'APPROVE',
       comments: findings,
-    });
+    }) || (findings.length > 0 && await submitReview(ctx, pr.number, {
+      body: approveBody,
+      event: 'APPROVE',
+    }));
     if (!approved) continue;
     reviewed += 1;
 

--- a/server/services/issueWatcher.js
+++ b/server/services/issueWatcher.js
@@ -154,7 +154,13 @@ function normalizeFinding(finding, anchors) {
   const line = Number(finding.line);
   const body = text(finding.body, 3_000);
   if (!path || side !== 'RIGHT' || !Number.isInteger(line) || line < 1 || !body) return null;
-  return anchors.has(`${path}\u0000${side}\u0000${line}`) ? { path, side, line, body } : null;
+  if (!anchors.has(`${path}\u0000${side}\u0000${line}`)) return null;
+  return {
+    comment: { path, side, line, body },
+    // A finding without an explicit boolean is blocking. The watcher must not
+    // turn an incomplete model response into an automatic merge.
+    blocking: finding.blocking !== false,
+  };
 }
 
 function normalizeReviewDecision(value) {
@@ -372,27 +378,32 @@ For each supplied comment, choose \`reply\` only when the project owner should a
 
 ${prs}
 
-Review every supplied diff for concrete correctness, security, data-loss, compatibility, and regression problems. Findings must anchor to an ADDED line in the supplied diff with exact \`path\`, \`line\`, and \`side: "RIGHT"\`. A truncated or insufficient diff must use \`defer\`, never \`approve\`.
+Review every supplied diff for concrete correctness, security, data-loss, compatibility, and regression problems. Findings must anchor to an ADDED line in the supplied diff with exact \`path\`, \`line\`, and \`side: "RIGHT"\`. Every finding MUST include \`blocking: true\` or \`blocking: false\`; omit a finding rather than guessing. A truncated or insufficient diff must use \`defer\`, never \`approve\`.
+
+Use \`request_changes\` only when at least one finding is blocking. Small, non-blocking findings should use \`approve\`: deterministic processing posts them as inline comments on the approving GitHub review and may merge once the normal CI/mergeability gates pass. Those comments are the follow-up record for later implementation work. Missing or invalid finding fields are treated as blocking by the deterministic validator.
 
 For a clean PR, decide:
 - \`rebaseRequired\`: true only when being behind the base creates a material integration/overlap risk; an independent clean change need not rebase merely because the count is nonzero.
 - \`ciPolicy: "required"\` for executable code, build/dependency/config/schema/security/auth changes, broad refactors, or anything whose behavior needs tests.
 - \`ciPolicy: "skippable"\` only when the supplied diff is plainly low risk and review is sufficient (for example documentation-only or isolated static styling). A known failing check can never be waived.
 
-Return exactly this payload shape through the completion sentinel:
+Return exactly this envelope through the completion sentinel (the outer \`summary\`/\`payload\` wrapper is required):
 
 \`\`\`json
 {
-  "issueComments": [{ "issueNumber": 1, "commentId": 2, "action": "reply|none", "body": "reply text or empty" }],
-  "pullRequests": [{
-    "number": 3,
-    "headSha": "exact supplied SHA",
-    "verdict": "approve|request_changes|defer",
-    "summary": "concise review summary",
-    "findings": [{ "path": "src/file.js", "line": 42, "side": "RIGHT", "body": "concrete problem and fix" }],
-    "rebaseRequired": false,
-    "ciPolicy": "required|skippable"
-  }]
+  "summary": "brief completion summary",
+  "payload": {
+    "issueComments": [{ "issueNumber": 1, "commentId": 2, "action": "reply|none", "body": "reply text or empty" }],
+    "pullRequests": [{
+      "number": 3,
+      "headSha": "exact supplied SHA",
+      "verdict": "approve|request_changes|defer",
+      "summary": "concise review summary",
+      "findings": [{ "path": "src/file.js", "line": 42, "side": "RIGHT", "blocking": true, "body": "concrete problem and fix" }],
+      "rebaseRequired": false,
+      "ciPolicy": "required|skippable"
+    }]
+  }
 }
 \`\`\`
 
@@ -600,7 +611,8 @@ function mergeApproval(existing, approval) {
 
 /** Validated reply/review/rebase/merge pass run after cognition. */
 export async function processTaskOutput({ appId, success, payload, task } = {}) {
-  if (!appId || !success || !isTaskOutputPayload(payload)) return { action: 'no-op', reason: !success ? 'agent-failed' : 'invalid-payload' };
+  if (!appId || !success) return { action: 'no-op', reason: !success ? 'agent-failed' : 'missing-app' };
+  if (!isTaskOutputPayload(payload)) return { action: 'no-op', reason: 'unparseable-response' };
   const expected = task?.metadata?.issueWatcher;
   if (!expected || !Array.isArray(expected.issueComments) || !Array.isArray(expected.pullRequests)) {
     return { action: 'no-op', reason: 'missing-hook-metadata' };
@@ -640,21 +652,39 @@ export async function processTaskOutput({ appId, success, payload, task } = {}) 
     const diff = await runGh(['pr', 'diff', String(pr.number), '--repo', ctx.repoSpec], ctx).catch(() => null);
     if (diff === null) continue;
     const anchors = parseAddedDiffLines(diff);
-    const findings = decision.findings.map((finding) => normalizeFinding(finding, anchors)).filter(Boolean);
+    const normalizedFindings = decision.findings.map((finding) => normalizeFinding(finding, anchors)).filter(Boolean);
+    const findings = normalizedFindings.map(({ comment }) => comment);
+    const blockingFindings = normalizedFindings.filter(({ blocking }) => blocking);
+    const hasInvalidFinding = normalizedFindings.length !== decision.findings.length;
+    const diffInsufficient = target.diffTruncated || diff.length > MAX_DIFF_CHARS;
 
-    if (decision.verdict !== 'approve' || decision.findings.length > 0 || target.diffTruncated || diff.length > MAX_DIFF_CHARS) {
+    // An approval with only explicitly non-blocking findings is still a real
+    // GitHub code review: the comments travel with the APPROVE event, while
+    // the findings stay as follow-up work instead of blocking this PR. Every
+    // other ambiguous/negative case remains a non-merging review.
+    const canApprove = decision.verdict === 'approve'
+      && !hasInvalidFinding
+      && !diffInsufficient
+      && blockingFindings.length === 0;
+    if (!canApprove) {
       const summary = decision.summary || 'This change needs follow-up before it can merge.';
-      const shouldRequestChanges = decision.verdict === 'request_changes' || findings.length > 0;
+      const shouldRequestChanges = decision.verdict === 'request_changes'
+        || hasInvalidFinding
+        || blockingFindings.length > 0;
       const posted = shouldRequestChanges
         ? await submitReview(ctx, pr.number, { body: summary, event: 'REQUEST_CHANGES', comments: findings })
           || await submitReview(ctx, pr.number, { body: summary, event: 'COMMENT', comments: findings })
-        : await submitReview(ctx, pr.number, { body: summary, event: 'COMMENT' })
+        : await submitReview(ctx, pr.number, { body: summary, event: 'COMMENT', comments: findings })
           || await postReviewFallback(ctx, pr.number, summary);
       if (posted) reviewed += 1;
       continue;
     }
 
-    const approved = await submitReview(ctx, pr.number, { body: decision.summary || 'Reviewed: no material issues found.', event: 'APPROVE' });
+    const approved = await submitReview(ctx, pr.number, {
+      body: decision.summary || 'Reviewed: no material issues found.',
+      event: 'APPROVE',
+      comments: findings,
+    });
     if (!approved) continue;
     reviewed += 1;
 

--- a/server/services/issueWatcher.test.js
+++ b/server/services/issueWatcher.test.js
@@ -166,6 +166,8 @@ describe('buildTaskInput', () => {
     expect(result.prompt).toContain('PR #7: Contributor update');
     expect(result.prompt).toContain('behind base: 2 commit(s)');
     expect(result.prompt).toContain('ciPolicy: "skippable"');
+    expect(result.prompt).toContain('"summary": "brief completion summary"');
+    expect(result.prompt).toContain('"blocking": true');
     expect(result.hookMetadata.issueWatcher.pullRequests).toEqual([
       { number: 7, headSha: 'a'.repeat(40), diffTruncated: false },
     ]);
@@ -330,6 +332,39 @@ describe('processTaskOutput', () => {
     expect(result).toMatchObject({ reviewed: 1, merged: 1 });
     const reviewCall = execGhMock.mock.calls.find(([args]) => args.includes('repos/o/r/pulls/7/reviews') && args.includes('--input'));
     expect(JSON.parse(reviewCall[2].input)).toMatchObject({ event: 'APPROVE', comments: [] });
+    expect(mergePrMock).toHaveBeenCalledWith(APP.repoPath, 7);
+  });
+
+  it('posts non-blocking findings on an approving review and still merges', async () => {
+    installDefaultGhMock();
+    mergePrMock.mockResolvedValue({ success: true });
+    const payload = {
+      issueComments: [],
+      pullRequests: [{
+        number: 7,
+        headSha: 'a'.repeat(40),
+        verdict: 'approve',
+        summary: 'Safe to merge; one small follow-up is noted.',
+        findings: [{
+          path: 'src/example.js', line: 2, side: 'RIGHT', blocking: false,
+          body: 'Consider making this helper name more specific in a follow-up.',
+        }],
+        rebaseRequired: false,
+        ciPolicy: 'required',
+      }],
+    };
+
+    const result = await processTaskOutput({ appId: APP.id, success: true, payload, task: { metadata } });
+
+    expect(result).toMatchObject({ reviewed: 1, merged: 1 });
+    const reviewCall = execGhMock.mock.calls.find(([args]) => args.includes('repos/o/r/pulls/7/reviews') && args.includes('--input'));
+    expect(JSON.parse(reviewCall[2].input)).toMatchObject({
+      event: 'APPROVE',
+      comments: [{
+        path: 'src/example.js', line: 2, side: 'RIGHT',
+        body: 'Consider making this helper name more specific in a follow-up.',
+      }],
+    });
     expect(mergePrMock).toHaveBeenCalledWith(APP.repoPath, 7);
   });
 

--- a/server/services/issueWatcher.test.js
+++ b/server/services/issueWatcher.test.js
@@ -298,6 +298,32 @@ describe('processTaskOutput', () => {
     expect(mergePrMock).not.toHaveBeenCalled();
   });
 
+  it('explains when an approval was blocked because a finding could not be anchored', async () => {
+    installDefaultGhMock();
+    const payload = {
+      issueComments: [],
+      pullRequests: [{
+        number: 7,
+        headSha: 'a'.repeat(40),
+        verdict: 'approve',
+        summary: 'Looks fine; one follow-up is noted.',
+        findings: [{
+          path: 'src/example.js', line: 99, side: 'RIGHT', blocking: false,
+          body: 'This line is not in the supplied diff.',
+        }],
+        rebaseRequired: false,
+        ciPolicy: 'required',
+      }],
+    };
+
+    await processTaskOutput({ appId: APP.id, success: true, payload, task: { metadata } });
+
+    const reviewCall = execGhMock.mock.calls.find(([args]) => args.includes('repos/o/r/pulls/7/reviews') && args.includes('--input'));
+    expect(JSON.parse(reviewCall[2].input)).toMatchObject({ event: 'REQUEST_CHANGES' });
+    expect(JSON.parse(reviewCall[2].input).body).toContain('could not anchor one or more reported findings');
+    expect(mergePrMock).not.toHaveBeenCalled();
+  });
+
   it('updates a behind branch when the reviewer requires a rebase, then waits for a fresh review', async () => {
     installDefaultGhMock();
     const payload = {
@@ -366,6 +392,63 @@ describe('processTaskOutput', () => {
       }],
     });
     expect(mergePrMock).toHaveBeenCalledWith(APP.repoPath, 7);
+  });
+
+  it('approves without inline comments when GitHub rejects the comment anchors', async () => {
+    installDefaultGhMock();
+    const defaultGhImplementation = execGhMock.getMockImplementation();
+    let reviewAttempts = 0;
+    execGhMock.mockImplementation(async (args, ...rest) => {
+      if (args[0] === 'api' && args.some((arg) => String(arg).endsWith('/pulls/7/reviews'))) {
+        reviewAttempts += 1;
+        if (reviewAttempts === 1) throw new Error('HTTP 422: invalid review comment');
+      }
+      return defaultGhImplementation(args, ...rest);
+    });
+    mergePrMock.mockResolvedValue({ success: true });
+    const payload = {
+      issueComments: [],
+      pullRequests: [{
+        number: 7,
+        headSha: 'a'.repeat(40),
+        verdict: 'approve',
+        summary: 'Safe to merge; comment delivery was unavailable.',
+        findings: [{
+          path: 'src/example.js', line: 2, side: 'RIGHT', blocking: false,
+          body: 'Track this small cleanup in a follow-up.',
+        }],
+        rebaseRequired: false,
+        ciPolicy: 'required',
+      }],
+    };
+
+    const result = await processTaskOutput({ appId: APP.id, success: true, payload, task: { metadata } });
+
+    expect(result).toMatchObject({ reviewed: 1, merged: 1 });
+    const reviewCalls = execGhMock.mock.calls.filter(([args]) => args.includes('repos/o/r/pulls/7/reviews') && args.includes('--input'));
+    expect(reviewCalls).toHaveLength(2);
+    expect(JSON.parse(reviewCalls[1][2].input)).toMatchObject({ event: 'APPROVE', comments: [] });
+    expect(mergePrMock).toHaveBeenCalledWith(APP.repoPath, 7);
+  });
+
+  it('treats a finding with no explicit blocking flag as blocking and does not merge', async () => {
+    installDefaultGhMock();
+    const payload = {
+      issueComments: [],
+      pullRequests: [{
+        number: 7, headSha: 'a'.repeat(40), verdict: 'approve',
+        summary: 'Looks fine.',
+        findings: [{ path: 'src/example.js', line: 2, side: 'RIGHT', body: 'Validate input before this call.' }],
+        rebaseRequired: false, ciPolicy: 'required',
+      }],
+    };
+
+    const result = await processTaskOutput({ appId: APP.id, success: true, payload, task: { metadata } });
+
+    expect(result).toMatchObject({ reviewed: 1, merged: 0 });
+    const reviewCall = execGhMock.mock.calls.find(([args]) => args.includes('repos/o/r/pulls/7/reviews') && args.includes('--input'));
+    expect(JSON.parse(reviewCall[2].input)).toMatchObject({ event: 'REQUEST_CHANGES' });
+    expect(mergePrMock).not.toHaveBeenCalled();
   });
 
   it('does not review or merge when the PR head changed after cognition', async () => {

--- a/server/services/taskTypeHooks.js
+++ b/server/services/taskTypeHooks.js
@@ -99,7 +99,9 @@ export function canRunTaskOutputHookWithoutPayload(taskType) {
 /**
  * The task type a hook is keyed on, for a task record. The SCHEDULED type lives in
  * `metadata.analysisType` (the top-level `task.taskType` is the CoS queue category,
- * e.g. 'internal'), falling back to `taskType` for a task shaped the other way.
+ * e.g. 'internal'). Archived agent/task projections historically called that
+ * field `metadata.taskAnalysisType`, so accept it as a compatibility fallback
+ * before falling back to `taskType` for a task shaped the other way.
  *
  * Single resolver on purpose (#2727): "does this task get the programmatic-I/O
  * success criterion?" and "does this task run an output hook?" must be the same
@@ -108,7 +110,7 @@ export function canRunTaskOutputHookWithoutPayload(taskType) {
  * #2700 bug, one shape over.
  */
 export function resolveTaskHookType(task) {
-  return task?.metadata?.analysisType || task?.taskType || null;
+  return task?.metadata?.analysisType || task?.metadata?.taskAnalysisType || task?.taskType || null;
 }
 
 /**

--- a/server/services/taskTypeHooks.test.js
+++ b/server/services/taskTypeHooks.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { canRunTaskOutputHookWithoutPayload, getTaskInputHook, getTaskOutputHook, isProgrammaticIoTaskType } from './taskTypeHooks.js';
+import { canRunTaskOutputHookWithoutPayload, getTaskInputHook, getTaskOutputHook, isProgrammaticIoTaskType, resolveTaskHookType } from './taskTypeHooks.js';
 
 describe('taskTypeHooks registry', () => {
   it('resolves both hooks for layered-intelligence to callables', async () => {
@@ -45,5 +45,15 @@ describe('isProgrammaticIoTaskType (#2700)', () => {
     // A truthiness check on the registry object would let these through.
     expect(isProgrammaticIoTaskType('constructor')).toBe(false);
     expect(isProgrammaticIoTaskType('toString')).toBe(false);
+  });
+});
+
+describe('resolveTaskHookType', () => {
+  it('prefers the live scheduled type and supports archived task projections', () => {
+    expect(resolveTaskHookType({ taskType: 'internal', metadata: { analysisType: 'issue-watcher', taskAnalysisType: 'layered-intelligence' } }))
+      .toBe('issue-watcher');
+    expect(resolveTaskHookType({ taskType: 'internal', metadata: { taskAnalysisType: 'issue-watcher' } }))
+      .toBe('issue-watcher');
+    expect(resolveTaskHookType({ taskType: 'layered-intelligence', metadata: {} })).toBe('layered-intelligence');
   });
 });


### PR DESCRIPTION
## Summary
- Restore issue-watcher structured output and task metadata across completion and resume paths.
- Submit GitHub reviews for clean and non-blocking findings, while blocking only on material or ambiguous findings.

## Test plan
- npx vitest run services/issueWatcher.test.js services/agentFinalization.transcriptRescue.test.js services/taskTypeHooks.test.js services/agentManagement.test.js services/cosTaskStore.test.js (from server)
- npm run build