### PR TITLE
Make the Eidoverse world unobstructed

### DIFF
--- a/client/src/components/eidoverse/EidoverseWorldDrawer.jsx
+++ b/client/src/components/eidoverse/EidoverseWorldDrawer.jsx
@@ -60,6 +60,13 @@ export default function EidoverseWorldDrawer({
   const design = worldState?.design || {};
   const reconciliation = design.reconciliation || {};
   const projectionSummary = worldState?.projection?.lastSummary || {};
+  const projectedIndicatorCount = Number.isFinite(projectionSummary.liveEntityCount)
+    ? projectionSummary.liveEntityCount
+    : null;
+  const projectedIndicatorLimit = projectionSummary.maxLiveEntities
+    ?? design.maxEntities
+    ?? recipeDraft?.maxEntities
+    ?? 48;
   const busy = configStatus === 'saving' || projectionStatus === 'running';
   const projectionActionBlocked = busy || dirty;
   const assetRecipes = recipeDraft?.assetRecipe?.slots || {};
@@ -129,8 +136,13 @@ export default function EidoverseWorldDrawer({
           <p className="mt-1 text-sm text-white">{worldState?.presence?.connected ? 'Connected' : 'Ready to reconnect'}</p>
         </div>
         <div className="rounded-lg border border-port-border bg-port-bg p-3">
-          <p className="text-xs text-gray-500">Live signal budget</p>
-          <p className="mt-1 text-sm text-white">{design.maxEntities ?? recipeDraft?.maxEntities ?? 48} maximum</p>
+          <p className="text-xs text-gray-500">PortOS indicators</p>
+          <p className="mt-1 text-sm text-white">
+            {projectedIndicatorCount === null ? 'Waiting for projection' : `${projectedIndicatorCount} shown`}
+          </p>
+          <p className="mt-1 text-[10px] leading-4 text-gray-500">
+            Up to {projectedIndicatorLimit} can be displayed at once. This is scene capacity, not a health score.
+          </p>
         </div>
       </div>
     </div>
@@ -139,7 +151,10 @@ export default function EidoverseWorldDrawer({
   const districtFields = (
     <div className="space-y-3">
       <p className="text-sm leading-6 text-gray-400">
-        PortOS projects bounded summaries, never raw records. Stable IDs keep each signal in its district across refreshes.
+        PortOS projects bounded summary indicators, never raw records. Stable IDs keep each indicator in its district across refreshes.
+        {projectedIndicatorCount === null
+          ? ' The first projection has not reported a scene count yet.'
+          : ` ${projectedIndicatorCount} are shown now; the ${projectedIndicatorLimit}-indicator limit keeps the scene legible.`}
       </p>
       {projectionSummary.truncated && (
         <p className="rounded-lg border border-port-warning/40 bg-port-warning/10 px-3 py-2 text-xs leading-5 text-port-warning" role="status">

--- a/client/src/pages/Eidoverse.jsx
+++ b/client/src/pages/Eidoverse.jsx
@@ -6,7 +6,6 @@ import {
   RotateCcw,
   Settings,
   SlidersHorizontal,
-  Sparkles,
 } from 'lucide-react';
 import { Link } from 'react-router';
 import PageHeader from '../components/PageHeader';
@@ -69,12 +68,6 @@ const worldIdentityFor = (world) => ({
   name: world?.identity?.name || world?.human?.name,
   avatar: world?.identity?.avatar || world?.human?.avatar,
 });
-
-const statusTone = (status) => {
-  if (status === 'complete') return 'border-port-success/45 bg-port-success/10 text-port-success';
-  if (status === 'failed') return 'border-port-error/45 bg-port-error/10 text-port-error';
-  return 'border-port-accent/45 bg-port-accent/10 text-port-accent';
-};
 
 const DELETE_DRAFT_VALUE = Symbol('delete-draft-value');
 const isDraftRecord = (value) => Boolean(value) && typeof value === 'object' && !Array.isArray(value);
@@ -430,16 +423,52 @@ export default function Eidoverse() {
 
   const actions = (
     <>
+      {phase === 'ready' && (
+        <>
+          <button
+            type="button"
+            aria-label="Refresh world"
+            onClick={() => { void runProjection().catch(() => {}); }}
+            disabled={projectionStatus === 'running' || draftDirty}
+            title={draftDirty ? 'Save changes in World controls before refreshing' : 'Refresh the PortOS projection'}
+            className="inline-flex min-h-[40px] min-w-[40px] items-center justify-center rounded-lg border border-port-border px-2 text-gray-200 transition-colors hover:border-port-accent hover:text-white disabled:cursor-wait disabled:opacity-60"
+          >
+            <RotateCcw size={16} className={projectionStatus === 'running' ? 'animate-spin' : ''} aria-hidden="true" />
+          </button>
+          <button
+            type="button"
+            aria-label="World controls"
+            onClick={() => setSettingsOpen(true)}
+            className="inline-flex min-h-[40px] items-center gap-1.5 rounded-lg bg-port-accent px-3 py-1.5 text-sm font-semibold text-black transition-opacity hover:opacity-90"
+          >
+            <SlidersHorizontal size={15} aria-hidden="true" />
+            <span aria-hidden="true" className="sm:hidden">Controls</span>
+            <span aria-hidden="true" className="hidden sm:inline">World controls</span>
+          </button>
+        </>
+      )}
       {hostUrl && (
-        <a href={hostUrl} target="_blank" rel="noreferrer" className="inline-flex min-h-[40px] items-center gap-1.5 rounded-lg border border-port-border px-3 py-1.5 text-sm text-gray-200 transition-colors hover:border-port-accent hover:text-white">
+        <a
+          href={hostUrl}
+          target="_blank"
+          rel="noreferrer"
+          aria-label="Open Eidoverse without PortOS controls"
+          title="Open Eidoverse in a separate tab without the PortOS page frame"
+          className="inline-flex min-h-[40px] items-center gap-1.5 rounded-lg border border-port-border px-3 py-1.5 text-sm text-gray-200 transition-colors hover:border-port-accent hover:text-white"
+        >
           <ExternalLink size={15} aria-hidden="true" />
-          Open full screen
+          <span className="hidden md:inline">Open Eidoverse alone</span>
+          <span className="md:hidden">World only</span>
         </a>
       )}
       {appId && (
-        <Link to={`/apps/${appId}/overview`} className="inline-flex min-h-[40px] items-center gap-1.5 rounded-lg border border-port-border px-3 py-1.5 text-sm text-gray-200 transition-colors hover:border-port-accent hover:text-white">
+        <Link
+          to={`/apps/${appId}/overview`}
+          aria-label="Manage Eidoverse app"
+          title="Manage Eidoverse app"
+          className="hidden min-h-[40px] min-w-[40px] items-center justify-center rounded-lg border border-port-border px-2 text-gray-200 transition-colors hover:border-port-accent hover:text-white sm:inline-flex"
+        >
           <Settings size={15} aria-hidden="true" />
-          Manage app
         </Link>
       )}
     </>
@@ -447,10 +476,6 @@ export default function Eidoverse() {
 
   const design = worldState?.design || {};
   const reconciliation = design.reconciliation || {};
-  const summary = worldState?.projection?.lastSummary || {};
-  const projectionProgress = reconciliation.operationCount > 0
-    ? `${Math.min(reconciliation.appliedOperations || 0, reconciliation.operationCount)}/${reconciliation.operationCount}`
-    : null;
   const freshWorldLighting = projectionStatus === 'running'
     && design.lastAppliedVersion == null
     && !FRESH_WORLD_VISIBLE_CHECKPOINTS.has(reconciliation.checkpoint);
@@ -483,56 +508,8 @@ export default function Eidoverse() {
             </div>
           )}
 
-          <div className="pointer-events-none absolute inset-x-0 top-0 flex flex-wrap items-start justify-between gap-3 p-3 sm:p-4">
-            <section className="port-media-overlay max-w-md rounded-2xl border border-port-border p-3 shadow-2xl sm:p-4">
-              <div className="flex flex-wrap items-center gap-2">
-                <span className="inline-flex items-center gap-1.5 rounded-full border border-port-accent/35 bg-port-accent/10 px-2 py-1 text-[11px] font-medium text-port-accent">
-                  <Sparkles size={12} aria-hidden="true" />
-                  {design.name || recipeDraft?.name || 'PortOS world'}
-                </span>
-                <span className={`rounded-full border px-2 py-1 text-[11px] ${statusTone(reconciliation.status)}`}>
-                  {projectionStatus === 'running'
-                    ? `Projecting${projectionProgress ? ` ${projectionProgress}` : ''}`
-                    : (reconciliation.status || 'Pending')}
-                </span>
-              </div>
-              <h2 className="mt-3 text-base font-semibold sm:text-lg">Your PortOS, made spatial</h2>
-              <p className="mt-1 hidden text-xs leading-5 text-port-text-muted sm:block">
-                The Nexus is system health. Eight districts turn bounded app signals into places, motion, and light—without copying raw records into the world.
-              </p>
-              <div className="mt-3 flex flex-wrap gap-x-4 gap-y-1 text-[11px] text-port-text-muted">
-                <span>Design V{design.selectedVersion || recipeDraft?.version}</span>
-                <span>{summary.liveEntityCount ?? 0}/{design.maxEntities || 48} live signals</span>
-                <span>{worldState?.presence?.connected ? 'CoS connected' : 'CoS ready'}</span>
-                {draftDirty && <span className="text-port-warning">Unsaved world changes</span>}
-              </div>
-            </section>
-
-            <div className="pointer-events-auto flex gap-2">
-              <button
-                type="button"
-                aria-label="Refresh world"
-                onClick={() => { void runProjection().catch(() => {}); }}
-                disabled={projectionStatus === 'running' || draftDirty}
-                title={draftDirty ? 'Save changes in World controls before refreshing' : undefined}
-                className="port-media-overlay-strong port-media-overlay-item inline-flex min-h-[42px] items-center gap-2 rounded-xl border border-port-border px-3 text-sm shadow-xl transition-colors hover:border-port-accent disabled:cursor-wait disabled:opacity-60"
-              >
-                <RotateCcw size={15} className={projectionStatus === 'running' ? 'animate-spin' : ''} aria-hidden="true" />
-                <span className="hidden sm:inline">{projectionStatus === 'running' ? 'Projecting…' : 'Refresh world'}</span>
-              </button>
-              <button
-                type="button"
-                onClick={() => setSettingsOpen(true)}
-                className="inline-flex min-h-[42px] items-center gap-2 rounded-xl bg-port-accent px-3 text-sm font-semibold text-black shadow-xl transition-opacity hover:opacity-90"
-              >
-                <SlidersHorizontal size={15} aria-hidden="true" />
-                World controls
-              </button>
-            </div>
-          </div>
-
           {projectionError && (
-            <div className="port-media-overlay-strong pointer-events-auto absolute inset-x-3 top-40 z-10 mx-auto flex max-w-2xl items-start gap-3 rounded-xl border border-port-error/50 p-3 text-sm text-port-error shadow-xl sm:top-44" role="status">
+            <div className="port-media-overlay-strong pointer-events-auto absolute inset-x-3 top-3 z-10 mx-auto flex max-w-2xl items-start gap-3 rounded-xl border border-port-error/50 p-3 text-sm text-port-error shadow-xl" role="status">
               <AlertTriangle className="mt-0.5 shrink-0" size={17} aria-hidden="true" />
               <div className="min-w-0 flex-1">
                 <p>{projectionError}</p>
@@ -541,22 +518,6 @@ export default function Eidoverse() {
             </div>
           )}
 
-          <section className="pointer-events-auto absolute inset-x-0 bottom-0 overflow-x-auto p-3 sm:p-4" aria-label="PortOS district legend">
-            <div className="port-media-overlay mb-2 ml-auto w-fit rounded-full border border-port-border px-3 py-1 text-[10px] text-port-text-muted">
-              Steady = current · slow bob = stale · raised pulse = attention · high fast pulse = error
-            </div>
-            <div className="port-media-overlay flex min-w-max gap-2 rounded-2xl border border-port-border p-2 shadow-2xl sm:grid sm:min-w-0 sm:grid-cols-4 lg:grid-cols-8">
-              {(recipeDraft?.districts || []).map((district) => (
-                <div key={district.id} className="port-media-overlay-item w-36 rounded-xl border border-port-border/70 px-3 py-2 sm:w-auto">
-                  <div className="flex items-center gap-2">
-                    <span className="h-2 w-2 rounded-full shadow-[0_0_12px_currentColor]" style={{ backgroundColor: district.accent, color: district.accent }} aria-hidden="true" />
-                    <span className="truncate text-[11px] font-medium">{district.label}</span>
-                  </div>
-                  <p className="mt-1 truncate text-[10px] text-gray-500">{district.direction} · {district.landmark}</p>
-                </div>
-              ))}
-            </div>
-          </section>
         </main>
       )}
 

--- a/client/src/pages/Eidoverse.test.jsx
+++ b/client/src/pages/Eidoverse.test.jsx
@@ -139,26 +139,50 @@ describe('Eidoverse hosted page', () => {
     api.updateEidoverseWorldConfig.mockResolvedValue({ ...worldResponse, human: worldResponse.identity });
   });
 
-  it('loads the installed managed app and renders the PortOS spatial overlay', async () => {
+  it('loads the installed managed app without covering Eidoverse controls', async () => {
+    const user = userEvent.setup();
     renderPage();
 
     const frame = await screen.findByTitle('Eidoverse Worlds');
     expect(frame).toHaveAttribute('src', `http://${window.location.hostname}:8940/?world=portos&name=example-portos-user`);
-    const overlayHeading = await screen.findByText('Your PortOS, made spatial');
-    expect(overlayHeading.closest('section')).toHaveClass('port-media-overlay');
-    expect(screen.getByText(/The Nexus is system health/)).toHaveClass('text-port-text-muted');
-    expect(screen.getByText('Design V2').parentElement).toHaveClass('text-port-text-muted');
-    expect(screen.getByText(/Steady = current/)).toHaveClass('text-port-text-muted');
-    expect(screen.getByRole('button', { name: 'Refresh world' }))
-      .toHaveClass('port-media-overlay-strong', 'port-media-overlay-item');
     expect(screen.getByRole('button', { name: 'Refresh world' }))
       .toHaveAttribute('aria-label', 'Refresh world');
-    expect(screen.getByRole('region', { name: 'PortOS district legend' }).querySelector('.port-media-overlay'))
-      .toBeInTheDocument();
-    expect(screen.getByText('App Terraces')).toBeInTheDocument();
-    expect(screen.getByText('12/48 live signals')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Refresh world' })).not.toHaveClass('port-media-overlay');
+    expect(screen.queryByText('Your PortOS, made spatial')).not.toBeInTheDocument();
+    expect(screen.queryByRole('region', { name: 'PortOS district legend' })).not.toBeInTheDocument();
+    expect(screen.queryByText('12/48 live signals')).not.toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Open Eidoverse without PortOS controls' }))
+      .toHaveAttribute('href', `http://${window.location.hostname}:8940/?world=portos&name=example-portos-user`);
     await waitFor(() => expect(api.projectEidoverseWorld).toHaveBeenCalledWith({ silent: true }));
-    expect(screen.getByRole('link', { name: 'Manage app' })).toHaveAttribute('href', '/apps/app-eidoverse/overview');
+    expect(screen.getByRole('link', { name: 'Manage Eidoverse app' })).toHaveAttribute('href', '/apps/app-eidoverse/overview');
+
+    await user.click(screen.getByRole('button', { name: 'World controls' }));
+    expect(screen.getByText('12 shown')).toBeInTheDocument();
+    expect(screen.getByText(/Up to 48 can be displayed at once\. This is scene capacity, not a health score\./)).toBeInTheDocument();
+    await user.click(screen.getByRole('tab', { name: 'Districts & Data' }));
+    expect(screen.getByText(/12 are shown now; the 48-indicator limit keeps the scene legible/)).toBeInTheDocument();
+    expect(screen.getByText('App Terraces')).toBeInTheDocument();
+  });
+
+  it('keeps an unknown indicator count distinct from a projected empty world', async () => {
+    const user = userEvent.setup();
+    api.getEidoverseWorldStatus.mockResolvedValueOnce({
+      ...worldResponse,
+      projection: { lastSummary: null },
+    });
+    api.projectEidoverseWorld.mockResolvedValueOnce({
+      success: true,
+      projection: { lastSummary: null },
+      presence: { connected: true, role: 'owner' },
+      design,
+      recipe,
+    });
+    renderPage();
+
+    await screen.findByTitle('Eidoverse Worlds');
+    await user.click(screen.getByRole('button', { name: 'World controls' }));
+    expect(screen.getByText('Waiting for projection')).toBeInTheDocument();
+    expect(screen.queryByText('0 shown')).not.toBeInTheDocument();
   });
 
   it('starts a stopped managed app before connecting', async () => {
@@ -266,7 +290,7 @@ describe('Eidoverse hosted page', () => {
 
     expect(screen.getByLabelText('World name')).toHaveAttribute('pattern', '[A-Za-z0-9_-]+');
     await user.click(screen.getByRole('tab', { name: 'Districts & Data' }));
-    expect(screen.getByText(/bounded summaries, never raw records/i)).toBeInTheDocument();
+    expect(screen.getByText(/bounded summary indicators, never raw records/i)).toBeInTheDocument();
     expect(screen.getByLabelText('Apps')).toBeChecked();
     expect(screen.getByText('3')).toBeInTheDocument();
     expect(screen.getAllByRole('link', { name: 'Open in PortOS' })
@@ -328,7 +352,8 @@ describe('Eidoverse hosted page', () => {
     api.projectEidoverseWorld.mockReturnValueOnce(new Promise((resolve) => { resolveProjection = resolve; }));
     renderPage();
 
-    expect(await screen.findByText('Projecting 5/20')).toBeInTheDocument();
+    const refresh = await screen.findByRole('button', { name: 'Refresh world' });
+    await waitFor(() => expect(refresh).toBeDisabled());
     await user.click(screen.getByRole('button', { name: 'World controls' }));
     await user.click(screen.getByRole('tab', { name: 'Updates & Advanced' }));
     expect(screen.getByRole('progressbar', { name: 'World reconciliation progress' })).toHaveAttribute('aria-valuenow', '5');
@@ -339,7 +364,7 @@ describe('Eidoverse hosted page', () => {
       design: { ...design, reconciliation: { status: 'complete', checkpoint: 'projection-committed' } },
       recipe,
     });
-    await waitFor(() => expect(screen.queryByText('Projecting 5/20')).not.toBeInTheDocument());
+    await waitFor(() => expect(refresh).toBeEnabled());
   });
 
   it('keeps a fresh-world curtain up until the dawn environment is applied', async () => {

--- a/docs/features/eidoverse.md
+++ b/docs/features/eidoverse.md
@@ -226,8 +226,10 @@ the initial landmarks and signals stream in. The stricter order above remains
 mandatory for every upgrade with a previously applied design.
 
 The hosted page retains a loading curtain until the embedded renderer arrives,
-then presents the scene as the primary surface with a district/status legend,
-live-signal budget, and real reconciliation checkpoint progress over the world.
+then leaves the scene unobstructed. PortOS refresh, configuration, and standalone
+launch actions live in the page header rather than over the renderer. District,
+indicator-capacity, and reconciliation details stay in the World Design drawer,
+where they remain available without covering Eidoverse's own chat and world tools.
 **World controls** opens the shared tabbed drawer:
 
 - **Experience** — durable identity and high-level design status;


### PR DESCRIPTION
## Summary

- move PortOS refresh, configuration, app-management, and standalone-world actions into the page header
- remove the permanent PortOS intro and district overlays so Eidoverse chat and native world controls remain interactive
- explain the projected indicator count and the 48-indicator scene-capacity ceiling in the World Design drawer, including the not-yet-projected state
- document the unobstructed hosted-page contract

Follow-up to #5500.

## Validation

- `npm run lint` in `client`
- `npm run test:ci:related -- src/pages/Eidoverse.jsx src/components/eidoverse/EidoverseWorldDrawer.jsx src/pages/Eidoverse.test.jsx` in `client`
- `npm run test:ci` in `client` — 832 files, 10,529 tests
- `npm run build` in `client`
- browser verification at desktop, compact desktop, and mobile widths; native sky controls and chat input remained interactive