### PR TITLE
feat: restart PortOS after enabling HTTPS

### DIFF
--- a/client/src/components/instances/TailnetHelpBanner.jsx
+++ b/client/src/components/instances/TailnetHelpBanner.jsx
@@ -1,0 +1,191 @@
+import { useState } from 'react';
+import {
+  AlertCircle,
+  ArrowUpRight,
+  CheckCircle2,
+  ChevronDown,
+  ChevronRight,
+  Info,
+  Lock,
+  RefreshCw,
+} from 'lucide-react';
+import toast from '../ui/Toast';
+import Pill from '../ui/Pill';
+import {
+  handleSelfRestart,
+  PORTOS_APP_ID,
+  provisionTailnetCert,
+  restartApp,
+} from '../../services/api';
+import { useLocalStorageBool } from '../../hooks/useLocalStorageBool';
+
+export default function TailnetHelpBanner({ tailnetInfo, networkExposure }) {
+  const [collapsed, setCollapsed] = useLocalStorageBool('portos-tailnet-help-collapsed', false);
+  const [provisioning, setProvisioning] = useState(false);
+  const [provisionResult, setProvisionResult] = useState(null);
+  const [restarting, setRestarting] = useState(false);
+
+  const toggle = () => setCollapsed((prev) => !prev);
+
+  const provision = async (e) => {
+    e.stopPropagation();
+    setProvisioning(true);
+    setProvisionResult(null);
+    const result = await provisionTailnetCert().catch(() => null);
+    setProvisioning(false);
+    if (!result?.ok) return; // request() already toasted the error
+    setProvisionResult(result);
+    toast.success(result.message);
+  };
+
+  const trustedHttpsPort = networkExposure?.bind?.port || 5555;
+
+  const restartPortos = async () => {
+    setRestarting(true);
+    const result = await restartApp(PORTOS_APP_ID, { silent: true }).catch((error) => {
+      toast.error(error.message || 'Could not restart PortOS');
+      return null;
+    });
+    if (!result) {
+      setRestarting(false);
+      return;
+    }
+    if (!result.selfRestart) {
+      toast.error('PortOS did not accept the restart request');
+      setRestarting(false);
+      return;
+    }
+
+    const targetHost = provisionResult.hostname || tailnetInfo?.self;
+    const targetOrigin = `https://${targetHost}:${trustedHttpsPort}`;
+    handleSelfRestart({ targetOrigin });
+  };
+
+  const status = tailnetInfo === null
+    ? { label: 'Tailscale DNS not detected', tone: 'warn', detail: 'Install Tailscale and enable MagicDNS in your tailnet admin to auto-suggest peer DNS names.' }
+    : tailnetInfo?.suffix
+      ? { label: `MagicDNS: ${tailnetInfo.suffix}`, tone: 'ok', detail: tailnetInfo.self ? `This instance: ${tailnetInfo.self}` : null }
+      : { label: 'Tailscale running but MagicDNS suffix not found', tone: 'warn', detail: 'Enable MagicDNS in your tailnet admin console (login.tailscale.com/admin/dns).' };
+
+  const ToneIcon = status.tone === 'ok' ? CheckCircle2 : AlertCircle;
+  const toneClass = status.tone === 'ok' ? 'text-port-success' : 'text-port-warning';
+  const trustedHttpsHost = networkExposure?.httpsEnabled && networkExposure?.cert?.mode === 'tailscale'
+    ? networkExposure.cert.tailscaleHost || tailnetInfo?.self || null
+    : null;
+  const trustedHttpsUrl = trustedHttpsHost ? `https://${trustedHttpsHost}:${trustedHttpsPort}` : null;
+
+  // Only offer the one-click provision button when Tailscale is actually
+  // detected and we have a MagicDNS hostname for this instance — otherwise
+  // the API call will fail with the same "enable MagicDNS first" guidance.
+  const canProvision = !!tailnetInfo?.self;
+
+  if (trustedHttpsHost) {
+    return (
+      <div className="bg-port-card border border-port-border rounded-xl px-4 py-3">
+        <div className="flex items-center gap-3 flex-wrap">
+          <Lock size={16} className="text-port-success shrink-0" />
+          <div className="flex-1 min-w-[220px]">
+            <div className="flex items-center gap-2 flex-wrap">
+              <span className="text-sm font-medium text-white">Tailnet DNS &amp; trusted HTTPS</span>
+              <Pill tone="success" size="xs" bordered={false} icon={CheckCircle2}>
+                Running on Tailscale HTTPS
+              </Pill>
+            </div>
+            <p className="text-xs text-gray-400 mt-1">
+              Currently running on HTTPS with Tailscale DNS.
+            </p>
+          </div>
+          {trustedHttpsUrl && (
+            <a
+              href={trustedHttpsUrl}
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex items-center gap-1.5 text-xs text-port-accent hover:text-port-accent/80 font-mono"
+              title={`Open ${trustedHttpsUrl}`}
+            >
+              {trustedHttpsHost}
+              <ArrowUpRight size={12} />
+            </a>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-port-card border border-port-border rounded-xl">
+      <button
+        onClick={toggle}
+        className="w-full flex items-center gap-2 p-4 text-left"
+      >
+        <Lock size={16} className="text-port-accent shrink-0" />
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 flex-wrap">
+            <span className="text-sm font-medium text-white">Tailnet DNS &amp; trusted HTTPS</span>
+            <Pill tone="bare" size="xs" bordered={false} icon={ToneIcon} className={`${toneClass} bg-port-bg`}>
+              {status.label}
+            </Pill>
+          </div>
+        </div>
+        {collapsed ? <ChevronRight size={14} className="text-gray-500" /> : <ChevronDown size={14} className="text-gray-500" />}
+      </button>
+
+      {!collapsed && (
+        <div className="px-4 pb-4 -mt-1 text-xs text-gray-400 space-y-2">
+          {status.detail && (
+            <div className="flex items-start gap-1.5">
+              <Info size={11} className="mt-0.5 text-gray-500 shrink-0" />
+              <span className="font-mono">{status.detail}</span>
+            </div>
+          )}
+          <p>
+            By default, federation traffic uses <span className="font-mono text-gray-300">http://{`<ip>`}:5555</span>. Setting a Tailscale MagicDNS host on a peer
+            switches that hop to <span className="font-mono text-gray-300">https://{`<host>`}.{tailnetInfo?.suffix || `<tailnet>`}.ts.net</span> with a
+            browser-trusted Let&apos;s Encrypt cert provisioned by Tailscale.
+          </p>
+          <ol className="list-decimal list-inside space-y-1 text-gray-500">
+            <li>On each instance, enable MagicDNS + HTTPS Certificates in your tailnet admin (<span className="font-mono">login.tailscale.com/admin/dns</span>).</li>
+            <li>
+              Click <span className="text-port-accent">Enable HTTPS</span> below to fetch the cert via Tailscale
+              (or run <span className="font-mono text-gray-300">npm run setup:cert</span> from a shell).
+            </li>
+            <li>Below, click <span className="text-port-accent">use {`<host>`}</span> on each peer to switch the link to HTTPS. Or click <span className="text-gray-400">use IP only</span> to revert.</li>
+          </ol>
+          <div className="flex items-center gap-2 flex-wrap pt-1">
+            <button
+              onClick={provision}
+              disabled={provisioning || !canProvision}
+              title={canProvision
+                ? `Run \`tailscale cert\` for ${tailnetInfo.self} and write data/certs/{cert,key}.pem`
+                : 'Enable MagicDNS in your tailnet admin first, then reload this page'}
+              className="inline-flex items-center gap-1.5 bg-port-accent hover:bg-port-accent/80 disabled:opacity-40 disabled:cursor-not-allowed text-white px-3 py-1.5 rounded text-xs font-medium transition-colors min-h-[40px] sm:min-h-0"
+            >
+              <Lock size={12} />
+              {provisioning ? 'Provisioning…' : 'Enable HTTPS'}
+            </button>
+            {provisionResult?.ok && (
+              <>
+                <span className="inline-flex items-center gap-1 text-[11px] text-port-success">
+                  <CheckCircle2 size={11} />
+                  {provisionResult.requiresRestart
+                    ? 'Cert installed — restart PortOS to activate HTTPS'
+                    : 'Cert installed and live'}
+                </span>
+                {provisionResult.requiresRestart && (
+                  <button
+                    onClick={restartPortos}
+                    disabled={restarting}
+                    className="inline-flex items-center gap-1.5 border border-port-accent text-port-accent hover:bg-port-accent/10 disabled:opacity-40 disabled:cursor-not-allowed px-3 py-1.5 rounded text-xs font-medium transition-colors min-h-[40px] sm:min-h-0"
+                  >
+                    <RefreshCw size={12} className={restarting ? 'animate-spin' : ''} />
+                    {restarting ? 'Restarting…' : 'Restart PortOS'}
+                  </button>
+                )}
+              </>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/components/instances/TailnetHelpBanner.test.jsx
+++ b/client/src/components/instances/TailnetHelpBanner.test.jsx
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+vi.mock('../../services/api', () => ({
+  handleSelfRestart: vi.fn(),
+  PORTOS_APP_ID: 'portos-default',
+  provisionTailnetCert: vi.fn(),
+  restartApp: vi.fn(),
+}));
+
+vi.mock('../ui/Toast', () => ({
+  default: { success: vi.fn(), error: vi.fn() },
+}));
+
+import {
+  handleSelfRestart,
+  provisionTailnetCert,
+  restartApp,
+} from '../../services/api';
+import toast from '../ui/Toast';
+import TailnetHelpBanner from './TailnetHelpBanner';
+
+const tailnetInfo = {
+  suffix: 'example-tailnet.ts.net',
+  self: 'host-alpha.example-tailnet.ts.net',
+};
+
+const networkExposure = {
+  httpsEnabled: false,
+  bind: { port: 5555 },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  localStorage.clear();
+});
+
+describe('TailnetHelpBanner HTTPS activation', () => {
+  it('offers a PortOS restart after provisioning and continues on the HTTPS origin', async () => {
+    provisionTailnetCert.mockResolvedValue({
+      ok: true,
+      hostname: tailnetInfo.self,
+      requiresRestart: true,
+      message: `Cert installed for ${tailnetInfo.self}.`,
+    });
+    restartApp.mockResolvedValue({ success: true, selfRestart: true });
+    const user = userEvent.setup();
+
+    render(
+      <TailnetHelpBanner
+        tailnetInfo={tailnetInfo}
+        networkExposure={networkExposure}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Enable HTTPS' }));
+    expect(await screen.findByText('Cert installed — restart PortOS to activate HTTPS')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Restart PortOS' }));
+
+    await waitFor(() => expect(restartApp).toHaveBeenCalledWith('portos-default', { silent: true }));
+    expect(handleSelfRestart).toHaveBeenCalledWith({
+      targetOrigin: 'https://host-alpha.example-tailnet.ts.net:5555',
+    });
+    expect(screen.getByRole('button', { name: 'Restarting…' })).toBeDisabled();
+  });
+
+  it('does not offer a restart when HTTPS was already active at provision time', async () => {
+    provisionTailnetCert.mockResolvedValue({
+      ok: true,
+      hostname: tailnetInfo.self,
+      requiresRestart: false,
+      message: `Cert installed for ${tailnetInfo.self}.`,
+    });
+
+    render(
+      <TailnetHelpBanner
+        tailnetInfo={tailnetInfo}
+        networkExposure={networkExposure}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'Enable HTTPS' }));
+
+    expect(await screen.findByText('Cert installed and live')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Restart PortOS' })).not.toBeInTheDocument();
+  });
+
+  it('re-enables the restart action when PortOS rejects the request', async () => {
+    provisionTailnetCert.mockResolvedValue({
+      ok: true,
+      hostname: tailnetInfo.self,
+      requiresRestart: true,
+      message: `Cert installed for ${tailnetInfo.self}.`,
+    });
+    restartApp.mockRejectedValue(new Error('Restart unavailable'));
+    const user = userEvent.setup();
+
+    render(
+      <TailnetHelpBanner
+        tailnetInfo={tailnetInfo}
+        networkExposure={networkExposure}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Enable HTTPS' }));
+    await user.click(await screen.findByRole('button', { name: 'Restart PortOS' }));
+
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Restart PortOS' })).toBeEnabled());
+    expect(toast.error).toHaveBeenCalledWith('Restart unavailable');
+    expect(handleSelfRestart).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/pages/Instances.jsx
+++ b/client/src/pages/Instances.jsx
@@ -7,14 +7,14 @@ import {
   Database, Brain, CheckCircle2, AlertCircle, Clock,
   RefreshCcw, Timer,
   Target, Sword, Fingerprint, HeartPulse, ChevronDown, ChevronRight,
-  Lock, Globe, Info, Sparkles, Film, Images, Library, BookOpen, FilePen, Music, Music2, Disc3, Clapperboard, Palette, BookText, FolderTree, Video, Waypoints
+  Lock, Globe, Sparkles, Film, Images, Library, BookOpen, FilePen, Music, Music2, Disc3, Clapperboard, Palette, BookText, FolderTree, Video, Waypoints
 } from 'lucide-react';
 import toast from '../components/ui/Toast';
 import Pill from '../components/ui/Pill';
 import socket from '../services/socket';
 import {
   getInstances, updateSelfInstance, addPeer, updatePeer,
-  removePeer, connectPeer, reciprocatePeer, probePeer, syncPeer, getTailnetInfo, provisionTailnetCert,
+  removePeer, connectPeer, reciprocatePeer, probePeer, syncPeer, getTailnetInfo,
   getNetworkExposure,
   listPeerSubscriptions,
   getPeerFullSyncCoverage,
@@ -27,8 +27,8 @@ import PeerMediaProviderPanel from '../components/instances/PeerMediaProviderPan
 import UnattendedRenderRouting from '../components/instances/UnattendedRenderRouting';
 import BrainParityPanel from '../components/instances/BrainParityPanel';
 import BrainParitySchedule from '../components/instances/BrainParitySchedule';
+import TailnetHelpBanner from '../components/instances/TailnetHelpBanner';
 import { timeAgo, timeUntil } from '../utils/formatters';
-import { useLocalStorageBool } from '../hooks/useLocalStorageBool';
 import { directionalCounts, describeDirectional } from '../lib/syncCounts';
 
 const STATUS_COLORS = {
@@ -73,142 +73,6 @@ function HealthSummary({ health, version }) {
         <div className="flex items-center gap-1.5 text-gray-400 col-span-2">
           <Bot size={12} />
           <span>{health.cos.activeAgents ?? 0} agents, {health.cos.queuedTasks ?? 0} queued</span>
-        </div>
-      )}
-    </div>
-  );
-}
-
-function TailnetHelpBanner({ tailnetInfo, networkExposure }) {
-  const [collapsed, setCollapsed] = useLocalStorageBool('portos-tailnet-help-collapsed', false);
-  const [provisioning, setProvisioning] = useState(false);
-  const [provisionResult, setProvisionResult] = useState(null);
-
-  const toggle = () => setCollapsed((prev) => !prev);
-
-  const provision = async (e) => {
-    e.stopPropagation();
-    setProvisioning(true);
-    setProvisionResult(null);
-    const result = await provisionTailnetCert().catch(() => null);
-    setProvisioning(false);
-    if (!result?.ok) return; // request() already toasted the error
-    setProvisionResult(result);
-    toast.success(result.message);
-  };
-
-  const status = tailnetInfo === null
-    ? { label: 'Tailscale DNS not detected', tone: 'warn', detail: 'Install Tailscale and enable MagicDNS in your tailnet admin to auto-suggest peer DNS names.' }
-    : tailnetInfo?.suffix
-      ? { label: `MagicDNS: ${tailnetInfo.suffix}`, tone: 'ok', detail: tailnetInfo.self ? `This instance: ${tailnetInfo.self}` : null }
-      : { label: 'Tailscale running but MagicDNS suffix not found', tone: 'warn', detail: 'Enable MagicDNS in your tailnet admin console (login.tailscale.com/admin/dns).' };
-
-  const ToneIcon = status.tone === 'ok' ? CheckCircle2 : AlertCircle;
-  const toneClass = status.tone === 'ok' ? 'text-port-success' : 'text-port-warning';
-  const trustedHttpsHost = networkExposure?.httpsEnabled && networkExposure?.cert?.mode === 'tailscale'
-    ? networkExposure.cert.tailscaleHost || tailnetInfo?.self || null
-    : null;
-  const trustedHttpsPort = networkExposure?.bind?.port || 5555;
-  const trustedHttpsUrl = trustedHttpsHost ? `https://${trustedHttpsHost}:${trustedHttpsPort}` : null;
-
-  // Only offer the one-click provision button when Tailscale is actually
-  // detected and we have a MagicDNS hostname for this instance — otherwise
-  // the API call will fail with the same "enable MagicDNS first" guidance.
-  const canProvision = !!tailnetInfo?.self;
-
-  if (trustedHttpsHost) {
-    return (
-      <div className="bg-port-card border border-port-border rounded-xl px-4 py-3">
-        <div className="flex items-center gap-3 flex-wrap">
-          <Lock size={16} className="text-port-success shrink-0" />
-          <div className="flex-1 min-w-[220px]">
-            <div className="flex items-center gap-2 flex-wrap">
-              <span className="text-sm font-medium text-white">Tailnet DNS &amp; trusted HTTPS</span>
-              <Pill tone="success" size="xs" bordered={false} icon={CheckCircle2}>
-                Running on Tailscale HTTPS
-              </Pill>
-            </div>
-            <p className="text-xs text-gray-400 mt-1">
-              Currently running on HTTPS with Tailscale DNS.
-            </p>
-          </div>
-          {trustedHttpsUrl && (
-            <a
-              href={trustedHttpsUrl}
-              target="_blank"
-              rel="noreferrer"
-              className="inline-flex items-center gap-1.5 text-xs text-port-accent hover:text-port-accent/80 font-mono"
-              title={`Open ${trustedHttpsUrl}`}
-            >
-              {trustedHttpsHost}
-              <ArrowUpRight size={12} />
-            </a>
-          )}
-        </div>
-      </div>
-    );
-  }
-
-  return (
-    <div className="bg-port-card border border-port-border rounded-xl">
-      <button
-        onClick={toggle}
-        className="w-full flex items-center gap-2 p-4 text-left"
-      >
-        <Lock size={16} className="text-port-accent shrink-0" />
-        <div className="flex-1 min-w-0">
-          <div className="flex items-center gap-2 flex-wrap">
-            <span className="text-sm font-medium text-white">Tailnet DNS &amp; trusted HTTPS</span>
-            <Pill tone="bare" size="xs" bordered={false} icon={ToneIcon} className={`${toneClass} bg-port-bg`}>
-              {status.label}
-            </Pill>
-          </div>
-        </div>
-        {collapsed ? <ChevronRight size={14} className="text-gray-500" /> : <ChevronDown size={14} className="text-gray-500" />}
-      </button>
-
-      {!collapsed && (
-        <div className="px-4 pb-4 -mt-1 text-xs text-gray-400 space-y-2">
-          {status.detail && (
-            <div className="flex items-start gap-1.5">
-              <Info size={11} className="mt-0.5 text-gray-500 shrink-0" />
-              <span className="font-mono">{status.detail}</span>
-            </div>
-          )}
-          <p>
-            By default, federation traffic uses <span className="font-mono text-gray-300">http://{`<ip>`}:5555</span>. Setting a Tailscale MagicDNS host on a peer
-            switches that hop to <span className="font-mono text-gray-300">https://{`<host>`}.{tailnetInfo?.suffix || `<tailnet>`}.ts.net</span> with a
-            browser-trusted Let&apos;s Encrypt cert provisioned by Tailscale.
-          </p>
-          <ol className="list-decimal list-inside space-y-1 text-gray-500">
-            <li>On each instance, enable MagicDNS + HTTPS Certificates in your tailnet admin (<span className="font-mono">login.tailscale.com/admin/dns</span>).</li>
-            <li>
-              Click <span className="text-port-accent">Enable HTTPS</span> below to fetch the cert via Tailscale
-              (or run <span className="font-mono text-gray-300">npm run setup:cert</span> from a shell).
-            </li>
-            <li>Below, click <span className="text-port-accent">use {`<host>`}</span> on each peer to switch the link to HTTPS. Or click <span className="text-gray-400">use IP only</span> to revert.</li>
-          </ol>
-          <div className="flex items-center gap-2 flex-wrap pt-1">
-            <button
-              onClick={provision}
-              disabled={provisioning || !canProvision}
-              title={canProvision
-                ? `Run \`tailscale cert\` for ${tailnetInfo.self} and write data/certs/{cert,key}.pem`
-                : 'Enable MagicDNS in your tailnet admin first, then reload this page'}
-              className="inline-flex items-center gap-1.5 bg-port-accent hover:bg-port-accent/80 disabled:opacity-40 disabled:cursor-not-allowed text-white px-3 py-1.5 rounded text-xs font-medium transition-colors min-h-[40px] sm:min-h-0"
-            >
-              <Lock size={12} />
-              {provisioning ? 'Provisioning…' : 'Enable HTTPS'}
-            </button>
-            {provisionResult?.ok && (
-              <span className="inline-flex items-center gap-1 text-[11px] text-port-success">
-                <CheckCircle2 size={11} />
-                {provisionResult.requiresRestart
-                  ? 'Cert installed — restart PortOS to activate HTTPS'
-                  : 'Cert installed and live'}
-              </span>
-            )}
-          </div>
         </div>
       )}
     </div>

--- a/client/src/services/apiApps.js
+++ b/client/src/services/apiApps.js
@@ -87,7 +87,8 @@ export const getNativeLaunchStatus = (id, options = {}) =>
 export const startApp = (id, options = {}) =>
   request(`/apps/${id}/start`, { method: 'POST', ...options });
 export const stopApp = (id) => request(`/apps/${id}/stop`, { method: 'POST' });
-export const restartApp = (id) => request(`/apps/${id}/restart`, { method: 'POST' });
+export const restartApp = (id, options = {}) =>
+  request(`/apps/${id}/restart`, { method: 'POST', ...options });
 export const upgradeAppTls = (id, body) => request(`/apps/${id}/upgrade-tls`, {
   method: 'POST',
   body: JSON.stringify(body),
@@ -95,18 +96,35 @@ export const upgradeAppTls = (id, body) => request(`/apps/${id}/upgrade-tls`, {
 });
 
 /**
- * Handle PortOS self-restart: show a loading toast, poll for server recovery, then reload.
+ * Handle PortOS self-restart: show a loading toast, poll for server recovery,
+ * then reload. When a restart changes HTTP to HTTPS, `targetOrigin` points the
+ * health probe and final navigation at the newly-secured listener.
  * Call this after restartApp() returns { selfRestart: true }.
  */
-export function handleSelfRestart() {
+export function handleSelfRestart({ targetOrigin = null } = {}) {
+  const restartOrigin = targetOrigin?.replace(/\/+$/, '') || null;
+  const healthUrl = restartOrigin
+    ? `${restartOrigin}${API_BASE}/system/health`
+    : `${API_BASE}/system/health`;
+
   toast.loading('Restarting PortOS...', { id: 'self-restart', duration: Infinity });
   const poll = async () => {
     for (let i = 0; i < 30; i++) {
       await new Promise(r => setTimeout(r, 2000));
-      const ok = await fetch(`${API_BASE}/system/health`).then(() => true).catch(() => false);
+      const healthRequest = restartOrigin
+        ? fetch(healthUrl, { mode: 'no-cors' })
+        : fetch(healthUrl);
+      const ok = await healthRequest.then(() => true).catch(() => false);
       if (ok) {
         toast.success('PortOS restarted successfully', { id: 'self-restart' });
-        setTimeout(() => window.location.reload(), 1000);
+        setTimeout(() => {
+          if (restartOrigin) {
+            const currentRoute = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+            window.location.assign(`${restartOrigin}${currentRoute}`);
+            return;
+          }
+          window.location.reload();
+        }, 1000);
         return;
       }
     }

--- a/client/src/services/apiApps.test.js
+++ b/client/src/services/apiApps.test.js
@@ -1,0 +1,56 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../components/ui/Toast', () => ({
+  default: { loading: vi.fn(), success: vi.fn(), error: vi.fn() },
+}));
+
+import toast from '../components/ui/Toast';
+import { handleSelfRestart } from './apiApps';
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe('handleSelfRestart', () => {
+  it('polls and navigates on the new HTTPS origin after a TLS-enabling restart', async () => {
+    const fetch = vi.fn().mockResolvedValue({ ok: true });
+    const assign = vi.fn();
+    vi.stubGlobal('fetch', fetch);
+    vi.stubGlobal('location', {
+      pathname: '/instances',
+      search: '?view=peers',
+      hash: '#https',
+      assign,
+      reload: vi.fn(),
+    });
+
+    handleSelfRestart({ targetOrigin: 'https://host-alpha.example-tailnet.ts.net:5555/' });
+
+    expect(toast.loading).toHaveBeenCalledWith('Restarting PortOS...', {
+      id: 'self-restart',
+      duration: Infinity,
+    });
+
+    await vi.advanceTimersByTimeAsync(2000);
+
+    expect(fetch).toHaveBeenCalledWith(
+      'https://host-alpha.example-tailnet.ts.net:5555/api/system/health',
+      { mode: 'no-cors' }
+    );
+    expect(toast.success).toHaveBeenCalledWith('PortOS restarted successfully', {
+      id: 'self-restart',
+    });
+
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(assign).toHaveBeenCalledWith(
+      'https://host-alpha.example-tailnet.ts.net:5555/instances?view=peers#https'
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- add a one-click PortOS restart action after Tailscale certificate provisioning
- poll the newly secured listener and preserve the current route when moving from HTTP to HTTPS
- keep restart failures recoverable and leave already-live HTTPS installs unchanged

## Test plan

- `cd client && npm test -- src/components/instances/TailnetHelpBanner.test.jsx src/services/apiApps.test.js`
- `cd client && npm run lint`
- `cd client && npm run build`
- reran all broad-suite timeout/worker files: 9 files, 150 tests passed