### PR TITLE
fix: reflect saved media prompts immediately

### DIFF
--- a/client/src/components/media/MediaPreview.jsx
+++ b/client/src/components/media/MediaPreview.jsx
@@ -1,4 +1,4 @@
-import { useMemo, useCallback } from 'react';
+import { useMemo, useCallback, useEffect, useState } from 'react';
 import MediaLightbox from './MediaLightbox';
 import { getMediaNavProps } from '../../lib/mediaNavigation';
 import { computeImageVariantGroup } from './variants';
@@ -23,10 +23,28 @@ export default function MediaPreview({
   onPromptSaved,
   ...handlers
 }) {
+  const [promptOverride, setPromptOverride] = useState(null);
   const navProps = useMemo(
     () => getMediaNavProps(items, preview, setPreview),
     [items, preview, setPreview]
   );
+  // `preview` is resolved from the URL and the host's item list. Keep a
+  // successful prompt edit visible immediately even for a host that does not
+  // own a mutable gallery list (the host callback still updates cards when it
+  // has one). This is keyed to the media identity, never to the selection
+  // itself, so the URL remains the source of truth for which item is open.
+  useEffect(() => {
+    setPromptOverride((current) => current?.key === preview?.key ? current : null);
+  }, [preview?.key]);
+  const displayedPreview = useMemo(() => {
+    if (!preview || promptOverride?.key !== preview.key) return preview;
+    const prompt = promptOverride.prompt;
+    return {
+      ...preview,
+      prompt,
+      raw: preview.raw ? { ...preview.raw, prompt: prompt === '(no prompt)' ? '' : prompt } : preview.raw,
+    };
+  }, [preview, promptOverride]);
   // Original-vs-cleaned toggle. Computed from the same `items` list that
   // drives prev/next nav — so if the cleaned copy was auto-filed into this
   // page's source collection, both variants are present and the toggle
@@ -44,15 +62,13 @@ export default function MediaPreview({
       ? await updateImagePrompt(item.filename, prompt, { silent: true })
       : await updateVideoPrompt(item.id, prompt, { silent: true });
     const nextPrompt = result?.prompt || '(no prompt)';
-    setPreview((current) => current?.key === item.key
-      ? { ...current, prompt: nextPrompt, raw: { ...current.raw, prompt: result?.prompt || '' } }
-      : current);
+    setPromptOverride({ key: item.key, prompt: nextPrompt });
     onPromptSaved?.(item, nextPrompt);
     return result;
-  }, [onPromptSaved, setPreview]);
+  }, [onPromptSaved]);
   return (
     <MediaLightbox
-      item={preview}
+      item={displayedPreview}
       onClose={() => setPreview(null)}
       annotation={annotations?.[preview?.key] ?? null}
       onAnnotationChange={preview && updateAnnotation ? (patch) => updateAnnotation(preview.key, patch) : undefined}

--- a/client/src/components/media/MediaPreview.test.jsx
+++ b/client/src/components/media/MediaPreview.test.jsx
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useState } from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, useLocation } from 'react-router';
+import MediaPreview from './MediaPreview';
+import usePreviewRoute from '../../hooks/usePreviewRoute';
+import { updateVideoPrompt } from '../../services/apiImageVideo';
+
+vi.mock('../../services/apiImageVideo', () => ({
+  updateImagePrompt: vi.fn(),
+  updateVideoPrompt: vi.fn(),
+}));
+
+// Keep this test focused on the wrapper's save/state contract. The lightbox has
+// its own interaction coverage; this stub exposes the item it receives and
+// invokes the same callback the real Save prompt button uses.
+vi.mock('./MediaLightbox', () => ({
+  default: ({ item, onPromptChange }) => item ? (
+    <div data-testid="lightbox">
+      <span data-testid="lightbox-prompt">{item.prompt}</span>
+      <button type="button" onClick={() => onPromptChange(item, 'a saved prompt')}>
+        Save prompt
+      </button>
+    </div>
+  ) : null,
+}));
+
+const VIDEO = {
+  kind: 'video',
+  key: 'video:video-1',
+  id: 'video-1',
+  filename: 'video-1.mp4',
+  prompt: '(no prompt)',
+  raw: { id: 'video-1', filename: 'video-1.mp4' },
+};
+
+function LocationProbe() {
+  const location = useLocation();
+  return <output data-testid="location">{location.search}</output>;
+}
+
+function PromptSaveHarness({ syncCard = true }) {
+  const [items, setItems] = useState([VIDEO]);
+  const [preview, setPreview] = usePreviewRoute(items);
+  const handlePromptSaved = (item, prompt) => {
+    setItems((current) => current.map((candidate) => candidate.key === item.key
+      ? { ...candidate, prompt }
+      : candidate));
+  };
+  return (
+    <>
+      <button type="button" onClick={() => setPreview(items[0])}>Open video</button>
+      <p data-testid="card-prompt">{items[0].prompt}</p>
+      <MediaPreview
+        preview={preview}
+        setPreview={setPreview}
+        items={items}
+        onPromptSaved={syncCard ? handlePromptSaved : undefined}
+      />
+      <LocationProbe />
+    </>
+  );
+}
+
+describe('MediaPreview prompt saving', () => {
+  beforeEach(() => {
+    updateVideoPrompt.mockReset();
+    updateVideoPrompt.mockResolvedValue({ id: VIDEO.id, prompt: 'a saved prompt' });
+  });
+
+  it('updates the card and modal immediately without treating the URL setter as React state', async () => {
+    render(
+      <MemoryRouter>
+        <PromptSaveHarness />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open video' }));
+    expect(screen.getByTestId('lightbox-prompt')).toHaveTextContent('(no prompt)');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save prompt' }));
+
+    await waitFor(() => {
+      expect(updateVideoPrompt).toHaveBeenCalledWith('video-1', 'a saved prompt', { silent: true });
+      expect(screen.getByTestId('card-prompt')).toHaveTextContent('a saved prompt');
+      expect(screen.getByTestId('lightbox-prompt')).toHaveTextContent('a saved prompt');
+    });
+    expect(screen.getByTestId('location')).toHaveTextContent('preview=video%3Avideo-1');
+  });
+
+  it('keeps the saved prompt visible when the host has no card-state callback', async () => {
+    render(
+      <MemoryRouter>
+        <PromptSaveHarness syncCard={false} />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open video' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Save prompt' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('lightbox-prompt')).toHaveTextContent('a saved prompt');
+    });
+    expect(screen.getByTestId('lightbox')).toBeInTheDocument();
+    expect(screen.getByTestId('location')).toHaveTextContent('preview=video%3Avideo-1');
+  });
+});

--- a/client/src/pages/ImageGen.jsx
+++ b/client/src/pages/ImageGen.jsx
@@ -1048,6 +1048,14 @@ export default function ImageGen() {
     setGallery((g) => g.filter((img) => img.filename !== filename));
   }, []);
 
+  const handlePromptSaved = useCallback((item, prompt) => {
+    const filename = item?.filename || item?.raw?.filename;
+    if (!filename) return;
+    setGallery((g) => g.map((img) => img.filename === filename
+      ? { ...img, prompt: prompt === '(no prompt)' ? '' : prompt }
+      : img));
+  }, []);
+
   const handleToggleHidden = useCallback(async (item) => {
     const img = item?.raw || item;
     const nextHidden = !img.hidden;
@@ -1690,6 +1698,7 @@ export default function ImageGen() {
         items={previewItems}
         annotations={annotations}
         updateAnnotation={updateAnnotation}
+        onPromptSaved={handlePromptSaved}
         onRemix={(item) => item?.raw && handleRemix(item.raw)}
         onSendToImage={(item) => item?.raw?.filename && handleSendToImage(item.raw)}
         onSendToVideo={(item) => item?.raw?.filename && sendToVideo(item.raw)}

--- a/client/src/pages/MediaCollectionDetail.jsx
+++ b/client/src/pages/MediaCollectionDetail.jsx
@@ -184,6 +184,27 @@ export default function MediaCollectionDetail() {
     toast.success(`Deleted ${item.kind === 'image' ? item.filename : 'video'}`);
   }, []);
 
+  const handlePromptSaved = useCallback((item, prompt) => {
+    const nextPrompt = prompt === '(no prompt)' ? '' : prompt;
+    if (item.kind === 'image') {
+      setImagesByName((current) => {
+        const existing = current.get(item.filename);
+        if (!existing) return current;
+        const next = new Map(current);
+        next.set(item.filename, { ...existing, prompt: nextPrompt });
+        return next;
+      });
+      return;
+    }
+    setVideosById((current) => {
+      const existing = current.get(item.id);
+      if (!existing) return current;
+      const next = new Map(current);
+      next.set(item.id, { ...existing, prompt: nextPrompt });
+      return next;
+    });
+  }, []);
+
   // Unordered membership — Set, not array.
   const toggleSelect = useCallback((key) => setSelected((prev) => {
     const next = new Set(prev);
@@ -571,6 +592,7 @@ export default function MediaCollectionDetail() {
         items={items}
         annotations={annotations}
         updateAnnotation={updateAnnotation}
+        onPromptSaved={handlePromptSaved}
         onRemix={handleRemix}
         onSendToImage={handleSendToImage}
         onSendToVideo={handleSendToVideo}

--- a/client/src/pages/VideoGen.jsx
+++ b/client/src/pages/VideoGen.jsx
@@ -323,6 +323,13 @@ export default function VideoGen() {
     await deleteVideoHistoryItem(raw.id, { silent: true }).catch((err) => toast.error(err.message || 'Delete failed'));
     setHistory((h) => h.filter((v) => v.id !== raw.id));
   }, []);
+  const handlePromptSaved = useCallback((item, prompt) => {
+    const id = item?.id || item?.raw?.id;
+    if (!id) return;
+    setHistory((h) => h.map((v) => v.id === id
+      ? { ...v, prompt: prompt === '(no prompt)' ? '' : prompt }
+      : v));
+  }, []);
   const handleToggleHistoryHidden = useCallback(async (item) => {
     const raw = item?.raw || item;
     const nextHidden = !raw.hidden;
@@ -1558,6 +1565,7 @@ export default function VideoGen() {
         items={previewItems}
         annotations={annotations}
         updateAnnotation={updateAnnotation}
+        onPromptSaved={handlePromptSaved}
         onContinue={handleContinue}
         onRemix={(item) => item?.raw && handleRemixVideo(item.raw)}
       />


### PR DESCRIPTION
## Summary

- Keep prompt edits visible immediately in the route-backed media preview after a successful save.
- Update in-memory image/video gallery and collection records so cards reflect saved prompts without a reload.
- Add regression coverage for card, modal, and URL synchronization.

## Test plan

- `npm test -- src/components/media/MediaPreview.test.jsx`
- `npx vitest related --run src/components/media/MediaPreview.jsx src/components/media/MediaPreview.test.jsx src/components/media/MediaLightbox.jsx src/hooks/usePreviewRoute.js src/pages/VideoGen.jsx src/pages/ImageGen.jsx src/pages/MediaCollectionDetail.jsx`
- `npm run lint`
- `npm run build`