### PR TITLE
fix: guard voice:call:detach so a failed teardown can't kill the server (#5661)

### DIFF
--- a/server/sockets/voice.js
+++ b/server/sockets/voice.js
@@ -34,6 +34,7 @@ import {
   endCall,
   getCallContext,
   getCallHost,
+  getCallState,
   isCallActive,
   markListening,
   markSpeaking,
@@ -540,8 +541,20 @@ export const registerVoiceHandlers = (socket) => {
   });
 
   socket.on('voice:call:detach', async () => {
-    call.endpointer = null;
-    emitCallState(await detachHost(socket));
+    try {
+      call.endpointer = null;
+      emitCallState(await detachHost(socket));
+    } catch (err) {
+      // Socket.IO hands a listener's promise to nobody: an unguarded throw in
+      // here surfaces as an unhandled rejection, which Node terminates the
+      // process for — taking every agent run, PTY session and media job with
+      // it. A detach during a live call funnels into endCall(), the same
+      // teardown voice:call:hangup guards below for exactly this reason. Emit
+      // the current state anyway so the client's call widget leaves its
+      // detaching state instead of hanging.
+      console.error(`❌ voice:call:detach failed: ${err.message}`);
+      emitCallState(getCallState());
+    }
   });
 
   // Hang up the active call from any tab, not just the one carrying the

--- a/server/sockets/voice.test.js
+++ b/server/sockets/voice.test.js
@@ -24,6 +24,16 @@ vi.mock('../services/voice/stt.js', () => ({ transcribe: vi.fn() }));
 // pipeline; stub it so the barge-in test below can observe exactly what
 // signal a call turn was given without a real STT/LLM/TTS round trip.
 vi.mock('../services/voice/pipeline.js', () => ({ runTurn: vi.fn(async () => ({})) }));
+// Partial-mock the call session so one test can make detachHost() reject the
+// way a failing teardown does. endCall()'s own hangup/journal/mind steps are
+// each internally guarded, so no dependency seam can force that rejection from
+// the outside. Only detachHost is wrapped, and its default implementation is
+// still the real one, so every other case in this file exercises the genuine
+// session.
+vi.mock(import('../services/voice/callSession.js'), async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, detachHost: vi.fn(actual.detachHost) };
+});
 
 const { truncateOnWordBoundary, registerVoiceHandlers } = await import('./voice.js');
 const {
@@ -37,6 +47,7 @@ const {
   attachHost: attachCallHost,
   __resetCallSession,
   __setCallSessionDeps,
+  detachHost,
   getCallState,
   pollCall,
   startCall,
@@ -393,6 +404,93 @@ describe('voice:call:hangup', () => {
     registerVoiceHandlers(socket);
     await expect(socket.fire('voice:call:hangup')).resolves.not.toThrow();
     expect(getCallState().active).toBe(false);
+  });
+});
+
+describe('voice:call:detach', () => {
+  beforeEach(() => {
+    __resetCallSession();
+    __setCallSessionDeps({
+      probe: vi.fn(async () => ({ state: 'connected' })),
+      call: vi.fn(async () => ({ state: 'dialing' })),
+      hangup: vi.fn(async () => ({ state: 'ended' })),
+      appendJournal: vi.fn(async () => ({})),
+      enqueueMindMessage: vi.fn(async () => ({})),
+    });
+  });
+
+  afterEach(() => detachHost.mockClear());
+
+  it('logs and still emits call state when the teardown throws, instead of rejecting out of the listener', async () => {
+    // Socket.IO never awaits a listener's promise, so a rejection escaping
+    // this handler is an unhandled rejection — process-fatal on Node >= 15,
+    // which would take every agent run, PTY session and media job down with
+    // the whole server. Detaching during a live call funnels into endCall(),
+    // the same teardown voice:call:hangup guards for exactly this reason.
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const host = makeFakeSocket();
+    registerVoiceHandlers(host);
+    await host.fire('voice:call:attach');
+    await startCall();
+    host.emitted.length = 0;
+
+    detachHost.mockRejectedValueOnce(new Error('teardown exploded'));
+    await expect(host.fire('voice:call:detach')).resolves.not.toThrow();
+
+    const logged = errorSpy.mock.calls.map(([msg]) => String(msg));
+    expect(logged.some((msg) => msg.includes('voice:call:detach failed'))).toBe(true);
+    // The client's call widget is left in a "detaching" state until a state
+    // frame arrives, so the failure path still has to send one.
+    expect(host.emitted.filter((e) => e.event === 'voice:call:state')).toHaveLength(1);
+    errorSpy.mockRestore();
+  });
+
+  it('emits the detached state on the success path', async () => {
+    const host = makeFakeSocket();
+    registerVoiceHandlers(host);
+    await host.fire('voice:call:attach');
+    host.emitted.length = 0;
+
+    await host.fire('voice:call:detach');
+
+    const states = host.emitted.filter((e) => e.event === 'voice:call:state');
+    expect(states.length).toBeGreaterThanOrEqual(1);
+    expect(states.at(-1).payload.hostAttached).toBe(false);
+  });
+});
+
+// A source scan rather than a runtime case per event: the failure mode this
+// guards is "someone adds handler #11 without the guard", which only a scan
+// catches. Scoped to this one file so it cannot fail on unrelated modules.
+describe('async socket handlers in voice.js are all guarded', () => {
+  it('opens every `socket.on(..., async ...)` body with a try block', async () => {
+    const { readFile } = await import('node:fs/promises');
+    const source = await readFile(new URL('./voice.js', import.meta.url), 'utf8');
+    // Every async registration, regardless of how its parameter list is
+    // written...
+    const asyncHandlers = [...source.matchAll(/socket\.on\('([^']+)',\s*async\b/g)];
+    // ...versus the ones this scan can actually parse a body out of.
+    const registrations = [...source.matchAll(/socket\.on\('([^']+)',\s*async\s*(?:\([^)]*\)|[A-Za-z_$][\w$]*)\s*=>\s*\{/g)];
+
+    // Guards the regex itself. A vacuous pass is the one way this scan fails
+    // silently, so an unrecognized handler shape (a bare `async payload =>`,
+    // an `async function () {}`) must fail loudly rather than be skipped.
+    expect(asyncHandlers.length).toBeGreaterThanOrEqual(7);
+    expect(registrations.map((match) => match[1])).toEqual(asyncHandlers.map((match) => match[1]));
+
+    const unguarded = registrations
+      .filter((match) => {
+        const body = source.slice(match.index + match[0].length);
+        // Skip leading blank lines and line comments to find the first real statement.
+        const firstStatement = body
+          .split('\n')
+          .map((line) => line.trim())
+          .find((line) => line && !line.startsWith('//'));
+        return firstStatement !== 'try {';
+      })
+      .map((match) => match[1]);
+
+    expect(unguarded).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## Summary

`voice:call:detach` was the one async handler in `server/sockets/voice.js` registered without a `try`/`catch`. Socket.IO invokes listeners through an `EventEmitter` and never awaits the promise an `async` listener returns, so a rejection escaping the handler becomes an unhandled rejection — process-fatal under Node 22. Every sibling handler in the same file (`voice:call:attach`, `voice:call:audio`, `voice:call:hangup`, `voice:capture:start`/`stop`) is wrapped, and the `disconnect` path already guards this exact call with `.catch(...)`.

The gap mattered because detaching during a live call funnels through `detachHost()` into `endCall('host-detached')` — precisely the teardown `voice:call:hangup` wraps *because it can throw*. A detach whose journal write, mind handoff, or FaceTime bridge teardown failed would take the whole PortOS server down: every agent run, PTY session, media job, and socket, instead of logging one line.

Root `AGENTS.md` makes this a rule, not a style preference: try/catch is required at PTY/child-process/timer boundaries and anything outside the Express request lifecycle, since there is no `next(err)` to bubble to.

**Changes**
- Wrap the `voice:call:detach` body in `try`/`catch`, matching `voice:call:hangup`'s shape. On catch it logs one single-line emoji-prefixed `console.error` and still emits the current call state, so the client's call widget leaves its "detaching" state instead of hanging.
- Import `getCallState` from `callSession.js` for that catch-path emit. It is the only pure state accessor the module exports; nothing already in this file's import list reads state without a side effect.

No changelog fragment — per `AGENTS.md`, individual PRs do not write changelog entries.

## Test plan

Two tests added to the existing `server/sockets/voice.test.js`. **Both were verified to fail against the unfixed source before the fix was applied** (`promise rejected "Error: teardown exploded" instead of resolving`, and `expected [ 'voice:call:detach' ] to deeply equal []`).

1. **Runtime regression** — a partial `vi.mock` of `callSession.js` wraps `detachHost` in a spy that delegates to the real implementation by default (so every other case in the file still exercises the genuine session). One case makes it reject, fires `voice:call:detach`, and asserts the listener resolves rather than rejecting out, logs the `❌ voice:call:detach failed` line, and still emits exactly one `voice:call:state` frame. A companion case pins the success path (`hostAttached: false`).
   - A dependency seam could not force this rejection from the outside: `endCall()`'s own hangup/journal/mind steps are each already internally guarded.
2. **Source scan** — reads `voice.js`, finds every `socket.on('…', async …)` registration, and asserts the first non-comment statement in each body is `try {`. A scan rather than a per-event runtime case because the failure mode being guarded is "someone adds handler #11 without the guard," which only a scan catches. Scoped to this one file so it cannot fail on unrelated socket modules.
   - The scan is hardened against a vacuous pass: it cross-checks the list of *all* `async` registrations against the list it can actually parse a body from, so an unrecognized handler shape (a bare `async payload =>`, an `async function () {}`) fails loudly rather than being silently skipped. Verified by temporarily rewriting a handler to the `async function` form and confirming the test fails.

`cd server && npm test` → `Test Files 1827 passed | 1 skipped (1828)`, `Tests 37107 passed | 13 skipped`.

A later full-suite run on the same tree showed 6 unrelated files red (`imageGen.clean`/`multipart`/`watermark`, `peerSyncAuthIntegration`, `settings.secretsStrip`, `privacyNeverFederates`) with a failure set that shifted between runs; all 6 pass in isolation. That is machine contention (parallel suites on one box), not this diff — none of them touch the voice tree.

Closes #5661
