### PR TITLE
fix: select affirmative TUI trust choice

### DIFF
--- a/server/lib/tuiHandshake.js
+++ b/server/lib/tuiHandshake.js
@@ -288,6 +288,24 @@ export const BRACKETED_PASTE_MODE_PATTERN = /\x1b\[\?2004([hl])/g;
 export const TUI_TRUST_PROMPT_PATTERN =
   /trustthisfolder|isthisaprojectyou(?:created|trust)|doyoutrustthecontentsofthis(?:directory|project|folder)/i;
 
+// Trust selectors have changed ordering across Claude Code releases. Older
+// builds (and Codex/agy) highlight the affirmative choice first, while newer
+// Claude Code builds can render "No, exit" first and highlight it. Consumers must
+// wait until the choices themselves have painted, then move off a highlighted
+// decline choice instead of assuming a bare Enter always accepts the folder.
+// These patterns run against createInputReadyTracker's whitespace-free tail.
+const TUI_TRUST_ACCEPT_OPTION_PATTERN = /(?:yes,?itrustthisfolder|yes,?continue)/i;
+const TUI_TRUST_DECLINE_OPTION_PATTERN = /no,?(?:exit|quit)/i;
+const TUI_HIGHLIGHT_PATTERN_PREFIX = String.raw`(?:❯|›|>)\d*\.?`;
+const TUI_TRUST_HIGHLIGHTED_ACCEPT_PATTERN = new RegExp(
+  `${TUI_HIGHLIGHT_PATTERN_PREFIX}(?:yes,?itrustthisfolder|yes,?continue)`,
+  'i',
+);
+const TUI_TRUST_HIGHLIGHTED_DECLINE_PATTERN = new RegExp(
+  `${TUI_HIGHLIGHT_PATTERN_PREFIX}no,?(?:exit|quit)`,
+  'i',
+);
+
 // Claude Code's auto-mode opt-in offer ("Make auto mode your default permission
 // mode? → 1. Yes, set auto mode as my default permission mode / 2. No, keep
 // don't ask"), added in v2.1.233. Like the trust gate it is NOT bypassed by
@@ -367,6 +385,8 @@ export function createInputReadyTracker({ readyTextPattern = null, directLaunch 
   // launches, where the TUI owns the PTY from byte zero and no shell OFF exists.
   let sawCommandRun = directLaunch;
   let needsTrust = false;
+  let trustChoiceReady = false;
+  let trustNeedsSelectionAdvance = false;
   let sawReadyText = false;
   // Auto-mode offer: latched when seen, cleared once answered. `autoModeAnswered`
   // makes the ack TERMINAL — `tail` is a rolling 4000-char window, so the modal's
@@ -407,6 +427,8 @@ export function createInputReadyTracker({ readyTextPattern = null, directLaunch 
         && (!readyTextPattern || sawReadyText);
     },
     get needsTrust() { return needsTrust; },
+    get trustChoiceReady() { return trustChoiceReady; },
+    get trustNeedsSelectionAdvance() { return trustNeedsSelectionAdvance; },
     get needsAutoModeChoice() { return needsAutoModeChoice; },
     get needsExternalImportsChoice() { return needsExternalImportsChoice; },
     get needsHookReview() { return needsHookReview; },
@@ -435,6 +457,23 @@ export function createInputReadyTracker({ readyTextPattern = null, directLaunch 
       if (strippedText) {
         tail = (tail + strippedText.replace(/\s+/g, '')).slice(-OBSERVE_TAIL_MAX_LEN);
         if (!needsTrust && TUI_TRUST_PROMPT_PATTERN.test(tail)) needsTrust = true;
+        if (needsTrust && !trustChoiceReady) {
+          const acceptMatch = TUI_TRUST_ACCEPT_OPTION_PATTERN.exec(tail);
+          const declineMatch = TUI_TRUST_DECLINE_OPTION_PATTERN.exec(tail);
+          if (acceptMatch) {
+            trustChoiceReady = true;
+            if (TUI_TRUST_HIGHLIGHTED_DECLINE_PATTERN.test(tail)) {
+              trustNeedsSelectionAdvance = true;
+            } else if (TUI_TRUST_HIGHLIGHTED_ACCEPT_PATTERN.test(tail)) {
+              trustNeedsSelectionAdvance = false;
+            } else if (declineMatch) {
+              // Ink highlights the first rendered option when its cursor glyph
+              // is unavailable in a captured transcript. Use ordering only as
+              // that fallback; explicit highlight chrome wins above.
+              trustNeedsSelectionAdvance = declineMatch.index < acceptMatch.index;
+            }
+          }
+        }
         if (!needsAutoModeChoice && !autoModeAnswered && TUI_AUTO_MODE_PROMPT_PATTERN.test(tail)) needsAutoModeChoice = true;
         if (!needsExternalImportsChoice && !externalImportsAnswered && TUI_EXTERNAL_IMPORTS_PROMPT_PATTERN.test(tail)) {
           needsExternalImportsChoice = true;

--- a/server/lib/tuiHandshake.js
+++ b/server/lib/tuiHandshake.js
@@ -385,8 +385,9 @@ export function createInputReadyTracker({ readyTextPattern = null, directLaunch 
   // launches, where the TUI owns the PTY from byte zero and no shell OFF exists.
   let sawCommandRun = directLaunch;
   let needsTrust = false;
+  let trustAnswered = false;
   let trustChoiceReady = false;
-  let trustNeedsSelectionAdvance = false;
+  let trustSelectionKey = '';
   let sawReadyText = false;
   // Auto-mode offer: latched when seen, cleared once answered. `autoModeAnswered`
   // makes the ack TERMINAL — `tail` is a rolling 4000-char window, so the modal's
@@ -422,16 +423,18 @@ export function createInputReadyTracker({ readyTextPattern = null, directLaunch 
     // modal is still swallowing input. Cleared by ackAutoModeChoice() once the
     // spawner has answered it.
     get ready() {
-      return sawCommandRun && pasteModeOn && !needsAutoModeChoice
+      return sawCommandRun && pasteModeOn && !needsTrust && !needsAutoModeChoice
         && !needsExternalImportsChoice && !needsHookReview
         && (!readyTextPattern || sawReadyText);
     },
     get needsTrust() { return needsTrust; },
     get trustChoiceReady() { return trustChoiceReady; },
-    get trustNeedsSelectionAdvance() { return trustNeedsSelectionAdvance; },
+    get trustSelectionKey() { return trustSelectionKey; },
     get needsAutoModeChoice() { return needsAutoModeChoice; },
     get needsExternalImportsChoice() { return needsExternalImportsChoice; },
     get needsHookReview() { return needsHookReview; },
+    /** Spawner selected the affirmative trust choice. */
+    ackTrustChoice() { needsTrust = false; trustAnswered = true; },
     /** Spawner reports the dismissal keystrokes went out; re-arms `ready`. */
     ackAutoModeChoice() { needsAutoModeChoice = false; autoModeAnswered = true; },
     /** Spawner selected Claude's "No, disable external imports" option. */
@@ -456,21 +459,21 @@ export function createInputReadyTracker({ readyTextPattern = null, directLaunch 
       }
       if (strippedText) {
         tail = (tail + strippedText.replace(/\s+/g, '')).slice(-OBSERVE_TAIL_MAX_LEN);
-        if (!needsTrust && TUI_TRUST_PROMPT_PATTERN.test(tail)) needsTrust = true;
+        if (!needsTrust && !trustAnswered && TUI_TRUST_PROMPT_PATTERN.test(tail)) needsTrust = true;
         if (needsTrust && !trustChoiceReady) {
           const acceptMatch = TUI_TRUST_ACCEPT_OPTION_PATTERN.exec(tail);
           const declineMatch = TUI_TRUST_DECLINE_OPTION_PATTERN.exec(tail);
           if (acceptMatch) {
             trustChoiceReady = true;
             if (TUI_TRUST_HIGHLIGHTED_DECLINE_PATTERN.test(tail)) {
-              trustNeedsSelectionAdvance = true;
+              trustSelectionKey = declineMatch && declineMatch.index < acceptMatch.index ? '\x1b[B' : '\x1b[A';
             } else if (TUI_TRUST_HIGHLIGHTED_ACCEPT_PATTERN.test(tail)) {
-              trustNeedsSelectionAdvance = false;
+              trustSelectionKey = '';
             } else if (declineMatch) {
               // Ink highlights the first rendered option when its cursor glyph
               // is unavailable in a captured transcript. Use ordering only as
               // that fallback; explicit highlight chrome wins above.
-              trustNeedsSelectionAdvance = declineMatch.index < acceptMatch.index;
+              trustSelectionKey = declineMatch.index < acceptMatch.index ? '\x1b[B' : '';
             }
           }
         }

--- a/server/lib/tuiHandshake.test.js
+++ b/server/lib/tuiHandshake.test.js
@@ -1031,12 +1031,15 @@ describe('createInputReadyTracker', () => {
 
   it('latches needsTrust on every vendor trust-gate wording', () => {
     const claude = createInputReadyTracker();
-    claude.observe('', 'Is this a project you trust?');
+    claude.observe('', 'Is this a project you trust?\n❯ 1. Yes, I trust this folder\n2. No, exit\n');
     expect(claude.needsTrust).toBe(true);
+    expect(claude.trustChoiceReady).toBe(true);
+    expect(claude.trustNeedsSelectionAdvance).toBe(false);
 
     const agy = createInputReadyTracker();
     agy.observe('', 'Do you trust the contents of this project?\n> Yes, I trust this folder\n');
     expect(agy.needsTrust).toBe(true);
+    expect(agy.trustChoiceReady).toBe(true);
 
     // Codex says "directory", and its options are "Yes, continue / No, quit" —
     // neither of the two older alternatives appears anywhere in the dialog, so it
@@ -1046,6 +1049,20 @@ describe('createInputReadyTracker', () => {
       + ' Working with untrusted contents comes with higher risk of prompt injection.\n'
       + '› 1. Yes, continue\n2. No, quit\nPress enter to continue\n');
     expect(codex.needsTrust).toBe(true);
+    expect(codex.trustChoiceReady).toBe(true);
+    expect(codex.trustNeedsSelectionAdvance).toBe(false);
+  });
+
+  it('detects when Claude highlights the decline choice before trust acceptance', () => {
+    const tracker = createInputReadyTracker({ directLaunch: true });
+    tracker.observe('', 'Quick safety check: Is this a project you created or one you trust?\n'
+      + '❯ No, exit\n'
+      + '  Yes, I trust this folder\n'
+      + 'Enter to confirm · Esc to cancel\n');
+
+    expect(tracker.needsTrust).toBe(true);
+    expect(tracker.trustChoiceReady).toBe(true);
+    expect(tracker.trustNeedsSelectionAdvance).toBe(true);
   });
 
   // Claude Code v2.1.233's auto-mode offer. Unlike the trust gate it paints with

--- a/server/lib/tuiHandshake.test.js
+++ b/server/lib/tuiHandshake.test.js
@@ -1034,7 +1034,7 @@ describe('createInputReadyTracker', () => {
     claude.observe('', 'Is this a project you trust?\n❯ 1. Yes, I trust this folder\n2. No, exit\n');
     expect(claude.needsTrust).toBe(true);
     expect(claude.trustChoiceReady).toBe(true);
-    expect(claude.trustNeedsSelectionAdvance).toBe(false);
+    expect(claude.trustSelectionKey).toBe('');
 
     const agy = createInputReadyTracker();
     agy.observe('', 'Do you trust the contents of this project?\n> Yes, I trust this folder\n');
@@ -1050,7 +1050,7 @@ describe('createInputReadyTracker', () => {
       + '› 1. Yes, continue\n2. No, quit\nPress enter to continue\n');
     expect(codex.needsTrust).toBe(true);
     expect(codex.trustChoiceReady).toBe(true);
-    expect(codex.trustNeedsSelectionAdvance).toBe(false);
+    expect(codex.trustSelectionKey).toBe('');
   });
 
   it('detects when Claude highlights the decline choice before trust acceptance', () => {
@@ -1062,7 +1062,37 @@ describe('createInputReadyTracker', () => {
 
     expect(tracker.needsTrust).toBe(true);
     expect(tracker.trustChoiceReady).toBe(true);
-    expect(tracker.trustNeedsSelectionAdvance).toBe(true);
+    expect(tracker.trustSelectionKey).toBe('\x1b[B');
+  });
+
+  it('uses option ordering when trust-choice highlight chrome is absent', () => {
+    const declineFirst = createInputReadyTracker();
+    declineFirst.observe('', 'Is this a project you trust?\nNo, exit\nYes, I trust this folder\n');
+    expect(declineFirst.trustChoiceReady).toBe(true);
+    expect(declineFirst.trustSelectionKey).toBe('\x1b[B');
+
+    const acceptFirst = createInputReadyTracker();
+    acceptFirst.observe('', 'Is this a project you trust?\nYes, I trust this folder\nNo, exit\n');
+    expect(acceptFirst.trustChoiceReady).toBe(true);
+    expect(acceptFirst.trustSelectionKey).toBe('');
+  });
+
+  it('moves upward when the highlighted decline choice follows the accept choice', () => {
+    const tracker = createInputReadyTracker();
+    tracker.observe('', 'Is this a project you trust?\nYes, I trust this folder\n❯ No, exit\n');
+    expect(tracker.trustSelectionKey).toBe('\x1b[A');
+  });
+
+  it('suppresses readiness until the trust choice is identified and acknowledged', () => {
+    const tracker = createInputReadyTracker({ directLaunch: true });
+    tracker.observe(PASTE_ON, 'Is this a project you trust?');
+    expect(tracker.needsTrust).toBe(true);
+    expect(tracker.trustChoiceReady).toBe(false);
+    expect(tracker.ready).toBe(false);
+
+    tracker.observe('', 'Yes, I trust this folder\nNo, exit\n');
+    tracker.ackTrustChoice();
+    expect(tracker.ready).toBe(true);
   });
 
   // Claude Code v2.1.233's auto-mode offer. Unlike the trust gate it paints with
@@ -1184,6 +1214,7 @@ describe('createInputReadyTracker', () => {
     tracker.observe('', 'Do you trust the contents of this project?\n> Yes, I trust this folder\n');
     expect(tracker.needsTrust).toBe(true);
     expect(tracker.ready).toBe(false); // still not ready while the trust menu is up
+    tracker.ackTrustChoice();
 
     tracker.observe('', '>\n? for shortcutsGemini 3.6 Flash · medium');
     expect(tracker.ready).toBe(true);

--- a/server/services/agentTuiSpawning.js
+++ b/server/services/agentTuiSpawning.js
@@ -1477,9 +1477,11 @@ export async function spawnTuiAgent({
       return;
     }
 
-    // Auto-confirm the first-run "trust this folder?" gate (claude's, agy's and
-    // codex's all default to yes) so agents can run in fresh worktrees. Send
-    // Enter once.
+    // Auto-confirm the first-run "trust this folder?" gate so agents can run in
+    // fresh worktrees. Wait for the choices themselves to paint: Claude Code
+    // releases disagree about their ordering, and newer builds can highlight
+    // "No, exit" by default. Move to the affirmative option when necessary,
+    // then submit it once.
     //
     // Like the hook-review selector this runs for EVERY TUI, not only the
     // positive input-ready providers below: codex takes the idle/deadline path,
@@ -1488,9 +1490,10 @@ export async function spawnTuiAgent({
     // the menu — which swallows it and all three paste retries
     // (agent-671af38f, 2026-08-21, `paste-not-rendered`). Answering the dialog
     // first is what lets the composer appear at all.
-    if (inputReady.needsTrust && !trustAccepted) {
+    if (inputReady.needsTrust && inputReady.trustChoiceReady && !trustAccepted) {
       trustAccepted = true;
-      shellService.writeToSession(sessionId, SUBMIT_KEY);
+      const trustInput = `${inputReady.trustNeedsSelectionAdvance ? '\x1b[B' : ''}${SUBMIT_KEY}`;
+      shellService.writeToSession(sessionId, trustInput);
       lastOutputAt = now;
       firstOutputAt = null;
       appendLine(`📟 Auto-confirmed ${tuiConfig.command} folder-trust prompt for session ${sessionId.slice(0, 8)}`);

--- a/server/services/agentTuiSpawning.js
+++ b/server/services/agentTuiSpawning.js
@@ -1492,11 +1492,29 @@ export async function spawnTuiAgent({
     // first is what lets the composer appear at all.
     if (inputReady.needsTrust && inputReady.trustChoiceReady && !trustAccepted) {
       trustAccepted = true;
-      const trustInput = `${inputReady.trustNeedsSelectionAdvance ? '\x1b[B' : ''}${SUBMIT_KEY}`;
+      const trustInput = `${inputReady.trustSelectionKey}${SUBMIT_KEY}`;
       shellService.writeToSession(sessionId, trustInput);
+      inputReady.ackTrustChoice();
       lastOutputAt = now;
       firstOutputAt = null;
       appendLine(`📟 Auto-confirmed ${tuiConfig.command} folder-trust prompt for session ${sessionId.slice(0, 8)}`);
+      return;
+    }
+
+    // A recognized trust heading with unknown choices is not an input prompt.
+    // Never fall through to either positive-readiness or idle delivery and paste
+    // the task into it. Fail explicitly at the provider's normal readiness cap
+    // so a future wording change is diagnosable without accepting an unknown
+    // highlighted default (which may be "No, exit").
+    if (inputReady.needsTrust && !inputReady.trustChoiceReady) {
+      const trustDeadlineMs = requireInputReady ? TUI_INPUT_READY_DEADLINE_MS : PASTE_DEADLINE_MS;
+      if (elapsed >= trustDeadlineMs) {
+        clearInterval(promptTimer);
+        safeFinishStartupFailure(
+          'tui-trust-choice-unrecognized',
+          `${tuiConfig.command} presented a folder-trust prompt whose affirmative choice PortOS could not identify, so no prompt was sent.`,
+        );
+      }
       return;
     }
 

--- a/server/services/agentTuiSpawning.test.js
+++ b/server/services/agentTuiSpawning.test.js
@@ -1084,6 +1084,25 @@ describe('spawnTuiAgent runtime', () => {
     expect(pasteCount()).toBe(1);
   });
 
+  it('claude trust gate: moves from a highlighted No choice before confirming', async () => {
+    runSpawn({ tuiConfig: claudeTuiConfig, useDurableRunner: true });
+    await flushMicrotasks();
+
+    await capturedOnData(Buffer.from(
+      'Quick safety check: Is this a project you created or one you trust?\n'
+      + '❯ No, exit\n'
+      + '  Yes, I trust this folder\n'
+      + 'Enter to confirm · Esc to cancel\n',
+    ));
+    await flushMicrotasks();
+    await vi.advanceTimersByTimeAsync(400);
+    await flushMicrotasks();
+
+    expect(vi.mocked(shellService.writeToSession).mock.calls.map(([, data]) => data))
+      .toContain('\x1b[B\r');
+    expect(pasteCount()).toBe(0);
+  });
+
   // Claude Code v2.1.233's auto-mode offer. The trust gate above paints BEFORE
   // the composer; this one paints after, with paste mode already on — so the old
   // gate said "ready" and the prompt went into a modal that ignored it. All four

--- a/server/services/tuiPromptRunner.js
+++ b/server/services/tuiPromptRunner.js
@@ -877,11 +877,13 @@ ${prompt}`;
       // ones: codex takes the idle/deadline path below, and its trust dialog
       // paints and then goes silent — which that path reads as "ready" and
       // pastes into, losing the prompt and every retry with it (agent-671af38f).
-      // Enter takes the highlighted default (claude/agy "Yes, I trust", codex
-      // "Yes, continue"); `trustAccepted` keeps it to one keystroke.
-      if (inputReady.needsTrust && !trustAccepted) {
+      // Wait for the options to paint before acting. Claude Code versions do
+      // not agree on their order: when "No, exit" is highlighted, select the
+      // next option before submitting. `trustAccepted` keeps this to one input.
+      if (inputReady.needsTrust && inputReady.trustChoiceReady && !trustAccepted) {
         trustAccepted = true;
-        dismissStartupDialog('\r', 'folder-trust prompt');
+        const trustInput = `${inputReady.trustNeedsSelectionAdvance ? '\x1b[B' : ''}${SUBMIT_KEY}`;
+        dismissStartupDialog(trustInput, 'folder-trust prompt');
         lastOutputAt = now;
         firstOutputAt = null;
         return;

--- a/server/services/tuiPromptRunner.js
+++ b/server/services/tuiPromptRunner.js
@@ -350,10 +350,8 @@ ${prompt}`;
   // retain their existing idle/deadline behavior.
   const inputReady = createInputReadyTracker({ directLaunch: true });
   const requiresInputReady = isClaudeCommand(command);
-  // needsTrust has no self-clearing latch in the tracker, so this flag is
-  // load-bearing to avoid re-sending Enter on every poll tick. needsAutoModeChoice
-  // doesn't need a matching flag below — ackAutoModeChoice() latches it false
-  // permanently on the tracker itself (see autoModeAnswered in tuiHandshake.js).
+  // Keep local one-shot flags alongside the tracker's terminal acknowledgements
+  // so a failed/delayed PTY write cannot cause repeated selector navigation.
   let trustAccepted = false;
   let hookReviewDeclined = false;
 
@@ -882,10 +880,24 @@ ${prompt}`;
       // next option before submitting. `trustAccepted` keeps this to one input.
       if (inputReady.needsTrust && inputReady.trustChoiceReady && !trustAccepted) {
         trustAccepted = true;
-        const trustInput = `${inputReady.trustNeedsSelectionAdvance ? '\x1b[B' : ''}${SUBMIT_KEY}`;
-        dismissStartupDialog(trustInput, 'folder-trust prompt');
+        const trustInput = `${inputReady.trustSelectionKey}${SUBMIT_KEY}`;
+        if (dismissStartupDialog(trustInput, 'folder-trust prompt')) inputReady.ackTrustChoice();
         lastOutputAt = now;
         firstOutputAt = null;
+        return;
+      }
+      if (inputReady.needsTrust && !inputReady.trustChoiceReady) {
+        const trustDeadlineMs = requiresInputReady ? TUI_INPUT_READY_DEADLINE_MS : PASTE_DEADLINE_MS;
+        if (elapsed >= trustDeadlineMs) {
+          clearInterval(readyTimer);
+          readyTimer = null;
+          finish({
+            success: false,
+            exitCode: 1,
+            error: `${command} presented a folder-trust prompt whose affirmative choice PortOS could not identify, so no prompt was sent.`,
+            reason: 'tui-trust-choice-unrecognized',
+          });
+        }
         return;
       }
       if (requiresInputReady) {

--- a/server/services/tuiPromptRunner.test.js
+++ b/server/services/tuiPromptRunner.test.js
@@ -617,6 +617,31 @@ describe('executeTuiRun', () => {
       await promise;
     });
 
+    it('moves off Claude\'s highlighted decline choice before accepting trust', async () => {
+      vi.useFakeTimers({
+        toFake: ['setTimeout', 'clearTimeout', 'setInterval', 'clearInterval', 'Date'],
+      });
+      const provider = { id: 'claude', type: 'tui', command: 'claude', tuiPromptDelayMs: 50 };
+      const promise = executeTuiRun({
+        runId: 'run-claude-decline-default', provider, prompt: 'return one structured response',
+        workspacePath: TEST_WORKSPACE, timeout: 60000,
+      });
+      await flushAsync();
+
+      const pty = ptyInstances[0];
+      pty.emitData('Quick safety check: Is this a project you created or one you trust?\n'
+        + '❯ No, exit\n'
+        + '  Yes, I trust this folder\n'
+        + 'Enter to confirm · Esc to cancel\n');
+      await vi.advanceTimersByTimeAsync(400);
+
+      expect(pty.write).toHaveBeenCalledWith('\x1b[B\r');
+      expect(pty.write).not.toHaveBeenCalledWith(expect.stringContaining('\x1b[200~'));
+
+      pty.emitExit({ exitCode: 0 });
+      await promise;
+    });
+
     it('declines Claude auto-mode and pastes only after dismissing the offer', async () => {
       vi.useFakeTimers({
         toFake: ['setTimeout', 'clearTimeout', 'setInterval', 'clearInterval', 'Date'],


### PR DESCRIPTION
## Summary
- Detect trust-selector choice ordering before submitting unattended TUI sessions.
- Select the affirmative choice even when Claude highlights the decline option first.
- Fail closed when a future trust-choice label is not recognized instead of pasting into the dialog.

## Test plan
- `cd server && npx vitest run lib/tuiHandshake.test.js services/agentTuiSpawning.test.js services/tuiPromptRunner.test.js`
- `cd server && npm test -- --bail=1 --silent=passed-only`