### PR TITLE
feat: make cron schedule saves harder to miss

### DIFF
--- a/client/src/components/CronInput.jsx
+++ b/client/src/components/CronInput.jsx
@@ -1,6 +1,7 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { DEFAULT_CRON } from '../utils/cronHelpers';
 import CronSchedulePicker from './CronSchedulePicker';
+import InlineConfirmRow from './ui/InlineConfirmRow';
 
 /**
  * Inline cron expression editor with a day-of-week + time-of-day picker.
@@ -8,48 +9,102 @@ import CronSchedulePicker from './CronSchedulePicker';
  * The picker is the easy path: toggle the days it should run and set the time,
  * no crontab syntax required (no days selected = every day). A collapsible
  * "advanced" row keeps the raw expression + presets for interval/stepped crons
- * the picker can't represent. Calls onSave with the validated expression,
- * onCancel to dismiss.
+ * the picker can't represent. Calls onSave with the validated expression, and
+ * confirms before onCancel can discard an edited schedule.
  */
 export default function CronInput({ value, onSave, onCancel, className = '' }) {
-  const [expr, setExpr] = useState(value || DEFAULT_CRON);
+  const savedExpression = String(value || DEFAULT_CRON);
+  const [expr, setExpr] = useState(savedExpression);
+  const [confirmingCancel, setConfirmingCancel] = useState(false);
+
+  useEffect(() => {
+    setExpr(savedExpression);
+    setConfirmingCancel(false);
+  }, [savedExpression]);
+
+  const trimmed = expr.trim();
+  const isDirty = trimmed !== savedExpression.trim();
+  const isValid = trimmed.split(/\s+/).length === 5;
 
   const handleSave = () => {
-    const trimmed = expr.trim();
-    if (trimmed.split(/\s+/).length !== 5) return;
+    if (!isValid) return;
+    setConfirmingCancel(false);
     onSave(trimmed);
   };
 
+  const handleCancel = () => {
+    if (isDirty) {
+      setConfirmingCancel(true);
+      return;
+    }
+    onCancel?.();
+  };
+
+  const discardChanges = () => {
+    setExpr(savedExpression);
+    setConfirmingCancel(false);
+    onCancel?.();
+  };
+
   return (
-    <div className={`flex flex-col gap-2 ${className}`}>
-      <div className="flex flex-wrap items-center gap-1.5">
+    <div
+      className={`flex flex-col gap-2 ${isDirty ? 'rounded-md border border-port-warning/50 bg-port-warning/10 p-2' : ''} ${className}`.trim()}
+      data-dirty={isDirty}
+    >
+      <div className="flex flex-wrap items-start gap-1.5">
         <CronSchedulePicker
           value={expr}
           onChange={setExpr}
           onCronKeyDown={event => {
             if (event.key === 'Enter') handleSave();
-            if (event.key === 'Escape') onCancel?.();
+            if (event.key === 'Escape') handleCancel();
           }}
         />
+      </div>
+
+      <div className="flex flex-wrap items-center justify-end gap-2 border-t border-port-border/60 pt-2">
+        <span
+          role="status"
+          aria-live="polite"
+          className={`mr-auto text-xs ${isDirty ? 'font-medium text-port-warning' : 'text-gray-500'}`}
+        >
+          {isDirty ? (isValid ? 'Unsaved changes — save before closing' : 'Enter a valid 5-field cron expression') : null}
+        </span>
         <button
           type="button"
           onClick={handleSave}
-          className="px-1.5 py-1 bg-port-accent/20 text-port-accent rounded text-xs hover:bg-port-accent/30"
+          disabled={!isValid}
+          title={isValid ? 'Save schedule changes' : 'Enter a valid 5-field cron expression before saving'}
+          className={`inline-flex min-h-[40px] items-center justify-center rounded px-4 py-2 text-sm font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${isDirty
+            ? 'bg-port-accent text-white shadow-sm ring-2 ring-port-accent/50 hover:bg-port-accent/80'
+            : 'bg-port-accent/20 text-port-accent hover:bg-port-accent/30'}`}
         >
-          OK
+          Save schedule
         </button>
         {onCancel && (
           <button
             type="button"
-            onClick={onCancel}
-            aria-label="Cancel custom cron expression"
-            className="px-1.5 py-1 text-gray-500 hover:text-gray-300 rounded text-xs"
+            onClick={handleCancel}
+            aria-label={isDirty ? 'Cancel schedule edits' : 'Close schedule editor'}
+            className="inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded px-3 py-2 text-sm text-gray-400 transition-colors hover:bg-port-border/50 hover:text-white"
           >
-            X
+            Cancel
           </button>
         )}
       </div>
 
+      {confirmingCancel && onCancel && (
+        <InlineConfirmRow
+          question="Discard your unsaved schedule changes?"
+          confirmText="Discard changes"
+          cancelText="Keep editing"
+          onConfirm={discardChanges}
+          onCancel={() => setConfirmingCancel(false)}
+          tone="warning"
+          autoFocus
+          aria-label="Discard unsaved schedule changes"
+        />
+      )}
     </div>
   );
 }

--- a/client/src/components/CronInput.test.jsx
+++ b/client/src/components/CronInput.test.jsx
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import CronInput from './CronInput.jsx';
+
+describe('CronInput', () => {
+  it('makes an edited schedule visibly unsaved and clears the state after the saved value changes', () => {
+    const onSave = vi.fn();
+    const { rerender } = render(
+      <CronInput value="0 7 * * *" onSave={onSave} onCancel={vi.fn()} />,
+    );
+
+    expect(screen.queryByText(/Unsaved changes/i)).toBeNull();
+
+    fireEvent.change(screen.getByLabelText('Time of day'), { target: { value: '03:30' } });
+
+    expect(screen.getByText('Unsaved changes — save before closing')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Save schedule' })).toHaveClass('ring-2');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save schedule' }));
+    expect(onSave).toHaveBeenCalledWith('30 3 * * *');
+
+    rerender(<CronInput value="30 3 * * *" onSave={onSave} onCancel={vi.fn()} />);
+    expect(screen.queryByText(/Unsaved changes/i)).toBeNull();
+  });
+
+  it('confirms before discarding an edited schedule from the close control', () => {
+    const onCancel = vi.fn();
+    render(<CronInput value="0 7 * * *" onSave={vi.fn()} onCancel={onCancel} />);
+
+    fireEvent.change(screen.getByLabelText('Time of day'), { target: { value: '03:30' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel schedule edits' }));
+
+    expect(onCancel).not.toHaveBeenCalled();
+    expect(screen.getByText('Discard your unsaved schedule changes?')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Keep editing' }));
+    expect(screen.queryByText('Discard your unsaved schedule changes?')).toBeNull();
+    expect(onCancel).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel schedule edits' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Discard changes' }));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText(/Unsaved changes/i)).toBeNull();
+  });
+
+  it('closes immediately when there are no edits', () => {
+    const onCancel = vi.fn();
+    render(<CronInput value="0 7 * * *" onSave={vi.fn()} onCancel={onCancel} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close schedule editor' }));
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText(/Discard your unsaved schedule changes/i)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- Make the visual cron editor show a persistent unsaved-change state.
- Replace the easy-to-miss OK control with a prominent Save schedule action and protect edited schedules from accidental dismissal.

## Test plan

- cd client && npm test
- cd client && npm run lint
- cd client && npm run build