### PR TITLE
fix: open Models navigation on LLMs

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -338,7 +338,7 @@ export default function App() {
           <Route path="voice/call-host" element={<VoiceCallHost />} />
           <Route path="api-reference" element={<Navigate to="/api-reference/catalog" replace />} />
           <Route path="api-reference/:tab" element={<ApiExplorer />} />
-          <Route path="models" element={<Navigate to="/models/performance" replace />} />
+          <Route path="models" element={<Navigate to="/models/llms" replace />} />
           {/* A tab's drill-down (today: the LoRA dataset workbench) renders through
               Models itself, so it keeps the section header and tab bar — see
               TAB_DETAIL there. */}

--- a/client/src/components/Layout.jsx
+++ b/client/src/components/Layout.jsx
@@ -349,7 +349,7 @@ const SECTION_PRESENTATION = {
   Create: { icon: Sparkles, defaultTo: '/media' },
   'Dev Tools': { icon: Terminal },
   Health: { icon: Heart, defaultTo: '/meatspace/overview' },
-  Models: { icon: Cpu, defaultTo: '/models/performance' },
+  Models: { icon: Cpu, defaultTo: '/models/llms' },
   Settings: { icon: Settings, defaultTo: '/settings/general' },
   Identity: { icon: Fingerprint, defaultTo: '/digital-twin/overview' },
   POST: { icon: Zap, defaultTo: '/post/launcher' },

--- a/client/src/components/Layout.test.jsx
+++ b/client/src/components/Layout.test.jsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, within, act, fireEvent, waitFor } from '@testing-library/react';
-import { MemoryRouter } from 'react-router';
+import { MemoryRouter, useLocation } from 'react-router';
 import { PINNED_KEY } from '../utils/navWorkingSet.js';
 import * as api from '../services/api';
 import { INSTANCE_FEATURES_CHANGED } from '../constants/events.js';
@@ -88,10 +88,16 @@ import { __resetInstanceFeatureCache } from '../hooks/useInstanceFeatures.js';
 import { NAV_COMMANDS } from '../../../server/lib/navManifest.js';
 import Layout, { isFullWidthRoute, NAV_PRESENTATION } from './Layout';
 
+const LocationProbe = () => {
+  const location = useLocation();
+  return <output data-testid="current-path">{location.pathname}</output>;
+};
+
 const renderLayout = async (initialPath = '/brain/inbox') => {
   const utils = render(
     <MemoryRouter initialEntries={[initialPath]}>
       <Layout />
+      <LocationProbe />
     </MemoryRouter>,
   );
   // The sidebar's dynamic sections fire async fetches (all mocked empty here).
@@ -313,6 +319,16 @@ describe('Layout — System Resources location state', () => {
     const link = screen.getByRole('link', { name: 'System Resources' });
     expect(link).toHaveAttribute('href', '/system-resources');
     expect(link.className).toContain('text-port-accent');
+  });
+});
+
+describe('Layout — section destinations', () => {
+  it('opens LLMs when the Models section label is clicked', async () => {
+    await renderLayout();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Models' }));
+
+    expect(screen.getByTestId('current-path')).toHaveTextContent('/models/llms');
   });
 });
 

--- a/client/src/pages/Models.jsx
+++ b/client/src/pages/Models.jsx
@@ -71,16 +71,15 @@ const TAB_DETAIL = {
 
 export default function Models() {
   const { tab, recordId } = useParams();
-  // An unknown slug lands on Performance rather than rendering a blank page —
-  // it is the tab that answers "which model should I use?", which is what most
-  // people arrive here for.
+  // An unknown slug lands on LLMs rather than rendering a blank page, matching
+  // the section's default destination in App and the primary navigation.
   //
   // OWN-property lookup, not plain indexing: the slug comes straight off the URL,
   // so `/models/constructor` (or `toString`, `__proto__`) would otherwise resolve
   // to an Object.prototype member, read as a valid tab, and get rendered as a
   // component. Same reason `unavailableReasonLabel` guards its map.
   const activeTab = tab && Object.hasOwn(TAB_CONTENT, tab) ? tab : null;
-  if (!activeTab) return <Navigate to="/models/performance" replace />;
+  if (!activeTab) return <Navigate to="/models/llms" replace />;
 
   // A record id in the URL selects the tab's drill-down, when it has one. A tab
   // with no detail view ignores the extra segment and renders its index — better

--- a/client/src/pages/Models.test.jsx
+++ b/client/src/pages/Models.test.jsx
@@ -74,12 +74,11 @@ describe('Models', () => {
     },
   );
 
-  // A stale ⌘K entry or a typo must not produce a blank page — Performance is
-  // the tab that answers "which model should I use?", which is why people land
-  // here at all.
-  it('redirects an unknown tab slug to Performance', async () => {
+  // A stale ⌘K entry or a typo must not produce a blank page; it follows the
+  // same LLMs default as the bare route and primary navigation.
+  it('redirects an unknown tab slug to LLMs', async () => {
     renderAt('/models/not-a-tab');
-    expect(await screen.findByText('assessments panel')).toBeInTheDocument();
+    expect(await screen.findByText('llms panel')).toBeInTheDocument();
   });
 
   // The slug comes straight off the URL, so a plain `TAB_CONTENT[tab]` lookup
@@ -89,7 +88,7 @@ describe('Models', () => {
     'treats the inherited property %s as an unknown tab',
     async (slug) => {
       renderAt(`/models/${slug}`);
-      expect(await screen.findByText('assessments panel')).toBeInTheDocument();
+      expect(await screen.findByText('llms panel')).toBeInTheDocument();
     },
   );
 
@@ -116,10 +115,10 @@ describe('Models', () => {
   });
 
   // A tab listed in the header but missing from TAB_CONTENT falls through to the
-  // unknown-slug redirect and silently lands on Performance. Selection state is
-  // what distinguishes "rendered this tab" from "bounced to Performance" — the
+  // unknown-slug redirect and silently lands on LLMs. Selection state is what
+  // distinguishes "rendered this tab" from "bounced to LLMs" — the
   // per-path cases above can't see it, because a bounced tab still renders A panel.
-  it('serves every /models tab the header advertises, without bouncing to Performance', () => {
+  it('serves every /models tab the header advertises, without bouncing to LLMs', () => {
     for (const tab of ownTabs) {
       const { unmount } = renderAt(tab.to);
       expect(screen.getByRole('tab', { name: tab.label })).toHaveAttribute('aria-selected', 'true');


### PR DESCRIPTION
## Summary

- Open the Models navigation section on LLMs instead of Performance.
- Align the bare Models route and invalid-tab recovery with the same LLMs default.

## Test plan

- `cd client && npm test -- --run src/pages/Models.test.jsx src/components/Layout.test.jsx`
- `cd client && npm run lint`
- `cd client && npm run build`