### PR TITLE
feat: copy diagnostic process logs from the UI

### DIFF
--- a/client/src/components/apps/tabs/ProcessesTab.jsx
+++ b/client/src/components/apps/tabs/ProcessesTab.jsx
@@ -199,14 +199,14 @@ export default function ProcessesTab({ appId, pm2ProcessNames, filterFn }) {
                               <span className="text-xs text-gray-600">{logs.length} lines</span>
                               <button
                                 onClick={clearLogs}
-                                className="min-h-[44px] px-1 text-xs text-gray-500 hover:text-white"
+                                className="min-h-[44px] min-w-[44px] px-1 text-xs text-gray-500 hover:text-white"
                               >
                                 Clear
                               </button>
                               <button
                                 onClick={copyLogs}
                                 disabled={logs.length === 0}
-                                className="min-h-[44px] px-1 text-xs text-gray-500 hover:text-white disabled:opacity-50 disabled:hover:text-gray-500"
+                                className="min-h-[44px] min-w-[44px] px-1 text-xs text-gray-500 hover:text-white disabled:opacity-50 disabled:hover:text-gray-500"
                               >
                                 Copy logs
                               </button>
@@ -265,7 +265,7 @@ export default function ProcessesTab({ appId, pm2ProcessNames, filterFn }) {
                 <span className="text-sm text-port-success">● streaming</span>
               )}
             </div>
-            <div className="flex items-center gap-4">
+            <div data-testid="fullscreen-log-controls" className="flex flex-wrap items-center gap-2 sm:gap-4">
               <FormField className="flex items-center gap-2" label="Tail lines:" labelClassName="text-sm text-gray-500">
                 <select
                   value={tailLines}
@@ -282,14 +282,14 @@ export default function ProcessesTab({ appId, pm2ProcessNames, filterFn }) {
               <span className="text-sm text-gray-600">{logs.length} lines</span>
               <button
                 onClick={clearLogs}
-                className="min-h-[44px] px-1 text-sm text-gray-500 hover:text-white"
+                className="min-h-[44px] min-w-[44px] px-1 text-sm text-gray-500 hover:text-white"
               >
                 Clear
               </button>
               <button
                 onClick={copyLogs}
                 disabled={logs.length === 0}
-                className="min-h-[44px] px-1 text-sm text-gray-500 hover:text-white disabled:opacity-50 disabled:hover:text-gray-500"
+                className="min-h-[44px] min-w-[44px] px-1 text-sm text-gray-500 hover:text-white disabled:opacity-50 disabled:hover:text-gray-500"
               >
                 Copy logs
               </button>

--- a/client/src/components/apps/tabs/ProcessesTab.jsx
+++ b/client/src/components/apps/tabs/ProcessesTab.jsx
@@ -8,7 +8,8 @@ import { FormField } from '../../ui/FormField';
 import ProcessLogLines from '../../ui/ProcessLogLines';
 import { useAutoRefetch } from '../../../hooks/useAutoRefetch';
 import { useProcessLogs } from '../../../hooks/useProcessLogs';
-import { formatBytes, formatDurationMs } from '../../../utils/formatters';
+import { copyToClipboard } from '../../../lib/clipboard';
+import { formatBytes, formatDurationMs, formatTimeOfDaySeconds } from '../../../utils/formatters';
 
 const getStatusClasses = (status) => {
   switch (status) {
@@ -61,6 +62,14 @@ export default function ProcessesTab({ appId, pm2ProcessNames, filterFn }) {
   // processName changes, so the new process never shows the old one's tail.
   const toggleExpand = (name) => {
     setExpandedProcess(prev => prev === name ? null : name);
+  };
+
+  const copyLogs = () => {
+    if (logs.length === 0) return;
+    const text = logs
+      .map(({ line, type, timestamp }) => `[${formatTimeOfDaySeconds(timestamp)}] [${type}] ${line}`)
+      .join('\n');
+    copyToClipboard(text, 'Logs copied');
   };
 
   const filteredProcesses = filterFn
@@ -190,13 +199,20 @@ export default function ProcessesTab({ appId, pm2ProcessNames, filterFn }) {
                               <span className="text-xs text-gray-600">{logs.length} lines</span>
                               <button
                                 onClick={clearLogs}
-                                className="text-xs text-gray-500 hover:text-white"
+                                className="min-h-[44px] px-1 text-xs text-gray-500 hover:text-white"
                               >
                                 Clear
                               </button>
                               <button
+                                onClick={copyLogs}
+                                disabled={logs.length === 0}
+                                className="min-h-[44px] px-1 text-xs text-gray-500 hover:text-white disabled:opacity-50 disabled:hover:text-gray-500"
+                              >
+                                Copy logs
+                              </button>
+                              <button
                                 onClick={() => setFullscreen(true)}
-                                className="text-xs text-gray-500 hover:text-white flex items-center gap-1"
+                                className="min-h-[44px] px-1 text-xs text-gray-500 hover:text-white flex items-center gap-1"
                                 title="Fullscreen"
                               >
                                 <Maximize2 size={12} />
@@ -266,13 +282,20 @@ export default function ProcessesTab({ appId, pm2ProcessNames, filterFn }) {
               <span className="text-sm text-gray-600">{logs.length} lines</span>
               <button
                 onClick={clearLogs}
-                className="text-sm text-gray-500 hover:text-white"
+                className="min-h-[44px] px-1 text-sm text-gray-500 hover:text-white"
               >
                 Clear
               </button>
               <button
+                onClick={copyLogs}
+                disabled={logs.length === 0}
+                className="min-h-[44px] px-1 text-sm text-gray-500 hover:text-white disabled:opacity-50 disabled:hover:text-gray-500"
+              >
+                Copy logs
+              </button>
+              <button
                 onClick={() => setFullscreen(false)}
-                className="p-2 text-gray-400 hover:text-white"
+                className="min-h-[44px] min-w-[44px] p-2 text-gray-400 hover:text-white flex items-center justify-center"
                 title="Exit fullscreen" aria-label="Exit fullscreen"
               >
                 <X size={20} />

--- a/client/src/components/apps/tabs/ProcessesTab.jsx
+++ b/client/src/components/apps/tabs/ProcessesTab.jsx
@@ -258,8 +258,8 @@ export default function ProcessesTab({ appId, pm2ProcessNames, filterFn }) {
       */}
       {fullscreen && expandedProcess && createPortal(
         <div className="fixed inset-0 bg-port-bg z-50 flex flex-col">
-          <div className="flex items-center justify-between px-6 py-4 border-b border-port-border bg-port-card">
-            <div className="flex items-center gap-4">
+          <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-2 px-4 sm:px-6 py-3 sm:py-4 border-b border-port-border bg-port-card">
+            <div className="flex flex-wrap items-center gap-2 sm:gap-4">
               <span className="text-lg font-medium text-white">Logs: {expandedProcess}</span>
               {subscribed && (
                 <span className="text-sm text-port-success">● streaming</span>

--- a/client/src/components/apps/tabs/ProcessesTab.test.jsx
+++ b/client/src/components/apps/tabs/ProcessesTab.test.jsx
@@ -18,17 +18,24 @@ vi.mock('../../../hooks/useProcessLogs', () => ({
   useProcessLogs: vi.fn(() => ({ logs: [], subscribed: false, clear: vi.fn() })),
 }));
 
+vi.mock('../../../lib/clipboard', () => ({ copyToClipboard: vi.fn() }));
 vi.mock('../../BrailleSpinner', () => ({ default: () => null }));
 vi.mock('../../ui/FormField', () => ({ FormField: ({ children }) => children }));
 vi.mock('../../ui/ProcessLogLines', () => ({ default: () => null }));
-vi.mock('../../../utils/formatters', () => ({ formatBytes: vi.fn(() => '0 B'), formatDurationMs: vi.fn() }));
+vi.mock('../../../utils/formatters', () => ({
+  formatBytes: vi.fn(() => '0 B'),
+  formatDurationMs: vi.fn(),
+  formatTimeOfDaySeconds: vi.fn((timestamp) => `time-${timestamp}`),
+}));
 
 import { useProcessLogs } from '../../../hooks/useProcessLogs';
+import { copyToClipboard } from '../../../lib/clipboard';
 import ProcessesTab from './ProcessesTab';
 
 describe('ProcessesTab', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    useProcessLogs.mockReturnValue({ logs: [], subscribed: false, clear: vi.fn() });
   });
 
   it('passes its app id to the expanded process log subscription', () => {
@@ -37,6 +44,43 @@ describe('ProcessesTab', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Expand details for example-api' }));
 
     expect(useProcessLogs).toHaveBeenLastCalledWith('example-api', { lines: 500, appId: 'app-1' });
+  });
+
+  it('copies the current live log snapshot from both viewers in display order', () => {
+    useProcessLogs.mockReturnValue({
+      logs: [
+        { line: 'boot ok', type: 'stdout', timestamp: 100 },
+        { line: 'failed once', type: 'stderr', timestamp: 200 },
+      ],
+      subscribed: true,
+      clear: vi.fn(),
+    });
+    render(<ProcessesTab appId="app-1" pm2ProcessNames={['example-api']} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Expand details for example-api' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Copy logs' }));
+
+    const expected = '[time-100] [stdout] boot ok\n[time-200] [stderr] failed once';
+    expect(copyToClipboard).toHaveBeenLastCalledWith(expected, 'Logs copied');
+
+    fireEvent.click(screen.getByTitle('Fullscreen'));
+    const copyButtons = screen.getAllByRole('button', { name: 'Copy logs' });
+    fireEvent.click(copyButtons[1]);
+    expect(copyToClipboard).toHaveBeenLastCalledWith(expected, 'Logs copied');
+    expect(copyToClipboard).toHaveBeenCalledTimes(2);
+  });
+
+  it('disables copy actions when the live log snapshot is empty', () => {
+    render(<ProcessesTab appId="app-1" pm2ProcessNames={['example-api']} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Expand details for example-api' }));
+    expect(screen.getByRole('button', { name: 'Copy logs' })).toBeDisabled();
+
+    fireEvent.click(screen.getByTitle('Fullscreen'));
+    expect(screen.getAllByRole('button', { name: 'Copy logs' })).toEqual([
+      expect.objectContaining({ disabled: true }),
+      expect.objectContaining({ disabled: true }),
+    ]);
   });
 
   // On "glass" themes a bordered/rounded `.bg-port-card` gets a backdrop-filter,

--- a/client/src/components/apps/tabs/ProcessesTab.test.jsx
+++ b/client/src/components/apps/tabs/ProcessesTab.test.jsx
@@ -99,6 +99,7 @@ describe('ProcessesTab', () => {
     expect(container.contains(overlay)).toBe(false);
     expect(overlay.parentElement).toBe(document.body);
     expect(screen.getByText('Logs: example-api')).toBeTruthy();
+    expect(screen.getByTestId('fullscreen-log-controls')).toHaveClass('flex-wrap');
 
     // Exiting fullscreen tears the portaled overlay back down.
     fireEvent.click(screen.getByRole('button', { name: 'Exit fullscreen' }));

--- a/client/src/components/ui/ProcessLogModal.jsx
+++ b/client/src/components/ui/ProcessLogModal.jsx
@@ -16,6 +16,7 @@ import { RefreshCw, X } from 'lucide-react';
 import Modal from './Modal';
 import BrailleSpinner from '../BrailleSpinner';
 import * as api from '../../services/api';
+import { copyToClipboard } from '../../lib/clipboard';
 
 // Keep the default tailLines (200) present here so the controlled <select>
 // renders a matching option on open rather than a mismatched first entry.
@@ -118,11 +119,18 @@ export default function ProcessLogModal({ open, onClose, processName, title = 'S
             <button
               onClick={loadLogs}
               disabled={loading || !selected}
-              className="p-1.5 text-gray-400 hover:text-white transition-colors disabled:opacity-50"
+              className="p-1.5 text-gray-400 hover:text-white transition-colors disabled:opacity-50 min-h-[44px] min-w-[44px] flex items-center justify-center"
               title="Refresh logs"
               aria-label="Refresh logs"
             >
               <RefreshCw size={14} className={loading ? 'animate-spin' : ''} />
+            </button>
+            <button
+              onClick={() => copyToClipboard(logs, 'Logs copied')}
+              disabled={loading || !logs}
+              className="px-2 text-xs text-gray-400 hover:text-white transition-colors disabled:opacity-50 disabled:hover:text-gray-400 min-h-[44px]"
+            >
+              Copy logs
             </button>
             <button
               onClick={onClose}

--- a/client/src/components/ui/ProcessLogModal.test.jsx
+++ b/client/src/components/ui/ProcessLogModal.test.jsx
@@ -6,7 +6,10 @@ vi.mock('../../services/api', () => ({
   getProcessLogs: vi.fn(),
 }));
 
+vi.mock('../../lib/clipboard', () => ({ copyToClipboard: vi.fn() }));
+
 import { getProcessesList, getProcessLogs } from '../../services/api';
+import { copyToClipboard } from '../../lib/clipboard';
 import ProcessLogModal from './ProcessLogModal';
 
 describe('ProcessLogModal', () => {
@@ -28,6 +31,23 @@ describe('ProcessLogModal', () => {
     expect(await screen.findByText(/error: boom/)).toBeInTheDocument();
   });
 
+  it('copies the latest displayed logs exactly as returned', async () => {
+    render(<ProcessLogModal open onClose={() => {}} processName="portos-server" />);
+    await screen.findByText(/error: boom/);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy logs' }));
+
+    expect(copyToClipboard).toHaveBeenCalledWith('boot ok\nerror: boom', 'Logs copied');
+  });
+
+  it('disables copying when logs are empty', async () => {
+    getProcessLogs.mockResolvedValueOnce({ logs: '' });
+    render(<ProcessLogModal open onClose={() => {}} processName="portos-server" />);
+
+    await waitFor(() => expect(getProcessLogs).toHaveBeenCalledWith('portos-server', 200));
+    expect(screen.getByRole('button', { name: 'Copy logs' })).toBeDisabled();
+  });
+
   it('refetches with the new tail length when changed', async () => {
     render(<ProcessLogModal open onClose={() => {}} processName="portos-server" />);
     await waitFor(() => expect(getProcessLogs).toHaveBeenCalledWith('portos-server', 200));
@@ -47,6 +67,7 @@ describe('ProcessLogModal', () => {
     await waitFor(() => expect(getProcessLogs).toHaveBeenLastCalledWith('portos-cos', 200));
     // The stale portos-server logs must be gone while portos-cos is still loading.
     expect(screen.queryByText('server logs here')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Copy logs' })).toBeDisabled();
 
     resolveSecond({ logs: 'cos logs here' });
     expect(await screen.findByText('cos logs here')).toBeInTheDocument();


### PR DESCRIPTION
## Summary

- add shared Copy logs actions to inline and fullscreen live process viewers
- serialize live logs with localized timestamps and stdout/stderr channels
- copy exact static modal output while preventing empty or stale copies
- keep log controls accessible and wrapped on narrow screens

## Test plan

- `npm test -- --run src/components/apps/tabs/ProcessesTab.test.jsx src/components/ui/ProcessLogModal.test.jsx`
- `npx biome lint --error-on-warnings src/components/apps/tabs/ProcessesTab.jsx src/components/apps/tabs/ProcessesTab.test.jsx src/components/ui/ProcessLogModal.jsx src/components/ui/ProcessLogModal.test.jsx`
- `npm run build`

Closes #5469