### PR TITLE
fix: make music master-detail empty states actionable

### DIFF
--- a/client/src/components/music/AlbumsManager.jsx
+++ b/client/src/components/music/AlbumsManager.jsx
@@ -255,7 +255,10 @@ export default function AlbumsManager() {
           {loading ? (
             <div className="text-sm p-2"><BrailleSpinner text="Loading…" /></div>
           ) : albums.length === 0 ? (
-            <div className="text-gray-500 text-sm p-2">No albums yet. Click <span className="text-port-accent">New Album</span>.</div>
+            <div className="text-gray-500 text-sm p-2">
+              No albums yet.{' '}
+              <button type="button" onClick={startCreate} className="text-port-accent hover:underline">New Album</button>
+            </div>
           ) : (
             <ul className="space-y-1">
               {albums.map((a) => (
@@ -292,7 +295,12 @@ export default function AlbumsManager() {
               </button>
             </div>
           ) : !isCreate && !selected ? (
-            <div className="text-gray-500 text-sm">Select an album to edit, or create a new one.</div>
+            <div className="text-gray-500 text-sm">
+              <p>Select an album to edit, or create a new one.</p>
+              <button type="button" onClick={startCreate} className="mt-3 inline-flex items-center gap-2 px-3 py-2 rounded-lg bg-port-accent hover:bg-port-accent/90 text-white text-sm font-medium">
+                <Plus size={16} aria-hidden="true" /> New Album
+              </button>
+            </div>
           ) : (
             <div className="space-y-3">
               <div className="flex gap-4 items-start">

--- a/client/src/components/music/TracksManager.jsx
+++ b/client/src/components/music/TracksManager.jsx
@@ -385,7 +385,10 @@ export default function TracksManager() {
           {loading ? (
             <div className="text-sm p-2"><BrailleSpinner text="Loading…" /></div>
           ) : tracks.length === 0 ? (
-            <div className="text-gray-500 text-sm p-2">No tracks yet. Click <span className="text-port-accent">New Track</span>.</div>
+            <div className="text-gray-500 text-sm p-2">
+              No tracks yet.{' '}
+              <button type="button" onClick={startCreate} className="text-port-accent hover:underline">New Track</button>
+            </div>
           ) : (
             <ul className="space-y-1">
               {tracks.map((t) => (
@@ -416,7 +419,12 @@ export default function TracksManager() {
               </button>
             </div>
           ) : !isCreate && !selected ? (
-            <div className="text-gray-500 text-sm">Select a track to edit, or create a new one.</div>
+            <div className="text-gray-500 text-sm">
+              <p>Select a track to edit, or create a new one.</p>
+              <button type="button" onClick={startCreate} className="mt-3 inline-flex items-center gap-2 px-3 py-2 rounded-lg bg-port-accent hover:bg-port-accent/90 text-white text-sm font-medium">
+                <Plus size={16} aria-hidden="true" /> New Track
+              </button>
+            </div>
           ) : (
             <div className="space-y-3">
               <div className="flex flex-col gap-3 rounded-lg border border-port-accent/30 bg-port-accent/5 p-3 sm:flex-row sm:items-center sm:justify-between">

--- a/client/src/components/persona/PersonaMasterDetail.jsx
+++ b/client/src/components/persona/PersonaMasterDetail.jsx
@@ -191,7 +191,10 @@ export default function PersonaMasterDetail({
           {loading ? (
             <div className="text-sm p-2"><BrailleSpinner text="Loading…" /></div>
           ) : records.length === 0 ? (
-            <div className="text-gray-500 text-sm p-2">No {plural.toLowerCase()} yet. Click <span className="text-port-accent">New {singular}</span>.</div>
+            <div className="text-gray-500 text-sm p-2">
+              No {plural.toLowerCase()} yet.{' '}
+              <button type="button" onClick={() => navigate(`${basePath}/new`)} className="text-port-accent hover:underline">New {singular}</button>
+            </div>
           ) : (
             <ul className="space-y-1">
               {records.map((record) => (
@@ -217,7 +220,10 @@ export default function PersonaMasterDetail({
               <button type="button" onClick={() => navigate(basePath)} className="text-port-accent hover:underline">Back to {plural.toLowerCase()}</button>
             </div>
           ) : !isCreate && !selected ? (
-            <div className="text-gray-500 text-sm">Select a {singular.toLowerCase()} to edit, or create a new one.</div>
+            <div className="text-gray-500 text-sm">
+              <p>Select a {singular.toLowerCase()} to edit, or create a new one.</p>
+              <CreateButton singular={singular} onClick={() => navigate(`${basePath}/new`)} />
+            </div>
           ) : (
             <div className="space-y-3">
               {fields.map((field) => (

--- a/client/src/pages/Authors.test.jsx
+++ b/client/src/pages/Authors.test.jsx
@@ -67,7 +67,9 @@ describe('Authors headshot generation', () => {
   const openCreateForm = async () => {
     renderAuthors();
     await screen.findByText(/No authors yet/i);
-    fireEvent.click(screen.getByRole('button', { name: /New Author/i }));
+    // The empty master-detail view now exposes contextual create actions in
+    // addition to the page-level action; all of them intentionally open /new.
+    fireEvent.click(screen.getAllByRole('button', { name: /New Author/i })[0]);
   };
 
   // Re-render the component without changing generation state, so a freshly


### PR DESCRIPTION
## Summary
- Make empty artist, album, and track lists actionable with clickable create controls.
- Add primary create actions to each unselected master-detail pane.
- Reuse the existing `/new` navigation paths so the name/title field receives focus.

## Test plan
- `git diff --check`
- `npm test -- --run` (existing unrelated Authors failures; see notes)

Closes #5566
