### PR TITLE
perf: page Brain inbox from projection index

### DIFF
--- a/server/lib/socketEventCatalog.generated.json
+++ b/server/lib/socketEventCatalog.generated.json
@@ -676,7 +676,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/backup.js",
-          "line": 331
+          "line": 332
         }
       ]
     },
@@ -689,7 +689,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/backup.js",
-          "line": 292
+          "line": 293
         }
       ]
     },
@@ -707,7 +707,7 @@
         {
           "direction": "server-to-client",
           "source": "server/services/backup.js",
-          "line": 298
+          "line": 299
         }
       ]
     },

--- a/server/services/backup.js
+++ b/server/services/backup.js
@@ -674,8 +674,11 @@ export async function restoreSnapshot(destPath, snapshotId, { dryRun = true, sub
     // A live restore writes outside normal service mutation paths. Re-sync the
     // caches whose backing files may have changed instead of serving the
     // pre-restore projection until each record is next mutated or the process
-    // restarts. A selective restore can target only one top-level directory.
-    if (!subdirFilter || subdirFilter === 'brain') invalidateBrainCaches();
+    // restarts. Selective restores may target either `brain` itself or a nested
+    // path such as `brain/inbox`.
+    if (!subdirFilter || subdirFilter === 'brain' || subdirFilter.startsWith('brain/')) {
+      invalidateBrainCaches();
+    }
     await reloadSettings();
   }
   return { dryRun, snapshotId, subdirFilter, changedFiles };

--- a/server/services/backup.js
+++ b/server/services/backup.js
@@ -22,6 +22,7 @@ import { emitErrorEvent, ServerError } from '../lib/errorHandler.js';
 import { isSafeSubdirFilter } from '../lib/sharedSchemas.js';
 import { getIo } from './socket.js';
 import { reloadSettings } from './settings.js';
+import { invalidateAllCaches as invalidateBrainCaches } from './brainStorage.js';
 
 // Module-level state
 let isRunning = false;
@@ -669,10 +670,14 @@ export async function restoreSnapshot(destPath, snapshotId, { dryRun = true, sub
   }
 
   const changedFiles = await runRsync(srcDir, PATHS.data, flags);
-  // A live restore rsyncs settings.json into place outside the save() path, so
-  // getSettings()'s read-cache (and other settings:updated-driven caches) would
-  // keep serving pre-restore values until the next save/restart. Re-sync them.
-  if (!dryRun) await reloadSettings();
+  if (!dryRun) {
+    // A live restore writes outside normal service mutation paths. Re-sync the
+    // caches whose backing files may have changed instead of serving the
+    // pre-restore projection until each record is next mutated or the process
+    // restarts. A selective restore can target only one top-level directory.
+    if (!subdirFilter || subdirFilter === 'brain') invalidateBrainCaches();
+    await reloadSettings();
+  }
   return { dryRun, snapshotId, subdirFilter, changedFiles };
 }
 

--- a/server/services/backup.test.js
+++ b/server/services/backup.test.js
@@ -1308,8 +1308,8 @@ describe('restoreSnapshot snapshotId, filter flags, and settings re-sync', () =>
       expect(spawn.mock.calls[0][1]).not.toContain('--dry-run');
     });
 
-    it('invalidates Brain projections after a selective live Brain restore', async () => {
-      await runRestore('/dest', 'snap-1', { dryRun: false, subdirFilter: 'brain' });
+    it('invalidates Brain projections after a nested selective live Brain restore', async () => {
+      await runRestore('/dest', 'snap-1', { dryRun: false, subdirFilter: 'brain/inbox' });
 
       expect(invalidateBrainCaches).toHaveBeenCalledTimes(1);
     });

--- a/server/services/backup.test.js
+++ b/server/services/backup.test.js
@@ -90,7 +90,12 @@ vi.mock('./settings.js', async (importOriginal) => ({
   ...(await importOriginal()),
   reloadSettings: vi.fn(async () => {}),
 }));
+vi.mock('./brainStorage.js', async (importOriginal) => ({
+  ...(await importOriginal()),
+  invalidateAllCaches: vi.fn(),
+}));
 import { reloadSettings } from './settings.js';
+import { invalidateAllCaches as invalidateBrainCaches } from './brainStorage.js';
 import { DEFAULT_EXCLUDES, computeEffectiveExcludes, listSnapshots, openSnapshotStream, restoreSnapshot } from './backup.js';
 
 // fs.access is mocked file-wide because backup.js probes the .in-progress marker
@@ -1218,6 +1223,7 @@ describe('restoreSnapshot snapshotId, filter flags, and settings re-sync', () =>
   beforeEach(() => {
     spawn.mockReset();
     reloadSettings.mockClear();
+    invalidateBrainCaches.mockClear();
   });
 
   // Drive a mocked rsync to a clean exit so restoreSnapshot resolves.
@@ -1297,14 +1303,28 @@ describe('restoreSnapshot snapshotId, filter flags, and settings re-sync', () =>
       await runRestore('/dest', 'snap-1', { dryRun: false });
 
       expect(reloadSettings).toHaveBeenCalledTimes(1);
+      expect(invalidateBrainCaches).toHaveBeenCalledTimes(1);
       // A live restore must not pass --dry-run to rsync.
       expect(spawn.mock.calls[0][1]).not.toContain('--dry-run');
+    });
+
+    it('invalidates Brain projections after a selective live Brain restore', async () => {
+      await runRestore('/dest', 'snap-1', { dryRun: false, subdirFilter: 'brain' });
+
+      expect(invalidateBrainCaches).toHaveBeenCalledTimes(1);
+    });
+
+    it('keeps Brain projections after a selective live restore outside Brain', async () => {
+      await runRestore('/dest', 'snap-1', { dryRun: false, subdirFilter: 'images' });
+
+      expect(invalidateBrainCaches).not.toHaveBeenCalled();
     });
 
     it('does not reload settings for a dry run', async () => {
       await runRestore('/dest', 'snap-1', { dryRun: true });
 
       expect(reloadSettings).not.toHaveBeenCalled();
+      expect(invalidateBrainCaches).not.toHaveBeenCalled();
       expect(spawn.mock.calls[0][1]).toContain('--dry-run');
     });
 

--- a/server/services/brainStorage.js
+++ b/server/services/brainStorage.js
@@ -802,15 +802,17 @@ async function appendJsonl(type, record) {
  */
 export async function getInboxLog(options = {}) {
   const { status, limit = 50, offset = 0 } = options;
-  let records = await getAll('inbox');
+  const rows = await resolveRecordIndex(summaryIndex, 'inbox', 0);
+  const matching = rows.filter(([, summary]) => summary && (!status || summary.status === status));
 
-  records = records.sort((a, b) => new Date(b.capturedAt) - new Date(a.capturedAt));
+  // Bulk captures can share one timestamp. The id tiebreak keeps adjacent
+  // offset pages stable so an entry is never duplicated or skipped.
+  matching.sort(([idA, a], [idB, b]) => (b.capturedAtMs - a.capturedAtMs) || idA.localeCompare(idB));
 
-  if (status) {
-    records = records.filter(r => r.status === status);
-  }
-
-  return records.slice(offset, offset + limit);
+  const pageIds = matching.slice(offset, offset + limit).map(([id]) => id);
+  const page = await Promise.all(pageIds.map((id) => getById('inbox', id)));
+  // A record deleted between resolving the index and loading its body is null.
+  return page.filter(Boolean);
 }
 
 /**
@@ -852,10 +854,9 @@ export async function deleteInboxLog(id) {
  */
 export async function getInboxLogCounts() {
   const rows = await resolveRecordIndex(summaryIndex, 'inbox', 0);
-  const records = rows.map(([, summary]) => summary).filter(Boolean);
 
   const counts = {
-    total: records.length,
+    total: 0,
     classifying: 0,
     filed: 0,
     needs_review: 0,
@@ -864,9 +865,11 @@ export async function getInboxLogCounts() {
     error: 0
   };
 
-  for (const record of records) {
-    if (counts[record.status] !== undefined) {
-      counts[record.status]++;
+  for (const [, summary] of rows) {
+    if (!summary) continue;
+    counts.total++;
+    if (counts[summary.status] !== undefined) {
+      counts[summary.status]++;
     }
   }
 
@@ -1067,7 +1070,11 @@ const linkSummaryIndex = createRecordIndex(projectLinkSummary);
 // lets their frequent count reads reuse the same per-record invalidation
 // machinery without parsing full record bodies in steady state.
 const projectSummary = (record) => (record && !isTombstone(record)
-  ? { status: record.status, isGitHubRepo: record.isGitHubRepo }
+  ? {
+    status: record.status,
+    isGitHubRepo: record.isGitHubRepo,
+    capturedAtMs: safeDate(record.capturedAt),
+  }
   : null);
 const summaryIndex = createRecordIndex(projectSummary);
 

--- a/server/services/brainStorage.test.js
+++ b/server/services/brainStorage.test.js
@@ -690,11 +690,18 @@ describe('getInboxLog (paginated inbox reads, issue #5440)', () => {
 
     const tieIds = [tieA.id, tieB.id].sort();
     const expected = [newest.id, ...tieIds, oldest.id, missing.id];
-    const pageOne = await brainStorage.getInboxLog({ limit: 2, offset: 0 });
-    const pageTwo = await brainStorage.getInboxLog({ limit: 3, offset: 2 });
-    expect([...pageOne, ...pageTwo].map(({ id }) => id)).toEqual(expected);
-    expect(new Set([...pageOne, ...pageTwo].map(({ id }) => id)).size).toBe(expected.length);
-    expect((await brainStorage.getInboxLog({ status: 'needs_review' })).map(({ id }) => id))
+    const seededIds = new Set(expected);
+    const all = await brainStorage.getInboxLog({ limit: 100 });
+    expect(all.filter(({ id }) => seededIds.has(id)).map(({ id }) => id)).toEqual(expected);
+
+    const split = Math.ceil(all.length / 2);
+    const pageOne = await brainStorage.getInboxLog({ limit: split, offset: 0 });
+    const pageTwo = await brainStorage.getInboxLog({ limit: 100, offset: split });
+    const pagedIds = [...pageOne, ...pageTwo].map(({ id }) => id);
+    expect(pagedIds).toEqual(all.map(({ id }) => id));
+    expect(new Set(pagedIds).size).toBe(all.length);
+    expect((await brainStorage.getInboxLog({ status: 'needs_review' }))
+      .filter(({ id }) => seededIds.has(id)).map(({ id }) => id))
       .toEqual([...tieIds, missing.id]);
   });
 

--- a/server/services/brainStorage.test.js
+++ b/server/services/brainStorage.test.js
@@ -664,6 +664,74 @@ describe('getLinksPage (paginated link reads, issue #3509)', () => {
   });
 });
 
+describe('getInboxLog (paginated inbox reads, issue #5440)', () => {
+  const stampCapturedAt = async (id, capturedAt) => {
+    const record = { ...(await rawRecord('inbox', id)) };
+    if (capturedAt === undefined) delete record.capturedAt;
+    else record.capturedAt = capturedAt;
+    await writeRawRecord('inbox', id, record);
+    brainStorage.invalidateAllCaches();
+  };
+
+  it('orders and filters deterministically, excluding tombstones and putting missing dates last', async () => {
+    const oldest = await brainStorage.createInboxLog({ capturedText: 'oldest', status: 'done' });
+    const tieA = await brainStorage.createInboxLog({ capturedText: 'tie-a', status: 'needs_review' });
+    const tieB = await brainStorage.createInboxLog({ capturedText: 'tie-b', status: 'needs_review' });
+    const newest = await brainStorage.createInboxLog({ capturedText: 'newest', status: 'filed' });
+    const missing = await brainStorage.createInboxLog({ capturedText: 'missing', status: 'needs_review' });
+    const removed = await brainStorage.createInboxLog({ capturedText: 'removed', status: 'needs_review' });
+
+    await stampCapturedAt(oldest.id, ISO('2098-01-01'));
+    await stampCapturedAt(tieA.id, ISO('2098-02-01'));
+    await stampCapturedAt(tieB.id, ISO('2098-02-01'));
+    await stampCapturedAt(newest.id, ISO('2098-03-01'));
+    await stampCapturedAt(missing.id, undefined);
+    await brainStorage.deleteInboxLog(removed.id);
+
+    const tieIds = [tieA.id, tieB.id].sort();
+    const expected = [newest.id, ...tieIds, oldest.id, missing.id];
+    const pageOne = await brainStorage.getInboxLog({ limit: 2, offset: 0 });
+    const pageTwo = await brainStorage.getInboxLog({ limit: 3, offset: 2 });
+    expect([...pageOne, ...pageTwo].map(({ id }) => id)).toEqual(expected);
+    expect(new Set([...pageOne, ...pageTwo].map(({ id }) => id)).size).toBe(expected.length);
+    expect((await brainStorage.getInboxLog({ status: 'needs_review' })).map(({ id }) => id))
+      .toEqual([...tieIds, missing.id]);
+  });
+
+  it('reads only the requested page bodies once the summary index is warm', async () => {
+    for (let i = 0; i < 8; i++) {
+      await brainStorage.createInboxLog({ capturedText: `page-${i}`, status: 'needs_review' });
+    }
+    await brainStorage.getInboxLog({ status: 'needs_review', limit: 1 });
+
+    readJSONFile.mockClear();
+    const page = await brainStorage.getInboxLog({ status: 'needs_review', limit: 1 });
+
+    expect(page).toHaveLength(1);
+    await brainStorage.getInboxLogCounts();
+    expect(readJSONFile).toHaveBeenCalledTimes(1);
+  });
+
+  it('invalidates the projection after status updates and deletes', async () => {
+    const moved = await brainStorage.createInboxLog({ capturedText: 'move me', status: 'needs_review' });
+    const removed = await brainStorage.createInboxLog({ capturedText: 'delete me', status: 'needs_review' });
+    await brainStorage.getInboxLog({ status: 'needs_review' });
+    const before = await brainStorage.getInboxLogCounts();
+
+    await brainStorage.updateInboxLog(moved.id, { status: 'done' });
+    await brainStorage.deleteInboxLog(removed.id);
+
+    expect((await brainStorage.getInboxLog({ status: 'needs_review' })).map(({ id }) => id))
+      .not.toEqual(expect.arrayContaining([moved.id, removed.id]));
+    expect((await brainStorage.getInboxLog({ status: 'done' })).map(({ id }) => id)).toContain(moved.id);
+    expect(await brainStorage.getInboxLogCounts()).toMatchObject({
+      total: before.total - 1,
+      needs_review: before.needs_review - 2,
+      done: before.done + 1,
+    });
+  });
+});
+
 // Overwrite a record's stored JSON directly, bypassing every brainStorage write
 // path (and therefore every brainEvents signal). Used to prove the live-id index
 // is answering from memory rather than re-reading the file.


### PR DESCRIPTION
## Summary
- page Brain inbox records from the shared summary projection instead of parsing every record body
- preserve deterministic timestamp ordering, status filtering, counts, and the existing array API
- invalidate Brain projections after live backup restores so restored records cannot leave stale cached pages

## Test plan
- `cd server && nvm exec 22 npm test` (1,768 files passed; 36,176 tests passed; 1 file and 23 tests skipped)
- required Codex branch review: clean
- optional Claude review: inconclusive after bounded silent run

Closes #5440