### PR TITLE
fix: keep auth status unknown on load failure (#5479)

### DIFF
--- a/client/src/components/settings/SecurityTab.jsx
+++ b/client/src/components/settings/SecurityTab.jsx
@@ -1,6 +1,7 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { Lock, ShieldCheck, ShieldOff } from 'lucide-react';
 import toast from '../ui/Toast';
+import Banner from '../ui/Banner';
 import FormField from '../ui/FormField';
 import BrailleSpinner from '../BrailleSpinner';
 import { getAuthStatus, setAuthPassword, clearAuthPassword } from '../../services/api';
@@ -12,7 +13,8 @@ import { getAuthStatus, setAuthPassword, clearAuthPassword } from '../../service
 // session cookie obtained by /api/auth/login.
 export function SecurityTab() {
   const [loading, setLoading] = useState(true);
-  const [enabled, setEnabled] = useState(false);
+  const [enabled, setEnabled] = useState(null);
+  const [loadError, setLoadError] = useState(false);
   const [currentPassword, setCurrentPassword] = useState('');
   const [newPassword, setNewPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
@@ -21,12 +23,25 @@ export function SecurityTab() {
   const [disablePassword, setDisablePassword] = useState('');
   const [disabling, setDisabling] = useState(false);
 
-  useEffect(() => {
+  const loadAuthStatus = useCallback(() => {
+    setLoading(true);
+    setLoadError(false);
+    setEnabled(null);
     getAuthStatus({ silent: true })
-      .then((s) => setEnabled(!!s?.enabled))
-      .catch(() => null)
+      .then((status) => {
+        if (typeof status?.enabled !== 'boolean') {
+          setLoadError(true);
+          return;
+        }
+        setEnabled(status.enabled);
+      })
+      .catch(() => setLoadError(true))
       .finally(() => setLoading(false));
   }, []);
+
+  useEffect(() => {
+    loadAuthStatus();
+  }, [loadAuthStatus]);
 
   const handleSubmit = async (event) => {
     event.preventDefault();
@@ -83,6 +98,28 @@ export function SecurityTab() {
       <div className="flex items-center justify-center py-16">
         <BrailleSpinner text="Loading" />
       </div>
+    );
+  }
+
+  if (loadError || enabled === null) {
+    return (
+      <Banner
+        tone="error"
+        size="md"
+        title="Authentication status unknown"
+        role="alert"
+        actions={
+          <button
+            type="button"
+            onClick={loadAuthStatus}
+            className="min-h-11 px-4 py-2 text-sm font-medium bg-port-error/20 hover:bg-port-error/30 text-port-error rounded transition-colors"
+          >
+            Retry
+          </button>
+        }
+      >
+        PortOS could not confirm whether login protection is enabled. Retry before changing security settings.
+      </Banner>
     );
   }
 

--- a/client/src/components/settings/SecurityTab.jsx
+++ b/client/src/components/settings/SecurityTab.jsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { Lock, ShieldCheck, ShieldOff } from 'lucide-react';
 import toast from '../ui/Toast';
 import Banner from '../ui/Banner';
@@ -22,21 +22,28 @@ export function SecurityTab() {
   const [showDisable, setShowDisable] = useState(false);
   const [disablePassword, setDisablePassword] = useState('');
   const [disabling, setDisabling] = useState(false);
+  const statusRequestRef = useRef(0);
 
   const loadAuthStatus = useCallback(() => {
+    const requestId = ++statusRequestRef.current;
     setLoading(true);
     setLoadError(false);
     setEnabled(null);
     getAuthStatus({ silent: true })
       .then((status) => {
+        if (requestId !== statusRequestRef.current) return;
         if (typeof status?.enabled !== 'boolean') {
           setLoadError(true);
           return;
         }
         setEnabled(status.enabled);
       })
-      .catch(() => setLoadError(true))
-      .finally(() => setLoading(false));
+      .catch(() => {
+        if (requestId === statusRequestRef.current) setLoadError(true);
+      })
+      .finally(() => {
+        if (requestId === statusRequestRef.current) setLoading(false);
+      });
   }, []);
 
   useEffect(() => {

--- a/client/src/components/settings/SecurityTab.test.jsx
+++ b/client/src/components/settings/SecurityTab.test.jsx
@@ -1,5 +1,6 @@
+import { StrictMode } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { SecurityTab } from './SecurityTab';
 import * as api from '../../services/api';
 
@@ -15,6 +16,16 @@ vi.mock('../ui/Toast', () => ({
     error: vi.fn(),
   },
 }));
+
+const deferred = () => {
+  let resolve;
+  let reject;
+  const promise = new Promise((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+};
 
 describe('SecurityTab', () => {
   beforeEach(() => {
@@ -85,5 +96,26 @@ describe('SecurityTab', () => {
     expect(screen.getByText('Change password')).toBeInTheDocument();
     expect(screen.queryByRole('alert')).not.toBeInTheDocument();
     await waitFor(() => expect(api.getAuthStatus).toHaveBeenCalledTimes(2));
+  });
+
+  it('ignores an obsolete failure when a newer StrictMode request succeeds', async () => {
+    const firstRequest = deferred();
+    const secondRequest = deferred();
+    api.getAuthStatus
+      .mockReturnValueOnce(firstRequest.promise)
+      .mockReturnValueOnce(secondRequest.promise);
+
+    render(
+      <StrictMode>
+        <SecurityTab />
+      </StrictMode>,
+    );
+
+    await waitFor(() => expect(api.getAuthStatus).toHaveBeenCalledTimes(2));
+    await act(async () => firstRequest.reject(new Error('Server unavailable')));
+    await act(async () => secondRequest.resolve({ enabled: true }));
+
+    expect(await screen.findByText('Login password enabled')).toBeInTheDocument();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
   });
 });

--- a/client/src/components/settings/SecurityTab.test.jsx
+++ b/client/src/components/settings/SecurityTab.test.jsx
@@ -1,0 +1,89 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { SecurityTab } from './SecurityTab';
+import * as api from '../../services/api';
+
+vi.mock('../../services/api', () => ({
+  getAuthStatus: vi.fn(),
+  setAuthPassword: vi.fn(),
+  clearAuthPassword: vi.fn(),
+}));
+
+vi.mock('../ui/Toast', () => ({
+  default: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+describe('SecurityTab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders the enabled password controls after a valid status response', async () => {
+    api.getAuthStatus.mockResolvedValue({ enabled: true });
+
+    render(<SecurityTab />);
+
+    expect(await screen.findByText('Login password enabled')).toBeInTheDocument();
+    expect(screen.getByText('Change password')).toBeInTheDocument();
+    expect(screen.getByLabelText('Current password')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Disable login' })).toBeInTheDocument();
+    expect(screen.queryByText('Set a password')).not.toBeInTheDocument();
+    expect(api.getAuthStatus).toHaveBeenCalledWith({ silent: true });
+  });
+
+  it('renders the disabled password controls after a valid status response', async () => {
+    api.getAuthStatus.mockResolvedValue({ enabled: false });
+
+    render(<SecurityTab />);
+
+    expect(await screen.findByText('Login password disabled')).toBeInTheDocument();
+    expect(screen.getByText('Set a password')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Enable login' })).toBeInTheDocument();
+    expect(screen.queryByLabelText('Current password')).not.toBeInTheDocument();
+  });
+
+  it('keeps both password flows hidden when the status request rejects', async () => {
+    api.getAuthStatus.mockRejectedValue(new Error('Server unavailable'));
+
+    render(<SecurityTab />);
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Authentication status unknown');
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
+    expect(screen.queryByText('Login password disabled')).not.toBeInTheDocument();
+    expect(screen.queryByText('Set a password')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Enable login' })).not.toBeInTheDocument();
+  });
+
+  it('treats a malformed success payload as an unknown status', async () => {
+    api.getAuthStatus.mockResolvedValue({ enabled: 'false' });
+
+    render(<SecurityTab />);
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Authentication status unknown');
+    expect(screen.queryByText('Login password disabled')).not.toBeInTheDocument();
+    expect(screen.queryByText('Set a password')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Enable login' })).not.toBeInTheDocument();
+  });
+
+  it('retries a failed status load and restores the matching controls', async () => {
+    api.getAuthStatus
+      .mockRejectedValueOnce(new Error('Server unavailable'))
+      .mockResolvedValueOnce({ enabled: true });
+
+    render(<SecurityTab />);
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Retry' }));
+
+    expect(await screen.findByText('Login password enabled')).toBeInTheDocument();
+    expect(screen.getByText('Change password')).toBeInTheDocument();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    await waitFor(() => expect(api.getAuthStatus).toHaveBeenCalledTimes(2));
+  });
+});


### PR DESCRIPTION
## Summary
- keep authentication status unknown until a validated boolean response arrives
- hide password mutation forms on load failure and provide an inline Retry action
- ignore stale status responses so StrictMode overlap cannot mask a newer success
- cover valid states, malformed and rejected responses, retry, and request ordering

## Tests
- `cd client && npm test -- src/components/settings/SecurityTab.test.jsx`
- `cd client && npm run lint`
- `cd client && npm run build`

Closes #5479