### PR TITLE
stop filing switched-off AI providers under "Needs setup"

### DIFF
--- a/client/src/components/providers/ProviderCard.jsx
+++ b/client/src/components/providers/ProviderCard.jsx
@@ -69,7 +69,7 @@ export const CARD_STATE_STYLES = {
     // Switched-off cards recede until hovered, so a long list reads as the
     // handful of providers that are actually live.
     dim: 'opacity-70 hover:opacity-100 transition-opacity',
-    hint: 'Ready to go, but switched off.',
+    hint: 'Switched off — nothing to do unless you want to use it.',
   },
 };
 
@@ -104,6 +104,13 @@ export default function ProviderCard({
   const fleetHost = fleetProvider && URL.canParse(provider.endpoint)
     ? new URL(provider.endpoint).hostname
     : null;
+  // What the provider is missing — carried by both BLOCKED and DISABLED.
+  const missingSummary = cardState.missing.map(m => m.label).join(' · ');
+  // Switched off, so every finding on this card is a note about enabling it
+  // rather than an outstanding task (see `providerCardState`). Read from
+  // `cardState`, not `provider.enabled`, so the setup widgets below can never
+  // tone one way while the badge, border, and section file the card another.
+  const optional = cardState.state === PROVIDER_CARD_STATE.DISABLED;
   return (
     <div
       className={`@container bg-port-card border border-l-4 rounded-xl p-4 ${style.border} ${style.dim || ''} ${
@@ -165,7 +172,7 @@ export default function ProviderCard({
           <span
             className={`text-xs px-2 py-0.5 rounded ${style.badge}`}
             title={cardState.state === PROVIDER_CARD_STATE.BLOCKED
-              ? cardState.missing.map(m => m.label).join(' · ')
+              ? missingSummary
               : (status?.message || style.hint)}
           >
             {style.label}
@@ -173,12 +180,15 @@ export default function ProviderCard({
               ? ` · ${status.reason}`
               : ''}
           </span>
-          {/* A blocked provider's toggle is not what's stopping it, so
-              spell out which way it sits rather than leaving the reader
-              to infer it from the Enable/Disable button. */}
-          {cardState.state === PROVIDER_CARD_STATE.BLOCKED && (
-            <span className="text-xs px-2 py-0.5 rounded bg-gray-500/20 text-gray-400">
-              {provider.enabled ? 'SWITCHED ON' : 'SWITCHED OFF'}
+          {/* A switched-off provider that would also need a CLI or a key says
+              so — wearing the DISABLED badge's own colors, because it is an FYI
+              for the day the user wants it, not a task this install is behind on. */}
+          {optional && missingSummary && (
+            <span
+              className={`text-xs px-2 py-0.5 rounded ${style.badge}`}
+              title={`To enable: ${missingSummary}`}
+            >
+              SETUP TO ENABLE
             </span>
           )}
           {/* Off the CoS Agent Runner's exec allowlist: the provider still
@@ -285,6 +295,7 @@ export default function ProviderCard({
         <ProviderRuntimeStatus
           runtime={runtime}
           onInstall={onInstallRuntime}
+          optional={optional}
         />
 
         {/* The other half of "can this actually run": is the local daemon this
@@ -298,6 +309,7 @@ export default function ProviderCard({
           onUseServedModel={(modelId) => onUseServedModel?.(provider, modelId)}
           onServeWantedModel={onServeWantedModel ? () => onServeWantedModel(provider) : undefined}
           serving={servingModel}
+          optional={optional}
         />
 
         {provider.enabled && status?.available === false && (
@@ -368,7 +380,9 @@ export default function ProviderCard({
                  orange "API key: not set" line for exactly those endpoints. */
               <p className="text-xs">API key: <span className="text-gray-500">none (private network endpoint)</span></p>
             ) : (
-              <p className="text-xs">API key: <span className="text-port-warning">not set — Edit this provider to paste one</span></p>
+              /* Amber only while the provider is switched ON, where a missing
+                 key is what's stopping it — `optional` mutes it otherwise. */
+              <p className="text-xs">API key: <span className={optional ? 'text-gray-400' : 'text-port-warning'}>not set — Edit this provider to paste one</span></p>
             )
           )}
           {compatibleModels.length > 0 && (

--- a/client/src/components/providers/ProviderCard.test.jsx
+++ b/client/src/components/providers/ProviderCard.test.jsx
@@ -20,7 +20,9 @@ const renderCard = (provider) => render(
   <MemoryRouter>
     <ProviderCard
       provider={provider}
-      cardState={{ state: PROVIDER_CARD_STATE.READY }}
+      // `providerCardState` returns `missing` on every path, so the fixture
+      // carries it too — the card reads it without a defensive guard.
+      cardState={{ state: PROVIDER_CARD_STATE.READY, missing: [] }}
       runtime={null}
       status={null}
       isDefault={false}

--- a/client/src/components/providers/ProviderReadiness.jsx
+++ b/client/src/components/providers/ProviderReadiness.jsx
@@ -70,7 +70,12 @@ function CodeText({ text }) {
   );
 }
 
-export default function ProviderReadiness({ readiness, onAutoSetup, onUseServedModel, onServeWantedModel, serving = false, className = '' }) {
+/**
+ * `optional` — the provider is switched off, so these checks are what enabling
+ * it would take rather than an outstanding task (see `providerCardState`). Same
+ * checks and same fix buttons, in an informational tone under a title saying so.
+ */
+export default function ProviderReadiness({ readiness, onAutoSetup, onUseServedModel, onServeWantedModel, serving = false, optional = false, className = '' }) {
   if (!readiness || !Array.isArray(readiness.checks) || readiness.checks.length === 0) return null;
   const { label, endpoint, ready, standby, standbyDetail, checks, manageUrl, setup } = readiness;
 
@@ -100,14 +105,17 @@ export default function ProviderReadiness({ readiness, onAutoSetup, onUseServedM
   }
 
   const blocked = checks.filter((check) => check.ok !== true).length;
+  const requirements = `${blocked} requirement${blocked === 1 ? '' : 's'}`;
 
   return (
     <Banner
-      tone="warning"
+      tone={optional ? 'info' : 'warning'}
       size="sm"
       icon={Wrench}
       className={className}
-      title={`${label} setup incomplete — ${blocked} requirement${blocked === 1 ? '' : 's'} unmet`}
+      title={optional
+        ? `${label} setup — ${requirements} to meet if you enable this provider`
+        : `${label} setup incomplete — ${requirements} unmet`}
     >
       <ul className="space-y-1 mt-1">
         {checks.map((check) => {
@@ -119,7 +127,7 @@ export default function ProviderReadiness({ readiness, onAutoSetup, onUseServedM
                 <CodeText text={check.label} />
                 {check.detail && <span className="text-gray-500"> — <CodeText text={check.detail} /></span>}
                 {check.fixHint && (
-                  <span className="block text-port-warning/90"><CodeText text={check.fixHint} /></span>
+                  <span className={`block ${optional ? 'text-port-accent/90' : 'text-port-warning/90'}`}><CodeText text={check.fixHint} /></span>
                 )}
                 {check.id === 'model' && check.ok === false
                   && Array.isArray(check.servedModels) && check.servedModels.length > 0 && (

--- a/client/src/components/providers/ProviderReadiness.test.jsx
+++ b/client/src/components/providers/ProviderReadiness.test.jsx
@@ -64,6 +64,18 @@ describe('ProviderReadiness', () => {
     expect(screen.getByText(/1 requirement unmet/)).toBeTruthy();
   });
 
+  // A switched-off provider is optional, not an unfinished step: the same
+  // checks and the same fix buttons, worded and toned as "if you enable this".
+  it('reframes the unmet requirements as optional for a switched-off provider', () => {
+    const { container } = renderWithRouter(<ProviderReadiness readiness={readiness()} optional />);
+    expect(screen.getByText(/2 requirements to meet if you enable this provider/)).toBeTruthy();
+    expect(screen.queryByText(/setup incomplete/)).toBeNull();
+    expect(screen.getByText(/Start llama\.cpp/)).toBeTruthy();
+    // The product claim: an optional provider never paints the amber that means
+    // "this install is behind". Which non-amber tone is Banner's business.
+    expect(container.querySelector('[class*="port-warning"]')).toBeNull();
+  });
+
   it('links to the Models → LLMs page as an in-app action — never to vendor setup docs', () => {
     renderWithRouter(<ProviderReadiness readiness={readiness()} />);
     expect(screen.getByText('Open the LLMs page').closest('a').getAttribute('href')).toBe('/models/llms');

--- a/client/src/components/providers/ProviderRuntimeStatus.jsx
+++ b/client/src/components/providers/ProviderRuntimeStatus.jsx
@@ -26,7 +26,13 @@ import Pill from '../ui/Pill';
 
 const ACTION_CLASS = 'inline-flex items-center gap-1 px-2 py-1 rounded bg-port-accent/20 text-port-accent hover:bg-port-accent/30 transition-colors';
 
-export default function ProviderRuntimeStatus({ runtime, onInstall, className = '' }) {
+/**
+ * `optional` — the provider is switched off, so a missing binary is a note on
+ * what enabling it would take, not a gap in the install (see
+ * `providerCardState`): the badge drops to the muted tone. The install button
+ * stays — it is still the one click that makes the provider usable.
+ */
+export default function ProviderRuntimeStatus({ runtime, onInstall, optional = false, className = '' }) {
   if (!runtime) return null;
   const { label, command, installed, installable, blockedReason, docsUrl, manageUrl } = runtime;
 
@@ -42,7 +48,7 @@ export default function ProviderRuntimeStatus({ runtime, onInstall, className = 
 
   return (
     <div className={`flex flex-wrap items-center gap-2 text-xs ${className}`}>
-      <Pill tone="warning" size="xs">{label} not installed</Pill>
+      <Pill tone={optional ? 'muted' : 'warning'} size="xs">{label} not installed</Pill>
       {installable ? (
         <button
           type="button"

--- a/client/src/pages/AIProviders.jsx
+++ b/client/src/pages/AIProviders.jsx
@@ -35,8 +35,10 @@ import FleetProviderSetup from '../components/providers/FleetProviderSetup';
 const LOCAL_APP_LABELS = { ollama: 'Ollama', lmstudio: 'LM Studio' };
 
 // The buckets the cards are grouped into, in the order they render.
-// "Needs setup" sits between them deliberately: a provider missing its CLI or
-// key can't be turned on at all, so it is neither enabled nor merely disabled.
+// "Needs setup" sits second because it is the page's only outstanding-task list,
+// and it is short: it holds ONLY providers the user switched ON that still can't
+// run. A switched-off one files under "Disabled" whatever it is missing — see
+// the precedence note on `providerCardState`.
 //
 // The last bucket is the machine's own veto: a provider the server has marked
 // hardware-`unavailable` can never run here no matter what the user toggles, so
@@ -56,14 +58,14 @@ export const PROVIDER_SECTIONS = [
   {
     key: 'blocked',
     title: 'Needs setup',
-    hint: 'Missing a CLI or an API key — these cannot run yet',
+    hint: 'Switched on but missing a CLI or an API key — these cannot run yet',
     dot: 'bg-port-warning',
     states: [PROVIDER_CARD_STATE.BLOCKED],
   },
   {
     key: 'disabled',
     title: 'Disabled',
-    hint: 'Fully configured, but switched off',
+    hint: 'Switched off — optional, nothing to do unless you want one',
     dot: 'bg-gray-500',
     states: [PROVIDER_CARD_STATE.DISABLED],
   },

--- a/client/src/pages/AIProviders.test.jsx
+++ b/client/src/pages/AIProviders.test.jsx
@@ -1267,11 +1267,17 @@ describe('readiness grouping', () => {
     expect(screen.getByText('NEEDS SETUP')).toBeInTheDocument();
     // The blocker itself stays where its fix is — the card's API-key row.
     expect(screen.getByText(/not set — Edit this provider to paste one/)).toBeInTheDocument();
+    // "Needs setup" is the only outstanding-task bucket, so it reads before the
+    // long optional catalog rather than being buried under it. Sections render
+    // in `PROVIDER_SECTIONS` order, so the array is what pins it.
+    expect(PROVIDER_SECTIONS.findIndex((s) => s.key === 'blocked'))
+      .toBeLessThan(PROVIDER_SECTIONS.findIndex((s) => s.key === 'disabled'));
   });
 
-  // A missing CLI is what stops the provider — not the toggle — so it belongs in
-  // "Needs setup" whichever way the switch sits.
-  it('files a switched-off provider with a missing CLI under Needs setup', async () => {
+  // "Needs setup" is the outstanding-task list, so only providers the user has
+  // switched ON belong in it. A switched-off one is optional — it files under
+  // Disabled and merely notes what enabling it would take.
+  it('files a switched-off provider with a missing CLI under Disabled, noting the setup', async () => {
     api.getProviders.mockResolvedValue({
       providers: [{ id: 'opencode-ollama', name: 'OpenCode Ollama', type: 'cli', command: 'opencode', enabled: false }],
       activeProvider: null,
@@ -1280,10 +1286,15 @@ describe('readiness grouping', () => {
 
     renderPage();
 
-    expect(await screen.findByText('NEEDS SETUP')).toBeInTheDocument();
-    expect(screen.getByText('OpenCode CLI not installed')).toBeInTheDocument();
-    expect(screen.getByText('SWITCHED OFF')).toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: new RegExp('^Disabled') })).not.toBeInTheDocument();
+    expect(await screen.findByRole('button', { name: new RegExp('^Disabled') })).toBeInTheDocument();
+    expect(screen.getByText('DISABLED')).toBeInTheDocument();
+    expect(screen.getByText('SETUP TO ENABLE')).toBeInTheDocument();
+    // The missing CLI is still named — that IS the note about enabling it — but
+    // in the muted tone, not the amber that would read as a gap in the install.
+    const runtimePill = screen.getByText('OpenCode CLI not installed');
+    expect(runtimePill).toBeInTheDocument();
+    expect(runtimePill.className).not.toMatch(/port-warning/);
+    expect(screen.queryByRole('button', { name: new RegExp('^Needs setup') })).not.toBeInTheDocument();
   });
 
   // The provider list is authoritative: no sibling means the wrapper has no key

--- a/client/src/utils/providers.js
+++ b/client/src/utils/providers.js
@@ -1507,10 +1507,13 @@ export const PROVIDER_CARD_STATE = Object.freeze({
  *                      explicitly empty configured value is `false`; a missing
  *                      or redacted value is unknown and must not be reported.
  *
- * `blocked` outranks `disabled`: a provider whose CLI isn't installed can't be
- * enabled at all, so it belongs in the "needs setup" bucket whichever way its
- * toggle happens to sit. `benched` only applies to an enabled provider that
- * otherwise meets its prerequisites.
+ * `disabled` outranks `blocked`: a provider the user switched off is not a gap
+ * in this install. PortOS ships dozens of provider records the user may never
+ * want, and calling every switched-off one "needs setup" makes an install with
+ * a perfectly good provider read as degraded or half-configured. What such a
+ * provider is missing is still returned in `missing` — a note for the user IF
+ * they decide to turn it on, not an outstanding task. `benched` only applies to
+ * an enabled provider that otherwise meets its prerequisites.
  *
  * @returns {{state: string, missing: {code: string, label: string}[]}}
  */
@@ -1567,8 +1570,10 @@ export const providerCardState = (provider, {
     }
   }
 
-  if (missing.length > 0) return { state: PROVIDER_CARD_STATE.BLOCKED, missing };
+  // Switched off wins over every finding — see the precedence note above. The
+  // findings ride along so the card can still say what enabling it would take.
   if (!provider?.enabled) return { state: PROVIDER_CARD_STATE.DISABLED, missing };
+  if (missing.length > 0) return { state: PROVIDER_CARD_STATE.BLOCKED, missing };
   if (status?.available === false) return { state: PROVIDER_CARD_STATE.BENCHED, missing };
   return { state: PROVIDER_CARD_STATE.READY, missing };
 };

--- a/client/src/utils/providers.test.js
+++ b/client/src/utils/providers.test.js
@@ -1698,11 +1698,12 @@ describe('providerCardState', () => {
       .toBe(PROVIDER_CARD_STATE.DISABLED);
   });
 
-  // The toggle is not what's stopping a provider whose CLI is missing, so the
-  // missing prerequisite outranks it — that's the bucket the user must act in.
-  it('keeps a switched-off provider with a missing prerequisite in the blocked bucket', () => {
-    expect(providerCardState(cli({ enabled: false }), { runtime: { label: 'OpenCode CLI', installed: false } }).state)
-      .toBe(PROVIDER_CARD_STATE.BLOCKED);
+  // Switched off outranks every finding, and the findings ride along so the
+  // card can still say what enabling it would take.
+  it('reads a switched-off provider with a missing prerequisite as disabled, keeping the findings', () => {
+    const readiness = providerCardState(cli({ enabled: false }), { runtime: { label: 'OpenCode CLI', installed: false } });
+    expect(readiness.state).toBe(PROVIDER_CARD_STATE.DISABLED);
+    expect(readiness.missing).toEqual([{ code: 'runtime', label: 'OpenCode CLI is not installed' }]);
   });
 
   it('collects every missing prerequisite at once', () => {

--- a/server/lib/capabilityMap.test.js
+++ b/server/lib/capabilityMap.test.js
@@ -23,6 +23,20 @@ describe('providersRow', () => {
     expect(providersRow([{ id: 'a', enabled: false }]).status).toBe(UNCONFIGURED);
   });
 
+  // The server half of the rule the AI Providers page states: a switched-off
+  // provider is optional, so it must never reach the "need setup" tally or pull
+  // the row out of OK. The `enabled` filter above is what enforces it.
+  it('ignores switched-off providers even when their prerequisites are blocked', () => {
+    const r = providersRow(
+      [{ id: 'a' }, { id: 'off', enabled: false }],
+      { providers: {} },
+      { a: { status: 'ready' }, off: { status: 'blocked', reasonCodes: ['runtime'] } },
+    );
+    expect(r).toMatchObject({ status: OK, setupComplete: true });
+    expect(r.detail).toMatchObject({ configured: 1, available: 1, blocked: 0, unknown: 0 });
+    expect(r.summary).not.toMatch(/need setup/);
+  });
+
   it('treats never-marked providers as available', () => {
     const r = providersRow([{ id: 'a' }, { id: 'b' }], { providers: {} });
     expect(r.status).toBe(OK);


### PR DESCRIPTION
## Summary

- **Disabled now outranks blocked** in `providerCardState`. PortOS ships dozens of optional provider records; ranking BLOCKED first filed every switched-off provider missing a CLI or API key under **Needs setup** and painted it amber, making an install with a perfectly good provider read as degraded or half-configured.
- **A switched-off card still says what enabling it would take** — the findings ride along in `missing`. They render as a muted `SETUP TO ENABLE` badge, an informational (not amber) readiness banner, and a muted runtime pill: a note for the day the user wants the provider, not an outstanding task.
- **"Needs setup" now means exactly one thing**: a provider the user switched ON that still can't run. It stays second in the section order as the page's only actionable bucket.
- **Server side already counted only enabled providers** (`providersRow` filters `enabled !== false`), so the Capability Map row and setup banner were already correct — a test now pins that so the two halves can't drift.

## Test plan

- `client`: 847 files / 10,625 tests pass; biome lint clean.
- `server`: 1,807 files / 36,796 tests pass.
- New coverage: the precedence flip and preserved findings (`providers.test.js`), the optional readiness tone and wording (`ProviderReadiness.test.jsx`), the Disabled filing plus muted runtime pill and section order (`AIProviders.test.jsx`), and the server tally ignoring switched-off providers (`capabilityMap.test.js`).