### PR TITLE
Add VH5 VHS Tape LoRA to MiniMax H3 curated suggestions

### DIFF
--- a/server/services/videoLoraSuggestions.js
+++ b/server/services/videoLoraSuggestions.js
@@ -33,6 +33,13 @@ const CURATED_VIDEO_LORAS = [
     name: 'LTX-2.3 Audio Reactive V2',
     note: 'Improved beat response for LTX-2.3 audio-conditioned renders. Use music as motion guidance; PortOS keeps generated vocals disabled.',
   },
+  {
+    repo: 'KennethFal/vh5tape-vhs-lora-minimax-h3',
+    file: 'vh5tape.safetensors',
+    family: VIDEO_LORA_FAMILIES.MINIMAX_H3,
+    name: 'VH5 VHS Tape (MiniMax H3)',
+    note: 'Retro 1980s VHS look — tracking artifacts, tape grain, and CRT color for MiniMax H3 renders.',
+  },
 ];
 
 const now = () => Date.now();

--- a/server/services/videoLoraSuggestions.test.js
+++ b/server/services/videoLoraSuggestions.test.js
@@ -29,6 +29,16 @@ describe('getVideoSuggestions', () => {
     expect(card.installUrl).toBe('https://huggingface.co/fal/ltx2.3-audio-reactive-lora');
   });
 
+  it('includes the MiniMax H3 curated card', async () => {
+    const fetchImpl = async () => mockJsonResponse({ cardData: {} });
+    const cards = await svc.getVideoSuggestions({ fetchImpl });
+    const card = cards.find((c) => c.repo === 'KennethFal/vh5tape-vhs-lora-minimax-h3');
+    expect(card).toBeTruthy();
+    expect(card.runnerFamily).toBe('minimax-h3');
+    expect(card.file).toBe('vh5tape.safetensors');
+    expect(card.installUrl).toBe('https://huggingface.co/KennethFal/vh5tape-vhs-lora-minimax-h3');
+  });
+
   it('degrades to the static card when the HF metadata fetch fails', async () => {
     const fetchImpl = async () => ({ ok: false, status: 404 });
     const cards = await svc.getVideoSuggestions({ fetchImpl });


### PR DESCRIPTION
## Summary
- Adds `KennethFal/vh5tape-vhs-lora-minimax-h3` (a MiniMax H3 adapter producing a retro VHS/CRT look) to the curated video-LoRA quick-install list in `server/services/videoLoraSuggestions.js`, giving it its first `minimax-h3` entry alongside the existing LTX-2.3 pick.

## Test plan
- `NODE_ENV=test npx vitest run services/videoLoraSuggestions.test.js` — 5 tests pass, including a new test asserting the MiniMax H3 card's repo/family/filename/installUrl.
- `NODE_ENV=test npx vitest run -t lora` — 97 lora-related tests pass across 23 files.