### PR TITLE
fix: give AI Providers, Prompt Manager and OpenClaw the shared page header (#5653)

### DIFF
--- a/client/src/components/PageHeader.test.jsx
+++ b/client/src/components/PageHeader.test.jsx
@@ -52,6 +52,25 @@ describe('PageHeader', () => {
     expect(screen.getByText('12 links')).toBeTruthy();
   });
 
+  // AIProviders/PromptManager/OpenClaw moved their page-action rows into this
+  // slot (#5653) precisely so the buttons stay on the title row instead of
+  // consuming a second band of vertical space above the fold.
+  it('keeps the actions inside the bar, on the title row', () => {
+    const { container } = render(
+      <PageHeader
+        title="AI Providers"
+        actions={<button type="button">Add Provider</button>}
+      />
+    );
+    const bar = container.firstChild;
+    const button = screen.getByRole('button', { name: 'Add Provider' });
+    const heading = screen.getByRole('heading', { level: 1 });
+    expect(bar.contains(button)).toBe(true);
+    // Both sit in the header's single flex row, so the actions never open a
+    // second band of vertical space below the title.
+    expect(button.closest('div').parentElement).toBe(heading.closest('div').parentElement.parentElement);
+  });
+
   it('keeps the standardized padding + border on the outer container', () => {
     const { container } = render(<PageHeader title="Goals" />);
     const cls = container.firstChild.getAttribute('class');

--- a/client/src/components/ui/OverflowMenu.jsx
+++ b/client/src/components/ui/OverflowMenu.jsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
+import { Link } from 'react-router';
 import { MoreHorizontal } from 'lucide-react';
 import useClickOutside from '../../hooks/useClickOutside';
 import useEscapeKey from '../../hooks/useEscapeKey';
@@ -7,6 +8,12 @@ import usePopoverPosition, { VIEWPORT_PADDING } from '../../hooks/usePopoverPosi
 
 // "…" overflow menu for demoting rare/destructive row actions out of the
 // always-visible control set, so the row keeps a single primary affordance.
+// An item is `{ id, label, icon?, tone? }` plus exactly one of `onSelect` (a
+// callback, which may also take `disabled`) or `to` (a route). A `to` item
+// renders a real `<Link>` so middle-click and open-in-new-tab keep working —
+// the reason a page header's navigation actions can be demoted here without
+// losing anchor semantics. Navigation is never conditionally unavailable here,
+// so `to` items have no disabled state; omit the item instead.
 // Keyboard: ArrowDown from the trigger opens and focuses the first item,
 // ArrowUp/ArrowDown cycle, Escape closes and returns focus to the trigger.
 // Trigger and items are >=44px on phones (the repo's touch-target floor) and
@@ -122,22 +129,39 @@ export default function OverflowMenu({ label, items = [], className = '', trigge
             visibility: style ? 'visible' : 'hidden',
           }}
         >
-          {items.map(item => (
-            <button
-              key={item.id}
-              type="button"
-              role="menuitem"
-              disabled={item.disabled}
-              // Close first so focus lands somewhere real; an item that reveals
-              // follow-up UI (an inline confirm) owns moving focus onward from
-              // there — its mount effect runs after this commit and wins.
-              onClick={() => { close(true); item.onSelect?.(); }}
-              className={`w-full px-3 py-2 min-h-[44px] sm:min-h-[40px] text-left text-xs flex items-center gap-2 transition-colors disabled:opacity-50 focus:outline-hidden focus:bg-port-border/70 ${TONES[item.tone] || TONES.default}`}
-            >
-              {item.icon ? <item.icon size={14} aria-hidden="true" /> : null}
-              <span>{item.label}</span>
-            </button>
-          ))}
+          {items.map(item => {
+            const itemClass = `w-full px-3 py-2 min-h-[44px] sm:min-h-[40px] text-left text-xs flex items-center gap-2 transition-colors disabled:opacity-50 focus:outline-hidden focus:bg-port-border/70 ${TONES[item.tone] || TONES.default}`;
+            const content = (
+              <>
+                {item.icon ? <item.icon size={14} aria-hidden="true" /> : null}
+                <span>{item.label}</span>
+              </>
+            );
+            // A navigating item is an anchor, not a button — the route change
+            // moves focus on its own, so don't hand it back to the trigger.
+            if (item.to) {
+              return (
+                <Link key={item.id} to={item.to} role="menuitem" className={itemClass} onClick={() => close(false)}>
+                  {content}
+                </Link>
+              );
+            }
+            return (
+              <button
+                key={item.id}
+                type="button"
+                role="menuitem"
+                disabled={item.disabled}
+                // Close first so focus lands somewhere real; an item that reveals
+                // follow-up UI (an inline confirm) owns moving focus onward from
+                // there — its mount effect runs after this commit and wins.
+                onClick={() => { close(true); item.onSelect?.(); }}
+                className={itemClass}
+              >
+                {content}
+              </button>
+            );
+          })}
         </div>,
         document.body,
       )}

--- a/client/src/components/ui/OverflowMenu.jsx
+++ b/client/src/components/ui/OverflowMenu.jsx
@@ -137,11 +137,13 @@ export default function OverflowMenu({ label, items = [], className = '', trigge
                 <span>{item.label}</span>
               </>
             );
-            // A navigating item is an anchor, not a button — the route change
-            // moves focus on its own, so don't hand it back to the trigger.
+            // A navigating item is an anchor, not a button. Hand focus back to
+            // the trigger the same way an action item does: the anchor unmounts
+            // with the menu, so without this a keyboard activation would strand
+            // focus on <body> whenever the route renders in place.
             if (item.to) {
               return (
-                <Link key={item.id} to={item.to} role="menuitem" className={itemClass} onClick={() => close(false)}>
+                <Link key={item.id} to={item.to} role="menuitem" className={itemClass} onClick={() => close(true)}>
                   {content}
                 </Link>
               );

--- a/client/src/components/ui/OverflowMenu.test.jsx
+++ b/client/src/components/ui/OverflowMenu.test.jsx
@@ -2,6 +2,7 @@ import { useRef } from 'react';
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router';
 import OverflowMenu from './OverflowMenu';
 
 const items = (overrides = {}) => ([
@@ -141,6 +142,28 @@ describe('OverflowMenu', () => {
     expect(screen.getByRole('menu')).toBeTruthy();
 
     await user.click(screen.getByRole('button', { name: 'outside' }));
+    expect(screen.queryByRole('menu')).toBeNull();
+  });
+
+  // A page header can demote its navigation actions here (#5653) only if they
+  // stay real anchors — a <button> would lose middle-click / open-in-new-tab.
+  it('renders a `to` item as a link and closes the menu on activation', async () => {
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter>
+        <OverflowMenu
+          label="More actions"
+          items={[{ id: 'compare', label: 'Compare local models', to: '/models/performance' }]}
+        />
+      </MemoryRouter>
+    );
+
+    await user.click(screen.getByRole('button', { name: 'More actions' }));
+    const item = screen.getByRole('menuitem', { name: 'Compare local models' });
+    expect(item.tagName).toBe('A');
+    expect(item).toHaveAttribute('href', '/models/performance');
+
+    await user.click(item);
     expect(screen.queryByRole('menu')).toBeNull();
   });
 });

--- a/client/src/components/ui/OverflowMenu.test.jsx
+++ b/client/src/components/ui/OverflowMenu.test.jsx
@@ -163,7 +163,11 @@ describe('OverflowMenu', () => {
     expect(item.tagName).toBe('A');
     expect(item).toHaveAttribute('href', '/models/performance');
 
+    const trigger = screen.getByRole('button', { name: 'More actions' });
     await user.click(item);
     expect(screen.queryByRole('menu')).toBeNull();
+    // The activated anchor unmounts with the menu, so focus has to be handed
+    // back or a keyboard user is stranded on <body>.
+    expect(document.activeElement).toBe(trigger);
   });
 });

--- a/client/src/pages/AIProviders.jsx
+++ b/client/src/pages/AIProviders.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import { Link, useLocation, useNavigate, useParams } from 'react-router';
-import { AlertTriangle, Gauge, Network } from 'lucide-react';
+import { AlertTriangle, Bot, Gauge, Network, Package } from 'lucide-react';
 import toast from '../components/ui/Toast';
 import * as api from '../services/api';
 import socket from '../services/socket';
@@ -9,7 +9,6 @@ import { copyToClipboard } from '../lib/clipboard';
 import { isHttpsUrl } from '../utils/urlNormalize';
 import useLocalModels from '../hooks/useLocalModels';
 import { useAutoRefetch } from '../hooks/useAutoRefetch';
-import BrailleSpinner from '../components/BrailleSpinner';
 import EmptyState from '../components/EmptyState';
 import Banner from '../components/ui/Banner';
 import {
@@ -21,6 +20,8 @@ import {
   TIMEOUT_INPUT_STEP_MS,
 } from '../utils/formatters';
 import SettingsTabsHeader from '../components/settings/SettingsTabsHeader';
+import PageHeader from '../components/PageHeader';
+import OverflowMenu from '../components/ui/OverflowMenu';
 import EffortSelect from '../components/cos/EffortSelect';
 import Drawer from '../components/Drawer';
 import useDrawerTab from '../hooks/useDrawerTab';
@@ -689,9 +690,7 @@ export default function AIProviders() {
   if (loading) {
     return (
       <div className="flex flex-col h-full">
-        <div className="flex items-center gap-3 p-4 border-b border-port-border">
-          <h1 className="text-2xl font-bold text-white">Settings</h1>
-        </div>
+        <PageHeader icon={Bot} title="AI Providers" />
         <SettingsTabsHeader activeTab="providers" />
         <div className="flex-1 flex items-center justify-center">
           <div className="text-gray-400">Loading providers...</div>
@@ -700,50 +699,49 @@ export default function AIProviders() {
     );
   }
 
+  // Only the two actions a user reaches for on nearly every visit stay as
+  // visible buttons; the rare ones are demoted to the overflow menu so the bar
+  // stays one row tall on a 360px viewport and the first provider card is
+  // reachable without scrolling (issue #5653).
+  const secondaryActions = [
+    { id: 'compare-models', label: 'Compare local models', icon: Gauge, to: '/models/performance' },
+    { id: 'fleet-setup', label: 'Fleet setup', icon: Network, to: '/ai/fleet' },
+    {
+      id: 'load-samples',
+      label: loadingSamples ? 'Loading samples…' : 'Load Samples',
+      icon: Package,
+      disabled: loadingSamples,
+      onSelect: handleLoadSamples,
+    },
+  ];
+
   return (
     <div className="flex flex-col h-full">
-      <div className="flex items-center gap-3 p-4 border-b border-port-border">
-        <h1 className="text-2xl font-bold text-white">Settings</h1>
-      </div>
+      <PageHeader
+        icon={Bot}
+        title="AI Providers"
+        actions={(
+          <>
+            <button
+              onClick={() => setShowRunPanel(!showRunPanel)}
+              className="inline-flex min-h-[40px] items-center rounded-lg bg-port-accent px-3 py-1.5 text-sm text-white transition-colors hover:bg-port-accent/80"
+            >
+              {showRunPanel ? 'Hide Runner' : 'Run Prompt'}
+            </button>
+            <button
+              onClick={() => openForm(null)}
+              className="inline-flex min-h-[40px] items-center rounded-lg bg-port-border px-3 py-1.5 text-sm text-white transition-colors hover:bg-port-border/80"
+            >
+              Add Provider
+            </button>
+            <OverflowMenu label="More provider actions" items={secondaryActions} />
+          </>
+        )}
+      />
 
       <SettingsTabsHeader activeTab="providers" />
 
       <div className="flex-1 overflow-auto p-4 space-y-6">
-      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
-        <h1 className="text-2xl font-bold text-white">AI Providers</h1>
-        <div className="flex flex-wrap gap-2">
-          <Link
-            to="/models/performance"
-            className="inline-flex items-center gap-1.5 px-4 py-2 bg-port-border hover:bg-port-border/80 text-white rounded-lg transition-colors text-sm sm:text-base"
-          >
-            <Gauge size={15} /> Compare local models
-          </Link>
-          <Link
-            to="/ai/fleet"
-            className="inline-flex items-center gap-1.5 px-4 py-2 bg-port-border hover:bg-port-border/80 text-white rounded-lg transition-colors text-sm sm:text-base"
-          >
-            <Network size={15} /> Fleet setup
-          </Link>
-          <button
-            onClick={() => setShowRunPanel(!showRunPanel)}
-            className="px-4 py-2 bg-port-accent hover:bg-port-accent/80 text-white rounded-lg transition-colors text-sm sm:text-base"
-          >
-            {showRunPanel ? 'Hide Runner' : 'Run Prompt'}
-          </button>
-          <button
-            onClick={handleLoadSamples}
-            className="px-4 py-2 bg-port-border hover:bg-port-border/80 text-white rounded-lg transition-colors text-sm sm:text-base"
-          >
-            {loadingSamples ? <BrailleSpinner text="Loading" /> : 'Load Samples'}
-          </button>
-          <button
-            onClick={() => openForm(null)}
-            className="px-4 py-2 bg-port-border hover:bg-port-border/80 text-white rounded-lg transition-colors text-sm sm:text-base"
-          >
-            Add Provider
-          </button>
-        </div>
-      </div>
 
       {/* Sample Providers Panel */}
       {showSamples && (

--- a/client/src/pages/AIProviders.test.jsx
+++ b/client/src/pages/AIProviders.test.jsx
@@ -79,6 +79,17 @@ const openEditorTab = async (label) => {
   fireEvent.click(await screen.findByRole('tab', { name: label }));
 };
 
+// The rare page actions (Compare local models, Fleet setup, Load Samples) sit
+// behind the header's overflow menu since #5653, so the bar stays one row tall.
+const openHeaderMenu = async () => {
+  fireEvent.click(await screen.findByRole('button', { name: 'More provider actions' }));
+};
+
+const clickLoadSamples = async () => {
+  await openHeaderMenu();
+  fireEvent.click(await screen.findByRole('menuitem', { name: 'Load Samples' }));
+};
+
 // One entry of the `runtimes` map from GET /api/providers/runtimes.
 const missingRuntime = {
   id: 'opencode',
@@ -253,9 +264,32 @@ describe('AIProviders page load error handling', () => {
     renderPage();
 
     expect(await screen.findByText('OpenAI')).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: /Compare local models/ })).toHaveAttribute('href', '/models/performance');
     expect(screen.queryByText('No providers configured')).not.toBeInTheDocument();
     expect(screen.queryByText('Failed to load AI providers')).not.toBeInTheDocument();
+
+    // Demoted to the overflow menu, but still a real anchor so it can be
+    // opened in a new tab.
+    await openHeaderMenu();
+    expect(screen.getByRole('menuitem', { name: /Compare local models/ })).toHaveAttribute('href', '/models/performance');
+  });
+
+  // The page hosts SettingsTabsHeader; before #5653 it also hand-rolled a
+  // `Settings` title bar above it, so every render stacked two h1s and pushed
+  // the first provider card off a phone viewport.
+  it('renders exactly one h1, naming the page rather than the settings section', async () => {
+    api.getProviders.mockResolvedValue({
+      providers: [
+        { id: 'p1', name: 'OpenAI', type: 'api', enabled: true, endpoint: 'https://api.openai.com', models: ['gpt-4'] }
+      ],
+      activeProvider: 'p1',
+    });
+
+    renderPage();
+
+    await screen.findByText('OpenAI');
+    const headings = screen.getAllByRole('heading', { level: 1 });
+    expect(headings).toHaveLength(1);
+    expect(headings[0]).toHaveAccessibleName('AI Providers');
   });
 
   it('shows a blank secret environment value as not set', async () => {
@@ -608,8 +642,7 @@ describe('handleAddSample error handling', () => {
 
     renderPage();
 
-    const loadSamplesBtn = await screen.findByRole('button', { name: 'Load Samples' });
-    fireEvent.click(loadSamplesBtn);
+    await clickLoadSamples();
 
     const addBtn = await screen.findByRole('button', { name: 'Add' });
     fireEvent.click(addBtn);
@@ -650,8 +683,7 @@ describe('handleAddAllSamples partial failure handling', () => {
 
     renderPage();
 
-    const loadSamplesBtn = await screen.findByRole('button', { name: 'Load Samples' });
-    fireEvent.click(loadSamplesBtn);
+    await clickLoadSamples();
 
     const addAllBtn = await screen.findByRole('button', { name: 'Add All (3)' });
     fireEvent.click(addAllBtn);
@@ -1508,7 +1540,7 @@ describe('hardware-incompatible providers', () => {
 
     renderPage();
 
-    fireEvent.click(await screen.findByRole('button', { name: 'Load Samples' }));
+    await clickLoadSamples();
 
     expect(await screen.findByText('Sample Runs Here')).toBeInTheDocument();
     expect(screen.queryByText('Sample Needs More RAM')).not.toBeInTheDocument();
@@ -1533,7 +1565,7 @@ describe('hardware-incompatible providers', () => {
 
     renderPage();
 
-    fireEvent.click(await screen.findByRole('button', { name: 'Load Samples' }));
+    await clickLoadSamples();
 
     expect(await screen.findByText(/cannot run on this machine/)).toBeInTheDocument();
   });

--- a/client/src/pages/OpenClaw.jsx
+++ b/client/src/pages/OpenClaw.jsx
@@ -35,6 +35,7 @@ import {
 import AppContextPicker from '../components/AppContextPicker';
 import FilePickerButton from '../components/ui/FilePickerButton';
 import SettingsTabsHeader from '../components/settings/SettingsTabsHeader';
+import PageHeader from '../components/PageHeader';
 import * as api from '../services/apiOpenClaw';
 import * as coreApi from '../services/api';
 import { formatDateTime } from '../utils/formatters';
@@ -314,40 +315,37 @@ export default function OpenClaw() {
 
   return (
     <div className="flex h-full flex-col">
-      <div className="flex flex-wrap items-center justify-between gap-3 border-b border-port-border p-4">
-        <div className="flex items-center gap-3">
-          <Bot className="h-7 w-7 shrink-0 text-port-accent" />
-          <div>
-            <h1 className="text-xl font-bold text-white">OpenClaw</h1>
-            <p className="hidden text-sm text-gray-500 sm:block">Operator chat surface with streaming, context, and attachments.</p>
-          </div>
-        </div>
-
-        <div className="flex items-center gap-2">
-          <button
-            type="button"
-            onClick={() => setShowSidePanel(current => !current)}
-            aria-expanded={showSidePanel}
-            className="inline-flex items-center gap-2 rounded-lg border border-port-border bg-port-card px-3 py-2 text-sm text-gray-200 transition-colors hover:border-gray-500 hover:text-white lg:hidden"
-          >
-            <MessageSquareText size={16} />
-            Sessions
-            <span className="text-xs text-gray-500">{sessions.length}</span>
-          </button>
-          <span className={`inline-flex items-center rounded-full border px-3 py-1 text-sm font-medium ${runtimeState.classes}`}>
-            {runtimeState.label}
-          </span>
-          <button
-            type="button"
-            onClick={loadRuntime}
-            disabled={statusLoading || sessionsLoading}
-            className="inline-flex items-center gap-2 rounded-lg border border-port-border bg-port-card px-3 py-2 text-sm text-gray-200 transition-colors hover:border-gray-500 hover:text-white disabled:cursor-not-allowed disabled:opacity-60"
-          >
-            <RefreshCw size={16} className={statusLoading || sessionsLoading ? 'animate-spin' : ''} />
-            Refresh
-          </button>
-        </div>
-      </div>
+      <PageHeader
+        icon={Bot}
+        title="OpenClaw"
+        subtitle="Operator chat surface with streaming, context, and attachments."
+        actions={(
+          <>
+            <button
+              type="button"
+              onClick={() => setShowSidePanel(current => !current)}
+              aria-expanded={showSidePanel}
+              className="inline-flex items-center gap-2 rounded-lg border border-port-border bg-port-card px-3 py-2 text-sm text-gray-200 transition-colors hover:border-gray-500 hover:text-white lg:hidden"
+            >
+              <MessageSquareText size={16} />
+              Sessions
+              <span className="text-xs text-gray-500">{sessions.length}</span>
+            </button>
+            <span className={`inline-flex items-center rounded-full border px-3 py-1 text-sm font-medium ${runtimeState.classes}`}>
+              {runtimeState.label}
+            </span>
+            <button
+              type="button"
+              onClick={loadRuntime}
+              disabled={statusLoading || sessionsLoading}
+              className="inline-flex items-center gap-2 rounded-lg border border-port-border bg-port-card px-3 py-2 text-sm text-gray-200 transition-colors hover:border-gray-500 hover:text-white disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              <RefreshCw size={16} className={statusLoading || sessionsLoading ? 'animate-spin' : ''} />
+              Refresh
+            </button>
+          </>
+        )}
+      />
 
       <SettingsTabsHeader activeTab="openclaw" />
 

--- a/client/src/pages/OpenClaw.test.jsx
+++ b/client/src/pages/OpenClaw.test.jsx
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+
+const openClawApi = vi.hoisted(() => ({
+  getOpenClawStatus: vi.fn(),
+  getOpenClawSessions: vi.fn(),
+  getOpenClawMessages: vi.fn(),
+  streamOpenClawMessage: vi.fn(),
+}));
+
+vi.mock('../services/apiOpenClaw', () => openClawApi);
+vi.mock('../services/api', () => ({ getApps: vi.fn(() => Promise.resolve([])) }));
+vi.mock('../hooks/useInstanceFeatures.js', () => ({
+  useInstanceFeatures: () => ({ isFeatureEnabled: () => true }),
+}));
+vi.mock('../components/settings/SettingsTabsHeader', () => ({
+  default: () => <div data-testid="settings-tabs-header" />,
+}));
+
+import OpenClaw from './OpenClaw';
+
+const renderPage = () => render(
+  <MemoryRouter initialEntries={['/openclaw']}>
+    <OpenClaw />
+  </MemoryRouter>,
+);
+
+describe('OpenClaw page header', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    openClawApi.getOpenClawStatus.mockResolvedValue({
+      configured: true,
+      enabled: true,
+      reachable: true,
+      label: 'OpenClaw Runtime',
+      defaultSession: 'session-1',
+    });
+    openClawApi.getOpenClawSessions.mockResolvedValue({
+      sessions: [{ id: 'session-1', title: 'Example session' }],
+    });
+    openClawApi.getOpenClawMessages.mockResolvedValue({ messages: [] });
+  });
+
+  // Before #5653 the page duplicated PageHeader's structure by hand with `p-4`
+  // padding, so it drifted from every other settings-group page's bar height.
+  it('renders exactly one h1 through the shared PageHeader', async () => {
+    renderPage();
+
+    const heading = await screen.findByRole('heading', { level: 1 });
+    expect(heading).toHaveAccessibleName('OpenClaw');
+    expect(screen.getAllByRole('heading', { level: 1 })).toHaveLength(1);
+  });
+
+  it('uses the shared compact bar padding rather than a hand-rolled p-4 one', async () => {
+    renderPage();
+
+    const heading = await screen.findByRole('heading', { level: 1 });
+    const bar = heading.closest('div.border-b');
+    expect(bar.className).toContain('px-3');
+    expect(bar.className).toContain('sm:px-4');
+    expect(bar).toContainElement(screen.getByRole('button', { name: /Refresh/ }));
+  });
+});

--- a/client/src/pages/PromptManager.jsx
+++ b/client/src/pages/PromptManager.jsx
@@ -14,6 +14,7 @@ import {
 } from '../utils/formatters';
 import useFieldDraft from '../hooks/useFieldDraft';
 import SettingsTabsHeader from '../components/settings/SettingsTabsHeader';
+import PageHeader from '../components/PageHeader';
 import { FormField } from '../components/ui/FormField';
 import Modal from '../components/ui/Modal';
 import InlineConfirmRow from '../components/ui/InlineConfirmRow';
@@ -28,6 +29,10 @@ import Pill from '../components/ui/Pill';
 import { buildStageGroups, stageGroupKeyFor } from '../lib/promptStageGroups';
 
 const VALID_PROMPT_TABS = ['stages', 'variables', 'job-skills'];
+
+// Shared by the loading and loaded branches so the bar doesn't change height
+// when the fetch settles.
+const PAGE_SUBTITLE = 'Customize AI prompts for backend operations';
 
 export default function PromptManager() {
   const [searchParams, setSearchParams] = useSearchParams();
@@ -455,9 +460,7 @@ export default function PromptManager() {
   if (loading) {
     return (
       <div className="flex flex-col h-full">
-        <div className="flex items-center gap-3 p-4 border-b border-port-border">
-          <h1 className="text-2xl font-bold text-white">Settings</h1>
-        </div>
+        <PageHeader icon={FileText} title="Prompt Manager" subtitle={PAGE_SUBTITLE} />
         <SettingsTabsHeader activeTab="prompts" />
         <div className="flex-1 flex items-center justify-center">
           <BrailleSpinner text="Loading prompts" />
@@ -468,28 +471,24 @@ export default function PromptManager() {
 
   return (
     <div className="flex flex-col h-full">
-      <div className="flex items-center gap-3 p-4 border-b border-port-border">
-        <h1 className="text-2xl font-bold text-white">Settings</h1>
-      </div>
+      <PageHeader
+        icon={FileText}
+        title="Prompt Manager"
+        subtitle={PAGE_SUBTITLE}
+        actions={(
+          <button
+            onClick={loadData}
+            className="p-2 text-gray-400 hover:text-white"
+            title="Reload" aria-label="Reload"
+          >
+            <RefreshCw size={20} />
+          </button>
+        )}
+      />
 
       <SettingsTabsHeader activeTab="prompts" />
 
       <div className="flex-1 overflow-auto p-4">
-      {/* Header */}
-      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 mb-6">
-        <div>
-          <h1 className="text-2xl font-bold text-white">Prompt Manager</h1>
-          <p className="text-gray-500 text-sm sm:text-base">Customize AI prompts for backend operations</p>
-        </div>
-        <button
-          onClick={loadData}
-          className="p-2 text-gray-400 hover:text-white self-end sm:self-auto"
-          title="Reload" aria-label="Reload"
-        >
-          <RefreshCw size={20} />
-        </button>
-      </div>
-
       {/* Tabs */}
       <div className="flex flex-wrap gap-2 mb-6">
         <button

--- a/client/src/pages/PromptManager.test.jsx
+++ b/client/src/pages/PromptManager.test.jsx
@@ -825,3 +825,21 @@ describe('PromptManager job skill unsaved-edit guard', () => {
   });
 });
 
+
+// The page hosts SettingsTabsHeader; before #5653 it also hand-rolled a
+// `Settings` title bar above it, so every render stacked two h1s and pushed the
+// first prompt group off a phone viewport.
+describe('PromptManager page header', () => {
+  beforeEach(() => {
+    getPrompts.mockReset().mockResolvedValue({ stages: STAGES, systemStages: SYSTEM_STAGES });
+  });
+
+  it('renders exactly one h1, naming the page rather than the settings section', async () => {
+    renderPage();
+
+    await screen.findByLabelText('Search prompt stages');
+    const headings = screen.getAllByRole('heading', { level: 1 });
+    expect(headings).toHaveLength(1);
+    expect(headings[0]).toHaveAccessibleName('Prompt Manager');
+  });
+});


### PR DESCRIPTION
## Summary

Four pages host `SettingsTabsHeader`, and only `Settings.jsx` used the shared `PageHeader`. `AIProviders.jsx` and `PromptManager.jsx` each hand-rolled a `p-4` bar with a `text-2xl` "Settings" `<h1>`, rendered the settings tab strip beneath it, then rendered a **second** `<h1>` (the actual page name) plus a subtitle and an action row inside the scroll body. On a 360x640 phone that stacked roughly 300px of chrome — bar, mobile tab `<select>`, duplicate heading, and four action buttons wrapping onto three rows — above the first provider card, and navigating Settings → Providers visibly jumped as the bar changed height and title scale. `OpenClaw.jsx` was a third variant: a hand copy of `PageHeader`'s exact structure with `p-4` padding.

All three now render the shared `PageHeader`, with the page's own name as the single `<h1>` — the tab strip already communicates that we are in Settings, and one specific heading beats two where one is a duplicate of the section name. `Settings.jsx` is unchanged; it is the reference.

On AI Providers the action row is also thinned out. `Run Prompt` and `Add Provider` stay as visible buttons; the three rare ones — `Compare local models`, `Fleet setup`, `Load Samples` — move into the existing shared `OverflowMenu`, so the bar is a title row plus at most one button row on a phone instead of three. `OverflowMenu` gained a `to` item variant that renders a real `<Link>` rather than a button, so the two navigation actions keep middle-click and open-in-new-tab; activating one hands focus back to the trigger, since the anchor unmounts with the menu.

`grep -rn 'text-2xl font-bold text-white">Settings<' client/src` now returns nothing, and `/ai`, `/prompts` and `/openclaw` each render exactly one `<h1>`.

## Test plan

- `cd client && npm test` — **851 test files passed, 10671 tests passed**, no failures.
- New regression tests, each verified to FAIL against the pre-fix source:
  - `AIProviders.test.jsx` / `PromptManager.test.jsx` — "renders exactly one h1, naming the page rather than the settings section" (failed pre-fix with `expected [<h1>, <h1>] to have a length of 1 but got 2`).
  - `OpenClaw.test.jsx` (new file) — single `<h1>`, plus "uses the shared compact bar padding rather than a hand-rolled p-4 one" (failed pre-fix on the missing `px-3`/`sm:px-4` tokens).
  - `OverflowMenu.test.jsx` — a `to` item renders as an `<a>` with the right `href`, closes the menu on activation, and returns focus to the trigger.
  - `PageHeader.test.jsx` — the `actions` slot's children render inside the bar, on the same flex row as the title (pins the slot contract the three converted pages now depend on).
- Existing `AIProviders.test.jsx` cases that clicked `Load Samples` / asserted the `Compare local models` href now go through a `clickLoadSamples` / `openHeaderMenu` helper, matching the actions' new home.

Closes #5653
