### PR TITLE
classify Ollama "does not support tools" as a model fault, not a bad request

### DIFF
--- a/server/services/agentErrorAnalysis.js
+++ b/server/services/agentErrorAnalysis.js
@@ -340,6 +340,49 @@ export const ERROR_PATTERNS = [
     }
   },
   {
+    // Ollama's capability rejection: the request asked a model for something its
+    // manifest doesn't declare — for an agent harness, almost always
+    // `API Error: 400 registry.ollama.ai/library/gemma3:27b does not support tools`.
+    // Must sit AHEAD of `bad-request`, which it arrives as, and which draws
+    // exactly the wrong conclusion: "check prompt formatting, tool names, and
+    // parameter sizes" sends the retry (and the investigation task it spawns)
+    // after a malformed request, when the request was fine and the MODEL simply
+    // cannot emit tool calls. No amount of reformatting fixes that; only picking
+    // a tool-capable model does, so this is a Tier 1 config correction, not a
+    // Tier 2 schema/type one.
+    //
+    // Categorized `model-not-found` to mirror the identical clause in
+    // aiToolkit/errorDetection.js (the API path) — same fault, same vocabulary,
+    // and the category is REQUEST-specific in providerCooldown, so a healthy
+    // Ollama daemon serving other tool-capable models is not benched for naming
+    // one model that can't.
+    //
+    // Anchored on the `API Error: 4NN` line rather than the bare phrase: this
+    // file's rules sweep the whole transcript, and "does not support tools" is
+    // a sentence an agent working on this very code writes in passing.
+    pattern: /API Error:\s*4\d\d[\s\S]{0,200}?["']?([\w.\-/:]+)["']?\s+does not support\s+(tools|thinking|insert|chat|generate|completions?|embeddings?)\b/i,
+    category: 'model-not-found',
+    actionable: true,
+    origin: 'provider',
+    escalation: 'Point this task at a model whose backend reports the missing capability (Ollama tags tool-callers with a `tools` capability), then approve the retry.',
+    extract: (match, output, task, model) => {
+      // Ollama echoes the fully-qualified registry path; the bare tag is what a
+      // provider's model field actually holds.
+      const affected = match[1].replace(/^.*\/library\//, '');
+      const capability = match[2].toLowerCase();
+      const forTools = capability === 'tools';
+      return {
+        message: `Model "${affected}" does not support ${capability}`,
+        suggestedFix: forTools
+          ? `"${affected}" cannot emit native tool calls, and an agent run is nothing but tool calls — every retry dies identically no matter how the prompt is written. Point this task's provider at a tool-capable model (AI Providers → the provider → Model; the Local LLMs tab marks these "🔧 tool use") and retry.`
+          : `The backend serving "${affected}" reports no "${capability}" capability, so this request can never succeed against it. Pick a model that declares it, or route this task to a provider that does.`,
+        affectedModel: affected,
+        affectedCapability: capability,
+        configuredModel: model
+      };
+    }
+  },
+  {
     pattern: /API Error: 400|invalid_request_error|bad.?request/i,
     category: 'bad-request',
     actionable: true,

--- a/server/services/agentErrorAnalysis.test.js
+++ b/server/services/agentErrorAnalysis.test.js
@@ -301,6 +301,44 @@ describe('analyzeAgentFailure — ERROR_PATTERNS classification', () => {
     expect(analysis.suggestedFix).toContain('num_ctx');
   });
 
+  it('classifies an Ollama tool-capability rejection as a model problem, not a bad request', () => {
+    const body = 'API Error: 400 registry.ollama.ai/library/gemma3:27b does not support tools';
+    const analysis = analyzeAgentFailure(withLead(body), { id: 't' }, 'gemma3:27b');
+    // NOT `bad-request`: the request was well-formed and the model simply can't
+    // emit tool calls, so "check prompt formatting" (that rule's advice) sends
+    // the retry after a defect that isn't there.
+    expect(analysis.category).toBe('model-not-found');
+    expect(analysis.origin).toBe('provider');
+    expect(analysis.actionable).toBe(true);
+    // The registry path is stripped down to the tag a provider's model field holds.
+    expect(analysis.affectedModel).toBe('gemma3:27b');
+    expect(analysis.affectedCapability).toBe('tools');
+    expect(analysis.suggestedFix).toMatch(/tool-capable model/i);
+  });
+
+  it('classifies the same rejection for a non-tools capability', () => {
+    const body = 'API Error: 400 {"error":"nomic-embed-text:latest does not support chat"}';
+    const analysis = analyzeAgentFailure(withLead(body), { id: 't' }, 'nomic-embed-text:latest');
+    expect(analysis.category).toBe('model-not-found');
+    expect(analysis.affectedModel).toBe('nomic-embed-text:latest');
+    expect(analysis.affectedCapability).toBe('chat');
+  });
+
+  it('does not classify prose about tool support as a model rejection', () => {
+    // This file's rules sweep the whole transcript, and an agent editing this
+    // very code writes the phrase in passing — without the `API Error: 4NN`
+    // anchor that output would be misread as a provider signal.
+    const prose = 'Noted in the review that gemma3:27b does not support tools, so the harness needs a different model.';
+    const analysis = analyzeAgentFailure(withLead(prose), { id: 't' }, 'x');
+    expect(analysis.category).not.toBe('model-not-found');
+  });
+
+  it('still classifies an ordinary malformed request as bad-request', () => {
+    const body = 'API Error: 400 {"type":"invalid_request_error","message":"messages: at least one message is required"}';
+    const analysis = analyzeAgentFailure(withLead(body), { id: 't' }, 'x');
+    expect(analysis.category).toBe('bad-request');
+  });
+
   it('falls back to an unknown, non-actionable category for unrecognized output', () => {
     const analysis = analyzeAgentFailure(withLead('The agent halted after an unrecognized condition with no diagnostic.'), { id: 't' }, 'x');
     expect(analysis.category).toBe('unknown');


### PR DESCRIPTION
## Summary

A CoS agent dispatched to an Ollama-backed provider running `gemma3:27b` died with:

```
API Error: 400 registry.ollama.ai/library/gemma3:27b does not support tools
```

`agentErrorAnalysis.js` had no rule for Ollama's capability rejection, so it fell through to the generic `bad-request` rule — whose advice, *"check prompt formatting, tool names, and parameter sizes"*, points at a defect that isn't there. The request was well-formed; the model simply cannot emit native tool calls, which is all an agent run is. Every retry died identically, and the failure spawned an investigation task for what is a one-field config change.

**The fix**: a rule ahead of `bad-request` for Ollama's capability rejection, mirroring the clause `aiToolkit/errorDetection.js` already carries on the API path.

- Reuses `model-not-found` rather than minting a category, which keeps the two vocabularies aligned and gets the right downstream behavior for free:
  - **Tier 1 (config/env)** instead of Tier 2 (schema/type) in `autoFixer`.
  - **No provider bench** — the category is request-specific in `providerCooldown`, so a healthy Ollama daemon serving other tool-capable models stays up.
  - **No dent to the task type's success rate** — already in `taskLearning`'s environmental set.
- The fix text names the model (registry path stripped to the bare tag a provider's model field holds) and tells the operator to pick a tool-capable one.
- Anchored on the `API Error: 4NN` line rather than the bare phrase: these rules sweep the whole transcript, and "does not support tools" is a sentence an agent editing this code writes in passing.

The non-`tools` capabilities Ollama rejects the same way (`chat`, `generate`, `embeddings`, `insert`, `thinking`) are covered by the same rule — an embedding-only model reached through `/api/chat` was landing in `bad-request` for the same reason.

No config change ships here: the local-LLM catalog already declares `gemma3:27b` as `['chat', 'vision']` with a description that says "without native tool calling", so the model selection is the operator's to correct — this makes the failure tell them that.

## Test plan

- 4 new cases in `agentErrorAnalysis.test.js`: the tools rejection, a non-tools capability (`chat`), prose about tool support staying unclassified, and an ordinary malformed request still landing in `bad-request`.
- `server/services/agentErrorAnalysis.test.js` — 125 passed
- `autoFixer` / `providerCooldown` / `errorDetection` / `layeredIntelligenceExecutionFailures` / `taskLearning` — 470 passed
- Full server suite: 37168 passed, 1 pre-existing timeout flake in `services/sprites/atlas.test.js` (passes in isolation, unrelated to this change)