### PR TITLE
fix: keep music prompt available on render step

### DIFF
--- a/client/src/components/music/MusicDesigner.jsx
+++ b/client/src/components/music/MusicDesigner.jsx
@@ -533,6 +533,24 @@ export default function MusicDesigner() {
 
       {step === 'render' && (
         <div className="space-y-4">
+          <label htmlFor="music-designer-render-prompt" className="block">
+            <span className={LABEL_CLASS}>Prompt for this render</span>
+            <textarea
+              id="music-designer-render-prompt"
+              value={description}
+              onChange={(event) => setDescription(event.target.value)}
+              onBlur={() => saveDraft({ prompt: description.trim() })}
+              disabled={draftLoading}
+              rows={6}
+              maxLength={8000}
+              placeholder={'Describe the sound, arrangement, vocals, instruments, mood, and production direction…'}
+              aria-describedby="music-designer-render-prompt-hint"
+              className={FIELD_CLASS}
+            />
+            <span id="music-designer-render-prompt-hint" className="mt-1 block text-xs text-gray-500">
+              Required. This editable description is the prompt sent to the selected audio engine.
+            </span>
+          </label>
           <label htmlFor="music-designer-title" className="block">
             <span className={LABEL_CLASS}>Title (optional)</span>
             <input

--- a/client/src/components/music/MusicDesigner.test.jsx
+++ b/client/src/components/music/MusicDesigner.test.jsx
@@ -145,6 +145,34 @@ describe('<MusicDesigner>', () => {
       await screen.findByLabelText(/what do you want to hear/i);
       expect(window.localStorage.getItem('portos.musicDesigner.activeDraft')).toBe('track-draft');
     });
+
+    it('keeps the render prompt visible and editable for a saved draft', async () => {
+      api.getTrack.mockResolvedValue({
+        id: 'track-saved', title: 'Named Track', concept: 'A dusk-time pulse',
+        prompt: 'Warm synths and a patient beat.', lyrics: '',
+      });
+      renderAt('/music/generate/render?trackId=track-saved');
+
+      const prompt = await screen.findByLabelText(/prompt for this render/i);
+      expect(prompt).toHaveValue('Warm synths and a patient beat.');
+      fireEvent.change(prompt, { target: { value: 'A brighter pulse with hand percussion.' } });
+      expect(screen.getByTestId('gen-panel')).toHaveAttribute('data-prompt', 'A brighter pulse with hand percussion.');
+      fireEvent.blur(prompt);
+
+      await waitFor(() => expect(api.updateTrack).toHaveBeenCalledWith(
+        'track-saved', { prompt: 'A brighter pulse with hand percussion.' }, { silent: true },
+      ));
+    });
+
+    it('lets a direct render visit supply the prompt before generating', async () => {
+      renderAt('/music/generate/render?trackId=track-draft');
+
+      const prompt = await screen.findByLabelText(/prompt for this render/i);
+      expect(prompt).toHaveValue('');
+      fireEvent.change(prompt, { target: { value: 'A quiet piano loop with tape hiss.' } });
+
+      expect(screen.getByTestId('gen-panel')).toHaveAttribute('data-prompt', 'A quiet piano loop with tape hiss.');
+    });
   });
 
   describe('the describe step', () => {


### PR DESCRIPTION
## Summary
- Keep the music prompt visible and editable when moving to the Render step on mobile.
- Persist prompt edits and pass them into the audio generation panel so Generate can become available.

## Test plan
- `npm test` (client): 832 files, 10,527 tests passed
- `npm run lint` (client)
- `npm run build` (client)