### PR TITLE
fix: stop the fine-tune eviction test racing the child's close event

### DIFF
--- a/server/services/voice/fineTuning.test.js
+++ b/server/services/voice/fineTuning.test.js
@@ -231,9 +231,15 @@ describe('fineTuning', () => {
       }, { timeout: 5_000, interval: 20 });
       await waitForTerminalJobRecord(jobId);
 
-      await vi.advanceTimersByTimeAsync(SSE_CLEANUP_DELAY_MS + 100);
-
-      await expect(getFineTuningJobStatus(jobId)).rejects.toThrow(/not found/i);
+      // The eviction timer is only scheduled once the child process closes, and
+      // the sidecar can already read terminal before that (a checkpoint write
+      // queued earlier serializes after the "completed" frame set the status).
+      // Advancing once would then fire nothing, so keep advancing until the
+      // in-memory entry is actually gone.
+      await vi.waitFor(async () => {
+        await vi.advanceTimersByTimeAsync(SSE_CLEANUP_DELAY_MS + 100);
+        await expect(getFineTuningJobStatus(jobId)).rejects.toThrow(/not found/i);
+      }, { timeout: 5_000, interval: 20 });
       expect((await getFineTuningJobStatus(jobId, PROFILE.id)).status).toBe('completed');
     } finally {
       vi.useRealTimers();


### PR DESCRIPTION
## Summary

`server/services/voice/fineTuning.test.js` failed ~1 run in 12 on the eviction test ("evicts the in-memory job entry after the grace window and keeps serving from disk").

The test used the `job.json` sidecar as its readiness signal, but that record can read terminal *before* the child process closes: a persist queued by the last checkpoint frame serializes after the `completed` frame already flipped the in-memory status. The eviction timer is only scheduled from the child's `close` handler, so on those runs the single `advanceTimersByTimeAsync` fired nothing and the assertion found the entry still resident.

Fix is test-side only — advance the fake clock inside a `waitFor` loop so the assertion holds regardless of when the eviction timer lands. No production code changed.

## Test plan

- `cd server && npx vitest run services/voice/fineTuning.test.js` — 20/20 consecutive runs green (was ~1 failure per 12 before).
- `cd server && npx vitest run services/voice` — 21 files, 549 tests pass.
- Guard verified: commenting out `closeJobAfterDelay(activeJobs, jobState.id)` in `fineTuning.js` still fails the test, so the regression it protects is intact.