### PR TITLE
fix: refresh socket event catalog

### DIFF
--- a/server/lib/socketEventCatalog.generated.json
+++ b/server/lib/socketEventCatalog.generated.json
@@ -2261,7 +2261,7 @@
         {
           "direction": "server-to-client",
           "source": "client/src/components/fableloom/LoomPlayPanel.jsx",
-          "line": 114
+          "line": 125
         }
       ]
     },
@@ -2300,7 +2300,7 @@
         {
           "direction": "server-to-client",
           "source": "client/src/components/fableloom/LoomPlayPanel.jsx",
-          "line": 145
+          "line": 156
         }
       ]
     },
@@ -2339,7 +2339,7 @@
         {
           "direction": "server-to-client",
           "source": "client/src/components/fableloom/LoomPlayPanel.jsx",
-          "line": 137
+          "line": 148
         }
       ]
     },
@@ -2365,7 +2365,7 @@
         {
           "direction": "server-to-client",
           "source": "client/src/components/fableloom/LoomPlayPanel.jsx",
-          "line": 118
+          "line": 129
         }
       ]
     },
@@ -2396,7 +2396,7 @@
         {
           "direction": "server-to-client",
           "source": "client/src/components/fableloom/LoomPlayPanel.jsx",
-          "line": 122
+          "line": 133
         }
       ]
     },
@@ -2409,7 +2409,7 @@
         {
           "direction": "server-to-client",
           "source": "client/src/components/fableloom/LoomPlayPanel.jsx",
-          "line": 126
+          "line": 137
         }
       ]
     },


### PR DESCRIPTION
## Summary

- regenerate the checked-in Socket.IO event catalog after the cinematic-player merge shifted listener line numbers
- restore the generated-file guard on current `main`
- unblock server CI for PRs branched from that merge

## Testing

- `npm test --prefix server -- --run ../scripts/generate-socket-event-catalog.test.js` (4 passed)