### PR TITLE
feat(client): use AutoSizeTextarea for task descriptions and media prompts

### DIFF
--- a/client/src/components/QuickImagePrompt.jsx
+++ b/client/src/components/QuickImagePrompt.jsx
@@ -10,6 +10,7 @@ import { useLocalStoragePersisted } from '../hooks/useLocalStorageBool';
 import useMounted from '../hooks/useMounted';
 import ResolutionField from './media/ResolutionField';
 import MediaJobThumb from './pipeline/MediaJobThumb';
+import AutoSizeTextarea from './ui/AutoSizeTextarea';
 import toast from './ui/Toast';
 
 // Universal presets only (no `compatible` gate) so the quick widget can offer
@@ -132,7 +133,7 @@ export default function QuickImagePrompt() {
       </div>
       <form onSubmit={handleGenerate} className="flex flex-col gap-2 flex-1 min-h-0">
         <label htmlFor="quick-image-prompt" className="sr-only">Image prompt</label>
-        <textarea
+        <AutoSizeTextarea
           id="quick-image-prompt"
           placeholder="A neon-lit alley at dusk, cinematic, 50mm..."
           value={prompt}
@@ -141,7 +142,7 @@ export default function QuickImagePrompt() {
             if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) handleGenerate(e);
           }}
           rows={3}
-          className="flex-1 min-h-[60px] px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white text-sm resize-none"
+          className="w-full min-h-[60px] px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white text-sm"
         />
 
         {/* Universe styling. Hidden entirely when no universe carries style
@@ -207,13 +208,13 @@ export default function QuickImagePrompt() {
           {showNegative && (
             <>
               <label htmlFor="quick-image-negative" className="sr-only">Negative prompt</label>
-              <textarea
+              <AutoSizeTextarea
                 id="quick-image-negative"
                 value={negativePrompt}
                 onChange={(e) => setNegativePrompt(e.target.value)}
                 placeholder="Things to avoid…"
                 rows={2}
-                className="mt-1 w-full px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white text-sm resize-none"
+                className="mt-1 w-full px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white text-sm min-h-[44px]"
               />
             </>
           )}

--- a/client/src/components/cos/TaskAddForm.jsx
+++ b/client/src/components/cos/TaskAddForm.jsx
@@ -628,7 +628,7 @@ export default function TaskAddForm({ providers, apps, onTaskAdded, compact = fa
                 handleAddTask();
               }
             }}
-            className="flex-1 px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white text-sm min-h-[44px]"
+            className="w-full sm:flex-1 px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white text-sm min-h-[44px]"
             aria-required="true"
           />
           <div className="flex gap-2">

--- a/client/src/components/cos/TaskAddForm.jsx
+++ b/client/src/components/cos/TaskAddForm.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef, useMemo, useCallback } from 'react';
 import { Plus, Image, X, ChevronDown, ChevronRight, Sparkles, Loader2, Paperclip, FileText, Zap, Bookmark, Ticket, GitBranch, GitPullRequest, Wand2 } from 'lucide-react';
 import toast from '../ui/Toast';
+import AutoSizeTextarea from '../ui/AutoSizeTextarea';
 import AppContextPicker from '../AppContextPicker';
 import * as api from '../../services/api';
 import { processScreenshotUploads, processAttachmentUploads } from '../../services/apiMedia';
@@ -616,13 +617,17 @@ export default function TaskAddForm({ providers, apps, onTaskAdded, compact = fa
       <div className="space-y-3">
         <div className="flex flex-col sm:flex-row gap-2">
           <label htmlFor="compact-task-desc" className="sr-only">Task description (required)</label>
-          <input
+          <AutoSizeTextarea
             id="compact-task-desc"
-            type="text"
             placeholder="Task description *"
             value={newTask.description}
             onChange={e => setNewTask(t => ({ ...t, description: e.target.value }))}
-            onKeyDown={e => e.key === 'Enter' && !e.shiftKey && !isSubmitting && handleAddTask()}
+            onKeyDown={e => {
+              if (e.key === 'Enter' && !e.shiftKey && !isSubmitting) {
+                e.preventDefault();
+                handleAddTask();
+              }
+            }}
             className="flex-1 px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white text-sm min-h-[44px]"
             aria-required="true"
           />
@@ -723,10 +728,9 @@ export default function TaskAddForm({ providers, apps, onTaskAdded, compact = fa
       <div className="space-y-2">
         <div>
           <label htmlFor="task-description" className="sr-only">Task description (required)</label>
-          <input
+          <AutoSizeTextarea
             id="task-description"
             ref={descriptionRef}
-            type="text"
             placeholder="Task description *"
             value={newTask.description}
             onChange={e => setNewTask(t => ({ ...t, description: e.target.value }))}

--- a/client/src/components/cos/TaskAddForm.test.jsx
+++ b/client/src/components/cos/TaskAddForm.test.jsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import TaskAddForm from './TaskAddForm';
 
@@ -554,5 +554,46 @@ describe('TaskAddForm worktree/PR defaults', () => {
     await waitFor(() => expect(screen.getByPlaceholderText('Task description *')).toBeInTheDocument());
     expect(worktreeToggle()).not.toBeChecked();
     expect(openPrToggle()).not.toBeChecked();
+  });
+
+  describe('description auto-sizing textarea', () => {
+    it('renders task description as an auto-sizing textarea in full mode', async () => {
+      render(<TaskAddForm providers={[]} apps={[]} onTaskAdded={vi.fn()} />);
+      await act(async () => {});
+      const fullDesc = screen.getByPlaceholderText('Task description *');
+      expect(fullDesc.tagName).toBe('TEXTAREA');
+      expect(fullDesc).toHaveClass('resize-none');
+      expect(fullDesc).toHaveClass('break-words');
+    });
+
+    it('renders task description as an auto-sizing textarea in compact mode', async () => {
+      render(<TaskAddForm providers={[]} apps={[]} onTaskAdded={vi.fn()} compact />);
+      await act(async () => {});
+      const compactDesc = screen.getByPlaceholderText('Task description *');
+      expect(compactDesc.tagName).toBe('TEXTAREA');
+      expect(compactDesc).toHaveClass('resize-none');
+      expect(compactDesc).toHaveClass('break-words');
+    });
+
+    it('submits on Enter without shiftKey, and preserves newlines when typing multi-line description', async () => {
+      const user = userEvent.setup();
+      const onTaskAdded = vi.fn();
+      api.addCosTask.mockResolvedValue({ id: 'task-1', description: 'Line 1\nLine 2', status: 'pending', metadata: {} });
+
+      render(<TaskAddForm providers={[]} apps={[]} onTaskAdded={onTaskAdded} />);
+      await act(async () => {});
+      const desc = screen.getByPlaceholderText('Task description *');
+
+      // Type multi-line text using Shift+Enter
+      await user.type(desc, 'Line 1{Shift>}{Enter}{/Shift}Line 2');
+      expect(desc).toHaveValue('Line 1\nLine 2');
+
+      // Press Enter to submit
+      await user.type(desc, '{Enter}');
+      await waitFor(() => expect(api.addCosTask).toHaveBeenCalledWith(
+        expect.objectContaining({ description: 'Line 1\nLine 2' }),
+        expect.anything()
+      ));
+    });
   });
 });

--- a/client/src/components/cos/tabs/TaskItem.jsx
+++ b/client/src/components/cos/tabs/TaskItem.jsx
@@ -21,6 +21,7 @@ import {
   Server
 } from 'lucide-react';
 import toast from '../../ui/Toast';
+import AutoSizeTextarea from '../../ui/AutoSizeTextarea';
 import * as api from '../../../services/api';
 import { effectiveModelFor, effortAwareModelOptions, effortSurvivingModel, seedModelEffort } from '../../../utils/providers';
 import { formatDurationMin, formatBytes } from '../../../utils/formatters';
@@ -432,12 +433,11 @@ export default function TaskItem({ task, isSystem, spawning = false, selected = 
 
           {editing ? (
             <div className="space-y-2" onPointerDown={e => e.stopPropagation()}>
-              <input
-                type="text"
+              <AutoSizeTextarea
                 value={editData.description}
                 aria-label="Task description"
                 onChange={e => setEditData(d => ({ ...d, description: e.target.value }))}
-                className="w-full px-2 py-1 bg-port-bg border border-port-border rounded text-white text-sm"
+                className="w-full px-2 py-1 bg-port-bg border border-port-border rounded text-white text-sm min-h-[34px]"
               />
               {/* A textarea, not an input: for orchestrator tasks this holds the
                   task's entire multi-line prompt, which is unreadable and

--- a/client/src/components/imageGen/ImageGenSettingsForm.jsx
+++ b/client/src/components/imageGen/ImageGenSettingsForm.jsx
@@ -18,6 +18,7 @@ import BackendChipStrip from '../media/BackendChipStrip';
 import ImageGenControls from './ImageGenControls';
 import LoraPicker from './LoraPicker';
 import StylePresetPicker from '../media/StylePresetPicker';
+import AutoSizeTextarea from '../ui/AutoSizeTextarea';
 import { IMAGE_GEN_MODE } from '../../lib/imageGenBackends';
 
 // Labeled card wrapper used only in `grouped` mode. Header is a plain heading
@@ -60,7 +61,7 @@ export default function ImageGenSettingsForm({
   const isAgy = cfg.mode === IMAGE_GEN_MODE.AGY;
   const isLocal = cfg.mode === IMAGE_GEN_MODE.LOCAL;
   const labelCls = 'block text-xs font-medium text-gray-400 mb-1';
-  const textareaCls = 'w-full bg-port-bg border border-port-border rounded-lg px-2 py-2 text-sm text-white focus:outline-none focus:border-port-accent disabled:opacity-50 resize-y';
+  const textareaCls = 'w-full bg-port-bg border border-port-border rounded-lg px-2 py-2 text-sm text-white focus:outline-none focus:border-port-accent disabled:opacity-50 min-h-[60px]';
 
   const noBackend = availableBackends.length === 0 ? (
     <div className="text-[11px] text-port-warning bg-port-warning/10 border border-port-warning/40 rounded px-2 py-1.5">
@@ -144,9 +145,10 @@ export default function ImageGenSettingsForm({
 
   const styleFields = showStyleFields ? (
     <div className="space-y-3">
-      <label className="block">
+      <label htmlFor="image-gen-extra-style" className="block">
         <span className={labelCls}>Extra style (optional)</span>
-        <textarea
+        <AutoSizeTextarea
+          id="image-gen-extra-style"
           rows={2}
           value={cfg.extraStyle || ''}
           onChange={(e) => merge({ extraStyle: e.target.value })}
@@ -155,9 +157,10 @@ export default function ImageGenSettingsForm({
           disabled={disabled}
         />
       </label>
-      <label className="block">
+      <label htmlFor="image-gen-negative-prompt" className="block">
         <span className={labelCls}>Negative prompt (optional)</span>
-        <textarea
+        <AutoSizeTextarea
+          id="image-gen-negative-prompt"
           rows={2}
           value={cfg.negativePrompt || ''}
           onChange={(e) => merge({ negativePrompt: e.target.value })}

--- a/client/src/components/media/MediaJobsQueue.jsx
+++ b/client/src/components/media/MediaJobsQueue.jsx
@@ -4,6 +4,7 @@ import BrailleSpinner from '../BrailleSpinner';
 import toast from '../ui/Toast';
 import ConfirmButtonPair from '../ui/ConfirmButtonPair';
 import { FormField } from '../ui/FormField';
+import AutoSizeTextarea from '../ui/AutoSizeTextarea';
 import { listMediaJobs, cancelMediaJob, cancelQueuedMediaJobs, deleteMediaJob, retryMediaJob, runMediaJobNow } from '../../services/apiMediaJobs.js';
 import { listLoraTrainingCheckpoints } from '../../services/apiLoraTraining.js';
 import { isCloudCliMode, IMAGE_GEN_MODE, CODEX_IMAGEGEN_DEFAULT_EFFORT, supportsCloudModelOverride, modeLabel } from '../../lib/imageGenBackends';
@@ -650,20 +651,20 @@ function EditRetryForm({ job, onSubmit, onCancel }) {
   return (
     <form onSubmit={submit} className="mt-3 pt-3 border-t border-port-border space-y-2">
       <FormField label="Prompt" labelClassName="block text-[10px] uppercase tracking-wide text-port-text-muted">
-        <textarea
+        <AutoSizeTextarea
           value={prompt}
           onChange={(e) => setPrompt(e.target.value)}
           rows={3}
-          className="w-full px-2 py-1.5 bg-port-bg border border-port-border rounded text-white text-xs"
+          className="w-full px-2 py-1.5 bg-port-bg border border-port-border rounded text-white text-xs min-h-[60px]"
           maxLength={8000}
         />
       </FormField>
       <FormField label="Negative prompt" labelClassName="block text-[10px] uppercase tracking-wide text-port-text-muted">
-        <textarea
+        <AutoSizeTextarea
           value={negativePrompt}
           onChange={(e) => setNegativePrompt(e.target.value)}
           rows={2}
-          className="w-full px-2 py-1.5 bg-port-bg border border-port-border rounded text-white text-xs"
+          className="w-full px-2 py-1.5 bg-port-bg border border-port-border rounded text-white text-xs min-h-[44px]"
           maxLength={8000}
         />
       </FormField>
@@ -929,10 +930,10 @@ function VideoRetryForm({ job, onSubmit, onCancel }) {
     <form onSubmit={submit} className="mt-3 pt-3 border-t border-port-border space-y-3">
       <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
         <FormField label="Prompt" labelClassName="block text-xs font-medium text-gray-400 mb-1">
-          <textarea value={prompt} onChange={(e) => setPrompt(e.target.value)} rows={3} maxLength={8000} className="w-full bg-port-bg border border-port-border rounded-lg px-3 py-2 text-sm text-white" />
+          <AutoSizeTextarea value={prompt} onChange={(e) => setPrompt(e.target.value)} rows={3} maxLength={8000} className="w-full bg-port-bg border border-port-border rounded-lg px-3 py-2 text-sm text-white min-h-[80px]" />
         </FormField>
         <FormField label="Negative Prompt" labelClassName="block text-xs font-medium text-gray-400 mb-1">
-          <textarea value={negativePrompt} onChange={(e) => setNegativePrompt(e.target.value)} rows={3} maxLength={8000} className="w-full bg-port-bg border border-port-border rounded-lg px-3 py-2 text-sm text-white" />
+          <AutoSizeTextarea value={negativePrompt} onChange={(e) => setNegativePrompt(e.target.value)} rows={3} maxLength={8000} className="w-full bg-port-bg border border-port-border rounded-lg px-3 py-2 text-sm text-white min-h-[80px]" />
         </FormField>
       </div>
       <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">

--- a/client/src/components/media/PromptRefineModal.jsx
+++ b/client/src/components/media/PromptRefineModal.jsx
@@ -4,6 +4,7 @@ import ProviderModelSelector from '../ProviderModelSelector';
 import toast from '../ui/Toast';
 import Modal from '../ui/Modal';
 import { FormField } from '../ui/FormField';
+import AutoSizeTextarea from '../ui/AutoSizeTextarea';
 import useProviderModels from '../../hooks/useProviderModels';
 import { generateImage, generateVideo, refineMediaPrompt } from '../../services/api';
 import { getRenderConfigForItem } from './normalize';
@@ -186,20 +187,20 @@ export default function PromptRefineModal({ item, open, onClose }) {
               )}
 
               <FormField label="New prompt" labelClassName="block text-[11px] uppercase tracking-wide text-gray-500 mb-1">
-                <textarea
+                <AutoSizeTextarea
                   value={refinedPrompt}
                   onChange={(e) => setRefinedPrompt(e.target.value)}
-                  rows={6}
-                  className="w-full bg-port-bg border border-port-border rounded-lg p-3 text-sm text-white focus:outline-none focus:border-port-accent resize-y"
+                  rows={4}
+                  className="w-full bg-port-bg border border-port-border rounded-lg p-3 text-sm text-white focus:outline-none focus:border-port-accent min-h-[100px]"
                 />
               </FormField>
 
               <FormField label="New negative prompt" labelClassName="block text-[11px] uppercase tracking-wide text-gray-500 mb-1">
-                <textarea
+                <AutoSizeTextarea
                   value={refinedNegative}
                   onChange={(e) => setRefinedNegative(e.target.value)}
-                  rows={3}
-                  className="w-full bg-port-bg border border-port-border rounded-lg p-3 text-sm text-white focus:outline-none focus:border-port-accent resize-y"
+                  rows={2}
+                  className="w-full bg-port-bg border border-port-border rounded-lg p-3 text-sm text-white focus:outline-none focus:border-port-accent min-h-[60px]"
                 />
               </FormField>
             </div>

--- a/client/src/components/ui/AutoSizeTextarea.jsx
+++ b/client/src/components/ui/AutoSizeTextarea.jsx
@@ -1,3 +1,4 @@
+import { forwardRef } from 'react';
 import useAutoSizeTextarea from '../../hooks/useAutoSizeTextarea';
 
 /**
@@ -6,15 +7,20 @@ import useAutoSizeTextarea from '../../hooks/useAutoSizeTextarea';
  * sets the inline height to the content height above that. Forwards every other
  * textarea prop (value, onChange, onBlur, disabled, placeholder, aria-label…).
  */
-export default function AutoSizeTextarea({ value, onChange, className = '', ...rest }) {
-  const [ref, resize] = useAutoSizeTextarea(value);
+const AutoSizeTextarea = forwardRef(function AutoSizeTextarea(
+  { value, onChange, className = '', ...rest },
+  forwardedRef
+) {
+  const [ref, resize] = useAutoSizeTextarea(value, forwardedRef);
   return (
     <textarea
       ref={ref}
       value={value}
       onChange={(e) => { onChange?.(e); resize(); }}
-      className={`resize-none overflow-hidden ${className}`}
+      className={`resize-none overflow-hidden break-words ${className}`}
       {...rest}
     />
   );
-}
+});
+
+export default AutoSizeTextarea;

--- a/client/src/components/ui/AutoSizeTextarea.test.jsx
+++ b/client/src/components/ui/AutoSizeTextarea.test.jsx
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { useRef } from 'react';
+import AutoSizeTextarea from './AutoSizeTextarea.jsx';
+
+describe('AutoSizeTextarea', () => {
+  it('renders a textarea with auto-sizing classes and custom classes', () => {
+    render(
+      <AutoSizeTextarea
+        value="Hello world"
+        onChange={vi.fn()}
+        className="custom-class min-h-[44px]"
+        placeholder="Enter text..."
+      />
+    );
+
+    const textarea = screen.getByPlaceholderText('Enter text...');
+    expect(textarea.tagName).toBe('TEXTAREA');
+    expect(textarea).toHaveClass('resize-none');
+    expect(textarea).toHaveClass('overflow-hidden');
+    expect(textarea).toHaveClass('break-words');
+    expect(textarea).toHaveClass('custom-class');
+    expect(textarea).toHaveClass('min-h-[44px]');
+    expect(textarea).toHaveValue('Hello world');
+  });
+
+  it('forwards ref to the underlying textarea element', () => {
+    let capturedRef = null;
+    function TestComponent() {
+      const ref = useRef(null);
+      capturedRef = ref;
+      return <AutoSizeTextarea ref={ref} value="" onChange={vi.fn()} placeholder="With ref" />;
+    }
+
+    render(<TestComponent />);
+    const textarea = screen.getByPlaceholderText('With ref');
+    expect(capturedRef.current).toBe(textarea);
+  });
+
+  it('forwards callback ref to the underlying textarea element', () => {
+    const callbackRef = vi.fn();
+    render(<AutoSizeTextarea ref={callbackRef} value="" onChange={vi.fn()} placeholder="Callback ref" />);
+    const textarea = screen.getByPlaceholderText('Callback ref');
+    expect(callbackRef).toHaveBeenCalledWith(textarea);
+  });
+
+  it('calls onChange handler and updates value on user input', () => {
+    const onChange = vi.fn();
+    render(<AutoSizeTextarea value="" onChange={onChange} placeholder="Type here" />);
+
+    const textarea = screen.getByPlaceholderText('Type here');
+    fireEvent.change(textarea, { target: { value: 'New text added' } });
+
+    expect(onChange).toHaveBeenCalled();
+  });
+
+  it('forwards additional standard textarea props', () => {
+    render(
+      <AutoSizeTextarea
+        id="test-id"
+        aria-label="Accessible description"
+        value="Readonly text"
+        rows={4}
+        disabled
+        onChange={vi.fn()}
+      />
+    );
+
+    const textarea = screen.getByLabelText('Accessible description');
+    expect(textarea).toBeDisabled();
+    expect(textarea).toHaveAttribute('id', 'test-id');
+    expect(textarea).toHaveAttribute('rows', '4');
+  });
+});

--- a/client/src/components/writers-room/StoryboardConfigTab.jsx
+++ b/client/src/components/writers-room/StoryboardConfigTab.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { Palette, Check, Dice5, Cpu, Settings as SettingsIcon } from 'lucide-react';
 import { randomSeed } from '../../lib/genUtils';
 import BackendChipStrip from '../media/BackendChipStrip';
+import AutoSizeTextarea from '../ui/AutoSizeTextarea';
 import { IMAGE_GEN_MODE } from '../../lib/imageGenBackends';
 import StagePromptModelPicker from './StagePromptModelPicker';
 import { STYLE_ID, EMPTY_IMAGE_STYLE } from '../../lib/wrImageDefaults';
@@ -101,28 +102,30 @@ function WorldStyleRow({ value, presets, onChange }) {
       </select>
       {value.presetId !== STYLE_ID.NONE && (
         <>
-          <label className="block">
+          <label htmlFor="wr-style-prompt" className="block">
             <span className="text-[9px] uppercase tracking-wider text-gray-500">
               Style prompt {value.presetId === STYLE_ID.CUSTOM && <Check size={9} className="inline text-port-accent" />}
             </span>
-            <textarea
+            <AutoSizeTextarea
+              id="wr-style-prompt"
               value={draftPrompt}
               onChange={(e) => setDraftPrompt(e.target.value)}
               onBlur={commitDraft}
               rows={3}
               placeholder="cinematic still, anamorphic lens…"
-              className="w-full mt-0.5 bg-port-bg border border-port-border rounded px-2 py-1 text-[11px] text-gray-200 font-sans resize-y"
+              className="w-full mt-0.5 bg-port-bg border border-port-border rounded px-2 py-1 text-[11px] text-gray-200 font-sans min-h-[60px]"
             />
           </label>
-          <label className="block">
+          <label htmlFor="wr-neg-prompt" className="block">
             <span className="text-[9px] uppercase tracking-wider text-gray-500">Negative prompt (optional)</span>
-            <textarea
+            <AutoSizeTextarea
+              id="wr-neg-prompt"
               value={draftNeg}
               onChange={(e) => setDraftNeg(e.target.value)}
               onBlur={commitDraft}
               rows={2}
               placeholder="cartoon, low quality…"
-              className="w-full mt-0.5 bg-port-bg border border-port-border rounded px-2 py-1 text-[11px] text-gray-200 font-sans resize-y"
+              className="w-full mt-0.5 bg-port-bg border border-port-border rounded px-2 py-1 text-[11px] text-gray-200 font-sans min-h-[44px]"
             />
           </label>
           <div className="text-[10px] text-gray-500">

--- a/client/src/hooks/useAutoSizeTextarea.js
+++ b/client/src/hooks/useAutoSizeTextarea.js
@@ -13,20 +13,29 @@ import { useCallback, useEffect, useLayoutEffect, useRef } from 'react';
  * the inline height this hook sets), and pair it with `resize-none` /
  * `overflow-hidden` so the browser scrollbar never appears.
  */
-export default function useAutoSizeTextarea(value) {
-  const ref = useRef(null);
+export default function useAutoSizeTextarea(value, externalRef) {
+  const localRef = useRef(null);
+  const externalRefRef = useRef(externalRef);
+  externalRefRef.current = externalRef;
+
   const resize = useCallback(() => {
-    const el = ref.current;
+    const el = localRef.current;
     if (!el) return;
     el.style.height = 'auto';
-    el.style.height = `${el.scrollHeight}px`;
+    const style = typeof window !== 'undefined' && window.getComputedStyle ? window.getComputedStyle(el) : null;
+    const borderOffset = style && style.boxSizing === 'border-box'
+      ? (parseFloat(style.borderTopWidth) || 0) + (parseFloat(style.borderBottomWidth) || 0)
+      : 0;
+    el.style.height = `${el.scrollHeight + borderOffset}px`;
   }, []);
+
   useLayoutEffect(() => { resize(); }, [value, resize]);
+
   // Re-fit on width changes only. Gating on width is essential: resize() mutates
   // the element's height, which would otherwise re-trigger the observer into a
   // feedback loop.
   useEffect(() => {
-    const el = ref.current;
+    const el = localRef.current;
     if (!el || typeof ResizeObserver === 'undefined') return undefined;
     let lastWidth = el.clientWidth;
     const ro = new ResizeObserver(() => {
@@ -38,5 +47,27 @@ export default function useAutoSizeTextarea(value) {
     ro.observe(el);
     return () => ro.disconnect();
   }, [resize]);
-  return [ref, resize];
+
+  const setRef = useCallback((el) => {
+    localRef.current = el;
+    setRef.current = el;
+    const ext = externalRefRef.current;
+    if (typeof ext === 'function') {
+      ext(el);
+    } else if (ext && typeof ext === 'object') {
+      ext.current = el;
+    }
+  }, []);
+  setRef.current = localRef.current;
+
+  useEffect(() => {
+    if (!externalRef) return;
+    if (typeof externalRef === 'function') {
+      externalRef(localRef.current);
+    } else if (typeof externalRef === 'object') {
+      externalRef.current = localRef.current;
+    }
+  }, [externalRef]);
+
+  return [setRef, resize];
 }

--- a/client/src/hooks/useAutoSizeTextarea.test.jsx
+++ b/client/src/hooks/useAutoSizeTextarea.test.jsx
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import useAutoSizeTextarea from './useAutoSizeTextarea.js';
+
+describe('useAutoSizeTextarea', () => {
+  let mockResizeObserver;
+  let observerCallback;
+  let observedElement;
+
+  beforeEach(() => {
+    observedElement = null;
+    mockResizeObserver = vi.fn(function(cb) {
+      observerCallback = cb;
+      this.observe = vi.fn((el) => { observedElement = el; });
+      this.unobserve = vi.fn();
+      this.disconnect = vi.fn();
+    });
+    vi.stubGlobal('ResizeObserver', mockResizeObserver);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('sets element height to scrollHeight on mount and when value changes', () => {
+    const el = document.createElement('textarea');
+    vi.spyOn(el, 'scrollHeight', 'get').mockReturnValue(80);
+    vi.spyOn(window, 'getComputedStyle').mockReturnValue({
+      boxSizing: 'content-box',
+    });
+
+    const { rerender } = renderHook(
+      ({ value }) => {
+        const [ref] = useAutoSizeTextarea(value);
+        ref(el);
+        return ref;
+      },
+      { initialProps: { value: 'initial' } }
+    );
+
+    expect(el.style.height).toBe('80px');
+
+    vi.spyOn(el, 'scrollHeight', 'get').mockReturnValue(140);
+    rerender({ value: 'updated with lots more text' });
+
+    expect(el.style.height).toBe('140px');
+  });
+
+  it('includes vertical border offset when boxSizing is border-box', () => {
+    const el = document.createElement('textarea');
+    vi.spyOn(el, 'scrollHeight', 'get').mockReturnValue(100);
+    vi.spyOn(window, 'getComputedStyle').mockReturnValue({
+      boxSizing: 'border-box',
+      borderTopWidth: '2px',
+      borderBottomWidth: '3px',
+    });
+
+    renderHook(() => {
+      const [ref] = useAutoSizeTextarea('hello');
+      ref(el);
+    });
+
+    expect(el.style.height).toBe('105px');
+  });
+
+  it('forwards the DOM node to an external ref object', () => {
+    const el = document.createElement('textarea');
+    const externalRef = { current: null };
+
+    renderHook(() => {
+      const [ref] = useAutoSizeTextarea('text', externalRef);
+      ref(el);
+      return ref;
+    });
+
+    expect(externalRef.current).toBe(el);
+
+    const [ref] = renderHook(() => useAutoSizeTextarea('text', externalRef)).result.current;
+    ref(null);
+    expect(externalRef.current).toBeNull();
+  });
+
+  it('forwards the DOM node to an external callback ref', () => {
+    const el = document.createElement('textarea');
+    const callbackRef = vi.fn();
+
+    renderHook(() => {
+      const [ref] = useAutoSizeTextarea('text', callbackRef);
+      ref(el);
+    });
+
+    expect(callbackRef).toHaveBeenCalledWith(el);
+  });
+
+  it('re-fits on width changes via ResizeObserver but ignores height-only changes', () => {
+    const el = document.createElement('textarea');
+    Object.defineProperty(el, 'clientWidth', { value: 300, writable: true, configurable: true });
+    vi.spyOn(el, 'scrollHeight', 'get').mockReturnValue(60);
+    vi.spyOn(window, 'getComputedStyle').mockReturnValue({ boxSizing: 'content-box' });
+
+    renderHook(() => {
+      const [ref] = useAutoSizeTextarea('test');
+      ref(el);
+    });
+
+    expect(mockResizeObserver).toHaveBeenCalled();
+    expect(observedElement).toBe(el);
+    expect(el.style.height).toBe('60px');
+
+    // Height changed on element, but width stayed same: should not re-trigger
+    vi.spyOn(el, 'scrollHeight', 'get').mockReturnValue(120);
+    act(() => {
+      observerCallback();
+    });
+    expect(el.style.height).toBe('60px');
+
+    // Width changed (e.g. mobile viewport resize / word re-wrapping): triggers re-fit
+    el.clientWidth = 200;
+    act(() => {
+      observerCallback();
+    });
+    expect(el.style.height).toBe('120px');
+  });
+
+  it('exposes the manual resize trigger function', () => {
+    const el = document.createElement('textarea');
+    vi.spyOn(el, 'scrollHeight', 'get').mockReturnValue(50);
+    vi.spyOn(window, 'getComputedStyle').mockReturnValue({ boxSizing: 'content-box' });
+
+    let resizeFn;
+    renderHook(() => {
+      const [ref, resize] = useAutoSizeTextarea('manual');
+      ref(el);
+      resizeFn = resize;
+    });
+
+    expect(el.style.height).toBe('50px');
+    vi.spyOn(el, 'scrollHeight', 'get').mockReturnValue(95);
+    act(() => {
+      resizeFn();
+    });
+    expect(el.style.height).toBe('95px');
+  });
+});

--- a/client/src/hooks/useAutoSizeTextarea.test.jsx
+++ b/client/src/hooks/useAutoSizeTextarea.test.jsx
@@ -68,16 +68,11 @@ describe('useAutoSizeTextarea', () => {
     const el = document.createElement('textarea');
     const externalRef = { current: null };
 
-    renderHook(() => {
-      const [ref] = useAutoSizeTextarea('text', externalRef);
-      ref(el);
-      return ref;
-    });
-
+    const { result } = renderHook(() => useAutoSizeTextarea('text', externalRef));
+    const [ref] = result.current;
+    act(() => { ref(el); });
     expect(externalRef.current).toBe(el);
-
-    const [ref] = renderHook(() => useAutoSizeTextarea('text', externalRef)).result.current;
-    ref(null);
+    act(() => { ref(null); });
     expect(externalRef.current).toBeNull();
   });
 

--- a/client/src/pages/CatalogIngredient.jsx
+++ b/client/src/pages/CatalogIngredient.jsx
@@ -13,6 +13,7 @@ import FilePickerButton from '../components/ui/FilePickerButton';
 import Modal from '../components/ui/Modal.jsx';
 import ConfirmButtonPair from '../components/ui/ConfirmButtonPair.jsx';
 import UnsavedChangesConfirm from '../components/ui/UnsavedChangesConfirm.jsx';
+import AutoSizeTextarea from '../components/ui/AutoSizeTextarea';
 import {
   getCatalogIngredientDetails,
   updateCatalogIngredient,
@@ -1126,23 +1127,25 @@ function GenerateImageControl({ ingredientId, name, description, universeId, onC
             <span className="text-xs font-semibold text-white">Generate image</span>
             {prefilling && <Loader2 size={12} className="animate-spin text-gray-400" aria-hidden="true" />}
           </div>
-          <label className="block">
+          <label htmlFor="ci-image-prompt" className="block">
             <span className="text-[11px] text-gray-400">Prompt</span>
-            <textarea
+            <AutoSizeTextarea
+              id="ci-image-prompt"
               value={prompt}
               onChange={(e) => setPrompt(e.target.value)}
-              rows={4}
+              rows={3}
               placeholder="Describe the image to render…"
-              className="mt-1 w-full text-xs bg-port-bg border border-port-border rounded px-2 py-1 text-gray-200 resize-y"
+              className="mt-1 w-full text-xs bg-port-bg border border-port-border rounded px-2 py-1 text-gray-200 min-h-[60px]"
             />
           </label>
-          <label className="block">
+          <label htmlFor="ci-image-negative-prompt" className="block">
             <span className="text-[11px] text-gray-400">Negative prompt (optional)</span>
-            <textarea
+            <AutoSizeTextarea
+              id="ci-image-negative-prompt"
               value={negativePrompt}
               onChange={(e) => setNegativePrompt(e.target.value)}
               rows={2}
-              className="mt-1 w-full text-xs bg-port-bg border border-port-border rounded px-2 py-1 text-gray-200 resize-y"
+              className="mt-1 w-full text-xs bg-port-bg border border-port-border rounded px-2 py-1 text-gray-200 min-h-[44px]"
             />
           </label>
           <div className="flex items-center justify-end gap-2 pt-1">

--- a/client/src/pages/ImageGen.jsx
+++ b/client/src/pages/ImageGen.jsx
@@ -33,6 +33,7 @@ import ReferenceImagePicker from '../components/imageGen/ReferenceImagePicker';
 import RemoteMediaTargetPicker from '../components/federatedMedia/RemoteMediaTargetPicker';
 import MediaJobsQueue from '../components/media/MediaJobsQueue';
 import { FormField } from '../components/ui/FormField';
+import AutoSizeTextarea from '../components/ui/AutoSizeTextarea';
 import { useMediaCompletionRefresh } from '../hooks/useMediaCompletionRefresh';
 import { useMediaAnnotations } from '../hooks/useMediaAnnotations';
 import { useAutoRefetch } from '../hooks/useAutoRefetch';
@@ -1301,22 +1302,22 @@ export default function ImageGen() {
           />
           <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
             <FormField label="Prompt" labelClassName="block text-xs font-medium text-gray-400 mb-1">
-              <textarea
+              <AutoSizeTextarea
                 value={prompt}
                 onChange={(e) => setPrompt(e.target.value)}
                 rows={3}
                 disabled={statusLoading}
-                className="w-full bg-port-bg border border-port-border rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-port-accent disabled:opacity-50 resize-y"
+                className="w-full bg-port-bg border border-port-border rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-port-accent disabled:opacity-50 min-h-[80px]"
                 placeholder="Describe the image you want to generate..."
               />
             </FormField>
             <FormField label="Negative Prompt" labelClassName="block text-xs font-medium text-gray-400 mb-1">
-              <textarea
+              <AutoSizeTextarea
                 value={negativePrompt}
                 onChange={(e) => setNegativePrompt(e.target.value)}
                 rows={3}
                 disabled={statusLoading}
-                className="w-full bg-port-bg border border-port-border rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-port-accent disabled:opacity-50 resize-y"
+                className="w-full bg-port-bg border border-port-border rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-port-accent disabled:opacity-50 min-h-[80px]"
                 placeholder="What to avoid..."
               />
             </FormField>

--- a/client/src/pages/MusicVideo.jsx
+++ b/client/src/pages/MusicVideo.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState, useCallback, useMemo } from 'react';
 import { useParams, useNavigate } from 'react-router';
 import { Plus, Film } from 'lucide-react';
 import toast from '../components/ui/Toast';
+import AutoSizeTextarea from '../components/ui/AutoSizeTextarea';
 import PageHeader from '../components/PageHeader';
 import {
   listMusicVideoProjects,
@@ -512,7 +513,7 @@ export default function MusicVideo() {
               <div className="mt-2 grid grid-cols-1 sm:grid-cols-2 gap-2">
                 <div>
                   <label htmlFor="mv-concept" className="block text-xs text-port-text-muted mb-1">Concept</label>
-                  <textarea
+                  <AutoSizeTextarea
                     id="mv-concept"
                     value={conceptDraft.value}
                     rows={2}
@@ -520,12 +521,12 @@ export default function MusicVideo() {
                     onChange={conceptDraft.onChange}
                     onBlur={conceptDraft.onBlur}
                     placeholder="What is this video about — story, theme, or narrative thread for the AI plan to build on."
-                    className="w-full bg-port-bg border border-port-border rounded px-2 py-1.5 text-sm"
+                    className="w-full bg-port-bg border border-port-border rounded px-2 py-1.5 text-sm min-h-[44px]"
                   />
                 </div>
                 <div>
                   <label htmlFor="mv-style" className="block text-xs text-port-text-muted mb-1">Visual style</label>
-                  <textarea
+                  <AutoSizeTextarea
                     id="mv-style"
                     value={styleDraft.value}
                     rows={2}
@@ -533,7 +534,7 @@ export default function MusicVideo() {
                     onChange={styleDraft.onChange}
                     onBlur={styleDraft.onBlur}
                     placeholder="Art style, references, palette, mood — appended to every generated frame and shot prompt."
-                    className="w-full bg-port-bg border border-port-border rounded px-2 py-1.5 text-sm"
+                    className="w-full bg-port-bg border border-port-border rounded px-2 py-1.5 text-sm min-h-[44px]"
                   />
                 </div>
               </div>

--- a/client/src/pages/VideoGen.jsx
+++ b/client/src/pages/VideoGen.jsx
@@ -70,6 +70,7 @@ import toast from '../components/ui/Toast';
 import MediaJobsQueue from '../components/media/MediaJobsQueue';
 import ModelSelect from '../components/ModelSelect';
 import { FormField } from '../components/ui/FormField';
+import AutoSizeTextarea from '../components/ui/AutoSizeTextarea';
 import ModelDownloadBadge, { deriveSizeEstimate } from '../components/media/ModelDownloadBadge';
 import { useModelDownloadStatus, TEXT_ENCODER_DOWNLOAD_ID, textEncoderDownloadId } from '../hooks/useModelDownloadStatus';
 import TextEncoderPicker from '../components/videoGen/TextEncoderPicker';
@@ -1035,21 +1036,21 @@ export default function VideoGen() {
           />
           <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
             <FormField label="Prompt" labelClassName="block text-xs font-medium text-gray-400 mb-1">
-              <textarea
+              <AutoSizeTextarea
                 value={prompt}
                 onChange={(e) => setPrompt(e.target.value)}
                 rows={3}
-                className="w-full bg-port-bg border border-port-border rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-port-accent disabled:opacity-50 resize-y"
+                className="w-full bg-port-bg border border-port-border rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-port-accent disabled:opacity-50 min-h-[80px]"
                 placeholder="Describe the video you want to generate..."
               />
             </FormField>
             <FormField label="Negative Prompt" labelClassName="block text-xs font-medium text-gray-400 mb-1">
-              <textarea
+              <AutoSizeTextarea
                 value={negativePrompt}
                 onChange={(e) => setNegativePrompt(e.target.value)}
                 disabled={!isGrok && currentModel?.supportsNegativePrompt === false}
                 rows={3}
-                className="w-full bg-port-bg border border-port-border rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-port-accent disabled:opacity-50 resize-y"
+                className="w-full bg-port-bg border border-port-border rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-port-accent disabled:opacity-50 min-h-[80px]"
                 placeholder={!isGrok && currentModel?.supportsNegativePrompt === false
                   ? 'This CFG-distilled model does not use a negative prompt.'
                   : 'What to avoid...'}


### PR DESCRIPTION
## Summary
- Enhance `useAutoSizeTextarea` and `AutoSizeTextarea` component to support forwarded refs, border-box compensation, and responsive word wrapping.
- Adopt `AutoSizeTextarea` for task descriptions in Chief of Staff (`TaskAddForm.jsx` in both full and compact mode, and `TaskItem.jsx` in edit mode).
- Adopt `AutoSizeTextarea` across image/video prompt fields (`ImageGen.jsx`, `VideoGen.jsx`, `ImageGenSettingsForm.jsx`, `PromptRefineModal.jsx`, `MediaJobsQueue.jsx`, `QuickImagePrompt.jsx`, `MusicVideo.jsx`, `CatalogIngredient.jsx`, `StoryboardConfigTab.jsx`).
- Add unit tests for `useAutoSizeTextarea`, `AutoSizeTextarea`, and `TaskAddForm` description behavior.