### PR TITLE
fix(media): enlarge floating lane remove targets

### DIFF
--- a/client/src/components/media/VideoTimelineLanes.jsx
+++ b/client/src/components/media/VideoTimelineLanes.jsx
@@ -112,12 +112,12 @@ export const LaneBlock = memo(function LaneBlock({
   const dur = Math.max(0.05, entry.durationSec || 0);
   const style = {
     left: `${(entry.startSec || 0) * pxPerSec}px`,
-    width: `${Math.max(28, dur * pxPerSec)}px`,
+    width: `${Math.max(56, dur * pxPerSec)}px`,
   };
   return (
     <div
       style={style}
-      className={`absolute top-1 bottom-1 rounded border cursor-pointer overflow-hidden ${
+      className={`absolute top-1 bottom-1 rounded border cursor-pointer ${
         isMissing
           ? 'bg-port-error/20 border-port-error'
           : isSelected
@@ -127,14 +127,14 @@ export const LaneBlock = memo(function LaneBlock({
       onClick={() => onSelect(entry._key)}
       {...clickableProps(() => onSelect(entry._key))}
     >
-      <span className="absolute inset-x-1 top-0.5 text-[9px] text-white truncate pointer-events-none">
+      <span className="absolute left-1 right-7 top-0.5 text-[9px] text-white truncate pointer-events-none">
         {isMissing ? '(missing)' : label}
       </span>
       <button
         type="button"
         onClick={(e) => { e.stopPropagation(); onRemove(entry._key); }}
         onPointerDown={(e) => e.stopPropagation()}
-        className="absolute bottom-0 right-0 inline-flex min-w-[28px] min-h-[28px] items-center justify-center p-1 text-white/70 hover:text-port-error"
+        className="absolute top-1/2 right-0 -translate-y-1/2 inline-flex min-w-[28px] min-h-[28px] items-center justify-center p-1 text-white/70 hover:text-port-error"
         title="Remove"
         aria-label={`Remove ${label} from timeline`}
       >

--- a/client/src/components/media/VideoTimelineLanes.jsx
+++ b/client/src/components/media/VideoTimelineLanes.jsx
@@ -111,7 +111,7 @@ export const LaneBlock = memo(function LaneBlock({
 }) {
   const dur = Math.max(0.05, entry.durationSec || 0);
   const width = Math.max(28, dur * pxPerSec);
-  const showRemove = isSelected || width >= 56;
+  const showRemove = width >= 56;
   const style = {
     left: `${(entry.startSec || 0) * pxPerSec}px`,
     width: `${width}px`,

--- a/client/src/components/media/VideoTimelineLanes.jsx
+++ b/client/src/components/media/VideoTimelineLanes.jsx
@@ -134,7 +134,7 @@ export const LaneBlock = memo(function LaneBlock({
         type="button"
         onClick={(e) => { e.stopPropagation(); onRemove(entry._key); }}
         onPointerDown={(e) => e.stopPropagation()}
-        className="absolute bottom-0 right-0 p-0.5 text-white/70 hover:text-port-error"
+        className="absolute bottom-0 right-0 inline-flex min-w-[28px] min-h-[28px] items-center justify-center p-1 text-white/70 hover:text-port-error"
         title="Remove"
         aria-label={`Remove ${label} from timeline`}
       >

--- a/client/src/components/media/VideoTimelineLanes.jsx
+++ b/client/src/components/media/VideoTimelineLanes.jsx
@@ -110,9 +110,11 @@ export const LaneBlock = memo(function LaneBlock({
   entry, label, tone, isSelected, isMissing, pxPerSec, onSelect, onRemove,
 }) {
   const dur = Math.max(0.05, entry.durationSec || 0);
+  const width = Math.max(28, dur * pxPerSec);
+  const showRemove = isSelected || width >= 56;
   const style = {
     left: `${(entry.startSec || 0) * pxPerSec}px`,
-    width: `${Math.max(56, dur * pxPerSec)}px`,
+    width: `${width}px`,
   };
   return (
     <div
@@ -121,25 +123,27 @@ export const LaneBlock = memo(function LaneBlock({
         isMissing
           ? 'bg-port-error/20 border-port-error'
           : isSelected
-            ? 'border-port-accent bg-port-accent/20'
+            ? 'z-10 border-port-accent bg-port-accent/20'
             : `${tone} hover:border-port-accent/50`
       }`}
       onClick={() => onSelect(entry._key)}
       {...clickableProps(() => onSelect(entry._key))}
     >
-      <span className="absolute left-1 right-7 top-0.5 text-[9px] text-white truncate pointer-events-none">
+      <span className={`absolute top-0.5 text-[9px] text-white truncate pointer-events-none ${showRemove ? 'left-1 right-7' : 'inset-x-1'}`}>
         {isMissing ? '(missing)' : label}
       </span>
-      <button
-        type="button"
-        onClick={(e) => { e.stopPropagation(); onRemove(entry._key); }}
-        onPointerDown={(e) => e.stopPropagation()}
-        className="absolute top-1/2 right-0 -translate-y-1/2 inline-flex min-w-[28px] min-h-[28px] items-center justify-center p-1 text-white/70 hover:text-port-error"
-        title="Remove"
-        aria-label={`Remove ${label} from timeline`}
-      >
-        <X className="w-3 h-3" aria-hidden="true" />
-      </button>
+      {showRemove && (
+        <button
+          type="button"
+          onClick={(e) => { e.stopPropagation(); onRemove(entry._key); }}
+          onPointerDown={(e) => e.stopPropagation()}
+          className="absolute top-1/2 right-0 -translate-y-1/2 inline-flex min-w-[28px] min-h-[28px] items-center justify-center p-1 text-white/70 hover:text-port-error"
+          title="Remove"
+          aria-label={`Remove ${label} from timeline`}
+        >
+          <X className="w-3 h-3" aria-hidden="true" />
+        </button>
+      )}
     </div>
   );
 });

--- a/client/src/components/media/VideoTimelineLanes.test.jsx
+++ b/client/src/components/media/VideoTimelineLanes.test.jsx
@@ -161,21 +161,51 @@ describe('LaneBlock — free-floating overlay/bed placement', () => {
     expect(screen.queryByText('gone.png')).not.toBeInTheDocument();
   });
 
-  it('reserves separate 28px hit targets for selection and removal', () => {
+  it('provides a 28px remove target without selecting a normal-width block', () => {
     const onSelect = vi.fn();
     const onRemove = vi.fn();
     render(
-      <LaneBlock entry={{ ...entry, durationSec: 0 }} label="logo.png" tone="" isSelected={false} isMissing={false} pxPerSec={40} onSelect={onSelect} onRemove={onRemove} />,
+      <LaneBlock entry={entry} label="logo.png" tone="" isSelected={false} isMissing={false} pxPerSec={40} onSelect={onSelect} onRemove={onRemove} />,
     );
 
     const remove = screen.getByRole('button', { name: 'Remove logo.png from timeline' });
-    const block = remove.parentElement;
-    expect(block).toHaveStyle({ width: '56px' });
-    expect(block.className).not.toContain('overflow-hidden');
     expect(remove.className).toContain('min-w-[28px]');
     expect(remove.className).toContain('min-h-[28px]');
     expect(remove.className).toContain('-translate-y-1/2');
 
+    fireEvent.pointerDown(remove);
+    fireEvent.click(remove);
+
+    expect(onSelect).not.toHaveBeenCalled();
+    expect(onRemove).toHaveBeenCalledOnce();
+    expect(onRemove).toHaveBeenCalledWith('ov-1');
+  });
+
+  it('keeps compact entries at their temporal width and reveals removal after selection', () => {
+    const compactEntry = { ...entry, durationSec: 0 };
+    const onSelect = vi.fn();
+    const onRemove = vi.fn();
+    const { rerender } = render(
+      <LaneBlock entry={compactEntry} label="logo.png" tone="" isSelected={false} isMissing={false} pxPerSec={40} onSelect={onSelect} onRemove={onRemove} />,
+    );
+
+    const block = screen.getByText('logo.png').closest('div');
+    expect(block).toHaveStyle({ width: '28px' });
+    expect(screen.queryByRole('button', { name: 'Remove logo.png from timeline' })).not.toBeInTheDocument();
+
+    fireEvent.click(block);
+    expect(onSelect).toHaveBeenCalledWith('ov-1');
+
+    rerender(
+      <LaneBlock entry={compactEntry} label="logo.png" tone="" isSelected isMissing={false} pxPerSec={40} onSelect={onSelect} onRemove={onRemove} />,
+    );
+    expect(block.className).toContain('z-10');
+
+    const remove = screen.getByRole('button', { name: 'Remove logo.png from timeline' });
+    expect(remove.className).toContain('min-w-[28px]');
+    expect(remove.className).toContain('min-h-[28px]');
+
+    onSelect.mockClear();
     fireEvent.pointerDown(remove);
     fireEvent.click(remove);
 

--- a/client/src/components/media/VideoTimelineLanes.test.jsx
+++ b/client/src/components/media/VideoTimelineLanes.test.jsx
@@ -161,16 +161,22 @@ describe('LaneBlock — free-floating overlay/bed placement', () => {
     expect(screen.queryByText('gone.png')).not.toBeInTheDocument();
   });
 
-  it('removes without also selecting the block', () => {
+  it('provides a 28px hit target and removes without selecting the block', () => {
     const onSelect = vi.fn();
     const onRemove = vi.fn();
     render(
       <LaneBlock entry={entry} label="logo.png" tone="" isSelected={false} isMissing={false} pxPerSec={40} onSelect={onSelect} onRemove={onRemove} />,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: 'Remove logo.png from timeline' }));
+    const remove = screen.getByRole('button', { name: 'Remove logo.png from timeline' });
+    expect(remove.className).toContain('min-w-[28px]');
+    expect(remove.className).toContain('min-h-[28px]');
+
+    fireEvent.pointerDown(remove);
+    fireEvent.click(remove);
 
     expect(onSelect).not.toHaveBeenCalled();
+    expect(onRemove).toHaveBeenCalledOnce();
     expect(onRemove).toHaveBeenCalledWith('ov-1');
   });
 });

--- a/client/src/components/media/VideoTimelineLanes.test.jsx
+++ b/client/src/components/media/VideoTimelineLanes.test.jsx
@@ -161,16 +161,20 @@ describe('LaneBlock — free-floating overlay/bed placement', () => {
     expect(screen.queryByText('gone.png')).not.toBeInTheDocument();
   });
 
-  it('provides a 28px hit target and removes without selecting the block', () => {
+  it('reserves separate 28px hit targets for selection and removal', () => {
     const onSelect = vi.fn();
     const onRemove = vi.fn();
     render(
-      <LaneBlock entry={entry} label="logo.png" tone="" isSelected={false} isMissing={false} pxPerSec={40} onSelect={onSelect} onRemove={onRemove} />,
+      <LaneBlock entry={{ ...entry, durationSec: 0 }} label="logo.png" tone="" isSelected={false} isMissing={false} pxPerSec={40} onSelect={onSelect} onRemove={onRemove} />,
     );
 
     const remove = screen.getByRole('button', { name: 'Remove logo.png from timeline' });
+    const block = remove.parentElement;
+    expect(block).toHaveStyle({ width: '56px' });
+    expect(block.className).not.toContain('overflow-hidden');
     expect(remove.className).toContain('min-w-[28px]');
     expect(remove.className).toContain('min-h-[28px]');
+    expect(remove.className).toContain('-translate-y-1/2');
 
     fireEvent.pointerDown(remove);
     fireEvent.click(remove);

--- a/client/src/components/media/VideoTimelineLanes.test.jsx
+++ b/client/src/components/media/VideoTimelineLanes.test.jsx
@@ -171,7 +171,6 @@ describe('LaneBlock — free-floating overlay/bed placement', () => {
     const remove = screen.getByRole('button', { name: 'Remove logo.png from timeline' });
     expect(remove.className).toContain('min-w-[28px]');
     expect(remove.className).toContain('min-h-[28px]');
-    expect(remove.className).toContain('-translate-y-1/2');
 
     fireEvent.pointerDown(remove);
     fireEvent.click(remove);
@@ -181,7 +180,7 @@ describe('LaneBlock — free-floating overlay/bed placement', () => {
     expect(onRemove).toHaveBeenCalledWith('ov-1');
   });
 
-  it('keeps compact entries at their temporal width and reveals removal after selection', () => {
+  it('keeps compact entries selectable without turning the block into a delete target', () => {
     const compactEntry = { ...entry, durationSec: 0 };
     const onSelect = vi.fn();
     const onRemove = vi.fn();
@@ -199,19 +198,13 @@ describe('LaneBlock — free-floating overlay/bed placement', () => {
     rerender(
       <LaneBlock entry={compactEntry} label="logo.png" tone="" isSelected isMissing={false} pxPerSec={40} onSelect={onSelect} onRemove={onRemove} />,
     );
-    expect(block.className).toContain('z-10');
-
-    const remove = screen.getByRole('button', { name: 'Remove logo.png from timeline' });
-    expect(remove.className).toContain('min-w-[28px]');
-    expect(remove.className).toContain('min-h-[28px]');
+    expect(screen.queryByRole('button', { name: 'Remove logo.png from timeline' })).not.toBeInTheDocument();
 
     onSelect.mockClear();
-    fireEvent.pointerDown(remove);
-    fireEvent.click(remove);
+    fireEvent.click(block);
 
-    expect(onSelect).not.toHaveBeenCalled();
-    expect(onRemove).toHaveBeenCalledOnce();
-    expect(onRemove).toHaveBeenCalledWith('ov-1');
+    expect(onSelect).toHaveBeenCalledWith('ov-1');
+    expect(onRemove).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Summary
- give overlay and audio lane remove controls a 28px touch target when the block has room for a distinct control
- preserve compact timeline geometry and keep short blocks selectable, with removal available from the selected Inspector
- verify remove clicks and pointer-down events never bubble into lane selection

## Tests
- npm test -- --run src/pages/VideoTimelineEditor.test.jsx src/components/media/VideoTimelineLanes.test.jsx src/components/media/VideoTimelineInspector.test.jsx
- npx biome lint src/components/media/VideoTimelineLanes.jsx src/components/media/VideoTimelineLanes.test.jsx
- npm run build

Closes #5426