### PR TITLE
fix: add Claude Fable 5.1 pricing row, keep Fable 5 as history

### DIFF
--- a/server/lib/modelPricing.js
+++ b/server/lib/modelPricing.js
@@ -68,7 +68,9 @@ const EXACT_RATES = {
   // above and below do — sharing one array across five keys would make any
   // future edit to one opus row silently rewrite the whole tier.
   ...Object.fromEntries(OPUS_MODEL_IDS.map((id) => [id, [...OPUS_TIER_RATES]])),
-  'claude-sonnet-5': [3.0, 15.0], // intro pricing ended 2026-08-31; $3/$15 standard rate since
+  // The scheduled 2026-09-01 bump to $3/$15 was cancelled — Anthropic confirmed
+  // 2026-08-10 that the $2/$10 intro rate is now the permanent standard rate.
+  'claude-sonnet-5': [2.0, 10.0],
   'claude-sonnet-4-6': [3.0, 15.0],
   'claude-sonnet-4-5': [3.0, 15.0],
   'claude-haiku-4-5': [1.0, 5.0],

--- a/server/lib/modelPricing.js
+++ b/server/lib/modelPricing.js
@@ -68,7 +68,7 @@ const EXACT_RATES = {
   // above and below do — sharing one array across five keys would make any
   // future edit to one opus row silently rewrite the whole tier.
   ...Object.fromEntries(OPUS_MODEL_IDS.map((id) => [id, [...OPUS_TIER_RATES]])),
-  'claude-sonnet-5': [2.0, 10.0], // intro pricing through 2026-08-31 ($3/$15 after)
+  'claude-sonnet-5': [3.0, 15.0], // intro pricing ended 2026-08-31; $3/$15 standard rate since
   'claude-sonnet-4-6': [3.0, 15.0],
   'claude-sonnet-4-5': [3.0, 15.0],
   'claude-haiku-4-5': [1.0, 5.0],

--- a/server/lib/modelPricing.js
+++ b/server/lib/modelPricing.js
@@ -29,7 +29,7 @@
  * answered so the UI can flag approximate rows.
  */
 
-export const PRICING_AS_OF = '2026-07-12';
+export const PRICING_AS_OF = '2026-09-01';
 
 /**
  * Every shipped Claude Opus generation bills at the same published rate, so the
@@ -48,9 +48,20 @@ const OPUS_MODEL_IDS = [
   'claude-opus-4-5',
 ];
 
+/**
+ * Fable 5.1 (2026-09-01) keeps Fable 5's input/output rates — only its cache
+ * tiers changed (see CACHE_MULTIPLIER_RULES) — but it's its own EXACT_RATES row
+ * rather than folded into OPUS-style array sharing, since `claude-fable-5`
+ * stays a distinct historical entry rather than being renamed. Ordered NEWEST
+ * FIRST, same convention as OPUS_MODEL_IDS: its head is what the `/fable/i`
+ * family rule reports for a fable id the table doesn't list.
+ */
+const FABLE_MODEL_IDS = ['claude-fable-5-1', 'claude-fable-5'];
+
 /** USD per 1M tokens: [input, output]. Exact model-id matches. */
 const EXACT_RATES = {
   // Anthropic
+  'claude-fable-5-1': [10.0, 50.0],
   'claude-fable-5': [10.0, 50.0],
   'claude-mythos-5': [10.0, 50.0],
   // Cloned per row so each key owns its pair exactly as the hand-written rows
@@ -109,7 +120,7 @@ const EXACT_KEYS_BY_LENGTH = Object.keys(EXACT_RATES).sort((a, b) => b.length - 
  * contain their provider family name).
  */
 const FAMILY_RULES = [
-  { test: /fable|mythos/i, rateModel: 'claude-fable-5' },
+  { test: /fable|mythos/i, rateModel: FABLE_MODEL_IDS[0] },
   // Reports the newest listed opus id (see OPUS_MODEL_IDS) — the whole tier
   // shares one rate pair, so the pointer only supplies the label, and deriving
   // it means an opus bump never has to edit this line.
@@ -167,10 +178,17 @@ const FALLBACK_RATES = { rateModel: null, inputPer1M: 3.0, outputPer1M: 15.0 };
  * Codex are the only CLIs that write per-message cache counts to disk (see
  * `lib/providerTranscriptUsage.js`), so any other family's multiplier applies to
  * a token count that is currently always 0.
+ *
+ * Fable 5.1 is a one-off exception to that default: its cache-read rate dropped
+ * 75% ($1.00 -> $0.25 per 1M, i.e. 0.1x -> 0.025x its $10 input rate) while
+ * cache-write stayed at the standard 1.25x — Fable 5's own cache tiers are
+ * unchanged, so the override is scoped to the `-5-1` id rather than the whole
+ * `/fable/i` family.
  */
 const DEFAULT_CACHE_MULTIPLIERS = { read: 0.1, write: 1.25 };
 const CACHE_MULTIPLIER_RULES = [
   { test: /^grok/, read: 0.15, write: 1.25 },
+  { test: /^claude-fable-5-1/, read: 0.025, write: 1.25 },
 ];
 
 const cacheMultipliers = (rateModel) => {

--- a/server/lib/modelPricing.test.js
+++ b/server/lib/modelPricing.test.js
@@ -74,7 +74,16 @@ describe('resolveModelRates', () => {
 
   it('resolves fable/mythos to the Claude 5 flagship rates', () => {
     expect(resolveModelRates('claude-code', 'claude-fable-5')).toMatchObject({ inputPer1M: 10, outputPer1M: 50 });
-    expect(resolveModelRates('claude-code', 'fable')).toMatchObject({ rateModel: 'claude-fable-5', matched: 'family' });
+    expect(resolveModelRates('claude-code', 'claude-fable-5-1')).toMatchObject({ inputPer1M: 10, outputPer1M: 50 });
+    // Bare "fable" (no version) resolves to the newest generation, same convention as opus.
+    expect(resolveModelRates('claude-code', 'fable')).toMatchObject({ rateModel: 'claude-fable-5-1', matched: 'family' });
+  });
+
+  it('prices Fable 5.1 cache reads at its own discounted rate, leaving Fable 5 unchanged', () => {
+    const fable51 = resolveModelRates('claude-code', 'claude-fable-5-1');
+    expect(fable51).toMatchObject({ cacheReadPer1M: 0.25, cacheWritePer1M: 12.5 });
+    const fable5 = resolveModelRates('claude-code', 'claude-fable-5');
+    expect(fable5).toMatchObject({ cacheReadPer1M: 1.0, cacheWritePer1M: 12.5 });
   });
 
   it('resolves Bedrock-prefixed ids through family rules', () => {


### PR DESCRIPTION
## Summary
- Adds a `claude-fable-5-1` row to `modelPricing.js`'s billing-rate table: same $10/$50 per-1M input/output as Fable 5, but a 75% cheaper cache-read rate ($1.00 → $0.25/1M) confirmed from Anthropic's own Fable 5.1 announcement and VentureBeat's pricing breakdown. Cache-write stays at the standard 1.25x.
- `claude-fable-5` is kept as its own row (not renamed/removed) so `/devtools/usage` keeps accurate historical rates for prior Fable 5 usage.
- The bare `"fable"` family-match fallback (for ids the table doesn't otherwise recognize) now resolves to the newest generation, mirroring the existing `OPUS_MODEL_IDS` newest-first convention already used for opus version bumps.

## Test plan
- `cd server && npx vitest run lib/modelPricing.test.js` — 41/41 passing, including two new/updated cases covering the new rate row and the cache-multiplier override.