### PR TITLE
fix: clamp modal dialogs to the visible viewport so iOS Safari can't hide their buttons (#5665)

### DIFF
--- a/client/src/components/FolderPicker.jsx
+++ b/client/src/components/FolderPicker.jsx
@@ -110,7 +110,7 @@ export default function FolderPicker({ value, onChange, defaultPath }) {
           size="md"
           usePortal
           ariaLabelledBy="folder-picker-title"
-          panelClassName="bg-port-card border border-port-border rounded-xl max-h-[80vh] flex flex-col shadow-2xl"
+          panelClassName="bg-port-card border border-port-border rounded-xl flex flex-col shadow-2xl"
         >
           {/* Header */}
           <div className="flex items-center justify-between p-4 border-b border-port-border">

--- a/client/src/components/IngredientPicker.jsx
+++ b/client/src/components/IngredientPicker.jsx
@@ -124,7 +124,7 @@ export default function IngredientPicker({
       onClose={onClose}
       size="xl"
       closeOnBackdrop
-      panelClassName="bg-port-card border border-port-border rounded-xl max-h-[85vh] flex flex-col"
+      panelClassName="bg-port-card border border-port-border rounded-xl flex flex-col"
       ariaLabelledBy="ingredient-picker-title"
     >
       <div className="flex items-center justify-between p-4 border-b border-port-border flex-shrink-0">

--- a/client/src/components/apps/DeployPanel.jsx
+++ b/client/src/components/apps/DeployPanel.jsx
@@ -130,7 +130,7 @@ export default function DeployPanel({ appId, appName }) {
           onEsc={handleEsc}
           size="xl"
           backdropClassName="bg-black/60"
-          panelClassName="bg-port-bg border border-port-border rounded-xl shadow-2xl max-h-[80vh] flex flex-col"
+          panelClassName="bg-port-bg border border-port-border rounded-xl shadow-2xl flex flex-col"
           ariaLabelledBy="deploy-panel-title"
         >
           <div className="flex items-center justify-between px-4 py-3 border-b border-port-border">

--- a/client/src/components/apps/tabs/GitTab.jsx
+++ b/client/src/components/apps/tabs/GitTab.jsx
@@ -1014,7 +1014,7 @@ export default function GitTab({ appId, appName, repoPath }) {
         size="none"
         align="none"
         backdropClassName="bg-black/50"
-        panelClassName="bg-port-card border border-port-border rounded-xl w-3/4 max-h-[80vh] overflow-hidden"
+        panelClassName="bg-port-card border border-port-border rounded-xl w-3/4 overflow-hidden"
         ariaLabelledBy="git-diff-modal-title"
       >
         <div className="flex items-center justify-between p-4 border-b border-port-border">

--- a/client/src/components/brain/ConversationViewer.jsx
+++ b/client/src/components/brain/ConversationViewer.jsx
@@ -32,7 +32,7 @@ export default function ConversationViewer({ record, onClose }) {
       onClose={onClose}
       size="xl"
       ariaLabel={record.title}
-      panelClassName="bg-port-card border border-port-border rounded-lg max-h-[85vh] flex flex-col"
+      panelClassName="bg-port-card border border-port-border rounded-lg flex flex-col"
     >
       <div className="flex items-center justify-between px-4 py-3 border-b border-port-border">
         <h3 className="font-medium text-white truncate pr-4">{record.title}</h3>

--- a/client/src/components/cos/tabs/AgentCard.jsx
+++ b/client/src/components/cos/tabs/AgentCard.jsx
@@ -963,7 +963,7 @@ export default function AgentCard({ agent, onPause, onKill, onDelete, onResume, 
 
       {/* Expanded output view */}
       {expanded && (
-        <div className="border-t border-port-border bg-port-bg/50 p-3 min-w-0 overflow-y-auto max-h-[60vh]">
+        <div className="border-t border-port-border bg-port-bg/50 p-3 min-w-0 overflow-y-auto max-h-dvh-cap [--dvh-cap:60dvh]">
           {/* Pipeline stage tabs */}
           {pipelineStages && (
             <div className="flex items-center gap-1 mb-2 overflow-x-auto">
@@ -1054,7 +1054,7 @@ export default function AgentCard({ agent, onPause, onKill, onDelete, onResume, 
         onClose={() => setPromptOpen(false)}
         size="2xl"
         usePortal
-        panelClassName="bg-port-card border border-port-border rounded-lg max-h-[80vh] flex flex-col"
+        panelClassName="bg-port-card border border-port-border rounded-lg flex flex-col"
         ariaLabel="Agent prompt"
       >
         <div className="flex items-center justify-between px-4 py-2 border-b border-port-border shrink-0">

--- a/client/src/components/cos/tabs/MemoryEditModal.jsx
+++ b/client/src/components/cos/tabs/MemoryEditModal.jsx
@@ -104,7 +104,7 @@ export default function MemoryEditModal({ memory, apps, onSave, onClose }) {
       closeOnEsc={false}
       size="lg"
       backdropClassName="bg-black/50"
-      panelClassName="bg-port-card border border-port-border rounded-xl p-4 sm:p-6 max-h-[90vh] overflow-auto"
+      panelClassName="bg-port-card border border-port-border rounded-xl p-4 sm:p-6"
       ariaLabelledBy="memory-edit-title"
     >
       <div className="flex items-center justify-between mb-4">

--- a/client/src/components/cos/tabs/ResumeAgentModal.jsx
+++ b/client/src/components/cos/tabs/ResumeAgentModal.jsx
@@ -120,7 +120,7 @@ export default function ResumeAgentModal({ agent, taskType = 'user', providers, 
       // applies the same flex centring without the default `p-4`.
       align="none"
       backdropClassName="bg-black/50"
-      panelClassName="bg-port-card border border-port-border rounded-xl p-6 max-h-[90vh] overflow-auto"
+      panelClassName="bg-port-card border border-port-border rounded-xl p-6"
       ariaLabelledBy="resume-agent-title"
     >
       <div className="flex items-center justify-between mb-4">

--- a/client/src/components/digital-twin/tabs/DocumentsTab.jsx
+++ b/client/src/components/digital-twin/tabs/DocumentsTab.jsx
@@ -323,7 +323,7 @@ export default function DocumentsTab({ onRefresh }) {
         closeOnBackdrop={false}
         closeOnEsc={false}
         ariaLabel="Create Soul Document"
-        panelClassName="bg-port-card rounded-lg border border-port-border p-4 sm:p-6 max-h-[90vh] overflow-y-auto"
+        panelClassName="bg-port-card rounded-lg border border-port-border p-4 sm:p-6"
       >
         <h2 className="text-lg font-semibold text-white mb-4">Create Soul Document</h2>
 

--- a/client/src/components/fableloom/LoomHostedSessionModal.jsx
+++ b/client/src/components/fableloom/LoomHostedSessionModal.jsx
@@ -126,7 +126,7 @@ export default function LoomHostedSessionModal({
       onClose={onClose}
       usePortal
       backdropClassName="bg-black/60 backdrop-blur-sm"
-      panelClassName="bg-port-card border border-port-border rounded-xl shadow-2xl overflow-hidden flex flex-col max-h-[90vh]"
+      panelClassName="bg-port-card border border-port-border rounded-xl shadow-2xl overflow-hidden flex flex-col"
       ariaLabelledBy="hosted-two-device-play-title"
     >
         {/* Header */}

--- a/client/src/components/goals/GoalsTreeView.jsx
+++ b/client/src/components/goals/GoalsTreeView.jsx
@@ -267,7 +267,7 @@ function OrganizePanel({ suggestion, goals, onApply, onClose, applying }) {
   if (!suggestion) return null;
 
   return (
-    <div className="absolute top-12 right-3 z-20 bg-port-card border border-port-border rounded-lg p-4 w-96 max-h-[80vh] overflow-y-auto shadow-xl">
+    <div className="absolute top-12 right-3 z-20 bg-port-card border border-port-border rounded-lg p-4 w-96 max-h-dvh-cap [--dvh-cap:80dvh] overflow-y-auto shadow-xl">
       <div className="flex items-center justify-between mb-3">
         <div className="flex items-center gap-2">
           <Wand2 className="w-4 h-4 text-port-accent" />

--- a/client/src/components/imageGen/Flux2InstallModal.jsx
+++ b/client/src/components/imageGen/Flux2InstallModal.jsx
@@ -75,7 +75,7 @@ export default function Flux2InstallModal({ open, onClose, onComplete }) {
       // imperceptible (~16px) and not worth a custom override.
       backdropClassName="bg-black/70 backdrop-blur-sm"
       ariaLabelledBy="flux2-install-title"
-      panelClassName="bg-port-card rounded-xl border border-port-border shadow-2xl overflow-hidden flex flex-col max-h-[80vh]"
+      panelClassName="bg-port-card rounded-xl border border-port-border shadow-2xl overflow-hidden flex flex-col"
     >
         {/* Header */}
         <div className="flex items-center justify-between px-5 py-4 border-b border-port-border">

--- a/client/src/components/imageGen/GalleryImagePicker.jsx
+++ b/client/src/components/imageGen/GalleryImagePicker.jsx
@@ -244,7 +244,7 @@ export default function GalleryImagePicker({
       // overlay beneath the page header/cards (and beneath a host modal when the
       // picker is opened from inside one).
       usePortal
-      panelClassName="bg-port-card border border-port-border rounded-xl max-h-[85vh] flex flex-col"
+      panelClassName="bg-port-card border border-port-border rounded-xl flex flex-col"
       ariaLabel="Pick an image from your gallery"
     >
       <div className="p-3 border-b border-port-border space-y-2">

--- a/client/src/components/install/RuntimeInstallModal.jsx
+++ b/client/src/components/install/RuntimeInstallModal.jsx
@@ -70,7 +70,7 @@ export default function RuntimeInstallModal({
       closeOnEsc={false}
       backdropClassName="bg-black/70 backdrop-blur-sm"
       ariaLabelledBy="runtime-install-title"
-      panelClassName="bg-port-card rounded-xl border border-port-border shadow-2xl overflow-hidden flex flex-col max-h-[80vh]"
+      panelClassName="bg-port-card rounded-xl border border-port-border shadow-2xl overflow-hidden flex flex-col"
     >
         <div className="flex items-center justify-between px-5 py-4 border-b border-port-border">
           <div className="flex items-center gap-2.5">

--- a/client/src/components/loraTraining/ImportGalleryDialog.jsx
+++ b/client/src/components/loraTraining/ImportGalleryDialog.jsx
@@ -81,7 +81,7 @@ export default function ImportGalleryDialog({ dataset, onClose, onImported }) {
       open
       onClose={onClose}
       size="3xl"
-      panelClassName="bg-port-card border border-port-border rounded-xl max-h-[85vh] flex flex-col"
+      panelClassName="bg-port-card border border-port-border rounded-xl flex flex-col"
       ariaLabel="Import images from your gallery"
     >
       <div className="flex items-center justify-between gap-3 p-3 border-b border-port-border">

--- a/client/src/components/meatspace/tabs/AlcoholTab.jsx
+++ b/client/src/components/meatspace/tabs/AlcoholTab.jsx
@@ -550,7 +550,7 @@ export default function AlcoholTab() {
           <h3 className="text-sm font-medium text-gray-400 uppercase tracking-wider mb-3">
             All Drink Entries ({allEntries.length} days)
           </h3>
-          <div className="max-h-[70vh] overflow-x-auto overflow-y-auto rounded-lg border border-port-border">
+          <div className="max-h-dvh-cap [--dvh-cap:70dvh] overflow-x-auto overflow-y-auto rounded-lg border border-port-border">
             <table className="w-full text-sm min-w-[600px]">
               <thead className="sticky top-0 bg-port-card z-10">
                 <tr className="border-b border-port-border text-left text-xs text-gray-500 uppercase">

--- a/client/src/components/meatspace/tabs/NicotineTab.jsx
+++ b/client/src/components/meatspace/tabs/NicotineTab.jsx
@@ -409,7 +409,7 @@ export default function NicotineTab() {
           <h3 className="text-sm font-medium text-gray-400 uppercase tracking-wider mb-3">
             History ({allEntries.length} days)
           </h3>
-          <div className="max-h-[70vh] overflow-x-auto overflow-y-auto rounded-lg border border-port-border">
+          <div className="max-h-dvh-cap [--dvh-cap:70dvh] overflow-x-auto overflow-y-auto rounded-lg border border-port-border">
             <table className="w-full text-sm min-w-[500px]">
               <thead className="sticky top-0 bg-port-card z-10">
                 <tr className="border-b border-port-border text-left text-xs text-gray-500 uppercase">

--- a/client/src/components/media/PromptFromMedia.jsx
+++ b/client/src/components/media/PromptFromMedia.jsx
@@ -398,7 +398,7 @@ export function PromptFromMediaModal({ item, open, onClose, kindDefault = 'both'
       zIndexClassName="z-[70]"
       backdropClassName="bg-black/80"
       ariaLabelledBy="prompt-from-media-title"
-      panelClassName="max-h-[90vh] overflow-hidden bg-port-card border border-port-border rounded-xl shadow-2xl flex flex-col"
+      panelClassName="overflow-hidden bg-port-card border border-port-border rounded-xl shadow-2xl flex flex-col"
     >
       <header className="flex items-center justify-between gap-3 px-4 py-3 border-b border-port-border">
         <div className="flex items-center gap-2 min-w-0">

--- a/client/src/components/media/PromptRefineModal.jsx
+++ b/client/src/components/media/PromptRefineModal.jsx
@@ -121,7 +121,7 @@ export default function PromptRefineModal({ item, open, onClose }) {
       zIndexClassName="z-[70]"
       backdropClassName="bg-black/80"
       ariaLabelledBy="prompt-refine-title"
-      panelClassName="max-h-[90vh] overflow-hidden bg-port-card border border-port-border rounded-xl shadow-2xl flex flex-col"
+      panelClassName="overflow-hidden bg-port-card border border-port-border rounded-xl shadow-2xl flex flex-col"
     >
       <header className="flex items-center justify-between gap-3 px-4 py-3 border-b border-port-border">
         <div className="flex items-center gap-2 min-w-0">

--- a/client/src/components/music/AlbumTrackPicker.jsx
+++ b/client/src/components/music/AlbumTrackPicker.jsx
@@ -46,7 +46,7 @@ export default function AlbumTrackPicker({ open, tracks = [], onClose, onAdd }) 
       open={open}
       onClose={onClose}
       size="lg"
-      panelClassName="bg-port-card border border-port-border rounded-xl max-h-[85vh] flex flex-col"
+      panelClassName="bg-port-card border border-port-border rounded-xl flex flex-col"
       ariaLabelledBy="album-track-picker-title"
     >
       <div className="flex items-center justify-between p-4 border-b border-port-border flex-shrink-0">

--- a/client/src/components/music/TrackRenderModal.jsx
+++ b/client/src/components/music/TrackRenderModal.jsx
@@ -34,7 +34,7 @@ export default function TrackRenderModal({ render, active = false, onClose, onSe
       size="lg"
       align="top"
       ariaLabelledBy="track-render-title"
-      panelClassName="bg-port-card rounded-xl border border-port-border shadow-2xl overflow-hidden flex flex-col max-h-[85vh]"
+      panelClassName="bg-port-card rounded-xl border border-port-border shadow-2xl overflow-hidden flex flex-col"
     >
       <div className="flex items-center justify-between px-5 py-3 border-b border-port-border">
         <h2 id="track-render-title" className="text-sm font-semibold text-white flex items-center gap-2">

--- a/client/src/components/openworld/OpenWorldFastTravel.jsx
+++ b/client/src/components/openworld/OpenWorldFastTravel.jsx
@@ -92,7 +92,7 @@ export default function OpenWorldFastTravel({ open, onClose, onTravel, activeReg
       usePortal
       ariaLabel="Village map"
       zIndexClassName="z-[120]"
-      panelClassName="w-full max-w-3xl max-h-[85vh] rounded-xl border port-media-overlay flex flex-col overflow-hidden"
+      panelClassName="w-full max-w-3xl rounded-xl border port-media-overlay flex flex-col overflow-hidden"
     >
       <div className="flex items-center gap-3 px-4 py-3 border-b border-current/10">
         <div className="font-pixel text-[12px] tracking-widest">VILLAGE MAP</div>

--- a/client/src/components/openworld/OpenWorldPhotoOverlay.jsx
+++ b/client/src/components/openworld/OpenWorldPhotoOverlay.jsx
@@ -167,7 +167,7 @@ export default function OpenWorldPhotoOverlay({ active, presetId, onPresetChange
         size="none"
         usePortal
         ariaLabel="OpenWorld postcard preview"
-        panelClassName="max-w-[80vw] max-h-[80vh] flex flex-col items-center gap-3"
+        panelClassName="max-w-[80vw] flex flex-col items-center gap-3"
       >
         <img src={postcard} alt="OpenWorld postcard" className="max-w-full max-h-[68vh] rounded-lg border border-cyan-500/40 shadow-[0_0_30px_rgba(6,182,212,0.3)]" />
         <div className="flex gap-3">

--- a/client/src/components/pipeline/manuscript/ManuscriptReadAloud.jsx
+++ b/client/src/components/pipeline/manuscript/ManuscriptReadAloud.jsx
@@ -225,8 +225,8 @@ export default function ManuscriptReadAloud({ open, onClose, section }) {
   const progressPct = totalMs > 0 ? Math.min(100, (elapsedMs / totalMs) * 100) : 0;
 
   return (
-    <Modal open={open} onClose={onClose} size="3xl" backdropClassName="bg-black/70 p-4" panelClassName="bg-port-card border border-port-border rounded-lg">
-      <div className="flex flex-col max-h-[85vh]">
+    <Modal open={open} onClose={onClose} size="3xl" backdropClassName="bg-black/70 p-4" panelClassName="bg-port-card border border-port-border rounded-lg overflow-hidden flex flex-col">
+      <div className="flex flex-col min-h-0">
         <header className="flex items-center gap-2 px-4 py-3 border-b border-port-border">
           <Volume2 className="w-4 h-4 text-port-accent" />
           <h2 className="text-sm font-semibold text-white">

--- a/client/src/components/shell/ShellProviderLauncher.jsx
+++ b/client/src/components/shell/ShellProviderLauncher.jsx
@@ -113,7 +113,7 @@ export default function ShellProviderLauncher({ providers, onLaunch, onOpen, loa
       {open && createPortal(
         <div
           ref={popoverRef}
-          className="fixed max-w-[calc(100vw-1rem)] max-h-[70vh] overflow-y-auto overscroll-contain z-[100] bg-port-card border border-port-border rounded-lg shadow-xl"
+          className="fixed max-w-[calc(100vw-1rem)] max-h-dvh-cap [--dvh-cap:70dvh] overflow-y-auto overscroll-contain z-[100] bg-port-card border border-port-border rounded-lg shadow-xl"
           style={{
             left: style?.left ?? `${VIEWPORT_PADDING}px`,
             top: style?.top ?? `${VIEWPORT_PADDING}px`,

--- a/client/src/components/sprites/ForkSpriteModal.jsx
+++ b/client/src/components/sprites/ForkSpriteModal.jsx
@@ -64,7 +64,7 @@ export default function ForkSpriteModal({ open, onClose, source, referencePath, 
       size="lg"
       usePortal
       closeOnBackdrop={false}
-      panelClassName="bg-port-card border border-port-border rounded-xl max-h-[85vh] flex flex-col"
+      panelClassName="bg-port-card border border-port-border rounded-xl flex flex-col"
       ariaLabel="Fork sprite"
     >
       <div className="flex items-center justify-between gap-3 p-3 border-b border-port-border">

--- a/client/src/components/sprites/SpriteReferencePicker.jsx
+++ b/client/src/components/sprites/SpriteReferencePicker.jsx
@@ -43,7 +43,7 @@ export default function SpriteReferencePicker({ open, onClose, onSelect, exclude
       onClose={onClose}
       size="3xl"
       usePortal
-      panelClassName="bg-port-card border border-port-border rounded-xl max-h-[85vh] flex flex-col"
+      panelClassName="bg-port-card border border-port-border rounded-xl flex flex-col"
       ariaLabel="Pick a reference sprite"
     >
       <div className="flex items-center justify-between gap-3 p-3 border-b border-port-border">

--- a/client/src/components/ui/Modal.jsx
+++ b/client/src/components/ui/Modal.jsx
@@ -35,6 +35,25 @@
  *   usePortal               LayoutEditor / KeyboardHelp — escape any
  *                           stacking-context ancestors.
  *
+ * Height: the panel is clamped to the *visible* viewport by Modal itself —
+ * `max-h-dvh-cap` (index.css) minus a per-align `--dvh-inset`. Call sites must
+ * NOT pass their own `max-h-[NNvh]` in `panelClassName`: the overlay is
+ * `fixed inset-0` (the small viewport on iOS Safari) and centres with
+ * `items-center`, so a panel taller than the overlay has its overflow split
+ * top and bottom — the dialog's title AND its Save/Cancel footer end up
+ * off-screen, which is unrecoverable on a modal that also opts out of Esc and
+ * backdrop dismissal. The clamp lives in the primitive for the same reason
+ * portaling does (`client/src/AGENTS.md`): so no call site has to remember it.
+ * `client/src/components/ui/modalPanelHeights.test.js` fails the build if the
+ * per-caller idiom comes back. The inset accounts for the align padding,
+ * including align='top' (`pt-[10dvh]`), so a top-aligned panel still ends
+ * above the bottom edge. A caller that wants a *shorter* panel sets the cap
+ * rather than a raw vh: `panelClassName="… [--dvh-cap:60dvh]"`. Modal also
+ * supplies `overflow-auto` unless `panelClassName` already declares an
+ * overflow utility, so a clamped panel is always scrollable — a panel that
+ * needs an un-portaled popover to escape its bounds declares
+ * `overflow-visible` and keeps the clamp.
+ *
  * Stacking: Modal uses a single module-scope bubble-phase `keydown`
  * listener that dispatches Esc only to the top-most open Modal — and only
  * the top-most. Every open Modal registers on the stack (regardless of its
@@ -67,12 +86,27 @@ const SIZE_CLASSES = {
 // order — see the note next to the overlay <div> below.
 const ALIGN_CLASSES = {
   center: 'items-center justify-center p-4',
-  top: 'items-start justify-center pt-[10vh] px-4 pb-4',
+  top: 'items-start justify-center pt-[10dvh] px-4 pb-4',
   // No padding — for callers that historically had a bare overlay (no `p-*`)
   // and provide their own panel-internal padding instead. Used by
   // ResumeAgentModal where the pre-refactor overlay was
   // `fixed inset-0 ... flex items-center justify-center` with no padding.
   none: 'items-center justify-center',
+};
+
+// Per-align `--dvh-inset` for the panel's unconditional `max-h-dvh-cap` clamp
+// (see the "Height" section of the docblock). The inset is the vertical space
+// the overlay's own padding already consumes, so the clamped panel never
+// exceeds the *visible* dynamic viewport:
+//   center  p-4                → 1rem top + 1rem bottom
+//   top     pt-[10dvh] + pb-4  → 10dvh top + 1rem bottom
+//   none    no padding         → 0
+// These must be written as literal class strings so Tailwind's source scanner
+// emits the arbitrary-property utilities.
+const ALIGN_DVH_INSET = {
+  center: '[--dvh-inset:2rem]',
+  top: '[--dvh-inset:calc(10dvh_+_1rem)]',
+  none: '[--dvh-inset:0px]',
 };
 
 // Module-scope stack of open Modal ids. A single bubble-phase keydown
@@ -271,6 +305,13 @@ export default function Modal({
   const alignClass = ALIGN_CLASSES[align] || ALIGN_CLASSES.center;
   const sizeClass = SIZE_CLASSES[size] ?? SIZE_CLASSES.md;
   const widthClass = size === 'none' ? '' : `w-full ${sizeClass}`;
+  const insetClass = ALIGN_DVH_INSET[align] || ALIGN_DVH_INSET.center;
+  // Only supply the scroll behaviour when the caller hasn't declared its own
+  // overflow. Tailwind precedence follows CSS source order, not class-string
+  // order (see the overlay note below), so emitting `overflow-auto` alongside
+  // a caller's `overflow-hidden` would be a coin flip rather than an override.
+  const overflowClass = /(^|\s|:)overflow-/.test(panelClassName) ? '' : 'overflow-auto';
+  const heightClass = `max-h-dvh-cap ${insetClass} ${overflowClass}`;
 
   const overlay = (
     <div
@@ -295,7 +336,7 @@ export default function Modal({
         aria-modal="true"
         aria-labelledby={ariaLabelledBy}
         aria-label={!ariaLabelledBy ? ariaLabel : undefined}
-        className={`relative ${widthClass} ${panelClassName}`}
+        className={`relative ${widthClass} ${heightClass} ${panelClassName}`}
         // Swallow click bubbling at the panel boundary. Two reasons: (1)
         // target-check on the backdrop already prevents panel clicks from
         // firing our own backdrop dismiss, but if this Modal is rendered as

--- a/client/src/components/ui/Modal.jsx
+++ b/client/src/components/ui/Modal.jsx
@@ -306,11 +306,16 @@ export default function Modal({
   const sizeClass = SIZE_CLASSES[size] ?? SIZE_CLASSES.md;
   const widthClass = size === 'none' ? '' : `w-full ${sizeClass}`;
   const insetClass = ALIGN_DVH_INSET[align] || ALIGN_DVH_INSET.center;
-  // Only supply the scroll behaviour when the caller hasn't declared its own
-  // overflow. Tailwind precedence follows CSS source order, not class-string
-  // order (see the overlay note below), so emitting `overflow-auto` alongside
-  // a caller's `overflow-hidden` would be a coin flip rather than an override.
-  const overflowClass = /(^|\s|:)overflow-/.test(panelClassName) ? '' : 'overflow-auto';
+  // Only supply the scroll behaviour when the caller declares an UNPREFIXED
+  // overflow of its own. Tailwind precedence follows CSS source order, not
+  // class-string order (see the overlay note below), so emitting
+  // `overflow-auto` alongside a caller's base `overflow-hidden` would be a
+  // coin flip rather than an override. A variant-prefixed utility
+  // (`sm:overflow-hidden`) is deliberately NOT a match: it only applies inside
+  // its media query — which does outrank the base utility — so suppressing the
+  // default would leave the panel clamped but unscrollable below that
+  // breakpoint.
+  const overflowClass = /(^|\s)!?overflow-/.test(panelClassName) ? '' : 'overflow-auto';
   const heightClass = `max-h-dvh-cap ${insetClass} ${overflowClass}`;
 
   const overlay = (

--- a/client/src/components/ui/Modal.test.jsx
+++ b/client/src/components/ui/Modal.test.jsx
@@ -136,4 +136,17 @@ describe('Modal viewport height clamp', () => {
     // a coin flip rather than an override.
     expect(dialog).not.toHaveClass('overflow-auto');
   });
+
+  it('still scrolls below a breakpoint when the caller only sets a variant overflow', () => {
+    render(
+      <Modal open onClose={() => {}} ariaLabel="x" panelClassName="lg:overflow-hidden">
+        <p>body</p>
+      </Modal>
+    );
+    const dialog = screen.getByRole('dialog');
+    // `lg:overflow-hidden` applies only inside its media query — where it
+    // outranks the base utility anyway — so suppressing the default would
+    // leave the panel clamped but unscrollable on a phone.
+    expect(dialog).toHaveClass('overflow-auto');
+  });
 });

--- a/client/src/components/ui/Modal.test.jsx
+++ b/client/src/components/ui/Modal.test.jsx
@@ -87,3 +87,53 @@ describe('Modal accessibility', () => {
     expect(screen.queryByRole('dialog')).toBeNull();
   });
 });
+
+// The overlay is `fixed inset-0` — the *small* viewport under iOS Safari's
+// retractable chrome — and centres with `items-center`, so an unclamped panel
+// has its overflow split top and bottom and loses both its title and its
+// footer buttons off-screen. Modal owns the clamp so no call site has to.
+describe('Modal viewport height clamp', () => {
+  it('clamps the panel to the dynamic viewport with no panelClassName', () => {
+    render(<Modal open onClose={() => {}} ariaLabel="x"><p>body</p></Modal>);
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveClass('max-h-dvh-cap');
+    // center align pads the overlay `p-4`, so the panel must give that back.
+    expect(dialog).toHaveClass('[--dvh-inset:2rem]');
+    expect(dialog).toHaveClass('overflow-auto');
+  });
+
+  it("insets by align='top' offset so a top-aligned panel clears the bottom edge", () => {
+    render(<Modal open onClose={() => {}} align="top" ariaLabel="x"><p>body</p></Modal>);
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveClass('max-h-dvh-cap');
+    expect(dialog).toHaveClass('[--dvh-inset:calc(10dvh_+_1rem)]');
+    expect(dialog.parentElement).toHaveClass('pt-[10dvh]');
+  });
+
+  it('keeps the clamp and appends panelClassName after it', () => {
+    render(
+      <Modal open onClose={() => {}} ariaLabel="x" panelClassName="bg-port-card [--dvh-cap:60dvh]">
+        <p>body</p>
+      </Modal>
+    );
+    const dialog = screen.getByRole('dialog');
+    const cls = dialog.className;
+    expect(cls.indexOf('max-h-dvh-cap')).toBeGreaterThan(-1);
+    expect(cls.indexOf('max-h-dvh-cap')).toBeLessThan(cls.indexOf('bg-port-card'));
+    // A caller shortening the panel sets the cap variable, not a raw vh.
+    expect(dialog).toHaveClass('[--dvh-cap:60dvh]');
+  });
+
+  it("yields the scroll utility to a caller's own overflow declaration", () => {
+    render(
+      <Modal open onClose={() => {}} ariaLabel="x" panelClassName="overflow-hidden flex flex-col">
+        <p>body</p>
+      </Modal>
+    );
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveClass('max-h-dvh-cap');
+    // Tailwind precedence follows CSS source order, so emitting both would be
+    // a coin flip rather than an override.
+    expect(dialog).not.toHaveClass('overflow-auto');
+  });
+});

--- a/client/src/components/ui/modalPanelHeights.test.js
+++ b/client/src/components/ui/modalPanelHeights.test.js
@@ -15,15 +15,47 @@ import { fileURLToPath } from 'url';
  * `closeOnEsc={false}` / `closeOnBackdrop={false}` there is then no way out.
  *
  * A caller that genuinely wants a *shorter* panel sets the cap instead:
- * `panelClassName="… [--dvh-cap:50dvh]"`, which still resolves against the
+ * `panelClassName="… [--dvh-cap:60dvh]"`, which still resolves against the
  * dynamic viewport.
  */
 
 const SRC_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
 
-// panelClassName="…" / {`…`} / {'…'} — the three literal forms in the tree.
-const PANEL_CLASS_RE = /panelClassName=(?:"([^"]*)"|\{`([^`]*)`\}|\{'([^']*)'\})/g;
+const ATTRIBUTE = 'panelClassName=';
 const RAW_VH_RE = /max-h-\[[\d.]+vh\]/;
+
+/**
+ * Every `panelClassName=` attribute value in `source`, as raw text.
+ *
+ * A quoted literal is taken verbatim; a `{…}` expression is taken whole (brace
+ * counting, so a ternary or template literal is captured entire rather than
+ * truncated at the first `}`). Capturing the expression rather than parsing it
+ * means a dynamic class string is still scanned for the banned idiom.
+ */
+function panelClassValues(source) {
+  const values = [];
+  let cursor = source.indexOf(ATTRIBUTE);
+  while (cursor !== -1) {
+    let i = cursor + ATTRIBUTE.length;
+    const opener = source[i];
+    if (opener === '"' || opener === "'") {
+      const end = source.indexOf(opener, i + 1);
+      if (end !== -1) values.push(source.slice(i + 1, end));
+    } else if (opener === '{') {
+      let depth = 0;
+      for (; i < source.length; i += 1) {
+        if (source[i] === '{') depth += 1;
+        else if (source[i] === '}') {
+          depth -= 1;
+          if (depth === 0) break;
+        }
+      }
+      values.push(source.slice(cursor + ATTRIBUTE.length + 1, i));
+    }
+    cursor = source.indexOf(ATTRIBUTE, cursor + ATTRIBUTE.length);
+  }
+  return values;
+}
 
 function collectSourceFiles(dir, out = []) {
   for (const entry of readdirSync(dir)) {
@@ -38,24 +70,37 @@ function collectSourceFiles(dir, out = []) {
 }
 
 describe('Modal panel heights', () => {
+  it('extracts panelClassName values in every syntactic form a caller can use', () => {
+    // Proves the sweep below can actually see an offender — otherwise a
+    // collector that silently matched nothing would make it vacuously green.
+    // The banned classes are interpolated rather than written out so Tailwind's
+    // source scanner doesn't emit CSS for a fixture nothing renders.
+    const vh = (n) => `max-h-[${n}vh]`;
+    const fixture = `
+      <Modal panelClassName="a ${vh(85)} b" />
+      <Modal panelClassName={ 'c ${vh(80)}' } />
+      <Modal panelClassName={\`d ${vh(42.5)}\`} />
+      <Modal panelClassName={wide ? 'e ${vh(90)}' : 'f'} />
+      <Modal panelClassName="clean [--dvh-cap:60dvh]" />
+    `;
+    const offenders = panelClassValues(fixture).filter((v) => RAW_VH_RE.test(v));
+    expect(offenders).toHaveLength(4);
+  });
+
   it('has no call site passing a raw viewport-height clamp in panelClassName', () => {
     const offenders = [];
+    let scanned = 0;
     for (const file of collectSourceFiles(SRC_ROOT)) {
       const source = readFileSync(file, 'utf8');
-      if (!source.includes('panelClassName')) continue;
-      for (const match of source.matchAll(PANEL_CLASS_RE)) {
-        const value = match[1] ?? match[2] ?? match[3] ?? '';
+      if (!source.includes(ATTRIBUTE)) continue;
+      for (const value of panelClassValues(source)) {
+        scanned += 1;
         if (RAW_VH_RE.test(value)) offenders.push(`${relative(SRC_ROOT, file)}: ${value}`);
       }
     }
+    // Reach check on the extracted values (not merely on files mentioning the
+    // prop), so a parser that stopped matching fails loudly here.
+    expect(scanned).toBeGreaterThan(20);
     expect(offenders).toEqual([]);
-  });
-
-  it('scans a representative set of Modal call sites (guards the regex itself)', () => {
-    // A collector that silently matched nothing would make the assertion above
-    // vacuously green, so pin the sweep's own reach.
-    const withPanelClass = collectSourceFiles(SRC_ROOT)
-      .filter((file) => readFileSync(file, 'utf8').includes('panelClassName='));
-    expect(withPanelClass.length).toBeGreaterThan(20);
   });
 });

--- a/client/src/components/ui/modalPanelHeights.test.js
+++ b/client/src/components/ui/modalPanelHeights.test.js
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync, statSync } from 'fs';
+import { dirname, join, relative } from 'path';
+import { fileURLToPath } from 'url';
+
+/**
+ * Migration pin for issue #5665.
+ *
+ * `Modal.jsx` clamps its panel to the *visible* viewport (`max-h-dvh-cap` plus
+ * a per-align `--dvh-inset`). A call site that re-adds its own `max-h-[NNvh]`
+ * defeats that: the overlay is `fixed inset-0` — the small viewport under iOS
+ * Safari's retractable chrome — and centres with `items-center`, so a taller
+ * panel has its overflow split top and bottom and the dialog loses both its
+ * title and its Save/Cancel row off-screen. On the long forms that also set
+ * `closeOnEsc={false}` / `closeOnBackdrop={false}` there is then no way out.
+ *
+ * A caller that genuinely wants a *shorter* panel sets the cap instead:
+ * `panelClassName="… [--dvh-cap:50dvh]"`, which still resolves against the
+ * dynamic viewport.
+ */
+
+const SRC_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+// panelClassName="…" / {`…`} / {'…'} — the three literal forms in the tree.
+const PANEL_CLASS_RE = /panelClassName=(?:"([^"]*)"|\{`([^`]*)`\}|\{'([^']*)'\})/g;
+const RAW_VH_RE = /max-h-\[[\d.]+vh\]/;
+
+function collectSourceFiles(dir, out = []) {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      collectSourceFiles(full, out);
+    } else if (/\.jsx?$/.test(entry) && !/\.(test|spec)\.jsx?$/.test(entry)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+describe('Modal panel heights', () => {
+  it('has no call site passing a raw viewport-height clamp in panelClassName', () => {
+    const offenders = [];
+    for (const file of collectSourceFiles(SRC_ROOT)) {
+      const source = readFileSync(file, 'utf8');
+      if (!source.includes('panelClassName')) continue;
+      for (const match of source.matchAll(PANEL_CLASS_RE)) {
+        const value = match[1] ?? match[2] ?? match[3] ?? '';
+        if (RAW_VH_RE.test(value)) offenders.push(`${relative(SRC_ROOT, file)}: ${value}`);
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it('scans a representative set of Modal call sites (guards the regex itself)', () => {
+    // A collector that silently matched nothing would make the assertion above
+    // vacuously green, so pin the sweep's own reach.
+    const withPanelClass = collectSourceFiles(SRC_ROOT)
+      .filter((file) => readFileSync(file, 'utf8').includes('panelClassName='));
+    expect(withPanelClass.length).toBeGreaterThan(20);
+  });
+});

--- a/client/src/components/universeBuilder/MoodBoardStyleSynthesis.jsx
+++ b/client/src/components/universeBuilder/MoodBoardStyleSynthesis.jsx
@@ -198,7 +198,7 @@ export default function MoodBoardStyleSynthesis({
         size="2xl"
         closeOnBackdrop={!bodyBusy}
         usePortal
-        panelClassName="bg-port-card border border-port-border rounded-xl max-h-[90vh] overflow-y-auto"
+        panelClassName="bg-port-card border border-port-border rounded-xl"
         ariaLabel="Synthesize universe style from mood board"
       >
         {open ? (

--- a/client/src/components/universeBuilder/UniverseStyleReferences.jsx
+++ b/client/src/components/universeBuilder/UniverseStyleReferences.jsx
@@ -146,7 +146,7 @@ export default function UniverseStyleReferences({
         size="2xl"
         closeOnBackdrop={!analyzing && !persisting}
         usePortal
-        panelClassName="bg-port-card border border-port-border rounded-xl max-h-[90vh] overflow-y-auto"
+        panelClassName="bg-port-card border border-port-border rounded-xl"
         ariaLabel="Add universe art style reference"
       >
         <div className="p-4 space-y-4">

--- a/client/src/components/videoGen/GalleryVideoPicker.jsx
+++ b/client/src/components/videoGen/GalleryVideoPicker.jsx
@@ -120,7 +120,7 @@ export default function GalleryVideoPicker({
       onClose={onClose}
       size="3xl"
       usePortal
-      panelClassName="bg-port-card border border-port-border rounded-xl max-h-[85vh] flex flex-col"
+      panelClassName="bg-port-card border border-port-border rounded-xl flex flex-col"
       ariaLabel="Pick a video from your gallery"
     >
       <div className="p-3 border-b border-port-border space-y-2">

--- a/client/src/pages/CatalogIngredient.jsx
+++ b/client/src/pages/CatalogIngredient.jsx
@@ -1390,9 +1390,9 @@ function GalleryPickerModal({ onClose, onPick }) {
 
   return (
     <Modal open onClose={onClose} size="lg" ariaLabelledBy="gallery-picker-title"
-      panelClassName="bg-port-card border border-port-border rounded-lg max-h-[80vh] overflow-hidden flex flex-col">
+      panelClassName="bg-port-card border border-port-border rounded-lg overflow-hidden flex flex-col">
       {/* Header + scroll area must be DIRECT flex children of the panel (a
-          fragment, not a wrapping <div>) so the panel's max-h-[80vh] flex
+          fragment, not a wrapping <div>) so the panel's clamped flex
           column constrains the scroll region's height — an intervening
           content-sized <div> would leave `overflow-y-auto` unbounded and clip
           long galleries. */}


### PR DESCRIPTION
## Summary

Dialogs opened on a phone could render with their title and their Save/Cancel row cut off above and below the screen, with no way to reach them. iOS Safari's retractable browser chrome makes `100vh` taller than the visible viewport, and every modal sized itself with its own raw `max-h-[NNvh]` — nine different values across 27 call sites. Because the modal overlay is `fixed inset-0` (the *small* viewport) and centres its panel with `items-center` and no scroll of its own, a taller panel had the excess split top and bottom. On the long forms that also opt out of Esc and backdrop dismissal (agent memory editing, resuming an agent) that left no way out of the dialog at all.

The shared `Modal` primitive now owns the clamp, for the same reason portaling is unconditional there — so no call site has to remember it.

- `client/src/components/ui/Modal.jsx` clamps every panel with the existing `max-h-dvh-cap` utility, minus a per-align `--dvh-inset` that gives back the overlay's own padding (`center` 2rem, `top` 10dvh + 1rem, `none` 0). `ALIGN_CLASSES.top` moves from `pt-[10vh]` to `pt-[10dvh]` in the same edit.
- The panel also gets `overflow-auto` unless the caller declares an unprefixed overflow of its own — Tailwind precedence follows CSS source order, not class-string order, so emitting both would be a coin flip rather than an override. A variant-prefixed utility (`lg:overflow-hidden`) deliberately does **not** count: it applies only inside its media query, where it outranks the base anyway, so treating it as a declaration would leave the panel clamped but unscrollable on a phone.
- All 27 call sites drop their hand-rolled `max-h-[NNvh]` (and the now-redundant `overflow-auto` / `overflow-y-auto`), so nine divergent dialog heights collapse to one shared behaviour. `ManuscriptReadAloud` kept its clamp on an inner wrapper rather than in `panelClassName`; the flex column is hoisted onto the panel so the primitive's clamp constrains its scroll region.
- Five non-modal full-height surfaces move to the same dynamic-viewport sizing with an explicit cap: the goals tree popover, the alcohol and nicotine log tables, the shell provider launcher, and the expanded agent output.

A dialog that deliberately wants to be shorter than the screen now says so with `[--dvh-cap:NNdvh]`, which still tracks the visible viewport instead of pinning to `vh`.

Deliberately left alone as out of scope for the modal clamp: `TerminalCoSPanel`'s `max-h-[50vh] lg:max-h-none` (a partial-height inner region with a responsive override that a utility swap would put at risk) and the `<=42vh` inner list caps, per the issue's "leave small caps alone" rule.

## Test plan

- `client/src/components/ui/Modal.test.jsx` — new `Modal viewport height clamp` block: the panel carries `max-h-dvh-cap` with no `panelClassName`; `align="top"` insets by its own offset; a caller's `panelClassName` is appended after the clamp and can shorten the panel via `--dvh-cap`; the scroll default yields to a caller's own `overflow-hidden` but survives a variant-only `lg:overflow-hidden`.
- `client/src/components/ui/modalPanelHeights.test.js` (new) — scans the client tree and fails if any `panelClassName` value carries a raw `max-h-[NNvh]`, pinning the migration. It parses braced expressions whole (ternaries and template literals included), counts what it parsed as a reach check, and proves against a fixture that it catches an offender in each syntactic form, so it cannot pass vacuously. Verified failing by reintroducing the idiom at a call site.
- `cd client && npm test` — 856 files / 10726 tests pass.
- `cd client && npm run build` — passes; the generated stylesheet emits every new arbitrary-property utility (`--dvh-inset:2rem`, `--dvh-inset:calc(10dvh + 1rem)`, `--dvh-inset:0px`, `--dvh-cap:60dvh|70dvh|80dvh`) and no longer contains any `max-h-[NNvh]` rule.

Closes #5665

https://claude.ai/code/session_01GMxEz43s3YCLaVZV9KmVwE
