### PR TITLE
Fix mediaJobQueue test flake: waitFor gave up on a predicate that read the snapshot before the first write landed

### DIFF
--- a/server/services/mediaJobQueue/index.test.js
+++ b/server/services/mediaJobQueue/index.test.js
@@ -1589,9 +1589,15 @@ describe('mediaJobQueue unreadable snapshot (#4115)', () => {
 
 async function waitFor(predicate, { timeoutMs = 3000, intervalMs = 30 } = {}) {
   const deadline = Date.now() + timeoutMs;
+  let lastError = null;
   while (Date.now() < deadline) {
-    if (predicate()) return;
+    try {
+      if (predicate()) return;
+      lastError = null;
+    } catch (err) {
+      lastError = err;
+    }
     await new Promise((r) => setTimeout(r, intervalMs));
   }
-  throw new Error('waitFor: predicate never became true within timeout');
+  throw new Error(`waitFor: predicate never became true within timeout${lastError ? `: ${lastError.message}` : ''}`);
 }

--- a/server/services/mediaJobQueue/index.test.js
+++ b/server/services/mediaJobQueue/index.test.js
@@ -1587,17 +1587,65 @@ describe('mediaJobQueue unreadable snapshot (#4115)', () => {
   });
 });
 
+// Polling helper for the async settles this suite waits on (a debounced disk
+// write, a worker tick). A predicate that THROWS counts as "not true yet" and
+// keeps polling: several predicates readFileSync the persisted snapshot, which
+// legitimately does not exist until the first write lands in the freshly-made
+// temp dir, so an unguarded throw escaped the loop and failed the test on its
+// FIRST poll instead of waiting for the write (#5512 — flaked on slow Windows
+// CI runners). Swallowing is bounded to the retry window only: the timeout
+// still throws, and names the predicate source plus the last error, so a
+// genuinely broken predicate stays diagnosable instead of becoming an
+// anonymous 3-second stall. No predicate here uses expect(), so a real
+// assertion failure cannot be downgraded into a timeout by the catch.
 async function waitFor(predicate, { timeoutMs = 3000, intervalMs = 30 } = {}) {
   const deadline = Date.now() + timeoutMs;
   let lastError = null;
-  while (Date.now() < deadline) {
+  for (;;) {
     try {
       if (predicate()) return;
       lastError = null;
     } catch (err) {
       lastError = err;
     }
+    // Deadline is checked AFTER a poll so the budget always ends on an
+    // evaluation. Checking first (the `while` this replaced) spent the final
+    // interval asleep and threw without ever re-testing the predicate, losing
+    // up to intervalMs of the window to the same race this helper guards.
+    if (Date.now() >= deadline) break;
     await new Promise((r) => setTimeout(r, intervalMs));
   }
-  throw new Error(`waitFor: predicate never became true within timeout${lastError ? `: ${lastError.message}` : ''}`);
+  const source = String(predicate).replace(/\s+/g, ' ').slice(0, 160);
+  throw new Error(
+    `waitFor: predicate never became true within ${timeoutMs}ms: ${source}${lastError ? ` — last error: ${lastError.message}` : ''}`,
+    lastError ? { cause: lastError } : undefined,
+  );
 }
+
+// Contract test for the helper above. The bug it guards (#5512) only surfaces
+// under timing luck on a slow runner, so it is pinned deterministically here
+// rather than left to the flake that found it. One short real timeout, not a
+// repeated sleep.
+describe('waitFor test helper (#5512)', () => {
+  it('treats a throwing predicate as not-yet-true and keeps polling', async () => {
+    let calls = 0;
+    await waitFor(() => {
+      calls += 1;
+      if (calls < 3) throw new Error('ENOENT: no such file or directory');
+      return true;
+    }, { timeoutMs: 1000, intervalMs: 1 });
+    expect(calls).toBe(3);
+  });
+
+  it('still fails loudly on timeout, naming the predicate and the last error', async () => {
+    await expect(waitFor(
+      () => { throw new Error('ENOENT: no such file or directory'); },
+      { timeoutMs: 20, intervalMs: 5 },
+    )).rejects.toThrow(/never became true within 20ms.*last error: ENOENT/s);
+  });
+
+  it('reports a cleanly-false predicate without inventing an error', async () => {
+    await expect(waitFor(() => false, { timeoutMs: 20, intervalMs: 5 }))
+      .rejects.toThrow(/never became true within 20ms(?!.*last error)/s);
+  });
+});


### PR DESCRIPTION
## Summary

- The suite's local `waitFor` called `predicate()` unguarded, so a predicate that `readFileSync`s the persisted snapshot threw ENOENT out of the retry loop and failed the test on its **first** poll instead of polling until the write landed. On a slow Windows runner that window is wide enough to flake. `waitFor` now treats a throwing predicate as "not true yet" and keeps polling, which covers every snapshot-reading predicate in the file rather than one call site.
- **This is a test-harness bug, not a product bug.** Verified by instrumenting the flaky test: with `atomicWrite` artificially slowed to widen the window, the pre-fix helper reproduces the exact CI error, and a 2ms watcher on the snapshot file shows it never disappears once created (`everExisted=true vanishedAfterExisting=false`). Nothing deletes or unlinks the file — the temp data dir simply starts empty and the first debounced write has not landed yet. The companion burst test in the same file already guards this with `existsSync(file)`, so the exposure was known and just missed at this call site.
- Kept the timeout loud, since swallowing is only safe while failures stay diagnosable: the timeout message now names the predicate source and the last error (all 88 call sites in this file otherwise share one identical message) and carries the error as `cause` so the original stack survives. No predicate in the file uses `expect()`, so the catch cannot downgrade a real assertion failure into a silent timeout.
- Moved the deadline check to after a poll — `while (Date.now() < deadline)` spent the final interval asleep and threw without re-testing the predicate, giving away up to `intervalMs` of the very window the helper exists to wait out.
- Added a contract test for the helper. The race only reproduces under timing luck on a slow runner, so the "throwing predicate keeps polling, timeout still throws" behaviour is now pinned deterministically rather than guarded only by the flake that found it.

Closes #5512

## Test plan

- `cd server && npx vitest run services/mediaJobQueue/index.test.js services/mediaJobQueue/sanitizeJob.test.js` — 71 passed, run 5 consecutive times, green every time.
- Flake reproduction: with the pre-fix `waitFor` and a 400ms delay injected into `atomicWrite`, `debounce-persists live progress before a terminal transition` fails with the exact CI error (`ENOENT ... media-jobs.json`). With the fix in place under the same injected delay it passes.
- Stress: the full 61-test file run 3 consecutive times with a 300ms delay on **every** `atomicWrite` — far more hostile than the real runner — 61 passed each time.
- Checked for a write-after-teardown leak by clearing `$TMPDIR` and counting `mediaJobQueue-test-*` dirs after a run: 0 left behind, so no pending debounce timer resurrects the temp dir after `rmSync`.