### PR TITLE
fix Codex ChatGPT sign-in on Windows: spawn the codex.cmd shim via cmd.exe

### DIFF
--- a/server/services/codexAppServer.js
+++ b/server/services/codexAppServer.js
@@ -36,6 +36,7 @@ import { tmpdir } from 'os';
 import { join } from 'path';
 
 import { spawn } from '../lib/childProcess.js';
+import { killProcessTree, prepareWindowsSafeSpawn } from '../lib/bufferedSpawn.js';
 import { ServerError } from '../lib/errorHandler.js';
 import { createLineReader } from '../lib/streamLines.js';
 import { findCommandOnPath } from '../lib/processEnv.js';
@@ -180,7 +181,10 @@ const stopTarget = (target, error) => {
   teardown(target, error);
   if (target.child.killed) return;
   try {
-    target.child.kill('SIGTERM');
+    // Not `child.kill()`: on Windows the child is the `cmd.exe /c` shim wrapper
+    // (see `openConnection`), and signalling it leaves the real codex process
+    // orphaned — still holding the JSON-RPC pipes PortOS just gave up on.
+    killProcessTree(target.child, 'SIGTERM');
   } catch (err) {
     console.error(`❌ Failed to stop Codex app-server: ${err.message}`);
   }
@@ -365,11 +369,18 @@ const openConnection = async () => {
     );
   }
 
+  // `codex` installs as a `codex.cmd` npm shim on Windows, which `spawn()`
+  // refuses under `shell: false` — "spawn EINVAL", so every account read and
+  // ChatGPT sign-in failed there (#5838). The canonical wrap (see
+  // `prepareWindowsSafeSpawn` for why, and #1865) is a no-op off Windows and
+  // for a native `codex.exe`; this spawner was the last site bypassing it.
+  const { command, args } = prepareWindowsSafeSpawn(binary, [...CODEX_APP_SERVER_ARGS]);
+
   let child = null;
   try {
     // Fixed argv, inherited env, no shell — nothing from a request or a stored
     // provider record reaches this command line.
-    child = spawn(binary, [...CODEX_APP_SERVER_ARGS], { stdio: ['pipe', 'pipe', 'pipe'] });
+    child = spawn(command, args, { stdio: ['pipe', 'pipe', 'pipe'] });
   } catch (err) {
     throw codexError(CODEX_ERROR_CODES.startFailed, `Codex app-server failed to start: ${err.message}`);
   }

--- a/server/services/codexAppServer.test.js
+++ b/server/services/codexAppServer.test.js
@@ -12,9 +12,21 @@ vi.mock('../lib/processEnv.js', async (importOriginal) => ({
   ...(await importOriginal()),
   findCommandOnPath: vi.fn(() => '/usr/local/bin/codex'),
 }));
+// Spied, not replaced: the real pure functions still run (so the POSIX no-op
+// path is exercised as shipped), while a test can force the Windows branch's
+// result without pretending to be on win32.
+vi.mock('../lib/bufferedSpawn.js', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    prepareWindowsSafeSpawn: vi.fn(actual.prepareWindowsSafeSpawn),
+    killProcessTree: vi.fn(actual.killProcessTree),
+  };
+});
 
 const { spawn } = await import('../lib/childProcess.js');
 const { findCommandOnPath } = await import('../lib/processEnv.js');
+const { killProcessTree, prepareWindowsSafeSpawn } = await import('../lib/bufferedSpawn.js');
 const { CODEX_ACCOUNT_STATUS, CODEX_ERROR_CODES } = await import('../lib/codexAccount.js');
 const {
   __resetCodexAppServer,
@@ -111,6 +123,38 @@ describe('spawning the app-server', () => {
     expect(spawn).not.toHaveBeenCalled();
     expect(readiness.status).toBe(CODEX_ACCOUNT_STATUS.runtimeMissing);
     expect(readiness.runtimeInstalled).toBe(false);
+  });
+
+  it('routes the resolved binary through prepareWindowsSafeSpawn, so a Windows codex.cmd shim starts (#5838)', async () => {
+    // The reported bug: `codex` installs as a `.cmd` npm shim on Windows, and
+    // Node's CVE-2024-27980 patch refuses that target under `shell: false`
+    // ("spawn EINVAL"), so every account read and ChatGPT sign-in failed there.
+    // The fix is the canonical wrap — asserted here with a sentinel, because
+    // the wrap itself is platform-gated and owned by bufferedSpawn.
+    findCommandOnPath.mockReturnValue('C:\\npm\\codex.cmd');
+    vi.mocked(prepareWindowsSafeSpawn).mockReturnValueOnce({
+      command: 'cmd.exe',
+      args: ['/c', 'C:\\npm\\codex.cmd', 'app-server'],
+    });
+
+    const promise = getCodexAccountReadiness();
+    await scripted(child, promise, [['initialize', {}], ['account/read', { account: null }]]);
+    await promise;
+
+    expect(prepareWindowsSafeSpawn).toHaveBeenCalledWith('C:\\npm\\codex.cmd', ['app-server']);
+    // spawn() received the wrapped pair, NOT the raw shim path.
+    expect(spawn.mock.calls[0][0]).toBe('cmd.exe');
+    expect(spawn.mock.calls[0][1]).toEqual(['/c', 'C:\\npm\\codex.cmd', 'app-server']);
+  });
+
+  it('tears the child down through killProcessTree, so a cmd.exe shim cannot orphan codex', async () => {
+    const promise = getCodexAccountReadiness();
+    await scripted(child, promise, [['initialize', {}], ['account/read', { account: null }]]);
+    await promise;
+
+    await stopCodexAppServer();
+
+    expect(killProcessTree).toHaveBeenCalledWith(child, 'SIGTERM');
   });
 
   it('reuses one child across calls, so a page poll cannot fan out processes', async () => {


### PR DESCRIPTION
Fixes #5838

## Summary

"Sign in with ChatGPT" on the Codex provider card failed on Windows with `Codex app-server failed to start: spawn EINVAL`, and the same error broke every `account/read`, so the card could never report the account either.

`codex` installs as a `codex.cmd` npm shim on Windows. Node's CVE-2024-27980 patch makes `spawn()` **refuse** a `.cmd`/`.bat` target under `shell: false` outright — per Node's own docs those files "are not executable on their own... and cannot be launched" that way. `openConnection()` passed the resolved shim path straight to `spawn()`, so the child never started.

This is the same class of bug as #1865, and the repo already owns the canonical fix in `server/lib/bufferedSpawn.js`. The app-server spawner was the one site that bypassed it.

## Changes

- **`server/services/codexAppServer.js`** — route the resolved binary through `prepareWindowsSafeSpawn`, which rewrites a `.cmd`/`.bat` target to Node's documented safe alternative (`cmd.exe /c <shim> app-server`) and returns a native `.exe` or any POSIX path untouched.
- **`server/services/codexAppServer.js`** — tear the child down with `killProcessTree` instead of `child.kill()`. On Windows the child is now the `cmd.exe /c` wrapper, and signalling only the wrapper would orphan the real codex process while it still holds the JSON-RPC pipes PortOS just gave up on. `killProcessTree` is the helper's documented requirement for exactly this case, and its POSIX branch is `child.kill(signal)` — identical to the previous behavior.
- **`server/services/codexAppServer.test.js`** — two regression tests: the resolved binary is routed through `prepareWindowsSafeSpawn` and `spawn()` receives the wrapped pair rather than the raw shim; and teardown goes through `killProcessTree`.

`prepareWindowsSafeSpawn` is pure and platform-gated, so there is **no behavior change off Windows** or for a native `codex.exe`.

## Test plan

- `server/services/codexAppServer.test.js` — 29 passed (27 pre-existing + 2 new)
- `server/services/codexAppServer.turn.test.js` — 25 passed
- `server/lib/bufferedSpawn.test.js`, `server/lib/childProcess.guards.test.js`, `server/routes/providers*` — 167 passed across 12 files
- Verified on the reporting machine that `where codex` resolves to `C:\ProgramData\npm\npm\codex.cmd` under Node v24, which is exactly the target `spawn()` rejects.