### PR TITLE
Cancel sibling CI jobs after the first required job fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
+          persist-credentials: false
           # See the impact job: depth 2 is the whole PR merge ref, which is all
           # the planner needs to identify changed sources.
           fetch-depth: 2
@@ -271,6 +272,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
+          persist-credentials: false
           # See the impact job: depth 2 is the whole PR merge ref, which is all
           # the planner needs to identify changed sources.
           fetch-depth: 2
@@ -353,6 +355,8 @@ jobs:
       PGPASSWORD: portos
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Use Node.js 24.x
         uses: actions/setup-node@v7
@@ -476,6 +480,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
+          persist-credentials: false
           # See the impact job: depth 2 is the whole PR merge ref, which is all
           # the planner needs to identify changed sources.
           fetch-depth: 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,7 +256,7 @@ jobs:
         run: npm run smoke
 
       - name: Cancel sibling CI jobs after failure
-        if: failure()
+        if: failure() && github.event_name == 'pull_request'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: node scripts/cancel-current-ci-run.js
@@ -321,7 +321,7 @@ jobs:
         run: npm run build --prefix client
 
       - name: Cancel sibling CI jobs after failure
-        if: failure()
+        if: failure() && github.event_name == 'pull_request'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: node scripts/cancel-current-ci-run.js
@@ -464,7 +464,7 @@ jobs:
           PGDATABASE: portos_test
 
       - name: Cancel sibling CI jobs after failure
-        if: failure()
+        if: failure() && github.event_name == 'pull_request'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: node scripts/cancel-current-ci-run.js
@@ -591,7 +591,7 @@ jobs:
         run: node scripts/run-ci-tests.js server
 
       - name: Cancel sibling CI jobs after failure
-        if: failure()
+        if: failure() && github.event_name == 'pull_request'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: node scripts/cancel-current-ci-run.js

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,9 @@ jobs:
     needs: impact
     if: needs.impact.outputs.server_mode != 'skip'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
     steps:
       - uses: actions/checkout@v7
         with:
@@ -251,11 +254,20 @@ jobs:
         if: needs.impact.outputs.smoke == 'true'
         run: npm run smoke
 
+      - name: Cancel sibling CI jobs after failure
+        if: failure()
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node scripts/cancel-current-ci-run.js
+
   client:
     name: Client tests and build
     needs: impact
     if: needs.impact.outputs.client_mode != 'skip' || needs.impact.outputs.build == 'true' || needs.impact.outputs.lint_mode != 'skip'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
     steps:
       - uses: actions/checkout@v7
         with:
@@ -306,11 +318,20 @@ jobs:
         if: needs.impact.outputs.build == 'true'
         run: npm run build --prefix client
 
+      - name: Cancel sibling CI jobs after failure
+        if: failure()
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node scripts/cancel-current-ci-run.js
+
   database:
     name: DB tests
     needs: impact
     if: needs.impact.outputs.db == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
     services:
       postgres:
         image: pgvector/pgvector:pg17
@@ -438,11 +459,20 @@ jobs:
         env:
           PGDATABASE: portos_test
 
+      - name: Cancel sibling CI jobs after failure
+        if: failure()
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node scripts/cancel-current-ci-run.js
+
   windows-server:
     name: Windows server unit tests
     needs: impact
     if: needs.impact.outputs.windows == 'true'
     runs-on: windows-latest
+    permissions:
+      contents: read
+      actions: write
     steps:
       - uses: actions/checkout@v7
         with:
@@ -554,6 +584,12 @@ jobs:
           PORTOS_TEST_QUIET: 1
           PGPASSWORD: portos
         run: node scripts/run-ci-tests.js server
+
+      - name: Cancel sibling CI jobs after failure
+        if: failure()
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node scripts/cancel-current-ci-run.js
 
   gate:
     name: CI Gate

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,9 @@ jobs:
   full-ci:
     needs: verify-ci
     if: needs.verify-ci.outputs.verified != 'true'
+    permissions:
+      contents: read
+      actions: write
     uses: ./.github/workflows/ci.yml
     with:
       full: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,14 @@ jobs:
   full-ci:
     needs: verify-ci
     if: needs.verify-ci.outputs.verified != 'true'
+    # `actions: write` looks unused from here — the fail-fast cancellation step
+    # in ci.yml's leaf jobs is gated on `github.event_name == 'pull_request'`,
+    # and a called workflow inherits the caller's event, which is this push.
+    # It still has to be granted: a called workflow's jobs cannot hold a
+    # permission the calling job does not, so narrowing this to `contents: read`
+    # strips `actions: write` from leaf jobs that declare it. This block also
+    # scopes full-ci DOWN from the workflow-level `contents: write` the release
+    # job needs; ci.yml only ever checks out. ci-fail-fast.test.js pins it.
     permissions:
       contents: read
       actions: write

--- a/docs/GITHUB_ACTIONS.md
+++ b/docs/GITHUB_ACTIONS.md
@@ -260,6 +260,33 @@ green PRs, and the `main` → `release` PR catches it before a release ships.
 Changes to CI/test configuration also force the full suite on their own PR.
 `[skip ci]` remains honored for push events only; PR CI always runs.
 
+### Fail-fast sibling cancellation
+
+Each selected leaf job (`server`, `client`, `database`, and
+`windows-server`) ends with an `if: failure()` step that asks GitHub to cancel
+the current workflow run. The request uses the repository-owned
+`scripts/cancel-current-ci-run.js` helper and the standard workflow-run cancel
+endpoint. The helper accepts no repository or run arguments: it validates and
+uses only `GITHUB_REPOSITORY` and `GITHUB_RUN_ID` supplied by Actions, with the
+step-scoped `GITHUB_TOKEN`.
+
+The leaf jobs request only `contents: read` and `actions: write`. The token is
+present in the environment only for the cancellation step, and no third-party
+action or long-lived secret is involved. The failing test/build step runs
+before cancellation, so its annotations and logs remain the evidence for the
+failure. A successful cancellation returns `202`; a `409` means the run is
+already terminal and is treated as a no-op.
+
+Cancellation is deliberately best-effort. Fork pull requests and other
+read-only-token runs may receive a permission failure, and transient API or
+network failures are also possible. The helper logs the unavailable
+cancellation and exits normally, preserving the original failed step and its
+failed job result. `CI Gate` still allows only `success` or `skipped` results;
+failed or canceled leaf jobs therefore cannot satisfy the required aggregate
+context. The target is for siblings to become canceled within 30 seconds of
+the first failing job completing, while the existing workflow-level
+concurrency cancellation continues to handle newer runs independently.
+
 ### Impact-planner safety rules
 
 - A directory feature such as `server/services/sprites/` selects tests carrying

--- a/docs/GITHUB_ACTIONS.md
+++ b/docs/GITHUB_ACTIONS.md
@@ -263,8 +263,12 @@ Changes to CI/test configuration also force the full suite on their own PR.
 ### Fail-fast sibling cancellation
 
 Each selected leaf job (`server`, `client`, `database`, and
-`windows-server`) ends with an `if: failure()` step that asks GitHub to cancel
-the current workflow run. The request uses the repository-owned
+`windows-server`) ends with an `if: failure() && github.event_name ==
+'pull_request'` step that asks GitHub to cancel the current pull-request
+workflow run. The event guard is important because the same workflow is reused
+by the release workflow: a failing reusable `full-ci` job must not cancel its
+parent release run before that workflow can report the release failure. The
+request uses the repository-owned
 `scripts/cancel-current-ci-run.js` helper and the standard workflow-run cancel
 endpoint. The helper accepts no repository or run arguments: it validates and
 uses only `GITHUB_REPOSITORY` and `GITHUB_RUN_ID` supplied by Actions, with the
@@ -281,11 +285,17 @@ Cancellation is deliberately best-effort. Fork pull requests and other
 read-only-token runs may receive a permission failure, and transient API or
 network failures are also possible. The helper logs the unavailable
 cancellation and exits normally, preserving the original failed step and its
-failed job result. `CI Gate` still allows only `success` or `skipped` results;
-failed or canceled leaf jobs therefore cannot satisfy the required aggregate
-context. The target is for siblings to become canceled within 30 seconds of
-the first failing job completing, while the existing workflow-level
-concurrency cancellation continues to handle newer runs independently.
+failed job result when the API is unavailable. When cancellation succeeds, the
+run-wide cancellation can mark the requesting job and `CI Gate` as canceled;
+the failed step's log and annotations remain the diagnostic evidence, and a
+canceled result is still non-mergeable. `CI Gate` allows only `success` or
+`skipped` results; failed or canceled leaf jobs therefore cannot satisfy the
+required aggregate context. The target is for siblings to become canceled
+within 30 seconds of the first failing job completing, while the existing
+workflow-level concurrency cancellation continues to handle newer runs
+independently. Scheduled, manually dispatched, and release-called runs skip
+this sibling cancellation so their aggregate diagnostics and cache post-steps
+can complete normally.
 
 ### Impact-planner safety rules
 

--- a/docs/GITHUB_ACTIONS.md
+++ b/docs/GITHUB_ACTIONS.md
@@ -274,28 +274,54 @@ endpoint. The helper accepts no repository or run arguments: it validates and
 uses only `GITHUB_REPOSITORY` and `GITHUB_RUN_ID` supplied by Actions, with the
 step-scoped `GITHUB_TOKEN`.
 
-The leaf jobs request only `contents: read` and `actions: write`. The token is
-present in the environment only for the cancellation step, and no third-party
-action or long-lived secret is involved. The failing test/build step runs
-before cancellation, so its annotations and logs remain the evidence for the
-failure. A successful cancellation returns `202`; a `409` means the run is
-already terminal and is treated as a no-op.
+The leaf jobs request only `contents: read` and `actions: write`, and check
+out with `persist-credentials: false` so a token that can now cancel runs is
+not left in `.git/config` for the test suite's own subprocesses to read. The
+token is present in the environment only for the cancellation step, and no
+third-party action or long-lived secret is involved. The failing test/build
+step runs before cancellation, so its annotations and logs remain the evidence
+for the failure. A successful cancellation returns `202`; a `409` means the run
+is already terminal and is treated as a no-op.
+
+`release.yml`'s `full-ci` job must grant `actions: write` to the workflow it
+calls even though the cancellation step never fires there — a called workflow's
+jobs cannot hold a permission the calling job lacks. See the comment on that
+job; `scripts/ci-fail-fast.test.js` pins it.
 
 Cancellation is deliberately best-effort. Fork pull requests and other
 read-only-token runs may receive a permission failure, and transient API or
 network failures are also possible. The helper logs the unavailable
 cancellation and exits normally, preserving the original failed step and its
-failed job result when the API is unavailable. When cancellation succeeds, the
-run-wide cancellation can mark the requesting job and `CI Gate` as canceled;
-the failed step's log and annotations remain the diagnostic evidence, and a
-canceled result is still non-mergeable. `CI Gate` allows only `success` or
-`skipped` results; failed or canceled leaf jobs therefore cannot satisfy the
-required aggregate context. The target is for siblings to become canceled
-within 30 seconds of the first failing job completing, while the existing
-workflow-level concurrency cancellation continues to handle newer runs
-independently. Scheduled, manually dispatched, and release-called runs skip
-this sibling cancellation so their aggregate diagnostics and cache post-steps
-can complete normally.
+failed job result when the API is unavailable. It imports only Node builtins,
+so it still runs from a job that failed before `npm ci`
+(`scripts/pre-install-entrypoints.test.js` enforces that).
+
+**Canceled is not mergeable.** A run-wide cancellation lands on the requesting
+job and on `CI Gate`, which is usually still waiting on its `needs` and so ends
+`cancelled` rather than running its comparison. Every consumer treats that as a
+non-pass, by allowlisting the green results rather than denylisting the red
+ones:
+
+- Branch protection requires the `CI Gate` context to conclude `success`;
+  `cancelled` does not satisfy it, and a gate that never publishes leaves the
+  required context unreported, which also blocks.
+- If the gate job does run, it accepts only `success` or `skipped` per job, so
+  the failed leaf (or its own `cancelled` result) fails the gate.
+- `scripts/verify-ci-status.js` accepts a `Full CI Gate` only at
+  `conclusion === 'success'`, so a canceled run can never let a release skip
+  the full suite.
+- PortOS's own auto-merge watcher (`server/services/prWatcher.js`) counts only
+  `SUCCESS`/`NEUTRAL`/`SKIPPED` as green.
+
+The consequence to expect in the UI: on a fail-fast run the required check
+reads *canceled*, not *failed*. The failing step's log and annotations are
+still the diagnosis. The target is for siblings to become canceled within 30
+seconds of the first failing job completing, while the existing workflow-level
+`concurrency.cancel-in-progress` continues to handle superseded runs
+independently — the two are orthogonal, one canceling this run by id and the
+other canceling an older run when a newer commit arrives. Scheduled, manually
+dispatched, and release-called runs skip this sibling cancellation so their
+aggregate diagnostics and cache post-steps can complete normally.
 
 ### Impact-planner safety rules
 

--- a/scripts/cancel-current-ci-run.js
+++ b/scripts/cancel-current-ci-run.js
@@ -26,15 +26,33 @@ function targetFromEnv(env) {
     ? env.GITHUB_RUN_ID.trim()
     : '';
   const token = typeof env.GITHUB_TOKEN === 'string' ? env.GITHUB_TOKEN.trim() : '';
+  const configuredApiUrl = typeof env.GITHUB_API_URL === 'string'
+    ? env.GITHUB_API_URL.trim()
+    : '';
 
   if (!/^[^/\s]+\/[^/\s]+$/.test(repository) || !/^\d+$/.test(runId) || !token) {
     return null;
   }
 
+  let apiBase = GITHUB_API_BASE;
+  if (configuredApiUrl) {
+    let parsedApiUrl;
+    try {
+      parsedApiUrl = new URL(configuredApiUrl);
+    } catch {
+      return null;
+    }
+    if (parsedApiUrl.protocol !== 'https:' || parsedApiUrl.username || parsedApiUrl.password
+      || parsedApiUrl.search || parsedApiUrl.hash) {
+      return null;
+    }
+    apiBase = configuredApiUrl.replace(/\/+$/, '');
+  }
+
   const [owner, repo] = repository.split('/');
   return {
     token,
-    url: `${GITHUB_API_BASE}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/actions/runs/${runId}/cancel`,
+    url: `${apiBase}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/actions/runs/${runId}/cancel`,
   };
 }
 

--- a/scripts/cancel-current-ci-run.js
+++ b/scripts/cancel-current-ci-run.js
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+
+/**
+ * Best-effort cancellation for the workflow run executing this step.
+ *
+ * The workflow deliberately supplies no target arguments. The repository and
+ * run id come only from GitHub Actions' environment, so a PR cannot redirect
+ * this request to another run or repository through script arguments.
+ *
+ * This script runs after a real CI failure. Cancellation errors must never
+ * replace the original failure, so every unavailable/invalid path returns
+ * normally after emitting a single diagnostic line.
+ */
+
+import { isDirectlyInvoked } from './lib/directInvocation.js';
+
+const GITHUB_API_VERSION = '2022-11-28';
+const GITHUB_API_BASE = 'https://api.github.com';
+const CANCELLATION_TIMEOUT_MS = 10_000;
+
+function targetFromEnv(env) {
+  const repository = typeof env.GITHUB_REPOSITORY === 'string'
+    ? env.GITHUB_REPOSITORY.trim()
+    : '';
+  const runId = typeof env.GITHUB_RUN_ID === 'string'
+    ? env.GITHUB_RUN_ID.trim()
+    : '';
+  const token = typeof env.GITHUB_TOKEN === 'string' ? env.GITHUB_TOKEN.trim() : '';
+
+  if (!/^[^/\s]+\/[^/\s]+$/.test(repository) || !/^\d+$/.test(runId) || !token) {
+    return null;
+  }
+
+  const [owner, repo] = repository.split('/');
+  return {
+    token,
+    url: `${GITHUB_API_BASE}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/actions/runs/${runId}/cancel`,
+  };
+}
+
+/**
+ * Ask GitHub to cancel the workflow run containing this step.
+ *
+ * @param {object} [options]
+ * @param {NodeJS.ProcessEnv} [options.env] - Actions environment to read.
+ * @param {typeof fetch} [options.fetchImpl] - Injectable fetch for tests.
+ * @param {{log?: Function, error?: Function}} [options.logger] - Injectable logger.
+ * @returns {Promise<{outcome: string, status?: number, reason?: string}>}
+ */
+export async function cancelCurrentCiRun({
+  env = process.env,
+  fetchImpl = globalThis.fetch,
+  logger = console,
+} = {}) {
+  const target = targetFromEnv(env);
+  if (!target) {
+    logger.error?.('⚠️ CI run cancellation skipped: required GitHub Actions environment is unavailable');
+    return { outcome: 'skipped', reason: 'invalid-environment' };
+  }
+
+  if (typeof fetchImpl !== 'function') {
+    logger.error?.('⚠️ CI run cancellation unavailable: fetch is not available');
+    return { outcome: 'unavailable', reason: 'fetch-unavailable' };
+  }
+
+  try {
+    const response = await fetchImpl(target.url, {
+      method: 'POST',
+      headers: {
+        Accept: 'application/vnd.github+json',
+        Authorization: `Bearer ${target.token}`,
+        'X-GitHub-Api-Version': GITHUB_API_VERSION,
+      },
+      signal: AbortSignal.timeout(CANCELLATION_TIMEOUT_MS),
+    });
+    const status = Number(response?.status) || 0;
+
+    if ((status >= 200 && status < 300) || response?.ok === true) {
+      logger.log?.('🛑 Requested cancellation of the current CI run');
+      return { outcome: 'requested', status };
+    }
+
+    if (status === 409) {
+      logger.log?.('ℹ️ Current CI run is already terminal; sibling cancellation was unnecessary');
+      return { outcome: 'already-terminal', status };
+    }
+
+    logger.error?.(`⚠️ Could not cancel the current CI run: GitHub API returned ${status || 'an unknown status'}`);
+    return { outcome: 'unavailable', status };
+  } catch (error) {
+    logger.error?.(`⚠️ Could not cancel the current CI run: ${error?.message || 'network request failed'}`);
+    return { outcome: 'unavailable', reason: 'request-failed' };
+  }
+}
+
+if (isDirectlyInvoked(import.meta.url)) {
+  await cancelCurrentCiRun();
+}

--- a/scripts/cancel-current-ci-run.test.js
+++ b/scripts/cancel-current-ci-run.test.js
@@ -54,6 +54,48 @@ describe('cancelCurrentCiRun', () => {
     expect(logger.error).not.toHaveBeenCalled();
   });
 
+  it('uses the Actions API base and falls back to the public API when it is absent', async () => {
+    const { fetchImpl, logger } = setup();
+    fetchImpl.mockResolvedValue(response(202));
+
+    await cancelCurrentCiRun({
+      env: { ...ENV, GITHUB_API_URL: 'https://github.example.test/api/v3/' },
+      fetchImpl,
+      logger,
+    });
+    expect(fetchImpl).toHaveBeenLastCalledWith(
+      'https://github.example.test/api/v3/repos/example/portos/actions/runs/123456789/cancel',
+      expect.any(Object),
+    );
+
+    fetchImpl.mockClear();
+    await cancelCurrentCiRun({ env: ENV, fetchImpl, logger });
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'https://api.github.com/repos/example/portos/actions/runs/123456789/cancel',
+      expect.any(Object),
+    );
+  });
+
+  it('rejects an unsafe API base without making a request', async () => {
+    const { fetchImpl, logger } = setup();
+
+    await expect(cancelCurrentCiRun({
+      env: { ...ENV, GITHUB_API_URL: 'http://example.invalid/api/v3' },
+      fetchImpl,
+      logger,
+    })).resolves.toEqual({ outcome: 'skipped', reason: 'invalid-environment' });
+
+    expect(fetchImpl).not.toHaveBeenCalled();
+
+    await expect(cancelCurrentCiRun({
+      env: { ...ENV, GITHUB_API_URL: 'not-a-url' },
+      fetchImpl,
+      logger,
+    })).resolves.toEqual({ outcome: 'skipped', reason: 'invalid-environment' });
+
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
   it('keeps a permission failure best-effort and preserves the original job failure', async () => {
     const { fetchImpl, logger } = setup();
     fetchImpl.mockResolvedValue(response(403));

--- a/scripts/cancel-current-ci-run.test.js
+++ b/scripts/cancel-current-ci-run.test.js
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { cancelCurrentCiRun } from './cancel-current-ci-run.js';
+
+const ENV = {
+  GITHUB_REPOSITORY: 'example/portos',
+  GITHUB_RUN_ID: '123456789',
+  GITHUB_TOKEN: 'ephemeral-test-token',
+};
+
+const response = (status) => ({ ok: status >= 200 && status < 300, status });
+
+function setup() {
+  return {
+    fetchImpl: vi.fn(),
+    logger: { log: vi.fn(), error: vi.fn() },
+  };
+}
+
+describe('cancelCurrentCiRun', () => {
+  it('cancels the current repository run with the step-scoped token', async () => {
+    const { fetchImpl, logger } = setup();
+    fetchImpl.mockResolvedValue(response(202));
+
+    await expect(cancelCurrentCiRun({ env: ENV, fetchImpl, logger })).resolves.toEqual({
+      outcome: 'requested',
+      status: 202,
+    });
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'https://api.github.com/repos/example/portos/actions/runs/123456789/cancel',
+      expect.objectContaining({
+        method: 'POST',
+        headers: {
+          Accept: 'application/vnd.github+json',
+          Authorization: 'Bearer ephemeral-test-token',
+          'X-GitHub-Api-Version': '2022-11-28',
+        },
+        signal: expect.any(AbortSignal),
+      }),
+    );
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it('treats an already-terminal run as a successful no-op', async () => {
+    const { fetchImpl, logger } = setup();
+    fetchImpl.mockResolvedValue(response(409));
+
+    await expect(cancelCurrentCiRun({ env: ENV, fetchImpl, logger })).resolves.toEqual({
+      outcome: 'already-terminal',
+      status: 409,
+    });
+
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it('keeps a permission failure best-effort and preserves the original job failure', async () => {
+    const { fetchImpl, logger } = setup();
+    fetchImpl.mockResolvedValue(response(403));
+
+    await expect(cancelCurrentCiRun({ env: ENV, fetchImpl, logger })).resolves.toEqual({
+      outcome: 'unavailable',
+      status: 403,
+    });
+
+    expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('403'));
+  });
+
+  it('keeps a network failure best-effort', async () => {
+    const { fetchImpl, logger } = setup();
+    fetchImpl.mockRejectedValue(new Error('network unavailable'));
+
+    await expect(cancelCurrentCiRun({ env: ENV, fetchImpl, logger })).resolves.toEqual({
+      outcome: 'unavailable',
+      reason: 'request-failed',
+    });
+
+    expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('network unavailable'));
+  });
+
+  it('does not make a request when the target cannot come from Actions environment', async () => {
+    const { fetchImpl, logger } = setup();
+
+    await expect(cancelCurrentCiRun({
+      env: { ...ENV, GITHUB_REPOSITORY: 'https://example.invalid/other', GITHUB_RUN_ID: 'run-from-args' },
+      fetchImpl,
+      logger,
+    })).resolves.toEqual({ outcome: 'skipped', reason: 'invalid-environment' });
+
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('environment'));
+  });
+});

--- a/scripts/ci-fail-fast.test.js
+++ b/scripts/ci-fail-fast.test.js
@@ -1,0 +1,68 @@
+import { readFileSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+import { describe, expect, it } from 'vitest';
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const WORKFLOW = readFileSync(join(REPO_ROOT, '.github/workflows/ci.yml'), 'utf8');
+const LEAF_JOBS = ['server', 'client', 'database', 'windows-server'];
+const NON_LEAF_JOBS = ['impact', 'gate', 'full-gate'];
+const FAIL_FAST_STEP = [
+  '      - name: Cancel sibling CI jobs after failure',
+  '        if: failure()',
+  '        env:',
+  '          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}',
+  '        run: node scripts/cancel-current-ci-run.js',
+].join('\n');
+
+function workflowJobs(yaml) {
+  const jobsStart = yaml.indexOf('\njobs:\n');
+  const body = yaml.slice(jobsStart);
+  const jobs = {};
+  let current = null;
+  for (const line of body.split('\n')) {
+    const header = line.match(/^ {2}([a-z][a-z0-9-]*):\s*$/);
+    if (header) {
+      current = header[1];
+      jobs[current] = [];
+      continue;
+    }
+    if (current) jobs[current].push(line);
+  }
+  return Object.fromEntries(Object.entries(jobs).map(([id, lines]) => [id, lines.join('\n')]));
+}
+
+describe('ci.yml fail-fast cancellation contract', () => {
+  const jobs = workflowJobs(WORKFLOW);
+
+  it('adds the cancellation step as the final step of every expensive leaf job', () => {
+    for (const id of LEAF_JOBS) {
+      const body = jobs[id];
+      expect(body, id).toBeTruthy();
+      const step = body.slice(body.lastIndexOf('      - name: Cancel sibling CI jobs after failure')).trimEnd();
+      expect(step, id).toBe(FAIL_FAST_STEP);
+      expect(body.match(/GITHUB_TOKEN:/g), id).toHaveLength(1);
+    }
+  });
+
+  it('grants only the leaf jobs the minimum cancellation permissions', () => {
+    for (const id of LEAF_JOBS) {
+      const body = jobs[id];
+      expect(body, id).toMatch(/\n    permissions:\n      contents: read\n      actions: write\n/);
+    }
+    for (const id of NON_LEAF_JOBS) {
+      expect(jobs[id], id).not.toContain('actions: write');
+    }
+  });
+
+  it('does not pass arbitrary repository or run targets to the helper', () => {
+    for (const id of LEAF_JOBS) {
+      const body = jobs[id];
+      expect(body, id).not.toMatch(/GITHUB_(?:REPOSITORY|RUN_ID):/);
+      const step = body.slice(body.lastIndexOf('      - name: Cancel sibling CI jobs after failure'));
+      expect(step, id).not.toContain('\n        with:');
+      expect(body, id).toContain('if: failure()');
+    }
+  });
+});

--- a/scripts/ci-fail-fast.test.js
+++ b/scripts/ci-fail-fast.test.js
@@ -10,7 +10,7 @@ const LEAF_JOBS = ['server', 'client', 'database', 'windows-server'];
 const NON_LEAF_JOBS = ['impact', 'gate', 'full-gate'];
 const FAIL_FAST_STEP = [
   '      - name: Cancel sibling CI jobs after failure',
-  '        if: failure()',
+  "        if: failure() && github.event_name == 'pull_request'",
   '        env:',
   '          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}',
   '        run: node scripts/cancel-current-ci-run.js',

--- a/scripts/ci-fail-fast.test.js
+++ b/scripts/ci-fail-fast.test.js
@@ -65,4 +65,20 @@ describe('ci.yml fail-fast cancellation contract', () => {
       expect(body, id).toContain('if: failure()');
     }
   });
+
+  it('does not persist the elevated checkout token into leaf job steps', () => {
+    for (const id of LEAF_JOBS) {
+      const body = jobs[id];
+      const checkoutStart = body.indexOf('      - uses: actions/checkout@v7');
+      const nextStep = body.indexOf('\n      - ', checkoutStart + 1);
+      const checkout = body.slice(checkoutStart, nextStep === -1 ? undefined : nextStep);
+      expect(checkout, id).toContain('persist-credentials: false');
+    }
+  });
+
+  it('grants the reusable release caller the permission leaf jobs require', () => {
+    const releaseWorkflow = readFileSync(join(REPO_ROOT, '.github/workflows/release.yml'), 'utf8');
+    const fullCi = releaseWorkflow.slice(releaseWorkflow.indexOf('\n  full-ci:'));
+    expect(fullCi).toMatch(/\n    permissions:\n      contents: read\n      actions: write\n/);
+  });
 });

--- a/scripts/ci-fail-fast.test.js
+++ b/scripts/ci-fail-fast.test.js
@@ -6,8 +6,7 @@ import { describe, expect, it } from 'vitest';
 
 const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 const WORKFLOW = readFileSync(join(REPO_ROOT, '.github/workflows/ci.yml'), 'utf8');
-const LEAF_JOBS = ['server', 'client', 'database', 'windows-server'];
-const NON_LEAF_JOBS = ['impact', 'gate', 'full-gate'];
+const NON_LEAF_JOBS = new Set(['impact', 'gate', 'full-gate']);
 const FAIL_FAST_STEP = [
   '      - name: Cancel sibling CI jobs after failure',
   "        if: failure() && github.event_name == 'pull_request'",
@@ -35,9 +34,16 @@ function workflowJobs(yaml) {
 
 describe('ci.yml fail-fast cancellation contract', () => {
   const jobs = workflowJobs(WORKFLOW);
+  const leafJobs = Object.keys(jobs).filter((id) => (
+    !NON_LEAF_JOBS.has(id) && /^\s*needs:\s*impact\s*$/m.test(jobs[id])
+  ));
+
+  it('discovers every direct impact leaf job for contract checks', () => {
+    expect(leafJobs).not.toHaveLength(0);
+  });
 
   it('adds the cancellation step as the final step of every expensive leaf job', () => {
-    for (const id of LEAF_JOBS) {
+    for (const id of leafJobs) {
       const body = jobs[id];
       expect(body, id).toBeTruthy();
       const step = body.slice(body.lastIndexOf('      - name: Cancel sibling CI jobs after failure')).trimEnd();
@@ -47,7 +53,7 @@ describe('ci.yml fail-fast cancellation contract', () => {
   });
 
   it('grants only the leaf jobs the minimum cancellation permissions', () => {
-    for (const id of LEAF_JOBS) {
+    for (const id of leafJobs) {
       const body = jobs[id];
       expect(body, id).toMatch(/\n    permissions:\n      contents: read\n      actions: write\n/);
     }
@@ -57,7 +63,7 @@ describe('ci.yml fail-fast cancellation contract', () => {
   });
 
   it('does not pass arbitrary repository or run targets to the helper', () => {
-    for (const id of LEAF_JOBS) {
+    for (const id of leafJobs) {
       const body = jobs[id];
       expect(body, id).not.toMatch(/GITHUB_(?:REPOSITORY|RUN_ID):/);
       const step = body.slice(body.lastIndexOf('      - name: Cancel sibling CI jobs after failure'));
@@ -67,7 +73,7 @@ describe('ci.yml fail-fast cancellation contract', () => {
   });
 
   it('does not persist the elevated checkout token into leaf job steps', () => {
-    for (const id of LEAF_JOBS) {
+    for (const id of leafJobs) {
       const body = jobs[id];
       const checkoutStart = body.indexOf('      - uses: actions/checkout@v7');
       const nextStep = body.indexOf('\n      - ', checkoutStart + 1);

--- a/scripts/ci-fail-fast.test.js
+++ b/scripts/ci-fail-fast.test.js
@@ -7,8 +7,20 @@ import { describe, expect, it } from 'vitest';
 const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 const WORKFLOW = readFileSync(join(REPO_ROOT, '.github/workflows/ci.yml'), 'utf8');
 const NON_LEAF_JOBS = new Set(['impact', 'gate', 'full-gate']);
+// The expensive fan-out jobs that exist today. A FLOOR, not a snapshot: a new
+// leaf job has to be discovered on its own and held to the contract below, so
+// nothing here has to be edited to add one. What this list catches is the
+// opposite — discovery silently ceasing to see one of the four while the other
+// three keep every assertion green.
+const EXPECTED_LEAF_JOBS = ['client', 'database', 'server', 'windows-server'];
+const CANCEL_STEP_HEADING = '      - name: Cancel sibling CI jobs after failure';
+// Both spellings of the dependency. Under a scalar-only pattern, a leaf job
+// rewritten to the list form (`needs: [impact]`) dropped out of every assertion
+// below without failing anything — the exact silent coverage loss this contract
+// exists to prevent.
+const NEEDS_IMPACT = /^\s*needs:\s*(?:impact\s*$|\[[^\]]*\bimpact\b)/m;
 const FAIL_FAST_STEP = [
-  '      - name: Cancel sibling CI jobs after failure',
+  CANCEL_STEP_HEADING,
   "        if: failure() && github.event_name == 'pull_request'",
   '        env:',
   '          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}',
@@ -35,18 +47,27 @@ function workflowJobs(yaml) {
 describe('ci.yml fail-fast cancellation contract', () => {
   const jobs = workflowJobs(WORKFLOW);
   const leafJobs = Object.keys(jobs).filter((id) => (
-    !NON_LEAF_JOBS.has(id) && /^\s*needs:\s*impact\s*$/m.test(jobs[id])
+    !NON_LEAF_JOBS.has(id) && NEEDS_IMPACT.test(jobs[id])
   ));
 
   it('discovers every direct impact leaf job for contract checks', () => {
-    expect(leafJobs).not.toHaveLength(0);
+    expect(leafJobs).toEqual(expect.arrayContaining(EXPECTED_LEAF_JOBS));
+  });
+
+  it('covers every cancellation step the workflow actually installs', () => {
+    // The discovery floor from the other side. A cancellation step added to a
+    // job this file does not classify as a leaf would never be checked for the
+    // `actions: write` grant it needs, and a missing grant fails only at
+    // runtime — inside a job that is otherwise passing.
+    const installed = WORKFLOW.split(CANCEL_STEP_HEADING).length - 1;
+    expect(installed).toBe(leafJobs.length);
   });
 
   it('adds the cancellation step as the final step of every expensive leaf job', () => {
     for (const id of leafJobs) {
       const body = jobs[id];
       expect(body, id).toBeTruthy();
-      const step = body.slice(body.lastIndexOf('      - name: Cancel sibling CI jobs after failure')).trimEnd();
+      const step = body.slice(body.lastIndexOf(CANCEL_STEP_HEADING)).trimEnd();
       expect(step, id).toBe(FAIL_FAST_STEP);
       expect(body.match(/GITHUB_TOKEN:/g), id).toHaveLength(1);
     }
@@ -66,7 +87,7 @@ describe('ci.yml fail-fast cancellation contract', () => {
     for (const id of leafJobs) {
       const body = jobs[id];
       expect(body, id).not.toMatch(/GITHUB_(?:REPOSITORY|RUN_ID):/);
-      const step = body.slice(body.lastIndexOf('      - name: Cancel sibling CI jobs after failure'));
+      const step = body.slice(body.lastIndexOf(CANCEL_STEP_HEADING));
       expect(step, id).not.toContain('\n        with:');
       expect(body, id).toContain('if: failure()');
     }
@@ -83,8 +104,11 @@ describe('ci.yml fail-fast cancellation contract', () => {
   });
 
   it('grants the reusable release caller the permission leaf jobs require', () => {
+    // Bounded to the full-ci job: slicing to end of file would let a
+    // permissions block on the later `release` job satisfy this instead.
     const releaseWorkflow = readFileSync(join(REPO_ROOT, '.github/workflows/release.yml'), 'utf8');
-    const fullCi = releaseWorkflow.slice(releaseWorkflow.indexOf('\n  full-ci:'));
+    const fullCi = workflowJobs(releaseWorkflow)['full-ci'];
+    expect(fullCi).toBeTruthy();
     expect(fullCi).toMatch(/\n    permissions:\n      contents: read\n      actions: write\n/);
   });
 });

--- a/scripts/pre-install-entrypoints.test.js
+++ b/scripts/pre-install-entrypoints.test.js
@@ -38,8 +38,11 @@ const PRE_INSTALL_ENTRYPOINTS = ['scripts/ci-base-sha.js', 'scripts/ci-test-plan
  * module-resolution stack trace instead. Its `pg` import is a dynamic
  * `import()` inside the database probe for the same reason, which is why it
  * does not show up in this static walk.
+ *
+ * `cancel-current-ci-run.js` is here because it runs from an `if: failure()`
+ * workflow step that may fire before or during a failed dependency install.
  */
-const BARE_CHECKOUT_SCRIPTS = ['scripts/doctor.js'];
+const BARE_CHECKOUT_SCRIPTS = ['scripts/cancel-current-ci-run.js', 'scripts/doctor.js'];
 
 const BUILTINS = new Set(builtinModules);
 const isBuiltin = (specifier) => BUILTINS.has(specifier.replace(/^node:/, ''));


### PR DESCRIPTION
## Summary

- Each expensive leaf job (`server`, `client`, `database`, `windows-server`) now ends with an `if: failure() && github.event_name == 'pull_request'` step that asks GitHub to cancel the current run, so the remaining siblings stop burning runner time on a verdict that can no longer pass.
- `scripts/cancel-current-ci-run.js` takes no arguments — it reads `GITHUB_REPOSITORY`/`GITHUB_RUN_ID` from the Actions environment, validates them, and POSTs to the workflow-run cancel endpoint with a step-scoped `GITHUB_TOKEN`. It imports only Node builtins so it still runs from a job that failed before `npm ci`, and it always exits 0: a 403 (fork/read-only token), a timeout, or a network failure logs one line and leaves the original test failure as the job's result.
- Scoped to pull requests. A called workflow inherits the caller's event, so the release workflow's `full-ci` never cancels its parent run; the nightly schedule and `workflow_dispatch` are likewise untouched. This is orthogonal to the existing `concurrency.cancel-in-progress`, which cancels a *superseded* run when a new commit arrives rather than siblings inside one run.
- **Canceled stays non-mergeable.** Every consumer allowlists green results instead of denylisting red ones: branch protection requires `CI Gate` to conclude `success`; the gate job accepts only `success`/`skipped` per job; `verify-ci-status.js` accepts a `Full CI Gate` only at `conclusion === 'success'`, so a canceled run can never let a release skip the full suite; and `prWatcher.js` counts only `SUCCESS`/`NEUTRAL`/`SKIPPED`. The visible consequence is that the required check reads *canceled* rather than *failed* — the failing step's log and annotations remain the diagnosis.
- Leaf jobs check out with `persist-credentials: false`, since they now hold a token that can cancel runs and should not leave it in `.git/config` for the suite's own subprocesses. None of them run authenticated git operations.
- `docs/GITHUB_ACTIONS.md` documents the behavior, the security boundary, the fork fallback, and why `release.yml`'s `full-ci` must grant `actions: write` even though the step never fires there (a called workflow's jobs cannot hold a permission the calling job lacks).

## Test plan

- `cd server && npx vitest run ../scripts/cancel-current-ci-run.test.js ../scripts/ci-fail-fast.test.js ../scripts/pre-install-entrypoints.test.js` — 3 files, 21 tests passing. Covers API success (202), already-terminal (409), permission failure (403), network failure, a rejected non-HTTPS `GITHUB_API_URL`, and refusal to act on an environment that did not come from Actions.
- Full `scripts` + server glob green: 338 files, 2495 tests.
- The workflow-contract test was bypass-probed rather than trusted: dropping `actions: write` from one leaf job fails it; adding a cancellation step to a job it does not classify as a leaf fails it; and taking a leaf job out of discovery fails it. Rewriting a job to `needs: [impact]` is now still discovered, where the previous scalar-only pattern silently dropped it while staying green.
- `node scripts/cancel-current-ci-run.js` with no Actions environment logs the skip and exits 0, confirming it cannot turn a passing job red.

Not verified here: the ≤30s wall-clock target from the issue's acceptance criteria needs a fault-injection run on real hosted runners.

Closes #5519