### PR TITLE
fix: colocate provider effort with default model

### DIFF
--- a/client/src/pages/AIProviders.jsx
+++ b/client/src/pages/AIProviders.jsx
@@ -1502,6 +1502,17 @@ function ProviderForm({ provider, onClose, onSave, onEditProvider, allProviders 
                 </p>
               </FormField>
 
+              <EffortSelect
+                provider={isProcessProvider(capabilityProvider) ? capabilityProvider : null}
+                model={formData.defaultModel}
+                value={formData.effort}
+                onChange={(effort) => setFormData(prev => ({ ...prev, effort }))}
+                label="Default Effort"
+                hint={generationControls
+                  ? 'Reasoning effort used when a run does not specify one — passed to the local model as reasoningEffort.'
+                  : 'Reasoning effort used when a run does not specify one.'}
+              />
+
               {/* Model Tiers */}
               <div className="border-t border-port-border pt-4 mt-4">
                 <h4 className="text-sm font-medium text-gray-300 mb-3">Model Tiers</h4>
@@ -1645,17 +1656,6 @@ function ProviderForm({ provider, onClose, onSave, onEditProvider, allProviders 
 
           {activeTab === 'generation' && (
             <div className="space-y-4">
-              <EffortSelect
-                provider={isProcessProvider(capabilityProvider) ? capabilityProvider : null}
-                model={formData.defaultModel}
-                value={formData.effort}
-                onChange={(effort) => setFormData(prev => ({ ...prev, effort }))}
-                label="Default Effort"
-                hint={generationControls
-                  ? 'Reasoning effort used when a run does not specify one — passed to the local model as reasoningEffort.'
-                  : 'Reasoning effort used when a run does not specify one.'}
-              />
-
               <FormField label="Timeout (ms)">
                 <input
                   type="number"

--- a/client/src/pages/AIProviders.test.jsx
+++ b/client/src/pages/AIProviders.test.jsx
@@ -651,7 +651,7 @@ describe('provider reasoning defaults', () => {
     renderPage();
 
     fireEvent.click(await screen.findByRole('button', { name: 'Edit' }));
-    await openEditorTab('Generation');
+    await openEditorTab('Models');
 
     const effort = await screen.findByLabelText('Default Effort');
     expect(effort).toHaveValue('');
@@ -690,11 +690,12 @@ describe('provider reasoning defaults', () => {
     renderPage();
 
     fireEvent.click(await screen.findByRole('button', { name: 'Edit' }));
-    await openEditorTab('Generation');
+    await openEditorTab('Models');
 
     const effort = await screen.findByLabelText('Default Effort');
     fireEvent.change(effort, { target: { value: 'high' } });
 
+    await openEditorTab('Generation');
     const thinking = screen.getByLabelText('Thinking mode');
     expect(thinking).toHaveValue('true');
     fireEvent.change(thinking, { target: { value: 'false' } });
@@ -731,9 +732,10 @@ describe('provider reasoning defaults', () => {
     renderPage();
 
     fireEvent.click(await screen.findByRole('button', { name: 'Edit' }));
-    await openEditorTab('Generation');
+    await openEditorTab('Models');
 
     fireEvent.change(await screen.findByLabelText('Default Effort'), { target: { value: 'high' } });
+    await openEditorTab('Generation');
     fireEvent.change(screen.getByLabelText('Temperature'), { target: { value: '0.2' } });
     fireEvent.change(screen.getByLabelText('Top-P'), { target: { value: '0.9' } });
     expect(screen.getByLabelText('Thinking mode')).toHaveValue('true');


### PR DESCRIPTION
## Summary

- Place the existing provider default effort selector beside Default Model in the Models tab.
- Preserve the existing effort persistence and runtime behavior while updating cross-tab coverage.

## Test plan

- npm test --prefix client
- npm run build --prefix client
- npx biome lint --error-on-warnings src/pages/AIProviders.jsx src/pages/AIProviders.test.jsx (from client/)