### PR TITLE
feat: split local LLM management into focused views

### DIFF
--- a/client/src/components/settings/LocalLlmTab.jsx
+++ b/client/src/components/settings/LocalLlmTab.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import { Link, useNavigate } from 'react-router';
-import { Cpu, Box, Download, RefreshCw, Search, Plus, ExternalLink, Star, Link2, Copy, Play, Power, PowerOff, AlertTriangle, Zap, ChevronDown, ChevronUp, Terminal } from 'lucide-react';
+import { Cpu, Box, Download, RefreshCw, Search, Plus, ExternalLink, Star, Link2, Copy, Play, Power, PowerOff, AlertTriangle, Zap, ChevronDown, ChevronUp, Terminal, Server } from 'lucide-react';
 import toast from '../ui/Toast';
 import FormField from '../ui/FormField';
 import BrailleSpinner from '../BrailleSpinner';
@@ -22,6 +22,7 @@ import RuntimeServersCard from './RuntimeServersCard.jsx';
 import MtplxServerCard from './MtplxServerCard.jsx';
 import LocalLlmBackendCard from './LocalLlmBackendCard.jsx';
 import LocalLlmInstalledModels from './LocalLlmInstalledModels.jsx';
+import TabPills from '../ui/TabPills.jsx';
 
 const BACKENDS = [
   { id: 'ollama', label: 'Ollama', icon: Cpu },
@@ -56,6 +57,11 @@ const LLAMA_TUNING_FIELDS = ['batchSize', 'ubatchSize', 'threads', 'cacheTypeK',
 const LLAMA_CACHE_TYPES = ['f16', 'q8_0', 'q4_0'];
 
 const btnClass = 'flex items-center gap-1.5 px-2 py-1 text-xs font-medium rounded transition-colors disabled:opacity-50';
+
+const LLM_VIEWS = [
+  { id: 'runtimes', label: 'Runtimes', icon: Server },
+  { id: 'library', label: 'Model Library', icon: Download },
+];
 
 const CATEGORY_LABELS = {
   general: 'General purpose',
@@ -148,8 +154,9 @@ function summarizeMigrate(r) {
   return `${labelFor(r.from)} → ${labelFor(r.to)}: ${parts.join(', ') || 'nothing to move'}`;
 }
 
-export function LocalLlmTab() {
+export function LocalLlmTab({ view }) {
   const navigate = useNavigate();
+  const activeView = LLM_VIEWS.some(({ id }) => id === view) ? view : 'runtimes';
   const [status, setStatus] = useState(null);
   const [loading, setLoading] = useState(true);
   const [selected, setSelected] = useState('ollama');
@@ -255,8 +262,10 @@ export function LocalLlmTab() {
   const loadStatus = useCallback(() => {
     const requestId = ++statusRequestId.current;
     setLoading(true);
-    loadLlamaStatus();
-    loadMtplxStatus();
+    if (activeView === 'runtimes') {
+      loadLlamaStatus();
+      loadMtplxStatus();
+    }
     return getLocalLlmStatus({ silent: true })
       .then((s) => {
         if (requestId !== statusRequestId.current) return;
@@ -273,7 +282,7 @@ export function LocalLlmTab() {
       .finally(() => {
         if (requestId === statusRequestId.current) setLoading(false);
       });
-  }, [loadLlamaStatus, loadMtplxStatus]);
+  }, [activeView, loadLlamaStatus, loadMtplxStatus]);
 
   // `source` and `category` are required rather than defaulted from state: a
   // state default would put them in the dep list, so `loadCatalog`'s identity
@@ -333,6 +342,7 @@ export function LocalLlmTab() {
   // carry and read as frozen. A terminal frame drops the row back to the
   // server's own view of the file, which the refresh below re-reads.
   useEffect(() => {
+    if (activeView !== 'runtimes') return undefined;
     const handleDownloadProgress = (frame) => {
       if (!frame?.presetId || !frame?.role) return;
       const key = downloadKey(frame.presetId, frame.role);
@@ -353,13 +363,14 @@ export function LocalLlmTab() {
     };
     socket.on('llamaServer:download', handleDownloadProgress);
     return () => socket.off('llamaServer:download', handleDownloadProgress);
-  }, [loadLlamaStatus]);
+  }, [activeView, loadLlamaStatus]);
 
   // MTPLX checkpoint download progress. A pull can run for hours, so the socket
   // — not the still-open HTTP request — is what the UI trusts: a terminal frame
   // clears the bar AND re-reads the cache, so the list is right even if the
   // request itself never comes back.
   useEffect(() => {
+    if (activeView !== 'runtimes') return undefined;
     const handleMtplxDownload = (frame) => {
       if (!frame) return;
       if (frame.event === 'complete' || frame.event === 'error' || frame.event === 'cancelled') {
@@ -378,7 +389,7 @@ export function LocalLlmTab() {
     };
     socket.on('mtplx:download', handleMtplxDownload);
     return () => socket.off('mtplx:download', handleMtplxDownload);
-  }, [loadMtplxStatus]);
+  }, [activeView, loadMtplxStatus]);
   // Debounce so typing in the search box doesn't fire a request per keystroke.
   //
   // `activeCategory` is a trigger for the Hugging Face source ONLY — the live
@@ -390,6 +401,7 @@ export function LocalLlmTab() {
   // constant when it doesn't, which keeps the whole effect one code path.
   const catalogCategoryKey = catalogSource === 'huggingface' ? activeCategory : 'client-filtered';
   useEffect(() => {
+    if (activeView !== 'library') return undefined;
     const t = setTimeout(() => loadCatalog(selected, query, catalogSource, activeCategory), catalogSource === 'huggingface' ? 450 : 250);
     return () => clearTimeout(t);
     // `activeCategory` is intentionally absent: `catalogCategoryKey` IS it
@@ -398,7 +410,7 @@ export function LocalLlmTab() {
     // closure can hold a stale category, which is harmless because that branch
     // of loadCatalog never reads the argument.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selected, query, catalogSource, catalogCategoryKey, loadCatalog]);
+  }, [activeView, selected, query, catalogSource, catalogCategoryKey, loadCatalog]);
 
   useEffect(() => {
     const handleProgress = (data) => {
@@ -414,7 +426,7 @@ export function LocalLlmTab() {
       if (data.event === 'complete') {
         progressTimer.current = setTimeout(() => setProgressMsg(''), 3000);
         loadStatus();
-        loadCatalog(selected, query, catalogSource, activeCategory);
+        if (activeView === 'library') loadCatalog(selected, query, catalogSource, activeCategory);
       }
       if (data.event === 'error') {
         progressTimer.current = setTimeout(() => setProgressMsg(''), 5000);
@@ -425,7 +437,7 @@ export function LocalLlmTab() {
       socket.off('localLlm:progress', handleProgress);
       clearTimeout(progressTimer.current);
     };
-  }, [loadStatus, loadCatalog, selected, query, catalogSource, activeCategory]);
+  }, [activeView, loadStatus, loadCatalog, selected, query, catalogSource, activeCategory]);
 
   const runAction = useCallback((key, fn, successMsg, options = {}) => {
     const { onError, clearConfirm = true, ollamaService = false } = options;
@@ -450,7 +462,7 @@ export function LocalLlmTab() {
           }) : prev);
         }
         loadStatus();
-        loadCatalog(selected, query, catalogSource, activeCategory);
+        if (activeView === 'library') loadCatalog(selected, query, catalogSource, activeCategory);
         return result;
       })
       .catch((err) => {
@@ -461,7 +473,7 @@ export function LocalLlmTab() {
         if (typeof onError === 'function') onError(err);
       })
       .finally(() => setActionInProgress(null));
-  }, [loadStatus, loadCatalog, selected, query, catalogSource, activeCategory]);
+  }, [activeView, loadStatus, loadCatalog, selected, query, catalogSource, activeCategory]);
 
   const busy = actionInProgress != null;
 
@@ -925,6 +937,27 @@ export function LocalLlmTab() {
 
   return (
     <div className="space-y-4">
+      <div className="space-y-2">
+        <TabPills
+          tabs={LLM_VIEWS}
+          activeTab={activeView}
+          onChange={(nextView) => navigate(`/models/llms/${nextView}`)}
+          variant="pills"
+          size="sm"
+          mobileDropdown
+          mobileSelectId="llm-management-view"
+          ariaLabel="LLM management sections"
+          controlsIdPrefix="llm-management-panel"
+        />
+        <p className="text-xs text-gray-500">
+          {activeView === 'runtimes'
+            ? 'Install, start, stop, and configure the local servers that run language models.'
+            : 'Find, install, compare, and remove the model weights available to Ollama and LM Studio.'}
+        </p>
+      </div>
+
+      {activeView === 'runtimes' && (
+        <section id="llm-management-panel-runtimes" role="tabpanel" aria-labelledby="tab-runtimes" className="space-y-4">
       {/* One start/stop/install surface for every local server PortOS can run */}
       <RuntimeServersCard
         status={status}
@@ -1452,7 +1485,11 @@ export function LocalLlmTab() {
           </div>
         )}
       </div>
+        </section>
+      )}
 
+      {activeView === 'library' && (
+        <section id="llm-management-panel-library" role="tabpanel" aria-labelledby="tab-library">
       {/* Models — backend picker + catalog/install + installed list */}
       <div className="bg-port-card border border-port-border rounded-xl p-4 sm:p-6 space-y-4">
         <div className="flex items-center justify-between gap-3 flex-wrap">
@@ -1831,6 +1868,8 @@ export function LocalLlmTab() {
           requestDelete={requestDelete}
         />
       </div>
+        </section>
+      )}
     </div>
   );
 }

--- a/client/src/components/settings/LocalLlmTab.test.jsx
+++ b/client/src/components/settings/LocalLlmTab.test.jsx
@@ -61,14 +61,19 @@ const LocationProbe = () => {
   return <output data-testid="location">{location.pathname}{location.search}</output>;
 };
 
-const renderTab = async () => {
+const renderTab = async (view = 'runtimes') => {
   render(
     <MemoryRouter>
-      <LocalLlmTab />
+      <LocalLlmTab view={view} />
       <LocationProbe />
     </MemoryRouter>,
   );
-  await waitFor(() => expect(screen.getByText(/Installed on Ollama/)).toBeTruthy());
+  await waitFor(() => expect(screen.getByRole('tabpanel')).toHaveAttribute('id', `llm-management-panel-${view}`));
+  if (view === 'library') {
+    await waitFor(() => expect(screen.getByText(/Installed on (Ollama|LM Studio)/)).toBeTruthy());
+  } else {
+    await waitFor(() => expect(screen.getByTitle(/PortOS routes local-LLM runs here by default/)).toBeInTheDocument());
+  }
   // The MTPLX checkpoint panel only mounts once the MTPLX status resolves, and
   // it then fetches its default listing — two chained awaits, so flush twice so
   // both state updates land inside act().
@@ -102,6 +107,35 @@ beforeEach(() => {
   deleteLocalLlmModel.mockResolvedValue({ success: true });
 });
 
+describe('LocalLlmTab information architecture', () => {
+  it('defaults the legacy LLM URL to runtime controls without loading the model catalog', async () => {
+    await renderTab();
+
+    expect(screen.getByRole('heading', { name: 'Local Runtime Servers' })).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: 'Models' })).not.toBeInTheDocument();
+    expect(getLocalLlmCatalog).not.toHaveBeenCalled();
+  });
+
+  it('gives model installation its own panel without mounting runtime management', async () => {
+    const { getLlamaServerStatus, getMtplxServerStatus } = await import('../../services/api');
+
+    await renderTab('library');
+
+    expect(screen.getByRole('heading', { name: 'Models' })).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: 'Local Runtime Servers' })).not.toBeInTheDocument();
+    expect(getLlamaServerStatus).not.toHaveBeenCalled();
+    expect(getMtplxServerStatus).not.toHaveBeenCalled();
+    await waitFor(() => expect(getLocalLlmCatalog).toHaveBeenCalled());
+  });
+
+  it('navigates between the focused panels with a shareable URL', async () => {
+    await renderTab();
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Model Library' }));
+    expect(screen.getByTestId('location')).toHaveTextContent('/models/llms/library');
+  });
+});
+
 describe('LocalLlmTab backend disable state', () => {
   it('suppresses the offline warning and persists the intentional disabled state', async () => {
     getLocalLlmStatus.mockResolvedValue({
@@ -119,11 +153,9 @@ describe('LocalLlmTab backend disable state', () => {
       lmstudio: { installed: true, available: false, disabled: true, modelCount: 0, models: [] },
     });
     await renderTab();
-    expect(screen.getByText(/LM Studio isn't running/)).toBeInTheDocument();
     fireEvent.click(screen.getByTitle('Mark LM Studio as intentionally disabled'));
     await waitFor(() => expect(patchSettingsSlice).toHaveBeenCalledWith('localLlm.lmstudio', { disabled: true }));
-    await waitFor(() => expect(screen.queryByText(/LM Studio isn't running/)).toBeNull());
-    expect(screen.getByText('Disabled')).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByText('Disabled')).toBeInTheDocument());
   });
 });
 
@@ -141,7 +173,7 @@ describe('LocalLlmTab runtime servers', () => {
       lmstudio: { installed: true, available: true, modelCount: 0, models: [] },
     });
 
-    await renderTab();
+    await renderTab('library');
 
     const blocker = screen.getByText("Ollama isn't installed yet.").closest('div');
     expect(within(blocker).queryByText(/npm run setup:llm/)).toBeNull();
@@ -165,7 +197,7 @@ describe('LocalLlmTab runtime servers', () => {
       },
     });
 
-    await renderTab();
+    await renderTab('library');
 
     const blocker = screen.getByText("LM Studio isn't installed yet.").closest('div');
     expect(within(blocker).queryByRole('button', { name: 'Install LM Studio' })).toBeNull();
@@ -262,14 +294,14 @@ describe('LocalLlmTab installed models', () => {
   });
 
   it('lets a long model id wrap instead of truncating it', async () => {
-    await renderTab();
+    await renderTab('library');
     const name = screen.getByText(LONG_ID);
     expect(name.className).toMatch(/\bbreak-all\b/);
     expect(name.className).not.toMatch(/\btruncate\b/);
   });
 
   it('stacks the row on mobile and keeps it inline from sm up', async () => {
-    await renderTab();
+    await renderTab('library');
     // The row is the flex container holding the name; on mobile it stacks so the
     // id gets the full width, and the action row drops beneath it.
     const row = screen.getByText(LONG_ID).closest('.rounded-lg');
@@ -278,7 +310,7 @@ describe('LocalLlmTab installed models', () => {
   });
 
   it('folds the model size into the wrapping metadata line', async () => {
-    await renderTab();
+    await renderTab('library');
     // Size used to be its own fixed-width column competing with the name; it now
     // rides along with params/quant/family so nothing is squeezed out.
     expect(screen.getByText(/^34\.7B · Q6_K · qwen2 · [\d.]+ GB$/)).toBeTruthy();
@@ -286,7 +318,7 @@ describe('LocalLlmTab installed models', () => {
 
   it('redownloads an installed model instead of requiring delete-then-install', async () => {
     installLocalLlmModel.mockResolvedValue({ success: true });
-    await renderTab();
+    await renderTab('library');
     fireEvent.click(screen.getByRole('button', { name: `Redownload ${LONG_ID}` }));
     await waitFor(() => expect(installLocalLlmModel).toHaveBeenCalledWith(
       'ollama',
@@ -307,7 +339,7 @@ describe('LocalLlmTab installed models', () => {
     });
     const toast = (await import('../ui/Toast')).default;
 
-    await renderTab();
+    await renderTab('library');
     for (const model of models.slice(0, 6)) {
       fireEvent.click(screen.getByRole('checkbox', { name: `Select ${model.name} for comparison` }));
     }
@@ -322,7 +354,7 @@ describe('LocalLlmTab installed models', () => {
   }, 10_000);
 
   it('requires inline confirmation before deleting an installed model', async () => {
-    await renderTab();
+    await renderTab('library');
     fireEvent.click(screen.getByRole('button', { name: `Delete ${LONG_ID}` }));
     expect(screen.getByText('Delete?')).toBeInTheDocument();
     expect(deleteLocalLlmModel).not.toHaveBeenCalled();
@@ -349,7 +381,7 @@ describe('LocalLlmTab installed models', () => {
     });
     render(
       <MemoryRouter>
-        <LocalLlmTab />
+        <LocalLlmTab view="library" />
       </MemoryRouter>,
     );
     await waitFor(() => expect(screen.getByText(/Installed on LM Studio/)).toBeTruthy());
@@ -374,7 +406,7 @@ describe('LocalLlmTab installed models', () => {
     });
     render(
       <MemoryRouter>
-        <LocalLlmTab />
+        <LocalLlmTab view="library" />
       </MemoryRouter>,
     );
     await waitFor(() => expect(screen.getByText(/Installed on LM Studio/)).toBeTruthy());
@@ -400,7 +432,7 @@ describe('LocalLlmTab recommendations', () => {
       }],
     });
 
-    await renderTab();
+    await renderTab('library');
 
     const termsLink = await screen.findByRole('link', { name: 'Accept terms' });
     expect(termsLink).toHaveAttribute('href', 'https://huggingface.co/orcarouter/Qwen3.8-27B-Uncensored-MLX');
@@ -428,7 +460,7 @@ describe('LocalLlmTab recommendations', () => {
       }],
     });
 
-    await renderTab();
+    await renderTab('library');
 
     expect(await screen.findByText('Best Qwen3.8 path')).toBeTruthy();
     expect(screen.getAllByText('General purpose').length).toBeGreaterThan(0);
@@ -453,7 +485,7 @@ describe('LocalLlmTab recommendations', () => {
         capabilities: ['chat'],
       }],
     });
-    await renderTab();
+    await renderTab('library');
     expect(await screen.findByText('Qwen3.8 27B')).toBeTruthy();
     fireEvent.click(screen.getByRole('button', { name: /^Redownload$/ }));
     await waitFor(() => expect(installLocalLlmModel).toHaveBeenCalledWith(
@@ -522,7 +554,7 @@ describe('LocalLlmTab measured fit badge', () => {
         assessedAt: '2026-01-02T00:00:00.000Z',
       })],
     });
-    await renderTab();
+    await renderTab('library');
 
     const badge = await screen.findByText(/exceeds RAM \(measured\)/);
     expect(badge).toBeInTheDocument();
@@ -533,7 +565,7 @@ describe('LocalLlmTab measured fit badge', () => {
 
   it('labels an unmeasured verdict as the estimate it is', async () => {
     getLocalLlmCatalog.mockResolvedValue({ models: [catalogEntry({ fit: 'comfortable', fitSource: 'estimated', estimatedFit: 'comfortable', measuredFit: null })] });
-    await renderTab();
+    await renderTab('library');
 
     const badge = await screen.findByText('fits comfortably');
     expect(badge.getAttribute('title')).toMatch(/Estimated fit/);
@@ -544,7 +576,7 @@ describe('LocalLlmTab measured fit badge', () => {
     // No amount of free RAM fixes a backend refusing a model, so `incompatible`
     // only ever comes from a real run.
     getLocalLlmCatalog.mockResolvedValue({ models: [catalogEntry({ fit: 'incompatible', fitSource: 'measured', estimatedFit: 'comfortable', measuredFit: 'incompatible', disagrees: true })] });
-    await renderTab();
+    await renderTab('library');
 
     expect(await screen.findByText(/backend refused it \(measured\)/)).toBeInTheDocument();
   });

--- a/client/src/pages/Models.jsx
+++ b/client/src/pages/Models.jsx
@@ -28,7 +28,7 @@ const MediaModels = lazyWithReload(() => import('./MediaModels'));
  *
  *   - **3D** — image-to-3D runtime install/repair (TRELLIS.2, Pixal3D).
  *   - **Embeddings** — the embedding model backing pgvector search.
- *   - **LLMs** — backends, the install catalog, the llama.cpp launcher.
+ *   - **LLMs** — focused runtime-management and model-library sub-routes.
  *   - **LoRAs** — installed image/video adapters.
  *   - **Media** — image/video checkpoints and the Hugging Face cache.
  *   - **Performance** — measured assessments and launch-tuning comparison.
@@ -81,9 +81,9 @@ export default function Models() {
   const activeTab = tab && Object.hasOwn(TAB_CONTENT, tab) ? tab : null;
   if (!activeTab) return <Navigate to="/models/llms" replace />;
 
-  // A record id in the URL selects the tab's drill-down, when it has one. A tab
-  // with no detail view ignores the extra segment and renders its index — better
-  // than 404ing a link that merely carries one segment too many.
+  // A record id in the URL selects the tab's drill-down, when it has one. Tabs
+  // without a detail component receive it as a focused sub-view id (LLMs uses
+  // `runtimes` and `library`); tabs that do not recognize it render their index.
   const DetailContent = recordId && Object.hasOwn(TAB_DETAIL, activeTab) ? TAB_DETAIL[activeTab] : null;
   const TabContent = TAB_CONTENT[activeTab];
 
@@ -97,7 +97,7 @@ export default function Models() {
         {/* Local boundary rather than the App-level one: a lazy tab must not blank
             out the section header and tab bar while its chunk loads. */}
         <Suspense fallback={<PageSkeleton />}>
-          {DetailContent ? <DetailContent recordId={recordId} /> : <TabContent />}
+          {DetailContent ? <DetailContent recordId={recordId} /> : <TabContent view={recordId} />}
         </Suspense>
       </div>
     </div>

--- a/client/src/pages/Models.test.jsx
+++ b/client/src/pages/Models.test.jsx
@@ -13,7 +13,9 @@ import { MemoryRouter, Route, Routes } from 'react-router';
 import { TABS } from '../components/models/ModelsTabsHeader';
 
 vi.mock('../components/settings/LocalModelAssessments.jsx', () => ({ default: () => <div>assessments panel</div> }));
-vi.mock('../components/settings/LocalLlmTab', () => ({ LocalLlmTab: () => <div>llms panel</div> }));
+vi.mock('../components/settings/LocalLlmTab', () => ({
+  LocalLlmTab: ({ view }) => <div data-testid="llms-view" data-view={view || 'runtimes'}>llms panel</div>,
+}));
 vi.mock('../components/settings/EmbeddingsTab', () => ({ default: () => <div>embeddings panel</div> }));
 vi.mock('../components/models/Image3dRuntimes', () => ({ default: () => <div>3d runtimes panel</div> }));
 vi.mock('../components/models/ModelStatusTab', () => ({ default: () => <div>status panel</div> }));
@@ -128,6 +130,12 @@ describe('Models', () => {
 });
 
 describe('Models — tab drill-downs', () => {
+  it('passes an LLM sub-route through to the focused LLM view', async () => {
+    renderAt('/models/llms/library');
+    expect(await screen.findByTestId('llms-view')).toHaveAttribute('data-view', 'library');
+    expect(screen.getByRole('tab', { name: 'LLMs' })).toHaveAttribute('aria-selected', 'true');
+  });
+
   it('renders a tab detail view INSIDE the section shell, not as a bare page', async () => {
     // Under /media these pages kept the shell's chrome for free, because MediaGen
     // was a layout route. Registering the workbench as its own top-level route
@@ -139,8 +147,8 @@ describe('Models — tab drill-downs', () => {
   });
 
   it('falls back to the tab index when the tab has no detail view', async () => {
-    // A link carrying one segment too many should land on something real rather
-    // than 404 — every tab except Training is in this case today.
+    // A tab that does not recognize the focused sub-view id should still land on
+    // something real rather than 404. LLMs consumes this segment; LoRAs does not.
     renderAt('/models/loras/some-id');
     expect(await screen.findByText('loras panel')).toBeInTheDocument();
   });


### PR DESCRIPTION
## Summary

- Split Models → LLMs into URL-addressable Runtimes and Model Library views.
- Keep runtime lifecycle controls separate from model discovery and installation.
- Avoid mounting or fetching inactive runtime and catalog surfaces.

## Test plan

- `cd client && npm run test:ci -- --maxWorkers=4`
- `cd client && npm run lint`
- `cd client && npm run build`