### PR TITLE
fix: clean up Media Gen mobile layout

### DIFF
--- a/client/src/pages/ImageGen.jsx
+++ b/client/src/pages/ImageGen.jsx
@@ -1228,15 +1228,15 @@ export default function ImageGen() {
   const statusUnknown = statusReadiness === 'unknown';
 
   return (
-    <div className="space-y-3">
-      <div className="flex items-center justify-between gap-2 text-xs">
-        <div className="flex items-center gap-2 flex-wrap">
+    <div className="min-w-0 max-w-full space-y-3">
+      <div className="flex min-w-0 flex-col gap-2 text-xs sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex min-w-0 flex-wrap items-center gap-2">
           {statusLoading ? (
             <span className="inline-flex items-center gap-1.5 px-2 py-1 rounded-full border border-port-border bg-port-card text-gray-400">
               <RefreshCw className="w-3 h-3 animate-spin" /> Checking {effectiveMode}…
             </span>
           ) : status ? (
-            <span className={`inline-flex items-center gap-1.5 px-2 py-1 rounded-full border ${
+            <span className={`inline-flex min-w-0 max-w-full items-start gap-1.5 px-2 py-1 rounded-full border ${
               statusReady
                 ? 'border-port-success/40 bg-port-success/10 text-port-success'
                 : statusUnknown
@@ -1267,7 +1267,7 @@ export default function ImageGen() {
             />
           )}
         </div>
-        <div className="flex items-center gap-1">
+        <div className="flex shrink-0 items-center gap-1 self-start sm:self-auto">
           <button
             onClick={() => refreshStatus(effectiveMode, modelId)}
             disabled={statusLoading}
@@ -1287,8 +1287,8 @@ export default function ImageGen() {
         </div>
       </div>
 
-      <form onSubmit={handleGenerate} className="grid grid-cols-1 lg:grid-cols-[3fr_2fr] gap-4">
-        <div className="bg-port-card border border-port-border rounded-xl p-4 space-y-3">
+      <form onSubmit={handleGenerate} className="grid min-w-0 max-w-full grid-cols-1 gap-4 lg:grid-cols-[3fr_2fr]">
+        <div className="min-w-0 bg-port-card border border-port-border rounded-xl p-3 sm:p-4 space-y-3">
           <UniverseStylePicker
             value={selectedUniverse?.id || ''}
             onChange={setSelectedUniverse}
@@ -1590,7 +1590,7 @@ export default function ImageGen() {
           )}
         </div>
 
-        <div className="bg-port-card border border-port-border rounded-xl p-4 space-y-2">
+        <div className="min-w-0 bg-port-card border border-port-border rounded-xl p-3 sm:p-4 space-y-2">
           <div className="flex items-center justify-between">
             <h2 className="text-xs font-medium text-gray-400 uppercase tracking-wide">Preview</h2>
             {result && !generating && (

--- a/client/src/pages/MediaGen.jsx
+++ b/client/src/pages/MediaGen.jsx
@@ -20,15 +20,23 @@ export default function MediaGen() {
   const activeTab = pathname.split('/')[2] || 'image';
 
   return (
-    <div className="flex flex-col h-full">
-      <div className="flex items-center gap-3 p-4 border-b border-port-border">
+    <div className="flex min-w-0 flex-col h-full">
+      <div className="flex min-w-0 items-center gap-3 p-3 sm:p-4 border-b border-port-border">
         <Layers className="w-6 h-6 text-port-accent" />
-        <h1 className="text-2xl font-bold text-white">Media Gen</h1>
+        <h1 className="min-w-0 truncate text-2xl font-bold text-white">Media Gen</h1>
       </div>
 
-      <TabPills tabs={TABS} activeTab={activeTab} onChange={(id) => navigate(`/media/${id}`)} ariaLabel="Media Gen sections" />
+      <TabPills
+        tabs={TABS}
+        activeTab={activeTab}
+        onChange={(id) => navigate(`/media/${id}`)}
+        ariaLabel="Media Gen sections"
+        mobileDropdown
+        mobileSelectId="media-gen-section-select"
+        className="w-full min-w-0"
+      />
 
-      <div className="flex-1 overflow-auto p-4">
+      <div className="min-w-0 flex-1 overflow-auto p-3 sm:p-4">
         <Outlet />
       </div>
     </div>

--- a/client/src/pages/MediaGen.test.jsx
+++ b/client/src/pages/MediaGen.test.jsx
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+
+import MediaGen, { TABS } from './MediaGen.jsx';
+
+describe('<MediaGen>', () => {
+  it('provides a labeled mobile section selector for the full tab set', () => {
+    render(
+      <MemoryRouter initialEntries={['/media/image']}>
+        <MediaGen />
+      </MemoryRouter>,
+    );
+
+    const select = screen.getByRole('combobox', { name: 'Media Gen sections' });
+    expect(select).toHaveAttribute('id', 'media-gen-section-select');
+    expect(within(select).getAllByRole('option')).toHaveLength(TABS.length);
+    expect(select).toHaveValue('image');
+  });
+});


### PR DESCRIPTION
## Summary
- Make the Media Gen shell and Image Gen form shrink to the mobile viewport.
- Replace the seven-tab phone overflow with the shared labeled section selector.
- Stack Image Gen status/actions cleanly on narrow screens.

## Test plan
- `npm test -- --run src/pages/MediaGen.test.jsx src/components/ui/TabPills.test.jsx`
- `npm run lint`
- `npm run build`