### PR TITLE
feat: expose merged branch cleanup in app Git tab

### DIFF
--- a/client/src/components/apps/tabs/GitTab.jsx
+++ b/client/src/components/apps/tabs/GitTab.jsx
@@ -400,10 +400,15 @@ export default function GitTab({ appId, appName, repoPath }) {
   };
 
   const mergedBranchCount = remoteBranches.filter(rb => rb.merged && !rb.isDefault).length;
-  // Branches checked out in a worktree can't be locally deleted, so cleanup-merged
-  // skips them — don't count them toward the "Clean N merged" button or it promises
-  // deletions the server refuses.
-  const localMergedCount = branches.filter(b => b.merged && !b.worktree).length;
+  // Keep the action visible for every merged local branch so a worktree-held
+  // branch does not make the cleanup affordance disappear. The server still
+  // protects branches in use; the disclosure beside the button explains why
+  // some branches may remain after cleanup.
+  const localMergedCount = branches.filter(b => b.merged).length;
+  const localWorktreeMergedCount = branches.filter(b => b.merged && b.worktree).length;
+  const localCleanupTitle = localWorktreeMergedCount > 0
+    ? `Cleans merged branches when safe; ${localWorktreeMergedCount} merged branch${localWorktreeMergedCount === 1 ? '' : 'es'} checked out in a worktree will be preserved`
+    : 'Deletes merged branches both locally and on the remote';
 
   const handleCleanupMerged = async () => {
     if (!repoPath || cleaningUp) return;
@@ -415,18 +420,25 @@ export default function GitTab({ appId, appName, repoPath }) {
     });
     setCleaningUp(false);
     if (result) {
-      const count = result.deleted.length;
+      const deleted = Array.isArray(result.deleted) ? result.deleted : [];
+      const skipped = Array.isArray(result.skipped) ? result.skipped : [];
+      const count = deleted.length;
       if (count === 0) {
-        toast('No merged branches to clean up', { icon: 'ℹ️' });
+        toast(
+          skipped.length > 0
+            ? `No branches deleted — ${skipped.length} merged branch${skipped.length === 1 ? '' : 'es'} preserved`
+            : 'No merged branches to clean up',
+          { icon: skipped.length > 0 ? '⚠️' : 'ℹ️' }
+        );
       } else {
         toast.success(`Cleaned up ${count} merged branch${count === 1 ? '' : 'es'}`);
-        const deletedLocals = new Set(result.deleted.filter(d => d.local === 'deleted').map(d => d.name));
-        const deletedRemotes = new Set(result.deleted.filter(d => d.remote === 'deleted').map(d => d.name));
+        const deletedLocals = new Set(deleted.filter(d => d.local === 'deleted').map(d => d.name));
+        const deletedRemotes = new Set(deleted.filter(d => d.remote === 'deleted').map(d => d.name));
         setBranches(prev => prev.filter(b => !deletedLocals.has(b.name)));
         setRemoteBranches(prev => prev.filter(b => !deletedRemotes.has(b.name)));
       }
-      if (result.skipped.length > 0) {
-        toast(`${result.skipped.length} branch${result.skipped.length === 1 ? '' : 'es'} skipped`, { icon: '⚠️' });
+      if (count > 0 && skipped.length > 0) {
+        toast(`${skipped.length} branch${skipped.length === 1 ? '' : 'es'} preserved`, { icon: '⚠️' });
       }
     }
   };
@@ -692,21 +704,31 @@ export default function GitTab({ appId, appName, repoPath }) {
                       <button
                         onClick={() => setCleanupConfirm('local')}
                         disabled={cleaningUp}
+                        title={localCleanupTitle}
                         className={`flex items-center gap-1 text-xs ${touchBtnCls} text-port-warning hover:text-port-error disabled:opacity-50`}
                       >
                         <Trash2 size={12} />
                         {cleaningUp ? 'Cleaning...' : `Clean ${localMergedCount} merged`}
                       </button>
                     )}
+                    {localWorktreeMergedCount > 0 && !cleanupConfirm && (
+                      <span className="text-xs text-gray-500" role="status">
+                        {localWorktreeMergedCount} merged branch{localWorktreeMergedCount === 1 ? '' : 'es'} in a worktree will be preserved
+                      </span>
+                    )}
                     {cleanupConfirm === 'local' && (
                       <div className="flex flex-wrap items-center gap-1">
                         <button
                           onClick={handleCleanupMerged}
                           disabled={cleaningUp}
-                          title="Deletes merged branches both locally and on the remote"
+                          title={localCleanupTitle}
                           className={`px-2 py-1 ${touchBtnCls} text-xs bg-port-error/20 text-port-error rounded hover:bg-port-error/30 disabled:opacity-50`}
                         >
-                          {cleaningUp ? 'Deleting...' : 'Delete all merged (local + remote)'}
+                          {cleaningUp
+                            ? 'Deleting...'
+                            : localWorktreeMergedCount > 0
+                              ? 'Delete eligible merged (local + remote)'
+                              : 'Delete all merged (local + remote)'}
                         </button>
                         <button
                           onClick={() => setCleanupConfirm(false)}

--- a/client/src/components/apps/tabs/GitTab.test.jsx
+++ b/client/src/components/apps/tabs/GitTab.test.jsx
@@ -151,8 +151,8 @@ describe('GitTab merged-branch cleanup scoping', () => {
 
 describe('GitTab merged branches checked out in worktrees', () => {
   beforeEach(() => {
-    // Both merged branches are checked out in worktrees, so cleanup-merged would
-    // skip them locally — the button must not advertise them as deletable.
+    // Both merged branches are checked out in worktrees, so the cleanup action
+    // remains visible while disclosing that the server will preserve them.
     api.getBranches.mockResolvedValue({
       branches: [
         { name: 'main', current: true, tracking: 'origin/main', ahead: 0, behind: 0, isDefault: true, merged: false, worktree: false },
@@ -163,13 +163,25 @@ describe('GitTab merged branches checked out in worktrees', () => {
     api.getRemoteBranches.mockResolvedValue({ branches: [], defaultBranch: 'main' });
   });
 
-  it('does not show the local "Clean N merged" button when every merged branch is locked in a worktree', async () => {
+  it('keeps the local cleanup button visible and discloses worktree-held branches', async () => {
     render(<GitTab appId="x" appName="App" repoPath="/repo" />);
 
-    // The merged branches still render (with their badges) so the user can see them...
+    // The merged branches still render (with their badges) so the user can see them.
     expect(await screen.findByText('claim/issue-1')).toBeInTheDocument();
-    // ...but there is no phantom cleanup button that would delete zero branches.
-    expect(screen.queryByText(/Clean \d+ merged/)).toBeNull();
+    const localCleanBtn = screen.getByRole('button', { name: 'Clean 2 merged' });
+    expect(localCleanBtn).toHaveAttribute('title', 'Cleans merged branches when safe; 2 merged branches checked out in a worktree will be preserved');
+    expect(screen.getByRole('status')).toHaveTextContent('2 merged branches in a worktree will be preserved');
+  });
+
+  it('uses an eligible-only confirmation when merged branches are held in worktrees', async () => {
+    render(<GitTab appId="x" appName="App" repoPath="/repo" />);
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Clean 2 merged' }));
+
+    expect(await screen.findByRole('button', { name: 'Delete eligible merged (local + remote)' })).toHaveAttribute(
+      'title',
+      'Cleans merged branches when safe; 2 merged branches checked out in a worktree will be preserved'
+    );
   });
 
   it('labels worktree-checked-out branches with a worktree badge', async () => {

--- a/server/services/git.deleteMergedBranches.test.js
+++ b/server/services/git.deleteMergedBranches.test.js
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('../lib/execGit.js', () => ({
+  execGit: vi.fn()
+}));
+
+vi.mock('./worktreeManager.js', () => ({
+  isGitLockError: vi.fn(),
+  listWorktrees: vi.fn().mockResolvedValue([])
+}));
+
+import { execGit } from '../lib/execGit.js';
+import { listWorktrees } from './worktreeManager.js';
+import { deleteMergedBranches } from './git.js';
+
+const result = (stdout = '', exitCode = 0, stderr = '') => ({ stdout, stderr, exitCode });
+
+beforeEach(() => {
+  listWorktrees.mockResolvedValue([{ branch: 'refs/heads/feature/locked' }]);
+  execGit.mockImplementation((args) => {
+    if (args[0] === 'symbolic-ref') return Promise.resolve(result('origin/main\n'));
+    if (args[0] === 'rev-parse' && args.includes('--verify')) return Promise.resolve(result('abc123\n'));
+    if (args[0] === 'rev-parse' && args.includes('--abbrev-ref')) return Promise.resolve(result('main\n'));
+    if (args[0] === 'branch' && args.includes('--list')) return Promise.resolve(result('  main\n  feature/locked\n  feature/free\n'));
+    if (args[0] === 'branch' && args.includes('-r') && args.includes('--merged')) return Promise.resolve(result(''));
+    if (args[0] === 'branch' && args.includes('--merged')) {
+      return Promise.resolve(result('main\nfeature/locked\nfeature/free\n'));
+    }
+    if (args[0] === 'fetch') return Promise.resolve(result());
+    if (args[0] === 'branch' && args[1] === '-d') return Promise.resolve(result());
+    return Promise.resolve(result());
+  });
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('deleteMergedBranches', () => {
+  it('reports merged branches held by worktrees while deleting eligible locals', async () => {
+    const cleanup = await deleteMergedBranches('/repo');
+
+    expect(cleanup.deleted).toEqual([{ name: 'feature/free', local: 'deleted', remote: null }]);
+    expect(cleanup.skipped).toEqual(['feature/locked (local: checked out in a worktree)']);
+    expect(execGit).toHaveBeenCalledWith(['branch', '-d', 'feature/free'], '/repo', { ignoreExitCode: true });
+    expect(execGit).not.toHaveBeenCalledWith(['branch', '-d', 'feature/locked'], '/repo', { ignoreExitCode: true });
+  });
+});

--- a/server/services/git.js
+++ b/server/services/git.js
@@ -1416,8 +1416,10 @@ export async function deleteMergedBranches(dir, { excludeBranches } = {}) {
     execGit(['branch', '-r', '--merged', `origin/${defaultBranch}`, '--format=%(refname:short)'], dir, { ignoreExitCode: true })
   ]);
 
-  const mergedLocalNames = [...localMergedNames]
-    .filter(name => !protectedSet.has(name) && !localOnlyProtected.has(name) && name !== currentBranch);
+  const mergedLocalCandidates = [...localMergedNames]
+    .filter(name => !protectedSet.has(name));
+  const mergedLocalNames = mergedLocalCandidates
+    .filter(name => !localOnlyProtected.has(name) && name !== currentBranch);
 
   const mergedRemoteNames = remoteMerged.stdout.trim().split('\n').filter(Boolean)
     .filter(ref => ref.startsWith('origin/'))
@@ -1429,7 +1431,16 @@ export async function deleteMergedBranches(dir, { excludeBranches } = {}) {
   const remoteSet = new Set(mergedRemoteNames);
 
   const deleted = [];
-  const skipped = [];
+  const skipped = mergedLocalCandidates
+    .filter(name => localOnlyProtected.has(name) || name === currentBranch)
+    .map(name => {
+      const reason = name === currentBranch
+        ? 'currently checked out'
+        : excludeBranches?.has(name)
+          ? 'used by an active agent'
+          : 'checked out in a worktree';
+      return `${name} (local: ${reason})`;
+    });
   const opts = { ignoreExitCode: true };
 
   for (const name of allMerged) {


### PR DESCRIPTION
## Summary
- Keep the Local Branches cleanup action visible when merged branches are checked out in worktrees.
- Explain protected worktree branches in the Git tab and report them as preserved by cleanup.
- Add service coverage for deleting eligible merged locals while preserving worktree-held branches.

## Test plan
- `npm test -- --run src/components/apps/tabs/GitTab.test.jsx`
- `npm test -- --run services/git.deleteMergedBranches.test.js`
- `npm run lint` (client)
- `npm run build` (client)
- Server full suite passed; client full suite has two unrelated existing failures in Catalog and SeriesLlmPicker.