### PR TITLE
fix: explain MTPLX runtime bootstrap failures (#5575)

### DIFF
--- a/server/services/mtplxServerManager.js
+++ b/server/services/mtplxServerManager.js
@@ -23,6 +23,9 @@
  */
 
 import { commandExists } from '../lib/commandExists.js';
+import { writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
 import { sleep } from '../lib/fileUtils.js';
 import { ServerError } from '../lib/errorHandler.js';
 import { launchArgs, normalizeTuning, tuningSpecsFor } from '../lib/localModelTuning.js';
@@ -117,18 +120,25 @@ const MTPLX_NO_MODEL_ERROR = 'MTPLX has no model weights cached, so its server e
 
 const MTPLX_RUNTIME_BOOTSTRAP_ERROR = 'MTPLX\'s own Python runtime failed to bootstrap because Homebrew\'s Python does not provide a working `ensurepip`. Try `brew reinstall python@3.13` (or `brew reinstall --build-from-source youssofal/mtplx/mtplx` to force a rebuild against a working interpreter), then start MTPLX again.';
 
-const MTPLX_LOG_DATE_FORMAT = 'YYYY-MM-DDTHH:mm:ss.SSS';
-const PM2_LOG_TIMESTAMP_PATTERN = /(?:^|\s)(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3})(?::|\s)/;
+/**
+ * Keep MTPLX startup logs raw while scoping each diagnosis to the current
+ * launch. PM2 appends to its configured files across process deletion, so
+ * stable, app-specific paths are truncated before every start.
+ */
+const MTPLX_LOG_FILES = {
+  stdout: join(tmpdir(), 'portos-mtplx-out.log'),
+  stderr: join(tmpdir(), 'portos-mtplx-error.log'),
+};
 
-const currentMtplxLogLines = (lines, launchStartedAt) => lines.filter((line) => {
-  const timestamp = line.match(PM2_LOG_TIMESTAMP_PATTERN)?.[1];
-  const loggedAt = timestamp ? Date.parse(timestamp) : NaN;
-  return Number.isFinite(loggedAt) && loggedAt >= launchStartedAt;
-});
+const resetMtplxLogs = () => Promise.all(
+  Object.values(MTPLX_LOG_FILES).map((path) => writeFile(path, '')),
+);
 
 const isMtplxRuntimeBootstrapFailure = (output) => {
   const text = String(output ?? '');
-  return /runtime is not installed|bootstrapping with pip/i.test(text) && /ensurepip/i.test(text);
+  return /runtime is not installed|bootstrapping with pip/i.test(text)
+    && /ensurepip/i.test(text)
+    && /returned non-zero exit status|no module named ensurepip|ensurepip is not available|failed to bootstrap/i.test(text);
 };
 
 let currentConfig = null;
@@ -465,13 +475,14 @@ export async function startMtplxServer(options = {}) {
   clearJlistCache();
 
   console.log(`🚄 MTPLX starting on ${DEFAULT_HOST}:${port}${model ? ` (model ${model})` : ' (MTPLX default model)'}${tuningArgs.length ? ` with ${tuningArgs.join(' ')}` : ''}`);
-  const launchStartedAt = Date.now();
+  await resetMtplxLogs();
   await execPm2([
     'start', binaryPath,
     '--name', MTPLX_APP,
     '--interpreter', 'none',
     '--no-autorestart',
-    '--log-date-format', MTPLX_LOG_DATE_FORMAT,
+    '--output', MTPLX_LOG_FILES.stdout,
+    '--error', MTPLX_LOG_FILES.stderr,
     '--',
     ...args,
   ]);
@@ -495,7 +506,7 @@ export async function startMtplxServer(options = {}) {
     for (const line of lines) appendLog(line);
     const tail = (lines.length ? lines : daemon.snapshotLogs()).slice(-4).join(' | ');
     lastExitError = `PM2 status: ${currentProc.status}`;
-    const message = isMtplxRuntimeBootstrapFailure(currentMtplxLogLines(lines, launchStartedAt).join('\n'))
+    const message = isMtplxRuntimeBootstrapFailure(lines.join('\n'))
       ? MTPLX_RUNTIME_BOOTSTRAP_ERROR
       : `MTPLX exited immediately (${lastExitError}).${tail ? ` Last output: ${tail}` : ''}`;
 

--- a/server/services/mtplxServerManager.js
+++ b/server/services/mtplxServerManager.js
@@ -115,7 +115,16 @@ export const MTPLX_UNSUPPORTED_REASON = 'MTPLX runs only on macOS with Apple Sil
  */
 const MTPLX_NO_MODEL_ERROR = 'MTPLX has no model weights cached, so its server exits before it binds a port. Use "Download default checkpoint" on the MTPLX card (or search for another MTP model there) to fetch one — a multi-gigabyte download PortOS will not start without you asking — then start MTPLX again.';
 
-const MTPLX_RUNTIME_BOOTSTRAP_ERROR = 'MTPLX\'s own Python runtime failed to bootstrap because Homebrew\'s Python does not provide a working `ensurepip`. Try `brew reinstall python@3.13` (or `brew install youssofal/mtplx/mtplx --build-from-source` to force a rebuild against a working interpreter), then start MTPLX again.';
+const MTPLX_RUNTIME_BOOTSTRAP_ERROR = 'MTPLX\'s own Python runtime failed to bootstrap because Homebrew\'s Python does not provide a working `ensurepip`. Try `brew reinstall python@3.13` (or `brew reinstall --build-from-source youssofal/mtplx/mtplx` to force a rebuild against a working interpreter), then start MTPLX again.';
+
+const MTPLX_LOG_DATE_FORMAT = 'YYYY-MM-DDTHH:mm:ss.SSS';
+const PM2_LOG_TIMESTAMP_PATTERN = /(?:^|\s)(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3})(?::|\s)/;
+
+const currentMtplxLogLines = (lines, launchStartedAt) => lines.filter((line) => {
+  const timestamp = line.match(PM2_LOG_TIMESTAMP_PATTERN)?.[1];
+  const loggedAt = timestamp ? Date.parse(timestamp) : NaN;
+  return Number.isFinite(loggedAt) && loggedAt >= launchStartedAt;
+});
 
 const isMtplxRuntimeBootstrapFailure = (output) => {
   const text = String(output ?? '');
@@ -456,11 +465,13 @@ export async function startMtplxServer(options = {}) {
   clearJlistCache();
 
   console.log(`🚄 MTPLX starting on ${DEFAULT_HOST}:${port}${model ? ` (model ${model})` : ' (MTPLX default model)'}${tuningArgs.length ? ` with ${tuningArgs.join(' ')}` : ''}`);
+  const launchStartedAt = Date.now();
   await execPm2([
     'start', binaryPath,
     '--name', MTPLX_APP,
     '--interpreter', 'none',
     '--no-autorestart',
+    '--log-date-format', MTPLX_LOG_DATE_FORMAT,
     '--',
     ...args,
   ]);
@@ -484,7 +495,7 @@ export async function startMtplxServer(options = {}) {
     for (const line of lines) appendLog(line);
     const tail = (lines.length ? lines : daemon.snapshotLogs()).slice(-4).join(' | ');
     lastExitError = `PM2 status: ${currentProc.status}`;
-    const message = isMtplxRuntimeBootstrapFailure(lines.join('\n'))
+    const message = isMtplxRuntimeBootstrapFailure(currentMtplxLogLines(lines, launchStartedAt).join('\n'))
       ? MTPLX_RUNTIME_BOOTSTRAP_ERROR
       : `MTPLX exited immediately (${lastExitError}).${tail ? ` Last output: ${tail}` : ''}`;
 

--- a/server/services/mtplxServerManager.js
+++ b/server/services/mtplxServerManager.js
@@ -130,9 +130,19 @@ const MTPLX_LOG_FILES = {
   stderr: join(tmpdir(), 'portos-mtplx-error.log'),
 };
 
-const resetMtplxLogs = () => Promise.all(
-  Object.values(MTPLX_LOG_FILES).map((path) => writeFile(path, '')),
-);
+const resetMtplxLogs = async () => {
+  const results = await Promise.all(
+    Object.entries(MTPLX_LOG_FILES).map(([stream, path]) => (
+      writeFile(path, '')
+        .then(() => true)
+        .catch((error) => {
+          console.error(`❌ MTPLX: could not reset ${stream} startup log (${error?.code || 'unknown'}); bootstrap diagnosis disabled for this launch`);
+          return false;
+        })
+    )),
+  );
+  return results.every(Boolean);
+};
 
 const isMtplxRuntimeBootstrapFailure = (output) => {
   const text = String(output ?? '');
@@ -475,7 +485,7 @@ export async function startMtplxServer(options = {}) {
   clearJlistCache();
 
   console.log(`🚄 MTPLX starting on ${DEFAULT_HOST}:${port}${model ? ` (model ${model})` : ' (MTPLX default model)'}${tuningArgs.length ? ` with ${tuningArgs.join(' ')}` : ''}`);
-  await resetMtplxLogs();
+  const logsReset = await resetMtplxLogs();
   await execPm2([
     'start', binaryPath,
     '--name', MTPLX_APP,
@@ -503,10 +513,11 @@ export async function startMtplxServer(options = {}) {
   if (currentProc && ['errored', 'stopped', 'not_found'].includes(currentProc.status)) {
     const pm2Logs = await execPm2(['logs', MTPLX_APP, '--nostream', '--lines', '15']).catch(() => null);
     const lines = `${pm2Logs?.stderr || pm2Logs?.stdout || ''}`.split('\n').map((l) => l.trimEnd()).filter(Boolean);
-    for (const line of lines) appendLog(line);
-    const tail = (lines.length ? lines : daemon.snapshotLogs()).slice(-4).join(' | ');
+    const currentLines = logsReset ? lines : [];
+    for (const line of currentLines) appendLog(line);
+    const tail = (currentLines.length ? currentLines : (logsReset ? daemon.snapshotLogs() : [])).slice(-4).join(' | ');
     lastExitError = `PM2 status: ${currentProc.status}`;
-    const message = isMtplxRuntimeBootstrapFailure(lines.join('\n'))
+    const message = logsReset && isMtplxRuntimeBootstrapFailure(currentLines.join('\n'))
       ? MTPLX_RUNTIME_BOOTSTRAP_ERROR
       : `MTPLX exited immediately (${lastExitError}).${tail ? ` Last output: ${tail}` : ''}`;
 

--- a/server/services/mtplxServerManager.js
+++ b/server/services/mtplxServerManager.js
@@ -125,14 +125,16 @@ const MTPLX_RUNTIME_BOOTSTRAP_ERROR = 'MTPLX\'s own Python runtime failed to boo
  * launch. PM2 appends to its configured files across process deletion, so
  * stable, app-specific paths are truncated before every start.
  */
-const MTPLX_LOG_FILES = {
+const DEFAULT_MTPLX_LOG_FILES = {
   stdout: join(tmpdir(), 'portos-mtplx-out.log'),
   stderr: join(tmpdir(), 'portos-mtplx-error.log'),
 };
 
+let mtplxLogFiles = DEFAULT_MTPLX_LOG_FILES;
+
 const resetMtplxLogs = async () => {
   const results = await Promise.all(
-    Object.entries(MTPLX_LOG_FILES).map(([stream, path]) => (
+    Object.entries(mtplxLogFiles).map(([stream, path]) => (
       writeFile(path, '')
         .then(() => true)
         .catch((error) => {
@@ -491,8 +493,8 @@ export async function startMtplxServer(options = {}) {
     '--name', MTPLX_APP,
     '--interpreter', 'none',
     '--no-autorestart',
-    '--output', MTPLX_LOG_FILES.stdout,
-    '--error', MTPLX_LOG_FILES.stderr,
+    '--output', mtplxLogFiles.stdout,
+    '--error', mtplxLogFiles.stderr,
     '--',
     ...args,
   ]);
@@ -515,10 +517,10 @@ export async function startMtplxServer(options = {}) {
     const lines = `${pm2Logs?.stderr || pm2Logs?.stdout || ''}`.split('\n').map((l) => l.trimEnd()).filter(Boolean);
     const currentLines = logsReset ? lines : [];
     for (const line of currentLines) appendLog(line);
-    const tail = (currentLines.length ? currentLines : (logsReset ? daemon.snapshotLogs() : [])).slice(-4).join(' | ');
+    const tail = (currentLines.length ? currentLines : daemon.snapshotLogs()).slice(-4).join(' | ');
     lastExitError = `PM2 status: ${currentProc.status}`;
     const message = logsReset && isMtplxRuntimeBootstrapFailure(currentLines.join('\n'))
-      ? MTPLX_RUNTIME_BOOTSTRAP_ERROR
+      ? `${MTPLX_RUNTIME_BOOTSTRAP_ERROR}${tail ? ` Last output: ${tail}` : ''}`
       : `MTPLX exited immediately (${lastExitError}).${tail ? ` Last output: ${tail}` : ''}`;
 
     await execPm2(['delete', MTPLX_APP]).catch(() => {});
@@ -752,8 +754,13 @@ export function _resetMtplxServerStateForTests({
   relaunchReadyTimeout,
   relaunchPoll,
   idleMinutes = 0,
+  logFiles,
 } = {}) {
   idleMinutesOverride = idleMinutes;
+  mtplxLogFiles = logFiles ? {
+    stdout: logFiles.stdout || DEFAULT_MTPLX_LOG_FILES.stdout,
+    stderr: logFiles.stderr || DEFAULT_MTPLX_LOG_FILES.stderr,
+  } : DEFAULT_MTPLX_LOG_FILES;
   currentConfig = null;
   daemon.resetLogs();
   lastExitError = null;

--- a/server/services/mtplxServerManager.js
+++ b/server/services/mtplxServerManager.js
@@ -115,6 +115,13 @@ export const MTPLX_UNSUPPORTED_REASON = 'MTPLX runs only on macOS with Apple Sil
  */
 const MTPLX_NO_MODEL_ERROR = 'MTPLX has no model weights cached, so its server exits before it binds a port. Use "Download default checkpoint" on the MTPLX card (or search for another MTP model there) to fetch one — a multi-gigabyte download PortOS will not start without you asking — then start MTPLX again.';
 
+const MTPLX_RUNTIME_BOOTSTRAP_ERROR = 'MTPLX\'s own Python runtime failed to bootstrap because Homebrew\'s Python does not provide a working `ensurepip`. Try `brew reinstall python@3.13` (or `brew install youssofal/mtplx/mtplx --build-from-source` to force a rebuild against a working interpreter), then start MTPLX again.';
+
+const isMtplxRuntimeBootstrapFailure = (output) => {
+  const text = String(output ?? '');
+  return /runtime is not installed|bootstrapping with pip/i.test(text) && /ensurepip/i.test(text);
+};
+
 let currentConfig = null;
 let lastExitError = null;
 
@@ -476,13 +483,16 @@ export async function startMtplxServer(options = {}) {
     const lines = `${pm2Logs?.stderr || pm2Logs?.stdout || ''}`.split('\n').map((l) => l.trimEnd()).filter(Boolean);
     for (const line of lines) appendLog(line);
     const tail = (lines.length ? lines : daemon.snapshotLogs()).slice(-4).join(' | ');
-
     lastExitError = `PM2 status: ${currentProc.status}`;
+    const message = isMtplxRuntimeBootstrapFailure(lines.join('\n'))
+      ? MTPLX_RUNTIME_BOOTSTRAP_ERROR
+      : `MTPLX exited immediately (${lastExitError}).${tail ? ` Last output: ${tail}` : ''}`;
+
     await execPm2(['delete', MTPLX_APP]).catch(() => {});
     clearJlistCache();
     currentConfig = null;
     throw new ServerError(
-      `MTPLX exited immediately (${lastExitError}).${tail ? ` Last output: ${tail}` : ''}`,
+      message,
       { status: 500, code: 'MTPLX_EXITED' }
     );
   }

--- a/server/services/mtplxServerManager.test.js
+++ b/server/services/mtplxServerManager.test.js
@@ -206,10 +206,10 @@ describe('mtplxServerManager', () => {
           return {
             stdout: '',
             stderr: [
-              '2000-01-01T00:00:00.000: runtime is not installed',
-              '2000-01-01T00:00:00.000: Bootstrapping with pip',
-              '2000-01-01T00:00:00.000: python3.13 -m ensurepip --upgrade --default-pip',
-              `${new Date().toISOString().slice(0, -1)}: error: model is not available locally`,
+              'runtime is not installed',
+              'Bootstrapping with pip',
+              'python3.13 -m ensurepip --upgrade --default-pip',
+              'error: model is not available locally',
             ].join('\n'),
           };
         }
@@ -228,16 +228,13 @@ describe('mtplxServerManager', () => {
         }
         if (args[0] === 'delete') pm2State = null;
         if (args[0] === 'logs') {
-          const timestamp = new Date().toISOString().slice(0, -1);
           return {
             stdout: '',
             stderr: [
-              ...[
-                'runtime is not installed',
-                'Bootstrapping with pip',
-                'python3.13 -m ensurepip --upgrade --default-pip',
-                "Command '['python3.13', '-m', 'ensurepip']' returned non-zero exit status 1",
-              ].map((line) => timestamp + ': ' + line),
+              'runtime is not installed',
+              'Bootstrapping with pip',
+              'python3.13 -m ensurepip --upgrade --default-pip',
+              "Command '['python3.13', '-m', 'ensurepip']' returned non-zero exit status 1",
             ].join('\n'),
           };
         }
@@ -250,6 +247,9 @@ describe('mtplxServerManager', () => {
       expect(err.message).toContain('Homebrew\'s Python does not provide a working `ensurepip`');
       expect(err.message).toContain('brew reinstall python@3.13');
       expect(err.message).toContain('brew reinstall --build-from-source youssofal/mtplx/mtplx');
+      const start = execPm2Calls.find((args) => args[0] === 'start');
+      expect(start[start.indexOf('--output') + 1]).toMatch(/portos-mtplx-out\.log$/);
+      expect(start[start.indexOf('--error') + 1]).toMatch(/portos-mtplx-error\.log$/);
       expect(err.message).not.toContain('returned non-zero exit status 1');
       expect(pm2State).toBeNull();
     });

--- a/server/services/mtplxServerManager.test.js
+++ b/server/services/mtplxServerManager.test.js
@@ -202,7 +202,17 @@ describe('mtplxServerManager', () => {
           pm2State = { name: MTPLX_APP, status: 'errored', pid: null, args: [] };
         }
         if (args[0] === 'delete') pm2State = null;
-        if (args[0] === 'logs') return { stdout: '', stderr: 'error: model is not available locally' };
+        if (args[0] === 'logs') {
+          return {
+            stdout: '',
+            stderr: [
+              '2000-01-01T00:00:00.000: runtime is not installed',
+              '2000-01-01T00:00:00.000: Bootstrapping with pip',
+              '2000-01-01T00:00:00.000: python3.13 -m ensurepip --upgrade --default-pip',
+              `${new Date().toISOString().slice(0, -1)}: error: model is not available locally`,
+            ].join('\n'),
+          };
+        }
         return { stdout: '', stderr: '' };
       });
       await expect(startMtplxServer()).rejects.toThrow(/model is not available locally/);
@@ -218,13 +228,16 @@ describe('mtplxServerManager', () => {
         }
         if (args[0] === 'delete') pm2State = null;
         if (args[0] === 'logs') {
+          const timestamp = new Date().toISOString().slice(0, -1);
           return {
             stdout: '',
             stderr: [
-              'runtime is not installed',
-              'Bootstrapping with pip',
-              'python3.13 -m ensurepip --upgrade --default-pip',
-              "Command '['python3.13', '-m', 'ensurepip']' returned non-zero exit status 1",
+              ...[
+                'runtime is not installed',
+                'Bootstrapping with pip',
+                'python3.13 -m ensurepip --upgrade --default-pip',
+                "Command '['python3.13', '-m', 'ensurepip']' returned non-zero exit status 1",
+              ].map((line) => timestamp + ': ' + line),
             ].join('\n'),
           };
         }
@@ -236,6 +249,7 @@ describe('mtplxServerManager', () => {
       expect(err).toMatchObject({ code: 'MTPLX_EXITED' });
       expect(err.message).toContain('Homebrew\'s Python does not provide a working `ensurepip`');
       expect(err.message).toContain('brew reinstall python@3.13');
+      expect(err.message).toContain('brew reinstall --build-from-source youssofal/mtplx/mtplx');
       expect(err.message).not.toContain('returned non-zero exit status 1');
       expect(pm2State).toBeNull();
     });

--- a/server/services/mtplxServerManager.test.js
+++ b/server/services/mtplxServerManager.test.js
@@ -1,3 +1,4 @@
+import { readFile, writeFile } from 'fs/promises';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import {
   getMtplxServerStatus,
@@ -251,6 +252,48 @@ describe('mtplxServerManager', () => {
       expect(start[start.indexOf('--output') + 1]).toMatch(/portos-mtplx-out\.log$/);
       expect(start[start.indexOf('--error') + 1]).toMatch(/portos-mtplx-error\.log$/);
       expect(err.message).not.toContain('returned non-zero exit status 1');
+      expect(pm2State).toBeNull();
+    });
+
+    it('does not classify bootstrap text left by a previous launch', async () => {
+      await startMtplxServer();
+      const firstStart = execPm2Calls.find((args) => args[0] === 'start');
+      const outputPath = firstStart[firstStart.indexOf('--output') + 1];
+      const errorPath = firstStart[firstStart.indexOf('--error') + 1];
+      await stopMtplxServer();
+
+      const staleBootstrap = [
+        'runtime is not installed',
+        'Bootstrapping with pip',
+        'python3.13 -m ensurepip --upgrade --default-pip',
+        "Command '['python3.13', '-m', 'ensurepip']' returned non-zero exit status 1",
+      ].join('\n');
+      await writeFile(outputPath, staleBootstrap);
+      await writeFile(errorPath, staleBootstrap);
+
+      execPm2Calls = [];
+      pm2Module.execPm2.mockImplementation(async (args) => {
+        execPm2Calls.push(args);
+        if (args[0] === 'start') {
+          pm2State = { name: MTPLX_APP, status: 'errored', pid: null, args: [] };
+        }
+        if (args[0] === 'delete') pm2State = null;
+        if (args[0] === 'logs') {
+          return {
+            stdout: await readFile(outputPath, 'utf8'),
+            stderr: await readFile(errorPath, 'utf8'),
+          };
+        }
+        return { stdout: '', stderr: '' };
+      });
+
+      const err = await startMtplxServer().catch((error) => error);
+
+      expect(err).toMatchObject({ code: 'MTPLX_EXITED' });
+      expect(err.message).toMatch(/MTPLX exited immediately/);
+      expect(err.message).not.toMatch(/Homebrew/);
+      expect(await readFile(outputPath, 'utf8')).toBe('');
+      expect(await readFile(errorPath, 'utf8')).toBe('');
       expect(pm2State).toBeNull();
     });
 

--- a/server/services/mtplxServerManager.test.js
+++ b/server/services/mtplxServerManager.test.js
@@ -1,4 +1,6 @@
-import { readFile, writeFile } from 'fs/promises';
+import { mkdtemp, readFile, rm, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import {
   getMtplxServerStatus,
@@ -36,9 +38,16 @@ const resetForTest = (overrides = {}) => {
 describe('mtplxServerManager', () => {
   let pm2State = null;
   let execPm2Calls = [];
+  let testLogDir = null;
 
-  beforeEach(() => {
-    resetForTest();
+  beforeEach(async () => {
+    testLogDir = await mkdtemp(join(tmpdir(), 'portos-mtplx-test-'));
+    resetForTest({
+      logFiles: {
+        stdout: join(testLogDir, 'portos-mtplx-out.log'),
+        stderr: join(testLogDir, 'portos-mtplx-error.log'),
+      },
+    });
     vi.restoreAllMocks();
     pm2State = null;
     execPm2Calls = [];
@@ -75,9 +84,11 @@ describe('mtplxServerManager', () => {
     vi.spyOn(pm2Module, 'clearJlistCache').mockImplementation(() => {});
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     _resetMtplxServerStateForTests();
     vi.restoreAllMocks();
+    await rm(testLogDir, { recursive: true, force: true });
+    testLogDir = null;
   });
 
   describe('getMtplxServerStatus', () => {
@@ -251,7 +262,7 @@ describe('mtplxServerManager', () => {
       const start = execPm2Calls.find((args) => args[0] === 'start');
       expect(start[start.indexOf('--output') + 1]).toMatch(/portos-mtplx-out\.log$/);
       expect(start[start.indexOf('--error') + 1]).toMatch(/portos-mtplx-error\.log$/);
-      expect(err.message).not.toContain('returned non-zero exit status 1');
+      expect(err.message).toContain('returned non-zero exit status 1');
       expect(pm2State).toBeNull();
     });
 
@@ -294,6 +305,31 @@ describe('mtplxServerManager', () => {
       expect(err.message).not.toMatch(/Homebrew/);
       expect(await readFile(outputPath, 'utf8')).toBe('');
       expect(await readFile(errorPath, 'utf8')).toBe('');
+      expect(pm2State).toBeNull();
+    });
+
+    it('keeps the in-memory launch context when log reset is unavailable', async () => {
+      resetForTest({
+        logFiles: {
+          stdout: join(testLogDir, 'missing', 'portos-mtplx-out.log'),
+          stderr: join(testLogDir, 'missing', 'portos-mtplx-error.log'),
+        },
+      });
+      vi.spyOn(console, 'error').mockImplementation(() => {});
+      vi.spyOn(pm2Module, 'execPm2').mockImplementation(async (args) => {
+        execPm2Calls.push(args);
+        if (args[0] === 'start') {
+          pm2State = { name: MTPLX_APP, status: 'errored', pid: null, args: [] };
+        }
+        if (args[0] === 'delete') pm2State = null;
+        return { stdout: '', stderr: '' };
+      });
+
+      const err = await startMtplxServer().catch((error) => error);
+
+      expect(err).toMatchObject({ code: 'MTPLX_EXITED' });
+      expect(err.message).toContain('Starting: mtplx serve');
+      expect(err.message).not.toMatch(/Homebrew/);
       expect(pm2State).toBeNull();
     });
 

--- a/server/services/mtplxServerManager.test.js
+++ b/server/services/mtplxServerManager.test.js
@@ -210,6 +210,36 @@ describe('mtplxServerManager', () => {
       expect(pm2State).toBeNull();
     });
 
+    it('explains how to recover when MTPLX cannot bootstrap its Python runtime', async () => {
+      vi.spyOn(pm2Module, 'execPm2').mockImplementation(async (args) => {
+        execPm2Calls.push(args);
+        if (args[0] === 'start') {
+          pm2State = { name: MTPLX_APP, status: 'errored', pid: null, args: [] };
+        }
+        if (args[0] === 'delete') pm2State = null;
+        if (args[0] === 'logs') {
+          return {
+            stdout: '',
+            stderr: [
+              'runtime is not installed',
+              'Bootstrapping with pip',
+              'python3.13 -m ensurepip --upgrade --default-pip',
+              "Command '['python3.13', '-m', 'ensurepip']' returned non-zero exit status 1",
+            ].join('\n'),
+          };
+        }
+        return { stdout: '', stderr: '' };
+      });
+
+      const err = await startMtplxServer().catch((error) => error);
+
+      expect(err).toMatchObject({ code: 'MTPLX_EXITED' });
+      expect(err.message).toContain('Homebrew\'s Python does not provide a working `ensurepip`');
+      expect(err.message).toContain('brew reinstall python@3.13');
+      expect(err.message).not.toContain('returned non-zero exit status 1');
+      expect(pm2State).toBeNull();
+    });
+
     it('reports the endpoint it actually bound, with no host it never passes', async () => {
       // MTPLX is a loopback daemon and no `--host` ever reaches its launch line,
       // so accepting a host would record an endpoint the server is not bound to.


### PR DESCRIPTION
## Summary

- Detect MTPLX ensurepip bootstrap failures and show actionable Homebrew recovery guidance.
- Preserve the raw PM2 tail and isolate per-launch logs so stale output cannot trigger the diagnosis.

## Test plan

- `cd server && npm test -- services/mtplxServerManager.test.js`
- `cd server && npm test`

The affected Homebrew failure was not reproducible locally because the local interpreter has working ensurepip; the change is limited to the explanatory error path.

Closes #5575