### PR TITLE
fix: emit a thinking-effort flag for grok, which silently dropped it

### DIFF
--- a/client/src/components/cos/EffortSelect.test.jsx
+++ b/client/src/components/cos/EffortSelect.test.jsx
@@ -7,11 +7,18 @@ const CLAUDE = { id: 'claude-code', command: 'claude' };
 const AGY = { id: 'antigravity-cli', command: 'agy' };
 const CODEX = { id: 'codex', command: 'codex' };
 const GROK = { id: 'grok-cli', command: 'grok' };
+const KIMI = { id: 'kimi-cli', command: 'kimi' };
 
 describe('EffortSelect', () => {
   it('renders nothing for a provider with no effort control', () => {
-    const { container } = render(<EffortSelect provider={GROK} value="" onChange={() => {}} />);
+    const { container } = render(<EffortSelect provider={KIMI} value="" onChange={() => {}} />);
     expect(container).toBeEmptyDOMElement();
+  });
+
+  it('offers grok its low|medium|high|xhigh ladder — no max, which grok rejects', () => {
+    render(<EffortSelect provider={GROK} value="" onChange={() => {}} />);
+    expect(screen.getAllByRole('option').map(o => o.textContent))
+      .toEqual(['Default effort', 'low', 'medium', 'high', 'xhigh']);
   });
 
   it('offers agy its narrower low|medium|high ladder', () => {

--- a/client/src/components/cos/ReviewerPicker.test.jsx
+++ b/client/src/components/cos/ReviewerPicker.test.jsx
@@ -455,10 +455,15 @@ describe('ReviewerPicker', () => {
       });
 
       it('renders no Effort control for a reviewer with no effort knob', () => {
-        render(<ReviewerPicker reviewers={['copilot', 'grok']} usernames={['flaky-bot']} onChange={() => {}} />);
+        render(<ReviewerPicker reviewers={['copilot']} usernames={['flaky-bot']} onChange={() => {}} />);
         expect(screen.queryByLabelText('Reasoning effort for Copilot')).not.toBeInTheDocument();
-        expect(screen.queryByLabelText('Reasoning effort for Grok')).not.toBeInTheDocument();
         expect(screen.queryByLabelText('Reasoning effort for @flaky-bot')).not.toBeInTheDocument();
+      });
+
+      it('offers grok its own ladder, which stops short of max', () => {
+        render(<ReviewerPicker reviewers={['grok']} onChange={() => {}} />);
+        const select = screen.getByLabelText('Reasoning effort for Grok');
+        expect([...select.options].map((o) => o.value)).toEqual(['', 'low', 'medium', 'high', 'xhigh']);
       });
 
       it('shows an existing pin and emits a picked tier', () => {

--- a/client/src/lib/reviewerPins.js
+++ b/client/src/lib/reviewerPins.js
@@ -2,7 +2,8 @@ import {
   CLAUDE_EFFORT_LEVELS,
   CODEX_EFFORT_LEVELS,
   ANTIGRAVITY_EFFORT_LEVELS,
-  CURSOR_EFFORT_LEVELS
+  CURSOR_EFFORT_LEVELS,
+  GROK_EFFORT_LEVELS
 } from '../utils/providers';
 
 /**
@@ -53,7 +54,7 @@ export const MAX_REVIEWER_MODEL_LENGTH = 200;
 export const LOCAL_LLM_EFFORT_LEVELS = Object.freeze(['low', 'medium', 'high']);
 
 // The effort ladder each reviewer offers, or absent when it has no effort control
-// (`copilot` is a GitHub review, `grok`'s CLI has no effort control at all, and an
+// (`copilot` is a GitHub review, and an
 // `@username` reviewer is a person). A ladder means the level is PICKABLE, not
 // that the CLI takes an `--effort` flag — `cursor` accepts one only as a
 // parameter of its model id, which the server folds in when it builds the
@@ -66,6 +67,7 @@ export const REVIEWER_EFFORT_LEVELS = Object.freeze({
   codex: CODEX_EFFORT_LEVELS,
   antigravity: ANTIGRAVITY_EFFORT_LEVELS,
   cursor: CURSOR_EFFORT_LEVELS,
+  grok: GROK_EFFORT_LEVELS,
   lmstudio: LOCAL_LLM_EFFORT_LEVELS,
   ollama: LOCAL_LLM_EFFORT_LEVELS,
 });

--- a/client/src/utils/providers.js
+++ b/client/src/utils/providers.js
@@ -88,6 +88,19 @@ export const isCodexProvider = (provider) => {
 };
 
 /**
+ * True when a provider is Grok-Build-flavored. MIRROR of `isGrokProvider` in
+ * server/lib/providerModels.js — the shipped `grok-cli`/`grok-tui` ids or a
+ * `grok` command basename. The bare `grok` id is the HTTP API provider, which
+ * has no CLI flag to carry an effort level, and is excluded.
+ * @param {{id?:string, command?:string}|null|undefined} provider
+ * @returns {boolean}
+ */
+export const isGrokProvider = (provider) => {
+  const id = String(provider?.id || '').toLowerCase();
+  return id === 'grok-cli' || id === 'grok-tui' || commandBasename(provider?.command) === 'grok';
+};
+
+/**
  * True when a CLI/TUI record uses Codex's ChatGPT subscription. This mirrors
  * server/lib/codexAccount.js: the command, not an editable provider id, owns
  * the account contract.
@@ -322,6 +335,11 @@ export const OPENCODE_LOCAL_EFFORT_LEVELS = Object.freeze(['low', 'medium', 'hig
 // syntax (`gpt-5[effort=max]`) — but the level is still user-pickable, so this
 // ladder drives the same selects as every other CLI's.
 export const CURSOR_EFFORT_LEVELS = Object.freeze(['low', 'medium', 'high', 'xhigh', 'max']);
+// Grok Build CLI. MIRROR of `GROK_EFFORT_LEVELS` in server/lib/providerModels.js.
+// Grok's own ladder, read off its rejection message rather than guessed
+// (`use one of: xhigh, high, medium, low`) — no `max`/`minimal`, so a stored
+// `max` clamps to `xhigh` here exactly as it does on the server.
+export const GROK_EFFORT_LEVELS = Object.freeze(['low', 'medium', 'high', 'xhigh']);
 
 const CODEX_ULTRA_MODELS = new Set(['gpt-5.6', 'gpt-5.6-sol', 'gpt-5.6-terra']);
 
@@ -530,6 +548,7 @@ export const effortLevelsForProvider = (provider, model = null) => {
     return perModel.length ? perModel : null;
   }
   if (isCursorProvider(provider)) return CURSOR_EFFORT_LEVELS;
+  if (isGrokProvider(provider)) return GROK_EFFORT_LEVELS;
   const id = String(provider.id || '').toLowerCase();
   if (id.startsWith('claude-code') || commandBasename(provider.command) === 'claude') return CLAUDE_EFFORT_LEVELS;
   // Sanitized provider inventories intentionally omit command/path/env details.

--- a/client/src/utils/providers.test.js
+++ b/client/src/utils/providers.test.js
@@ -60,6 +60,7 @@ import {
   CLAUDE_EFFORT_LEVELS,
   CODEX_EFFORT_LEVELS,
   CURSOR_EFFORT_LEVELS,
+  GROK_EFFORT_LEVELS,
   ANTIGRAVITY_EFFORT_LEVELS,
   isConfiguredDefaultModel,
   configuredDefaultIn,
@@ -101,6 +102,7 @@ describe('resolveCliEffort (server mirror)', () => {
   const CLAUDE = { id: 'claude-code', command: 'claude' };
   const CODEX = { id: 'codex', command: 'codex' };
   const GROK = { id: 'grok-cli', command: 'grok' };
+  const KIMI = { id: 'kimi-cli', command: 'kimi' };
 
   it.each([
     ['supported value passes through', 'medium', AGY, 'medium'],
@@ -114,7 +116,13 @@ describe('resolveCliEffort (server mirror)', () => {
     ['codex accepts max', 'max', CODEX, 'max'],
     ['ultra resolves to codex max without a supported model', 'ultra', CODEX, 'max'],
     ['unknown value yields no flag', 'bogus', AGY, null],
-    ['effort-less provider yields no flag', 'high', GROK, null],
+    ['effort-less provider yields no flag', 'high', KIMI, null],
+    // grok's ladder tops out at xhigh, so a level saved against claude/codex
+    // clamps rather than dropping — on BOTH sides of the mirror.
+    ['grok accepts its whole ladder', 'xhigh', GROK, 'xhigh'],
+    ['above grok ladder clamps to xhigh', 'max', GROK, 'xhigh'],
+    ['ultra clamps to grok xhigh', 'ultra', GROK, 'xhigh'],
+    ['below grok ladder takes the weakest', 'minimal', GROK, 'low'],
     ['unset yields no flag', '', AGY, null],
     ['null yields no flag', null, CLAUDE, null],
   ])('%s', (_label, effort, provider, expected) => {
@@ -150,7 +158,13 @@ describe('effortLevelsForProvider (server mirror)', () => {
     ['OpenCode vLLM TUI', { id: 'opencode-vllm-tui', command: 'opencode', vllmBacked: true }, ['low', 'medium', 'high']],
     ['OpenCode SGLang TUI', { id: 'opencode-sglang-tui', command: 'opencode', sglangBacked: true }, ['low', 'medium', 'high']],
     ['OpenCode with no local backend', { id: 'opencode', command: 'opencode' }, null],
-    ['grok (no effort control)', { id: 'grok-cli', command: 'grok' }, null],
+    // grok DOES have an effort control (`--reasoning-effort`, aliased `--effort`);
+    // its ladder stops at xhigh, which is why it is not simply CLAUDE's.
+    ['grok CLI', { id: 'grok-cli', command: 'grok' }, GROK_EFFORT_LEVELS],
+    ['grok TUI', { id: 'grok-tui' }, GROK_EFFORT_LEVELS],
+    ['path-configured grok', { id: 'custom', command: '/Users/x/.grok/bin/grok' }, GROK_EFFORT_LEVELS],
+    // The bare `grok` id is the HTTP API provider — no CLI, so no flag to carry a level.
+    ['grok API provider', { id: 'grok', type: 'api' }, null],
     ['blank command is not claude', { id: 'ollama' }, null],
   ];
 
@@ -380,7 +394,7 @@ describe('Antigravity base-model split (server mirror)', () => {
     });
 
     it('drops the effort for a provider with no effort control at all', () => {
-      expect(effortSurvivingModel({ id: 'grok-cli', command: 'grok' }, 'grok-4', 'high')).toBe('');
+      expect(effortSurvivingModel({ id: 'kimi-cli', command: 'kimi' }, 'kimi-k2', 'high')).toBe('');
     });
 
     it('normalizes a nullish effort to the empty sentinel', () => {

--- a/server/lib/cosValidation.test.js
+++ b/server/lib/cosValidation.test.js
@@ -39,7 +39,7 @@ import {
   taskTemplateSettingsSchema,
 } from './cosValidation.js';
 import { LOCAL_AGENT_REVIEWERS } from './slashdoInvocation.js';
-import { EFFORT_LEVELS, CLAUDE_EFFORT_LEVELS, CODEX_EFFORT_LEVELS, ANTIGRAVITY_EFFORT_LEVELS, CURSOR_EFFORT_LEVELS } from './providerModels.js';
+import { EFFORT_LEVELS, CLAUDE_EFFORT_LEVELS, CODEX_EFFORT_LEVELS, ANTIGRAVITY_EFFORT_LEVELS, CURSOR_EFFORT_LEVELS, GROK_EFFORT_LEVELS } from './providerModels.js';
 
 describe('cosValidation effort field', () => {
   it('accepts every EFFORT_LEVELS value on create and rejects unknown values', () => {
@@ -292,16 +292,18 @@ describe('per-reviewer reasoning effort (reviewerEfforts)', () => {
     // the level is a variant of its model id, folded in by `reviewerModelArg`.
     expect(reviewerEffortLevels('cursor')).toEqual(CURSOR_EFFORT_LEVELS);
     expect(reviewerEffortLevels('cursor-agent')).toEqual(CURSOR_EFFORT_LEVELS);
-    // No effort control: copilot is a GitHub review, grok's CLI takes no flag,
-    // and a `@username` reviewer is a person.
+    // grok's ladder stops at xhigh — derived from effortLevelsForProvider, so it
+    // is exactly what `grok --reasoning-effort` accepts.
+    expect(reviewerEffortLevels('grok')).toEqual(GROK_EFFORT_LEVELS);
+    // No effort control: copilot is a GitHub review, and a `@username` reviewer
+    // is a person.
     expect(reviewerEffortLevels('copilot')).toBeNull();
-    expect(reviewerEffortLevels('grok')).toBeNull();
     expect(reviewerEffortLevels('@somebody')).toBeNull();
   });
 
   it('EFFORT_SELECTABLE_REVIEWERS is exactly the reviewers with a non-empty ladder', () => {
     expect([...EFFORT_SELECTABLE_REVIEWERS].sort())
-      .toEqual(['antigravity', 'claude', 'codex', 'cursor', 'lmstudio', 'ollama']);
+      .toEqual(['antigravity', 'claude', 'codex', 'cursor', 'grok', 'lmstudio', 'ollama']);
     for (const reviewer of REVIEWER_VALUES) {
       expect(EFFORT_SELECTABLE_REVIEWERS.includes(reviewer))
         .toBe((reviewerEffortLevels(reviewer) || []).length > 0);
@@ -321,8 +323,11 @@ describe('per-reviewer reasoning effort (reviewerEfforts)', () => {
     // `agy` really does reject `--effort max`; clamping it to `high` would review
     // at a different effort than the picker shows.
     expect(normalizeReviewerEfforts({ antigravity: 'max' })).toEqual({});
+    // grok rejects `max` the way agy rejects it — dropped, not clamped.
+    expect(normalizeReviewerEfforts({ grok: 'max' })).toEqual({});
+    expect(normalizeReviewerEfforts({ grok: 'xhigh' })).toEqual({ grok: 'xhigh' });
     // Reviewers with no effort control at all.
-    expect(normalizeReviewerEfforts({ copilot: 'high', grok: 'high', '@bot': 'high' })).toEqual({});
+    expect(normalizeReviewerEfforts({ copilot: 'high', '@bot': 'high' })).toEqual({});
     // Non-strings and blanks are absent, never an empty pin.
     expect(normalizeReviewerEfforts({ codex: '', claude: null, ollama: 3 })).toEqual({});
     // Non-object input is undefined so an omitted field isn't persisted as `{}`.
@@ -343,8 +348,8 @@ describe('per-reviewer reasoning effort (reviewerEfforts)', () => {
       antigravityEffort: 'max',   // not in agy's ladder — dropped, not clamped
       ollamaEffort: 'medium',
       lmstudioEffort: 'ultra',    // OpenAI-shaped backends don't take this tier
-      grokEffort: 'high',         // grok has no effort control at all
-    })).toEqual({ codex: 'high', claude: 'xhigh', ollama: 'medium' });
+      grokEffort: 'high',         // in grok's ladder — kept
+    })).toEqual({ codex: 'high', claude: 'xhigh', ollama: 'medium', grok: 'high' });
     expect(reviewerEffortsFromDefaults(null)).toEqual({});
   });
 
@@ -353,7 +358,10 @@ describe('per-reviewer reasoning effort (reviewerEfforts)', () => {
     expect(reviewerEffortArgs('codex', 'high')).toEqual(['-c', 'model_reasoning_effort=high']);
     // The `antigravity` slug names no executable — `agy` does, and it takes --effort.
     expect(reviewerEffortArgs('antigravity', 'low')).toEqual(['--effort', 'low']);
-    expect(reviewerEffortArgs('grok', 'high')).toEqual([]);
+    // grok's CLI takes `--reasoning-effort`, aliased `--effort` — the alias is
+    // what buildEffortArgs emits, and `max` is outside its ladder so it drops.
+    expect(reviewerEffortArgs('grok', 'xhigh')).toEqual(['--effort', 'xhigh']);
+    expect(reviewerEffortArgs('grok', 'max')).toEqual([]);
     expect(reviewerEffortArgs('copilot', 'high')).toEqual([]);
     expect(reviewerEffortArgs('claude', null)).toEqual([]);
   });
@@ -478,7 +486,7 @@ describe('per-reviewer reasoning effort (reviewerEfforts)', () => {
     // An explicitly empty MAP is KEPT: it's a real "use each reviewer's own
     // default for this task" choice that must override the Code Review Defaults.
     expect(sanitizeTaskMetadata({ reviewerEfforts: {} })).toEqual({ reviewerEfforts: {} });
-    expect(sanitizeTaskMetadata({ reviewerEfforts: { claude: 'high', grok: 'high' } }))
+    expect(sanitizeTaskMetadata({ reviewerEfforts: { claude: 'high', grok: 'max' } }))
       .toEqual({ reviewerEfforts: { claude: 'high' } });
   });
 
@@ -607,10 +615,11 @@ describe('per-reviewer model pins', () => {
     expect(buildReviewWithArgs(['grok'], { reviewerModels: { grok: 'grok-code-fast-1' } }))
       .toBe('--review-with grok[grok-code-fast-1]');
     // Only agy bakes an effort into the model id. A grok id passes through whole,
-    // and grok gains no effort pin from having one — its CLI takes no effort flag.
+    // and a bare model pin adds no effort pin — grok carries its level on its own
+    // flag, not inside the model id.
     expect(pairReviewerModelsAndEfforts({ grok: 'grok-code-fast-1' }, {}))
       .toEqual({ reviewerModels: { grok: 'grok-code-fast-1' }, reviewerEfforts: {} });
-    expect(reviewerEffortLevels('grok')).toBeNull();
+    expect(reviewerEffortLevels('grok')).toEqual(GROK_EFFORT_LEVELS);
   });
 });
 

--- a/server/lib/providerModels.js
+++ b/server/lib/providerModels.js
@@ -104,6 +104,12 @@ export const OPENCODE_LOCAL_EFFORT_LEVELS = Object.freeze(['low', 'medium', 'hig
 // identical is the point, since the same pin has to survive a round trip
 // through slashdo.
 export const CURSOR_EFFORT_LEVELS = Object.freeze(['low', 'medium', 'high', 'xhigh', 'max']);
+// Grok Build CLI. `--reasoning-effort <EFFORT>` (aliased `--effort`, which is what
+// `buildEffortArgs` emits). The ladder is grok's own, read off its rejection
+// message rather than guessed: `grok --reasoning-effort bogus` answers
+// `use one of: xhigh, high, medium, low` — so there is no `max`/`minimal` here,
+// and `resolveCliEffort` clamps a stored `max`/`ultra` down to `xhigh`.
+export const GROK_EFFORT_LEVELS = Object.freeze(['low', 'medium', 'high', 'xhigh']);
 
 /** Union of every accepted effort value across effort-capable CLIs, low→high. */
 export const EFFORT_LEVELS = Object.freeze([...new Set([
@@ -216,6 +222,22 @@ export function antigravityModelEffortLevels(model, models) {
 export function isCodexProvider(provider) {
   const id = String(provider?.id || '').toLowerCase();
   return id === 'codex' || id === 'codex-tui' || commandBasename(provider?.command) === 'codex';
+}
+
+/**
+ * True when a provider is Grok-Build-flavored — the shipped `grok-cli`/`grok-tui`
+ * ids or any provider whose launch command basename is `grok`. Same posture as
+ * `isCodexProvider`, and deliberately defined here rather than imported from
+ * `grok.js`: that module imports THIS one, so importing back would cycle.
+ *
+ * The bare `grok` id is the HTTP API provider, which has no CLI to pass a flag
+ * to — it is excluded so it gets no effort ladder.
+ * @param {{id?:string, command?:string}|null|undefined} provider
+ * @returns {boolean}
+ */
+export function isGrokProvider(provider) {
+  const id = String(provider?.id || '').toLowerCase();
+  return id === 'grok-cli' || id === 'grok-tui' || commandBasename(provider?.command) === 'grok';
 }
 
 /**
@@ -363,6 +385,7 @@ export function effortLevelsForProvider(provider, model = null) {
     return perModel.length ? perModel : null;
   }
   if (isCursorProvider(provider)) return CURSOR_EFFORT_LEVELS;
+  if (isGrokProvider(provider)) return GROK_EFFORT_LEVELS;
   if (isClaudeProvider(provider)) return CLAUDE_EFFORT_LEVELS;
   return null;
 }
@@ -406,11 +429,21 @@ export function resolveCliEffort(effort, provider, model = null) {
 // analyzer when a config rejection has to be blamed on PortOS or on the user.
 export const CODEX_EFFORT_KEY = 'model_reasoning_effort';
 
+// Every spelling of the effort flag a provider CLI accepts as a VALUE-taking
+// argument. `--reasoning-effort` is grok's canonical long form (`--effort` is its
+// documented alias, and the alias is what buildEffortArgs emits) — it has to be
+// recognized here or a user who baked `--reasoning-effort high` into their
+// provider args gets a SECOND, injected `--effort <level>` appended. Grok's
+// parser accepts the duplicate and takes the last one, so their explicit pin
+// would be silently overridden — the exact opposite of the contract below.
+const EFFORT_FLAG_NAMES = Object.freeze(['--effort', '--reasoning-effort']);
+
 /**
  * True when the user has already baked an effort override into the provider's
- * args — claude's `--effort <level>` / `--effort=<level>` or a codex
- * `-c model_reasoning_effort=…` config pair. Mirrors `hasModelFlag`: a baked
- * pin wins and the runner-injected effort is suppressed.
+ * args — claude/agy/grok's `--effort <level>` / `--effort=<level>`, grok's
+ * `--reasoning-effort` long form, or a codex `-c model_reasoning_effort=…`
+ * config pair. Mirrors `hasModelFlag`: a baked pin wins and the
+ * runner-injected effort is suppressed.
  * @param {unknown[]} args
  * @returns {boolean}
  */
@@ -418,10 +451,12 @@ export function hasEffortFlag(args) {
   if (!Array.isArray(args)) return false;
   return args.some((a, i) => {
     if (typeof a !== 'string') return false;
-    if (a.startsWith('--effort=') && a.length > '--effort='.length) return true;
-    if (a === '--effort') {
-      const next = args[i + 1];
-      return typeof next === 'string' && next.length > 0 && !next.startsWith('-');
+    for (const flag of EFFORT_FLAG_NAMES) {
+      if (a.startsWith(`${flag}=`) && a.length > flag.length + 1) return true;
+      if (a === flag) {
+        const next = args[i + 1];
+        if (typeof next === 'string' && next.length > 0 && !next.startsWith('-')) return true;
+      }
     }
     return a.startsWith(`${CODEX_EFFORT_KEY}=`);
   });

--- a/server/lib/providerModels.test.js
+++ b/server/lib/providerModels.test.js
@@ -27,6 +27,7 @@ import {
   CODEX_EFFORT_LEVELS,
   ANTIGRAVITY_EFFORT_LEVELS,
   CURSOR_EFFORT_LEVELS,
+  GROK_EFFORT_LEVELS,
   EFFORT_LEVELS,
   isAntigravityProvider,
   isCursorProvider,
@@ -235,6 +236,16 @@ describe('providerModels', () => {
       expect(effortLevelsForProvider({ id: 'claude-ollama', command: '/usr/local/bin/claude' })).toBe(CLAUDE_EFFORT_LEVELS);
     });
 
+    it('returns grok levels for grok CLI/TUI ids and the grok command, but not the API provider', () => {
+      expect(effortLevelsForProvider({ id: 'grok-cli', command: 'grok' })).toBe(GROK_EFFORT_LEVELS);
+      expect(effortLevelsForProvider({ id: 'grok-tui' })).toBe(GROK_EFFORT_LEVELS);
+      expect(effortLevelsForProvider({ id: 'custom', command: '/Users/x/.grok/bin/grok' })).toBe(GROK_EFFORT_LEVELS);
+      expect(effortLevelsForProvider({ id: 'custom', command: 'Grok.exe' })).toBe(GROK_EFFORT_LEVELS);
+      // The bare `grok` id is the HTTP API provider — no CLI, so no flag to
+      // carry a level, and offering the picker one would be a lie.
+      expect(effortLevelsForProvider({ id: 'grok', type: 'api' })).toBeNull();
+    });
+
     it('returns the narrower agy ladder for antigravity ids and the agy command', () => {
       expect(effortLevelsForProvider({ id: 'antigravity-cli', command: 'agy' })).toBe(ANTIGRAVITY_EFFORT_LEVELS);
       expect(effortLevelsForProvider({ id: 'antigravity-tui' })).toBe(ANTIGRAVITY_EFFORT_LEVELS);
@@ -256,7 +267,8 @@ describe('providerModels', () => {
     });
 
     it('returns null for providers without an effort control (and does NOT default blank commands to claude)', () => {
-      expect(effortLevelsForProvider({ id: 'grok-cli', command: 'grok' })).toBeNull();
+      expect(effortLevelsForProvider({ id: 'kimi-cli', command: 'kimi' })).toBeNull();
+      expect(effortLevelsForProvider({ id: 'opencode', command: 'opencode' })).toBeNull();
       expect(effortLevelsForProvider({ id: 'ollama' })).toBeNull();
       expect(effortLevelsForProvider(null)).toBeNull();
     });
@@ -379,6 +391,15 @@ describe('providerModels', () => {
   });
 
   describe('buildEffortArgs', () => {
+    it('emits grok’s --effort alias, and suppresses it when --reasoning-effort is baked in', () => {
+      const grok = { id: 'grok-cli', command: 'grok' };
+      expect(buildEffortArgs('xhigh', grok, [])).toEqual(['--effort', 'xhigh']);
+      // A user's own long-form pin wins. Grok's parser takes the LAST occurrence,
+      // so appending a second flag here would silently override their choice.
+      expect(buildEffortArgs('low', grok, ['--reasoning-effort', 'high'])).toEqual([]);
+      expect(buildEffortArgs('low', grok, ['--reasoning-effort=high'])).toEqual([]);
+    });
+
     it('emits --effort for claude and a -c config pair for codex', () => {
       expect(buildEffortArgs('high', { id: 'claude-code', command: 'claude' })).toEqual(['--effort', 'high']);
       expect(buildEffortArgs('xhigh', { id: 'codex', command: 'codex' })).toEqual(['-c', 'model_reasoning_effort=xhigh']);
@@ -401,7 +422,7 @@ describe('providerModels', () => {
 
     it('returns [] when unset, unsupported, or already baked into existing args', () => {
       expect(buildEffortArgs(null, { id: 'codex', command: 'codex' })).toEqual([]);
-      expect(buildEffortArgs('high', { id: 'grok-cli', command: 'grok' })).toEqual([]);
+      expect(buildEffortArgs('high', { id: 'kimi-cli', command: 'kimi' })).toEqual([]);
       expect(buildEffortArgs('max', { id: 'claude-code', command: 'claude' }, ['--effort', 'low'])).toEqual([]);
     });
 
@@ -483,6 +504,18 @@ describe('providerModels', () => {
   });
 
   describe('resolveCliEffort', () => {
+    it('clamps an out-of-ladder effort down to grok’s xhigh ceiling', () => {
+      const grok = { id: 'grok-cli', command: 'grok' };
+      // grok's ladder stops at xhigh — a level saved against claude/codex must
+      // clamp rather than vanish, the same contract agy's ladder has.
+      expect(resolveCliEffort('max', grok)).toBe('xhigh');
+      expect(resolveCliEffort('ultra', grok)).toBe('xhigh');
+      expect(resolveCliEffort('xhigh', grok)).toBe('xhigh');
+      expect(resolveCliEffort('low', grok)).toBe('low');
+      // Nothing sits below `minimal`, so it lands on the weakest level.
+      expect(resolveCliEffort('minimal', grok)).toBe('low');
+    });
+
     it('passes a supported level through for claude and codex', () => {
       expect(resolveCliEffort('high', { id: 'claude-code', command: 'claude' })).toBe('high');
       expect(resolveCliEffort('minimal', { id: 'codex', command: 'codex' })).toBe('minimal');
@@ -512,7 +545,7 @@ describe('providerModels', () => {
       expect(resolveCliEffort('', { id: 'codex', command: 'codex' })).toBeNull();
       expect(resolveCliEffort('bogus', { id: 'codex', command: 'codex' })).toBeNull();
       expect(resolveCliEffort('bogus', { id: 'antigravity-cli', command: 'agy' })).toBeNull();
-      expect(resolveCliEffort('high', { id: 'grok-cli', command: 'grok' })).toBeNull();
+      expect(resolveCliEffort('high', { id: 'kimi-cli', command: 'kimi' })).toBeNull();
     });
 
     it('clamps to the tiers the selected agy model has, so agy never sees an invalid pair', () => {
@@ -545,6 +578,15 @@ describe('providerModels', () => {
     it('detects a baked --effort pin in both arg shapes', () => {
       expect(hasEffortFlag(['--effort', 'high'])).toBe(true);
       expect(hasEffortFlag(['--effort=high'])).toBe(true);
+    });
+
+    it('detects grok’s --reasoning-effort long form in both arg shapes', () => {
+      expect(hasEffortFlag(['--reasoning-effort', 'high'])).toBe(true);
+      expect(hasEffortFlag(['--reasoning-effort=high'])).toBe(true);
+      // Same dangling/valueless rules as the short form.
+      expect(hasEffortFlag(['--reasoning-effort'])).toBe(false);
+      expect(hasEffortFlag(['--reasoning-effort', '--verbose'])).toBe(false);
+      expect(hasEffortFlag(['--reasoning-effort='])).toBe(false);
     });
 
     it('detects a baked codex model_reasoning_effort config pair', () => {

--- a/server/services/agentTuiSpawning.test.js
+++ b/server/services/agentTuiSpawning.test.js
@@ -473,8 +473,18 @@ describe('agent TUI spawning', () => {
     const noEffort = buildTuiSpawnConfig({ id: 'claude-code-tui', command: 'claude', type: 'tui', args: [] }, null);
     expect(noEffort.args).not.toContain('--effort');
 
+    // kimi's TUI takes no effort flag at all, so a pinned level emits nothing.
+    const kimi = buildTuiSpawnConfig({ id: 'kimi-tui', command: 'kimi', type: 'tui', args: [] }, null, { effort: 'high' });
+    expect(kimi.args.join(' ')).not.toContain('effort');
+  });
+
+  it('injects grok’s effort into the TUI — its --reasoning-effort/--effort is a root flag', () => {
     const grok = buildTuiSpawnConfig({ id: 'grok-tui', command: 'grok', type: 'tui', args: [] }, null, { effort: 'high' });
-    expect(grok.args.join(' ')).not.toContain('effort');
+    expect(grok.args).toEqual(expect.arrayContaining(['--effort', 'high']));
+    // Outside grok's ladder — clamped down rather than passed through as-is,
+    // because grok rejects an unknown level outright.
+    const clamped = buildTuiSpawnConfig({ id: 'grok-tui', command: 'grok', type: 'tui', args: [] }, null, { effort: 'max' });
+    expect(clamped.args).toEqual(expect.arrayContaining(['--effort', 'xhigh']));
   });
 
   it('passes --effort through to the Antigravity TUI, clamped to its low|medium|high ladder', () => {

--- a/server/services/cleanupAgentWorktree.test.js
+++ b/server/services/cleanupAgentWorktree.test.js
@@ -1006,18 +1006,17 @@ describe('cleanupAgentWorktree - PR-creation path', () => {
     await cleanupAgentWorktree('agent-1', true, {
       prCreation: 'always', requestCopilotReview: true, reviewers: ['copilot', 'antigravity', 'claude', 'grok'],
       reviewerModels: { claude: 'qwen2.5:7b', grok: 'grok-code-fast-1' },
-      // `codex` isn't in the reviewer list; `copilot` has no effort control at all,
-      // and neither does `grok` — its CLI takes no effort flag.
+      // `codex` isn't in the reviewer list and `copilot` has no effort control at
+      // all, so both drop; `grok` is listed AND effort-capable, so it survives.
       reviewerEfforts: { antigravity: 'high', claude: 'xhigh', codex: 'low', copilot: 'high', grok: 'high' },
       description: 'Build',
       originalTask: { id: 'task-orig', priority: 'MEDIUM', metadata: { app: 'sparsetree' }, description: 'Build' }
     });
 
     const [followUp] = addTask.mock.calls[0];
-    // `grok` is a listed reviewer but takes no effort, so its effort pin is dropped…
-    expect(followUp.metadata.reviewLoopReviewerEfforts).toEqual({ antigravity: 'high', claude: 'xhigh' });
-    // …while its MODEL pin survives: the model map narrows on its own roster and is
-    // unaffected by the effort pins.
+    // Only the listed, effort-capable reviewers survive the narrowing…
+    expect(followUp.metadata.reviewLoopReviewerEfforts).toEqual({ antigravity: 'high', claude: 'xhigh', grok: 'high' });
+    // …and the MODEL map narrows on its own roster, unaffected by the effort pins.
     expect(followUp.metadata.reviewLoopReviewerModels).toEqual({ claude: 'qwen2.5:7b', grok: 'grok-code-fast-1' });
   });
 

--- a/server/services/stageRunner.test.js
+++ b/server/services/stageRunner.test.js
@@ -841,7 +841,8 @@ describe('stageRunner — effort threading into the run (#3641)', () => {
     const effort = resolveEffortHint(null, { effortDefault: 'high' });
     expect(buildEffortArgs(effort, { id: 'codex', command: 'codex' })).toEqual(['-c', 'model_reasoning_effort=high']);
     expect(buildEffortArgs(effort, { id: 'claude-cli', command: 'claude' })).toEqual(['--effort', 'high']);
-    expect(buildEffortArgs(effort, { id: 'grok-cli', command: 'grok' })).toEqual([]);
+    expect(buildEffortArgs(effort, { id: 'grok-cli', command: 'grok' })).toEqual(['--effort', 'high']);
+    expect(buildEffortArgs(effort, { id: 'kimi-cli', command: 'kimi' })).toEqual([]);
     expect(buildEffortArgs(effort, { id: 'openai-api', type: 'api' })).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

A thinking-effort level saved against a **grok** provider never reached the CLI — and the effort select was hidden, so nothing revealed the setting was inert. This affected task pins, pipeline stages, scheduled tasks, and reviewer rows alike.

`effortLevelsForProvider` had no grok arm and returned `null`, which short-circuits `resolveCliEffort` so `buildEffortArgs` emits nothing. Grok has accepted an effort flag all along — `--reasoning-effort <EFFORT>`, aliased `--effort`, which is exactly what `buildEffortArgs` already emits for every non-codex/cursor vendor. Only the ladder was missing.

The ladder is read off the CLI rather than guessed:

```
$ grok --reasoning-effort bogus -p hi
--effort/--reasoning-effort: unknown effort level 'bogus'; use one of: xhigh, high, medium, low
```

No `max`/`minimal`, so a level saved against claude or codex clamps to `xhigh`, the same contract agy's narrower ladder already has.

- **`GROK_EFFORT_LEVELS` + `isGrokProvider`** in `server/lib/providerModels.js`, mirrored in `client/src/utils/providers.js`. The predicate is defined inline rather than imported from `grok.js` — that module imports providerModels, so importing back would cycle. The bare `grok` id is the HTTP API provider and is excluded: no CLI, no flag to carry a level.
- **`hasEffortFlag` now also matches `--reasoning-effort`.** Grok's parser accepts a duplicate flag and takes the last one, so without this a user who baked `--reasoning-effort high` into their provider args got a second injected `--effort` that silently overrode their pin — the opposite of that function's documented "a baked pin wins" contract.

### Two surfaces picked it up on their own

`REVIEWER_EFFORT_LEVELS` is *derived* from `effortLevelsForProvider` ("a CLI that gains or loses a tier moves both at once"), so grok became an effort-selectable reviewer server-side with no edit. Its hand-written client mirror in `reviewerPins.js` needed the matching entry. The Effort select and reviewer picker then render grok's tiers with no component change — the design working as intended.

Tests that had used grok as their canonical "provider with no effort control" now use **kimi**, which genuinely has none, so each keeps its original point rather than being deleted.

## Test plan

- `server/lib/providerModels.test.js` — ladder for the `grok-cli`/`grok-tui` ids, a path-configured command, and `Grok.exe`; `null` for the `grok` API provider. `resolveCliEffort` clamps `max`/`ultra` → `xhigh` and `minimal` → `low`. `buildEffortArgs` emits `['--effort', <level>]`, and emits nothing when `--reasoning-effort` is already baked in (both separated and joined forms). `hasEffortFlag` gets the long form in both shapes plus its dangling/valueless cases.
- `client/src/utils/providers.test.js` — the server-mirror parity cases now assert the ladder on both implementations, including the clamp.
- `server/lib/cosValidation.test.js` — grok as an effort-selectable reviewer: `reviewerEffortLevels`, `EFFORT_SELECTABLE_REVIEWERS`, drop-don't-clamp on `max`, the settings-scalar fold, and `reviewerEffortArgs`.
- `server/services/agentTuiSpawning.test.js` — grok's TUI gets the flag (it is a root-level flag on the same binary), and an out-of-ladder level clamps.
- `client` — `EffortSelect` and `ReviewerPicker` offer grok `low|medium|high|xhigh` and no `max`.
- Full suites: server **37,478 passed / 0 failed**; client **10,769 passed**. The residual red in both runs is pre-existing load contention, green in isolation — server `imageGen.multipart` (20/20 alone) and five client page suites (190/190 alone), the class tracked in #5857.

Closes #5854
