### PR TITLE
feat(local-llm): refresh curated local model catalog

### DIFF
--- a/server/lib/localLlmCatalog.js
+++ b/server/lib/localLlmCatalog.js
@@ -172,6 +172,20 @@ export const LOCAL_LLM_CATALOG = [
     ollama: 'qwen3.5:4b',
     lmstudio: 'lmstudio-community/Qwen3.5-4B-GGUF'
   },
+  {
+    key: 'phi-4-mini',
+    name: 'Phi-4 Mini 3.8B',
+    category: 'lightweight',
+    recommendedFor: ['lightweight', 'reasoning', 'chat'],
+    params: '3.8B',
+    size: '2.4 GB',
+    family: 'phi',
+    description: "Microsoft's lightweight 3.8B model with 128K context, strong reasoning, multilingual support, and function calling.",
+    capabilities: ['chat', 'reasoning', 'tools', 'multilingual'],
+    context: 131072,
+    ollama: 'phi4-mini',
+    lmstudio: 'lmstudio-community/Phi-4-mini-instruct-GGUF'
+  },
   // ── General-purpose laptop tier (16–32GB) ──
   {
     key: 'lfm2.5-8b-a1b',
@@ -422,6 +436,20 @@ export const LOCAL_LLM_CATALOG = [
     lmstudio: 'lmstudio-community/DeepSeek-R1-Distill-Llama-8B-GGUF'
   },
   {
+    key: 'deepseek-r1-14b',
+    name: 'DeepSeek-R1 14B',
+    category: 'reasoning',
+    recommendedFor: ['reasoning'],
+    params: '14B',
+    size: '9.0 GB',
+    family: 'deepseek',
+    description: "DeepSeek's open reasoning model distilled into a 14B Qwen architecture — deeper chain-of-thought thinking for math, logic, and complex problem-solving.",
+    capabilities: ['chat', 'reasoning'],
+    context: 131072,
+    ollama: 'deepseek-r1:14b',
+    lmstudio: 'lmstudio-community/DeepSeek-R1-Distill-Qwen-14B-GGUF'
+  },
+  {
     key: 'phi-4-14b',
     name: 'Phi-4 14B',
     category: 'reasoning',
@@ -509,6 +537,20 @@ export const LOCAL_LLM_CATALOG = [
     context: 131072,
     ollama: 'qwen2.5-coder:7b',
     lmstudio: 'lmstudio-community/Qwen2.5-Coder-7B-Instruct-GGUF'
+  },
+  {
+    key: 'codestral-22b',
+    name: 'Codestral 22B',
+    category: 'coding',
+    recommendedFor: ['coding'],
+    params: '22B',
+    size: '13 GB',
+    family: 'codestral',
+    description: "Mistral AI's 22B code model supporting over 80 programming languages, tuned for code completion and generation.",
+    capabilities: ['chat', 'code', 'tools'],
+    context: 32768,
+    ollama: 'codestral',
+    lmstudio: 'lmstudio-community/Codestral-22B-v0.1-GGUF'
   },
   {
     key: 'ornith-9b',
@@ -679,6 +721,20 @@ export const LOCAL_LLM_CATALOG = [
     ollama: 'qwen3-vl:30b',
     lmstudio: 'lmstudio-community/Qwen3-VL-30B-A3B-Instruct-GGUF'
   },
+  {
+    key: 'llama3.2-vision-11b',
+    name: 'Llama 3.2 Vision 11B',
+    category: 'vision',
+    recommendedFor: ['vision', 'general'],
+    params: '11B',
+    size: '7.9 GB',
+    family: 'llama',
+    description: "Meta's instruction-tuned multimodal model with vision capabilities for image reasoning and captioning.",
+    capabilities: ['chat', 'tools', 'vision'],
+    context: 128000,
+    ollama: 'llama3.2-vision:11b',
+    lmstudio: 'lmstudio-community/Llama-3.2-11B-Vision-Instruct-GGUF'
+  },
   // ── Multilingual tier ──
   {
     key: 'aya-expanse-8b',
@@ -692,6 +748,20 @@ export const LOCAL_LLM_CATALOG = [
     capabilities: ['chat', 'multilingual'],
     ollama: 'aya-expanse:8b',
     lmstudio: 'lmstudio-community/Aya-Expanse-8B-GGUF'
+  },
+  {
+    key: 'aya-expanse-32b',
+    name: 'Aya Expanse 32B',
+    category: 'multilingual',
+    recommendedFor: ['multilingual', 'chat', 'general'],
+    params: '32B',
+    size: '19.5 GB',
+    family: 'aya',
+    description: "Cohere For AI's high-capacity 32B multilingual model covering 23 languages with advanced translation and localized dialogue.",
+    capabilities: ['chat', 'multilingual'],
+    context: 128000,
+    ollama: 'aya-expanse:32b',
+    lmstudio: 'lmstudio-community/Aya-Expanse-32B-GGUF'
   },
   // ── Text embeddings ──
   // PortOS's memory/recall pipeline expects 768-dimension vectors


### PR DESCRIPTION
## Summary
Refreshes PortOS's curated catalog of suggested local LLMs (`server/lib/localLlmCatalog.js`) to keep up with current open model releases across key categories.

### Added Models
- **Phi-4 Mini 3.8B** (`phi4-mini` / `lmstudio-community/Phi-4-mini-instruct-GGUF`): Added to `lightweight` category for reasoning, tool-calling, and multilingual support in under 3GB. (Verified via Ollama Library `phi4-mini` and HF `lmstudio-community/Phi-4-mini-instruct-GGUF`).
- **DeepSeek-R1 14B** (`deepseek-r1:14b` / `lmstudio-community/DeepSeek-R1-Distill-Qwen-14B-GGUF`): Added to `reasoning` category for deeper Qwen-distilled chain-of-thought reasoning. (Verified via Ollama Library `deepseek-r1:14b` and HF `lmstudio-community/DeepSeek-R1-Distill-Qwen-14B-GGUF`).
- **Codestral 22B** (`codestral` / `lmstudio-community/Codestral-22B-v0.1-GGUF`): Added to `coding` category for multi-language code generation and tool use. (Verified via Ollama Library `codestral` and HF `lmstudio-community/Codestral-22B-v0.1-GGUF`).
- **Llama 3.2 Vision 11B** (`llama3.2-vision:11b` / `lmstudio-community/Llama-3.2-11B-Vision-Instruct-GGUF`): Added to `vision` category for visual recognition and image reasoning. (Verified via Ollama Library `llama3.2-vision:11b` and HF `lmstudio-community/Llama-3.2-11B-Vision-Instruct-GGUF`).
- **Aya Expanse 32B** (`aya-expanse:32b` / `lmstudio-community/Aya-Expanse-32B-GGUF`): Added to `multilingual` category for high-capacity 23-language dialogue and translation. (Verified via Ollama Library `aya-expanse:32b` and HF `lmstudio-community/Aya-Expanse-32B-GGUF`).

## Test plan
Ran affected unit tests in `server`:
`cd ./server && npx vitest run lib/localLlmCatalog lib/localModelHeuristics lib/index.test.js`
All 59 tests passed cleanly.