### PR TITLE
feat: apply universe styles to media generation

### DIFF
--- a/client/src/components/media/UniverseStylePicker.jsx
+++ b/client/src/components/media/UniverseStylePicker.jsx
@@ -1,0 +1,88 @@
+import { useEffect, useId, useMemo, useState } from 'react';
+import { Globe, X } from 'lucide-react';
+import { listUniverseStyles } from '../../services/api';
+import { universeStylePreset } from '../../lib/universeStylePreset';
+
+// Universe style is intentionally a separate picker from StylePresetPicker:
+// the former reads the user's saved embrace/avoid influences, while the latter
+// reads the shipped image-style catalog. Both can be layered onto one render.
+export default function UniverseStylePicker({
+  value,
+  onChange,
+  disabled = false,
+  className = '',
+  label = 'Universe style',
+}) {
+  const [styles, setStyles] = useState([]);
+  const selectId = useId();
+
+  useEffect(() => {
+    let cancelled = false;
+    listUniverseStyles({ silent: true }).then((rows) => {
+      if (cancelled) return;
+      setStyles(Array.isArray(rows) ? rows : []);
+    }).catch(() => { /* unavailable styles leave the picker hidden */ });
+    return () => { cancelled = true; };
+  }, []);
+
+  const activeUniverse = useMemo(
+    () => (value ? styles.find((universe) => universe.id === value) : null),
+    [value, styles],
+  );
+  const activePreset = useMemo(
+    () => (activeUniverse ? universeStylePreset(activeUniverse) : null),
+    [activeUniverse],
+  );
+
+  const handleChange = (event) => {
+    const id = event.target.value;
+    onChange?.(id ? styles.find((universe) => universe.id === id) || null : null);
+  };
+
+  // Universes with no style influences are omitted by the endpoint, so an
+  // empty result should not add an inert control to the media form.
+  if (styles.length === 0) return null;
+
+  return (
+    <div className={className}>
+      <div className="flex items-center justify-between mb-1">
+        <label htmlFor={selectId} className="text-xs font-medium text-gray-400 flex items-center gap-1">
+          <Globe className="w-3 h-3" /> {label}
+        </label>
+        {value && (
+          <button
+            type="button"
+            onClick={() => onChange?.(null)}
+            disabled={disabled}
+            className="text-[10px] text-gray-500 hover:text-port-error flex items-center gap-0.5 disabled:opacity-50"
+            title="Clear universe style"
+          >
+            <X className="w-3 h-3" /> Clear
+          </button>
+        )}
+      </div>
+      <select
+        id={selectId}
+        value={value || ''}
+        onChange={handleChange}
+        disabled={disabled}
+        className="w-full bg-port-bg border border-port-border rounded-lg px-2 py-2 text-sm text-white focus:outline-none focus:border-port-accent disabled:opacity-50"
+      >
+        <option value="">None — use prompt as-is</option>
+        {styles.map((universe) => (
+          <option key={universe.id} value={universe.id}>{universe.name}</option>
+        ))}
+      </select>
+      {activePreset?.prompt && (
+        <p className="mt-1 text-[10px] text-port-success/80 truncate" title={activePreset.prompt}>
+          Positive: {activePreset.prompt}
+        </p>
+      )}
+      {activePreset?.negativePrompt && (
+        <p className="text-[10px] text-port-error/80 truncate" title={activePreset.negativePrompt}>
+          Negative: {activePreset.negativePrompt}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/client/src/components/media/UniverseStylePicker.test.jsx
+++ b/client/src/components/media/UniverseStylePicker.test.jsx
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+const listUniverseStyles = vi.fn();
+vi.mock('../../services/api', () => ({
+  listUniverseStyles: (...args) => listUniverseStyles(...args),
+}));
+
+import UniverseStylePicker from './UniverseStylePicker';
+
+const STYLES = [{
+  id: 'u-1',
+  name: 'Example Universe',
+  influences: { embrace: ['inky linework'], avoid: ['glossy'] },
+}];
+
+describe('UniverseStylePicker', () => {
+  beforeEach(() => {
+    listUniverseStyles.mockReset().mockResolvedValue(STYLES);
+  });
+
+  it('loads styled universes with a silent request and pairs the label to the select', async () => {
+    render(<UniverseStylePicker value="" onChange={() => {}} />);
+
+    const select = await screen.findByLabelText('Universe style');
+    const label = screen.getByText('Universe style').closest('label');
+    expect(listUniverseStyles).toHaveBeenCalledWith({ silent: true });
+    expect(label.getAttribute('for')).toBe(select.id);
+    expect(screen.getByRole('option', { name: 'Example Universe' })).toBeInTheDocument();
+  });
+
+  it('returns the selected universe and previews both style directions', async () => {
+    const onChange = vi.fn();
+    const { rerender } = render(<UniverseStylePicker value="" onChange={onChange} />);
+    const select = await screen.findByLabelText('Universe style');
+
+    fireEvent.change(select, { target: { value: 'u-1' } });
+    rerender(<UniverseStylePicker value="u-1" onChange={onChange} />);
+
+    expect(onChange).toHaveBeenCalledWith(STYLES[0]);
+    expect(screen.getByText('Positive: inky linework')).toBeInTheDocument();
+    expect(screen.getByText('Negative: glossy')).toBeInTheDocument();
+  });
+
+  it('renders nothing when no universe has style tokens', async () => {
+    listUniverseStyles.mockResolvedValue([]);
+    render(<UniverseStylePicker value="" onChange={() => {}} />);
+    await waitFor(() => expect(listUniverseStyles).toHaveBeenCalled());
+    expect(screen.queryByLabelText('Universe style')).not.toBeInTheDocument();
+  });
+});

--- a/client/src/hooks/useVideoGenFieldState.js
+++ b/client/src/hooks/useVideoGenFieldState.js
@@ -25,6 +25,7 @@ export function useVideoGenFieldState({
   const [prompt, setPrompt] = useState(incomingPrompt || '');
   const [negativePrompt, setNegativePrompt] = useState(incomingNegativePrompt || '');
   const [stylePreset, setStylePreset] = useState(null);
+  const [selectedUniverse, setSelectedUniverse] = useState(null);
   const [modelId, setModelId] = useState('');
   const [remixSourceModel, setRemixSourceModel] = useState(null);
   const [remixModelFallback, setRemixModelFallback] = useState(null);
@@ -105,6 +106,7 @@ export function useVideoGenFieldState({
     remixSourceModel, setRemixSourceModel,
     seed, setSeed,
     selectedLoras, setSelectedLoras,
+    selectedUniverse, setSelectedUniverse,
     sizeManuallySetRef,
     speedProfileId, setSpeedProfileId,
     draftDecode, setDraftDecode,

--- a/client/src/hooks/useVideoGenForm.js
+++ b/client/src/hooks/useVideoGenForm.js
@@ -114,6 +114,7 @@ export function useVideoGenForm({ models, status, availableLoras, grokEnabled, r
     remixSourceModel, setRemixSourceModel,
     seed, setSeed,
     selectedLoras, setSelectedLoras,
+    selectedUniverse, setSelectedUniverse,
     sizeManuallySetRef,
     speedProfileId, setSpeedProfileId,
     draftDecode, setDraftDecode,
@@ -178,11 +179,15 @@ export function useVideoGenForm({ models, status, availableLoras, grokEnabled, r
   }, [incomingSourceImage]);
   // A prompt handed in through the URL (Continue, Send-to-Video, Remix) is the
   // COMPOSED prompt of an existing render — composeStyledPrompt already prefixed
-  // it with whatever style preset produced it. Drop the picker's selection with
-  // it, or the next submit prefixes a preset onto a prompt that already carries
-  // one (the same double-styling applyRemix clears the preset to avoid).
+  // it with whatever style layers produced it. Drop both pickers' selections
+  // with it, or the next submit prefixes a style onto a prompt that already
+  // carries one (the same double-styling applyRemix clears both pickers).
   useEffect(() => {
-    if (incomingPrompt) { setPrompt(incomingPrompt); setStylePreset(null); }
+    if (incomingPrompt) {
+      setPrompt(incomingPrompt);
+      setStylePreset(null);
+      setSelectedUniverse(null);
+    }
   }, [incomingPrompt]);
   useEffect(() => {
     if (incomingNegativePrompt) setNegativePrompt(incomingNegativePrompt);
@@ -898,9 +903,12 @@ export function useVideoGenForm({ models, status, availableLoras, grokEnabled, r
     const srcPrompt = (source.prompt === '(no prompt)' ? '' : source.prompt || '').trim();
     const srcNeg = (source.negativePrompt || source.negative_prompt || '').trim();
     // History stores the COMPOSED prompt (composeStyledPrompt prefixes the
-    // preset), so a preset left selected would prefix itself a second time on
-    // the next submit — the same reason applyRemix clears it.
-    if (fillIfUntouched('prompt', srcPrompt, prompt, setPrompt)) setStylePreset(null);
+    // preset), so either picker left selected would compose itself a second time
+    // on the next submit — the same reason applyRemix clears both.
+    if (fillIfUntouched('prompt', srcPrompt, prompt, setPrompt)) {
+      setStylePreset(null);
+      setSelectedUniverse(null);
+    }
     fillIfUntouched('negativePrompt', srcNeg, negativePrompt, setNegativePrompt);
   };
   // `source` is the history record behind `videoId`, supplied by the picker
@@ -960,6 +968,7 @@ export function useVideoGenForm({ models, status, availableLoras, grokEnabled, r
     setRemixSourceModel(null);
     setRemixModelFallback(null);
     setStylePreset(null);
+    setSelectedUniverse(null);
     // prompt: always set explicitly. Legacy entries can be missing `prompt`
     // (normalizeVideo surfaces them as '(no prompt)') — clear the form instead
     // of leaving whatever the user previously typed, matching the
@@ -1118,6 +1127,8 @@ export function useVideoGenForm({ models, status, availableLoras, grokEnabled, r
   // /active, so a page reload doesn't lose what the running job is rendering.
   // The page owns the SSE re-attach; this only replays the params into state.
   const applyResumedParams = (p = {}) => {
+    setStylePreset(null);
+    setSelectedUniverse(null);
     if (p.prompt) setPrompt(p.prompt);
     if (p.negativePrompt) setNegativePrompt(p.negativePrompt);
     if (p.modelId) setModelId(p.modelId);
@@ -1219,7 +1230,7 @@ export function useVideoGenForm({ models, status, availableLoras, grokEnabled, r
   // stays pure so all three backend contracts can be tested independently.
   const submissionState = {
     isGrok, grokDuration, remoteSubmissionFields,
-    prompt, negativePrompt, stylePreset,
+    prompt, negativePrompt, stylePreset, selectedUniverse,
     width, height, mode, sourceImageFile, sourceImageUpload,
     numFrames, fps, steps, guidanceScale, seed,
     currentModel, models, modelId, tiling, textEncoderId, speedProfileId, draftDecode,
@@ -1245,6 +1256,7 @@ export function useVideoGenForm({ models, status, availableLoras, grokEnabled, r
     envelopedPrompt,
     negativePrompt, setNegativePrompt,
     stylePreset, setStylePreset,
+    selectedUniverse, setSelectedUniverse,
     remixModelFallback,
     // Model
     modelId, handleModelChange, currentModel, visibleModels,

--- a/client/src/hooks/useVideoGenSubmitFlow.test.jsx
+++ b/client/src/hooks/useVideoGenSubmitFlow.test.jsx
@@ -13,9 +13,12 @@ const submissionState = (prompt) => ({
   keyframes: [],
   keyframesActive: false,
   mode: 'text',
+  negativePrompt: '',
   noMusic: false,
   prompt,
   selectedLoras: [],
+  selectedUniverse: null,
+  stylePreset: null,
 });
 
 describe('useVideoGenSubmitFlow', () => {
@@ -30,5 +33,25 @@ describe('useVideoGenSubmitFlow', () => {
     rerender({ prompt: 'updated prompt' });
     expect(result.current.buildGeneratePayload).toBe(build);
     expect(build().prompt).toBe('updated prompt');
+  });
+
+  it('layers the selected universe style into the video payload', () => {
+    const state = {
+      ...submissionState('a quiet harbor'),
+      negativePrompt: 'lowres',
+      selectedUniverse: {
+        id: 'u-1',
+        name: 'Example Universe',
+        influences: { embrace: ['inky linework'], avoid: ['glossy'] },
+      },
+      stylePreset: { prompt: 'film noir', negativePrompt: 'pastel' },
+    };
+    const { result } = renderHook(() => useVideoGenSubmitFlow(state));
+
+    expect(result.current.envelopedPrompt).toBe('inky linework. film noir. a quiet harbor');
+    expect(result.current.buildGeneratePayload()).toMatchObject({
+      prompt: 'inky linework. film noir. a quiet harbor',
+      negativePrompt: 'lowres, glossy, pastel',
+    });
   });
 });

--- a/client/src/lib/composeStyledPrompt.js
+++ b/client/src/lib/composeStyledPrompt.js
@@ -1,17 +1,18 @@
-// Compose user prompt + negative with an optional style preset.
-// Preset prompt prefixes the user prompt — diffusion models weight earlier
+// Compose user prompt + negative with optional style preset(s).
+// Preset prompts prefix the user prompt — diffusion models weight earlier
 // tokens heaviest, so the broad aesthetic carries over the user's content.
-// Preset negative appends to user negative so user-specified avoids stay
-// first-class.
+// Preset negatives append to the user negative so user-specified avoids stay
+// first-class. An array is accepted when a caller combines independent style
+// sources, such as a universe style and a built-in preset.
 
 import { universeStylePreset } from './universeStylePreset';
 
 export function composeStyledPrompt(userPrompt, userNegative, preset) {
   const prompt = (userPrompt || '').trim();
   const negative = (userNegative || '').trim();
-  if (!preset) return { prompt, negativePrompt: negative };
-  const stylePart = (preset.prompt || '').trim();
-  const styleNeg = (preset.negativePrompt || '').trim();
+  const presets = Array.isArray(preset) ? preset : [preset];
+  const stylePart = presets.map((item) => (item?.prompt || '').trim()).filter(Boolean).join('. ');
+  const styleNeg = presets.map((item) => (item?.negativePrompt || '').trim()).filter(Boolean).join(', ');
   // Avoid trailing ". " when only one of the two parts is non-empty so the
   // composed prompt is clean and deterministic regardless of which input
   // is missing.

--- a/client/src/lib/composeStyledPrompt.test.js
+++ b/client/src/lib/composeStyledPrompt.test.js
@@ -14,6 +14,17 @@ describe('composeStyledPrompt', () => {
     expect(out.negativePrompt).toBe('lowres, blur');
   });
 
+  it('layers multiple style sources in order', () => {
+    const out = composeStyledPrompt('a hero', 'lowres', [
+      { prompt: 'inky linework', negativePrompt: 'glossy' },
+      { prompt: 'film noir', negativePrompt: 'pastel' },
+    ]);
+    expect(out).toEqual({
+      prompt: 'inky linework. film noir. a hero',
+      negativePrompt: 'lowres, glossy, pastel',
+    });
+  });
+
   it('avoids a trailing ". " when only one part is present', () => {
     expect(composeStyledPrompt('', 'lowres', { prompt: 'noir comic', negativePrompt: '' }).prompt)
       .toBe('noir comic');

--- a/client/src/lib/videoGenSubmission.js
+++ b/client/src/lib/videoGenSubmission.js
@@ -1,4 +1,5 @@
 import { composeStyledPrompt } from './composeStyledPrompt';
+import { universeStylePreset } from './universeStylePreset.js';
 import { isLtx2FamilyRuntime } from './runnerFamilies';
 import { isDefaultI2vReferenceMode } from './videoReferenceModes';
 import { clampImageEdge } from './imageGenResolutions';
@@ -17,10 +18,15 @@ import {
 
 // The form owns state transitions and validation. This module owns the three
 // request contracts the video route accepts: Grok, federated, and local.
+const stylePresetsFor = (selectedUniverse, stylePreset) => [
+  selectedUniverse ? universeStylePreset(selectedUniverse) : null,
+  stylePreset,
+].filter(Boolean);
+
 export function envelopVideoPrompt(text, {
-  currentModel, negativePrompt, stylePreset, noMusic, disableAudio,
+  currentModel, negativePrompt, stylePreset, selectedUniverse, noMusic, disableAudio,
 }) {
-  const composed = composeStyledPrompt(text, negativePrompt, stylePreset);
+  const composed = composeStyledPrompt(text, negativePrompt, stylePresetsFor(selectedUniverse, stylePreset));
   const effectiveDisableAudio = supportsVideoAudioControls(currentModel) && disableAudio;
   return (supportsVideoAudioPromptControls(currentModel) && noMusic && !effectiveDisableAudio && !/no music/i.test(composed.prompt))
     ? `${composed.prompt}\n\nno music, no soundtrack`
@@ -29,7 +35,7 @@ export function envelopVideoPrompt(text, {
 
 export function buildVideoGenSubmission({
   isGrok, grokDuration, remoteSubmissionFields,
-  prompt, negativePrompt, stylePreset,
+  prompt, negativePrompt, stylePreset, selectedUniverse,
   width, height, mode, sourceImageFile, sourceImageUpload,
   numFrames, fps, steps, guidanceScale, seed,
   currentModel, models, modelId, tiling, textEncoderId, speedProfileId, draftDecode,
@@ -40,10 +46,10 @@ export function buildVideoGenSubmission({
   icReferenceImageFiles, icStrength, icSkipStage2,
   chainingActive, chunks, chunkPrompts, contextFrames,
 }) {
-  const composed = composeStyledPrompt(prompt, negativePrompt, stylePreset);
+  const composed = composeStyledPrompt(prompt, negativePrompt, stylePresetsFor(selectedUniverse, stylePreset));
   const effectiveDisableAudio = supportsVideoAudioControls(currentModel) && disableAudio;
   const withEnvelope = (text) => envelopVideoPrompt(text, {
-    currentModel, negativePrompt, stylePreset, noMusic, disableAudio,
+    currentModel, negativePrompt, stylePreset, selectedUniverse, noMusic, disableAudio,
   });
   // The backing array is deliberately not truncated as chunks change. Only
   // slice live chunks at the wire boundary.

--- a/client/src/pages/ImageGen.federatedTarget.test.jsx
+++ b/client/src/pages/ImageGen.federatedTarget.test.jsx
@@ -76,6 +76,19 @@ vi.mock('../components/ui/Toast', () => ({
 }));
 vi.mock('../components/media/PromptEnhancer', () => ({ default: () => null }));
 vi.mock('../components/media/PromptFromMedia', () => ({ default: () => null }));
+vi.mock('../components/media/UniverseStylePicker', () => ({
+  default: ({ onChange }) => (
+    <button
+      type="button"
+      onClick={() => onChange({
+        id: 'u-1', name: 'Example Universe',
+        influences: { embrace: ['inky linework'], avoid: ['glossy'] },
+      })}
+    >
+      Use universe style
+    </button>
+  ),
+}));
 vi.mock('../components/media/StylePresetPicker', () => ({ default: () => null }));
 vi.mock('../components/media/MediaPreview', () => ({ default: () => null }));
 vi.mock('../components/media/MediaJobsQueue', () => ({ default: () => null }));
@@ -128,6 +141,19 @@ describe('ImageGen federated render target', () => {
     for (const field of ['mode', 'quantize', 'cleanC2PA', 'denoise', 'loraFilenames', 'cloudModel']) {
       expect(state.generateImage.mock.calls[0][0]).not.toHaveProperty(field);
     }
+  });
+
+  it('adds the selected universe positive and negative style tokens to the image payload', async () => {
+    await mount();
+    fireEvent.click(screen.getByRole('button', { name: 'Use universe style' }));
+
+    await act(async () => { fireEvent.click(screen.getByRole('button', { name: /^Generate$/ })); });
+
+    await waitFor(() => expect(state.generateImage).toHaveBeenCalled());
+    expect(state.generateImage.mock.calls[0][0]).toMatchObject({
+      prompt: 'inky linework. a lighthouse at dusk',
+      negativePrompt: expect.stringContaining('glossy'),
+    });
   });
 
   it('hides the generation target field when Grok is selected', async () => {

--- a/client/src/pages/ImageGen.jsx
+++ b/client/src/pages/ImageGen.jsx
@@ -16,6 +16,7 @@ import MediaCard from '../components/media/MediaCard';
 import MediaPreview from '../components/media/MediaPreview';
 import FavoritesFilterChip from '../components/media/FavoritesFilterChip';
 import StylePresetPicker from '../components/media/StylePresetPicker';
+import UniverseStylePicker from '../components/media/UniverseStylePicker';
 import PromptEnhancer from '../components/media/PromptEnhancer';
 import PromptFromMedia from '../components/media/PromptFromMedia';
 import BackendChipStrip from '../components/media/BackendChipStrip';
@@ -41,6 +42,7 @@ import {
   AlertTriangle, X, Film,
 } from 'lucide-react';
 import { composeStyledPrompt } from '../lib/composeStyledPrompt';
+import { universeStylePreset } from '../lib/universeStylePreset';
 import { isCloudCliMode, deriveAvailableBackends, AGY_IMAGEGEN_DEFAULT_MODEL, IMAGE_GEN_MODE, cloudPromptRequired, imageGenReadiness, isI2iCapableMode, pickI2iMode, modeLabel, referenceSlotsFor, supportsReferenceStrength } from '../lib/imageGenBackends';
 import { clampImageDimensions, clampImageEdge } from '../lib/imageGenResolutions';
 import { peerModelRequiresInput } from '../lib/federatedMediaReadiness.js';
@@ -153,6 +155,7 @@ export default function ImageGen() {
   const [prompt, setPrompt] = useState('');
   const [negativePrompt, setNegativePrompt] = useState(DEFAULT_NEGATIVE_PROMPT);
   const [stylePreset, setStylePreset] = useState(null);
+  const [selectedUniverse, setSelectedUniverse] = useState(null);
   const [modelId, setModelId] = useState('');
   const [width, setWidth] = useState(1024);
   const [height, setHeight] = useState(1024);
@@ -382,6 +385,10 @@ export default function ImageGen() {
     // come back to the same prompt + settings + live preview frame.
     getActiveImageJob().then(({ activeJob }) => {
       if (!activeJob) return;
+      // Active-job prompt fields are already style-composed. Do not apply a
+      // newly-selected style a second time while restoring the form.
+      setStylePreset(null);
+      setSelectedUniverse(null);
       if (activeJob.prompt) setPrompt(activeJob.prompt);
       if (activeJob.negativePrompt != null) setNegativePrompt(activeJob.negativePrompt);
       if (activeJob.modelId) setModelId(activeJob.modelId);
@@ -468,7 +475,13 @@ export default function ImageGen() {
     const present = remixKeys.filter((k) => searchParams.get(k) != null);
     if (!initFile && present.length === 0) return;
     const get = (k) => searchParams.get(k);
-    if (get('prompt')) setPrompt(get('prompt'));
+    if (get('prompt')) {
+      setPrompt(get('prompt'));
+      // URL handoffs carry the prompt that was submitted, including any style
+      // layers, so the picker must not compose them again.
+      setStylePreset(null);
+      setSelectedUniverse(null);
+    }
     if (get('negativePrompt')) setNegativePrompt(get('negativePrompt'));
     if (get('modelId')) setModelId(get('modelId'));
     if (get('width')) setWidth(Number(get('width')));
@@ -661,9 +674,13 @@ export default function ImageGen() {
   // trigger-word hint and its "+ trigger" append both judge presence against
   // THIS, not the raw textarea, so neither can disagree with the server-side
   // weave when the style preset already supplies a trigger token.
+  const activeStylePresets = useMemo(() => [
+    selectedUniverse ? universeStylePreset(selectedUniverse) : null,
+    stylePreset,
+  ].filter(Boolean), [selectedUniverse, stylePreset]);
   const styledPrompt = useMemo(
-    () => composeStyledPrompt(prompt, negativePrompt, stylePreset).prompt,
-    [prompt, negativePrompt, stylePreset],
+    () => composeStyledPrompt(prompt, negativePrompt, activeStylePresets).prompt,
+    [prompt, negativePrompt, activeStylePresets],
   );
   const activeReferenceImages = useMemo(
     () => referenceImages.slice(0, referenceSlotCount),
@@ -826,7 +843,7 @@ export default function ImageGen() {
   // POST — the user keeps watching the active render and the new submission
   // sits in the server queue until the active one finishes.
   const submitGenerationPayload = async () => {
-    const composed = composeStyledPrompt(prompt, negativePrompt, stylePreset);
+    const composed = composeStyledPrompt(prompt, negativePrompt, activeStylePresets);
     // Custom-dimension inputs emit raw values for smooth typing and snap on blur;
     // an Enter-submit (or a field cleared to 0) can bypass that blur, so clamp to
     // the server's per-edge bounds here too — the last line of defense before the
@@ -1003,7 +1020,7 @@ export default function ImageGen() {
         await startLocalGeneration();
         await extras;
       } else {
-        const composed = composeStyledPrompt(prompt, negativePrompt, stylePreset);
+        const composed = composeStyledPrompt(prompt, negativePrompt, activeStylePresets);
         const payload = {
           prompt: composed.prompt,
           negativePrompt: composed.negativePrompt || undefined,
@@ -1142,6 +1159,7 @@ export default function ImageGen() {
     // Preset was already folded into the recorded prompt at submit time;
     // clear the picker so the user sees what actually produced the image.
     setStylePreset(null);
+    setSelectedUniverse(null);
     if (img.prompt) setPrompt(img.prompt);
     if (img.negativePrompt || img.negative_prompt) setNegativePrompt(img.negativePrompt || img.negative_prompt);
     if (img.seed != null) setSeed(String(img.seed));
@@ -1271,6 +1289,11 @@ export default function ImageGen() {
 
       <form onSubmit={handleGenerate} className="grid grid-cols-1 lg:grid-cols-[3fr_2fr] gap-4">
         <div className="bg-port-card border border-port-border rounded-xl p-4 space-y-3">
+          <UniverseStylePicker
+            value={selectedUniverse?.id || ''}
+            onChange={setSelectedUniverse}
+            disabled={statusLoading}
+          />
           <StylePresetPicker
             value={stylePreset?.id || ''}
             onChange={setStylePreset}

--- a/client/src/pages/VideoGen.composeWhileBusy.test.jsx
+++ b/client/src/pages/VideoGen.composeWhileBusy.test.jsx
@@ -111,6 +111,19 @@ vi.mock('../components/media/PromptFromMedia', () => ({
     <div data-testid="prompt-from-media" data-disabled={disabled ? '1' : '0'}>Prompt from media</div>
   ),
 }));
+vi.mock('../components/media/UniverseStylePicker', () => ({
+  default: ({ onChange }) => (
+    <button
+      type="button"
+      onClick={() => onChange({
+        id: 'u-1', name: 'Example Universe',
+        influences: { embrace: ['inky linework'], avoid: ['glossy'] },
+      })}
+    >
+      Use universe style
+    </button>
+  ),
+}));
 
 vi.mock('../components/Drawer', () => ({ default: () => null }));
 vi.mock('../components/settings/ImageGenTab', () => ({ ImageGenTab: () => null }));
@@ -180,6 +193,24 @@ describe('VideoGen compose-while-busy', () => {
     expect(screen.getByTestId('prompt-from-media')).toHaveAttribute('data-disabled', '0');
     expect(screen.getByRole('button', { name: /Add to queue/ })).toBeEnabled();
   });
+
+  it('includes the selected universe style in the submitted video prompt', async () => {
+    await act(async () => {
+      render(
+        <MemoryRouter initialEntries={['/media/video']}>
+          <VideoGen />
+        </MemoryRouter>,
+      );
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Use universe style' }));
+    fireEvent.change(await screen.findByLabelText('Prompt'), { target: { value: 'a fox watches the rain' } });
+    fireEvent.click(screen.getByRole('button', { name: /^Generate$/ }));
+
+    await waitFor(() => expect(state.generateVideo).toHaveBeenCalled());
+    expect(state.generateVideo.mock.calls[0][0].prompt).toBe('inky linework. a fox watches the rain');
+  });
+
   it('submits an additional render to the server queue while another render is active', async () => {
     await act(async () => {
       render(

--- a/client/src/pages/VideoGen.federatedTarget.test.jsx
+++ b/client/src/pages/VideoGen.federatedTarget.test.jsx
@@ -146,6 +146,7 @@ vi.mock('../components/videoGen/RuntimeFingerprint', () => ({ default: () => nul
 vi.mock('../components/videoGen/VideoGenGallery', () => ({ default: () => null }));
 vi.mock('../components/media/MediaPreview', () => ({ default: () => null }));
 vi.mock('../components/media/StylePresetPicker', () => ({ default: () => null }));
+vi.mock('../components/media/UniverseStylePicker', () => ({ default: () => null }));
 vi.mock('../components/media/MediaJobsQueue', () => ({ default: () => null }));
 vi.mock('../components/imageGen/LoraPicker', () => ({ default: () => null }));
 vi.mock('../components/media/ResolutionField', () => ({ default: () => null }));

--- a/client/src/pages/VideoGen.jsx
+++ b/client/src/pages/VideoGen.jsx
@@ -58,6 +58,7 @@ import VideoGenGallery from '../components/videoGen/VideoGenGallery';
 import GalleryImagePicker from '../components/imageGen/GalleryImagePicker';
 import MediaPreview from '../components/media/MediaPreview';
 import StylePresetPicker from '../components/media/StylePresetPicker';
+import UniverseStylePicker from '../components/media/UniverseStylePicker';
 import PromptEnhancer from '../components/media/PromptEnhancer';
 import PromptFromMedia from '../components/media/PromptFromMedia';
 import { normalizeVideo } from '../components/media/normalize';
@@ -150,7 +151,8 @@ export default function VideoGen() {
   const {
     backend, isGrok, handleBackendChange, grokDuration, setGrokDuration,
     mode, handleModeChange,
-    prompt, setPrompt, envelopedPrompt, negativePrompt, setNegativePrompt, stylePreset, setStylePreset, remixModelFallback,
+    prompt, setPrompt, envelopedPrompt, negativePrompt, setNegativePrompt, stylePreset, setStylePreset,
+    selectedUniverse, setSelectedUniverse, remixModelFallback,
     modelId, handleModelChange, currentModel, visibleModels,
     loraFamily, videoLoras, loraUnavailableHint,
     selectedLoras, setSelectedLoras,
@@ -1023,6 +1025,10 @@ export default function VideoGen() {
               repairing={modelDownload.repairing}
             />
           )}
+          <UniverseStylePicker
+            value={selectedUniverse?.id || ''}
+            onChange={setSelectedUniverse}
+          />
           <StylePresetPicker
             value={stylePreset?.id || ''}
             onChange={setStylePreset}

--- a/client/src/pages/VideoGen.terms.test.jsx
+++ b/client/src/pages/VideoGen.terms.test.jsx
@@ -135,6 +135,7 @@ vi.mock('../components/videoGen/RuntimeFingerprint', () => ({ default: () => nul
 vi.mock('../components/videoGen/VideoGenGallery', () => ({ default: () => null }));
 vi.mock('../components/media/MediaPreview', () => ({ default: () => null }));
 vi.mock('../components/media/StylePresetPicker', () => ({ default: () => null }));
+vi.mock('../components/media/UniverseStylePicker', () => ({ default: () => null }));
 vi.mock('../components/media/MediaJobsQueue', () => ({ default: () => null }));
 vi.mock('../components/imageGen/LoraPicker', () => ({ default: () => null }));
 vi.mock('../components/media/ResolutionField', () => ({ default: () => null }));

--- a/client/src/pages/VideoGen.textEncoderAutoDownload.test.jsx
+++ b/client/src/pages/VideoGen.textEncoderAutoDownload.test.jsx
@@ -151,6 +151,7 @@ vi.mock('../components/videoGen/RuntimeFingerprint', () => ({ default: () => nul
 vi.mock('../components/videoGen/VideoGenGallery', () => ({ default: () => null }));
 vi.mock('../components/media/MediaPreview', () => ({ default: () => null }));
 vi.mock('../components/media/StylePresetPicker', () => ({ default: () => null }));
+vi.mock('../components/media/UniverseStylePicker', () => ({ default: () => null }));
 vi.mock('../components/media/MediaJobsQueue', () => ({ default: () => null }));
 vi.mock('../components/imageGen/LoraPicker', () => ({ default: () => null }));
 vi.mock('../components/media/ResolutionField', () => ({ default: () => null }));


### PR DESCRIPTION
## Summary
- Add an accessible universe-style selector to Image Gen and Video Gen.
- Compose selected universe embrace/avoid influences with existing prompts and style presets across all render lanes.
- Prevent saved styles from being composed twice when remixes or active jobs are restored.

## Test plan
- `npm run lint --prefix client`
- `npm run build --prefix client`
- Focused Vitest coverage for the picker, prompt composition, and Image Gen/Video Gen submission paths