### PR TITLE
fix: bound voice LLM streams so turns recover (#5497)

### DIFF
--- a/client/src/pages/VoiceCallHost.jsx
+++ b/client/src/pages/VoiceCallHost.jsx
@@ -68,17 +68,18 @@ export default function VoiceCallHost() {
   const [captureState, setCaptureState] = useState(null);
   const [level, setLevel] = useState(0);
   const [notice, setNotice] = useState(null);
-  const audio = useRef({ context: null, stream: null, node: null, source: null, outputId: null, pending: [] });
+  const audio = useRef({ context: null, stream: null, node: null, source: null, playing: null, outputId: null, pending: [] });
   const lockRelease = useRef(null);
 
   const teardown = useCallback(() => {
     const current = audio.current;
+    current.playing?.pause?.();
     current.node?.port?.close?.();
     current.node?.disconnect?.();
     current.source?.disconnect?.();
     current.stream?.getTracks?.().forEach((track) => track.stop());
     current.context?.close?.();
-    audio.current = { context: null, stream: null, node: null, source: null, outputId: current.outputId, pending: [] };
+    audio.current = { context: null, stream: null, node: null, source: null, playing: null, outputId: current.outputId, pending: [] };
     setLevel(0);
   }, []);
 
@@ -91,13 +92,19 @@ export default function VoiceCallHost() {
     const element = new Audio();
     const blob = new Blob([wav], { type: 'audio/wav' });
     element.src = URL.createObjectURL(blob);
+    audio.current.playing = element;
     try {
       if (audio.current.outputId) await element.setSinkId(audio.current.outputId);
+      if (audio.current.playing !== element) return;
       await element.play();
+      if (audio.current.playing !== element) element.pause();
     } catch (error) {
-      setNotice(`Could not play into the call: ${error.message}`);
+      if (audio.current.playing === element) setNotice(`Could not play into the call: ${error.message}`);
     } finally {
-      element.addEventListener('ended', () => URL.revokeObjectURL(element.src), { once: true });
+      element.addEventListener('ended', () => {
+        URL.revokeObjectURL(element.src);
+        if (audio.current.playing === element) audio.current.playing = null;
+      }, { once: true });
     }
   }, []);
 
@@ -196,7 +203,7 @@ export default function VoiceCallHost() {
     };
     source.connect(node);
 
-    audio.current = { context, stream, node, source, outputId: output?.deviceId ?? null, pending: [] };
+    audio.current = { context, stream, node, source, playing: null, outputId: output?.deviceId ?? null, pending: [] };
     // Two literal emits, not a computed event name — a computed
     // `socket.emit(x ? 'a' : 'b')` is invisible to the static
     // socket-event inventory scan (`server/lib/socketEventInventory.js`),
@@ -245,13 +252,20 @@ export default function VoiceCallHost() {
       setAttached(Boolean(snapshot?.hostAttached));
     };
     const onTts = ({ wav }) => { if (wav) playToCall(wav); };
+    const onTtsCancel = () => {
+      const playing = audio.current.playing;
+      playing?.pause?.();
+      if (audio.current.playing === playing) audio.current.playing = null;
+    };
     socket.on('voice:call:state', onCallState);
     socket.on('voice:capture:state', onCaptureState);
     socket.on('voice:call:tts', onTts);
+    socket.on('voice:tts:cancel', onTtsCancel);
     return () => {
       socket.off('voice:call:state', onCallState);
       socket.off('voice:capture:state', onCaptureState);
       socket.off('voice:call:tts', onTts);
+      socket.off('voice:tts:cancel', onTtsCancel);
       if (modeRef.current === 'call') socket.emit('voice:call:detach');
       else socket.emit('voice:capture:stop');
       teardown();

--- a/client/src/pages/VoiceCallHost.jsx
+++ b/client/src/pages/VoiceCallHost.jsx
@@ -53,6 +53,15 @@ const DEFAULT_INPUT_LABEL = 'BlackHole 16ch';
 const DEFAULT_OUTPUT_LABEL = 'BlackHole 2ch';
 const MODES = ['call', 'capture'];
 
+const releaseCallAudio = (playing, element) => {
+  if (!playing?.delete(element)) return;
+  element.pause?.();
+  if (element.src) {
+    URL.revokeObjectURL(element.src);
+    element.src = '';
+  }
+};
+
 export default function VoiceCallHost() {
   // Deep-linkable mode, not local state: `?mode=capture` is shareable and
   // survives a reload, same convention as a drawer's active tab.
@@ -68,18 +77,18 @@ export default function VoiceCallHost() {
   const [captureState, setCaptureState] = useState(null);
   const [level, setLevel] = useState(0);
   const [notice, setNotice] = useState(null);
-  const audio = useRef({ context: null, stream: null, node: null, source: null, playing: null, outputId: null, pending: [] });
+  const audio = useRef({ context: null, stream: null, node: null, source: null, playing: new Set(), outputId: null, pending: [] });
   const lockRelease = useRef(null);
 
   const teardown = useCallback(() => {
     const current = audio.current;
-    current.playing?.pause?.();
+    for (const element of current.playing) releaseCallAudio(current.playing, element);
     current.node?.port?.close?.();
     current.node?.disconnect?.();
     current.source?.disconnect?.();
     current.stream?.getTracks?.().forEach((track) => track.stop());
     current.context?.close?.();
-    audio.current = { context: null, stream: null, node: null, source: null, playing: null, outputId: current.outputId, pending: [] };
+    audio.current = { context: null, stream: null, node: null, source: null, playing: new Set(), outputId: current.outputId, pending: [] };
     setLevel(0);
   }, []);
 
@@ -92,19 +101,20 @@ export default function VoiceCallHost() {
     const element = new Audio();
     const blob = new Blob([wav], { type: 'audio/wav' });
     element.src = URL.createObjectURL(blob);
-    audio.current.playing = element;
+    audio.current.playing.add(element);
+    const release = () => releaseCallAudio(audio.current.playing, element);
+    element.addEventListener('ended', release, { once: true });
+    element.addEventListener('error', release, { once: true });
     try {
       if (audio.current.outputId) await element.setSinkId(audio.current.outputId);
-      if (audio.current.playing !== element) return;
+      if (!audio.current.playing.has(element)) return;
       await element.play();
-      if (audio.current.playing !== element) element.pause();
+      if (!audio.current.playing.has(element)) return;
     } catch (error) {
-      if (audio.current.playing === element) setNotice(`Could not play into the call: ${error.message}`);
-    } finally {
-      element.addEventListener('ended', () => {
-        URL.revokeObjectURL(element.src);
-        if (audio.current.playing === element) audio.current.playing = null;
-      }, { once: true });
+      if (audio.current.playing.has(element)) {
+        setNotice(`Could not play into the call: ${error.message}`);
+        releaseCallAudio(audio.current.playing, element);
+      }
     }
   }, []);
 
@@ -203,7 +213,7 @@ export default function VoiceCallHost() {
     };
     source.connect(node);
 
-    audio.current = { context, stream, node, source, playing: null, outputId: output?.deviceId ?? null, pending: [] };
+    audio.current = { context, stream, node, source, playing: new Set(), outputId: output?.deviceId ?? null, pending: [] };
     // Two literal emits, not a computed event name — a computed
     // `socket.emit(x ? 'a' : 'b')` is invisible to the static
     // socket-event inventory scan (`server/lib/socketEventInventory.js`),
@@ -253,9 +263,9 @@ export default function VoiceCallHost() {
     };
     const onTts = ({ wav }) => { if (wav) playToCall(wav); };
     const onTtsCancel = () => {
-      const playing = audio.current.playing;
-      playing?.pause?.();
-      if (audio.current.playing === playing) audio.current.playing = null;
+      for (const element of audio.current.playing) {
+        releaseCallAudio(audio.current.playing, element);
+      }
     };
     socket.on('voice:call:state', onCallState);
     socket.on('voice:capture:state', onCaptureState);

--- a/client/src/pages/VoiceCallHost.test.jsx
+++ b/client/src/pages/VoiceCallHost.test.jsx
@@ -117,6 +117,28 @@ describe('VoiceCallHost', () => {
     expect(screen.getByText('Detach call host')).toBeTruthy();
   });
 
+  it('pauses call audio when the server cancels a timed-out voice turn', async () => {
+    const element = {
+      addEventListener: vi.fn(),
+      play: vi.fn(() => Promise.resolve()),
+      pause: vi.fn(),
+      setSinkId: vi.fn(() => Promise.resolve()),
+      src: '',
+    };
+    vi.stubGlobal('Audio', function FakeAudio() { return element; });
+    vi.stubGlobal('URL', {
+      createObjectURL: vi.fn(() => 'blob:call-audio'),
+      revokeObjectURL: vi.fn(),
+    });
+    render(<VoiceCallHost />, { wrapper: MemoryRouter });
+
+    act(() => socket.__fire('voice:call:tts', { wav: new ArrayBuffer(8) }));
+    await waitFor(() => expect(element.play).toHaveBeenCalledTimes(1));
+    act(() => socket.__fire('voice:tts:cancel'));
+
+    expect(element.pause).toHaveBeenCalledTimes(1);
+  });
+
   it('detaches on unmount so a closed tab does not leave a phantom host', () => {
     const { unmount } = render(<VoiceCallHost />, { wrapper: MemoryRouter });
     unmount();

--- a/client/src/pages/VoiceCallHost.test.jsx
+++ b/client/src/pages/VoiceCallHost.test.jsx
@@ -118,25 +118,34 @@ describe('VoiceCallHost', () => {
   });
 
   it('pauses call audio when the server cancels a timed-out voice turn', async () => {
-    const element = {
+    const makeElement = () => ({
       addEventListener: vi.fn(),
       play: vi.fn(() => Promise.resolve()),
       pause: vi.fn(),
       setSinkId: vi.fn(() => Promise.resolve()),
       src: '',
-    };
-    vi.stubGlobal('Audio', function FakeAudio() { return element; });
+    });
+    const [first, second] = [makeElement(), makeElement()];
+    const elements = [first, second];
+    vi.stubGlobal('Audio', function FakeAudio() { return elements.shift(); });
+    const revokeObjectURL = vi.fn();
     vi.stubGlobal('URL', {
       createObjectURL: vi.fn(() => 'blob:call-audio'),
-      revokeObjectURL: vi.fn(),
+      revokeObjectURL,
     });
     render(<VoiceCallHost />, { wrapper: MemoryRouter });
 
-    act(() => socket.__fire('voice:call:tts', { wav: new ArrayBuffer(8) }));
-    await waitFor(() => expect(element.play).toHaveBeenCalledTimes(1));
+    act(() => {
+      socket.__fire('voice:call:tts', { wav: new ArrayBuffer(8) });
+      socket.__fire('voice:call:tts', { wav: new ArrayBuffer(8) });
+    });
+    await waitFor(() => expect(first.play).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(second.play).toHaveBeenCalledTimes(1));
     act(() => socket.__fire('voice:tts:cancel'));
 
-    expect(element.pause).toHaveBeenCalledTimes(1);
+    expect(first.pause).toHaveBeenCalledTimes(1);
+    expect(second.pause).toHaveBeenCalledTimes(1);
+    expect(revokeObjectURL).toHaveBeenCalledTimes(2);
   });
 
   it('detaches on unmount so a closed tab does not leave a phantom host', () => {

--- a/client/src/services/voiceClient.js
+++ b/client/src/services/voiceClient.js
@@ -152,7 +152,6 @@ const enqueuePlay = async (bytes) => {
   ttsQueueDepth += 1;
   playQueue = playQueue.then(() => new Promise((resolve) => {
     if (generation !== playbackGeneration) {
-      ttsQueueDepth = Math.max(0, ttsQueueDepth - 1);
       resolve();
       return;
     }

--- a/client/src/services/voiceClient.js
+++ b/client/src/services/voiceClient.js
@@ -28,6 +28,7 @@ let audioCtx = null;
 let playQueue = Promise.resolve();
 let currentSource = null;
 let ttsQueueDepth = 0;
+let playbackGeneration = 0;
 // Timestamp after which the post-TTS echo-tail window ends. See VAD.ttsTailMs.
 let ttsCooldownUntil = 0;
 // Raised when a turn is cancelled (barge-in, explicit interrupt, reset, new
@@ -61,6 +62,7 @@ const ensureCtx = () => {
 };
 
 const stopPlayback = () => {
+  playbackGeneration += 1;
   if (currentSource) {
     try { currentSource.stop(); } catch { /* already stopped */ }
     currentSource = null;
@@ -141,12 +143,19 @@ const blobToWav16k = async (blob) => {
 };
 
 const enqueuePlay = async (bytes) => {
+  const generation = playbackGeneration;
   const ctx = ensureCtx();
   // decodeAudioData consumes its buffer — clone so we don't mutate the socket frame
   const copy = bytes.slice(0);
   const buffer = await ctx.decodeAudioData(copy);
+  if (generation !== playbackGeneration) return;
   ttsQueueDepth += 1;
   playQueue = playQueue.then(() => new Promise((resolve) => {
+    if (generation !== playbackGeneration) {
+      ttsQueueDepth = Math.max(0, ttsQueueDepth - 1);
+      resolve();
+      return;
+    }
     const src = ctx.createBufferSource();
     src.buffer = buffer;
     src.connect(ctx.destination);
@@ -347,6 +356,11 @@ socket.on('voice:tts:audio', ({ sentence, wav }) => {
   if (!ab) return;
   enqueuePlay(ab).catch((err) => console.warn('[voice] playback failed:', err));
 });
+
+// A provider timeout can happen after earlier sentences were already emitted.
+// Clear those browser-side frames too, so recovery does not leave the stale
+// reply speaking over the next turn.
+socket.on('voice:tts:cancel', () => stopPlayback());
 
 // Proactive CoS speech. Server-pushed lines (alerts/briefings/reminders) come
 // in on a separate channel so the client can render a distinct visual cue;

--- a/client/src/services/voiceClient.test.js
+++ b/client/src/services/voiceClient.test.js
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeAll, beforeEach, afterAll } from 'vitest';
+
+const { socket, listeners, audio, FakeAudioContext } = vi.hoisted(() => {
+  const listeners = new Map();
+  const audio = {
+    decodeCalls: 0,
+    decodeImpl: () => Promise.resolve({}),
+    sources: [],
+  };
+  const socket = {
+    connected: false,
+    on: vi.fn((event, handler) => {
+      const handlers = listeners.get(event) || [];
+      handlers.push(handler);
+      listeners.set(event, handlers);
+      return socket;
+    }),
+    off: vi.fn((event, handler) => {
+      listeners.set(event, (listeners.get(event) || []).filter((fn) => fn !== handler));
+      return socket;
+    }),
+    emit: vi.fn(),
+  };
+  class FakeAudioContext {
+    constructor() {
+      this.destination = {};
+      this.state = 'running';
+    }
+
+    resume() {
+      return Promise.resolve();
+    }
+
+    decodeAudioData(bytes) {
+      audio.decodeCalls++;
+      return audio.decodeImpl(bytes);
+    }
+
+    createBufferSource() {
+      const source = {
+        buffer: null,
+        connect: vi.fn(),
+        onended: null,
+        start: vi.fn(),
+        stop: vi.fn(),
+      };
+      audio.sources.push(source);
+      return source;
+    }
+  }
+  return { socket, listeners, audio, FakeAudioContext };
+});
+
+vi.mock('./socket', () => ({ default: socket }));
+
+let voiceClient;
+
+const trigger = (event, payload) => {
+  for (const handler of listeners.get(event) || []) handler(payload);
+};
+
+const emitTtsAudio = (sentence) => trigger('voice:tts:audio', {
+  sentence,
+  wav: new ArrayBuffer(8),
+});
+
+describe('voice playback cancellation', () => {
+  beforeAll(async () => {
+    vi.stubGlobal('AudioContext', FakeAudioContext);
+    voiceClient = await import('./voiceClient.js');
+  });
+
+  beforeEach(() => {
+    trigger('voice:tts:cancel');
+    audio.decodeCalls = 0;
+    audio.decodeImpl = () => Promise.resolve({});
+    audio.sources.length = 0;
+    socket.emit.mockClear();
+  });
+
+  afterAll(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('stops active and queued audio when a provider timeout is signaled', async () => {
+    trigger('voice:transcript');
+    emitTtsAudio('first sentence');
+    emitTtsAudio('second sentence');
+    await vi.waitFor(() => expect(audio.sources).toHaveLength(1));
+
+    const activeSource = audio.sources[0];
+    trigger('voice:tts:cancel');
+
+    expect(activeSource.stop).toHaveBeenCalledTimes(1);
+    await expect(voiceClient.whenPlaybackDrained()).resolves.toBe(true);
+
+    // The old queue can finish after cancellation. It must not decrement the
+    // newly reset depth or create the queued stale source.
+    activeSource.onended?.();
+    await vi.waitFor(() => expect(audio.sources).toHaveLength(1));
+  });
+
+  it('drops a frame whose decode finishes after cancellation', async () => {
+    let resolveDecode;
+    audio.decodeImpl = () => new Promise((resolve) => { resolveDecode = resolve; });
+
+    trigger('voice:transcript');
+    emitTtsAudio('late sentence');
+    await vi.waitFor(() => expect(audio.decodeCalls).toBe(1));
+
+    trigger('voice:tts:cancel');
+    resolveDecode({});
+    await vi.waitFor(() => expect(voiceClient.whenPlaybackDrained()).resolves.toBe(true));
+
+    expect(audio.sources).toHaveLength(0);
+  });
+
+  it('drops canceled-turn frames until the next transcript starts a turn', async () => {
+    trigger('voice:tts:cancel');
+    emitTtsAudio('stale sentence');
+    await Promise.resolve();
+    expect(audio.decodeCalls).toBe(0);
+
+    trigger('voice:transcript');
+    emitTtsAudio('fresh sentence');
+    await vi.waitFor(() => expect(audio.sources).toHaveLength(1));
+  });
+});

--- a/client/src/services/voiceClient.test.js
+++ b/client/src/services/voiceClient.test.js
@@ -97,7 +97,8 @@ describe('voice playback cancellation', () => {
     // The old queue can finish after cancellation. It must not decrement the
     // newly reset depth or create the queued stale source.
     activeSource.onended?.();
-    await vi.waitFor(() => expect(audio.sources).toHaveLength(1));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(audio.sources).toHaveLength(1);
   });
 
   it('drops a frame whose decode finishes after cancellation', async () => {

--- a/server/services/voice/llm.js
+++ b/server/services/voice/llm.js
@@ -372,6 +372,11 @@ export const streamChat = async (messages, opts = {}) => {
   }
   const timeoutId = setTimeout(() => {
     timedOut = true;
+    try {
+      opts.onTimeout?.();
+    } catch (err) {
+      console.error(`🤖 voice.llm.timeout_hook failed: ${err.message}`);
+    }
     requestController.abort();
   }, VOICE_LLM_TIMEOUT_MS);
 
@@ -393,6 +398,12 @@ export const streamChat = async (messages, opts = {}) => {
     const decoder = new TextDecoder();
     reader = res.body.getReader();
     if (requestController.signal.aborted) cancelReader();
+    const throwIfAborted = () => {
+      if (timedOut) throw new Error(VOICE_LLM_TIMEOUT_MESSAGE);
+      if (requestController.signal.aborted) {
+        throw requestController.signal.reason || new Error('The voice LLM request was aborted');
+      }
+    };
     let buffer = '';
     let text = '';
     let ttfbMs = null;
@@ -473,7 +484,7 @@ export const streamChat = async (messages, opts = {}) => {
 
     while (true) {
       const { value, done } = await reader.read();
-      if (timedOut) throw new Error(VOICE_LLM_TIMEOUT_MESSAGE);
+      throwIfAborted();
       if (done) break;
       buffer += decoder.decode(value, { stream: true });
 
@@ -484,6 +495,7 @@ export const streamChat = async (messages, opts = {}) => {
         if (!line.startsWith('data:')) continue;
         const payload = line.slice(5).trim();
         if (payload === '[DONE]') {
+          throwIfAborted();
           return finalizeReturn();
         }
         // Malformed SSE frames (proxy keep-alive, truncated write) would otherwise
@@ -497,6 +509,7 @@ export const streamChat = async (messages, opts = {}) => {
           if (ttfbMs === null) ttfbMs = Date.now() - started;
           text += delta.content;
           forwardClean(delta.content);
+          throwIfAborted();
         }
         for (const tc of delta.tool_calls || []) {
           const frag = toolCallFrags.get(tc.index) || {

--- a/server/services/voice/llm.js
+++ b/server/services/voice/llm.js
@@ -53,6 +53,12 @@ export const resolveLlmEndpoint = async (providerId = 'lmstudio') => {
 
 export const authHeaders = (apiKey) => (apiKey ? { Authorization: `Bearer ${apiKey}` } : {});
 
+// A voice turn must eventually release its socket state even when an upstream
+// accepts the request but never sends headers or stops its SSE stream. This is
+// a total request-plus-stream budget, rather than an idle-chunk timeout.
+export const VOICE_LLM_TIMEOUT_MS = 30_000;
+export const VOICE_LLM_TIMEOUT_MESSAGE = 'Voice LLM request timed out';
+
 // Approximate parameter count from LM Studio model id so 'auto' avoids a 70B
 // when smaller, faster models are available. Returns Infinity for non-matches
 // and utility models so they sort last rather than silently winning ties.
@@ -345,166 +351,206 @@ export const streamChat = async (messages, opts = {}) => {
     body.tool_choice = opts.toolChoice ?? 'auto';
   }
 
-  const reqStart = Date.now();
-  const res = await fetch(`${apiBase}/chat/completions`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...authHeaders(apiKey) },
-    body: JSON.stringify(body),
-    signal: opts.signal,
-  });
-  console.log(`🤖 ${tag}voice.llm.headers ${res.status} in ${Date.now() - reqStart}ms`);
-  if (!res.ok || !res.body) {
-    const errBody = await res.text().catch(() => '');
-    throw new Error(`${providerName} chat failed: ${res.status} ${errBody.slice(0, 200)}`);
+  const requestController = new AbortController();
+  let timedOut = false;
+  const onExternalAbort = opts.signal
+    ? () => requestController.abort(opts.signal.reason)
+    : null;
+  let reader = null;
+  const cancelReader = () => {
+    if (typeof reader?.cancel !== 'function') return;
+    try {
+      void Promise.resolve(reader.cancel()).catch(() => {});
+    } catch (err) {
+      console.error(`🤖 voice.llm.reader_cancel failed: ${err.message}`);
+    }
+  };
+  requestController.signal.addEventListener('abort', cancelReader, { once: true });
+  if (opts.signal) {
+    if (opts.signal.aborted) onExternalAbort();
+    else opts.signal.addEventListener('abort', onExternalAbort, { once: true });
   }
+  const timeoutId = setTimeout(() => {
+    timedOut = true;
+    requestController.abort();
+  }, VOICE_LLM_TIMEOUT_MS);
 
-  const decoder = new TextDecoder();
-  const reader = res.body.getReader();
-  let buffer = '';
-  let text = '';
-  let ttfbMs = null;
-  let finishReason = null;
-  // Tool calls stream as fragments keyed by index; accumulate until [DONE].
-  const toolCallFrags = new Map();
-
-  // Streaming tool-call stripper: when a model emits Granite-style inline
-  // `<tool_call>[...]</tool_call>` or `<tool_request>[...]` in `delta.content`,
-  // we must NOT forward those chunks to onDelta — the pipeline feeds deltas to
-  // TTS and would speak the raw JSON. Reasoning models likewise emit `<think>`
-  // blocks that should be hidden even when our disable directives don't take.
-  // We still accumulate everything into `text` so the post-stream parser can
-  // hoist into structured `toolCalls`. Tail characters that could be a partial
-  // open/close tag are held across chunks. All tag spellings handled in parallel.
-  const STRIP_TAGS = [...TOOL_TAG_SPELLINGS, 'think', 'thinking', 'reasoning'];
-  const OPEN_TAGS = STRIP_TAGS.map((s) => `<${s}>`);
-  const CLOSE_TAGS = STRIP_TAGS.map((s) => `</${s}>`);
-  let activeClose = null; // set when we entered a tool block
-  let tailHold = '';
-  // Find the earliest match of any candidate in `data`, starting at 0.
-  const earliestIndex = (data, candidates) => {
-    let best = -1;
-    let bestLen = 0;
-    for (const c of candidates) {
-      const i = data.indexOf(c);
-      if (i !== -1 && (best === -1 || i < best)) { best = i; bestLen = c.length; }
+  const requestPromise = (async () => {
+    const reqStart = Date.now();
+    const res = await fetch(`${apiBase}/chat/completions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...authHeaders(apiKey) },
+      body: JSON.stringify(body),
+      signal: requestController.signal,
+    });
+    console.log(`🤖 ${tag}voice.llm.headers ${res.status} in ${Date.now() - reqStart}ms`);
+    if (!res.ok || !res.body) {
+      const errBody = await res.text().catch(() => '');
+      throw new Error(`${providerName} chat failed: ${res.status} ${errBody.slice(0, 200)}`);
     }
-    return best === -1 ? null : [best, bestLen];
-  };
-  // Longest suffix of `data` that is a prefix of any candidate — characters we
-  // must withhold because they might begin a real tag once more data arrives.
-  const longestPrefixHold = (data, candidates) => {
-    const max = Math.max(...candidates.map((c) => c.length - 1));
-    const limit = Math.min(data.length, max);
-    for (let k = limit; k > 0; k--) {
-      const tail = data.slice(data.length - k);
-      if (candidates.some((c) => c.startsWith(tail))) return k;
-    }
-    return 0;
-  };
-  const forwardClean = (chunk) => {
-    let data = tailHold + chunk;
-    tailHold = '';
-    let out = '';
-    while (data.length) {
-      if (!activeClose) {
-        const hit = earliestIndex(data, OPEN_TAGS);
-        if (hit) {
-          out += data.slice(0, hit[0]);
-          const spelling = data.slice(hit[0] + 1, hit[0] + hit[1] - 1); // strip '<' and '>'
-          activeClose = `</${spelling}>`;
-          data = data.slice(hit[0] + hit[1]);
-          continue;
-        }
-        const hold = longestPrefixHold(data, OPEN_TAGS);
-        if (hold) {
-          out += data.slice(0, data.length - hold);
-          tailHold = data.slice(data.length - hold);
-        } else {
-          out += data;
-        }
-        data = '';
-      } else {
-        const i = data.indexOf(activeClose);
-        if (i !== -1) {
-          data = data.slice(i + activeClose.length);
-          activeClose = null;
-          continue;
-        }
-        const hold = longestPrefixHold(data, [activeClose]);
-        if (hold) tailHold = data.slice(data.length - hold);
-        data = '';
-      }
-    }
-    if (out) opts.onDelta?.(out);
-  };
 
-  while (true) {
-    const { value, done } = await reader.read();
-    if (done) break;
-    buffer += decoder.decode(value, { stream: true });
+    const decoder = new TextDecoder();
+    reader = res.body.getReader();
+    if (requestController.signal.aborted) cancelReader();
+    let buffer = '';
+    let text = '';
+    let ttfbMs = null;
+    let finishReason = null;
+    // Tool calls stream as fragments keyed by index; accumulate until [DONE].
+    const toolCallFrags = new Map();
 
-    let idx;
-    while ((idx = buffer.indexOf('\n')) >= 0) {
-      const line = buffer.slice(0, idx).trim();
-      buffer = buffer.slice(idx + 1);
-      if (!line.startsWith('data:')) continue;
-      const payload = line.slice(5).trim();
-      if (payload === '[DONE]') {
-        return finalizeReturn();
+    // Streaming tool-call stripper: when a model emits Granite-style inline
+    // `<tool_call>[...]</tool_call>` or `<tool_request>[...]` in `delta.content`,
+    // we must NOT forward those chunks to onDelta — the pipeline feeds deltas to
+    // TTS and would speak the raw JSON. Reasoning models likewise emit `<think>`
+    // blocks that should be hidden even when our disable directives don't take.
+    // We still accumulate everything into `text` so the post-stream parser can
+    // hoist into structured `toolCalls`. Tail characters that could be a partial
+    // open/close tag are held across chunks. All tag spellings handled in parallel.
+    const STRIP_TAGS = [...TOOL_TAG_SPELLINGS, 'think', 'thinking', 'reasoning'];
+    const OPEN_TAGS = STRIP_TAGS.map((s) => `<${s}>`);
+    const CLOSE_TAGS = STRIP_TAGS.map((s) => `</${s}>`);
+    let activeClose = null; // set when we entered a tool block
+    let tailHold = '';
+    // Find the earliest match of any candidate in `data`, starting at 0.
+    const earliestIndex = (data, candidates) => {
+      let best = -1;
+      let bestLen = 0;
+      for (const c of candidates) {
+        const i = data.indexOf(c);
+        if (i !== -1 && (best === -1 || i < best)) { best = i; bestLen = c.length; }
       }
-      // Malformed SSE frames (proxy keep-alive, truncated write) would otherwise
-      // abort the whole turn; skip the line and keep streaming.
-      let obj;
-      try { obj = JSON.parse(payload); } catch { continue; }
-      const choice = obj?.choices?.[0];
-      if (choice?.finish_reason) finishReason = choice.finish_reason;
-      const delta = choice?.delta || {};
-      if (delta.content) {
-        if (ttfbMs === null) ttfbMs = Date.now() - started;
-        text += delta.content;
-        forwardClean(delta.content);
-      }
-      for (const tc of delta.tool_calls || []) {
-        const frag = toolCallFrags.get(tc.index) || {
-          index: tc.index,
-          id: '',
-          type: 'function',
-          function: { name: '', arguments: '' },
-        };
-        if (tc.id) frag.id = tc.id;
-        if (tc.type) frag.type = tc.type;
-        // `name` is sent once per tool call per the OpenAI spec; set-once
-        // rather than concatenate so a split fragment can't produce garbage.
-        if (tc.function?.name && !frag.function.name) frag.function.name = tc.function.name;
-        if (tc.function?.arguments) frag.function.arguments += tc.function.arguments;
-        toolCallFrags.set(tc.index, frag);
-      }
-    }
-  }
-  return finalizeReturn();
-
-  function finalizeReturn() {
-    const streamed = [...toolCallFrags.values()].sort((a, b) => a.index - b.index);
-    // Post-stream: if the model emitted no structured tool_calls but wrote
-    // Granite-style `<tool_call>[...]</tool_call>` in content, extract them
-    // and clean the visible text. No-ops when the regex doesn't match.
-    const { text: cleanedText, toolCalls: inlineCalls } = streamed.length
-      ? { text, toolCalls: [] }
-      : extractInlineToolCalls(text);
-    const toolCalls = streamed.length ? streamed : inlineCalls;
-    // Strip any `<think>...`/`<reasoning>...` blocks from the canonical text
-    // too — the streaming stripper kept them out of TTS, but they'd still
-    // pollute conversation history and the assistant.content we persist.
-    const finalText = stripReasoningTags(cleanedText);
-    return {
-      text: finalText,
-      toolCalls,
-      model,
-      ttfbMs,
-      totalMs: Date.now() - started,
-      finishReason,
+      return best === -1 ? null : [best, bestLen];
     };
-  }
+    // Longest suffix of `data` that is a prefix of any candidate — characters we
+    // must withhold because they might begin a real tag once more data arrives.
+    const longestPrefixHold = (data, candidates) => {
+      const max = Math.max(...candidates.map((c) => c.length - 1));
+      const limit = Math.min(data.length, max);
+      for (let k = limit; k > 0; k--) {
+        const tail = data.slice(data.length - k);
+        if (candidates.some((c) => c.startsWith(tail))) return k;
+      }
+      return 0;
+    };
+    const forwardClean = (chunk) => {
+      let data = tailHold + chunk;
+      tailHold = '';
+      let out = '';
+      while (data.length) {
+        if (!activeClose) {
+          const hit = earliestIndex(data, OPEN_TAGS);
+          if (hit) {
+            out += data.slice(0, hit[0]);
+            const spelling = data.slice(hit[0] + 1, hit[0] + hit[1] - 1); // strip '<' and '>'
+            activeClose = `</${spelling}>`;
+            data = data.slice(hit[0] + hit[1]);
+            continue;
+          }
+          const hold = longestPrefixHold(data, OPEN_TAGS);
+          if (hold) {
+            out += data.slice(0, data.length - hold);
+            tailHold = data.slice(data.length - hold);
+          } else {
+            out += data;
+          }
+          data = '';
+        } else {
+          const i = data.indexOf(activeClose);
+          if (i !== -1) {
+            data = data.slice(i + activeClose.length);
+            activeClose = null;
+            continue;
+          }
+          const hold = longestPrefixHold(data, [activeClose]);
+          if (hold) tailHold = data.slice(data.length - hold);
+          data = '';
+        }
+      }
+      if (out) opts.onDelta?.(out);
+    };
+
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+
+      let idx;
+      while ((idx = buffer.indexOf('\n')) >= 0) {
+        const line = buffer.slice(0, idx).trim();
+        buffer = buffer.slice(idx + 1);
+        if (!line.startsWith('data:')) continue;
+        const payload = line.slice(5).trim();
+        if (payload === '[DONE]') {
+          return finalizeReturn();
+        }
+        // Malformed SSE frames (proxy keep-alive, truncated write) would otherwise
+        // abort the whole turn; skip the line and keep streaming.
+        let obj;
+        try { obj = JSON.parse(payload); } catch { continue; }
+        const choice = obj?.choices?.[0];
+        if (choice?.finish_reason) finishReason = choice.finish_reason;
+        const delta = choice?.delta || {};
+        if (delta.content) {
+          if (ttfbMs === null) ttfbMs = Date.now() - started;
+          text += delta.content;
+          forwardClean(delta.content);
+        }
+        for (const tc of delta.tool_calls || []) {
+          const frag = toolCallFrags.get(tc.index) || {
+            index: tc.index,
+            id: '',
+            type: 'function',
+            function: { name: '', arguments: '' },
+          };
+          if (tc.id) frag.id = tc.id;
+          if (tc.type) frag.type = tc.type;
+          // `name` is sent once per tool call per the OpenAI spec; set-once
+          // rather than concatenate so a split fragment can't produce garbage.
+          if (tc.function?.name && !frag.function.name) frag.function.name = tc.function.name;
+          if (tc.function?.arguments) frag.function.arguments += tc.function.arguments;
+          toolCallFrags.set(tc.index, frag);
+        }
+      }
+    }
+    return finalizeReturn();
+
+    function finalizeReturn() {
+      const streamed = [...toolCallFrags.values()].sort((a, b) => a.index - b.index);
+      // Post-stream: if the model emitted no structured tool_calls but wrote
+      // Granite-style `<tool_call>[...]</tool_call>` in content, extract them
+      // and clean the visible text. No-ops when the regex doesn't match.
+      const { text: cleanedText, toolCalls: inlineCalls } = streamed.length
+        ? { text, toolCalls: [] }
+        : extractInlineToolCalls(text);
+      const toolCalls = streamed.length ? streamed : inlineCalls;
+      // Strip any `<think>...`/`<reasoning>...` blocks from the canonical text
+      // too — the streaming stripper kept them out of TTS, but they'd still
+      // pollute conversation history and the assistant.content we persist.
+      const finalText = stripReasoningTags(cleanedText);
+      return {
+        text: finalText,
+        toolCalls,
+        model,
+        ttfbMs,
+        totalMs: Date.now() - started,
+        finishReason,
+      };
+    }
+  })();
+
+  return requestPromise
+    .catch((err) => {
+      if (timedOut) throw new Error(VOICE_LLM_TIMEOUT_MESSAGE);
+      throw err;
+    })
+    .finally(() => {
+      clearTimeout(timeoutId);
+      requestController.signal.removeEventListener('abort', cancelReader);
+      if (opts.signal && onExternalAbort) {
+        opts.signal.removeEventListener('abort', onExternalAbort);
+      }
+    });
 };
 
 const REASONING_TAG_RE = /<(think|thinking|reasoning)>[\s\S]*?(?:<\/\1>|$)/gi;

--- a/server/services/voice/llm.js
+++ b/server/services/voice/llm.js
@@ -383,6 +383,7 @@ export const streamChat = async (messages, opts = {}) => {
       body: JSON.stringify(body),
       signal: requestController.signal,
     });
+    if (timedOut) throw new Error(VOICE_LLM_TIMEOUT_MESSAGE);
     console.log(`🤖 ${tag}voice.llm.headers ${res.status} in ${Date.now() - reqStart}ms`);
     if (!res.ok || !res.body) {
       const errBody = await res.text().catch(() => '');
@@ -472,6 +473,7 @@ export const streamChat = async (messages, opts = {}) => {
 
     while (true) {
       const { value, done } = await reader.read();
+      if (timedOut) throw new Error(VOICE_LLM_TIMEOUT_MESSAGE);
       if (done) break;
       buffer += decoder.decode(value, { stream: true });
 

--- a/server/services/voice/llm.test.js
+++ b/server/services/voice/llm.test.js
@@ -355,6 +355,41 @@ describe('streamChat request lifecycle', () => {
     expect(reader.cancel).toHaveBeenCalledTimes(1);
   });
 
+  it('bounds a stream that keeps yielding without completing', async () => {
+    let releaseRead;
+    let reads = 0;
+    const reader = {
+      read: vi.fn(() => {
+        reads++;
+        if (reads === 1) {
+          return Promise.resolve({
+            value: new TextEncoder().encode('data: {"choices":[{"delta":{"content":"Still working"}}]}\n\n'),
+            done: false,
+          });
+        }
+        return new Promise((resolve) => { releaseRead = resolve; });
+      }),
+      cancel: vi.fn(() => {
+        releaseRead?.({ value: undefined, done: true });
+        return Promise.resolve();
+      }),
+    };
+    installFetch(() => Promise.resolve({
+      ok: true,
+      status: 200,
+      body: { getReader: () => reader },
+    }));
+
+    const result = streamChat([], { provider: 'test-provider', model: 'test-model' });
+    await vi.waitFor(() => expect(reader.read).toHaveBeenCalledTimes(2));
+    const rejection = expect(result).rejects.toThrow(VOICE_LLM_TIMEOUT_MESSAGE);
+    await vi.advanceTimersByTimeAsync(VOICE_LLM_TIMEOUT_MS);
+
+    await rejection;
+    expect(chatSignal.aborted).toBe(true);
+    expect(reader.cancel).toHaveBeenCalledTimes(1);
+  });
+
   it('preserves explicit cancellation when an active reader closes as done', async () => {
     let releaseRead;
     const reader = {

--- a/server/services/voice/llm.test.js
+++ b/server/services/voice/llm.test.js
@@ -8,6 +8,7 @@ import { getProviderById } from '../providers.js';
 import {
   extractInlineToolCalls, isToolCapable, isReasoningModel,
   TOOL_CAPABLE_PATTERNS, REASONING_PATTERNS, resolveLlmEndpoint,
+  streamChat, VOICE_LLM_TIMEOUT_MS, VOICE_LLM_TIMEOUT_MESSAGE,
 } from './llm.js';
 
 describe('extractInlineToolCalls', () => {
@@ -265,5 +266,130 @@ describe('resolveLlmEndpoint', () => {
     const ep = await resolveLlmEndpoint();
     expect(getProviderById).toHaveBeenCalledWith('lmstudio');
     expect(ep.apiBase).toBe('http://localhost:1234/v1');
+  });
+});
+
+describe('streamChat request lifecycle', () => {
+  let fetchMock;
+  let chatSignal;
+
+  const provider = {
+    id: 'test-provider',
+    type: 'api',
+    endpoint: 'https://example.com/v1',
+    apiKey: '',
+    defaultModel: 'test-model',
+    name: 'Test Provider',
+  };
+
+  const modelResponse = () => Promise.resolve({
+    ok: true,
+    json: async () => ({ data: [{ id: 'test-model' }] }),
+  });
+
+  const pendingUntilAbort = (signal) => new Promise((_, reject) => {
+    const abort = () => reject(signal.reason);
+    if (signal.aborted) abort();
+    else signal.addEventListener('abort', abort, { once: true });
+  });
+
+  const installFetch = (chatFetch) => {
+    fetchMock.mockImplementation((url, options = {}) => {
+      if (url.endsWith('/models')) return modelResponse();
+      chatSignal = options.signal;
+      return chatFetch(options);
+    });
+  };
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    getProviderById.mockReset();
+    getProviderById.mockResolvedValue(provider);
+    fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it('aborts a provider request that never returns headers', async () => {
+    installFetch(({ signal }) => pendingUntilAbort(signal));
+
+    const result = streamChat([], { provider: 'test-provider', model: 'test-model' });
+    const rejection = expect(result).rejects.toThrow(VOICE_LLM_TIMEOUT_MESSAGE);
+    await vi.advanceTimersByTimeAsync(VOICE_LLM_TIMEOUT_MS);
+
+    await rejection;
+    expect(chatSignal.aborted).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('aborts a provider stream that stops yielding SSE data', async () => {
+    const reader = {
+      read: vi.fn(({ signal } = {}) => pendingUntilAbort(signal || chatSignal)),
+      cancel: vi.fn(),
+    };
+    installFetch(({ signal }) => Promise.resolve({
+      ok: true,
+      status: 200,
+      body: { getReader: () => reader },
+    }));
+
+    const result = streamChat([], { provider: 'test-provider', model: 'test-model' });
+    await vi.waitFor(() => expect(reader.read).toHaveBeenCalledTimes(1));
+    const rejection = expect(result).rejects.toThrow(VOICE_LLM_TIMEOUT_MESSAGE);
+    await vi.advanceTimersByTimeAsync(VOICE_LLM_TIMEOUT_MS);
+
+    await rejection;
+    expect(chatSignal.aborted).toBe(true);
+    expect(reader.cancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears the deadline and external abort listener after a successful stream', async () => {
+    const external = new AbortController();
+    const chunks = [
+      { value: new TextEncoder().encode('data: {"choices":[{"delta":{"content":"Hello"}}]}\n\n'), done: false },
+      { value: new TextEncoder().encode('data: [DONE]\n\n'), done: false },
+    ];
+    const reader = { read: vi.fn(async () => chunks.shift() || { value: undefined, done: true }) };
+    installFetch(() => Promise.resolve({ ok: true, status: 200, body: { getReader: () => reader } }));
+
+    await expect(streamChat([], {
+      provider: 'test-provider', model: 'test-model', signal: external.signal,
+    })).resolves.toMatchObject({ text: 'Hello', model: 'test-model' });
+
+    expect(chatSignal.aborted).toBe(false);
+    external.abort();
+    await vi.advanceTimersByTimeAsync(VOICE_LLM_TIMEOUT_MS);
+    expect(chatSignal.aborted).toBe(false);
+  });
+
+  it('clears the deadline after a provider failure', async () => {
+    const providerError = new Error('provider unavailable');
+    installFetch(() => Promise.reject(providerError));
+
+    await expect(streamChat([], { provider: 'test-provider', model: 'test-model' }))
+      .rejects.toBe(providerError);
+
+    expect(chatSignal.aborted).toBe(false);
+    await vi.advanceTimersByTimeAsync(VOICE_LLM_TIMEOUT_MS);
+    expect(chatSignal.aborted).toBe(false);
+  });
+
+  it('preserves an explicit caller cancellation instead of reporting a timeout', async () => {
+    const external = new AbortController();
+    installFetch(({ signal }) => pendingUntilAbort(signal));
+
+    const result = streamChat([], {
+      provider: 'test-provider', model: 'test-model', signal: external.signal,
+    });
+    await vi.waitFor(() => expect(chatSignal).toBeInstanceOf(AbortSignal));
+    external.abort();
+
+    await expect(result).rejects.toMatchObject({ name: 'AbortError' });
+    expect(chatSignal.aborted).toBe(true);
+    await vi.advanceTimersByTimeAsync(VOICE_LLM_TIMEOUT_MS);
   });
 });

--- a/server/services/voice/llm.test.js
+++ b/server/services/voice/llm.test.js
@@ -327,9 +327,13 @@ describe('streamChat request lifecycle', () => {
   });
 
   it('aborts a provider stream that stops yielding SSE data', async () => {
+    let releaseRead;
     const reader = {
-      read: vi.fn(({ signal } = {}) => pendingUntilAbort(signal || chatSignal)),
-      cancel: vi.fn(),
+      read: vi.fn(() => new Promise((resolve) => { releaseRead = resolve; })),
+      cancel: vi.fn(() => {
+        releaseRead?.({ value: undefined, done: true });
+        return Promise.resolve();
+      }),
     };
     installFetch(({ signal }) => Promise.resolve({
       ok: true,

--- a/server/services/voice/llm.test.js
+++ b/server/services/voice/llm.test.js
@@ -316,12 +316,16 @@ describe('streamChat request lifecycle', () => {
 
   it('aborts a provider request that never returns headers', async () => {
     installFetch(({ signal }) => pendingUntilAbort(signal));
+    const onTimeout = vi.fn();
 
-    const result = streamChat([], { provider: 'test-provider', model: 'test-model' });
+    const result = streamChat([], {
+      provider: 'test-provider', model: 'test-model', onTimeout,
+    });
     const rejection = expect(result).rejects.toThrow(VOICE_LLM_TIMEOUT_MESSAGE);
     await vi.advanceTimersByTimeAsync(VOICE_LLM_TIMEOUT_MS);
 
     await rejection;
+    expect(onTimeout).toHaveBeenCalledTimes(1);
     expect(chatSignal.aborted).toBe(true);
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
@@ -349,6 +353,35 @@ describe('streamChat request lifecycle', () => {
     await rejection;
     expect(chatSignal.aborted).toBe(true);
     expect(reader.cancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves explicit cancellation when an active reader closes as done', async () => {
+    let releaseRead;
+    const reader = {
+      read: vi.fn(() => new Promise((resolve) => { releaseRead = resolve; })),
+      cancel: vi.fn(() => {
+        releaseRead?.({ value: undefined, done: true });
+        return Promise.resolve();
+      }),
+    };
+    installFetch(() => Promise.resolve({
+      ok: true,
+      status: 200,
+      body: { getReader: () => reader },
+    }));
+
+    const external = new AbortController();
+    const result = streamChat([], {
+      provider: 'test-provider', model: 'test-model', signal: external.signal,
+    });
+    await vi.waitFor(() => expect(reader.read).toHaveBeenCalledTimes(1));
+    const rejection = expect(result).rejects.toMatchObject({ name: 'AbortError' });
+    external.abort();
+
+    await rejection;
+    expect(chatSignal.aborted).toBe(true);
+    expect(reader.cancel).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(VOICE_LLM_TIMEOUT_MS);
   });
 
   it('clears the deadline and external abort listener after a successful stream', async () => {

--- a/server/services/voice/pipeline.js
+++ b/server/services/voice/pipeline.js
@@ -14,6 +14,7 @@ import { getToolSpecsForIntent, classifyIntent, dispatchTool, getAllToolNames, U
 import { isEchoOfRecentTts, rememberTtsSentence } from './echo.js';
 import { appendJournal, getToday } from '../brainJournal.js';
 import { resolvePending, isExpired } from './confirmGate.js';
+import { anyAbortSignal } from '../../lib/requestAbort.js';
 // getRelevantMemories is imported lazily inside buildMemoryContext — it only
 // runs for retrieval-shaped turns, so keep its memory-backend + embeddings
 // dependency graph out of voice startup / non-retrieval turns (same rationale
@@ -610,13 +611,18 @@ export const runTurn = async ({ audio, text, mimeType, source, history = [], emi
   let pending = '';
   const ttsTimings = [];
   let ttsIdx = 0;
+  // Keep TTS cancellation coupled to the turn, while retaining a separate
+  // deadline path so a timed-out LLM can stop queued audio without making the
+  // socket mistake the timeout for a user cancellation.
+  const ttsController = new AbortController();
+  const ttsSignal = anyAbortSignal([signal, ttsController.signal]);
   const speak = async (sentence) => {
-    if (signal?.aborted || !sentence) return;
+    if (ttsSignal?.aborted || !sentence) return;
     const i = ++ttsIdx;
     const t0 = Date.now();
     tlog(`tts.start #${i} chars=${sentence.length}`);
-    const { wav, latencyMs } = await synthesize(sentence, { signal });
-    if (signal?.aborted) return;
+    const { wav, latencyMs } = await synthesize(sentence, { signal: ttsSignal });
+    if (ttsSignal?.aborted) return;
     ttsTimings.push(latencyMs);
     tlog(`tts.done  #${i} ${latencyMs}ms synth+queue=${Date.now() - t0}ms`);
     // Track what we just said so the next inbound transcript can be checked
@@ -636,7 +642,7 @@ export const runTurn = async ({ audio, text, mimeType, source, history = [], emi
         // Barge-in aborts the turn mid-synthesis — Kokoro throws Error('aborted')
         // and Piper rejects 'piper synthesis aborted'. That's expected, not a
         // real failure, so don't surface it as voice:error.
-        if (signal?.aborted || /aborted/i.test(err?.message || '')) return;
+        if (ttsSignal?.aborted || /aborted/i.test(err?.message || '')) return;
         emit('voice:error', { stage: 'tts', message: err.message });
       });
     }
@@ -663,6 +669,7 @@ export const runTurn = async ({ audio, text, mimeType, source, history = [], emi
       provider: cfg.llm.provider,
       model: cfg.llm.model,
       signal,
+      onTimeout: () => ttsController.abort(),
       tools: toolSpecs,
       tag: turnId,
       onDelta: (delta) => {

--- a/server/services/voice/pipeline.js
+++ b/server/services/voice/pipeline.js
@@ -669,7 +669,10 @@ export const runTurn = async ({ audio, text, mimeType, source, history = [], emi
       provider: cfg.llm.provider,
       model: cfg.llm.model,
       signal,
-      onTimeout: () => ttsController.abort(),
+      onTimeout: () => {
+        ttsController.abort();
+        emit('voice:tts:cancel', { reason: 'timeout' });
+      },
       tools: toolSpecs,
       tag: turnId,
       onDelta: (delta) => {

--- a/server/services/voice/pipelineTimeout.test.js
+++ b/server/services/voice/pipelineTimeout.test.js
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  getVoiceConfig: vi.fn(async () => ({
+    enabled: true,
+    llm: {
+      model: 'test-model',
+      provider: 'test-provider',
+      usePersonality: false,
+      systemPrompt: 'sys',
+      tools: { enabled: false, maxIterations: 1 },
+    },
+  })),
+  synthesize: vi.fn(async (text) => ({ wav: Buffer.alloc(8), latencyMs: 1, _text: text })),
+  streamChat: vi.fn(),
+}));
+
+vi.mock('./config.js', () => ({ getVoiceConfig: mocks.getVoiceConfig }));
+vi.mock('./stt.js', () => ({ transcribe: vi.fn() }));
+vi.mock('./tts.js', () => ({ synthesize: (...args) => mocks.synthesize(...args) }));
+vi.mock('./llm.js', () => ({ streamChat: (...args) => mocks.streamChat(...args) }));
+vi.mock('./tools.js', () => ({
+  getToolSpecsForIntent: () => ({ specs: undefined, activeGroups: new Set() }),
+  classifyIntent: () => new Set(),
+  dispatchTool: vi.fn(),
+  getAllToolNames: () => [],
+  UI_KINDS: ['tab', 'button', 'link', 'input', 'textarea', 'select', 'checkbox', 'radio'],
+}));
+vi.mock('./echo.js', () => ({
+  isEchoOfRecentTts: () => false,
+  rememberTtsSentence: vi.fn(),
+}));
+vi.mock('../brainJournal.js', () => ({ appendJournal: vi.fn(), getToday: vi.fn() }));
+vi.mock('./confirmGate.js', () => ({ resolvePending: vi.fn(), isExpired: vi.fn() }));
+
+const { runTurn } = await import('./pipeline.js');
+
+describe('runTurn LLM timeout recovery', () => {
+  it('cancels queued TTS without converting the timeout into user cancellation', async () => {
+    mocks.synthesize.mockClear();
+    mocks.streamChat.mockImplementationOnce(async (_messages, { onDelta, onTimeout }) => {
+      onDelta('The provider stalled.');
+      onTimeout();
+      throw new Error('Voice LLM request timed out');
+    });
+
+    const events = [];
+    const signal = new AbortController().signal;
+    const turn = runTurn({
+      text: 'hello',
+      history: [],
+      emit: (event, payload) => events.push({ event, payload }),
+      signal,
+      state: {},
+    });
+
+    await expect(turn).rejects.toThrow('Voice LLM request timed out');
+    await vi.waitFor(() => expect(mocks.synthesize).not.toHaveBeenCalled());
+    expect(signal.aborted).toBe(false);
+    expect(events.some(({ event }) => event === 'voice:tts:audio')).toBe(false);
+  });
+});

--- a/server/services/voice/pipelineTimeout.test.js
+++ b/server/services/voice/pipelineTimeout.test.js
@@ -57,6 +57,10 @@ describe('runTurn LLM timeout recovery', () => {
     await expect(turn).rejects.toThrow('Voice LLM request timed out');
     await vi.waitFor(() => expect(mocks.synthesize).not.toHaveBeenCalled());
     expect(signal.aborted).toBe(false);
+    expect(events).toContainEqual({
+      event: 'voice:tts:cancel',
+      payload: { reason: 'timeout' },
+    });
     expect(events.some(({ event }) => event === 'voice:tts:audio')).toBe(false);
   });
 });

--- a/server/sockets/voice.js
+++ b/server/sockets/voice.js
@@ -3,7 +3,7 @@
 //           | voice:dictation:set | voice:ui:index | voice:screenshot:result
 //           | voice:ui:read-response | voice:output:available | voice:output:claim
 // Outbound: voice:transcript | voice:llm:delta | voice:llm:done | voice:tts:audio
-//           | voice:tool | voice:dictation | voice:navigate
+//           | voice:tts:cancel | voice:tool | voice:dictation | voice:navigate
 //           | voice:ui:click | voice:ui:fill | voice:ui:select | voice:ui:check
 //           | voice:ui:read-request
 //           | voice:dailyLog:appended | voice:error | voice:idle

--- a/server/sockets/voice.test.js
+++ b/server/sockets/voice.test.js
@@ -226,6 +226,30 @@ describe('voice:text validation', () => {
   });
 });
 
+describe('voice:text turn recovery', () => {
+  afterEach(() => runTurn.mockClear());
+
+  it('emits voice:error and voice:idle when the LLM deadline expires', async () => {
+    const socket = makeFakeSocket();
+    registerVoiceHandlers(socket);
+    runTurn.mockImplementationOnce(async () => {
+      throw new Error('Voice LLM request timed out');
+    });
+
+    socket.fire('voice:text', { text: 'hello' });
+    await vi.waitFor(() => expect(socket.emitted.filter((e) => e.event === 'voice:idle')).toHaveLength(1));
+
+    expect(socket.emitted.filter((e) => e.event === 'voice:error')).toEqual([{
+      event: 'voice:error',
+      payload: { stage: 'text', message: 'Voice LLM request timed out' },
+    }]);
+    expect(socket.emitted.filter((e) => e.event === 'voice:idle')).toEqual([{
+      event: 'voice:idle',
+      payload: { reason: 'error' },
+    }]);
+  });
+});
+
 describe('voice:output single-recipient wiring', () => {
   beforeEach(() => __resetVoiceOutput());
 


### PR DESCRIPTION
## Summary
- bound voice provider requests and SSE streams to a 30-second deadline
- preserve explicit voice cancellation while surfacing timeout recovery
- cancel server, widget, call-host, and browser TTS work when a voice LLM times out

## Test plan
- cd server && npm test -- --run services/voice/llm.test.js services/voice/pipeline.test.js services/voice/pipelineTimeout.test.js sockets/voice.test.js
- cd server && npm test
- cd client && npm test

Closes #5497