### PR TITLE
feat: install missing LLM backends from model catalog

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,1 @@
+- [x] [models-contextual-backend-install] Install a missing Ollama or LM Studio backend directly from the model catalog blocker instead of sending the user to a terminal command.

--- a/client/src/components/settings/LocalLlmTab.jsx
+++ b/client/src/components/settings/LocalLlmTab.jsx
@@ -1486,10 +1486,31 @@ export function LocalLlmTab() {
         {selectedData && !selectedData.available && !selectedData.disabled && (
           <div className="flex items-center gap-2 flex-wrap text-xs text-port-warning">
             <span>
-              {labelFor(selected)} isn't running — {selectedData.installed
-                ? (selected === 'ollama' ? 'use the controls to start it or keep it running at login.' : 'launch the app and enable the local server.')
-                : 'install it first (Models → LLMs prompts at setup, or run `npm run setup:llm`).'}
+              {selectedData.installed
+                ? `${labelFor(selected)} isn't running — ${selected === 'ollama' ? 'use the controls to start it or keep it running at login.' : 'launch the app and enable the local server.'}`
+                : `${labelFor(selected)} isn't installed yet.`}
             </span>
+            {!selectedData.installed && selectedData.canAutoInstall && (
+              <button
+                onClick={() => installRuntimeBackend(selected)}
+                disabled={busy}
+                className={`${btnClass} bg-port-accent/20 hover:bg-port-accent/30 text-port-accent`}
+              >
+                {actionInProgress === `runtime-install-${selected}` ? <BrailleSpinner /> : <Download size={12} />}
+                Install {labelFor(selected)}
+              </button>
+            )}
+            {!selectedData.installed && !selectedData.canAutoInstall && selectedData.downloadUrl && (
+              <a
+                href={selectedData.downloadUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className={`${btnClass} bg-port-border hover:bg-port-border/70 text-white no-underline`}
+              >
+                <ExternalLink size={12} />
+                Download {labelFor(selected)}
+              </a>
+            )}
             {selected === 'ollama' && selectedData.installed && selectedData.canControl && (
               <button
                 onClick={() => runAction(

--- a/client/src/components/settings/LocalLlmTab.test.jsx
+++ b/client/src/components/settings/LocalLlmTab.test.jsx
@@ -151,6 +151,28 @@ describe('LocalLlmTab runtime servers', () => {
     await waitFor(() => expect(installLocalLlmBackend).toHaveBeenCalledWith('ollama'));
   });
 
+  it('offers the vendor download when PortOS cannot auto-install the backend', async () => {
+    getLocalLlmStatus.mockResolvedValue({
+      backend: 'lmstudio',
+      ollama: { installed: true, available: true, modelCount: 0, models: [] },
+      lmstudio: {
+        installed: false,
+        available: false,
+        canAutoInstall: false,
+        downloadUrl: 'https://lmstudio.ai/download',
+        modelCount: 0,
+        models: [],
+      },
+    });
+
+    await renderTab();
+
+    const blocker = screen.getByText("LM Studio isn't installed yet.").closest('div');
+    expect(within(blocker).queryByRole('button', { name: 'Install LM Studio' })).toBeNull();
+    expect(within(blocker).getByRole('link', { name: 'Download LM Studio' }))
+      .toHaveAttribute('href', 'https://lmstudio.ai/download');
+  });
+
   it('mounts one control surface covering every local runtime, not just the catalog backends', async () => {
     await renderTab();
     const card = screen.getByRole('heading', { name: 'Local Runtime Servers' }).closest('div.bg-port-card');

--- a/client/src/components/settings/LocalLlmTab.test.jsx
+++ b/client/src/components/settings/LocalLlmTab.test.jsx
@@ -45,6 +45,7 @@ import {
   deleteLocalLlmModel,
   getLocalLlmStatus,
   getLocalLlmCatalog,
+  installLocalLlmBackend,
   patchSettingsSlice,
   installLocalLlmModel,
 } from '../../services/api';
@@ -96,6 +97,7 @@ beforeEach(() => {
     lmstudio: { installed: false, available: false, modelCount: 0, models: [] },
   });
   getLocalLlmCatalog.mockResolvedValue({ models: [] });
+  installLocalLlmBackend.mockResolvedValue({ success: true });
   patchSettingsSlice.mockResolvedValue({});
   deleteLocalLlmModel.mockResolvedValue({ success: true });
 });
@@ -126,6 +128,29 @@ describe('LocalLlmTab backend disable state', () => {
 });
 
 describe('LocalLlmTab runtime servers', () => {
+  it('installs a missing catalog backend at the blocker without sending the user to a terminal', async () => {
+    getLocalLlmStatus.mockResolvedValue({
+      backend: 'ollama',
+      ollama: {
+        installed: false,
+        available: false,
+        canAutoInstall: true,
+        modelCount: 0,
+        models: [],
+      },
+      lmstudio: { installed: true, available: true, modelCount: 0, models: [] },
+    });
+
+    await renderTab();
+
+    const blocker = screen.getByText("Ollama isn't installed yet.").closest('div');
+    expect(within(blocker).queryByText(/npm run setup:llm/)).toBeNull();
+
+    fireEvent.click(within(blocker).getByRole('button', { name: 'Install Ollama' }));
+
+    await waitFor(() => expect(installLocalLlmBackend).toHaveBeenCalledWith('ollama'));
+  });
+
   it('mounts one control surface covering every local runtime, not just the catalog backends', async () => {
     await renderTab();
     const card = screen.getByRole('heading', { name: 'Local Runtime Servers' }).closest('div.bg-port-card');


### PR DESCRIPTION
## Summary

- add an in-context installer for missing Ollama and LM Studio backends in the model catalog
- fall back to the vendor download on platforms PortOS cannot auto-install
- record the completed brainstorm item in PLAN.md

## Test plan

- cd client && npm test -- --run src/components/settings/LocalLlmTab.test.jsx
- cd client && npm test
- cd client && npm run lint
- cd client && npm run build