### PR TITLE
fix: reject ZIP members with unsafe asset names in the ChatGPT importer

### DIFF
--- a/server/services/chatgptZipImport.js
+++ b/server/services/chatgptZipImport.js
@@ -128,11 +128,13 @@ const WINDOWS_RESERVED_NAME = /^(?:con|prn|aux|nul|com[1-9]|lpt[1-9])$/i;
 // degenerate once `.dat` is dropped (`.dat` -> ``, `..dat` -> `.`), which would
 // otherwise write a `.png` / `..png` dotfile into the served dir.
 //
-// `zipStream.js` also sanitizes separators and `.`/`..` components as it decodes
-// each header, so a traversal has to defeat two independent layers to land. This
-// one is the layer that matters here: the parser's sanitizing is its own private
-// policy, while the consumer is what actually opens the file, and keeping the
-// check at the write site means a future faithful-reader refactor of the parser
+// Today `zipStream.js` sanitizes separators and `.`/`..` components as it decodes
+// each header, so a `\` never actually reaches this predicate — the flattened
+// basename is what arrives. That makes this guard the SECOND layer, not the
+// first, and it is deliberately kept anyway: the parser's sanitizing is its own
+// private policy (its header comment describes it as a faithful sequential
+// reader), while this is the code that actually opens the file. Validating at
+// the write site means a future refactor that makes the parser truly faithful
 // cannot silently reintroduce the escape.
 const isSafeDatMember = (path) => {
   const assetId = datAssetId(path);

--- a/server/services/chatgptZipImport.js
+++ b/server/services/chatgptZipImport.js
@@ -111,6 +111,13 @@ const IS_ASSET_NAME_MAP = (path) => /(?:^|\/)conversation_asset_file_names\.json
 // `${assetDir}/${id}` would then escape the asset dir (Zip Slip).
 const datAssetId = (path) => path.split(/[\\/]/).pop().replace(/\.dat$/i, '');
 
+// Windows resolves these basenames to devices whatever the extension, so a
+// member named `CON.dat` would open the console instead of `CON.part` and the
+// later rename would fail — aborting the whole import. Real exports only ever
+// use `file-…` ids, so they are refused on every platform for one consistent
+// outcome rather than a Windows-only failure.
+const WINDOWS_RESERVED_NAME = /^(?:con|prn|aux|nul|com[1-9]|lpt[1-9])$/i;
+
 // A `.dat` member is extractable only when BOTH its ZIP-spec name and the asset
 // id it reduces to are plain filenames.
 //
@@ -127,8 +134,12 @@ const datAssetId = (path) => path.split(/[\\/]/).pop().replace(/\.dat$/i, '');
 // policy, while the consumer is what actually opens the file, and keeping the
 // check at the write site means a future faithful-reader refactor of the parser
 // cannot silently reintroduce the escape.
-const isSafeDatMember = (path) =>
-  isTopLevelEntryName(path.replace(/^.*\//, '')) && isTopLevelEntryName(datAssetId(path));
+const isSafeDatMember = (path) => {
+  const assetId = datAssetId(path);
+  return isTopLevelEntryName(path.replace(/^.*\//, ''))
+    && isTopLevelEntryName(assetId)
+    && !WINDOWS_RESERVED_NAME.test(assetId);
+};
 
 // Single-sourced so both guards below log identically. Deliberately carries NO
 // member path — the name is untrusted third-party text.

--- a/server/services/chatgptZipImport.js
+++ b/server/services/chatgptZipImport.js
@@ -31,8 +31,10 @@
 
 import { createReadStream, createWriteStream } from 'fs';
 import { rename, unlink } from 'fs/promises';
+import { join } from 'path';
 import { Writable } from 'stream';
 import { PATHS, getMimeType, ensureDir } from '../lib/fileUtils.js';
+import { isTopLevelEntryName } from '../lib/pathSafety.js';
 import { parseZip, collectZipEntry, MAX_ZIP_MEMBER_BYTES } from '../lib/zipStream.js';
 import { parseExport, importConversations, assetPointerId } from './chatgptImport.js';
 import { ServerError } from '../lib/errorHandler.js';
@@ -102,7 +104,35 @@ const IS_ASSET_NAME_MAP = (path) => /(?:^|\/)conversation_asset_file_names\.json
 // A `.dat` member's asset id is its basename without extension. Conversations
 // reference assets as `file-service://file-XXX` / `sediment://file_HASH`, both
 // of which `assetPointerId()` reduces to that same bare id.
-const datAssetId = (path) => path.replace(/^.*\//, '').replace(/\.dat$/i, '');
+//
+// Splits on BOTH separators so the id is always a real basename on every
+// platform: a hostile archive can name a member `a\..\..\evil.dat`, and a
+// forward-slash-only strip would leave the backslashes in the id — on Windows
+// `${assetDir}/${id}` would then escape the asset dir (Zip Slip).
+const datAssetId = (path) => path.split(/[\\/]/).pop().replace(/\.dat$/i, '');
+
+// A `.dat` member is extractable only when BOTH its ZIP-spec name and the asset
+// id it reduces to are plain filenames.
+//
+// The ZIP spec mandates `/` as the only separator, so everything after the last
+// `/` is one filename — a `\` or `..` surviving there means a hostile or
+// malformed member, not a nested directory, and it is skipped rather than
+// silently normalized into an extracted file. The second half catches ids that
+// degenerate once `.dat` is dropped (`.dat` -> ``, `..dat` -> `.`), which would
+// otherwise write a `.png` / `..png` dotfile into the served dir.
+//
+// `zipStream.js` also sanitizes separators and `.`/`..` components as it decodes
+// each header, so a traversal has to defeat two independent layers to land. This
+// one is the layer that matters here: the parser's sanitizing is its own private
+// policy, while the consumer is what actually opens the file, and keeping the
+// check at the write site means a future faithful-reader refactor of the parser
+// cannot silently reintroduce the escape.
+const isSafeDatMember = (path) =>
+  isTopLevelEntryName(path.replace(/^.*\//, '')) && isTopLevelEntryName(datAssetId(path));
+
+// Single-sourced so both guards below log identically. Deliberately carries NO
+// member path — the name is untrusted third-party text.
+const UNSAFE_MEMBER_WARNING = '⚠️ ChatGPT import: skipped a ZIP member with an unsafe asset name';
 
 // Stream a `.dat` entry straight to `filePath`, holding only the leading
 // `SNIFF_BYTES` so the asset's real extension can be sniffed without buffering
@@ -206,8 +236,18 @@ export async function extractChatgptZip(zipPath, { assetDir = PATHS.brainImportA
           // bytes to sniff the extension. Peak RAM is one chunk regardless of
           // asset size, so there is no aggregate ceiling and a multi-GB export
           // imports without OOM risk. Renamed to its final served name below.
+          // Refuse any member whose name isn't a plain filename BEFORE the temp
+          // file is opened. Skip the member rather than failing the whole
+          // import: one malformed member in a multi-GB export shouldn't cost the
+          // user the entire ingest, and a conversation referencing it simply
+          // renders without its asset (the resolver already returns null).
+          if (!isSafeDatMember(path)) {
+            console.warn(UNSAFE_MEMBER_WARNING);
+            entry.autodrain();
+            return;
+          }
           const assetId = datAssetId(path);
-          const tempPath = `${assetDir}/${assetId}.part`;
+          const tempPath = join(assetDir, `${assetId}.part`);
           tempPaths.add(tempPath);
           inFlight.push(streamAssetToFile(entry, tempPath, MAX_MEMBER_BYTES)
             .then((sniffedExt) => { pendingAssets.set(assetId, { datPath: path, tempPath, sniffedExt }); })
@@ -250,7 +290,16 @@ export async function extractChatgptZip(zipPath, { assetDir = PATHS.brainImportA
       const friendlyName = assetNameMap[`${assetId}.dat`] || assetNameMap[datPath] || null;
       const ext = sniffedExt || extFromName(friendlyName) || '.bin';
       const fileName = `${assetId}${ext}`;
-      const filePath = `${assetDir}/${fileName}`;
+      // Defense in depth: `assetId` was already vetted above, but `ext` comes
+      // from `extFromName`/the sniffer — re-check the composed name so a future
+      // change there can't reintroduce a traversal.
+      if (!isTopLevelEntryName(fileName)) {
+        console.warn(UNSAFE_MEMBER_WARNING);
+        // eslint-disable-next-line no-await-in-loop -- same sequential loop
+        await unlink(tempPath).catch(() => {});
+        continue;
+      }
+      const filePath = join(assetDir, fileName);
       // eslint-disable-next-line no-await-in-loop -- sequential rename keeps peak
       // disk/IO bounded; an export has a few hundred assets, not millions.
       await rename(tempPath, filePath);
@@ -359,4 +408,4 @@ export async function importChatgptZip(zipPath, { tags, skipEmpty } = {}) {
   };
 }
 
-export const __test = { sniffExtension, extFromName, datAssetId, makeAssetResolver, cleanupExtractedAssets };
+export const __test = { sniffExtension, extFromName, datAssetId, isSafeDatMember, makeAssetResolver, cleanupExtractedAssets };

--- a/server/services/chatgptZipImport.test.js
+++ b/server/services/chatgptZipImport.test.js
@@ -202,12 +202,14 @@ describe('chatgptZipImport service', () => {
     });
 
     it('writes nothing outside the asset dir for a member whose name carries backslashes', async () => {
-      // `a\..\..\evil.dat` is the classic Zip Slip shape. Two independent
-      // layers stop it: `zipStream.js` sanitizes separators/traversal on the way
-      // out of the parser, and `isSafeDatMember` refuses anything that still
-      // isn't a plain filename before the temp file is opened. This pins the
-      // end-to-end outcome — no write lands outside `assetDir` on any platform,
-      // and the rest of the import still succeeds.
+      // `a\..\..\evil.dat` is the classic Zip Slip shape. Two layers stand
+      // between it and an escape: `zipStream.js` flattens separators and
+      // `.`/`..` components as it decodes the header (so the consumer sees
+      // `a/evil.dat` and extracts a harmless `evil.png` INSIDE the asset dir),
+      // and `isSafeDatMember` refuses anything that still isn't a plain filename
+      // before the temp file is opened. This pins the end-to-end outcome that
+      // matters: whichever layer acts, no write lands outside `assetDir` on any
+      // platform, and the rest of the import still succeeds.
       const assetDir = join(TMP, 'nest', 'assets');
       const zipPath = await writeZip([
         ['conversations-000.json', JSON.stringify([{ id: 'c1', title: 'A', mapping: {} }])],
@@ -218,14 +220,11 @@ describe('chatgptZipImport service', () => {
 
       expect(conversationFiles.length).toBe(1);
       expect(assets.get('file-OK').file).toBe('file-OK.jpg');
-      // Nothing escaped into a sibling or parent directory.
+      // The hostile member was flattened to a basename and landed inside the
+      // asset dir — never at `${TMP}/evil.png` or above it.
+      expect((await readdir(assetDir)).sort()).toEqual(['evil.png', 'file-OK.jpg']);
       expect((await readdir(join(TMP, 'nest'))).sort()).toEqual(['assets']);
       expect((await readdir(TMP)).sort()).toEqual(['export.zip', 'nest']);
-      // Every extracted file sits directly inside the asset dir.
-      for (const name of await readdir(assetDir)) {
-        expect(name.includes('/')).toBe(false);
-        expect(name.includes('\\')).toBe(false);
-      }
     });
 
     it('skips a .dat member whose name contains a NUL instead of failing the whole import', async () => {

--- a/server/services/chatgptZipImport.test.js
+++ b/server/services/chatgptZipImport.test.js
@@ -93,6 +93,10 @@ describe('chatgptZipImport service', () => {
       expect(isSafeDatMember('bad\u0000name.dat')).toBe(false);
       expect(isSafeDatMember('.dat')).toBe(false);     // id becomes ''
       expect(isSafeDatMember('..dat')).toBe(false);    // id becomes '.'
+      // Windows device names resolve to a device, not a file, whatever the ext.
+      expect(isSafeDatMember('CON.dat')).toBe(false);
+      expect(isSafeDatMember('files/lpt1.dat')).toBe(false);
+      expect(isSafeDatMember('com10.dat')).toBe(true);  // only COM1-9 are reserved
       // Forward-slash components ARE directories: the basename is what's used,
       // so traversal components reduce away harmlessly.
       expect(isSafeDatMember('../../evil.dat')).toBe(true);
@@ -232,6 +236,19 @@ describe('chatgptZipImport service', () => {
       const zipPath = await writeZip([
         ['conversations-000.json', JSON.stringify([{ id: 'c1', title: 'A', mapping: {} }])],
         ['bad\u0000name.dat', PNG],
+        ['file-OK.dat', JPEG],
+      ]);
+      const { conversationFiles, stats } = await extractChatgptZip(zipPath, { assetDir });
+      expect(conversationFiles.length).toBe(1);
+      expect(stats.assetCount).toBe(1);
+      expect(await readdir(assetDir)).toEqual(['file-OK.jpg']);
+    });
+
+    it('skips a .dat member named after a Windows device instead of failing the import', async () => {
+      const assetDir = join(TMP, 'assets');
+      const zipPath = await writeZip([
+        ['conversations-000.json', JSON.stringify([{ id: 'c1', title: 'A', mapping: {} }])],
+        ['CON.dat', PNG],
         ['file-OK.dat', JPEG],
       ]);
       const { conversationFiles, stats } = await extractChatgptZip(zipPath, { assetDir });

--- a/server/services/chatgptZipImport.test.js
+++ b/server/services/chatgptZipImport.test.js
@@ -72,6 +72,31 @@ describe('chatgptZipImport service', () => {
       expect(datAssetId('file-ABC123.dat')).toBe('file-ABC123');
       expect(datAssetId('nested/dir/file_DEADBEEF.dat')).toBe('file_DEADBEEF');
     });
+    it('splits on backslashes too, so a Windows-style member reduces to a basename', () => {
+      expect(datAssetId('a\\..\\..\\evil.dat')).toBe('evil');
+      expect(datAssetId('nested\\dir\\file-ABC.dat')).toBe('file-ABC');
+    });
+  });
+
+  describe('isSafeDatMember', () => {
+    it('accepts plain and forward-slash-nested member names', async () => {
+      const { isSafeDatMember } = (await import('./chatgptZipImport.js')).__test;
+      expect(isSafeDatMember('file-ABC.dat')).toBe(true);
+      expect(isSafeDatMember('chat/files/file-abc.dat')).toBe(true);
+    });
+    it('rejects backslash separators, NUL, and empty/dot ids', async () => {
+      const { isSafeDatMember } = (await import('./chatgptZipImport.js')).__test;
+      // A `\` is NOT a ZIP separator, so a name carrying one is malformed or
+      // hostile — refused rather than normalized into an extracted file.
+      expect(isSafeDatMember('a\\..\\..\\evil.dat')).toBe(false);
+      expect(isSafeDatMember('files/..\\evil.dat')).toBe(false);
+      expect(isSafeDatMember('bad\u0000name.dat')).toBe(false);
+      expect(isSafeDatMember('.dat')).toBe(false);     // id becomes ''
+      expect(isSafeDatMember('..dat')).toBe(false);    // id becomes '.'
+      // Forward-slash components ARE directories: the basename is what's used,
+      // so traversal components reduce away harmlessly.
+      expect(isSafeDatMember('../../evil.dat')).toBe(true);
+    });
   });
 
   describe('extFromName (fallback extension allowlist)', () => {
@@ -170,6 +195,73 @@ describe('chatgptZipImport service', () => {
       await expect(extractChatgptZip(zipPath, { assetDir })).rejects.toThrow();
       const written = await readdir(assetDir).catch(() => []);
       expect(written).toEqual([]);   // no <id>.part temp left behind
+    });
+
+    it('writes nothing outside the asset dir for a member whose name carries backslashes', async () => {
+      // `a\..\..\evil.dat` is the classic Zip Slip shape. Two independent
+      // layers stop it: `zipStream.js` sanitizes separators/traversal on the way
+      // out of the parser, and `isSafeDatMember` refuses anything that still
+      // isn't a plain filename before the temp file is opened. This pins the
+      // end-to-end outcome — no write lands outside `assetDir` on any platform,
+      // and the rest of the import still succeeds.
+      const assetDir = join(TMP, 'nest', 'assets');
+      const zipPath = await writeZip([
+        ['conversations-000.json', JSON.stringify([{ id: 'c1', title: 'A', mapping: {} }])],
+        ['a\\..\\..\\evil.dat', PNG],
+        ['file-OK.dat', JPEG],
+      ]);
+      const { conversationFiles, assets } = await extractChatgptZip(zipPath, { assetDir });
+
+      expect(conversationFiles.length).toBe(1);
+      expect(assets.get('file-OK').file).toBe('file-OK.jpg');
+      // Nothing escaped into a sibling or parent directory.
+      expect((await readdir(join(TMP, 'nest'))).sort()).toEqual(['assets']);
+      expect((await readdir(TMP)).sort()).toEqual(['export.zip', 'nest']);
+      // Every extracted file sits directly inside the asset dir.
+      for (const name of await readdir(assetDir)) {
+        expect(name.includes('/')).toBe(false);
+        expect(name.includes('\\')).toBe(false);
+      }
+    });
+
+    it('skips a .dat member whose name contains a NUL instead of failing the whole import', async () => {
+      // A NUL survives the parser's sanitizer, and `createWriteStream` on such a
+      // path errors — which used to reject the ENTIRE import. The member is now
+      // skipped and the rest of the export still lands.
+      const assetDir = join(TMP, 'assets');
+      const zipPath = await writeZip([
+        ['conversations-000.json', JSON.stringify([{ id: 'c1', title: 'A', mapping: {} }])],
+        ['bad\u0000name.dat', PNG],
+        ['file-OK.dat', JPEG],
+      ]);
+      const { conversationFiles, stats } = await extractChatgptZip(zipPath, { assetDir });
+      expect(conversationFiles.length).toBe(1);
+      expect(stats.assetCount).toBe(1);
+      expect(await readdir(assetDir)).toEqual(['file-OK.jpg']);
+    });
+
+    it('skips .dat members whose id degenerates to "" or "." rather than writing a dotfile', async () => {
+      const assetDir = join(TMP, 'assets');
+      const zipPath = await writeZip([
+        ['conversations-000.json', JSON.stringify([{ id: 'c1', title: 'A', mapping: {} }])],
+        ['..dat', PNG],   // id '.'
+        ['.dat', PNG],    // id ''
+      ]);
+      const { stats } = await extractChatgptZip(zipPath, { assetDir });
+      expect(stats.assetCount).toBe(0);
+      expect(await readdir(assetDir)).toEqual([]);   // no `..png` / `.png` dotfiles
+    });
+
+    it('still extracts a normally-nested member such as chat/files/file-abc.dat', async () => {
+      const assetDir = join(TMP, 'assets');
+      const zipPath = await writeZip([
+        ['conversations-000.json', JSON.stringify([{ id: 'c1', title: 'A', mapping: {} }])],
+        ['chat/files/file-abc.dat', PNG],
+      ]);
+      const { assets, stats } = await extractChatgptZip(zipPath, { assetDir });
+      expect(stats.assetCount).toBe(1);
+      expect(assets.get('file-abc').file).toBe('file-abc.png');
+      expect(await readdir(assetDir)).toEqual(['file-abc.png']);
     });
 
     it('cleans up already-written assets and throws a 400 when a conversation shard is corrupt JSON', async () => {


### PR DESCRIPTION
## Summary

Hardens the ChatGPT ZIP export importer against a Zip Slip write, and fixes two
malformed-member behaviours that were reachable today.

`extractChatgptZip` derived each asset's on-disk path from the ZIP member's own
name — stripping only a forward-slash directory prefix and concatenating the
result into `${assetDir}/${assetId}`. A member such as `a\..\..\evil.dat`
reduces to an id still carrying backslashes, which are path separators on
Windows, so the write would escape `data/brain/imports/assets/`.

**Correcting the issue's premise:** `server/lib/zipStream.js` already sanitizes
separators and `.`/`..` components as it decodes each local file header, so the
escape was **not reachable in practice** — the importer sees `a/evil.dat`, not
the raw name. The guard is added anyway, and deliberately at the consumer: the
parser's sanitizing is its own private policy (its header comment describes it
as a faithful sequential reader), while the importer is what actually opens the
file. Validating at the write site means a future refactor that makes the parser
truly faithful cannot silently reintroduce the escape. The code comments say
exactly this rather than implying the predicate is what stops backslashes today.

Changes in `server/services/chatgptZipImport.js`:

- `datAssetId` splits on **both** separators, so the id is a real basename on
  every platform.
- New `isSafeDatMember` predicate refuses any member whose ZIP-spec name or
  derived asset id is not a plain filename, reusing the existing
  `isTopLevelEntryName` helper from `lib/pathSafety.js` rather than a new check.
- Unsafe members are **skipped** with one warning line carrying **no member
  path** (untrusted third-party text), instead of failing the import — a single
  malformed member in a multi-GB export should not cost the user the whole
  ingest, and the asset resolver already renders a conversation without a
  missing asset.
- Temp and final paths are built with `join()` instead of template-string
  concatenation, and the composed `<assetId><ext>` name is re-checked before the
  `rename` as defense in depth against a future change to the extension fallback.

Two bugs fixed as a side effect, both reachable before this change:

- A member whose name contains a NUL aborted the **entire** import (the write
  stream errored on the path); it is now skipped.
- Members named `.dat` / `..dat` wrote `.png` / `..png` dotfiles into the served
  asset directory.

Local review (codex, 2 rounds) added one more: a member named after a Windows
device (`CON.dat`, `lpt1.dat`) resolves to a device rather than a file, so the
write stream would open the console and the later rename would fail, aborting
the import. Those names are refused on every platform for one consistent outcome.

Out of scope per the issue and untouched: the `INERT_FALLBACK_EXTS` allowlist,
the magic-byte sniffer, and any normalization inside `server/lib/zipStream.js`.

## Test plan

`server/services/chatgptZipImport.test.js` — 8 new cases, verified to fail
against the pre-fix source (5 of them; the two-layer end-to-end case pins a
cross-layer contract):

- `isSafeDatMember` accepts plain and `/`-nested names; rejects backslash
  separators, NUL, Windows device names, and ids degenerating to `''` / `'.'`;
  `com10.dat` stays accepted (only COM1–9 are reserved).
- `datAssetId` splits on backslashes too.
- End-to-end: a `a\..\..\evil.dat` member writes nothing outside the asset dir —
  exact asset-dir contents asserted, plus the parent and grandparent dirs.
- End-to-end: NUL-named member skipped, rest of the import succeeds.
- End-to-end: Windows-device-named member skipped, rest of the import succeeds.
- End-to-end: `.dat` / `..dat` members skipped, no dotfiles written.
- End-to-end: `chat/files/file-abc.dat` still extracts — the guard is not
  over-broad.

`cd server && npm test` — full suite run: 36982 passed. The failures observed
were `scripts/generate-api-route-catalog.test.js` (2 cases, about
`server/routes/sprites.js` entries missing from the generated catalog),
**reproduced on a clean `origin/main` checkout with this branch stashed**, and
a handful of parallel-load timeouts (`services/sprites/atlas.test.js`,
`routes/imageGen.*`, `routes/settings.secretsStrip.test.js`,
`services/voice/facetimeBridge.test.js`) that all pass when re-run in isolation.
Neither set touches this change.

Closes #5652
