### PR TITLE
feat: searchable album track picker (#5567)

### DIFF
--- a/client/src/components/music/AlbumTrackPicker.jsx
+++ b/client/src/components/music/AlbumTrackPicker.jsx
@@ -1,0 +1,120 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Check, Music2, Plus, Search, X } from 'lucide-react';
+import Modal from '../ui/Modal';
+import { formatTimecode } from '../../utils/formatters';
+
+// Searchable, batch-oriented picker for adding existing library tracks to an
+// album. The parent owns persistence and ordering; this component only returns
+// the selected records in their current library order.
+export default function AlbumTrackPicker({ open, tracks = [], onClose, onAdd }) {
+  const [query, setQuery] = useState('');
+  const [selectedIds, setSelectedIds] = useState(() => new Set());
+
+  useEffect(() => {
+    if (!open) return;
+    setQuery('');
+    setSelectedIds(new Set());
+  }, [open]);
+
+  const filteredTracks = useMemo(() => {
+    const terms = query.trim().toLowerCase().split(/\s+/).filter(Boolean);
+    if (terms.length === 0) return tracks;
+    return tracks.filter((track) => {
+      const searchable = `${track.title || ''} ${track.artist || ''}`.toLowerCase();
+      return terms.every((term) => searchable.includes(term));
+    });
+  }, [tracks, query]);
+
+  const toggleTrack = (trackId) => {
+    setSelectedIds((previous) => {
+      const next = new Set(previous);
+      if (next.has(trackId)) next.delete(trackId);
+      else next.add(trackId);
+      return next;
+    });
+  };
+
+  const handleAdd = () => {
+    const selectedTracks = tracks.filter((track) => selectedIds.has(track.id));
+    if (selectedTracks.length === 0) return;
+    onAdd(selectedTracks);
+    onClose();
+  };
+
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      size="lg"
+      panelClassName="bg-port-card border border-port-border rounded-xl max-h-[85vh] flex flex-col"
+      ariaLabelledBy="album-track-picker-title"
+    >
+      <div className="flex items-center justify-between p-4 border-b border-port-border flex-shrink-0">
+        <div className="flex items-center gap-2">
+          <Music2 className="w-5 h-5 text-port-accent" aria-hidden="true" />
+          <h2 id="album-track-picker-title" className="text-lg font-bold text-white">Add tracks</h2>
+        </div>
+        <button type="button" onClick={onClose} aria-label="Close track picker" className="p-2 text-gray-500 hover:text-white rounded min-h-[44px] min-w-[44px] flex items-center justify-center">
+          <X size={18} aria-hidden="true" />
+        </button>
+      </div>
+
+      <div className="p-4 border-b border-port-border flex-shrink-0">
+        <div className="relative">
+          <Search size={14} className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-500" aria-hidden="true" />
+          <label htmlFor="album-track-picker-search" className="sr-only">Search tracks by title or artist</label>
+          <input
+            id="album-track-picker-search"
+            type="search"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Search by title or artist…"
+            autoFocus
+            className="w-full pl-9 pr-3 py-2 bg-port-bg border border-port-border rounded text-white text-sm focus:outline-none focus:border-port-accent"
+          />
+        </div>
+      </div>
+
+      <div className="flex-1 overflow-y-auto p-4 min-h-0">
+        {filteredTracks.length === 0 ? (
+          <p className="text-sm text-gray-400">No matching tracks.</p>
+        ) : (
+          <ul className="space-y-2">
+            {filteredTracks.map((track) => {
+              const checked = selectedIds.has(track.id);
+              return (
+                <li key={track.id}>
+                  <label className={`flex items-center gap-3 w-full p-3 rounded border bg-port-bg/40 cursor-pointer transition-colors ${checked ? 'border-port-accent' : 'border-port-border hover:border-gray-500'}`}>
+                    <input
+                      type="checkbox"
+                      checked={checked}
+                      onChange={() => toggleTrack(track.id)}
+                      className="accent-port-accent"
+                      aria-label={`Select ${track.title || 'untitled track'}`}
+                    />
+                    <span className="min-w-0 flex-1">
+                      <span className="block text-sm font-medium text-white truncate">{track.title || '(untitled)'}</span>
+                      {track.artist ? <span className="block text-xs text-gray-400 truncate">{track.artist}</span> : null}
+                    </span>
+                    {track.durationSec ? <span className="text-xs text-gray-500">{formatTimecode(track.durationSec)}</span> : null}
+                    {checked ? <Check size={16} className="text-port-accent shrink-0" aria-hidden="true" /> : null}
+                  </label>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+
+      <div className="p-4 border-t border-port-border flex items-center justify-between gap-3 flex-shrink-0">
+        <span className="text-xs text-gray-400">{selectedIds.size} selected</span>
+        <div className="flex items-center gap-2">
+          <button type="button" onClick={onClose} className="px-3 py-2 rounded text-sm text-gray-400 hover:text-white">Cancel</button>
+          <button type="button" onClick={handleAdd} disabled={selectedIds.size === 0} className="inline-flex items-center gap-2 px-3 py-2 rounded bg-port-accent hover:bg-port-accent/90 disabled:opacity-50 disabled:cursor-not-allowed text-white text-sm font-medium">
+            <Plus size={14} aria-hidden="true" /> Add selected
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/client/src/components/music/AlbumTrackPicker.test.jsx
+++ b/client/src/components/music/AlbumTrackPicker.test.jsx
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import AlbumTrackPicker from './AlbumTrackPicker';
+
+const tracks = [
+  { id: 'track-1', title: 'Northern Lights', artist: 'The Examples', durationSec: 201 },
+  { id: 'track-2', title: 'Midnight Signal', artist: 'Test Artist', durationSec: 185 },
+  { id: 'track-3', title: 'Daybreak', artist: 'The Examples' },
+];
+
+describe('AlbumTrackPicker', () => {
+  it('searches by title or artist and adds multiple selected tracks in library order', () => {
+    const onAdd = vi.fn();
+    const onClose = vi.fn();
+    render(<AlbumTrackPicker open tracks={tracks} onAdd={onAdd} onClose={onClose} />);
+
+    fireEvent.change(screen.getByRole('searchbox', { name: /search tracks/i }), { target: { value: 'examples' } });
+    expect(screen.getByText('Northern Lights')).toBeTruthy();
+    expect(screen.getByText('Daybreak')).toBeTruthy();
+    expect(screen.queryByText('Midnight Signal')).toBeNull();
+
+    fireEvent.click(screen.getByLabelText('Select Daybreak'));
+    fireEvent.click(screen.getByLabelText('Select Northern Lights'));
+    fireEvent.click(screen.getByRole('button', { name: /add selected/i }));
+
+    expect(onAdd).toHaveBeenCalledWith([tracks[0], tracks[2]]);
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('does not allow an empty batch to be added', () => {
+    render(<AlbumTrackPicker open tracks={tracks} onAdd={() => {}} onClose={() => {}} />);
+    expect(screen.getByRole('button', { name: /add selected/i })).toBeDisabled();
+  });
+});

--- a/client/src/components/music/AlbumsManager.jsx
+++ b/client/src/components/music/AlbumsManager.jsx
@@ -22,6 +22,7 @@ import { useConfirmDelete } from '../../hooks/useConfirmDelete';
 import { DEFAULT_NEGATIVE_PROMPT } from '../../lib/imageGenDefaults';
 import { formatTimecode } from '../../utils/formatters';
 import ArtistPicker from './ArtistPicker';
+import AlbumTrackPicker from './AlbumTrackPicker';
 import {
   listAlbums, createAlbum, updateAlbum, deleteAlbum,
   listTracks, generateImage,
@@ -75,6 +76,7 @@ export default function AlbumsManager() {
   const [galleryOpen, setGalleryOpen] = useState(false);
   const [startingGen, setStartingGen] = useState(false);
   const [genJobId, setGenJobId] = useState(null);
+  const [trackPickerOpen, setTrackPickerOpen] = useState(false);
   const genRequestRef = useRef(0);
 
   const gen = useMediaJobProgress(genJobId);
@@ -131,6 +133,7 @@ export default function AlbumsManager() {
     hydratedRef.current = selectionKey;
     cancelDelete();
     clearGeneration();
+    setTrackPickerOpen(false);
     if (isCreate) setForm(emptyForm());
     else if (selected) setForm(formFromAlbum(selected));
   }, [selectionKey, isCreate, selected, loading]);
@@ -229,6 +232,7 @@ export default function AlbumsManager() {
   };
 
   const availableTracks = allTracks.filter((t) => !form.trackIds.includes(t.id));
+  const addTracks = (tracks) => tracks.forEach((track) => addTrack(track.id));
 
   return (
     <div>
@@ -365,17 +369,9 @@ export default function AlbumsManager() {
                   </ol>
                 )}
                 {availableTracks.length > 0 ? (
-                  <select
-                    aria-label="Add a track"
-                    value=""
-                    onChange={(e) => { if (e.target.value) addTrack(e.target.value); }}
-                    className="mt-2 w-full px-3 py-2 bg-port-bg border border-port-border rounded text-white text-sm"
-                  >
-                    <option value="">+ Add a track…</option>
-                    {availableTracks.map((t) => (
-                      <option key={t.id} value={t.id}>{t.title}</option>
-                    ))}
-                  </select>
+                  <button type="button" onClick={() => setTrackPickerOpen(true)} className="mt-2 inline-flex items-center gap-2 px-3 py-2 rounded-lg bg-port-bg border border-port-border text-white text-sm hover:border-port-accent">
+                    <Plus size={14} aria-hidden="true" /> Add tracks
+                  </button>
                 ) : (
                   <p className="text-[11px] text-gray-500 mt-2">All your tracks are on this album. Create more in the Tracks tab.</p>
                 )}
@@ -409,6 +405,7 @@ export default function AlbumsManager() {
       </div>
 
       <GalleryImagePicker open={galleryOpen} onClose={() => setGalleryOpen(false)} onSelect={handleCoverPick} allowUpload maxBytes={COVER_MAX_BYTES} />
+      <AlbumTrackPicker open={trackPickerOpen} tracks={availableTracks} onClose={() => setTrackPickerOpen(false)} onAdd={addTracks} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Replace the reset-on-select album track dropdown with a searchable batch picker.
- Let people filter tracks by title or artist, choose several, and preserve existing track ordering controls.

## Validation

- `npm test -- --run src/components/music/AlbumTrackPicker.test.jsx`
- `npm run lint`
- `npm run build`

Closes #5567
