### PR TITLE
fix: clarify scheduled task intent and summaries

### DIFF
--- a/client/src/components/apps/tabs/CustomTasksSection.jsx
+++ b/client/src/components/apps/tabs/CustomTasksSection.jsx
@@ -93,10 +93,10 @@ function TaskForm({ form, setForm, onSave, onCancel, saveLabel, timezone, provid
           className="w-full px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white text-sm"
         />
       </FormField>
-      <FormField label="Description">
+      <FormField label="Card summary" hint="Shown beneath the task name on its card.">
         <input
           type="text"
-          placeholder="Description"
+          placeholder="One-line summary (optional)"
           value={form.description}
           onChange={e => update('description', e.target.value)}
           className="w-full px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white text-sm"

--- a/client/src/components/apps/tabs/CustomTasksSection.test.jsx
+++ b/client/src/components/apps/tabs/CustomTasksSection.test.jsx
@@ -21,6 +21,7 @@ const task = {
   id: 'job-1',
   appId: 'app-1',
   name: 'Example Task',
+  description: 'A short card summary',
   enabled: true,
   type: 'agent',
   interval: 'daily',
@@ -102,6 +103,7 @@ describe('CustomTasksSection trigger outcomes', () => {
     await screen.findByText('Example Task');
     fireEvent.click(screen.getByRole('button', { name: /New Custom Task/ }));
     fireEvent.change(screen.getByPlaceholderText('Task name *'), { target: { value: 'Pinned Task' } });
+    fireEvent.change(screen.getByPlaceholderText('One-line summary (optional)'), { target: { value: 'A concise card summary' } });
     fireEvent.change(screen.getByPlaceholderText('Prompt for the agent *'), { target: { value: 'Do the thing' } });
     fireEvent.change(screen.getByLabelText('Provider'), { target: { value: 'codex' } });
     fireEvent.change(screen.getByLabelText('Model'), { target: { value: 'gpt-5' } });
@@ -112,6 +114,7 @@ describe('CustomTasksSection trigger outcomes', () => {
     await waitFor(() => expect(api.createCosJob).toHaveBeenCalledWith(expect.objectContaining({
       appId: 'app-1',
       type: 'agent',
+      description: 'A concise card summary',
       providerId: 'codex',
       model: 'gpt-5',
       effort: 'high',

--- a/client/src/components/cos/JobCard.jsx
+++ b/client/src/components/cos/JobCard.jsx
@@ -363,6 +363,9 @@ export default function JobCard({
               </span>
             )}
           </div>
+          {job.description?.trim() && (
+            <p className="text-xs text-gray-400 truncate mt-1" title={job.description}>{job.description}</p>
+          )}
           <div className="flex items-center gap-3 text-xs text-gray-500 mt-1 flex-wrap">
             <span className="flex items-center gap-1">
               <Clock size={10} />
@@ -422,9 +425,14 @@ export default function JobCard({
                   className="w-full px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white text-sm"
                 />
               </FormField>
-              <FormField label="Description" labelClassName="block text-xs text-gray-400 mb-1">
+              <FormField
+                label="Card summary"
+                hint="Shown beneath the task name on its card."
+                labelClassName="block text-xs text-gray-400 mb-1"
+              >
                 <input
                   type="text"
+                  placeholder="One-line summary (optional)"
                   value={editData.description}
                   onChange={e => setEditData(d => ({ ...d, description: e.target.value }))}
                   className="w-full px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white text-sm"

--- a/client/src/components/cos/tabs/JobsTab.jsx
+++ b/client/src/components/cos/tabs/JobsTab.jsx
@@ -243,9 +243,14 @@ export default function JobsTab() {
                 />
               </FormField>
             </div>
-            <FormField label="Description" labelClassName="block text-xs text-gray-400 mb-1">
+            <FormField
+              label="Card summary"
+              hint="Shown beneath the task name on its card."
+              labelClassName="block text-xs text-gray-400 mb-1"
+            >
               <input
                 type="text"
+                placeholder="One-line summary (optional)"
                 value={newJob.description}
                 onChange={e => setNewJob(j => ({ ...j, description: e.target.value }))}
                 className="w-full px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white text-sm"

--- a/client/src/components/cos/tabs/schedule/AppTaskCard.jsx
+++ b/client/src/components/cos/tabs/schedule/AppTaskCard.jsx
@@ -19,6 +19,8 @@ export default function AppTaskCard({ taskType, config, apps, onTrigger, onConfi
   const coverage = coverageTone(enabledCount, totalCount);
   const coveragePct = hasApps ? Math.round((enabledCount / totalCount) * 100) : 0;
   const nextRun = describeNextRun(config);
+  const userInvokable = config.invocation?.userInvokable !== false;
+  const invocationDescription = config.invocation?.description || 'Runs as part of another automation and is not directly invokable.';
   // A pipeline task resolves provider/model per stage — a single card-level pin
   // would be ignored, so point at the drawer instead of offering one.
   const stageCount = pipelineStages(config).length;
@@ -68,7 +70,7 @@ export default function AppTaskCard({ taskType, config, apps, onTrigger, onConfi
       </button>
 
       {/* Quick model pins — the drawer's Global defaults, inline */}
-      {onUpdate && (stageCount > 0 ? (
+      {userInvokable && onUpdate && (stageCount > 0 ? (
         <button
           type="button"
           onClick={() => onConfigure(taskType)}
@@ -83,21 +85,29 @@ export default function AppTaskCard({ taskType, config, apps, onTrigger, onConfi
 
       {/* Footer actions */}
       <div className="flex items-center gap-2 px-4 py-2.5 border-t border-port-border">
-        <RunTaskButton
-          taskType={taskType}
-          apps={apps}
-          onTrigger={onTrigger}
-          installWide={config.installWide}
-          disabledReason={improvementDisabled ? IMPROVEMENT_DISABLED_TITLE : (pins.saving ? SAVING_TITLE : '')}
-        />
-        <button
-          type="button"
-          onClick={() => onConfigure(taskType)}
-          className="ml-auto flex items-center gap-1.5 px-3 py-1.5 text-sm rounded text-gray-300 hover:text-white hover:bg-port-border/50 transition-colors"
-        >
-          <SlidersHorizontal size={13} />
-          Configure
-        </button>
+        {userInvokable ? (
+          <>
+            <RunTaskButton
+              taskType={taskType}
+              apps={apps}
+              onTrigger={onTrigger}
+              installWide={config.installWide}
+              disabledReason={improvementDisabled ? IMPROVEMENT_DISABLED_TITLE : (pins.saving ? SAVING_TITLE : '')}
+            />
+            <button
+              type="button"
+              onClick={() => onConfigure(taskType)}
+              className="ml-auto flex items-center gap-1.5 px-3 py-1.5 text-sm rounded text-gray-300 hover:text-white hover:bg-port-border/50 transition-colors"
+            >
+              <SlidersHorizontal size={13} />
+              Configure
+            </button>
+          </>
+        ) : (
+          <span className="text-xs text-port-warning/80" title={invocationDescription}>
+            {config.invocation?.label || 'Automation-only'} — runs from its parent automation
+          </span>
+        )}
       </div>
     </div>
   );

--- a/client/src/components/cos/tabs/schedule/AppTaskCard.test.jsx
+++ b/client/src/components/cos/tabs/schedule/AppTaskCard.test.jsx
@@ -57,6 +57,12 @@ describe('AppTaskCard', () => {
     expect(screen.getByText('App coverage')).toBeTruthy();
   });
 
+  it('shows the shipped task summary beneath the task name', () => {
+    const summary = 'Review contributor changes before they merge';
+    renderCard({ description: summary });
+    expect(screen.getByText(summary)).toBeInTheDocument();
+  });
+
   it('shows a future next-run countdown for active scheduled tasks', () => {
     renderCard();
     // timeUntil for a year-2999 date returns an "in …" string.
@@ -79,6 +85,23 @@ describe('AppTaskCard', () => {
   it('shows "Paused" for disabled tasks', () => {
     renderCard({ enabled: false });
     expect(screen.getByText('Paused')).toBeTruthy();
+  });
+
+  it('marks an automation-only task and removes direct actions', () => {
+    const { onTrigger, onConfigure } = renderCard({
+      invocation: {
+        kind: 'subsidiary',
+        visibility: 'visible',
+        userInvokable: false,
+        label: 'Automation-only',
+        description: 'Runs from a parent automation.'
+      }
+    });
+    expect(screen.getAllByText('Automation-only').length).toBeGreaterThan(0);
+    expect(screen.queryByRole('button', { name: /Run Now|Run on App/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Configure/i })).not.toBeInTheDocument();
+    expect(onTrigger).not.toHaveBeenCalled();
+    expect(onConfigure).not.toHaveBeenCalled();
   });
 
   it('shows the dependency wait state', () => {

--- a/client/src/components/cos/tabs/schedule/GlobalConfigControls.jsx
+++ b/client/src/components/cos/tabs/schedule/GlobalConfigControls.jsx
@@ -234,6 +234,8 @@ export default function GlobalConfigControls({ taskType, config, onUpdate, onTri
   // (this panel persists a separate Thinking Effort), and keeps a stale suffixed
   // pin selectable so it still runs while showing what it is.
   const status = config.status || {};
+  const userInvokable = config.invocation?.userInvokable !== false;
+  const invocationDescription = config.invocation?.description || 'Runs as part of another automation and is not directly invokable.';
 
   return (
     <div className="space-y-4">
@@ -675,14 +677,20 @@ export default function GlobalConfigControls({ taskType, config, onUpdate, onTri
       )}
 
       <div className="flex gap-2">
-        <RunTaskButton
-          taskType={taskType}
-          apps={apps}
-          onTrigger={onTrigger}
-          installWide={config.installWide}
-          // `updating` covers an in-flight pin write here, same race the card gates on.
-          disabledReason={improvementDisabled ? IMPROVEMENT_DISABLED_TITLE : (updating ? SAVING_TITLE : '')}
-        />
+        {userInvokable ? (
+          <RunTaskButton
+            taskType={taskType}
+            apps={apps}
+            onTrigger={onTrigger}
+            installWide={config.installWide}
+            // `updating` covers an in-flight pin write here, same race the card gates on.
+            disabledReason={improvementDisabled ? IMPROVEMENT_DISABLED_TITLE : (updating ? SAVING_TITLE : '')}
+          />
+        ) : (
+          <div className="text-xs text-port-warning/80" title={invocationDescription}>
+            {config.invocation?.label || 'Automation-only'} — runs from its parent automation
+          </div>
+        )}
         {config.type === 'once' && status.reason === 'once-completed' && (
           <button
             onClick={() => onReset(taskType)}

--- a/client/src/components/cos/tabs/schedule/PipelineStageConfig.jsx
+++ b/client/src/components/cos/tabs/schedule/PipelineStageConfig.jsx
@@ -107,7 +107,7 @@ export default function PipelineStageConfig({ taskType, config, providers, onUpd
           );
         })}
       </div>
-      <p className="text-xs text-gray-500 mt-2">Each stage runs as a separate agent. Configure different providers per stage (e.g., Codex for review, Claude for implementation).</p>
+      <p className="text-xs text-gray-500 mt-2">Each stage runs as a separate agent inside this pipeline; stages are not scheduled independently. Configure different providers per stage (e.g., Codex for review, Claude for implementation).</p>
     </div>
   );
 }

--- a/client/src/components/cos/tabs/schedule/PromptEditor.jsx
+++ b/client/src/components/cos/tabs/schedule/PromptEditor.jsx
@@ -12,6 +12,22 @@ export default function PromptEditor({ config, promptValue, setPromptValue, edit
   }, [stages?.length, activeTab]);
 
   if (!hasPipeline) {
+    if (config.promptMode === 'runtime-generated') {
+      return (
+        <div className="space-y-2">
+          <div className="flex items-center gap-2">
+            <span className="text-sm text-gray-400">Task Prompt</span>
+            <span className="text-[10px] px-1.5 py-0.5 bg-port-accent/10 text-port-accent rounded">Generated at run time</span>
+          </div>
+          <div className="bg-port-bg border border-port-border rounded px-3 py-2 text-sm text-gray-400">
+            {config.promptDescription || 'This task builds its prompt from fresh runtime context before each run.'}
+          </div>
+          <p className="text-xs text-gray-500">
+            There is no stored prompt template to edit; the task hook owns the runtime prompt.
+          </p>
+        </div>
+      );
+    }
     // Standard single prompt editor
     return (
       <div>

--- a/client/src/components/cos/tabs/schedule/PromptEditor.test.jsx
+++ b/client/src/components/cos/tabs/schedule/PromptEditor.test.jsx
@@ -1,0 +1,31 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import PromptEditor from './PromptEditor';
+
+afterEach(cleanup);
+
+describe('PromptEditor', () => {
+  it('explains that hook-owned prompts are generated per run', () => {
+    render(
+      <PromptEditor
+        config={{
+          promptMode: 'runtime-generated',
+          promptDescription: 'Generated from fresh forge activity.'
+        }}
+        promptValue=""
+        setPromptValue={() => {}}
+        editingPrompt={false}
+        setEditingPrompt={() => {}}
+        handleSavePrompt={() => {}}
+        updating={false}
+        activeApps={[]}
+      />
+    );
+
+    expect(screen.getByText('Generated at run time')).toBeInTheDocument();
+    expect(screen.getByText('Generated from fresh forge activity.')).toBeInTheDocument();
+    expect(screen.getByText(/no stored prompt template to edit/i)).toBeInTheDocument();
+    expect(screen.queryByText('No prompt configured')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Edit' })).not.toBeInTheDocument();
+  });
+});

--- a/client/src/components/cos/tabs/schedule/TaskHeader.jsx
+++ b/client/src/components/cos/tabs/schedule/TaskHeader.jsx
@@ -8,6 +8,8 @@ import IntervalBadge from './IntervalBadge';
 export default function TaskHeader({ taskType, config }) {
   const group = getTaskStatusGroup(config);
   const stages = pipelineStages(config);
+  const invocation = config.invocation;
+  const automationOnly = invocation?.userInvokable === false;
   // Swarm (`/do:next --swarm`) is on when the global default carries a size ≥2.
   // Per-app overrides aren't reflected in this global header (the per-app row
   // shows its own override select).
@@ -16,32 +18,48 @@ export default function TaskHeader({ taskType, config }) {
   const branchesPerAgent = config.taskMetadata?.branchesPerAgent;
   const branchBatchOn = taskType === 'branch-reconcile' && Number.isInteger(branchesPerAgent) && branchesPerAgent > 0;
   return (
-    <div className="flex items-center justify-between gap-2 min-w-0">
-      <div className="flex items-center gap-2 min-w-0 flex-1">
-        <span className={`w-2 h-2 rounded-full shrink-0 ${statusDot(group)}`} title={group} aria-hidden="true" />
-        <span className="font-mono text-sm text-white truncate leading-tight" title={taskType}>{taskType}</span>
+    <div className="space-y-1.5 min-w-0">
+      <div className="flex items-center justify-between gap-2 min-w-0">
+        <div className="flex items-center gap-2 min-w-0 flex-1">
+          <span className={`w-2 h-2 rounded-full shrink-0 ${statusDot(group)}`} title={group} aria-hidden="true" />
+          <span className="font-mono text-sm text-white truncate leading-tight" title={taskType}>{taskType}</span>
+        </div>
+        <div className="flex items-center gap-1.5 shrink-0 flex-wrap justify-end">
+          {automationOnly && (
+            <span
+              className={`${badge('warning')} whitespace-nowrap`}
+              title={invocation.description || 'Runs as part of another automation and is not directly invokable.'}
+            >
+              {invocation.label || 'Automation-only'}
+            </span>
+          )}
+          {swarmOn && (
+            <span className={`${badge('cyan')} whitespace-nowrap`} title={`Swarm mode — claims & ships up to ${swarmCount} independent issues in parallel per run`}>
+              <Users size={11} className="inline mr-0.5" />
+              ×{swarmCount}
+            </span>
+          )}
+          {branchBatchOn && (
+            <span className={`${badge('cyan')} whitespace-nowrap`} title={`Branch-reconcile batch — up to ${branchesPerAgent} branch(es) per coordinator run`}>
+              <GitBranch size={11} className="inline mr-0.5" />
+              ×{branchesPerAgent}
+            </span>
+          )}
+          {stages?.length > 0 && (
+            <span className={`${badge('purple')} whitespace-nowrap`} title={stages.map(s => s.name).join(' → ')}>
+              <GitMerge size={11} className="inline mr-0.5" />
+              {stages.length}
+            </span>
+          )}
+          <IntervalBadge type={config.type} cronExpression={config.cronExpression} />
+        </div>
       </div>
-      <div className="flex items-center gap-1.5 shrink-0 flex-wrap justify-end">
-        {swarmOn && (
-          <span className={`${badge('cyan')} whitespace-nowrap`} title={`Swarm mode — claims & ships up to ${swarmCount} independent issues in parallel per run`}>
-            <Users size={11} className="inline mr-0.5" />
-            ×{swarmCount}
-          </span>
-        )}
-        {branchBatchOn && (
-          <span className={`${badge('cyan')} whitespace-nowrap`} title={`Branch-reconcile batch — up to ${branchesPerAgent} branch(es) per coordinator run`}>
-            <GitBranch size={11} className="inline mr-0.5" />
-            ×{branchesPerAgent}
-          </span>
-        )}
-        {stages?.length > 0 && (
-          <span className={`${badge('purple')} whitespace-nowrap`} title={stages.map(s => s.name).join(' → ')}>
-            <GitMerge size={11} className="inline mr-0.5" />
-            {stages.length}
-          </span>
-        )}
-        <IntervalBadge type={config.type} cronExpression={config.cronExpression} />
-      </div>
+      {config.description && (
+        <p className="text-xs text-gray-400 line-clamp-2" title={config.description}>{config.description}</p>
+      )}
+      {automationOnly && invocation.description && (
+        <p className="text-xs text-port-warning/80">{invocation.description}</p>
+      )}
     </div>
   );
 }

--- a/server/services/taskSchedule.js
+++ b/server/services/taskSchedule.js
@@ -42,6 +42,8 @@ import {
   INSTALL_WIDE_TASK_TYPES,
   MANAGED_AGENT_OPTIONS,
   getTaskTypeDescription,
+  getTaskTypeInvocation,
+  getTaskTypePromptInfo,
   enforceBranchReconcileBatch,
   enforceManagedAgentOptions
 } from './taskScheduleRegistry.js';
@@ -63,7 +65,8 @@ export {
 export {
   DEFAULT_BRANCHES_PER_AGENT, DEFAULT_TASK_INTERVALS, INSTALL_WIDE_TASK_TYPES,
   MANAGED_AGENT_OPTIONS, PERPETUAL_DRAIN_DISPATCH_CAP, SELF_IMPROVEMENT_TASK_TYPES,
-  TASK_TYPE_DESCRIPTIONS, stripManagedAgentOptionsFromOverride
+  TASK_TYPE_DESCRIPTIONS, TASK_TYPE_INVOCATION, TASK_TYPE_PROMPT_INFO,
+  getTaskTypeInvocation, getTaskTypePromptInfo, stripManagedAgentOptionsFromOverride
 } from './taskScheduleRegistry.js';
 export { loadSchedule } from './taskScheduleStore.js';
 export {
@@ -1142,6 +1145,10 @@ export async function triggerOnDemandTask(taskType, appId = null, { emit = true,
     if (!(await createFeatureGate()(tasks[taskType]))) {
       return { result: { error: `Task type '${taskType}' requires the '${tasks[taskType].feature}' feature` }, changed: false };
     }
+    const invocation = getTaskTypeInvocation(taskType);
+    if (origin === ON_DEMAND_ORIGINS.USER && !invocation.userInvokable) {
+      return { result: { error: `Task type '${taskType}' is managed by another automation and cannot be run manually` }, changed: false };
+    }
 
     // Reject if the master Improve toggle is off — request would be silently dropped downstream
     const state = await loadState();
@@ -1231,7 +1238,8 @@ export async function getScheduleStatus() {
   // Surface the master Improve toggle so the UI can disable Run Now affordances
   const [schedule, state] = await Promise.all([loadSchedule(), loadState()]);
   const featureEnabled = createFeatureGate();
-  const onDemandRequests = await getAvailableOnDemandRequests(schedule, featureEnabled);
+  const onDemandRequests = (await getAvailableOnDemandRequests(schedule, featureEnabled))
+    .filter(request => getTaskTypeInvocation(request.taskType).visibility !== 'hidden');
 
   const status = {
     lastUpdated: schedule.lastUpdated,
@@ -1249,7 +1257,10 @@ export async function getScheduleStatus() {
 
   for (const [taskType, interval] of Object.entries(schedule.tasks)) {
     if (!(await featureEnabled(interval))) continue;
+    const invocation = getTaskTypeInvocation(taskType);
+    if (invocation.visibility === 'hidden') continue;
     const execution = schedule.executions[`task:${taskType}`] || { lastRun: null, count: 0, perApp: {} };
+    const promptInfo = getTaskTypePromptInfo(taskType);
 
     // Get learning adjustment info
     const baseInterval = interval.type === 'daily' ? DAY : interval.type === 'weekly' ? WEEK : (interval.intervalMs || DAY);
@@ -1299,6 +1310,10 @@ export async function getScheduleStatus() {
       dataPoints: learningInfo.dataPoints,
       adjustedIntervalMs: learningInfo.adjustedIntervalMs,
       recommendation: learningInfo.recommendation,
+      description: getTaskTypeDescription(taskType),
+      promptMode: promptInfo.mode,
+      ...(promptInfo.description ? { promptDescription: promptInfo.description } : {}),
+      invocation,
       // Whether a "Run Now" with NO app is this type's real run (it sweeps every
       // managed app in one dispatch). Served from the server registry rather than
       // mirrored in client constants, so the UI cannot drift from the set the
@@ -1425,6 +1440,7 @@ export async function getUpcomingTasks(limit = 10) {
   for (const [taskType, interval] of Object.entries(schedule.tasks)) {
     if (!interval.enabled) continue;
     if (!(await featureEnabled(interval))) continue;
+    if (getTaskTypeInvocation(taskType).visibility === 'hidden') continue;
     if (interval.type === INTERVAL_TYPES.ON_DEMAND) continue;
 
     const check = await shouldRunTask(taskType, null, { featureEnabled });

--- a/server/services/taskSchedule.test.js
+++ b/server/services/taskSchedule.test.js
@@ -154,6 +154,9 @@ import {
   MANAGED_AGENT_OPTIONS,
   stripManagedAgentOptionsFromOverride,
   TASK_TYPE_DESCRIPTIONS,
+  TASK_TYPE_INVOCATION,
+  TASK_TYPE_PROMPT_INFO,
+  getTaskTypeInvocation,
   REFERENCE_WATCH_AUDITED_VERSION,
   boundParkedUntil
 } from './taskSchedule.js'
@@ -344,12 +347,13 @@ describe('taskSchedule', () => {
   });
 
   describe('issue-watcher (programmatic-I/O agent task)', () => {
-    it('ships as an enabled on-demand task with a 30-minute fallback and no persisted prompt', () => {
+    it('ships as an enabled on-demand task with a 30-minute fallback and a runtime-generated prompt', () => {
       expect(SELF_IMPROVEMENT_TASK_TYPES).toContain('issue-watcher');
       expect(DEFAULT_TASK_INTERVALS['issue-watcher']).toMatchObject({
         type: INTERVAL_TYPES.ON_DEMAND, intervalMs: 30 * 60 * 1000, enabled: true, prompt: null
       });
       expect(DEFAULT_TASK_PROMPTS['issue-watcher']).toBeUndefined();
+      expect(TASK_TYPE_PROMPT_INFO['issue-watcher']).toMatchObject({ mode: 'runtime-generated' });
     });
 
     it('locks the reasoning-only throwaway-worktree posture', () => {
@@ -2043,6 +2047,33 @@ describe('taskSchedule', () => {
       const status = await getScheduleStatus()
 
       expect(status.improvementEnabled).toBe(false)
+    })
+
+    it('projects task summaries and explains hook-owned prompts', async () => {
+      mockSchedule()
+
+      const status = await getScheduleStatus()
+
+      expect(status.tasks['issue-watcher']).toMatchObject({
+        description: TASK_TYPE_DESCRIPTIONS['issue-watcher'],
+        promptMode: 'runtime-generated',
+        promptDescription: expect.stringContaining('deterministic GitHub gathering'),
+        invocation: { kind: 'direct', visibility: 'visible', userInvokable: true },
+      })
+      expect(status.tasks.security).toMatchObject({
+        description: TASK_TYPE_DESCRIPTIONS.security,
+        promptMode: 'template',
+        invocation: { kind: 'direct', visibility: 'visible', userInvokable: true },
+      })
+    })
+
+    it('keeps subsidiary-task visibility explicit instead of inferring it from task names', () => {
+      expect(Object.keys(TASK_TYPE_INVOCATION)).toEqual([])
+      for (const taskType of SELF_IMPROVEMENT_TASK_TYPES) {
+        expect(getTaskTypeInvocation(taskType), taskType).toEqual({
+          kind: 'direct', visibility: 'visible', userInvokable: true
+        })
+      }
     })
 
     it('hides shipped tasks whose required instance feature is disabled', async () => {

--- a/server/services/taskScheduleModules.test.js
+++ b/server/services/taskScheduleModules.test.js
@@ -15,6 +15,7 @@ describe('taskSchedule module boundaries', () => {
         .map((name) => [name, constants[name]]),
       ...['DEFAULT_BRANCHES_PER_AGENT', 'DEFAULT_TASK_INTERVALS', 'MANAGED_AGENT_OPTIONS',
         'PERPETUAL_DRAIN_DISPATCH_CAP', 'SELF_IMPROVEMENT_TASK_TYPES', 'TASK_TYPE_DESCRIPTIONS',
+        'TASK_TYPE_INVOCATION', 'TASK_TYPE_PROMPT_INFO', 'getTaskTypeInvocation', 'getTaskTypePromptInfo',
         'stripManagedAgentOptionsFromOverride'].map((name) => [name, registry[name]]),
       ...['FAILURE_BACKOFF_BASE_MS', 'FAILURE_BACKOFF_CAP_MS', 'FAILURE_PARK_THRESHOLD',
         'clearTaskTypeFailurePark', 'computeFailureBackoffMs', 'recordTaskTypeFailure',

--- a/server/services/taskScheduleRegistry.js
+++ b/server/services/taskScheduleRegistry.js
@@ -490,7 +490,7 @@ export function enforceBranchReconcileBatch(taskType, config) {
   return false;
 }
 
-// Short human-readable blurb per task type, shown in the schedule UI's
+// Short human-readable blurb per task type, shown on schedule cards and in the
 // upcoming-tasks list. Every entry in SELF_IMPROVEMENT_TASK_TYPES must have a
 // key here — a missing one falls back to a dasherized label ("claim work"),
 // which reads as an orphaned/legacy task. A parity guard in taskSchedule.test.js
@@ -515,9 +515,9 @@ export const TASK_TYPE_DESCRIPTIONS = {
   'release-check': 'Check for release readiness',
   'error-handling': 'Failure-path audit — file issues or implement fixes',
   'typing': 'TypeScript types — file issues or implement fixes',
-  'pr-reviewer': 'Review open PRs from contributors',
+  'pr-reviewer': 'Review contributor PRs with a security scan before code review and merge',
   'pr-watcher': 'Run a custom prompt on PRs newly opened against the default branch',
-  'issue-watcher': 'Assign issue volunteers and review external PRs with deterministic GitHub actions around one reasoning pass',
+  'issue-watcher': 'Watch external issues and PRs: assign volunteers, review changes, and apply deterministic GitHub actions around one reasoning pass',
   'code-reviewer-a': 'Review the codebase and triage/implement findings (independent provider/model instance A)',
   'code-reviewer-b': 'Review the codebase and triage/implement findings (independent provider/model instance B)',
   'do-replan': 'Audit and prune PLAN.md after merges and branch cleanup so it reflects what actually shipped',
@@ -540,4 +540,55 @@ export const TASK_TYPE_DESCRIPTIONS = {
 
 export function getTaskTypeDescription(taskType) {
   return TASK_TYPE_DESCRIPTIONS[taskType] || taskType.replace(/-/g, ' ');
+}
+
+/**
+ * Prompt presentation metadata for task types whose prompt is assembled by a
+ * programmatic input hook rather than read from the persisted schedule.
+ *
+ * Keeping this separate from DEFAULT_TASK_PROMPTS is intentional: adding a
+ * placeholder prompt there would make the schedule look configured while the
+ * hook still replaces it at dispatch time. The UI can therefore explain the
+ * real execution shape without changing prompt-version migration state.
+ */
+export const TASK_TYPE_PROMPT_INFO = Object.freeze({
+  'issue-watcher': Object.freeze({
+    mode: 'runtime-generated',
+    description: 'Generated for each run after deterministic GitHub gathering. The reasoning agent receives bounded, untrusted issue/PR data and has no tools.'
+  }),
+  'layered-intelligence': Object.freeze({
+    mode: 'runtime-generated',
+    description: 'Generated for each run from the app\'s configured goals, metrics, and repository context.'
+  })
+});
+
+/**
+ * Sparse, explicit contract for task types owned by another automation.
+ *
+ * The current scheduled task catalog has no top-level subsidiary-only entries:
+ * every task card is a user-invokable task, while pipeline stages are nested
+ * inside their parent task. Future automation-only types belong here instead
+ * of being inferred from names or from a task's implementation details.
+ *
+ * A visible subsidiary entry should use:
+ *   { kind: 'subsidiary', visibility: 'visible', userInvokable: false,
+ *     label: 'Automation-only', description: '...' }
+ * A hidden entry should use `visibility: 'hidden'` and still set
+ * `userInvokable: false`.
+ */
+export const TASK_TYPE_INVOCATION = Object.freeze({});
+
+const DEFAULT_TASK_TYPE_PROMPT_INFO = Object.freeze({ mode: 'template', description: null });
+const DEFAULT_TASK_TYPE_INVOCATION = Object.freeze({
+  kind: 'direct',
+  visibility: 'visible',
+  userInvokable: true
+});
+
+export function getTaskTypePromptInfo(taskType) {
+  return TASK_TYPE_PROMPT_INFO[taskType] || DEFAULT_TASK_TYPE_PROMPT_INFO;
+}
+
+export function getTaskTypeInvocation(taskType) {
+  return TASK_TYPE_INVOCATION[taskType] || DEFAULT_TASK_TYPE_INVOCATION;
 }


### PR DESCRIPTION
## Summary
- Show a human-readable summary on every built-in scheduled-task card and in its configuration header.
- Explain hook-owned runtime prompts such as issue-watcher instead of displaying “No prompt configured”.
- Add explicit metadata and server-side guards for future automation-only task types, and clarify that pipeline stages are nested inside their parent task.
- Let custom task cards accept an optional one-line summary.

## Validation
- `cd server && npm test -- --run services/taskSchedule.test.js services/taskScheduleModules.test.js`
- `cd client && npm test -- --run src/components/cos/tabs/schedule/AppTaskCard.test.jsx src/components/cos/tabs/schedule/PromptEditor.test.jsx src/components/cos/tabs/schedule/GlobalConfigControls.test.jsx src/components/apps/tabs/CustomTasksSection.test.jsx src/components/cos/tabs/JobsTab.test.jsx`
- `cd client && npm run lint`
- `cd client && npm run build`