### PR TITLE
fix: contextualize collapsed tab disclosures (#5558)

### DIFF
--- a/client/src/components/songbook/TabSheetView.jsx
+++ b/client/src/components/songbook/TabSheetView.jsx
@@ -180,6 +180,7 @@ function TabSheetView({
   const hasTabstaff = lines.some((line) => line.type === 'tabstaff');
   const [legendOpen, setLegendOpen] = useState(false);
   const legendId = useId();
+  const staffIdPrefix = useId();
 
   // Unique chord names in order of first appearance (chords-used strip).
   // Dash-joined quick changes split into their segments FIRST, so "Am-Am7"
@@ -323,6 +324,7 @@ function TabSheetView({
           const collapse = instrumentView === 'piano'
             ? true
             : instrumentView === 'ukulele' && looksGuitar;
+          const staffId = `${staffIdPrefix}-staff-${bi}`;
           if (collapse && !expandedStaffs.has(bi)) {
             return (
               <div key={bi} className="my-1 flex items-center gap-2 text-xs text-gray-500 italic font-sans">
@@ -330,6 +332,9 @@ function TabSheetView({
                 <button
                   type="button"
                   onClick={() => setExpandedStaffs((prev) => new Set(prev).add(bi))}
+                  aria-label={`Show ${looksGuitar ? 'guitar ' : ''}tablature staff (section ${bi + 1})`}
+                  aria-expanded={false}
+                  aria-controls={staffId}
                   className="not-italic text-port-accent hover:underline px-1 py-2 -my-2"
                 >
                   show
@@ -338,7 +343,7 @@ function TabSheetView({
             );
           }
           return (
-            <div key={bi} className="overflow-x-auto whitespace-pre text-gray-300 my-1">
+            <div id={staffId} key={bi} className="overflow-x-auto whitespace-pre text-gray-300 my-1">
               {block.lines.map((line, li) => <div key={li}>{line.text}</div>)}
             </div>
           );

--- a/client/src/components/songbook/TabSheetView.test.jsx
+++ b/client/src/components/songbook/TabSheetView.test.jsx
@@ -191,9 +191,15 @@ describe('TabSheetView', () => {
       expect(screen.queryByText('e|--3--2--|')).toBeNull();
       // The 2-line SAMPLE staff isn't identifiably guitar — generic label.
       expect(screen.getByText(/tablature — switch to Guitar or Ukulele view/)).toBeTruthy();
-      fireEvent.click(screen.getByRole('button', { name: 'show' }));
+      const expand = screen.getByRole('button', { name: 'Show tablature staff (section 4)' });
+      const staffId = expand.getAttribute('aria-controls');
+      expect(expand.getAttribute('aria-expanded')).toBe('false');
+      expect(document.getElementById(staffId)).toBeNull();
+
+      fireEvent.click(expand);
       expect(screen.getByText('e|--3--2--|')).toBeTruthy();
       expect(screen.getByText('B|--0-----|')).toBeTruthy();
+      expect(document.getElementById(staffId)).toBeTruthy();
     });
 
     const SIX_LINE_STAFF = ['e|--0--|', 'B|--1--|', 'G|--0--|', 'D|--2--|', 'A|--3--|', 'E|-----|'].join('\n');
@@ -206,6 +212,21 @@ describe('TabSheetView', () => {
       expect(screen.getByText(/guitar tab — switch to Guitar view/)).toBeTruthy();
       // …while the 4-line (plausibly ukulele) staff renders in place.
       expect(screen.getByText('G|--2--|')).toBeTruthy();
+    });
+
+    it('gives each collapsed staff a unique accessible disclosure name and target', () => {
+      render(
+        <TabSheetView
+          text={`${SIX_LINE_STAFF}\n\n[Solo]\n${SIX_LINE_STAFF}`}
+          instrumentView="piano"
+        />,
+      );
+
+      const expanders = screen.getAllByRole('button', { name: /Show guitar tablature staff \(section \d+\)/ });
+      expect(expanders).toHaveLength(2);
+      expect(expanders[0].getAttribute('aria-label')).not.toBe(expanders[1].getAttribute('aria-label'));
+      expect(expanders.map((button) => button.getAttribute('aria-expanded'))).toEqual(['false', 'false']);
+      expect(new Set(expanders.map((button) => button.getAttribute('aria-controls'))).size).toBe(2);
     });
   });
 });


### PR DESCRIPTION
## Summary

- give every collapsed tablature disclosure a unique, descriptive accessible name
- expose the collapsed state and connect the disclosure to the staff container it reveals
- preserve the compact visual `show` label and add rendered interaction coverage for multiple staffs

## Test plan

- `cd client && npm test -- --run src/components/songbook/TabSheetView.test.jsx`
- `cd client && npx biome lint --error-on-warnings src/components/songbook/TabSheetView.jsx src/components/songbook/TabSheetView.test.jsx`
- `git diff --check`

Closes #5558
