### PR TITLE
fix: honour a Stop that lands while the Codex thread is starting (#5649)

### DIFF
--- a/server/services/codexAppServer.js
+++ b/server/services/codexAppServer.js
@@ -794,6 +794,13 @@ export async function runCodexTextTurn({
   // silently send this turn's frames to a child that has never heard of its
   // thread id.
   const owner = await connect();
+  // `connect()` can spawn and handshake a whole app-server child, which is the
+  // longest await in this function. Re-read the signal before paying for a
+  // thread the caller has already abandoned — the up-front check above ran
+  // several awaits ago, and no listener is registered yet.
+  if (signal?.aborted) {
+    throw codexError(CODEX_TURN_ERROR_CODES.turnInterrupted, 'The Codex turn was cancelled.', { status: 499 });
+  }
   const started = await sendRequest(owner, CODEX_TURN_RPC.threadStart, {
     ...CODEX_TEXT_THREAD_CONFIG,
     cwd,
@@ -829,7 +836,12 @@ export async function runCodexTextTurn({
   timer.unref?.();
 
   const onAbort = () => fail(codexError(CODEX_TURN_ERROR_CODES.turnInterrupted, 'The Codex turn was cancelled.', { status: 499 }));
-  signal?.addEventListener('abort', onAbort, { once: true });
+  // An AbortSignal fires its 'abort' event exactly once; a listener added after
+  // the fact never runs. An abort raised during `connect()`/`thread/start` has
+  // to be honoured by re-reading the flag, or the turn streams for the whole
+  // deadline and bills for an answer nobody is waiting for.
+  if (signal?.aborted) onAbort();
+  else signal?.addEventListener('abort', onAbort, { once: true });
 
   try {
     const response = await sendRequest(owner, CODEX_TURN_RPC.turnStart, {

--- a/server/services/codexAppServer.js
+++ b/server/services/codexAppServer.js
@@ -740,6 +740,10 @@ const cachedModelEntry = (modelId) => {
   return modelsCache.models.find((entry) => entry.id === modelId) ?? null;
 };
 
+/** The one shape a caller's Stop takes, wherever in a turn it is noticed. */
+const turnCancelledError = () =>
+  codexError(CODEX_TURN_ERROR_CODES.turnInterrupted, 'The Codex turn was cancelled.', { status: 499 });
+
 /**
  * Run ONE bounded text turn against the ChatGPT subscription.
  *
@@ -773,7 +777,7 @@ export async function runCodexTextTurn({
   // later, so the caller's cancellation has to be honoured here or the turn runs
   // (and bills) for an answer nobody is waiting for.
   if (signal?.aborted) {
-    throw codexError(CODEX_TURN_ERROR_CODES.turnInterrupted, 'The Codex turn was cancelled.', { status: 499 });
+    throw turnCancelledError();
   }
   const benched = getCodexTextTransportBench();
   if (benched) {
@@ -799,7 +803,7 @@ export async function runCodexTextTurn({
   // thread the caller has already abandoned — the up-front check above ran
   // several awaits ago, and no listener is registered yet.
   if (signal?.aborted) {
-    throw codexError(CODEX_TURN_ERROR_CODES.turnInterrupted, 'The Codex turn was cancelled.', { status: 499 });
+    throw turnCancelledError();
   }
   const started = await sendRequest(owner, CODEX_TURN_RPC.threadStart, {
     ...CODEX_TEXT_THREAD_CONFIG,
@@ -835,7 +839,7 @@ export async function runCodexTextTurn({
   }, timeoutMs);
   timer.unref?.();
 
-  const onAbort = () => fail(codexError(CODEX_TURN_ERROR_CODES.turnInterrupted, 'The Codex turn was cancelled.', { status: 499 }));
+  const onAbort = () => fail(turnCancelledError());
   // An AbortSignal fires its 'abort' event exactly once; a listener added after
   // the fact never runs. An abort raised during `connect()`/`thread/start` has
   // to be honoured by re-reading the flag, or the turn streams for the whole

--- a/server/services/codexAppServer.js
+++ b/server/services/codexAppServer.js
@@ -848,6 +848,11 @@ export async function runCodexTextTurn({
   else signal?.addEventListener('abort', onAbort, { once: true });
 
   try {
+    // Already aborted: `onAbort` has rejected `finished`, so awaiting it here
+    // surfaces the cancellation WITHOUT dispatching a turn — no quota is spent,
+    // and Stop does not have to wait out a `turn/start` response that would
+    // only be thrown away. The `finally` below still runs the shared cleanup.
+    if (signal?.aborted) await finished;
     const response = await sendRequest(owner, CODEX_TURN_RPC.turnStart, {
       threadId,
       input: [{ type: 'text', text: prompt }],

--- a/server/services/codexAppServer.turn.test.js
+++ b/server/services/codexAppServer.turn.test.js
@@ -168,6 +168,42 @@ describe('running a text turn', () => {
     expect(child.lastRequest('turn/interrupt').params).toEqual({ threadId: 'thread-1', turnId: 'turn-1' });
   });
 
+  it('abandons the turn when the caller aborts during the app-server cold start', async () => {
+    // `connect()` can spawn and handshake a whole child, so the up-front
+    // `signal.aborted` check is many awaits stale by the time it resolves and
+    // no listener is registered yet. Without a re-read, a Stop pressed here
+    // dispatched a full turn against the subscription.
+    const controller = new AbortController();
+    const promise = runCodexTextTurn({ prompt: 'long one', signal: controller.signal });
+
+    let frame = null;
+    await vi.waitFor(() => { frame = child.take('initialize'); expect(frame).toBeTruthy(); });
+    controller.abort();
+    child.reply(frame, {});
+
+    await expect(promise).rejects.toMatchObject({ code: CODEX_TURN_ERROR_CODES.turnInterrupted });
+    expect(child.lastRequest('thread/start')).toBeUndefined();
+    expect(child.lastRequest('turn/start')).toBeUndefined();
+  });
+
+  it('honours an abort that lands while the thread is starting, which fires no late event', async () => {
+    // An AbortSignal emits 'abort' exactly once: aborting before the listener
+    // is registered means the listener never runs, so the flag has to be
+    // re-read at registration time.
+    const controller = new AbortController();
+    const promise = runCodexTextTurn({ prompt: 'long one', signal: controller.signal });
+    await handshake();
+    await awaitRequest(child, 'thread/start', (frame) => {
+      controller.abort();
+      child.reply(frame, { thread: { id: 'thread-1' } });
+    });
+    await awaitRequest(child, 'turn/start', { turn: { id: 'turn-1', items: [], status: 'inProgress' } });
+
+    await expect(promise).rejects.toMatchObject({ code: CODEX_TURN_ERROR_CODES.turnInterrupted });
+    await vi.waitFor(() => expect(child.lastRequest('turn/interrupt')).toBeTruthy());
+    expect(child.lastRequest('turn/interrupt').params).toEqual({ threadId: 'thread-1', turnId: 'turn-1' });
+  });
+
   it('carries a quota failure out as a usage-limit category', async () => {
     const promise = runCodexTextTurn({ prompt: 'hi' });
     await handshake();

--- a/server/services/codexAppServer.turn.test.js
+++ b/server/services/codexAppServer.turn.test.js
@@ -197,11 +197,11 @@ describe('running a text turn', () => {
       controller.abort();
       child.reply(frame, { thread: { id: 'thread-1' } });
     });
-    await awaitRequest(child, 'turn/start', { turn: { id: 'turn-1', items: [], status: 'inProgress' } });
 
     await expect(promise).rejects.toMatchObject({ code: CODEX_TURN_ERROR_CODES.turnInterrupted });
-    await vi.waitFor(() => expect(child.lastRequest('turn/interrupt')).toBeTruthy());
-    expect(child.lastRequest('turn/interrupt').params).toEqual({ threadId: 'thread-1', turnId: 'turn-1' });
+    // Cancellation is surfaced without dispatching the turn at all, so Stop
+    // neither spends quota nor waits out a `turn/start` round trip.
+    expect(child.lastRequest('turn/start')).toBeUndefined();
   });
 
   it('carries a quota failure out as a usage-limit category', async () => {


### PR DESCRIPTION
## Summary

Pressing **Stop** while a Codex subscription turn was cold-starting did nothing: the turn was dispatched anyway and streamed for up to five minutes, burning ChatGPT-subscription quota for an answer nobody was waiting for.

`runCodexTextTurn` read `signal.aborted` once, before any await, and registered its `abort` listener four awaits later — past an `mkdtemp`, a `connect()` that can spawn and handshake a whole `codex app-server` child (20s), and a `thread/start` round trip (15s). An `AbortSignal` fires `abort` exactly once, so a listener added after that window never runs, and nothing re-read the flag in between.

Three changes close the gap:

1. **Re-read the signal immediately after `connect()`** — an abort raised during the app-server cold start now never even creates a thread, so no `thread/start` or `turn/start` frame is written.
2. **Register the listener in the repo's standard aborted-first form** (`if (signal?.aborted) onAbort(); else addEventListener(...)`), matching `aiProvider.js:209-212`. An abort that lands while the thread is starting is now honoured instead of silently lost.
3. **Do not dispatch `turn/start` when the signal is already aborted.** `onAbort()` only rejects the parked `finished` promise, which isn't awaited until *after* the `turn/start` round trip — so on its own it would still have dispatched the turn and then blocked on the response (up to the full deadline if the app-server stalled), spending exactly the quota the abort was meant to save. Awaiting `finished` instead surfaces the cancellation immediately; the existing `finally` runs the same cleanup (timer cleared, `activeTurns` entry deleted, best-effort `turn/interrupt` when a turn is actually live).

The turn-cancelled `ServerError` is now built by one `turnCancelledError()` helper rather than being spelled out at three call sites.

No behavior change on the success path, and the abort-mid-turn path (listener fires while streaming) is untouched — its existing `turn/interrupt` test still passes.

## Test plan

- `server/services/codexAppServer.turn.test.js` gains two cases, each verified to **fail before the fix** and pass after:
  - *abandons the turn when the caller aborts during the app-server cold start* — aborts while `connect()`'s `initialize` handshake is in flight; asserts a `CODEX_TURN_INTERRUPTED` rejection and that **neither** `thread/start` nor `turn/start` was ever written to the transport. Uniquely catches a missing post-`connect()` re-read.
  - *honours an abort that lands while the thread is starting, which fires no late event* — aborts as the `thread/start` reply is handed back, so the `abort` event has already fired by the time the listener would be registered; asserts the rejection and that no `turn/start` frame was written. Uniquely catches the missing aborted-first registration.
- `cd server && npx vitest run services/codexAppServer` — 2 files, 52 tests passing.
- `cd server && npm test` — **1827 files passed, 1 skipped; 37106 tests passed, 13 skipped.** (An intermediate run showed timeout-only failures in `imageGen.*`, `peerSyncAuthIntegration`, `settings.secretsStrip`, `privacyNeverFederates` and `sprites/atlas` — all 10s hook/test timeouts in files this diff does not touch, caused by concurrent load on the machine. A clean re-run is fully green.)
- No client changes, so the client suite was not run.

## Reviewed

Two rounds of a local read-only reviewer. Round 1 raised a real defect — that calling `onAbort()` still left the function blocked on the `turn/start` response — which is fixed here as change 3 above.

Round 2's two remaining findings are **pre-existing and deliberately out of scope** for this issue: an abort raised *while* `thread/start` or `turn/start` is in flight is not observed until that RPC answers or times out. Neither lets a turn run to completion (the abort is still honoured the moment the RPC settles), both are bounded by the existing request deadlines, and bailing out early would forfeit the `turnId` that `turn/interrupt` needs — so the wait is what makes the interrupt possible at all. Filed separately rather than folded in here.

Closes #5649
