### PR TITLE
feat: install Bun with Eidoverse setup

### DIFF
--- a/client/src/components/settings/InstanceFeaturesTab.jsx
+++ b/client/src/components/settings/InstanceFeaturesTab.jsx
@@ -127,7 +127,7 @@ export function InstanceFeaturesTab() {
           const installing = savingId === feature.id;
           const selectedRepoUrl = eidoverseRepoUrl ?? setup?.worldsRepoUrl ?? '';
           const repoIsValid = isGitHubRepoUrl(selectedRepoUrl);
-          const canInstall = repoIsValid && setup?.bunAvailable === true && setup?.registryAvailable !== false;
+          const canInstall = repoIsValid && setup?.registryAvailable !== false;
           const canUpdateSource = repoIsValid
             && normalizeGitHubRepo(selectedRepoUrl) !== setup?.worldsRepoUrl
             && setup?.registryAvailable !== false;
@@ -153,7 +153,7 @@ export function InstanceFeaturesTab() {
                 {isEidoverse && (
                   <div className="mt-3 space-y-1 text-xs text-gray-400">
                     {needsInstall && <p>
-                      PortOS will clone your selected Worlds repository and the upstream video runtime as separate AGPL-3.0 repositories, install their Bun dependencies, and register Worlds under Apps. It will not start the server automatically.
+                      PortOS will install Bun if needed, clone your selected Worlds repository and the upstream video runtime as separate AGPL-3.0 repositories, install their dependencies, and register Worlds under Apps. It will not start the server automatically.
                     </p>}
                     <label className="block pt-2" htmlFor="eidoverse-worlds-repo">
                       <span className="block text-gray-300 mb-1">Worlds GitHub repository</span>
@@ -195,13 +195,13 @@ export function InstanceFeaturesTab() {
                     {needsInstall && <>
                       {setup?.bunAvailable === false && (
                         <p className="text-port-warning">
-                          Bun is required. <a className="underline hover:text-white" href="https://bun.sh" target="_blank" rel="noreferrer">Install Bun</a>, then retry.
+                          Bun is not installed. PortOS will install it automatically when you install and enable Eidoverse Worlds.
                         </p>
                       )}
                       {setup?.registryAvailable === false && (
                         <p className="text-port-error">The managed-app registry could not be read. Repair that before installing to avoid a duplicate app record.</p>
                       )}
-                      {(setup?.bunAvailable === false || setup?.registryAvailable === false) && (
+                      {setup?.registryAvailable === false && (
                         <button
                           type="button"
                           onClick={handleEidoverseRecheck}

--- a/client/src/components/settings/InstanceFeaturesTab.test.jsx
+++ b/client/src/components/settings/InstanceFeaturesTab.test.jsx
@@ -219,28 +219,19 @@ describe('InstanceFeaturesTab', () => {
     expect(screen.getByRole('button', { name: 'Install & enable' })).toBeDisabled();
   });
 
-  it('explains the Bun prerequisite before installation', async () => {
+  it('offers to install Bun automatically as part of Eidoverse setup', async () => {
     mock.getInstanceFeatures.mockResolvedValue({
       features: [{ ...EIDOVERSE_FEATURE, setup: { ...EIDOVERSE_FEATURE.setup, bunAvailable: false } }],
     });
-    render(<InstanceFeaturesTab />);
+    render(<MemoryRouter><InstanceFeaturesTab /></MemoryRouter>);
 
-    expect(await screen.findByRole('button', { name: 'Install & enable' })).toBeDisabled();
-    expect(screen.getByRole('link', { name: 'Install Bun' })).toHaveAttribute('href', 'https://bun.sh');
-  });
+    const install = await screen.findByRole('button', { name: 'Install & enable' });
+    expect(install).toBeEnabled();
+    expect(screen.getByText(/PortOS will install it automatically/i)).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'Install Bun' })).toBeNull();
 
-  it('rechecks Eidoverse requirements after Bun is installed', async () => {
-    const missingBun = { ...EIDOVERSE_FEATURE, setup: { ...EIDOVERSE_FEATURE.setup, bunAvailable: false } };
-    mock.getInstanceFeatures
-      .mockResolvedValueOnce({ features: [missingBun] })
-      .mockResolvedValueOnce({ features: [EIDOVERSE_FEATURE] });
-    render(<InstanceFeaturesTab />);
-
-    expect(await screen.findByRole('button', { name: 'Install & enable' })).toBeDisabled();
-    fireEvent.click(screen.getByRole('button', { name: 'Recheck requirements' }));
-
-    await waitFor(() => expect(screen.getByRole('button', { name: 'Install & enable' })).toBeEnabled());
-    expect(mock.getInstanceFeatures).toHaveBeenCalledTimes(2);
+    fireEvent.click(install);
+    await waitFor(() => expect(mock.installEidoverseFeature).toHaveBeenCalledOnce());
   });
 
   // The sidebar and ⌘K read the same module cache; a retry that updated only

--- a/docs/features/eidoverse.md
+++ b/docs/features/eidoverse.md
@@ -4,6 +4,8 @@ Eidoverse Worlds is an optional, disabled-by-default PortOS feature. It is not
 vendored into PortOS and is not a git submodule. Choosing **Install & enable**
 under **Settings → Features** is the explicit consent boundary that downloads,
 installs, and enables the runtime; the ordinary feature toggle never installs it.
+If Bun is not already available, the same action first runs Bun's official
+platform installer under the PortOS service account on Windows, macOS, or Linux.
 
 ## What PortOS installs
 
@@ -31,10 +33,11 @@ untouched. The companion video checkout remains on its upstream repository.
 
 ## Runtime and data ownership
 
-The managed app uses port `8940` and starts with:
+The managed app uses port `8940` and starts with the Bun executable found or
+installed during setup:
 
 ```text
-bun --env-file=.env.portos server/server.ts
+<bun> --env-file=.env.portos server/server.ts
 ```
 
 Installation does not start the server. Start, stop, logs, updates, and launch

--- a/server/services/appUpdater.js
+++ b/server/services/appUpdater.js
@@ -4,6 +4,7 @@ import { readFile } from 'fs/promises';
 import * as gitService from './git.js';
 import * as pm2Service from './pm2.js';
 import { bufferedSpawnOrThrow } from '../lib/bufferedSpawn.js';
+import { parseCommandArgs } from '../lib/commandSecurity.js';
 
 const CMD_TIMEOUT_MS = 5 * 60 * 1000;
 
@@ -49,6 +50,10 @@ async function _doUpdate(app, emit) {
   const dir = app.repoPath;
   const steps = [];
   const packageManager = app.type === 'bun' ? 'bun' : 'npm';
+  const configuredRuntime = parseCommandArgs(app.startCommands?.[0] || '')[0];
+  const packageManagerCommand = packageManager === 'bun' && configuredRuntime
+    ? configuredRuntime
+    : packageManager;
   const installArgs = packageManager === 'bun' ? ['install', '--frozen-lockfile'] : ['install'];
 
   emit('git-pull', 'running', 'Pulling latest changes...');
@@ -76,7 +81,7 @@ async function _doUpdate(app, emit) {
       const label = sub || 'root';
       const stepId = `${packageManager}-install:${label}`;
       emit(stepId, 'running', `Installing ${label} dependencies...`);
-      await runCommand(packageManager, installArgs, subDir);
+      await runCommand(packageManagerCommand, installArgs, subDir);
       emit(stepId, 'done', `${label} dependencies installed`);
       steps.push({ step: stepId, success: true });
     }
@@ -87,7 +92,7 @@ async function _doUpdate(app, emit) {
     const pkg = JSON.parse(await readFile(pkgPath, 'utf-8'));
     if (pkg.scripts?.setup) {
       emit('setup', 'running', 'Running setup...');
-      await runCommand(packageManager, ['run', 'setup'], dir);
+      await runCommand(packageManagerCommand, ['run', 'setup'], dir);
       emit('setup', 'done', 'Setup complete');
       steps.push({ step: 'setup', success: true });
     }

--- a/server/services/appUpdater.test.js
+++ b/server/services/appUpdater.test.js
@@ -36,20 +36,22 @@ describe('managed app updates', () => {
   it('uses Bun and its frozen lockfile for Bun-managed apps', async () => {
     const emit = vi.fn();
     const companionRepo = join(repo, '..', 'eidoverse-video');
+    const bunCommand = join(repo, 'tools with spaces', 'bun');
     const result = await updateApp({
       name: 'Eidoverse Worlds',
       type: 'bun',
       repoPath: repo,
       companionRepoPaths: [companionRepo],
       pm2ProcessNames: ['eidoverse-worlds'],
+      startCommands: [`"${bunCommand}" --env-file=.env.portos server/server.ts`],
     }, emit);
 
     expect(result.success).toBe(true);
     expect(mock.pull).toHaveBeenNthCalledWith(1, repo);
     expect(mock.pull).toHaveBeenNthCalledWith(2, companionRepo);
-    expect(mock.spawn).toHaveBeenCalledWith('bun', ['install', '--frozen-lockfile'], expect.objectContaining({ cwd: repo }));
-    expect(mock.spawn).toHaveBeenCalledWith('bun', ['install', '--frozen-lockfile'], expect.objectContaining({ cwd: join(repo, 'client') }));
-    expect(mock.spawn).toHaveBeenCalledWith('bun', ['run', 'setup'], expect.objectContaining({ cwd: repo }));
+    expect(mock.spawn).toHaveBeenCalledWith(bunCommand, ['install', '--frozen-lockfile'], expect.objectContaining({ cwd: repo }));
+    expect(mock.spawn).toHaveBeenCalledWith(bunCommand, ['install', '--frozen-lockfile'], expect.objectContaining({ cwd: join(repo, 'client') }));
+    expect(mock.spawn).toHaveBeenCalledWith(bunCommand, ['run', 'setup'], expect.objectContaining({ cwd: repo }));
     expect(mock.spawn).not.toHaveBeenCalledWith('npm', expect.anything(), expect.anything());
     expect(emit).toHaveBeenCalledWith('git-pull:companion-1', 'done', 'Already up to date');
     expect(emit).toHaveBeenCalledWith('bun-install:root', 'done', 'root dependencies installed');

--- a/server/services/eidoverse.js
+++ b/server/services/eidoverse.js
@@ -1,4 +1,5 @@
-import { join } from 'path';
+import { delimiter, dirname, join } from 'path';
+import { homedir } from 'os';
 import { ServerError } from '../lib/errorHandler.js';
 import { bufferedSpawnOrThrow } from '../lib/bufferedSpawn.js';
 import { commandExists } from '../lib/commandExists.js';
@@ -13,6 +14,41 @@ export const DEFAULT_EIDOVERSE_WORLDS_REPO = 'https://github.com/anima-research/
 export const EIDOVERSE_VIDEO_REPO = 'https://github.com/anima-research/eidoverse-video';
 export const EIDOVERSE_PORT = 8940;
 export const EIDOVERSE_PROCESS_NAME = 'eidoverse-worlds';
+
+const BUN_INSTALL_URL = 'https://bun.com/install';
+const BUN_INSTALL_PS1_URL = 'https://bun.com/install.ps1';
+const INSTALL_TIMEOUT_MS = 10 * 60 * 1000;
+
+export function getBunExecutable({
+  platform = process.platform,
+  home = homedir(),
+  installRoot = process.env.BUN_INSTALL,
+} = {}) {
+  const root = typeof installRoot === 'string' && installRoot.trim()
+    ? installRoot.trim()
+    : join(home, '.bun');
+  return join(root, 'bin', platform === 'win32' ? 'bun.exe' : 'bun');
+}
+
+export function getBunInstallInvocation(platform = process.platform) {
+  if (platform === 'win32') {
+    return {
+      command: 'powershell',
+      args: [
+        '-NoProfile',
+        '-NonInteractive',
+        '-ExecutionPolicy',
+        'Bypass',
+        '-Command',
+        `Invoke-RestMethod '${BUN_INSTALL_PS1_URL}' | Invoke-Expression`,
+      ],
+    };
+  }
+  return {
+    command: 'bash',
+    args: ['-c', `curl -fsSL ${BUN_INSTALL_URL} | bash`],
+  };
+}
 
 export function normalizeEidoverseWorldsRepo(worldsRepoUrl) {
   const parsed = parseGitHubUrl(worldsRepoUrl);
@@ -37,9 +73,9 @@ export function getEidoversePaths(worldsRepoUrl = DEFAULT_EIDOVERSE_WORLDS_REPO)
   });
 }
 
-const INSTALL_TIMEOUT_MS = 10 * 60 * 1000;
+const quoteCommandToken = (token) => (/\s/.test(token) ? `"${token}"` : token);
 
-const managedAppFields = (paths) => ({
+const managedAppFields = (paths, bunCommand) => ({
   name: 'Eidoverse Worlds',
   description: 'Private 3D world for a PortOS human and their agents. Installed separately under its own AGPL-3.0 license.',
   repoPath: paths.worlds,
@@ -47,7 +83,7 @@ const managedAppFields = (paths) => ({
   type: 'bun',
   uiPort: EIDOVERSE_PORT,
   apiPort: EIDOVERSE_PORT,
-  startCommands: ['bun --env-file=.env.portos server/server.ts'],
+  startCommands: [`${quoteCommandToken(bunCommand)} --env-file=.env.portos server/server.ts`],
   pm2ProcessNames: [EIDOVERSE_PROCESS_NAME],
   envFile: '.env.portos',
   workTracker: 'auto',
@@ -89,10 +125,10 @@ async function resolveEidoverseInstallPaths(worldsRepoUrl) {
   });
 }
 
-async function registerManagedApp(paths) {
+async function registerManagedApp(paths, bunCommand) {
   const apps = await getAllApps();
   const existing = findManagedApp(apps);
-  const fields = managedAppFields(paths);
+  const fields = managedAppFields(paths, bunCommand);
   const app = existing
     ? await updateApp(existing.id, fields)
     : await createApp(fields);
@@ -100,9 +136,55 @@ async function registerManagedApp(paths) {
   return app;
 }
 
-async function installDependencies(directory) {
-  await bufferedSpawnOrThrow('bun', ['install', '--frozen-lockfile'], {
+const bunRuntimeEnv = (bunExecutable) => {
+  const binDirectory = dirname(bunExecutable);
+  const env = { ...process.env };
+  const inheritedPath = env.PATH || env.Path || '';
+  for (const key of Object.keys(env)) {
+    if (key.toLowerCase() === 'path') delete env[key];
+  }
+  return {
+    ...env,
+    BUN_INSTALL: dirname(binDirectory),
+    PATH: `${binDirectory}${delimiter}${inheritedPath}`,
+  };
+};
+
+async function resolveBunRuntime() {
+  if (await commandExists('bun')) return { command: 'bun', env: process.env };
+
+  const command = getBunExecutable();
+  const env = bunRuntimeEnv(command);
+  return await commandExists(command, ['--version'], { env }) ? { command, env } : null;
+}
+
+async function ensureBunRuntime() {
+  const existing = await resolveBunRuntime();
+  if (existing) return existing;
+
+  const command = getBunExecutable();
+  const env = bunRuntimeEnv(command);
+  const installer = getBunInstallInvocation();
+  console.log('📦 Installing Bun for Eidoverse Worlds');
+  await bufferedSpawnOrThrow(installer.command, installer.args, {
+    env,
+    timeoutMs: INSTALL_TIMEOUT_MS,
+    timeoutLabel: 'Bun installation',
+  });
+
+  if (!await commandExists(command, ['--version'], { env })) {
+    throw new ServerError('Bun installation completed without a runnable Bun binary.', {
+      status: 500,
+      code: 'EIDOVERSE_BUN_INSTALL_FAILED',
+    });
+  }
+  return { command, env };
+}
+
+async function installDependencies(directory, bun) {
+  await bufferedSpawnOrThrow(bun.command, ['install', '--frozen-lockfile'], {
     cwd: directory,
+    env: bun.env,
     timeoutMs: INSTALL_TIMEOUT_MS,
   });
 }
@@ -110,12 +192,7 @@ async function installDependencies(directory) {
 let installInFlight = null;
 
 async function performInstall(worldsRepoUrl) {
-  if (!await commandExists('bun')) {
-    throw new ServerError('Eidoverse Worlds requires Bun. Install Bun, then retry.', {
-      status: 412,
-      code: 'EIDOVERSE_BUN_REQUIRED',
-    });
-  }
+  const bun = await ensureBunRuntime();
 
   const configuredPaths = getEidoversePaths(worldsRepoUrl);
   const paths = await resolveEidoverseInstallPaths(worldsRepoUrl);
@@ -125,13 +202,13 @@ async function performInstall(worldsRepoUrl) {
   ]);
 
   await Promise.all([
-    installDependencies(paths.worlds),
-    installDependencies(join(paths.worlds, 'client')),
+    installDependencies(paths.worlds, bun),
+    installDependencies(join(paths.worlds, 'client'), bun),
   ]);
 
   await ensureDir(paths.worldData);
   await atomicWrite(paths.envFile, envFileContents(paths));
-  await registerManagedApp(paths);
+  await registerManagedApp(paths, bun.command);
 
   console.log('🌐 Eidoverse Worlds installed as a managed app');
   return getEidoverseStatus({ worldsRepoUrl });
@@ -160,8 +237,8 @@ export async function installEidoverse({ worldsRepoUrl = DEFAULT_EIDOVERSE_WORLD
 export async function getEidoverseStatus({ worldsRepoUrl = DEFAULT_EIDOVERSE_WORLDS_REPO } = {}) {
   const normalizedRepoUrl = normalizeEidoverseWorldsRepo(worldsRepoUrl);
   const configuredPaths = getEidoversePaths(normalizedRepoUrl);
-  const [bunAvailable, videoRepo, worldDataReady, registry] = await Promise.all([
-    commandExists('bun'),
+  const [bunRuntime, videoRepo, worldDataReady, registry] = await Promise.all([
+    resolveBunRuntime(),
     pathExists(join(configuredPaths.video, '.git')),
     pathExists(configuredPaths.worldData),
     getAllApps().then(
@@ -198,7 +275,7 @@ export async function getEidoverseStatus({ worldsRepoUrl = DEFAULT_EIDOVERSE_WOR
     worldsRepoUrl: normalizedRepoUrl,
     installed,
     partial: !installed && [worldsRepo, videoRepo, rootDependencies, clientDependencies, configured, worldDataReady, appRegistered].some(Boolean),
-    bunAvailable,
+    bunAvailable: bunRuntime !== null,
     worldsRepo,
     videoRepo,
     rootDependencies,

--- a/server/services/eidoverse.test.js
+++ b/server/services/eidoverse.test.js
@@ -4,6 +4,7 @@ import { join } from 'path';
 const mock = vi.hoisted(() => ({
   existing: new Set(),
   bunAvailable: true,
+  installedBunAvailable: false,
   apps: [],
   registryError: null,
   cloneRepo: vi.fn(),
@@ -24,7 +25,9 @@ vi.mock('../lib/fileUtils.js', () => ({
 }));
 
 vi.mock('../lib/commandExists.js', () => ({
-  commandExists: vi.fn(async () => mock.bunAvailable),
+  commandExists: vi.fn(async (command) => (
+    command === 'bun' ? mock.bunAvailable : mock.installedBunAvailable
+  )),
 }));
 
 vi.mock('../lib/execGit.js', () => ({
@@ -57,6 +60,8 @@ import {
   __resetEidoverseInstallForTests,
   DEFAULT_EIDOVERSE_WORLDS_REPO,
   EIDOVERSE_VIDEO_REPO,
+  getBunExecutable,
+  getBunInstallInvocation,
   getEidoversePaths,
   getEidoverseStatus,
   installEidoverse,
@@ -72,6 +77,7 @@ describe('Eidoverse managed-app installer', () => {
     vi.clearAllMocks();
     mock.existing.clear();
     mock.bunAvailable = true;
+    mock.installedBunAvailable = false;
     mock.apps = [];
     mock.registryError = null;
     mock.execGit.mockResolvedValue({ stdout: '', stderr: '', exitCode: 0 });
@@ -82,8 +88,12 @@ describe('Eidoverse managed-app installer', () => {
         ? join(selectedPaths.worlds, '.git')
         : join(selectedPaths.video, '.git'));
     });
-    mock.spawn.mockImplementation(async (_cmd, _args, { cwd }) => {
-      mock.existing.add(join(cwd, 'node_modules'));
+    mock.spawn.mockImplementation(async (command, _args, options = {}) => {
+      if (command === 'powershell' || command === 'bash') {
+        mock.installedBunAvailable = true;
+      } else {
+        mock.existing.add(join(options.cwd, 'node_modules'));
+      }
       return { stdout: '', stderr: '' };
     });
     mock.ensureDir.mockImplementation(async (path) => {
@@ -158,19 +168,80 @@ describe('Eidoverse managed-app installer', () => {
       .toBe(SELECTED_WORLDS_REPO);
   });
 
+  it('selects the official unattended Bun installer for each supported platform', () => {
+    expect(getBunInstallInvocation('win32')).toEqual({
+      command: 'powershell',
+      args: [
+        '-NoProfile',
+        '-NonInteractive',
+        '-ExecutionPolicy',
+        'Bypass',
+        '-Command',
+        "Invoke-RestMethod 'https://bun.com/install.ps1' | Invoke-Expression",
+      ],
+    });
+    expect(getBunInstallInvocation('darwin')).toEqual({
+      command: 'bash',
+      args: ['-c', 'curl -fsSL https://bun.com/install | bash'],
+    });
+    expect(getBunInstallInvocation('linux')).toEqual(getBunInstallInvocation('darwin'));
+  });
+
   it('rejects non-GitHub Worlds repositories before cloning', async () => {
     await expect(installEidoverse({ worldsRepoUrl: 'https://example.com/eidoverse-worlds' }))
       .rejects.toMatchObject({ status: 400, code: 'EIDOVERSE_REPO_INVALID' });
     expect(mock.cloneRepo).not.toHaveBeenCalled();
   });
 
-  it('refuses installation before creating files when Bun is unavailable', async () => {
+  it('installs Bun automatically before cloning when it is unavailable', async () => {
     mock.bunAvailable = false;
 
     await expect(installEidoverse({ worldsRepoUrl: SELECTED_WORLDS_REPO }))
-      .rejects.toMatchObject({ status: 412, code: 'EIDOVERSE_BUN_REQUIRED' });
+      .resolves.toMatchObject({ installed: true, bunAvailable: true });
+
+    const installer = getBunInstallInvocation();
+    const bunExecutable = getBunExecutable();
+    expect(mock.spawn).toHaveBeenCalledWith(
+      installer.command,
+      installer.args,
+      expect.objectContaining({ timeoutLabel: 'Bun installation' }),
+    );
+    expect(mock.spawn).toHaveBeenCalledWith(
+      bunExecutable,
+      ['install', '--frozen-lockfile'],
+      expect.objectContaining({ cwd: selectedPaths.worlds }),
+    );
+    expect(mock.createApp).toHaveBeenCalledWith(expect.objectContaining({
+      startCommands: [expect.stringContaining(bunExecutable)],
+    }));
+  });
+
+  it('reuses the default Bun installation even when it is not on PATH', async () => {
+    mock.bunAvailable = false;
+    mock.installedBunAvailable = true;
+
+    await installEidoverse({ worldsRepoUrl: SELECTED_WORLDS_REPO });
+
+    const installer = getBunInstallInvocation();
+    expect(mock.spawn).not.toHaveBeenCalledWith(
+      installer.command,
+      installer.args,
+      expect.anything(),
+    );
+    expect(mock.spawn).toHaveBeenCalledWith(
+      getBunExecutable(),
+      ['install', '--frozen-lockfile'],
+      expect.objectContaining({ cwd: selectedPaths.worlds }),
+    );
+  });
+
+  it('stops before cloning when the Bun installer does not produce a runnable binary', async () => {
+    mock.bunAvailable = false;
+    mock.spawn.mockResolvedValue({ stdout: '', stderr: '' });
+
+    await expect(installEidoverse({ worldsRepoUrl: SELECTED_WORLDS_REPO }))
+      .rejects.toMatchObject({ status: 500, code: 'EIDOVERSE_BUN_INSTALL_FAILED' });
     expect(mock.cloneRepo).not.toHaveBeenCalled();
-    expect(mock.atomicWrite).not.toHaveBeenCalled();
   });
 
   it('keeps an unreadable app registry distinct from a confirmed missing registration', async () => {


### PR DESCRIPTION
## Summary
- install Bun automatically through its official unattended installer when Eidoverse setup needs it
- resolve and persist the Bun executable so managed starts and updates keep working across PATH differences
- replace the manual prerequisite link with clear automatic-install messaging

## Test plan
- cd server && npm test -- --run services/eidoverse.test.js services/appUpdater.test.js routes/settings.test.js
- cd client && npm test -- --run src/components/settings/InstanceFeaturesTab.test.jsx
- cd client && npm run lint