### PR TITLE
fix: add accessible fretbox voicing descriptions

### DIFF
--- a/client/src/components/songbook/ChordDiagram.jsx
+++ b/client/src/components/songbook/ChordDiagram.jsx
@@ -20,6 +20,23 @@ const SIZES = {
   md: { cell: 16, row: 15, dot: 4.5, font: 8.5 },
 };
 
+const formatFretPosition = (fret, baseFret) => {
+  if (fret < 0) return 'muted';
+  if (fret === 0) return 'open';
+  const absoluteFret = baseFret > 1 ? baseFret + fret - 1 : fret;
+  return `fret ${absoluteFret}`;
+};
+
+const fretboxDescription = (voicing) => {
+  const { frets, baseFret, instrument, bass } = voicing;
+  const strings = frets
+    .map((fret, index) => `string ${frets.length - index}: ${formatFretPosition(fret, baseFret)}`)
+    .join(', ');
+  const base = baseFret > 1 ? ` Base fret ${baseFret}.` : '';
+  const bassHint = bass ? ` Bass note ${bass}.` : '';
+  return `${instrument} chord voicing. ${strings}.${base}${bassHint}`;
+};
+
 const FretboxDiagram = ({ voicing, size }) => {
   const s = SIZES[size] || SIZES.md;
   const { frets, baseFret } = voicing;
@@ -32,13 +49,15 @@ const FretboxDiagram = ({ voicing, size }) => {
   const stringX = (i) => left + i * s.cell;
 
   return (
-    <svg
-      width={width}
-      height={height}
-      viewBox={`0 0 ${width} ${height}`}
-      aria-hidden="true"
-      className="text-gray-400"
-    >
+    <>
+      <span className="sr-only">{fretboxDescription(voicing)}</span>
+      <svg
+        width={width}
+        height={height}
+        viewBox={`0 0 ${width} ${height}`}
+        aria-hidden="true"
+        className="text-gray-400"
+      >
       {/* Nut (thick at first position) + frets */}
       {Array.from({ length: rows + 1 }, (_, j) => (
         <line
@@ -113,7 +132,8 @@ const FretboxDiagram = ({ voicing, size }) => {
           />
         ) : null))}
       </g>
-    </svg>
+      </svg>
+    </>
   );
 };
 

--- a/client/src/components/songbook/ChordDiagram.test.jsx
+++ b/client/src/components/songbook/ChordDiagram.test.jsx
@@ -15,6 +15,14 @@ describe('ChordDiagram', () => {
     expect(container.textContent).not.toMatch(/fr/);
   });
 
+  it('provides an accessible fret description for guitar voicings', () => {
+    const { container } = render(<ChordDiagram name="Am" instrument="guitar" />);
+    const description = container.querySelector('.sr-only');
+    expect(description).toHaveTextContent(
+      'guitar chord voicing. string 6: muted, string 5: open, string 4: fret 2, string 3: fret 2, string 2: fret 1, string 1: open.',
+    );
+  });
+
   it('labels the fret window for shapes above the nut', () => {
     // C#m7 = A-form barre at fret 4.
     const { container } = render(<ChordDiagram name="C#m7" instrument="guitar" />);
@@ -28,6 +36,13 @@ describe('ChordDiagram', () => {
     expect(svg).toBeTruthy();
     expect(svg.querySelectorAll('g circle').length).toBe(3);
     expect(container.textContent).not.toContain('×');
+  });
+
+  it('provides an accessible fret description for ukulele voicings', () => {
+    const { container } = render(<ChordDiagram name="G7" instrument="ukulele" />);
+    expect(container.querySelector('.sr-only')).toHaveTextContent(
+      'ukulele chord voicing. string 4: open, string 3: fret 2, string 2: fret 1, string 1: fret 2.',
+    );
   });
 
   it('renders piano voicings as note chips, prepending the slash bass', () => {

--- a/client/src/components/songbook/ChordDiagram.test.jsx
+++ b/client/src/components/songbook/ChordDiagram.test.jsx
@@ -12,7 +12,7 @@ describe('ChordDiagram', () => {
     const dots = svg.querySelectorAll('g circle');
     expect(dots.length).toBe(3);
     // First position — no window label.
-    expect(container.textContent).not.toMatch(/fr/);
+    expect(svg.textContent).not.toMatch(/fr/);
   });
 
   it('provides an accessible fret description for guitar voicings', () => {


### PR DESCRIPTION
## Summary

- Add screen-reader text alternatives for guitar and ukulele fretbox chord diagrams.
- Describe each string as muted, open, or its absolute fret, including higher-position base frets and bass notes.
- Cover both instrument voicings with focused component tests.

## Tests

- `npm test -- --run src/components/songbook/ChordDiagram.test.jsx`
- `npm test -- --run src/components/songbook/TabSheetView.test.jsx`
- `npx biome check src/components/songbook/ChordDiagram.jsx src/components/songbook/ChordDiagram.test.jsx`

Closes #5556
