### PR TITLE
docs: expand architecture extension points and JSDoc annotations

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -340,23 +340,40 @@ PostgreSQL itself is not PM2-managed — it runs as the system service (`:5432`)
 ## Extension Points
 
 ### Adding a New Page
-1. Create component in `client/src/pages/`
-2. Add route in `client/src/App.jsx`
-3. Add navigation link in `client/src/components/Layout.jsx`
+1. Create component in `client/src/pages/`.
+2. Add `<Route>` in `client/src/App.jsx`.
+3. Add a navigation command entry in `server/lib/navManifest.js` (`NAV_COMMANDS`) with its keywords, section, icon, and title so the `⌘K` command palette and the voice agent's `ui_navigate` tool can discover and navigate to the page.
+4. If the page belongs to an optional feature (e.g. `post`, `datadog`, `jira`, `gsd`), register the feature in `server/lib/instanceFeatureRegistry.js` and tag the nav command with `feature: '<id>'` (or map its section in `SECTION_FEATURE`).
+5. Add the sidebar navigation link in `client/src/components/Layout.jsx` (tagged with `feature` if optional).
 
 ### Adding an API Endpoint
-1. Create route file in `server/routes/`
-2. Register in `server/index.js`
-3. Add Zod schema if needed in `server/lib/validation.js`
+1. Create route file in `server/routes/` and mount it in `server/index.js`.
+2. Validate incoming request parameters and bodies using `validateRequest` with reusable Zod schemas (in `server/lib/validation.js` or domain-specific validation modules).
+3. Register detailed API operation metadata and schemas in `server/lib/apiOperationContracts.js`. Add `x-portos-tool` if the operation should be exposed as an agent-callable tool, and declare thrown error codes in `x-portos-error-codes`.
+4. If the endpoint or domain emits real-time Socket.IO events, declare their payload contracts in `server/lib/socketEventContracts.js`.
 
 ### Adding a Service
-1. Create service file in `server/services/`
-2. Export functions (not classes)
-3. Import in routes as needed
+1. Create service file in `server/services/`.
+2. Export pure or domain functions (favor functional programming over classes).
+3. Import in routes and wrap handlers with `asyncHandler` from `server/lib/errorHandler.js`.
+
+### Adding a Shared Helper, Hook, or Utility
+1. Choose the proper directory by concern:
+   - Pure / side-effect-free server helpers → `server/lib/`
+   - Pure / side-effect-free client helpers → `client/src/lib/`
+   - React state and lifecycle hooks → `client/src/hooks/` (prefix with `use`)
+   - Pure formatting and mathematical helpers → `client/src/utils/`
+   - API / network / WebSocket clients → `client/src/services/` (prefix with `api*`)
+2. **Catalog Parity Rule**: Every new module MUST be re-exported in that directory's `index.js` barrel (or `services/api.js`) AND documented in that directory's `README.md` table. This invariant is enforced by unit tests (e.g., `server/lib/index.test.js`, `client/src/lib/index.test.js`).
+
+### Adding a Data Store
+1. Determine the storage tier according to `docs/STORAGE.md`.
+2. Core application relational records are `db-primary` and must be stored in PostgreSQL with schema migrations in `scripts/migrations/`.
+3. File-backed collections under `data/` should use `createCollectionStore` (`server/lib/collectionStore.js`) for schema-versioned layouts (`data/{type}/{id}/index.json`) with atomic writes and per-record queues.
 
 ### Adding CoS Task Types
-1. Add the task type to `SELF_IMPROVEMENT_TASK_TYPES` and `DEFAULT_TASK_INTERVALS` in `server/services/taskSchedule.js`
-2. Add its prompt template to `DEFAULT_TASK_PROMPTS` in `server/services/taskPromptDefaults/prompts.js` (bump `PROMPT_VERSIONS` + append the outgoing default to `PREVIOUS_DEFAULT_PROMPTS` if you are changing an existing default)
-3. If it is an audit that should be configurable to **file issues** or **do the work**, add it to `AUDIT_DEFINITIONS` in `server/lib/auditCatalog.js` (and map any matching quota-burn preset via `quotaBurnId`)
-4. If it ALWAYS files findings/plans into the app's work tracker (never implements), add a wording preset to `TRACKER_FILING_PRESETS` in `server/lib/workTracker.js` and reference `{trackerInstructions}` in its prompt template — membership is what makes `resolveTrackerFilingBlock` file on every dispatch
-5. Give it a home in `WORKFLOW_STAGES` (`server/services/workflow.js`) so the Workflow tab doesn't render it under Ambient
+1. Add the task type to `SELF_IMPROVEMENT_TASK_TYPES` and `DEFAULT_TASK_INTERVALS` in `server/services/taskSchedule.js`.
+2. Add its prompt template to `DEFAULT_TASK_PROMPTS` in `server/services/taskPromptDefaults/prompts.js` (bump `PROMPT_VERSIONS` + append the outgoing default to `PREVIOUS_DEFAULT_PROMPTS` if you are changing an existing default).
+3. If it is an audit that should be configurable to **file issues** or **do the work**, add it to `AUDIT_DEFINITIONS` in `server/lib/auditCatalog.js` (and map any matching quota-burn preset via `quotaBurnId`).
+4. If it ALWAYS files findings/plans into the app's work tracker (never implements), add a wording preset to `TRACKER_FILING_PRESETS` in `server/lib/workTracker.js` and reference `{trackerInstructions}` in its prompt template — membership is what makes `resolveTrackerFilingBlock` file on every dispatch.
+5. Give it a home in `WORKFLOW_STAGES` (`server/services/workflow.js`) so the Workflow tab doesn't render it under Ambient.

--- a/server/lib/auditCatalog.js
+++ b/server/lib/auditCatalog.js
@@ -309,10 +309,22 @@ export const AUDIT_DEFINITIONS = Object.freeze({
 
 export const AUDIT_TASK_TYPES = new Set(Object.keys(AUDIT_DEFINITIONS));
 
+/**
+ * Check if a task type is an audit task registered in the catalog.
+ *
+ * @param {string} taskType - Task type identifier (e.g. 'security', 'code-quality')
+ * @returns {boolean} True if registered in AUDIT_DEFINITIONS
+ */
 export function isAuditTaskType(taskType) {
   return AUDIT_TASK_TYPES.has(taskType);
 }
 
+/**
+ * Get the default file-issues setting for an audit task type.
+ *
+ * @param {string} taskType - Task type identifier
+ * @returns {boolean} True if the audit defaults to filing issues rather than fixing
+ */
 export function defaultFileIssuesFor(taskType) {
   return AUDIT_DEFINITIONS[taskType]?.defaultFileIssues === true;
 }
@@ -322,6 +334,10 @@ export function defaultFileIssuesFor(taskType) {
  * on the merged task metadata wins; otherwise the catalog default applies.
  * Accepts the `'true'`/`'false'` string forms for parity with other metadata
  * gates that round-trip through TASKS.md as text.
+ *
+ * @param {string} taskType - Task type identifier
+ * @param {Record<string, unknown>} [metadata] - Task metadata object
+ * @returns {boolean} True if this dispatch should file issues instead of making code changes
  */
 export function isFileIssuesMode(taskType, metadata) {
   if (!isAuditTaskType(taskType)) return false;
@@ -331,10 +347,22 @@ export function isFileIssuesMode(taskType, metadata) {
   return defaultFileIssuesFor(taskType);
 }
 
+/**
+ * Retrieve filing preset configuration for an audit task type.
+ *
+ * @param {string} taskType - Task type identifier
+ * @returns {object|null} Filing preset metadata (slugPrefix, label, issueLabel, planItemBody, etc.) or null
+ */
 export function getAuditFilingPreset(taskType) {
   return AUDIT_DEFINITIONS[taskType]?.filing || null;
 }
 
+/**
+ * Return the appropriate mode banner contract string for the given execution mode.
+ *
+ * @param {boolean} fileIssues - Whether the dispatch is in file-issues mode
+ * @returns {string} The contract text defining the operating constraints for the agent
+ */
 export function modeContractFor(fileIssues) {
   return fileIssues ? FILE_ISSUES_MODE_CONTRACT : DO_WORK_MODE_CONTRACT;
 }
@@ -343,6 +371,10 @@ export function modeContractFor(fileIssues) {
  * Ensure a prompt carries the mode banner. If the template already has a
  * `{modeInstructions}` placeholder the generator will substitute it; otherwise
  * the banner is prepended so a customized stored prompt still honors the mode.
+ *
+ * @param {string} promptTemplate - The raw prompt template or prompt string
+ * @param {string} modeInstructions - The mode contract banner to wrap or inject
+ * @returns {string} Wrapped prompt string
  */
 export function applyAuditModeWrapper(promptTemplate, modeInstructions) {
   const prompt = typeof promptTemplate === 'string' ? promptTemplate : '';

--- a/server/lib/quotaReset.js
+++ b/server/lib/quotaReset.js
@@ -150,6 +150,13 @@ export function normalizeResetAt(limit, { now = Date.now(), timeZone } = {}) {
   return epochMs === null ? { epochMs: null, source: 'unknown' } : { epochMs, source: 'parsed' };
 }
 
+/**
+ * Compute fractional hours remaining until quota window reset.
+ *
+ * @param {{ resetsAt?: string, timezone?: string }} limit - Limit object containing resetsAt string
+ * @param {{ now?: number, timeZone?: string }} [opts] - Reference timestamp and optional fallback timeZone
+ * @returns {number|null} Fractional hours until reset (negative if already in the past), or null if indeterminate
+ */
 export function hoursUntilReset(limit, opts = {}) {
   const { epochMs } = normalizeResetAt(limit, opts);
   return epochMs === null ? null : (epochMs - (opts.now ?? Date.now())) / HOUR_MS;


### PR DESCRIPTION
## Summary
- Expanded **Extension Points** in `docs/ARCHITECTURE.md` to provide complete, step-by-step developer checklists for:
  - Adding a new page (including `navManifest.js` / `NAV_COMMANDS`, optional feature gating in `instanceFeatureRegistry.js`, and sidebar layout integration).
  - Adding an API endpoint (covering Zod validation schemas, `apiOperationContracts.js` / `x-portos-tool` registration, and `socketEventContracts.js`).
  - Adding a service, data store (`docs/STORAGE.md` classification & `collectionStore.js`), and shared helpers/hooks (enforcing catalog parity with `index.js` and `README.md`).
- Added complete JSDoc annotations and parameter/return types to exported helper functions in `server/lib/auditCatalog.js` and `server/lib/quotaReset.js`.

## Test Plan
- Ran targeted Vitest suites:
  - `npx vitest run lib/auditCatalog.test.js lib/quotaReset.test.js lib/index.test.js` (server)
  - `npx vitest run src/lib/index.test.js src/hooks/index.test.js src/services/index.test.js src/utils/index.test.js` (client)
- Verified all catalog parity tests pass cleanly with zero regressions.