### PR TITLE
fix(pr-reviewer): scan every external pull request

### DIFF
--- a/client/src/components/settings/LocalLlmTab.test.jsx
+++ b/client/src/components/settings/LocalLlmTab.test.jsx
@@ -469,6 +469,31 @@ describe('LocalLlmTab recommendations', () => {
     await waitFor(() => expect(screen.getByText('Qwen3.8 27B')).toBeTruthy());
   });
 
+  it('highlights the catalog recommendation for the Security Scan', async () => {
+    getLocalLlmCatalog.mockResolvedValue({
+      models: [{
+        id: 'gemma3:27b',
+        key: 'gemma3-27b-it',
+        name: 'Gemma 3 27B IT',
+        category: 'general',
+        recommendedFor: ['general', 'reasoning'],
+        featured: {
+          label: 'Recommended for Security Scan',
+          description: 'A verified local text model without native tool capability.',
+        },
+        params: '27B',
+        size: '17 GB',
+        description: 'Long-context local analysis.',
+        capabilities: ['chat', 'vision'],
+      }],
+    });
+
+    await renderTab('library');
+
+    expect(await screen.findByText('Recommended for Security Scan')).toBeInTheDocument();
+    expect(screen.getByText('A verified local text model without native tool capability.')).toBeInTheDocument();
+  });
+
   it('offers redownload on an already-installed catalog card', async () => {
     installLocalLlmModel.mockResolvedValue({ success: true });
     getLocalLlmCatalog.mockResolvedValue({

--- a/server/lib/localLlmCatalog.js
+++ b/server/lib/localLlmCatalog.js
@@ -292,9 +292,30 @@ export const LOCAL_LLM_CATALOG = [
     size: '12 GB',
     family: 'gpt-oss',
     description: 'Open-weights 20B model — the default local thinking model.',
-    capabilities: ['chat', 'reasoning'],
+    capabilities: ['chat', 'reasoning', 'tools'],
     ollama: 'gpt-oss:20b',
     lmstudio: 'lmstudio-community/gpt-oss-20b-GGUF'
+  },
+  {
+    key: 'gemma3-27b-it',
+    name: 'Gemma 3 27B IT',
+    category: 'general',
+    recommendedFor: ['general', 'reasoning'],
+    featured: {
+      label: 'Recommended for Security Scan',
+      description: 'Purpose-specific pick for reviewing untrusted contributor diffs: long-context local text analysis in the verified Ollama build, with no native tool capability to expose.'
+    },
+    params: '27B',
+    size: '17 GB',
+    family: 'gemma',
+    description: "Google's Gemma 3 27B instruction model — long-context local analysis for code-review findings without native tool calling.",
+    note: 'The Security Scan verifies Ollama capabilities before every run and remains read-only; Hugging Face’s official Gemma repository requires accepting its terms.',
+    repository: 'google/gemma-3-27b-it',
+    gated: true,
+    capabilities: ['chat', 'vision'],
+    context: 131072,
+    ollama: 'gemma3:27b',
+    lmstudio: 'lmstudio-community/gemma-3-27b-it-GGUF'
   },
   // ── Large general-purpose / long-context tier (32–128GB unified memory) ──
   // Best suited for whole-manuscript editorial review, where prose quality and a

--- a/server/lib/localLlmCatalog.test.js
+++ b/server/lib/localLlmCatalog.test.js
@@ -165,6 +165,21 @@ describe('localLlmCatalog', () => {
     it('ships the refreshed local models for reasoning, coding, and multilingual categories', () => {
       const ollama = getCatalog('ollama');
       expect(ollama.find((m) => m.key === 'deepseek-r1-8b')?.id).toBe('deepseek-r1:8b');
+      expect(ollama.find((m) => m.key === 'gemma3-27b-it')).toMatchObject({
+        id: 'gemma3:27b',
+        category: 'general',
+        recommendedFor: expect.arrayContaining(['general', 'reasoning']),
+        featured: { label: 'Recommended for Security Scan' },
+        repository: 'google/gemma-3-27b-it',
+        gated: true,
+        capabilities: ['chat', 'vision'],
+        contextLength: 131072,
+      });
+      expect(ollama.find((m) => m.key === 'gemma3-27b-it').capabilities).not.toContain('tools');
+      // Gemma 4 is newer, but its native function-calling capability makes it
+      // ineligible for the read-only Security Scan model pin.
+      expect(ollama.find((m) => m.key === 'gemma4-12b').capabilities).toContain('tools');
+      expect(ollama.find((m) => m.key === 'gpt-oss-20b').capabilities).toContain('tools');
       expect(ollama.find((m) => m.key === 'qwen2.5-coder-7b')?.id).toBe('qwen2.5-coder:7b');
       expect(ollama.find((m) => m.key === 'phi-4-14b')?.id).toBe('phi4');
       expect(ollama.find((m) => m.key === 'aya-expanse-8b')?.id).toBe('aya-expanse:8b');

--- a/server/services/prReviewerSecurity.js
+++ b/server/services/prReviewerSecurity.js
@@ -179,6 +179,7 @@ export async function runPrReviewerSecurityScan({ app, providerId, model, effort
   if (!target.ok) return target
 
   const reviewedPrs = []
+  let hasFindings = false
   for (const pr of target.prs) {
     const diff = await execGh(['pr', 'diff', String(pr.number), '--repo', target.repoSpec]).catch(() => null)
     if (diff === null) return failure('security-scan-diff-unavailable', { reviewedPrs })
@@ -202,17 +203,19 @@ export async function runPrReviewerSecurityScan({ app, providerId, model, effort
 
     const passed = verdict.findings.trim() === 'No findings.'
     reviewedPrs.push({ number: pr.number, passed })
-    if (!passed) {
-      return {
-        ok: true,
-        passed: false,
-        code: 'security-scan-findings',
-        backend: selected.backend,
-        model: selected.model,
-        repoFullName: target.repoFullName,
-        defaultBranch: target.defaultBranch,
-        reviewedPrs,
-      }
+    if (!passed) hasFindings = true
+  }
+
+  if (hasFindings) {
+    return {
+      ok: true,
+      passed: false,
+      code: 'security-scan-findings',
+      backend: selected.backend,
+      model: selected.model,
+      repoFullName: target.repoFullName,
+      defaultBranch: target.defaultBranch,
+      reviewedPrs,
     }
   }
 

--- a/server/services/prReviewerSecurity.test.js
+++ b/server/services/prReviewerSecurity.test.js
@@ -139,7 +139,7 @@ describe('pr-reviewer Security Scan execution', () => {
     ])
   })
 
-  it('stops on the first non-clean verdict and fails the pipeline', async () => {
+  it('reviews every external PR before failing the pipeline on any non-clean verdict', async () => {
     runLocalCodeReviewMock.mockResolvedValue({ ok: true, findings: 'Finding: suspicious install script.' })
     execGhMock
       .mockResolvedValueOnce('main')
@@ -148,11 +148,12 @@ describe('pr-reviewer Security Scan execution', () => {
         { number: 13, author: { login: 'contributor-b' } },
       ]))
       .mockResolvedValueOnce('diff for twelve')
+      .mockResolvedValueOnce('diff for thirteen')
 
     const result = await runPrReviewerSecurityScan({ app, providerId: 'ollama', model: 'safe-model' })
 
     expect(result).toMatchObject({ ok: true, passed: false, code: 'security-scan-findings' })
-    expect(result.reviewedPrs).toEqual([{ number: 12, passed: false }])
-    expect(runLocalCodeReviewMock).toHaveBeenCalledTimes(1)
+    expect(result.reviewedPrs).toEqual([{ number: 12, passed: false }, { number: 13, passed: false }])
+    expect(runLocalCodeReviewMock).toHaveBeenCalledTimes(2)
   })
 })


### PR DESCRIPTION
## Summary
- continue the read-only Security Scan across every external open PR
- aggregate pass/fail tokens before deciding whether Stage 2 may start
- keep the pipeline fail-closed when any PR has findings

## Validation
- `cd server && npm test -- --run services/prReviewerSecurity.test.js services/cosTaskGenerator.test.js`
- live local replay reviewed all three external PRs without checkout or execution; all returned non-clean verdicts

No contributor branch was checked out or executed.