### PR TITLE
fix: bind chiptune mode to track brief

### DIFF
--- a/client/src/components/music/ChiptunePanel.jsx
+++ b/client/src/components/music/ChiptunePanel.jsx
@@ -27,8 +27,14 @@ import {
 const slugify = (s) => String(s || '').toLowerCase().trim().replace(/[^a-z0-9-]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 64);
 const DEFAULT_SUBDIR = 'game/assets/music';
 
-export default function ChiptunePanel({ track, onTrackUpdate, remix }) {
-  const [prompt, setPrompt] = useState(track?.chiptunePrompt || '');
+const buildSourceBrief = (sourcePrompt, sourceLyrics) => [
+  sourcePrompt?.trim(),
+  sourceLyrics?.trim() ? `Lyrics:\n${sourceLyrics.trim()}` : '',
+].filter(Boolean).join('\n\n');
+
+export default function ChiptunePanel({ track, onTrackUpdate, remix, sourcePrompt = '', sourceLyrics = '' }) {
+  const sourceBrief = buildSourceBrief(sourcePrompt, sourceLyrics);
+  const [prompt, setPrompt] = useState(track?.chiptunePrompt || sourceBrief);
   const [fresh, setFresh] = useState(false);
   const [generating, setGenerating] = useState(false);
   const [rendering, setRendering] = useState(false);
@@ -70,7 +76,7 @@ export default function ChiptunePanel({ track, onTrackUpdate, remix }) {
 
   // Reseed the prompt + publish slug from the newly-selected track.
   useEffect(() => {
-    setPrompt(track?.chiptunePrompt || '');
+    setPrompt(track?.chiptunePrompt || sourceBrief);
     setFresh(false);
     setPublishedFiles(null);
     setPublishSlug(slugify(track?.title));
@@ -271,6 +277,10 @@ export default function ChiptunePanel({ track, onTrackUpdate, remix }) {
       <div className="flex items-center gap-2 text-sm text-gray-300">
         <Gamepad2 size={14} className="text-port-accent" /> Chiptune score — looping 8-bit background music
       </div>
+
+      <p className="text-xs text-gray-400">
+        This brief is seeded from the track editor&apos;s Prompt and Lyrics. Refine it here for the chiptune composer; changes are used when you compose the score.
+      </p>
 
       <label className="block">
         <span className="block text-[11px] uppercase tracking-wider text-gray-500 mb-1">Describe the music</span>

--- a/client/src/components/music/TracksManager.jsx
+++ b/client/src/components/music/TracksManager.jsx
@@ -518,6 +518,8 @@ export default function TracksManager() {
                 ) : genMode === 'chiptune' ? (
                   <ChiptunePanel
                     track={persisted}
+                    sourcePrompt={form.prompt}
+                    sourceLyrics={form.lyrics}
                     remix={chiptuneRemix}
                     onTrackUpdate={(updated) => {
                       upsertLocal(updated); // list update is id-keyed → always safe

--- a/client/src/components/music/TracksManager.test.jsx
+++ b/client/src/components/music/TracksManager.test.jsx
@@ -3,6 +3,7 @@ import { MemoryRouter, Routes, Route, useLocation } from 'react-router';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const musicGenProps = vi.hoisted(() => ({ current: null }));
+const chiptuneProps = vi.hoisted(() => ({ current: null }));
 
 // Stub the heavy children — this suite pins the MIDI read-through wiring
 // (#2477 follow-up), not the editor/generation internals.
@@ -11,7 +12,10 @@ vi.mock('./MusicGenPanel', () => ({ default: (props) => {
   musicGenProps.current = props;
   return <div data-testid="gen-panel" />;
 } }));
-vi.mock('./ChiptunePanel', () => ({ default: () => <div data-testid="chiptune-panel" /> }));
+vi.mock('./ChiptunePanel', () => ({ default: (props) => {
+  chiptuneProps.current = props;
+  return <div data-testid="chiptune-panel" />;
+} }));
 vi.mock('./TrackRenderCard', () => ({ default: ({ render: item, onRemix, onSendToVideo }) => (
   <>
     <button type="button" data-testid="render-card" onClick={() => onRemix(item)}>Remix {item.id}</button>
@@ -172,6 +176,18 @@ describe('<TracksManager> generator mode toggle', () => {
 
     expect(await screen.findByTestId('gen-panel')).toBeInTheDocument();
     expect(screen.queryByTestId('chiptune-panel')).toBeNull();
+  });
+
+  it('passes the current track brief into chiptune mode', async () => {
+    listTracks.mockResolvedValue([{ ...TRACK, prompt: 'Rainy arcade chase', lyrics: '[verse]\nRun!' }]);
+    renderAt('track-1');
+    await screen.findByTestId('gen-panel');
+    fireEvent.click(modeButton('Chiptune score'));
+
+    expect(chiptuneProps.current).toMatchObject({
+      sourcePrompt: 'Rainy arcade chase',
+      sourceLyrics: '[verse]\nRun!',
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- Seed the chiptune composer from the track editor's current Prompt and Lyrics.
- Explain which fields condition each generation mode and let users refine the chiptune brief before composing.

## Tests
- `npm test -- --run src/components/music/TracksManager.test.jsx src/components/music/ChiptunePanel.test.jsx`

Closes #5569
