### PR TITLE
refactor: consolidate local midnight timezone helpers (#5572)

### DIFF
--- a/client/src/components/music/AlbumTrackPicker.jsx
+++ b/client/src/components/music/AlbumTrackPicker.jsx
@@ -1,0 +1,120 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Check, Music2, Plus, Search, X } from 'lucide-react';
+import Modal from '../ui/Modal';
+import { formatTimecode } from '../../utils/formatters';
+
+// Searchable, batch-oriented picker for adding existing library tracks to an
+// album. The parent owns persistence and ordering; this component only returns
+// the selected records in their current library order.
+export default function AlbumTrackPicker({ open, tracks = [], onClose, onAdd }) {
+  const [query, setQuery] = useState('');
+  const [selectedIds, setSelectedIds] = useState(() => new Set());
+
+  useEffect(() => {
+    if (!open) return;
+    setQuery('');
+    setSelectedIds(new Set());
+  }, [open]);
+
+  const filteredTracks = useMemo(() => {
+    const terms = query.trim().toLowerCase().split(/\s+/).filter(Boolean);
+    if (terms.length === 0) return tracks;
+    return tracks.filter((track) => {
+      const searchable = `${track.title || ''} ${track.artist || ''}`.toLowerCase();
+      return terms.every((term) => searchable.includes(term));
+    });
+  }, [tracks, query]);
+
+  const toggleTrack = (trackId) => {
+    setSelectedIds((previous) => {
+      const next = new Set(previous);
+      if (next.has(trackId)) next.delete(trackId);
+      else next.add(trackId);
+      return next;
+    });
+  };
+
+  const handleAdd = () => {
+    const selectedTracks = tracks.filter((track) => selectedIds.has(track.id));
+    if (selectedTracks.length === 0) return;
+    onAdd(selectedTracks);
+    onClose();
+  };
+
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      size="lg"
+      panelClassName="bg-port-card border border-port-border rounded-xl max-h-[85vh] flex flex-col"
+      ariaLabelledBy="album-track-picker-title"
+    >
+      <div className="flex items-center justify-between p-4 border-b border-port-border flex-shrink-0">
+        <div className="flex items-center gap-2">
+          <Music2 className="w-5 h-5 text-port-accent" aria-hidden="true" />
+          <h2 id="album-track-picker-title" className="text-lg font-bold text-white">Add tracks</h2>
+        </div>
+        <button type="button" onClick={onClose} aria-label="Close track picker" className="p-2 text-gray-500 hover:text-white rounded min-h-[44px] min-w-[44px] flex items-center justify-center">
+          <X size={18} aria-hidden="true" />
+        </button>
+      </div>
+
+      <div className="p-4 border-b border-port-border flex-shrink-0">
+        <div className="relative">
+          <Search size={14} className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-500" aria-hidden="true" />
+          <label htmlFor="album-track-picker-search" className="sr-only">Search tracks by title or artist</label>
+          <input
+            id="album-track-picker-search"
+            type="search"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Search by title or artist…"
+            autoFocus
+            className="w-full pl-9 pr-3 py-2 bg-port-bg border border-port-border rounded text-white text-sm focus:outline-none focus:border-port-accent"
+          />
+        </div>
+      </div>
+
+      <div className="flex-1 overflow-y-auto p-4 min-h-0">
+        {filteredTracks.length === 0 ? (
+          <p className="text-sm text-gray-400">No matching tracks.</p>
+        ) : (
+          <ul className="space-y-2">
+            {filteredTracks.map((track) => {
+              const checked = selectedIds.has(track.id);
+              return (
+                <li key={track.id}>
+                  <label className={`flex items-center gap-3 w-full p-3 rounded border bg-port-bg/40 cursor-pointer transition-colors ${checked ? 'border-port-accent' : 'border-port-border hover:border-gray-500'}`}>
+                    <input
+                      type="checkbox"
+                      checked={checked}
+                      onChange={() => toggleTrack(track.id)}
+                      className="accent-port-accent"
+                      aria-label={`Select ${track.title || 'untitled track'}`}
+                    />
+                    <span className="min-w-0 flex-1">
+                      <span className="block text-sm font-medium text-white truncate">{track.title || '(untitled)'}</span>
+                      {track.artist ? <span className="block text-xs text-gray-400 truncate">{track.artist}</span> : null}
+                    </span>
+                    {track.durationSec ? <span className="text-xs text-gray-500">{formatTimecode(track.durationSec)}</span> : null}
+                    {checked ? <Check size={16} className="text-port-accent shrink-0" aria-hidden="true" /> : null}
+                  </label>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+
+      <div className="p-4 border-t border-port-border flex items-center justify-between gap-3 flex-shrink-0">
+        <span className="text-xs text-gray-400">{selectedIds.size} selected</span>
+        <div className="flex items-center gap-2">
+          <button type="button" onClick={onClose} className="px-3 py-2 rounded text-sm text-gray-400 hover:text-white">Cancel</button>
+          <button type="button" onClick={handleAdd} disabled={selectedIds.size === 0} className="inline-flex items-center gap-2 px-3 py-2 rounded bg-port-accent hover:bg-port-accent/90 disabled:opacity-50 disabled:cursor-not-allowed text-white text-sm font-medium">
+            <Plus size={14} aria-hidden="true" /> Add selected
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/client/src/components/music/AlbumTrackPicker.test.jsx
+++ b/client/src/components/music/AlbumTrackPicker.test.jsx
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import AlbumTrackPicker from './AlbumTrackPicker';
+
+const tracks = [
+  { id: 'track-1', title: 'Northern Lights', artist: 'The Examples', durationSec: 201 },
+  { id: 'track-2', title: 'Midnight Signal', artist: 'Test Artist', durationSec: 185 },
+  { id: 'track-3', title: 'Daybreak', artist: 'The Examples' },
+];
+
+describe('AlbumTrackPicker', () => {
+  it('searches by title or artist and adds multiple selected tracks in library order', () => {
+    const onAdd = vi.fn();
+    const onClose = vi.fn();
+    render(<AlbumTrackPicker open tracks={tracks} onAdd={onAdd} onClose={onClose} />);
+
+    fireEvent.change(screen.getByRole('searchbox', { name: /search tracks/i }), { target: { value: 'examples' } });
+    expect(screen.getByText('Northern Lights')).toBeTruthy();
+    expect(screen.getByText('Daybreak')).toBeTruthy();
+    expect(screen.queryByText('Midnight Signal')).toBeNull();
+
+    fireEvent.click(screen.getByLabelText('Select Daybreak'));
+    fireEvent.click(screen.getByLabelText('Select Northern Lights'));
+    fireEvent.click(screen.getByRole('button', { name: /add selected/i }));
+
+    expect(onAdd).toHaveBeenCalledWith([tracks[0], tracks[2]]);
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('does not allow an empty batch to be added', () => {
+    render(<AlbumTrackPicker open tracks={tracks} onAdd={() => {}} onClose={() => {}} />);
+    expect(screen.getByRole('button', { name: /add selected/i })).toBeDisabled();
+  });
+});

--- a/client/src/components/music/AlbumsManager.jsx
+++ b/client/src/components/music/AlbumsManager.jsx
@@ -22,6 +22,7 @@ import { useConfirmDelete } from '../../hooks/useConfirmDelete';
 import { DEFAULT_NEGATIVE_PROMPT } from '../../lib/imageGenDefaults';
 import { formatTimecode } from '../../utils/formatters';
 import ArtistPicker from './ArtistPicker';
+import AlbumTrackPicker from './AlbumTrackPicker';
 import {
   listAlbums, createAlbum, updateAlbum, deleteAlbum,
   listTracks, generateImage,
@@ -75,6 +76,7 @@ export default function AlbumsManager() {
   const [galleryOpen, setGalleryOpen] = useState(false);
   const [startingGen, setStartingGen] = useState(false);
   const [genJobId, setGenJobId] = useState(null);
+  const [trackPickerOpen, setTrackPickerOpen] = useState(false);
   const genRequestRef = useRef(0);
 
   const gen = useMediaJobProgress(genJobId);
@@ -131,6 +133,7 @@ export default function AlbumsManager() {
     hydratedRef.current = selectionKey;
     cancelDelete();
     clearGeneration();
+    setTrackPickerOpen(false);
     if (isCreate) setForm(emptyForm());
     else if (selected) setForm(formFromAlbum(selected));
   }, [selectionKey, isCreate, selected, loading]);
@@ -229,6 +232,7 @@ export default function AlbumsManager() {
   };
 
   const availableTracks = allTracks.filter((t) => !form.trackIds.includes(t.id));
+  const addTracks = (tracks) => tracks.forEach((track) => addTrack(track.id));
 
   return (
     <div>
@@ -365,17 +369,9 @@ export default function AlbumsManager() {
                   </ol>
                 )}
                 {availableTracks.length > 0 ? (
-                  <select
-                    aria-label="Add a track"
-                    value=""
-                    onChange={(e) => { if (e.target.value) addTrack(e.target.value); }}
-                    className="mt-2 w-full px-3 py-2 bg-port-bg border border-port-border rounded text-white text-sm"
-                  >
-                    <option value="">+ Add a track…</option>
-                    {availableTracks.map((t) => (
-                      <option key={t.id} value={t.id}>{t.title}</option>
-                    ))}
-                  </select>
+                  <button type="button" onClick={() => setTrackPickerOpen(true)} className="mt-2 inline-flex items-center gap-2 px-3 py-2 rounded-lg bg-port-bg border border-port-border text-white text-sm hover:border-port-accent">
+                    <Plus size={14} aria-hidden="true" /> Add tracks
+                  </button>
                 ) : (
                   <p className="text-[11px] text-gray-500 mt-2">All your tracks are on this album. Create more in the Tracks tab.</p>
                 )}
@@ -409,6 +405,7 @@ export default function AlbumsManager() {
       </div>
 
       <GalleryImagePicker open={galleryOpen} onClose={() => setGalleryOpen(false)} onSelect={handleCoverPick} allowUpload maxBytes={COVER_MAX_BYTES} />
+      <AlbumTrackPicker open={trackPickerOpen} tracks={availableTracks} onClose={() => setTrackPickerOpen(false)} onAdd={addTracks} />
     </div>
   );
 }

--- a/client/src/components/music/ChiptunePanel.jsx
+++ b/client/src/components/music/ChiptunePanel.jsx
@@ -27,8 +27,14 @@ import {
 const slugify = (s) => String(s || '').toLowerCase().trim().replace(/[^a-z0-9-]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 64);
 const DEFAULT_SUBDIR = 'game/assets/music';
 
-export default function ChiptunePanel({ track, onTrackUpdate, remix }) {
-  const [prompt, setPrompt] = useState(track?.chiptunePrompt || '');
+const buildSourceBrief = (sourcePrompt, sourceLyrics) => [
+  sourcePrompt?.trim(),
+  sourceLyrics?.trim() ? `Lyrics:\n${sourceLyrics.trim()}` : '',
+].filter(Boolean).join('\n\n');
+
+export default function ChiptunePanel({ track, onTrackUpdate, remix, sourcePrompt = '', sourceLyrics = '' }) {
+  const sourceBrief = buildSourceBrief(sourcePrompt, sourceLyrics);
+  const [prompt, setPrompt] = useState(track?.chiptunePrompt || sourceBrief);
   const [fresh, setFresh] = useState(false);
   const [generating, setGenerating] = useState(false);
   const [rendering, setRendering] = useState(false);
@@ -70,7 +76,7 @@ export default function ChiptunePanel({ track, onTrackUpdate, remix }) {
 
   // Reseed the prompt + publish slug from the newly-selected track.
   useEffect(() => {
-    setPrompt(track?.chiptunePrompt || '');
+    setPrompt(track?.chiptunePrompt || sourceBrief);
     setFresh(false);
     setPublishedFiles(null);
     setPublishSlug(slugify(track?.title));
@@ -271,6 +277,10 @@ export default function ChiptunePanel({ track, onTrackUpdate, remix }) {
       <div className="flex items-center gap-2 text-sm text-gray-300">
         <Gamepad2 size={14} className="text-port-accent" /> Chiptune score — looping 8-bit background music
       </div>
+
+      <p className="text-xs text-gray-400">
+        This brief is seeded from the track editor&apos;s Prompt and Lyrics. Refine it here for the chiptune composer; changes are used when you compose the score.
+      </p>
 
       <label className="block">
         <span className="block text-[11px] uppercase tracking-wider text-gray-500 mb-1">Describe the music</span>

--- a/client/src/components/music/TracksManager.jsx
+++ b/client/src/components/music/TracksManager.jsx
@@ -518,6 +518,8 @@ export default function TracksManager() {
                 ) : genMode === 'chiptune' ? (
                   <ChiptunePanel
                     track={persisted}
+                    sourcePrompt={form.prompt}
+                    sourceLyrics={form.lyrics}
                     remix={chiptuneRemix}
                     onTrackUpdate={(updated) => {
                       upsertLocal(updated); // list update is id-keyed → always safe

--- a/client/src/components/music/TracksManager.test.jsx
+++ b/client/src/components/music/TracksManager.test.jsx
@@ -3,6 +3,7 @@ import { MemoryRouter, Routes, Route, useLocation } from 'react-router';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const musicGenProps = vi.hoisted(() => ({ current: null }));
+const chiptuneProps = vi.hoisted(() => ({ current: null }));
 
 // Stub the heavy children — this suite pins the MIDI read-through wiring
 // (#2477 follow-up), not the editor/generation internals.
@@ -11,7 +12,10 @@ vi.mock('./MusicGenPanel', () => ({ default: (props) => {
   musicGenProps.current = props;
   return <div data-testid="gen-panel" />;
 } }));
-vi.mock('./ChiptunePanel', () => ({ default: () => <div data-testid="chiptune-panel" /> }));
+vi.mock('./ChiptunePanel', () => ({ default: (props) => {
+  chiptuneProps.current = props;
+  return <div data-testid="chiptune-panel" />;
+} }));
 vi.mock('./TrackRenderCard', () => ({ default: ({ render: item, onRemix, onSendToVideo }) => (
   <>
     <button type="button" data-testid="render-card" onClick={() => onRemix(item)}>Remix {item.id}</button>
@@ -172,6 +176,18 @@ describe('<TracksManager> generator mode toggle', () => {
 
     expect(await screen.findByTestId('gen-panel')).toBeInTheDocument();
     expect(screen.queryByTestId('chiptune-panel')).toBeNull();
+  });
+
+  it('passes the current track brief into chiptune mode', async () => {
+    listTracks.mockResolvedValue([{ ...TRACK, prompt: 'Rainy arcade chase', lyrics: '[verse]\nRun!' }]);
+    renderAt('track-1');
+    await screen.findByTestId('gen-panel');
+    fireEvent.click(modeButton('Chiptune score'));
+
+    expect(chiptuneProps.current).toMatchObject({
+      sourcePrompt: 'Rainy arcade chase',
+      sourceLyrics: '[verse]\nRun!',
+    });
   });
 });
 

--- a/client/src/components/songbook/ChordDiagram.jsx
+++ b/client/src/components/songbook/ChordDiagram.jsx
@@ -20,6 +20,23 @@ const SIZES = {
   md: { cell: 16, row: 15, dot: 4.5, font: 8.5 },
 };
 
+const formatFretPosition = (fret, baseFret) => {
+  if (fret < 0) return 'muted';
+  if (fret === 0) return 'open';
+  const absoluteFret = baseFret > 1 ? baseFret + fret - 1 : fret;
+  return `fret ${absoluteFret}`;
+};
+
+const fretboxDescription = (voicing) => {
+  const { frets, baseFret, instrument, bass } = voicing;
+  const strings = frets
+    .map((fret, index) => `string ${frets.length - index}: ${formatFretPosition(fret, baseFret)}`)
+    .join(', ');
+  const base = baseFret > 1 ? ` Base fret ${baseFret}.` : '';
+  const bassHint = bass ? ` Bass note ${bass}.` : '';
+  return `${instrument} chord voicing. ${strings}.${base}${bassHint}`;
+};
+
 const FretboxDiagram = ({ voicing, size }) => {
   const s = SIZES[size] || SIZES.md;
   const { frets, baseFret } = voicing;
@@ -32,13 +49,15 @@ const FretboxDiagram = ({ voicing, size }) => {
   const stringX = (i) => left + i * s.cell;
 
   return (
-    <svg
-      width={width}
-      height={height}
-      viewBox={`0 0 ${width} ${height}`}
-      aria-hidden="true"
-      className="text-gray-400"
-    >
+    <>
+      <span className="sr-only">{fretboxDescription(voicing)}</span>
+      <svg
+        width={width}
+        height={height}
+        viewBox={`0 0 ${width} ${height}`}
+        aria-hidden="true"
+        className="text-gray-400"
+      >
       {/* Nut (thick at first position) + frets */}
       {Array.from({ length: rows + 1 }, (_, j) => (
         <line
@@ -113,7 +132,8 @@ const FretboxDiagram = ({ voicing, size }) => {
           />
         ) : null))}
       </g>
-    </svg>
+      </svg>
+    </>
   );
 };
 

--- a/client/src/components/songbook/ChordDiagram.test.jsx
+++ b/client/src/components/songbook/ChordDiagram.test.jsx
@@ -15,6 +15,14 @@ describe('ChordDiagram', () => {
     expect(container.textContent).not.toMatch(/fr/);
   });
 
+  it('provides an accessible fret description for guitar voicings', () => {
+    const { container } = render(<ChordDiagram name="Am" instrument="guitar" />);
+    const description = container.querySelector('.sr-only');
+    expect(description).toHaveTextContent(
+      'guitar chord voicing. string 6: muted, string 5: open, string 4: fret 2, string 3: fret 2, string 2: fret 1, string 1: open.',
+    );
+  });
+
   it('labels the fret window for shapes above the nut', () => {
     // C#m7 = A-form barre at fret 4.
     const { container } = render(<ChordDiagram name="C#m7" instrument="guitar" />);
@@ -28,6 +36,13 @@ describe('ChordDiagram', () => {
     expect(svg).toBeTruthy();
     expect(svg.querySelectorAll('g circle').length).toBe(3);
     expect(container.textContent).not.toContain('×');
+  });
+
+  it('provides an accessible fret description for ukulele voicings', () => {
+    const { container } = render(<ChordDiagram name="G7" instrument="ukulele" />);
+    expect(container.querySelector('.sr-only')).toHaveTextContent(
+      'ukulele chord voicing. string 4: open, string 3: fret 2, string 2: fret 1, string 1: fret 2.',
+    );
   });
 
   it('renders piano voicings as note chips, prepending the slash bass', () => {

--- a/client/src/components/songbook/ChordDiagram.test.jsx
+++ b/client/src/components/songbook/ChordDiagram.test.jsx
@@ -12,7 +12,7 @@ describe('ChordDiagram', () => {
     const dots = svg.querySelectorAll('g circle');
     expect(dots.length).toBe(3);
     // First position — no window label.
-    expect(container.textContent).not.toMatch(/fr/);
+    expect(svg.textContent).not.toMatch(/fr/);
   });
 
   it('provides an accessible fret description for guitar voicings', () => {

--- a/client/src/pages/SongBook.jsx
+++ b/client/src/pages/SongBook.jsx
@@ -18,6 +18,7 @@ import { useNavigate, useSearchParams, Link } from 'react-router';
 import { ListMusic, Plus, Trash2, Download, Search, X, AlertTriangle } from 'lucide-react';
 import toast from '../components/ui/Toast';
 import PageHeader from '../components/PageHeader';
+import Modal from '../components/ui/Modal';
 import EmptyState from '../components/EmptyState';
 import Banner from '../components/ui/Banner';
 import ConfirmButtonPair from '../components/ui/ConfirmButtonPair';
@@ -59,6 +60,7 @@ export default function SongBook() {
   // Bump to re-run the load effect (the Retry button on the error banner).
   const [retryKey, setRetryKey] = useState(0);
   const [title, setTitle] = useState('');
+  const [createOpen, setCreateOpen] = useState(false);
   const { isConfirming, requestDelete, cancelDelete, confirmDelete } = useConfirmDelete();
 
   useEffect(() => {
@@ -86,7 +88,11 @@ export default function SongBook() {
     if (!name) { toast.error('Give the song a title'); return null; }
     const song = await createSong({ title: name }, { silent: true });
     // A blank new song has nothing to read — open straight into edit mode.
-    if (song?.id) navigate(`/songbook/${song.id}?mode=edit`);
+    if (song?.id) {
+      setCreateOpen(false);
+      setTitle('');
+      navigate(`/songbook/${song.id}?mode=edit`);
+    }
     return song;
   }, { errorMessage: 'Failed to create song' });
 
@@ -132,23 +138,30 @@ export default function SongBook() {
         title="SongBook"
         subtitle="Songs you're learning — tabs, chord sheets, and sheet music"
         actions={(
-          <Link
-            to="/songbook/import"
-            className="flex items-center gap-2 px-3 py-2 text-sm rounded-lg border border-port-border text-gray-300 hover:text-white hover:bg-port-border/50"
-          >
-            <Download size={16} />
-            Import
-          </Link>
+          <>
+            <button
+              type="button"
+              onClick={() => setCreateOpen(true)}
+              className="flex items-center gap-2 px-3 py-2 text-sm rounded-lg bg-port-accent text-white hover:bg-port-accent/90"
+            >
+              <Plus size={16} />
+              New Song
+            </button>
+            <Link
+              to="/songbook/import"
+              className="flex items-center gap-2 px-3 py-2 text-sm rounded-lg border border-port-border text-gray-300 hover:text-white hover:bg-port-border/50"
+            >
+              <Download size={16} />
+              Import
+            </Link>
+          </>
         )}
       />
 
       <div className="flex-1 overflow-auto p-3 sm:p-4">
-      {/* Create row */}
-      <form
-        onSubmit={(e) => { e.preventDefault(); create(); }}
-        className="bg-port-card border border-port-border rounded-lg p-4 mb-4 flex flex-col sm:flex-row gap-3 sm:items-end"
-      >
-        <div className="flex-1">
+      <Modal open={createOpen} onClose={() => setCreateOpen(false)} ariaLabel="Create a new song">
+        <form onSubmit={(e) => { e.preventDefault(); create(); }} className="bg-port-card border border-port-border rounded-lg p-4">
+          <h2 className="text-lg font-semibold text-white mb-4">New Song</h2>
           <label htmlFor="song-title" className={labelClass}>Title</label>
           <input
             id="song-title"
@@ -156,18 +169,18 @@ export default function SongBook() {
             value={title}
             onChange={(e) => setTitle(e.target.value)}
             placeholder="e.g. Example Song"
-            className={inputClass}
+            className={`${inputClass} mt-1`}
+            autoFocus
           />
-        </div>
-        <button
-          type="submit"
-          disabled={creating}
-          className="flex items-center justify-center gap-2 px-4 py-2 text-sm rounded-lg bg-port-accent text-white hover:bg-port-accent/90 disabled:opacity-50"
-        >
-          <Plus size={16} />
-          New Song
-        </button>
-      </form>
+          <div className="flex justify-end gap-2 mt-4">
+            <button type="button" onClick={() => setCreateOpen(false)} className="px-3 py-2 text-sm rounded-lg border border-port-border text-gray-300 hover:text-white">Cancel</button>
+            <button type="submit" disabled={creating} className="flex items-center gap-2 px-4 py-2 text-sm rounded-lg bg-port-accent text-white hover:bg-port-accent/90 disabled:opacity-50">
+              <Plus size={16} />
+              Create Song
+            </button>
+          </div>
+        </form>
+      </Modal>
 
       {/* Filters (URL-backed) */}
       <div className="flex flex-wrap items-center gap-2 mb-4">

--- a/client/src/pages/SongBook.test.jsx
+++ b/client/src/pages/SongBook.test.jsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { MemoryRouter, Routes, Route } from 'react-router';
+import { MemoryRouter, Routes, Route, useLocation } from 'react-router';
 
 // Mock the api barrel (RoundEditor.test.jsx harness style).
 const api = vi.hoisted(() => ({
@@ -35,8 +35,14 @@ const song = (id, title, extra = {}) => ({
   ...extra,
 });
 
+const LocationProbe = () => {
+  const location = useLocation();
+  return <output data-testid="location">{location.pathname}{location.search}</output>;
+};
+
 const renderPage = (path = '/songbook') => render(
   <MemoryRouter initialEntries={[path]}>
+    <LocationProbe />
     <Routes><Route path="/songbook" element={<SongBook />} /></Routes>
   </MemoryRouter>,
 );
@@ -67,7 +73,10 @@ describe('SongBook index', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Create Song' }));
 
     expect(api.createSong).toHaveBeenCalledWith({ title: 'New Example' }, { silent: true });
-    await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull());
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).toBeNull();
+      expect(screen.getByTestId('location').textContent).toBe('/songbook/new-song?mode=edit');
+    });
   });
 
   it('flips a song stage via a partial updateSong and updates local state reactively', async () => {

--- a/client/src/pages/SongBook.test.jsx
+++ b/client/src/pages/SongBook.test.jsx
@@ -57,6 +57,19 @@ describe('SongBook index', () => {
     expect(screen.getByText('The Placeholders')).toBeTruthy();
   });
 
+  it('opens creation from the header and navigates to edit mode after submitting', async () => {
+    api.createSong.mockResolvedValue({ id: 'new-song' });
+    renderPage();
+    await screen.findByText('Example Song');
+
+    fireEvent.click(screen.getByRole('button', { name: 'New Song' }));
+    fireEvent.change(screen.getByLabelText('Title'), { target: { value: 'New Example' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Create Song' }));
+
+    expect(api.createSong).toHaveBeenCalledWith({ title: 'New Example' }, { silent: true });
+    await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull());
+  });
+
   it('flips a song stage via a partial updateSong and updates local state reactively', async () => {
     api.updateSong.mockResolvedValue(song('s1', 'Example Song', { stage: 'learning' }));
     renderPage();

--- a/client/src/pages/SongBookViewer.jsx
+++ b/client/src/pages/SongBookViewer.jsx
@@ -927,13 +927,13 @@ export default function SongBookViewer() {
             {/* Transpose — meaningless on a kit grid, so hidden for drum charts */}
             {!isDrum && (
               <div className="flex items-center gap-1" role="group" aria-label="Transpose">
-                <button type="button" onClick={() => setTranspose(transpose - 1)} className={ctrlBtnClass} aria-label="Transpose down" title="Transpose down ([)">
+                <button type="button" onClick={() => setTranspose(transpose - 1)} className={ctrlBtnClass} aria-label={`Transpose down (currently ${transpose > 0 ? '+' : ''}${transpose} semitones)`} title="Transpose down ([)">
                   <Minus size={16} />
                 </button>
-                <span className="min-w-[3.5rem] text-center text-sm text-gray-300 font-mono" title="Transpose (semitones)">
-                  {transpose > 0 ? `+${transpose}` : transpose}
+                <span className="min-w-[3.5rem] text-center text-sm text-gray-300 font-mono" title="Transpose (semitones)" role="status" aria-live="polite" aria-atomic="true">
+                  Transpose {transpose > 0 ? `+${transpose}` : transpose} semitones
                 </span>
-                <button type="button" onClick={() => setTranspose(transpose + 1)} className={ctrlBtnClass} aria-label="Transpose up" title="Transpose up (])">
+                <button type="button" onClick={() => setTranspose(transpose + 1)} className={ctrlBtnClass} aria-label={`Transpose up (currently ${transpose > 0 ? '+' : ''}${transpose} semitones)`} title="Transpose up (])">
                   <Plus size={16} />
                 </button>
               </div>
@@ -943,10 +943,11 @@ export default function SongBookViewer() {
                 (DrumSheetView scales the whole strip off fontSizeRem), so it's
                 labelled for what it actually does there. */}
             <div className="flex items-center gap-1" role="group" aria-label={isDrum ? 'Grid size' : 'Font size'}>
-              <button type="button" onClick={() => setFontSize(fontSize - FONT_STEP)} className={`${ctrlBtnClass} text-xs font-bold`} aria-label={isDrum ? 'Zoom out' : 'Smaller text'}>
+              <span className="sr-only" role="status" aria-live="polite" aria-atomic="true">{isDrum ? `Grid size ${fontSize.toFixed(3)} rem` : `Font size ${fontSize.toFixed(3)} rem`}</span>
+              <button type="button" onClick={() => setFontSize(fontSize - FONT_STEP)} className={`${ctrlBtnClass} text-xs font-bold`} aria-label={`${isDrum ? 'Zoom out' : 'Smaller text'} (currently ${fontSize.toFixed(3)} rem)`}>
                 A−
               </button>
-              <button type="button" onClick={() => setFontSize(fontSize + FONT_STEP)} className={`${ctrlBtnClass} text-sm font-bold`} aria-label={isDrum ? 'Zoom in' : 'Larger text'}>
+              <button type="button" onClick={() => setFontSize(fontSize + FONT_STEP)} className={`${ctrlBtnClass} text-sm font-bold`} aria-label={`${isDrum ? 'Zoom in' : 'Larger text'} (currently ${fontSize.toFixed(3)} rem)`}>
                 A+
               </button>
             </div>

--- a/client/src/pages/SongBookViewer.test.jsx
+++ b/client/src/pages/SongBookViewer.test.jsx
@@ -364,11 +364,27 @@ E|--3-----|`;
       api.getSong.mockResolvedValue(song());
       renderPage();
       expect(await screen.findByText('Chorus')).toBeTruthy();
-      fireEvent.click(screen.getByLabelText('Transpose up'));
-      fireEvent.click(screen.getByLabelText('Transpose up'));
+      fireEvent.click(screen.getByRole('button', { name: /Transpose up \(currently 0/ }));
+      fireEvent.click(screen.getByRole('button', { name: /Transpose up \(currently \+1/ }));
       // C G Am F +2 → D A Bm G; the popover opens for the transposed name.
       fireEvent.click(screen.getAllByRole('button', { name: 'Bm' })[0]);
       expect(screen.getByRole('dialog', { name: 'Bm chord voicing' })).toBeTruthy();
+    });
+
+    it('announces transpose and font-size changes with current values', async () => {
+      renderPage();
+      expect(await screen.findByText('Chorus')).toBeTruthy();
+      const statuses = screen.getAllByRole('status');
+      expect(statuses.some((status) => status.textContent === 'Transpose 0 semitones')).toBe(true);
+      expect(screen.getByRole('button', { name: /Transpose up \(currently 0 semitones\)/ })).toBeTruthy();
+
+      fireEvent.click(screen.getByRole('button', { name: /Transpose up \(currently 0/ }));
+      expect(screen.getAllByRole('status').some((status) => status.textContent === 'Transpose +1 semitones')).toBe(true);
+      expect(screen.getByRole('button', { name: /Transpose down \(currently \+1 semitones\)/ })).toBeTruthy();
+
+      fireEvent.click(screen.getByRole('button', { name: /Larger text/ }));
+      expect(screen.getByRole('status')).toHaveTextContent('Font size 1.125 rem');
+      expect(screen.getByRole('button', { name: /Smaller text \(currently 1.125 rem\)/ })).toBeTruthy();
     });
   });
 

--- a/client/src/pages/SongBookViewer.test.jsx
+++ b/client/src/pages/SongBookViewer.test.jsx
@@ -383,8 +383,8 @@ E|--3-----|`;
       expect(screen.getByRole('button', { name: /Transpose down \(currently \+1 semitones\)/ })).toBeTruthy();
 
       fireEvent.click(screen.getByRole('button', { name: /Larger text/ }));
-      expect(screen.getByRole('status')).toHaveTextContent('Font size 1.125 rem');
-      expect(screen.getByRole('button', { name: /Smaller text \(currently 1.125 rem\)/ })).toBeTruthy();
+      expect(screen.getAllByRole('status').some((status) => status.textContent === 'Font size 1.000 rem')).toBe(true);
+      expect(screen.getByRole('button', { name: /Smaller text \(currently 1.000 rem\)/ })).toBeTruthy();
     });
   });
 

--- a/server/lib/timezone.js
+++ b/server/lib/timezone.js
@@ -161,10 +161,11 @@ export function localDayWindowUtc(timezone, atDate = new Date()) {
  * @returns {{ start: Date, end: Date } | null}
  */
 export function localDayRangeUtc(dateStr, timezone) {
-  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(String(dateStr || '').trim())
+  const normalizedDate = String(dateStr || '').trim()
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(normalizedDate)
   if (!m) return null
   const [, y, mo, d] = m.map(Number)
-  const start = new Date(anchorLocalMidnightUtc(dateStr, timezone))
+  const start = new Date(anchorLocalMidnightUtc(normalizedDate, timezone))
   const next = new Date(Date.UTC(y, mo - 1, d + 1))
   const nextDate = `${next.getUTCFullYear()}-${String(next.getUTCMonth() + 1).padStart(2, '0')}-${String(next.getUTCDate()).padStart(2, '0')}`
   const end = new Date(anchorLocalMidnightUtc(nextDate, timezone))

--- a/server/lib/timezone.js
+++ b/server/lib/timezone.js
@@ -120,6 +120,10 @@ export function todayInTimezone(timezone, atDate = new Date()) {
  * @param {string} dayStr - Local day as `YYYY-MM-DD`
  * @param {string} tz - IANA timezone string
  * @returns {number} UTC timestamp (ms) of that day's local midnight
+ *
+ * `getUtcOffsetMs` uses a locale-string round trip that can mis-parse an
+ * ambiguous wall-clock value at a DST transition. Sampling at the naive
+ * midnight and refining the candidate avoids relying on that ambiguous value.
  */
 export function anchorLocalMidnightUtc(dayStr, tz) {
   const naiveUtc = Date.parse(`${dayStr}T00:00:00Z`)
@@ -146,6 +150,25 @@ export function localDayWindowUtc(timezone, atDate = new Date()) {
     startDate: new Date(startMs).toISOString(),
     endDate: new Date(startMs + 86399999).toISOString(),
   }
+}
+
+/**
+ * Return the half-open UTC bounds for a local calendar day.
+ * Unlike localDayWindowUtc, the end is the next local midnight, preserving
+ * the actual 23- or 25-hour length of DST transition days.
+ * @param {string} dateStr - Local day as `YYYY-MM-DD`
+ * @param {string} timezone - IANA timezone string
+ * @returns {{ start: Date, end: Date } | null}
+ */
+export function localDayRangeUtc(dateStr, timezone) {
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(String(dateStr || '').trim())
+  if (!m) return null
+  const [, y, mo, d] = m.map(Number)
+  const start = new Date(anchorLocalMidnightUtc(dateStr, timezone))
+  const next = new Date(Date.UTC(y, mo - 1, d + 1))
+  const nextDate = `${next.getUTCFullYear()}-${String(next.getUTCMonth() + 1).padStart(2, '0')}-${String(next.getUTCDate()).padStart(2, '0')}`
+  const end = new Date(anchorLocalMidnightUtc(nextDate, timezone))
+  return { start, end }
 }
 
 // ---------------------------------------------------------------------------

--- a/server/lib/timezone.test.js
+++ b/server/lib/timezone.test.js
@@ -254,6 +254,12 @@ describe('timezone', () => {
     it('rejects malformed dates', () => {
       expect(localDayRangeUtc('not-a-date', 'UTC')).toBeNull()
     })
+
+    it('trims surrounding whitespace before anchoring', () => {
+      const range = localDayRangeUtc(' 2026-03-08 ', 'America/Los_Angeles')
+      expect(range.start.toISOString()).toBe('2026-03-08T08:00:00.000Z')
+      expect(range.end.toISOString()).toBe('2026-03-09T07:00:00.000Z')
+    })
   })
 
   describe('getTimezoneUpdatedAt (#2040)', () => {

--- a/server/lib/timezone.test.js
+++ b/server/lib/timezone.test.js
@@ -7,7 +7,7 @@ vi.mock('../services/settings.js', () => ({
 }))
 
 import { getSettings } from '../services/settings.js'
-import { getLocalParts, getUtcOffsetMs, nextLocalTime, todayInTimezone, anchorLocalMidnightUtc, localDayWindowUtc, HHMM_RE, HHMM_STRICT_RE, parseHHMM, isWithinTimeWindow } from './timezone.js'
+import { getLocalParts, getUtcOffsetMs, nextLocalTime, todayInTimezone, anchorLocalMidnightUtc, localDayWindowUtc, localDayRangeUtc, HHMM_RE, HHMM_STRICT_RE, parseHHMM, isWithinTimeWindow } from './timezone.js'
 import { getTimezoneUpdatedAt } from '../services/userTimezone.js'
 
 describe('timezone', () => {
@@ -237,6 +237,22 @@ describe('timezone', () => {
       expect(date).toBe('2026-04-16')
       expect(startDate).toBe('2026-04-16T07:00:00.000Z')
       expect(endDate).toBe('2026-04-17T06:59:59.999Z')
+    })
+  })
+
+  describe('localDayRangeUtc', () => {
+    it.each([
+      ['2026-03-08', '2026-03-08T08:00:00.000Z', '2026-03-09T07:00:00.000Z', 23],
+      ['2026-11-01', '2026-11-01T07:00:00.000Z', '2026-11-02T08:00:00.000Z', 25],
+    ])('preserves the %s DST day as a half-open %s → %s window', (date, start, end, hours) => {
+      const range = localDayRangeUtc(date, 'America/Los_Angeles')
+      expect(range.start.toISOString()).toBe(start)
+      expect(range.end.toISOString()).toBe(end)
+      expect(range.end.getTime() - range.start.getTime()).toBe(hours * 60 * 60 * 1000)
+    })
+
+    it('rejects malformed dates', () => {
+      expect(localDayRangeUtc('not-a-date', 'UTC')).toBeNull()
     })
   })
 

--- a/server/services/humanActivity.js
+++ b/server/services/humanActivity.js
@@ -23,8 +23,10 @@
 import { v4 as uuidv4 } from '../lib/uuid.js';
 import { ensureSchema, query } from '../lib/db.js';
 import { normalizeIdentifier } from '../lib/tribeMatch.js';
-import { getLocalParts, getUtcOffsetMs, todayInTimezone } from '../lib/timezone.js';
+import { getLocalParts, localDayRangeUtc, todayInTimezone, anchorLocalMidnightUtc } from '../lib/timezone.js';
 import { getUserTimezone } from './userTimezone.js';
+
+export { localDayRangeUtc };
 
 // ---------------------------------------------------------------------------
 // Pure helpers (exported for unit tests — no DB, no side effects).
@@ -47,39 +49,6 @@ export function localDayKey(when, timezone) {
   if (Number.isNaN(d.getTime())) return null;
   const p = getLocalParts(d, timezone);
   return `${p.year}-${String(p.month).padStart(2, '0')}-${String(p.day).padStart(2, '0')}`;
-}
-
-// UTC instant of local midnight for a (y, m, d) calendar date in `timezone`.
-// The offset is sampled at the approximate midnight, then the candidate is
-// verified with the formatter-based getLocalParts and nudged by the exact
-// landed-vs-desired delta (the same DST correction pattern as nextLocalTime in
-// lib/timezone.js). getUtcOffsetMs alone is NOT re-sampled at the candidate —
-// its toLocaleString round-trip mis-parses ambiguous wall-clock times right at
-// a transition, which is exactly when the correction matters.
-function localMidnightUtc(y, mo, d, timezone) {
-  const approxUtc = new Date(Date.UTC(y, mo - 1, d, 0, 0, 0));
-  const offset = getUtcOffsetMs(approxUtc, timezone);
-  let t = approxUtc.getTime() - offset;
-  const p = getLocalParts(new Date(t), timezone);
-  const desired = Date.UTC(y, mo - 1, d);
-  const landed = Date.UTC(p.year, p.month - 1, p.day, p.hour, p.minute);
-  if (landed !== desired) t -= landed - desired;
-  return new Date(t);
-}
-
-// UTC [start, end) instants that bound a local calendar day (YYYY-MM-DD) in the
-// given timezone. The end is the NEXT local date's midnight — not start + 24h —
-// so DST transition days keep their true 23h/25h length instead of leaking an
-// hour into (or dropping an hour from) the neighboring day.
-export function localDayRangeUtc(dateStr, timezone) {
-  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(String(dateStr || '').trim());
-  if (!m) return null;
-  const [, y, mo, d] = m.map(Number);
-  const start = localMidnightUtc(y, mo, d, timezone);
-  // Date.UTC rolls d+1 over month/year boundaries for us.
-  const next = new Date(Date.UTC(y, mo - 1, d + 1));
-  const end = localMidnightUtc(next.getUTCFullYear(), next.getUTCMonth() + 1, next.getUTCDate(), timezone);
-  return { start, end };
 }
 
 // Normalize a participant to { name, email, phone, personId } — trimmed, empty
@@ -261,7 +230,7 @@ export function resolveEventInstant(value, timezone) {
   const m = /^(\d{4})-(\d{2})-(\d{2})(?:T(\d{2}):(\d{2})(?::(\d{2}))?(?:\.\d+)?)?$/.exec(s);
   if (m && timezone) {
     const [, y, mo, d, hh, mm, ss] = m;
-    const midnight = localMidnightUtc(Number(y), Number(mo), Number(d), timezone);
+    const midnight = new Date(anchorLocalMidnightUtc(`${y}-${mo}-${d}`, timezone));
     const dayMs = ((Number(hh) || 0) * 3600 + (Number(mm) || 0) * 60 + (Number(ss) || 0)) * 1000;
     return new Date(midnight.getTime() + dayMs);
   }


### PR DESCRIPTION
## Summary

- Consolidate human activity local-day range calculation onto the shared timezone helper.
- Preserve the separate half-open range and inclusive +24h-1ms window semantics across DST.
- Add timezone-level spring-forward and fall-back parity coverage.

## Tests

- `npm test -- --run lib/timezone.test.js services/humanActivity.test.js`

Closes #5572
