### PR TITLE
report a template use as successful only when its usage write landed

### DIFF
--- a/client/src/components/cos/TaskAddForm.jsx
+++ b/client/src/components/cos/TaskAddForm.jsx
@@ -373,8 +373,13 @@ export default function TaskAddForm({ providers, apps, onTaskAdded, compact = fa
       setWorktreeChangesExpected(false);
     }
     descriptionRef.current?.focus();
-    await api.applyCosTaskTemplate(template.id).catch(() => {});
-    toast.success(`Template applied: ${template.name}`);
+    const usageRecorded = await api.applyCosTaskTemplate(template.id, { silent: true })
+      .then(() => true)
+      .catch(() => {
+        toast.warning('Template applied locally, but usage could not be recorded');
+        return false;
+      });
+    if (usageRecorded) toast.success(`Template applied: ${template.name}`);
   }, [newTask.app, planOnly, providers, selectedApp]);
 
   // Save current form as template (inline input instead of window.prompt)

--- a/client/src/components/cos/TaskAddForm.jsx
+++ b/client/src/components/cos/TaskAddForm.jsx
@@ -373,9 +373,16 @@ export default function TaskAddForm({ providers, apps, onTaskAdded, compact = fa
       setWorktreeChangesExpected(false);
     }
     descriptionRef.current?.focus();
+    // The popularity counter is best-effort: the template has already been
+    // applied to local form state above, so a failed write must not read as a
+    // failed application — but it must not read as a successful one either
+    // (#5494). `silent: true` suppresses the shared helper's error toast so the
+    // failure is reported once, here, with the underlying reason logged for
+    // diagnosis (the helper's toast was the only place it used to surface).
     const usageRecorded = await api.applyCosTaskTemplate(template.id, { silent: true })
       .then(() => true)
-      .catch(() => {
+      .catch((err) => {
+        console.warn(`⚠️ Template usage not recorded for ${template.id}: ${err?.message || err}`);
         toast.warning('Template applied locally, but usage could not be recorded');
         return false;
       });

--- a/client/src/components/cos/TaskAddForm.test.jsx
+++ b/client/src/components/cos/TaskAddForm.test.jsx
@@ -333,6 +333,11 @@ describe('TaskAddForm quick templates', () => {
     await waitFor(() => expect(toast.warning).toHaveBeenCalledWith(
       'Template applied locally, but usage could not be recorded'
     ));
+    // Reported ONCE: `silent: true` keeps the shared API helper quiet, so the
+    // component's warning is the only notice — no paired red error toast, and
+    // no success claim about a write that did not happen.
+    expect(toast.warning).toHaveBeenCalledTimes(1);
+    expect(toast.error).not.toHaveBeenCalled();
     expect(toast.success).not.toHaveBeenCalled();
   });
 });

--- a/client/src/components/cos/TaskAddForm.test.jsx
+++ b/client/src/components/cos/TaskAddForm.test.jsx
@@ -17,8 +17,16 @@ const api = vi.hoisted(() => ({
 // useAssignableInstances reads the instance registry straight off apiSystem, so
 // the picker (#4520) has to be driven from there rather than the `api` barrel.
 const apiSystem = vi.hoisted(() => ({ getAssignableInstances: vi.fn() }));
+const toast = vi.hoisted(() => {
+  const toastFn = vi.fn();
+  toastFn.success = vi.fn();
+  toastFn.error = vi.fn();
+  toastFn.warning = vi.fn();
+  return toastFn;
+});
 vi.mock('../../services/apiSystem', () => apiSystem);
 vi.mock('../../services/api', () => api);
+vi.mock('../ui/Toast', () => ({ default: toast }));
 
 const worktreeToggle = () => screen.getByTitle(/isolated git worktree/i).closest('label').querySelector('input');
 const openPrToggle = () => screen.getByTitle(/Open a pull request/i).closest('label').querySelector('input');
@@ -287,7 +295,7 @@ describe('TaskAddForm quick templates', () => {
     await waitFor(() => expect(planOnlyToggle()).toBeChecked());
     expect(screen.queryByTitle(/isolated git worktree/i)).toBeNull();
     expect(screen.getByPlaceholderText('Task description *')).toHaveValue('Investigate and file an issue for: ');
-    expect(api.applyCosTaskTemplate).toHaveBeenCalledWith('builtin-do-plan-task');
+    expect(api.applyCosTaskTemplate).toHaveBeenCalledWith('builtin-do-plan-task', { silent: true });
   });
 
   it('leaves the toggles as-is for a template with no settings block', async () => {
@@ -307,6 +315,25 @@ describe('TaskAddForm quick templates', () => {
     // A template that pins no app must not clear the one already selected —
     // clearing it also silently reset the app's worktree/PR defaults.
     expect(screen.getByLabelText(/target application/i)).toHaveValue('example-app');
+  });
+
+  it('keeps the local template application and warns when usage recording fails', async () => {
+    const user = userEvent.setup();
+    api.getCosPopularTemplates.mockResolvedValue({
+      templates: [{ id: 'user-failed', name: 'Offline Template', description: 'Do the thing locally', isBuiltin: false }]
+    });
+    api.applyCosTaskTemplate.mockRejectedValue(new Error('Server unreachable'));
+
+    renderForm();
+    await openTemplates(user);
+    await user.click(screen.getByText('Offline Template'));
+
+    await waitFor(() => expect(api.applyCosTaskTemplate).toHaveBeenCalledWith('user-failed', { silent: true }));
+    expect(screen.getByPlaceholderText('Task description *')).toHaveValue('Do the thing locally');
+    await waitFor(() => expect(toast.warning).toHaveBeenCalledWith(
+      'Template applied locally, but usage could not be recorded'
+    ));
+    expect(toast.success).not.toHaveBeenCalled();
   });
 });
 

--- a/client/src/services/apiAgents.js
+++ b/client/src/services/apiAgents.js
@@ -270,7 +270,10 @@ export const createCosTemplateFromTask = (task, templateName) => request('/cos/t
   method: 'POST',
   body: JSON.stringify({ task, templateName })
 });
-export const applyCosTaskTemplate = (id) => request(`/cos/templates/${id}/use`, { method: 'POST' });
+export const applyCosTaskTemplate = (id, options = {}) => request(`/cos/templates/${id}/use`, {
+  method: 'POST',
+  ...options
+});
 export const updateCosTaskTemplate = (id, data) => request(`/cos/templates/${id}`, {
   method: 'PUT',
   body: JSON.stringify(data)


### PR DESCRIPTION
## Summary

- Selecting a quick task template showed `Template applied: <name>` even when the `POST /api/cos/templates/:id/use` write that records the selection had just failed — the empty `.catch(() => {})` swallowed the rejection and the next line always claimed success, right after the shared API helper had already toasted "Server unreachable".
- The usage call now passes `{ silent: true }` (so the shared helper does not toast) and the component reports the outcome once: a success toast only when the write landed, otherwise a warning that says the template was applied locally but its usage was not recorded. Local form state is still applied either way — that is synchronous, not a server mutation.
- `applyCosTaskTemplate` gains the same optional request-options pass-through the other `apiAgents` wrappers use (`repairRunRecords`, `callCosTool`), so a caller can opt into silent handling deliberately.
- The failure reason is logged to the console (`⚠️ Template usage not recorded for …`), matching the other best-effort `silent: true` callers. Without it, silencing the helper's toast would have removed the only place the underlying error ever surfaced, leaving the same undiagnosable outcome the issue set out to fix.
- Server side was audited and needed no change: `recordTemplateUsage` → `saveState` → `atomicWrite` propagates a write failure through `asyncHandler` to the error middleware, so `{ success: true }` is only ever sent after the counter is persisted.

Closes #5494

## Test plan

- `cd client && npx vitest run src/components/cos/TaskAddForm.test.jsx` — 24 passed, including a new rejection-path test asserting the form still adopts the template, exactly one warning fires, and neither an error nor a success toast does.
- `cd client && npx vitest run src/services src/components/cos` — 58 files / 670 tests passed.
- `cd client && npx vitest run src/components/ui/Toast.test.jsx` — 19 passed (`toast.warning` is a real Toast method, not just a test double).
- `cd client && npx biome lint --error-on-warnings` on the changed files — clean.
