### PR TITLE
fix: drop stale Three.js model poll responses

### DIFF
--- a/client/src/pages/ThreejsModelDetail.jsx
+++ b/client/src/pages/ThreejsModelDetail.jsx
@@ -28,6 +28,7 @@ const providerFilter = (provider) =>
   provider.enabled !== false && ['api', 'cli', 'tui'].includes(provider.type);
 
 const MAX_IN_FLIGHT_POLLS = 2;
+const POLL_TIMEOUT_MS = 30_000;
 
 const SEVERITY_STYLE = {
   error: 'border-port-error/40 bg-port-error/10 text-port-error',
@@ -292,8 +293,8 @@ export default function ThreejsModelDetail() {
   const requestSequenceRef = useRef(0);
   const pollSequenceRef = useRef(0);
   const lastAppliedRequestRef = useRef(0);
-  const inFlightPollsRef = useRef(new Set());
-  const load = useCallback(async ({ initial = false } = {}) => {
+  const inFlightPollsRef = useRef(new Map());
+  const load = useCallback(async ({ initial = false, signal } = {}) => {
     const lifecycleGeneration = lifecycleGenerationRef.current;
     const requestSequence = ++requestSequenceRef.current;
     const isCurrent = () => mountedRef.current && lifecycleGeneration === lifecycleGenerationRef.current;
@@ -303,7 +304,10 @@ export default function ThreejsModelDetail() {
       setNotFound(false);
       setRecord(null);
     }
-    const next = await getThreejsModel(id, { silent: true }).catch((error) => {
+    const next = await getThreejsModel(id, {
+      silent: true,
+      ...(signal ? { signal } : {}),
+    }).catch((error) => {
       if (!isAuthoritative()) return null;
       if (error.status === 404) {
         lastAppliedRequestRef.current = requestSequence;
@@ -332,11 +336,27 @@ export default function ThreejsModelDetail() {
     const handle = setInterval(() => {
       if (inFlightPollsRef.current.size >= MAX_IN_FLIGHT_POLLS) return;
       const pollSequence = ++pollSequenceRef.current;
-      inFlightPollsRef.current.add(pollSequence);
-      void load().finally(() => { inFlightPollsRef.current.delete(pollSequence); });
+      const controller = new AbortController();
+      const poll = { controller, timeoutId: null };
+      inFlightPollsRef.current.set(pollSequence, poll);
+      poll.timeoutId = setTimeout(() => {
+        if (inFlightPollsRef.current.get(pollSequence)?.controller !== controller) return;
+        inFlightPollsRef.current.delete(pollSequence);
+        controller.abort();
+      }, POLL_TIMEOUT_MS);
+      void load({ signal: controller.signal }).finally(() => {
+        const activePoll = inFlightPollsRef.current.get(pollSequence);
+        if (activePoll?.controller !== controller) return;
+        clearTimeout(activePoll.timeoutId);
+        inFlightPollsRef.current.delete(pollSequence);
+      });
     }, 2_000);
     return () => {
       clearInterval(handle);
+      for (const { controller, timeoutId } of inFlightPollsRef.current.values()) {
+        clearTimeout(timeoutId);
+        controller.abort();
+      }
       inFlightPollsRef.current.clear();
       lifecycleGenerationRef.current += 1;
     };

--- a/client/src/pages/ThreejsModelDetail.jsx
+++ b/client/src/pages/ThreejsModelDetail.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { ArrowLeft, Box, Check, Code2, Download, Info, LoaderCircle, RefreshCw, Trash2, X } from 'lucide-react';
 import { Link, useNavigate, useParams } from 'react-router';
 import MediaImage from '../components/MediaImage';
@@ -7,6 +7,7 @@ import SubjectFamilySelect from '../components/threejsModels/SubjectFamilySelect
 import ThreejsModelPreview from '../components/threejsModels/ThreejsModelPreview';
 import PageSkeleton from '../components/ui/PageSkeleton';
 import InlineConfirmRow from '../components/ui/InlineConfirmRow';
+import useMounted from '../hooks/useMounted';
 import useProviderModels from '../hooks/useProviderModels';
 import useThreejsModelFamilies, { GENERAL_FAMILY_ID, resolveFamilyId } from '../hooks/useThreejsModelFamilies';
 import {
@@ -284,38 +285,44 @@ export default function ThreejsModelDetail() {
     // server, so Antigravity lists base models with effort picked separately.
   } = useProviderModels({ filter: providerFilter, silent: true, withEffort: true });
 
-  const load = async ({ initial = false } = {}) => {
+  const mountedRef = useMounted();
+  const loadGenerationRef = useRef(0);
+  const load = useCallback(async ({ initial = false } = {}) => {
+    const generation = ++loadGenerationRef.current;
+    const isCurrent = () => mountedRef.current && generation === loadGenerationRef.current;
+    if (initial && isCurrent()) {
+      setLoading(true);
+      setNotFound(false);
+    }
     const next = await getThreejsModel(id, { silent: true }).catch((error) => {
+      if (!isCurrent()) return null;
       if (error.status === 404) setNotFound(true);
       else if (initial) toast.error(error.message || 'Failed to load model');
       return null;
     });
+    if (!isCurrent()) return null;
     if (next) {
       setRecord(next);
       setNotFound(false);
     }
     if (initial) setLoading(false);
     return next;
-  };
+  }, [id, mountedRef]);
 
   useEffect(() => {
-    let cancelled = false;
-    getThreejsModel(id, { silent: true })
-      .then((next) => { if (!cancelled) setRecord(next); })
-      .catch((error) => {
-        if (cancelled) return;
-        if (error.status === 404) setNotFound(true);
-        else toast.error(error.message || 'Failed to load model');
-      })
-      .finally(() => { if (!cancelled) setLoading(false); });
-    return () => { cancelled = true; };
-  }, [id]);
+    loadGenerationRef.current += 1;
+    void load({ initial: true });
+    return () => { loadGenerationRef.current += 1; };
+  }, [id, load]);
 
   useEffect(() => {
-    if (record?.status !== 'generating') return undefined;
+    if (record?.id !== id || record?.status !== 'generating') return undefined;
     const handle = setInterval(() => { void load(); }, 2_000);
-    return () => clearInterval(handle);
-  }, [record?.status, id]);
+    return () => {
+      clearInterval(handle);
+      loadGenerationRef.current += 1;
+    };
+  }, [record?.id, record?.status, id, load]);
 
   useEffect(() => {
     if (!record || providers.length === 0) return;

--- a/client/src/pages/ThreejsModelDetail.jsx
+++ b/client/src/pages/ThreejsModelDetail.jsx
@@ -286,21 +286,27 @@ export default function ThreejsModelDetail() {
   } = useProviderModels({ filter: providerFilter, silent: true, withEffort: true });
 
   const mountedRef = useMounted();
-  const loadGenerationRef = useRef(0);
+  const lifecycleGenerationRef = useRef(0);
+  const requestSequenceRef = useRef(0);
+  const lastAppliedRequestRef = useRef(0);
   const load = useCallback(async ({ initial = false } = {}) => {
-    const generation = ++loadGenerationRef.current;
-    const isCurrent = () => mountedRef.current && generation === loadGenerationRef.current;
+    const lifecycleGeneration = lifecycleGenerationRef.current;
+    const requestSequence = ++requestSequenceRef.current;
+    const isCurrent = () => mountedRef.current && lifecycleGeneration === lifecycleGenerationRef.current;
+    const isAuthoritative = () => isCurrent() && requestSequence >= lastAppliedRequestRef.current;
     if (initial && isCurrent()) {
       setLoading(true);
       setNotFound(false);
     }
     const next = await getThreejsModel(id, { silent: true }).catch((error) => {
-      if (!isCurrent()) return null;
+      if (!isAuthoritative()) return null;
+      lastAppliedRequestRef.current = requestSequence;
       if (error.status === 404) setNotFound(true);
       else if (initial) toast.error(error.message || 'Failed to load model');
       return null;
     });
-    if (!isCurrent()) return null;
+    if (!isAuthoritative()) return null;
+    lastAppliedRequestRef.current = requestSequence;
     if (next) {
       setRecord(next);
       setNotFound(false);
@@ -310,9 +316,9 @@ export default function ThreejsModelDetail() {
   }, [id, mountedRef]);
 
   useEffect(() => {
-    loadGenerationRef.current += 1;
+    lifecycleGenerationRef.current += 1;
     void load({ initial: true });
-    return () => { loadGenerationRef.current += 1; };
+    return () => { lifecycleGenerationRef.current += 1; };
   }, [id, load]);
 
   useEffect(() => {
@@ -320,7 +326,7 @@ export default function ThreejsModelDetail() {
     const handle = setInterval(() => { void load(); }, 2_000);
     return () => {
       clearInterval(handle);
-      loadGenerationRef.current += 1;
+      lifecycleGenerationRef.current += 1;
     };
   }, [record?.id, record?.status, id, load]);
 

--- a/client/src/pages/ThreejsModelDetail.jsx
+++ b/client/src/pages/ThreejsModelDetail.jsx
@@ -327,8 +327,14 @@ export default function ThreejsModelDetail() {
 
   useEffect(() => {
     lifecycleGenerationRef.current += 1;
-    void load({ initial: true });
-    return () => { lifecycleGenerationRef.current += 1; };
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), POLL_TIMEOUT_MS);
+    void load({ initial: true, signal: controller.signal }).finally(() => clearTimeout(timeoutId));
+    return () => {
+      clearTimeout(timeoutId);
+      controller.abort();
+      lifecycleGenerationRef.current += 1;
+    };
   }, [id, load]);
 
   useEffect(() => {

--- a/client/src/pages/ThreejsModelDetail.jsx
+++ b/client/src/pages/ThreejsModelDetail.jsx
@@ -27,6 +27,8 @@ import { seedModelEffort } from '../utils/providers';
 const providerFilter = (provider) =>
   provider.enabled !== false && ['api', 'cli', 'tui'].includes(provider.type);
 
+const MAX_IN_FLIGHT_POLLS = 2;
+
 const SEVERITY_STYLE = {
   error: 'border-port-error/40 bg-port-error/10 text-port-error',
   warning: 'border-port-warning/40 bg-port-warning/10 text-port-warning',
@@ -288,7 +290,9 @@ export default function ThreejsModelDetail() {
   const mountedRef = useMounted();
   const lifecycleGenerationRef = useRef(0);
   const requestSequenceRef = useRef(0);
+  const pollSequenceRef = useRef(0);
   const lastAppliedRequestRef = useRef(0);
+  const inFlightPollsRef = useRef(new Set());
   const load = useCallback(async ({ initial = false } = {}) => {
     const lifecycleGeneration = lifecycleGenerationRef.current;
     const requestSequence = ++requestSequenceRef.current;
@@ -297,6 +301,7 @@ export default function ThreejsModelDetail() {
     if (initial && isCurrent()) {
       setLoading(true);
       setNotFound(false);
+      setRecord(null);
     }
     const next = await getThreejsModel(id, { silent: true }).catch((error) => {
       if (!isAuthoritative()) return null;
@@ -323,13 +328,19 @@ export default function ThreejsModelDetail() {
   }, [id, load]);
 
   useEffect(() => {
-    if (loading || record?.id !== id || record?.status !== 'generating') return undefined;
-    const handle = setInterval(() => { void load(); }, 2_000);
+    if (loading || notFound || record?.id !== id || record?.status !== 'generating') return undefined;
+    const handle = setInterval(() => {
+      if (inFlightPollsRef.current.size >= MAX_IN_FLIGHT_POLLS) return;
+      const pollSequence = ++pollSequenceRef.current;
+      inFlightPollsRef.current.add(pollSequence);
+      void load().finally(() => { inFlightPollsRef.current.delete(pollSequence); });
+    }, 2_000);
     return () => {
       clearInterval(handle);
+      inFlightPollsRef.current.clear();
       lifecycleGenerationRef.current += 1;
     };
-  }, [loading, record?.id, record?.status, id, load]);
+  }, [loading, notFound, record?.id, record?.status, id, load]);
 
   useEffect(() => {
     if (!record || providers.length === 0) return;

--- a/client/src/pages/ThreejsModelDetail.jsx
+++ b/client/src/pages/ThreejsModelDetail.jsx
@@ -300,14 +300,15 @@ export default function ThreejsModelDetail() {
     }
     const next = await getThreejsModel(id, { silent: true }).catch((error) => {
       if (!isAuthoritative()) return null;
-      lastAppliedRequestRef.current = requestSequence;
-      if (error.status === 404) setNotFound(true);
-      else if (initial) toast.error(error.message || 'Failed to load model');
+      if (error.status === 404) {
+        lastAppliedRequestRef.current = requestSequence;
+        setNotFound(true);
+      } else if (initial) toast.error(error.message || 'Failed to load model');
       return null;
     });
     if (!isAuthoritative()) return null;
-    lastAppliedRequestRef.current = requestSequence;
     if (next) {
+      lastAppliedRequestRef.current = requestSequence;
       setRecord(next);
       setNotFound(false);
     }
@@ -322,13 +323,13 @@ export default function ThreejsModelDetail() {
   }, [id, load]);
 
   useEffect(() => {
-    if (record?.id !== id || record?.status !== 'generating') return undefined;
+    if (loading || record?.id !== id || record?.status !== 'generating') return undefined;
     const handle = setInterval(() => { void load(); }, 2_000);
     return () => {
       clearInterval(handle);
       lifecycleGenerationRef.current += 1;
     };
-  }, [record?.id, record?.status, id, load]);
+  }, [loading, record?.id, record?.status, id, load]);
 
   useEffect(() => {
     if (!record || providers.length === 0) return;

--- a/client/src/pages/ThreejsModelDetail.test.jsx
+++ b/client/src/pages/ThreejsModelDetail.test.jsx
@@ -1,6 +1,6 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { MemoryRouter, Route, Routes } from 'react-router';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes, useNavigate } from 'react-router';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import ThreejsModelDetail from './ThreejsModelDetail';
 
 vi.mock('../services/api', () => ({
@@ -58,13 +58,75 @@ const resetMocks = () => {
   listThreejsModelFamilies.mockResolvedValue(FAMILY_OPTIONS);
 };
 
-const renderDetail = () => render(
-  <MemoryRouter initialEntries={['/media/threejs/threejs-example']}>
+const RouteSwitcher = () => {
+  const navigate = useNavigate();
+  return (
+    <button type="button" onClick={() => navigate('/media/threejs/model-b')}>
+      Switch to model B
+    </button>
+  );
+};
+
+const renderDetail = (initialEntries = ['/media/threejs/threejs-example']) => render(
+  <MemoryRouter initialEntries={initialEntries}>
     <Routes>
-      <Route path="/media/threejs/:id" element={<ThreejsModelDetail />} />
+      <Route path="/media/threejs/:id" element={<><RouteSwitcher /><ThreejsModelDetail /></>} />
     </Routes>
   </MemoryRouter>,
 );
+
+const deferred = () => {
+  let resolve;
+  const promise = new Promise((fulfill) => { resolve = fulfill; });
+  return { promise, resolve };
+};
+
+describe('ThreejsModelDetail request lifecycle', () => {
+  beforeEach(resetMocks);
+  afterEach(() => { vi.useRealTimers(); });
+
+  it('ignores a poll response after navigating to another model', async () => {
+    vi.useFakeTimers();
+    const modelAInitial = deferred();
+    const modelAPoll = deferred();
+    const modelBInitial = deferred();
+    const requests = {
+      'model-a': [modelAInitial, modelAPoll],
+      'model-b': [modelBInitial],
+    };
+    getThreejsModel.mockImplementation((id) => requests[id].shift().promise);
+    renderDetail(['/media/threejs/model-a']);
+
+    await act(async () => { modelAInitial.resolve({ ...baseRecord, id: 'model-a', name: 'Model A', status: 'generating' }); });
+    await act(async () => { vi.advanceTimersByTime(2_000); });
+    fireEvent.click(screen.getByRole('button', { name: 'Switch to model B' }));
+    await act(async () => { modelBInitial.resolve({ ...baseRecord, id: 'model-b', name: 'Model B', status: 'ready' }); });
+    expect(screen.getByText('Model B')).toBeInTheDocument();
+
+    await act(async () => { modelAPoll.resolve({ ...baseRecord, id: 'model-a', name: 'Model A', status: 'generating' }); });
+    expect(screen.getByText('Model B')).toBeInTheDocument();
+    expect(screen.queryByText('Model A')).not.toBeInTheDocument();
+  });
+
+  it('keeps a newer terminal poll result authoritative over an older generating response', async () => {
+    vi.useFakeTimers();
+    const initial = deferred();
+    const olderPoll = deferred();
+    const newerPoll = deferred();
+    const requests = [initial, olderPoll, newerPoll];
+    getThreejsModel.mockImplementation(() => requests.shift().promise);
+    renderDetail(['/media/threejs/model-a']);
+
+    await act(async () => { initial.resolve({ ...baseRecord, id: 'model-a', name: 'Model A', status: 'generating' }); });
+    await act(async () => { vi.advanceTimersByTime(4_000); });
+    await act(async () => { newerPoll.resolve({ ...baseRecord, id: 'model-a', name: 'Model A', status: 'ready' }); });
+    await act(async () => { olderPoll.resolve({ ...baseRecord, id: 'model-a', name: 'Model A', status: 'generating' }); });
+
+    expect(screen.getByText('ready', { exact: true })).toBeInTheDocument();
+    await act(async () => { vi.advanceTimersByTime(2_000); });
+    expect(getThreejsModel).toHaveBeenCalledTimes(3);
+  });
+});
 
 describe('ThreejsModelDetail assembly coverage', () => {
   beforeEach(resetMocks);

--- a/client/src/pages/ThreejsModelDetail.test.jsx
+++ b/client/src/pages/ThreejsModelDetail.test.jsx
@@ -108,12 +108,18 @@ describe('ThreejsModelDetail request lifecycle', () => {
       'model-a': [modelAInitial, modelAPoll],
       'model-b': [modelBInitial],
     };
-    getThreejsModel.mockImplementation((id) => requests[id].shift().promise);
+    const signals = [];
+    getThreejsModel.mockImplementation((id, options) => {
+      signals.push(options?.signal);
+      return requests[id].shift().promise;
+    });
     renderLifecycleDetail(['/media/threejs/model-a']);
 
     await act(async () => { modelAInitial.resolve({ ...baseRecord, id: 'model-a', name: 'Model A', status: 'generating' }); });
     await act(async () => { vi.advanceTimersByTime(2_000); });
     fireEvent.click(screen.getByRole('button', { name: 'Switch to model B' }));
+    expect(signals[1]).toBeInstanceOf(AbortSignal);
+    expect(signals[1].aborted).toBe(true);
     await act(async () => { modelBInitial.resolve({ ...baseRecord, id: 'model-b', name: 'Model B', status: 'ready' }); });
     expect(screen.getByText('Model B')).toBeInTheDocument();
 
@@ -171,16 +177,20 @@ describe('ThreejsModelDetail request lifecycle', () => {
     vi.useFakeTimers();
     const initial = deferred();
     const hungPoll = deferred();
+    const secondPoll = deferred();
     const replacementPoll = deferred();
-    const requests = [initial, hungPoll, replacementPoll];
+    const requests = [initial, hungPoll, secondPoll, replacementPoll];
     getThreejsModel.mockImplementation(() => requests.shift().promise);
     renderLifecycleDetail(['/media/threejs/model-a']);
 
     await act(async () => { initial.resolve({ ...baseRecord, id: 'model-a', name: 'Model A', status: 'generating' }); });
-    await act(async () => { vi.advanceTimersByTime(2_000); });
-    await act(async () => { vi.advanceTimersByTime(30_000); });
+    await act(async () => { vi.advanceTimersByTime(4_000); });
+    await act(async () => { vi.advanceTimersByTime(4_000); });
     expect(getThreejsModel).toHaveBeenCalledTimes(3);
 
+    await act(async () => { vi.advanceTimersByTime(24_000); });
+    await act(async () => { vi.advanceTimersByTime(2_000); });
+    expect(getThreejsModel).toHaveBeenCalledTimes(4);
     await act(async () => { replacementPoll.resolve({ ...baseRecord, id: 'model-a', name: 'Model A', status: 'ready' }); });
   });
 

--- a/client/src/pages/ThreejsModelDetail.test.jsx
+++ b/client/src/pages/ThreejsModelDetail.test.jsx
@@ -72,13 +72,18 @@ const RouteSwitcher = () => {
   );
 };
 
-const renderDetail = (initialEntries = ['/media/threejs/threejs-example']) => render(
+const renderDetail = (
+  initialEntries = ['/media/threejs/threejs-example'],
+  { withSwitcher = false } = {},
+) => render(
   <MemoryRouter initialEntries={initialEntries}>
     <Routes>
-      <Route path="/media/threejs/:id" element={<><RouteSwitcher /><ThreejsModelDetail /></>} />
+      <Route path="/media/threejs/:id" element={<>{withSwitcher && <RouteSwitcher />}<ThreejsModelDetail /></>} />
     </Routes>
   </MemoryRouter>,
 );
+
+const renderLifecycleDetail = (initialEntries) => renderDetail(initialEntries, { withSwitcher: true });
 
 const deferred = () => {
   let resolve;
@@ -104,7 +109,7 @@ describe('ThreejsModelDetail request lifecycle', () => {
       'model-b': [modelBInitial],
     };
     getThreejsModel.mockImplementation((id) => requests[id].shift().promise);
-    renderDetail(['/media/threejs/model-a']);
+    renderLifecycleDetail(['/media/threejs/model-a']);
 
     await act(async () => { modelAInitial.resolve({ ...baseRecord, id: 'model-a', name: 'Model A', status: 'generating' }); });
     await act(async () => { vi.advanceTimersByTime(2_000); });
@@ -128,7 +133,7 @@ describe('ThreejsModelDetail request lifecycle', () => {
       'model-b': [modelBInitial],
     };
     getThreejsModel.mockImplementation((id) => requests[id].shift().promise);
-    renderDetail(['/media/threejs/model-a']);
+    renderLifecycleDetail(['/media/threejs/model-a']);
 
     await act(async () => { modelAInitial.resolve({ ...baseRecord, id: 'model-a', name: 'Model A', status: 'generating' }); });
     fireEvent.click(screen.getByRole('button', { name: 'Switch to model B' }));
@@ -149,7 +154,7 @@ describe('ThreejsModelDetail request lifecycle', () => {
     const laterPoll = deferred();
     const requests = [initial, slowPoll, laterPoll];
     getThreejsModel.mockImplementation(() => requests.shift().promise);
-    renderDetail(['/media/threejs/model-a']);
+    renderLifecycleDetail(['/media/threejs/model-a']);
 
     await act(async () => { initial.resolve({ ...baseRecord, id: 'model-a', name: 'Model A', status: 'generating' }); });
     await act(async () => { vi.advanceTimersByTime(4_000); });
@@ -162,6 +167,23 @@ describe('ThreejsModelDetail request lifecycle', () => {
     expect(screen.getByText('ready', { exact: true })).toBeInTheDocument();
   });
 
+  it('releases a hung poll slot after its timeout', async () => {
+    vi.useFakeTimers();
+    const initial = deferred();
+    const hungPoll = deferred();
+    const replacementPoll = deferred();
+    const requests = [initial, hungPoll, replacementPoll];
+    getThreejsModel.mockImplementation(() => requests.shift().promise);
+    renderLifecycleDetail(['/media/threejs/model-a']);
+
+    await act(async () => { initial.resolve({ ...baseRecord, id: 'model-a', name: 'Model A', status: 'generating' }); });
+    await act(async () => { vi.advanceTimersByTime(2_000); });
+    await act(async () => { vi.advanceTimersByTime(30_000); });
+    expect(getThreejsModel).toHaveBeenCalledTimes(3);
+
+    await act(async () => { replacementPoll.resolve({ ...baseRecord, id: 'model-a', name: 'Model A', status: 'ready' }); });
+  });
+
   it('keeps an older terminal poll result when a newer poll fails transiently', async () => {
     vi.useFakeTimers();
     const initial = deferred();
@@ -169,7 +191,7 @@ describe('ThreejsModelDetail request lifecycle', () => {
     const newerPoll = deferred();
     const requests = [initial, olderPoll, newerPoll];
     getThreejsModel.mockImplementation(() => requests.shift().promise);
-    renderDetail(['/media/threejs/model-a']);
+    renderLifecycleDetail(['/media/threejs/model-a']);
 
     await act(async () => { initial.resolve({ ...baseRecord, id: 'model-a', name: 'Model A', status: 'generating' }); });
     await act(async () => { vi.advanceTimersByTime(4_000); });
@@ -186,7 +208,7 @@ describe('ThreejsModelDetail request lifecycle', () => {
     const unexpectedPoll = deferred();
     const requests = [initial, poll, unexpectedPoll];
     getThreejsModel.mockImplementation(() => requests.shift().promise);
-    renderDetail(['/media/threejs/model-a']);
+    renderLifecycleDetail(['/media/threejs/model-a']);
 
     await act(async () => { initial.resolve({ ...baseRecord, id: 'model-a', name: 'Model A', status: 'generating' }); });
     await act(async () => { vi.advanceTimersByTime(2_000); });

--- a/client/src/pages/ThreejsModelDetail.test.jsx
+++ b/client/src/pages/ThreejsModelDetail.test.jsx
@@ -108,6 +108,24 @@ describe('ThreejsModelDetail request lifecycle', () => {
     expect(screen.queryByText('Model A')).not.toBeInTheDocument();
   });
 
+  it('does not starve a slow poll when the next interval tick starts', async () => {
+    vi.useFakeTimers();
+    const initial = deferred();
+    const slowPoll = deferred();
+    const laterPoll = deferred();
+    const requests = [initial, slowPoll, laterPoll];
+    getThreejsModel.mockImplementation(() => requests.shift().promise);
+    renderDetail(['/media/threejs/model-a']);
+
+    await act(async () => { initial.resolve({ ...baseRecord, id: 'model-a', name: 'Model A', status: 'generating' }); });
+    await act(async () => { vi.advanceTimersByTime(4_000); });
+    await act(async () => { slowPoll.resolve({ ...baseRecord, id: 'model-a', name: 'Model A', status: 'ready' }); });
+    expect(screen.getByText('ready', { exact: true })).toBeInTheDocument();
+
+    await act(async () => { laterPoll.resolve({ ...baseRecord, id: 'model-a', name: 'Model A', status: 'generating' }); });
+    expect(screen.getByText('ready', { exact: true })).toBeInTheDocument();
+  });
+
   it('keeps a newer terminal poll result authoritative over an older generating response', async () => {
     vi.useFakeTimers();
     const initial = deferred();

--- a/client/src/pages/ThreejsModelDetail.test.jsx
+++ b/client/src/pages/ThreejsModelDetail.test.jsx
@@ -61,9 +61,14 @@ const resetMocks = () => {
 const RouteSwitcher = () => {
   const navigate = useNavigate();
   return (
-    <button type="button" onClick={() => navigate('/media/threejs/model-b')}>
-      Switch to model B
-    </button>
+    <>
+      <button type="button" onClick={() => navigate('/media/threejs/model-b')}>
+        Switch to model B
+      </button>
+      <button type="button" onClick={() => navigate('/media/threejs/model-a')}>
+        Switch to model A
+      </button>
+    </>
   );
 };
 
@@ -77,8 +82,12 @@ const renderDetail = (initialEntries = ['/media/threejs/threejs-example']) => re
 
 const deferred = () => {
   let resolve;
-  const promise = new Promise((fulfill) => { resolve = fulfill; });
-  return { promise, resolve };
+  let reject;
+  const promise = new Promise((fulfill, fail) => {
+    resolve = fulfill;
+    reject = fail;
+  });
+  return { promise, resolve, reject };
 };
 
 describe('ThreejsModelDetail request lifecycle', () => {
@@ -108,6 +117,31 @@ describe('ThreejsModelDetail request lifecycle', () => {
     expect(screen.queryByText('Model A')).not.toBeInTheDocument();
   });
 
+  it('does not start polling before a new route initial load settles', async () => {
+    vi.useFakeTimers();
+    const modelAInitial = deferred();
+    const modelBInitial = deferred();
+    const modelAReturn = deferred();
+    const modelAReturnPoll = deferred();
+    const requests = {
+      'model-a': [modelAInitial, modelAReturn, modelAReturnPoll],
+      'model-b': [modelBInitial],
+    };
+    getThreejsModel.mockImplementation((id) => requests[id].shift().promise);
+    renderDetail(['/media/threejs/model-a']);
+
+    await act(async () => { modelAInitial.resolve({ ...baseRecord, id: 'model-a', name: 'Model A', status: 'generating' }); });
+    fireEvent.click(screen.getByRole('button', { name: 'Switch to model B' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Switch to model A' }));
+    await act(async () => { vi.advanceTimersByTime(2_000); });
+    expect(getThreejsModel).toHaveBeenCalledTimes(3);
+
+    await act(async () => { modelAReturn.resolve({ ...baseRecord, id: 'model-a', name: 'Model A', status: 'generating' }); });
+    await act(async () => { vi.advanceTimersByTime(2_000); });
+    expect(getThreejsModel).toHaveBeenCalledTimes(4);
+    await act(async () => { modelAReturnPoll.resolve({ ...baseRecord, id: 'model-a', name: 'Model A', status: 'ready' }); });
+  });
+
   it('does not starve a slow poll when the next interval tick starts', async () => {
     vi.useFakeTimers();
     const initial = deferred();
@@ -123,6 +157,23 @@ describe('ThreejsModelDetail request lifecycle', () => {
     expect(screen.getByText('ready', { exact: true })).toBeInTheDocument();
 
     await act(async () => { laterPoll.resolve({ ...baseRecord, id: 'model-a', name: 'Model A', status: 'generating' }); });
+    expect(screen.getByText('ready', { exact: true })).toBeInTheDocument();
+  });
+
+  it('keeps an older terminal poll result when a newer poll fails transiently', async () => {
+    vi.useFakeTimers();
+    const initial = deferred();
+    const olderPoll = deferred();
+    const newerPoll = deferred();
+    const requests = [initial, olderPoll, newerPoll];
+    getThreejsModel.mockImplementation(() => requests.shift().promise);
+    renderDetail(['/media/threejs/model-a']);
+
+    await act(async () => { initial.resolve({ ...baseRecord, id: 'model-a', name: 'Model A', status: 'generating' }); });
+    await act(async () => { vi.advanceTimersByTime(4_000); });
+    await act(async () => { newerPoll.reject(new Error('Temporary outage')); });
+    await act(async () => { olderPoll.resolve({ ...baseRecord, id: 'model-a', name: 'Model A', status: 'ready' }); });
+
     expect(screen.getByText('ready', { exact: true })).toBeInTheDocument();
   });
 

--- a/client/src/pages/ThreejsModelDetail.test.jsx
+++ b/client/src/pages/ThreejsModelDetail.test.jsx
@@ -153,6 +153,8 @@ describe('ThreejsModelDetail request lifecycle', () => {
 
     await act(async () => { initial.resolve({ ...baseRecord, id: 'model-a', name: 'Model A', status: 'generating' }); });
     await act(async () => { vi.advanceTimersByTime(4_000); });
+    await act(async () => { vi.advanceTimersByTime(2_000); });
+    expect(getThreejsModel).toHaveBeenCalledTimes(3);
     await act(async () => { slowPoll.resolve({ ...baseRecord, id: 'model-a', name: 'Model A', status: 'ready' }); });
     expect(screen.getByText('ready', { exact: true })).toBeInTheDocument();
 
@@ -175,6 +177,24 @@ describe('ThreejsModelDetail request lifecycle', () => {
     await act(async () => { olderPoll.resolve({ ...baseRecord, id: 'model-a', name: 'Model A', status: 'ready' }); });
 
     expect(screen.getByText('ready', { exact: true })).toBeInTheDocument();
+  });
+
+  it('stops polling after a model disappears', async () => {
+    vi.useFakeTimers();
+    const initial = deferred();
+    const poll = deferred();
+    const unexpectedPoll = deferred();
+    const requests = [initial, poll, unexpectedPoll];
+    getThreejsModel.mockImplementation(() => requests.shift().promise);
+    renderDetail(['/media/threejs/model-a']);
+
+    await act(async () => { initial.resolve({ ...baseRecord, id: 'model-a', name: 'Model A', status: 'generating' }); });
+    await act(async () => { vi.advanceTimersByTime(2_000); });
+    await act(async () => { poll.reject({ status: 404, message: 'Model disappeared' }); });
+    expect(screen.getByText('That Three.js model does not exist.')).toBeInTheDocument();
+
+    await act(async () => { vi.advanceTimersByTime(4_000); });
+    expect(getThreejsModel).toHaveBeenCalledTimes(2);
   });
 
   it('keeps a newer terminal poll result authoritative over an older generating response', async () => {


### PR DESCRIPTION
## Summary

- Ignore model responses that belong to an outdated route, lifecycle, or request order.
- Cancel and time-bound initial/poll requests while limiting overlapping polls.
- Add deferred-response coverage for navigation, terminal ordering, transient errors, disappearing models, stalled polls, and route-load gating.

## Test plan

- `cd client && npm test -- src/pages/ThreejsModelDetail.test.jsx`
- `cd client && npm run lint`
- `cd client && npm test`
- `npm test`
- `npm run build --prefix client`

Closes #5498