### PR TITLE
fix: expose Codex Ultra effort for supported models

### DIFF
--- a/client/src/components/cos/EffortSelect.test.jsx
+++ b/client/src/components/cos/EffortSelect.test.jsx
@@ -20,10 +20,10 @@ describe('EffortSelect', () => {
       .toEqual(['Default effort', 'low', 'medium', 'high']);
   });
 
-  it('offers codex its full ladder', () => {
-    render(<EffortSelect provider={CODEX} value="" onChange={() => {}} />);
+  it('offers Ultra when Codex runs a model that supports automatic delegation', () => {
+    render(<EffortSelect provider={CODEX} model="gpt-5.6-sol" value="" onChange={() => {}} />);
     expect(screen.getAllByRole('option').map(o => o.textContent))
-      .toEqual(['Default effort', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max']);
+      .toEqual(['Default effort', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max', 'ultra']);
   });
 
   it('uses a server-published ladder for a renamed custom CLI', () => {

--- a/client/src/utils/providers.js
+++ b/client/src/utils/providers.js
@@ -230,11 +230,13 @@ export const filterHardwareCompatibleProviderModels = (models, provider) =>
  * `-c model_reasoning_effort=<level>`.
  *
  * Codex's config enum includes `max` alongside
- * `none|minimal|low|medium|high|xhigh`. `ultra` is retained only as a legacy
- * stored value and resolves to `max` when sent to codex.
+ * `none|minimal|low|medium|high|xhigh`. Sol and Terra additionally advertise
+ * `ultra`, which adds automatic task delegation; older models and Luna top out
+ * at `max`.
  */
 export const CLAUDE_EFFORT_LEVELS = Object.freeze(['low', 'medium', 'high', 'xhigh', 'max']);
 export const CODEX_EFFORT_LEVELS = Object.freeze(['minimal', 'low', 'medium', 'high', 'xhigh', 'max']);
+export const CODEX_ULTRA_EFFORT_LEVELS = Object.freeze([...CODEX_EFFORT_LEVELS, 'ultra']);
 export const ANTIGRAVITY_EFFORT_LEVELS = Object.freeze(['low', 'medium', 'high']);
 // OpenCode passes this through as `reasoningEffort` to its configured local
 // provider. The OpenAI-compatible local backends accept this narrow ladder for
@@ -245,6 +247,12 @@ export const OPENCODE_LOCAL_EFFORT_LEVELS = Object.freeze(['low', 'medium', 'hig
 // syntax (`gpt-5[effort=max]`) — but the level is still user-pickable, so this
 // ladder drives the same selects as every other CLI's.
 export const CURSOR_EFFORT_LEVELS = Object.freeze(['low', 'medium', 'high', 'xhigh', 'max']);
+
+const CODEX_ULTRA_MODELS = new Set(['gpt-5.6', 'gpt-5.6-sol', 'gpt-5.6-terra']);
+
+const codexEffortLevelsForModel = (model) => CODEX_ULTRA_MODELS.has(String(model || '').trim().toLowerCase())
+  ? CODEX_ULTRA_EFFORT_LEVELS
+  : CODEX_EFFORT_LEVELS;
 
 /**
  * True when an OpenCode process provider runs against one of the local
@@ -440,7 +448,7 @@ export const seedModelEffort = (provider, model, effort) => {
 export const effortLevelsForProvider = (provider, model = null) => {
   if (!provider) return null;
   if (isOpencodeLocalProvider(provider)) return OPENCODE_LOCAL_EFFORT_LEVELS;
-  if (isCodexProvider(provider)) return CODEX_EFFORT_LEVELS;
+  if (isCodexProvider(provider)) return codexEffortLevelsForModel(model);
   if (isAntigravityProvider(provider)) {
     const perModel = model ? antigravityModelEffortLevels(model, provider.models) : null;
     if (perModel === null) return ANTIGRAVITY_EFFORT_LEVELS;

--- a/client/src/utils/providers.test.js
+++ b/client/src/utils/providers.test.js
@@ -108,7 +108,7 @@ describe('resolveCliEffort (server mirror)', () => {
     ['codex-only minimal clamps on claude', 'minimal', CLAUDE, 'low'],
     ['codex accepts its whole ladder', 'minimal', CODEX, 'minimal'],
     ['codex accepts max', 'max', CODEX, 'max'],
-    ['legacy ultra resolves to codex max', 'ultra', CODEX, 'max'],
+    ['ultra resolves to codex max without a supported model', 'ultra', CODEX, 'max'],
     ['unknown value yields no flag', 'bogus', AGY, null],
     ['effort-less provider yields no flag', 'high', GROK, null],
     ['unset yields no flag', '', AGY, null],
@@ -116,6 +116,15 @@ describe('resolveCliEffort (server mirror)', () => {
   ])('%s', (_label, effort, provider, expected) => {
     expect(resolveCliEffort(effort, provider)).toBe(expected);
     expect(serverResolveCliEffort(effort, provider)).toBe(expected);
+  });
+
+  it('passes Ultra through for Sol and Terra but clamps it for Luna', () => {
+    for (const model of ['gpt-5.6', 'gpt-5.6-sol', 'gpt-5.6-terra']) {
+      expect(resolveCliEffort('ultra', CODEX, model)).toBe('ultra');
+      expect(serverResolveCliEffort('ultra', CODEX, model)).toBe('ultra');
+    }
+    expect(resolveCliEffort('ultra', CODEX, 'gpt-5.6-luna')).toBe('max');
+    expect(serverResolveCliEffort('ultra', CODEX, 'gpt-5.6-luna')).toBe('max');
   });
 });
 

--- a/server/lib/providerModels.js
+++ b/server/lib/providerModels.js
@@ -74,12 +74,13 @@ export const resolveCliModel = (model) => isConfiguredDefaultModel(model) ? null
 // (`--effort <level>`) and Codex (`-c model_reasoning_effort=<level>`) all
 // accept a per-invocation override of how hard the model thinks. Value sets
 // verified against claude CLI v2.1.x (`--help`), current Codex CLI config
-// values (`none`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max`) and agy
+// values (`none`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max`, plus
+// model-gated `ultra`) and agy
 // (`--help`: "Reasoning effort for the current CLI session (low|medium|high)"). Mirrored in
 // client/src/utils/providers.js — keep in sync.
 //
-// `ultra` remains accepted as a legacy stored value and resolves to the
-// strongest supported level, `max`, when sent to Codex.
+// Codex Ultra adds automatic task delegation on the models that advertise it.
+// Keep it model-gated: older Codex models and Luna top out at `max`.
 //
 // `none` is a real codex variant but is deliberately NOT offered: it means "do
 // not reason at all", which no PortOS effort control should be able to select.
@@ -87,6 +88,7 @@ export const resolveCliModel = (model) => isConfiguredDefaultModel(model) ? null
 
 export const CLAUDE_EFFORT_LEVELS = Object.freeze(['low', 'medium', 'high', 'xhigh', 'max']);
 export const CODEX_EFFORT_LEVELS = Object.freeze(['minimal', 'low', 'medium', 'high', 'xhigh', 'max']);
+export const CODEX_ULTRA_EFFORT_LEVELS = Object.freeze([...CODEX_EFFORT_LEVELS, 'ultra']);
 export const ANTIGRAVITY_EFFORT_LEVELS = Object.freeze(['low', 'medium', 'high']);
 // OpenCode forwards this narrow OpenAI-compatible ladder as `reasoningEffort`
 // to whichever local backend it is wired to (Ollama, llama.cpp, MTPLX,
@@ -102,21 +104,19 @@ export const OPENCODE_LOCAL_EFFORT_LEVELS = Object.freeze(['low', 'medium', 'hig
 // through slashdo.
 export const CURSOR_EFFORT_LEVELS = Object.freeze(['low', 'medium', 'high', 'xhigh', 'max']);
 
-// Effort values no CLI ladder accepts any more, kept ACCEPTED as stored/API
-// input so records saved under an older ladder still validate after an install
-// updates (see the distribution model in AGENTS.md — installs update
-// independently). `resolveCliEffort` clamps them to a level the target CLI
-// really takes, so none of these ever reaches a CLI verbatim.
-const LEGACY_EFFORT_LEVELS = Object.freeze(['ultra']);
-
 /** Union of every accepted effort value across effort-capable CLIs, low→high. */
 export const EFFORT_LEVELS = Object.freeze([...new Set([
-  ...CODEX_EFFORT_LEVELS,
+  ...CODEX_ULTRA_EFFORT_LEVELS,
   ...CLAUDE_EFFORT_LEVELS,
   ...ANTIGRAVITY_EFFORT_LEVELS,
   ...CURSOR_EFFORT_LEVELS,
-  ...LEGACY_EFFORT_LEVELS,
 ])]);
+
+const CODEX_ULTRA_MODELS = new Set(['gpt-5.6', 'gpt-5.6-sol', 'gpt-5.6-terra']);
+
+const codexEffortLevelsForModel = (model) => CODEX_ULTRA_MODELS.has(String(model || '').trim().toLowerCase())
+  ? CODEX_ULTRA_EFFORT_LEVELS
+  : CODEX_EFFORT_LEVELS;
 
 // ---------------------------------------------------------------------------
 // Antigravity base-model ↔ effort-suffix split.
@@ -355,7 +355,7 @@ export function foldCursorEffortIntoModel(model, effort) {
 export function effortLevelsForProvider(provider, model = null) {
   if (!provider) return null;
   if (isOpencodeProvider(provider) && getOpencodeLocalProviderNamespace(provider)) return OPENCODE_LOCAL_EFFORT_LEVELS;
-  if (isCodexProvider(provider)) return CODEX_EFFORT_LEVELS;
+  if (isCodexProvider(provider)) return codexEffortLevelsForModel(model);
   if (isAntigravityProvider(provider)) {
     const perModel = model ? antigravityModelEffortLevels(model, provider.models) : null;
     if (perModel === null) return ANTIGRAVITY_EFFORT_LEVELS;
@@ -377,7 +377,7 @@ const EFFORT_RANK = Object.freeze(['minimal', 'low', 'medium', 'high', 'xhigh', 
  * accepts, or null when the flag should be omitted entirely (no override set,
  * provider has no effort control, or the value isn't a known effort at all).
  * An out-of-range value is clamped to the nearest supported level at or below
- * it (`ultra`→`max` on claude/codex,
+ * it (`ultra`→`max` on claude and Codex models without Ultra,
  * `xhigh`/`max`/`ultra`→`high` on agy), falling back to the provider's weakest
  * level when nothing sits below it (`minimal`→`low`) — rather than being
  * dropped.

--- a/server/lib/providerModels.test.js
+++ b/server/lib/providerModels.test.js
@@ -387,10 +387,14 @@ describe('providerModels', () => {
         .toEqual(['-c', 'model_reasoning_effort=xhigh']);
     });
 
-    it('emits max for codex and resolves legacy ultra to max', () => {
+    it('emits Ultra for supported Codex models and clamps it elsewhere', () => {
       const codex = { id: 'codex', command: 'codex' };
       expect(buildEffortArgs('max', codex)).toEqual(['-c', 'model_reasoning_effort=max']);
       expect(buildEffortArgs('ultra', codex)).toEqual(['-c', 'model_reasoning_effort=max']);
+      expect(buildEffortArgs('ultra', codex, [], 'gpt-5.6-sol'))
+        .toEqual(['-c', 'model_reasoning_effort=ultra']);
+      expect(buildEffortArgs('ultra', codex, [], 'gpt-5.6-luna'))
+        .toEqual(['-c', 'model_reasoning_effort=max']);
     });
 
     it('returns [] when unset, unsupported, or already baked into existing args', () => {

--- a/server/lib/providerVendors.js
+++ b/server/lib/providerVendors.js
@@ -111,7 +111,7 @@ function codexCliArgs(baseArgs, { model, effort, provider }) {
   if (model) {
     args.push('--model', model);
   }
-  args.push(...buildEffortArgs(effort, provider, args));
+  args.push(...buildEffortArgs(effort, provider, args, model));
   args.push('-'); // stdin marker
   return args;
 }
@@ -129,7 +129,7 @@ function codexSpawnArgs(provider, { effectiveModel, effort, maxConcurrentThreads
   if (effectiveModel) {
     args.push('--model', effectiveModel);
   }
-  args.push(...buildEffortArgs(effort, provider, args));
+  args.push(...buildEffortArgs(effort, provider, args, effectiveModel));
   return { command: provider?.command || CODEX_COMMAND, args, stdinMode: 'prompt' };
 }
 
@@ -427,7 +427,12 @@ export function injectTuiModelAndEffort(command, baseArgs, provider, model, effo
   const withModel = shouldInject
     ? [...baseArgs, '--model', resolveInjectedTuiModel(effectiveModel, provider, command)]
     : baseArgs;
-  return [...withModel, ...buildEffortArgs(effort, { id: provider?.id, command }, withModel)];
+  return [...withModel, ...buildEffortArgs(
+    effort,
+    { id: provider?.id, command },
+    withModel,
+    effectiveModel,
+  )];
 }
 
 // Every command a shipped vendor row resolves to, PLUS legacy/custom commands

--- a/server/services/agentCliSpawning.test.js
+++ b/server/services/agentCliSpawning.test.js
@@ -411,12 +411,14 @@ describe('buildCliSpawnConfig', () => {
       expect(config.args).toContain('model_reasoning_effort=xhigh');
     });
 
-    it('passes max to codex and resolves legacy ultra to max', () => {
+    it('passes Ultra to supported Codex models and clamps it elsewhere', () => {
       const codex = { id: 'codex', command: 'codex' };
       const maxConfig = buildCliSpawnConfig(codex, 'gpt-5.4', {}, { effort: 'max' });
       expect(maxConfig.args).toContain('model_reasoning_effort=max');
-      const legacyConfig = buildCliSpawnConfig(codex, 'gpt-5.4', {}, { effort: 'ultra' });
-      expect(legacyConfig.args).toContain('model_reasoning_effort=max');
+      const ultraConfig = buildCliSpawnConfig(codex, 'gpt-5.6-sol', {}, { effort: 'ultra' });
+      expect(ultraConfig.args).toContain('model_reasoning_effort=ultra');
+      const clampedConfig = buildCliSpawnConfig(codex, 'gpt-5.4', {}, { effort: 'ultra' });
+      expect(clampedConfig.args).toContain('model_reasoning_effort=max');
     });
 
     it('adds --effort for claude', () => {

--- a/server/services/agentTuiSpawning.test.js
+++ b/server/services/agentTuiSpawning.test.js
@@ -450,6 +450,15 @@ describe('agent TUI spawning', () => {
     expect(codex.args).not.toContain('--effort');
   });
 
+  it('passes Ultra through when a Codex TUI runs Sol', () => {
+    const codex = buildTuiSpawnConfig(
+      { id: 'codex-tui', command: 'codex', type: 'tui', args: [] },
+      'gpt-5.6-sol',
+      { effort: 'ultra' },
+    );
+    expect(codex.args).toContain('model_reasoning_effort=ultra');
+  });
+
   it('gives a cloud Codex swarm enough threads for its root plus every worker', () => {
     const config = buildTuiSpawnConfig(
       { id: 'codex-tui', command: 'codex', type: 'tui', args: [] },

--- a/server/services/persistentMindTaskCapability.test.js
+++ b/server/services/persistentMindTaskCapability.test.js
@@ -5,7 +5,7 @@ const mocks = vi.hoisted(() => ({
   apps: [{ id: 'portos', name: 'PortOS', repoPath: '/example/portos' }],
   providers: [{
     id: 'codex', name: 'Codex', type: 'cli', enabled: true, command: 'codex',
-    defaultModel: 'gpt-5', models: ['gpt-5', 'gpt-5-mini'],
+    defaultModel: 'gpt-5', models: ['gpt-5', 'gpt-5-mini', 'gpt-5.6-sol', 'gpt-5.6-luna'],
   }],
   existing: null,
   addTask: vi.fn(),
@@ -62,7 +62,7 @@ beforeEach(() => {
   mocks.apps = [{ id: 'portos', name: 'PortOS', repoPath: '/example/portos' }];
   mocks.providers = [{
     id: 'codex', name: 'Codex', type: 'cli', enabled: true, command: 'codex',
-    defaultModel: 'gpt-5', models: ['gpt-5', 'gpt-5-mini'],
+    defaultModel: 'gpt-5', models: ['gpt-5', 'gpt-5-mini', 'gpt-5.6-sol', 'gpt-5.6-luna'],
   }];
   mocks.existing = null;
   mocks.getAppWorkTracker.mockResolvedValue({ resolved: 'plan' });
@@ -93,6 +93,8 @@ describe('persistent mind CoS-task capability', () => {
         models: [
           { id: 'gpt-5', efforts: expect.arrayContaining(['high']) },
           { id: 'gpt-5-mini', efforts: expect.arrayContaining(['high']) },
+          { id: 'gpt-5.6-sol', efforts: expect.arrayContaining(['high', 'ultra']) },
+          { id: 'gpt-5.6-luna', efforts: expect.not.arrayContaining(['ultra']) },
         ],
       }],
       providerReadiness: {
@@ -307,9 +309,20 @@ describe('persistent mind CoS-task capability', () => {
     expect(queued.effort).toBeUndefined();
   });
 
-  it('rejects invented models and unsupported effort before queueing', async () => {
+  it('queues Ultra for Sol and rejects it for a Codex model without Ultra', async () => {
+    const [supported] = await executePersistentMindTaskRequests({
+      taskRequests: [taskRequest({ model: 'gpt-5.6-sol', effort: 'ultra' })],
+      turnId: 'turn-ultra',
+      wake: { kind: 'message', message: { id: 'message-ultra' } },
+    });
+    expect(supported).toMatchObject({ success: true });
+    expect(mocks.addTask).toHaveBeenCalledWith(expect.objectContaining({
+      model: 'gpt-5.6-sol', effort: 'ultra',
+    }), 'internal');
+
+    mocks.addTask.mockClear();
     const results = await executePersistentMindTaskRequests({
-      taskRequests: [taskRequest({ model: 'invented' }), taskRequest({ effort: 'ultra' })],
+      taskRequests: [taskRequest({ model: 'invented' }), taskRequest({ model: 'gpt-5.6-luna', effort: 'ultra' })],
       turnId: 'turn-3',
       wake: { kind: 'message', message: { id: 'message-3' } },
     });


### PR DESCRIPTION
## Summary
- expose Ultra in CoS effort selectors when Codex uses GPT-5.6 Sol or Terra
- keep Luna and older Codex models capped at Max
- preserve the selected model through CLI and TUI effort resolution so Ultra reaches the spawned Codex process

## Test plan
- `cd server && npm test -- --run lib/providerModels.test.js services/agentCliSpawning.test.js services/agentTuiSpawning.test.js services/persistentMindTaskCapability.test.js`
- `cd server && npm test -- --run lib/cosValidation.test.js services/aiAssignments.test.js services/persistentMindProfile.test.js routes/cosMindRoutes.test.js`
- `cd client && npm test -- --run src/utils/providers.test.js src/components/cos/EffortSelect.test.jsx`
- `cd client && npm test -- --run src/components/ProviderModelSelector.test.jsx src/components/cos/TaskAddForm.test.jsx src/pages/PersistentMindTools.test.jsx`
- `cd client && npx biome lint --error-on-warnings src/utils/providers.js src/utils/providers.test.js src/components/cos/EffortSelect.test.jsx`
- `cd client && npm run build`