### PR TITLE
fix: surface scheduled task queue status

### DIFF
--- a/client/src/components/cos/tabs/ScheduleTab.jsx
+++ b/client/src/components/cos/tabs/ScheduleTab.jsx
@@ -25,6 +25,17 @@ export function mergeUpdatedTaskInterval(schedule, taskType, interval) {
   };
 }
 
+function mergeOnDemandRequest(schedule, request) {
+  if (!schedule || !request?.id) return schedule;
+  return {
+    ...schedule,
+    onDemandRequests: [
+      ...(schedule.onDemandRequests || []).filter(current => current.id !== request.id),
+      request,
+    ],
+  };
+}
+
 // `providers` is owned by ChiefOfStaff (30s poll, see useAutoRefetch there) and
 // passed down — same convention as TasksTab/AgentsTab — so this tab's provider/
 // model pickers stay live without standing up a second independent poll of the
@@ -87,11 +98,21 @@ export default function ScheduleTab({ apps, providers, activeProviderId }) {
       toast.error(err.message);
       return null;
     });
-    if (result?.success) {
-      toast.success(`Triggered ${taskType} task${appId ? ' for app' : ''} - will run on next evaluation`);
-      fetchSchedule();
+    if (!result?.success) return null;
+
+    const appName = appId ? apps?.find(app => app.id === appId)?.name || 'selected app' : null;
+    toast.success(`Queued ${taskType} request${appName ? ` for ${appName}` : ''} — it will appear in Tasks when evaluation begins`);
+
+    // The POST returns the persisted request. Paint it immediately instead of
+    // waiting for a second round trip; the evaluator may drain it into Tasks
+    // before that GET returns, while RunTaskButton retains the sent receipt at
+    // the click locus either way.
+    if (result.request) {
+      setSchedule(current => mergeOnDemandRequest(current, result.request));
     }
-  }, [fetchSchedule]);
+    fetchSchedule();
+    return result.request || true;
+  }, [apps, fetchSchedule]);
 
   const handleResetTask = async (taskType) => {
     const result = await api.resetCosTaskHistory(taskType, null, { silent: true }).catch(err => {
@@ -164,7 +185,7 @@ export default function ScheduleTab({ apps, providers, activeProviderId }) {
           <div className="space-y-1 mt-2">
             {schedule.onDemandRequests.map(req => (
               <div key={req.id} className="text-sm text-gray-300">
-                {req.taskType}{req.appId ? ` (${req.appId})` : ''} - requested {formatTimeOfDaySeconds(req.requestedAt)}
+                {req.taskType}{req.appId ? ` (${apps?.find(app => app.id === req.appId)?.name || req.appId})` : ''} - requested {formatTimeOfDaySeconds(req.requestedAt)}
               </div>
             ))}
           </div>

--- a/client/src/components/cos/tabs/ScheduleTab.test.jsx
+++ b/client/src/components/cos/tabs/ScheduleTab.test.jsx
@@ -1,5 +1,19 @@
-import { describe, expect, it } from 'vitest';
-import { mergeUpdatedTaskInterval } from './ScheduleTab';
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router';
+
+const toast = vi.hoisted(() => ({ success: vi.fn(), error: vi.fn() }));
+const api = vi.hoisted(() => ({
+  getCodeReviewDefaults: vi.fn(),
+  getCosSchedule: vi.fn(),
+  triggerCosOnDemandTask: vi.fn(),
+}));
+
+vi.mock('../../ui/Toast', () => ({ default: toast }));
+vi.mock('../../../services/api', () => api);
+
+const { default: ScheduleTab, mergeUpdatedTaskInterval } = await import('./ScheduleTab');
 
 describe('mergeUpdatedTaskInterval', () => {
   it('applies the persisted interval while retaining derived schedule status', () => {
@@ -27,5 +41,61 @@ describe('mergeUpdatedTaskInterval', () => {
       },
     });
     expect(schedule.tasks['plan-feature'].dataInputs).toEqual(['project-goals']);
+  });
+});
+
+describe('ScheduleTab on-demand feedback', () => {
+  it('names the selected app and paints the returned request before the refresh settles', async () => {
+    const user = userEvent.setup();
+    const request = {
+      id: 'request-1',
+      taskType: 'review',
+      appId: 'app-1',
+      requestedAt: '2026-09-01T12:00:00.000Z',
+    };
+    api.getCodeReviewDefaults.mockResolvedValue({});
+    api.getCosSchedule
+      .mockResolvedValueOnce({
+        improvementEnabled: true,
+        tasks: {
+          review: {
+            type: 'on-demand',
+            enabled: true,
+            enabledAppCount: 1,
+            totalAppCount: 1,
+            invocation: { userInvokable: true },
+          },
+        },
+        onDemandRequests: [],
+      })
+      // Hold the background refresh so this assertion uniquely proves the
+      // mutation response updates the visible schedule immediately.
+      .mockReturnValueOnce(new Promise(() => {}));
+    api.triggerCosOnDemandTask.mockResolvedValue({ success: true, request });
+
+    render(
+      <MemoryRouter>
+        <ScheduleTab
+          apps={[{ id: 'app-1', name: 'Example App' }]}
+          providers={[]}
+          activeProviderId={null}
+        />
+      </MemoryRouter>,
+    );
+
+    await user.click(await screen.findByRole('button', { name: /Run on App/i }));
+    await user.click(screen.getByRole('button', { name: 'Example App' }));
+
+    await waitFor(() => expect(api.triggerCosOnDemandTask).toHaveBeenCalledWith(
+      'review',
+      'app-1',
+      { silent: true },
+    ));
+    expect(toast.success).toHaveBeenCalledWith(
+      'Queued review request for Example App — it will appear in Tasks when evaluation begins',
+    );
+    expect(await screen.findByText('Request sent to Example App')).toBeVisible();
+    expect(screen.getByText('Pending On-Demand Tasks')).toBeVisible();
+    expect(screen.getByText(/review \(Example App\) - requested/)).toBeVisible();
   });
 });

--- a/client/src/components/cos/tabs/schedule/RunTaskButton.jsx
+++ b/client/src/components/cos/tabs/schedule/RunTaskButton.jsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect } from 'react';
 import { createPortal } from 'react-dom';
-import { Play, ChevronDown, Package } from 'lucide-react';
+import { CheckCircle2, ChevronDown, Loader2, Package, Play } from 'lucide-react';
 import { triggerButtonClass } from './scheduleConstants';
 import useClickOutside from '../../../../hooks/useClickOutside.js';
 import usePopoverPosition, { VIEWPORT_PADDING } from '../../../../hooks/usePopoverPosition.js';
@@ -18,9 +18,13 @@ const MENU_WIDTH = 256; // w-64
 // author had in mind.
 export default function RunTaskButton({ taskType, apps, onTrigger, installWide = false, disabledReason = '' }) {
   const [open, setOpen] = useState(false);
+  const [triggering, setTriggering] = useState(false);
+  const [lastRequest, setLastRequest] = useState('');
   const ref = useRef(null);
+  const triggerSeqRef = useRef(0);
+  const triggerInFlightRef = useRef(false);
   const activeApps = apps?.filter(app => !app.archived) || [];
-  const disabled = !!disabledReason;
+  const disabled = !!disabledReason || triggering;
 
   // The app list is portaled to <body> and placed in viewport coordinates. This
   // button sits mid-row on a task card, so the old `absolute bottom-full left-0`
@@ -45,50 +49,104 @@ export default function RunTaskButton({ taskType, apps, onTrigger, installWide =
     if (disabled) setOpen(false);
   }, [disabled]);
 
+  // The drawer reuses this component when the selected task changes. Do not
+  // carry the previous task's receipt across that prop swap, and ignore any
+  // stale response that settles after the swap.
+  useEffect(() => {
+    triggerSeqRef.current += 1;
+    triggerInFlightRef.current = false;
+    setTriggering(false);
+    setLastRequest('');
+  }, [taskType]);
+
+  const triggerTask = (app = null) => {
+    if (disabledReason || triggerInFlightRef.current) return;
+    triggerInFlightRef.current = true;
+    const requestSeq = ++triggerSeqRef.current;
+    setTriggering(true);
+    setLastRequest('');
+
+    const settle = (result) => {
+      if (requestSeq !== triggerSeqRef.current) return;
+      triggerInFlightRef.current = false;
+      setTriggering(false);
+      if (!result) return;
+      setLastRequest(app?.name
+        ? `Request sent to ${app.name}`
+        : installWide ? 'Request sent for all apps' : 'Request sent');
+    };
+
+    // ScheduleTab owns error feedback and always resolves to null on failure.
+    // Keep synchronous test/embedding callbacks synchronous too; forcing an
+    // `await` around a non-Promise schedules an unnecessary follow-up render.
+    const result = app ? onTrigger(taskType, app.id) : onTrigger(taskType);
+    if (result && typeof result.then === 'function') result.then(settle, () => settle(null));
+    else settle(result);
+  };
+
+  const requestStatus = (
+    <span
+      role="status"
+      title={lastRequest || undefined}
+      className={lastRequest
+        ? 'mt-1 flex min-w-0 max-w-48 items-center gap-1 text-[11px] text-port-success'
+        : 'sr-only'}
+    >
+      {lastRequest && <CheckCircle2 size={12} className="shrink-0" />}
+      <span className={lastRequest ? 'min-w-0 flex-1 truncate' : ''}>{triggering ? 'Sending request' : lastRequest}</span>
+    </span>
+  );
+
   // An install-wide task sweeps every managed app in ONE dispatch, so its real
   // run is the app-less one. Without this the picker would be the only way to
   // start it on any install that has apps, and every click would send an appId —
   // silently reducing an install-wide sweep to a single repo.
   if (activeApps.length === 0 || installWide) {
     return (
-      <span
-        title={disabledReason || (installWide
-          ? 'Run this task across every managed app in one sweep'
-          : 'Run this task immediately (bypasses schedule)')}
-        className="inline-block"
-      >
-        <button
-          type="button"
-          onClick={() => !disabled && onTrigger(taskType)}
-          disabled={disabled}
-          aria-disabled={disabled || undefined}
-          className={triggerButtonClass(disabled)}
+      <span className="inline-flex min-w-0 flex-col items-start">
+        <span
+          title={triggering ? 'Sending run request' : disabledReason || (installWide
+            ? 'Run this task across every managed app in one sweep'
+            : 'Run this task immediately (bypasses schedule)')}
+          className="inline-block"
         >
-          <Play size={14} />
-          {installWide ? 'Run on All Apps' : 'Run Now'}
-        </button>
+          <button
+            type="button"
+            onClick={() => !disabled && triggerTask()}
+            disabled={disabled}
+            aria-disabled={disabled || undefined}
+            aria-busy={triggering || undefined}
+            className={triggerButtonClass(disabled)}
+          >
+            {triggering ? <Loader2 size={14} className="animate-spin" /> : <Play size={14} />}
+            {triggering ? 'Sending…' : installWide ? 'Run on All Apps' : 'Run Now'}
+          </button>
+        </span>
+        {requestStatus}
       </span>
     );
   }
 
   return (
-    <div ref={ref}>
+    <div ref={ref} className="min-w-0">
       {/* Tooltip on the wrapper, not the button: most browsers skip hover events on disabled controls. */}
-      <span title={disabledReason || 'Run this task on a specific app'} className="inline-block">
+      <span title={triggering ? 'Sending run request' : disabledReason || 'Run this task on a specific app'} className="inline-block">
         <button
           ref={triggerRef}
           type="button"
           onClick={() => !disabled && setOpen(o => !o)}
           disabled={disabled}
           aria-disabled={disabled || undefined}
+          aria-busy={triggering || undefined}
           aria-expanded={open}
           className={triggerButtonClass(disabled)}
         >
-          <Play size={14} />
-          Run on App
-          <ChevronDown size={12} className={`transition-transform ${open ? 'rotate-180' : ''}`} />
+          {triggering ? <Loader2 size={14} className="animate-spin" /> : <Play size={14} />}
+          {triggering ? 'Sending…' : 'Run on App'}
+          {!triggering && <ChevronDown size={12} className={`transition-transform ${open ? 'rotate-180' : ''}`} />}
         </button>
       </span>
+      {requestStatus}
       {open && !disabled && createPortal(
         <div
           ref={popoverRef}
@@ -108,7 +166,7 @@ export default function RunTaskButton({ taskType, apps, onTrigger, installWide =
               <button
                 key={app.id}
                 type="button"
-                onClick={() => { onTrigger(taskType, app.id); setOpen(false); }}
+                onClick={() => { setOpen(false); triggerTask(app); }}
                 className="w-full px-3 py-2 text-left text-sm hover:bg-port-border/50 flex items-center gap-2 min-h-[40px]"
               >
                 <Package size={14} className="text-gray-400 shrink-0" />

--- a/client/src/components/cos/tabs/schedule/RunTaskButton.test.jsx
+++ b/client/src/components/cos/tabs/schedule/RunTaskButton.test.jsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import RunTaskButton from './RunTaskButton';
@@ -58,6 +58,25 @@ describe('RunTaskButton', () => {
     expect(onTrigger).toHaveBeenCalledWith('review', 'app-1');
     // Picking an app dismisses the panel.
     expect(screen.queryByText('Example App')).toBeNull();
+  });
+
+  it('shows sending progress and keeps a receipt at the app-card action', async () => {
+    const user = userEvent.setup();
+    let resolveTrigger;
+    const onTrigger = vi.fn(() => new Promise(resolve => { resolveTrigger = resolve; }));
+    render(<RunTaskButton taskType="review" apps={APPS} onTrigger={onTrigger} />);
+
+    await user.click(screen.getByRole('button', { name: /Run on App/i }));
+    await user.click(screen.getByText('Example App'));
+
+    expect(screen.getByRole('button', { name: 'Sending…' })).toBeDisabled();
+    expect(screen.getByRole('status')).toHaveTextContent('Sending request');
+
+    await act(async () => { resolveTrigger({ id: 'request-1' }); });
+
+    expect(screen.getByRole('status')).toHaveTextContent('Request sent to Example App');
+    expect(screen.getByText('Request sent to Example App')).toBeVisible();
+    expect(screen.getByRole('button', { name: /Run on App/i })).toBeEnabled();
   });
 
   it('keeps the app panel inside the viewport on a phone-width screen', async () => {


### PR DESCRIPTION
## Summary
- show a sending state and durable, app-specific receipt on scheduled-task Run actions
- name the selected app in the success notification and pending-request banner
- render the persisted on-demand request immediately while the schedule refresh runs

## Test plan
- `cd client && npm run lint`
- `cd client && npm run test:ci` (10,642 tests)
- `cd client && npm run build`