### PR TITLE
hide hardware-incompatible providers from the AI Providers page

### DIFF
--- a/client/src/pages/AIProviders.jsx
+++ b/client/src/pages/AIProviders.jsx
@@ -33,9 +33,17 @@ import CollapsibleSection from '../components/ui/CollapsibleSection';
 // links there instead of offering an install of its own.
 const LOCAL_APP_LABELS = { ollama: 'Ollama', lmstudio: 'LM Studio' };
 
-// The three buckets the cards are grouped into, in the order they render.
+// The buckets the cards are grouped into, in the order they render.
 // "Needs setup" sits between them deliberately: a provider missing its CLI or
 // key can't be turned on at all, so it is neither enabled nor merely disabled.
+//
+// The last bucket is the machine's own veto: a provider the server has marked
+// hardware-`unavailable` can never run here no matter what the user toggles, so
+// it is pulled out of the three readiness buckets and parked in a section that
+// stays COLLAPSED. Deleting it outright is not an option — the record is shared
+// across a user's federated machines, and one that is unavailable here may be
+// the workhorse on another — so it stays editable/deletable one click away
+// instead of adding noise to the three sections that describe real choices.
 export const PROVIDER_SECTIONS = [
   {
     key: 'enabled',
@@ -57,6 +65,17 @@ export const PROVIDER_SECTIONS = [
     hint: 'Fully configured, but switched off',
     dot: 'bg-gray-500',
     states: [PROVIDER_CARD_STATE.DISABLED],
+  },
+  {
+    key: 'incompatible',
+    title: 'Unavailable on this machine',
+    hint: 'This hardware cannot run them — kept for your other machines',
+    dot: 'bg-port-error',
+    // Matched by hardware, not by card state: `states` stays empty so the
+    // readiness filter never claims one of these cards back.
+    states: [],
+    hardwareIncompatible: true,
+    defaultOpen: false,
   },
 ];
 
@@ -110,6 +129,13 @@ export default function AIProviders() {
   const [sampleProviders, setSampleProviders] = useState([]);
   const [loadingSamples, setLoadingSamples] = useState(false);
   const [addingSample, setAddingSample] = useState({});
+  // Samples this machine could actually run. One the server marked
+  // hardware-`unavailable` has no path to becoming usable here, so it is not
+  // listed at all rather than listed with a dead "Unavailable" button.
+  const addableSamples = useMemo(
+    () => sampleProviders.filter(isProviderHardwareCompatible),
+    [sampleProviders],
+  );
   // CLI availability per provider card, keyed by `providerRuntimeKey`. An empty
   // map means the endpoint was not reached (for example, an older server during
   // an upgrade) — distinct from a confirmed missing CLI — and simply renders no
@@ -390,13 +416,12 @@ export default function AIProviders() {
   };
 
   const handleAddAllSamples = async () => {
-    const compatibleSamples = sampleProviders.filter(isProviderHardwareCompatible);
-    if (compatibleSamples.length === 0) return;
+    if (addableSamples.length === 0) return;
 
     const succeededIds = [];
     const failedIds = [];
 
-    for (const provider of compatibleSamples) {
+    for (const provider of addableSamples) {
       try {
         await api.createProvider(provider);
         succeededIds.push(provider.id);
@@ -482,13 +507,19 @@ export default function AIProviders() {
       const idx = list.findIndex(p => p.id === activeProviderId);
       return idx <= 0 ? list : [list[idx], ...list.slice(0, idx), ...list.slice(idx + 1)];
     };
+    // The hardware veto is decided first: what this machine cannot run never
+    // reaches the readiness buckets, so a card lands in exactly one section.
+    const runnable = providers.filter(isProviderHardwareCompatible);
+    const unrunnable = providers.filter(p => !isProviderHardwareCompatible(p));
     return {
       providersById: byId,
       runtimeByProviderId: runtimeById,
       cardStateByProviderId: readinessById,
       providersBySection: Object.fromEntries(PROVIDER_SECTIONS.map(section => [
         section.key,
-        defaultFirst(providers.filter(p => section.states.includes(readinessById[p.id].state))),
+        defaultFirst(section.hardwareIncompatible
+          ? unrunnable
+          : runnable.filter(p => section.states.includes(readinessById[p.id].state))),
       ])),
     };
   }, [providers, statuses, activeProviderId, runtimeForProvider]);
@@ -572,12 +603,12 @@ export default function AIProviders() {
           <div className="flex items-center justify-between">
             <h2 className="text-lg font-semibold text-white">Sample Providers</h2>
             <div className="flex gap-2">
-              {sampleProviders.filter(isProviderHardwareCompatible).length > 1 && (
+              {addableSamples.length > 1 && (
                 <button
                   onClick={handleAddAllSamples}
                   className="px-3 py-1.5 text-sm bg-port-accent hover:bg-port-accent/80 text-white rounded transition-colors"
                 >
-                  Add All ({sampleProviders.filter(isProviderHardwareCompatible).length})
+                  Add All ({addableSamples.length})
                 </button>
               )}
               <button
@@ -591,13 +622,15 @@ export default function AIProviders() {
 
           {loadingSamples ? (
             <div className="text-center py-6 text-gray-400">Loading sample providers...</div>
-          ) : sampleProviders.length === 0 ? (
+          ) : addableSamples.length === 0 ? (
             <div className="text-center py-6 text-gray-500">
-              All sample providers are already in your configuration.
+              {sampleProviders.length === 0
+                ? 'All sample providers are already in your configuration.'
+                : 'The remaining sample providers cannot run on this machine’s hardware.'}
             </div>
           ) : (
             <div className="grid gap-3">
-              {sampleProviders.map(provider => (
+              {addableSamples.map(provider => (
                 <div
                   key={provider.id}
                   className="bg-port-bg border border-port-border rounded-lg p-3 flex flex-col sm:flex-row sm:items-start justify-between gap-3"
@@ -647,11 +680,6 @@ export default function AIProviders() {
                       {filterSelectableModels(provider.models).length > 0 && (
                         <p>Models: {filterSelectableModels(provider.models).slice(0, 3).join(', ')}{filterSelectableModels(provider.models).length > 3 ? ` +${filterSelectableModels(provider.models).length - 3}` : ''}</p>
                       )}
-                      {!isProviderHardwareCompatible(provider) && (
-                        <p className="text-port-warning">
-                          Unavailable on this machine: {provider.hardwareCompatibility?.reasons?.join(' · ') || 'hardware requirements are not met'}
-                        </p>
-                      )}
                       {provider.envVars && Object.keys(provider.envVars).length > 0 && (
                         <div className="mt-0.5">
                           <span>Env:</span>
@@ -668,10 +696,10 @@ export default function AIProviders() {
                   </div>
                   <button
                     onClick={() => handleAddSample(provider)}
-                    disabled={addingSample[provider.id] || !isProviderHardwareCompatible(provider)}
+                    disabled={Boolean(addingSample[provider.id])}
                     className="px-4 py-1.5 text-sm bg-port-success/20 text-port-success hover:bg-port-success/30 rounded transition-colors disabled:opacity-50 shrink-0"
                   >
-                    {addingSample[provider.id] ? 'Adding...' : isProviderHardwareCompatible(provider) ? 'Add' : 'Unavailable'}
+                    {addingSample[provider.id] ? 'Adding...' : 'Add'}
                   </button>
                 </div>
               ))}
@@ -779,7 +807,7 @@ export default function AIProviders() {
                 <CollapsibleSection
                   key={section.key}
                   size="lg"
-                  defaultOpen
+                  defaultOpen={section.defaultOpen !== false}
                   buttonClassName="flex-wrap border-b border-port-border/60 pb-1.5"
                   bodyClassName="grid gap-4 pt-3"
                   label={(

--- a/client/src/pages/AIProviders.test.jsx
+++ b/client/src/pages/AIProviders.test.jsx
@@ -1240,6 +1240,114 @@ describe('readiness grouping', () => {
   });
 });
 
+describe('hardware-incompatible providers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    api.getApps.mockResolvedValue([]);
+    api.getProviderStatuses.mockResolvedValue({ providers: {} });
+    api.getProviderRuntimes.mockResolvedValue({ runtimes: {} });
+    api.getProviderReadiness.mockResolvedValue({ readiness: {} });
+    api.getSampleProviders.mockResolvedValue({ providers: [] });
+  });
+
+  // A provider this machine cannot run is not a choice the user can act on, so
+  // it must not sit among the enabled cards adding a HARDWARE MISMATCH badge to
+  // a section that otherwise lists live providers.
+  it('parks an unrunnable provider in a collapsed section instead of Enabled', async () => {
+    api.getProviders.mockResolvedValue({
+      providers: [
+        { id: 'ok', name: 'Runs Here', type: 'cli', command: 'claude', enabled: true },
+        {
+          id: 'huge',
+          name: 'Needs More RAM',
+          type: 'api',
+          enabled: true,
+          endpoint: 'http://localhost:1234',
+          hardwareCompatibility: { state: 'unavailable', reasons: ['needs 128GB of RAM'] },
+        },
+      ],
+      activeProvider: 'ok',
+    });
+
+    renderPage();
+
+    const enabled = await screen.findByRole('button', { name: new RegExp('^Enabled') });
+    expect(enabled).toHaveTextContent('1');
+    expect(screen.getByText('Runs Here')).toBeInTheDocument();
+
+    // Collapsed by default: neither the card nor its badge is on screen.
+    const parked = screen.getByRole('button', { name: /Unavailable on this machine/ });
+    expect(parked).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.queryByText('Needs More RAM')).not.toBeInTheDocument();
+    expect(screen.queryByText('HARDWARE MISMATCH')).not.toBeInTheDocument();
+
+    // Still one click from being edited or deleted.
+    fireEvent.click(parked);
+    expect(screen.getByText('Needs More RAM')).toBeInTheDocument();
+  });
+
+  it('omits the section entirely when every provider runs here', async () => {
+    api.getProviders.mockResolvedValue({
+      providers: [{ id: 'ok', name: 'Runs Here', type: 'cli', command: 'claude', enabled: true }],
+      activeProvider: 'ok',
+    });
+
+    renderPage();
+
+    await screen.findByText('Runs Here');
+    expect(screen.queryByRole('button', { name: /Unavailable on this machine/ })).not.toBeInTheDocument();
+  });
+
+  it('leaves an unrunnable sample out of the sample list', async () => {
+    api.getProviders.mockResolvedValue({ providers: [], activeProvider: null });
+    api.getSampleProviders.mockResolvedValue({
+      providers: [
+        { id: 'sample-ok', name: 'Sample Runs Here', type: 'api', enabled: true, endpoint: 'https://api.example.com', models: ['m1'] },
+        {
+          id: 'sample-huge',
+          name: 'Sample Needs More RAM',
+          type: 'api',
+          enabled: true,
+          endpoint: 'https://api.example.com',
+          models: ['m2'],
+          hardwareCompatibility: { state: 'unavailable', reasons: ['needs 128GB of RAM'] },
+        },
+      ],
+    });
+
+    renderPage();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Load Samples' }));
+
+    expect(await screen.findByText('Sample Runs Here')).toBeInTheDocument();
+    expect(screen.queryByText('Sample Needs More RAM')).not.toBeInTheDocument();
+    // One addable sample, so no Add All button and no dead 'Unavailable' action.
+    expect(screen.queryByRole('button', { name: /^Add All/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Unavailable' })).not.toBeInTheDocument();
+  });
+
+  it('says why the sample list is empty when nothing on offer runs here', async () => {
+    api.getProviders.mockResolvedValue({ providers: [], activeProvider: null });
+    api.getSampleProviders.mockResolvedValue({
+      providers: [{
+        id: 'sample-huge',
+        name: 'Sample Needs More RAM',
+        type: 'api',
+        enabled: true,
+        endpoint: 'https://api.example.com',
+        models: ['m2'],
+        hardwareCompatibility: { state: 'unavailable', reasons: ['needs 128GB of RAM'] },
+      }],
+    });
+
+    renderPage();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Load Samples' }));
+
+    expect(await screen.findByText(/cannot run on this machine/)).toBeInTheDocument();
+  });
+});
+
 // Both tables are keyed off PROVIDER_CARD_STATE, and a state missing from either
 // fails quietly: no PROVIDER_SECTIONS row and those cards vanish from the page,
 // no CARD_STATE_STYLES row and the card throws on `style.border`.


### PR DESCRIPTION
## Summary

- Providers the server marks hardware-`unavailable` no longer sit among the Enabled / Needs setup / Disabled cards wearing a `HARDWARE MISMATCH` badge — they can never run here, so the badge was noise.
- They now collect in a **collapsed** "Unavailable on this machine" section. Kept rather than dropped: the record syncs across a user's federated machines, and one that is unavailable here may be the workhorse elsewhere — so it stays editable/deletable one click away.
- Unrunnable **sample** providers drop out of the sample list entirely, instead of being listed with a permanently disabled "Unavailable" button. The empty-list message distinguishes "already added everything" from "nothing on offer runs here".

## Test plan

- `client`: 4 new cases in `AIProviders.test.jsx` cover the parked section (collapsed by default, no badge on screen, expands to the card), the section being absent when everything runs here, an unrunnable sample being omitted, and the empty-sample message.
- `npx vitest run src/pages/AIProviders.test.jsx` — 62 passed; provider utils/components suites — 318 passed; `npm run lint` clean.