### PR TITLE
fix: authorize peer pulls on the /api/sync snapshot transport

### DIFF
--- a/server/routes/dataSync.js
+++ b/server/routes/dataSync.js
@@ -22,9 +22,17 @@
  *    refusing to federate these records was precisely that "the pull path
  *    carries no peer identity": docs/decisions/2026-08-08-privacy-records-machine-local.md.
  *
- * Scope: what a category CONTAINS, and whether a configured, identified peer
- * may sync it, are unchanged — a user federating their own two machines keeps
- * working. Only an unidentified/unknown/outbound-disallowed caller is refused.
+ * Consent is per-category, not just per-peer: the gate resolves the caller's
+ * `syncCategories` map (`peerAllowsCategoryPull`) rather than only asking
+ * whether the peer may receive anything at all. A peer the user enabled for
+ * `universe` must not be able to ask for `digitalTwin` — that is the same
+ * shape of hole #3659 closed for records. Resolving through
+ * `resolveEffectiveCategories` also keeps a default-ON category (`usage`)
+ * flowing for a peer whose other sync the user switched off.
+ *
+ * Scope: what a category CONTAINS is unchanged, and a user federating their own
+ * two machines keeps working as long as the SOURCE machine has that category
+ * ticked for the peer asking — which is exactly what its sharing config means.
  */
 
 import { Router } from 'express';
@@ -50,6 +58,7 @@ const PII_CATEGORIES = new Set(['digitalTwin', 'meatspace', 'character']);
 // The one gate both reads share, so the checksum can never become the weaker
 // door: a checksum is a fingerprint of the same payload.
 const authorizeSyncPull = (req, category) => authorizePeerPull(req, {
+  syncCategory: category,
   route: `sync ${category}`,
   alwaysEnforce: PII_CATEGORIES.has(category),
 });

--- a/server/routes/dataSync.js
+++ b/server/routes/dataSync.js
@@ -3,12 +3,35 @@
  *
  * Endpoints for snapshot-based data sync between PortOS peer instances.
  * Each category returns its full data + checksum for merge-based sync.
+ *
+ * Authorization (#5663). This is the OLDER of the two pull transports; the
+ * per-record `/api/peer-sync/*` routes got receiver-side peer-pull
+ * authorization in #3659 and these did not, so the whole of every category —
+ * including the user's identity record — was served to anything that could
+ * reach the port. Both reads now run the SAME `authorizePeerPull` gate, keyed
+ * on the caller's `X-PortOS-Instance-Id` (which `syncOrchestrator.fetchPeer`
+ * sends via `peerFetch`).
+ *
+ * Two tiers, deliberately:
+ *  - Ordinary categories keep #3659's warn-first ramp — an un-upgraded peer is
+ *    still served and logs one `⚠️`, because the distribution model requires
+ *    peers that upgrade on their own schedule to keep syncing.
+ *  - `PII_CATEGORIES` are refused outright (`alwaysEnforce`) whatever
+ *    `federation.strictPullAuthorization` says. Root `AGENTS.md` forbids PII on
+ *    the federation layer at all, and the privacy ADR's stated reason for
+ *    refusing to federate these records was precisely that "the pull path
+ *    carries no peer identity": docs/decisions/2026-08-08-privacy-records-machine-local.md.
+ *
+ * Scope: what a category CONTAINS, and whether a configured, identified peer
+ * may sync it, are unchanged — a user federating their own two machines keeps
+ * working. Only an unidentified/unknown/outbound-disallowed caller is refused.
  */
 
 import { Router } from 'express';
 import { z } from 'zod';
 import * as dataSync from '../services/dataSync.js';
 import { sweepTombstones, getSweepStatus, TOMBSTONE_GRACE_MS } from '../services/sharing/tombstoneGc.js';
+import { authorizePeerPull } from '../services/sharing/peerPullAuthorization.js';
 import { asyncHandler, ServerError } from '../lib/errorHandler.js';
 
 const router = Router();
@@ -17,6 +40,19 @@ const router = Router();
 // registered in the service but absent here 400s before its snapshot/apply
 // handler can run (the latent bug #730 hit for `storyBuilder`).
 const categoryParam = z.enum(['goals', 'character', 'digitalTwin', 'meatspace', 'universe', 'pipeline', 'mediaCollections', 'videoHistory', 'storyBuilder', 'usage']);
+
+// Categories whose payload is the user's own person rather than their creative
+// work — `digitalTwin` alone carries identity, chronotype, longevity markers,
+// taste profile, autobiography stories and social accounts. These skip the
+// warn-first ramp entirely (see the header note).
+const PII_CATEGORIES = new Set(['digitalTwin', 'meatspace', 'character']);
+
+// The one gate both reads share, so the checksum can never become the weaker
+// door: a checksum is a fingerprint of the same payload.
+const authorizeSyncPull = (req, category) => authorizePeerPull(req, {
+  route: `sync ${category}`,
+  alwaysEnforce: PII_CATEGORIES.has(category),
+});
 
 // Tombstone GC manual trigger. Declared BEFORE `/:category/*` so the literal
 // "tombstones" segment wins Express's first-match lookup (categoryParam's
@@ -63,6 +99,7 @@ const forPeerOf = (req) => {
 // GET /api/sync/:category/checksum — return checksum only (lightweight)
 router.get('/:category/checksum', asyncHandler(async (req, res) => {
   const category = categoryParam.parse(req.params.category);
+  await authorizeSyncPull(req, category);
   const result = await dataSync.getChecksum(category, { forPeerId: forPeerOf(req) });
   if (!result) throw new ServerError('Category not found', { status: 404 });
   res.json(result);
@@ -71,6 +108,7 @@ router.get('/:category/checksum', asyncHandler(async (req, res) => {
 // GET /api/sync/:category/snapshot — return category data + checksum
 router.get('/:category/snapshot', asyncHandler(async (req, res) => {
   const category = categoryParam.parse(req.params.category);
+  await authorizeSyncPull(req, category);
   const snapshot = await dataSync.getSnapshot(category, { forPeerId: forPeerOf(req) });
   if (!snapshot) throw new ServerError('Category not found', { status: 404 });
   res.json(snapshot);

--- a/server/routes/dataSync.test.js
+++ b/server/routes/dataSync.test.js
@@ -18,9 +18,40 @@ vi.mock('../services/dataSync.js', () => ({
   getSupportedCategories: vi.fn(() => []),
 }));
 
+// Stub only the two leaves the REAL peer-pull gate reads — the peer registry
+// and the settings file — so `findPeerById` / `peerAllowsOutbound` and the
+// warn-first ramp all run for real here. Mocking `authorizePeerPull` itself
+// would let the route and the gate drift, which is the whole bug (#5663).
+const peers = [];
+vi.mock('../services/instances.js', () => ({
+  getPeers: async () => peers,
+  UNKNOWN_INSTANCE_ID: 'unknown',
+}));
+let settings = {};
+vi.mock('../services/settings.js', () => ({
+  getSettings: async () => settings,
+}));
+
 import { sweepTombstones, getSweepStatus } from '../services/sharing/tombstoneGc.js';
 import { getChecksum, getSnapshot } from '../services/dataSync.js';
+import { PEER_INSTANCE_ID_HEADER, __resetPullWarnThrottleForTests } from '../services/sharing/peerPullAuthorization.js';
 import dataSyncRoutes from './dataSync.js';
+
+const PEER_ID = 'peer-a-instance-id';
+// Obviously-fake peer record — outbound-allowed, which is all the snapshot
+// gate checks (the transport is per-category, not per-record-kind).
+const allowedPeer = (overrides = {}) => ({
+  instanceId: PEER_ID,
+  name: 'Example Peer',
+  enabled: true,
+  syncEnabled: true,
+  directions: ['outbound', 'inbound'],
+  ...overrides,
+});
+const setPeers = (...next) => {
+  peers.length = 0;
+  peers.push(...next);
+};
 
 const buildApp = () => {
   const app = express();
@@ -92,6 +123,9 @@ describe('POST /api/sync/tombstones/sweep', () => {
 describe('GET /api/sync/:category/checksum — forPeer scoping', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    settings = {};
+    setPeers(allowedPeer());
+    __resetPullWarnThrottleForTests();
     getChecksum.mockResolvedValue({ checksum: 'abc' });
     getSnapshot.mockResolvedValue({ data: {}, checksum: 'abc' });
   });
@@ -123,7 +157,94 @@ describe('GET /api/sync/:category/checksum — forPeer scoping', () => {
     'goals', 'character', 'digitalTwin', 'meatspace',
     'universe', 'pipeline', 'mediaCollections', 'videoHistory', 'storyBuilder', 'usage',
   ])('accepts the %s category (enum parity with getSupportedCategories)', async (category) => {
-    const res = await request(buildApp()).get(`/api/sync/${category}/checksum`);
+    // Identified as a configured peer so the PII categories clear the pull gate
+    // (#5663) and this stays a test of the ENUM, not of authorization.
+    const res = await request(buildApp())
+      .get(`/api/sync/${category}/checksum`)
+      .set(PEER_INSTANCE_ID_HEADER, PEER_ID);
     expect(res.status).not.toBe(400);
+  });
+});
+
+// #5663 — the snapshot transport predates the peer-pull gate #3659 added to
+// `/api/peer-sync/*`, so it served the user's identity record to anything that
+// could reach the port.
+describe('GET /api/sync/:category — peer-pull authorization', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    settings = {};
+    setPeers(allowedPeer());
+    __resetPullWarnThrottleForTests();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    getChecksum.mockResolvedValue({ checksum: 'abc' });
+    getSnapshot.mockResolvedValue({ data: { identity: 'redacted' }, checksum: 'abc' });
+  });
+
+  it('403s the digitalTwin snapshot for a caller with no X-PortOS-Instance-Id', async () => {
+    const res = await request(buildApp()).get('/api/sync/digitalTwin/snapshot');
+    expect(res.status).toBe(403);
+    expect(getSnapshot).not.toHaveBeenCalled();
+  });
+
+  it('403s the digitalTwin snapshot for an id that matches no configured peer', async () => {
+    const res = await request(buildApp())
+      .get('/api/sync/digitalTwin/snapshot')
+      .set(PEER_INSTANCE_ID_HEADER, 'some-other-instance');
+    expect(res.status).toBe(403);
+    expect(getSnapshot).not.toHaveBeenCalled();
+  });
+
+  it('403s the digitalTwin snapshot for a peer the user disabled sync for', async () => {
+    setPeers(allowedPeer({ syncEnabled: false }));
+    const res = await request(buildApp())
+      .get('/api/sync/digitalTwin/snapshot')
+      .set(PEER_INSTANCE_ID_HEADER, PEER_ID);
+    expect(res.status).toBe(403);
+    expect(getSnapshot).not.toHaveBeenCalled();
+  });
+
+  it.each(['digitalTwin', 'meatspace', 'character'])(
+    '403s the %s checksum too — a checksum must not be the weaker door',
+    async (category) => {
+      const res = await request(buildApp()).get(`/api/sync/${category}/checksum`);
+      expect(res.status).toBe(403);
+      expect(getChecksum).not.toHaveBeenCalled();
+    },
+  );
+
+  it('refuses a PII category even with strictPullAuthorization explicitly off', async () => {
+    settings = { federation: { strictPullAuthorization: false } };
+    const res = await request(buildApp()).get('/api/sync/meatspace/snapshot');
+    expect(res.status).toBe(403);
+  });
+
+  it('serves the digitalTwin snapshot to a configured, outbound-allowed peer', async () => {
+    const res = await request(buildApp())
+      .get('/api/sync/digitalTwin/snapshot')
+      .set(PEER_INSTANCE_ID_HEADER, PEER_ID);
+    expect(res.status).toBe(200);
+    expect(getSnapshot).toHaveBeenCalledWith('digitalTwin', { forPeerId: undefined });
+  });
+
+  it('still serves a non-PII snapshot to an unidentified caller, warning once', async () => {
+    const app = buildApp();
+    expect((await request(app).get('/api/sync/universe/snapshot')).status).toBe(200);
+    expect((await request(app).get('/api/sync/universe/snapshot')).status).toBe(200);
+    expect(getSnapshot).toHaveBeenCalledTimes(2);
+    expect(console.warn).toHaveBeenCalledTimes(1);
+  });
+
+  it('403s a non-PII snapshot once the user opts into strict enforcement', async () => {
+    settings = { federation: { strictPullAuthorization: true } };
+    const res = await request(buildApp()).get('/api/sync/universe/snapshot');
+    expect(res.status).toBe(403);
+  });
+
+  it('leaves the write direction alone — apply is gated by its schema-version check, not this', async () => {
+    const { applyRemote } = await import('../services/dataSync.js');
+    applyRemote.mockResolvedValue({ applied: true, count: 1 });
+    const res = await request(buildApp()).post('/api/sync/digitalTwin/apply').send({ data: { a: 1 } });
+    expect(res.status).toBe(200);
+    expect(applyRemote).toHaveBeenCalled();
   });
 });

--- a/server/routes/dataSync.test.js
+++ b/server/routes/dataSync.test.js
@@ -23,9 +23,12 @@ vi.mock('../services/dataSync.js', () => ({
 // warn-first ramp all run for real here. Mocking `authorizePeerPull` itself
 // would let the route and the gate drift, which is the whole bug (#5663).
 const peers = [];
-vi.mock('../services/instances.js', () => ({
+vi.mock('../services/instances.js', async () => ({
+  // Keep the REAL resolveEffectiveCategories + shipped category defaults: a
+  // hand-written stand-in would let the gate's idea of "enabled for this peer"
+  // drift from the sync loop's and the settings UI's.
+  ...(await vi.importActual('../services/instances.js')),
   getPeers: async () => peers,
-  UNKNOWN_INSTANCE_ID: 'unknown',
 }));
 let settings = {};
 vi.mock('../services/settings.js', () => ({
@@ -38,13 +41,16 @@ import { PEER_INSTANCE_ID_HEADER, __resetPullWarnThrottleForTests } from '../ser
 import dataSyncRoutes from './dataSync.js';
 
 const PEER_ID = 'peer-a-instance-id';
-// Obviously-fake peer record — outbound-allowed, which is all the snapshot
-// gate checks (the transport is per-category, not per-record-kind).
+// Obviously-fake peer record. `fullSync` stands in for "the user ticked every
+// category for this peer" — the snapshot gate's unit of consent is the sync
+// CATEGORY, so a fixture without one would be denied on category grounds and
+// the identity assertions below would pass for the wrong reason.
 const allowedPeer = (overrides = {}) => ({
   instanceId: PEER_ID,
   name: 'Example Peer',
   enabled: true,
   syncEnabled: true,
+  fullSync: true,
   directions: ['outbound', 'inbound'],
   ...overrides,
 });
@@ -195,12 +201,43 @@ describe('GET /api/sync/:category — peer-pull authorization', () => {
   });
 
   it('403s the digitalTwin snapshot for a peer the user disabled sync for', async () => {
-    setPeers(allowedPeer({ syncEnabled: false }));
+    setPeers(allowedPeer({ fullSync: false, syncEnabled: false, syncCategories: { digitalTwin: true } }));
     const res = await request(buildApp())
       .get('/api/sync/digitalTwin/snapshot')
       .set(PEER_INSTANCE_ID_HEADER, PEER_ID);
     expect(res.status).toBe(403);
     expect(getSnapshot).not.toHaveBeenCalled();
+  });
+
+  it('403s the digitalTwin snapshot for a peer the user only enabled for universe', async () => {
+    // Per-category consent, not just per-peer: this is the record-side hole
+    // #3659 closed, applied to the snapshot transport's unit of sharing.
+    setPeers(allowedPeer({ fullSync: false, syncCategories: { universe: true } }));
+    const res = await request(buildApp())
+      .get('/api/sync/digitalTwin/snapshot')
+      .set(PEER_INSTANCE_ID_HEADER, PEER_ID);
+    expect(res.status).toBe(403);
+    expect(getSnapshot).not.toHaveBeenCalled();
+  });
+
+  it('403s a peer that only ANNOUNCED itself (inbound-only, never approved here)', async () => {
+    setPeers(allowedPeer({ directions: ['inbound'] }));
+    const res = await request(buildApp())
+      .get('/api/sync/digitalTwin/snapshot')
+      .set(PEER_INSTANCE_ID_HEADER, PEER_ID);
+    expect(res.status).toBe(403);
+  });
+
+  it('keeps serving the default-ON usage category to a peer whose other sync is off', async () => {
+    // `usage` survives the master switch by design; folding the switch into the
+    // resolved category map (rather than checking it separately) is what keeps
+    // that true here. Non-PII, so this is the warn-first tier.
+    settings = { federation: { strictPullAuthorization: true } };
+    setPeers(allowedPeer({ fullSync: false, syncEnabled: false }));
+    const res = await request(buildApp())
+      .get('/api/sync/usage/snapshot')
+      .set(PEER_INSTANCE_ID_HEADER, PEER_ID);
+    expect(res.status).toBe(200);
   });
 
   it.each(['digitalTwin', 'meatspace', 'character'])(

--- a/server/services/sharing/peerPullAuthorization.js
+++ b/server/services/sharing/peerPullAuthorization.js
@@ -1,5 +1,9 @@
 /**
- * Receiver-side authorization for peer-sync PULL requests (#3659).
+ * Receiver-side authorization for peer PULL requests (#3659, #5663).
+ *
+ * Covers BOTH pull transports: the per-record `/api/peer-sync/*` routes
+ * (`server/routes/peerSync.js`) and the older snapshot transport
+ * `/api/sync/:category/*` (`server/routes/dataSync.js`).
  *
  * The push direction has always been gated on the user's per-peer sharing
  * config (`peerAllowsOutbound` + `peerHasCategory`, see peerSyncPush.js). The
@@ -24,6 +28,12 @@
  * single throttled `⚠️` per caller per boot. Only when the user opts in via
  * `settings.federation.strictPullAuthorization === true` does a denied pull
  * get a 403. The default flips in a later release once peers have upgraded.
+ *
+ * `alwaysEnforce` opts a route OUT of that ramp: a denial is a 403 whatever the
+ * setting says. It exists for the PII snapshot categories, which root
+ * `AGENTS.md` forbids on the federation layer at all — the ramp protects
+ * creative-work sync from breaking mid-upgrade, and no compatibility argument
+ * covers shipping an identity record to a host we cannot name.
  */
 import { ServerError } from '../../lib/errorHandler.js';
 import { findPeerById, peerAllowsOutbound, peerHasCategory } from './peerSyncShared.js';
@@ -96,37 +106,58 @@ async function strictPullAuthorizationEnabled() {
   return settings?.federation?.strictPullAuthorization === true;
 }
 
-function warnOnce(decision, route) {
-  const key = decision.callerId || PULL_DENY_UNIDENTIFIED;
+// Throttle key space is shared by the "served anyway" and "refused" lines, so
+// a caller that trips both still gets one of each (distinct prefixes).
+function logOnce(key, message) {
   if (warnedCallers.has(key)) return;
   if (warnedCallers.size >= WARNED_CALLERS_MAX) warnedCallers.clear();
   warnedCallers.add(key);
-  const who = decision.peer?.name
-    ? `peer "${decision.peer.name}"`
-    : (decision.callerId ? `instance ${decision.callerId.slice(0, 8)}…` : 'an unidentified caller');
-  console.warn(`⚠️ Serving peer-sync ${route} to ${who} that sharing config would deny (${decision.reason}) — enable federation.strictPullAuthorization to enforce`);
+  console.warn(message);
 }
 
+function describeCaller(decision) {
+  if (decision.peer?.name) return `peer "${decision.peer.name}"`;
+  return decision.callerId ? `instance ${decision.callerId.slice(0, 8)}…` : 'an unidentified caller';
+}
+
+function warnOnce(decision, route) {
+  const key = decision.callerId || PULL_DENY_UNIDENTIFIED;
+  logOnce(`serve:${key}`, `⚠️ Serving peer-sync ${route} to ${describeCaller(decision)} that sharing config would deny (${decision.reason}) — enable federation.strictPullAuthorization to enforce`);
+}
+
+function refuseOnce(decision, route) {
+  const key = decision.callerId || PULL_DENY_UNIDENTIFIED;
+  logOnce(`deny:${key}`, `🔒 Refused peer-sync ${route} for ${describeCaller(decision)} (${decision.reason}) — this data only federates to a configured, outbound-allowed peer`);
+}
+
+const pullForbidden = (decision) => new ServerError('peer not authorized for this record', {
+  status: 403,
+  code: 'PEER_PULL_FORBIDDEN',
+  context: { reason: decision.reason },
+});
+
 /**
- * Gate a pull route. Throws a 403 ServerError only when the request is denied
- * AND `federation.strictPullAuthorization` is on; otherwise serves the request
- * and warns at most once per caller per boot.
+ * Gate a pull route. Throws a 403 ServerError when the request is denied AND
+ * either `alwaysEnforce` is set for this route or
+ * `federation.strictPullAuthorization` is on; otherwise serves the request and
+ * warns at most once per caller per boot.
  *
  * Returns the decision so a caller can branch further if it ever needs to.
  */
-export async function authorizePeerPull(req, { recordKind = null, route } = {}) {
+export async function authorizePeerPull(req, { recordKind = null, route, alwaysEnforce = false } = {}) {
   const decision = await decidePeerPull({ callerId: readCallerInstanceId(req), recordKind });
   if (decision.allowed) return decision;
-  if (await strictPullAuthorizationEnabled()) {
-    throw new ServerError('peer not authorized for this record', {
-      status: 403,
-      code: 'PEER_PULL_FORBIDDEN',
-      context: { reason: decision.reason },
-    });
+  const label = route || 'pull';
+  // `alwaysEnforce` short-circuits the settings read: the answer cannot change.
+  if (alwaysEnforce) {
+    refuseOnce(decision, label);
+    throw pullForbidden(decision);
   }
-  warnOnce(decision, route || 'pull');
+  if (await strictPullAuthorizationEnabled()) throw pullForbidden(decision);
+  warnOnce(decision, label);
   return decision;
 }
+
 
 /** Test-support: clear the per-boot warn throttle. */
 export function __resetPullWarnThrottleForTests() {

--- a/server/services/sharing/peerPullAuthorization.js
+++ b/server/services/sharing/peerPullAuthorization.js
@@ -36,7 +36,7 @@
  * covers shipping an identity record to a host we cannot name.
  */
 import { ServerError } from '../../lib/errorHandler.js';
-import { findPeerById, peerAllowsOutbound, peerHasCategory } from './peerSyncShared.js';
+import { findPeerById, peerAllowsOutbound, peerAllowsCategoryPull, peerHasCategory } from './peerSyncShared.js';
 import { getSettings } from '../settings.js';
 import { UNKNOWN_INSTANCE_ID } from '../instances.js';
 
@@ -84,16 +84,28 @@ export function readCallerInstanceId(req) {
  * setting or logging — the pure-ish decision half, so tests can assert it
  * agrees with the push path for a given peer/kind pair.
  *
- * `recordKind` is optional: the manifest routes (`/library-manifest`,
- * `/cos-history-manifest`, `/cos-tasks`) aren't scoped to one record kind, so
- * they gate on `peerAllowsOutbound` alone.
+ * Scope, at most one of:
+ *  - `recordKind` — a per-record `/api/peer-sync/*` read. Gated on
+ *    `peerAllowsOutbound` + `peerHasCategory`, the predicates the push path uses.
+ *  - `syncCategory` — a whole-category `/api/sync/*` snapshot read. Gated on
+ *    `peerAllowsCategoryPull`, which folds the master switch into the resolved
+ *    category map instead of checking it separately, so a default-ON category
+ *    still flows for a peer whose other sync the user turned off.
+ *  - neither — the manifest routes (`/library-manifest`, `/cos-history-manifest`,
+ *    `/cos-tasks`) aren't scoped to one kind, so they gate on
+ *    `peerAllowsOutbound` alone.
  *
  * Returns `{ allowed, reason, peer, callerId }`.
  */
-export async function decidePeerPull({ callerId, recordKind = null }) {
+export async function decidePeerPull({ callerId, recordKind = null, syncCategory = null }) {
   if (!callerId) return { allowed: false, reason: PULL_DENY_UNIDENTIFIED, peer: null, callerId: null };
   const peer = await findPeerById(callerId);
   if (!peer) return { allowed: false, reason: PULL_DENY_UNKNOWN_PEER, peer: null, callerId };
+  if (syncCategory) {
+    return peerAllowsCategoryPull(peer, syncCategory)
+      ? { allowed: true, reason: null, peer, callerId }
+      : { allowed: false, reason: PULL_DENY_CATEGORY, peer, callerId };
+  }
   if (!peerAllowsOutbound(peer)) return { allowed: false, reason: PULL_DENY_OUTBOUND, peer, callerId };
   if (recordKind && !peerHasCategory(peer, recordKind)) {
     return { allowed: false, reason: PULL_DENY_CATEGORY, peer, callerId };
@@ -144,8 +156,8 @@ const pullForbidden = (decision) => new ServerError('peer not authorized for thi
  *
  * Returns the decision so a caller can branch further if it ever needs to.
  */
-export async function authorizePeerPull(req, { recordKind = null, route, alwaysEnforce = false } = {}) {
-  const decision = await decidePeerPull({ callerId: readCallerInstanceId(req), recordKind });
+export async function authorizePeerPull(req, { recordKind = null, syncCategory = null, route, alwaysEnforce = false } = {}) {
+  const decision = await decidePeerPull({ callerId: readCallerInstanceId(req), recordKind, syncCategory });
   if (decision.allowed) return decision;
   const label = route || 'pull';
   // `alwaysEnforce` short-circuits the settings read: the answer cannot change.

--- a/server/services/sharing/peerPullAuthorization.js
+++ b/server/services/sharing/peerPullAuthorization.js
@@ -36,7 +36,7 @@
  * covers shipping an identity record to a host we cannot name.
  */
 import { ServerError } from '../../lib/errorHandler.js';
-import { findPeerById, peerAllowsOutbound, peerAllowsCategoryPull, peerHasCategory } from './peerSyncShared.js';
+import { findPeerById, peerAllowsOutbound, peerOutboundEligible, peerAllowsCategoryPull, peerHasCategory } from './peerSyncShared.js';
 import { getSettings } from '../settings.js';
 import { UNKNOWN_INSTANCE_ID } from '../instances.js';
 
@@ -102,9 +102,14 @@ export async function decidePeerPull({ callerId, recordKind = null, syncCategory
   const peer = await findPeerById(callerId);
   if (!peer) return { allowed: false, reason: PULL_DENY_UNKNOWN_PEER, peer: null, callerId };
   if (syncCategory) {
-    return peerAllowsCategoryPull(peer, syncCategory)
-      ? { allowed: true, reason: null, peer, callerId }
-      : { allowed: false, reason: PULL_DENY_CATEGORY, peer, callerId };
+    // Split the two denials so the reason a caller/log sees means the same
+    // thing it does on the record routes: "we don't share with you at all" vs
+    // "we don't share THIS with you".
+    if (!peerOutboundEligible(peer)) return { allowed: false, reason: PULL_DENY_OUTBOUND, peer, callerId };
+    if (!peerAllowsCategoryPull(peer, syncCategory)) {
+      return { allowed: false, reason: PULL_DENY_CATEGORY, peer, callerId };
+    }
+    return { allowed: true, reason: null, peer, callerId };
   }
   if (!peerAllowsOutbound(peer)) return { allowed: false, reason: PULL_DENY_OUTBOUND, peer, callerId };
   if (recordKind && !peerHasCategory(peer, recordKind)) {

--- a/server/services/sharing/peerPullAuthorization.test.js
+++ b/server/services/sharing/peerPullAuthorization.test.js
@@ -217,7 +217,26 @@ describe('peerPullAuthorization', () => {
 
     it('denies a peer that only announced itself (inbound-only, never approved here)', async () => {
       setPeers(universePeer({ directions: ['inbound'] }));
-      expect((await decidePeerPull({ callerId: PEER_A, syncCategory: 'universe' })).allowed).toBe(false);
+      // Reason parity with the record routes: "we don't share with you at all"
+      // must not read as "we don't share THIS with you".
+      expect(await decidePeerPull({ callerId: PEER_A, syncCategory: 'universe' }))
+        .toMatchObject({ allowed: false, reason: PULL_DENY_OUTBOUND });
+    });
+
+    it('denies a disabled peer as outbound-disallowed, not category-disabled', async () => {
+      setPeers(universePeer({ enabled: false }));
+      expect(await decidePeerPull({ callerId: PEER_A, syncCategory: 'universe' }))
+        .toMatchObject({ allowed: false, reason: PULL_DENY_OUTBOUND });
+    });
+
+    it('lets the master switch beat a stale fullSync flag', async () => {
+      // `{ fullSync: true, syncEnabled: false }` is reachable (set full mirror,
+      // then flip the switch off) and contradictory — every push is already
+      // refused for it, so a pull must not hand it the whole install.
+      setPeers(universePeer({ fullSync: true, syncEnabled: false }));
+      expect((await decidePeerPull({ callerId: PEER_A, syncCategory: 'digitalTwin' })).allowed).toBe(false);
+      // The default-ON category still survives the switch, as everywhere else.
+      expect((await decidePeerPull({ callerId: PEER_A, syncCategory: 'usage' })).allowed).toBe(true);
     });
   });
 

--- a/server/services/sharing/peerPullAuthorization.test.js
+++ b/server/services/sharing/peerPullAuthorization.test.js
@@ -6,9 +6,12 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 // `peerAllowsOutbound` / `peerHasCategory` run — which is the point: the test
 // asserts pull agrees with push because both use those same predicates.
 const peers = [];
-vi.mock('../instances.js', () => ({
+vi.mock('../instances.js', async () => ({
+  // Real `resolveEffectiveCategories` + shipped defaults, for the same reason:
+  // the category-scoped pull decision must agree with what the sync loop and
+  // the settings UI resolve for that peer.
+  ...(await vi.importActual('../instances.js')),
   getPeers: async () => peers,
-  UNKNOWN_INSTANCE_ID: 'unknown',
 }));
 
 let settings = {};
@@ -181,6 +184,40 @@ describe('peerPullAuthorization', () => {
     it('treats an unreadable settings file as strict-off (warn, do not break sync)', async () => {
       settings = null;
       await expect(authorizePeerPull(req(null), { recordKind: 'universe' })).resolves.toBeDefined();
+    });
+  });
+
+  // #5663 — the snapshot transport's unit of consent is a whole sync CATEGORY,
+  // not a record kind, so it resolves the peer's category map directly.
+  describe('syncCategory scope', () => {
+    it('allows a category the user ticked for this peer', async () => {
+      setPeers(universePeer());
+      const decision = await decidePeerPull({ callerId: PEER_A, syncCategory: 'universe' });
+      expect(decision.allowed).toBe(true);
+    });
+
+    it('denies a category the user did NOT tick, even for an outbound-allowed peer', async () => {
+      setPeers(universePeer());
+      const decision = await decidePeerPull({ callerId: PEER_A, syncCategory: 'digitalTwin' });
+      expect(decision).toMatchObject({ allowed: false, reason: PULL_DENY_CATEGORY });
+    });
+
+    it('allows anything for a full-sync ("mirror everything") peer', async () => {
+      setPeers(universePeer({ fullSync: true, syncCategories: {} }));
+      expect((await decidePeerPull({ callerId: PEER_A, syncCategory: 'digitalTwin' })).allowed).toBe(true);
+    });
+
+    it('keeps a default-ON category flowing when the master sync switch is off', async () => {
+      // `usage` is retained by resolveEffectiveCategories' master-switch mask;
+      // gating on peerAllowsOutbound instead would refuse it outright.
+      setPeers(universePeer({ syncEnabled: false }));
+      expect((await decidePeerPull({ callerId: PEER_A, syncCategory: 'usage' })).allowed).toBe(true);
+      expect((await decidePeerPull({ callerId: PEER_A, syncCategory: 'universe' })).allowed).toBe(false);
+    });
+
+    it('denies a peer that only announced itself (inbound-only, never approved here)', async () => {
+      setPeers(universePeer({ directions: ['inbound'] }));
+      expect((await decidePeerPull({ callerId: PEER_A, syncCategory: 'universe' })).allowed).toBe(false);
     });
   });
 

--- a/server/services/sharing/peerPullAuthorization.test.js
+++ b/server/services/sharing/peerPullAuthorization.test.js
@@ -183,4 +183,38 @@ describe('peerPullAuthorization', () => {
       await expect(authorizePeerPull(req(null), { recordKind: 'universe' })).resolves.toBeDefined();
     });
   });
+
+  // #5663 — the PII snapshot categories opt out of the warn-first ramp: root
+  // AGENTS.md forbids those records on the federation layer at all, so an
+  // unidentified caller must never be served one regardless of the setting.
+  describe('alwaysEnforce', () => {
+    it('403s a denied pull with strictPullAuthorization off', async () => {
+      settings = { federation: { strictPullAuthorization: false } };
+      await expect(authorizePeerPull(req(null), { route: 'sync digitalTwin', alwaysEnforce: true }))
+        .rejects.toMatchObject({ status: 403, code: 'PEER_PULL_FORBIDDEN' });
+    });
+
+    it('still allows a configured, outbound-allowed peer', async () => {
+      setPeers(universePeer());
+      const decision = await authorizePeerPull(req(PEER_A), { route: 'sync digitalTwin', alwaysEnforce: true });
+      expect(decision.allowed).toBe(true);
+      expect(console.warn).not.toHaveBeenCalled();
+    });
+
+    it('logs the refusal once per caller per boot', async () => {
+      const opts = { route: 'sync digitalTwin', alwaysEnforce: true };
+      await expect(authorizePeerPull(req(null), opts)).rejects.toThrow();
+      await expect(authorizePeerPull(req(null), opts)).rejects.toThrow();
+      expect(console.warn).toHaveBeenCalledTimes(1);
+      expect(console.warn.mock.calls[0][0]).toContain('🔒');
+    });
+
+    it('does not consume the served-anyway throttle slot for the same caller', async () => {
+      // Distinct throttle keys: a caller refused a PII pull must still produce
+      // the one compatibility ⚠️ when it pulls a creative-work category.
+      await expect(authorizePeerPull(req(null), { route: 'sync digitalTwin', alwaysEnforce: true })).rejects.toThrow();
+      await authorizePeerPull(req(null), { route: 'sync universe' });
+      expect(console.warn).toHaveBeenCalledTimes(2);
+    });
+  });
 });

--- a/server/services/sharing/peerSyncShared.js
+++ b/server/services/sharing/peerSyncShared.js
@@ -13,7 +13,7 @@
 import { join } from 'path';
 import { EventEmitter } from 'events';
 import { PATHS, atomicWrite, readJSONFile, ensureDir } from '../../lib/fileUtils.js';
-import { getPeers } from '../instances.js';
+import { getPeers, resolveEffectiveCategories } from '../instances.js';
 
 
 export const PEER_SUBSCRIBABLE_KINDS = Object.freeze(['universe', 'series', 'mediaCollection', 'author', 'artist', 'album', 'track', 'creativeDirectorProject', 'moodBoard', 'fableLoom', 'writersRoomWork', 'writersRoomFolder', 'writersRoomExercise', 'musicVideoProject', 'commissionFeedback', 'creativeCommission']);
@@ -106,8 +106,19 @@ export const KIND_TO_CATEGORY = Object.freeze({
   creativeCommission: 'creativeCommissions',
 });
 
-export function peerAllowsOutbound(peer) {
+// The half every outbound predicate shares: the peer exists, the user has not
+// disabled it, and the relationship was established FROM here. An absent/empty
+// `directions` is a legacy record (permissive); `['inbound']` is a peer that
+// merely announced itself to us and was auto-created with no approval step, so
+// nothing may flow back out to it.
+function peerOutboundEligible(peer) {
   if (!peer || peer.enabled === false) return false;
+  const directions = Array.isArray(peer.directions) ? peer.directions : [];
+  return directions.length === 0 || directions.includes('outbound');
+}
+
+export function peerAllowsOutbound(peer) {
+  if (!peerOutboundEligible(peer)) return false;
   // `syncEnabled` is the global "sync this peer at all" toggle (separate from
   // per-category `syncCategories.*`). When the user has globally disabled sync
   // for a peer, auto-subscribe MUST NOT create subscriptions or fire pushes —
@@ -115,9 +126,24 @@ export function peerAllowsOutbound(peer) {
   // per-category check (peerHasCategory) is necessary but not sufficient on
   // its own, because syncCategories can be set independently.
   if (peer.syncEnabled === false) return false;
-  const directions = Array.isArray(peer.directions) ? peer.directions : [];
-  if (directions.length > 0 && !directions.includes('outbound')) return false;
   return true;
+}
+
+/**
+ * Category-level counterpart of `peerHasCategory`, for the snapshot transport
+ * (`server/routes/dataSync.js`) whose unit of consent is a whole sync CATEGORY
+ * rather than one record kind.
+ *
+ * Resolves through `resolveEffectiveCategories` — the single definition of
+ * "what syncs with this peer" — so the pull gate agrees with the sync loop and
+ * the settings UI on fullSync, on the shipped defaults, and on the master
+ * `syncEnabled` switch masking down to the default-ON categories (which is
+ * what keeps `usage` flowing for a peer the user otherwise silenced, instead of
+ * `peerAllowsOutbound` refusing it outright).
+ */
+export function peerAllowsCategoryPull(peer, category) {
+  if (!peerOutboundEligible(peer)) return false;
+  return resolveEffectiveCategories(peer)[category] === true;
 }
 
 export function peerHasCategory(peer, recordKind) {

--- a/server/services/sharing/peerSyncShared.js
+++ b/server/services/sharing/peerSyncShared.js
@@ -111,7 +111,7 @@ export const KIND_TO_CATEGORY = Object.freeze({
 // `directions` is a legacy record (permissive); `['inbound']` is a peer that
 // merely announced itself to us and was auto-created with no approval step, so
 // nothing may flow back out to it.
-function peerOutboundEligible(peer) {
+export function peerOutboundEligible(peer) {
   if (!peer || peer.enabled === false) return false;
   const directions = Array.isArray(peer.directions) ? peer.directions : [];
   return directions.length === 0 || directions.includes('outbound');
@@ -143,7 +143,15 @@ export function peerAllowsOutbound(peer) {
  */
 export function peerAllowsCategoryPull(peer, category) {
   if (!peerOutboundEligible(peer)) return false;
-  return resolveEffectiveCategories(peer)[category] === true;
+  // `resolveEffectiveCategories` short-circuits `fullSync` BEFORE applying the
+  // master-switch mask. That is the right reading for a loop deciding what to
+  // ASK a peer for, and the wrong one for a gate deciding what to HAND OUT: the
+  // reachable-but-contradictory `{ fullSync: true, syncEnabled: false }` state
+  // (set full mirror, then flip the switch off) would otherwise be handed every
+  // category here while `peerAllowsOutbound` refuses it every push. Resolve
+  // with fullSync dropped so the mask wins and only default-ON survives.
+  const masked = peer.syncEnabled === false ? { ...peer, fullSync: false } : peer;
+  return resolveEffectiveCategories(masked)[category] === true;
 }
 
 export function peerHasCategory(peer, recordKind) {

--- a/server/services/syncOrchestrator.js
+++ b/server/services/syncOrchestrator.js
@@ -13,7 +13,7 @@ import { createMutex } from '../lib/asyncMutex.js';
 import { instanceEvents } from './instanceEvents.js';
 import { getPeers, resolveEffectiveCategories, updatePeer, getInstanceId, UNKNOWN_INSTANCE_ID } from './instances.js';
 import { peerBaseUrl } from '../lib/peerUrl.js';
-import { peerAuthHeaders } from '../lib/peerHttpClient.js';
+import { peerFetch } from '../lib/peerHttpClient.js';
 import * as brainSync from './brainSync.js';
 import { BRAIN_ENTITY_TYPES } from './brainStorage.js';
 import * as brainSyncLog from './brainSyncLog.js';
@@ -22,7 +22,7 @@ import * as memorySync from './memorySync.js';
 import * as catalogSync from './catalogSync.js';
 import * as dataSync from './dataSync.js';
 import { getBackendName } from './memoryBackend.js';
-import { fetchWithTimeout } from '../lib/fetchWithTimeout.js';
+import { withAbortTimeout } from '../lib/abortTimeout.js';
 
 const CURSORS_FILE = dataPath('instances_sync_cursors.json');
 const SYNC_INTERVAL_MS = 60000;
@@ -76,15 +76,20 @@ async function withCursors(fn) {
 
 // --- Peer fetch helper ---
 
+// Every outbound hop goes through `peerFetch` so it carries
+// `X-PortOS-Instance-Id` (and the peer's stored Basic credential). The receiver
+// keys its per-peer sharing config on that header — without it the snapshot
+// transport reads as an unidentified caller and the PII categories now refuse
+// it outright (#5663). `peerFetch` also carries the peer HTTPS agent, so a
+// self-signed tailnet peer no longer fails TLS validation on these pulls.
+// Contract is unchanged: null on transport failure, non-2xx, or bad JSON.
 async function fetchPeer(peer, path) {
   const url = `${peerBaseUrl(peer)}${path}`;
-  try {
-    const res = await fetchWithTimeout(url, { headers: peerAuthHeaders(peer) }, FETCH_TIMEOUT_MS);
+  return withAbortTimeout(FETCH_TIMEOUT_MS, async (signal) => {
+    const res = await peerFetch(url, { signal }, peer);
     if (!res.ok) return null;
     return await res.json();
-  } catch {
-    return null;
-  }
+  }).catch(() => null);
 }
 
 /**
@@ -103,16 +108,16 @@ async function syncImageFromPeer(peer, avatarPath) {
   if (exists) return;
 
   const url = `${peerBaseUrl(peer)}${avatarPath}`;
-  try {
-    const res = await fetchWithTimeout(url, { headers: peerAuthHeaders(peer) }, FETCH_TIMEOUT_MS);
+  // Same `peerFetch` hop as fetchPeer — identifies us and survives a
+  // self-signed peer cert. Non-critical: a failure just retries next cycle.
+  await withAbortTimeout(FETCH_TIMEOUT_MS, async (signal) => {
+    const res = await peerFetch(url, { signal }, peer);
     if (!res.ok) return;
     const buffer = Buffer.from(await res.arrayBuffer());
     await ensureDir(PATHS.images);
     await writeFile(localPath, buffer);
     console.log(`🔄 Synced avatar image: ${filename}`);
-  } catch {
-    // Non-critical — avatar will sync on next cycle
-  }
+  }).catch(() => {});
 }
 
 // --- Status ---

--- a/server/services/syncOrchestrator.js
+++ b/server/services/syncOrchestrator.js
@@ -83,10 +83,11 @@ async function withCursors(fn) {
 // it outright (#5663). `peerFetch` also carries the peer HTTPS agent, so a
 // self-signed tailnet peer no longer fails TLS validation on these pulls.
 //
-// The timeout bounds the REQUEST only, not the body read — `withAbortTimeout`
-// clears its timer as soon as the callback settles, which reproduces what
-// `fetchWithTimeout` did here. Bounding the body too would abort a large
-// snapshot mid-download on a slow link, every cycle, forever.
+// The timeout bounds the peerFetch call and nothing after it, so the JSON
+// decode of an already-received body can't be aborted — the same shape
+// `fetchWithTimeout` had here. (Over HTTPS the budget does still cover the
+// download itself, because the insecure-agent shim buffers the whole body
+// before it resolves; that is a property of that transport, not of this call.)
 // Contract is unchanged: null on transport failure, non-2xx, or bad JSON.
 async function fetchPeer(peer, path) {
   const url = `${peerBaseUrl(peer)}${path}`;
@@ -112,9 +113,8 @@ async function syncImageFromPeer(peer, avatarPath) {
   if (exists) return;
 
   const url = `${peerBaseUrl(peer)}${avatarPath}`;
-  // Same `peerFetch` hop as fetchPeer, and the same request-only timeout — an
-  // avatar download must not be aborted mid-body. Non-critical either way: a
-  // failure just retries next cycle.
+  // Same `peerFetch` hop and the same timeout scope as fetchPeer. Non-critical
+  // either way: a failure just retries next cycle.
   const res = await withAbortTimeout(FETCH_TIMEOUT_MS, (signal) => peerFetch(url, { signal }, peer))
     .catch(() => null);
   if (!res?.ok) return;

--- a/server/services/syncOrchestrator.js
+++ b/server/services/syncOrchestrator.js
@@ -82,14 +82,18 @@ async function withCursors(fn) {
 // transport reads as an unidentified caller and the PII categories now refuse
 // it outright (#5663). `peerFetch` also carries the peer HTTPS agent, so a
 // self-signed tailnet peer no longer fails TLS validation on these pulls.
+//
+// The timeout bounds the REQUEST only, not the body read — `withAbortTimeout`
+// clears its timer as soon as the callback settles, which reproduces what
+// `fetchWithTimeout` did here. Bounding the body too would abort a large
+// snapshot mid-download on a slow link, every cycle, forever.
 // Contract is unchanged: null on transport failure, non-2xx, or bad JSON.
 async function fetchPeer(peer, path) {
   const url = `${peerBaseUrl(peer)}${path}`;
-  return withAbortTimeout(FETCH_TIMEOUT_MS, async (signal) => {
-    const res = await peerFetch(url, { signal }, peer);
-    if (!res.ok) return null;
-    return await res.json();
-  }).catch(() => null);
+  const res = await withAbortTimeout(FETCH_TIMEOUT_MS, (signal) => peerFetch(url, { signal }, peer))
+    .catch(() => null);
+  if (!res?.ok) return null;
+  return res.json().catch(() => null);
 }
 
 /**
@@ -108,16 +112,19 @@ async function syncImageFromPeer(peer, avatarPath) {
   if (exists) return;
 
   const url = `${peerBaseUrl(peer)}${avatarPath}`;
-  // Same `peerFetch` hop as fetchPeer — identifies us and survives a
-  // self-signed peer cert. Non-critical: a failure just retries next cycle.
-  await withAbortTimeout(FETCH_TIMEOUT_MS, async (signal) => {
-    const res = await peerFetch(url, { signal }, peer);
-    if (!res.ok) return;
-    const buffer = Buffer.from(await res.arrayBuffer());
-    await ensureDir(PATHS.images);
-    await writeFile(localPath, buffer);
-    console.log(`🔄 Synced avatar image: ${filename}`);
-  }).catch(() => {});
+  // Same `peerFetch` hop as fetchPeer, and the same request-only timeout — an
+  // avatar download must not be aborted mid-body. Non-critical either way: a
+  // failure just retries next cycle.
+  const res = await withAbortTimeout(FETCH_TIMEOUT_MS, (signal) => peerFetch(url, { signal }, peer))
+    .catch(() => null);
+  if (!res?.ok) return;
+  await res.arrayBuffer()
+    .then(async (bytes) => {
+      await ensureDir(PATHS.images);
+      await writeFile(localPath, Buffer.from(bytes));
+      console.log(`🔄 Synced avatar image: ${filename}`);
+    })
+    .catch(() => {});
 }
 
 // --- Status ---

--- a/server/services/syncOrchestrator.test.js
+++ b/server/services/syncOrchestrator.test.js
@@ -88,6 +88,12 @@ tryReadFile: vi.fn().mockResolvedValue(null),
 vi.mock('../lib/asyncMutex.js', () => ({
   createMutex: () => async (fn) => fn()
 }));
+// Spy on the REAL peerFetch (not a stand-in) so the orchestrator's hops still
+// go through the production client — the assertion is only that they do.
+vi.mock('../lib/peerHttpClient.js', async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, peerFetch: vi.fn(actual.peerFetch) };
+});
 vi.mock('fs/promises', () => ({
   writeFile: vi.fn().mockResolvedValue(),
   rename: vi.fn().mockResolvedValue()
@@ -103,6 +109,7 @@ import { instanceEvents } from './instanceEvents.js';
 import { getCurrentSeq, compactLog } from './brainSyncLog.js';
 import { getBrainChecksum, applyBrainSnapshot } from './brainReconcile.js';
 import { getMaxSequence } from './memorySync.js';
+import { peerFetch } from '../lib/peerHttpClient.js';
 import { syncWithPeer, syncAllPeers, getSyncStatus, initSyncOrchestrator, stopSyncOrchestrator } from './syncOrchestrator.js';
 
 const mockFetch = vi.fn();
@@ -323,6 +330,28 @@ describe('syncOrchestrator', () => {
       // Categories still pulled, but WITHOUT the forPeer param (full snapshot).
       expect(urls.some((u) => u.includes('/api/sync/universe/'))).toBe(true);
       expect(urls.some((u) => u.includes('forPeer='))).toBe(false);
+    });
+
+    it('pulls snapshots through peerFetch, with the peer record, so the hop is identified (#5663)', async () => {
+      // The receiver's peer-pull gate keys on `X-PortOS-Instance-Id`; without
+      // it the PII categories now refuse us outright. Passing the peer record
+      // as peerFetch's third arg is what attaches that header AND the stored
+      // Basic credential (header contents themselves: peerHttpClient.test.js).
+      // `forPeer` is a payload-scoping hint, NOT identity — don't confuse them.
+      const dataSync = await import('./dataSync.js');
+      dataSync.getSupportedCategories.mockReturnValue(['digitalTwin']);
+      const peerWithCats = {
+        ...mockPeer,
+        syncCategories: { digitalTwin: true },
+        auth: { username: 'alice', password: 'pw' },
+      };
+      mockFetch.mockResolvedValue({ ok: true, json: async () => ({ checksum: 'x', data: null }) });
+      await syncWithPeer(peerWithCats);
+      const call = peerFetch.mock.calls.find((c) => c[0].includes('/api/sync/digitalTwin/'));
+      expect(call).toBeDefined();
+      expect(call[2]).toBe(peerWithCats);
+      // The 15s budget survived the move off fetchWithTimeout.
+      expect(call[1].signal).toBeInstanceOf(AbortSignal);
     });
   });
 


### PR DESCRIPTION
## Summary

`GET /api/sync/:category/{checksum,snapshot}` is the older of PortOS's two federation pull transports. The per-record `/api/peer-sync/*` routes got receiver-side peer-pull authorization; this one never did. It resolved no caller and consulted no per-peer sharing config, so under the documented default posture (instance password off) any host that could reach the port could read a whole sync category — including `digitalTwin` and `meatspace`, which carry the user's identity record, chronotype, longevity markers, taste profile, autobiography stories and social accounts. The client half didn't identify itself either: the sync orchestrator called `fetchWithTimeout` directly, so it never sent the `X-PortOS-Instance-Id` header any receiver-side gate keys on.

Both reads now run the same `authorizePeerPull` gate, in two tiers:

- **Ordinary categories keep the warn-first ramp.** An un-upgraded peer is still served and logs one throttled `⚠️`; it 403s only once the user opts into `federation.strictPullAuthorization`. The distribution model requires peers that upgrade on their own schedule to keep syncing.
- **`digitalTwin`, `meatspace` and `character` opt out of that ramp** via a new `alwaysEnforce` option and are refused outright, whatever the setting says. Those are the records the privacy ADR keeps machine-local, and its stated reason was precisely that the pull path carried no peer identity. No compatibility argument covers handing an identity record to a host we cannot name.

Consent is resolved **per category, not just per peer**: a peer the user enabled for `universe` must not be able to ask for `digitalTwin`. A new `peerAllowsCategoryPull` reads the peer's category map through the existing `resolveEffectiveCategories`, so the gate agrees with the sync loop and the settings UI instead of adding a second resolver — and so the default-ON `usage` category keeps flowing for a peer whose master switch is off, which a bare `peerAllowsOutbound` check would have refused under strict mode.

The orchestrator's peer hops now go through `peerFetch`, which attaches the instance id alongside the peer's stored Basic credential. Side effect worth having: those hops also pick up the peer HTTPS agent, so snapshot and avatar pulls from a peer with a self-signed certificate now succeed instead of failing TLS validation.

**Behavior changes to know about**

- A PII category is served only to a peer that has that category enabled on the **source** machine. An asymmetric setup (enabled on the puller, not on the source) stops syncing that category — which is what the source's own sharing config already said.
- A peer running an older PortOS cannot pull `digitalTwin` / `meatspace` / `character` until it upgrades, because it sends no instance id. Creative-work categories are unaffected.
- Out of scope, unchanged: `POST /:category/apply` (the write direction, which has its own schema-version gate), the category enum, and the default of `federation.strictPullAuthorization`.

**Known limitation, not introduced here:** `X-PortOS-Instance-Id` is identification, not authentication — it is self-asserted and spoofable on an unauthenticated tailnet, as the authorization module already documents. The real authentication control remains the optional instance password. This PR makes the pull path honor the sharing config the user actually configured; it does not change that framing.

## Test plan

`cd server && npm test` — 1830 files / 37183 tests pass.

New coverage:

- `server/routes/dataSync.test.js` — a new authorization block driving the **real** gate (only the peer registry and settings file are stubbed): `digitalTwin` snapshot 403s for a caller with no instance id, for an id matching no configured peer, for a peer the user silenced, and for a peer enabled only for `universe`; the same three PII categories 403 on `/checksum` too, so the cheap door isn't the weaker one; a PII category 403s with `strictPullAuthorization` explicitly off; a configured peer is still served; `universe` still serves an unidentified caller and warns exactly once; `usage` still reaches a peer whose master switch is off; and `POST /apply` is untouched.
- `server/services/sharing/peerPullAuthorization.test.js` — the `syncCategory` decision branch (ticked / not ticked / full-mirror / default-ON under a master switch that is off / announce-only peer), denial-reason parity with the record routes, and the `alwaysEnforce` tier including its once-per-caller refusal log.
- `server/services/syncOrchestrator.test.js` — the snapshot hop goes through `peerFetch` with the peer record and a timeout signal, so the two halves of the contract cannot drift back apart.

Manual verification is not included: exercising it needs two federated installs, and the header/decision contract is pinned by the tests above plus the existing `peerHttpClient` header suite.

Closes #5663

https://claude.ai/code/session_01GMUUt1MMMwKQ7xqPGS2dfQ
