### PR TITLE
fix: keep hosted audience controls inside dynamic viewport (#5499)

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -249,6 +249,9 @@ export default function App() {
       <Routes>
         <Route path="/login" element={<Login />} />
         <Route path="/ambient" element={<Ambient />} />
+        {/* Hosted audience devices need the full dynamic viewport, without the
+            app chrome consuming part of the height or clipping the controls. */}
+        <Route path="/fableloom/join" element={<FableLoomHostedJoin />} />
         <Route path="/" element={<Layout />}>
           <Route index element={<Dashboard />} />
           <Route path="apps" element={<Apps />} />
@@ -520,7 +523,6 @@ export default function App() {
           <Route path="sharing/:section" element={<Sharing />} />
           <Route path="sharing/:section/:bucketId" element={<Sharing />} />
           <Route path="importer" element={<Importer />} />
-          <Route path="fableloom/join" element={<FableLoomHostedJoin />} />
           <Route path="fableloom" element={<FableLoom />} />
           <Route path="fableloom/:loomId" element={<FableLoomStory />} />
           <Route path="fableloom/:loomId/:episodeId/outline" element={<FableLoomStory view="outline" />} />

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -244,7 +244,7 @@ function useDocumentTitle(enabled = true) {
 
 export default function App() {
   const { pathname } = useLocation();
-  const isHostedAudienceRoute = pathname === '/fableloom/join';
+  const isHostedAudienceRoute = pathname.replace(/\/+$/, '') === '/fableloom/join';
   useTimezoneBootstrap(!isHostedAudienceRoute);
   useDocumentTitle(!isHostedAudienceRoute);
 

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -217,34 +217,38 @@ if (import.meta.hot) {
 // date-scoped features (daily log, schedulers) land on the wrong day. Push
 // the browser's IANA zone once so remote/VPN clients don't need to visit
 // Settings before their first entry is correct.
-function useTimezoneBootstrap() {
+function useTimezoneBootstrap(enabled = true) {
   useEffect(() => {
+    if (!enabled) return;
     getSettings().then((s) => {
       if (s?.timezone) return;
       const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
       if (!tz || tz === 'UTC') return;
       return updateSettings({ timezone: tz });
     }).catch(() => null);
-  }, []);
+  }, [enabled]);
 }
 
 // Stamp the machine's instance name into the browser tab so multiple federated
 // installs are distinguishable at a glance — "PortOS: {name}". Falls back to the
 // static "PortOS" title (set in index.html) when the name is missing/unfetchable.
-function useDocumentTitle() {
+function useDocumentTitle(enabled = true) {
   useEffect(() => {
+    if (!enabled) return;
     getSelfInstance({ silent: true }).then((self) => {
       const name = self?.name?.trim();
       if (name) document.title = `PortOS: ${name}`;
     }).catch(() => null);
-  }, []);
+  }, [enabled]);
 }
 
 export default function App() {
-  useTimezoneBootstrap();
-  useDocumentTitle();
-  return (
-    <CatalogTypesProvider>
+  const { pathname } = useLocation();
+  const isHostedAudienceRoute = pathname === '/fableloom/join';
+  useTimezoneBootstrap(!isHostedAudienceRoute);
+  useDocumentTitle(!isHostedAudienceRoute);
+
+  const routeContent = (
     <Suspense fallback={<PageLoader />}>
       <Routes>
         <Route path="/login" element={<Login />} />
@@ -566,6 +570,8 @@ export default function App() {
         </Route>
       </Routes>
     </Suspense>
-    </CatalogTypesProvider>
   );
+  return isHostedAudienceRoute
+    ? routeContent
+    : <CatalogTypesProvider>{routeContent}</CatalogTypesProvider>;
 }

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -86,7 +86,7 @@ const router = createBrowserRouter([
 // The QR audience route is intentionally a no-bootstrap guest surface. Avoid
 // the theme settings request on a password-gated install: its 401 redirect
 // would otherwise replace the URL and discard the fragment credentials.
-const isHostedAudienceRoute = window.location.pathname === '/fableloom/join';
+const isHostedAudienceRoute = window.location.pathname.replace(/\/+$/, '') === '/fableloom/join';
 const app = isHostedAudienceRoute
   ? <RouterProvider router={router} />
   : (

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -83,12 +83,22 @@ const router = createBrowserRouter([
   },
 ]);
 
+// The QR audience route is intentionally a no-bootstrap guest surface. Avoid
+// the theme settings request on a password-gated install: its 401 redirect
+// would otherwise replace the URL and discard the fragment credentials.
+const isHostedAudienceRoute = window.location.pathname === '/fableloom/join';
+const app = isHostedAudienceRoute
+  ? <RouterProvider router={router} />
+  : (
+    <ThemeProvider>
+      <RouterProvider router={router} />
+    </ThemeProvider>
+  );
+
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
     <ErrorBoundary>
-      <ThemeProvider>
-        <RouterProvider router={router} />
-      </ThemeProvider>
+      {app}
     </ErrorBoundary>
   </React.StrictMode>
 );

--- a/client/src/pages/FableLoomHostedJoin.jsx
+++ b/client/src/pages/FableLoomHostedJoin.jsx
@@ -175,7 +175,7 @@ export default function FableLoomHostedJoin() {
 
   if (authError) {
     return (
-      <div className="min-h-dvh-cap bg-slate-950 text-white flex flex-col items-center justify-center p-6 text-center">
+      <div className="h-dvh-screen bg-slate-950 text-white flex flex-col items-center justify-center p-6 text-center">
         <div className="w-16 h-16 rounded-full bg-red-500/10 border border-red-500/20 flex items-center justify-center mb-4">
           <AlertCircle className="w-8 h-8 text-red-400" />
         </div>
@@ -186,7 +186,7 @@ export default function FableLoomHostedJoin() {
   }
 
   return (
-    <div className="min-h-dvh-cap bg-slate-950 text-white flex flex-col justify-between max-w-md mx-auto relative overflow-hidden shadow-2xl">
+    <div className="h-dvh-screen bg-slate-950 text-white flex flex-col justify-between max-w-md mx-auto relative overflow-hidden shadow-2xl">
       <audio ref={audioPlayerRef} className="hidden" />
 
       {/* Header */}
@@ -231,7 +231,7 @@ export default function FableLoomHostedJoin() {
       {/* Transcript Stream */}
       <div
         ref={transcriptScrollRef}
-        className="flex-1 p-4 overflow-y-auto space-y-3 font-sans text-sm"
+        className="flex-1 min-h-0 p-4 overflow-y-auto space-y-3 font-sans text-sm"
       >
         {transcript.length === 0 ? (
           <div className="h-full flex flex-col items-center justify-center text-center text-slate-500 text-xs py-12">

--- a/client/src/pages/FableLoomHostedJoin.jsx
+++ b/client/src/pages/FableLoomHostedJoin.jsx
@@ -231,7 +231,7 @@ export default function FableLoomHostedJoin() {
       {/* Transcript Stream */}
       <div
         ref={transcriptScrollRef}
-        className="flex-1 min-h-0 p-4 overflow-y-auto space-y-3 font-sans text-sm"
+        className="flex-1 min-h-[8rem] p-4 overflow-y-auto space-y-3 font-sans text-sm"
       >
         {transcript.length === 0 ? (
           <div className="h-full flex flex-col items-center justify-center text-center text-slate-500 text-xs py-12">

--- a/client/src/pages/FableLoomHostedJoin.jsx
+++ b/client/src/pages/FableLoomHostedJoin.jsx
@@ -186,11 +186,11 @@ export default function FableLoomHostedJoin() {
   }
 
   return (
-    <main className="h-dvh-screen bg-slate-950 text-white flex flex-col justify-between max-w-md mx-auto relative overflow-hidden shadow-2xl">
+    <main className="h-dvh-screen bg-slate-950 text-white flex flex-col justify-between max-w-md mx-auto relative overflow-y-auto shadow-2xl">
       <audio ref={audioPlayerRef} className="hidden" />
 
       {/* Header */}
-      <header className="px-5 py-4 border-b border-slate-800/80 bg-slate-900/50 backdrop-blur flex items-center justify-between">
+      <header className="shrink-0 px-5 py-4 border-b border-slate-800/80 bg-slate-900/50 backdrop-blur flex items-center justify-between">
         <div className="flex items-center gap-2.5">
           <Smartphone className="w-5 h-5 text-indigo-400" />
           <div>
@@ -205,7 +205,7 @@ export default function FableLoomHostedJoin() {
       </header>
 
       {/* Live Turn Phase Banner */}
-      <div className="px-4 py-2.5 border-b border-slate-800 bg-slate-900/30 flex items-center justify-center">
+      <div className="shrink-0 px-4 py-2.5 border-b border-slate-800 bg-slate-900/30 flex items-center justify-center">
         {turnPhase === 'listening' ? (
           <div className="flex items-center gap-2 text-emerald-400 text-xs font-semibold animate-pulse">
             <Mic className="w-4 h-4" />
@@ -267,7 +267,7 @@ export default function FableLoomHostedJoin() {
       </div>
 
       {/* Mobile Push-To-Talk / Interaction Control */}
-      <div className="p-4 bg-slate-900/80 border-t border-slate-800 space-y-3">
+      <div className="shrink-0 p-4 bg-slate-900/80 border-t border-slate-800 space-y-3">
         <div className="flex flex-col items-center justify-center py-2">
           <button
             type="button"

--- a/client/src/pages/FableLoomHostedJoin.jsx
+++ b/client/src/pages/FableLoomHostedJoin.jsx
@@ -175,7 +175,7 @@ export default function FableLoomHostedJoin() {
 
   if (authError) {
     return (
-      <div className="min-h-screen bg-slate-950 text-white flex flex-col items-center justify-center p-6 text-center">
+      <div className="min-h-dvh-cap bg-slate-950 text-white flex flex-col items-center justify-center p-6 text-center">
         <div className="w-16 h-16 rounded-full bg-red-500/10 border border-red-500/20 flex items-center justify-center mb-4">
           <AlertCircle className="w-8 h-8 text-red-400" />
         </div>
@@ -186,7 +186,7 @@ export default function FableLoomHostedJoin() {
   }
 
   return (
-    <div className="min-h-screen bg-slate-950 text-white flex flex-col justify-between max-w-md mx-auto relative overflow-hidden shadow-2xl">
+    <div className="min-h-dvh-cap bg-slate-950 text-white flex flex-col justify-between max-w-md mx-auto relative overflow-hidden shadow-2xl">
       <audio ref={audioPlayerRef} className="hidden" />
 
       {/* Header */}
@@ -308,7 +308,7 @@ export default function FableLoomHostedJoin() {
             type="submit"
             aria-label="Send message"
             disabled={!textInput.trim() || turnPhase === 'thinking' || turnPhase === 'speaking'}
-            className="p-2 bg-indigo-600 hover:bg-indigo-500 disabled:opacity-40 disabled:cursor-not-allowed rounded-lg text-white transition-colors"
+            className="min-w-[44px] min-h-[44px] p-2 bg-indigo-600 hover:bg-indigo-500 disabled:opacity-40 disabled:cursor-not-allowed rounded-lg text-white transition-colors flex items-center justify-center"
           >
             <Send className="w-4 h-4" />
           </button>

--- a/client/src/pages/FableLoomHostedJoin.jsx
+++ b/client/src/pages/FableLoomHostedJoin.jsx
@@ -175,18 +175,18 @@ export default function FableLoomHostedJoin() {
 
   if (authError) {
     return (
-      <div className="h-dvh-screen bg-slate-950 text-white flex flex-col items-center justify-center p-6 text-center">
+      <main className="h-dvh-screen bg-slate-950 text-white flex flex-col items-center justify-center p-6 text-center">
         <div className="w-16 h-16 rounded-full bg-red-500/10 border border-red-500/20 flex items-center justify-center mb-4">
           <AlertCircle className="w-8 h-8 text-red-400" />
         </div>
         <h1 className="text-xl font-bold mb-2">Hosted Play Error</h1>
         <p className="text-slate-400 text-sm max-w-xs">{authError}</p>
-      </div>
+      </main>
     );
   }
 
   return (
-    <div className="h-dvh-screen bg-slate-950 text-white flex flex-col justify-between max-w-md mx-auto relative overflow-hidden shadow-2xl">
+    <main className="h-dvh-screen bg-slate-950 text-white flex flex-col justify-between max-w-md mx-auto relative overflow-hidden shadow-2xl">
       <audio ref={audioPlayerRef} className="hidden" />
 
       {/* Header */}
@@ -314,6 +314,6 @@ export default function FableLoomHostedJoin() {
           </button>
         </form>
       </div>
-    </div>
+    </main>
   );
 }

--- a/client/src/pages/FableLoomHostedJoin.test.jsx
+++ b/client/src/pages/FableLoomHostedJoin.test.jsx
@@ -50,12 +50,16 @@ describe('FableLoomHostedJoin', () => {
     render(<FableLoomHostedJoin />);
 
     const shell = screen.getByRole('main');
-    expect(shell).toHaveClass('h-dvh-screen', 'overflow-hidden');
+    expect(shell).toHaveClass('h-dvh-screen', 'overflow-y-auto');
+    expect(shell).not.toHaveClass('overflow-hidden');
     expect(shell).not.toHaveClass('min-h-screen');
 
     const scrollRegions = shell.querySelectorAll('.overflow-y-auto');
     expect(scrollRegions).toHaveLength(1);
     expect(scrollRegions[0]).toHaveClass('flex-1', 'min-h-0');
+    expect(screen.getByRole('banner')).toHaveClass('shrink-0');
+    expect(screen.getByRole('banner').nextElementSibling).toHaveClass('shrink-0');
+    expect(screen.getByPlaceholderText('Or type a message…').closest('form').parentElement).toHaveClass('shrink-0');
   });
 
   it('sends text input fallback when submitted', async () => {

--- a/client/src/pages/FableLoomHostedJoin.test.jsx
+++ b/client/src/pages/FableLoomHostedJoin.test.jsx
@@ -24,6 +24,10 @@ describe('FableLoomHostedJoin', () => {
     render(<FableLoomHostedJoin />);
     expect(screen.getByText('Hosted Play Error')).toBeInTheDocument();
     expect(screen.getByText(/Invalid or missing join credentials/i)).toBeInTheDocument();
+
+    const shell = screen.getByRole('heading', { name: 'Hosted Play Error' }).parentElement;
+    expect(shell).toHaveClass('min-h-dvh-cap');
+    expect(shell).not.toHaveClass('min-h-screen');
   });
 
   it('connects to /fableloom-hosted when hash credentials are provided', async () => {
@@ -40,6 +44,19 @@ describe('FableLoomHostedJoin', () => {
     expect(screen.getByText('Audience Microphone UI')).toBeInTheDocument();
   });
 
+  it('keeps the transcript as the only inner scroll region of the dynamic shell', () => {
+    window.location.hash = '#session=sess-123&token=tok-abc';
+    render(<FableLoomHostedJoin />);
+
+    const shell = screen.getByRole('banner').parentElement;
+    expect(shell).toHaveClass('min-h-dvh-cap', 'overflow-hidden');
+    expect(shell).not.toHaveClass('min-h-screen');
+
+    const scrollRegions = shell.querySelectorAll('.overflow-y-auto');
+    expect(scrollRegions).toHaveLength(1);
+    expect(scrollRegions[0]).toHaveClass('flex-1');
+  });
+
   it('sends text input fallback when submitted', async () => {
     window.location.hash = '#session=sess-123&token=tok-abc';
     render(<FableLoomHostedJoin />);
@@ -47,7 +64,15 @@ describe('FableLoomHostedJoin', () => {
     const input = screen.getByPlaceholderText('Or type a message…');
     fireEvent.change(input, { target: { value: 'Look around the room' } });
 
-    expect(screen.getByRole('button', { name: 'Send message' })).toBeInTheDocument();
+    const sendButton = screen.getByRole('button', { name: 'Send message' });
+    expect(sendButton).toBeInTheDocument();
+    expect(sendButton).toHaveClass(
+      'min-w-[44px]',
+      'min-h-[44px]',
+      'flex',
+      'items-center',
+      'justify-center',
+    );
     fireEvent.submit(input.closest('form'));
 
     expect(mockSocket.emit).toHaveBeenCalledWith('hosted:turn:text', { text: 'Look around the room' });

--- a/client/src/pages/FableLoomHostedJoin.test.jsx
+++ b/client/src/pages/FableLoomHostedJoin.test.jsx
@@ -25,7 +25,8 @@ describe('FableLoomHostedJoin', () => {
     expect(screen.getByText('Hosted Play Error')).toBeInTheDocument();
     expect(screen.getByText(/Invalid or missing join credentials/i)).toBeInTheDocument();
 
-    const shell = screen.getByRole('heading', { name: 'Hosted Play Error' }).parentElement;
+    const shell = screen.getByRole('main');
+    expect(shell).toContainElement(screen.getByRole('heading', { name: 'Hosted Play Error' }));
     expect(shell).toHaveClass('h-dvh-screen');
     expect(shell).not.toHaveClass('min-h-screen');
   });
@@ -48,7 +49,7 @@ describe('FableLoomHostedJoin', () => {
     window.location.hash = '#session=sess-123&token=tok-abc';
     render(<FableLoomHostedJoin />);
 
-    const shell = screen.getByRole('banner').parentElement;
+    const shell = screen.getByRole('main');
     expect(shell).toHaveClass('h-dvh-screen', 'overflow-hidden');
     expect(shell).not.toHaveClass('min-h-screen');
 

--- a/client/src/pages/FableLoomHostedJoin.test.jsx
+++ b/client/src/pages/FableLoomHostedJoin.test.jsx
@@ -56,9 +56,10 @@ describe('FableLoomHostedJoin', () => {
 
     const scrollRegions = shell.querySelectorAll('.overflow-y-auto');
     expect(scrollRegions).toHaveLength(1);
-    expect(scrollRegions[0]).toHaveClass('flex-1', 'min-h-0');
-    expect(screen.getByRole('banner')).toHaveClass('shrink-0');
-    expect(screen.getByRole('banner').nextElementSibling).toHaveClass('shrink-0');
+    expect(scrollRegions[0]).toHaveClass('flex-1', 'min-h-[8rem]');
+    const header = shell.querySelector('header');
+    expect(header).toHaveClass('shrink-0');
+    expect(header.nextElementSibling).toHaveClass('shrink-0');
     expect(screen.getByPlaceholderText('Or type a message…').closest('form').parentElement).toHaveClass('shrink-0');
   });
 

--- a/client/src/pages/FableLoomHostedJoin.test.jsx
+++ b/client/src/pages/FableLoomHostedJoin.test.jsx
@@ -26,7 +26,7 @@ describe('FableLoomHostedJoin', () => {
     expect(screen.getByText(/Invalid or missing join credentials/i)).toBeInTheDocument();
 
     const shell = screen.getByRole('heading', { name: 'Hosted Play Error' }).parentElement;
-    expect(shell).toHaveClass('min-h-dvh-cap');
+    expect(shell).toHaveClass('h-dvh-screen');
     expect(shell).not.toHaveClass('min-h-screen');
   });
 
@@ -49,12 +49,12 @@ describe('FableLoomHostedJoin', () => {
     render(<FableLoomHostedJoin />);
 
     const shell = screen.getByRole('banner').parentElement;
-    expect(shell).toHaveClass('min-h-dvh-cap', 'overflow-hidden');
+    expect(shell).toHaveClass('h-dvh-screen', 'overflow-hidden');
     expect(shell).not.toHaveClass('min-h-screen');
 
     const scrollRegions = shell.querySelectorAll('.overflow-y-auto');
     expect(scrollRegions).toHaveLength(1);
-    expect(scrollRegions[0]).toHaveClass('flex-1');
+    expect(scrollRegions[0]).toHaveClass('flex-1', 'min-h-0');
   });
 
   it('sends text input fallback when submitted', async () => {

--- a/client/src/services/socket.js
+++ b/client/src/services/socket.js
@@ -6,10 +6,12 @@ import toast from '../components/ui/Toast';
 
 // Connect to Socket.IO using relative path (works with Tailscale)
 // The connection will use the same host the page was loaded from
+const isHostedAudienceRoute = typeof window !== 'undefined' &&
+  window.location.pathname.replace(/\/+$/, '') === '/fableloom/join';
 const socket = io({
   path: '/socket.io',
   transports: ['websocket', 'polling'],
-  autoConnect: true,
+  autoConnect: !isHostedAudienceRoute,
   reconnection: true,
   reconnectionAttempts: 10,
   reconnectionDelay: 1000
@@ -27,7 +29,7 @@ socket.on('connect_error', (err) => {
   // Auth gate rejected the handshake (server: services/authGate.js socketAuthGate).
   // Bounce to /login so the user can sign back in; skip if already there.
   if (err?.data?.code === 'AUTH_REQUIRED' && typeof window !== 'undefined') {
-    if (!window.location.pathname.startsWith('/login')) {
+    if (!window.location.pathname.startsWith('/login') && !isHostedAudienceRoute) {
       const next = encodeURIComponent(window.location.pathname + window.location.search);
       window.location.replace(`/login?next=${next}`);
     }

--- a/server/lib/navManifest.test.js
+++ b/server/lib/navManifest.test.js
@@ -416,6 +416,8 @@ describe('getNavAliasMap — voice-agent compatibility', () => {
 // a second test fails if an opt-out entry goes stale (route deleted, or the path
 // gained a manifest entry) so the allow-list can't quietly rot.
 const APP_JSX = path.join(REPO_ROOT, 'client/src/App.jsx');
+const MAIN_JSX = path.join(REPO_ROOT, 'client/src/main.jsx');
+const SOCKET_JS = path.join(REPO_ROOT, 'client/src/services/socket.js');
 
 // Concrete leaf routes that render a real page but are deliberately absent from
 // the nav manifest — reached via an in-page button or as a create-mode sentinel,
@@ -557,6 +559,19 @@ describe('nav coverage — every navigable App.jsx route has a manifest entry', 
     // The hosted audience shell owns a full dynamic viewport and must not be
     // nested under Layout's shorter overflow-hidden main (#5499).
     expect(scan.topLevel).toContain('/fableloom/join');
+  });
+
+  it('keeps hosted audience joins free of authenticated app bootstraps', () => {
+    // A password-gated install must not redirect a QR audience device before
+    // the fragment token reaches FableLoomHostedJoin (#5499).
+    const appSrc = fs.readFileSync(APP_JSX, 'utf8');
+    const mainSrc = fs.readFileSync(MAIN_JSX, 'utf8');
+    const socketSrc = fs.readFileSync(SOCKET_JS, 'utf8');
+    expect(appSrc).toMatch(/useTimezoneBootstrap\(!isHostedAudienceRoute\)/);
+    expect(appSrc).toMatch(/useDocumentTitle\(!isHostedAudienceRoute\)/);
+    expect(appSrc).toMatch(/isHostedAudienceRoute\s*\?\s*routeContent/);
+    expect(mainSrc).toContain("const isHostedAudienceRoute = window.location.pathname.replace(/\\/+$/, '')");
+    expect(socketSrc).toMatch(/autoConnect: !isHostedAudienceRoute/);
   });
 
   // Every page that has ever moved leaves its old path behind in bookmarks, in

--- a/server/lib/navManifest.test.js
+++ b/server/lib/navManifest.test.js
@@ -454,6 +454,8 @@ function joinRoutePath(segments) {
 // containers. Returns:
 //  - required: absolute paths of every concrete, non-redirect, non-param leaf
 //    route — the set that must each have a NAV_COMMANDS entry (or an opt-out)
+//  - topLevel: absolute paths of concrete leaves directly under <Routes>, rather
+//    than inside a layout/container route
 //  - malformed: <Route>-opening lines whose tag doesn't close on the same line
 //  - stackDepth: open containers left unclosed at EOF
 // The scanner assumes each <Route> is a single line (true in App.jsx today). A
@@ -466,6 +468,7 @@ function joinRoutePath(segments) {
 function scanRoutes(appSrc) {
   const stack = []; // parent path segments of currently-open <Route> containers
   const required = [];
+  const topLevel = [];
   const redirects = []; // { from, to } for every forwarding leaf route
   const malformed = [];
   for (const rawLine of appSrc.split('\n')) {
@@ -493,6 +496,7 @@ function scanRoutes(appSrc) {
     const absolute = routePath === null
       ? joinRoutePath(stack)
       : joinRoutePath([...stack, routePath]);
+    if (stack.length === 0) topLevel.push(absolute);
 
     // Redirects are recorded rather than dropped: a moved page's old path has to
     // keep landing somewhere, and that is only assertable if the scanner reports
@@ -512,7 +516,7 @@ function scanRoutes(appSrc) {
     if (absolute.split('/').some((s) => s.startsWith(':'))) continue; // param route
     required.push(absolute);
   }
-  return { required: [...new Set(required)], redirects, malformed, stackDepth: stack.length };
+  return { required: [...new Set(required)], topLevel: [...new Set(topLevel)], redirects, malformed, stackDepth: stack.length };
 }
 
 // Settings owns a small declarative redirect map for retired tabs, while App.jsx
@@ -547,6 +551,12 @@ describe('nav coverage — every navigable App.jsx route has a manifest entry', 
     const uncovered = [...routePaths]
       .filter((p) => !navPaths.has(p) && !NAV_COVERAGE_OPT_OUT.has(p));
     expect(uncovered).toEqual([]);
+  });
+
+  it('keeps the hosted audience join route outside the chrome layout', () => {
+    // The hosted audience shell owns a full dynamic viewport and must not be
+    // nested under Layout's shorter overflow-hidden main (#5499).
+    expect(scan.topLevel).toContain('/fableloom/join');
   });
 
   // Every page that has ever moved leaves its old path behind in bookmarks, in


### PR DESCRIPTION
## Summary

- Render the hosted audience join route as a chrome-free standalone dynamic-viewport surface.
- Keep transcript and control flex behavior reachable on narrow viewports, with a 44px typed fallback target.
- Skip authenticated app bootstrap and socket work on the QR guest route, including trailing-slash links, while retaining a main landmark and regression guards.

## Validation

- `npm test` — 831 test files and 10,514 tests passed
- `npm test --prefix client -- --run src/pages/FableLoomHostedJoin.test.jsx` — passed
- `npm run build --prefix client` — passed; existing large-chunk warnings remain

Closes #5499