### PR TITLE
Harden public review safety gates

### DIFF
--- a/server/lib/providerVendors.js
+++ b/server/lib/providerVendors.js
@@ -320,11 +320,12 @@ function claudeSpawnArgs(provider, { effectiveModel, effort, systemPromptFile, s
 
 const CLAUDE_PUBLIC_REVIEW_ARGS = [
   '--permission-mode', 'plan',
-  // The code-review model gets the cleared PR material in its prompt. No
-  // tool call is needed, so an accidental model/tool interaction cannot read
-  // another file, invoke a shell, or reach the network.
+  // The code-review model gets the cleared PR material in its prompt. Keep
+  // both controls: `--restricted` removes the command/network-capable built-in
+  // tools, while the explicit empty set prevents Claude Code from advertising
+  // any tool schema to a local model that does not support tool calls.
+  '--restricted',
   '--tools', '',
-  '--disallowedTools', 'Bash,Read,Glob,Grep,WebFetch,WebSearch,Write,Edit,NotebookEdit,Task,Skill,TodoWrite',
   '--strict-mcp-config',
   '--mcp-config', '{"mcpServers":{}}',
   '--no-chrome',

--- a/server/lib/providerVendors.publicReview.test.js
+++ b/server/lib/providerVendors.publicReview.test.js
@@ -44,6 +44,7 @@ describe('public-review provider profile', () => {
     expect(config.stdinMode).toBe('prompt');
     expect(config.args).toContain('--permission-mode');
     expect(config.args).toContain('plan');
+    expect(config.args).toContain('--restricted');
     expect(config.args).toContain('--tools');
     expect(config.args[config.args.indexOf('--tools') + 1]).toBe('');
     expect(config.args).toContain('--strict-mcp-config');
@@ -53,6 +54,7 @@ describe('public-review provider profile', () => {
     expect(config.args).toContain('--effort');
     expect(config.args).not.toContain('--dangerously-skip-permissions');
     expect(config.args).not.toContain('Bash');
+    expect(config.args).not.toContain('--disallowedTools');
   });
 
   it('fails closed instead of assigning the profile to cloud or unknown providers', () => {

--- a/server/services/agentLifecycle.js
+++ b/server/services/agentLifecycle.js
@@ -94,6 +94,24 @@ import { handleOrphanedTask } from './agentManagement.js';
 
 const ROOT_DIR = PATHS.root;
 const AGENTS_DIR = PATHS.cosAgents;
+const PUBLIC_REVIEW_SCAN_STATUSES = new Set(['passed', 'findings']);
+
+function publicReviewScanBlock(task) {
+  const scan = task?.metadata?.pipeline?.securityScan;
+  const hasClearedPr = Number.isInteger(scan?.safePrCount) && scan.safePrCount > 0;
+  if (scan?.completed === true && PUBLIC_REVIEW_SCAN_STATUSES.has(scan.status) && hasClearedPr) return null;
+
+  if (scan?.completed === true && scan.status === 'findings' && !hasClearedPr) {
+    return {
+      reason: 'Public review withheld: the model-abuse scan cleared no pull requests',
+      category: 'public-review-no-cleared-prs',
+    };
+  }
+  return {
+    reason: `Public review withheld: the model-abuse scan is incomplete${scan?.code ? ` (${scan.code})` : ''}`,
+    category: 'public-review-security-scan-incomplete',
+  };
+}
 
 
 
@@ -376,6 +394,26 @@ async function runAgentSpawn(task) {
     const { provider, selectedModel, modelSelection } = resolution;
     const isTui = isTuiProvider(provider);
     const publicReview = task.metadata?.executionProfile === PUBLIC_REVIEW_EXECUTION_PROFILE;
+    if (publicReview) {
+      const scanBlock = publicReviewScanBlock(task);
+      if (scanBlock) {
+        await updateTask(task.id, {
+          status: 'blocked',
+          metadata: {
+            ...task.metadata,
+            blockedReason: scanBlock.reason,
+            blockedCategory: scanBlock.category,
+            blockedAt: new Date().toISOString(),
+          },
+        }, task.taskType || 'user').catch(() => {});
+        await cleanupOnError(scanBlock.reason);
+        // This is an expected fail-closed safety outcome, not an agent/provider
+        // failure. Do not emit agent:error, which would create an automatic
+        // investigator and potentially retry the same unvalidated input.
+        emitLog('warn', `Public review withheld for task ${task.id}: ${scanBlock.category}`, { taskId: task.id });
+        return null;
+      }
+    }
     if (publicReview && !supportsPublicReviewProvider(provider, { tui: isTui })) {
       const reason = `Provider '${provider?.id || provider?.command || 'unknown'}' has no enforced read-only public-content review mode`;
       await updateTask(task.id, {

--- a/server/services/agentLifecycle.test.js
+++ b/server/services/agentLifecycle.test.js
@@ -303,6 +303,16 @@ describe('agentLifecycle — guard wiring', () => {
     // The synchronous mirror, not a re-implemented disk read.
     expect(AGENT_LIFECYCLE_SRC).toMatch(/import \{ isUpdateInProgress \} from '\.\/updateChecker\.js'/);
   });
+
+  it('fails closed before spawning when public-review security screening is incomplete', () => {
+    expect(AGENT_LIFECYCLE_SRC).toContain('public-review-security-scan-incomplete');
+    expect(AGENT_LIFECYCLE_SRC).toContain('public-review-no-cleared-prs');
+    expect(AGENT_LIFECYCLE_SRC).toMatch(/if \(scanBlock\) \{[\s\S]*?status: 'blocked'/);
+    expect(AGENT_LIFECYCLE_SRC).toMatch(/expected fail-closed safety outcome/);
+    const gateStart = AGENT_LIFECYCLE_SRC.indexOf('const scanBlock = publicReviewScanBlock(task)');
+    const gateEnd = AGENT_LIFECYCLE_SRC.indexOf('if (publicReview && !supportsPublicReviewProvider', gateStart);
+    expect(AGENT_LIFECYCLE_SRC.slice(gateStart, gateEnd)).not.toContain("cosEvents.emit('agent:error'");
+  });
 });
 
 // ─── Coverage guard for the self-update spawn gate (issue #4124) ────────────

--- a/server/services/cosTaskGenerator.js
+++ b/server/services/cosTaskGenerator.js
@@ -2261,7 +2261,7 @@ async function runPrReviewerSecurityPreflight(taskType, app, metadata) {
       stage: 0,
       name: securityStage.name,
       agentId: null,
-      success: true,
+      success: scan.ok,
       completedAt: new Date().toISOString(),
       summary: {
         guardId: scan.guardId || MODEL_ABUSE_GUARD_ID,

--- a/server/services/subAgentSpawner.dispatchHolds.test.js
+++ b/server/services/subAgentSpawner.dispatchHolds.test.js
@@ -157,6 +157,24 @@ describe('subAgentSpawner — runner-down hold', () => {
   });
 });
 
+describe('subAgentSpawner — approval hold', () => {
+  beforeEach(async () => {
+    await initSpawner();
+    vi.clearAllMocks();
+    vi.useRealTimers();
+    setUseRunner(true);
+    isRunnerReachable.mockResolvedValue(true);
+    isUpdateInProgress.mockReturnValue(false);
+  });
+
+  it('honors an approval-required task before any runner or agent dispatch', async () => {
+    await dispatch({ id: 'cos-approval-1', approvalRequired: true, metadata: {} });
+
+    expect(isRunnerReachable).not.toHaveBeenCalled();
+    expect(spawnAgentForTask).not.toHaveBeenCalled();
+  });
+});
+
 describe('subAgentSpawner — self-update hold (#4124)', () => {
   beforeEach(async () => {
     await initSpawner();

--- a/server/services/subAgentSpawner.js
+++ b/server/services/subAgentSpawner.js
@@ -155,6 +155,14 @@ let spawnerInitPromise = null;
  * process-level unhandled-rejection toast with no task id in it.
  */
 async function handleTaskReady(task) {
+  // The on-demand generator normally clears approval for a user-triggered Run,
+  // but a task type can deliberately retain a non-bypassable approval marker
+  // (for example, a public review that would hand a later coordinator the
+  // ability to act on external PRs). Keep this check at the shared dispatch
+  // chokepoint so every emitter honors it, including on-demand and job paths.
+  if (task?.approvalRequired === true) {
+    return holdTask(task, 'task requires approval');
+  }
   // ── HOLDS, at the one chokepoint all seven `task:ready` emitters funnel
   // through. Each leaves the task queued (no status write, no retry charged)
   // for a condition that clears on its own.


### PR DESCRIPTION
## Summary
- enforce a restricted, no-tool execution profile for local public-review agents, independent of saved provider arguments
- keep public review fail-closed until the model-abuse scan is complete and has cleared at least one pull request
- hold approval-required tasks at the shared dispatch boundary so on-demand and scheduled paths cannot bypass the gate
- expose an accurate failed scan-stage result and keep the collected report available for operator review
- refresh the generated API route catalog after the latest local-LLM route changes

## Verification
- focused server contracts: 298 passed
- full server suite: 37,098 passed, 23 skipped
- validation run performed no GitHub comments, labels, closures, merges, or issue changes

## Security boundary
Stage 1 screens untrusted public content for model-abuse signals. Stage 2 is not started unless the scan is complete and has cleared content for review; the coordinator remains responsible for any later repository action.