### PR TITLE
refactor: drop redundant try/catch from contacts import route (#5676)

### DIFF
--- a/server/routes/contacts.js
+++ b/server/routes/contacts.js
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 import { z } from 'zod';
 
-import { asyncHandler, ServerError } from '../lib/errorHandler.js';
+import { asyncHandler } from '../lib/errorHandler.js';
 import { validateRequest } from '../lib/validation.js';
 import * as contactsSync from '../services/contactsSync.js';
 import * as identityResolve from '../services/identityResolve.js';
@@ -84,15 +84,8 @@ const importBodySchema = z.object({
 
 router.post('/import-to-tribe', asyncHandler(async (req, res) => {
   const body = validateRequest(importBodySchema, req.body || {});
-  try {
-    const result = await tribeContacts.importContactToTribe(body);
-    res.status(result.created ? 201 : 200).json(result);
-  } catch (err) {
-    if (err?.status === 400) {
-      throw new ServerError(err.message, { status: 400, code: err.code || 'BAD_REQUEST' });
-    }
-    throw err;
-  }
+  const result = await tribeContacts.importContactToTribe(body);
+  res.status(result.created ? 201 : 200).json(result);
 }));
 
 export default router;

--- a/server/routes/contacts.test.js
+++ b/server/routes/contacts.test.js
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import express from 'express';
 import { request } from '../lib/testHelper.js';
-import { errorMiddleware } from '../lib/errorHandler.js';
+import { errorMiddleware, ServerError } from '../lib/errorHandler.js';
 
 vi.mock('../services/contactsSync.js', () => ({
   checkSetup: vi.fn(async () => ({ ok: true, sourceCount: 2, rawContactRows: 100 })),
@@ -22,6 +22,7 @@ vi.mock('../services/tribeContacts.js', () => ({
 }));
 
 const { default: router } = await import('./contacts.js');
+const tribeContacts = await import('../services/tribeContacts.js');
 
 function makeApp() {
   const app = express();
@@ -69,5 +70,25 @@ describe('contacts routes (#2415)', () => {
     const res = await request(makeApp()).post('/api/contacts/import-to-tribe').send({ contactId: 'c1', name: 'Sam' });
     expect(res.status).toBe(201);
     expect(res.body.created).toBe(true);
+  });
+
+  // #5676: the route no longer re-wraps service errors — the shared middleware
+  // normalizes them. Pin the envelope so dropping that catch stays invisible
+  // to callers.
+  it('POST /import-to-tribe surfaces a service ServerError as its own 400 envelope', async () => {
+    tribeContacts.importContactToTribe.mockRejectedValueOnce(
+      new ServerError('name is required', { status: 400, code: 'BAD_REQUEST' }),
+    );
+    const res = await request(makeApp()).post('/api/contacts/import-to-tribe').send({ contactId: 'c1' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('name is required');
+    expect(res.body.code).toBe('BAD_REQUEST');
+  });
+
+  it('POST /import-to-tribe maps an unexpected service throw to a 500 envelope', async () => {
+    tribeContacts.importContactToTribe.mockRejectedValueOnce(new Error('address book exploded'));
+    const res = await request(makeApp()).post('/api/contacts/import-to-tribe').send({ contactId: 'c1' });
+    expect(res.status).toBe(500);
+    expect(res.body.code).toBe('INTERNAL_ERROR');
   });
 });

--- a/server/services/tribeContacts.js
+++ b/server/services/tribeContacts.js
@@ -15,6 +15,7 @@ import {
   normalizePhone,
   identityFromHandle,
 } from '../lib/tribeMatch.js';
+import { ServerError } from '../lib/errorHandler.js';
 import { loadContactIndex } from './contactsSync.js';
 import * as tribe from './tribe.js';
 import * as humanActivity from './humanActivity.js';
@@ -198,10 +199,7 @@ export async function importContactToTribe({
   }
   const personName = String(name || contact?.displayName || organization || contact?.organization || '').trim();
   if (!personName) {
-    const err = new Error('name is required');
-    err.status = 400;
-    err.code = 'BAD_REQUEST';
-    throw err;
+    throw new ServerError('name is required', { status: 400, code: 'BAD_REQUEST' });
   }
   const personPhones = phones || contact?.phones || [];
   const personEmails = emails || contact?.emails || [];


### PR DESCRIPTION
## Summary

`POST /api/contacts/import-to-tribe` wrapped its service call in a try/catch purely to re-wrap a 400 into a `ServerError`. That violated the repo's "no try/catch — errors bubble to centralized middleware" rule, and the branch was also dead: `normalizeError` already promotes a plain `Error` carrying `.status`/`.code` into the identical `ServerError`, so the response envelope was byte-identical either way.

Fixed at the root rather than just deleting the catch:

- `server/services/tribeContacts.js` — `importContactToTribe` now throws the shared `ServerError` instead of a hand-mutated `new Error` with attached `status`/`code`. Used `ServerError` directly rather than a `createServiceErrorMapper`, since this service has exactly one error case and no code→status table to justify a mapper.
- `server/routes/contacts.js` — handler reduced to the two statements it needs; the now-unused `ServerError` import dropped (grepped: nothing else in the file used it).

Behavior is unchanged: missing name still returns `400 { error: 'name is required', code: 'BAD_REQUEST' }`.

## Test plan

- Added two route tests in `server/routes/contacts.test.js` pinning the envelope the removed catch used to produce: a service `ServerError` still yields the 400 body above, and an unexpected service throw still yields a 500 with `code: 'INTERNAL_ERROR'`.
- `cd server && npm test` — 1832 files passed / 1 skipped, 37255 tests passed / 13 skipped.
- Local reviewer (codex, `gpt-5.6-terra`): no defects found.

Out of scope per the issue: no try/catch sweep across other route files, no change to the import validation schema.

Closes #5676

https://claude.ai/code/session_01DxNA8g7B5hZd4uswfUM1xn
