### PR TITLE
Add a per-PR trigger for the pr-reviewer scheduled task

### DIFF
--- a/client/src/components/apps/tabs/PullRequestsTab.jsx
+++ b/client/src/components/apps/tabs/PullRequestsTab.jsx
@@ -287,12 +287,13 @@ export default function PullRequestsTab({ appId, appName }) {
     already: `pr-reviewer is already queued for ${forgeLabel} #${pullRequest.number}`,
   });
 
-  // pr-reviewer's model-abuse preflight reads the forge through `gh`, so the
-  // targeted review button is meaningless on a GitLab remote. The server refuses
-  // it there anyway; hiding it keeps the row from offering a guaranteed failure.
-  const rowActions = [
+  // pr-reviewer covers only GitHub PRs opened by someone else against the default
+  // branch, and the server answers every other row with 409. `reviewEligible` is
+  // the server's own verdict per row, so the button appears exactly where it can
+  // work rather than offering a guaranteed failure.
+  const rowActionsFor = pullRequest => [
     { kind: 'resolve', onQueue: handleResolve },
-    ...(data?.forge === 'github' ? [{ kind: 'review', onQueue: handleReview }] : []),
+    ...(pullRequest.reviewEligible ? [{ kind: 'review', onQueue: handleReview }] : []),
   ];
 
   if (loading && !data) return <BrailleSpinner text="Loading pull requests" />;
@@ -335,9 +336,9 @@ export default function PullRequestsTab({ appId, appName }) {
         <p>
           Resolve and merge queues a PortOS agent to inspect feedback, fix the branch, wait for checks, and merge when the forge allows it. It uses the configured Code Review Defaults.
         </p>
-        {data?.forge === 'github' && (
+        {(data?.pullRequests || []).some(pullRequest => pullRequest.reviewEligible) && (
           <p>
-            PR review points the <span className="font-mono">pr-reviewer</span> scheduled task at this one request instead of letting it sweep every open contributor PR. It covers requests opened by someone else against the default branch, and its security scan still holds the review behind approval.
+            PR review points the <span className="font-mono">pr-reviewer</span> scheduled task at this one request instead of letting it sweep every open contributor PR. It appears only on requests it can review — opened by someone else against the default branch — and its security scan still holds the review behind approval.
           </p>
         )}
       </div>
@@ -428,7 +429,7 @@ export default function PullRequestsTab({ appId, appName }) {
                   </div>
 
                   <div className="shrink-0 lg:pt-0.5 flex flex-wrap items-start gap-2">
-                    {rowActions.map(({ kind, onQueue }) => {
+                    {rowActionsFor(pullRequest).map(({ kind, onQueue }) => {
                       const { label, Icon, title } = ACTION_KINDS[kind];
                       const actionStatus = actions[kind][pullRequest.number]?.status;
                       if (actionStatus && actionStatus !== 'queuing') {

--- a/client/src/components/apps/tabs/PullRequestsTab.jsx
+++ b/client/src/components/apps/tabs/PullRequestsTab.jsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback, useMemo, useRef, useId } from 'react'
 import { Link } from 'react-router';
 import {
   AlertTriangle, CheckCircle2, ExternalLink, GitBranch, GitMerge,
-  GitPullRequest, Loader2, RefreshCw, Rocket, Search, ShieldAlert, User
+  GitPullRequest, Loader2, RefreshCw, Rocket, ScanSearch, Search, ShieldAlert, User
 } from 'lucide-react';
 import BrailleSpinner from '../../BrailleSpinner';
 import Banner from '../../ui/Banner';
@@ -28,6 +28,41 @@ const actionStatusForTask = status => ({
   completed: 'completed',
   blocked: 'blocked',
 }[status] || null);
+
+// The two per-row agent actions. They share every piece of state machinery —
+// only the CoS task that backs each one differs, so the kind is data rather
+// than a duplicated block of hooks.
+//   resolve — the review-loop follow-up that fixes and merges the branch.
+//   review  — `pr-reviewer` narrowed to this one request.
+// `field` is where the GET response carries this kind's server-side state, and
+// `queued` reads the same record out of the POST response. `matches` is the
+// LATE-BINDING rule: a click knows its PR number before the server has a task
+// id, so a socket update is claimed by the row it names.
+const ACTION_KINDS = {
+  resolve: {
+    label: 'Resolve & merge',
+    Icon: Rocket,
+    field: 'agentAction',
+    queued: result => result.task && { taskId: result.task.id, status: result.task.status },
+    title: (forgeLabel, number, appName) =>
+      `Queue a CoS agent to resolve and merge ${forgeLabel} request #${number} for ${appName}`,
+    matches: (task, appId, number) => task.metadata?.app === appId
+      && Number(task.metadata?.reviewLoopPRNumber) === number,
+  },
+  review: {
+    label: 'PR review',
+    Icon: ScanSearch,
+    field: 'reviewAction',
+    queued: result => result.reviewAction,
+    title: (forgeLabel, number, appName) =>
+      `Run the pr-reviewer scheduled task against ${forgeLabel} request #${number} for ${appName}`,
+    matches: (task, appId, number) => task.metadata?.app === appId
+      && task.metadata?.analysisType === 'pr-reviewer'
+      && Number(task.metadata?.targetPullRequest) === number,
+  },
+};
+const KIND_IDS = Object.keys(ACTION_KINDS);
+const emptyActions = () => Object.fromEntries(KIND_IDS.map(kind => [kind, {}]));
 
 const EMPTY_REASONS = {
   'no-repo-path': 'This app has no repo path configured.',
@@ -95,19 +130,30 @@ export default function PullRequestsTab({ appId, appName }) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
   const [query, setQuery] = useState('');
-  const [actions, setActions] = useState({});
-  const actionsRef = useRef({});
+  const [actions, setActions] = useState(emptyActions);
+  const actionsRef = useRef(emptyActions());
   const requestRef = useRef(0);
 
+  // One writer for the whole `{ kind: { number: action } }` bag so the ref the
+  // socket handler reads and the state React renders can never disagree.
   const replaceActions = useCallback(updater => {
     const next = updater(actionsRef.current);
     actionsRef.current = next;
     setActions(next);
   }, []);
 
+  const setAction = useCallback((kind, number, action) => {
+    replaceActions(previous => ({
+      ...previous,
+      [kind]: action
+        ? { ...previous[kind], [number]: action }
+        : Object.fromEntries(Object.entries(previous[kind]).filter(([key]) => Number(key) !== number)),
+    }));
+  }, [replaceActions]);
+
   useEffect(() => {
-    actionsRef.current = {};
-    setActions({});
+    actionsRef.current = emptyActions();
+    setActions(emptyActions());
   }, [appId]);
 
   const applyTaskUpdate = useCallback(task => {
@@ -116,17 +162,18 @@ export default function PullRequestsTab({ appId, appName }) {
     if (!nextStatus) return;
 
     replaceActions(current => {
-      const next = { ...current };
       let changed = false;
-      for (const [number, action] of Object.entries(current)) {
-        const matches = action.taskId === task.id || (
-          !action.taskId
-          && task.metadata?.app === appId
-          && Number(task.metadata?.reviewLoopPRNumber) === Number(number)
-        );
-        if (!matches || actionRank(nextStatus) < actionRank(action.status)) continue;
-        next[number] = { ...action, taskId: action.taskId || task.id, status: nextStatus };
-        changed = true;
+      const next = { ...current };
+      for (const kind of KIND_IDS) {
+        const updated = { ...current[kind] };
+        for (const [number, action] of Object.entries(current[kind])) {
+          const matches = action.taskId === task.id
+            || (!action.taskId && ACTION_KINDS[kind].matches(task, appId, Number(number)));
+          if (!matches || actionRank(nextStatus) < actionRank(action.status)) continue;
+          updated[number] = { ...action, taskId: action.taskId || task.id, status: nextStatus };
+          changed = true;
+        }
+        next[kind] = updated;
       }
       return changed ? next : current;
     });
@@ -152,17 +199,22 @@ export default function PullRequestsTab({ appId, appName }) {
     setData(result);
     replaceActions(previous => {
       const next = { ...previous };
-      for (const pullRequest of result.pullRequests || []) {
-        const serverAction = actionStatusFromRecord(pullRequest.agentAction);
-        if (!serverAction) continue;
-        const current = next[pullRequest.number];
-        if (!current || actionRank(serverAction) >= actionRank(current.status)) {
-          next[pullRequest.number] = {
-            ...(current || {}),
-            taskId: current?.taskId || pullRequest.agentAction.taskId || null,
-            status: serverAction,
-          };
+      for (const kind of KIND_IDS) {
+        const merged = { ...previous[kind] };
+        for (const pullRequest of result.pullRequests || []) {
+          const record = pullRequest[ACTION_KINDS[kind].field];
+          const serverAction = actionStatusFromRecord(record);
+          if (!serverAction) continue;
+          const current = merged[pullRequest.number];
+          if (!current || actionRank(serverAction) >= actionRank(current.status)) {
+            merged[pullRequest.number] = {
+              ...(current || {}),
+              taskId: current?.taskId || record.taskId || null,
+              status: serverAction,
+            };
+          }
         }
+        next[kind] = merged;
       }
       return next;
     });
@@ -188,43 +240,60 @@ export default function PullRequestsTab({ appId, appName }) {
   const requestNoun = data?.forge === 'gitlab' ? 'merge requests' : 'pull requests';
   const unavailable = data?.transient === true;
 
-  const handleResolve = async pullRequest => {
-    replaceActions(previous => ({
-      ...previous,
-      [pullRequest.number]: { status: 'queuing', taskId: null },
-    }));
-    const result = await api.resolveAppPullRequest(appId, pullRequest.number).catch(err => {
-      toast.error(err?.message || `Failed to queue an agent for #${pullRequest.number}`);
+  // Both row actions queue a CoS task and then track it identically: optimistic
+  // `queuing`, roll back on failure, and never let a stale response downgrade a
+  // status a socket update already advanced.
+  const queueAction = async (kind, pullRequest, { call, queued, already }) => {
+    const { number } = pullRequest;
+    setAction(kind, number, { status: 'queuing', taskId: null });
+    const result = await call().catch(err => {
+      toast.error(err?.message || `Failed to queue an agent for #${number}`);
       return null;
     });
     if (!result) {
-      replaceActions(previous => {
-        const next = { ...previous };
-        delete next[pullRequest.number];
-        return next;
-      });
+      setAction(kind, number, null);
       return;
     }
 
-    const taskStatus = actionStatusForTask(result.task?.status) || 'queued';
+    const record = ACTION_KINDS[kind].queued(result);
+    const taskStatus = actionStatusFromRecord(record) || 'queued';
     replaceActions(previous => {
-      const current = previous[pullRequest.number];
-      const status = actionRank(taskStatus) >= actionRank(current?.status)
-        ? taskStatus
-        : current?.status;
+      const current = previous[kind][number];
+      const status = actionRank(taskStatus) >= actionRank(current?.status) ? taskStatus : current?.status;
       return {
         ...previous,
-        [pullRequest.number]: {
-          ...(current || {}),
-          taskId: current?.taskId || result.task?.id || null,
-          status,
+        [kind]: {
+          ...previous[kind],
+          [number]: {
+            ...(current || {}),
+            taskId: current?.taskId || record?.taskId || null,
+            status,
+          },
         },
       };
     });
-    toast.success(result.duplicate
-      ? `An agent is already resolving ${forgeLabel} #${pullRequest.number}`
-      : `Queued an agent to resolve and merge ${forgeLabel} #${pullRequest.number}`);
+    toast.success(result.duplicate ? already : queued);
   };
+
+  const handleResolve = pullRequest => queueAction('resolve', pullRequest, {
+    call: () => api.resolveAppPullRequest(appId, pullRequest.number),
+    queued: `Queued an agent to resolve and merge ${forgeLabel} #${pullRequest.number}`,
+    already: `An agent is already resolving ${forgeLabel} #${pullRequest.number}`,
+  });
+
+  const handleReview = pullRequest => queueAction('review', pullRequest, {
+    call: () => api.reviewAppPullRequest(appId, pullRequest.number),
+    queued: `Queued the pr-reviewer task for ${forgeLabel} #${pullRequest.number}`,
+    already: `pr-reviewer is already queued for ${forgeLabel} #${pullRequest.number}`,
+  });
+
+  // pr-reviewer's model-abuse preflight reads the forge through `gh`, so the
+  // targeted review button is meaningless on a GitLab remote. The server refuses
+  // it there anyway; hiding it keeps the row from offering a guaranteed failure.
+  const rowActions = [
+    { kind: 'resolve', onQueue: handleResolve },
+    ...(data?.forge === 'github' ? [{ kind: 'review', onQueue: handleReview }] : []),
+  ];
 
   if (loading && !data) return <BrailleSpinner text="Loading pull requests" />;
 
@@ -262,8 +331,15 @@ export default function PullRequestsTab({ appId, appName }) {
         </button>
       </div>
 
-      <div className="px-3 py-2 text-xs text-gray-500 bg-port-card border border-port-border rounded-lg">
-        Resolve and merge queues a PortOS agent to inspect feedback, fix the branch, wait for checks, and merge when the forge allows it. It uses the configured Code Review Defaults.
+      <div className="px-3 py-2 text-xs text-gray-500 bg-port-card border border-port-border rounded-lg space-y-1">
+        <p>
+          Resolve and merge queues a PortOS agent to inspect feedback, fix the branch, wait for checks, and merge when the forge allows it. It uses the configured Code Review Defaults.
+        </p>
+        {data?.forge === 'github' && (
+          <p>
+            PR review points the <span className="font-mono">pr-reviewer</span> scheduled task at this one request instead of letting it sweep every open contributor PR. It covers requests opened by someone else against the default branch, and its security scan still holds the review behind approval.
+          </p>
+        )}
       </div>
 
       {error && (
@@ -294,8 +370,6 @@ export default function PullRequestsTab({ appId, appName }) {
       {filteredPullRequests.length > 0 && (
         <div className="border border-port-border rounded-lg divide-y divide-port-border overflow-hidden">
           {filteredPullRequests.map(pullRequest => {
-            const action = actions[pullRequest.number];
-            const actionStatus = action?.status;
             const review = reviewSummary(pullRequest);
             const checks = checkSummary(pullRequest);
             const merge = mergeSummary(pullRequest);
@@ -353,28 +427,37 @@ export default function PullRequestsTab({ appId, appName }) {
                     </div>
                   </div>
 
-                  <div className="shrink-0 lg:pt-0.5">
-                    {actionStatus && actionStatus !== 'queuing' ? (
-                      <Link
-                        to="/cos/agents"
-                        className="px-3 py-1.5 bg-port-success/20 text-port-success hover:bg-port-success/30 border border-port-border rounded-lg text-xs flex items-center gap-1.5 transition-colors"
-                      >
-                        <Rocket size={14} /> {ACTION_STATUS_LABEL[actionStatus] || 'Queued — view'}
-                      </Link>
-                    ) : (
-                      <button
-                        type="button"
-                        onClick={() => handleResolve(pullRequest)}
-                        disabled={actionStatus === 'queuing'}
-                        title={`Queue a CoS agent to resolve and merge ${forgeLabel} request #${pullRequest.number} for ${appName}`}
-                        className="px-3 py-1.5 bg-port-accent/20 text-port-accent enabled:hover:bg-port-accent/30 border border-port-border rounded-lg text-xs flex items-center gap-1.5 disabled:opacity-50 transition-colors"
-                      >
-                        {actionStatus === 'queuing'
-                          ? <Loader2 size={14} className="animate-spin" />
-                          : <Rocket size={14} />}
-                        {actionStatus === 'queuing' ? 'Queuing…' : 'Resolve & merge'}
-                      </button>
-                    )}
+                  <div className="shrink-0 lg:pt-0.5 flex flex-wrap items-start gap-2">
+                    {rowActions.map(({ kind, onQueue }) => {
+                      const { label, Icon, title } = ACTION_KINDS[kind];
+                      const actionStatus = actions[kind][pullRequest.number]?.status;
+                      if (actionStatus && actionStatus !== 'queuing') {
+                        return (
+                          <Link
+                            key={kind}
+                            to="/cos/agents"
+                            className="px-3 py-1.5 bg-port-success/20 text-port-success hover:bg-port-success/30 border border-port-border rounded-lg text-xs flex items-center gap-1.5 transition-colors"
+                          >
+                            <Icon size={14} /> {label}: {ACTION_STATUS_LABEL[actionStatus] || 'Queued — view'}
+                          </Link>
+                        );
+                      }
+                      return (
+                        <button
+                          key={kind}
+                          type="button"
+                          onClick={() => onQueue(pullRequest)}
+                          disabled={actionStatus === 'queuing'}
+                          title={title(forgeLabel, pullRequest.number, appName)}
+                          className="px-3 py-1.5 bg-port-accent/20 text-port-accent enabled:hover:bg-port-accent/30 border border-port-border rounded-lg text-xs flex items-center gap-1.5 disabled:opacity-50 transition-colors"
+                        >
+                          {actionStatus === 'queuing'
+                            ? <Loader2 size={14} className="animate-spin" />
+                            : <Icon size={14} />}
+                          {actionStatus === 'queuing' ? 'Queuing…' : label}
+                        </button>
+                      );
+                    })}
                   </div>
                 </div>
               </div>

--- a/client/src/components/apps/tabs/PullRequestsTab.test.jsx
+++ b/client/src/components/apps/tabs/PullRequestsTab.test.jsx
@@ -19,6 +19,7 @@ vi.mock('../../../services/socket', () => ({ default: socketMock }));
 vi.mock('../../../services/api', () => ({
   getAppPullRequests: vi.fn(),
   resolveAppPullRequest: vi.fn(),
+  reviewAppPullRequest: vi.fn(),
 }));
 
 import * as api from '../../../services/api';
@@ -73,6 +74,11 @@ beforeEach(() => {
   api.getAppPullRequests.mockResolvedValue(okPayload([PULL_REQUEST]));
   api.resolveAppPullRequest.mockResolvedValue({
     task: { id: 'task-1', status: 'pending' },
+    duplicate: false,
+  });
+  api.reviewAppPullRequest.mockResolvedValue({
+    requestId: 'demand-abc',
+    reviewAction: { taskId: null, status: 'pending' },
     duplicate: false,
   });
 });
@@ -184,6 +190,55 @@ describe('PullRequestsTab', () => {
 
     expect(await screen.findByRole('link', { name: /Active/ })).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /Resolve & merge/ })).not.toBeInTheDocument();
+  });
+
+  it('queues a pr-reviewer run scoped to the row it was pressed on', async () => {
+    await renderTab();
+
+    fireEvent.click(await screen.findByRole('button', { name: /PR review/ }));
+
+    await waitFor(() => expect(api.reviewAppPullRequest).toHaveBeenCalledWith('app-1', 17));
+    expect(await screen.findByRole('link', { name: /PR review: Queued/ })).toBeInTheDocument();
+    // The resolve action is a separate lane and must stay offered.
+    expect(screen.getByRole('button', { name: /Resolve & merge/ })).toBeInTheDocument();
+  });
+
+  it('binds a pr-reviewer task update to the row by its target PR number', async () => {
+    await renderTab();
+
+    fireEvent.click(await screen.findByRole('button', { name: /PR review/ }));
+    expect(await screen.findByRole('link', { name: /PR review: Queued/ })).toBeInTheDocument();
+
+    act(() => socketHandlers.get('cos:tasks:changed')({
+      task: {
+        id: 'app-improve-17',
+        status: 'in_progress',
+        metadata: { app: 'app-1', analysisType: 'pr-reviewer', targetPullRequest: 17 },
+      },
+    }));
+
+    expect(await screen.findByRole('link', { name: /PR review: Active/ })).toBeInTheDocument();
+  });
+
+  it('hydrates an in-flight pr-reviewer run without offering the button again', async () => {
+    api.getAppPullRequests.mockResolvedValue(okPayload([{
+      ...PULL_REQUEST,
+      reviewAction: { taskId: 'app-improve-17', status: 'in_progress' },
+    }]));
+
+    await renderTab();
+
+    expect(await screen.findByRole('link', { name: /PR review: Active/ })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /PR review/ })).not.toBeInTheDocument();
+  });
+
+  it('omits the pr-reviewer action on a GitLab remote', async () => {
+    api.getAppPullRequests.mockResolvedValue({ ...okPayload([PULL_REQUEST]), forge: 'gitlab' });
+
+    await renderTab();
+
+    expect(await screen.findByRole('button', { name: /Resolve & merge/ })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /PR review/ })).not.toBeInTheDocument();
   });
 
   it('keeps forge failures distinct from a healthy empty list', async () => {

--- a/client/src/components/apps/tabs/PullRequestsTab.test.jsx
+++ b/client/src/components/apps/tabs/PullRequestsTab.test.jsx
@@ -40,6 +40,7 @@ const PULL_REQUEST = {
   mergeStateStatus: 'DIRTY',
   mergeable: 'CONFLICTING',
   labels: ['bug'],
+  reviewEligible: true,
   checks: [
     { name: 'unit', status: 'SUCCESS', url: null },
     { name: 'lint', status: 'SUCCESS', url: null },
@@ -232,8 +233,8 @@ describe('PullRequestsTab', () => {
     expect(screen.queryByRole('button', { name: /PR review/ })).not.toBeInTheDocument();
   });
 
-  it('omits the pr-reviewer action on a GitLab remote', async () => {
-    api.getAppPullRequests.mockResolvedValue({ ...okPayload([PULL_REQUEST]), forge: 'gitlab' });
+  it('omits the pr-reviewer action on a row the server marked ineligible', async () => {
+    api.getAppPullRequests.mockResolvedValue(okPayload([{ ...PULL_REQUEST, reviewEligible: false }]));
 
     await renderTab();
 

--- a/client/src/services/apiApps.js
+++ b/client/src/services/apiApps.js
@@ -55,6 +55,17 @@ export const resolveAppPullRequest = (id, number, options = {}) =>
     silent: true,
     ...options,
   });
+// Queue the `pr-reviewer` scheduled task narrowed to ONE open PR/MR instead of
+// letting it pick from the app's whole external open set. The server owns the
+// eligibility check (open, GitHub, opened by someone else) and the duplicate
+// guard, so a refusal comes back as an explained error rather than a run that
+// silently reviews nothing.
+export const reviewAppPullRequest = (id, number, options = {}) =>
+  request(`/apps/${id}/pull-requests/${encodeURIComponent(number)}/review`, {
+    method: 'POST',
+    silent: true,
+    ...options,
+  });
 // Effective Layered Intelligence config (self-improvement loop) for an app —
 // stored partial merged over the shipped defaults. Read-only; saved through
 // updateApp (the `layeredIntelligence` key routes to the merge helper server-

--- a/server/lib/apiRouteCatalog.generated.json
+++ b/server/lib/apiRouteCatalog.generated.json
@@ -1112,6 +1112,14 @@
     },
     {
       "method": "POST",
+      "path": "/api/apps/:id/pull-requests/:number/review",
+      "mountPath": "/api/apps",
+      "sources": [
+        "server/routes/apps/pullRequests.js"
+      ]
+    },
+    {
+      "method": "POST",
       "path": "/api/apps/:id/refresh-config",
       "mountPath": "/api/apps",
       "sources": [
@@ -17409,8 +17417,8 @@
   ],
   "stats": {
     "mounts": 147,
-    "operations": 2156,
-    "declarations": 2160,
+    "operations": 2157,
+    "declarations": 2161,
     "sourceFiles": 229
   }
 }

--- a/server/routes/apps/pullRequests.js
+++ b/server/routes/apps/pullRequests.js
@@ -22,7 +22,11 @@ import { resolveReviewLoopOptions } from '../../services/codeReview.js';
 import { getAllTasks } from '../../services/cos.js';
 import { spawnReviewLoopFollowUp } from '../../services/agentWorktreeCleanup.js';
 import { listAppPullRequests } from '../../services/appPullRequests.js';
-import { listExternalOpenPullRequests } from '../../services/prReviewerSecurity.js';
+import {
+  isReviewablePullRequest,
+  listExternalOpenPullRequests,
+  resolvePrReviewerTargetScope,
+} from '../../services/prReviewerSecurity.js';
 import { getOnDemandRequests, triggerOnDemandTask } from '../../services/taskSchedule.js';
 import { loadApp } from './shared.js';
 
@@ -82,12 +86,31 @@ async function readActiveTasks() {
 // is queued through the on-demand lane, so without these a row would show no
 // action at all between the click and the generator's next cycle — and a page
 // refresh in that window would offer the button again.
+//
+// `null` means UNREADABLE, which is not the same as "nothing queued": collapsing
+// the two would let the review route miss an existing request and queue a
+// duplicate scan of the same public PR. The POST fails closed on it; the GET,
+// which only paints a button, degrades to showing no queued action.
 async function readPendingOnDemandRequests() {
   const requests = await getOnDemandRequests().catch(err => {
     console.error(`❌ app-pull-requests: could not read on-demand requests: ${err.message}`);
-    return [];
+    return null;
   });
-  return Array.isArray(requests) ? requests : [];
+  return Array.isArray(requests) ? requests : null;
+}
+
+// Per-row pr-reviewer eligibility, resolved from the SAME facts the security
+// preflight filters on. Without it the tab would paint a Review button on every
+// GitHub row, including the ones the route answers with 409 — an action that is
+// guaranteed to fail. Only worth the extra `gh repo view` when the forge is
+// GitHub; every other forge is ineligible by construction.
+async function resolveReviewEligibility(app, result) {
+  if (result.forge !== 'github') return () => false;
+  const scope = await resolvePrReviewerTargetScope(app).catch(err => {
+    console.error(`❌ app-pull-requests: could not resolve pr-reviewer scope: ${err.message}`);
+    return null;
+  });
+  return pullRequest => isReviewablePullRequest(scope, pullRequest);
 }
 
 function actionFor(pullRequest, tasks, appId) {
@@ -99,7 +122,7 @@ function actionFor(pullRequest, tasks, appId) {
 function reviewActionFor(pullRequest, tasks, requests, appId) {
   const task = tasks?.find(candidate => isReviewTaskFor(candidate, appId, pullRequest));
   if (task) return { taskId: task.id, status: task.status };
-  const queued = requests.find(request => isReviewRequestFor(request, appId, pullRequest));
+  const queued = requests?.find(request => isReviewRequestFor(request, appId, pullRequest));
   return queued ? { taskId: null, status: 'pending' } : null;
 }
 
@@ -114,7 +137,11 @@ async function listWithActionState(app) {
   const pullRequests = Array.isArray(result?.pullRequests) ? result.pullRequests : [];
   if (!pullRequests.length || result.transient) return { result, tasks: null };
 
-  const [tasks, requests] = await Promise.all([readActiveTasks(), readPendingOnDemandRequests()]);
+  const [tasks, requests, reviewEligible] = await Promise.all([
+    readActiveTasks(),
+    readPendingOnDemandRequests(),
+    resolveReviewEligibility(app, result),
+  ]);
   return {
     result: {
       ...result,
@@ -122,6 +149,7 @@ async function listWithActionState(app) {
         ...pullRequest,
         agentAction: actionFor(pullRequest, tasks, app.id),
         reviewAction: reviewActionFor(pullRequest, tasks, requests, app.id),
+        reviewEligible: reviewEligible(pullRequest),
       })),
     },
     tasks,
@@ -270,18 +298,30 @@ router.post('/:id/pull-requests/:number/review', loadApp, asyncHandler(async (re
       context: { reason: target.code || 'security-scan-target-unavailable' },
     });
   }
-  if (!target.prs.some(candidate => candidate.number === number)) {
+  const pullRequest = target.prs.find(candidate => candidate.number === number);
+  if (!pullRequest) {
     throw new ServerError(
       `Pull request #${number} is not reviewable — PR review covers open GitHub pull requests against the default branch that were opened by someone else`,
       { status: 409, code: 'PULL_REQUEST_NOT_REVIEWABLE' },
     );
   }
+  // The security scan fingerprints the PR set by head commit, and the reader
+  // normalizes an unusable `headRefOid` to null. Accepting one anyway would
+  // return 202 for a run the preflight then drops on a null fingerprint — the UI
+  // would show a queued review that can never start.
+  if (!pullRequest.headRefOid) {
+    throw new ServerError(
+      `Pull request #${number} has no resolvable head commit, so its content cannot be safety-screened`,
+      { status: 502, code: 'PULL_REQUEST_CONTEXT_UNAVAILABLE' },
+    );
+  }
 
   const [tasks, requests] = await Promise.all([readActiveTasks(), readPendingOnDemandRequests()]);
-  // Fail CLOSED on an unreadable task store, matching /resolve: `reviewActionFor`
-  // reads a null task list as "no run in flight", so queueing anyway would spend a
-  // second model-abuse scan and code review on a public PR already being reviewed.
-  if (tasks === null) {
+  // Fail CLOSED on unreadable task or on-demand state, matching /resolve:
+  // `reviewActionFor` reads either as "no run in flight", so queueing anyway would
+  // spend a second model-abuse scan and code review on a public PR already being
+  // reviewed.
+  if (tasks === null || requests === null) {
     throw new ServerError('Could not inspect existing CoS actions before queueing this review', {
       status: 503,
       code: 'AGENT_ACTION_UNAVAILABLE',

--- a/server/routes/apps/pullRequests.js
+++ b/server/routes/apps/pullRequests.js
@@ -278,6 +278,15 @@ router.post('/:id/pull-requests/:number/review', loadApp, asyncHandler(async (re
   }
 
   const [tasks, requests] = await Promise.all([readActiveTasks(), readPendingOnDemandRequests()]);
+  // Fail CLOSED on an unreadable task store, matching /resolve: `reviewActionFor`
+  // reads a null task list as "no run in flight", so queueing anyway would spend a
+  // second model-abuse scan and code review on a public PR already being reviewed.
+  if (tasks === null) {
+    throw new ServerError('Could not inspect existing CoS actions before queueing this review', {
+      status: 503,
+      code: 'AGENT_ACTION_UNAVAILABLE',
+    });
+  }
   const existing = reviewActionFor({ number }, tasks, requests, app.id);
   if (existing) {
     res.json({ appId: app.id, appName: app.name, number, reviewAction: existing, duplicate: true });

--- a/server/routes/apps/pullRequests.js
+++ b/server/routes/apps/pullRequests.js
@@ -3,10 +3,13 @@
  *
  *   GET  /:id/pull-requests                         → open forge requests
  *   POST /:id/pull-requests/:number/resolve         → queue a review-loop agent
+ *   POST /:id/pull-requests/:number/review          → queue pr-reviewer for ONE PR
  *
- * The POST route only queues PortOS's existing review-loop follow-up. The
- * follow-up owns fetching feedback, fixing the branch, waiting for checks, and
- * merging; this route never merges a user's PR directly.
+ * Neither POST route merges a user's PR directly. `/resolve` queues PortOS's
+ * existing review-loop follow-up, which owns fetching feedback, fixing the
+ * branch, waiting for checks, and merging. `/review` queues the `pr-reviewer`
+ * scheduled task narrowed to a single request, so the security-scan → review
+ * pipeline that normally sweeps every external PR can be pointed at one.
  */
 
 import { Router } from 'express';
@@ -19,6 +22,8 @@ import { resolveReviewLoopOptions } from '../../services/codeReview.js';
 import { getAllTasks } from '../../services/cos.js';
 import { spawnReviewLoopFollowUp } from '../../services/agentWorktreeCleanup.js';
 import { listAppPullRequests } from '../../services/appPullRequests.js';
+import { listExternalOpenPullRequests } from '../../services/prReviewerSecurity.js';
+import { getOnDemandRequests, triggerOnDemandTask } from '../../services/taskSchedule.js';
 import { loadApp } from './shared.js';
 
 const router = Router();
@@ -28,6 +33,7 @@ const pullRequestParamsSchema = z.object({
 });
 
 const ACTIVE_TASK_STATUSES = new Set(['pending', 'in_progress', 'blocked']);
+const PR_REVIEWER_TASK_TYPE = 'pr-reviewer';
 
 const flattenTasks = (taskData) => [
   ...(Array.isArray(taskData?.user?.tasks) ? taskData.user.tasks : []),
@@ -42,7 +48,25 @@ const isResolveTaskFor = (task, appId, pullRequest) => {
     && Number(metadata.reviewLoopPRNumber) === pullRequest.number;
 };
 
-async function readActiveResolveTasks() {
+// A pr-reviewer run narrowed to this one request (`targetPullRequest` is stamped
+// by the generator's security preflight). The unnarrowed sweep is deliberately
+// NOT matched: it covers every external PR, so reporting it as this row's action
+// would hide the per-row trigger behind an unrelated run.
+const isReviewTaskFor = (task, appId, pullRequest) => {
+  const metadata = task?.metadata;
+  return ACTIVE_TASK_STATUSES.has(task?.status)
+    && metadata?.analysisType === PR_REVIEWER_TASK_TYPE
+    && metadata?.app === appId
+    && Number(metadata.targetPullRequest) === pullRequest.number;
+};
+
+const isReviewRequestFor = (request, appId, pullRequest) => (
+  request?.taskType === PR_REVIEWER_TASK_TYPE
+  && request?.appId === appId
+  && Number(request?.targetPullRequest) === pullRequest.number
+);
+
+async function readActiveTasks() {
   const taskData = await getAllTasks().catch(err => {
     console.error(`❌ app-pull-requests: could not read CoS tasks: ${err.message}`);
     return null;
@@ -54,10 +78,29 @@ async function readActiveResolveTasks() {
   return flattenTasks(taskData);
 }
 
+// Queued on-demand requests that have not yet become tasks. A pr-reviewer run
+// is queued through the on-demand lane, so without these a row would show no
+// action at all between the click and the generator's next cycle — and a page
+// refresh in that window would offer the button again.
+async function readPendingOnDemandRequests() {
+  const requests = await getOnDemandRequests().catch(err => {
+    console.error(`❌ app-pull-requests: could not read on-demand requests: ${err.message}`);
+    return [];
+  });
+  return Array.isArray(requests) ? requests : [];
+}
+
 function actionFor(pullRequest, tasks, appId) {
   if (!tasks) return null;
   const task = tasks.find(candidate => isResolveTaskFor(candidate, appId, pullRequest));
   return task ? { taskId: task.id, status: task.status } : null;
+}
+
+function reviewActionFor(pullRequest, tasks, requests, appId) {
+  const task = tasks?.find(candidate => isReviewTaskFor(candidate, appId, pullRequest));
+  if (task) return { taskId: task.id, status: task.status };
+  const queued = requests.find(request => isReviewRequestFor(request, appId, pullRequest));
+  return queued ? { taskId: null, status: 'pending' } : null;
 }
 
 const taskResponse = task => task ? {
@@ -71,13 +114,14 @@ async function listWithActionState(app) {
   const pullRequests = Array.isArray(result?.pullRequests) ? result.pullRequests : [];
   if (!pullRequests.length || result.transient) return { result, tasks: null };
 
-  const tasks = await readActiveResolveTasks();
+  const [tasks, requests] = await Promise.all([readActiveTasks(), readPendingOnDemandRequests()]);
   return {
     result: {
       ...result,
       pullRequests: pullRequests.map(pullRequest => ({
         ...pullRequest,
         agentAction: actionFor(pullRequest, tasks, app.id),
+        reviewAction: reviewActionFor(pullRequest, tasks, requests, app.id),
       })),
     },
     tasks,
@@ -201,6 +245,58 @@ router.post('/:id/pull-requests/:number/resolve', loadApp, asyncHandler(async (r
     pullRequest: { ...pullRequest, agentAction: { taskId: task.id, status: task.status } },
     task: taskResponse(task),
     duplicate: task.duplicate === true,
+  });
+}));
+
+// POST /api/apps/:id/pull-requests/:number/review — queue the `pr-reviewer`
+// scheduled task narrowed to ONE request. The scheduled task normally decides
+// for itself which of the app's external PRs to sweep; a targeted request pins
+// it to the row the user pressed.
+//
+// Eligibility is answered by the same reader the generator's security preflight
+// uses, so the answer here is the answer there: GitHub only, open against the
+// default branch, and opened by someone other than the signed-in gh account.
+// Checking now turns "the run silently produced nothing an hour later" into an
+// immediate, explained refusal.
+router.post('/:id/pull-requests/:number/review', loadApp, asyncHandler(async (req, res) => {
+  const app = req.loadedApp;
+  const { number } = validateRequest(pullRequestParamsSchema, req.params);
+
+  const target = await listExternalOpenPullRequests(app);
+  if (!target.ok) {
+    throw new ServerError('Could not read the reviewable pull requests for this app', {
+      status: 503,
+      code: 'FORGE_UNAVAILABLE',
+      context: { reason: target.code || 'security-scan-target-unavailable' },
+    });
+  }
+  if (!target.prs.some(candidate => candidate.number === number)) {
+    throw new ServerError(
+      `Pull request #${number} is not reviewable — PR review covers open GitHub pull requests against the default branch that were opened by someone else`,
+      { status: 409, code: 'PULL_REQUEST_NOT_REVIEWABLE' },
+    );
+  }
+
+  const [tasks, requests] = await Promise.all([readActiveTasks(), readPendingOnDemandRequests()]);
+  const existing = reviewActionFor({ number }, tasks, requests, app.id);
+  if (existing) {
+    res.json({ appId: app.id, appName: app.name, number, reviewAction: existing, duplicate: true });
+    return;
+  }
+
+  const request = await triggerOnDemandTask(PR_REVIEWER_TASK_TYPE, app.id, { targetPullRequest: number });
+  if (request?.error) {
+    throw new ServerError(request.error, { status: 409, code: 'PR_REVIEWER_UNAVAILABLE' });
+  }
+
+  console.log(`🔍 Queued pr-reviewer request ${request.id} for app ${app.id} request #${number}`);
+  res.status(202).json({
+    appId: app.id,
+    appName: app.name,
+    number,
+    requestId: request.id,
+    reviewAction: { taskId: null, status: 'pending' },
+    duplicate: false,
   });
 }));
 

--- a/server/routes/apps/pullRequests.test.js
+++ b/server/routes/apps/pullRequests.test.js
@@ -18,12 +18,21 @@ vi.mock('../../services/codeReview.js', () => ({
 vi.mock('../../services/agentWorktreeCleanup.js', () => ({
   spawnReviewLoopFollowUp: vi.fn(),
 }));
+vi.mock('../../services/prReviewerSecurity.js', () => ({
+  listExternalOpenPullRequests: vi.fn(),
+}));
+vi.mock('../../services/taskSchedule.js', () => ({
+  getOnDemandRequests: vi.fn(),
+  triggerOnDemandTask: vi.fn(),
+}));
 
 import * as appsService from '../../services/apps.js';
 import { listAppPullRequests } from '../../services/appPullRequests.js';
 import { getAllTasks } from '../../services/cos.js';
 import { resolveReviewLoopOptions } from '../../services/codeReview.js';
 import { spawnReviewLoopFollowUp } from '../../services/agentWorktreeCleanup.js';
+import { listExternalOpenPullRequests } from '../../services/prReviewerSecurity.js';
+import { getOnDemandRequests, triggerOnDemandTask } from '../../services/taskSchedule.js';
 
 const APP = { id: 'app-001', name: 'Widget', repoPath: '/repo', workTracker: 'auto' };
 const PULL_REQUEST = {
@@ -70,6 +79,15 @@ describe('app pull-request routes', () => {
       status: 'pending',
       description: '[Review Loop] Resolve and merge PR #17 for Widget (https://github.com/acme/widget/pull/17)',
     });
+    listExternalOpenPullRequests.mockResolvedValue({
+      ok: true,
+      repoSpec: 'acme/widget',
+      repoFullName: 'acme/widget',
+      defaultBranch: 'main',
+      prs: [{ number: 17, authorLogin: 'alice', headRefOid: 'a'.repeat(40) }],
+    });
+    getOnDemandRequests.mockResolvedValue([]);
+    triggerOnDemandTask.mockResolvedValue({ id: 'demand-abc', taskType: 'pr-reviewer', appId: 'app-001', targetPullRequest: 17 });
   });
 
   it('lists open requests and annotates an active resolve task', async () => {
@@ -181,6 +199,115 @@ describe('app pull-request routes', () => {
 
     expect(response.status).toBe(400);
     expect(listAppPullRequests).not.toHaveBeenCalled();
+  });
+
+  it('annotates a pr-reviewer run that is scoped to this request', async () => {
+    getAllTasks.mockResolvedValue({
+      user: { tasks: [] },
+      cos: { tasks: [{
+        id: 'app-improve-17',
+        status: 'in_progress',
+        description: 'review',
+        metadata: { app: 'app-001', analysisType: 'pr-reviewer', targetPullRequest: 17 },
+      }] },
+    });
+
+    const response = await request(app).get('/api/apps/app-001/pull-requests');
+
+    expect(response.status).toBe(200);
+    expect(response.body.pullRequests[0].reviewAction).toEqual({ taskId: 'app-improve-17', status: 'in_progress' });
+  });
+
+  it('does not attribute an unscoped pr-reviewer sweep to a row', async () => {
+    getAllTasks.mockResolvedValue({
+      user: { tasks: [] },
+      cos: { tasks: [{
+        id: 'app-improve-sweep',
+        status: 'in_progress',
+        description: 'review',
+        metadata: { app: 'app-001', analysisType: 'pr-reviewer' },
+      }] },
+    });
+
+    const response = await request(app).get('/api/apps/app-001/pull-requests');
+
+    expect(response.body.pullRequests[0].reviewAction).toBeNull();
+  });
+
+  it('shows a queued on-demand request before its task exists', async () => {
+    getOnDemandRequests.mockResolvedValue([
+      { id: 'demand-abc', taskType: 'pr-reviewer', appId: 'app-001', targetPullRequest: 17 },
+    ]);
+
+    const response = await request(app).get('/api/apps/app-001/pull-requests');
+
+    expect(response.body.pullRequests[0].reviewAction).toEqual({ taskId: null, status: 'pending' });
+  });
+
+  it('queues a pr-reviewer run scoped to one request', async () => {
+    const response = await request(app).post('/api/apps/app-001/pull-requests/17/review');
+
+    expect(response.status).toBe(202);
+    expect(triggerOnDemandTask).toHaveBeenCalledWith('pr-reviewer', 'app-001', { targetPullRequest: 17 });
+    expect(response.body).toMatchObject({
+      appId: 'app-001',
+      number: 17,
+      requestId: 'demand-abc',
+      duplicate: false,
+      reviewAction: { taskId: null, status: 'pending' },
+    });
+  });
+
+  it('refuses a request the pr-reviewer preflight would not review', async () => {
+    listExternalOpenPullRequests.mockResolvedValue({
+      ok: true,
+      repoSpec: 'acme/widget',
+      repoFullName: 'acme/widget',
+      defaultBranch: 'main',
+      prs: [],
+    });
+
+    const response = await request(app).post('/api/apps/app-001/pull-requests/17/review');
+
+    expect(response.status).toBe(409);
+    expect(response.body.code).toBe('PULL_REQUEST_NOT_REVIEWABLE');
+    expect(triggerOnDemandTask).not.toHaveBeenCalled();
+  });
+
+  it('surfaces an unreadable forge instead of queueing a run that reviews nothing', async () => {
+    listExternalOpenPullRequests.mockResolvedValue({ ok: false, code: 'security-scan-forge-unreachable', prs: [] });
+
+    const response = await request(app).post('/api/apps/app-001/pull-requests/17/review');
+
+    expect(response.status).toBe(503);
+    expect(triggerOnDemandTask).not.toHaveBeenCalled();
+  });
+
+  it('returns the in-flight pr-reviewer run instead of queuing a second one', async () => {
+    getAllTasks.mockResolvedValue({
+      user: { tasks: [] },
+      cos: { tasks: [{
+        id: 'app-improve-17',
+        status: 'pending',
+        description: 'review',
+        metadata: { app: 'app-001', analysisType: 'pr-reviewer', targetPullRequest: 17 },
+      }] },
+    });
+
+    const response = await request(app).post('/api/apps/app-001/pull-requests/17/review');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({ duplicate: true, reviewAction: { taskId: 'app-improve-17', status: 'pending' } });
+    expect(triggerOnDemandTask).not.toHaveBeenCalled();
+  });
+
+  it('reports why the schedule refused the on-demand run', async () => {
+    triggerOnDemandTask.mockResolvedValue({ error: "Task type 'pr-reviewer' is disabled" });
+
+    const response = await request(app).post('/api/apps/app-001/pull-requests/17/review');
+
+    expect(response.status).toBe(409);
+    expect(response.body.error).toContain('disabled');
   });
 
   it('returns 404 for an unknown app', async () => {

--- a/server/routes/apps/pullRequests.test.js
+++ b/server/routes/apps/pullRequests.test.js
@@ -18,8 +18,10 @@ vi.mock('../../services/codeReview.js', () => ({
 vi.mock('../../services/agentWorktreeCleanup.js', () => ({
   spawnReviewLoopFollowUp: vi.fn(),
 }));
-vi.mock('../../services/prReviewerSecurity.js', () => ({
+vi.mock('../../services/prReviewerSecurity.js', async (importOriginal) => ({
+  ...(await importOriginal()),
   listExternalOpenPullRequests: vi.fn(),
+  resolvePrReviewerTargetScope: vi.fn(),
 }));
 vi.mock('../../services/taskSchedule.js', () => ({
   getOnDemandRequests: vi.fn(),
@@ -31,7 +33,7 @@ import { listAppPullRequests } from '../../services/appPullRequests.js';
 import { getAllTasks } from '../../services/cos.js';
 import { resolveReviewLoopOptions } from '../../services/codeReview.js';
 import { spawnReviewLoopFollowUp } from '../../services/agentWorktreeCleanup.js';
-import { listExternalOpenPullRequests } from '../../services/prReviewerSecurity.js';
+import { listExternalOpenPullRequests, resolvePrReviewerTargetScope } from '../../services/prReviewerSecurity.js';
 import { getOnDemandRequests, triggerOnDemandTask } from '../../services/taskSchedule.js';
 
 const APP = { id: 'app-001', name: 'Widget', repoPath: '/repo', workTracker: 'auto' };
@@ -39,7 +41,9 @@ const PULL_REQUEST = {
   number: 17,
   title: 'Fix the save path',
   url: 'https://github.com/acme/widget/pull/17',
+  author: 'alice',
   headBranch: 'fix/save-path',
+  baseBranch: 'main',
 };
 
 const listResult = () => ({
@@ -85,6 +89,13 @@ describe('app pull-request routes', () => {
       repoFullName: 'acme/widget',
       defaultBranch: 'main',
       prs: [{ number: 17, authorLogin: 'alice', headRefOid: 'a'.repeat(40) }],
+    });
+    resolvePrReviewerTargetScope.mockResolvedValue({
+      ok: true,
+      repoSpec: 'acme/widget',
+      repoFullName: 'acme/widget',
+      defaultBranch: 'main',
+      selfLogin: 'bob',
     });
     getOnDemandRequests.mockResolvedValue([]);
     triggerOnDemandTask.mockResolvedValue({ id: 'demand-abc', taskType: 'pr-reviewer', appId: 'app-001', targetPullRequest: 17 });
@@ -242,6 +253,68 @@ describe('app pull-request routes', () => {
     const response = await request(app).get('/api/apps/app-001/pull-requests');
 
     expect(response.body.pullRequests[0].reviewAction).toEqual({ taskId: null, status: 'pending' });
+  });
+
+  it('marks a contributor PR against the default branch as pr-reviewer eligible', async () => {
+    const response = await request(app).get('/api/apps/app-001/pull-requests');
+
+    expect(response.body.pullRequests[0].reviewEligible).toBe(true);
+  });
+
+  it('marks the operator\'s own PR as ineligible so the row offers no failing action', async () => {
+    listAppPullRequests.mockResolvedValue({
+      ...listResult(),
+      pullRequests: [{ ...PULL_REQUEST, author: 'bob' }],
+    });
+
+    const response = await request(app).get('/api/apps/app-001/pull-requests');
+
+    expect(response.body.pullRequests[0].reviewEligible).toBe(false);
+  });
+
+  it('marks a PR against a non-default base as ineligible', async () => {
+    listAppPullRequests.mockResolvedValue({
+      ...listResult(),
+      pullRequests: [{ ...PULL_REQUEST, baseBranch: 'release' }],
+    });
+
+    const response = await request(app).get('/api/apps/app-001/pull-requests');
+
+    expect(response.body.pullRequests[0].reviewEligible).toBe(false);
+  });
+
+  it('marks every row ineligible when the pr-reviewer scope cannot be resolved', async () => {
+    resolvePrReviewerTargetScope.mockResolvedValue({ ok: false, code: 'security-scan-forge-unreachable' });
+
+    const response = await request(app).get('/api/apps/app-001/pull-requests');
+
+    expect(response.body.pullRequests[0].reviewEligible).toBe(false);
+  });
+
+  it('refuses a target whose head commit cannot be fingerprinted', async () => {
+    listExternalOpenPullRequests.mockResolvedValue({
+      ok: true,
+      repoSpec: 'acme/widget',
+      repoFullName: 'acme/widget',
+      defaultBranch: 'main',
+      prs: [{ number: 17, authorLogin: 'alice', headRefOid: null }],
+    });
+
+    const response = await request(app).post('/api/apps/app-001/pull-requests/17/review');
+
+    expect(response.status).toBe(502);
+    expect(response.body.code).toBe('PULL_REQUEST_CONTEXT_UNAVAILABLE');
+    expect(triggerOnDemandTask).not.toHaveBeenCalled();
+  });
+
+  it('fails closed when the on-demand queue cannot be read before queueing a review', async () => {
+    getOnDemandRequests.mockRejectedValue(new Error('schedule unreadable'));
+
+    const response = await request(app).post('/api/apps/app-001/pull-requests/17/review');
+
+    expect(response.status).toBe(503);
+    expect(response.body.code).toBe('AGENT_ACTION_UNAVAILABLE');
+    expect(triggerOnDemandTask).not.toHaveBeenCalled();
   });
 
   it('queues a pr-reviewer run scoped to one request', async () => {

--- a/server/routes/apps/pullRequests.test.js
+++ b/server/routes/apps/pullRequests.test.js
@@ -283,6 +283,16 @@ describe('app pull-request routes', () => {
     expect(triggerOnDemandTask).not.toHaveBeenCalled();
   });
 
+  it('fails closed when CoS task state cannot be read before queueing a review', async () => {
+    getAllTasks.mockRejectedValue(new Error('task store unavailable'));
+
+    const response = await request(app).post('/api/apps/app-001/pull-requests/17/review');
+
+    expect(response.status).toBe(503);
+    expect(response.body.code).toBe('AGENT_ACTION_UNAVAILABLE');
+    expect(triggerOnDemandTask).not.toHaveBeenCalled();
+  });
+
   it('returns the in-flight pr-reviewer run instead of queuing a second one', async () => {
     getAllTasks.mockResolvedValue({
       user: { tasks: [] },

--- a/server/services/agentLifecycle.js
+++ b/server/services/agentLifecycle.js
@@ -685,6 +685,11 @@ async function runAgentSpawn(task) {
       // the auto-run-gated queue lane. `isTruthyMeta` accepts the boolean set at
       // spawn AND the string `"true"` a COS-TASKS.md round-trip yields.
       taskOnDemand: isTruthyMeta(task.metadata?.onDemand),
+      // The single PR a pr-reviewer run was narrowed to. Same hand-picked-projection
+      // reason as the keys around it: perpetualRefillPlan must see from the AGENT
+      // record that this run was scoped, or its untargeted re-issue silently widens
+      // a per-row click back into a sweep of every open PR.
+      taskTargetPullRequest: task.metadata?.targetPullRequest || null,
       // LI hand-off provenance (#2765): projected onto the agent so the completion
       // hook (recordTaskCompletion) can attribute the run's success/failure back to
       // the proposal's domain. agent.metadata is a hand-picked projection of

--- a/server/services/agentLifecycle.test.js
+++ b/server/services/agentLifecycle.test.js
@@ -705,7 +705,10 @@ describe('runAgentSpawn source — instance provenance + claim ordering (#1563)'
 
   it('records claimFlow separately from CoS-managed PR/worktree flags', () => {
     const registerIdx = AGENT_LIFECYCLE_SRC.indexOf('registerAgent(agentId, task.id, {');
-    const metaSlice = AGENT_LIFECYCLE_SRC.slice(registerIdx, registerIdx + 8_000);
+    // Slice to the END of the call, not a fixed byte window: the projected keys
+    // sit near the bottom of a growing metadata object, so a magic-number window
+    // makes an unrelated comment above them read as a missing key.
+    const metaSlice = AGENT_LIFECYCLE_SRC.slice(registerIdx, AGENT_LIFECYCLE_SRC.indexOf('\n  });', registerIdx));
     expect(metaSlice).toContain('configOpenPR: isTruthyMeta(task.metadata?.openPR)');
     expect(metaSlice).toContain('configClaimFlow: isClaimFlowTask(task, isTruthyMeta)');
     expect(metaSlice.indexOf('configClaimFlow')).toBeGreaterThan(metaSlice.indexOf('configOpenPR'));

--- a/server/services/cos.js
+++ b/server/services/cos.js
@@ -1016,7 +1016,8 @@ async function spawnDequeuePriority0OnDemand(ctx) {
       await taskScheduleMod.recordExecution(`task:${request.taskType}`, targetApp.id);
       task = await generateManagedAppImprovementTaskForType(request.taskType, targetApp, state, {
         skipPreconditions: true,
-        deferPerpetualDispatch: true
+        deferPerpetualDispatch: true,
+        targetPullRequest: request.targetPullRequest ?? null
       });
       if (task) {
         await bindAppReviewAgent(targetApp.id, `on-demand-${Date.now()}`);
@@ -1503,6 +1504,10 @@ export function isPerpetualRefillCandidate(agent, schedule) {
  */
 export function perpetualRefillPlan(agent, schedule) {
   if (!isPerpetualRefillCandidate(agent, schedule)) return { lane: 'skip' };
+  // A run narrowed to ONE pull request is a one-shot the user asked for on a
+  // specific row. A refill carries no target, so continuing the drain here would
+  // silently promote that click into a sweep of every open contributor PR.
+  if (agent?.metadata?.taskTargetPullRequest) return { lane: 'skip' };
   if (agent?.metadata?.taskOnDemand) {
     return { lane: 'onDemand', taskType: agentScheduledType(agent), appId: agent?.metadata?.taskApp || null };
   }

--- a/server/services/cos.test.js
+++ b/server/services/cos.test.js
@@ -2268,6 +2268,13 @@ describe('perpetualRefillPlan — manual vs scheduled drain lane', () => {
     )).toEqual({ lane: 'onDemand', taskType: 'claim-issue', appId: null });
   });
 
+  it('does not refill a run that was narrowed to one pull request', () => {
+    expect(perpetualRefillPlan(
+      agent({ taskAnalysisType: 'claim-issue', taskOnDemand: true, taskApp: 'app-42', taskTargetPullRequest: 17 }),
+      schedule,
+    )).toEqual({ lane: 'skip' });
+  });
+
   it('skips a non-candidate even when it is marked on-demand (disabled / non-perpetual / unknown)', () => {
     expect(perpetualRefillPlan(agent({ taskAnalysisType: 'claim-issue-disabled', taskOnDemand: true }), schedule))
       .toEqual({ lane: 'skip' });

--- a/server/services/cosTaskGenerator.js
+++ b/server/services/cosTaskGenerator.js
@@ -954,7 +954,8 @@ async function spawnPriority0OnDemand(ctx) {
         await taskSchedule.recordExecution(`task:${request.taskType}`, targetApp.id);
         task = await generateManagedAppImprovementTaskForType(request.taskType, targetApp, state, {
           skipPreconditions: true,
-          deferPerpetualDispatch: true
+          deferPerpetualDispatch: true,
+          targetPullRequest: request.targetPullRequest ?? null
         });
         if (task) {
           await bindAppReviewAgent(targetApp.id, `on-demand-${Date.now()}`);
@@ -2159,6 +2160,26 @@ export function buildSecurityScanPipelineOutput(scan, reports, status) {
   return JSON.stringify({ ...base, complete: true, reviewedPrs: included })
 }
 
+/**
+ * Name the single PR a targeted pr-reviewer run covers. The number goes in the
+ * FIRST line specifically: `addTask`'s duplicate guard keys on (first line +
+ * app), so without it, targeting a second PR while the first run is still in
+ * flight would be rejected as a duplicate of it. The trailing sentence repeats
+ * the scope for the agent; the header keeps its `[Improvement: <app>] …` shape
+ * so the CoS queue still reads the same way.
+ */
+function scopeDescriptionToPullRequest(description, metadata) {
+  const number = metadata?.targetPullRequest;
+  if (!number) return description;
+  const [firstLine, ...rest] = description.split('\n');
+  return [
+    `${firstLine} — pull request #${number} only`,
+    ...rest,
+    '',
+    `This run is scoped to pull request #${number}: it is the only request the server cleared, and the only one this run may act on.`,
+  ].join('\n');
+}
+
 function formatSecurityScanContext(scan, reports, status) {
   const findingCount = reports.filter((report) => !reportIsSafe(report)).length
   return [
@@ -2195,8 +2216,15 @@ async function findActiveSecurityScanTask(appId, scanKey) {
  * External contributor PRs are held for human approval before the stage that
  * can review, comment, or merge. The preflight itself remains read-only and
  * does not checkout or execute any contributor branch.
+ *
+ * `targetPullRequest` narrows the run to ONE open PR — the per-row "Review this
+ * PR" trigger on an app's PRs / MRs tab. The narrowing happens BEFORE the
+ * fingerprint and the security scan, so every downstream contract (scan key,
+ * public-review snapshot, `issueWatcher.pullRequests` coverage, and the output
+ * hook's strict envelope check) is scoped to that one PR by construction rather
+ * than by a prompt asking the agent to ignore the rest.
  */
-async function runPrReviewerSecurityPreflight(taskType, app, metadata) {
+async function runPrReviewerSecurityPreflight(taskType, app, metadata, targetPullRequest = null) {
   if (taskType !== 'pr-reviewer') return { skipped: false };
 
   const stages = metadata.pipeline?.stages;
@@ -2209,7 +2237,7 @@ async function runPrReviewerSecurityPreflight(taskType, app, metadata) {
 
   const { listExternalOpenPullRequests, runPrReviewerSecurityScan, securityScanFingerprint } = await import('./prReviewerSecurity.js');
   const { writePublicReviewInputSnapshot } = await import('./modelAbuseGuard.js');
-  const target = await listExternalOpenPullRequests(app);
+  let target = await listExternalOpenPullRequests(app);
   if (!target.ok) {
     emitLog('warn', `Skipping pr-reviewer for ${app.name}: ${target.code || 'security-scan-target-unavailable'}`, { appId: app.id, analysisType: taskType });
     return { skipped: true };
@@ -2217,6 +2245,15 @@ async function runPrReviewerSecurityPreflight(taskType, app, metadata) {
   if (target.prs.length === 0) {
     emitLog('info', `Skipping pr-reviewer for ${app.name}: no-external-open-prs`, { appId: app.id, analysisType: taskType });
     return { skipped: true, reason: 'no-external-open-prs' };
+  }
+  if (targetPullRequest) {
+    const scoped = target.prs.filter((pr) => pr.number === targetPullRequest);
+    if (scoped.length === 0) {
+      emitLog('warn', `Skipping pr-reviewer for ${app.name}: target-pull-request-not-reviewable (#${targetPullRequest})`, { appId: app.id, analysisType: taskType });
+      return { skipped: true, reason: 'target-pull-request-not-reviewable' };
+    }
+    target = { ...target, prs: scoped };
+    metadata.targetPullRequest = targetPullRequest;
   }
   const scanKey = securityScanFingerprint(target);
   const active = await findActiveSecurityScanTask(app.id, scanKey);
@@ -3421,7 +3458,8 @@ function applyProviderModelPins(metadata, interval, appPin, hookOverride) {
 export async function generateManagedAppImprovementTaskForType(taskType, app, state, {
   skipPreconditions = false,
   ignoreTaskId = null,
-  deferPerpetualDispatch = false
+  deferPerpetualDispatch = false,
+  targetPullRequest = null
 } = {}) {
   const { updateAppActivity } = await import('./appActivity.js');
   const taskSchedule = await import('./taskSchedule.js');
@@ -3453,7 +3491,7 @@ export async function generateManagedAppImprovementTaskForType(taskType, app, st
   const metadata = buildImprovementTaskMetadata(taskType, app, interval, taskSchedule, appOverride);
 
   initializePipelineMetadata(metadata);
-  const securityPreflight = await runPrReviewerSecurityPreflight(taskType, app, metadata);
+  const securityPreflight = await runPrReviewerSecurityPreflight(taskType, app, metadata, targetPullRequest);
   if (securityPreflight.skipped) return null;
   if (!skipPreconditions && shouldSkipForPrecondition(metadata, app, taskType)) return null;
 
@@ -3587,7 +3625,10 @@ export async function generateManagedAppImprovementTaskForType(taskType, app, st
     }
   });
   const taskDataInputs = await resolveTaskDataInputs(interval.dataInputs, { app });
-  const description = appendTaskDataInputs(baseDescription, taskDataInputs);
+  const description = scopeDescriptionToPullRequest(
+    appendTaskDataInputs(baseDescription, taskDataInputs),
+    metadata
+  );
 
   applyAppWorktreeDefault(metadata, app);
   // File-issues posture wins over app worktree/PR defaults — the deliverable

--- a/server/services/cosTaskGenerator.js
+++ b/server/services/cosTaskGenerator.js
@@ -2441,9 +2441,16 @@ async function generateManagedAppImprovementTask(app, state, { ignoreTaskId = nu
 
   let nextType;
   let selectionReason;
+  // A stolen on-demand request may be SCOPED to one PR (the PRs/MRs tab's
+  // per-row pr-reviewer trigger). Carrying it is not optional: the generator
+  // reads no target as "sweep every external PR", so dropping it here would
+  // silently promote the user's one-row click into a full-repo review — the
+  // same widening the perpetual-refill skip guards against on the other side.
+  let targetPullRequest = null;
 
   if (appRequests.length > 0) {
     const request = appRequests[0];
+    targetPullRequest = request.targetPullRequest ?? null;
     await taskSchedule.clearOnDemandRequest(request.id);
     // Only a human "Run" may clear the drain's brakes (park state, dispatch
     // count); the policy lives in applyOnDemandRunResets so this idle-review
@@ -2491,7 +2498,8 @@ async function generateManagedAppImprovementTask(app, state, { ignoreTaskId = nu
   // spawn; the per-type generator does not record execution itself.
   const task = await generateManagedAppImprovementTaskForType(nextType, app, state, {
     ignoreTaskId,
-    deferPerpetualDispatch: true
+    deferPerpetualDispatch: true,
+    targetPullRequest
   });
   // Idle-review can steal a queued on-demand request for this app. That
   // request is still a user Run — apply the same consent as Priority 0.

--- a/server/services/cosTaskGenerator.test.js
+++ b/server/services/cosTaskGenerator.test.js
@@ -327,7 +327,10 @@ describe('both on-demand engines apply consent before addTask', () => {
   it('idle-review steal path consents when it drains an on-demand request', () => {
     const start = GEN_SRC.indexOf('async function generateManagedAppImprovementTask(app, state');
     expect(start).toBeGreaterThan(-1);
-    const body = GEN_SRC.slice(start, start + 3500);
+    // Slice to the end of the function, not a fixed byte window: the consent line
+    // sits at the bottom of a body that grows, so a magic number makes an
+    // unrelated comment above it read as a missing consent call.
+    const body = GEN_SRC.slice(start, GEN_SRC.indexOf('\n  return task;', start));
     expect(body).toMatch(/selectionReason === 'on-demand'\) applyOnDemandConsent\(task\)/);
   });
 });
@@ -1868,6 +1871,15 @@ describe('pr-reviewer security preflight wiring', () => {
     // widening the run back out to every open PR.
     expect(body).toContain('target-pull-request-not-reviewable');
     expect(body).toContain('metadata.targetPullRequest = targetPullRequest');
+  });
+
+  it('carries a stolen on-demand request\'s PR target through the idle-review path', () => {
+    const start = GEN_SRC.indexOf('const appRequests = onDemandRequests.filter(');
+    const body = GEN_SRC.slice(start, GEN_SRC.indexOf('\n  return task;', start));
+    // The idle tier can consume a queued on-demand request instead of Priority 0.
+    // Dropping the target there re-widens a one-row click into a full sweep.
+    expect(body).toContain('targetPullRequest = request.targetPullRequest ?? null');
+    expect(body).toMatch(/generateManagedAppImprovementTaskForType\([\s\S]*?targetPullRequest\n/);
   });
 
   it('keeps a targeted run distinguishable from the sweep in the duplicate guard', () => {

--- a/server/services/cosTaskGenerator.test.js
+++ b/server/services/cosTaskGenerator.test.js
@@ -1838,7 +1838,7 @@ describe('pr-reviewer security preflight wiring', () => {
   it('runs the direct preflight before stage gates and resolves the next-stage prompt', () => {
     const start = GEN_SRC.indexOf('export async function generateManagedAppImprovementTaskForType');
     const body = GEN_SRC.slice(start, GEN_SRC.indexOf('return task;', start));
-    const preflightAt = body.indexOf('runPrReviewerSecurityPreflight(taskType, app, metadata)');
+    const preflightAt = body.indexOf('runPrReviewerSecurityPreflight(taskType, app, metadata, targetPullRequest)');
     const preconditionAt = body.indexOf('shouldSkipForPrecondition(metadata, app, taskType)');
     const promptAt = body.indexOf('getStagePrompt(taskType, currentStageIndex)');
 
@@ -1852,6 +1852,29 @@ describe('pr-reviewer security preflight wiring', () => {
     expect(GEN_SRC).toContain('no-external-open-prs');
     expect(GEN_SRC).toContain('findActiveSecurityScanTask');
     expect(GEN_SRC).toContain('securityScanFingerprint');
+  });
+
+  it('narrows a targeted run before the fingerprint, the scan, and the stage-2 allowlist', () => {
+    const start = GEN_SRC.indexOf('async function runPrReviewerSecurityPreflight');
+    const body = GEN_SRC.slice(start, GEN_SRC.indexOf('\n  return { skipped: false, scan };', start));
+    const narrowAt = body.indexOf('target = { ...target, prs: scoped }');
+    const fingerprintAt = body.indexOf('securityScanFingerprint(target)');
+    const scanAt = body.indexOf('runPrReviewerSecurityScan(');
+
+    expect(narrowAt, 'a targeted run must filter the external PR set itself').toBeGreaterThan(-1);
+    expect(narrowAt).toBeLessThan(fingerprintAt);
+    expect(narrowAt).toBeLessThan(scanAt);
+    // Refusing an unmatched target is what keeps a stale row from silently
+    // widening the run back out to every open PR.
+    expect(body).toContain('target-pull-request-not-reviewable');
+    expect(body).toContain('metadata.targetPullRequest = targetPullRequest');
+  });
+
+  it('keeps a targeted run distinguishable from the sweep in the duplicate guard', () => {
+    expect(GEN_SRC).toContain('function scopeDescriptionToPullRequest(description, metadata)');
+    const genStart = GEN_SRC.indexOf('export async function generateManagedAppImprovementTaskForType');
+    const body = GEN_SRC.slice(genStart, GEN_SRC.indexOf('return task;', genStart));
+    expect(body).toContain('scopeDescriptionToPullRequest(');
   });
 
   it('passes only safe PR metadata to Stage 2, never report prose or model output', () => {

--- a/server/services/prReviewerSecurity.js
+++ b/server/services/prReviewerSecurity.js
@@ -33,7 +33,16 @@ const safeText = (value, max) => typeof value === 'string' ? value.slice(0, max)
  * Find every currently-open PR from an external human contributor. This is a
  * public-metadata operation only; it does not fetch a branch or run code.
  */
-export async function listExternalOpenPullRequests(app) {
+/**
+ * The three facts that decide which of a repo's open PRs pr-reviewer may target:
+ * the `gh` repo selector, the default branch it reviews against, and the login
+ * whose own PRs are excluded. Split out of `listExternalOpenPullRequests` so a
+ * caller that already HAS the PR rows — the PRs/MRs tab, deciding whether to
+ * offer its per-row Review action — can answer "is this row reviewable?" from
+ * the same source of truth instead of re-listing every PR or re-deriving the
+ * rule and drifting from it.
+ */
+export async function resolvePrReviewerTargetScope(app) {
   const origin = await getOriginInfo(app?.repoPath).catch(() => null);
   const repoSpec = githubRepoSpec(origin);
   if (!repoSpec) return failure('security-scan-not-a-github-repo');
@@ -51,9 +60,38 @@ export async function listExternalOpenPullRequests(app) {
   const selfLogin = await getSelfLogin(githubApiHost(origin.host));
   if (!selfLogin) return failure('security-scan-self-login-unavailable');
 
+  return {
+    ok: true,
+    repoSpec,
+    repoFullName: origin.fullName,
+    defaultBranch: defaultBranch.trim(),
+    selfLogin,
+  };
+}
+
+/**
+ * Whether one already-listed PR row is a pr-reviewer target, per a resolved
+ * scope. Mirrors exactly what `listExternalOpenPullRequests` keeps — open
+ * against the default branch, opened by someone other than the signed-in
+ * account — so a UI gated on this and the route's authoritative check agree.
+ */
+export function isReviewablePullRequest(scope, pullRequest) {
+  const author = pullRequest?.author;
+  return scope?.ok === true
+    && pullRequest?.baseBranch === scope.defaultBranch
+    && typeof author === 'string'
+    && author.length > 0
+    && author.toLowerCase() !== String(scope.selfLogin).toLowerCase();
+}
+
+export async function listExternalOpenPullRequests(app) {
+  const scope = await resolvePrReviewerTargetScope(app);
+  if (!scope.ok) return scope;
+  const { repoSpec, repoFullName, defaultBranch, selfLogin } = scope;
+
   const raw = await execGh([
     'pr', 'list', '--repo', repoSpec,
-    '--base', defaultBranch.trim(), '--state', 'open',
+    '--base', defaultBranch, '--state', 'open',
     '--limit', String(SECURITY_SCAN_MAX_OPEN_PRS),
     '--json', 'number,author,url,headRefOid,updatedAt,title,body',
   ]).catch(() => null);
@@ -85,8 +123,8 @@ export async function listExternalOpenPullRequests(app) {
   return {
     ok: true,
     repoSpec,
-    repoFullName: origin.fullName,
-    defaultBranch: defaultBranch.trim(),
+    repoFullName,
+    defaultBranch,
     prs: prs.filter((pr) => String(pr.authorLogin).toLowerCase() !== String(selfLogin).toLowerCase()),
   };
 }

--- a/server/services/taskSchedule.js
+++ b/server/services/taskSchedule.js
@@ -1149,7 +1149,12 @@ export async function getNextTaskType(appId = null, lastType = '', { perpetualOn
  * perpetual drain re-issued ITSELF through the same lane after a completed run —
  * automated, and therefore NOT allowed to clear its own brakes.
  */
-export async function triggerOnDemandTask(taskType, appId = null, { emit = true, origin = ON_DEMAND_ORIGINS.USER } = {}) {
+export async function triggerOnDemandTask(taskType, appId = null, { emit = true, origin = ON_DEMAND_ORIGINS.USER, targetPullRequest = null } = {}) {
+  // A targeted run names ONE open PR/MR instead of letting the task pick from
+  // the app's whole open set (the PR/MR row's "Review this PR" button). Coerced
+  // and validated here so a bad value can't reach the generator's forge filter.
+  const requested = Number(targetPullRequest);
+  const scopedPullRequest = Number.isInteger(requested) && requested > 0 ? requested : null;
   const request = await updateSchedule(async (schedule) => {
     // Cheap per-task-type check first; the master-flag check pays a state.json read.
     const tasks = schedule.tasks || {};
@@ -1185,7 +1190,8 @@ export async function triggerOnDemandTask(taskType, appId = null, { emit = true,
       taskType,
       appId,
       origin,
-      requestedAt: new Date().toISOString()
+      requestedAt: new Date().toISOString(),
+      ...(scopedPullRequest ? { targetPullRequest: scopedPullRequest } : {})
     };
 
     schedule.onDemandRequests.push(request);
@@ -1203,8 +1209,8 @@ export async function triggerOnDemandTask(taskType, appId = null, { emit = true,
       type: 'cos.schedule.trigger',
       target: taskType,
       targetName: appId,
-      summary: `Ran scheduled task '${taskType}' on demand${appId ? ` for ${appId}` : ''}`,
-      payload: { taskType, appId: appId ?? null, requestId: request.id },
+      summary: `Ran scheduled task '${taskType}' on demand${appId ? ` for ${appId}` : ''}${scopedPullRequest ? ` (#${scopedPullRequest})` : ''}`,
+      payload: { taskType, appId: appId ?? null, requestId: request.id, ...(scopedPullRequest ? { targetPullRequest: scopedPullRequest } : {}) },
       source: { service: 'taskSchedule', fn: 'triggerOnDemandTask' },
       happenedAt: request.requestedAt,
       dedupeKey: `cos.schedule.trigger:${request.id}`,

--- a/server/services/taskSchedule.test.js
+++ b/server/services/taskSchedule.test.js
@@ -1971,6 +1971,30 @@ describe('taskSchedule', () => {
       expect((await getOnDemandRequests()).filter(r => r.taskType === 'pr-reviewer')).toHaveLength(0)
     })
 
+    it('carries a targeted PR number onto the queued request', async () => {
+      mockSchedule({
+        tasks: { 'pr-reviewer': { type: INTERVAL_TYPES.ON_DEMAND, enabled: true } }
+      })
+
+      const result = await triggerOnDemandTask('pr-reviewer', 'app-1', { targetPullRequest: 17 })
+
+      expect(result.error).toBeUndefined()
+      expect(result.targetPullRequest).toBe(17)
+      const queued = (await getOnDemandRequests()).find(r => r.id === result.id)
+      expect(queued.targetPullRequest).toBe(17)
+    })
+
+    it('drops a non-positive-integer PR target rather than queueing an unusable filter', async () => {
+      mockSchedule({
+        tasks: { 'pr-reviewer': { type: INTERVAL_TYPES.ON_DEMAND, enabled: true } }
+      })
+
+      const result = await triggerOnDemandTask('pr-reviewer', 'app-1', { targetPullRequest: 'all' })
+
+      expect(result.error).toBeUndefined()
+      expect('targetPullRequest' in result).toBe(false)
+    })
+
     it('should reject unknown task types instead of silently queuing them', async () => {
       mockSchedule({
         tasks: { 'feature-ideas': { type: 'weekly', enabled: true } }


### PR DESCRIPTION
## Summary

Managed app PR/MR rows get a second action beside **Resolve & merge**: **PR review** queues the `pr-reviewer` scheduled task narrowed to *that one request*, instead of letting the task pick from whichever external PRs it finds for itself.

## How the targeting works

Targeting is threaded end to end rather than asked for in a prompt:

- `triggerOnDemandTask` accepts an optional `targetPullRequest` (coerced and validated there, so a bad value can't reach the forge filter).
- All three on-demand consumers forward it — `spawnPriority0OnDemand`, `spawnDequeuePriority0OnDemand`, and the idle-review tier, which can *steal* a queued request and would otherwise re-widen the run.
- The pr-reviewer security preflight filters the external PR set to that number **before** computing the scan fingerprint and running the model-abuse scan.

Because the narrowing happens upstream of the fingerprint, every downstream contract — scan key, public-review snapshot, `issueWatcher.pullRequests` coverage, and the output hook's strict envelope check — is scoped to the single PR *by construction*. An unmatched target skips with `target-pull-request-not-reviewable` rather than silently sweeping.

Two guards keep a per-row click from becoming a repo-wide sweep:

- The task's **first line** carries the PR number, so CoS's duplicate guard (first line + app) can tell two targeted runs apart while one is still in flight.
- A targeted run is **excluded from the perpetual drain refill** — a re-issue carries no target, so continuing the drain would promote the click into a sweep.

## API

`POST /api/apps/:id/pull-requests/:number/review` answers eligibility up front through the same reader the preflight uses (GitHub, open against the default branch, opened by someone else), so an ineligible row gets an immediate explanation instead of a run that reviews nothing an hour later. It fails closed when task or on-demand state is unreadable, and refuses a target whose head commit can't be fingerprinted.

The GET route annotates each row with `reviewEligible` plus any in-flight pr-reviewer run or queued on-demand request, so the button appears only where it can work and its state survives a refresh.

## Review

A local `codex` pass (`gpt-5.6-luna`, effort max) surfaced 5 findings; 4 were confirmed and fixed in the second commit. The fifth — resolving the target through the app's forge pin for a custom-host GitHub origin — was declined: the route intentionally uses the same reader the preflight uses, so accepting an origin the preflight rejects would return `202` for a run that then silently reviews nothing. Widening that resolver changes the security scan's own targeting and belongs in its own change.

## Test plan

- `server`: 37,178 passed / 13 skipped — full suite (includes `../scripts`, `../lib`, `../autofixer`).
- `client`: 10,686 passed — full suite; `biome lint --error-on-warnings` clean.
- New coverage: route contracts for eligibility (eligible / self-authored / non-default base / unresolvable scope), the fail-closed paths, the duplicate guard, and the unscannable-head refusal; client tests for queueing, socket late-binding by `targetPullRequest`, hydration, and the ineligible-row gate; generator source guards pinning that narrowing precedes the fingerprint and that the idle path carries the target.