### PR TITLE
fix: move the app-update audit row onto the socket path, then drop the caller-less HTTP route

### DIFF
--- a/server/lib/apiRouteCatalog.generated.json
+++ b/server/lib/apiRouteCatalog.generated.json
@@ -1216,14 +1216,6 @@
     },
     {
       "method": "POST",
-      "path": "/api/apps/:id/update",
-      "mountPath": "/api/apps",
-      "sources": [
-        "server/routes/apps/lifecycle.js"
-      ]
-    },
-    {
-      "method": "POST",
       "path": "/api/apps/:id/upgrade-tls",
       "mountPath": "/api/apps",
       "sources": [
@@ -17465,8 +17457,8 @@
   ],
   "stats": {
     "mounts": 147,
-    "operations": 2163,
-    "declarations": 2167,
+    "operations": 2162,
+    "declarations": 2166,
     "sourceFiles": 229
   }
 }

--- a/server/lib/validation.js
+++ b/server/lib/validation.js
@@ -354,10 +354,6 @@ export const referenceRepoUpdateSchema = z.object({
 // either — all ref CRUD goes through /api/apps/:appId/reference-repos.
 export const appUpdateSchema = partialWithoutDefaults(appSchema);
 
-export const managedAppUpdateSchema = z.object({
-  syncFork: z.boolean().optional(),
-}).strict();
-
 const standardizePlanFileSchema = z.string().trim().min(1).max(500)
   .refine((file) => {
     const segments = file.split(/[/\\]/);

--- a/server/routes/apps/lifecycle.js
+++ b/server/routes/apps/lifecycle.js
@@ -20,11 +20,9 @@ import { tryReadFile, safeJSONParse } from '../../lib/fileUtils.js';
 import * as appsService from '../../services/apps.js';
 import { notifyAppsChanged, PORTOS_APP_ID } from '../../services/apps.js';
 import * as pm2Service from '../../services/pm2.js';
-import * as appUpdater from '../../services/appUpdater.js';
 import * as appBuilder from '../../services/appBuilder.js';
 import { logAction } from '../../services/history.js';
 import { asyncHandler, ServerError } from '../../lib/errorHandler.js';
-import { managedAppUpdateSchema, validateRequest } from '../../lib/validation.js';
 import { parseEcosystemFromPath, usesPm2, isDesktopType } from '../../services/streamingDetect.js';
 import { detectAppIcon, isUsableSvg } from '../../services/appIconDetect.js';
 import { loadApp, pathExists, deriveUiPort } from './shared.js';
@@ -234,30 +232,6 @@ router.post('/:id/restart', loadApp, asyncHandler(async (req, res) => {
   notifyAppsChanged('restart');
 
   res.json({ success: true, results });
-}));
-
-// POST /api/apps/:id/update - Pull, install deps, setup, restart
-router.post('/:id/update', loadApp, asyncHandler(async (req, res) => {
-  const app = req.loadedApp;
-  const options = validateRequest(managedAppUpdateSchema, req.body || {});
-
-  if (!app.repoPath || !await pathExists(app.repoPath)) {
-    throw new ServerError('App repo path does not exist', { status: 400, code: 'PATH_NOT_FOUND' });
-  }
-
-  console.log(`⬇️ Starting update for ${app.name}`);
-  const progressSteps = [];
-  const emit = (step, status, message) => {
-    progressSteps.push({ step, status, message, timestamp: Date.now() });
-  };
-
-  const result = await appUpdater.updateApp(app, emit, options);
-  const success = result.success;
-  await logAction('update', app.id, app.name, { steps: result.steps }, success);
-  notifyAppsChanged('update');
-  console.log(`${success ? '✅' : '❌'} Update ${success ? 'complete' : 'failed'} for ${app.name}`);
-
-  res.json({ success, steps: result.steps, progress: progressSteps });
 }));
 
 // POST /api/apps/:id/build - Build production UI

--- a/server/routes/apps/lifecycle.test.js
+++ b/server/routes/apps/lifecycle.test.js
@@ -398,43 +398,6 @@ describe('Apps Lifecycle Routes', () => {
     });
   });
 
-  describe('POST /api/apps/:id/update', () => {
-    const mockApp = {
-      id: 'app-001',
-      name: 'Test App',
-      repoPath: REAL_DIR,
-      pm2ProcessNames: ['test-app'],
-    };
-
-    it('passes the validated fork-sync request to the managed updater', async () => {
-      appsService.getAppById.mockResolvedValue(mockApp);
-      appUpdater.updateApp.mockResolvedValue({ success: true, steps: [] });
-      history.logAction.mockResolvedValue();
-
-      const response = await request(app)
-        .post('/api/apps/app-001/update')
-        .send({ syncFork: true });
-
-      expect(response.status).toBe(200);
-      expect(appUpdater.updateApp).toHaveBeenCalledWith(
-        mockApp,
-        expect.any(Function),
-        { syncFork: true },
-      );
-    });
-
-    it('rejects a non-boolean fork-sync request before updating', async () => {
-      appsService.getAppById.mockResolvedValue(mockApp);
-
-      const response = await request(app)
-        .post('/api/apps/app-001/update')
-        .send({ syncFork: 'yes' });
-
-      expect(response.status).toBe(400);
-      expect(appUpdater.updateApp).not.toHaveBeenCalled();
-    });
-  });
-
   describe('POST /api/apps/:id/build', () => {
     it('should return 404 if app not found', async () => {
       appsService.getAppById.mockResolvedValue(null);

--- a/server/services/socket.test.js
+++ b/server/services/socket.test.js
@@ -14,7 +14,9 @@ vi.mock('./pm2.js', () => ({
 }));
 vi.mock('./streamingDetect.js', () => ({ streamDetection: vi.fn() }));
 vi.mock('./cosEvents.js', () => ({ cosEvents: { on: vi.fn() }, emitLog: vi.fn() }));
-vi.mock('./apps.js', () => ({ appsEvents: { on: vi.fn() }, getAppById: vi.fn(), resolvePm2HomeForProcess: vi.fn(), updateApp: vi.fn() }));
+vi.mock('./apps.js', () => ({ appsEvents: { on: vi.fn() }, getAppById: vi.fn(), notifyAppsChanged: vi.fn(), resolvePm2HomeForProcess: vi.fn(), updateApp: vi.fn() }));
+// logAction appends to the real history file — mock it or this suite writes to data/.
+vi.mock('./history.js', () => ({ logAction: vi.fn(async () => {}) }));
 vi.mock('../lib/errorHandler.js', () => ({ errorEvents: { on: vi.fn() } }));
 vi.mock('./autoFixer.js', () => ({ handleErrorRecovery: vi.fn() }));
 vi.mock('./pm2Standardizer.js', () => ({ analyzeApp: vi.fn(), createGitBackup: vi.fn(), applyStandardization: vi.fn(), runStandardizeFlow: vi.fn(), standardizeRefusalFor: vi.fn(() => null) }));
@@ -73,7 +75,8 @@ vi.mock('../sockets/voice.js', () => ({ registerVoiceHandlers: vi.fn() }));
 
 import { initSocket } from './socket.js';
 import { spawnPm2 } from './pm2.js';
-import { getAppById, resolvePm2HomeForProcess } from './apps.js';
+import { getAppById, notifyAppsChanged, resolvePm2HomeForProcess } from './apps.js';
+import { logAction } from './history.js';
 import { cosEvents } from './cosEvents.js';
 import { mediaJobEvents } from './mediaJobQueue/index.js';
 import { audioGenEvents } from './audioGen/events.js';
@@ -783,6 +786,36 @@ describe('socket.js — initSocket', () => {
       await flush();
       expect(vi.mocked(runAppUpdate)).toHaveBeenCalledTimes(2);
       expect(vi.mocked(runAppUpdate).mock.calls.at(-1)[2]).toEqual({ syncFork: true });
+    });
+
+    // The HTTP route that used to own these two calls is gone; the socket is the
+    // only update path, so it has to write the ledger row and fan out the
+    // apps-changed broadcast itself.
+    it('records a successful update in the action ledger and notifies apps-changed', async () => {
+      const socket = makeSocket('app-op-ledger');
+      io.connect(socket);
+
+      vi.mocked(runAppUpdate).mockResolvedValueOnce({ success: true, steps: [{ step: 'pull' }] });
+      await socket.handlers['app:update']({ appId: APP.id });
+      await flush();
+
+      expect(vi.mocked(logAction)).toHaveBeenCalledWith(
+        'update', APP.id, APP.name, { steps: [{ step: 'pull' }] }, true, null,
+      );
+      expect(vi.mocked(notifyAppsChanged)).toHaveBeenCalledWith('update', APP.id);
+    });
+
+    it('still writes a ledger row when the update throws, flagged unsuccessful', async () => {
+      const socket = makeSocket('app-op-ledger-fail');
+      io.connect(socket);
+
+      vi.mocked(runAppUpdate).mockRejectedValueOnce(new Error('pull failed'));
+      await socket.handlers['app:update']({ appId: APP.id });
+      await flush();
+
+      expect(vi.mocked(logAction)).toHaveBeenCalledWith(
+        'update', APP.id, APP.name, { steps: [] }, false, 'pull failed',
+      );
     });
 
     it('blocks a second app record that points at the same checkout', async () => {

--- a/server/sockets/apps.js
+++ b/server/sockets/apps.js
@@ -1,6 +1,7 @@
 import { streamDetection } from '../services/streamingDetect.js';
 import * as pm2Standardizer from '../services/pm2Standardizer.js';
 import * as appsService from '../services/apps.js';
+import { logAction } from '../services/history.js';
 import * as appUpdater from '../services/appUpdater.js';
 import * as appDeployer from '../services/appDeployer.js';
 import {
@@ -119,10 +120,18 @@ export const registerAppHandlers = (socket, io) => {
         io.emit('app:update:step', frame);
       };
 
+      let failure = null;
       const result = await appUpdater.updateApp(app, emit, { syncFork: data.syncFork === true }).catch(err => {
+        failure = err;
         io.emit('app:update:error', { appId: app.id, message: err.message });
         return null;
       });
+
+      // The ledger and the apps-changed broadcast are the socket path's job now
+      // that it is the only way to update an app — a thrown update still gets a
+      // row, with success:false, rather than vanishing from the history.
+      await logAction('update', app.id, app.name, { steps: result?.steps ?? [] }, result?.success === true, failure?.message ?? null);
+      appsService.notifyAppsChanged('update', app.id);
 
       if (result) {
         io.emit('app:update:complete', { appId: app.id, success: result.success, steps: result.steps });


### PR DESCRIPTION
## Summary

`POST /api/apps/:id/update` had no caller left — the update flow moved to the Socket.IO `app:update` event, and both entry points called the same `appUpdater.updateApp`. Surfaced while clearing the orphaned client wrappers in #5848.

**It was not a pure duplicate, so this is not a straight delete.** The route owned two side effects the socket handler never picked up:

- **`logAction('update', …)` — the app action ledger.** Every update run from the live UI since the socket migration has gone unrecorded.
- **`notifyAppsChanged('update')`** — fans `apps:changed` out to every client. The socket path emitted only `app:update:complete`, so views watching the apps list did not refresh.

Both now live in the socket handler, which is the richer path anyway (in-flight duplicate guard, live progress streaming). Deleting the route without moving them would have cemented the audit gap instead of closing it.

One deliberate improvement over the old route: **the ledger row is written on the failure path too.** A thrown update gets a row with `success: false` and the error message; the route left nothing behind, because it threw to the error middleware before reaching `logAction`.

`managedAppUpdateSchema` went with the route — the socket's `appUpdateSchema` already validates the same `syncFork` option. `apiRouteCatalog.generated.json` regenerated.

Verified nothing else reaches the route: no client caller, no peer/federation hop (`instances.js` only fetches `/api/apps`), no script, no `docs/`. The `/apps/:id/update` string in `UpdateBanners.test.jsx` is a client-side UI deep link, not this endpoint.

## Test plan

- [x] Two new cases in `socket.test.js` pin the moved behavior — a successful update writes the ledger row and calls `notifyAppsChanged`, and a thrown update still writes a row flagged unsuccessful
- [x] **Bypass probe:** removed both calls from the handler and re-ran — both new cases fail (`2 failed | 51 passed`). Restored.
- [x] Added the `history.js` mock to `socket.test.js` — without it `logAction` appends to the real history file under `data/`
- [x] Removed the route's own `describe` block from `lifecycle.test.js`
- [x] Full server suite: **1847 files / 37482 tests passed**, 24 skipped
