### PR TITLE
fix: keep Music Designer lyrics controls visible (#5565)

### DIFF
--- a/client/src/components/music/MusicDesigner.jsx
+++ b/client/src/components/music/MusicDesigner.jsx
@@ -495,17 +495,6 @@ export default function MusicDesigner() {
               </button>
             )}
           </div>
-          <div className="rounded border border-port-border bg-port-bg/60 p-3 text-xs text-gray-400">
-            <p className="mb-2 font-medium text-gray-300">Manual composition structure</p>
-            <p className="mb-2">Put one section tag on its own line, then begin its singable words on the next line. A useful arc is: intro → verse → pre-chorus → chorus → verse 2 → chorus → bridge → final chorus → outro.</p>
-            <ul className="mb-3 list-disc space-y-1 pl-4">
-              <li>Use 4–8 short lines for a verse and 2–4 lines for a pre-chorus or bridge.</li>
-              <li>Give the chorus a repeated hook; repeat the tag when the chorus returns.</li>
-              <li>Use tags such as <code className="text-gray-300">[instrumental]</code> and <code className="text-gray-300">[solo]</code> for wordless sections; keep tempo, meter, and production direction in the description.</li>
-              <li>Include enough sections for the intended duration—MiniMax can end early when the lyric structure runs out.</li>
-            </ul>
-            <pre className="overflow-x-auto rounded bg-port-bg p-2 font-mono text-[11px] text-gray-300">{`[verse]\nShort image, short line\nA second line to sing\n\n[pre-chorus]\nBuild the thought\nTurn toward the hook\n\n[chorus]\nA repeatable hook\nA repeatable hook`}</pre>
-          </div>
           <label htmlFor="music-designer-lyrics" className="block">
             <span className={LABEL_CLASS}>Lyrics</span>
             <textarea
@@ -528,6 +517,19 @@ export default function MusicDesigner() {
               On the render step, enable Instrumental only to prohibit wordless or background vocals too.
             </p>
           )}
+          <details className="rounded border border-port-border bg-port-bg/60 p-3 text-xs text-gray-400">
+            <summary className="cursor-pointer font-medium text-gray-300">Manual composition structure</summary>
+            <div className="pt-2">
+              <p className="mb-2">Put one section tag on its own line, then begin its singable words on the next line. A useful arc is: intro → verse → pre-chorus → chorus → verse 2 → chorus → bridge → final chorus → outro.</p>
+              <ul className="mb-3 list-disc space-y-1 pl-4">
+                <li>Use 4–8 short lines for a verse and 2–4 lines for a pre-chorus or bridge.</li>
+                <li>Give the chorus a repeated hook; repeat the tag when the chorus returns.</li>
+                <li>Use tags such as <code className="text-gray-300">[instrumental]</code> and <code className="text-gray-300">[solo]</code> for wordless sections; keep tempo, meter, and production direction in the description.</li>
+                <li>Include enough sections for the intended duration—MiniMax can end early when the lyric structure runs out.</li>
+              </ul>
+              <pre className="overflow-x-auto rounded bg-port-bg p-2 font-mono text-[11px] text-gray-300">{`[verse]\nShort image, short line\nA second line to sing\n\n[pre-chorus]\nBuild the thought\nTurn toward the hook\n\n[chorus]\nA repeatable hook\nA repeatable hook`}</pre>
+            </div>
+          </details>
         </div>
       )}
 

--- a/client/src/components/music/MusicDesigner.test.jsx
+++ b/client/src/components/music/MusicDesigner.test.jsx
@@ -252,7 +252,13 @@ describe('<MusicDesigner>', () => {
       fireEvent.click(screen.getByRole('button', { name: /generate lyrics/i }));
 
       await waitFor(() => expect(screen.getByLabelText('Lyrics')).toHaveValue('[verse]\nrain on the window'));
-      expect(screen.getByText(/manual composition structure/i)).toBeInTheDocument();
+      const lyricsField = screen.getByLabelText('Lyrics');
+      const guide = screen.getByText(/manual composition structure/i);
+      expect(guide).toBeInTheDocument();
+      expect(guide.closest('details')).not.toHaveAttribute('open');
+      expect(lyricsField.compareDocumentPosition(guide)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+      fireEvent.click(guide);
+      expect(guide.closest('details')).toHaveAttribute('open');
       expect(api.generateLyrics).toHaveBeenCalledWith({
         description: 'Lush pads over a broken beat.',
         guidance: 'about leaving at dawn',


### PR DESCRIPTION
## Summary
- Keep the editable lyrics textarea and progression action directly after the lyrics generation controls.
- Move the manual composition reference into a collapsed, expandable details section below the primary controls.

## Tests
- `npm test -- --run src/components/music/MusicDesigner.test.jsx` (20 passed)
- `npx biome check ...` could not run because the installed Biome binary is permission-denied.

Closes #5565
