### PR TITLE
fix: persist voice fine-tuning jobs so checkpoints stay promotable after a restart (#5664)

### DIFF
--- a/server/lib/sseUtils.js
+++ b/server/lib/sseUtils.js
@@ -78,7 +78,9 @@ export const closeJobAfterDelay = (jobs, jobId, delay = SSE_CLEANUP_DELAY_MS, ex
       for (const c of expectedJob.clients || []) c.end();
       return;
     }
-    if (job) for (const c of job.clients) c.end();
+    // `clients` is absent on job maps that use this purely for eviction (the
+    // voice fine-tuning registry has no SSE route), so guard like the branch above.
+    if (job) for (const c of job.clients || []) c.end();
     jobs.delete(jobId);
   }, delay);
 };

--- a/server/routes/voice.js
+++ b/server/routes/voice.js
@@ -247,7 +247,10 @@ const fineTuneStartSchema = z.object({
 
 const fineTuneJobParamsSchema = z.object({
   id: z.string().trim().regex(/^[a-z0-9][a-z0-9-]{0,79}$/),
-  jobId: z.string().trim().min(1).max(80),
+  // Job ids are minted with randomUUID and are joined into a filesystem path
+  // when the run is resolved from its on-disk record, so anything that could
+  // carry a separator or `..` is rejected here.
+  jobId: z.string().trim().uuid(),
 }).strict();
 
 const fineTunePromoteSchema = z.object({

--- a/server/routes/voice.js
+++ b/server/routes/voice.js
@@ -340,8 +340,8 @@ router.post('/profiles/:id/fine-tune/start', asyncHandler(async (req, res) => {
 }));
 
 router.get('/profiles/:id/fine-tune/:jobId', asyncHandler(async (req, res) => {
-  const { jobId } = validateRequest(fineTuneJobParamsSchema, req.params);
-  const result = getFineTuningJobStatus(jobId);
+  const { id: profileId, jobId } = validateRequest(fineTuneJobParamsSchema, req.params);
+  const result = await getFineTuningJobStatus(jobId, profileId);
   res.json(result);
 }));
 

--- a/server/routes/voice.test.js
+++ b/server/routes/voice.test.js
@@ -203,24 +203,33 @@ describe('Voice Routes', () => {
     });
 
     it('manages fine-tuning lifecycle: start, status, cancel, promote', async () => {
-      fineTuning.startFineTuningJob.mockResolvedValue({ jobId: 'job-1', status: 'running' });
-      fineTuning.getFineTuningJobStatus.mockReturnValue({ jobId: 'job-1', status: 'completed', checkpoints: [{ id: 'ckpt-1' }] });
-      fineTuning.cancelFineTuningJob.mockReturnValue({ ok: true, jobId: 'job-1', status: 'cancelled' });
+      const jobId = '11111111-2222-4333-8444-555555555555';
+      fineTuning.startFineTuningJob.mockResolvedValue({ jobId, status: 'running' });
+      fineTuning.getFineTuningJobStatus.mockResolvedValue({ jobId, status: 'completed', checkpoints: [{ id: 'ckpt-1' }] });
+      fineTuning.cancelFineTuningJob.mockReturnValue({ ok: true, jobId, status: 'cancelled' });
       fineTuning.promoteCheckpoint.mockResolvedValue({ id: 'voice-profile-1', kind: 'fine-tuned' });
 
       const startRes = await request(buildApp()).post('/api/voice/profiles/voice-profile-1/fine-tune/start').send({ epochs: 5 });
       expect(startRes.status).toBe(202);
 
-      const statusRes = await request(buildApp()).get('/api/voice/profiles/voice-profile-1/fine-tune/job-1');
+      const statusRes = await request(buildApp()).get(`/api/voice/profiles/voice-profile-1/fine-tune/${jobId}`);
       expect(statusRes.status).toBe(200);
       expect(statusRes.body.status).toBe('completed');
+      expect(fineTuning.getFineTuningJobStatus).toHaveBeenCalledWith(jobId, 'voice-profile-1');
 
-      const cancelRes = await request(buildApp()).post('/api/voice/profiles/voice-profile-1/fine-tune/job-1/cancel').send({});
+      const cancelRes = await request(buildApp()).post(`/api/voice/profiles/voice-profile-1/fine-tune/${jobId}/cancel`).send({});
       expect(cancelRes.status).toBe(200);
 
-      const promoteRes = await request(buildApp()).post('/api/voice/profiles/voice-profile-1/fine-tune/job-1/promote').send({ checkpointId: 'ckpt-1' });
+      const promoteRes = await request(buildApp()).post(`/api/voice/profiles/voice-profile-1/fine-tune/${jobId}/promote`).send({ checkpointId: 'ckpt-1' });
       expect(promoteRes.status).toBe(200);
       expect(promoteRes.body.profile.kind).toBe('fine-tuned');
+    });
+
+    it('rejects a fine-tuning job id that could escape the profile directory', async () => {
+      const res = await request(buildApp())
+        .get('/api/voice/profiles/voice-profile-1/fine-tune/..%2F..%2Fother-profile');
+      expect(res.status).toBe(400);
+      expect(fineTuning.getFineTuningJobStatus).not.toHaveBeenCalled();
     });
 
     it('probes Qwen3 runtime status and downloads model on demand', async () => {

--- a/server/services/voice/fineTuning.js
+++ b/server/services/voice/fineTuning.js
@@ -38,8 +38,25 @@ const activeJobs = new Map();
 // together, rather than in a separate store that could outlive them.
 const JOB_RECORD_FILE = 'job.json';
 
+// Job ids are minted with randomUUID; anything else never named a real run and
+// must not reach `join`, where a separator or `..` would escape the profile's
+// directory. Enforced here as well as in the route schema because this path is
+// built from a caller-supplied id.
+const JOB_ID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 const jobRecordPath = (profileId, jobId) =>
   join(profileArtifactDirectory(profileId), 'fine-tune', jobId, JOB_RECORD_FILE);
+
+// A record that parsed but is not shaped like a job (a truncated `{}`, a `null`,
+// a hand-edited file) is not a usable recovery — it must not masquerade as a
+// live job whose `checkpoints` a caller is about to `.find` over.
+const isJobRecord = (record) => Boolean(
+  record
+  && typeof record === 'object'
+  && typeof record.id === 'string'
+  && typeof record.status === 'string'
+  && Array.isArray(record.checkpoints)
+);
 
 // Drops the runtime-only handles (abort controller, child process, write chain,
 // finalize latch) that cannot — and must not — be serialized.
@@ -71,9 +88,9 @@ const persistJob = (jobState) => {
 async function loadJob(jobId, profileId) {
   const active = activeJobs.get(jobId);
   if (active) return active;
-  if (!profileId) return null;
+  if (!profileId || !JOB_ID_RE.test(jobId)) return null;
   const { ok, value } = await readJSONFileStrict(jobRecordPath(profileId, jobId), null);
-  if (!ok) {
+  if (!ok || (value !== null && !isJobRecord(value))) {
     throw new ServerError('Fine-tuning job record is unreadable', {
       status: 500,
       code: 'JOB_RECORD_UNREADABLE',

--- a/server/services/voice/fineTuning.js
+++ b/server/services/voice/fineTuning.js
@@ -10,11 +10,13 @@
 
 import { randomUUID } from 'node:crypto';
 import { existsSync } from 'node:fs';
-import { mkdir, readdir, stat } from 'node:fs/promises';
+import { mkdir, readdir } from 'node:fs/promises';
 import { join } from 'node:path';
 import { spawn } from '../../lib/childProcess.js';
 import { ServerError } from '../../lib/errorHandler.js';
+import { atomicWrite, readJSONFile } from '../../lib/fileUtils.js';
 import { safeChildProcessOptions } from '../../lib/processEnv.js';
+import { closeJobAfterDelay } from '../../lib/sseUtils.js';
 import {
   DEFAULT_CLONE_MODEL,
   QWEN3_TTS_RUNNER_SCRIPT,
@@ -26,8 +28,63 @@ import {
   promoteFineTunedProfile,
 } from './profiles.js';
 
-// In-memory active training job map
+// In-memory active training job map. Entries are evicted once terminal (see
+// `finalizeJob`); the durable record is the `job.json` sidecar written beside
+// the run's checkpoints, so a restart mid-training does not orphan them.
 const activeJobs = new Map();
+
+// Sidecar record written into `<profileDir>/fine-tune/<jobId>/`. It lives with
+// the checkpoints it indexes so the record and its artifacts are deleted
+// together, rather than in a separate store that could outlive them.
+const JOB_RECORD_FILE = 'job.json';
+
+const jobRecordPath = (profileId, jobId) =>
+  join(profileArtifactDirectory(profileId), 'fine-tune', jobId, JOB_RECORD_FILE);
+
+// Drops the runtime-only handles (abort controller, child process, write chain,
+// finalize latch) that cannot — and must not — be serialized.
+const serializableJob = ({
+  controller: _controller,
+  child: _child,
+  persistChain: _persistChain,
+  finalized: _finalized,
+  ...record
+}) => record;
+
+/**
+ * Write the job record to disk. Writes are chained per job because `close` and
+ * `error` can both fire for one child and each rewrites the same file.
+ */
+const persistJob = (jobState) => {
+  jobState.persistChain = (jobState.persistChain || Promise.resolve())
+    .then(() => atomicWrite(jobRecordPath(jobState.profileId, jobState.id), serializableJob(jobState)))
+    .catch((err) => console.error(`❌ Failed to persist fine-tune job ${jobState.id}: ${err.message}`));
+  return jobState.persistChain;
+};
+
+/**
+ * Resolve a job from memory, falling back to its on-disk record. Returns null
+ * when neither exists.
+ */
+async function loadJob(jobId, profileId) {
+  const active = activeJobs.get(jobId);
+  if (active) return active;
+  if (!profileId) return null;
+  return readJSONFile(jobRecordPath(profileId, jobId), null);
+}
+
+/**
+ * Persist the terminal state, then evict the in-memory entry after the SSE
+ * grace window so a status poll racing completion still hits memory while the
+ * map stays bounded. Runs at most once per job — `error` and `close` can both
+ * fire for the same child.
+ */
+const finalizeJob = (jobState) => {
+  if (jobState.finalized) return;
+  jobState.finalized = true;
+  persistJob(jobState);
+  closeJobAfterDelay(activeJobs, jobState.id);
+};
 
 /**
  * Validate training dataset readiness for a given voice profile.
@@ -123,9 +180,11 @@ export async function startFineTuningJob({
     completedAt: null,
     error: null,
     controller: abortController,
+    child: null,
   };
 
   activeJobs.set(jobId, jobState);
+  await persistJob(jobState);
 
   const args = [
     QWEN3_TTS_RUNNER_SCRIPT,
@@ -138,6 +197,8 @@ export async function startFineTuningJob({
   ];
 
   const child = spawn(python, args, safeChildProcessOptions({ signal: abortController.signal }));
+  // Keep a handle on the child so a future shutdown hook can reach in-flight training.
+  jobState.child = child;
 
   let lineBuffer = '';
   child.stdout.on('data', (chunk) => {
@@ -186,12 +247,14 @@ export async function startFineTuningJob({
       }
       jobState.completedAt = new Date().toISOString();
     }
+    finalizeJob(jobState);
   });
 
   child.on('error', (err) => {
     jobState.status = 'failed';
     jobState.error = err.message;
     jobState.completedAt = new Date().toISOString();
+    finalizeJob(jobState);
   });
 
   return {
@@ -204,15 +267,15 @@ export async function startFineTuningJob({
 }
 
 /**
- * Get the current status and checkpoints of a fine-tuning job.
+ * Get the current status and checkpoints of a fine-tuning job, from memory
+ * while it is live and from its `job.json` sidecar afterwards.
  */
-export function getFineTuningJobStatus(jobId) {
-  const job = activeJobs.get(jobId);
+export async function getFineTuningJobStatus(jobId, profileId) {
+  const job = await loadJob(jobId, profileId);
   if (!job) {
     throw new ServerError('Fine-tuning job not found', { status: 404, code: 'JOB_NOT_FOUND' });
   }
-  const { controller: _c, ...serializable } = job;
-  return serializable;
+  return serializableJob(job);
 }
 
 /**
@@ -235,7 +298,7 @@ export function cancelFineTuningJob(jobId) {
  * Explicitly promote a selected checkpoint to the character's voice profile.
  */
 export async function promoteCheckpoint({ profileId, jobId, checkpointId }) {
-  const job = activeJobs.get(jobId);
+  const job = await loadJob(jobId, profileId);
   if (!job) {
     throw new ServerError('Fine-tuning job not found', { status: 404, code: 'JOB_NOT_FOUND' });
   }

--- a/server/services/voice/fineTuning.js
+++ b/server/services/voice/fineTuning.js
@@ -14,7 +14,7 @@ import { mkdir, readdir } from 'node:fs/promises';
 import { join } from 'node:path';
 import { spawn } from '../../lib/childProcess.js';
 import { ServerError } from '../../lib/errorHandler.js';
-import { atomicWrite, readJSONFile } from '../../lib/fileUtils.js';
+import { atomicWrite, readJSONFileStrict } from '../../lib/fileUtils.js';
 import { safeChildProcessOptions } from '../../lib/processEnv.js';
 import { closeJobAfterDelay } from '../../lib/sseUtils.js';
 import {
@@ -64,13 +64,22 @@ const persistJob = (jobState) => {
 
 /**
  * Resolve a job from memory, falling back to its on-disk record. Returns null
- * when neither exists.
+ * only when the record is genuinely absent — a present-but-unreadable record
+ * throws instead, because reporting 404 would tell the operator their run is
+ * gone while its checkpoints are still sitting on disk.
  */
 async function loadJob(jobId, profileId) {
   const active = activeJobs.get(jobId);
   if (active) return active;
   if (!profileId) return null;
-  return readJSONFile(jobRecordPath(profileId, jobId), null);
+  const { ok, value } = await readJSONFileStrict(jobRecordPath(profileId, jobId), null);
+  if (!ok) {
+    throw new ServerError('Fine-tuning job record is unreadable', {
+      status: 500,
+      code: 'JOB_RECORD_UNREADABLE',
+    });
+  }
+  return value;
 }
 
 /**
@@ -225,6 +234,11 @@ export async function startFineTuningJob({
             loss: event.loss,
             createdAt: new Date().toISOString(),
           });
+          // Checkpoints are the promotable artifact, so index each one as it
+          // lands — a restart mid-training must not orphan the ones already
+          // written. Step/loss progress deliberately is not persisted: it
+          // arrives every step and is worthless once the process is gone.
+          persistJob(jobState);
         } else if (event.stage === 'completed') {
           jobState.status = 'completed';
           jobState.progress = 100;

--- a/server/services/voice/fineTuning.test.js
+++ b/server/services/voice/fineTuning.test.js
@@ -205,6 +205,12 @@ describe('fineTuning', () => {
     const restarted = await import('./fineTuning.js');
     await expect(restarted.getFineTuningJobStatus(jobId, PROFILE.id))
       .rejects.toMatchObject({ code: 'JOB_RECORD_UNREADABLE' });
+
+    // Parsing cleanly is not enough — a record without the job shape would let
+    // promoteCheckpoint blow up on `job.checkpoints.find`.
+    await writeFile(jobRecordPath(jobId), '{}');
+    await expect(restarted.getFineTuningJobStatus(jobId, PROFILE.id))
+      .rejects.toMatchObject({ code: 'JOB_RECORD_UNREADABLE' });
   });
 
   it('evicts the in-memory job entry after the grace window and keeps serving from disk', async () => {

--- a/server/services/voice/fineTuning.test.js
+++ b/server/services/voice/fineTuning.test.js
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { mkdtemp, rm, mkdir, writeFile } from 'node:fs/promises';
+import { mkdtemp, rm, mkdir, writeFile, readFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { SSE_CLEANUP_DELAY_MS } from '../../lib/sseUtils.js';
 
 let voiceProfilesRoot = '';
 const queryMock = vi.fn();
@@ -47,15 +48,31 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
-  await rm(voiceProfilesRoot, { recursive: true, force: true });
+  // maxRetries absorbs the ENOTEMPTY race with a job.json write still in flight
+  // from a child that exited as the test ended.
+  await rm(voiceProfilesRoot, { recursive: true, force: true, maxRetries: 5, retryDelay: 20 });
 });
+
+const seedSourceAudio = async () => {
+  const sourceDir = join(voiceProfilesRoot, PROFILE.id, 'source');
+  await mkdir(sourceDir, { recursive: true });
+  await writeFile(join(sourceDir, 'sample.wav'), Buffer.from('RIFFdata'));
+};
+
+const jobRecordPath = (jobId) => join(voiceProfilesRoot, PROFILE.id, 'fine-tune', jobId, 'job.json');
+
+// The sidecar is rewritten from the child's terminal handler, so every test that
+// outlives a run waits for that write instead of racing the temp-dir teardown.
+const waitForTerminalJobRecord = (jobId) => vi.waitFor(async () => {
+  const record = JSON.parse(await readFile(jobRecordPath(jobId), 'utf8'));
+  expect(record.status).not.toBe('running');
+  return record;
+}, { timeout: 5_000, interval: 20 });
 
 describe('fineTuning', () => {
   it('validates dataset readiness and checks source recordings', async () => {
     queryMock.mockResolvedValueOnce({ rows: [{ data: PROFILE }] });
-    const profileDir = join(voiceProfilesRoot, PROFILE.id, 'source');
-    await mkdir(profileDir, { recursive: true });
-    await writeFile(join(profileDir, 'sample.wav'), Buffer.from('RIFFdata'));
+    await seedSourceAudio();
 
     const result = await validateFineTuningDataset(PROFILE.id);
     expect(result.ready).toBe(true);
@@ -65,9 +82,7 @@ describe('fineTuning', () => {
 
   it('runs fine tuning lifecycle, emits checkpoints, and promotes checkpoint', async () => {
     queryMock.mockResolvedValue({ rows: [{ data: PROFILE }] });
-    const profileDir = join(voiceProfilesRoot, PROFILE.id, 'source');
-    await mkdir(profileDir, { recursive: true });
-    await writeFile(join(profileDir, 'sample.wav'), Buffer.from('RIFFdata'));
+    await seedSourceAudio();
 
     const startRes = await startFineTuningJob({
       profileId: PROFILE.id,
@@ -79,11 +94,12 @@ describe('fineTuning', () => {
       status: 'running',
     });
 
-    await vi.waitFor(() => {
-      expect(getFineTuningJobStatus(startRes.jobId).status).toBe('completed');
+    await vi.waitFor(async () => {
+      expect((await getFineTuningJobStatus(startRes.jobId, PROFILE.id)).status).toBe('completed');
     }, { timeout: 5_000, interval: 20 });
 
-    const status = getFineTuningJobStatus(startRes.jobId);
+    await waitForTerminalJobRecord(startRes.jobId);
+    const status = await getFineTuningJobStatus(startRes.jobId, PROFILE.id);
     expect(status.status).toBe('completed');
     expect(status.checkpoints.length).toBeGreaterThan(0);
 
@@ -100,9 +116,7 @@ describe('fineTuning', () => {
 
   it('cancels an active fine tuning job', async () => {
     queryMock.mockResolvedValue({ rows: [{ data: PROFILE }] });
-    const profileDir = join(voiceProfilesRoot, PROFILE.id, 'source');
-    await mkdir(profileDir, { recursive: true });
-    await writeFile(join(profileDir, 'sample.wav'), Buffer.from('RIFFdata'));
+    await seedSourceAudio();
 
     const startRes = await startFineTuningJob({
       profileId: PROFILE.id,
@@ -115,5 +129,88 @@ describe('fineTuning', () => {
       jobId: startRes.jobId,
       status: 'cancelled',
     });
+    await waitForTerminalJobRecord(startRes.jobId);
+  });
+
+  it('persists a job.json sidecar beside the checkpoints when the run finishes', async () => {
+    queryMock.mockResolvedValue({ rows: [{ data: PROFILE }] });
+    await seedSourceAudio();
+
+    const { jobId } = await startFineTuningJob({
+      profileId: PROFILE.id,
+      epochs: 2,
+      checkpointInterval: 20,
+    });
+    await vi.waitFor(async () => {
+      expect((await getFineTuningJobStatus(jobId, PROFILE.id)).status).toBe('completed');
+    }, { timeout: 5_000, interval: 20 });
+
+    const record = await waitForTerminalJobRecord(jobId);
+
+    expect(record.status).toBe('completed');
+    expect(record.id).toBe(jobId);
+    expect(record.profileId).toBe(PROFILE.id);
+    expect(record.checkpoints.length).toBeGreaterThan(0);
+    expect(record.completedAt).toEqual(expect.any(String));
+    // Runtime-only handles must never reach disk.
+    expect(record.controller).toBeUndefined();
+    expect(record.child).toBeUndefined();
+  });
+
+  it('promotes a checkpoint from the sidecar after a restart drops the in-memory job', async () => {
+    queryMock.mockResolvedValue({ rows: [{ data: PROFILE }] });
+    await seedSourceAudio();
+
+    const { jobId } = await startFineTuningJob({
+      profileId: PROFILE.id,
+      epochs: 2,
+      checkpointInterval: 20,
+    });
+    const status = await vi.waitFor(async () => {
+      const current = await getFineTuningJobStatus(jobId, PROFILE.id);
+      expect(current.status).toBe('completed');
+      expect(current.checkpoints.length).toBeGreaterThan(0);
+      return current;
+    }, { timeout: 5_000, interval: 20 });
+    await waitForTerminalJobRecord(jobId);
+
+    // A restart loses `activeJobs` entirely; the sidecar is the only record left.
+    vi.resetModules();
+    const restarted = await import('./fineTuning.js');
+
+    await expect(restarted.getFineTuningJobStatus(jobId)).rejects.toThrow(/not found/i);
+    const promoted = await restarted.promoteCheckpoint({
+      profileId: PROFILE.id,
+      jobId,
+      checkpointId: status.checkpoints[0].id,
+    });
+    expect(promoted).toMatchObject({ kind: 'fine-tuned', approval: { status: 'approved' } });
+  });
+
+  it('evicts the in-memory job entry after the grace window and keeps serving from disk', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      queryMock.mockResolvedValue({ rows: [{ data: PROFILE }] });
+      await seedSourceAudio();
+
+      const { jobId } = await startFineTuningJob({
+        profileId: PROFILE.id,
+        epochs: 2,
+        checkpointInterval: 20,
+      });
+      // Without a profileId the in-memory map is the only lookup source, so this
+      // resolving proves the entry is still resident.
+      await vi.waitFor(async () => {
+        expect((await getFineTuningJobStatus(jobId)).status).toBe('completed');
+      }, { timeout: 5_000, interval: 20 });
+      await waitForTerminalJobRecord(jobId);
+
+      await vi.advanceTimersByTimeAsync(SSE_CLEANUP_DELAY_MS + 100);
+
+      await expect(getFineTuningJobStatus(jobId)).rejects.toThrow(/not found/i);
+      expect((await getFineTuningJobStatus(jobId, PROFILE.id)).status).toBe('completed');
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/server/services/voice/fineTuning.test.js
+++ b/server/services/voice/fineTuning.test.js
@@ -187,6 +187,26 @@ describe('fineTuning', () => {
     expect(promoted).toMatchObject({ kind: 'fine-tuned', approval: { status: 'approved' } });
   });
 
+  it('reports an unreadable job record as an error rather than a missing job', async () => {
+    queryMock.mockResolvedValue({ rows: [{ data: PROFILE }] });
+    await seedSourceAudio();
+
+    const { jobId } = await startFineTuningJob({
+      profileId: PROFILE.id,
+      epochs: 2,
+      checkpointInterval: 20,
+    });
+    await waitForTerminalJobRecord(jobId);
+    await writeFile(jobRecordPath(jobId), '{ truncated');
+
+    // A corrupt record must not read as "no such job" — the checkpoints it
+    // indexes are still on disk.
+    vi.resetModules();
+    const restarted = await import('./fineTuning.js');
+    await expect(restarted.getFineTuningJobStatus(jobId, PROFILE.id))
+      .rejects.toMatchObject({ code: 'JOB_RECORD_UNREADABLE' });
+  });
+
   it('evicts the in-memory job entry after the grace window and keeps serving from disk', async () => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
     try {


### PR DESCRIPTION
## Summary

Qwen3-TTS fine-tuning runs lived only in an in-memory `activeJobs` map that was never persisted and never evicted. Training takes tens of minutes, so "PortOS restarted during or shortly after a run" is the common case — and after a restart the operator could no longer promote a checkpoint that was sitting complete on disk, because both `getFineTuningJobStatus` and `promoteCheckpoint` 404'd on the missing map entry. Every finished run also leaked its full state (checkpoints array plus a dead `AbortController`) for the life of the process; this was the only in-memory job registry without the `closeJobAfterDelay` eviction its siblings use.

- **Durable record.** Each run writes a `job.json` sidecar into its own `<profileDir>/fine-tune/<jobId>/` directory via `atomicWrite`, next to the checkpoints it indexes, so the record and its artifacts are created and deleted together. It is written at start, rewritten as each checkpoint lands (checkpoints are the promotable artifact — a restart mid-training must not orphan the ones already on disk), and rewritten from the child's terminal handlers with the final status/error/completedAt. Per-step progress is deliberately not persisted: it arrives every step and is meaningless once the process is gone. Writes are chained per job because `close` and `error` can both fire for one child.
- **Recovery.** A shared `loadJob(jobId, profileId)` prefers the live in-memory entry and falls back to the sidecar; `getFineTuningJobStatus` (now async, taking `profileId`) and `promoteCheckpoint` both route through it, so promotion works after a restart while a job with neither still 404s.
- **Eviction.** Once terminal, the in-memory entry is dropped via `closeJobAfterDelay`, so a status poll racing completion still hits memory for the grace window and the map stays bounded. `closeJobAfterDelay` is guarded against a job record with no `clients` array (this registry has no SSE route), matching the guard already present in its sibling branch.
- **Child handle.** The spawned child is kept on the job state so a future shutdown hook has something to reach. No shutdown hook is added here (out of scope).

Two rounds of local review added:

- The job id is now required to be a UUID, both in the route param schema and again in the service before it is joined into a filesystem path. It was a free-form 1–80 character string, so an encoded separator or `..` in the status/promote URL could have walked out of the profile's fine-tune directory once the lookup started reading from disk.
- The sidecar is read through `readJSONFileStrict` and shape-checked, so a corrupt or non-job record raises `JOB_RECORD_UNREADABLE` (500) rather than collapsing into the `JOB_NOT_FOUND` 404 that would tell the operator their run is gone while its checkpoints are still on disk.

`promoteFineTunedProfile`'s promotion semantics are unchanged.

## Test plan

`server/services/voice/fineTuning.test.js` gains four tests, and the route suite one:

- A completed run writes `job.json` beside its checkpoints with `status: 'completed'`, the recorded checkpoints, and no runtime-only handles (`controller`, `child`).
- After `vi.resetModules()` drops `activeJobs` entirely (a restart), `promoteCheckpoint` still resolves the checkpoint from the sidecar instead of 404ing.
- The in-memory entry is gone after the grace window (asserted through a `profileId`-less lookup, where memory is the only source) while the disk record keeps serving.
- A corrupt sidecar, and one that parses but is not job-shaped, both surface `JOB_RECORD_UNREADABLE` rather than "job not found".
- `server/routes/voice.test.js`: a traversal-shaped job id is rejected with 400 before the service is called.

Existing tests were updated for the now-async status lookup and share a source-audio seed helper; the temp-dir teardown waits for the terminal sidecar write so it cannot race the child's exit.

```
cd server && npm test
Test Files  1832 passed | 1 skipped (1833)
     Tests  37258 passed | 13 skipped (37271)
```

Closes #5664

https://claude.ai/code/session_01DxNA8g7B5hZd4uswfUM1xn
