### PR TITLE
fix: show managed app update progress on git tab

### DIFF
--- a/client/src/components/apps/AppOperationBanner.jsx
+++ b/client/src/components/apps/AppOperationBanner.jsx
@@ -12,7 +12,7 @@ const LABELS = {
  * app list rather than inside the expanded row so collapsing the row — or
  * returning to /apps mid-operation — still shows what is running (#3435).
  */
-export default function AppOperationBanner({ appName, type, steps, error, completed, onDismiss }) {
+export default function AppOperationBanner({ appName, type, steps, error, completed, onDismiss, completedMessage }) {
   const labels = LABELS[type] || LABELS.update;
   const name = appName || 'app';
   const heading = error ? `${labels.failed} ${name}` : completed ? `${labels.done} ${name}` : `${labels.running} ${name}…`;
@@ -43,7 +43,7 @@ export default function AppOperationBanner({ appName, type, steps, error, comple
             {error
               ? error
               : completed
-                ? 'You can start another operation now.'
+                ? completedMessage || 'You can start another operation now.'
                 : 'This keeps running if you collapse the row or leave the page.'}
           </div>
         </div>

--- a/client/src/components/apps/tabs/RepositorySourcePanel.jsx
+++ b/client/src/components/apps/tabs/RepositorySourcePanel.jsx
@@ -12,6 +12,8 @@ import * as api from '../../../services/api';
 import BrailleSpinner from '../../BrailleSpinner';
 import Modal from '../../ui/Modal';
 import toast from '../../ui/Toast';
+import AppOperationBanner from '../AppOperationBanner';
+import { useAppOperation } from '../../../hooks/useAppOperation';
 
 const statusTone = {
   current: 'bg-port-success/15 text-port-success',
@@ -142,7 +144,7 @@ export default function RepositorySourcePanel({ appId, appName, onUpdated, refre
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
   const [syncingFork, setSyncingFork] = useState(false);
-  const [updating, setUpdating] = useState(false);
+  const [updateRequested, setUpdateRequested] = useState(false);
   const [error, setError] = useState(null);
   const [updateIntent, setUpdateIntent] = useState(null);
   const lastRefreshKey = useRef(refreshKey);
@@ -159,6 +161,28 @@ export default function RepositorySourcePanel({ appId, appName, onUpdated, refre
     setLoading(false);
     setRefreshing(false);
     return result;
+  }, [appId]);
+
+  const handleOperationComplete = useCallback(() => {
+    onUpdated?.();
+  }, [onUpdated]);
+  const {
+    steps: operationSteps,
+    isOperating,
+    operationType,
+    error: operationError,
+    completed: operationCompleted,
+    startUpdate,
+  } = useAppOperation({ appId, onComplete: handleOperationComplete });
+  const updating = isOperating && operationType === 'update';
+  const operationBusy = isOperating;
+
+  useEffect(() => {
+    if (updating) setUpdateRequested(true);
+  }, [updating]);
+
+  useEffect(() => {
+    setUpdateRequested(false);
   }, [appId]);
 
   useEffect(() => {
@@ -209,36 +233,11 @@ export default function RepositorySourcePanel({ appId, appName, onUpdated, refre
     setSyncingFork(false);
   };
 
-  const handleManagedUpdate = async () => {
+  const handleManagedUpdate = () => {
     const intent = updateIntent;
     setUpdateIntent(null);
-    setUpdating(true);
-
-    const targetOrigin = appId === api.PORTOS_APP_ID && status?.updateRestartsApp
-      ? await api.getPreferredSelfRestartOrigin()
-      : null;
-    const result = await api.pullAndUpdateApp(
-      appId,
-      { syncFork: intent?.syncFork === true },
-      { silent: true },
-    ).catch((reason) => {
-      if (appId === api.PORTOS_APP_ID && status?.updateRestartsApp && !reason?.status) {
-        api.handleSelfRestart({ targetOrigin });
-        return { selfRestartTriggered: true };
-      }
-      toast.error(reason.message || `Could not update ${appName || 'the app'}`);
-      return null;
-    });
-    if (result?.selfRestartTriggered) {
-      setUpdating(false);
-      return;
-    }
-    if (result?.success) {
-      toast.success(`${appName || 'App'} updated${status?.updateRestartsApp ? ' and restarted' : ''}`);
-      await load();
-      onUpdated?.();
-    }
-    setUpdating(false);
+    setUpdateRequested(true);
+    startUpdate(appId, appName, { syncFork: intent?.syncFork === true });
   };
 
   return (
@@ -255,13 +254,26 @@ export default function RepositorySourcePanel({ appId, appName, onUpdated, refre
         </div>
         <button
           onClick={() => load()}
-          disabled={loading || refreshing || syncingFork || updating}
+          disabled={loading || refreshing || syncingFork || operationBusy || updateRequested}
           className="flex min-h-[40px] items-center gap-1.5 rounded-lg border border-port-border px-3 py-2 text-sm text-gray-300 hover:border-port-accent hover:text-white disabled:opacity-50"
         >
           <RefreshCw size={15} className={refreshing ? 'animate-spin' : ''} />
           {refreshing ? 'Checking...' : 'Check sources'}
         </button>
       </div>
+
+      {(isOperating || operationError || operationCompleted) && (
+        <div className="mt-4">
+          <AppOperationBanner
+            appName={appName}
+            type={operationType || 'update'}
+            steps={operationSteps}
+            error={operationError}
+            completed={operationCompleted}
+            completedMessage={operationType === 'update' ? 'Reload this page before starting another update.' : undefined}
+          />
+        </div>
+      )}
 
       {loading && !status ? (
         <div className="py-8 text-center"><BrailleSpinner text="Checking repository sources" /></div>
@@ -290,7 +302,7 @@ export default function RepositorySourcePanel({ appId, appName, onUpdated, refre
               {primary?.origin?.isFork && (
                 <button
                   onClick={handleSyncOnly}
-                  disabled={syncingFork || updating || forkDiverged}
+                  disabled={syncingFork || operationBusy || updateRequested || forkDiverged}
                   title={forkDiverged
                     ? 'Reconcile the fork commits on GitHub before syncing'
                     : 'Fast-forward the GitHub fork only; does not touch the checkout or restart the app'}
@@ -303,11 +315,11 @@ export default function RepositorySourcePanel({ appId, appName, onUpdated, refre
               {shouldOfferUpdate && (
                 <button
                   onClick={() => setUpdateIntent({ syncFork: forkNeedsSync })}
-                  disabled={!canUpdate || syncingFork || updating}
+                  disabled={!canUpdate || syncingFork || operationBusy || updateRequested}
                   className="flex min-h-[40px] items-center gap-1.5 rounded-lg bg-port-accent px-4 py-2 text-sm text-white hover:bg-port-accent/80 disabled:opacity-50"
                 >
                   <Download size={16} className={updating ? 'animate-bounce' : ''} />
-                  {updating ? 'Updating...' : primaryLabel}
+                  {updating ? 'Updating...' : updateRequested ? 'Reload to update again' : primaryLabel}
                 </button>
               )}
             </div>
@@ -350,6 +362,7 @@ export default function RepositorySourcePanel({ appId, appName, onUpdated, refre
           <button onClick={() => setUpdateIntent(null)} className="px-4 py-2 text-sm text-gray-400 hover:text-white">Cancel</button>
           <button
             onClick={handleManagedUpdate}
+            disabled={updateRequested || operationBusy}
             className="flex items-center gap-2 rounded-lg bg-port-accent px-4 py-2 text-sm text-white hover:bg-port-accent/80"
           >
             <Download size={16} />

--- a/client/src/components/apps/tabs/RepositorySourcePanel.test.jsx
+++ b/client/src/components/apps/tabs/RepositorySourcePanel.test.jsx
@@ -9,8 +9,12 @@ vi.mock('../../../services/api', () => ({
   getPreferredSelfRestartOrigin: vi.fn(),
   handleSelfRestart: vi.fn(),
 }));
+vi.mock('../../../hooks/useAppOperation', () => ({
+  useAppOperation: vi.fn(),
+}));
 
 import * as api from '../../../services/api';
+import { useAppOperation } from '../../../hooks/useAppOperation';
 import RepositorySourcePanel from './RepositorySourcePanel';
 
 const source = ({
@@ -80,6 +84,10 @@ const canonicalStatus = () => ({
 
 beforeEach(() => {
   vi.clearAllMocks();
+  useAppOperation.mockReturnValue({
+    steps: [], isOperating: false, operationType: null, error: null, completed: false,
+    startUpdate: vi.fn(),
+  });
   api.getAppRepositorySources.mockResolvedValue(canonicalStatus());
   api.syncAppRepositoryFork.mockResolvedValue({ synced: true, alreadyUpToDate: false });
   api.pullAndUpdateApp.mockResolvedValue({ success: true });
@@ -98,6 +106,21 @@ describe('managed app repository sources', () => {
     expect(screen.getByTestId('repository-source-companion-1')).toHaveTextContent('prod-serving @ 2222222');
     expect(screen.getByTestId('repository-source-companion-1')).toHaveTextContent('Current');
     expect(screen.getByRole('button', { name: 'Update app' })).toBeInTheDocument();
+  });
+
+  it('keeps the current update step visible while the operation is running', async () => {
+    useAppOperation.mockReturnValue({
+      steps: [{ step: 'npm-install:root', status: 'running', message: 'Installing root dependencies...' }],
+      isOperating: true,
+      operationType: 'update',
+      error: null,
+      completed: false,
+      startUpdate: vi.fn(),
+    });
+    render(<RepositorySourcePanel appId="app-example" appName="Example App" />);
+
+    expect(await screen.findByRole('status', { name: 'App operation status' })).toHaveTextContent('Installing root dependencies...');
+    expect(screen.getByRole('button', { name: 'Updating...' })).toBeDisabled();
   });
 
   it('shows local, fork, and upstream as separate version hops and can sync only the fork', async () => {
@@ -152,13 +175,11 @@ describe('managed app repository sources', () => {
     expect(dialog).toHaveTextContent('Restart the app\'s managed processes');
 
     fireEvent.click(screen.getByRole('button', { name: 'Sync fork and update' }));
-    await waitFor(() => expect(api.pullAndUpdateApp).toHaveBeenCalledWith(
-      'app-example',
-      { syncFork: true },
-      { silent: true },
+    await waitFor(() => expect(useAppOperation.mock.results[0].value.startUpdate).toHaveBeenCalledWith(
+      'app-example', 'Example App', { syncFork: true },
     ));
     expect(api.syncAppRepositoryFork).not.toHaveBeenCalled();
-    await waitFor(() => expect(onUpdated).toHaveBeenCalledOnce());
+    expect(onUpdated).not.toHaveBeenCalled();
   });
 
   it('refreshes source status when the parent Git tab reports a branch update', async () => {
@@ -190,17 +211,17 @@ describe('managed app repository sources', () => {
     await waitFor(() => expect(screen.getByTestId('repository-source-primary')).toHaveTextContent('Current'));
   });
 
-  it('treats a PortOS update disconnect as the expected self-restart', async () => {
-    api.getPreferredSelfRestartOrigin.mockResolvedValueOnce('https://host-alpha.example-tailnet.ts.net:5555');
-    api.pullAndUpdateApp.mockRejectedValueOnce(new Error('Server unreachable — check your connection and try again'));
+  it('locks the update action after dispatch until the page reloads', async () => {
     render(<RepositorySourcePanel appId="portos-default" appName="PortOS" />);
 
     fireEvent.click(await screen.findByRole('button', { name: 'Update app' }));
     fireEvent.click(within(await screen.findByRole('dialog')).getByRole('button', { name: 'Update app' }));
 
-    await waitFor(() => expect(api.handleSelfRestart).toHaveBeenCalledWith({
-      targetOrigin: 'https://host-alpha.example-tailnet.ts.net:5555',
-    }));
+    const updateButton = screen.getByRole('button', { name: 'Reload to update again' });
+    expect(updateButton).toBeDisabled();
+    expect(useAppOperation.mock.results[0].value.startUpdate).toHaveBeenCalledWith(
+      'portos-default', 'PortOS', { syncFork: false },
+    );
   });
 
   it('refuses automatic fork sync after divergence but still permits updating from the fork as-is', async () => {
@@ -224,7 +245,7 @@ describe('managed app repository sources', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Update app from fork' }));
     fireEvent.click(await screen.findByRole('button', { name: 'Update app' }));
 
-    await waitFor(() => expect(api.pullAndUpdateApp).toHaveBeenCalledOnce());
+    await waitFor(() => expect(useAppOperation.mock.results[0].value.startUpdate).toHaveBeenCalledOnce());
     expect(api.syncAppRepositoryFork).not.toHaveBeenCalled();
   });
 

--- a/client/src/hooks/useAppOperation.js
+++ b/client/src/hooks/useAppOperation.js
@@ -155,14 +155,14 @@ export function useAppOperation({ onComplete, appId: scopeAppId } = {}) {
     };
   }, [scopeAppId, drop]);
 
-  const start = useCallback((type, appId, appName) => {
+  const start = useCallback((type, appId, appName, options = {}) => {
     clearTimeout(clearTimersRef.current[appId]);
     delete clearTimersRef.current[appId];
     setOperations(prev => ({ ...prev, [appId]: { appId, appName, type, steps: [], error: null, completed: false } }));
-    socket.emit(type === 'update' ? 'app:update' : 'app:standardize', { appId });
+    socket.emit(type === 'update' ? 'app:update' : 'app:standardize', { appId, ...options });
   }, []);
 
-  const startUpdate = useCallback((appId, appName) => start('update', appId, appName), [start]);
+  const startUpdate = useCallback((appId, appName, options = {}) => start('update', appId, appName, options), [start]);
   const startStandardize = useCallback((appId, appName) => start('standardize', appId, appName), [start]);
 
   const list = Object.values(operations);

--- a/server/lib/socketValidation.js
+++ b/server/lib/socketValidation.js
@@ -83,7 +83,8 @@ export const shellStopSchema = shellSessionIdSchema;
 
 // app:update — app ID for pull/install/restart cycle
 export const appUpdateSchema = z.object({
-  appId: z.string().min(1, 'appId is required')
+  appId: z.string().min(1, 'appId is required'),
+  syncFork: z.boolean().optional()
 });
 
 // app:standardize — app ID for PM2 standardization.

--- a/server/lib/socketValidation.test.js
+++ b/server/lib/socketValidation.test.js
@@ -165,6 +165,8 @@ describe('socketValidation schemas', () => {
   describe('app schemas', () => {
     it('appUpdateSchema and appStandardizeSchema require appId', () => {
       expect(appUpdateSchema.safeParse({ appId: 'foo' }).success).toBe(true);
+      expect(appUpdateSchema.safeParse({ appId: 'foo', syncFork: true }).success).toBe(true);
+      expect(appUpdateSchema.safeParse({ appId: 'foo', syncFork: 'yes' }).success).toBe(false);
       expect(appStandardizeSchema.safeParse({ appId: 'foo' }).success).toBe(true);
       expect(appUpdateSchema.safeParse({}).success).toBe(false);
       expect(appStandardizeSchema.safeParse({}).success).toBe(false);

--- a/server/services/socket.test.js
+++ b/server/services/socket.test.js
@@ -779,9 +779,10 @@ describe('socket.js — initSocket', () => {
 
       // …and a fresh dispatch is accepted again.
       vi.mocked(runAppUpdate).mockResolvedValueOnce({ success: true, steps: [] });
-      await socket.handlers['app:update']({ appId: APP.id });
+      await socket.handlers['app:update']({ appId: APP.id, syncFork: true });
       await flush();
       expect(vi.mocked(runAppUpdate)).toHaveBeenCalledTimes(2);
+      expect(vi.mocked(runAppUpdate).mock.calls.at(-1)[2]).toEqual({ syncFork: true });
     });
 
     it('blocks a second app record that points at the same checkout', async () => {

--- a/server/sockets/apps.js
+++ b/server/sockets/apps.js
@@ -119,7 +119,7 @@ export const registerAppHandlers = (socket, io) => {
         io.emit('app:update:step', frame);
       };
 
-      const result = await appUpdater.updateApp(app, emit).catch(err => {
+      const result = await appUpdater.updateApp(app, emit, { syncFork: data.syncFork === true }).catch(err => {
         io.emit('app:update:error', { appId: app.id, message: err.message });
         return null;
       });


### PR DESCRIPTION
## Summary

Move managed-app Git-tab updates onto the server-owned socket operation stream so long Windows updates keep showing progress and cannot be dispatched twice in one page session.

## Test plan

- node --check server/sockets/apps.js server/lib/socketValidation.js client/src/hooks/useAppOperation.js
- git diff --check
- Vitest unavailable: npm ci was blocked by Windows EPERM locks on native sharp and lightningcss binaries.
- Local lmstudio review endpoint returned 401 AUTH_REQUIRED; optional reviewer recorded inconclusive.