### PR TITLE
perf: cache Brain summary projections

### DIFF
--- a/server/services/brainStorage.js
+++ b/server/services/brainStorage.js
@@ -1286,9 +1286,10 @@ export function invalidateAllCaches() {
  * Get brain data summary (for dashboard)
  */
 export async function getSummary() {
-  const types = ['people', 'projects', 'ideas', 'admin', 'memories', 'links', 'buckets'];
-  const [typeRows, inboxCounts, meta] = await Promise.all([
+  const types = ['people', 'projects', 'ideas', 'admin', 'memories', 'buckets'];
+  const [typeRows, linkRows, inboxCounts, meta] = await Promise.all([
     Promise.all(types.map((type) => resolveRecordIndex(summaryIndex, type, 0))),
+    resolveLinkSummaries(),
     getInboxLogCounts(),
     loadMeta()
   ]);
@@ -1296,6 +1297,7 @@ export async function getSummary() {
     type,
     typeRows[i].map(([, summary]) => summary).filter(Boolean),
   ]));
+  const links = linkRows.map(([, summary]) => summary).filter(Boolean);
 
   return {
     counts: {
@@ -1304,14 +1306,14 @@ export async function getSummary() {
       ideas: summaries.ideas.length,
       admin: summaries.admin.length,
       memories: summaries.memories.length,
-      links: summaries.links.length,
+      links: links.length,
       buckets: summaries.buckets.length,
       inbox: inboxCounts
     },
     activeProjects: summaries.projects.filter(p => p.status === 'active').length,
     activeIdeas: summaries.ideas.filter(i => !i.status || i.status === 'active').length,
     openAdmin: summaries.admin.filter(a => a.status === 'open').length,
-    gitHubRepos: summaries.links.filter(l => l.isGitHubRepo).length,
+    gitHubRepos: links.filter(l => l.isGitHubRepo).length,
     needsReview: inboxCounts.needs_review,
     lastDailyDigest: meta.lastDailyDigest,
     lastWeeklyReview: meta.lastWeeklyReview

--- a/server/services/brainStorage.js
+++ b/server/services/brainStorage.js
@@ -851,7 +851,8 @@ export async function deleteInboxLog(id) {
  * Get inbox log count by status
  */
 export async function getInboxLogCounts() {
-  const records = await getAll('inbox');
+  const rows = await resolveRecordIndex(summaryIndex, 'inbox', 0);
+  const records = rows.map(([, summary]) => summary).filter(Boolean);
 
   const counts = {
     total: records.length,
@@ -1060,6 +1061,15 @@ const projectLinkSummary = (record) => (record && !isTombstone(record)
   }
   : null);
 const linkSummaryIndex = createRecordIndex(projectLinkSummary);
+
+// The Brain header and inbox gates need only these two fields from each
+// user-visible record. Keeping that projection beside the link summary index
+// lets their frequent count reads reuse the same per-record invalidation
+// machinery without parsing full record bodies in steady state.
+const projectSummary = (record) => (record && !isTombstone(record)
+  ? { status: record.status, isGitHubRepo: record.isGitHubRepo }
+  : null);
+const summaryIndex = createRecordIndex(projectSummary);
 
 const resolveLinkSummaries = () => resolveRecordIndex(linkSummaryIndex, 'links', 0);
 
@@ -1276,33 +1286,32 @@ export function invalidateAllCaches() {
  * Get brain data summary (for dashboard)
  */
 export async function getSummary() {
-  const [people, projects, ideas, adminItems, memoryEntries, links, buckets, inboxCounts, meta] = await Promise.all([
-    getAll('people'),
-    getAll('projects'),
-    getAll('ideas'),
-    getAll('admin'),
-    getAll('memories'),
-    getAll('links'),
-    getAll('buckets'),
+  const types = ['people', 'projects', 'ideas', 'admin', 'memories', 'links', 'buckets'];
+  const [typeRows, inboxCounts, meta] = await Promise.all([
+    Promise.all(types.map((type) => resolveRecordIndex(summaryIndex, type, 0))),
     getInboxLogCounts(),
     loadMeta()
   ]);
+  const summaries = Object.fromEntries(types.map((type, i) => [
+    type,
+    typeRows[i].map(([, summary]) => summary).filter(Boolean),
+  ]));
 
   return {
     counts: {
-      people: people.length,
-      projects: projects.length,
-      ideas: ideas.length,
-      admin: adminItems.length,
-      memories: memoryEntries.length,
-      links: links.length,
-      buckets: buckets.length,
+      people: summaries.people.length,
+      projects: summaries.projects.length,
+      ideas: summaries.ideas.length,
+      admin: summaries.admin.length,
+      memories: summaries.memories.length,
+      links: summaries.links.length,
+      buckets: summaries.buckets.length,
       inbox: inboxCounts
     },
-    activeProjects: projects.filter(p => p.status === 'active').length,
-    activeIdeas: ideas.filter(i => !i.status || i.status === 'active').length,
-    openAdmin: adminItems.filter(a => a.status === 'open').length,
-    gitHubRepos: links.filter(l => l.isGitHubRepo).length,
+    activeProjects: summaries.projects.filter(p => p.status === 'active').length,
+    activeIdeas: summaries.ideas.filter(i => !i.status || i.status === 'active').length,
+    openAdmin: summaries.admin.filter(a => a.status === 'open').length,
+    gitHubRepos: summaries.links.filter(l => l.isGitHubRepo).length,
     needsReview: inboxCounts.needs_review,
     lastDailyDigest: meta.lastDailyDigest,
     lastWeeklyReview: meta.lastWeeklyReview

--- a/server/services/brainStorage.test.js
+++ b/server/services/brainStorage.test.js
@@ -17,7 +17,7 @@ function getTempRoot() {
 
 vi.mock('../lib/fileUtils.js', async () => {
   const actual = await vi.importActual('../lib/fileUtils.js');
-  return makePathsProxy(actual, { dataRoot: () => getTempRoot() });
+  return makePathsProxy({ ...actual, readJSONFile: vi.fn(actual.readJSONFile) }, { dataRoot: () => getTempRoot() });
 });
 
 // getInstanceId is used by create()/backfill; stub to a stable id.
@@ -35,6 +35,7 @@ vi.mock('./brainSyncLog.js', async () => {
 
 import * as brainStorage from './brainStorage.js';
 import * as brainSyncLog from './brainSyncLog.js';
+import { readJSONFile } from '../lib/fileUtils.js';
 
 afterAll(() => { if (tempRoot) rmSync(tempRoot, { recursive: true, force: true }); });
 
@@ -435,6 +436,94 @@ describe('listLiveIds (embedding-coverage id index, issue #3508)', () => {
   });
 });
 
+describe('Brain summary projection index (issue #5438)', () => {
+  const recordBodyReads = () => readJSONFile.mock.calls.filter(([path]) =>
+    /[/\\]brain[/\\][^/\\]+[/\\][^/\\]+[/\\]index\.json$/.test(path)
+  ).length;
+
+  it('preserves summary predicates while excluding tombstones and unreadable records', async () => {
+    const before = await brainStorage.getSummary();
+    const fixtures = {
+      people: { name: 'Summary Person' },
+      projects: { name: 'Summary Project', status: 'active' },
+      ideas: { title: 'Summary Idea' },
+      admin: { title: 'Summary Admin', status: 'open' },
+      memories: { title: 'Summary Memory' },
+      links: { url: 'https://example.com/summary-repo', isGitHubRepo: true },
+      buckets: { name: 'Summary Bucket' },
+    };
+
+    for (const [type, record] of Object.entries(fixtures)) {
+      await brainStorage.create(type, record);
+      const archived = await brainStorage.create(type, { ...record, archived: true });
+      expect(archived.id).toBeTruthy();
+      const removed = await brainStorage.create(type, record);
+      await brainStorage.remove(type, removed.id);
+      writeCorruptRecord(type, `corrupt-summary-${type}`);
+    }
+    await brainStorage.createInboxLog({ text: 'Visible summary inbox', status: 'filed' });
+    await brainStorage.createInboxLog({ text: 'Archived summary inbox', status: 'filed', archived: true });
+    const removedInbox = await brainStorage.createInboxLog({ text: 'Removed summary inbox', status: 'filed' });
+    await brainStorage.remove('inbox', removedInbox.id);
+    writeCorruptRecord('inbox', 'corrupt-summary-inbox');
+    brainStorage.invalidateAllCaches();
+
+    const summary = await brainStorage.getSummary();
+    expect(Object.keys(summary)).toEqual(Object.keys(before));
+    expect(Object.keys(summary.counts)).toEqual(Object.keys(before.counts));
+    for (const type of Object.keys(fixtures)) {
+      expect(summary.counts[type]).toBe(before.counts[type] + 2);
+    }
+    expect(summary.counts.inbox.total).toBe(before.counts.inbox.total + 2);
+    expect(summary.counts.inbox.filed).toBe(before.counts.inbox.filed + 2);
+    expect(summary.activeProjects).toBe(before.activeProjects + 2);
+    expect(summary.activeIdeas).toBe(before.activeIdeas + 2);
+    expect(summary.openAdmin).toBe(before.openAdmin + 2);
+    expect(summary.gitHubRepos).toBe(before.gitHubRepos + 2);
+    expect(summary).toEqual(expect.objectContaining({
+      needsReview: summary.counts.inbox.needs_review,
+      lastDailyDigest: before.lastDailyDigest,
+      lastWeeklyReview: before.lastWeeklyReview,
+    }));
+  });
+
+  it('serves repeated summary and inbox counts without re-reading record bodies', async () => {
+    await brainStorage.createInboxLog({ text: 'Summary cache', status: 'needs_review' });
+    await brainStorage.getSummary();
+    await brainStorage.getInboxLogCounts();
+    const readsAfterPrime = recordBodyReads();
+
+    await brainStorage.getSummary();
+    await brainStorage.getInboxLogCounts();
+    expect(recordBodyReads()).toBe(readsAfterPrime);
+  });
+
+  it('reflects local create, status update, delete, and peer-applied changes', async () => {
+    const before = await brainStorage.getSummary();
+    const project = await brainStorage.create('projects', { name: 'Mutable Summary', status: 'active' });
+    expect((await brainStorage.getSummary()).activeProjects).toBe(before.activeProjects + 1);
+
+    await brainStorage.update('projects', project.id, { status: 'done' });
+    expect((await brainStorage.getSummary()).activeProjects).toBe(before.activeProjects);
+
+    const inbox = await brainStorage.createInboxLog({ text: 'Remove me', status: 'needs_review' });
+    const withInbox = await brainStorage.getInboxLogCounts();
+    await brainStorage.remove('inbox', inbox.id);
+    const withoutInbox = await brainStorage.getInboxLogCounts();
+    expect(withoutInbox.total).toBe(withInbox.total - 1);
+    expect(withoutInbox.needs_review).toBe(withInbox.needs_review - 1);
+
+    await brainStorage.applyRemoteRecord('ideas', 'peer-summary-idea', {
+      title: 'Peer Summary Idea', status: 'active', updatedAt: ISO('2099-01-01'), originInstanceId: 'peer-example',
+    }, 'create');
+    expect((await brainStorage.getSummary()).activeIdeas).toBe(before.activeIdeas + 1);
+    await brainStorage.applyRemoteRecord('ideas', 'peer-summary-idea', {
+      title: 'Peer Summary Idea', status: 'done', updatedAt: ISO('2099-01-02'), originInstanceId: 'peer-example',
+    }, 'update');
+    expect((await brainStorage.getSummary()).activeIdeas).toBe(before.activeIdeas);
+  });
+});
+
 describe('getLinksPage (paginated link reads, issue #3509)', () => {
   // The temp store is shared by every test in this file, so assertions filter
   // the page down to the ids the test itself created rather than assuming the
@@ -581,6 +670,12 @@ describe('getLinksPage (paginated link reads, issue #3509)', () => {
 async function writeRawRecord(type, id, record) {
   const { PATHS, atomicWrite } = await import('../lib/fileUtils.js');
   await atomicWrite(join(PATHS.brain, type, id, 'index.json'), record);
+}
+
+function writeCorruptRecord(type, id) {
+  const dir = join(getTempRoot(), 'brain', type, id);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, 'index.json'), '{not-json');
 }
 
 // Read the raw stored record (including tombstones) by bypassing the read


### PR DESCRIPTION
## Summary
- answer Brain header and inbox counters from per-record projection indexes
- reuse the existing link projection for repository counts
- cover semantic parity, steady-state zero body reads, and local/peer invalidation

## Test plan
- `cd server && npm test -- --run services/brainStorage.test.js` (40 passed)
- `cd server && npm test` (36,166 passed; one host-environment failure in `scripts/checkNpmVersion.test.js` because the running Node/npm bundle is unsupported)

Closes #5438