### PR TITLE
fix: confine POST /api/detect/ai to PORTOS_WORKSPACE_ROOTS

### DIFF
--- a/server/lib/apiRouteCatalog.generated.json
+++ b/server/lib/apiRouteCatalog.generated.json
@@ -7175,7 +7175,7 @@
       "sources": [
         {
           "source": "server/routes/detect.js",
-          "line": 239
+          "line": 263
         }
       ]
     },
@@ -7186,7 +7186,7 @@
       "sources": [
         {
           "source": "server/routes/detect.js",
-          "line": 215
+          "line": 235
         }
       ]
     },
@@ -7197,7 +7197,7 @@
       "sources": [
         {
           "source": "server/routes/detect.js",
-          "line": 171
+          "line": 191
         }
       ]
     },
@@ -7208,7 +7208,7 @@
       "sources": [
         {
           "source": "server/routes/detect.js",
-          "line": 33
+          "line": 70
         }
       ]
     },
@@ -18590,7 +18590,7 @@
         },
         {
           "source": "server/routes/providers.js",
-          "line": 767
+          "line": 776
         }
       ]
     },
@@ -18643,6 +18643,10 @@
         {
           "source": "server/lib/aiToolkit/routes/providers.js",
           "line": 110
+        },
+        {
+          "source": "server/routes/providers.js",
+          "line": 765
         }
       ]
     },
@@ -19908,7 +19912,7 @@
       "sources": [
         {
           "source": "server/routes/sprites.js",
-          "line": 154
+          "line": 159
         }
       ]
     },
@@ -19919,7 +19923,7 @@
       "sources": [
         {
           "source": "server/routes/sprites.js",
-          "line": 218
+          "line": 223
         }
       ]
     },
@@ -19930,7 +19934,7 @@
       "sources": [
         {
           "source": "server/routes/sprites.js",
-          "line": 490
+          "line": 498
         }
       ]
     },
@@ -19941,7 +19945,7 @@
       "sources": [
         {
           "source": "server/routes/sprites.js",
-          "line": 231
+          "line": 236
         }
       ]
     },
@@ -19952,7 +19956,7 @@
       "sources": [
         {
           "source": "server/routes/sprites.js",
-          "line": 476
+          "line": 484
         }
       ]
     },
@@ -19963,7 +19967,7 @@
       "sources": [
         {
           "source": "server/routes/sprites.js",
-          "line": 278
+          "line": 283
         }
       ]
     },
@@ -19974,7 +19978,7 @@
       "sources": [
         {
           "source": "server/routes/sprites.js",
-          "line": 485
+          "line": 493
         }
       ]
     },
@@ -19985,7 +19989,7 @@
       "sources": [
         {
           "source": "server/routes/sprites.js",
-          "line": 455
+          "line": 463
         }
       ]
     },
@@ -19996,7 +20000,7 @@
       "sources": [
         {
           "source": "server/routes/sprites.js",
-          "line": 468
+          "line": 476
         }
       ]
     },
@@ -20007,7 +20011,7 @@
       "sources": [
         {
           "source": "server/routes/sprites.js",
-          "line": 336
+          "line": 344
         }
       ]
     },
@@ -20018,7 +20022,7 @@
       "sources": [
         {
           "source": "server/routes/sprites.js",
-          "line": 463
+          "line": 471
         }
       ]
     },
@@ -20029,7 +20033,7 @@
       "sources": [
         {
           "source": "server/routes/sprites.js",
-          "line": 286
+          "line": 291
         }
       ]
     },
@@ -20040,7 +20044,7 @@
       "sources": [
         {
           "source": "server/routes/sprites.js",
-          "line": 306
+          "line": 314
         }
       ]
     },
@@ -20051,7 +20055,7 @@
       "sources": [
         {
           "source": "server/routes/sprites.js",
-          "line": 322
+          "line": 330
         }
       ]
     },
@@ -20062,7 +20066,7 @@
       "sources": [
         {
           "source": "server/routes/sprites.js",
-          "line": 329
+          "line": 337
         }
       ]
     },
@@ -20073,7 +20077,7 @@
       "sources": [
         {
           "source": "server/routes/sprites.js",
-          "line": 314
+          "line": 322
         }
       ]
     },
@@ -20084,7 +20088,7 @@
       "sources": [
         {
           "source": "server/routes/sprites.js",
-          "line": 365
+          "line": 373
         }
       ]
     },
@@ -20095,7 +20099,7 @@
       "sources": [
         {
           "source": "server/routes/sprites.js",
-          "line": 358
+          "line": 366
         }
       ]
     },
@@ -20106,7 +20110,7 @@
       "sources": [
         {
           "source": "server/routes/sprites.js",
-          "line": 372
+          "line": 380
         }
       ]
     },
@@ -20117,7 +20121,7 @@
       "sources": [
         {
           "source": "server/routes/sprites.js",
-          "line": 381
+          "line": 389
         }
       ]
     },
@@ -20128,7 +20132,7 @@
       "sources": [
         {
           "source": "server/routes/sprites.js",
-          "line": 344
+          "line": 352
         }
       ]
     },
@@ -20139,7 +20143,7 @@
       "sources": [
         {
           "source": "server/routes/sprites.js",
-          "line": 414
+          "line": 422
         }
       ]
     },
@@ -20150,7 +20154,7 @@
       "sources": [
         {
           "source": "server/routes/sprites.js",
-          "line": 399
+          "line": 407
         }
       ]
     },
@@ -20161,7 +20165,7 @@
       "sources": [
         {
           "source": "server/routes/sprites.js",
-          "line": 423
+          "line": 431
         }
       ]
     },
@@ -20172,7 +20176,7 @@
       "sources": [
         {
           "source": "server/routes/sprites.js",
-          "line": 440
+          "line": 448
         }
       ]
     },
@@ -20183,7 +20187,7 @@
       "sources": [
         {
           "source": "server/routes/sprites.js",
-          "line": 407
+          "line": 415
         }
       ]
     },
@@ -20194,7 +20198,7 @@
       "sources": [
         {
           "source": "server/routes/sprites.js",
-          "line": 447
+          "line": 455
         }
       ]
     },
@@ -20205,7 +20209,7 @@
       "sources": [
         {
           "source": "server/routes/sprites.js",
-          "line": 390
+          "line": 398
         }
       ]
     },
@@ -20216,7 +20220,7 @@
       "sources": [
         {
           "source": "server/routes/sprites.js",
-          "line": 212
+          "line": 217
         }
       ]
     },
@@ -20227,7 +20231,7 @@
       "sources": [
         {
           "source": "server/routes/sprites.js",
-          "line": 183
+          "line": 188
         }
       ]
     },
@@ -20238,7 +20242,7 @@
       "sources": [
         {
           "source": "server/routes/sprites.js",
-          "line": 187
+          "line": 192
         }
       ]
     },
@@ -20249,7 +20253,7 @@
       "sources": [
         {
           "source": "server/routes/sprites.js",
-          "line": 198
+          "line": 203
         }
       ]
     },
@@ -20260,7 +20264,7 @@
       "sources": [
         {
           "source": "server/routes/sprites.js",
-          "line": 192
+          "line": 197
         }
       ]
     },
@@ -20271,7 +20275,7 @@
       "sources": [
         {
           "source": "server/routes/sprites.js",
-          "line": 226
+          "line": 231
         }
       ]
     },
@@ -20282,7 +20286,7 @@
       "sources": [
         {
           "source": "server/routes/sprites.js",
-          "line": 165
+          "line": 170
         }
       ]
     },
@@ -20293,7 +20297,7 @@
       "sources": [
         {
           "source": "server/routes/sprites.js",
-          "line": 171
+          "line": 176
         }
       ]
     },
@@ -23865,7 +23869,7 @@
   "stats": {
     "mounts": 147,
     "operations": 2153,
-    "declarations": 2156,
+    "declarations": 2157,
     "sourceFiles": 229
   }
 }

--- a/server/lib/workspaceRoots.js
+++ b/server/lib/workspaceRoots.js
@@ -3,9 +3,15 @@ import { resolve, relative, isAbsolute, delimiter, basename } from 'path';
 import { homedir, tmpdir } from 'os';
 
 // Allowed workspace roots shared by routes that accept a caller-supplied
-// filesystem path: command execution (`routes/commands.js`), repo detection
-// (`routes/detect.js`), scaffolding (`routes/scaffold.js`), submodule reads
-// (`routes/git.js`).
+// filesystem path: command execution (`routes/commands.js`), scaffolding
+// (`routes/scaffold.js`), submodule reads (`routes/git.js`), and detection
+// (`routes/detect.js`).
+//
+// Coverage is per-HANDLER, not per-file — a route module listed here does not
+// imply every handler in it is scoped. In `routes/detect.js` the two handlers
+// that take a path (`POST /repo`, `POST /ai`) both go through one shared
+// `checkWorkspacePathAllowed` helper; its other handlers (`POST /port`,
+// `POST /pm2`) take no path at all.
 //
 // Repos legitimately live on secondary volumes, so the defaults cover home plus
 // the places each platform mounts them: /Volumes (macOS), /mnt + /media (Linux),

--- a/server/routes/detect.js
+++ b/server/routes/detect.js
@@ -13,6 +13,42 @@ import { isWithinAllowedRoots, outsideAllowedRootsMessage, WORKSPACE_ROOTS_CONFI
 const execAsync = promisify(exec);
 const router = Router();
 
+// Optional confinement, shared by every handler here that takes a caller-supplied
+// path (POST /repo and POST /ai): enforced only when the operator has configured
+// PORTOS_WORKSPACE_ROOTS. realpath() first so a symlink can't smuggle a path past
+// the containment check. realpathSync can throw on a permission/TOCTOU edge (the
+// path deleted between an earlier stat and here) — reported as a refusal rather
+// than leaking a 500. This is the sanctioned fs-edge-case exception to the
+// no-try/catch rule (see commands.js).
+//
+// Returns { ok: true } or { ok: false, error, code } so each caller shapes the
+// refusal its own way: /repo answers with its valid:false verdict (deciding
+// "is this a usable repo?" is that route's whole product), while /ai — which has
+// no such field, and where {success:false} could not be told apart from
+// "provider unavailable" — throws a 400. The resolved path stays out of both,
+// appearing only in the redacted server-side diagnostic.
+const checkWorkspacePathAllowed = (path) => {
+  if (!WORKSPACE_ROOTS_CONFIGURED) return { ok: true };
+
+  let realPath;
+  try {
+    realPath = realpathSync(resolve(path));
+  } catch {
+    return { ok: false, error: 'Path is not accessible', code: 'PATH_NOT_ACCESSIBLE' };
+  }
+
+  if (!isWithinAllowedRoots(realPath)) {
+    console.error(`❌ ${outsideAllowedRootsMessage(realPath)}`);
+    return {
+      ok: false,
+      error: 'Path is outside the configured workspace roots (PORTOS_WORKSPACE_ROOTS)',
+      code: 'PATH_OUTSIDE_WORKSPACE_ROOTS'
+    };
+  }
+
+  return { ok: true };
+};
+
 // POST /api/detect/repo - Validate repo path and detect project type
 //
 // TRUST MODEL: This endpoint accepts an arbitrary, caller-supplied filesystem
@@ -29,7 +65,8 @@ const router = Router();
 // `routes/commands.js` uses to scope command execution). When that env var is set,
 // this route enforces the allow-list too — a path outside the roots returns valid:false
 // rather than reading its files. When it is unset (the default), detection is
-// unrestricted, matching the pre-existing behavior.
+// unrestricted, matching the pre-existing behavior. POST /ai enforces the same
+// allow-list via the shared `checkWorkspacePathAllowed` helper above.
 router.post('/repo', asyncHandler(async (req, res) => {
   const { path } = req.body;
 
@@ -54,26 +91,9 @@ router.post('/repo', asyncHandler(async (req, res) => {
     });
   }
 
-  // Optional confinement: only when the operator has configured workspace roots.
-  // realpath() first so a symlink can't smuggle a path past the containment check.
-  // realpathSync can throw on a permission/TOCTOU edge (path deleted between the
-  // stat above and here) — convert that to the same valid:false shape the rest of
-  // this route returns for unusable paths, rather than leaking a 500. This is the
-  // sanctioned fs-edge-case exception to the no-try/catch rule (see commands.js).
-  if (WORKSPACE_ROOTS_CONFIGURED) {
-    let realPath;
-    try {
-      realPath = realpathSync(resolve(path));
-    } catch {
-      return res.json({ valid: false, error: 'Path is not accessible' });
-    }
-    if (!isWithinAllowedRoots(realPath)) {
-      console.error(`❌ ${outsideAllowedRootsMessage(realPath)}`);
-      return res.json({
-        valid: false,
-        error: 'Path is outside the configured workspace roots (PORTOS_WORKSPACE_ROOTS)'
-      });
-    }
+  const confinement = checkWorkspacePathAllowed(path);
+  if (!confinement.ok) {
+    return res.json({ valid: false, error: confinement.error });
   }
 
   // Detect project type
@@ -236,11 +256,20 @@ router.post('/pm2', asyncHandler(async (req, res) => {
 }));
 
 // POST /api/detect/ai - AI-powered app detection
+// Unlike /repo this reads package.json, config files, .env port lines and the
+// README, then ships them to a configured AI provider (possibly a hosted API) and
+// runs that provider's CLI with cwd set here — so the confinement check must run
+// BEFORE detectAppWithAi, or a refused path has already left the machine.
 router.post('/ai', asyncHandler(async (req, res) => {
   const { path, providerId } = req.body;
 
   if (!path) {
     throw new ServerError('Path is required', { status: 400, code: 'MISSING_PATH' });
+  }
+
+  const confinement = checkWorkspacePathAllowed(path);
+  if (!confinement.ok) {
+    throw new ServerError(confinement.error, { status: 400, code: confinement.code });
   }
 
   const result = await detectAppWithAi(path, providerId);

--- a/server/routes/detect.test.js
+++ b/server/routes/detect.test.js
@@ -1,5 +1,8 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import express from 'express';
+import { mkdtempSync, realpathSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
 import { errorMiddleware } from '../lib/errorHandler.js';
 import { request } from '../lib/testHelper.js';
 import detectRoutes from './detect.js';
@@ -42,5 +45,84 @@ describe('Detect Routes', () => {
     expect(response.status).toBe(500);
     expect(response.body).toMatchObject({ error: 'provider crashed', code: 'INTERNAL_ERROR' });
     expect(response.body).not.toHaveProperty('success');
+  });
+});
+
+// PORTOS_WORKSPACE_ROOTS is read once at module load, so these stub the env and
+// re-import a fresh copy of the route graph. The module-registry reset drops the
+// hoisted vi.mock above with it, so the AI service is re-mocked per load via
+// vi.doMock (which applies to subsequent dynamic imports).
+describe('POST /api/detect/ai workspace-root confinement', () => {
+  let roots;
+  let outside;
+
+  const loadApp = async (workspaceRoots) => {
+    vi.resetModules();
+    vi.stubEnv('PORTOS_WORKSPACE_ROOTS', workspaceRoots);
+    const detect = vi.fn();
+    vi.doMock('../services/aiDetect.js', () => ({ detectAppWithAi: detect }));
+    const routes = await import('./detect.js');
+    const errors = await import('../lib/errorHandler.js');
+    const scoped = express();
+    scoped.use(express.json());
+    scoped.use('/api/detect', routes.default);
+    scoped.use(errors.errorMiddleware);
+    return { app: scoped, detect };
+  };
+
+  beforeEach(() => {
+    // realpathSync so macOS's /var -> /private/var symlink doesn't make the
+    // configured root and the resolved request path disagree.
+    roots = realpathSync(mkdtempSync(join(tmpdir(), 'portos-roots-')));
+    outside = realpathSync(mkdtempSync(join(tmpdir(), 'portos-outside-')));
+  });
+
+  afterEach(() => {
+    vi.doUnmock('../services/aiDetect.js');
+    vi.unstubAllEnvs();
+    vi.resetModules();
+    rmSync(roots, { recursive: true, force: true });
+    rmSync(outside, { recursive: true, force: true });
+  });
+
+  it('refuses a path outside the configured roots without invoking the provider', async () => {
+    const { app: scoped, detect } = await loadApp(roots);
+
+    const response = await request(scoped)
+      .post('/api/detect/ai')
+      .send({ path: outside });
+
+    expect(response.status).toBe(400);
+    expect(response.body).toMatchObject({ code: 'PATH_OUTSIDE_WORKSPACE_ROOTS' });
+    // The refusal must not echo the rejected filesystem path back to the caller.
+    expect(JSON.stringify(response.body)).not.toContain(outside);
+    // The regression this uniquely catches: no file was read and nothing was
+    // shipped to a (possibly hosted) AI provider.
+    expect(detect).not.toHaveBeenCalled();
+  });
+
+  it('allows a path inside the configured roots', async () => {
+    const { app: scoped, detect } = await loadApp(roots);
+    detect.mockResolvedValue({ success: true, app: { name: 'example' } });
+
+    const response = await request(scoped)
+      .post('/api/detect/ai')
+      .send({ path: roots });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ success: true, app: { name: 'example' } });
+    expect(detect).toHaveBeenCalledWith(roots, undefined);
+  });
+
+  it('stays unrestricted when PORTOS_WORKSPACE_ROOTS is unset', async () => {
+    const { app: scoped, detect } = await loadApp('');
+    detect.mockResolvedValue({ success: true, app: { name: 'example' } });
+
+    const response = await request(scoped)
+      .post('/api/detect/ai')
+      .send({ path: outside });
+
+    expect(response.status).toBe(200);
+    expect(detect).toHaveBeenCalledWith(outside, undefined);
   });
 });

--- a/server/routes/detect.test.js
+++ b/server/routes/detect.test.js
@@ -1,8 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import express from 'express';
-import { mkdtempSync, realpathSync, rmSync } from 'fs';
-import { tmpdir } from 'os';
-import { join } from 'path';
+import { realpathSync } from 'fs';
+import { homedir } from 'os';
 import { errorMiddleware } from '../lib/errorHandler.js';
 import { request } from '../lib/testHelper.js';
 import detectRoutes from './detect.js';
@@ -48,14 +47,21 @@ describe('Detect Routes', () => {
   });
 });
 
+// A directory that exists on the host but sits OUTSIDE DEFAULT_WORKSPACE_ROOTS,
+// so the only thing that can admit it is PORTOS_WORKSPACE_ROOTS. Deliberately not
+// a mkdtemp() directory: `tmpdir()` is itself a default root on Linux (/tmp) and
+// Windows, so a temp dir is always allowed there and would make the refusal test
+// pass only on macOS. realpathSync because macOS's /etc is a symlink to
+// /private/etc and the route realpath()s before checking containment.
+const OUTSIDE_DEFAULT_ROOTS = realpathSync(
+  process.platform === 'win32' ? (process.env.SystemRoot || 'C:\\Windows') : '/etc'
+);
+
 // PORTOS_WORKSPACE_ROOTS is read once at module load, so these stub the env and
 // re-import a fresh copy of the route graph. The module-registry reset drops the
 // hoisted vi.mock above with it, so the AI service is re-mocked per load via
 // vi.doMock (which applies to subsequent dynamic imports).
 describe('POST /api/detect/ai workspace-root confinement', () => {
-  let roots;
-  let outside;
-
   const loadApp = async (workspaceRoots) => {
     vi.resetModules();
     vi.stubEnv('PORTOS_WORKSPACE_ROOTS', workspaceRoots);
@@ -70,48 +76,39 @@ describe('POST /api/detect/ai workspace-root confinement', () => {
     return { app: scoped, detect };
   };
 
-  beforeEach(() => {
-    // realpathSync so macOS's /var -> /private/var symlink doesn't make the
-    // configured root and the resolved request path disagree.
-    roots = realpathSync(mkdtempSync(join(tmpdir(), 'portos-roots-')));
-    outside = realpathSync(mkdtempSync(join(tmpdir(), 'portos-outside-')));
-  });
-
   afterEach(() => {
     vi.doUnmock('../services/aiDetect.js');
     vi.unstubAllEnvs();
     vi.resetModules();
-    rmSync(roots, { recursive: true, force: true });
-    rmSync(outside, { recursive: true, force: true });
   });
 
   it('refuses a path outside the configured roots without invoking the provider', async () => {
-    const { app: scoped, detect } = await loadApp(roots);
+    const { app: scoped, detect } = await loadApp(homedir());
 
     const response = await request(scoped)
       .post('/api/detect/ai')
-      .send({ path: outside });
+      .send({ path: OUTSIDE_DEFAULT_ROOTS });
 
     expect(response.status).toBe(400);
     expect(response.body).toMatchObject({ code: 'PATH_OUTSIDE_WORKSPACE_ROOTS' });
     // The refusal must not echo the rejected filesystem path back to the caller.
-    expect(JSON.stringify(response.body)).not.toContain(outside);
+    expect(JSON.stringify(response.body)).not.toContain(OUTSIDE_DEFAULT_ROOTS);
     // The regression this uniquely catches: no file was read and nothing was
     // shipped to a (possibly hosted) AI provider.
     expect(detect).not.toHaveBeenCalled();
   });
 
-  it('allows a path inside the configured roots', async () => {
-    const { app: scoped, detect } = await loadApp(roots);
+  it('allows a path the configured roots admit but the defaults would not', async () => {
+    const { app: scoped, detect } = await loadApp(OUTSIDE_DEFAULT_ROOTS);
     detect.mockResolvedValue({ success: true, app: { name: 'example' } });
 
     const response = await request(scoped)
       .post('/api/detect/ai')
-      .send({ path: roots });
+      .send({ path: OUTSIDE_DEFAULT_ROOTS });
 
     expect(response.status).toBe(200);
     expect(response.body).toEqual({ success: true, app: { name: 'example' } });
-    expect(detect).toHaveBeenCalledWith(roots, undefined);
+    expect(detect).toHaveBeenCalledWith(OUTSIDE_DEFAULT_ROOTS, undefined);
   });
 
   it('stays unrestricted when PORTOS_WORKSPACE_ROOTS is unset', async () => {
@@ -120,9 +117,9 @@ describe('POST /api/detect/ai workspace-root confinement', () => {
 
     const response = await request(scoped)
       .post('/api/detect/ai')
-      .send({ path: outside });
+      .send({ path: OUTSIDE_DEFAULT_ROOTS });
 
     expect(response.status).toBe(200);
-    expect(detect).toHaveBeenCalledWith(outside, undefined);
+    expect(detect).toHaveBeenCalledWith(OUTSIDE_DEFAULT_ROOTS, undefined);
   });
 });


### PR DESCRIPTION
## Summary

`POST /api/detect/repo` enforces the operator's opt-in `PORTOS_WORKSPACE_ROOTS` allow-list — a path outside the configured roots is refused rather than read. Its sibling `POST /api/detect/ai` took the same caller-supplied `path` and skipped the check entirely, while doing something strictly more dangerous: it reads `package.json`, up to nine config files, the port lines of `.env` / `.env.local` / `.env.development`, and the README from that directory, splices them into a prompt, ships them to a configured AI provider (possibly a hosted, paid API), and runs that provider's CLI with `cwd` set there. The one control an operator has for saying "PortOS may only read inside these roots" silently did not apply to the endpoint that sends file contents off the machine.

- Extracted the confinement block into one local `checkWorkspacePathAllowed` helper in `server/routes/detect.js`, so the two path-taking handlers cannot drift apart again.
- `POST /ai` calls it immediately after the `!path` check, **before** `detectAppWithAi` — a refused path never reaches the filesystem or the provider.
- `/repo` keeps answering with its `valid: false` verdict (deciding "is this a usable repo?" is that route's whole product); `/ai` throws a 400 `PATH_OUTSIDE_WORKSPACE_ROOTS` instead, because it has no such field and a `{ success: false }` body could not be told apart from "provider unavailable".
- The resolved path stays out of both HTTP bodies; it appears only in the existing redacted `outsideAllowedRootsMessage` server-side diagnostic.
- `server/lib/workspaceRoots.js` now spells out that coverage is per-**handler**, not per-file, so `routes/detect.js` no longer reads as blanket coverage.

With `PORTOS_WORKSPACE_ROOTS` unset — the default — behavior is unchanged on both routes.

### Also included

`server/lib/apiRouteCatalog.generated.json` is regenerated (`npm run generate:api-docs`). The catalog pins route line numbers, which this change shifts. It had **already** drifted on `main` (42 stale entries from other routes, mostly `sprites.js`/`providers.js`), so `scripts/generate-api-route-catalog.test.js` was red before this branch and is green on it.

## Test plan

Three cases added to `server/routes/detect.test.js`, each loading a fresh route graph under a stubbed env (`PORTOS_WORKSPACE_ROOTS` is read once at module load):

- **refuses a path outside the configured roots without invoking the provider** — the regression this uniquely catches: asserts 400 + `PATH_OUTSIDE_WORKSPACE_ROOTS`, that the body does not echo the rejected path, and that `detectAppWithAi` was never called (no bytes read, no provider call). Verified it fails against the pre-fix handler and passes after.
- **allows a path the configured roots admit but the defaults would not** — pins that the guard is not over-broad.
- **stays unrestricted when `PORTOS_WORKSPACE_ROOTS` is unset** — pins that the documented default posture stays permissive.

The "outside" path is deliberately not a `mkdtemp()` directory: `tmpdir()` is itself a default allowed root on Linux (`/tmp`) and Windows, so a temp dir would have been admitted by the defaults and the refusal case would only have proven anything on macOS. It uses `/etc` (or `%SystemRoot%` on Windows), which exists on the host and sits outside `DEFAULT_WORKSPACE_ROOTS` on every platform CI runs.

`cd server && npm test` — 37,000+ tests pass. Two unrelated suites (`services/sprites/atlas.test.js`, `services/sharing/privacyNeverFederates.test.js` and friends) time out only under a loaded parallel run and pass with `--maxWorkers=1`; `scripts/generate-api-route-catalog.test.js` was failing on `main` before this branch and is fixed here.

## Out of scope

Per the issue: no confinement added to `POST /api/runs` (agent runs intentionally take an arbitrary workspace), and no change to what `gatherProjectContext` reads (finding security-06).

A local review round raised passing the canonical `realPath` to `detectAppWithAi` to close a symlink-swap TOCTOU. Declined: PortOS's trust model explicitly excludes defending against a second competing actor inside one install, `/repo` has the identical validate-realpath-then-use-`path` shape, and swapping in the resolved path would change the directory the provider is told about.

Closes #5650
