### PR TITLE
Require DB-backed suites in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -353,6 +353,7 @@ jobs:
       PGPORT: 5432
       PGUSER: portos
       PGPASSWORD: portos
+      PORTOS_REQUIRE_DB: '1'
     steps:
       - uses: actions/checkout@v7
         with:

--- a/server/lib/README.md
+++ b/server/lib/README.md
@@ -482,6 +482,7 @@ The barrel `server/lib/index.js` is a machine-checkable enumeration of every pub
 
 | Module | Purpose |
 |---|---|
+| `dbTestGate.js` | `requireDbOrSkip(label, dbReady, reason)` keeps a missing local test database as a visible skipped suite, but throws when `PORTOS_REQUIRE_DB` is set so CI cannot pass after DB-backed suites disappear. |
 | `gitTestRepo.js` | Shared real-git sandbox for integration tests (#4394): one initialized template (working tree + bare origin) per worker, then `fs.cp` into a fresh temp dir. `makeGitSandbox({ origin })`, `attachBareOrigin(scratch, repo)`, `materializeGitRepo(dest)`, `destroyGitSandbox`, plus `SKIP_HEAVY_INTEGRATION` (`VITEST_FAST=1`). Every entry point runs `assertTempPath` first, so a path outside `os.tmpdir()` throws instead of `git init`-ing or `rm -rf`-ing a real checkout (#4554). Still real git — just not rebuilt from `init`+`commit`+`push` in every `beforeEach`. |
 | `mirrorParity.js` | Source-comparison primitives for the `*.mirror.test.js` server↔client parity tests: `stripCommentsAndNormalize` (so per-side commentary may diverge but logic may not), `extractDeclaration(src, name)` (balanced `{}`/`()`/`[]` walk over `function` / `async function` / `const`), and `compareDeclaration(serverSrc, clientSrc, name)`. Use these instead of hand-rolling a brace-walker per mirror. Pure — no `vitest` import — so callers own the assertions. |
 | `mockPathsDataRoot.js` | Shared Vitest helpers for `PATHS.data → temp dir` and no-peer record creation guards. |

--- a/server/lib/dbTestGate.js
+++ b/server/lib/dbTestGate.js
@@ -1,0 +1,15 @@
+/**
+ * Keep locally unavailable database suites visible as skips, while letting CI
+ * fail fast when its required test database was not provisioned correctly.
+ */
+export function requireDbOrSkip(label, dbReady, reason) {
+  if (dbReady) return true;
+
+  const skipReason = reason || 'no database';
+  if (process.env.PORTOS_REQUIRE_DB) {
+    throw new Error(`${label}: DB-backed suite skipped but PORTOS_REQUIRE_DB is set — ${skipReason}`);
+  }
+
+  console.log(`⏭️ ${label}: skipping suite — ${skipReason}`);
+  return false;
+}

--- a/server/lib/dbTestGate.test.js
+++ b/server/lib/dbTestGate.test.js
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { requireDbOrSkip } from './dbTestGate.js';
+
+const originalRequireDb = process.env.PORTOS_REQUIRE_DB;
+
+afterEach(() => {
+  if (originalRequireDb === undefined) delete process.env.PORTOS_REQUIRE_DB;
+  else process.env.PORTOS_REQUIRE_DB = originalRequireDb;
+  vi.restoreAllMocks();
+});
+
+describe('requireDbOrSkip', () => {
+  it('returns false and logs when the DB is absent and the flag is unset', () => {
+    delete process.env.PORTOS_REQUIRE_DB;
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    expect(requireDbOrSkip('routes/catalog.test', false, 'catalog schema not present')).toBe(false);
+    expect(log).toHaveBeenCalledWith('⏭️ routes/catalog.test: skipping suite — catalog schema not present');
+  });
+
+  it('throws naming the suite and reason when PORTOS_REQUIRE_DB is set', () => {
+    process.env.PORTOS_REQUIRE_DB = '1';
+
+    expect(() => requireDbOrSkip('routes/catalog.test', false, 'catalog schema not present'))
+      .toThrow('routes/catalog.test: DB-backed suite skipped but PORTOS_REQUIRE_DB is set — catalog schema not present');
+  });
+
+  it('returns true and logs nothing when the DB is ready', () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    expect(requireDbOrSkip('routes/catalog.test', true, 'unused')).toBe(true);
+    expect(log).not.toHaveBeenCalled();
+  });
+});

--- a/server/lib/index.js
+++ b/server/lib/index.js
@@ -459,4 +459,5 @@ export * from './zodCompat.js';
 export * from './gitTestRepo.js';
 export * from './mockPathsDataRoot.js';
 export * from './settingsTestUtil.js';
+export * from './dbTestGate.js';
 export * from './testHelper.js';

--- a/server/routes/catalog.test.js
+++ b/server/routes/catalog.test.js
@@ -20,6 +20,7 @@ import express from 'express';
 import { request } from '../lib/testHelper.js';
 import { errorMiddleware } from '../lib/errorHandler.js';
 import { checkHealth, ensureSchema, close, query } from '../lib/db.js';
+import { requireDbOrSkip } from '../lib/dbTestGate.js';
 
 // Mock embeddings — the bulk-import + restore routes call these; we don't want a
 // network round-trip and the assertions never inspect the vector.
@@ -47,7 +48,7 @@ let skipReason = '';
     else skipReason = 'catalog schema not present';
   }
 }
-if (!dbReady) console.log(`⏭️ routes/catalog.test: skipping suite — ${skipReason || 'no database'}`);
+const runDb = requireDbOrSkip('routes/catalog.test', dbReady, skipReason);
 
 function makeApp() {
   const app = express();
@@ -76,7 +77,7 @@ afterAll(async () => {
   await close();
 });
 
-describe.skipIf(!dbReady)('POST /api/catalog/bulk-import — scrap persistence', () => {
+describe.skipIf(!runDb)('POST /api/catalog/bulk-import — scrap persistence', () => {
   it('persists a round-tripped `### Scraps` bullet as a catalog_scraps row + source link', async () => {
     const markdown = [
       `## Character: Scrap Persist Hero ${NONCE}`,
@@ -121,7 +122,7 @@ describe.skipIf(!dbReady)('POST /api/catalog/bulk-import — scrap persistence',
   });
 });
 
-describe.skipIf(!dbReady)('POST /api/catalog/scraps — chunking', () => {
+describe.skipIf(!runDb)('POST /api/catalog/scraps — chunking', () => {
   it('chunks a long paste into a parent + children but returns the parent scrap', async () => {
     // Over the 12k cap so createChunkedScrap splits it.
     const para = `Para body ${NONCE} `.repeat(300); // ~5400 chars
@@ -176,7 +177,7 @@ describe.skipIf(!dbReady)('POST /api/catalog/scraps — chunking', () => {
   });
 });
 
-describe.skipIf(!dbReady)('POST /api/catalog/bulk-import — export-bundle ref recreation', () => {
+describe.skipIf(!runDb)('POST /api/catalog/bulk-import — export-bundle ref recreation', () => {
   it('recreates the bundle ref link from `bundleRef` and honors per-row role', async () => {
     const seriesId = `test-series-${NONCE}`;
     const bundle = {
@@ -206,7 +207,7 @@ describe.skipIf(!dbReady)('POST /api/catalog/bulk-import — export-bundle ref r
   });
 });
 
-describe.skipIf(!dbReady)('POST /api/catalog/ingredients/:id/revisions/:revisionId/restore', () => {
+describe.skipIf(!runDb)('POST /api/catalog/ingredients/:id/revisions/:revisionId/restore', () => {
   it('restores the revision payload verbatim, preserving its schemaVersion, and records a new revision', async () => {
     // Seed an ingredient, then write an "old shape" payload (schemaVersion 0) so
     // a later restore can prove the marker is preserved, not re-stamped.
@@ -249,7 +250,7 @@ describe.skipIf(!dbReady)('POST /api/catalog/ingredients/:id/revisions/:revision
   });
 });
 
-describe.skipIf(!dbReady)('GET /api/catalog/ingredients/:id/details — batched hydration', () => {
+describe.skipIf(!runDb)('GET /api/catalog/ingredients/:id/details — batched hydration', () => {
   it('returns ingredient + refs + sources + relations + revisions + media + missingMedia in one response', async () => {
     const a = await catalogDB.createIngredient({ type: 'character', name: `Details A ${NONCE}`, payload: { physicalDescription: 'lead' } });
     const b = await catalogDB.createIngredient({ type: 'place', name: `Details B ${NONCE}`, payload: { description: 'a place' } });
@@ -299,7 +300,7 @@ describe.skipIf(!dbReady)('GET /api/catalog/ingredients/:id/details — batched 
   });
 });
 
-describe.skipIf(!dbReady)('GET /api/catalog/facets + ingredient filters (#1762)', () => {
+describe.skipIf(!runDb)('GET /api/catalog/facets + ingredient filters (#1762)', () => {
   const UNI = `route-uni-${NONCE}`;
   afterAll(async () => {
     await query('DELETE FROM catalog_ingredient_refs WHERE ref_id = $1', [UNI]).catch(() => {});

--- a/server/scripts/run-db-migrations.test.js
+++ b/server/scripts/run-db-migrations.test.js
@@ -19,6 +19,7 @@ import { mkdtemp, writeFile, rm } from 'fs/promises';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { checkHealth, ensureSchema, query, withTransaction, close } from '../lib/db.js';
+import { requireDbOrSkip } from '../lib/dbTestGate.js';
 import { runDbMigrations } from './run-db-migrations.js';
 
 let dbReady = false;
@@ -37,7 +38,7 @@ let skipReason = '';
   }
 }
 
-if (!dbReady) console.log(`⏭️  run-db-migrations.test.js skipped: ${skipReason}`);
+const runDb = requireDbOrSkip('scripts/run-db-migrations.test', dbReady, skipReason);
 
 // Test fixtures use a unique id prefix so we can clean ONLY our own rows /
 // scratch tables without touching a developer's real migration history.
@@ -46,7 +47,7 @@ const SCRATCH = `${PREFIX}scratch`;
 
 const db = { query, withTransaction };
 
-describe.skipIf(!dbReady)('versioned DB-migration runner', () => {
+describe.skipIf(!runDb)('versioned DB-migration runner', () => {
   let dir;
 
   beforeAll(async () => {

--- a/server/services/albums/db.test.js
+++ b/server/services/albums/db.test.js
@@ -8,6 +8,7 @@ import { describe, it, expect, vi, afterAll, beforeAll, beforeEach } from 'vites
 import { rmSync } from 'fs';
 import { join } from 'path';
 import { checkHealth, ensureSchema, query, close } from '../../lib/db.js';
+import { requireDbOrSkip } from '../../lib/dbTestGate.js';
 import { getSyncBaseHash, __resetBaseHashCacheForTests } from '../../lib/conflictJournal.js';
 
 const testState = vi.hoisted(() => ({ dataRoot: null, writeCounter: { baseHash: 0 } }));
@@ -43,11 +44,11 @@ let skipReason = '';
   }
 }
 
-if (!dbReady) console.log(`⏭️  services/albums/db.test.js skipped: ${skipReason}`);
+const runDb = requireDbOrSkip('services/albums/db.test', dbReady, skipReason);
 
 afterAll(() => rmSync(testState.dataRoot, { recursive: true, force: true }));
 
-describe.skipIf(!dbReady)('albums DB adapter round-trip', () => {
+describe.skipIf(!runDb)('albums DB adapter round-trip', () => {
   let db;
   let snap = [];
   beforeAll(async () => {

--- a/server/services/artists/db.test.js
+++ b/server/services/artists/db.test.js
@@ -15,6 +15,7 @@ import { describe, it, expect, vi, afterAll, beforeAll, beforeEach } from 'vites
 import { rmSync } from 'fs';
 import { join } from 'path';
 import { checkHealth, ensureSchema, query, close } from '../../lib/db.js';
+import { requireDbOrSkip } from '../../lib/dbTestGate.js';
 import { getSyncBaseHash, __resetBaseHashCacheForTests } from '../../lib/conflictJournal.js';
 
 const testState = vi.hoisted(() => ({ dataRoot: null, writeCounter: { baseHash: 0 } }));
@@ -50,11 +51,11 @@ let skipReason = '';
   }
 }
 
-if (!dbReady) console.log(`⏭️  services/artists/db.test.js skipped: ${skipReason}`);
+const runDb = requireDbOrSkip('services/artists/db.test', dbReady, skipReason);
 
 afterAll(() => rmSync(testState.dataRoot, { recursive: true, force: true }));
 
-describe.skipIf(!dbReady)('artists DB adapter round-trip', () => {
+describe.skipIf(!runDb)('artists DB adapter round-trip', () => {
   let db;
   let snap = [];
   beforeAll(async () => {

--- a/server/services/authors/db.test.js
+++ b/server/services/authors/db.test.js
@@ -13,6 +13,7 @@
 
 import { describe, it, expect, afterAll, beforeAll, beforeEach } from 'vitest';
 import { checkHealth, ensureSchema, query, close } from '../../lib/db.js';
+import { requireDbOrSkip } from '../../lib/dbTestGate.js';
 
 let dbReady = false;
 let skipReason = '';
@@ -30,9 +31,9 @@ let skipReason = '';
   }
 }
 
-if (!dbReady) console.log(`⏭️  services/authors/db.test.js skipped: ${skipReason}`);
+const runDb = requireDbOrSkip('services/authors/db.test', dbReady, skipReason);
 
-describe.skipIf(!dbReady)('authors DB adapter round-trip', () => {
+describe.skipIf(!runDb)('authors DB adapter round-trip', () => {
   let db;
   let snap = [];
   beforeAll(async () => {

--- a/server/services/catalogCanonProjection.test.js
+++ b/server/services/catalogCanonProjection.test.js
@@ -19,6 +19,7 @@
 
 import { describe, it, expect, afterAll, vi } from 'vitest';
 import { checkHealth, ensureSchema, close } from '../lib/db.js';
+import { requireDbOrSkip } from '../lib/dbTestGate.js';
 import * as catalogDB from './catalogDB.js';
 import { projectToCanon, projectToCatalog, _inFlightSize } from './catalogCanonProjection.js';
 
@@ -35,7 +36,7 @@ let skipReason = '';
     else skipReason = 'catalog schema not present';
   }
 }
-if (!dbReady) console.log(`⏭️ catalogCanonProjection.test: skipping suite — ${skipReason || 'no database'}`);
+const runDb = requireDbOrSkip('services/catalogCanonProjection.test', dbReady, skipReason);
 
 const createdIngredientIds = new Set();
 afterAll(async () => {
@@ -54,7 +55,7 @@ async function makeLinkedCharacter(universeId, { name = 'Proj Test', payload = {
   return ing;
 }
 
-describe.skipIf(!dbReady)('catalogCanonProjection', () => {
+describe.skipIf(!runDb)('catalogCanonProjection', () => {
   it('projectToCanon fans a catalog edit into every linked universe canon entry', async () => {
     const uA = `u-proj-${Date.now()}-a`;
     const uB = `u-proj-${Date.now()}-b`;

--- a/server/services/catalogDB.facets.db.test.js
+++ b/server/services/catalogDB.facets.db.test.js
@@ -14,6 +14,7 @@
 
 import { describe, it, expect, afterAll, beforeAll } from 'vitest';
 import { checkHealth, ensureSchema, close, query } from '../lib/db.js';
+import { requireDbOrSkip } from '../lib/dbTestGate.js';
 import * as catalogDB from './catalogDB.js';
 
 let dbReady = false;
@@ -29,7 +30,7 @@ let skipReason = '';
     else skipReason = 'catalog schema not present';
   }
 }
-if (!dbReady) console.log(`⏭️ catalogDB.facets.db.test: skipping suite — ${skipReason || 'no database'}`);
+const runDb = requireDbOrSkip('services/catalogDB.facets.db.test', dbReady, skipReason);
 
 const nonce = `f${Date.now()}`;
 const UNI_ID = `uni-${nonce}`;
@@ -55,7 +56,7 @@ afterAll(async () => {
   await close();
 });
 
-describe.skipIf(!dbReady)('catalogDB facets + album filters (#1762)', () => {
+describe.skipIf(!runDb)('catalogDB facets + album filters (#1762)', () => {
   it('lists ingredients by universe ref (membership), composing with type', async () => {
     const linked = await catalogDB.createIngredient({ type: 'character', name: `Linked ${nonce}`, tags: [TAG] });
     const other = await catalogDB.createIngredient({ type: 'place', name: `Other ${nonce}` });

--- a/server/services/catalogDB.test.js
+++ b/server/services/catalogDB.test.js
@@ -16,11 +16,12 @@
 
 import { describe, it, expect, afterAll } from 'vitest';
 import { checkHealth, ensureSchema, close } from '../lib/db.js';
+import { requireDbOrSkip } from '../lib/dbTestGate.js';
 import { setUserCatalogTypes } from '../lib/catalogTypes.js';
 import * as catalogDB from './catalogDB.js';
 
 // Probe the DB ONCE at module load via top-level await, so the suite is
-// registered with `describe.skipIf(!dbReady)` below and the runner reports
+// registered with `describe.skipIf(!runDb)` below and the runner reports
 // its tests as SKIPPED when Postgres is unreachable — rather than as
 // zero-assertion green, which would silently mask a broken connection in CI.
 let dbReady = false;
@@ -38,7 +39,7 @@ let skipReason = '';
     else skipReason = 'catalog schema not present (ensureSchema did not create catalog tables)';
   }
 }
-if (!dbReady) console.log(`⏭️ catalogDB.test: skipping suite — ${skipReason || 'no database'}`);
+const runDb = requireDbOrSkip('services/catalogDB.test', dbReady, skipReason);
 
 // Secondary guard for the (registered) tests: when the suite runs, dbReady is
 // always true here, so this is a no-op; describe.skipIf is the real gate.
@@ -91,7 +92,7 @@ describe('cdRefRoleForType', () => {
   });
 });
 
-describe.skipIf(!dbReady)('catalogDB (Postgres CRUD round-trip)', () => {
+describe.skipIf(!runDb)('catalogDB (Postgres CRUD round-trip)', () => {
   it('creates and reads back an ingredient with payload + tags', async () => {
     if (!requireDb('create/get ingredient')) return;
     const created = await catalogDB.createIngredient({

--- a/server/services/catalogRefResolver.test.js
+++ b/server/services/catalogRefResolver.test.js
@@ -14,6 +14,7 @@
 
 import { describe, it, expect, afterAll, beforeAll, beforeEach } from 'vitest';
 import { checkHealth, ensureSchema, query, close } from '../lib/db.js';
+import { requireDbOrSkip } from '../lib/dbTestGate.js';
 import { REF_TARGET_TABLES, RESOLVABLE_REF_KINDS } from './catalogRefResolver.js';
 import { REF_KINDS } from '../lib/catalogValidation.js';
 
@@ -44,7 +45,7 @@ let skipReason = '';
     else skipReason = 'catalog_ingredient_refs table not present';
   }
 }
-if (!dbReady) console.log(`⏭️  catalogRefResolver.test.js (live) skipped: ${skipReason}`);
+const runDb = requireDbOrSkip('services/catalogRefResolver.test', dbReady, skipReason);
 
 // The catalog refs table FKs ingredient_id → catalog_ingredients(id), so we
 // need a real ingredient row (ING) to hang refs on. Synthetic target rows use a
@@ -62,7 +63,7 @@ async function cleanSynthetic() {
   await query(`DELETE FROM catalog_ingredients WHERE id = $1`, [ING]).catch(() => {});
 }
 
-describe.skipIf(!dbReady)('catalog ref resolver — live resolution + dangling report', () => {
+describe.skipIf(!runDb)('catalog ref resolver — live resolution + dangling report', () => {
   let resolver;
 
   beforeAll(async () => { resolver = await import('./catalogRefResolver.js'); });

--- a/server/services/catalogUserTypes/db.test.js
+++ b/server/services/catalogUserTypes/db.test.js
@@ -11,6 +11,7 @@
 
 import { describe, it, expect, afterAll, beforeAll, beforeEach } from 'vitest';
 import { checkHealth, ensureSchema, query, close } from '../../lib/db.js';
+import { requireDbOrSkip } from '../../lib/dbTestGate.js';
 
 let dbReady = false;
 let skipReason = '';
@@ -28,11 +29,11 @@ let skipReason = '';
   }
 }
 
-if (!dbReady) console.log(`⏭️  catalogUserTypes/db.test.js skipped: ${skipReason}`);
+const runDb = requireDbOrSkip('services/catalogUserTypes/db.test', dbReady, skipReason);
 
 const T = (id, extra = {}) => ({ id, label: id, primaryContentKey: 'description', fields: [], ...extra });
 
-describe.skipIf(!dbReady)('catalog user-type DB round-trip', () => {
+describe.skipIf(!runDb)('catalog user-type DB round-trip', () => {
   let db;
   let snapshot = [];
   beforeAll(async () => {

--- a/server/services/creativeCommissions/db.test.js
+++ b/server/services/creativeCommissions/db.test.js
@@ -16,6 +16,7 @@
 
 import { describe, it, expect, afterAll } from 'vitest';
 import { checkHealth, ensureSchema, query, close } from '../../lib/db.js';
+import { requireDbOrSkip } from '../../lib/dbTestGate.js';
 import { readRaw, listRaw, writeRaw, deleteRaw } from './db.js';
 
 let dbReady = false;
@@ -34,7 +35,7 @@ let skipReason = '';
   }
 }
 
-if (!dbReady) console.log(`⏭️  creativeCommissions/db.test.js skipped: ${skipReason}`);
+const runDb = requireDbOrSkip('services/creativeCommissions/db.test', dbReady, skipReason);
 
 const nonce = `cc${Date.now()}`;
 const cid = (n) => `${nonce}-${n}`;
@@ -61,7 +62,7 @@ afterAll(async () => {
   }
 });
 
-describe.skipIf(!dbReady)('creativeCommissions DB adapter round-trip', () => {
+describe.skipIf(!runDb)('creativeCommissions DB adapter round-trip', () => {
   it('writes and reads a record back verbatim', async () => {
     const r = rec(cid('rw'), { brief: { intent: 'noir', constraints: { universeId: 'u-1' } } });
     await writeRaw(r.id, r);

--- a/server/services/creativeDirector/projectsDB.test.js
+++ b/server/services/creativeDirector/projectsDB.test.js
@@ -14,6 +14,7 @@
 
 import { describe, it, expect, afterAll, beforeAll, vi } from 'vitest';
 import { checkHealth, ensureSchema, query, close } from '../../lib/db.js';
+import { requireDbOrSkip } from '../../lib/dbTestGate.js';
 
 vi.mock('../mediaCollections.js', () => ({
   createCollection: vi.fn(async () => ({ id: 'col-test' })),
@@ -38,7 +39,7 @@ let skipReason = '';
   }
 }
 
-if (!dbReady) console.log(`⏭️  projectsDB.test.js skipped: ${skipReason}`);
+const runDb = requireDbOrSkip('services/creativeDirector/projectsDB.test', dbReady, skipReason);
 
 const CREATE_INPUT = {
   name: 'DB round-trip', aspectRatio: '1:1', quality: 'draft', modelId: 'm', targetDurationSeconds: 9,
@@ -48,7 +49,7 @@ const TREATMENT = {
   scenes: [{ sceneId: 'scene-1', order: 0, intent: 'bounce', prompt: 'a bouncing ball', durationSeconds: 3 }],
 };
 
-describe.skipIf(!dbReady)('projectsDB round-trip', () => {
+describe.skipIf(!runDb)('projectsDB round-trip', () => {
   const created = [];
   let db;
   // Import AFTER the skip gate so a no-DB run never touches the pool.

--- a/server/services/humanActivity.db.test.js
+++ b/server/services/humanActivity.db.test.js
@@ -13,6 +13,7 @@
  */
 import { describe, it, expect, afterAll } from 'vitest';
 import { checkHealth, ensureSchema, close, query } from '../lib/db.js';
+import { requireDbOrSkip } from '../lib/dbTestGate.js';
 import { recordEvents, listEvents, getDaySummary, stripParticipantsForAccount } from './humanActivity.js';
 
 let dbReady = false;
@@ -26,7 +27,7 @@ let skipReason = '';
     dbReady = true;
   }
 }
-if (!dbReady) console.log(`⏭️ humanActivity.db.test: skipping suite — ${skipReason || 'no database'}`);
+const runDb = requireDbOrSkip('services/humanActivity.db.test', dbReady, skipReason);
 
 const nonce = `ha${Date.now()}`;
 const SOURCE = `test-${nonce}`;
@@ -52,7 +53,7 @@ const mk = (over = {}) => ({
   ...over,
 });
 
-describe.skipIf(!dbReady)('humanActivity store (#2150)', () => {
+describe.skipIf(!runDb)('humanActivity store (#2150)', () => {
   it('records events and is idempotent on (source, dedupe_key)', async () => {
     const cands = [
       mk({ dedupeKey: 'dup-1', title: 'First' }),
@@ -135,7 +136,7 @@ describe.skipIf(!dbReady)('humanActivity store (#2150)', () => {
   });
 });
 
-describe.skipIf(!dbReady)('stripParticipantsForAccount — send-as alias backfill (#2855)', () => {
+describe.skipIf(!runDb)('stripParticipantsForAccount — send-as alias backfill (#2855)', () => {
   const ACCT = `acct-${nonce}`;
   const OTHER_ACCT = `other-${nonce}`;
   const ALIAS = 'alias@example.com';

--- a/server/services/mediaAssetIndex/db.test.js
+++ b/server/services/mediaAssetIndex/db.test.js
@@ -10,6 +10,7 @@
 
 import { describe, it, expect, afterAll, beforeAll } from 'vitest';
 import { checkHealth, ensureSchema, query, close } from '../../lib/db.js';
+import { requireDbOrSkip } from '../../lib/dbTestGate.js';
 
 let dbReady = false;
 let skipReason = '';
@@ -27,13 +28,13 @@ let skipReason = '';
   }
 }
 
-if (!dbReady) console.log(`⏭️  mediaAssetIndex/db.test.js skipped: ${skipReason}`);
+const runDb = requireDbOrSkip('services/mediaAssetIndex/db.test', dbReady, skipReason);
 
 // Test rows use a recognizable prefix so cleanup can target them without
 // touching any real indexed assets that happen to share the dev DB.
 const PFX = 'test-mai-';
 
-describe.skipIf(!dbReady)('media asset index DB round-trip', () => {
+describe.skipIf(!runDb)('media asset index DB round-trip', () => {
   let db;
   // reconcile is a GLOBAL sweep (it prunes every row not on disk), so it would
   // wipe any real index rows on a shared dev DB. Snapshot the table up front and

--- a/server/services/memoryDB.db.test.js
+++ b/server/services/memoryDB.db.test.js
@@ -27,6 +27,7 @@
 
 import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
 import { checkHealth, ensureSchema, close, query } from '../lib/db.js';
+import { requireDbOrSkip } from '../lib/dbTestGate.js';
 import { mockNoPeers, mockPathsDataRoot } from '../lib/mockPathsDataRoot.js';
 import { DEFAULT_MEMORY_CONFIG } from './memoryConfig.js';
 
@@ -63,7 +64,7 @@ let skipReason = '';
     else skipReason = 'memory schema not present';
   }
 }
-if (!dbReady) console.log(`⏭️ memoryDB.db.test: skipping suite — ${skipReason || 'no database'}`);
+const runDb = requireDbOrSkip('services/memoryDB.db.test', dbReady, skipReason);
 
 // ---------------------------------------------------------------------------
 // Fixture helpers
@@ -113,7 +114,7 @@ afterAll(async () => {
 // CRUD
 // ---------------------------------------------------------------------------
 
-describe.skipIf(!dbReady)('memoryDB CRUD (#3447)', () => {
+describe.skipIf(!runDb)('memoryDB CRUD (#3447)', () => {
   beforeAll(async () => {
     if (!dbReady) return;
     await resetMemories();
@@ -305,7 +306,7 @@ describe.skipIf(!dbReady)('memoryDB CRUD (#3447)', () => {
 // Listing / filtering
 // ---------------------------------------------------------------------------
 
-describe.skipIf(!dbReady)('memoryDB listing filters (#3447)', () => {
+describe.skipIf(!runDb)('memoryDB listing filters (#3447)', () => {
   let brainFact;
   let studioPreference;
   let archivedFact;
@@ -390,7 +391,7 @@ describe.skipIf(!dbReady)('memoryDB listing filters (#3447)', () => {
 // Search
 // ---------------------------------------------------------------------------
 
-describe.skipIf(!dbReady)('memoryDB search (#3447)', () => {
+describe.skipIf(!runDb)('memoryDB search (#3447)', () => {
   let quasar;      // VEC_A,      app 'brain'
   let zebrafish;   // VEC_NEAR_A, app 'studio'
   let pantry;      // VEC_FAR,    no app
@@ -523,7 +524,7 @@ describe.skipIf(!dbReady)('memoryDB search (#3447)', () => {
 // Consolidation
 // ---------------------------------------------------------------------------
 
-describe.skipIf(!dbReady)('memoryDB consolidateMemories (#3447)', () => {
+describe.skipIf(!runDb)('memoryDB consolidateMemories (#3447)', () => {
   let keeper;   // importance 0.9, VEC_A
   let duplicate; // importance 0.3, VEC_NEAR_A (≈0.995 similar to keeper)
   let lone;      // importance 0.5, orthogonal
@@ -572,7 +573,7 @@ describe.skipIf(!dbReady)('memoryDB consolidateMemories (#3447)', () => {
 // Decay
 // ---------------------------------------------------------------------------
 
-describe.skipIf(!dbReady)('memoryDB applyDecay boundaries (#3447)', () => {
+describe.skipIf(!runDb)('memoryDB applyDecay boundaries (#3447)', () => {
   it('is a no-op at decayRate 0 for memories past the recency-bonus window', async () => {
     await resetMemories();
     // The recency bonus is GREATEST(0, 0.1 - daysSinceAccess * 0.001) — zero once
@@ -647,7 +648,7 @@ describe.skipIf(!dbReady)('memoryDB applyDecay boundaries (#3447)', () => {
 // Graph
 // ---------------------------------------------------------------------------
 
-describe.skipIf(!dbReady)('memoryDB getGraphData (#3447)', () => {
+describe.skipIf(!runDb)('memoryDB getGraphData (#3447)', () => {
   let hub;      // VEC_A
   let spoke;    // VEC_FAR, explicitly linked to hub
   let neighbour; // VEC_NEAR_A, similar to hub by embedding only

--- a/server/services/moodBoard/db.test.js
+++ b/server/services/moodBoard/db.test.js
@@ -13,6 +13,7 @@ import { describe, it, expect, afterAll, beforeAll, beforeEach, vi } from 'vites
 import { rmSync } from 'fs';
 import { join } from 'path';
 import { checkHealth, ensureSchema, query, close } from '../../lib/db.js';
+import { requireDbOrSkip } from '../../lib/dbTestGate.js';
 import { getSyncBaseHash, __resetBaseHashCacheForTests } from '../../lib/conflictJournal.js';
 
 const testState = vi.hoisted(() => ({ dataRoot: null, writeCounter: { baseHash: 0 } }));
@@ -48,11 +49,11 @@ let skipReason = '';
   }
 }
 
-if (!dbReady) console.log(`⏭️  moodBoard/db.test.js skipped: ${skipReason}`);
+const runDb = requireDbOrSkip('services/moodBoard/db.test', dbReady, skipReason);
 
 afterAll(() => rmSync(testState.dataRoot, { recursive: true, force: true }));
 
-describe.skipIf(!dbReady)('mood board DB round-trip', () => {
+describe.skipIf(!runDb)('mood board DB round-trip', () => {
   let db;
   const created = [];
   beforeAll(async () => {
@@ -136,7 +137,7 @@ describe.skipIf(!dbReady)('mood board DB round-trip', () => {
   });
 });
 
-describe.skipIf(!dbReady)('mood board federation (#1564)', () => {
+describe.skipIf(!runDb)('mood board federation (#1564)', () => {
   let db;
   const created = [];
   const remote = (id, over = {}) => ({

--- a/server/services/musicVideo/projectsDB.test.js
+++ b/server/services/musicVideo/projectsDB.test.js
@@ -11,6 +11,7 @@ import { describe, it, expect, vi, afterAll, beforeAll, beforeEach } from 'vites
 import { rmSync } from 'fs';
 import { join } from 'path';
 import { checkHealth, ensureSchema, query, close } from '../../lib/db.js';
+import { requireDbOrSkip } from '../../lib/dbTestGate.js';
 import { getSyncBaseHash, __resetBaseHashCacheForTests } from '../../lib/conflictJournal.js';
 
 const testState = vi.hoisted(() => ({ dataRoot: null, writeCounter: { baseHash: 0 } }));
@@ -46,7 +47,7 @@ let skipReason = '';
   }
 }
 
-if (!dbReady) console.log(`⏭️  musicVideo/projectsDB.test.js skipped: ${skipReason}`);
+const runDb = requireDbOrSkip('services/musicVideo/projectsDB.test', dbReady, skipReason);
 
 afterAll(() => rmSync(testState.dataRoot, { recursive: true, force: true }));
 
@@ -62,7 +63,7 @@ const project = (id, deletedAt) => ({
   deletedAt,
 });
 
-describe.skipIf(!dbReady)('music video projects DB adapter', () => {
+describe.skipIf(!runDb)('music video projects DB adapter', () => {
   let db;
 
   beforeAll(async () => { db = await import('./projectsDB.js'); });

--- a/server/services/pipeline/issuesStore/db.test.js
+++ b/server/services/pipeline/issuesStore/db.test.js
@@ -5,6 +5,7 @@
 
 import { describe, it, expect, afterAll, beforeAll, beforeEach } from 'vitest';
 import { checkHealth, ensureSchema, query, close } from '../../../lib/db.js';
+import { requireDbOrSkip } from '../../../lib/dbTestGate.js';
 
 let dbReady = false;
 let skipReason = '';
@@ -22,7 +23,7 @@ let skipReason = '';
   }
 }
 
-if (!dbReady) console.log(`⏭️  pipeline/issuesStore/db.test.js skipped: ${skipReason}`);
+const runDb = requireDbOrSkip('services/pipeline/issuesStore/db.test', dbReady, skipReason);
 
 const I = (id, extra = {}) => ({
   id, seriesId: 'ser-1', seasonId: null, number: 1, status: 'draft', title: id,
@@ -30,7 +31,7 @@ const I = (id, extra = {}) => ({
   deleted: false, deletedAt: null, ...extra,
 });
 
-describe.skipIf(!dbReady)('pipeline issues DB adapter round-trip', () => {
+describe.skipIf(!runDb)('pipeline issues DB adapter round-trip', () => {
   let db;
   let snap = [];
   beforeAll(async () => {

--- a/server/services/pipeline/seriesStore/db.test.js
+++ b/server/services/pipeline/seriesStore/db.test.js
@@ -8,6 +8,7 @@
 
 import { describe, it, expect, afterAll, beforeAll, beforeEach } from 'vitest';
 import { checkHealth, ensureSchema, query, close } from '../../../lib/db.js';
+import { requireDbOrSkip } from '../../../lib/dbTestGate.js';
 
 let dbReady = false;
 let skipReason = '';
@@ -25,7 +26,7 @@ let skipReason = '';
   }
 }
 
-if (!dbReady) console.log(`⏭️  pipeline/seriesStore/db.test.js skipped: ${skipReason}`);
+const runDb = requireDbOrSkip('services/pipeline/seriesStore/db.test', dbReady, skipReason);
 
 const S = (id, extra = {}) => ({
   id, name: id, universeId: null, writersRoomWorkId: null,
@@ -33,7 +34,7 @@ const S = (id, extra = {}) => ({
   deleted: false, deletedAt: null, ...extra,
 });
 
-describe.skipIf(!dbReady)('pipeline series DB adapter round-trip', () => {
+describe.skipIf(!runDb)('pipeline series DB adapter round-trip', () => {
   let db;
   let snap = [];
   beforeAll(async () => {

--- a/server/services/postRunDb.db.test.js
+++ b/server/services/postRunDb.db.test.js
@@ -1,6 +1,7 @@
 /** PostgreSQL atomicity/idempotency coverage for normalized POST runs (#4441). */
 import { afterAll, describe, expect, it } from 'vitest';
 import { checkHealth, close, ensureSchema, query, withTransaction } from '../lib/db.js';
+import { requireDbOrSkip } from '../lib/dbTestGate.js';
 import { saveNormalizedRun } from './postRunDb.js';
 
 let dbReady = false;
@@ -15,7 +16,7 @@ let skipReason = '';
     if (!dbReady) skipReason = 'post_runs schema unavailable';
   }
 }
-if (!dbReady) console.log(`⏭️ postRunDb.db.test: skipping suite — ${skipReason}`);
+const runDb = requireDbOrSkip('services/postRunDb.db.test', dbReady, skipReason);
 
 const nonce = `post-test-${Date.now()}`;
 const runIds = [`${nonce}-one`, `${nonce}-owner`, `${nonce}-rollback`, `${nonce}-concurrent`];
@@ -41,7 +42,7 @@ afterAll(async () => {
   }
 });
 
-describe.skipIf(!dbReady)('postRunDb transaction (#4441)', () => {
+describe.skipIf(!runDb)('postRunDb transaction (#4441)', () => {
   it('upserts one run and its complete attempt set idempotently', async () => {
     await saveNormalizedRun(db, makeRun(runIds[0], [attempt(`${nonce}-a1`), attempt(`${nonce}-a2`)]));
     await saveNormalizedRun(db, makeRun(runIds[0], [attempt(`${nonce}-a2`), attempt(`${nonce}-a1`, 95)]));

--- a/server/services/privacyBrokers.db.test.js
+++ b/server/services/privacyBrokers.db.test.js
@@ -9,6 +9,7 @@
 
 import { describe, it, expect, afterAll, beforeAll } from 'vitest';
 import { checkHealth, ensureSchema, query, close } from '../lib/db.js';
+import { requireDbOrSkip } from '../lib/dbTestGate.js';
 
 // A valid vault key BEFORE privacyVault is imported so the runScanPass test can
 // create a scan-eligible name without touching the repo's real .env.
@@ -31,9 +32,9 @@ let skipReason = '';
   }
 }
 
-if (!dbReady) console.log(`⏭️  privacyBrokers.db.test.js skipped: ${skipReason}`);
+const runDb = requireDbOrSkip('services/privacyBrokers.db.test', dbReady, skipReason);
 
-describe.skipIf(!dbReady)('privacy brokers DB round-trip', () => {
+describe.skipIf(!runDb)('privacy brokers DB round-trip', () => {
   let svc;
   let scan;
   let vault;

--- a/server/services/privacyChanges.db.test.js
+++ b/server/services/privacyChanges.db.test.js
@@ -11,6 +11,7 @@
 
 import { describe, it, expect, afterAll, beforeAll, vi } from 'vitest';
 import { checkHealth, ensureSchema, query, close } from '../lib/db.js';
+import { requireDbOrSkip } from '../lib/dbTestGate.js';
 
 vi.mock('./messageAccounts.js', () => ({
   listAccounts: vi.fn(async () => [{ id: 'acct-test', type: 'gmail', name: 'Test' }]),
@@ -39,9 +40,9 @@ let skipReason = '';
   }
 }
 
-if (!dbReady) console.log(`⏭️  privacyChanges.db.test.js skipped: ${skipReason}`);
+const runDb = requireDbOrSkip('services/privacyChanges.db.test', dbReady, skipReason);
 
-describe.skipIf(!dbReady)('privacy changes DB round-trip', () => {
+describe.skipIf(!runDb)('privacy changes DB round-trip', () => {
   let changes;
   let orgs;
   let vault;

--- a/server/services/privacyOptOut.db.test.js
+++ b/server/services/privacyOptOut.db.test.js
@@ -11,6 +11,7 @@
 
 import { describe, it, expect, afterAll, beforeAll } from 'vitest';
 import { checkHealth, ensureSchema, query, close } from '../lib/db.js';
+import { requireDbOrSkip } from '../lib/dbTestGate.js';
 
 const originalKey = process.env.PRIVACY_VAULT_KEY;
 process.env.PRIVACY_VAULT_KEY = 'e'.repeat(64);
@@ -31,9 +32,9 @@ let skipReason = '';
   }
 }
 
-if (!dbReady) console.log(`⏭️  privacyOptOut.db.test.js skipped: ${skipReason}`);
+const runDb = requireDbOrSkip('services/privacyOptOut.db.test', dbReady, skipReason);
 
-describe.skipIf(!dbReady)('privacy opt-out engine DB round-trip', () => {
+describe.skipIf(!runDb)('privacy opt-out engine DB round-trip', () => {
   let svc; // privacyOptOut
   let brokers; // privacyBrokers
   let vault;

--- a/server/services/privacyOrgs.db.test.js
+++ b/server/services/privacyOrgs.db.test.js
@@ -11,6 +11,7 @@
 
 import { describe, it, expect, afterAll, beforeAll } from 'vitest';
 import { checkHealth, ensureSchema, query, close } from '../lib/db.js';
+import { requireDbOrSkip } from '../lib/dbTestGate.js';
 
 const HEX_KEY = 'd'.repeat(64);
 const originalKey = process.env.PRIVACY_VAULT_KEY;
@@ -32,9 +33,9 @@ let skipReason = '';
   }
 }
 
-if (!dbReady) console.log(`⏭️  privacyOrgs.db.test.js skipped: ${skipReason}`);
+const runDb = requireDbOrSkip('services/privacyOrgs.db.test', dbReady, skipReason);
 
-describe.skipIf(!dbReady)('privacy orgs DB round-trip', () => {
+describe.skipIf(!runDb)('privacy orgs DB round-trip', () => {
   let orgs;
   let vault;
   const createdOrgs = [];

--- a/server/services/privacySubjects.db.test.js
+++ b/server/services/privacySubjects.db.test.js
@@ -13,6 +13,7 @@
 
 import { describe, it, expect, afterAll, beforeAll } from 'vitest';
 import { checkHealth, ensureSchema, query, close } from '../lib/db.js';
+import { requireDbOrSkip } from '../lib/dbTestGate.js';
 
 // A valid key BEFORE the service is imported/called so ensureVaultKey never
 // touches the repo's real .env during the run (createVaultRecord encrypts).
@@ -36,9 +37,9 @@ let skipReason = '';
   }
 }
 
-if (!dbReady) console.log(`⏭️  privacySubjects.db.test.js skipped: ${skipReason}`);
+const runDb = requireDbOrSkip('services/privacySubjects.db.test', dbReady, skipReason);
 
-describe.skipIf(!dbReady)('privacy household subjects DB round-trip', () => {
+describe.skipIf(!runDb)('privacy household subjects DB round-trip', () => {
   let subjects;
   let vault;
   let selfSubjectId = '';

--- a/server/services/privacyVault.db.test.js
+++ b/server/services/privacyVault.db.test.js
@@ -12,6 +12,7 @@
 
 import { describe, it, expect, afterAll, beforeAll } from 'vitest';
 import { checkHealth, ensureSchema, query, close } from '../lib/db.js';
+import { requireDbOrSkip } from '../lib/dbTestGate.js';
 
 // A valid key BEFORE the service is imported/called so ensureVaultKey never
 // touches the repo's real .env during the run.
@@ -35,9 +36,9 @@ let skipReason = '';
   }
 }
 
-if (!dbReady) console.log(`⏭️  privacyVault.db.test.js skipped: ${skipReason}`);
+const runDb = requireDbOrSkip('services/privacyVault.db.test', dbReady, skipReason);
 
-describe.skipIf(!dbReady)('privacy vault DB round-trip', () => {
+describe.skipIf(!runDb)('privacy vault DB round-trip', () => {
   let vault;
   let subjects;
   const created = [];

--- a/server/services/storyBuilderStore/db.test.js
+++ b/server/services/storyBuilderStore/db.test.js
@@ -5,6 +5,7 @@
 
 import { describe, it, expect, afterAll, beforeAll, beforeEach } from 'vitest';
 import { checkHealth, ensureSchema, query, close } from '../../lib/db.js';
+import { requireDbOrSkip } from '../../lib/dbTestGate.js';
 
 let dbReady = false;
 let skipReason = '';
@@ -22,7 +23,7 @@ let skipReason = '';
   }
 }
 
-if (!dbReady) console.log(`⏭️  storyBuilderStore/db.test.js skipped: ${skipReason}`);
+const runDb = requireDbOrSkip('services/storyBuilderStore/db.test', dbReady, skipReason);
 
 const S = (id, extra = {}) => ({
   id, title: id, intakeMode: 'seed', universeId: 'u-1', seriesId: 'ser-1',
@@ -31,7 +32,7 @@ const S = (id, extra = {}) => ({
   deleted: false, deletedAt: null, ...extra,
 });
 
-describe.skipIf(!dbReady)('Story Builder sessions DB adapter round-trip', () => {
+describe.skipIf(!runDb)('Story Builder sessions DB adapter round-trip', () => {
   let db;
   let snap = [];
   beforeAll(async () => {

--- a/server/services/tracks/db.test.js
+++ b/server/services/tracks/db.test.js
@@ -6,6 +6,7 @@
 
 import { describe, it, expect, afterAll, beforeAll, beforeEach } from 'vitest';
 import { checkHealth, ensureSchema, query, close } from '../../lib/db.js';
+import { requireDbOrSkip } from '../../lib/dbTestGate.js';
 
 let dbReady = false;
 let skipReason = '';
@@ -23,9 +24,9 @@ let skipReason = '';
   }
 }
 
-if (!dbReady) console.log(`⏭️  services/tracks/db.test.js skipped: ${skipReason}`);
+const runDb = requireDbOrSkip('services/tracks/db.test', dbReady, skipReason);
 
-describe.skipIf(!dbReady)('tracks DB adapter round-trip', () => {
+describe.skipIf(!runDb)('tracks DB adapter round-trip', () => {
   let db;
   let snap = [];
   beforeAll(async () => {

--- a/server/services/universeBuilder/db.test.js
+++ b/server/services/universeBuilder/db.test.js
@@ -11,6 +11,7 @@
 
 import { describe, it, expect, afterAll, beforeAll, beforeEach } from 'vitest';
 import { checkHealth, ensureSchema, query, close } from '../../lib/db.js';
+import { requireDbOrSkip } from '../../lib/dbTestGate.js';
 
 let dbReady = false;
 let skipReason = '';
@@ -28,7 +29,7 @@ let skipReason = '';
   }
 }
 
-if (!dbReady) console.log(`⏭️  universeBuilder/db.test.js skipped: ${skipReason}`);
+const runDb = requireDbOrSkip('services/universeBuilder/db.test', dbReady, skipReason);
 
 const U = (id, extra = {}) => ({
   id, name: id, schemaVersion: 4,
@@ -36,7 +37,7 @@ const U = (id, extra = {}) => ({
   deleted: false, deletedAt: null, ...extra,
 });
 
-describe.skipIf(!dbReady)('universeBuilder DB adapter round-trip', () => {
+describe.skipIf(!runDb)('universeBuilder DB adapter round-trip', () => {
   let db;
   let uSnap = [];
   let rSnap = [];

--- a/server/services/userActions.db.test.js
+++ b/server/services/userActions.db.test.js
@@ -16,6 +16,7 @@
  */
 import { describe, it, expect, afterAll, beforeAll } from 'vitest';
 import * as db from '../lib/db.js';
+import { requireDbOrSkip } from '../lib/dbTestGate.js';
 import { checkHealth, ensureSchema, close, query } from '../lib/db.js';
 import {
   insertUserActionEvent,
@@ -35,7 +36,7 @@ let skipReason = '';
     dbReady = true;
   }
 }
-if (!dbReady) console.log(`⏭️ userActions.db.test: skipping suite — ${skipReason || 'no database'}`);
+const runDb = requireDbOrSkip('services/userActions.db.test', dbReady, skipReason);
 
 const nonce = `ua${Date.now()}`;
 const key = (suffix) => `${nonce}:${suffix}`;
@@ -71,7 +72,7 @@ const listMine = async (options = {}) => {
   return rows.filter((row) => row.dedupeKey.startsWith(`${nonce}:`));
 };
 
-describe.skipIf(!dbReady)('user_action_events store (#5594)', () => {
+describe.skipIf(!runDb)('user_action_events store (#5594)', () => {
   it('inserts and round-trips the full row shape', async () => {
     const row = event({
       dedupeKey: key('shape'),

--- a/server/services/writersRoom/db.test.js
+++ b/server/services/writersRoom/db.test.js
@@ -9,6 +9,7 @@
 
 import { describe, it, expect, afterAll, beforeAll, beforeEach } from 'vitest';
 import { checkHealth, ensureSchema, query, close } from '../../lib/db.js';
+import { requireDbOrSkip } from '../../lib/dbTestGate.js';
 
 const TABLES = [
   'writers_room_folders', 'writers_room_works',
@@ -31,7 +32,7 @@ let skipReason = '';
   }
 }
 
-if (!dbReady) console.log(`⏭️  writersRoom/db.test.js skipped: ${skipReason}`);
+const runDb = requireDbOrSkip('services/writersRoom/db.test', dbReady, skipReason);
 
 const draft = (id, extra = {}) => ({
   id, label: 'Draft 1', contentFile: `drafts/${id}.md`, contentHash: 'h'.repeat(64),
@@ -45,7 +46,7 @@ const manifest = (id, extra = {}) => ({
   createdAt: '2026-01-01T00:00:00.000Z', updatedAt: '2026-01-02T00:00:00.000Z', ...extra,
 });
 
-describe.skipIf(!dbReady)('Writers Room DB adapter round-trip', () => {
+describe.skipIf(!runDb)('Writers Room DB adapter round-trip', () => {
   let db;
   const snaps = {};
   beforeAll(async () => {


### PR DESCRIPTION
## Summary
- Fail CI when a DB-backed suite would be skipped after test-database provisioning.
- Preserve visible local skips when the database is unavailable.
- Route every DB probe through the shared gate and cover both modes.

## Tests
- `npm test -- dbTestGate.test.js lib/index.test.js`
- `npm run setup:db:test`
- `npm run test:db`
- Simulated unavailable DB with and without `PORTOS_REQUIRE_DB=1`

Closes #5731