### PR TITLE
fix: keep FableLoom browser bundles Node-free

### DIFF
--- a/client/src/pages/FableLoomStory.browser.test.js
+++ b/client/src/pages/FableLoomStory.browser.test.js
@@ -1,0 +1,61 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { builtinModules } from 'node:module';
+import { dirname, extname, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
+const ENTRY = resolve(REPO_ROOT, 'client/src/pages/FableLoomStory.jsx');
+const SOURCE_EXTENSIONS = ['.js', '.jsx', '.ts', '.tsx'];
+const BUILTINS = new Set([
+  ...builtinModules,
+  ...builtinModules.map((name) => `node:${name}`),
+]);
+
+const importSpecifiers = (source) => [
+  ...source.matchAll(/^\s*import\s+(?:[^'"]*?\s+from\s+)?['"]([^'"]+)['"]/gm),
+  ...source.matchAll(/^\s*export\s+(?:\*|{)[^'"]*?\s+from\s+['"]([^'"]+)['"]/gm),
+].map((match) => match[1]);
+
+const resolveSourceImport = (fromFile, specifier) => {
+  const base = resolve(dirname(fromFile), specifier);
+  const candidates = extname(base)
+    ? [base]
+    : [
+      ...SOURCE_EXTENSIONS.map((extension) => `${base}${extension}`),
+      ...SOURCE_EXTENSIONS.map((extension) => resolve(base, `index${extension}`)),
+    ];
+  return candidates.find((candidate) => existsSync(candidate)) || null;
+};
+
+const browserBuiltinImports = (entry) => {
+  const visited = new Set();
+  const findings = [];
+  const pending = [entry];
+
+  while (pending.length) {
+    const file = pending.pop();
+    if (visited.has(file)) continue;
+    visited.add(file);
+
+    for (const specifier of importSpecifiers(readFileSync(file, 'utf8'))) {
+      if (BUILTINS.has(specifier)) {
+        findings.push(`${relative(REPO_ROOT, file)} imports ${specifier}`);
+        continue;
+      }
+      if (!specifier.startsWith('.')) continue;
+      const importedFile = resolveSourceImport(file, specifier);
+      if (importedFile && SOURCE_EXTENSIONS.includes(extname(importedFile))) {
+        pending.push(importedFile);
+      }
+    }
+  }
+
+  return findings.sort();
+};
+
+describe('FableLoomStory browser dependency boundary', () => {
+  it('keeps the route import graph free of Node builtins', () => {
+    expect(browserBuiltinImports(ENTRY)).toEqual([]);
+  });
+});

--- a/client/src/pages/FableLoomStory.browser.test.js
+++ b/client/src/pages/FableLoomStory.browser.test.js
@@ -15,6 +15,7 @@ const BUILTINS = new Set([
 const importSpecifiers = (source) => [
   ...source.matchAll(/^\s*import\s+(?:[^'"]*?\s+from\s+)?['"]([^'"]+)['"]/gm),
   ...source.matchAll(/^\s*export\s+(?:\*|{)[^'"]*?\s+from\s+['"]([^'"]+)['"]/gm),
+  ...source.matchAll(/\bimport\s*\(\s*['"]([^'"]+)['"]\s*\)/g),
 ].map((match) => match[1]);
 
 const resolveSourceImport = (fromFile, specifier) => {
@@ -45,17 +46,25 @@ const browserBuiltinImports = (entry) => {
       }
       if (!specifier.startsWith('.')) continue;
       const importedFile = resolveSourceImport(file, specifier);
-      if (importedFile && SOURCE_EXTENSIONS.includes(extname(importedFile))) {
+      if (!importedFile) {
+        findings.push(`${relative(REPO_ROOT, file)} has an unresolvable relative import ${specifier}`);
+      } else if (SOURCE_EXTENSIONS.includes(extname(importedFile))) {
         pending.push(importedFile);
       }
     }
   }
 
-  return findings.sort();
+  return { findings: findings.sort(), visited };
 };
 
 describe('FableLoomStory browser dependency boundary', () => {
   it('keeps the route import graph free of Node builtins', () => {
-    expect(browserBuiltinImports(ENTRY)).toEqual([]);
+    const { findings, visited } = browserBuiltinImports(ENTRY);
+    expect(findings).toEqual([]);
+    const reached = [...visited].map((file) => relative(REPO_ROOT, file));
+    expect(reached).toEqual(expect.arrayContaining([
+      'server/lib/fableLoomOutline.js',
+      'server/lib/textUtils.js',
+    ]));
   });
 });

--- a/server/lib/README.md
+++ b/server/lib/README.md
@@ -374,7 +374,7 @@ The barrel `server/lib/index.js` is a machine-checkable enumeration of every pub
 | `goalFeatureMap.js` | Deterministic goal `category` → PortOS feature-area map (deep-links sourced from `NAV_COMMANDS`). `getGoalFeatureAreas(goal)` honors the per-goal `featureAreas` override, else the category default. Mirrored byte-for-byte to `client/src/lib/`. |
 | `navManifest.js` | Single source of truth for nav (`⌘K` palette + voice). Add an entry when you add a page. |
 | `personaTraitBlend.js` | Digital-twin persona trait-blending (M34 P7). Blends a persona's `traitAdjustments` against the base twin's communication profile + Big-Five into a "Communication Calibration" directive. Mirrored to `client/src/lib/`. |
-| `textUtils.js` | Pure server-side prose helpers. `countWords(text)` — canonical whitespace-token count (`\S+`), the single home for what `writersRoom/local.js`, `issueLength.js`, and the client's `formatters.js` used to each re-implement. |
+| `textUtils.js` | Pure dependency-free prose helpers. `countWords(text)` is the canonical whitespace-token count (`\S+`); `trimTo(value, max)` trims and bounds strings without coercing non-strings, and is safe for shared modules consumed by the browser. |
 | `pipelineIssueOrder.js` | Pure renumber algorithm for pipeline issues. |
 | `postAdaptive.js` | Pure POST adaptive-difficulty policy — nudges a math drill's primary knob (`steps`/`maxDigits`/`maxExponent`/`tolerancePct`) up/down within clamped bounds from recent scored performance. Opt-in via the config Adaptive toggle. |
 | `postAppliedNumeracy.js` | Pure seeded Applied Numeracy pack — everyday percentage, ratio, unit, rate, and estimation scenarios plus server-authoritative numeric/fraction/unit scoring with explicit tolerance handling. |

--- a/server/lib/fableLoomOutline.js
+++ b/server/lib/fableLoomOutline.js
@@ -8,9 +8,9 @@
  * before an outline is expanded and whenever an author edits it by hand.
  */
 
-import { trimTo } from './storyBible.js';
 import { LOOM_LIMITS } from './fableLoomLimits.js';
 import { FABLELOOM_PROTAGONIST_PRESENCE } from './fableLoomPlayback.js';
+import { trimTo } from './textUtils.js';
 
 const asArray = (value) => (Array.isArray(value) ? value : []);
 const isObject = (value) => value && typeof value === 'object';

--- a/server/lib/storyBible.js
+++ b/server/lib/storyBible.js
@@ -14,10 +14,12 @@ import { normalizeSlugline } from './scenePrompt.js';
 import { PATHS, resolveImageRef } from './fileUtils.js';
 import { isPlainObject } from './objects.js';
 import { shortCanonPrimaryField } from './canonPrompt.js';
+import { trimTo } from './textUtils.js';
 
 // Re-export so callers (writers-room domain files) can import a single
 // canonical normalizer when they need to match places by slugline.
 export { normalizeSlugline };
+export { trimTo };
 
 export const BIBLE_LIMITS = Object.freeze({
   NAME_MAX: 200,
@@ -326,10 +328,10 @@ const DEFAULT_ID_PREFIX = Object.freeze({
   object: 'obj-',
 });
 
-// Tiny string helpers — exported so adjacent server modules (pipeline
-// series.js, issues.js, etc.) stop redefining the same one-liners.
+// Shared string predicate retained here for the story-bible domain. `trimTo`
+// now lives in dependency-free textUtils and is re-exported above so existing
+// story-bible consumers keep the same public contract.
 export const isStr = (v) => typeof v === 'string';
-export const trimTo = (v, max) => (isStr(v) ? v.trim().slice(0, max) : '');
 
 // Smallest share of the budget a sentence-boundary cut may keep. A cut that
 // lands above this wins over a mid-sentence clip; below it, gutting the record

--- a/server/lib/textUtils.js
+++ b/server/lib/textUtils.js
@@ -26,6 +26,17 @@ export function countWords(text) {
 }
 
 /**
+ * Trim a string and cap it to a maximum number of characters.
+ *
+ * Kept in this dependency-free module so browser-consumed shared helpers do
+ * not have to import a larger server domain module just for string bounding.
+ * Non-string values normalize to the empty string rather than being coerced.
+ */
+export const trimTo = (value, max) => (
+  typeof value === 'string' ? value.trim().slice(0, max) : ''
+);
+
+/**
  * Escape a string for literal use inside a RegExp.
  *
  * Exported because this was hand-rolled privately in seven other modules

--- a/server/lib/textUtils.test.js
+++ b/server/lib/textUtils.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { countWords } from './textUtils.js';
+import { countWords, trimTo } from './textUtils.js';
 
 describe('countWords', () => {
   it('counts whitespace-separated tokens', () => {
@@ -24,5 +24,14 @@ describe('countWords', () => {
     expect(countWords(undefined)).toBe(0);
     expect(countWords(42)).toBe(0);
     expect(countWords({})).toBe(0);
+  });
+});
+
+describe('trimTo', () => {
+  it('trims and caps strings without coercing other values', () => {
+    expect(trimTo('  bounded text  ', 7)).toBe('bounded');
+    expect(trimTo(' short ', 20)).toBe('short');
+    expect(trimTo(null, 20)).toBe('');
+    expect(trimTo(42, 20)).toBe('');
   });
 });


### PR DESCRIPTION
## Summary

- keep the browser-consumed FableLoom outline analyzer on a dependency-free import path
- preserve the existing story-bible text helper contract through a compatibility re-export
- guard the FableLoom route import graph against Node builtins and unresolved edges

## Test plan

- server Vitest: text utilities, FableLoom outline, story bible, and lib barrel
- client Vitest: FableLoom route, outline planner, series plan, and browser dependency boundary
- client Biome lint
- client production build and browser smoke test