### PR TITLE
fix: remove auth from public review child env

### DIFF
--- a/server/lib/cliChildEnv.js
+++ b/server/lib/cliChildEnv.js
@@ -130,15 +130,15 @@ export function composeProviderEnv({ before = null, provider = null, model = nul
 
 // Public contributor content is run through a no-tools local Claude wrapper.
 // Keep only runtime essentials plus the local Anthropic-compatible endpoint;
-// in particular, never pass forge, cloud, SSH, or arbitrary provider env vars
-// into the child. This is a second boundary in addition to the CLI argv.
+// in particular, never pass forge, cloud, SSH, auth, or arbitrary provider env
+// vars into the child. This is a second boundary in addition to the CLI argv.
 const PUBLIC_REVIEW_ENV_KEYS = new Set([
   'PATH', 'Path', 'HOME', 'USER', 'LOGNAME', 'SHELL', 'PWD', 'TMPDIR', 'TMP', 'TEMP',
   'LANG', 'LANGUAGE', 'TERM', 'COLORTERM', 'TZ', 'NODE', 'NODE_ENV', 'NODE_PATH',
   'NVM_DIR', 'NVM_BIN', 'XDG_CONFIG_HOME', 'XDG_CACHE_HOME', 'XDG_DATA_HOME',
   'SystemRoot', 'SystemDrive', 'ComSpec', 'PATHEXT', 'USERPROFILE', 'APPDATA',
   'LOCALAPPDATA', 'ProgramData', 'ProgramFiles', 'HOMEDRIVE', 'HOMEPATH',
-  'ANTHROPIC_BASE_URL', 'ANTHROPIC_AUTH_TOKEN', 'ANTHROPIC_SMALL_FAST_MODEL',
+  'ANTHROPIC_BASE_URL', 'ANTHROPIC_SMALL_FAST_MODEL',
   'CLAUDE_CODE_MAX_OUTPUT_TOKENS', 'MAX_THINKING_TOKENS',
 ]);
 

--- a/server/lib/cliChildEnv.test.js
+++ b/server/lib/cliChildEnv.test.js
@@ -138,8 +138,8 @@ describe('buildCliChildEnv — public-review profile', () => {
       HOME: '/home/example',
       LC_ALL: 'C',
       ANTHROPIC_BASE_URL: 'http://127.0.0.1:11434',
-      ANTHROPIC_AUTH_TOKEN: 'local-only',
     });
+    expect(env).not.toHaveProperty('ANTHROPIC_AUTH_TOKEN');
     expect(env).not.toHaveProperty('GH_TOKEN');
     expect(env).not.toHaveProperty('GITHUB_TOKEN');
     expect(env).not.toHaveProperty('AWS_SECRET_ACCESS_KEY');
@@ -166,7 +166,7 @@ describe('buildCliChildEnv — public-review profile', () => {
     });
 
     expect(env.ANTHROPIC_BASE_URL).toBe('http://127.0.0.1:11434');
-    expect(env.ANTHROPIC_AUTH_TOKEN).toBe('local-only');
+    expect(env).not.toHaveProperty('ANTHROPIC_AUTH_TOKEN');
     expect(env.PWD).toBe('/tmp/public-review');
     expect(env).not.toHaveProperty('GH_TOKEN');
     expect(env).not.toHaveProperty('AWS_PROFILE');


### PR DESCRIPTION
## Summary
- remove Anthropic auth tokens from the public-review child environment
- retain only the local endpoint and non-secret runtime settings
- add regression coverage for inherited and provider-supplied tokens

## Verification
- focused server tests: 213 passed
- `git diff --check` clean

This keeps the no-tools local review boundary aligned with the model-abuse screening design. No contributor PRs were modified.