### PR TITLE
feat(llm): recommend a verified no-tools reviewer model

### DIFF
--- a/client/src/components/settings/LocalLlmTab.test.jsx
+++ b/client/src/components/settings/LocalLlmTab.test.jsx
@@ -469,6 +469,31 @@ describe('LocalLlmTab recommendations', () => {
     await waitFor(() => expect(screen.getByText('Qwen3.8 27B')).toBeTruthy());
   });
 
+  it('highlights the catalog recommendation for the Security Scan', async () => {
+    getLocalLlmCatalog.mockResolvedValue({
+      models: [{
+        id: 'gemma3:27b',
+        key: 'gemma3-27b-it',
+        name: 'Gemma 3 27B IT',
+        category: 'general',
+        recommendedFor: ['general', 'reasoning'],
+        featured: {
+          label: 'Recommended for Security Scan',
+          description: 'A verified local text model without native tool capability.',
+        },
+        params: '27B',
+        size: '17 GB',
+        description: 'Long-context local analysis.',
+        capabilities: ['chat', 'vision'],
+      }],
+    });
+
+    await renderTab('library');
+
+    expect(await screen.findByText('Recommended for Security Scan')).toBeInTheDocument();
+    expect(screen.getByText('A verified local text model without native tool capability.')).toBeInTheDocument();
+  });
+
   it('offers redownload on an already-installed catalog card', async () => {
     installLocalLlmModel.mockResolvedValue({ success: true });
     getLocalLlmCatalog.mockResolvedValue({

--- a/server/lib/localLlmCatalog.js
+++ b/server/lib/localLlmCatalog.js
@@ -292,9 +292,30 @@ export const LOCAL_LLM_CATALOG = [
     size: '12 GB',
     family: 'gpt-oss',
     description: 'Open-weights 20B model — the default local thinking model.',
-    capabilities: ['chat', 'reasoning'],
+    capabilities: ['chat', 'reasoning', 'tools'],
     ollama: 'gpt-oss:20b',
     lmstudio: 'lmstudio-community/gpt-oss-20b-GGUF'
+  },
+  {
+    key: 'gemma3-27b-it',
+    name: 'Gemma 3 27B IT',
+    category: 'general',
+    recommendedFor: ['general', 'reasoning'],
+    featured: {
+      label: 'Recommended for Security Scan',
+      description: 'Purpose-specific pick for reviewing untrusted contributor diffs: long-context local text analysis in the verified Ollama build, with no native tool capability to expose.'
+    },
+    params: '27B',
+    size: '17 GB',
+    family: 'gemma',
+    description: "Google's Gemma 3 27B instruction model — long-context local analysis for code-review findings without native tool calling.",
+    note: 'The Security Scan verifies Ollama capabilities before every run and remains read-only; Hugging Face’s official Gemma repository requires accepting its terms.',
+    repository: 'google/gemma-3-27b-it',
+    gated: true,
+    capabilities: ['chat', 'vision'],
+    context: 131072,
+    ollama: 'gemma3:27b',
+    lmstudio: 'lmstudio-community/gemma-3-27b-it-GGUF'
   },
   // ── Large general-purpose / long-context tier (32–128GB unified memory) ──
   // Best suited for whole-manuscript editorial review, where prose quality and a

--- a/server/lib/localLlmCatalog.test.js
+++ b/server/lib/localLlmCatalog.test.js
@@ -165,6 +165,21 @@ describe('localLlmCatalog', () => {
     it('ships the refreshed local models for reasoning, coding, and multilingual categories', () => {
       const ollama = getCatalog('ollama');
       expect(ollama.find((m) => m.key === 'deepseek-r1-8b')?.id).toBe('deepseek-r1:8b');
+      expect(ollama.find((m) => m.key === 'gemma3-27b-it')).toMatchObject({
+        id: 'gemma3:27b',
+        category: 'general',
+        recommendedFor: expect.arrayContaining(['general', 'reasoning']),
+        featured: { label: 'Recommended for Security Scan' },
+        repository: 'google/gemma-3-27b-it',
+        gated: true,
+        capabilities: ['chat', 'vision'],
+        contextLength: 131072,
+      });
+      expect(ollama.find((m) => m.key === 'gemma3-27b-it').capabilities).not.toContain('tools');
+      // Gemma 4 is newer, but its native function-calling capability makes it
+      // ineligible for the read-only Security Scan model pin.
+      expect(ollama.find((m) => m.key === 'gemma4-12b').capabilities).toContain('tools');
+      expect(ollama.find((m) => m.key === 'gpt-oss-20b').capabilities).toContain('tools');
       expect(ollama.find((m) => m.key === 'qwen2.5-coder-7b')?.id).toBe('qwen2.5-coder:7b');
       expect(ollama.find((m) => m.key === 'phi-4-14b')?.id).toBe('phi4');
       expect(ollama.find((m) => m.key === 'aya-expanse-8b')?.id).toBe('aya-expanse:8b');


### PR DESCRIPTION
## Summary
- add Gemma 3 27B IT as the featured recommendation for the read-only Security Scan
- keep the recommendation tied to the verified local Ollama build and document that runtime capability checks remain authoritative
- correct the GPT-OSS catalog tool capability and cover the Gemma 4 tool-capability distinction
- verify the catalog recommendation is highlighted in the model library

## Validation
- `cd server && npm test -- --run lib/localLlmCatalog.test.js`
- `cd client && npm test -- --run src/components/settings/LocalLlmTab.test.jsx`
- `cd client && npm run lint`
- `cd client && npm run build`

Gemma 4 remains available in the general catalog, but is intentionally not eligible for this security preflight because its native function-calling capability violates the no-tools selection policy.