### PR TITLE
fix: enforce the FableLoom hosted-session HTTPS gate under the test runner (#5670)

### DIFF
--- a/server/services/fableLoom/hostedSession.js
+++ b/server/services/fableLoom/hostedSession.js
@@ -113,12 +113,11 @@ export async function checkHostedSessionReadiness({ loomId, episodeId, loom: cus
 
   // 1. HTTPS & Network Exposure check
   const netStatus = getNetworkExposureStatus();
-  const httpsEnabled = netStatus.httpsEnabled === true || process.env.NODE_ENV === 'test';
   const joinHost = netStatus.cert?.tailscaleHost
     || (netStatus.bind?.host && !isLoopbackHost(netStatus.bind.host) && netStatus.bind.host !== '0.0.0.0' ? netStatus.bind.host : null)
     || 'localhost';
   const joinPort = netStatus.bind?.port || PORTS.API;
-  const isHttps = netStatus.scheme === 'https' || process.env.NODE_ENV === 'test';
+  const isHttps = netStatus.scheme === 'https';
   const httpsUrl = isHttps
     ? `https://${joinHost}${joinPort === 443 ? '' : `:${joinPort}`}`
     : `http://${joinHost}${joinPort === 80 ? '' : `:${joinPort}`}`;

--- a/server/services/fableLoom/hostedSession.test.js
+++ b/server/services/fableLoom/hostedSession.test.js
@@ -67,9 +67,27 @@ describe('fableLoom hostedSession', () => {
     }],
   };
 
+  // Hosted-session preflight gates on the live network posture. Every test
+  // that isn't specifically exercising the HTTPS gate runs against this
+  // TLS-provisioned snapshot so the rest of the readiness checks are what
+  // the assertion is about.
+  const httpsExposure = () => ({
+    scheme: 'https',
+    httpsEnabled: true,
+    bind: { host: '0.0.0.0', port: 5555, audience: 'all-interfaces' },
+    cert: { mode: 'tailscale', tailscaleHost: 'host-example.example-tailnet.ts.net' },
+  });
+
+  const httpExposure = () => ({
+    ...httpsExposure(),
+    scheme: 'http',
+    httpsEnabled: false,
+  });
+
   beforeEach(() => {
     _resetHostedSessions();
     vi.restoreAllMocks();
+    vi.spyOn(networkExposure, 'getNetworkExposureStatus').mockImplementation(httpsExposure);
     vi.spyOn(records, 'getLoom').mockResolvedValue(mockLoom);
     vi.spyOn(tts, 'synthesize').mockResolvedValue({
       wav: Buffer.from('RIFFmockwavdata'),
@@ -97,11 +115,25 @@ describe('fableLoom hostedSession', () => {
   });
 
   describe('checkHostedSessionReadiness', () => {
-    it('passes readiness when loom, episode, and start scene are configured', async () => {
+    it('passes readiness when loom, episode, and start scene are configured over HTTPS', async () => {
       const result = await checkHostedSessionReadiness({ loomId: 'loom-1', episodeId: 'ep-1' });
       expect(result.ready).toBe(true);
-      expect(result.https.url).toMatch(/^https?:\/\//);
+      expect(result.https.enabled).toBe(true);
+      expect(result.https.url).toMatch(/^https:\/\//);
+      expect(result.checks.https.ok).toBe(true);
       expect(result.checks.host.ok).toBe(true);
+    });
+
+    it('flags error when the install is serving plain HTTP', async () => {
+      vi.spyOn(networkExposure, 'getNetworkExposureStatus').mockImplementation(httpExposure);
+      const result = await checkHostedSessionReadiness({ loomId: 'loom-1', episodeId: 'ep-1' });
+      expect(result.ready).toBe(false);
+      expect(result.https.enabled).toBe(false);
+      expect(result.checks.https.ok).toBe(false);
+      expect(result.https.url).toMatch(/^http:\/\//);
+      expect(result.errors).toContain(
+        'HTTPS is required for mobile device QR microphone join (run npm run setup:cert to enable TLS).',
+      );
     });
 
     it('flags error if start scene is missing', async () => {
@@ -141,6 +173,14 @@ describe('fableLoom hostedSession', () => {
       expect(verifyHostedToken(result.session.id, result.token)).toBe(true);
       expect(verifyHostedToken(result.session.id, 'wrong-token')).toBe(false);
       expect(verifyHostedToken('missing-session', result.token)).toBe(false);
+    });
+
+    it('refuses to start a session on an HTTP-only install with a 412 preflight failure', async () => {
+      vi.spyOn(networkExposure, 'getNetworkExposureStatus').mockImplementation(httpExposure);
+      await expect(createHostedSession('loom-1', 'ep-1', { audioTarget: 'host' })).rejects.toMatchObject({
+        status: 412,
+        code: 'HOSTED_SESSION_PREFLIGHT_FAILED',
+      });
     });
   });
 

--- a/server/sockets/fableLoomHosted.test.js
+++ b/server/sockets/fableLoomHosted.test.js
@@ -9,6 +9,7 @@ import {
   getHostedSession,
 } from '../services/fableLoom/hostedSession.js';
 import * as records from '../services/fableLoom/records.js';
+import * as networkExposure from '../lib/networkExposure.js';
 import * as tts from '../services/voice/tts.js';
 import * as stt from '../services/voice/stt.js';
 
@@ -45,6 +46,14 @@ describe('fableLoomHosted Socket.IO namespace', () => {
   beforeEach(() => {
     _resetHostedSessions();
     vi.restoreAllMocks();
+    // createHostedSession runs the readiness preflight, which refuses to start
+    // a session unless the install is serving HTTPS.
+    vi.spyOn(networkExposure, 'getNetworkExposureStatus').mockReturnValue({
+      scheme: 'https',
+      httpsEnabled: true,
+      bind: { host: '0.0.0.0', port: 5555, audience: 'all-interfaces' },
+      cert: { mode: 'tailscale', tailscaleHost: 'host-example.example-tailnet.ts.net' },
+    });
     vi.spyOn(records, 'getLoom').mockResolvedValue(mockLoom);
     vi.spyOn(tts, 'synthesize').mockResolvedValue({ wav: Buffer.from('mockwav'), latencyMs: 20 });
     vi.spyOn(stt, 'transcribe').mockResolvedValue({ text: 'go next', latencyMs: 50 });


### PR DESCRIPTION
## Summary

`checkHostedSessionReadiness` forced its HTTPS posture to "enabled" whenever `NODE_ENV === 'test'` — a test-only hack in production code that made the one preflight check actually blocking a hosted FableLoom play session unreachable from the suite. The behavior that matters ("HTTPS off ⇒ `startHostedSession` throws 412 `HOSTED_SESSION_PREFLIGHT_FAILED`") had never been pinned by a test and could regress silently. The same line also computed an `httpsEnabled` binding that nothing in the file read.

- Removed the dead `httpsEnabled` binding.
- `isHttps` now reads the real network posture only: `netStatus.scheme === 'https'`.
- Tests mock `getNetworkExposureStatus` instead, matching how the rest of the server treats that dependency.
- `server/sockets/fableLoomHosted.test.js` gets the same TLS-provisioned snapshot, since it drives the real `createHostedSession`.

Every other readiness check (start scene, STT, TTS, playback) and the join-URL host resolution are untouched.

## Test plan

New coverage in `server/services/fableLoom/hostedSession.test.js`:
- HTTPS on ⇒ `ready: true`, `https.enabled: true`, `https.url` starts `https://`, `checks.https.ok`.
- HTTPS off (`scheme: 'http'`) ⇒ `ready: false`, `checks.https.ok: false`, and `errors` contains the `HTTPS is required…` message.
- HTTPS off ⇒ `createHostedSession` rejects with `status: 412` / `code: 'HOSTED_SESSION_PREFLIGHT_FAILED'` — the regression this uniquely catches, which was impossible to fail before because the gate was disarmed under the runner.

Verified the two new tests fail against the pre-fix source and pass after. `cd server && npm test` is green (37,264 passed; the one flaky `routes/imageGen.multipart.test.js` `beforeAll` hook timeout under full-suite load passes on its own re-run and is unrelated to this change).

Acceptance criteria from the issue: `grep -n "NODE_ENV" server/services/fableLoom/hostedSession.js` returns nothing, and `httpsEnabled` no longer appears in the file.

Closes #5670

https://claude.ai/code/session_01GMxEz43s3YCLaVZV9KmVwE
