### PR TITLE
Recover GitHub repo links stranded at cloneStatus 'cloning' after a restart

### DIFF
--- a/server/lib/apiRouteCatalog.generated.json
+++ b/server/lib/apiRouteCatalog.generated.json
@@ -2125,7 +2125,7 @@
       "sources": [
         {
           "source": "server/routes/brainLinks.js",
-          "line": 295
+          "line": 300
         }
       ]
     },
@@ -2136,7 +2136,7 @@
       "sources": [
         {
           "source": "server/routes/brainLinks.js",
-          "line": 305
+          "line": 310
         }
       ]
     },
@@ -2147,7 +2147,7 @@
       "sources": [
         {
           "source": "server/routes/brainLinks.js",
-          "line": 344
+          "line": 349
         }
       ]
     },
@@ -2158,7 +2158,7 @@
       "sources": [
         {
           "source": "server/routes/brainLinks.js",
-          "line": 329
+          "line": 334
         }
       ]
     },
@@ -2169,7 +2169,7 @@
       "sources": [
         {
           "source": "server/routes/brainLinks.js",
-          "line": 317
+          "line": 322
         }
       ]
     },
@@ -2741,7 +2741,7 @@
       "sources": [
         {
           "source": "server/routes/brainLinks.js",
-          "line": 216
+          "line": 221
         }
       ]
     },
@@ -2752,7 +2752,7 @@
       "sources": [
         {
           "source": "server/routes/brainLinks.js",
-          "line": 195
+          "line": 200
         }
       ]
     },
@@ -2763,7 +2763,7 @@
       "sources": [
         {
           "source": "server/routes/brainLinks.js",
-          "line": 246
+          "line": 251
         }
       ]
     },
@@ -2774,7 +2774,7 @@
       "sources": [
         {
           "source": "server/routes/brainLinks.js",
-          "line": 275
+          "line": 280
         }
       ]
     },

--- a/server/lib/brainValidation.js
+++ b/server/lib/brainValidation.js
@@ -443,6 +443,9 @@ export const linkRecordSchema = z.object({
   localPath: z.string().max(500).optional(),
   cloneStatus: z.enum(['pending', 'cloning', 'cloned', 'failed', 'none']).default('none'),
   cloneError: z.string().max(500).optional(),
+  // The instance currently responsible for an in-flight clone. This differs
+  // from immutable originInstanceId when a peer retries a shared link.
+  cloneInstanceId: z.string().optional(),
   malwareScan: z.object({
     reportId: z.string().uuid(),
     taskId: z.string().optional(),

--- a/server/lib/brainValidation.js
+++ b/server/lib/brainValidation.js
@@ -445,7 +445,10 @@ export const linkRecordSchema = z.object({
   cloneError: z.string().max(500).optional(),
   // The instance currently responsible for an in-flight clone. This differs
   // from immutable originInstanceId when a peer retries a shared link.
-  cloneInstanceId: z.string().optional(),
+  cloneInstanceId: z.string().nullable().optional(),
+  // True only when boot recovery observed an interrupted attempt. Retry uses
+  // this to replace a legacy direct-to-destination partial checkout safely.
+  cloneInterrupted: z.boolean().optional().default(false),
   malwareScan: z.object({
     reportId: z.string().uuid(),
     taskId: z.string().optional(),

--- a/server/routes/brainLinks.js
+++ b/server/routes/brainLinks.js
@@ -182,8 +182,13 @@ router.post('/links/:id/clone', asyncHandler(async (req, res) => {
     });
   }
 
-  // Start clone in background
-  brainService.cloneRepoInBackground(link.id, link.url);
+  // Start clone in background. Deliberately not awaited, so it needs its own
+  // catch: the setup steps before the clone's own handlers are armed (identity
+  // resolve, the `cloning` stamp) run outside the request lifecycle, and an
+  // unhandled rejection there would crash the process instead of logging.
+  brainService.cloneRepoInBackground(link.id, link.url).catch(err => {
+    console.error(`❌ Background clone setup failed for ${link.id}: ${err.message}`);
+  });
 
   res.json({ message: 'Clone started', linkId: link.id });
 }));

--- a/server/routes/brainLinks.test.js
+++ b/server/routes/brainLinks.test.js
@@ -160,3 +160,22 @@ describe('POST /api/brain/links/reorder', () => {
     expect(brainService.reorderLinks).not.toHaveBeenCalled();
   });
 });
+
+describe('POST /api/brain/links/:id/clone', () => {
+  it('starts a new clone for a link recovered to failed', async () => {
+    brainService.getLinkById.mockResolvedValue({
+      id: 'repo-link',
+      url: 'https://github.com/acme/widgets',
+      isGitHubRepo: true,
+      cloneStatus: 'failed',
+    });
+
+    const res = await request(app).post('/api/brain/links/repo-link/clone');
+
+    expect(res.status).toBe(200);
+    expect(brainService.cloneRepoInBackground).toHaveBeenCalledWith(
+      'repo-link',
+      'https://github.com/acme/widgets',
+    );
+  });
+});

--- a/server/routes/brainLinks.test.js
+++ b/server/routes/brainLinks.test.js
@@ -162,13 +162,16 @@ describe('POST /api/brain/links/reorder', () => {
 });
 
 describe('POST /api/brain/links/:id/clone', () => {
-  it('starts a new clone for a link recovered to failed', async () => {
-    brainService.getLinkById.mockResolvedValue({
-      id: 'repo-link',
-      url: 'https://github.com/acme/widgets',
-      isGitHubRepo: true,
-      cloneStatus: 'failed',
-    });
+  const repoLink = (cloneStatus) => ({
+    id: 'repo-link',
+    url: 'https://github.com/acme/widgets',
+    isGitHubRepo: true,
+    cloneStatus,
+  });
+
+  it('starts a new clone for a link boot recovery reset to failed', async () => {
+    brainService.getLinkById.mockResolvedValue(repoLink('failed'));
+    brainService.cloneRepoInBackground.mockResolvedValue();
 
     const res = await request(app).post('/api/brain/links/repo-link/clone');
 
@@ -177,5 +180,20 @@ describe('POST /api/brain/links/:id/clone', () => {
       'repo-link',
       'https://github.com/acme/widgets',
     );
+  });
+
+  it('logs rather than crashing when the un-awaited clone kickoff rejects', async () => {
+    // The kickoff runs outside the request lifecycle, so its pre-clone steps
+    // (identity resolve, the `cloning` stamp) have no `next(err)` to bubble to.
+    brainService.getLinkById.mockResolvedValue(repoLink('none'));
+    brainService.cloneRepoInBackground.mockRejectedValue(new Error('identity unavailable'));
+    const logged = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const res = await request(app).post('/api/brain/links/repo-link/clone');
+    await new Promise(resolve => setImmediate(resolve));
+
+    expect(res.status).toBe(200);
+    expect(logged).toHaveBeenCalledWith(expect.stringContaining('identity unavailable'));
+    logged.mockRestore();
   });
 });

--- a/server/services/bootstrap.js
+++ b/server/services/bootstrap.js
@@ -100,7 +100,7 @@ import { startImageCleanTmpGc } from './imageCleanTmpGc.js';
 import { initBridge as initBrainMemoryBridge } from './brainMemoryBridge.js';
 import { initDrillCache } from './meatspacePostDrillCache.js';
 import { registerPostReminderSchedule } from './meatspacePostReminder.js';
-import { recoverStuckClassifications } from './brain.js';
+import { recoverInterruptedRepoClones, recoverStuckClassifications } from './brain.js';
 import { recoverStuckAnalyses } from './writersRoom/evaluator.js';
 import { recoverStuckAutoRuns } from './pipeline/autoRunner.js';
 import { recoverStuckAutopilots } from './pipeline/seriesAutopilot.js';
@@ -740,11 +740,12 @@ export const runBootSequence = ({ io, httpServer, localHttpServer, httpsEnabled,
     ensureSelf,
     initSyncLog,
 
-    // Recover inbox entries stuck in 'classifying' from a previous crash. Must
-    // run AFTER initSyncLog() because updateInboxLog() appends to the brain sync
-    // log — running it before currentSeq is loaded would mint colliding seqs and
-    // corrupt peer cursors.
+    // Recover inbox classifications and repository clones interrupted by a
+    // previous crash. Must run AFTER initSyncLog() because both recovery paths
+    // append to the brain sync log — running them before currentSeq is loaded
+    // would mint colliding seqs and corrupt peer cursors.
     recoverStuckClassifications,
+    recoverInterruptedRepoClones,
 
     // Awaited by the sequence so data/ exists and the worker loop is running
     // before /api/video-gen or /api/image-gen can enqueue (otherwise persist()

--- a/server/services/bootstrapSequence.js
+++ b/server/services/bootstrapSequence.js
@@ -280,9 +280,11 @@ export const runDatabasePhase = async ({ gate, migrate, warmStores, reconcileSta
  *      is armed, never fired, so nothing below depends on it.
  *   2. `ensureSelf` → `initSyncLog` awaited before anything can mutate brain
  *      records, so sync sequence numbers are loaded before the first append.
- *   3. `recoverStuckClassifications` AFTER `initSyncLog` (it appends to the sync
- *      log; running it earlier mints colliding seqs and corrupts peer cursors)
- *      but fire-and-forget, since nothing below reads its result.
+ *   3. Brain record recovery AFTER `initSyncLog` (updates append to the sync
+ *      log; running earlier mints colliding seqs and corrupts peer cursors).
+ *      Interrupted clone recovery is awaited so the first links request cannot
+ *      observe an orphaned `cloning` state; inbox recovery remains best-effort
+ *      in the background because nothing below reads its result.
  *   4. `initMediaJobQueue` awaited before `initMediaJobDependentHooks` — the
  *      hooks must be listening before the queue replays `completed` events for
  *      reloaded jobs, and before a route can enqueue against a half-init queue.
@@ -300,6 +302,7 @@ export const runPostRouteSequence = ({
   ensureSelf,
   initSyncLog,
   recoverStuckClassifications,
+  recoverInterruptedRepoClones,
   initMediaJobQueue,
   initMediaJobDependentHooks,
   initSharing,
@@ -316,6 +319,7 @@ export const runPostRouteSequence = ({
     .then(() => initSyncLog())
     .then(() => {
       bestEffort(recoverStuckClassifications(), logFailure('Brain recovery failed'));
+      return bestEffort(recoverInterruptedRepoClones(), logFailure('Brain clone recovery failed'));
     })
     .then(() => initMediaJobQueue())
     .then(() => initMediaJobDependentHooks())

--- a/server/services/bootstrapSequence.test.js
+++ b/server/services/bootstrapSequence.test.js
@@ -498,6 +498,7 @@ describe('runPostRouteSequence — post-route boot order', () => {
       ensureSelf: step('ensureSelf', () => Promise.resolve()),
       initSyncLog: step('initSyncLog', () => Promise.resolve()),
       recoverStuckClassifications: step('recoverStuckClassifications', () => Promise.resolve()),
+      recoverInterruptedRepoClones: step('recoverInterruptedRepoClones', () => Promise.resolve()),
       initMediaJobQueue: step('initMediaJobQueue', () => Promise.resolve()),
       initMediaJobDependentHooks: step('initMediaJobDependentHooks'),
       initSharing: step('initSharing', () => Promise.resolve()),
@@ -520,6 +521,7 @@ describe('runPostRouteSequence — post-route boot order', () => {
       'ensureSelf',
       'initSyncLog',
       'recoverStuckClassifications',
+      'recoverInterruptedRepoClones',
       'initMediaJobQueue',
       'initMediaJobDependentHooks',
       'initSharing',
@@ -550,9 +552,11 @@ describe('runPostRouteSequence — post-route boot order', () => {
     // Recovering earlier would mint colliding sync sequence numbers and corrupt
     // every peer's cursor.
     expect(recorder.calls).not.toContain('recoverStuckClassifications');
+    expect(recorder.calls).not.toContain('recoverInterruptedRepoClones');
     gate.resolve();
     await done;
     expect(recorder.calls).toContain('recoverStuckClassifications');
+    expect(recorder.calls).toContain('recoverInterruptedRepoClones');
   });
 
   it('awaits the media job queue before wiring its completion hooks', async () => {
@@ -565,14 +569,29 @@ describe('runPostRouteSequence — post-route boot order', () => {
     await flush();
     // The hooks must be listening before the queue replays `completed` for
     // reloaded jobs, and no route may enqueue against a half-init queue.
-    expect(recorder.calls).toEqual(['startBackgroundServices', 'ensureSelf', 'initSyncLog', 'recoverStuckClassifications', 'initMediaJobQueue']);
+    expect(recorder.calls).toEqual(['startBackgroundServices', 'ensureSelf', 'initSyncLog', 'recoverStuckClassifications', 'recoverInterruptedRepoClones', 'initMediaJobQueue']);
     gate.resolve();
     await done;
     expect(recorder.calls).toContain('initMediaJobDependentHooks');
     expect(recorder.calls).toContain('startListening');
   });
 
-  it('does NOT await brain recovery, sharing, CD recovery, or the cover backfill', async () => {
+  it('finishes interrupted clone recovery before accepting requests', async () => {
+    const recorder = createRecorder();
+    const gate = deferred();
+    const deps = buildDeps(recorder, {
+      recoverInterruptedRepoClones: recorder.step('recoverInterruptedRepoClones', () => gate.promise),
+    });
+    const done = runPostRouteSequence(deps);
+    await flush();
+    expect(recorder.calls).not.toContain('initMediaJobQueue');
+    expect(recorder.calls).not.toContain('startListening');
+    gate.resolve();
+    await done;
+    expect(recorder.calls).toContain('startListening');
+  });
+
+  it('does NOT await inbox recovery, sharing, CD recovery, or the cover backfill', async () => {
     const recorder = createRecorder();
     const stuck = deferred();
     const deps = buildDeps(recorder, {
@@ -645,6 +664,7 @@ describe('runPostRouteSequence — post-route boot order', () => {
     const recorder = createRecorder();
     const deps = buildDeps(recorder, {
       recoverStuckClassifications: recorder.step('recoverStuckClassifications', () => Promise.reject(new Error('brain boom'))),
+      recoverInterruptedRepoClones: recorder.step('recoverInterruptedRepoClones', () => Promise.reject(new Error('clone boom'))),
       initSharing: recorder.step('initSharing', () => Promise.reject(new Error('bucket gone'))),
       loadSeriesCoverBackfill: recorder.step('loadSeriesCoverBackfill', () =>
         Promise.resolve(recorder.step('backfillSeriesCoverImages', () => Promise.reject(new Error('no covers')))))
@@ -654,6 +674,7 @@ describe('runPostRouteSequence — post-route boot order', () => {
     expect(deps.onFatal).not.toHaveBeenCalled();
     expect(recorder.calls).toContain('startListening');
     expect(console.error).toHaveBeenCalledWith(expect.stringContaining('Brain recovery failed'));
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('Brain clone recovery failed'));
     expect(console.error).toHaveBeenCalledWith(expect.stringContaining('Sharing init failed'));
     expect(console.error).toHaveBeenCalledWith(expect.stringContaining('series cover backfill failed at boot'));
   });

--- a/server/services/brain.js
+++ b/server/services/brain.js
@@ -844,6 +844,8 @@ export async function recoverStuckClassifications() {
  * can keep writing its private staging directory without racing a retry.
  */
 export async function recoverInterruptedRepoClones() {
+  await githubCloner.reapStaleCloneStaging()
+    .catch(err => console.error(`❌ Clone staging recovery failed: ${err.message}`));
   const instanceId = await getInstanceId();
   const links = await storage.getLinks({ cloneStatus: 'cloning' });
   let recovered = 0;
@@ -853,11 +855,19 @@ export async function recoverInterruptedRepoClones() {
     if (link.cloneStatus !== 'cloning') continue;
     // New records name the instance that started this attempt. For older
     // records, originInstanceId is the safest compatibility fallback.
-    const cloneOwner = link.cloneInstanceId ?? link.originInstanceId;
-    if (cloneOwner && cloneOwner !== instanceId) continue;
+    if (link.cloneInstanceId && link.cloneInstanceId !== instanceId) continue;
+    // Old peers did not stamp cloneInstanceId. Preserve a recent peer-origin
+    // attempt, but recover it once it is older than the client stall window so
+    // a mixed-version crash cannot strand the link forever.
+    if (!link.cloneInstanceId && link.originInstanceId && link.originInstanceId !== instanceId) {
+      const updatedAt = Date.parse(link.updatedAt);
+      if (!Number.isFinite(updatedAt) || Date.now() - updatedAt < 10 * 60 * 1000) continue;
+    }
     await storage.updateLink(link.id, {
       cloneStatus: 'failed',
-      cloneError: 'Clone interrupted by a server restart. Retry to clone the repository again.'
+      cloneError: 'Clone interrupted by a server restart. Retry to clone the repository again.',
+      cloneInstanceId: null,
+      cloneInterrupted: true
     });
     recovered++;
   }
@@ -989,15 +999,22 @@ function hostnameFromUrl(url) {
  * queue an agent against a path that doesn't exist.
  */
 export async function cloneRepoInBackground(linkId, url) {
+  const previous = await storage.getLinkById(linkId);
   const cloneInstanceId = await getInstanceId();
-  await storage.updateLink(linkId, { cloneStatus: 'cloning', cloneInstanceId });
+  await storage.updateLink(linkId, {
+    cloneStatus: 'cloning',
+    cloneInstanceId,
+    cloneInterrupted: false
+  });
 
-  githubCloner.cloneRepo(url)
+  githubCloner.cloneRepo(url, { replaceIncomplete: previous?.cloneInterrupted === true })
     .then(async (result) => {
       const link = await storage.updateLink(linkId, {
         localPath: result.localPath,
         cloneStatus: 'cloned',
-        cloneError: null
+        cloneError: null,
+        cloneInstanceId: null,
+        cloneInterrupted: false
       });
       console.log(`✅ Background clone complete: ${linkId}`);
       // `link` is null when the user deleted the bookmark mid-clone — nothing
@@ -1019,7 +1036,9 @@ export async function cloneRepoInBackground(linkId, url) {
     .catch(async (err) => {
       await storage.updateLink(linkId, {
         cloneStatus: 'failed',
-        cloneError: err.message
+        cloneError: err.message,
+        cloneInstanceId: null,
+        cloneInterrupted: false
       });
       console.error(`❌ Background clone failed: ${linkId} - ${err.message}`);
     });

--- a/server/services/brain.js
+++ b/server/services/brain.js
@@ -10,7 +10,7 @@
 
 import * as storage from './brainStorage.js';
 import { brainEvents } from './brainStorage.js';
-import { getInstanceId } from './instances.js';
+import { getInstanceId, ensureInstanceId, UNKNOWN_INSTANCE_ID } from './instances.js';
 import { getActiveProvider, getProviderById } from './providers.js';
 import { buildPrompt } from './promptService.js';
 import { validate } from '../lib/validation.js';
@@ -838,31 +838,44 @@ export async function recoverStuckClassifications() {
   }
 }
 
+// Matches the client's clone stall window (#5442). Past it, a `cloning` record
+// this install cannot attribute to itself is treated as orphaned rather than
+// left in place — see `shouldRecoverInterruptedClone`.
+const CLONE_STALE_MS = 10 * 60 * 1000;
+
+/**
+ * Whether THIS install should reset `link` out of `cloning` at boot.
+ *
+ * Ours, or unattributed (pre-#5463 records carry no `cloneInstanceId`) — always,
+ * because no in-process clone survives a restart. A clone another instance owns
+ * is left alone while it could still be running, but ages out of that
+ * protection: a peer that crashed mid-clone and never comes back must not
+ * strand the link at `cloning` forever, which is the whole bug (#5463).
+ */
+const shouldRecoverInterruptedClone = (link, instanceId) => {
+  const owner = link.cloneInstanceId ?? link.originInstanceId ?? null;
+  if (!owner || owner === instanceId) return true;
+  const updatedAt = Date.parse(link.updatedAt);
+  return Number.isFinite(updatedAt) && Date.now() - updatedAt >= CLONE_STALE_MS;
+};
+
 /**
  * Recover repository clones interrupted by a previous server shutdown.
  * Clone work is published only after git exits successfully; an orphaned child
  * can keep writing its private staging directory without racing a retry.
  */
 export async function recoverInterruptedRepoClones() {
-  await githubCloner.reapStaleCloneStaging()
-    .catch(err => console.error(`❌ Clone staging recovery failed: ${err.message}`));
-  const instanceId = await getInstanceId();
+  // `ensureInstanceId`, not `getInstanceId`: this comparison decides a durable
+  // record mutation, and the sentinel would match every other uninitialized
+  // install's records while missing our own.
+  const instanceId = await ensureInstanceId();
   const links = await storage.getLinks({ cloneStatus: 'cloning' });
   let recovered = 0;
   for (const link of links) {
     // Keep the state guard even though storage applies the filter so a future
     // storage implementation cannot broaden this boot-time mutation by accident.
     if (link.cloneStatus !== 'cloning') continue;
-    // New records name the instance that started this attempt. For older
-    // records, originInstanceId is the safest compatibility fallback.
-    if (link.cloneInstanceId && link.cloneInstanceId !== instanceId) continue;
-    // Old peers did not stamp cloneInstanceId. Preserve a recent peer-origin
-    // attempt, but recover it once it is older than the client stall window so
-    // a mixed-version crash cannot strand the link forever.
-    if (!link.cloneInstanceId && link.originInstanceId && link.originInstanceId !== instanceId) {
-      const updatedAt = Date.parse(link.updatedAt);
-      if (!Number.isFinite(updatedAt) || Date.now() - updatedAt < 10 * 60 * 1000) continue;
-    }
+    if (!shouldRecoverInterruptedClone(link, instanceId)) continue;
     await storage.updateLink(link.id, {
       cloneStatus: 'failed',
       cloneError: 'Clone interrupted by a server restart. Retry to clone the repository again.',
@@ -874,6 +887,11 @@ export async function recoverInterruptedRepoClones() {
   if (recovered > 0) {
     console.log(`🧠 Recovered ${recovered} interrupted repository clone(s)`);
   }
+  // Detached on purpose: boot AWAITS this function so the first links request
+  // can't see an orphaned `cloning` badge, and a recursive scan plus `rm -rf` of
+  // abandoned partial checkouts must not sit in front of `startListening()`.
+  githubCloner.reapStaleCloneStaging()
+    .catch(err => console.error(`❌ Clone staging recovery failed: ${err.message}`));
 }
 
 // Re-export storage functions for convenience
@@ -1000,9 +1018,18 @@ function hostnameFromUrl(url) {
  */
 export async function cloneRepoInBackground(linkId, url) {
   const previous = await storage.getLinkById(linkId);
-  const cloneInstanceId = await getInstanceId();
+  // `ensureInstanceId`, and null rather than the sentinel: `cloneInstanceId`
+  // lands on a durable, federated record, and a stamped 'unknown' would read as
+  // "some other install owns this" at boot on every machine — re-stranding the
+  // exact record this recovery exists to free.
+  const resolvedInstanceId = await ensureInstanceId();
+  const cloneInstanceId = resolvedInstanceId === UNKNOWN_INSTANCE_ID ? null : resolvedInstanceId;
   await storage.updateLink(linkId, {
     cloneStatus: 'cloning',
+    // The Links tab renders `cloneError` whenever it is set, independent of
+    // status — leaving the previous attempt's message would show the failure
+    // text beside the new attempt's spinner.
+    cloneError: null,
     cloneInstanceId,
     cloneInterrupted: false
   });

--- a/server/services/brain.js
+++ b/server/services/brain.js
@@ -840,16 +840,21 @@ export async function recoverStuckClassifications() {
 
 /**
  * Recover repository clones interrupted by a previous server shutdown.
- * A clone process cannot survive the PortOS process that started it, so every
- * persisted `cloning` state observed during boot is orphaned and retryable.
+ * Clone work is published only after git exits successfully; an orphaned child
+ * can keep writing its private staging directory without racing a retry.
  */
 export async function recoverInterruptedRepoClones() {
+  const instanceId = await getInstanceId();
   const links = await storage.getLinks({ cloneStatus: 'cloning' });
   let recovered = 0;
   for (const link of links) {
     // Keep the state guard even though storage applies the filter so a future
     // storage implementation cannot broaden this boot-time mutation by accident.
     if (link.cloneStatus !== 'cloning') continue;
+    // New records name the instance that started this attempt. For older
+    // records, originInstanceId is the safest compatibility fallback.
+    const cloneOwner = link.cloneInstanceId ?? link.originInstanceId;
+    if (cloneOwner && cloneOwner !== instanceId) continue;
     await storage.updateLink(link.id, {
       cloneStatus: 'failed',
       cloneError: 'Clone interrupted by a server restart. Retry to clone the repository again.'
@@ -984,7 +989,8 @@ function hostnameFromUrl(url) {
  * queue an agent against a path that doesn't exist.
  */
 export async function cloneRepoInBackground(linkId, url) {
-  await storage.updateLink(linkId, { cloneStatus: 'cloning' });
+  const cloneInstanceId = await getInstanceId();
+  await storage.updateLink(linkId, { cloneStatus: 'cloning', cloneInstanceId });
 
   githubCloner.cloneRepo(url)
     .then(async (result) => {

--- a/server/services/brain.js
+++ b/server/services/brain.js
@@ -838,6 +838,29 @@ export async function recoverStuckClassifications() {
   }
 }
 
+/**
+ * Recover repository clones interrupted by a previous server shutdown.
+ * A clone process cannot survive the PortOS process that started it, so every
+ * persisted `cloning` state observed during boot is orphaned and retryable.
+ */
+export async function recoverInterruptedRepoClones() {
+  const links = await storage.getLinks({ cloneStatus: 'cloning' });
+  let recovered = 0;
+  for (const link of links) {
+    // Keep the state guard even though storage applies the filter so a future
+    // storage implementation cannot broaden this boot-time mutation by accident.
+    if (link.cloneStatus !== 'cloning') continue;
+    await storage.updateLink(link.id, {
+      cloneStatus: 'failed',
+      cloneError: 'Clone interrupted by a server restart. Retry to clone the repository again.'
+    });
+    recovered++;
+  }
+  if (recovered > 0) {
+    console.log(`🧠 Recovered ${recovered} interrupted repository clone(s)`);
+  }
+}
+
 // Re-export storage functions for convenience
 export const loadMeta = storage.loadMeta;
 export const updateMeta = storage.updateMeta;

--- a/server/services/brain.test.js
+++ b/server/services/brain.test.js
@@ -68,7 +68,8 @@ vi.mock('./brainStorage.js', () => {
 // kick off a background clone; stub it so no test ever shells out to git.
 vi.mock('./githubCloner.js', () => ({
   parseGitHubUrl: vi.fn(() => null),
-  cloneRepo: vi.fn()
+  cloneRepo: vi.fn(),
+  reapStaleCloneStaging: vi.fn(() => Promise.resolve(0))
 }));
 
 // Mock chatgptImport — brain.js's deleteMemoryEntry wrapper delegates the
@@ -312,7 +313,8 @@ describe('brain service', () => {
       }));
       expect(storage.updateLink).toHaveBeenCalledWith('link-001', {
         cloneStatus: 'cloning',
-        cloneInstanceId: 'local-instance'
+        cloneInstanceId: 'local-instance',
+        cloneInterrupted: false
       });
     });
 
@@ -979,6 +981,9 @@ describe('brain service', () => {
         { id: 'pending', cloneStatus: 'pending' },
         { id: 'cloning', cloneStatus: 'cloning', cloneInstanceId: 'local-instance' },
         { id: 'peer-cloning', cloneStatus: 'cloning', cloneInstanceId: 'peer-x' },
+        { id: 'old-peer-recent', cloneStatus: 'cloning', originInstanceId: 'peer-x', updatedAt: new Date().toISOString() },
+        { id: 'old-peer-stale', cloneStatus: 'cloning', originInstanceId: 'peer-x', updatedAt: '2020-01-01T00:00:00.000Z' },
+        { id: 'legacy-local', cloneStatus: 'cloning' },
         { id: 'cloned', cloneStatus: 'cloned' },
         { id: 'failed', cloneStatus: 'failed' },
         { id: 'none', cloneStatus: 'none' },
@@ -988,12 +993,23 @@ describe('brain service', () => {
       await recoverInterruptedRepoClones();
 
       expect(storage.getLinks).toHaveBeenCalledWith({ cloneStatus: 'cloning' });
-      expect(storage.updateLink).toHaveBeenCalledTimes(1);
+      expect(storage.updateLink).toHaveBeenCalledTimes(3);
       expect(storage.updateLink).toHaveBeenCalledWith('cloning', {
         cloneStatus: 'failed',
         cloneError: 'Clone interrupted by a server restart. Retry to clone the repository again.',
+        cloneInstanceId: null,
+        cloneInterrupted: true,
       });
       expect(storage.updateLink).not.toHaveBeenCalledWith('peer-cloning', expect.anything());
+      expect(storage.updateLink).not.toHaveBeenCalledWith('old-peer-recent', expect.anything());
+      expect(storage.updateLink).toHaveBeenCalledWith('old-peer-stale', expect.objectContaining({
+        cloneStatus: 'failed',
+        cloneInstanceId: null,
+      }));
+      expect(storage.updateLink).toHaveBeenCalledWith('legacy-local', expect.objectContaining({
+        cloneStatus: 'failed',
+        cloneInstanceId: null,
+      }));
     });
   });
 

--- a/server/services/brain.test.js
+++ b/server/services/brain.test.js
@@ -113,6 +113,8 @@ tryReadFile: vi.fn().mockResolvedValue(null),
 // entries; stub it to a stable id.
 vi.mock('./instances.js', () => ({
   getInstanceId: () => Promise.resolve('local-instance'),
+  ensureInstanceId: () => Promise.resolve('local-instance'),
+  UNKNOWN_INSTANCE_ID: 'unknown',
 }));
 
 // Mock the central LLM handler — brain.js used to spawn child_process
@@ -313,6 +315,9 @@ describe('brain service', () => {
       }));
       expect(storage.updateLink).toHaveBeenCalledWith('link-001', {
         cloneStatus: 'cloning',
+        // Cleared, so a recovered link's "interrupted by a server restart"
+        // message doesn't sit beside the retry's spinner.
+        cloneError: null,
         cloneInstanceId: 'local-instance',
         cloneInterrupted: false
       });
@@ -1010,6 +1015,37 @@ describe('brain service', () => {
         cloneStatus: 'failed',
         cloneInstanceId: null,
       }));
+    });
+
+    it('ages a stale peer-owned attempt out so a dead peer cannot strand the link', async () => {
+      // The peer that owned this clone crashed and never came back. Skipping it
+      // forever on ownership alone is the original #5463 bug, one hop removed.
+      storage.getLinks.mockResolvedValue([
+        { id: 'peer-dead', cloneStatus: 'cloning', cloneInstanceId: 'peer-x', updatedAt: '2020-01-01T00:00:00.000Z' },
+      ]);
+      storage.updateLink.mockResolvedValue({});
+
+      await recoverInterruptedRepoClones();
+
+      expect(storage.updateLink).toHaveBeenCalledWith('peer-dead', expect.objectContaining({
+        cloneStatus: 'failed',
+        cloneInterrupted: true,
+      }));
+    });
+
+    it('does not block on the staging sweep', async () => {
+      // Boot awaits this function before it starts listening, so an `rm -rf` of
+      // abandoned partial checkouts must not gate the server accepting requests.
+      // `Once`, so the never-settling promise can't leak into a later test —
+      // mockReturnValue survives clearAllMocks.
+      let released;
+      githubCloner.reapStaleCloneStaging.mockReturnValueOnce(new Promise(resolve => { released = resolve; }));
+      storage.getLinks.mockResolvedValue([]);
+
+      await recoverInterruptedRepoClones();
+
+      expect(githubCloner.reapStaleCloneStaging).toHaveBeenCalled();
+      released(0);
     });
   });
 

--- a/server/services/brain.test.js
+++ b/server/services/brain.test.js
@@ -147,6 +147,7 @@ import {
   deleteInboxEntry,
   deleteMemoryEntry,
   recoverStuckClassifications,
+  recoverInterruptedRepoClones,
   createLinkFromUrl
 } from './brain.js';
 
@@ -962,6 +963,32 @@ describe('brain service', () => {
       expect(storage.updateInboxLog).toHaveBeenCalledWith('legacy', { status: 'needs_review' });
       expect(storage.updateInboxLog).not.toHaveBeenCalledWith('peers', expect.anything());
       expect(storage.updateInboxLog).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  // ===========================================================================
+  // recoverInterruptedRepoClones
+  // ===========================================================================
+
+  describe('recoverInterruptedRepoClones', () => {
+    it('marks only interrupted clones as failed so they can be retried', async () => {
+      storage.getLinks.mockResolvedValue([
+        { id: 'pending', cloneStatus: 'pending' },
+        { id: 'cloning', cloneStatus: 'cloning' },
+        { id: 'cloned', cloneStatus: 'cloned' },
+        { id: 'failed', cloneStatus: 'failed' },
+        { id: 'none', cloneStatus: 'none' },
+      ]);
+      storage.updateLink.mockResolvedValue({});
+
+      await recoverInterruptedRepoClones();
+
+      expect(storage.getLinks).toHaveBeenCalledWith({ cloneStatus: 'cloning' });
+      expect(storage.updateLink).toHaveBeenCalledTimes(1);
+      expect(storage.updateLink).toHaveBeenCalledWith('cloning', {
+        cloneStatus: 'failed',
+        cloneError: 'Clone interrupted by a server restart. Retry to clone the repository again.',
+      });
     });
   });
 

--- a/server/services/brain.test.js
+++ b/server/services/brain.test.js
@@ -310,7 +310,10 @@ describe('brain service', () => {
         isGitHubRepo: true,
         cloneStatus: 'pending'
       }));
-      expect(storage.updateLink).toHaveBeenCalledWith('link-001', { cloneStatus: 'cloning' });
+      expect(storage.updateLink).toHaveBeenCalledWith('link-001', {
+        cloneStatus: 'cloning',
+        cloneInstanceId: 'local-instance'
+      });
     });
 
     it('files a URL to Links even when the creative flag is set', async () => {
@@ -974,7 +977,8 @@ describe('brain service', () => {
     it('marks only interrupted clones as failed so they can be retried', async () => {
       storage.getLinks.mockResolvedValue([
         { id: 'pending', cloneStatus: 'pending' },
-        { id: 'cloning', cloneStatus: 'cloning' },
+        { id: 'cloning', cloneStatus: 'cloning', cloneInstanceId: 'local-instance' },
+        { id: 'peer-cloning', cloneStatus: 'cloning', cloneInstanceId: 'peer-x' },
         { id: 'cloned', cloneStatus: 'cloned' },
         { id: 'failed', cloneStatus: 'failed' },
         { id: 'none', cloneStatus: 'none' },
@@ -989,6 +993,7 @@ describe('brain service', () => {
         cloneStatus: 'failed',
         cloneError: 'Clone interrupted by a server restart. Retry to clone the repository again.',
       });
+      expect(storage.updateLink).not.toHaveBeenCalledWith('peer-cloning', expect.anything());
     });
   });
 

--- a/server/services/githubCloner.js
+++ b/server/services/githubCloner.js
@@ -7,6 +7,7 @@
 
 import { spawn } from '../lib/childProcess.js';
 import { existsSync } from 'fs';
+import { mkdtemp, rename, rm } from 'fs/promises';
 import { join } from 'path';
 import { ensureDir, PATHS } from '../lib/fileUtils.js';
 import { parseGitHubUrl, isGitHubRepoUrl } from '../lib/githubRepoUrl.js';
@@ -69,6 +70,12 @@ export async function cloneRepo(url, options = {}) {
     await ensureDir(ownerDir);
   }
 
+  // Clone into attempt-specific staging, then publish it only after git exits.
+  // An abruptly orphaned git child can keep writing its private directory, but
+  // a retry gets a different directory and cannot race the live checkout.
+  const stagingRoot = await mkdtemp(join(ownerDir, `.${repo}-cloning-`));
+  const stagingPath = join(stagingRoot, repo);
+
   // Build clone command with shallow clone for space efficiency
   const httpsUrl = `https://github.com/${owner}/${repo}.git`;
   const args = [
@@ -76,12 +83,12 @@ export async function cloneRepo(url, options = {}) {
     '--depth', '1',
     '--single-branch',
     httpsUrl,
-    localPath
+    stagingPath
   ];
 
   console.log(`📥 Cloning ${owner}/${repo}...`);
 
-  return new Promise((resolve, reject) => {
+  const clone = new Promise((resolve, reject) => {
     const child = spawn('git', args, {
       env: process.env,
       shell: false
@@ -93,15 +100,15 @@ export async function cloneRepo(url, options = {}) {
       stderr += data.toString();
     });
 
+    const timeout = setTimeout(() => {
+      child.kill();
+      reject(new Error('Clone timed out after 5 minutes'));
+    }, 300000);
+
     child.on('close', (code) => {
+      clearTimeout(timeout);
       if (code === 0) {
-        console.log(`✅ Cloned ${owner}/${repo} to ${localPath}`);
-        resolve({
-          localPath,
-          owner,
-          repo,
-          alreadyCloned: false
-        });
+        resolve();
       } else {
         console.error(`❌ Failed to clone ${owner}/${repo}: ${stderr}`);
         reject(new Error(`Git clone failed: ${stderr || `exit code ${code}`}`));
@@ -109,15 +116,29 @@ export async function cloneRepo(url, options = {}) {
     });
 
     child.on('error', (err) => {
+      clearTimeout(timeout);
       console.error(`❌ Git clone error: ${err.message}`);
       reject(err);
     });
+  });
 
-    // Timeout after 5 minutes
-    setTimeout(() => {
-      child.kill();
-      reject(new Error('Clone timed out after 5 minutes'));
-    }, 300000);
+  const cleanupStaging = () => rm(stagingRoot, { recursive: true, force: true })
+    .catch(err => console.error(`❌ Failed to clean clone staging directory: ${err.message}`));
+
+  return clone.then(async () => {
+    // A concurrent attempt may have won while this one was cloning. Keep the
+    // completed checkout and discard only this attempt's private staging dir.
+    if (existsSync(join(localPath, '.git'))) {
+      await cleanupStaging();
+      return { localPath, owner, repo, alreadyCloned: true };
+    }
+    await rename(stagingPath, localPath);
+    await cleanupStaging();
+    console.log(`✅ Cloned ${owner}/${repo} to ${localPath}`);
+    return { localPath, owner, repo, alreadyCloned: false };
+  }).catch(async (err) => {
+    await cleanupStaging();
+    throw err;
   });
 }
 

--- a/server/services/githubCloner.js
+++ b/server/services/githubCloner.js
@@ -164,7 +164,13 @@ export async function reapStaleCloneStaging({ cloneDir = DEFAULT_CLONE_DIR, now 
   for (const owner of owners) {
     if (!owner.isDirectory()) continue;
     const ownerDir = join(cloneDir, owner.name);
-    const entries = await readdir(ownerDir, { withFileTypes: true });
+    // One unreadable owner directory (removed mid-sweep, or not ours to read)
+    // must not abort the sweep and leave every later owner's staging behind.
+    const entries = await readdir(ownerDir, { withFileTypes: true })
+      .catch(err => {
+        console.error(`⚠️ Skipped clone staging sweep for ${owner.name}: ${err.message}`);
+        return [];
+      });
     for (const entry of entries) {
       if (!entry.isDirectory()) continue;
       const match = entry.name.match(CLONE_STAGING_RE);

--- a/server/services/githubCloner.js
+++ b/server/services/githubCloner.js
@@ -7,13 +7,16 @@
 
 import { spawn } from '../lib/childProcess.js';
 import { existsSync } from 'fs';
-import { mkdtemp, rename, rm } from 'fs/promises';
+import { mkdtemp, readdir, rename, rm } from 'fs/promises';
 import { join } from 'path';
 import { ensureDir, PATHS } from '../lib/fileUtils.js';
 import { parseGitHubUrl, isGitHubRepoUrl } from '../lib/githubRepoUrl.js';
 
 // Default directory for cloned repos (can be configured in settings)
 const DEFAULT_CLONE_DIR = PATHS.repos;
+const CLONE_STAGING_PREFIX = '.portos-clone-';
+const CLONE_STAGING_MAX_AGE_MS = 10 * 60 * 1000;
+const CLONE_STAGING_RE = /^\.portos-clone-(\d{13})-[A-Za-z0-9]+$/;
 
 // The owner/repo parse rule lives in lib/ so the client can mirror it — the
 // Brain capture boxes have to predict "this URL will be cloned" before submit.
@@ -53,6 +56,13 @@ export async function cloneRepo(url, options = {}) {
   const cloneDir = await ensureCloneDir(options.cloneDir);
   const localPath = join(cloneDir, owner, repo);
 
+  // Boot recovery marks only a known interrupted attempt. Old PortOS versions
+  // cloned straight into localPath, so their partial checkout must be replaced
+  // before the normal already-cloned compatibility check can trust `.git`.
+  if (options.replaceIncomplete === true) {
+    await rm(localPath, { recursive: true, force: true });
+  }
+
   // Check if already cloned
   if (existsSync(join(localPath, '.git'))) {
     console.log(`📦 Repo already cloned: ${owner}/${repo}`);
@@ -73,7 +83,7 @@ export async function cloneRepo(url, options = {}) {
   // Clone into attempt-specific staging, then publish it only after git exits.
   // An abruptly orphaned git child can keep writing its private directory, but
   // a retry gets a different directory and cannot race the live checkout.
-  const stagingRoot = await mkdtemp(join(ownerDir, `.${repo}-cloning-`));
+  const stagingRoot = await mkdtemp(join(ownerDir, `${CLONE_STAGING_PREFIX}${Date.now()}-`));
   const stagingPath = join(stagingRoot, repo);
 
   // Build clone command with shallow clone for space efficiency
@@ -140,6 +150,31 @@ export async function cloneRepo(url, options = {}) {
     await cleanupStaging();
     throw err;
   });
+}
+
+/**
+ * Remove only PortOS-owned clone staging directories older than twice the git
+ * timeout. A freshly orphaned child may still be writing; the age gate leaves
+ * it alone while bounding disk retained across repeated interrupted attempts.
+ */
+export async function reapStaleCloneStaging({ cloneDir = DEFAULT_CLONE_DIR, now = Date.now() } = {}) {
+  const owners = await readdir(cloneDir, { withFileTypes: true })
+    .catch(err => err.code === 'ENOENT' ? [] : Promise.reject(err));
+  let reaped = 0;
+  for (const owner of owners) {
+    if (!owner.isDirectory()) continue;
+    const ownerDir = join(cloneDir, owner.name);
+    const entries = await readdir(ownerDir, { withFileTypes: true });
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      const match = entry.name.match(CLONE_STAGING_RE);
+      if (!match || now - Number(match[1]) < CLONE_STAGING_MAX_AGE_MS) continue;
+      await rm(join(ownerDir, entry.name), { recursive: true, force: true });
+      reaped++;
+    }
+  }
+  if (reaped > 0) console.log(`🧹 Reaped ${reaped} stale repository clone staging director${reaped === 1 ? 'y' : 'ies'}`);
+  return reaped;
 }
 
 /**

--- a/server/services/githubCloner.test.js
+++ b/server/services/githubCloner.test.js
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import EventEmitter from 'node:events';
+
+vi.mock('fs', () => ({ existsSync: vi.fn() }));
+vi.mock('fs/promises', () => ({
+  mkdtemp: vi.fn(),
+  rename: vi.fn(),
+  rm: vi.fn(),
+}));
+vi.mock('../lib/childProcess.js', () => ({ spawn: vi.fn() }));
+vi.mock('../lib/fileUtils.js', () => ({
+  ensureDir: vi.fn(),
+  PATHS: { repos: '/repos' },
+}));
+
+import { existsSync } from 'fs';
+import { mkdtemp, rename, rm } from 'fs/promises';
+import { spawn } from '../lib/childProcess.js';
+import { cloneRepo } from './githubCloner.js';
+
+const createChild = () => {
+  const child = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.kill = vi.fn();
+  return child;
+};
+
+describe('cloneRepo', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    existsSync.mockImplementation(path => !String(path).endsWith('.git'));
+    mkdtemp.mockResolvedValue('/repos/acme/.widgets-cloning-attempt');
+    rename.mockResolvedValue();
+    rm.mockResolvedValue();
+  });
+
+  it('publishes a clone only after git completes in attempt-specific staging', async () => {
+    const child = createChild();
+    spawn.mockReturnValue(child);
+
+    const resultPromise = cloneRepo('https://github.com/acme/widgets');
+    await vi.waitFor(() => expect(spawn).toHaveBeenCalled());
+
+    expect(spawn).toHaveBeenCalledWith('git', [
+      'clone', '--depth', '1', '--single-branch',
+      'https://github.com/acme/widgets.git',
+      '/repos/acme/.widgets-cloning-attempt/widgets'
+    ], expect.objectContaining({ shell: false }));
+    expect(rename).not.toHaveBeenCalled();
+
+    child.emit('close', 0);
+
+    await expect(resultPromise).resolves.toMatchObject({
+      localPath: '/repos/acme/widgets',
+      alreadyCloned: false
+    });
+    expect(rename).toHaveBeenCalledWith(
+      '/repos/acme/.widgets-cloning-attempt/widgets',
+      '/repos/acme/widgets'
+    );
+    expect(rm).toHaveBeenCalledWith(
+      '/repos/acme/.widgets-cloning-attempt',
+      { recursive: true, force: true }
+    );
+  });
+});

--- a/server/services/githubCloner.test.js
+++ b/server/services/githubCloner.test.js
@@ -78,8 +78,67 @@ describe('cloneRepo', () => {
     await resultPromise;
   });
 
+  it('never removes the destination for an ordinary clone', async () => {
+    // `replaceIncomplete` is the ONLY thing licensed to delete a checkout the
+    // user may already be using; a plain clone must stage and rename instead.
+    const child = createChild();
+    spawn.mockReturnValue(child);
+
+    const resultPromise = cloneRepo('https://github.com/acme/widgets');
+    await vi.waitFor(() => expect(spawn).toHaveBeenCalled());
+    child.emit('close', 0);
+    await resultPromise;
+
+    expect(rm).not.toHaveBeenCalledWith('/repos/acme/widgets', expect.anything());
+  });
+
+  it('discards staging and surfaces the git error when the clone fails', async () => {
+    const child = createChild();
+    spawn.mockReturnValue(child);
+
+    const resultPromise = cloneRepo('https://github.com/acme/widgets');
+    await vi.waitFor(() => expect(spawn).toHaveBeenCalled());
+    child.stderr.emit('data', Buffer.from('fatal: repository not found'));
+    child.emit('close', 128);
+
+    await expect(resultPromise).rejects.toThrow('fatal: repository not found');
+    // Nothing published, and the abandoned partial checkout is gone rather than
+    // left for the boot-time reaper.
+    expect(rename).not.toHaveBeenCalled();
+    expect(rm).toHaveBeenCalledWith(
+      '/repos/acme/.widgets-cloning-attempt',
+      { recursive: true, force: true }
+    );
+  });
+
+  it('keeps a checkout a concurrent attempt already published', async () => {
+    const child = createChild();
+    spawn.mockReturnValue(child);
+
+    const resultPromise = cloneRepo('https://github.com/acme/widgets');
+    await vi.waitFor(() => expect(spawn).toHaveBeenCalled());
+    // The rival attempt won while git was running.
+    existsSync.mockReturnValue(true);
+    child.emit('close', 0);
+
+    await expect(resultPromise).resolves.toMatchObject({
+      localPath: '/repos/acme/widgets',
+      alreadyCloned: true
+    });
+    expect(rename).not.toHaveBeenCalled();
+  });
+});
+
+describe('reapStaleCloneStaging', () => {
+  const directory = name => ({ name, isDirectory: () => true });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    rm.mockResolvedValue();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
   it('reaps only expired PortOS clone staging directories', async () => {
-    const directory = name => ({ name, isDirectory: () => true });
     readdir
       .mockResolvedValueOnce([directory('acme')])
       .mockResolvedValueOnce([
@@ -94,6 +153,30 @@ describe('cloneRepo', () => {
     })).resolves.toBe(1);
 
     expect(rm).toHaveBeenCalledTimes(1);
+    expect(rm).toHaveBeenCalledWith(
+      '/repos/acme/.portos-clone-1000000000000-old123',
+      { recursive: true, force: true }
+    );
+  });
+
+  it('reports an empty repos directory rather than throwing', async () => {
+    readdir.mockRejectedValueOnce(Object.assign(new Error('nope'), { code: 'ENOENT' }));
+
+    await expect(reapStaleCloneStaging({ cloneDir: '/repos' })).resolves.toBe(0);
+    expect(rm).not.toHaveBeenCalled();
+  });
+
+  it('keeps sweeping after an unreadable owner directory', async () => {
+    readdir
+      .mockResolvedValueOnce([directory('locked'), directory('acme')])
+      .mockRejectedValueOnce(Object.assign(new Error('permission denied'), { code: 'EACCES' }))
+      .mockResolvedValueOnce([directory('.portos-clone-1000000000000-old123')]);
+
+    await expect(reapStaleCloneStaging({
+      cloneDir: '/repos',
+      now: 2000000000000
+    })).resolves.toBe(1);
+
     expect(rm).toHaveBeenCalledWith(
       '/repos/acme/.portos-clone-1000000000000-old123',
       { recursive: true, force: true }

--- a/server/services/githubCloner.test.js
+++ b/server/services/githubCloner.test.js
@@ -4,6 +4,7 @@ import EventEmitter from 'node:events';
 vi.mock('fs', () => ({ existsSync: vi.fn() }));
 vi.mock('fs/promises', () => ({
   mkdtemp: vi.fn(),
+  readdir: vi.fn(),
   rename: vi.fn(),
   rm: vi.fn(),
 }));
@@ -14,9 +15,9 @@ vi.mock('../lib/fileUtils.js', () => ({
 }));
 
 import { existsSync } from 'fs';
-import { mkdtemp, rename, rm } from 'fs/promises';
+import { mkdtemp, readdir, rename, rm } from 'fs/promises';
 import { spawn } from '../lib/childProcess.js';
-import { cloneRepo } from './githubCloner.js';
+import { cloneRepo, reapStaleCloneStaging } from './githubCloner.js';
 
 const createChild = () => {
   const child = new EventEmitter();
@@ -30,6 +31,7 @@ describe('cloneRepo', () => {
     vi.clearAllMocks();
     existsSync.mockImplementation(path => !String(path).endsWith('.git'));
     mkdtemp.mockResolvedValue('/repos/acme/.widgets-cloning-attempt');
+    readdir.mockResolvedValue([]);
     rename.mockResolvedValue();
     rm.mockResolvedValue();
   });
@@ -60,6 +62,40 @@ describe('cloneRepo', () => {
     );
     expect(rm).toHaveBeenCalledWith(
       '/repos/acme/.widgets-cloning-attempt',
+      { recursive: true, force: true }
+    );
+  });
+
+  it('removes a legacy partial destination only for a recovered attempt', async () => {
+    const child = createChild();
+    spawn.mockReturnValue(child);
+
+    const resultPromise = cloneRepo('https://github.com/acme/widgets', { replaceIncomplete: true });
+    await vi.waitFor(() => expect(spawn).toHaveBeenCalled());
+
+    expect(rm).toHaveBeenCalledWith('/repos/acme/widgets', { recursive: true, force: true });
+    child.emit('close', 0);
+    await resultPromise;
+  });
+
+  it('reaps only expired PortOS clone staging directories', async () => {
+    const directory = name => ({ name, isDirectory: () => true });
+    readdir
+      .mockResolvedValueOnce([directory('acme')])
+      .mockResolvedValueOnce([
+        directory('.portos-clone-1000000000000-old123'),
+        directory('.portos-clone-1999999999999-new123'),
+        directory('.unrelated'),
+      ]);
+
+    await expect(reapStaleCloneStaging({
+      cloneDir: '/repos',
+      now: 2000000000000
+    })).resolves.toBe(1);
+
+    expect(rm).toHaveBeenCalledTimes(1);
+    expect(rm).toHaveBeenCalledWith(
+      '/repos/acme/.portos-clone-1000000000000-old123',
       { recursive: true, force: true }
     );
   });


### PR DESCRIPTION
## Summary

- Boot-time sweep resets any link left at `cloneStatus: 'cloning'` to `failed` with an explanatory `cloneError`, restoring the Links tab's existing Retry affordance with no new UI or API. Closes #5463.
- Clones now run in an attempt-private staging directory and are published by `rename` only after git exits 0, so an orphaned child can never leave a half-checkout that the "already cloned?" check mistakes for a real clone. A recovered retry additionally replaces a legacy direct-to-destination partial. Abandoned staging dirs are reaped on a 10-minute age gate.
- Ownership is tracked on `cloneInstanceId` so a peer's in-flight clone isn't reset out from under it — but it ages out of that protection after 10 minutes, so a peer that crashed mid-clone can't strand the link either. The id is resolved with `ensureInstanceId()` and stored as `null` rather than the `UNKNOWN_INSTANCE_ID` sentinel; stamping the sentinel on a federated record would read as "someone else owns this" on every machine and re-strand the exact link this fixes.
- The record sweep is awaited before the server starts listening (so the first `/api/brain/links` response can't show an orphaned spinner); the staging `rm -rf` is detached so filesystem work doesn't gate boot.
- `cloneError` is cleared when a retry stamps `cloning` — the Links tab renders it independent of status, so the recovery message otherwise sat beside the retry's own spinner.
- The route's un-awaited clone kickoff now has its own catch: its pre-clone steps run outside the request lifecycle, where an unhandled rejection takes the process down instead of logging.

## Test plan

- `cd server && npx vitest run` — 1786 files, 36454 tests passing.
- New/updated coverage: `githubCloner.test.js` (staging publish, `replaceIncomplete` only deleting the destination for a recovered attempt, clone-failure cleanup, concurrent-publish, staging reaper age gate + fault tolerance); `brain.test.js` (recovery resets `cloning` and leaves every other `cloneStatus` untouched, stale peer-owned attempt ages out, sweep does not block); `brainLinks.test.js` (retry after recovery starts a clone; a rejected kickoff logs instead of crashing); `bootstrapSequence.test.js` (boot order and best-effort failure handling).
- `cd client && npx vitest run src/components/brain/tabs/LinksTab.test.jsx` — 12 passing.
- Bypass probes: reverting the route catch and re-awaiting the staging sweep each fails its guard test.