### PR TITLE
fix: establish notification list response contract

### DIFF
--- a/client/src/hooks/useNotifications.test.jsx
+++ b/client/src/hooks/useNotifications.test.jsx
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+
+const api = vi.hoisted(() => ({
+  getNotifications: vi.fn(),
+  getNotificationCount: vi.fn(),
+  markNotificationRead: vi.fn(),
+  markAllNotificationsRead: vi.fn(),
+  deleteNotification: vi.fn(),
+  clearNotifications: vi.fn()
+}));
+
+const socket = vi.hoisted(() => ({
+  emit: vi.fn(),
+  on: vi.fn(),
+  off: vi.fn()
+}));
+
+vi.mock('../services/api', () => api);
+vi.mock('./useSocket', () => ({ useSocket: () => socket }));
+
+import NotificationDropdown from '../components/NotificationDropdown.jsx';
+import { useNotifications } from './useNotifications.js';
+
+const NOTIFICATION = {
+  id: 'n1',
+  type: 'agent_warning',
+  title: 'Example notification',
+  description: 'A notification returned by the list endpoint.',
+  priority: 'medium',
+  read: false,
+  timestamp: '2025-01-01T00:00:00.000Z'
+};
+
+function NotificationSurface() {
+  const state = useNotifications();
+
+  return (
+    <>
+      <output data-testid="notification-loading">{String(state.loading)}</output>
+      <NotificationDropdown
+        notifications={state.notifications}
+        unreadCount={state.unreadCount}
+        onMarkAsRead={state.markAsRead}
+        onMarkAllAsRead={state.markAllAsRead}
+        onRemove={state.removeNotification}
+        onClearAll={state.clearAll}
+      />
+    </>
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  api.getNotifications.mockResolvedValue([NOTIFICATION]);
+  api.getNotificationCount.mockResolvedValue({ count: 1 });
+});
+
+describe('useNotifications response contract', () => {
+  it('keeps the bare list response renderable by NotificationDropdown', async () => {
+    render(
+      <MemoryRouter>
+        <NotificationSurface />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('notification-loading')).toHaveTextContent('false');
+    });
+
+    expect(api.getNotifications).toHaveBeenCalledWith({ limit: 50 });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Notifications (1 unread)' }));
+
+    expect(screen.getByRole('button', { name: 'View notification: Example notification' })).toBeInTheDocument();
+  });
+});

--- a/docs/API.md
+++ b/docs/API.md
@@ -507,6 +507,27 @@ backward-compatible historical snapshot/introspection endpoints.
 | DELETE | `/notifications/:id` | Delete notification |
 | DELETE | `/notifications` | Clear all notifications |
 
+`GET /notifications` returns a bare JSON array of notification objects, newest
+first. It accepts the optional query parameters `type`, `unreadOnly=true`, and
+`limit`; the filters are applied before the result is returned. It does not
+return an `{ items, total }` envelope.
+
+```json
+[
+  {
+    "id": "notification-id",
+    "type": "agent_warning",
+    "title": "Example notification",
+    "description": "Example description",
+    "priority": "medium",
+    "timestamp": "2025-01-01T00:00:00.000Z",
+    "link": "/example",
+    "read": false,
+    "metadata": {}
+  }
+]
+```
+
 ### Media (Audio/Video Capture)
 
 | Method | Endpoint | Description |

--- a/server/routes/notifications.test.js
+++ b/server/routes/notifications.test.js
@@ -97,14 +97,20 @@ describe('notifications routes', () => {
       expect(res.body.map(({ id }) => id)).toEqual(['n4', 'n3', 'n2', 'n1']);
     });
 
-    it('applies type, unreadOnly, and limit filters through the real service', async () => {
+    it('applies type and unreadOnly filters through the real service', async () => {
+      const type = notifications.NOTIFICATION_TYPES.MEMORY_APPROVAL;
+      const res = await request(buildApp()).get(`/api/notifications?type=${type}&unreadOnly=true`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.map(({ id }) => id)).toEqual(['n4', 'n1']);
+    });
+
+    it('applies limit after the type and unreadOnly filters', async () => {
       const type = notifications.NOTIFICATION_TYPES.MEMORY_APPROVAL;
       const res = await request(buildApp()).get(`/api/notifications?type=${type}&unreadOnly=true&limit=1`);
 
       expect(res.status).toBe(200);
-      expect(res.body).toEqual([
-        expect.objectContaining({ id: 'n4', type, read: false })
-      ]);
+      expect(res.body.map(({ id }) => id)).toEqual(['n4']);
     });
   });
 

--- a/server/routes/notifications.test.js
+++ b/server/routes/notifications.test.js
@@ -3,22 +3,76 @@ import express from 'express';
 import { request } from '../lib/testHelper.js';
 import { errorMiddleware } from '../lib/errorHandler.js';
 
-vi.mock('../services/notifications.js', () => ({
-  getNotifications: vi.fn(),
+const fileUtils = vi.hoisted(() => ({
+  ensureDir: vi.fn().mockResolvedValue(),
+  readJSONFile: vi.fn(),
+  atomicWrite: vi.fn().mockResolvedValue()
+}));
+
+const notificationMocks = vi.hoisted(() => ({
   getUnreadCount: vi.fn(),
   getCountsByType: vi.fn(),
   markAsRead: vi.fn(),
   markAllAsRead: vi.fn(),
   removeNotification: vi.fn(),
-  clearAll: vi.fn(),
-  NOTIFICATION_TYPES: {
-    MEMORY_APPROVAL: 'memory_approval',
-    TASK_APPROVAL: 'task_approval'
-  }
+  clearAll: vi.fn()
+}));
+
+vi.mock('../lib/fileUtils.js', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    PATHS: { ...actual.PATHS, data: '/mock/data' },
+    ensureDir: fileUtils.ensureDir,
+    readJSONFile: fileUtils.readJSONFile,
+    atomicWrite: fileUtils.atomicWrite
+  };
+});
+
+// Keep the route's mutation/count endpoints isolated, but retain the real list
+// service so this boundary test cannot document a response shape the service
+// does not return.
+vi.mock('../services/notifications.js', async (importOriginal) => ({
+  ...(await importOriginal()),
+  ...notificationMocks
 }));
 
 import * as notifications from '../services/notifications.js';
 import notificationsRoutes from './notifications.js';
+
+const NOTIFICATION_FIXTURE = {
+  version: 1,
+  notifications: [
+    {
+      id: 'n1',
+      type: 'memory_approval',
+      title: 'Memory review',
+      read: false,
+      timestamp: '2025-01-01T00:00:00.000Z'
+    },
+    {
+      id: 'n2',
+      type: 'memory_approval',
+      title: 'Older memory review',
+      read: true,
+      timestamp: '2025-01-02T00:00:00.000Z'
+    },
+    {
+      id: 'n3',
+      type: 'task_approval',
+      title: 'Task review',
+      read: false,
+      timestamp: '2025-01-03T00:00:00.000Z'
+    },
+    {
+      id: 'n4',
+      type: 'memory_approval',
+      title: 'Newest memory review',
+      read: false,
+      timestamp: '2025-01-04T00:00:00.000Z'
+    }
+  ]
+};
 
 const buildApp = () => {
   const app = express();
@@ -31,30 +85,26 @@ const buildApp = () => {
 describe('notifications routes', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    fileUtils.readJSONFile.mockResolvedValue(JSON.parse(JSON.stringify(NOTIFICATION_FIXTURE)));
+    notifications.invalidateCache();
   });
 
   describe('GET /api/notifications', () => {
-    it('returns the notifications list with default options', async () => {
-      notifications.getNotifications.mockResolvedValue({ items: [{ id: 'n1' }], total: 1 });
+    it('returns the real service list as a bare array with default options', async () => {
       const res = await request(buildApp()).get('/api/notifications');
       expect(res.status).toBe(200);
-      expect(res.body).toEqual({ items: [{ id: 'n1' }], total: 1 });
-      expect(notifications.getNotifications).toHaveBeenCalledWith({
-        type: undefined,
-        unreadOnly: false,
-        limit: undefined
-      });
+      expect(Array.isArray(res.body)).toBe(true);
+      expect(res.body.map(({ id }) => id)).toEqual(['n4', 'n3', 'n2', 'n1']);
     });
 
-    it('parses query string options into the service call', async () => {
-      notifications.getNotifications.mockResolvedValue({ items: [], total: 0 });
+    it('applies type, unreadOnly, and limit filters through the real service', async () => {
       const type = notifications.NOTIFICATION_TYPES.MEMORY_APPROVAL;
-      await request(buildApp()).get(`/api/notifications?type=${type}&unreadOnly=true&limit=25`);
-      expect(notifications.getNotifications).toHaveBeenCalledWith({
-        type,
-        unreadOnly: true,
-        limit: 25
-      });
+      const res = await request(buildApp()).get(`/api/notifications?type=${type}&unreadOnly=true&limit=1`);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual([
+        expect.objectContaining({ id: 'n4', type, read: false })
+      ]);
     });
   });
 


### PR DESCRIPTION
## Summary

- Keeps GET /api/notifications as a bare newest-first array across the service, route contract tests, client hook, and API documentation.
- Exercises the real route/service filtering behavior for type, unreadOnly, and limit.
- Verifies that the client hook response remains renderable by NotificationDropdown.

## Test plan

- cd server && npm test -- routes/notifications.test.js services/notifications.test.js
- cd client && npm test -- src/hooks/useNotifications.test.jsx src/components/NotificationDropdown.test.jsx
- npm run lint --prefix client
- npm test

Closes #5496