### PR TITLE
feat: guide fleet LLM provider setup

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -280,13 +280,15 @@ export default function App() {
           <Route path="devtools/agents" element={<AgentsPage />} />
           <Route path="eidoverse" element={<Eidoverse />} />
           <Route path="ai" element={<AIProviders />} />
-          {/* The provider editor is a deep-linkable slide-in over the same page:
-              /ai/new creates, /ai/edit/:providerId edits. The id sits under its
-              own `edit` segment rather than directly under /ai so the create
-              route can't be shadowed by a real provider: ids are slugified from
-              the display name, so a provider named "New" gets the id `new` and
-              /ai/new would otherwise match the static create route instead. */}
+          {/* Provider overlays are deep-linkable over the same page: /ai/new
+              creates, /ai/fleet walks through a remote GPU host, and
+              /ai/edit/:providerId edits. The id sits under its own `edit`
+              segment rather than directly under /ai so the create route can't
+              be shadowed by a real provider: ids are slugified from the display
+              name, so a provider named "New" gets the id `new` and /ai/new
+              would otherwise match the static create route instead. */}
           <Route path="ai/new" element={<AIProviders />} />
+          <Route path="ai/fleet" element={<AIProviders />} />
           <Route path="ai/edit/:providerId" element={<AIProviders />} />
           <Route path="prompts" element={<PromptManager />} />
           <Route path="cos" element={<Navigate to="/cos/tasks" replace />} />

--- a/client/src/components/providers/FleetProviderSetup.jsx
+++ b/client/src/components/providers/FleetProviderSetup.jsx
@@ -1,0 +1,327 @@
+import { useMemo, useState } from 'react';
+import { Link } from 'react-router';
+import { ExternalLink, Network, Server, WandSparkles } from 'lucide-react';
+import Drawer from '../Drawer';
+import useDrawerTab from '../../hooks/useDrawerTab';
+import { FormField } from '../ui/FormField';
+import Banner from '../ui/Banner';
+import { isLocalEndpoint, isPrivateNetworkEndpoint } from '../../utils/providers';
+
+const FLEET_TABS = [
+  { id: 'architecture', label: 'Architecture' },
+  { id: 'host', label: 'GPU host' },
+  { id: 'client', label: 'Connect client' },
+  { id: 'verify', label: 'Verify' },
+];
+const FLEET_TAB_IDS = FLEET_TABS.map(({ id }) => id);
+const DEFAULT_MODEL = 'qwen3.8-27b';
+const DEFAULT_PORT = 18020;
+
+const endpointForPeer = (peer) => {
+  const rawHost = String(peer?.host || peer?.address || '').trim();
+  if (!rawHost) return '';
+  const candidate = /^https?:\/\//i.test(rawHost) ? rawHost : `http://${rawHost}`;
+  const parsedHost = URL.canParse(candidate) ? new URL(candidate).hostname : rawHost;
+  const host = parsedHost.replace(/^\[|\]$/g, '').replace(/\.$/, '');
+  return `http://${host}:${DEFAULT_PORT}/v1`;
+};
+
+const normalizeEndpoint = (value) => {
+  const trimmed = String(value || '').trim().replace(/\/+$/, '');
+  if (!trimmed) return '';
+  const withScheme = /^https?:\/\//i.test(trimmed) ? trimmed : `http://${trimmed}`;
+  return /\/v\d+$/i.test(withScheme) ? withScheme : `${withScheme}/v1`;
+};
+
+/**
+ * Build the provider record created by the fleet walkthrough.
+ *
+ * The endpoint intentionally appears twice on an OpenCode record: the provider
+ * field drives PortOS model refresh/readiness, while OPENCODE_CONFIG_CONTENT is
+ * what the spawned harness actually uses. Updating only the former paints a
+ * correct-looking remote card whose agent still calls localhost.
+ */
+export const buildFleetProvider = ({ name, endpoint, apiKey, model, harness }) => {
+  const common = {
+    name: name.trim(),
+    endpoint,
+    apiKey: apiKey.trim(),
+    models: [model.trim()],
+    defaultModel: model.trim(),
+    vllmBacked: true,
+    temperature: 0.7,
+    topP: 0.8,
+    thinking: false,
+    timeout: 600000,
+    enabled: true,
+  };
+  if (harness === 'api') return { ...common, type: 'api' };
+  return {
+    ...common,
+    type: 'tui',
+    command: 'opencode',
+    args: [],
+    envVars: {
+      OPENCODE_CONFIG_CONTENT: JSON.stringify({
+        permission: 'allow',
+        provider: {
+          vllm: {
+            npm: '@ai-sdk/openai-compatible',
+            name: 'Fleet vLLM Qwen3.8-27B',
+            options: { baseURL: endpoint },
+          },
+        },
+      }),
+    },
+    secretEnvVars: [],
+    tuiPromptDelayMs: 2500,
+    tuiIdleTimeoutMs: 180000,
+  };
+};
+
+export default function FleetProviderSetup({ peers = [], onClose, onCreate }) {
+  const [activeTab, setActiveTab] = useDrawerTab('fleetStep', 'architecture', FLEET_TAB_IDS);
+  const [selectedPeerId, setSelectedPeerId] = useState('');
+  const [endpointInput, setEndpointInput] = useState('');
+  const [name, setName] = useState('Fleet GPU · OpenCode TUI');
+  const [apiKey, setApiKey] = useState('');
+  const [model, setModel] = useState(DEFAULT_MODEL);
+  const [harness, setHarness] = useState('tui');
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState('');
+  const availablePeers = useMemo(
+    () => peers.filter((peer) => peer?.enabled !== false && (peer?.host || peer?.address)),
+    [peers],
+  );
+  const endpoint = normalizeEndpoint(endpointInput);
+
+  const selectPeer = (peerId) => {
+    setSelectedPeerId(peerId);
+    const peer = availablePeers.find(({ id }) => id === peerId);
+    setEndpointInput(peer ? endpointForPeer(peer) : '');
+  };
+
+  const selectHarness = (next) => {
+    setHarness(next);
+    setName(next === 'tui' ? 'Fleet GPU · OpenCode TUI' : 'Fleet GPU · API');
+  };
+
+  const submit = (event) => {
+    event.preventDefault();
+    setError('');
+    if (!name.trim()) return setError('Provider name is required.');
+    if (!URL.canParse(endpoint)) return setError('Enter a full HTTP endpoint for the GPU host.');
+    if (isLocalEndpoint(endpoint) || !isPrivateNetworkEndpoint(endpoint)) {
+      return setError('Use a private LAN, MagicDNS, or Tailscale endpoint on another machine.');
+    }
+    if (!apiKey.trim()) return setError('The networked vLLM runtime must have an API key.');
+    if (!model.trim()) return setError('Model id is required.');
+
+    setSaving(true);
+    return onCreate(buildFleetProvider({ name, endpoint, apiKey, model, harness }))
+      .then(onClose)
+      .catch((err) => setError(err?.message || 'Could not create the fleet provider.'))
+      .finally(() => setSaving(false));
+  };
+
+  return (
+    <Drawer
+      open
+      onClose={onClose}
+      title="Fleet LLM setup"
+      subtitle="Use one dedicated GPU host from every PortOS instance"
+      size="lg"
+      tabs={FLEET_TABS}
+      activeTab={activeTab}
+      onTabChange={setActiveTab}
+      closeOnEsc={false}
+      closeOnBackdrop={false}
+    >
+      {activeTab === 'architecture' && (
+        <div className="space-y-4 text-sm text-gray-300">
+          <Banner tone="success" icon={WandSparkles}>
+            <p className="font-medium">Recommended for one RTX 3090: vLLM + Qwen3.8-27B + DFlash2 on the host, OpenCode TUI on coding clients.</p>
+            <p className="mt-1 text-port-success/80">Use a direct API provider instead when PortOS only needs text synthesis. Both connect straight to the same authenticated OpenAI-compatible endpoint over Tailscale.</p>
+          </Banner>
+
+          <div className="grid gap-3 sm:grid-cols-2">
+            <RuntimeChoice
+              title="vLLM DFlash2"
+              badge="3090 default"
+              body="Measured on the RTX 3090, supports prefix caching, tool calls, concurrent request slots, and an authenticated network server. Best fit for an always-on fleet host."
+            />
+            <RuntimeChoice
+              title="EXL3 + MTP / DFlash2"
+              badge="Context alternative"
+              body="The MiaAI-Lab kit fits the native 262K window with MTP and 3.5-bpw weights, but its published numbers are from GB10 and its server queues at batch one. Keep it as the long-context experiment until it is measured on the 3090."
+            />
+            <RuntimeChoice
+              title="LM Studio"
+              badge="Easy fallback"
+              body="The simplest desktop-managed network API and already supported by PortOS. It does not run this EXL3 deployment kit and is less reproducible as a dedicated appliance."
+            />
+            <RuntimeChoice
+              title="MTPLX"
+              badge="Apple Silicon"
+              body="A native-MTP option for Apple Silicon, not the CUDA runtime for a 3090. Use it for a Mac fleet host, not this hardware."
+            />
+          </div>
+
+          <p className="text-xs text-gray-500">
+            The runtime is reached directly rather than proxied through PortOS. That avoids an extra hop and lets OpenCode use the standard OpenAI-compatible tool stream.
+          </p>
+        </div>
+      )}
+
+      {activeTab === 'host' && (
+        <div className="space-y-4 text-sm text-gray-300">
+          <Banner tone="info" icon={Server}>
+            Do this on the dedicated RTX 3090 PortOS instance. No model download or provider call happens from this walkthrough.
+          </Banner>
+          <ol className="list-decimal pl-5 space-y-3">
+            <li>Open <strong>Load Samples</strong> on AI Providers and add <strong>OpenCode vLLM TUI (Qwen3.8-27B)</strong>.</li>
+            <li>Use that card’s setup checklist to prepare the vLLM stack. Set <code>SPEC=dflash2</code>, <code>PREFIX_CACHE=1</code>, and a strong <code>VLLM_API_KEY</code>.</li>
+            <li>Keep the runtime bound on port <code>18020</code>. The stack listens on the network; use Tailscale ACLs and the API key to limit clients.</li>
+            <li>Because this is a dedicated host, configure the container to restart unless stopped. Do not do that on a mixed media workstation: the model occupies nearly the whole GPU.</li>
+            <li>Confirm <code>/v1/models</code> answers through the host’s MagicDNS name or Tailscale IP before configuring clients.</li>
+          </ol>
+          <div className="flex flex-wrap gap-3">
+            <a
+              href="https://github.com/atomantic/PortOS/blob/main/docs/features/fleet-llm-host.md"
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex items-center gap-1.5 text-port-accent hover:underline"
+            >
+              Fleet host guide <ExternalLink size={13} />
+            </a>
+            <a
+              href="https://github.com/syv-ai/qwen38-27b-rtx3090"
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex items-center gap-1.5 text-port-accent hover:underline"
+            >
+              Runtime source <ExternalLink size={13} />
+            </a>
+          </div>
+        </div>
+      )}
+
+      {activeTab === 'client' && (
+        <form onSubmit={submit} className="space-y-4">
+          <Banner tone="info" icon={Network}>
+            Create this provider on each client PortOS instance. The saved endpoint and the spawned OpenCode harness will point at the same fleet host.
+          </Banner>
+
+          {availablePeers.length > 0 && (
+            <FormField label="Known PortOS peer">
+              <select
+                value={selectedPeerId}
+                onChange={(event) => selectPeer(event.target.value)}
+                className="w-full px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white focus:border-port-accent focus:outline-hidden"
+              >
+                <option value="">Enter an endpoint manually</option>
+                {availablePeers.map((peer) => (
+                  <option key={peer.id} value={peer.id}>
+                    {peer.name || peer.host || peer.address}{peer.status ? ` · ${peer.status}` : ''}
+                  </option>
+                ))}
+              </select>
+            </FormField>
+          )}
+
+          <FormField label="GPU host endpoint" hint="Use the runtime endpoint, not the PortOS :5555 address.">
+            <input
+              type="text"
+              value={endpointInput}
+              onChange={(event) => {
+                setSelectedPeerId('');
+                setEndpointInput(event.target.value);
+              }}
+              placeholder="http://gpu-host.example.ts.net:18020/v1"
+              className="w-full px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white focus:border-port-accent focus:outline-hidden"
+            />
+          </FormField>
+
+          <FormField label="Harness">
+            <select
+              value={harness}
+              onChange={(event) => selectHarness(event.target.value)}
+              className="w-full px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white focus:border-port-accent focus:outline-hidden"
+            >
+              <option value="tui">OpenCode TUI — coding agents (recommended)</option>
+              <option value="api">Direct API — text and thinking workflows</option>
+            </select>
+          </FormField>
+
+          <div className="grid gap-4 sm:grid-cols-2">
+            <FormField label="Provider name">
+              <input
+                type="text"
+                value={name}
+                onChange={(event) => setName(event.target.value)}
+                className="w-full px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white focus:border-port-accent focus:outline-hidden"
+              />
+            </FormField>
+            <FormField label="Served model id">
+              <input
+                type="text"
+                value={model}
+                onChange={(event) => setModel(event.target.value)}
+                className="w-full px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white focus:border-port-accent focus:outline-hidden"
+              />
+            </FormField>
+          </div>
+
+          <FormField label="vLLM API key" hint="Use the VLLM_API_KEY configured on the GPU host.">
+            <input
+              type="password"
+              value={apiKey}
+              onChange={(event) => setApiKey(event.target.value)}
+              autoComplete="off"
+              className="w-full px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white focus:border-port-accent focus:outline-hidden"
+            />
+          </FormField>
+
+          {error && <Banner tone="error">{error}</Banner>}
+
+          <div className="flex items-center justify-between gap-3 pt-2">
+            <Link to="/instances" className="text-sm text-port-accent hover:underline">Manage peers</Link>
+            <button
+              type="submit"
+              disabled={saving}
+              className="px-4 py-2 rounded-lg bg-port-accent hover:bg-port-accent/80 text-white disabled:opacity-50"
+            >
+              {saving ? 'Creating…' : 'Create fleet provider'}
+            </button>
+          </div>
+        </form>
+      )}
+
+      {activeTab === 'verify' && (
+        <div className="space-y-4 text-sm text-gray-300">
+          <ol className="list-decimal pl-5 space-y-3">
+            <li>Open the new card and click <strong>Refresh Models</strong>. Confirm the served id appears.</li>
+            <li>Click <strong>Test</strong>. A fleet badge should name the remote host and no local-runtime installer should appear.</li>
+            <li>For the TUI harness, click <strong>Launch in Shell</strong> and ask it to inspect a small workspace before assigning unattended tasks.</li>
+            <li>Set it as the default only after the tool-call test succeeds. Keep a cloud or local fallback for host maintenance and reboots.</li>
+          </ol>
+          <Banner tone="warning">
+            A Tailscale connection protects transport inside the tailnet; the API key still prevents another tailnet process from using the model accidentally. Never copy the key into a shared issue, log, or provider name.
+          </Banner>
+        </div>
+      )}
+    </Drawer>
+  );
+}
+
+function RuntimeChoice({ title, badge, body }) {
+  return (
+    <section className="rounded-lg border border-port-border bg-port-bg/50 p-3 space-y-2">
+      <div className="flex flex-wrap items-center gap-2">
+        <h3 className="font-medium text-white">{title}</h3>
+        <span className="rounded bg-port-border px-2 py-0.5 text-[11px] uppercase tracking-wide text-gray-300">{badge}</span>
+      </div>
+      <p className="text-xs leading-relaxed text-gray-400">{body}</p>
+    </section>
+  );
+}

--- a/client/src/components/providers/ProviderCard.jsx
+++ b/client/src/components/providers/ProviderCard.jsx
@@ -12,7 +12,7 @@
  */
 
 import { Link } from 'react-router';
-import { Terminal } from 'lucide-react';
+import { Network, Terminal } from 'lucide-react';
 import {
   CONTEXT_WINDOW_SOURCE,
   PROVIDER_CARD_STATE,
@@ -20,6 +20,7 @@ import {
   isApiProvider,
   gatewayForProvider,
   isPrivateNetworkEndpoint,
+  isFleetProvider,
   isProcessProvider,
   isRunnerAllowedCommand,
   isProviderHardwareCompatible,
@@ -99,6 +100,10 @@ export default function ProviderCard({
 }) {
   const style = CARD_STATE_STYLES[cardState.state];
   const compatibleModels = filterHardwareCompatibleProviderModels(provider.models, provider);
+  const fleetProvider = isFleetProvider(provider);
+  const fleetHost = fleetProvider && URL.canParse(provider.endpoint)
+    ? new URL(provider.endpoint).hostname
+    : null;
   return (
     <div
       className={`@container bg-port-card border border-l-4 rounded-xl p-4 ${style.border} ${style.dim || ''} ${
@@ -122,6 +127,14 @@ export default function ProviderCard({
           {isDefault && (
             <span className="text-xs px-2 py-0.5 rounded bg-port-accent/20 text-port-accent">
               DEFAULT
+            </span>
+          )}
+          {fleetProvider && (
+            <span
+              className="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded bg-cyan-500/20 text-cyan-300 border border-cyan-500/30"
+              title={`Runs on ${fleetHost || 'another private-network machine'}`}
+            >
+              <Network size={11} /> FLEET HOST
             </span>
           )}
           {provider.llamaBacked && (
@@ -322,7 +335,7 @@ export default function ProviderCard({
           )}
           {provider.vllmBacked && (
             <p className="text-xs text-emerald-300/90">
-              Local vLLM container (endpoint: <code className="text-emerald-200">{provider.endpoint}</code>) — Qwen3.8-27B with DFlash 2 drafting. It holds the whole GPU, so stop it before running local image/video generation.
+              {fleetProvider ? 'Fleet vLLM runtime' : 'Local vLLM container'} (endpoint: <code className="text-emerald-200">{provider.endpoint}</code>) — Qwen3.8-27B with DFlash 2 drafting. {fleetProvider ? 'This PortOS sends work over the private network; runtime lifecycle stays on the GPU host.' : 'It holds the whole GPU, so stop it before running local image/video generation.'}
             </p>
           )}
           {provider.sglangBacked && (
@@ -335,6 +348,11 @@ export default function ProviderCard({
           )}
           {isApiProvider(provider) && (
             <p className="break-words">Endpoint: <code className="text-gray-300 break-all">{provider.endpoint}</code></p>
+          )}
+          {fleetProvider && (
+            <p className="text-xs text-cyan-300/90">
+              Runs on <span className="font-medium">{fleetHost || 'another private-network machine'}</span>; install, start, and GPU-memory controls belong to that host.
+            </p>
           )}
           {/* API-type providers auth solely via the stored apiKey (sent as a
               Bearer header) — surface its state here so "where does the key

--- a/client/src/components/providers/ProviderCard.test.jsx
+++ b/client/src/components/providers/ProviderCard.test.jsx
@@ -62,3 +62,23 @@ describe('ProviderCard context window', () => {
     expect(screen.queryByText(/assumed/)).toBeNull();
   });
 });
+
+describe('ProviderCard fleet identity', () => {
+  it('decorates a private remote runtime and assigns lifecycle to that host', () => {
+    renderCard(wrapper({
+      name: 'Fleet GPU',
+      endpoint: 'http://gpu-host.example.ts.net:18020/v1',
+      vllmBacked: true,
+    }));
+
+    expect(screen.getByText('FLEET HOST')).toBeInTheDocument();
+    expect(screen.getByText(/Fleet vLLM runtime/)).toBeInTheDocument();
+    expect(screen.getByText(/Runs on/)).toHaveTextContent('gpu-host.example.ts.net');
+    expect(screen.queryByText(/Local vLLM container/)).not.toBeInTheDocument();
+  });
+
+  it('does not decorate a public hosted API as a fleet host', () => {
+    renderCard(wrapper({ endpoint: 'https://api.example.com/v1' }));
+    expect(screen.queryByText('FLEET HOST')).not.toBeInTheDocument();
+  });
+});

--- a/client/src/pages/AIProviders.jsx
+++ b/client/src/pages/AIProviders.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import { Link, useLocation, useNavigate, useParams } from 'react-router';
-import { AlertTriangle, Gauge } from 'lucide-react';
+import { AlertTriangle, Gauge, Network } from 'lucide-react';
 import toast from '../components/ui/Toast';
 import * as api from '../services/api';
 import socket from '../services/socket';
@@ -27,6 +27,7 @@ import RuntimeInstallModal from '../components/install/RuntimeInstallModal';
 import ProviderCard from '../components/providers/ProviderCard';
 import { GatewayKeyHint } from '../components/providers/ProviderNotices';
 import CollapsibleSection from '../components/ui/CollapsibleSection';
+import FleetProviderSetup from '../components/providers/FleetProviderSetup';
 
 // The two local apps an API provider can front. Their installer lives on the
 // Models → LLMs page (it starts the service too), so the provider card
@@ -129,6 +130,7 @@ export default function AIProviders() {
   const [sampleProviders, setSampleProviders] = useState([]);
   const [loadingSamples, setLoadingSamples] = useState(false);
   const [addingSample, setAddingSample] = useState({});
+  const [fleetPeers, setFleetPeers] = useState([]);
   // Samples this machine could actually run. One the server marked
   // hardware-`unavailable` has no path to becoming usable here, so it is not
   // listed at all rather than listed with a dead "Unavailable" button.
@@ -174,6 +176,7 @@ export default function AIProviders() {
   const location = useLocation();
   const { providerId: editingProviderId } = useParams();
   const creatingProvider = location.pathname.replace(/\/+$/, '').endsWith('/ai/new');
+  const fleetSetupOpen = location.pathname.replace(/\/+$/, '').endsWith('/ai/fleet');
   const closeForm = useCallback(() => navigate('/ai'), [navigate]);
   const openForm = useCallback((target) => navigate(target ? `/ai/edit/${target.id}` : '/ai/new'), [navigate]);
 
@@ -190,6 +193,13 @@ export default function AIProviders() {
   }, []);
 
   useEffect(() => { loadRuntimes(); }, [loadRuntimes]);
+
+  useEffect(() => {
+    if (!fleetSetupOpen) return;
+    api.getInstances({ silent: true })
+      .then((data) => setFleetPeers(Array.isArray(data?.peers) ? data.peers : []))
+      .catch(() => setFleetPeers([]));
+  }, [fleetSetupOpen]);
 
   useEffect(() => {
     if (!activeRun) return;
@@ -415,6 +425,13 @@ export default function AIProviders() {
     }
   };
 
+  const handleCreateFleetProvider = async (provider) => {
+    const created = await api.createProvider(provider);
+    setProviders((current) => [...current, created]);
+    toast.success(`${created.name} is connected to the fleet GPU host`);
+    return created;
+  };
+
   const handleAddAllSamples = async () => {
     if (addableSamples.length === 0) return;
 
@@ -575,6 +592,12 @@ export default function AIProviders() {
             className="inline-flex items-center gap-1.5 px-4 py-2 bg-port-border hover:bg-port-border/80 text-white rounded-lg transition-colors text-sm sm:text-base"
           >
             <Gauge size={15} /> Compare local models
+          </Link>
+          <Link
+            to="/ai/fleet"
+            className="inline-flex items-center gap-1.5 px-4 py-2 bg-port-border hover:bg-port-border/80 text-white rounded-lg transition-colors text-sm sm:text-base"
+          >
+            <Network size={15} /> Fleet setup
           </Link>
           <button
             onClick={() => setShowRunPanel(!showRunPanel)}
@@ -896,6 +919,13 @@ export default function AIProviders() {
         flushMs={250}
         description={`Installing ${installingRuntime?.label} from ${installingRuntime?.method === 'script' ? "the vendor's official install script" : 'its global npm package'}.`}
       />
+      {fleetSetupOpen && (
+        <FleetProviderSetup
+          peers={fleetPeers}
+          onClose={closeForm}
+          onCreate={handleCreateFleetProvider}
+        />
+      )}
       {/* The readiness checklist's one-click fix. Same streaming modal as the
           CLI installer, pointed at the local-daemon setup endpoint — which
           re-derives the runtime and its endpoint from the provider record, so

--- a/client/src/pages/AIProviders.test.jsx
+++ b/client/src/pages/AIProviders.test.jsx
@@ -8,6 +8,7 @@ const api = vi.hoisted(() => ({
   getProviderStatuses: vi.fn(),
   getProviderRuntimes: vi.fn(),
   getProviderReadiness: vi.fn(),
+  getInstances: vi.fn(),
   getSampleProviders: vi.fn(),
   createProvider: vi.fn(),
   updateProvider: vi.fn(),
@@ -58,6 +59,7 @@ const renderPage = (initialPath = '/ai') => render(
     <Routes>
       <Route path="/ai" element={<AIProviders />} />
       <Route path="/ai/new" element={<AIProviders />} />
+      <Route path="/ai/fleet" element={<AIProviders />} />
       <Route path="/ai/edit/:providerId" element={<AIProviders />} />
     </Routes>
   </MemoryRouter>
@@ -496,6 +498,81 @@ describe('an API provider pointed at another machine', () => {
     renderPage();
 
     expect(await screen.findByText(/LM Studio not installed/)).toBeInTheDocument();
+  });
+});
+
+describe('fleet LLM setup walkthrough', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    api.getApps.mockResolvedValue([]);
+    api.getProviderStatuses.mockResolvedValue({ providers: {} });
+    api.getProviderRuntimes.mockResolvedValue({ runtimes: {} });
+    api.getProviderReadiness.mockResolvedValue({ readiness: {} });
+    api.getProviders.mockResolvedValue({ providers: [], activeProvider: null });
+    api.getInstances.mockResolvedValue({
+      peers: [{
+        id: 'peer-example',
+        name: 'Example GPU host',
+        host: 'gpu-host.example.ts.net',
+        address: '100.64.0.10',
+        status: 'online',
+        enabled: true,
+      }],
+    });
+    api.createProvider.mockImplementation(async (provider) => ({
+      id: 'fleet-gpu-opencode-tui',
+      ...provider,
+      hasApiKey: true,
+    }));
+  });
+
+  it('creates an OpenCode provider whose actual baseURL points at the selected peer', async () => {
+    renderPage('/ai/fleet');
+
+    expect(await screen.findByRole('heading', { name: 'Fleet LLM setup' })).toBeInTheDocument();
+    expect(screen.getByText(/Recommended for one RTX 3090/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Connect client' }));
+    fireEvent.change(await screen.findByLabelText('Known PortOS peer'), { target: { value: 'peer-example' } });
+    fireEvent.change(screen.getByLabelText('vLLM API key'), { target: { value: 'example-secret' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Create fleet provider' }));
+
+    await waitFor(() => expect(api.createProvider).toHaveBeenCalledTimes(1));
+    const created = api.createProvider.mock.calls[0][0];
+    expect(created).toMatchObject({
+      type: 'tui',
+      command: 'opencode',
+      endpoint: 'http://gpu-host.example.ts.net:18020/v1',
+      apiKey: 'example-secret',
+      defaultModel: 'qwen3.8-27b',
+      vllmBacked: true,
+      thinking: false,
+      enabled: true,
+    });
+    expect(JSON.parse(created.envVars.OPENCODE_CONFIG_CONTENT).provider.vllm.options.baseURL)
+      .toBe('http://gpu-host.example.ts.net:18020/v1');
+    await waitFor(() => expect(screen.queryByRole('heading', { name: 'Fleet LLM setup' })).not.toBeInTheDocument());
+    expect(toast.success).toHaveBeenCalledWith('Fleet GPU · OpenCode TUI is connected to the fleet GPU host');
+  });
+
+  it('creates a direct API provider without an inert OpenCode config', async () => {
+    renderPage('/ai/fleet?fleetStep=client');
+
+    fireEvent.change(await screen.findByLabelText('Known PortOS peer'), { target: { value: 'peer-example' } });
+    fireEvent.change(screen.getByLabelText('Harness'), { target: { value: 'api' } });
+    fireEvent.change(screen.getByLabelText('vLLM API key'), { target: { value: 'example-secret' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Create fleet provider' }));
+
+    await waitFor(() => expect(api.createProvider).toHaveBeenCalledTimes(1));
+    const created = api.createProvider.mock.calls[0][0];
+    expect(created).toMatchObject({
+      name: 'Fleet GPU · API',
+      type: 'api',
+      endpoint: 'http://gpu-host.example.ts.net:18020/v1',
+      vllmBacked: true,
+    });
+    expect(created).not.toHaveProperty('command');
+    expect(created).not.toHaveProperty('envVars');
   });
 });
 

--- a/client/src/pages/AIProviders.test.jsx
+++ b/client/src/pages/AIProviders.test.jsx
@@ -514,7 +514,7 @@ describe('fleet LLM setup walkthrough', () => {
         id: 'peer-example',
         name: 'Example GPU host',
         host: 'gpu-host.example.ts.net',
-        address: '100.64.0.10',
+        address: '192.0.2.10',
         status: 'online',
         enabled: true,
       }],

--- a/client/src/utils/providers.js
+++ b/client/src/utils/providers.js
@@ -851,6 +851,16 @@ export const isLocalInstanceProvider = (provider) => {
   return isLocalEndpoint(endpoint);
 };
 
+/**
+ * Does this provider run on another machine inside the private network?
+ *
+ * This is presentation identity, not a trust escalation: prerequisite and key
+ * rules still come from {@link isPrivateNetworkEndpoint}. Public hosted APIs
+ * stay ordinary remote providers; loopback daemons stay local.
+ */
+export const isFleetProvider = (provider) =>
+  !isLocalInstanceProvider(provider) && isPrivateNetworkEndpoint(provider?.endpoint);
+
 export const isLikelyLargeContextProvider = (provider) => {
   if (isProcessProvider(provider)) return true;
   return isApiProvider(provider) && !isLocalEndpoint(provider.endpoint);

--- a/docs/features/fleet-llm-host.md
+++ b/docs/features/fleet-llm-host.md
@@ -1,0 +1,111 @@
+# Dedicated LLM host for a PortOS fleet
+
+One PortOS machine with a capable GPU can serve every other install on the
+tailnet. Clients connect directly to the model runtime's OpenAI-compatible API;
+PortOS federation supplies the known-peer address, but it does not proxy prompts
+or responses through `:5555`.
+
+For one RTX 3090, the default stack is:
+
+```text
+PortOS clients ── Tailscale ──> vLLM :18020 ──> Qwen3.8-27B + DFlash2
+      │
+      ├─ OpenCode TUI provider: coding agents and tool use
+      └─ API provider: text generation, analysis, and thinking workflows
+```
+
+Open **Settings → AI Providers → Fleet setup** on each client to create either
+provider. The walkthrough can prefill the endpoint from an existing PortOS peer
+and writes it into both the provider record and OpenCode's actual `baseURL`.
+
+## Why this stack on a 3090
+
+The [syv-ai RTX 3090 kit](https://github.com/syv-ai/qwen38-27b-rtx3090) is the
+current default because its important claims are measurements on this exact
+card, not projections from another architecture:
+
+- roughly 118 tok/s with MTP and 132–133 tok/s with DFlash2 for one stream at
+  the documented operating point;
+- prefix caching that makes a repeated 25k-token prefix start in about 0.56 s
+  instead of 22.4 s;
+- tool-call parsing, authenticated network serving, concurrent request slots,
+  and a published container;
+- 64k in its conservative low-latency profile, with documented longer-context
+  modes up to the model's native 262k window.
+
+The [MiaAI-Lab EXL3 kit](https://github.com/MiaAI-Lab/Qwen3.8-27B-DFlash2-EXL3-5.0bpw)
+is a useful alternative when maximum resident context is the main constraint.
+Its 3.5-bpw target plus MTP head is substantially smaller and its Hadamard-4 KV
+lane is designed to fit 262k on a 24 GB Ampere card. It is not the fleet default
+yet for two concrete reasons: its published throughput was measured on GB10 and
+explicitly has not been benchmarked on RTX, and its bundled server generates one
+request at a time while concurrent calls queue. Measure it on a real 3090 before
+replacing the vLLM appliance.
+
+Other existing PortOS paths remain useful, but solve different problems:
+
+| Runtime | Use it when | Why it is not the 3090 fleet default |
+| --- | --- | --- |
+| LM Studio | A desktop-managed server and the easiest first network test matter most | It does not run the referenced EXL3 kit and is less reproducible as an unattended appliance |
+| MTPLX | The host is Apple Silicon and native MTP is desired | It is an MLX runtime, not the CUDA path for a 3090 |
+| llama.cpp | A portable GGUF runtime matters more than this model-specific throughput | The DFlash2 path is not the measured, packaged 3090 stack |
+| SGLang | The host is Hopper or Blackwell | Its published Qwen3.8 recipes do not include Ampere 24 GB |
+
+## Host setup
+
+Follow [vLLM Qwen3.8-27B on an RTX 3090](./qwen38-rtx3090.md) for installation
+and WSL2 requirements. For a fleet host, these settings are load-bearing:
+
+1. Set a strong `VLLM_API_KEY`. The runtime listens on `0.0.0.0`; never expose
+   it to the LAN or tailnet without the key.
+2. Use `SPEC=dflash2` and `PREFIX_CACHE=1`. Keep the normal seven-token draft
+   depth for agent work; `DFLASH_TOKENS=15` trades away request slots and context
+   for prompt-reproduction workloads.
+3. Keep model id `qwen3.8-27b`, or enter the actual id in the client walkthrough.
+4. Confirm `http://<gpu-host>:18020/v1/models` answers from another tailnet
+   machine with the bearer key.
+5. On a **dedicated** host, configure the container with `restart:
+   unless-stopped` (or Docker's equivalent) and ensure Docker starts at boot.
+
+The last step is intentionally different from PortOS's mixed-workstation
+default. Qwen3.8 occupies nearly all 24 GB of VRAM, so PortOS never auto-starts
+the container on a machine that may also render images or video. A dedicated
+fleet host has made the opposite allocation decision: availability is its job.
+
+Use Tailscale ACLs to restrict `:18020` to the client machines. The API key is
+still required: the tailnet authenticates machines, while the key prevents an
+unrelated process on one of those machines from consuming the model.
+
+## Client setup
+
+On each client PortOS:
+
+1. Add the GPU host under **Instances** if it is not already a peer.
+2. Open **AI Providers → Fleet setup → Connect client**.
+3. Select the peer (or enter its MagicDNS/IP endpoint), paste the host's
+   `VLLM_API_KEY`, and keep the served model id in sync.
+4. Choose **OpenCode TUI** for CoS coding agents. Choose **Direct API** for
+   PortOS text-generation calls that do not need a file/tool harness.
+5. Create the provider, refresh models, run the card test, then test one small
+   tool-using workspace before making it the default.
+
+OpenCode is the optimal coding harness for this vLLM server because it speaks
+the OpenAI-compatible protocol directly and preserves structured tool calls.
+Claude Code would require an Anthropic-compatible translation layer for this
+specific runtime. A direct API provider has no coding harness: it is deliberately
+the lighter path for ordinary synthesis.
+
+Fleet cards carry a **FLEET HOST** badge and name the remote host. They never
+offer to install or start the runtime locally; lifecycle and GPU-memory controls
+belong to the dedicated machine.
+
+## Availability and failure policy
+
+Keep at least one fallback provider on every client. A dedicated host still has
+driver updates, container restarts, and network maintenance. PortOS should route
+around that outage rather than cold-start another large model on each client.
+
+No cold-bootstrap request is involved in this feature. Opening the walkthrough
+only reads the saved peer list. The model is contacted only when the user clicks
+Refresh Models, Test, or starts a real task.
+

--- a/docs/features/qwen38-rtx3090.md
+++ b/docs/features/qwen38-rtx3090.md
@@ -27,6 +27,12 @@ agent session attached to it dies with it, and a cold start is ~5–7 minutes. T
 symmetry is also why PortOS never auto-starts it — a container that came up on
 boot would silently take the card away from whatever else the box does.
 
+That default is for a mixed workstation. If this machine is intentionally the
+always-on model appliance for several PortOS installs, configure Docker to
+restart the container unless stopped and let the GPU stay allocated. The
+[fleet LLM host guide](./fleet-llm-host.md) covers the Tailscale endpoint,
+client-side OpenCode/API providers, and fallback policy for that topology.
+
 The probe costs nothing on a machine this does not apply to: it is skipped
 entirely when no `vllmBacked` provider is enabled, and on any host without an
 NVIDIA GPU. A probe that fails or times out means the container is *not* serving,
@@ -292,6 +298,23 @@ time-to-first-token dropping from 22.4 s on the first turn to 0.56 s on the
 follow-up, which is what makes a multi-turn TUI session feel different from a
 one-shot completion.
 
+## Why not the EXL3 3.5-bpw kit by default?
+
+The [MiaAI-Lab EXL3 deployment kit](https://github.com/MiaAI-Lab/Qwen3.8-27B-DFlash2-EXL3-5.0bpw)
+is a credible long-context alternative: its 14.2 GB target plus the in-checkpoint
+MTP head leaves enough room for a Hadamard-4 KV cache at the model's native 262k
+window on a 3090. Its DFlash2 draft is about 1.4 GB and trades some of that
+context for throughput.
+
+It does not replace this recipe yet. The EXL3 kit's published throughput and
+quality rows were measured on a DGX Spark/GB10, while the maintainers explicitly
+describe RTX performance as an unmeasured expectation. Its included server also
+generates one request at a time and queues concurrent calls. This vLLM stack has
+reproducible 3090 measurements, structured tool calling, prefix caching, and
+multi-request operation — better evidence for an always-available fleet service.
+Re-evaluate after the EXL3 stack publishes 3090 agent/tool benchmarks and a
+concurrent server result.
+
 ## Environment overrides
 
 | Variable | Default | Purpose |
@@ -302,6 +325,8 @@ one-shot completion.
 ## Related
 
 - [MTPLX](./mtplx.md) — the Apple Silicon native-MTP equivalent.
+- [Dedicated fleet LLM host](./fleet-llm-host.md) — expose this authenticated
+  runtime over Tailscale and create OpenCode/API providers on peer installs.
 - [DFlash 2 / DSpark on llama.cpp](./dflash2.md) — the llama-server path, and the
   2026-08-19 evaluation that concluded PortOS should not vendor an unmerged
   engine patch. That conclusion still holds; what changed is that upstream froze

--- a/server/lib/navManifest.js
+++ b/server/lib/navManifest.js
@@ -86,6 +86,7 @@ const RAW_NAV_COMMANDS = [
   { id: 'nav.writers-room.guide', path: '/writers-room/guide', label: 'Writers Room Guide', section: 'Create', aliases: ['writers-room-guide', 'writing-guide', 'writing-rules', 'word-count', 'length-targets'], keywords: ['microfiction', 'flash fiction', 'short story', 'novelette', 'novella', 'novel length', 'word count', 'character count', 'book length', 'craft', 'writing advice', 'emotional roadmap', 'documentation', 'help'] },
   { id: 'nav.settings.prompts', path: '/prompts', label: 'Prompts', section: 'Settings', aliases: ['prompts'] },
   { id: 'nav.settings.providers', path: '/ai', label: 'Providers', section: 'Settings', aliases: ['providers', 'ai-providers'] },
+  { id: 'nav.settings.fleet-llm', path: '/ai/fleet', label: 'Fleet LLM Setup', section: 'Settings', aliases: ['fleet-llm', 'gpu-host', 'remote-ai-provider'], keywords: ['3090', 'tailscale', 'vllm', 'qwen', 'coding model', 'dedicated host'] },
 
   { id: 'nav.brain.inbox', path: '/brain/inbox', label: 'Inbox', section: 'Brain', aliases: ['brain', 'brain-inbox', 'inbox'] },
   { id: 'nav.brain.config', path: '/brain/config', label: 'Config', section: 'Brain', aliases: ['brain-config'] },


### PR DESCRIPTION
## Summary

- add a deep-linkable AI Providers fleet setup walkthrough for a dedicated RTX 3090 model host
- create correctly wired OpenCode TUI or direct API providers from known Tailscale peers
- decorate remote private-network providers and document the vLLM versus EXL3 runtime decision

## Test plan

- `cd client && npm run lint -- --files src/components/providers/FleetProviderSetup.jsx src/components/providers/ProviderCard.jsx src/pages/AIProviders.jsx src/utils/providers.js src/App.jsx`
- `cd client && npm test -- --run src/pages/AIProviders.test.jsx src/components/providers/ProviderCard.test.jsx src/utils/providers.test.js`
- `cd client && npm run build`