### PR TITLE
drop the two apps API wrappers the socket-driven update flow orphaned

### DIFF
--- a/client/src/components/apps/tabs/RepositorySourcePanel.test.jsx
+++ b/client/src/components/apps/tabs/RepositorySourcePanel.test.jsx
@@ -5,8 +5,6 @@ vi.mock('../../../services/api', () => ({
   PORTOS_APP_ID: 'portos-default',
   getAppRepositorySources: vi.fn(),
   syncAppRepositoryFork: vi.fn(),
-  pullAndUpdateApp: vi.fn(),
-  getPreferredSelfRestartOrigin: vi.fn(),
   handleSelfRestart: vi.fn(),
 }));
 vi.mock('../../../hooks/useAppOperation', () => ({
@@ -90,7 +88,6 @@ beforeEach(() => {
   });
   api.getAppRepositorySources.mockResolvedValue(canonicalStatus());
   api.syncAppRepositoryFork.mockResolvedValue({ synced: true, alreadyUpToDate: false });
-  api.pullAndUpdateApp.mockResolvedValue({ success: true });
 });
 
 afterEach(() => cleanup());
@@ -147,7 +144,7 @@ describe('managed app repository sources', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Sync fork' }));
     await waitFor(() => expect(api.syncAppRepositoryFork).toHaveBeenCalledWith('app-example', { silent: true }));
-    expect(api.pullAndUpdateApp).not.toHaveBeenCalled();
+    expect(useAppOperation.mock.results[0].value.startUpdate).not.toHaveBeenCalled();
   });
 
   it('confirms that one managed update syncs the fork and updates every checkout', async () => {

--- a/client/src/services/apiApps.js
+++ b/client/src/services/apiApps.js
@@ -1,6 +1,5 @@
 import toast from '../components/ui/Toast';
 import { request, API_BASE } from './apiCore.js';
-import { getNetworkExposure } from './apiSystem.js';
 
 // Apps
 export const getApps = (options) => request('/apps', options);
@@ -163,22 +162,6 @@ export const openAppFolder = (id) => request(`/apps/${id}/open-folder`, { method
 // comes back as a real error instead of a silent `xcode://` no-op.
 export const openAppInXcode = (id) => request(`/apps/${id}/open-xcode`, { method: 'POST' });
 export const refreshAppConfig = (id) => request(`/apps/${id}/refresh-config`, { method: 'POST' });
-// Capture the server's currently trusted origin before a PortOS restart. A
-// Vite dev UI on :5554 must not be reused after the server comes back when a
-// Tailscale HTTPS origin is available. The read is best-effort so an instance
-// without trusted HTTPS keeps the existing same-origin recovery behavior.
-export const getPreferredSelfRestartOrigin = async () => {
-  const exposure = await getNetworkExposure({ silent: true }).catch(() => null);
-  const trustedUrl = exposure?.setup?.trustedUrl;
-  return typeof trustedUrl === 'string' && trustedUrl.startsWith('https://')
-    ? trustedUrl
-    : null;
-};
-export const pullAndUpdateApp = (id, body = {}, options = {}) => request(`/apps/${id}/update`, {
-  method: 'POST',
-  body: JSON.stringify(body),
-  ...options,
-});
 // `options` lets a caller suppress request()'s auto-toast with `{ silent: true }`
 // when it already renders its own error UI.
 export const buildApp = (id, options = {}) => request(`/apps/${id}/build`, { method: 'POST', ...options });

--- a/client/src/services/apiApps.test.js
+++ b/client/src/services/apiApps.test.js
@@ -4,16 +4,12 @@ vi.mock('../components/ui/Toast', () => ({
   default: { loading: vi.fn(), success: vi.fn(), error: vi.fn() },
 }));
 
-const mockNetwork = vi.hoisted(() => ({ getNetworkExposure: vi.fn() }));
-vi.mock('./apiSystem.js', () => mockNetwork);
-
 import toast from '../components/ui/Toast';
-import { getPreferredSelfRestartOrigin, handleSelfRestart } from './apiApps';
+import { handleSelfRestart } from './apiApps';
 
 beforeEach(() => {
   vi.useFakeTimers();
   vi.clearAllMocks();
-  mockNetwork.getNetworkExposure.mockResolvedValue({ setup: { trustedUrl: null } });
 });
 
 afterEach(() => {
@@ -56,26 +52,5 @@ describe('handleSelfRestart', () => {
     expect(assign).toHaveBeenCalledWith(
       'https://host-alpha.example-tailnet.ts.net:5555/instances?view=peers#https'
     );
-  });
-});
-
-describe('getPreferredSelfRestartOrigin', () => {
-  it('returns the active trusted origin supplied by network exposure', async () => {
-    mockNetwork.getNetworkExposure.mockResolvedValueOnce({
-      setup: { trustedUrl: 'https://host-alpha.example-tailnet.ts.net:5555' },
-    });
-
-    await expect(getPreferredSelfRestartOrigin()).resolves.toBe(
-      'https://host-alpha.example-tailnet.ts.net:5555',
-    );
-    expect(mockNetwork.getNetworkExposure).toHaveBeenCalledWith({ silent: true });
-  });
-
-  it('does not turn an unavailable or non-HTTPS setup value into a restart target', async () => {
-    mockNetwork.getNetworkExposure.mockResolvedValueOnce({
-      setup: { pendingTrustedUrl: 'https://host-alpha.example-tailnet.ts.net:5555', trustedUrl: null },
-    });
-
-    await expect(getPreferredSelfRestartOrigin()).resolves.toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

- `client/src/services/api.deadExports.test.js` fails on any **full-mode** client run with `caller-less wrappers: apiApps.js:getPreferredSelfRestartOrigin, apiApps.js:pullAndUpdateApp`. `main`'s CI is green only because the run planner scopes tests to changed files, so this blocks unrelated PRs (e.g. #5625, a server-only change).
- Root cause: `2e996e4d2` moved `RepositorySourcePanel.jsx` onto the socket-driven `useAppOperation` hook. Its only remaining `api.*` calls are `getAppRepositorySources` and `syncAppRepositoryFork`.
- **Deleted** (not un-exported) both symbols: neither is referenced inside `apiApps.js` — `handleSelfRestart` does not call `getPreferredSelfRestartOrigin`, so there is no intra-module use to preserve.
- Removed the now-unused `import { getNetworkExposure } from './apiSystem.js'` and its `vi.mock`/`vi.hoisted` scaffolding in `apiApps.test.js`. **No cascade**: `getNetworkExposure` still has live callers in `NetworkExposureWidget.jsx` and `Instances.jsx`.
- Test cleanup: dropped the dead `getPreferredSelfRestartOrigin` describe block, the two dead `vi.fn()` mocks in `RepositorySourcePanel.test.jsx`, and retargeted the vacuous `expect(api.pullAndUpdateApp).not.toHaveBeenCalled()` at the live surface (`useAppOperation(...).startUpdate`) so the "Sync fork must not kick off an update" regression is still covered.
- No barrel or README change needed — `api.js` re-exports `apiApps.js` with `export *`, and the services README catalogs modules, not individual exports.

### `POST /api/apps/:id/update` consumer finding

- The server route (`server/routes/apps/lifecycle.js:240`) is **left untouched** — removing it is out of scope.
- It now has **no client caller**. The live update path is the Socket.IO `app:update` event (`server/sockets/apps.js:91`), which `useAppOperation.js:162` emits; both handlers call the same `appUpdater.updateApp`.
- Remaining references are its own route test (`server/routes/apps/lifecycle.test.js:401`), the generated route catalog, and a historical changelog entry. No sockets, palette/voice manifest entries, or scripts reach it.

## Test plan

- `client && npx vitest run src/services/api.deadExports.test.js src/services/apiApps.test.js src/components/apps/tabs/RepositorySourcePanel.test.jsx` — 3 files, 13 tests passed.
- **Full client suite** `client && npm run test:ci` — **861 passed | 1 skipped (862 files), 10756 passed | 2 skipped (10758 tests)**, 142s. Zero failures; the dead-export guard is green in full mode, which is the point of the fix.
- `client && npm run build` — clean.

Fixes #5848