### PR TITLE
fix: one throw after an event handler no longer permanently stops a CoS schedule

### DIFF
--- a/server/services/eventScheduler.js
+++ b/server/services/eventScheduler.js
@@ -835,6 +835,9 @@ async function triggerNow(id) {
   const event = scheduledEvents.get(id)
   if (!event) return false
 
+  // Disarm before running: a long manual run must not have its own pending
+  // deadline elapse underneath it and start a second, concurrent run.
+  clearPendingTimer(id)
   await runEvent(event)
   return true
 }

--- a/server/services/eventScheduler.js
+++ b/server/services/eventScheduler.js
@@ -507,7 +507,7 @@ function scheduleNextRun(event) {
   if (delay < 0) {
     // Already past - run immediately for non-recurring, or calculate next for recurring
     if (event.type === 'once') {
-      runEvent(event)
+      runEventFloating(event)
       return
     }
     // Calculate next occurrence
@@ -516,8 +516,90 @@ function scheduleNextRun(event) {
     return
   }
 
-  const timer = createSafeTimer(() => runEvent(event), delay, event.id)
+  const timer = createSafeTimer(() => runEventFloating(event), delay, event.id)
   activeTimers.set(event.id, timer)
+}
+
+/**
+ * Start a run without awaiting it, from a timer or another fire-and-forget path.
+ * runEvent already swallows handler failures; this catch exists so a defect in
+ * runEvent's own bookkeeping surfaces as one log line instead of an unhandled
+ * rejection that can take the process down.
+ * @param {Object} event - Event object
+ */
+function runEventFloating(event) {
+  runEvent(event).catch(err => {
+    console.error(`❌ Event ${event.id} run failed: ${err.message}`)
+  })
+}
+
+/**
+ * Stop an event and drop its pending timer handle.
+ * @param {Object} event - Event object
+ */
+function deactivate(event) {
+  event.active = false
+  activeTimers.delete(event.id)
+}
+
+/**
+ * Re-arm an event after a run.
+ *
+ * Runs from runEvent's `finally`, so a throw anywhere earlier in the run can
+ * never leave a recurring schedule un-armed but still listed as active. A next
+ * run time that cannot be computed (malformed cron, recurrence past its `until`)
+ * deactivates the event with one error line rather than leaving the CoS Schedule
+ * tab showing an armed schedule that will never fire again.
+ *
+ * @param {Object} event - Event object
+ */
+function rearm(event) {
+  if (!event.active) return
+
+  if (event.type === 'once') {
+    deactivate(event)
+    return
+  }
+
+  try {
+    updateNextRunTime(event)
+  } catch (err) {
+    console.error(`❌ Event ${event.id} could not compute its next run (${err.message}) - schedule stopped`)
+    deactivate(event)
+    return
+  }
+
+  if (!event.nextRunAt) {
+    console.error(`❌ Event ${event.id} has no next run time - schedule stopped`)
+    deactivate(event)
+    return
+  }
+
+  scheduleNextRun(event)
+}
+
+/**
+ * Append one run to the bounded history ring.
+ * @param {Object} event - Event object
+ * @param {Object} result - Run outcome
+ * @param {number} result.startTime - Run start timestamp
+ * @param {boolean} result.success - Whether the handler completed
+ * @param {string|null} result.error - Handler failure message, if any
+ */
+function recordEventHistory(event, { startTime, success, error }) {
+  // push + truncate is faster than unshift + pop for large arrays
+  eventHistory.push({
+    eventId: event.id,
+    type: event.type,
+    runAt: startTime,
+    duration: Date.now() - startTime,
+    success,
+    error
+  })
+
+  if (eventHistory.length > MAX_HISTORY) {
+    eventHistory.splice(0, eventHistory.length - MAX_HISTORY)
+  }
 }
 
 /**
@@ -539,36 +621,17 @@ async function runEvent(event) {
     success = false
     error = err.message
     console.error(`⚠️ Event ${event.id} failed: ${err.message}`)
-  }
+  } finally {
+    recordEventHistory(event, { startTime, success, error })
 
-  // Record in history (push + truncate is faster than unshift + pop for large arrays)
-  eventHistory.push({
-    eventId: event.id,
-    type: event.type,
-    runAt: startTime,
-    duration: Date.now() - startTime,
-    success,
-    error
-  })
+    // A synchronous listener that throws must not cost the schedule its re-arm
+    try {
+      cosEvents.emit('scheduler:ran', { id: event.id, success, runCount: event.runCount })
+    } catch (err) {
+      console.error(`⚠️ Event ${event.id} scheduler:ran listener threw: ${err.message}`)
+    }
 
-  if (eventHistory.length > MAX_HISTORY) {
-    eventHistory.splice(0, eventHistory.length - MAX_HISTORY)
-  }
-
-  // Emit completion
-  cosEvents.emit('scheduler:ran', {
-    id: event.id,
-    success,
-    runCount: event.runCount
-  })
-
-  // Schedule next run for recurring events
-  if (event.active && event.type !== 'once') {
-    updateNextRunTime(event)
-    scheduleNextRun(event)
-  } else if (event.type === 'once') {
-    event.active = false
-    activeTimers.delete(event.id)
+    rearm(event)
   }
 }
 

--- a/server/services/eventScheduler.js
+++ b/server/services/eventScheduler.js
@@ -516,6 +516,9 @@ function scheduleNextRun(event) {
     return
   }
 
+  // Drop any handle this arm replaces (e.g. triggerNow re-arming ahead of the
+  // pending deadline) so the old timeout can't fire a duplicate run later.
+  clearPendingTimer(event.id)
   const timer = createSafeTimer(() => runEventFloating(event), delay, event.id)
   activeTimers.set(event.id, timer)
 }
@@ -534,12 +537,22 @@ function runEventFloating(event) {
 }
 
 /**
+ * Clear an event's pending timeout and forget its handle.
+ * @param {string} id - Event identifier
+ */
+function clearPendingTimer(id) {
+  const timer = activeTimers.get(id)
+  if (timer) clearTimeout(timer.timerId)
+  activeTimers.delete(id)
+}
+
+/**
  * Stop an event and drop its pending timer handle.
  * @param {Object} event - Event object
  */
 function deactivate(event) {
   event.active = false
-  activeTimers.delete(event.id)
+  clearPendingTimer(event.id)
 }
 
 /**
@@ -547,9 +560,10 @@ function deactivate(event) {
  *
  * Runs from runEvent's `finally`, so a throw anywhere earlier in the run can
  * never leave a recurring schedule un-armed but still listed as active. A next
- * run time that cannot be computed (malformed cron, recurrence past its `until`)
- * deactivates the event with one error line rather than leaving the CoS Schedule
- * tab showing an armed schedule that will never fire again.
+ * run time that cannot be computed (malformed cron, a recurrence with no
+ * occurrence left in the search horizon) deactivates the event with an error
+ * line naming the reason, rather than leaving the CoS Schedule tab showing an
+ * armed schedule that will never fire again.
  *
  * @param {Object} event - Event object
  */
@@ -671,12 +685,7 @@ function cancel(id) {
   if (!event) return false
 
   event.active = false
-
-  const timer = activeTimers.get(id)
-  if (timer) {
-    clearTimeout(timer.timerId)
-    activeTimers.delete(id)
-  }
+  clearPendingTimer(id)
 
   scheduledEvents.delete(id)
   console.log(`📅 Event cancelled: ${id}`)
@@ -695,12 +704,7 @@ function pause(id) {
   if (!event) return false
 
   event.active = false
-
-  const timer = activeTimers.get(id)
-  if (timer) {
-    clearTimeout(timer.timerId)
-    activeTimers.delete(id)
-  }
+  clearPendingTimer(id)
 
   console.log(`⏸️ Event paused: ${id}`)
   return true

--- a/server/services/eventScheduler.test.js
+++ b/server/services/eventScheduler.test.js
@@ -375,6 +375,20 @@ describe('schedule() lifecycle with fake timers', () => {
     expect(handler).toHaveBeenCalledTimes(1);
   });
 
+  it('triggerNow() replaces the pending timer instead of leaving a duplicate run armed', async () => {
+    const handler = vi.fn();
+    schedule({ id: 'trigger-dup', type: 'interval', intervalMs: 60000, handler });
+
+    expect(await triggerNow('trigger-dup')).toBe(true);
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(getStats().activeTimers).toBe(1);
+
+    // The original 60s deadline must have been cleared by the re-arm, so only the
+    // fresh 60s-from-now timer fires in the next minute.
+    await vi.advanceTimersByTimeAsync(60000);
+    expect(handler).toHaveBeenCalledTimes(2);
+  });
+
   it('triggerNow() returns false for an unknown id', async () => {
     expect(await triggerNow('does-not-exist')).toBe(false);
   });
@@ -431,7 +445,7 @@ describe('schedule() lifecycle with fake timers', () => {
     }
   });
 
-  it('stops a cron event whose expression became unparseable, with one error log', async () => {
+  it('stops a cron event whose expression became unparseable, naming the reason', async () => {
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     try {
@@ -456,7 +470,7 @@ describe('schedule() lifecycle with fake timers', () => {
     }
   });
 
-  it('stops a recurrence event that yields no next occurrence, with one error log', async () => {
+  it('stops a recurrence event that yields no next occurrence, naming the reason', async () => {
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     try {

--- a/server/services/eventScheduler.test.js
+++ b/server/services/eventScheduler.test.js
@@ -389,6 +389,22 @@ describe('schedule() lifecycle with fake timers', () => {
     expect(handler).toHaveBeenCalledTimes(2);
   });
 
+  it('triggerNow() does not let the original deadline fire during a long manual run', async () => {
+    let release;
+    const handler = vi.fn(() => new Promise(resolve => { release = resolve; }));
+    schedule({ id: 'trigger-slow', type: 'interval', intervalMs: 60000, handler });
+
+    const running = triggerNow('trigger-slow');
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    // Cross the original 60s deadline while the manual run is still in flight
+    await vi.advanceTimersByTimeAsync(60000);
+    expect(handler).toHaveBeenCalledTimes(1); // no concurrent duplicate run
+
+    release();
+    expect(await running).toBe(true);
+  });
+
   it('triggerNow() returns false for an unknown id', async () => {
     expect(await triggerNow('does-not-exist')).toBe(false);
   });

--- a/server/services/eventScheduler.test.js
+++ b/server/services/eventScheduler.test.js
@@ -16,6 +16,7 @@ import {
   parseRecurrenceToNextRun,
   isValidRecurrence,
 } from './eventScheduler.js';
+import { cosEvents } from './cosEvents.js';
 
 // eventScheduler.js's "UTC" branch (the default, and what every consumer below
 // uses unless it passes an explicit IANA timezone) reads local Date methods
@@ -403,6 +404,79 @@ describe('schedule() lifecycle with fake timers', () => {
     expect(entry.success).toBe(true);
     expect(entry.error).toBeNull();
     expect(entry.duration).toBeGreaterThanOrEqual(0);
+  });
+
+  it('re-arms a recurring event even when a scheduler:ran listener throws', async () => {
+    // The re-arm used to sit after the emit, outside any try — one throwing
+    // listener permanently stopped the schedule while the UI still showed it active.
+    const handler = vi.fn();
+    const listener = vi.fn(() => { throw new Error('listener boom'); });
+    cosEvents.on('scheduler:ran', listener);
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      schedule({ id: 'listener-throw', type: 'interval', intervalMs: 5000, handler });
+
+      await vi.advanceTimersByTimeAsync(5000);
+      expect(handler).toHaveBeenCalledTimes(1);
+      expect(listener).toHaveBeenCalledTimes(1);
+      expect(getEvent('listener-throw').active).toBe(true);
+      expect(getStats().activeTimers).toBe(1); // re-armed with a fresh handle
+
+      await vi.advanceTimersByTimeAsync(5000);
+      expect(handler).toHaveBeenCalledTimes(2); // schedule survived the throw
+    } finally {
+      cosEvents.off('scheduler:ran', listener);
+      consoleError.mockRestore();
+    }
+  });
+
+  it('stops a cron event whose expression became unparseable, with one error log', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      // The handler receives the live event object — corrupt the cron mid-run the
+      // same way a bad persisted value would surface on the next recompute.
+      schedule({
+        id: 'bad-cron',
+        type: 'cron',
+        cron: '* * * * *',
+        handler: event => { event.cron = '* * *'; },
+      });
+
+      await vi.advanceTimersByTimeAsync(60 * 1000);
+
+      expect(getEvent('bad-cron').active).toBe(false);
+      expect(getStats().activeTimers).toBe(0);
+      expect(consoleError).toHaveBeenCalledWith(
+        expect.stringContaining('Event bad-cron could not compute its next run')
+      );
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  it('stops a recurrence event that yields no next occurrence, with one error log', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      schedule({
+        id: 'no-next',
+        type: 'recurrence',
+        recurrence: { frequency: 'weekly', interval: 1, weekdays: [1], time: '00:05', anchorDate: '2024-01-01' },
+        handler: event => { event.recurrence = { frequency: 'weekly', interval: 0 }; },
+      });
+
+      await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
+
+      expect(getEvent('no-next').active).toBe(false);
+      expect(getStats().activeTimers).toBe(0);
+      expect(consoleError).toHaveBeenCalledWith(
+        expect.stringContaining('Event no-next has no next run time')
+      );
+    } finally {
+      consoleError.mockRestore();
+    }
   });
 
   it('cancelAll() removes every scheduled event and reports the count removed', () => {


### PR DESCRIPTION
## Summary

A CoS schedule could permanently stop itself after a single throw, while the CoS Schedule tab kept listing it as active.

`runEvent` in `server/services/eventScheduler.js` re-armed its recurring timer as the *last* statements of the function, outside the `try` wrapping `event.handler(event)`. Anything that threw between the handler's catch and the re-arm skipped `scheduleNextRun` entirely — a synchronous `scheduler:ran` listener, or `updateNextRunTime`'s cron parser, which throws on a malformed expression. The event was left neither re-scheduled nor cleaned up, and because the run is floated from a timer with no `.catch`, the only trace was an unhandled rejection. Every health-check, improvement-check, pending-merge sweep, and per-job autonomous schedule was exposed; the affected one stayed dead until PortOS restarted. A quieter second door: when the next run time legitimately came back `null`, `scheduleNextRun` returned on its first line with no log at all.

Changes:

- The re-arm now runs from a `finally`, so nothing after the handler can cost a schedule its next run. The `scheduler:ran` emit is isolated in its own `try` so one bad listener cannot take the chain down with it.
- New `rearm()` recomputes the next run defensively. When it cannot be computed — an unparseable cron, a recurrence with no occurrence left in the horizon — the event is marked inactive with one `❌` line naming the reason. That is the deliberate call: a schedule the UI shows as armed while nothing will ever fire is the worse of the two states, and `active = false` makes the Schedule tab tell the truth.
- Timer-launched runs are floated through `runEventFloating`, which catches, so a defect in the scheduler's own bookkeeping is a log line instead of an unhandled rejection.
- History recording is extracted to `recordEventHistory()` (behavior unchanged) so the `finally` block reads as three named steps.

Two adjacent timer-ownership bugs surfaced during local review and are fixed here, since both hinge on the same re-arm path:

- Arming a schedule overwrote the pending timer handle without clearing the timeout, so "Run Now" on a recurring schedule left the original deadline live and fired a duplicate run — and each manual run added another orphaned chain. Arming now clears the handle it replaces, and `cancel`/`pause`/`deactivate` share that one `clearPendingTimer` helper.
- "Run Now" also left the deadline armed *during* the manual run, so a run that outlasted its own interval had the timer start a second copy concurrently. `triggerNow` now disarms before it starts; the normal re-arm puts a fresh timer back afterwards.

No cron/recurrence parsing semantics, catch-up logic, or `cosJobScheduler` behavior changed.

## Test plan

- Four new cases in `server/services/eventScheduler.test.js`, each verified to fail against the pre-fix source and pass after:
  - a recurring `interval` event whose `scheduler:ran` listener throws still re-arms and fires again (pins the missing `finally`);
  - a `cron` event whose expression becomes unparseable mid-run logs the reason, flips `active` to `false`, and drops its `activeTimers` entry;
  - a `recurrence` event that yields no next occurrence does the same via the `nextRunAt === null` door;
  - `triggerNow()` replaces the pending timer rather than leaving a duplicate run armed, and does not let the original deadline fire during a long manual run.
- Existing coverage for the rejecting-handler path (`records a failed handler in history without deactivating a recurring event`) still passes, guarding the behavior this refactor preserves.
- Full server suite green: `cd server && npm test` → 1830 files, 37162 tests passing, 13 skipped.

Closes #5651

https://claude.ai/code/session_01GMUUt1MMMwKQ7xqPGS2dfQ
