### PR TITLE
feat: install CoS tasks as on-demand actions

### DIFF
--- a/docs/features/jira-sprint-manager.md
+++ b/docs/features/jira-sprint-manager.md
@@ -1,10 +1,10 @@
 # JIRA Sprint Manager Job
 
-Scheduled task that triages and implements JIRA tickets for apps with JIRA integration enabled. Combines triage (reviewing, commenting, prioritizing) with implementation (worktree, PR, JIRA transition) in a single daily run.
+Task that triages and implements JIRA tickets for apps with JIRA integration enabled. It is installed as an on-demand action so the user can explicitly start a run; choosing a cadence schedules the combined triage and implementation workflow.
 
 ## Overview
 
-The JIRA Sprint Manager is a daily task in the Schedule system (defined in `server/services/taskSchedule.js`), disabled by default. When enabled, it first triages all sprint tickets across JIRA-enabled apps, then implements the highest-priority ready ticket.
+The JIRA Sprint Manager is an on-demand task in the Schedule system (defined in `server/services/taskScheduleRegistry.js`). A manual run first triages all sprint tickets across JIRA-enabled apps, then implements the highest-priority ready ticket. Users can select a daily schedule when they want unattended runs.
 
 ## How It Works
 
@@ -38,10 +38,10 @@ The JIRA Sprint Manager is a daily task in the Schedule system (defined in `serv
 
 | Setting | Default | Description |
 |---------|---------|-------------|
-| Interval | Daily at 09:00 | Weekdays only |
+| Interval | On demand | Manual Run by default; a cadence can be selected |
 | Priority | HIGH | Job priority |
 | Autonomy Level | yolo | Fully autonomous |
-| Enabled | false | Disabled by default |
+| Enabled | true | Available for an explicit manual run; scheduling remains opt-in |
 
 ### App-Level JIRA Configuration
 

--- a/scripts/migrations/170-branch-reconcile-to-cos-task.js
+++ b/scripts/migrations/170-branch-reconcile-to-cos-task.js
@@ -69,6 +69,10 @@ export default {
       if (isObject(schedule) && isObject(schedule.tasks)) {
         const task = isObject(schedule.tasks['branch-reconcile']) ? schedule.tasks['branch-reconcile'] : {};
         task.enabled = true;
+        // The legacy enabled flag was explicit consent to an automatic drain.
+        // A missing/new default is now on-demand, so retain that old behavior
+        // when the migration has no previously selected cadence to preserve.
+        if (!task.type || task.type === 'on-demand') task.type = 'perpetual';
         if (typeof old.cron === 'string' && old.cron.trim().split(/\s+/).length === 5) {
           task.recheckCron = old.cron;
         }

--- a/scripts/migrations/170-branch-reconcile-to-cos-task.js
+++ b/scripts/migrations/170-branch-reconcile-to-cos-task.js
@@ -5,9 +5,10 @@
  * The old feature was a bespoke daily cron gated by `settings.branchReconcile`
  * (enabled/cron/actions), hardwired to the PortOS checkout. Its scheduler,
  * `/api/branch-reconcile` route, and settings schema were removed when the
- * feature became the per-app `branch-reconcile` task type — which is disabled by
- * default. Without this migration, an install that had `branchReconcile.enabled:
- * true` would silently STOP reconciling after the upgrade.
+ * feature became the per-app `branch-reconcile` task type — installed as an
+ * enabled on-demand action by default, with scheduled cadence requiring an
+ * explicit choice. Without this migration, an install that had
+ * `branchReconcile.enabled: true` would silently STOP reconciling after the upgrade.
  *
  * This migration:
  *   1. If the old reconciler was ENABLED, enables the new `branch-reconcile`
@@ -85,7 +86,7 @@ export default {
         await writeFile(schedulePath, `${JSON.stringify(schedule, null, 2)}\n`);
         console.log('📝 branch-reconcile: carried the enabled PortOS reconciler into the new per-app CoS task');
       } else {
-        console.log('⚠️ branch-reconcile: no task-schedule.json to enable — loadSchedule will backfill the disabled default; enable it under Chief of Staff');
+        console.log('⚠️ branch-reconcile: no task-schedule.json to configure — loadSchedule will install the on-demand default; manual Run is available under Chief of Staff');
       }
 
       // 1b. Preserve PortOS-only scope: disable the task on every non-PortOS app.

--- a/scripts/migrations/170-branch-reconcile-to-cos-task.test.js
+++ b/scripts/migrations/170-branch-reconcile-to-cos-task.test.js
@@ -78,6 +78,16 @@ describe('migration 170 — branch reconciler → per-app CoS task', () => {
     expect(meta).toMatchObject({ cleanupMerged: true, openPr: true, resolveConflicts: true, autoMerge: true });
   });
 
+  it('preserves the legacy automatic drain when the new task entry is absent', async () => {
+    writeJson(settingsPath, { branchReconcile: { enabled: true } });
+    writeJson(schedulePath, { tasks: {} });
+
+    await migration.up({ rootDir });
+
+    expect(readJson(schedulePath).tasks['branch-reconcile'].type).toBe('perpetual');
+    expect(readJson(schedulePath).tasks['branch-reconcile'].enabled).toBe(true);
+  });
+
   it('preserves PortOS-only scope by disabling the task on other managed apps', async () => {
     writeJson(settingsPath, { branchReconcile: { enabled: true } });
     writeJson(schedulePath, { tasks: { 'branch-reconcile': {} } });

--- a/scripts/migrations/184-migrate-layered-intelligence-to-scheduled-task.js
+++ b/scripts/migrations/184-migrate-layered-intelligence-to-scheduled-task.js
@@ -131,6 +131,8 @@ export default {
 
     // 3. Preserve effective enablement: if the old global job was on, enable the
     //    task TYPE globally (the master switch every per-app override is gated on).
+    //    A missing schedule gets the enabled on-demand default; the migrated
+    //    per-app cadence still controls scheduled runs where it was configured.
     if (globalEnabled) {
       const schedulePath = join(rootDir, SCHEDULE_REL);
       const schedule = await readJson(schedulePath);
@@ -143,7 +145,7 @@ export default {
           console.log('📝 layered-intelligence: enabled the scheduled task type (the global job was on)');
         }
       } else {
-        console.log('⚠️ layered-intelligence: no task-schedule.json to enable — loadSchedule backfills the disabled default; enable it under Chief of Staff → Schedule');
+        console.log('⚠️ layered-intelligence: no task-schedule.json to configure — loadSchedule installs the enabled on-demand default; manual Run is available under Chief of Staff → Schedule');
       }
     }
 

--- a/server/services/cos.js
+++ b/server/services/cos.js
@@ -21,6 +21,7 @@ import { join } from 'path';
 import { getActiveProvider } from './providers.js';
 import { isInternalTaskId } from '../lib/taskParser.js';
 import { isAutoApprovableInvestigation } from '../lib/investigationTasks.js';
+import { INTERVAL_TYPES, isReconcileDrainTaskType } from './taskScheduleConstants.js';
 import { isRetryHeld, isStaleRetryHold } from '../lib/taskRetryHold.js';
 import { isAppOnCooldown, markAppReviewCooldown, bindAppReviewAgent, clearStaleActiveAgents } from './appActivity.js';
 import { getActiveApps } from './apps.js';
@@ -1425,17 +1426,18 @@ async function dequeueNextTask({ ignoreTaskId = null } = {}) {
 }
 
 /**
- * Pure gate: did the just-completed agent belong to an *enabled perpetual*
- * schedule (e.g. claim-issue)? Perpetual tasks are documented as "drain
- * actionable work back-to-back (re-queue on completion)" (taskSchedule.js), but
- * `dequeueNextTask` above only drains already-queued tasks — it never
- * regenerates perpetual work. Without an explicit refill on completion the next
- * run waits for the ~hourly `cos-improvement-check` timer (a "ready" perpetual
- * task doesn't even shorten that timer — cosJobScheduler gates the delay on
- * `status:'scheduled'` tasks only). This gate lets the completion handler decide
- * whether to refill the perpetual queue immediately instead of idling. Reads
- * the analysis type the same way `queueEligibleImprovementTasks` /
- * `isDisabledAnalysisType` do, and never throws on partial inputs.
+ * Pure gate: did the just-completed agent belong to an enabled drain schedule
+ * (e.g. claim-issue)? Perpetual tasks and the detector-driven
+ * reconciliation tasks are documented as draining actionable work back-to-back
+ * (re-queue on completion) (taskSchedule.js), but `dequeueNextTask` above only
+ * drains already-queued tasks — it never regenerates work. Without an explicit
+ * refill on completion the next run waits for the ~hourly
+ * `cos-improvement-check` timer (a "ready" task doesn't even shorten that timer
+ * — cosJobScheduler gates the delay on `status:'scheduled'` tasks only). This
+ * gate lets the completion handler decide whether to refill the drain immediately
+ * instead of idling. Reads the analysis type the same way
+ * `queueEligibleImprovementTasks` / `isDisabledAnalysisType` do, and never throws
+ * on partial inputs.
  */
 /**
  * The scheduled task type a completed agent belongs to, if any — the key
@@ -1453,14 +1455,19 @@ export function isPerpetualRefillCandidate(agent, schedule) {
   const analysisType = agentScheduledType(agent);
   if (!analysisType) return false;
   const taskDef = schedule?.tasks?.[analysisType];
-  return Boolean(taskDef?.enabled) && taskDef.type === 'perpetual';
+  const isPerpetual = taskDef?.type === INTERVAL_TYPES.PERPETUAL;
+  const isOnDemandReconcile = taskDef?.type === INTERVAL_TYPES.ON_DEMAND
+    && isReconcileDrainTaskType(analysisType);
+  // Reconciliation keeps its drain semantics even though its fresh-install
+  // interval is on-demand; all other on-demand tasks remain single-run actions.
+  return Boolean(taskDef?.enabled) && (isPerpetual || isOnDemandReconcile);
 }
 
 /**
- * Decide which "lane" a completed perpetual run's drain must continue in. Pure,
- * so the branch is unit-testable without a live daemon.
+ * Decide which "lane" a completed drain run must continue in. Pure, so the
+ * branch is unit-testable without a live daemon.
  *
- *   - `'skip'`     — not a perpetual refill candidate (disabled/non-perpetual/no
+ *   - `'skip'`     — not a drain refill candidate (disabled/non-draining/no
  *                    analysis type); nothing to refill.
  *   - `'onDemand'` — the completed run was a MANUAL "Run Now" drain, marked by
  *                    the on-demand spawn engines (`metadata.onDemand`, projected

--- a/server/services/cos.test.js
+++ b/server/services/cos.test.js
@@ -2145,6 +2145,7 @@ describe('isPerpetualRefillCandidate — perpetual drain on completion', () => {
     tasks: {
       'claim-issue': { type: 'perpetual', enabled: true },
       'claim-issue-disabled': { type: 'perpetual', enabled: false },
+      'branch-reconcile': { type: 'on-demand', enabled: true },
       'plan-task': { type: 'daily', enabled: true },
     },
   };
@@ -2162,6 +2163,10 @@ describe('isPerpetualRefillCandidate — perpetual drain on completion', () => {
 
   it('is false for a non-perpetual schedule type', () => {
     expect(isPerpetualRefillCandidate(agentFor('plan-task'), schedule)).toBe(false);
+  });
+
+  it('is true for an enabled on-demand reconciliation drain', () => {
+    expect(isPerpetualRefillCandidate(agentFor('branch-reconcile'), schedule)).toBe(true);
   });
 
   it('is false for an unknown / unscheduled type', () => {
@@ -2193,6 +2198,7 @@ describe('perpetualRefillPlan — manual vs scheduled drain lane', () => {
     tasks: {
       'claim-issue': { type: 'perpetual', enabled: true },
       'claim-issue-disabled': { type: 'perpetual', enabled: false },
+      'branch-reconcile': { type: 'on-demand', enabled: true },
       'plan-task': { type: 'daily', enabled: true },
     },
   };
@@ -2208,6 +2214,13 @@ describe('perpetualRefillPlan — manual vs scheduled drain lane', () => {
       agent({ taskAnalysisType: 'claim-issue', taskOnDemand: true, taskApp: 'app-42' }),
       schedule,
     )).toEqual({ lane: 'onDemand', taskType: 'claim-issue', appId: 'app-42' });
+  });
+
+  it('routes an on-demand reconciliation drain to the on-demand lane', () => {
+    expect(perpetualRefillPlan(
+      agent({ taskAnalysisType: 'branch-reconcile', taskOnDemand: true, taskApp: 'app-1' }),
+      schedule,
+    )).toEqual({ lane: 'onDemand', taskType: 'branch-reconcile', appId: 'app-1' });
   });
 
   it('a manual run with no app resolves appId to null (global on-demand re-issue)', () => {

--- a/server/services/cosTaskGenerator.js
+++ b/server/services/cosTaskGenerator.js
@@ -54,6 +54,7 @@ import {
   applyAuditModeWrapper,
 } from '../lib/auditCatalog.js';
 import { TIMED_COOLDOWN_BLOCKED_CATEGORIES } from '../lib/taskBlockCategories.js';
+import { isReconcileDrainTaskType } from './taskScheduleConstants.js';
 import {
   appendClaimOverrideContext,
   appendPrefetchedIssueContext,
@@ -2155,9 +2156,9 @@ function takePerpetualTransient(taskType, appId) {
  * Surface WHY a user-initiated on-demand "Run" produced no task, so the trigger
  * isn't a silent no-op the user only discovers in the pm2 logs. Emits
  * `schedule:on-demand-empty` (which the client toasts) with an `outcome`:
- *   - 'parked'    → a perpetual detector re-checked and found no actionable work;
+ *   - 'parked'    → a detector-driven task re-checked and found no actionable work;
  *                   carries the reason + open/in-flight/filtered breakdown.
- *   - 'transient' → a perpetual task that did NOT park — a gh/glab probe
+ *   - 'transient' → a detector-driven task that did NOT park — a gh/glab probe
  *                   failure — so the check didn't actually complete. Carries a
  *                   `forge` block naming the real fault when the CLI is broken
  *                   in a way that will NOT clear on its own.
@@ -2174,8 +2175,9 @@ function takePerpetualTransient(taskType, appId) {
 export async function emitOnDemandEmpty({ taskScheduleMod, request, targetApp, taskConfig }) {
   const appId = targetApp?.id || null;
   const parkInfo = await taskScheduleMod.getPerpetualParkInfo(request.taskType, appId).catch(() => null);
-  const isPerpetual = taskConfig?.type === taskScheduleMod.INTERVAL_TYPES.PERPETUAL;
-  const outcome = parkInfo ? 'parked' : (isPerpetual ? 'transient' : 'idle');
+  const isDetectorDriven = taskConfig?.type === taskScheduleMod.INTERVAL_TYPES.PERPETUAL
+    || isReconcileDrainTaskType(request.taskType);
+  const outcome = parkInfo ? 'parked' : (isDetectorDriven ? 'transient' : 'idle');
 
   // Layered Intelligence skips (e.g. a provider that can't drive an agent) record
   // an actionable last-run reason. Surface it so a manual "Run" toasts WHY it
@@ -2419,8 +2421,9 @@ async function applyPerpetualWorkGate(app, taskType, promptTaskType, metadata, i
 }
 
 /**
- * The ONE consecutive-dispatch cap for every perpetual drain, checked at the
- * choke point all four spawn engines funnel through.
+ * The ONE consecutive-dispatch cap for every perpetual or on-demand
+ * reconciliation drain, checked at the choke point all four spawn engines funnel
+ * through.
  *
  * Every perpetual drain re-issues itself the moment its run completes, so
  * "keeps finding work" and "is stuck in a loop" look identical one cycle at a
@@ -2439,7 +2442,10 @@ async function applyPerpetualWorkGate(app, taskType, promptTaskType, metadata, i
  * @returns {Promise<{skip:boolean}>}
  */
 export async function applyPerpetualDrainCap(app, taskType, interval, taskSchedule) {
-  if (interval.type !== taskSchedule.INTERVAL_TYPES.PERPETUAL) return { skip: false };
+  const isPerpetual = interval.type === taskSchedule.INTERVAL_TYPES.PERPETUAL;
+  const isOnDemandReconcile = interval.type === taskSchedule.INTERVAL_TYPES.ON_DEMAND
+    && isReconcileDrainTaskType(taskType);
+  if (!isPerpetual && !isOnDemandReconcile) return { skip: false };
   // Coerce before validating: this key is not on the schedule route's allowlist, so
   // the only way it arrives non-numeric is a hand-edited schedule.json, where `"5"`
   // is the likeliest shape and reading it as "no cap" would silently unbound the

--- a/server/services/cosTaskGenerator.test.js
+++ b/server/services/cosTaskGenerator.test.js
@@ -1110,7 +1110,7 @@ describe('emitOnDemandEmpty', () => {
   // and the INTERVAL_TYPES enum the perpetual check reads.
   const stubMod = {
     getPerpetualParkInfo: async () => null,
-    INTERVAL_TYPES: { PERPETUAL: 'perpetual' }
+    INTERVAL_TYPES: { ON_DEMAND: 'on-demand', PERPETUAL: 'perpetual' }
   };
 
   it("emits an 'idle' event with reason null for a non-LI task type", async () => {
@@ -1159,6 +1159,24 @@ describe('emitOnDemandEmpty', () => {
     // Nothing recorded ⇒ we cannot name the fault, so the client keeps the
     // generic "try again shortly" copy rather than guessing at a CLI.
     expect(await emitTransient('claim-issue')).toMatchObject({ outcome: 'transient', forge: null });
+  });
+
+  it('treats on-demand reconciliation as detector-driven for transient feedback', async () => {
+    recordPerpetualTransient('branch-reconcile', 'app-1', { cli: null, reason: 'probe-failed' });
+    const events = [];
+    const handler = (data) => events.push(data);
+    cosEvents.on('schedule:on-demand-empty', handler);
+    try {
+      await emitOnDemandEmpty({
+        taskScheduleMod: stubMod,
+        request: { id: 'req-reconcile', taskType: 'branch-reconcile' },
+        targetApp: { id: 'app-1', name: 'App One' },
+        taskConfig: { type: 'on-demand' }
+      });
+    } finally {
+      cosEvents.off('schedule:on-demand-empty', handler);
+    }
+    expect(events[0]).toMatchObject({ taskType: 'branch-reconcile', outcome: 'transient' });
   });
 
   it('skips the gh probe for a non-gh transient verdict, so a glab/git fault never toasts a gh remedy', async () => {
@@ -1555,7 +1573,7 @@ describe('resolveReconcileDrainGate', () => {
  */
 describe('applyPerpetualDrainCap', () => {
   const fakeSchedule = (dispatchCount = 0) => ({
-    INTERVAL_TYPES: { PERPETUAL: 'perpetual' },
+    INTERVAL_TYPES: { ON_DEMAND: 'on-demand', PERPETUAL: 'perpetual' },
     getPerpetualDrainState: vi.fn(async () => ({ signature: null, dispatchCount })),
     parkPerpetual: vi.fn(async () => {})
   });
@@ -1597,8 +1615,13 @@ describe('applyPerpetualDrainCap', () => {
 
   it('ignores non-perpetual intervals entirely', async () => {
     const ts = fakeSchedule(500);
-    expect(await applyPerpetualDrainCap(app, 'branch-reconcile', { type: 'daily', drainDispatchCap: 5 }, ts)).toEqual({ skip: false });
+    expect(await applyPerpetualDrainCap(app, 'security', { type: 'daily', drainDispatchCap: 5 }, ts)).toEqual({ skip: false });
     expect(ts.getPerpetualDrainState).not.toHaveBeenCalled();
+  });
+
+  it('applies the cap to the on-demand reconciliation drain', async () => {
+    const ts = fakeSchedule(5);
+    expect(await applyPerpetualDrainCap(app, 'branch-reconcile', { type: 'on-demand', drainDispatchCap: 5 }, ts)).toEqual({ skip: true });
   });
 });
 

--- a/server/services/taskSchedule.js
+++ b/server/services/taskSchedule.js
@@ -713,8 +713,9 @@ export async function applyOnDemandRunResets(request, appId = null) {
  * Returns { satisfied, pending } where pending lists unfinished dependency task types.
  *
  * Dependencies that are disabled — either globally (missing from the schedule or
- * `enabled: false`) or disabled for the requesting app — are skipped, since they
- * will never run and would otherwise block the dependent task indefinitely.
+ * `enabled: false`) — or use an on-demand interval are skipped, since they will
+ * not run automatically and would otherwise block the dependent task indefinitely.
+ * A scheduled per-app override keeps its dependency gate active.
  */
 async function checkRunAfterDeps(schedule, taskType, appId = null) {
   const interval = schedule.tasks[taskType];
@@ -730,6 +731,8 @@ async function checkRunAfterDeps(schedule, taskType, appId = null) {
     const depConfig = schedule.tasks[dep];
     if (!depConfig || !depConfig.enabled) continue;
     if (appId && !(await isTaskTypeEnabledForApp(appId, dep))) continue;
+    const depPerAppInterval = appId ? await getAppTaskTypeInterval(appId, dep) : null;
+    if ((depPerAppInterval || depConfig.type) === INTERVAL_TYPES.ON_DEMAND) continue;
 
     const depKey = `task:${dep}`;
     const depExec = schedule.executions[depKey] || { lastRun: null, perApp: {} };

--- a/server/services/taskSchedule.test.js
+++ b/server/services/taskSchedule.test.js
@@ -381,6 +381,16 @@ describe('taskSchedule', () => {
       expect(schedule.tasks['security'].providerId).toBe('p1')
     })
 
+    it('preserves an existing paused cadence when loading new defaults', async () => {
+      mockSchedule({
+        tasks: { security: { type: INTERVAL_TYPES.WEEKLY, enabled: false, providerId: null, model: null, prompt: null } }
+      })
+
+      const schedule = await loadSchedule()
+
+      expect(schedule.tasks.security).toMatchObject({ type: INTERVAL_TYPES.WEEKLY, enabled: false })
+    })
+
     it('should merge defaults for missing task types', async () => {
       mockSchedule({
         tasks: { 'security': { type: 'weekly', enabled: true, providerId: null, model: null, prompt: null } }
@@ -1102,6 +1112,22 @@ describe('taskSchedule', () => {
           isTaskTypeEnabledForApp.mockReset()
         }
       }
+    })
+
+    it('feature-ideas ignores an enabled on-demand do-replan dependency', async () => {
+      const twoDaysAgo = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString()
+
+      mockSchedule({
+        tasks: {
+          'feature-ideas': { type: 'daily', enabled: true, providerId: null, model: null, prompt: null },
+          'do-replan': { type: INTERVAL_TYPES.ON_DEMAND, enabled: true, providerId: null, model: null, prompt: null }
+        },
+        executions: { 'task:feature-ideas': { lastRun: twoDaysAgo, count: 1, perApp: {} } }
+      })
+
+      const result = await shouldRunTask('feature-ideas')
+      expect(result.shouldRun).toBe(true)
+      expect(result.reason).toContain('daily-due')
     })
 
     it('feature-ideas runs when do-replan has run since its last run', async () => {

--- a/server/services/taskSchedule.test.js
+++ b/server/services/taskSchedule.test.js
@@ -275,10 +275,10 @@ describe('taskSchedule', () => {
   })
 
   describe('layered-intelligence (programmatic-I/O agent task)', () => {
-    it('is registered as a self-improvement task with a description and a daily default', () => {
+    it('is registered as a self-improvement task with a description and an on-demand default', () => {
       expect(SELF_IMPROVEMENT_TASK_TYPES).toContain('layered-intelligence');
       expect(TASK_TYPE_DESCRIPTIONS['layered-intelligence']).toBeTruthy();
-      expect(DEFAULT_TASK_INTERVALS['layered-intelligence']).toMatchObject({ type: 'daily', enabled: false });
+      expect(DEFAULT_TASK_INTERVALS['layered-intelligence']).toMatchObject({ type: INTERVAL_TYPES.ON_DEMAND, enabled: true });
     });
 
     it('has NO default prompt — the buildTaskInput hook renders it', () => {
@@ -311,10 +311,10 @@ describe('taskSchedule', () => {
   });
 
   describe('issue-watcher (programmatic-I/O agent task)', () => {
-    it('ships as a disabled 30-minute task with no persisted prompt', () => {
+    it('ships as an enabled on-demand task with a 30-minute fallback and no persisted prompt', () => {
       expect(SELF_IMPROVEMENT_TASK_TYPES).toContain('issue-watcher');
       expect(DEFAULT_TASK_INTERVALS['issue-watcher']).toMatchObject({
-        type: 'custom', intervalMs: 30 * 60 * 1000, enabled: false, prompt: null
+        type: INTERVAL_TYPES.ON_DEMAND, intervalMs: 30 * 60 * 1000, enabled: true, prompt: null
       });
       expect(DEFAULT_TASK_PROMPTS['issue-watcher']).toBeUndefined();
     });
@@ -328,10 +328,10 @@ describe('taskSchedule', () => {
   });
 
   describe('do-replan task type', () => {
-    it('should default to weekly, disabled, with worktree+PR metadata', async () => {
+    it('should default to on-demand and enabled, with worktree+PR metadata', async () => {
       const interval = await getTaskInterval('do-replan')
-      expect(interval.type).toBe('weekly')
-      expect(interval.enabled).toBe(false)
+      expect(interval.type).toBe(INTERVAL_TYPES.ON_DEMAND)
+      expect(interval.enabled).toBe(true)
       expect(interval.taskMetadata?.useWorktree).toBe(true)
       expect(interval.taskMetadata?.openPR).toBe(true)
     })
@@ -357,6 +357,17 @@ describe('taskSchedule', () => {
       expect(schedule.version).toBe(2)
       expect(schedule.tasks).toBeDefined()
       expect(schedule.executions).toBeDefined()
+    })
+
+    it('installs every registered task as an enabled on-demand action', async () => {
+      const schedule = await loadSchedule()
+
+      for (const taskType of SELF_IMPROVEMENT_TASK_TYPES) {
+        expect(schedule.tasks[taskType], taskType).toMatchObject({
+          type: INTERVAL_TYPES.ON_DEMAND,
+          enabled: true
+        })
+      }
     })
 
     it('should load and return existing v2 schedule', async () => {
@@ -660,7 +671,8 @@ describe('taskSchedule', () => {
   describe('getTaskInterval', () => {
     it('should return interval for known task type', async () => {
       const interval = await getTaskInterval('security')
-      expect(interval.type).toBe('weekly')
+      expect(interval.type).toBe(INTERVAL_TYPES.ON_DEMAND)
+      expect(interval.enabled).toBe(true)
     })
 
     it('should return disabled defaults for unknown task type', async () => {
@@ -1540,8 +1552,8 @@ describe('taskSchedule', () => {
 
     it('defaults to self-filed issues with worktree/PR managed by the agent', () => {
       const cfg = DEFAULT_TASK_INTERVALS['claim-issue']
-      expect(cfg.type).toBe(INTERVAL_TYPES.DAILY)
-      expect(cfg.enabled).toBe(false)
+      expect(cfg.type).toBe(INTERVAL_TYPES.ON_DEMAND)
+      expect(cfg.enabled).toBe(true)
       // Default is the slashdo /do:next --self security boundary.
       expect(cfg.taskMetadata.issueAuthorFilter).toBe('self')
       // Mirrors plan-task: the agent creates its own worktree + opens the PR,
@@ -1568,11 +1580,11 @@ describe('taskSchedule', () => {
       expect(TASK_TYPE_DESCRIPTIONS['ux']).toBe('UX/design audit — file issues (default) or implement fixes')
     })
 
-    it('defaults to weekly + disabled with file-issues on (worktree/PR off)', () => {
+    it('defaults to on-demand + enabled with file-issues on (worktree/PR off)', () => {
       const cfg = DEFAULT_TASK_INTERVALS['ux']
-      expect(cfg.type).toBe(INTERVAL_TYPES.WEEKLY)
-      // Off by default — enabling it is the user's consent to a weekly LLM run.
-      expect(cfg.enabled).toBe(false)
+      expect(cfg.type).toBe(INTERVAL_TYPES.ON_DEMAND)
+      // Manual Run is explicit consent; choosing a cadence opts into scheduling.
+      expect(cfg.enabled).toBe(true)
       expect(cfg.taskMetadata.fileIssues).toBe(true)
       expect(cfg.taskMetadata.useWorktree).toBe(false)
       expect(cfg.taskMetadata.openPR).toBe(false)
@@ -1606,11 +1618,11 @@ describe('taskSchedule', () => {
       expect(TASK_TYPE_DESCRIPTIONS['plan-feature']).toBeTruthy()
     })
 
-    it('defaults to weekly + disabled, grounded on do-replan, with no worktree/PR', () => {
+    it('defaults to on-demand + enabled, grounded on do-replan, with no worktree/PR', () => {
       const cfg = DEFAULT_TASK_INTERVALS['plan-feature']
-      expect(cfg.type).toBe(INTERVAL_TYPES.WEEKLY)
-      // Off by default — enabling it is the user's consent to scheduled LLM runs.
-      expect(cfg.enabled).toBe(false)
+      expect(cfg.type).toBe(INTERVAL_TYPES.ON_DEMAND)
+      // Manual Run is explicit consent; choosing a cadence opts into scheduling.
+      expect(cfg.enabled).toBe(true)
       // Refresh the configured work tracker before filing a new proposal.
       expect(cfg.runAfter).toEqual(['do-replan'])
       expect(cfg.dataInputs).toEqual([
@@ -1660,13 +1672,13 @@ describe('taskSchedule', () => {
   })
 
   describe('audit file-issues types', () => {
-    it('registers data-safety and simplify as disabled weekly file-issues audits', () => {
+    it('registers data-safety and simplify as enabled on-demand file-issues audits', () => {
       for (const taskType of ['data-safety', 'simplify']) {
         expect(SELF_IMPROVEMENT_TASK_TYPES).toContain(taskType)
         expect(TASK_TYPE_DESCRIPTIONS[taskType]).toBeTruthy()
         const cfg = DEFAULT_TASK_INTERVALS[taskType]
-        expect(cfg.type).toBe(INTERVAL_TYPES.WEEKLY)
-        expect(cfg.enabled).toBe(false)
+        expect(cfg.type).toBe(INTERVAL_TYPES.ON_DEMAND)
+        expect(cfg.enabled).toBe(true)
         expect(cfg.taskMetadata.fileIssues).toBe(true)
         expect(cfg.taskMetadata.useWorktree).toBe(false)
         expect(cfg.taskMetadata.openPR).toBe(false)
@@ -1765,6 +1777,19 @@ describe('taskSchedule', () => {
       expect(result.error).toMatch(/'feature-ideas' is disabled/i)
       // loadState should not have been called — task-type check short-circuits before loadState.
       expect(loadState).not.toHaveBeenCalled()
+    })
+
+    it('should accept a manual run for an enabled on-demand task', async () => {
+      mockSchedule({
+        tasks: { 'security': { type: INTERVAL_TYPES.ON_DEMAND, enabled: true } }
+      })
+
+      const result = await triggerOnDemandTask('security', 'app-1')
+
+      expect(result.error).toBeUndefined()
+      expect(result.taskType).toBe('security')
+      expect(result.appId).toBe('app-1')
+      expect(result.origin).toBe(ON_DEMAND_ORIGINS.USER)
     })
 
     it('should reject unknown task types instead of silently queuing them', async () => {

--- a/server/services/taskScheduleConstants.js
+++ b/server/services/taskScheduleConstants.js
@@ -21,3 +21,5 @@ export const FAILURE_BACKOFF_CAP_MS = DAY_MS;
 export const FAILURE_PARK_THRESHOLD = 5;
 export const ON_DEMAND_ORIGINS = { USER: 'user', REFILL: 'refill' };
 export const isRefillRequest = (request) => request?.origin === ON_DEMAND_ORIGINS.REFILL;
+const RECONCILE_DRAIN_TASK_TYPES = new Set(['branch-reconcile', 'issue-reconcile']);
+export const isReconcileDrainTaskType = (taskType) => RECONCILE_DRAIN_TASK_TYPES.has(taskType);

--- a/server/services/taskScheduleRegistry.js
+++ b/server/services/taskScheduleRegistry.js
@@ -143,7 +143,7 @@ const LEGACY_MANAGED_TASK_METADATA = {
 };
 
 // Shared config for code-reviewer-a and code-reviewer-b (two instances for independent provider/model configuration)
-const CODE_REVIEWER_INTERVAL = { type: INTERVAL_TYPES.WEEKLY, enabled: false, weekdaysOnly: true, providerId: null, model: null, prompt: null, taskMetadata: { useWorktree: true, openPR: true, simplify: true, pipeline: { stages: [{ name: 'Codebase Review', promptKey: 'code-reviewer-review', readOnly: true, providerId: null, model: null, precondition: { fileNotExists: 'REVIEW.md' } }, { name: 'Triage & Implement', promptKey: 'code-reviewer-implement', readOnly: false, providerId: null, model: null, precondition: { fileExists: 'REVIEW.md' } }] } } };
+const CODE_REVIEWER_INTERVAL = { type: INTERVAL_TYPES.ON_DEMAND, enabled: true, weekdaysOnly: true, providerId: null, model: null, prompt: null, taskMetadata: { useWorktree: true, openPR: true, simplify: true, pipeline: { stages: [{ name: 'Codebase Review', promptKey: 'code-reviewer-review', readOnly: true, providerId: null, model: null, precondition: { fileNotExists: 'REVIEW.md' } }, { name: 'Triage & Implement', promptKey: 'code-reviewer-implement', readOnly: false, providerId: null, model: null, precondition: { fileExists: 'REVIEW.md' } }] } } };
 
 /**
  * Default `drainDispatchCap` for the reconcile drains: how many times a perpetual
@@ -187,12 +187,17 @@ export const DEFAULT_BRANCHES_PER_AGENT = 3;
  */
 export const INSTALL_WIDE_TASK_TYPES = new Set(['repo-sync']);
 
+// Fresh installs expose every task as an enabled manual action. The on-demand
+// type keeps provider work silent until the user explicitly runs a task, while
+// retaining timing metadata such as custom intervals and recheck settings if
+// they later choose a scheduled interval. Existing persisted settings still
+// win when a schedule is loaded.
 export const DEFAULT_TASK_INTERVALS = {
-  'security':            { type: INTERVAL_TYPES.WEEKLY, enabled: false, providerId: null, model: null, prompt: null, taskMetadata: { fileIssues: false } },
-  'code-quality':        { type: INTERVAL_TYPES.ROTATION, enabled: false, providerId: null, model: null, prompt: null, taskMetadata: { fileIssues: false } },
-  'test-coverage':       { type: INTERVAL_TYPES.WEEKLY, enabled: false, providerId: null, model: null, prompt: null, taskMetadata: { fileIssues: false } },
-  'performance':         { type: INTERVAL_TYPES.WEEKLY, enabled: false, providerId: null, model: null, prompt: null, taskMetadata: { fileIssues: false } },
-  'accessibility':       { type: INTERVAL_TYPES.ONCE, enabled: false, providerId: null, model: null, prompt: null, taskMetadata: { fileIssues: false } },
+  'security':            { type: INTERVAL_TYPES.ON_DEMAND, enabled: true, providerId: null, model: null, prompt: null, taskMetadata: { fileIssues: false } },
+  'code-quality':        { type: INTERVAL_TYPES.ON_DEMAND, enabled: true, providerId: null, model: null, prompt: null, taskMetadata: { fileIssues: false } },
+  'test-coverage':       { type: INTERVAL_TYPES.ON_DEMAND, enabled: true, providerId: null, model: null, prompt: null, taskMetadata: { fileIssues: false } },
+  'performance':         { type: INTERVAL_TYPES.ON_DEMAND, enabled: true, providerId: null, model: null, prompt: null, taskMetadata: { fileIssues: false } },
+  'accessibility':       { type: INTERVAL_TYPES.ON_DEMAND, enabled: true, providerId: null, model: null, prompt: null, taskMetadata: { fileIssues: false } },
   // branch-reconcile first removes fully-merged, clean orphaned worktrees and
   // branches, then finishes THIS machine's remaining in-flight LOCAL branches
   // per app (open a PR for pushed-but-unopened work, resolve merge conflicts,
@@ -211,9 +216,9 @@ export const DEFAULT_TASK_INTERVALS = {
   // sibling worktrees; a CoS-managed worktree would hide the branches and could
   // trigger cleanupAgentWorktree's auto-merge. Its edits likewise land in those
   // SIBLING worktrees, never in its own cwd — hence the shared non-committing
-  // -coordinator posture above. Off by default — enabling it is the user's
-  // explicit consent to let it drive PRs on a schedule.
-  'branch-reconcile':    { type: INTERVAL_TYPES.PERPETUAL, enabled: false, providerId: null, model: null, prompt: null, recheckCron: '0 3 * * *', drainDispatchCap: PERPETUAL_DRAIN_DISPATCH_CAP, taskMetadata: { ...NON_COMMITTING_COORDINATOR_METADATA, cleanupMerged: true, openPr: true, resolveConflicts: true, autoMerge: true, finishAbandoned: true, branchesPerAgent: DEFAULT_BRANCHES_PER_AGENT } },
+  // -coordinator posture above. On-demand by default — a manual Run is the
+  // explicit consent to drive PRs; choosing a cadence enables scheduled runs.
+  'branch-reconcile':    { type: INTERVAL_TYPES.ON_DEMAND, enabled: true, providerId: null, model: null, prompt: null, recheckCron: '0 3 * * *', drainDispatchCap: PERPETUAL_DRAIN_DISPATCH_CAP, taskMetadata: { ...NON_COMMITTING_COORDINATOR_METADATA, cleanupMerged: true, openPr: true, resolveConflicts: true, autoMerge: true, finishAbandoned: true, branchesPerAgent: DEFAULT_BRANCHES_PER_AGENT } },
   // issue-reconcile heals ZOMBIE issues: open + `in-progress` (claimed) yet with
   // their PR already MERGED and no live claim anywhere — a partial ship left the
   // claim marker on, so the queue (which skips `in-progress`) never re-picks the
@@ -227,17 +232,17 @@ export const DEFAULT_TASK_INTERVALS = {
   // per-app toggle: OFF forbids closing/filing — comment + unlabel only.
   // The coordinator works purely over `gh` — no code changes, no worktree, and
   // issue-state mutation is its whole deliverable — hence the shared
-  // non-committing-coordinator posture above. Off by default — enabling it is the
-  // user's explicit consent to let it mutate issue state on a schedule.
-  'issue-reconcile':     { type: INTERVAL_TYPES.PERPETUAL, enabled: false, providerId: null, model: null, prompt: null, recheckCron: '0 4 * * *', drainDispatchCap: PERPETUAL_DRAIN_DISPATCH_CAP, taskMetadata: { ...NON_COMMITTING_COORDINATOR_METADATA, autoClose: true } },
-  'console-errors':      { type: INTERVAL_TYPES.ROTATION, enabled: false, providerId: null, model: null, prompt: null, taskMetadata: { fileIssues: false } },
-  'dependency-updates':  { type: INTERVAL_TYPES.WEEKLY, enabled: false, providerId: null, model: null, prompt: null },
-  'documentation':       { type: INTERVAL_TYPES.ONCE, enabled: false, providerId: null, model: null, prompt: null, taskMetadata: { fileIssues: false } },
-  'ui-bugs':             { type: INTERVAL_TYPES.ON_DEMAND, enabled: false, providerId: null, model: null, prompt: null, taskMetadata: { fileIssues: false } },
-  'mobile-responsive':   { type: INTERVAL_TYPES.ON_DEMAND, enabled: false, providerId: null, model: null, prompt: null, taskMetadata: { fileIssues: false } },
+  // non-committing-coordinator posture above. On-demand by default — a manual
+  // Run is the explicit consent to mutate issue state; a cadence is opt-in.
+  'issue-reconcile':     { type: INTERVAL_TYPES.ON_DEMAND, enabled: true, providerId: null, model: null, prompt: null, recheckCron: '0 4 * * *', drainDispatchCap: PERPETUAL_DRAIN_DISPATCH_CAP, taskMetadata: { ...NON_COMMITTING_COORDINATOR_METADATA, autoClose: true } },
+  'console-errors':      { type: INTERVAL_TYPES.ON_DEMAND, enabled: true, providerId: null, model: null, prompt: null, taskMetadata: { fileIssues: false } },
+  'dependency-updates':  { type: INTERVAL_TYPES.ON_DEMAND, enabled: true, providerId: null, model: null, prompt: null },
+  'documentation':       { type: INTERVAL_TYPES.ON_DEMAND, enabled: true, providerId: null, model: null, prompt: null, taskMetadata: { fileIssues: false } },
+  'ui-bugs':             { type: INTERVAL_TYPES.ON_DEMAND, enabled: true, providerId: null, model: null, prompt: null, taskMetadata: { fileIssues: false } },
+  'mobile-responsive':   { type: INTERVAL_TYPES.ON_DEMAND, enabled: true, providerId: null, model: null, prompt: null, taskMetadata: { fileIssues: false } },
   // feature-ideas waits for do-replan so new work is grounded in a fresh PLAN.md
   // that already accounts for any in-flight or unmerged work.
-  'feature-ideas':       { type: INTERVAL_TYPES.DAILY, enabled: false, providerId: null, model: null, prompt: null, runAfter: ['do-replan'], taskMetadata: { useWorktree: true, openPR: true, simplify: true } },
+  'feature-ideas':       { type: INTERVAL_TYPES.ON_DEMAND, enabled: true, providerId: null, model: null, prompt: null, runAfter: ['do-replan'], taskMetadata: { useWorktree: true, openPR: true, simplify: true } },
   // plan-task is a strict executor of PLAN.md items — no brainstorm fallback, no
   // runAfter deps. Picks the next unchecked item, implements it, and removes it
   // from PLAN.md in the same commit (changelog + git log are the audit trail).
@@ -253,7 +258,7 @@ export const DEFAULT_TASK_INTERVALS = {
   // it should provision and publish a managed worktree. Conflating them sent
   // claim agents into the generic commit-only handoff (#4153).
   // The agent runs in the source repo's working directory; `git worktree add` doesn't touch that working tree, so it's safe even with uncommitted user changes.
-  'plan-task':           { type: INTERVAL_TYPES.DAILY, enabled: false, providerId: null, model: null, prompt: null, taskMetadata: { useWorktree: false, openPR: false, claimFlow: true, simplify: true } },
+  'plan-task':           { type: INTERVAL_TYPES.ON_DEMAND, enabled: true, providerId: null, model: null, prompt: null, taskMetadata: { useWorktree: false, openPR: false, claimFlow: true, simplify: true } },
   // claim-issue drives the /claim --issues flow — the agent creates its OWN
   // claim/issue-<num> worktree, opens the PR (Closes #<num>), merges via
   // `gh pr merge`, and cleans up. Both `useWorktree` and `openPR` are OFF on the
@@ -271,7 +276,7 @@ export const DEFAULT_TASK_INTERVALS = {
   // (perpetualWork.js) — e.g. `good first issue`, to leave those open for human
   // contributors. Per-app override supported via taskTypeOverrides, like
   // `issueAuthorFilter`.
-  'claim-issue':         { type: INTERVAL_TYPES.DAILY, enabled: false, providerId: null, model: null, prompt: null, taskMetadata: { useWorktree: false, openPR: false, claimFlow: true, simplify: true, issueAuthorFilter: 'self', issueExcludeLabels: [] } },
+  'claim-issue':         { type: INTERVAL_TYPES.ON_DEMAND, enabled: true, providerId: null, model: null, prompt: null, taskMetadata: { useWorktree: false, openPR: false, claimFlow: true, simplify: true, issueAuthorFilter: 'self', issueExcludeLabels: [] } },
   // claim-work is the SINGLE-SOURCE router: one toggle per app that ships the
   // next work item from whatever tracker the app is configured for
   // (app.workTracker, default 'auto' → resolved from the git origin host). At
@@ -285,14 +290,14 @@ export const DEFAULT_TASK_INTERVALS = {
   // hide the claim slug and trigger cleanupAgentWorktree's auto-merge).
   // `issueAuthorFilter` / `issueExcludeLabels` apply only when the resolved
   // tracker is a forge (github/gitlab); both are inert for plan/jira.
-  'claim-work':          { type: INTERVAL_TYPES.DAILY, enabled: false, providerId: null, model: null, prompt: null, taskMetadata: { useWorktree: false, openPR: false, claimFlow: true, simplify: true, issueAuthorFilter: 'self', issueExcludeLabels: [] } },
-  'error-handling':      { type: INTERVAL_TYPES.ROTATION, enabled: false, providerId: null, model: null, prompt: null, taskMetadata: { fileIssues: false } },
-  'typing':              { type: INTERVAL_TYPES.ONCE, enabled: false, providerId: null, model: null, prompt: null, taskMetadata: { fileIssues: false } },
+  'claim-work':          { type: INTERVAL_TYPES.ON_DEMAND, enabled: true, providerId: null, model: null, prompt: null, taskMetadata: { useWorktree: false, openPR: false, claimFlow: true, simplify: true, issueAuthorFilter: 'self', issueExcludeLabels: [] } },
+  'error-handling':      { type: INTERVAL_TYPES.ON_DEMAND, enabled: true, providerId: null, model: null, prompt: null, taskMetadata: { fileIssues: false } },
+  'typing':              { type: INTERVAL_TYPES.ON_DEMAND, enabled: true, providerId: null, model: null, prompt: null, taskMetadata: { fileIssues: false } },
   // Release-check inspects and mutates release state (for example, the main →
   // release PR) rather than producing source commits. It must run from the app's
   // live main checkout so its branch/ref checks describe the real release flow;
   // a CoS worktree hides that checkout and creates an irrelevant task branch.
-  'release-check':       { type: INTERVAL_TYPES.ON_DEMAND, enabled: false, providerId: null, model: null, prompt: null, taskMetadata: { ...RELEASE_CHECK_METADATA } },
+  'release-check':       { type: INTERVAL_TYPES.ON_DEMAND, enabled: true, providerId: null, model: null, prompt: null, taskMetadata: { ...RELEASE_CHECK_METADATA } },
   // stash-cleanup triages `git stash list` and drops what's superseded/stale,
   // leaving real unlanded work in place for the user to recover by hand. It
   // runs in the app's live checkout (never a CoS worktree — a stash is a
@@ -300,7 +305,7 @@ export const DEFAULT_TASK_INTERVALS = {
   // ships no code of its own. On-demand only: unlike branch/issue reconcile,
   // there's no useful cadence for a stash a user hasn't necessarily touched
   // since the last run — they trigger it when they notice stash clutter.
-  'stash-cleanup':       { type: INTERVAL_TYPES.ON_DEMAND, enabled: false, providerId: null, model: null, prompt: null, taskMetadata: { ...NON_COMMITTING_COORDINATOR_METADATA } },
+  'stash-cleanup':       { type: INTERVAL_TYPES.ON_DEMAND, enabled: true, providerId: null, model: null, prompt: null, taskMetadata: { ...NON_COMMITTING_COORDINATOR_METADATA } },
   // repo-sync sweeps EVERY managed app's checkout in one run (see the type list
   // above). Like stash-cleanup it runs in the live checkouts — a branch, a stash,
   // and a worktree are all properties of the checkout they live in, so a CoS
@@ -309,20 +314,20 @@ export const DEFAULT_TASK_INTERVALS = {
   // switch branches under a checkout they may be sitting in. Every action toggle
   // is ON except `reapRemotes`, which DELETES branches on origin and so stays
   // opt-in even though the reconciler only ever reaps already-merged ones.
-  'repo-sync':           { type: INTERVAL_TYPES.ON_DEMAND, enabled: false, providerId: null, model: null, prompt: null, taskMetadata: { ...NON_COMMITTING_COORDINATOR_METADATA, syncPush: true, syncPull: true, switchDefault: true, cleanupMerged: true, dropStashes: true, reapRemotes: false, verifyMode: DEFAULT_REPO_SYNC_VERIFY_MODE } },
-  'pr-reviewer':         { type: INTERVAL_TYPES.CUSTOM, intervalMs: 7200000, enabled: false, weekdaysOnly: true, providerId: null, model: null, prompt: null, taskMetadata: { readOnly: true, pipeline: { stages: [{ name: 'Security Scan', promptKey: 'pr-reviewer-security', readOnly: true }, { name: 'Code Review & Merge', promptKey: 'pr-reviewer-review', readOnly: false }] } } },
+  'repo-sync':           { type: INTERVAL_TYPES.ON_DEMAND, enabled: true, providerId: null, model: null, prompt: null, taskMetadata: { ...NON_COMMITTING_COORDINATOR_METADATA, syncPush: true, syncPull: true, switchDefault: true, cleanupMerged: true, dropStashes: true, reapRemotes: false, verifyMode: DEFAULT_REPO_SYNC_VERIFY_MODE } },
+  'pr-reviewer':         { type: INTERVAL_TYPES.ON_DEMAND, intervalMs: 7200000, enabled: true, weekdaysOnly: true, providerId: null, model: null, prompt: null, taskMetadata: { readOnly: true, pipeline: { stages: [{ name: 'Security Scan', promptKey: 'pr-reviewer-security', readOnly: true }, { name: 'Code Review & Merge', promptKey: 'pr-reviewer-review', readOnly: false }] } } },
   'code-reviewer-a':     { ...CODE_REVIEWER_INTERVAL },
   'code-reviewer-b':     { ...CODE_REVIEWER_INTERVAL },
-  'jira-sprint-manager': { type: INTERVAL_TYPES.DAILY, enabled: false, weekdaysOnly: true, providerId: null, model: null, prompt: null, taskMetadata: { useWorktree: true, openPR: true, simplify: true } },
+  'jira-sprint-manager': { type: INTERVAL_TYPES.ON_DEMAND, enabled: true, weekdaysOnly: true, providerId: null, model: null, prompt: null, taskMetadata: { useWorktree: true, openPR: true, simplify: true } },
   // jira-status-report posts its report to JIRA and edits nothing in the repo, so it
   // takes the shared non-committing-coordinator posture above. `readOnly: true` alone
   // was NOT enough: it skips worktree creation but leaves `openPR` free to be filled
   // from the app's `defaultOpenPR`, and the finalize-time PR-claim check reads
   // `metadata.openPR` directly — scoring a posted report as `pr-missing`.
-  'jira-status-report':  { type: INTERVAL_TYPES.WEEKLY, enabled: false, weekdaysOnly: true, providerId: null, model: null, prompt: null, taskMetadata: { ...NON_COMMITTING_COORDINATOR_METADATA, readOnly: true } },
+  'jira-status-report':  { type: INTERVAL_TYPES.ON_DEMAND, enabled: true, weekdaysOnly: true, providerId: null, model: null, prompt: null, taskMetadata: { ...NON_COMMITTING_COORDINATOR_METADATA, readOnly: true } },
   // do-replan audits PLAN.md after open PRs and stale branches have been cleaned up,
   // so the plan reflects what actually merged.
-  'do-replan':           { type: INTERVAL_TYPES.WEEKLY, enabled: false, providerId: null, model: null, prompt: null, runAfter: ['pr-reviewer', 'branch-reconcile'], taskMetadata: { useWorktree: true, openPR: true } },
+  'do-replan':           { type: INTERVAL_TYPES.ON_DEMAND, enabled: true, providerId: null, model: null, prompt: null, runAfter: ['pr-reviewer', 'branch-reconcile'], taskMetadata: { useWorktree: true, openPR: true } },
   // Writable — the v2 reference-watch prompt (PROMPT_VERSIONS['reference-watch'] = 2)
   // instructs the agent to APPEND slug-tagged `[ref-watch-…]` checklist items to
   // PLAN.md and commit them. `readOnly: true` would inject the "do not modify or
@@ -335,22 +340,23 @@ export const DEFAULT_TASK_INTERVALS = {
   // `readOnly` is coupled to PROMPT_VERSIONS['reference-watch'] — see
   // REFERENCE_WATCH_AUDITED_VERSION above; bumping the prompt version requires
   // re-auditing this default (a guard test in taskSchedule.test.js enforces it).
-  'reference-watch':     { type: INTERVAL_TYPES.WEEKLY, enabled: false, providerId: null, model: null, prompt: null, taskMetadata: { readOnly: false } },
+  'reference-watch':     { type: INTERVAL_TYPES.ON_DEMAND, enabled: true, providerId: null, model: null, prompt: null, taskMetadata: { readOnly: false } },
   // ux audits the RUNNING app UI. Defaults to filing tracker issues
   // (`fileIssues: true`); flip that off to implement. `readOnly: false` so the
   // PLAN.md path can commit checklist items / forge paths can `gh issue create`.
-  // Off by default (AI Provider Usage Policy — enabling it is the user's consent
-  // to a weekly browser-driving LLM run).
-  'ux':                  { type: INTERVAL_TYPES.WEEKLY, enabled: false, providerId: null, model: null, prompt: null, taskMetadata: { fileIssues: true, useWorktree: false, openPR: false, readOnly: false } },
+  // On-demand by default (AI Provider Usage Policy — a manual Run is the user's
+  // consent to a browser-driving LLM run; choosing a cadence opts into scheduling).
+  'ux':                  { type: INTERVAL_TYPES.ON_DEMAND, enabled: true, providerId: null, model: null, prompt: null, taskMetadata: { fileIssues: true, useWorktree: false, openPR: false, readOnly: false } },
   // data-safety / simplify are the scheduled counterparts of the quota-burn
   // `data-safety-audit` and `simplify-audit` presets. New types default to
-  // file-issues so an unattended enable doesn't land code. Off by default.
-  'data-safety':         { type: INTERVAL_TYPES.WEEKLY, enabled: false, providerId: null, model: null, prompt: null, taskMetadata: { fileIssues: true, useWorktree: false, openPR: false } },
-  'simplify':            { type: INTERVAL_TYPES.WEEKLY, enabled: false, providerId: null, model: null, prompt: null, taskMetadata: { fileIssues: true, useWorktree: false, openPR: false } },
-  'api-contract':      { type: INTERVAL_TYPES.WEEKLY, enabled: false, providerId: null, model: null, prompt: null, taskMetadata: { fileIssues: true, useWorktree: false, openPR: false } },
-  'react-lifecycle':   { type: INTERVAL_TYPES.WEEKLY, enabled: false, providerId: null, model: null, prompt: null, taskMetadata: { fileIssues: true, useWorktree: false, openPR: false } },
-  'observability':     { type: INTERVAL_TYPES.WEEKLY, enabled: false, providerId: null, model: null, prompt: null, taskMetadata: { fileIssues: true, useWorktree: false, openPR: false } },
-  'copy':                { type: INTERVAL_TYPES.WEEKLY, enabled: false, providerId: null, model: null, prompt: null, taskMetadata: { fileIssues: true, useWorktree: false, openPR: false } },
+  // file-issues so an unattended scheduled run doesn't land code. On-demand
+  // defaults keep manual filing available without opting into scheduling.
+  'data-safety':         { type: INTERVAL_TYPES.ON_DEMAND, enabled: true, providerId: null, model: null, prompt: null, taskMetadata: { fileIssues: true, useWorktree: false, openPR: false } },
+  'simplify':            { type: INTERVAL_TYPES.ON_DEMAND, enabled: true, providerId: null, model: null, prompt: null, taskMetadata: { fileIssues: true, useWorktree: false, openPR: false } },
+  'api-contract':      { type: INTERVAL_TYPES.ON_DEMAND, enabled: true, providerId: null, model: null, prompt: null, taskMetadata: { fileIssues: true, useWorktree: false, openPR: false } },
+  'react-lifecycle':   { type: INTERVAL_TYPES.ON_DEMAND, enabled: true, providerId: null, model: null, prompt: null, taskMetadata: { fileIssues: true, useWorktree: false, openPR: false } },
+  'observability':     { type: INTERVAL_TYPES.ON_DEMAND, enabled: true, providerId: null, model: null, prompt: null, taskMetadata: { fileIssues: true, useWorktree: false, openPR: false } },
+  'copy':                { type: INTERVAL_TYPES.ON_DEMAND, enabled: true, providerId: null, model: null, prompt: null, taskMetadata: { fileIssues: true, useWorktree: false, openPR: false } },
   // pr-watcher polls for newly-opened PRs, so it runs on a short custom
   // interval rather than the loose rotation/daily cadence. 30 min keeps the
   // gh polling cheap while still reacting to a PR within one cycle. Default
@@ -358,19 +364,19 @@ export const DEFAULT_TASK_INTERVALS = {
   // it to 'self' or 'others' in the schedule UI. `readOnly: false` so a
   // customized prompt can make changes if the operator wants — the shipped
   // default prompt only reviews + comments.
-  'pr-watcher':          { type: INTERVAL_TYPES.CUSTOM, intervalMs: 1800000, enabled: false, providerId: null, model: null, prompt: null, taskMetadata: { prAuthorFilter: 'any', readOnly: false } },
+  'pr-watcher':          { type: INTERVAL_TYPES.ON_DEMAND, intervalMs: 1800000, enabled: true, providerId: null, model: null, prompt: null, taskMetadata: { prAuthorFilter: 'any', readOnly: false } },
   // issue-watcher uses deterministic GitHub reads/mutations around a bounded
-  // reasoning-only review pass. Off by default: enabling it is explicit consent
-  // to replies, assignments, reviews, branch updates, and merges.
-  'issue-watcher':       { type: INTERVAL_TYPES.CUSTOM, intervalMs: 1800000, enabled: false, providerId: null, model: null, prompt: null, taskMetadata: { useWorktree: true, openPR: false, discardWorktree: true } },
+  // reasoning-only review pass. On-demand by default: a manual Run is explicit
+  // consent to replies, assignments, reviews, branch updates, and merges.
+  'issue-watcher':       { type: INTERVAL_TYPES.ON_DEMAND, intervalMs: 1800000, enabled: true, providerId: null, model: null, prompt: null, taskMetadata: { useWorktree: true, openPR: false, discardWorktree: true } },
   // plan-feature files a plan, not code — tracker-filing posture mirrors
   // reference-watch: writable (a file-based tracker commits checklist items), no
-  // managed worktree, no PR. Weekly (not daily like feature-ideas) so an
-  // enabled run doesn't flood the tracker with plans — one filed plan per run.
+  // managed worktree, no PR. On-demand by default; when scheduled, weekly (not
+  // daily like feature-ideas) so it doesn't flood the tracker with plans.
   // runAfter do-replan so proposals are checked against the freshest available
   // work tracker before a new feature plan is filed.
-  'plan-feature':         { type: INTERVAL_TYPES.WEEKLY, enabled: false, providerId: null, model: null, prompt: null, dataInputs: ['product-requirements', 'project-goals', 'open-issues', 'open-pull-requests', 'closed-unmerged-pull-requests'], runAfter: ['do-replan'], taskMetadata: { useWorktree: false, openPR: false, readOnly: false } },
-  // layered-intelligence is a programmatic-I/O task (agent-backed, hooked). Daily
+  'plan-feature':         { type: INTERVAL_TYPES.ON_DEMAND, enabled: true, providerId: null, model: null, prompt: null, dataInputs: ['product-requirements', 'project-goals', 'open-issues', 'open-pull-requests', 'closed-unmerged-pull-requests'], runAfter: ['do-replan'], taskMetadata: { useWorktree: false, openPR: false, readOnly: false } },
+  // layered-intelligence is a programmatic-I/O task (agent-backed, hooked). On-demand
   // by default; per-app scheduling (enabled/interval/provider/model) is set in the
   // Intelligence tab and stored on the app's taskTypeOverrides['layered-intelligence'].
   // No `prompt` field — the buildTaskInput hook renders the prompt (no
@@ -379,7 +385,7 @@ export const DEFAULT_TASK_INTERVALS = {
   // agent runs in a worktree that is discarded without a commit/merge/PR
   // (discardWorktree), so it can't land code — its `.agent-done` payload is the
   // only sanctioned output (consumed by the processTaskOutput hook).
-  'layered-intelligence': { type: INTERVAL_TYPES.DAILY, enabled: false, providerId: null, model: null, prompt: null, taskMetadata: { useWorktree: true, openPR: false, discardWorktree: true } }
+  'layered-intelligence': { type: INTERVAL_TYPES.ON_DEMAND, enabled: true, providerId: null, model: null, prompt: null, taskMetadata: { useWorktree: true, openPR: false, discardWorktree: true } }
 };
 
 // Agent-options that a task manages internally — UI locks the toggle, and

--- a/server/services/taskScheduleRegistry.js
+++ b/server/services/taskScheduleRegistry.js
@@ -201,10 +201,11 @@ export const DEFAULT_TASK_INTERVALS = {
   // branch-reconcile first removes fully-merged, clean orphaned worktrees and
   // branches, then finishes THIS machine's remaining in-flight LOCAL branches
   // per app (open a PR for pushed-but-unopened work, resolve merge conflicts,
-  // drive the review loop, auto-merge when green). PERPETUAL (drain-until-done):
-  // the generator runs the deterministic reconcile every dispatch, and dispatches
-  // the coordinator agent only while actionable in-flight branches remain — then
-  // PARKS on the daily recheckCron. The action toggles (cleanupMerged / openPr /
+  // drive the review loop, auto-merge when green). Detector-driven drain behavior:
+  // the generator runs the deterministic reconcile every manual/on-demand
+  // dispatch (or selected perpetual dispatch), and dispatches the coordinator
+  // agent only while actionable in-flight branches remain — then PARKS on the
+  // daily recheckCron. The action toggles (cleanupMerged / openPr /
   // resolveConflicts / autoMerge / finishAbandoned) are per-app taskMetadata
   // booleans (each ON unless explicitly false); `finishAbandoned` covers the work
   // a dead agent left UNCOMMITTED in its worktree — commit + ship it, or report it
@@ -222,10 +223,11 @@ export const DEFAULT_TASK_INTERVALS = {
   // issue-reconcile heals ZOMBIE issues: open + `in-progress` (claimed) yet with
   // their PR already MERGED and no live claim anywhere — a partial ship left the
   // claim marker on, so the queue (which skips `in-progress`) never re-picks the
-  // remaining scope. PERPETUAL (drain-until-done): the generator runs the
-  // deterministic gh/git scan every dispatch and dispatches the coordinator agent
-  // only while zombies remain — then PARKS on the daily recheckCron (offset an
-  // hour after branch-reconcile so merged-branch cleanup lands first). The
+  // remaining scope. Detector-driven drain behavior: the generator runs the
+  // deterministic gh/git scan every manual/on-demand dispatch (or selected
+  // perpetual dispatch) and dispatches the coordinator agent only while zombies
+  // remain — then PARKS on the daily recheckCron (offset an hour after
+  // branch-reconcile so merged-branch cleanup lands first). The
   // coordinator applies the partial-ship hybrid per zombie (close + file a scoped
   // follow-up when the remainder is separable, else comment "done/remaining" +
   // release the claim). `autoClose` (ON unless explicitly false) is the only


### PR DESCRIPTION
## Summary
- Install fresh CoS task types as enabled on-demand actions so manual Run is available without scheduler-driven provider work.
- Preserve existing saved schedules and per-app opt-in behavior while retaining reconciliation drain semantics and legacy migration behavior.
- Add regression coverage and update the related migration and Jira documentation.

## Test plan
- `npm run build`
- `npm test --prefix server`
- `npm test --prefix server -- services/taskSchedule.test.js services/cosTaskGenerator.test.js services/cos.test.js scripts/migrations/170-branch-reconcile-to-cos-task.test.js