### PR TITLE
fix: bring the autofixer workspace inside the dependency-governance perimeter (#5658)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,11 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
-  # server/ and client/ carry their own package.json + overrides, and their
-  # lockfiles are gitignored — without these entries their dependency trees are
-  # invisible to Dependabot (a critical node-tar advisory sat unreported).
+  # server/, client/ and autofixer/ each carry their own package.json +
+  # overrides and their own lockfile, so npm resolves each tree separately —
+  # without an entry per directory those trees are invisible to Dependabot (a
+  # critical node-tar advisory sat unreported). browser/ is deliberately absent:
+  # it has zero dependencies and its lockfile is gitignored.
   - package-ecosystem: npm
     directory: /server
     schedule:
@@ -15,6 +17,11 @@ updates:
     open-pull-requests-limit: 10
   - package-ecosystem: npm
     directory: /client
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+  - package-ecosystem: npm
+    directory: /autofixer
     schedule:
       interval: weekly
     open-pull-requests-limit: 10

--- a/autofixer/package-lock.json
+++ b/autofixer/package-lock.json
@@ -217,9 +217,9 @@
       }
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -396,9 +396,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -577,9 +577,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.0.tgz",
-      "integrity": "sha512-PuseHIvAnz3bjrM2rGJtSgo1zjgxapTLZ7x2pjhzWwlp4SJQgK3f3iZIQwkpEnBaKz6seKBADpM4B4ySkuYypg==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -600,12 +600,13 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
-      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -712,14 +713,14 @@
       "license": "ISC"
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -731,13 +732,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"

--- a/autofixer/package.json
+++ b/autofixer/package.json
@@ -9,5 +9,10 @@
   },
   "dependencies": {
     "express": "5.2.1"
+  },
+  "overrides": {
+    "path-to-regexp": "8.4.2",
+    "body-parser": "2.3.0",
+    "qs": "6.15.3"
   }
 }

--- a/docs/DEPS.md
+++ b/docs/DEPS.md
@@ -19,8 +19,8 @@ Before removing a Tier 3 candidate, run a transitive-dep check (`npm ls <pkg>`).
 
 | Package | Tier | Verdict | Where Used | Notes |
 |---------|------|---------|------------|-------|
-| **Root devDeps** | | | | |
-| `pm2` | 1 | KEEP | top-level scripts | Process manager, foundational. Pinned `7.0.4` (aligned with server pin) |
+| **Root deps** | | | | |
+| `pm2` | 1 | KEEP | top-level scripts | Process manager, foundational. Declared in root `dependencies` (the root manifest has no devDependencies). Pinned `7.0.4` (aligned with server pin) |
 | **Server deps** | | | | |
 | `@novnc/novnc` | 1 | KEEP | PortDeck remote desktop viewer | Mature RFB/VNC protocol implementation; replacing it would require owning multiple security types and framebuffer encodings |
 | `@googleapis/calendar` | 1 | KEEP | Calendar integration | Scoped official Google SDK (replaced monolithic `googleapis`) |
@@ -77,6 +77,10 @@ Before removing a Tier 3 candidate, run a transitive-dep check (`npm ls <pkg>`).
 | `@testing-library/react` | 1 | KEEP | component tests | |
 | `@testing-library/user-event` | 1 | KEEP | interaction tests | |
 | `rollup-plugin-visualizer` | 2 | KEEP | bundle-size analysis | Dev-only, opt-in |
+| **Autofixer deps** | | | | |
+| `express` | 1 | KEEP | `autofixer/ui.js` | Same framework and pin (`5.2.1`) as the server workspace, but a separate install prefix with its own lockfile — so it needs its own `overrides` block to inherit the server's express-tree pins |
+| **Browser workspace** | | | | |
+| _(none)_ | — | — | `browser/server.js` | Zero dependencies — Node built-ins only, plus one in-repo import from `server/lib/`. No Dependabot entry, and its lockfile is gitignored |
 
 ## Detailed Findings — Tier 2/3 Audits
 
@@ -119,14 +123,12 @@ This is intentionally NOT done in default mode — current dependency footprint 
 
 ## Override Pins (`overrides`)
 
-Defined in `package.json` (root + server + client) — kept current to dodge known upstream advisories:
+Defined in `package.json` (root + server + client + autofixer) — kept current to dodge known upstream advisories:
 
 - `ws@8.21.3` (all three)
 - `lodash@4.18.1`, `follow-redirects@1.16.0`, `js-yaml@4.3.1`, `ip-address@10.5.0` (root + server)
 - `nanoid@3.3.18`, `socket.io-parser@4.2.7` (server + client)
-- `path-to-regexp@8.4.2` (server only)
-- `body-parser@2.3.0` (server only)
-- `qs@6.15.3` (server only)
+- `path-to-regexp@8.4.2`, `body-parser@2.3.0`, `qs@6.15.3` (server + autofixer — the express-reachable subset; `autofixer/` mirrors only these three because a pin for a package absent from the tree reads as protection that does not exist)
 - `tar@7.5.22` (server only)
 - `engine.io@6.6.9` (server only)
 - `postcss@8.5.26` (server only)
@@ -138,7 +140,7 @@ Defined in `package.json` (root + server + client) — kept current to dodge kno
 
 These exist purely to force-bump transitive deps; revisit if `npm audit` flags new advisories.
 
-**Keep this list in sync with the manifests** — a stale entry here reads as a pin that exists when it doesn't. `server/dependency-overrides.test.js` guards the pins themselves (cross-manifest version parity, plus a `MINIMUM_SAFE` floor per remediated advisory), but it does not read this document. When a floor moves because a *new* advisory covers the version already pinned — as `js-yaml@4.3.0` did under GHSA-5p4m-2wfm-xmqj — bump the pin, the `MINIMUM_SAFE` row, and this list together.
+**Keep this list in sync with the manifests** — a stale entry here reads as a pin that exists when it doesn't. `server/dependency-overrides.test.js` guards the pins themselves (cross-manifest version parity, a `MINIMUM_SAFE` floor per remediated advisory, that every workspace shipping a tracked lockfile is in the governed manifest list, and that each tracked lockfile actually resolves the pinned version), but it does not read this document. When a floor moves because a *new* advisory covers the version already pinned — as `js-yaml@4.3.0` did under GHSA-5p4m-2wfm-xmqj — bump the pin, the `MINIMUM_SAFE` row, and this list together.
 
 **Not every compromised package warrants a pin.** A pin only helps when the installed version is *below* the top of its permitted range — otherwise there is nothing to force. The August 2026 `keyv` / `flat-cache` / `file-entry-cache` compromise deliberately got **no** pin: each range was already at its ceiling (highest published `keyv@4.x` *is* `4.5.4`, etc.), so a pin would have been a no-op, and the packages were removed outright instead. Check headroom (`npm view <pkg>@<major> version`) before adding an entry here.
 

--- a/scripts/ci-test-plan.js
+++ b/scripts/ci-test-plan.js
@@ -12,7 +12,7 @@ const MAX_TARGETED_TEST_FILES = 120;
 
 const FULL_TRIGGER_RULES = [
   { re: /^\.github\/workflows\//, reason: 'workflow definition changed' },
-  { re: /^(?:package|server\/package|client\/package)(?:-lock)?\.json$/, reason: 'dependency manifest changed' },
+  { re: /^(?:package|server\/package|client\/package|autofixer\/package)(?:-lock)?\.json$/, reason: 'dependency manifest changed' },
   { re: /^(?:server|client)\/vitest\.config(?:\.db)?\.js$/, reason: 'test runner configuration changed' },
   { re: /^scripts\/vitestCiPool(?:\.test)?\.js$/, reason: 'test runner pool configuration changed' },
   { re: /^server\/vitest\.setup\.js$/, reason: 'server test setup changed' },
@@ -129,6 +129,7 @@ export const ALWAYS_RUN_TESTS = [
   'scripts/node-version-drift.test.js',
   'scripts/repo-scan-guards.test.js',
   'scripts/tailnet-identity-leak.test.js',
+  'server/dependency-overrides.test.js',
   'server/lib/qwenAgentParsers.test.js',
   'server/lib/testDataIsolation.guards.test.js',
   'server/lib/testHelper.test.js',

--- a/server/dependency-overrides.test.js
+++ b/server/dependency-overrides.test.js
@@ -1,21 +1,44 @@
 import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'child_process';
 import { readFileSync } from 'fs';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
+import { discoverWorkspaces } from '../scripts/trusted-rebuilds.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = join(__dirname, '..');
 
-const MANIFESTS = ['package.json', 'server/package.json', 'client/package.json'];
+const MANIFESTS = [
+  'package.json',
+  'server/package.json',
+  'client/package.json',
+  'autofixer/package.json'
+];
 
 const readOverrides = (rel) => {
   const pkg = JSON.parse(readFileSync(join(REPO_ROOT, rel), 'utf8'));
   return pkg.overrides ?? {};
 };
 
-// PortOS pins security fixes for transitive dependencies as `overrides` in THREE
-// independent manifests (root, server/, client/) — each with its own lockfile, so
-// npm resolves each tree separately. The recurring failure (issue #2848) is that a
+// Tracked, not on-disk. `browser/package-lock.json` is deliberately gitignored
+// (.gitignore) yet appears the moment anyone runs an install there, so an
+// existsSync() probe would make these assertions depend on the developer's
+// working tree. What ships in the repo is the thing under governance.
+const trackedLockfiles = () =>
+  new Set(
+    execFileSync('git', ['ls-files', '--', '*package-lock.json'], {
+      cwd: REPO_ROOT,
+      encoding: 'utf8'
+    })
+      .split('\n')
+      .filter(Boolean)
+  );
+
+const workspacePrefix = (label) => (label === 'root' ? '' : `${label}/`);
+
+// PortOS pins security fixes for transitive dependencies as `overrides` in FOUR
+// independent manifests (root, server/, client/, autofixer/) — each with its own
+// lockfile, so npm resolves each tree separately. The recurring failure (issue #2848) is that a
 // CVE gets pinned in one manifest and the others quietly keep the vulnerable
 // version: `brace-expansion` sat at the patched 5.0.6 in server/ while root and
 // client/ stayed on the vulnerable 5.0.5, so `npm audit` stayed red in two of three
@@ -110,5 +133,63 @@ describe('dependency override parity across manifests (#2848)', () => {
     }
 
     expect(stale).toEqual([]);
+  });
+
+  // The three mechanisms that govern a dependency tree — the manifest `overrides`
+  // block, a Dependabot entry, and the assertions above — were all hardcoded to
+  // root/server/client, so `autofixer/` (a fourth npm install prefix with its own
+  // tracked lockfile) sat outside every one of them and quietly resolved
+  // path-to-regexp@8.4.0 / qs@6.15.2 while server/ enforced 8.4.2 / 6.15.3
+  // (issue #5658). MANIFESTS is a hand-written list; this derives the roster from
+  // the same `discoverWorkspaces()` the install-script allowlist uses, so a fifth
+  // workspace added later fails here instead of silently inheriting no governance.
+  it('governs every workspace manifest that ships its own lockfile', () => {
+    const tracked = trackedLockfiles();
+    const ungoverned = discoverWorkspaces()
+      .map(workspacePrefix)
+      .filter((prefix) => tracked.has(`${prefix}package-lock.json`))
+      .map((prefix) => `${prefix}package.json`)
+      .filter((manifest) => !MANIFESTS.includes(manifest));
+
+    expect(ungoverned).toEqual([]);
+  });
+
+  // The source-level assertions above compare manifest against manifest and so
+  // cannot see a pin that was declared but never applied: adding an `overrides`
+  // entry without regenerating that workspace's lockfile leaves the vulnerable
+  // version installed while the manifest reads as remediated. Reading the
+  // lockfiles closes that gap in both directions — a workspace that resolves a
+  // package another workspace has pinned must land on the pinned version, whether
+  // it declares the pin itself or has simply never noticed it needs one.
+  it('resolves every pinned package to its pinned version in all tracked lockfiles', () => {
+    const pins = new Map();
+    for (const rel of MANIFESTS) {
+      for (const [name, version] of Object.entries(readOverrides(rel))) {
+        // Nested overrides are scoped to one consumer's subtree — same exclusion
+        // as the parity assertion above.
+        if (typeof version !== 'string') continue;
+        if (!pins.has(name)) pins.set(name, new Set());
+        pins.get(name).add(version);
+      }
+    }
+
+    const NESTED = 'node_modules/';
+    const drift = [];
+    for (const lockRel of [...trackedLockfiles()].sort()) {
+      const packages = JSON.parse(readFileSync(join(REPO_ROOT, lockRel), 'utf8')).packages ?? {};
+      for (const [path, meta] of Object.entries(packages)) {
+        // '' is the workspace itself, workspace-link entries carry no
+        // `node_modules/` segment, and `link: true` entries carry no version.
+        if (!path?.includes(NESTED) || !meta?.version) continue;
+        const name = path.slice(path.lastIndexOf(NESTED) + NESTED.length);
+        const pinned = pins.get(name);
+        // A package with disagreeing pins is already reported by the parity
+        // assertion above; don't double-report it as drift here.
+        if (!pinned || pinned.size > 1 || pinned.has(meta.version)) continue;
+        drift.push(`${lockRel}: ${name}@${meta.version} != pinned ${[...pinned][0]}`);
+      }
+    }
+
+    expect(drift).toEqual([]);
   });
 });

--- a/server/lib/apiRouteCatalog.generated.json
+++ b/server/lib/apiRouteCatalog.generated.json
@@ -11938,7 +11938,7 @@
       "sources": [
         {
           "source": "server/routes/localLlm.js",
-          "line": 534
+          "line": 540
         }
       ]
     },
@@ -11949,7 +11949,7 @@
       "sources": [
         {
           "source": "server/routes/localLlm.js",
-          "line": 557
+          "line": 563
         }
       ]
     },
@@ -11960,7 +11960,7 @@
       "sources": [
         {
           "source": "server/routes/localLlm.js",
-          "line": 605
+          "line": 611
         }
       ]
     },
@@ -11971,7 +11971,7 @@
       "sources": [
         {
           "source": "server/routes/localLlm.js",
-          "line": 542
+          "line": 548
         }
       ]
     },
@@ -11982,7 +11982,7 @@
       "sources": [
         {
           "source": "server/routes/localLlm.js",
-          "line": 592
+          "line": 598
         }
       ]
     },
@@ -11993,7 +11993,7 @@
       "sources": [
         {
           "source": "server/routes/localLlm.js",
-          "line": 573
+          "line": 579
         }
       ]
     },
@@ -12004,7 +12004,7 @@
       "sources": [
         {
           "source": "server/routes/localLlm.js",
-          "line": 598
+          "line": 604
         }
       ]
     },
@@ -12015,7 +12015,7 @@
       "sources": [
         {
           "source": "server/routes/localLlm.js",
-          "line": 629
+          "line": 635
         }
       ]
     },
@@ -12026,7 +12026,7 @@
       "sources": [
         {
           "source": "server/routes/localLlm.js",
-          "line": 665
+          "line": 671
         }
       ]
     },
@@ -12037,7 +12037,7 @@
       "sources": [
         {
           "source": "server/routes/localLlm.js",
-          "line": 656
+          "line": 662
         }
       ]
     },
@@ -12048,7 +12048,7 @@
       "sources": [
         {
           "source": "server/routes/localLlm.js",
-          "line": 636
+          "line": 642
         }
       ]
     },
@@ -12070,7 +12070,7 @@
       "sources": [
         {
           "source": "server/routes/localLlm.js",
-          "line": 515
+          "line": 521
         }
       ]
     },
@@ -12081,7 +12081,7 @@
       "sources": [
         {
           "source": "server/routes/localLlm.js",
-          "line": 360
+          "line": 366
         }
       ]
     },
@@ -12092,7 +12092,7 @@
       "sources": [
         {
           "source": "server/routes/localLlm.js",
-          "line": 212
+          "line": 218
         }
       ]
     },
@@ -12103,7 +12103,7 @@
       "sources": [
         {
           "source": "server/routes/localLlm.js",
-          "line": 310
+          "line": 316
         }
       ]
     },
@@ -12114,7 +12114,7 @@
       "sources": [
         {
           "source": "server/routes/localLlm.js",
-          "line": 244
+          "line": 250
         }
       ]
     },
@@ -12125,7 +12125,7 @@
       "sources": [
         {
           "source": "server/routes/localLlm.js",
-          "line": 698
+          "line": 704
         }
       ]
     },
@@ -12136,7 +12136,7 @@
       "sources": [
         {
           "source": "server/routes/localLlm.js",
-          "line": 712
+          "line": 718
         }
       ]
     },
@@ -12147,7 +12147,7 @@
       "sources": [
         {
           "source": "server/routes/localLlm.js",
-          "line": 739
+          "line": 745
         }
       ]
     },
@@ -12158,7 +12158,7 @@
       "sources": [
         {
           "source": "server/routes/localLlm.js",
-          "line": 724
+          "line": 730
         }
       ]
     },
@@ -12169,7 +12169,7 @@
       "sources": [
         {
           "source": "server/routes/localLlm.js",
-          "line": 679
+          "line": 685
         }
       ]
     },
@@ -12180,7 +12180,7 @@
       "sources": [
         {
           "source": "server/routes/localLlm.js",
-          "line": 732
+          "line": 738
         }
       ]
     },
@@ -12191,7 +12191,7 @@
       "sources": [
         {
           "source": "server/routes/localLlm.js",
-          "line": 690
+          "line": 696
         }
       ]
     },
@@ -12202,7 +12202,7 @@
       "sources": [
         {
           "source": "server/routes/localLlm.js",
-          "line": 750
+          "line": 756
         }
       ]
     },
@@ -12213,7 +12213,7 @@
       "sources": [
         {
           "source": "server/routes/localLlm.js",
-          "line": 292
+          "line": 298
         }
       ]
     },
@@ -12224,7 +12224,7 @@
       "sources": [
         {
           "source": "server/routes/localLlm.js",
-          "line": 410
+          "line": 416
         }
       ]
     },
@@ -12235,7 +12235,7 @@
       "sources": [
         {
           "source": "server/routes/localLlm.js",
-          "line": 384
+          "line": 390
         }
       ]
     },
@@ -12246,7 +12246,7 @@
       "sources": [
         {
           "source": "server/routes/localLlm.js",
-          "line": 802
+          "line": 808
         }
       ]
     },
@@ -12257,7 +12257,7 @@
       "sources": [
         {
           "source": "server/routes/localLlm.js",
-          "line": 830
+          "line": 836
         }
       ]
     },
@@ -12268,7 +12268,7 @@
       "sources": [
         {
           "source": "server/routes/localLlm.js",
-          "line": 841
+          "line": 847
         }
       ]
     },
@@ -12279,7 +12279,7 @@
       "sources": [
         {
           "source": "server/routes/localLlm.js",
-          "line": 821
+          "line": 827
         }
       ]
     },
@@ -12290,7 +12290,7 @@
       "sources": [
         {
           "source": "server/routes/localLlm.js",
-          "line": 780
+          "line": 786
         }
       ]
     },
@@ -12301,7 +12301,7 @@
       "sources": [
         {
           "source": "server/routes/localLlm.js",
-          "line": 775
+          "line": 781
         }
       ]
     },
@@ -12312,7 +12312,7 @@
       "sources": [
         {
           "source": "server/routes/localLlm.js",
-          "line": 795
+          "line": 801
         }
       ]
     },
@@ -12323,7 +12323,7 @@
       "sources": [
         {
           "source": "server/routes/localLlm.js",
-          "line": 261
+          "line": 267
         }
       ]
     },
@@ -12334,7 +12334,7 @@
       "sources": [
         {
           "source": "server/routes/localLlm.js",
-          "line": 859
+          "line": 865
         }
       ]
     },
@@ -12356,7 +12356,7 @@
       "sources": [
         {
           "source": "server/routes/localLlm.js",
-          "line": 203
+          "line": 209
         }
       ]
     },
@@ -12389,7 +12389,7 @@
       "sources": [
         {
           "source": "server/routes/localLlm.js",
-          "line": 368
+          "line": 374
         }
       ]
     },
@@ -12400,7 +12400,7 @@
       "sources": [
         {
           "source": "server/routes/localLlm.js",
-          "line": 454
+          "line": 460
         }
       ]
     },
@@ -12411,7 +12411,7 @@
       "sources": [
         {
           "source": "server/routes/localLlm.js",
-          "line": 467
+          "line": 473
         }
       ]
     },
@@ -12433,7 +12433,7 @@
       "sources": [
         {
           "source": "server/routes/localLlm.js",
-          "line": 433
+          "line": 439
         }
       ]
     },
@@ -12444,7 +12444,7 @@
       "sources": [
         {
           "source": "server/routes/localLlm.js",
-          "line": 343
+          "line": 349
         }
       ]
     },


### PR DESCRIPTION
## Summary

PortOS governs its dependency trees through three coordinated mechanisms — a per-manifest `overrides` block, a Dependabot entry per npm install directory, and the cross-manifest parity assertions in `server/dependency-overrides.test.js`. All three were hardcoded to root/`server`/`client`, so `autofixer/` — a fourth npm install prefix with its own `package.json`, its own tracked `package-lock.json`, its own `.npmrc`, a real `express` runtime dependency (`autofixer/ui.js`), and a tree the server suite already exercises — sat outside every one of them.

It had already drifted below the pins the other manifests enforce: `path-to-regexp@8.4.0` (server pins `8.4.2`) and `qs@6.15.2` (server pins `6.15.3`).

- **`autofixer/package.json`** — adds an `overrides` block mirroring the express-reachable subset of the server's pins: `path-to-regexp@8.4.2`, `body-parser@2.3.0`, `qs@6.15.3`. Only packages actually present in the tree are pinned; a pin for an absent package reads as protection that does not exist.
- **`autofixer/package-lock.json`** — regenerated in place (not from scratch) so only the pinned packages and their direct consequences move. `qs@6.15.3` pulls `side-channel@^1.1.1`, which carries `hasown` / `es-object-atoms` / `side-channel-list` patch bumps along with it. No majors, and no unrelated float.
- **`.github/dependabot.yml`** — adds the `/autofixer` npm entry. The block comment above the per-directory entries now describes the actual condition (own manifest + own lockfile, resolved as a separate tree) instead of the stale "lockfiles are gitignored" wording, and records why `browser/` deliberately stays out.
- **`server/dependency-overrides.test.js`** — `MANIFESTS` now includes `autofixer/package.json`, which immediately extends the existing parity and `MINIMUM_SAFE` floor assertions to the new block. Two new guards:
  - `governs every workspace manifest that ships its own lockfile` — derives the roster from `discoverWorkspaces()` (the same source the install-script allowlist uses) rather than trusting the hand-written `MANIFESTS`, so a fifth workspace added later fails here instead of silently inheriting no governance.
  - `resolves every pinned package to its pinned version in all tracked lockfiles` — the existing assertions compare manifest against manifest and so cannot see a pin that was declared but never applied. This reads the lockfiles, and is what catches the `path-to-regexp 8.4.0 vs 8.4.2` drift measured above.
- **`scripts/ci-test-plan.js`** — two follow-ons the change forces:
  - `server/dependency-overrides.test.js` joins `ALWAYS_RUN_TESTS`. It now enumerates the tracked tree with `git ls-files`, so CI's import-graph selection can never reach it (`scripts/repo-scan-guards.test.js` fails the build otherwise — that guard caught this).
  - The `dependency manifest changed` full-suite trigger was the *same* hardcoded root/server/client list, so an autofixer dependency change produced only a scoped plan. `autofixer/package*.json` now forces the full suite like every other manifest.
- **`docs/DEPS.md`** — adds an **Autofixer deps** row for `express` and a **Browser workspace** row recording its zero dependencies, notes the shared pins in the Override Pins list, and corrects the `**Root devDeps**` header: `pm2` is in root `dependencies` (the root manifest has no `devDependencies` at all).

Lockfiles are read via `git ls-files`, not `existsSync`: `browser/package-lock.json` is deliberately gitignored yet appears the moment anyone installs there, so an on-disk probe would make the assertions depend on the developer's working tree.

## Second commit: an unrelated `main` regression this PR surfaced

`chore: regenerate the API route catalog after the Prompt Guard gate` is not part of the fix. `server/lib/apiRouteCatalog.generated.json` is a committed artifact that `scripts/generate-api-route-catalog.test.js` re-derives and compares byte-for-byte. Commit `10fa574ac` ("feat: gate Prompt Guard install on Hugging Face access") added 10 lines to `server/routes/localLlm.js` without regenerating it, so every route declared below that point shifted — 42 line numbers, no route added or removed — and the catalog went stale on `main`.

That test only runs under a full-suite plan, which is exactly what this PR now triggers (a dependency manifest moved). Regenerated with `npm run generate:api-docs`; the diff is line numbers only.

## Test plan

- Both new tests verified to **fail before the fix** and pass after — reverting the manifest/lockfile and dropping `autofixer/package.json` from `MANIFESTS` reproduces exactly:
  - `expected [ 'autofixer/package.json' ] to deeply equal []`
  - `[ "autofixer/package-lock.json: path-to-regexp@8.4.0 != pinned 8.4.2", "autofixer/package-lock.json: qs@6.15.2 != pinned 6.15.3" ]`
- `cd server && npm test` — **Test Files 1827 passed | 1 skipped (1828)**, Tests 37106 passed | 13 skipped, 0 failed.
- `cd autofixer && npm audit` — `found 0 vulnerabilities`.
- Lockfile pins confirmed: `path-to-regexp@8.4.2`, `qs@6.15.3`, `body-parser@2.3.0`, `express@5.2.1` unchanged.
- `buildCiTestPlan(['autofixer/package.json', 'autofixer/package-lock.json'])` → `full: true`, reason `dependency manifest changed`.
- No changelog fragment, per AGENTS.md.

## Out of scope

Per the issue: `browser/` gets no Dependabot entry (zero dependencies, lockfile gitignored), no pin version changed in root/server/client, and `TRUSTED_REBUILDS` is untouched. A local review pass also flagged that CI never runs `npm ci --prefix autofixer` (only `server` and `client`) — a pre-existing gap in a different mechanism, filed separately rather than widened into this PR.

Closes #5658
