### PR TITLE
fix: keep timeline workspace above mobile library (#5424)

### DIFF
--- a/client/src/pages/VideoTimelineEditor.jsx
+++ b/client/src/pages/VideoTimelineEditor.jsx
@@ -109,6 +109,9 @@ export default function VideoTimelineEditor() {
   const [playing, setPlaying] = useState(false);
   const [muted, setMuted] = useState(false);
   const [renderJobId, setRenderJobId] = useState(null);
+  const [isDesktop, setIsDesktop] = useState(() => (
+    typeof window === 'undefined' || window.innerWidth >= 1024
+  ));
   const [showLibrary, setShowLibrary] = useState(() => (
     typeof window === 'undefined' || window.innerWidth >= 1024
   ));
@@ -116,6 +119,12 @@ export default function VideoTimelineEditor() {
   // Local input draft. Editing the canonical state on every keystroke makes the
   // rename onBlur-vs-canonical comparison always-equal.
   const [nameDraft, setNameDraft] = useState('');
+
+  useEffect(() => {
+    const updateLayout = () => setIsDesktop(window.innerWidth >= 1024);
+    window.addEventListener('resize', updateLayout);
+    return () => window.removeEventListener('resize', updateLayout);
+  }, []);
 
   const videoRef = useRef(null);
   const lastSrcRef = useRef('');
@@ -688,6 +697,60 @@ export default function VideoTimelineEditor() {
 
   const laneWidth = Math.max(240, total * pxPerSec);
   const playheadSec = Math.min(t, total);
+  const libraryPanel = (
+    <div className="bg-port-card/50 border border-port-border rounded-lg p-2 max-h-[600px] overflow-y-auto">
+      <div className="flex gap-1 mb-2" role="tablist" aria-label="Clip library">
+        {LIBRARY_TABS.map(({ id, label, Icon }) => (
+          <button
+            key={id}
+            type="button"
+            role="tab"
+            aria-selected={libraryTab === id}
+            onClick={() => setLibraryTab(id)}
+            className={`flex-1 flex items-center justify-center gap-1 px-1.5 py-1 text-[10px] rounded ${
+              libraryTab === id
+                ? 'bg-port-accent/20 text-port-accent'
+                : 'text-gray-400 hover:text-white border border-port-border'
+            }`}
+          >
+            <Icon className="w-3 h-3" aria-hidden="true" /> {label}
+          </button>
+        ))}
+      </div>
+
+      {libraryTab === 'clips' && (libraryClips.length === 0 ? (
+        <div className="text-xs text-gray-500 px-1 py-4">No clips. Generate some on the Video page.</div>
+      ) : (
+        <div className="grid grid-cols-1 gap-2">
+          {libraryClips.map((clip) => (
+            <div key={clip.id} className={usedClipIds.has(clip.id) ? 'ring-1 ring-port-accent/40 rounded-md' : ''}>
+              <LibraryTile clip={clip} onAdd={addClip} />
+            </div>
+          ))}
+        </div>
+      ))}
+
+      {libraryTab === 'stills' && (images.length === 0 ? (
+        <div className="text-xs text-gray-500 px-1 py-4">No images. Generate some on the Image page.</div>
+      ) : (
+        <div className="grid grid-cols-1 gap-2">
+          {images.map((image) => (
+            <StillTile key={image.filename} image={image} onAddStill={addStill} onAddOverlay={addOverlay} />
+          ))}
+        </div>
+      ))}
+
+      {libraryTab === 'audio' && (musicTracks.length === 0 ? (
+        <div className="text-xs text-gray-500 px-1 py-4">No audio in the shared music library.</div>
+      ) : (
+        <div className="grid grid-cols-1 gap-1.5">
+          {musicTracks.map((track) => (
+            <AudioRow key={track.filename} track={track} onAdd={addBed} />
+          ))}
+        </div>
+      ))}
+    </div>
+  );
 
   return (
     <div className="space-y-3">
@@ -758,63 +821,10 @@ export default function VideoTimelineEditor() {
         showLibrary ? 'lg:grid-cols-[260px_1fr_240px]' : 'lg:grid-cols-[1fr_240px]'
       } gap-3 min-h-[400px]`}>
         {/* Left rail — library */}
-        {showLibrary && (
-          <div className="order-2 lg:order-1 bg-port-card/50 border border-port-border rounded-lg p-2 max-h-[600px] overflow-y-auto">
-            <div className="flex gap-1 mb-2" role="tablist" aria-label="Clip library">
-              {LIBRARY_TABS.map(({ id, label, Icon }) => (
-                <button
-                  key={id}
-                  type="button"
-                  role="tab"
-                  aria-selected={libraryTab === id}
-                  onClick={() => setLibraryTab(id)}
-                  className={`flex-1 flex items-center justify-center gap-1 px-1.5 py-1 text-[10px] rounded ${
-                    libraryTab === id
-                      ? 'bg-port-accent/20 text-port-accent'
-                      : 'text-gray-400 hover:text-white border border-port-border'
-                  }`}
-                >
-                  <Icon className="w-3 h-3" aria-hidden="true" /> {label}
-                </button>
-              ))}
-            </div>
-
-            {libraryTab === 'clips' && (libraryClips.length === 0 ? (
-              <div className="text-xs text-gray-500 px-1 py-4">No clips. Generate some on the Video page.</div>
-            ) : (
-              <div className="grid grid-cols-1 gap-2">
-                {libraryClips.map((clip) => (
-                  <div key={clip.id} className={usedClipIds.has(clip.id) ? 'ring-1 ring-port-accent/40 rounded-md' : ''}>
-                    <LibraryTile clip={clip} onAdd={addClip} />
-                  </div>
-                ))}
-              </div>
-            ))}
-
-            {libraryTab === 'stills' && (images.length === 0 ? (
-              <div className="text-xs text-gray-500 px-1 py-4">No images. Generate some on the Image page.</div>
-            ) : (
-              <div className="grid grid-cols-1 gap-2">
-                {images.map((image) => (
-                  <StillTile key={image.filename} image={image} onAddStill={addStill} onAddOverlay={addOverlay} />
-                ))}
-              </div>
-            ))}
-
-            {libraryTab === 'audio' && (musicTracks.length === 0 ? (
-              <div className="text-xs text-gray-500 px-1 py-4">No audio in the shared music library.</div>
-            ) : (
-              <div className="grid grid-cols-1 gap-1.5">
-                {musicTracks.map((track) => (
-                  <AudioRow key={track.filename} track={track} onAdd={addBed} />
-                ))}
-              </div>
-            ))}
-          </div>
-        )}
+        {showLibrary && isDesktop && libraryPanel}
 
         {/* Center — preview + tracks */}
-        <div className="order-1 lg:order-2 space-y-3 min-w-0">
+        <div className="space-y-3 min-w-0">
           {/* The preview adopts the CANONICAL render canvas, not a fixed 16:9
               box — overlay x/y/width are normalized against that canvas, so a
               portrait or square project would otherwise place them somewhere
@@ -988,8 +998,11 @@ export default function VideoTimelineEditor() {
           </div>
         </div>
 
+        {/* On mobile the library follows the workspace in both visual and focus order. */}
+        {showLibrary && !isDesktop && libraryPanel}
+
         {/* Right rail — inspector */}
-        <div className="order-3 bg-port-card/50 border border-port-border rounded-lg p-3 space-y-3">
+        <div className="bg-port-card/50 border border-port-border rounded-lg p-3 space-y-3">
           <div className="text-xs uppercase text-gray-500 tracking-wide">Inspector</div>
 
           {!selected && (

--- a/client/src/pages/VideoTimelineEditor.jsx
+++ b/client/src/pages/VideoTimelineEditor.jsx
@@ -109,7 +109,9 @@ export default function VideoTimelineEditor() {
   const [playing, setPlaying] = useState(false);
   const [muted, setMuted] = useState(false);
   const [renderJobId, setRenderJobId] = useState(null);
-  const [showLibrary, setShowLibrary] = useState(true);
+  const [showLibrary, setShowLibrary] = useState(() => (
+    typeof window === 'undefined' || window.innerWidth >= 1024
+  ));
   const [libraryTab, setLibraryTab] = useState('clips');
   // Local input draft. Editing the canonical state on every keystroke makes the
   // rename onBlur-vs-canonical comparison always-equal.
@@ -755,7 +757,7 @@ export default function VideoTimelineEditor() {
       <div className="grid grid-cols-1 lg:grid-cols-[260px_1fr_240px] gap-3 min-h-[400px]">
         {/* Left rail — library */}
         {showLibrary && (
-          <div className="bg-port-card/50 border border-port-border rounded-lg p-2 max-h-[600px] overflow-y-auto">
+          <div className="order-2 lg:order-1 bg-port-card/50 border border-port-border rounded-lg p-2 max-h-[600px] overflow-y-auto">
             <div className="flex gap-1 mb-2" role="tablist" aria-label="Clip library">
               {LIBRARY_TABS.map(({ id, label, Icon }) => (
                 <button
@@ -810,7 +812,7 @@ export default function VideoTimelineEditor() {
         )}
 
         {/* Center — preview + tracks */}
-        <div className="space-y-3 min-w-0">
+        <div className="order-1 lg:order-2 space-y-3 min-w-0">
           {/* The preview adopts the CANONICAL render canvas, not a fixed 16:9
               box — overlay x/y/width are normalized against that canvas, so a
               portrait or square project would otherwise place them somewhere
@@ -985,7 +987,7 @@ export default function VideoTimelineEditor() {
         </div>
 
         {/* Right rail — inspector */}
-        <div className="bg-port-card/50 border border-port-border rounded-lg p-3 space-y-3">
+        <div className="order-3 bg-port-card/50 border border-port-border rounded-lg p-3 space-y-3">
           <div className="text-xs uppercase text-gray-500 tracking-wide">Inspector</div>
 
           {!selected && (

--- a/client/src/pages/VideoTimelineEditor.jsx
+++ b/client/src/pages/VideoTimelineEditor.jsx
@@ -67,6 +67,10 @@ const LIBRARY_TABS = [
   { id: 'audio', label: 'Audio', Icon: Music },
 ];
 
+const desktopTimelineLayout = () => (
+  typeof window === 'undefined' || window.matchMedia('(min-width: 64rem)').matches
+);
+
 // One accessor per lane, so adding a lane doesn't mean a fourth branch in
 // every ternary chain that needs "the entries for this lane".
 const laneEntries = (lanes, lane) => {
@@ -109,22 +113,11 @@ export default function VideoTimelineEditor() {
   const [playing, setPlaying] = useState(false);
   const [muted, setMuted] = useState(false);
   const [renderJobId, setRenderJobId] = useState(null);
-  const [isDesktop, setIsDesktop] = useState(() => (
-    typeof window === 'undefined' || window.innerWidth >= 1024
-  ));
-  const [showLibrary, setShowLibrary] = useState(() => (
-    typeof window === 'undefined' || window.innerWidth >= 1024
-  ));
+  const [showLibrary, setShowLibrary] = useState(desktopTimelineLayout);
   const [libraryTab, setLibraryTab] = useState('clips');
   // Local input draft. Editing the canonical state on every keystroke makes the
   // rename onBlur-vs-canonical comparison always-equal.
   const [nameDraft, setNameDraft] = useState('');
-
-  useEffect(() => {
-    const updateLayout = () => setIsDesktop(window.innerWidth >= 1024);
-    window.addEventListener('resize', updateLayout);
-    return () => window.removeEventListener('resize', updateLayout);
-  }, []);
 
   const videoRef = useRef(null);
   const lastSrcRef = useRef('');
@@ -698,7 +691,10 @@ export default function VideoTimelineEditor() {
   const laneWidth = Math.max(240, total * pxPerSec);
   const playheadSec = Math.min(t, total);
   const libraryPanel = showLibrary ? (
-    <div className="bg-port-card/50 border border-port-border rounded-lg p-2 max-h-[600px] overflow-y-auto">
+    <div
+      id="timeline-library"
+      className="order-2 lg:order-1 bg-port-card/50 border border-port-border rounded-lg p-2 max-h-[600px] overflow-y-auto"
+    >
       <div className="flex gap-1 mb-2" role="tablist" aria-label="Clip library">
         {LIBRARY_TABS.map(({ id, label, Icon }) => (
           <button
@@ -801,6 +797,8 @@ export default function VideoTimelineEditor() {
           <button
             type="button"
             onClick={() => setShowLibrary((v) => !v)}
+            aria-expanded={showLibrary}
+            aria-controls="timeline-library"
             className="px-2 py-1.5 text-xs text-gray-400 hover:text-white border border-port-border rounded-md"
           >
             {showLibrary ? 'Hide library' : 'Show library'}
@@ -820,11 +818,8 @@ export default function VideoTimelineEditor() {
       <div className={`grid grid-cols-1 ${
         showLibrary ? 'lg:grid-cols-[260px_1fr_240px]' : 'lg:grid-cols-[1fr_240px]'
       } gap-3 min-h-[400px]`}>
-        {/* Left rail — library */}
-        {showLibrary && isDesktop && libraryPanel}
-
         {/* Center — preview + tracks */}
-        <div className="space-y-3 min-w-0">
+        <div className="order-1 lg:order-2 space-y-3 min-w-0">
           {/* The preview adopts the CANONICAL render canvas, not a fixed 16:9
               box — overlay x/y/width are normalized against that canvas, so a
               portrait or square project would otherwise place them somewhere
@@ -998,11 +993,12 @@ export default function VideoTimelineEditor() {
           </div>
         </div>
 
-        {/* On mobile the library follows the workspace in both visual and focus order. */}
-        {showLibrary && !isDesktop && libraryPanel}
+        {/* The library follows the workspace in DOM/focus order on mobile, then
+            moves into the desktop grid's left rail without remounting. */}
+        {libraryPanel}
 
         {/* Right rail — inspector */}
-        <div className="bg-port-card/50 border border-port-border rounded-lg p-3 space-y-3">
+        <div className="order-3 bg-port-card/50 border border-port-border rounded-lg p-3 space-y-3">
           <div className="text-xs uppercase text-gray-500 tracking-wide">Inspector</div>
 
           {!selected && (

--- a/client/src/pages/VideoTimelineEditor.jsx
+++ b/client/src/pages/VideoTimelineEditor.jsx
@@ -697,7 +697,7 @@ export default function VideoTimelineEditor() {
 
   const laneWidth = Math.max(240, total * pxPerSec);
   const playheadSec = Math.min(t, total);
-  const libraryPanel = (
+  const libraryPanel = showLibrary ? (
     <div className="bg-port-card/50 border border-port-border rounded-lg p-2 max-h-[600px] overflow-y-auto">
       <div className="flex gap-1 mb-2" role="tablist" aria-label="Clip library">
         {LIBRARY_TABS.map(({ id, label, Icon }) => (
@@ -750,7 +750,7 @@ export default function VideoTimelineEditor() {
         </div>
       ))}
     </div>
-  );
+  ) : null;
 
   return (
     <div className="space-y-3">

--- a/client/src/pages/VideoTimelineEditor.jsx
+++ b/client/src/pages/VideoTimelineEditor.jsx
@@ -754,7 +754,9 @@ export default function VideoTimelineEditor() {
         </div>
       </div>
 
-      <div className="grid grid-cols-1 lg:grid-cols-[260px_1fr_240px] gap-3 min-h-[400px]">
+      <div className={`grid grid-cols-1 ${
+        showLibrary ? 'lg:grid-cols-[260px_1fr_240px]' : 'lg:grid-cols-[1fr_240px]'
+      } gap-3 min-h-[400px]`}>
         {/* Left rail — library */}
         {showLibrary && (
           <div className="order-2 lg:order-1 bg-port-card/50 border border-port-border rounded-lg p-2 max-h-[600px] overflow-y-auto">

--- a/client/src/pages/VideoTimelineEditor.test.jsx
+++ b/client/src/pages/VideoTimelineEditor.test.jsx
@@ -161,21 +161,27 @@ describe('workspace layout — mobile library regression (#5424)', () => {
     const workspace = screen.getByRole('button', { name: 'Play' }).parentElement?.parentElement;
     const inspector = screen.getByText('Inspector').parentElement;
     expect(screen.queryByRole('tablist', { name: 'Clip library' })).not.toBeInTheDocument();
-    expect(workspace).toHaveClass('order-1', 'lg:order-2');
-    expect(inspector).toHaveClass('order-3');
     expect(workspace?.parentElement).toHaveClass('lg:grid-cols-[1fr_240px]');
+    expect(workspace?.compareDocumentPosition(inspector) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
 
     fireEvent.click(showLibrary);
 
     const library = screen.getByRole('tablist', { name: 'Clip library' }).parentElement;
     expect(screen.getByRole('button', { name: 'Hide library' })).toBeInTheDocument();
-    expect(library).toHaveClass('order-2', 'lg:order-1');
     expect(workspace?.parentElement).toHaveClass('lg:grid-cols-[260px_1fr_240px]');
+    expect(workspace?.compareDocumentPosition(library) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
 
     fireEvent.click(screen.getByRole('button', { name: 'Add to timeline' }));
     await waitFor(() => expect(
       screen.getByRole('button', { name: 'Remove A dramatic sunrise from timeline' }),
     ).toBeInTheDocument());
+
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: 1024 });
+    fireEvent(window, new Event('resize'));
+    await waitFor(() => {
+      const desktopLibrary = screen.getByRole('tablist', { name: 'Clip library' }).parentElement;
+      expect(desktopLibrary?.compareDocumentPosition(workspace) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    });
   });
 
   it('keeps the desktop library visible in the original left-rail order', async () => {
@@ -184,9 +190,8 @@ describe('workspace layout — mobile library regression (#5424)', () => {
     const library = screen.getByRole('tablist', { name: 'Clip library' }).parentElement;
     const workspace = screen.getByRole('button', { name: 'Play' }).parentElement?.parentElement;
     expect(screen.getByRole('button', { name: 'Hide library' })).toBeInTheDocument();
-    expect(library).toHaveClass('order-2', 'lg:order-1');
-    expect(workspace).toHaveClass('order-1', 'lg:order-2');
     expect(workspace?.parentElement).toHaveClass('lg:grid-cols-[260px_1fr_240px]');
+    expect(library?.compareDocumentPosition(workspace) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
 
     fireEvent.click(screen.getByRole('button', { name: 'Hide library' }));
     expect(workspace?.parentElement).toHaveClass('lg:grid-cols-[1fr_240px]');

--- a/client/src/pages/VideoTimelineEditor.test.jsx
+++ b/client/src/pages/VideoTimelineEditor.test.jsx
@@ -163,12 +163,14 @@ describe('workspace layout — mobile library regression (#5424)', () => {
     expect(screen.queryByRole('tablist', { name: 'Clip library' })).not.toBeInTheDocument();
     expect(workspace).toHaveClass('order-1', 'lg:order-2');
     expect(inspector).toHaveClass('order-3');
+    expect(workspace?.parentElement).toHaveClass('lg:grid-cols-[1fr_240px]');
 
     fireEvent.click(showLibrary);
 
     const library = screen.getByRole('tablist', { name: 'Clip library' }).parentElement;
     expect(screen.getByRole('button', { name: 'Hide library' })).toBeInTheDocument();
     expect(library).toHaveClass('order-2', 'lg:order-1');
+    expect(workspace?.parentElement).toHaveClass('lg:grid-cols-[260px_1fr_240px]');
 
     fireEvent.click(screen.getByRole('button', { name: 'Add to timeline' }));
     await waitFor(() => expect(
@@ -184,6 +186,10 @@ describe('workspace layout — mobile library regression (#5424)', () => {
     expect(screen.getByRole('button', { name: 'Hide library' })).toBeInTheDocument();
     expect(library).toHaveClass('order-2', 'lg:order-1');
     expect(workspace).toHaveClass('order-1', 'lg:order-2');
+    expect(workspace?.parentElement).toHaveClass('lg:grid-cols-[260px_1fr_240px]');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Hide library' }));
+    expect(workspace?.parentElement).toHaveClass('lg:grid-cols-[1fr_240px]');
   });
 });
 

--- a/client/src/pages/VideoTimelineEditor.test.jsx
+++ b/client/src/pages/VideoTimelineEditor.test.jsx
@@ -66,6 +66,7 @@ const overlayEntry = { type: 'image', assetKind: 'images', assetFile: 'logo.png'
 const bedEntry = { assetKind: 'music', assetFile: 'bed.mp3', startSec: 0, offsetSec: 0, durationSec: 4, volume: 1, fadeInSec: 0, fadeOutSec: 0 };
 
 beforeEach(() => {
+  Object.defineProperty(window, 'innerWidth', { configurable: true, value: 1024 });
   toastError.mockClear();
   api.project = project();
   api.history = [{ id: CLIP_A, prompt: 'A dramatic sunrise', filename: 'a.mp4', thumbnail: 'a.jpg', width: 1920, height: 1080, fps: 24, numFrames: 96 }];
@@ -148,6 +149,41 @@ describe('header layout — mobile overflow regression (#5425)', () => {
     await renderEditor();
     const summarySpan = screen.getByText(/1 segments · 1 overlays · 1 beds/);
     expect(summarySpan).toHaveClass('hidden', 'sm:inline');
+  });
+});
+
+describe('workspace layout — mobile library regression (#5424)', () => {
+  it('starts with the library hidden and keeps the workspace before it when opened', async () => {
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: 375 });
+    await renderEditor();
+
+    const showLibrary = screen.getByRole('button', { name: 'Show library' });
+    const workspace = screen.getByRole('button', { name: 'Play' }).parentElement?.parentElement;
+    const inspector = screen.getByText('Inspector').parentElement;
+    expect(screen.queryByRole('tablist', { name: 'Clip library' })).not.toBeInTheDocument();
+    expect(workspace).toHaveClass('order-1', 'lg:order-2');
+    expect(inspector).toHaveClass('order-3');
+
+    fireEvent.click(showLibrary);
+
+    const library = screen.getByRole('tablist', { name: 'Clip library' }).parentElement;
+    expect(screen.getByRole('button', { name: 'Hide library' })).toBeInTheDocument();
+    expect(library).toHaveClass('order-2', 'lg:order-1');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add to timeline' }));
+    await waitFor(() => expect(
+      screen.getByRole('button', { name: 'Remove A dramatic sunrise from timeline' }),
+    ).toBeInTheDocument());
+  });
+
+  it('keeps the desktop library visible in the original left-rail order', async () => {
+    await renderEditor();
+
+    const library = screen.getByRole('tablist', { name: 'Clip library' }).parentElement;
+    const workspace = screen.getByRole('button', { name: 'Play' }).parentElement?.parentElement;
+    expect(screen.getByRole('button', { name: 'Hide library' })).toBeInTheDocument();
+    expect(library).toHaveClass('order-2', 'lg:order-1');
+    expect(workspace).toHaveClass('order-1', 'lg:order-2');
   });
 });
 

--- a/client/src/pages/VideoTimelineEditor.test.jsx
+++ b/client/src/pages/VideoTimelineEditor.test.jsx
@@ -67,6 +67,12 @@ const bedEntry = { assetKind: 'music', assetFile: 'bed.mp3', startSec: 0, offset
 
 beforeEach(() => {
   Object.defineProperty(window, 'innerWidth', { configurable: true, value: 1024 });
+  window.matchMedia = vi.fn((query) => ({
+    matches: query === '(min-width: 64rem)' && window.innerWidth >= 1024,
+    media: query,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  }));
   toastError.mockClear();
   api.project = project();
   api.history = [{ id: CLIP_A, prompt: 'A dramatic sunrise', filename: 'a.mp4', thumbnail: 'a.jpg', width: 1920, height: 1080, fps: 24, numFrames: 96 }];
@@ -161,14 +167,20 @@ describe('workspace layout — mobile library regression (#5424)', () => {
     const workspace = screen.getByRole('button', { name: 'Play' }).parentElement?.parentElement;
     const inspector = screen.getByText('Inspector').parentElement;
     expect(screen.queryByRole('tablist', { name: 'Clip library' })).not.toBeInTheDocument();
+    expect(showLibrary).toHaveAttribute('aria-expanded', 'false');
+    expect(showLibrary).toHaveAttribute('aria-controls', 'timeline-library');
     expect(workspace?.parentElement).toHaveClass('lg:grid-cols-[1fr_240px]');
+    expect(workspace).toHaveClass('order-1', 'lg:order-2');
     expect(workspace?.compareDocumentPosition(inspector) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
 
     fireEvent.click(showLibrary);
 
     const library = screen.getByRole('tablist', { name: 'Clip library' }).parentElement;
     expect(screen.getByRole('button', { name: 'Hide library' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Hide library' })).toHaveAttribute('aria-expanded', 'true');
     expect(workspace?.parentElement).toHaveClass('lg:grid-cols-[260px_1fr_240px]');
+    expect(library).toHaveAttribute('id', 'timeline-library');
+    expect(library).toHaveClass('order-2', 'lg:order-1');
     expect(workspace?.compareDocumentPosition(library) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
 
     fireEvent.click(screen.getByRole('button', { name: 'Add to timeline' }));
@@ -176,22 +188,22 @@ describe('workspace layout — mobile library regression (#5424)', () => {
       screen.getByRole('button', { name: 'Remove A dramatic sunrise from timeline' }),
     ).toBeInTheDocument());
 
+    const mountedLibrary = library;
     Object.defineProperty(window, 'innerWidth', { configurable: true, value: 1024 });
     fireEvent(window, new Event('resize'));
-    await waitFor(() => {
-      const desktopLibrary = screen.getByRole('tablist', { name: 'Clip library' }).parentElement;
-      expect(desktopLibrary?.compareDocumentPosition(workspace) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
-    });
+    expect(screen.getByRole('tablist', { name: 'Clip library' }).parentElement).toBe(mountedLibrary);
   });
 
-  it('keeps the desktop library visible in the original left-rail order', async () => {
+  it('keeps the desktop library visible in the original left-rail grid position', async () => {
     await renderEditor();
 
     const library = screen.getByRole('tablist', { name: 'Clip library' }).parentElement;
     const workspace = screen.getByRole('button', { name: 'Play' }).parentElement?.parentElement;
     expect(screen.getByRole('button', { name: 'Hide library' })).toBeInTheDocument();
     expect(workspace?.parentElement).toHaveClass('lg:grid-cols-[260px_1fr_240px]');
-    expect(library?.compareDocumentPosition(workspace) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(workspace).toHaveClass('order-1', 'lg:order-2');
+    expect(library).toHaveClass('order-2', 'lg:order-1');
+    expect(workspace?.compareDocumentPosition(library) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
 
     fireEvent.click(screen.getByRole('button', { name: 'Hide library' }));
     expect(workspace?.parentElement).toHaveClass('lg:grid-cols-[1fr_240px]');


### PR DESCRIPTION
## Summary
- hide the timeline library by default below the Tailwind `lg` breakpoint
- keep the preview and timeline first in mobile DOM and visual order while preserving the desktop left rail
- preserve the mounted library across breakpoint changes and expose toggle state to assistive technology
- keep the desktop grid valid when the library is hidden

## Test plan
- `npm run test:ci:related -- src/pages/VideoTimelineEditor.jsx src/pages/VideoTimelineEditor.test.jsx`
- `npx biome lint --error-on-warnings src/pages/VideoTimelineEditor.jsx src/pages/VideoTimelineEditor.test.jsx`
- `npm run build`

Closes #5424