### PR TITLE
feat(video-gen): add FastH3 Dense Data-Free MLX to Apple Silicon video gen

### DIFF
--- a/data.reference/media-models.json
+++ b/data.reference/media-models.json
@@ -16,7 +16,7 @@
             "url": "https://pypi.org/project/mlx-video-with-audio/"
           },
           "estimatedDownloadGb": 53.5,
-          "reviewedAt": "2026-08-30"
+          "reviewedAt": "2026-09-02"
         }
       },
       {
@@ -33,7 +33,7 @@
             "url": "https://pypi.org/project/mlx-video-with-audio/"
           },
           "estimatedDownloadGb": 22.8,
-          "reviewedAt": "2026-08-30"
+          "reviewedAt": "2026-09-02"
         }
       },
       {
@@ -54,7 +54,7 @@
             "url": "https://github.com/dgrauet/ltx-2-mlx/blob/main/LICENSE"
           },
           "estimatedDownloadGb": 59.7,
-          "reviewedAt": "2026-08-30"
+          "reviewedAt": "2026-09-02"
         }
       },
       {
@@ -75,7 +75,7 @@
             "url": "https://github.com/dgrauet/ltx-2-mlx/blob/main/LICENSE"
           },
           "estimatedDownloadGb": 87.5,
-          "reviewedAt": "2026-08-30"
+          "reviewedAt": "2026-09-02"
         }
       },
       {
@@ -100,7 +100,7 @@
             "url": "https://github.com/MrMoferFRAN/ltx-2-mlx/blob/57952288076766abe27dda3a774b2c24f7346977/LICENSE"
           },
           "estimatedDownloadGb": 67.7,
-          "reviewedAt": "2026-08-30"
+          "reviewedAt": "2026-09-02"
         },
         "speedProfiles": [
           {
@@ -249,7 +249,7 @@
             "url": "https://github.com/PipeNetwork/minimax-h3-mlx/blob/fcd9e9b79a1d6018d91ac477c0968de1fa067e49/LICENSE"
           },
           "estimatedDownloadGb": 103.3,
-          "reviewedAt": "2026-08-30"
+          "reviewedAt": "2026-09-02"
         },
         "termsGate": {
           "id": "minimax-h3-community-license-2026-08-02",
@@ -354,7 +354,7 @@
             "url": "https://github.com/sawfwair/mere-run/blob/v0.47.0/LICENSE"
           },
           "estimatedDownloadGb": 70.9,
-          "reviewedAt": "2026-08-30"
+          "reviewedAt": "2026-09-02"
         },
         "termsGate": {
           "id": "minimax-h3-community-license-2026-08-02",
@@ -412,7 +412,7 @@
             "url": "https://github.com/lpalbou/mlx-gen/blob/main/LICENSE"
           },
           "estimatedDownloadGb": 18.2,
-          "reviewedAt": "2026-08-30"
+          "reviewedAt": "2026-09-02"
         }
       },
       {
@@ -447,7 +447,7 @@
             "url": "https://github.com/lpalbou/mlx-gen/blob/main/LICENSE"
           },
           "estimatedDownloadGb": 42.4,
-          "reviewedAt": "2026-08-30"
+          "reviewedAt": "2026-09-02"
         }
       },
       {
@@ -482,7 +482,7 @@
             "url": "https://github.com/lpalbou/mlx-gen/blob/main/LICENSE"
           },
           "estimatedDownloadGb": 42.4,
-          "reviewedAt": "2026-08-30"
+          "reviewedAt": "2026-09-02"
         }
       },
       {
@@ -532,7 +532,7 @@
             "url": "https://github.com/lpalbou/mlx-gen/blob/main/LICENSE"
           },
           "estimatedDownloadGb": 44.9,
-          "reviewedAt": "2026-08-30"
+          "reviewedAt": "2026-09-02"
         },
         "finishModelId": "wan22_t2v_a14b"
       },
@@ -583,7 +583,7 @@
             "url": "https://github.com/lpalbou/mlx-gen/blob/main/LICENSE"
           },
           "estimatedDownloadGb": 44.9,
-          "reviewedAt": "2026-08-30"
+          "reviewedAt": "2026-09-02"
         }
       },
       {
@@ -612,8 +612,8 @@
             "name": "Apache-2.0",
             "url": "https://github.com/hao-ai-lab/FastVideo/blob/main/LICENSE"
           },
-          "estimatedDownloadGb": 3.5,
-          "reviewedAt": "2026-08-30"
+          "estimatedDownloadGb": 13.4,
+          "reviewedAt": "2026-09-02"
         }
       },
       {
@@ -642,8 +642,8 @@
             "name": "Apache-2.0",
             "url": "https://github.com/hao-ai-lab/FastVideo/blob/main/LICENSE"
           },
-          "estimatedDownloadGb": 10.2,
-          "reviewedAt": "2026-08-30"
+          "estimatedDownloadGb": 19.5,
+          "reviewedAt": "2026-09-02"
         }
       },
       {
@@ -672,8 +672,90 @@
             "name": "Apache-2.0",
             "url": "https://github.com/hao-ai-lab/FastVideo/blob/main/LICENSE"
           },
-          "estimatedDownloadGb": 25.4,
-          "reviewedAt": "2026-08-30"
+          "estimatedDownloadGb": 42.3,
+          "reviewedAt": "2026-09-02"
+        }
+      },
+      {
+        "id": "fasth3_dense_datafree_mlx_int4",
+        "name": "FastH3 Preview v1 Dense Data-Free MLX INT4 (video + audio, ~89 GB download, 36+ GB RAM, 4-step)",
+        "repo": "MrMofer/FastVideo-FastH3-4-step-Preview-v1-Dense-DataFree-MLX-INT4",
+        "revision": "4c8c3e54da8cd667b5db10f6074b4cb9b7559f15",
+        "runtime": "fastvideo",
+        "fastvideoFamily": "fasth3",
+        "supportedModes": [
+          "text"
+        ],
+        "defaultWidth": 832,
+        "defaultHeight": 480,
+        "defaultFrames": 124,
+        "frameOptions": [
+          107,
+          124,
+          141,
+          158,
+          175,
+          192,
+          209,
+          226,
+          243,
+          260,
+          277,
+          294,
+          311,
+          328,
+          345,
+          362
+        ],
+        "fpsOptions": [
+          24
+        ],
+        "resolutionStep": 32,
+        "resolutionOptions": [
+          {
+            "label": "832x480 (16:9 FastH3 default)",
+            "w": 832,
+            "h": 480
+          },
+          {
+            "label": "1280x720 (16:9 HD)",
+            "w": 1280,
+            "h": 720
+          }
+        ],
+        "memoryGb": 36,
+        "steps": 4,
+        "guidance": 1,
+        "samplerLocked": true,
+        "samplerNote": "FastH3 Preview v1 is a 4-step DMD2 model. This export is dense-attention only — it does not support VSA. Renders video with audio at a fixed 24 fps.",
+        "supportsNegativePrompt": false,
+        "supportsTiling": false,
+        "supportsDisableAudio": false,
+        "disclosure": {
+          "modelCardUrl": "https://huggingface.co/MrMofer/FastVideo-FastH3-4-step-Preview-v1-Dense-DataFree-MLX-INT4",
+          "weightsLicense": {
+            "name": "MiniMax H3 Community License",
+            "url": "https://huggingface.co/MiniMaxAI/MiniMax-H3/blob/6818f6c32d12b210915e44ad56a4228c2608f160/LICENSE"
+          },
+          "runtimeLicense": {
+            "name": "Apache-2.0",
+            "url": "https://github.com/hao-ai-lab/FastVideo/blob/main/LICENSE"
+          },
+          "estimatedDownloadGb": 89.3,
+          "reviewedAt": "2026-09-02"
+        },
+        "termsGate": {
+          "id": "minimax-h3-community-license-2026-08-02",
+          "title": "MiniMax H3 eligibility and terms",
+          "summary": "MiniMax grants use only in its Applicable Territory. The license excludes the European Union, United Kingdom, Republic of Korea, and United States of America.",
+          "acknowledgement": "I confirm I am in the Applicable Territory and agree to the MiniMax H3 Community License and its Acceptable Use Policy.",
+          "licenseUrl": "https://huggingface.co/MiniMaxAI/MiniMax-H3/blob/6818f6c32d12b210915e44ad56a4228c2608f160/LICENSE",
+          "excludedTerritories": [
+            "European Union",
+            "United Kingdom",
+            "Republic of Korea",
+            "United States of America"
+          ]
         }
       }
     ],
@@ -689,7 +771,7 @@
             "name": "Apache-2.0",
             "url": "https://github.com/huggingface/diffusers/blob/main/LICENSE"
           },
-          "reviewedAt": "2026-08-30"
+          "reviewedAt": "2026-09-02"
         }
       },
       {
@@ -706,10 +788,15 @@
           "latent_upscale_models/ltx-2.5-latent-spatial-upscaler-x2-bf16-1.0.safetensors"
         ],
         "runtime": "ltx25_cuda",
-        "supportedModes": ["text", "image"],
+        "supportedModes": [
+          "text",
+          "image"
+        ],
         "defaultFrames": 121,
         "resolutionStep": 64,
-        "fpsOptions": [24],
+        "fpsOptions": [
+          24
+        ],
         "steps": 8,
         "guidance": 1,
         "samplerLocked": true,
@@ -733,8 +820,8 @@
             "name": "Apache-2.0",
             "url": "https://github.com/Lightricks/LTX-2/blob/v1.2.0/LICENSE"
           },
-          "estimatedDownloadGb": 72.1,
-          "reviewedAt": "2026-08-30"
+          "estimatedDownloadGb": 71.1,
+          "reviewedAt": "2026-09-02"
         }
       },
       {
@@ -743,13 +830,17 @@
         "repo": "Wan-AI/Wan2.2-TI2V-5B-Diffusers",
         "revision": "b8fff7315c768468a5333511427288870b2e9635",
         "runtime": "wan22_cuda",
-        "supportedModes": ["text"],
+        "supportedModes": [
+          "text"
+        ],
         "defaultWidth": 1280,
         "defaultHeight": 704,
         "resolutionStep": 16,
         "defaultFrames": 121,
         "frameStride": 4,
-        "fpsOptions": [24],
+        "fpsOptions": [
+          24
+        ],
         "steps": 50,
         "guidance": 5,
         "supportsNegativePrompt": true,
@@ -770,7 +861,7 @@
             "url": "https://github.com/huggingface/diffusers/blob/main/LICENSE"
           },
           "estimatedDownloadGb": 34.2,
-          "reviewedAt": "2026-08-30"
+          "reviewedAt": "2026-09-02"
         }
       },
       {
@@ -921,7 +1012,7 @@
             "url": "https://github.com/huggingface/diffusers/blob/main/LICENSE"
           },
           "estimatedDownloadGb": 144.1,
-          "reviewedAt": "2026-08-30"
+          "reviewedAt": "2026-09-02"
         },
         "termsGate": {
           "id": "minimax-h3-community-license-2026-08-02",

--- a/scripts/generate_fastvideo.py
+++ b/scripts/generate_fastvideo.py
@@ -120,6 +120,10 @@ def build_command(args, entry_script: Path, model_root: Path, mlx_checkpoint: Pa
     single list with `if family == ...` guards around half its elements reads
     as one contract when it is two.
     """
+    # Shared prefix only. The step/rate flags and the trailing seed/output pair
+    # are appended per family so FastMetal keeps the EXACT argv it emitted
+    # before the split — argparse is order-insensitive, but an identical
+    # ordering is what makes "FastMetal is untouched" checkable by eye.
     common = [
         sys.executable,
         str(entry_script),
@@ -129,14 +133,13 @@ def build_command(args, entry_script: Path, model_root: Path, mlx_checkpoint: Pa
         "--width", str(args.width),
         "--height", str(args.height),
         "--num-frames", str(args.num_frames),
-        "--seed", str(args.seed),
-        "--output-path", str(args.output),
     ]
+    tail = ["--seed", str(args.seed), "--output-path", str(args.output)]
     if args.family != "fasth3":
         cmd = common + [
             "--num-inference-steps", str(args.steps),
             "--fps", str(args.fps),
-        ]
+        ] + tail
         if args.fast:
             cmd.append("--fast")
         if args.enhance_prompt:
@@ -163,7 +166,7 @@ def build_command(args, entry_script: Path, model_root: Path, mlx_checkpoint: Pa
     if args.fps and args.fps != FASTH3_NATIVE_FPS:
         print(f"STATUS:FastH3 always writes {FASTH3_NATIVE_FPS} fps — ignoring the requested {args.fps} fps",
               file=sys.stderr, flush=True)
-    cmd = common + ["--steps", str(args.steps)]
+    cmd = common + ["--steps", str(args.steps)] + tail
     if args.fast:
         cmd.append("--fast")
     return cmd

--- a/scripts/generate_fastvideo.py
+++ b/scripts/generate_fastvideo.py
@@ -4,6 +4,18 @@
 Spawns the pinned FastVideo inference script from the ~/.portos/fastvideo
 checkout. Generation is cache-only: PortOS downloads model weights through
 the Video Gen UI before launching this helper.
+
+Two model families share this helper because they share one venv, one repo
+checkout and one progress protocol -- but NOT one entry script or one argv
+shape:
+
+  fastmetal - the DMD2-distilled Wan exports, via mlx_wan_prompt_to_video.py.
+  fasth3    - FastH3 Preview v1 Dense/Data-Free, via mlx_fasth3.py, which
+              takes a pre-quantized MLX DiT and emits muxed video+audio.
+
+`--family` is what selects between them. It is explicit rather than sniffed
+from the checkpoint, so a mis-tagged registry row fails on an argument the
+entry script rejects instead of silently rendering through the wrong pipeline.
 """
 
 import argparse
@@ -40,6 +52,8 @@ def translate_line(line: str) -> str:
 def parse_args() -> argparse.Namespace:
     p = argparse.ArgumentParser(description="PortOS FastVideo MLX helper")
     p.add_argument("--repo-dir", default=None, help="Path to cloned FastVideo repo")
+    p.add_argument("--family", choices=("fastmetal", "fasth3"), default="fastmetal",
+                   help="Which FastVideo entry script and argv shape to use")
     p.add_argument("--model-root", required=True, help="HF model snapshot path")
     p.add_argument("--mlx-checkpoint", default=None, help="MLX checkpoint path (defaults to model-root)")
     p.add_argument("--prompt", required=True)
@@ -59,20 +73,100 @@ def parse_args() -> argparse.Namespace:
     return p.parse_args()
 
 
-def find_entry_script(repo_dir: Path) -> Path:
-    candidates = [
-        repo_dir / "examples" / "inference" / "basic" / "mlx_wan_prompt_to_video.py",
-        repo_dir / "examples" / "inference" / "basic" / "mlx_wan22_generate.py",
-        repo_dir / "examples" / "mlx_wan_prompt_to_video.py",
-    ]
-    for cand in candidates:
+# Per-family entry-script candidates, most-preferred first. The trailing glob
+# name is the fallback when a checkout moves the examples tree.
+_ENTRY_SCRIPTS = {
+    "fastmetal": (
+        [
+            ("examples", "inference", "basic", "mlx_wan_prompt_to_video.py"),
+            ("examples", "inference", "basic", "mlx_wan22_generate.py"),
+            ("examples", "mlx_wan_prompt_to_video.py"),
+        ],
+        "mlx_wan_prompt_to_video.py",
+    ),
+    "fasth3": (
+        [
+            ("examples", "inference", "basic", "mlx_fasth3.py"),
+            ("examples", "mlx_fasth3.py"),
+        ],
+        "mlx_fasth3.py",
+    ),
+}
+
+
+def find_entry_script(repo_dir: Path, family: str = "fastmetal") -> Path:
+    candidates, glob_name = _ENTRY_SCRIPTS[family]
+    for parts in candidates:
+        cand = repo_dir.joinpath(*parts)
         if cand.is_file():
             return cand
-    # Fallback to glob search in repo
-    found = list(repo_dir.glob("**/mlx_wan_prompt_to_video.py"))
+    found = list(repo_dir.glob(f"**/{glob_name}"))
     if found:
         return found[0]
-    raise FileNotFoundError(f"Could not find mlx_wan_prompt_to_video.py under {repo_dir}")
+    raise FileNotFoundError(f"Could not find {glob_name} under {repo_dir}")
+
+
+# mlx_fasth3.py always muxes H.264 at 24 fps with 32 kHz stereo AAC and exposes
+# no --fps flag, so a differing request is reported rather than silently ignored.
+FASTH3_NATIVE_FPS = 24
+
+
+def build_command(args, entry_script: Path, model_root: Path, mlx_checkpoint: Path) -> list:
+    """Build the child argv for the selected family.
+
+    Split by family rather than by conditional flag because the two entry
+    scripts disagree on the NAME of shared concepts (`--steps` vs
+    `--num-inference-steps`) as well as on which concepts exist at all. A
+    single list with `if family == ...` guards around half its elements reads
+    as one contract when it is two.
+    """
+    common = [
+        sys.executable,
+        str(entry_script),
+        "--model-root", str(model_root),
+        "--mlx-checkpoint", str(mlx_checkpoint),
+        "--prompt", args.prompt,
+        "--width", str(args.width),
+        "--height", str(args.height),
+        "--num-frames", str(args.num_frames),
+        "--seed", str(args.seed),
+        "--output-path", str(args.output),
+    ]
+    if args.family != "fasth3":
+        cmd = common + [
+            "--num-inference-steps", str(args.steps),
+            "--fps", str(args.fps),
+        ]
+        if args.fast:
+            cmd.append("--fast")
+        if args.enhance_prompt:
+            cmd.append("--enhance-prompt")
+        if args.refine:
+            cmd.append("--refine")
+        if args.image:
+            cmd.extend(["--image-path", str(args.image)])
+        return cmd
+
+    # FastH3: text-to-video-with-audio only. The entry script has no --fps,
+    # --guidance, --negative-prompt or --image-path, so anything the caller
+    # passed for those is surfaced as a STATUS line instead of being dropped
+    # into a flag the child would reject.
+    for label, unsupported in (
+        ("negative prompt", args.negative_prompt),
+        ("conditioning image", args.image),
+        ("prompt enhancer", args.enhance_prompt),
+        ("refinement pass", args.refine),
+    ):
+        if unsupported:
+            print(f"STATUS:FastH3 ignores the requested {label} — this entry point is text-to-video-with-audio only",
+                  file=sys.stderr, flush=True)
+    if args.fps and args.fps != FASTH3_NATIVE_FPS:
+        print(f"STATUS:FastH3 always writes {FASTH3_NATIVE_FPS} fps — ignoring the requested {args.fps} fps",
+              file=sys.stderr, flush=True)
+    cmd = common + ["--steps", str(args.steps)]
+    if args.fast:
+        cmd.append("--fast")
+    return cmd
 
 
 def main() -> int:
@@ -90,7 +184,7 @@ def main() -> int:
         return 1
 
     try:
-        entry_script = find_entry_script(repo_dir)
+        entry_script = find_entry_script(repo_dir, args.family)
     except FileNotFoundError as err:
         print(f"❌ {err}", file=sys.stderr)
         return 1
@@ -98,37 +192,16 @@ def main() -> int:
     model_root = Path(args.model_root).resolve()
     mlx_checkpoint = Path(args.mlx_checkpoint).resolve() if args.mlx_checkpoint else model_root
 
-    cmd = [
-        sys.executable,
-        str(entry_script),
-        "--model-root", str(model_root),
-        "--mlx-checkpoint", str(mlx_checkpoint),
-        "--prompt", args.prompt,
-        "--width", str(args.width),
-        "--height", str(args.height),
-        "--num-frames", str(args.num_frames),
-        "--num-inference-steps", str(args.steps),
-        "--fps", str(args.fps),
-        "--seed", str(args.seed),
-        "--output-path", str(args.output),
-    ]
-    if args.fast:
-        cmd.append("--fast")
-    if args.enhance_prompt:
-        cmd.append("--enhance-prompt")
-    if args.refine:
-        cmd.append("--refine")
-    if args.image:
-        cmd.extend(["--image-path", str(args.image)])
+    cmd = build_command(args, entry_script, model_root, mlx_checkpoint)
 
     print("STAGE:inference", file=sys.stderr, flush=True)
-    print(f"🎬 fastvideo generate {args.width}x{args.height} frames={args.num_frames} steps={args.steps} seed={args.seed}", file=sys.stderr, flush=True)
+    print(f"🎬 fastvideo {args.family} generate {args.width}x{args.height} frames={args.num_frames} steps={args.steps} seed={args.seed}", file=sys.stderr, flush=True)
 
     env = os.environ.copy()
     env["PYTHONPATH"] = f"{str(repo_dir)}:{env.get('PYTHONPATH', '')}".rstrip(":")
     # Mirrors train_mflux_lora.py's M5 Metal-watchdog mitigation. Preserve an
     # explicit caller override, but make the validated safe value the default
-    # for the sustained FastMetal denoise child.
+    # for the sustained denoise child of either family.
     env.setdefault("AGX_RELAX_CDM_CTXSTORE_TIMEOUT", "1")
     print(
         f"STATUS:watchdog mitigation · AGX_RELAX_CDM_CTXSTORE_TIMEOUT={env['AGX_RELAX_CDM_CTXSTORE_TIMEOUT']}",

--- a/scripts/generate_fastvideo_test.py
+++ b/scripts/generate_fastvideo_test.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Unit tests for the generate_fastvideo family split (#5860).
+
+One venv and one repo checkout serve two FastVideo model families, but their
+entry scripts do not accept the same flags. These lock the two argv shapes so a
+FastH3 row can never be handed FastMetal's `--num-inference-steps` / `--fps`
+(which mlx_fasth3.py rejects), and FastMetal keeps the argv it already ships.
+"""
+from __future__ import annotations
+
+import importlib.util
+import io
+import sys
+import unittest
+from contextlib import redirect_stderr
+from pathlib import Path
+from types import SimpleNamespace
+
+HELPER_PATH = Path(__file__).with_name("generate_fastvideo.py")
+
+
+def load_helper():
+    spec = importlib.util.spec_from_file_location("generate_fastvideo_under_test", HELPER_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.path.insert(0, str(HELPER_PATH.parent))
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.path.pop(0)
+    return module
+
+
+def make_args(**overrides):
+    args = SimpleNamespace(
+        family="fastmetal",
+        prompt="a paper boat on a puddle",
+        negative_prompt="",
+        width=832,
+        height=480,
+        num_frames=124,
+        fps=24,
+        steps=4,
+        guidance=1.0,
+        seed=2026,
+        output="/fixture/out/render.mp4",
+        image=None,
+        fast=False,
+        enhance_prompt=False,
+        refine=False,
+    )
+    for key, value in overrides.items():
+        setattr(args, key, value)
+    return args
+
+
+class BuildCommandTest(unittest.TestCase):
+    def setUp(self):
+        self.helper = load_helper()
+        self.entry = Path("/fixture/entry.py")
+        self.root = Path("/fixture/model-root")
+        self.ckpt = Path("/fixture/mlx-checkpoint")
+
+    def build(self, **overrides):
+        stderr = io.StringIO()
+        with redirect_stderr(stderr):
+            cmd = self.helper.build_command(make_args(**overrides), self.entry, self.root, self.ckpt)
+        return cmd, stderr.getvalue()
+
+    def flag(self, cmd, name):
+        return cmd[cmd.index(name) + 1]
+
+    def test_fastmetal_keeps_its_existing_argv(self):
+        cmd, _ = self.build(family="fastmetal")
+        self.assertEqual(self.flag(cmd, "--num-inference-steps"), "4")
+        self.assertEqual(self.flag(cmd, "--fps"), "24")
+        self.assertEqual(self.flag(cmd, "--mlx-checkpoint"), str(self.ckpt))
+        self.assertNotIn("--steps", cmd)
+
+    def test_fastmetal_forwards_its_optional_flags(self):
+        cmd, _ = self.build(family="fastmetal", fast=True, enhance_prompt=True, refine=True,
+                            image="/fixture/first.png")
+        for flag in ("--fast", "--enhance-prompt", "--refine"):
+            self.assertIn(flag, cmd)
+        self.assertEqual(self.flag(cmd, "--image-path"), "/fixture/first.png")
+
+    def test_fasth3_uses_steps_and_omits_flags_its_entry_script_lacks(self):
+        cmd, _ = self.build(family="fasth3")
+        self.assertEqual(self.flag(cmd, "--steps"), "4")
+        self.assertEqual(self.flag(cmd, "--model-root"), str(self.root))
+        self.assertEqual(self.flag(cmd, "--mlx-checkpoint"), str(self.ckpt))
+        self.assertEqual(self.flag(cmd, "--output-path"), "/fixture/out/render.mp4")
+        for absent in ("--num-inference-steps", "--fps", "--guidance", "--negative-prompt",
+                       "--image-path", "--enhance-prompt", "--refine"):
+            self.assertNotIn(absent, cmd)
+
+    def test_fasth3_reports_rather_than_silently_dropping_unsupported_requests(self):
+        cmd, stderr = self.build(family="fasth3", negative_prompt="blurry",
+                                 image="/fixture/first.png", enhance_prompt=True, refine=True)
+        self.assertNotIn("--negative-prompt", cmd)
+        self.assertNotIn("--image-path", cmd)
+        for label in ("negative prompt", "conditioning image", "prompt enhancer", "refinement pass"):
+            self.assertIn(label, stderr)
+
+    def test_fasth3_reports_a_non_native_fps_and_stays_quiet_at_24(self):
+        _, noisy = self.build(family="fasth3", fps=30)
+        self.assertIn("30 fps", noisy)
+        _, quiet = self.build(family="fasth3", fps=self.helper.FASTH3_NATIVE_FPS)
+        self.assertNotIn("fps", quiet)
+
+    def test_fasth3_still_forwards_fast_mode(self):
+        cmd, _ = self.build(family="fasth3", fast=True)
+        self.assertIn("--fast", cmd)
+
+
+class EntryScriptTest(unittest.TestCase):
+    def setUp(self):
+        self.helper = load_helper()
+
+    def test_each_family_resolves_its_own_entry_script(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            basic = repo / "examples" / "inference" / "basic"
+            basic.mkdir(parents=True)
+            (basic / "mlx_wan_prompt_to_video.py").write_text("")
+            (basic / "mlx_fasth3.py").write_text("")
+
+            self.assertEqual(
+                self.helper.find_entry_script(repo, "fastmetal").name, "mlx_wan_prompt_to_video.py")
+            self.assertEqual(
+                self.helper.find_entry_script(repo, "fasth3").name, "mlx_fasth3.py")
+
+    def test_a_checkout_without_the_fasth3_entry_script_fails_loudly(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            basic = repo / "examples" / "inference" / "basic"
+            basic.mkdir(parents=True)
+            (basic / "mlx_wan_prompt_to_video.py").write_text("")
+
+            with self.assertRaises(FileNotFoundError) as ctx:
+                self.helper.find_entry_script(repo, "fasth3")
+            self.assertIn("mlx_fasth3.py", str(ctx.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/generate_fastvideo_test.py
+++ b/scripts/generate_fastvideo_test.py
@@ -76,6 +76,25 @@ class BuildCommandTest(unittest.TestCase):
         self.assertEqual(self.flag(cmd, "--mlx-checkpoint"), str(self.ckpt))
         self.assertNotIn("--steps", cmd)
 
+    def test_fastmetal_argv_is_byte_identical_to_the_pre_split_baseline(self):
+        # The exact list this helper emitted before the family split. Pinned so
+        # a later edit to the shared prefix cannot quietly reshape the argv of
+        # the three FastMetal rows that already ship.
+        cmd, _ = self.build(family="fastmetal")
+        self.assertEqual(cmd[1:], [
+            str(self.entry),
+            "--model-root", str(self.root),
+            "--mlx-checkpoint", str(self.ckpt),
+            "--prompt", "a paper boat on a puddle",
+            "--width", "832",
+            "--height", "480",
+            "--num-frames", "124",
+            "--num-inference-steps", "4",
+            "--fps", "24",
+            "--seed", "2026",
+            "--output-path", "/fixture/out/render.mp4",
+        ])
+
     def test_fastmetal_forwards_its_optional_flags(self):
         cmd, _ = self.build(family="fastmetal", fast=True, enhance_prompt=True, refine=True,
                             image="/fixture/first.png")

--- a/scripts/migrations/333-fasth3-dense-datafree-mlx.js
+++ b/scripts/migrations/333-fasth3-dense-datafree-mlx.js
@@ -1,0 +1,91 @@
+/**
+ * Add the FastH3 Preview v1 Dense / Data-Free MLX INT4 model to existing macOS
+ * video registries (#5860). Fresh installs receive it from
+ * data.reference/media-models.json.
+ *
+ * Same shape as migration 314 (FastMetal): the entry rides the existing
+ * `fastvideo` BYOV runtime rather than introducing one, and `fastvideoFamily`
+ * is what selects the FastH3 entry script inside that runtime.
+ */
+
+import { readFile } from 'fs/promises';
+import { join } from 'path';
+import { atomicWrite } from '../../server/lib/fileUtils.js';
+import { VIDEO_BUCKET_MLX, readVideoBucket } from '../../server/lib/mediaModelBuckets.js';
+
+const REL_PATH = 'data/media-models.json';
+
+const NEW_ENTRIES = [
+  {
+    id: 'fasth3_dense_datafree_mlx_int4',
+    name: 'FastH3 Preview v1 Dense Data-Free MLX INT4 (video + audio, ~89 GB download, 36+ GB RAM, 4-step)',
+    repo: 'MrMofer/FastVideo-FastH3-4-step-Preview-v1-Dense-DataFree-MLX-INT4',
+    revision: '4c8c3e54da8cd667b5db10f6074b4cb9b7559f15',
+    runtime: 'fastvideo',
+    fastvideoFamily: 'fasth3',
+    supportedModes: ['text'],
+    defaultWidth: 832,
+    defaultHeight: 480,
+    defaultFrames: 124,
+    // H3's video VAE decodes only 17n+5 frame counts, and FastH3 is a distilled
+    // H3. Inlined rather than imported from lib/mediaModels.js: a migration must
+    // keep writing the values it shipped with, not whatever the live registry
+    // constant becomes three releases later.
+    frameOptions: [107, 124, 141, 158, 175, 192, 209, 226, 243, 260, 277, 294, 311, 328, 345, 362],
+    fpsOptions: [24],
+    resolutionStep: 32,
+    resolutionOptions: [
+      { label: '832x480 (16:9 FastH3 default)', w: 832, h: 480 },
+      { label: '1280x720 (16:9 HD)', w: 1280, h: 720 },
+    ],
+    memoryGb: 36,
+    steps: 4,
+    guidance: 1,
+    samplerLocked: true,
+    samplerNote: 'FastH3 Preview v1 is a 4-step DMD2 model. This export is dense-attention only — it does not support VSA. Renders video with audio at a fixed 24 fps.',
+    supportsNegativePrompt: false,
+    supportsTiling: false,
+    supportsDisableAudio: false,
+  },
+];
+
+export default {
+  async up({ rootDir }) {
+    const path = join(rootDir, REL_PATH);
+    const raw = await readFile(path, 'utf-8').catch((err) => {
+      if (err.code === 'ENOENT') return null;
+      throw err;
+    });
+    if (raw == null) return;
+    let config;
+    try {
+      config = JSON.parse(raw);
+    } catch (err) {
+      throw new Error(`Cannot migrate ${REL_PATH}: invalid JSON (${err.message})`, { cause: err });
+    }
+    const mlxEntries = readVideoBucket(config?.video, VIDEO_BUCKET_MLX);
+    if (!Array.isArray(mlxEntries)) return;
+
+    let changed = false;
+    const present = new Set(mlxEntries.map((entry) => entry?.id));
+    for (const entry of NEW_ENTRIES) {
+      if (present.has(entry.id)) continue;
+      mlxEntries.push(structuredClone(entry));
+      present.add(entry.id);
+      changed = true;
+    }
+    const shipped = readVideoBucket(config?._shippedDefaults?.video, VIDEO_BUCKET_MLX);
+    if (Array.isArray(shipped)) {
+      for (const entry of NEW_ENTRIES) {
+        if (!shipped.includes(entry.id)) {
+          shipped.push(entry.id);
+          changed = true;
+        }
+      }
+    }
+    if (changed) {
+      await atomicWrite(path, `${JSON.stringify(config, null, 2)}\n`);
+      console.log(`📝 ${REL_PATH}: added FastH3 Dense Data-Free MLX model`);
+    }
+  },
+};

--- a/scripts/migrations/333-fasth3-dense-datafree-mlx.test.js
+++ b/scripts/migrations/333-fasth3-dense-datafree-mlx.test.js
@@ -1,0 +1,93 @@
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import migration from './333-fasth3-dense-datafree-mlx.js';
+
+const NEW_ID = 'fasth3_dense_datafree_mlx_int4';
+
+describe('333-fasth3-dense-datafree-mlx migration', () => {
+  let rootDir;
+  let registryFile;
+
+  beforeEach(() => {
+    rootDir = join(tmpdir(), `portos-test-333-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(join(rootDir, 'data'), { recursive: true });
+    registryFile = join(rootDir, 'data', 'media-models.json');
+  });
+
+  afterEach(() => {
+    rmSync(rootDir, { recursive: true, force: true });
+  });
+
+  const write = (config) => writeFileSync(registryFile, JSON.stringify(config, null, 2));
+  const read = () => JSON.parse(readFileSync(registryFile, 'utf-8'));
+
+  it('skips gracefully when media-models.json does not exist', async () => {
+    await expect(migration.up({ rootDir })).resolves.toBeUndefined();
+  });
+
+  it('adds the FastH3 row to an existing MLX registry and its shipped list', async () => {
+    write({
+      video: { mlx: [{ id: 'fastmetal_1_3b_qad', name: 'FastMetal 1.3B' }], cuda: [] },
+      _shippedDefaults: { video: { mlx: ['fastmetal_1_3b_qad'] } },
+    });
+
+    await migration.up({ rootDir });
+
+    const updated = read();
+    const entry = updated.video.mlx.find((m) => m.id === NEW_ID);
+    expect(entry).toBeDefined();
+    // The row rides the EXISTING fastvideo runtime; `fastvideoFamily` is what
+    // routes it to the FastH3 entry script. A new runtime id here would mean
+    // an unprovisioned venv and an unrenderable entry.
+    expect(entry.runtime).toBe('fastvideo');
+    expect(entry.fastvideoFamily).toBe('fasth3');
+    // Pinned: the pack is a specific conversion of a specific source revision.
+    expect(entry.revision).toMatch(/^[0-9a-f]{40}$/);
+    expect(entry.supportedModes).toEqual(['text']);
+    expect(entry.steps).toBe(4);
+    // The UI reads its frame/fps/capability limits straight off the entry, so
+    // an upgraded install must receive them too — not just a fresh seed.
+    expect(entry.frameOptions.every((f) => (f - 5) % 17 === 0)).toBe(true);
+    expect(entry.frameOptions).toContain(entry.defaultFrames);
+    expect(entry.fpsOptions).toEqual([24]);
+    expect(entry.supportsNegativePrompt).toBe(false);
+    expect(entry.supportsTiling).toBe(false);
+    expect(entry.supportsDisableAudio).toBe(false);
+    expect(updated._shippedDefaults.video.mlx).toContain(NEW_ID);
+  });
+
+  it('leaves the CUDA bucket untouched', async () => {
+    write({ video: { mlx: [], cuda: [{ id: 'ltx_video' }] } });
+
+    await migration.up({ rootDir });
+
+    expect(read().video.cuda.map((m) => m.id)).toEqual(['ltx_video']);
+  });
+
+  it('is idempotent when run multiple times', async () => {
+    write({ video: { mlx: [{ id: 'fastmetal_1_3b_qad' }] } });
+
+    await migration.up({ rootDir });
+    const firstPass = readFileSync(registryFile, 'utf-8');
+    await migration.up({ rootDir });
+
+    expect(readFileSync(registryFile, 'utf-8')).toBe(firstPass);
+  });
+
+  it('does not re-add a row the user deleted from the shipped list only', async () => {
+    // A user who removed the entry but kept the shipped-defaults marker must
+    // not have it pushed back on the next upgrade.
+    write({
+      video: { mlx: [{ id: NEW_ID, name: 'edited by user', runtime: 'fastvideo' }] },
+      _shippedDefaults: { video: { mlx: [NEW_ID] } },
+    });
+
+    await migration.up({ rootDir });
+
+    const mlx = read().video.mlx;
+    expect(mlx).toHaveLength(1);
+    expect(mlx[0].name).toBe('edited by user');
+  });
+});

--- a/server/lib/huggingfaceModel.js
+++ b/server/lib/huggingfaceModel.js
@@ -81,7 +81,18 @@ const detectVideoRuntime = (blob) => {
   if (/\bwan[\s._-]?2|wan-ai\b/.test(blob) || /\bwan2\.\d/.test(blob)) {
     return { runtime: 'wan22', installHint: 'INSTALL_WAN22=1 bash scripts/setup-image-video.sh' };
   }
-  if (/fastvideo|fastmetal/i.test(blob)) {
+  if (/fastvideo|fastmetal|fasth3/i.test(blob)) {
+    // FastH3 needs more than the venv: the row also has to declare
+    // `fastvideoFamily: 'fasth3'` (a different entry script and argv shape),
+    // and the published packs are split across a components repo and a DiT
+    // pack — neither of which a single-repo self-service add can express. Say
+    // that instead of pointing at an install script that would not fix it.
+    if (/fasth3/i.test(blob)) {
+      return {
+        runtime: 'fastvideo',
+        refusal: 'needs a FastH3 registry row (its own entry script, and for the split packs a second download) that the self-service add flow cannot express — use the shipped FastH3 entry in Video Gen, or add it to data/media-models.json by hand',
+      };
+    }
     return { runtime: 'fastvideo', installHint: 'INSTALL_FASTVIDEO=1 bash scripts/setup-image-video.sh' };
   }
   if (/hunyuan/.test(blob)) {
@@ -297,9 +308,10 @@ export const classifyHfMediaModel = ({ repo, model, kind, runtime, runner, isWin
   // (which would otherwise route it into the image branch and skip this check
   // entirely, persisting a Wan/Hunyuan repo as a bogus image model).
   if (detectedVideo && !ADDABLE_VIDEO_RUNTIMES.includes(detectedVideo.runtime)) {
-    const runtimeReason = detectedVideo.installHint
-      ? `needs a dedicated venv (${detectedVideo.installHint}) and can't be added self-service — set it up via the script, then edit data/media-models.json`
-      : 'is not supported by PortOS';
+    const runtimeReason = detectedVideo.refusal
+      || (detectedVideo.installHint
+        ? `needs a dedicated venv (${detectedVideo.installHint}) and can't be added self-service — set it up via the script, then edit data/media-models.json`
+        : 'is not supported by PortOS');
     throw new ServerError(
       `HuggingFace repo "${repo}" targets the "${detectedVideo.runtime}" runtime, which ${runtimeReason}.`,
       { status: 422, code: 'HF_UNSUPPORTED_RUNTIME' },

--- a/server/lib/mediaModels.js
+++ b/server/lib/mediaModels.js
@@ -132,6 +132,23 @@ const h3FrameGrid = (min, max) => {
   return Object.freeze(out);
 };
 
+// FastH3 Preview v1's output contract (#5860). It is a distilled MiniMax H3, so
+// it inherits H3's 17n+5 VAE frame grid and 32px edge rounding — but NOT H3's
+// canvas: the MLX FastH3 entry point is validated at 832x480 (its own default,
+// and the resolution upstream's conversion manifest records a passing 124-frame
+// generation at), and its docstring documents 1280x720 as the other supported
+// request. `resolutionOptions` are presets rather than a whitelist, so a custom
+// size still resolves through `resolutionStep`.
+export const FASTH3_OUTPUT_PROFILE = Object.freeze({
+  frameOptions: h3FrameGrid(107, 362),
+  fpsOptions: Object.freeze([24]),
+  resolutionStep: 32,
+  resolutionOptions: Object.freeze([
+    Object.freeze({ label: '832x480 (16:9 FastH3 default)', w: 832, h: 480 }),
+    Object.freeze({ label: '1280x720 (16:9 HD)', w: 1280, h: 720 }),
+  ]),
+});
+
 // The MLX entry's output profile: the shared canvas above PLUS the upgrade
 // machinery migration 267 and `upgradeMiniMaxH3OutputControls` key off (the id,
 // the repo it was checked against, and the frame list it supersedes). That
@@ -613,6 +630,42 @@ const DEFAULT_REGISTRY = {
         guidance: 1.0,
         samplerLocked: true,
         samplerNote: 'FastMetal models are DMD2-distilled 3-step models with affine INT8 quantization.',
+      },
+      // FastH3 Preview v1 Dense / Data-Free, packed for MLX (#5860). Same
+      // `fastvideo` venv and checkout as FastMetal above, but a different entry
+      // script and argv shape — `fastvideoFamily` is what routes it, see
+      // buildFastVideoArgs. Text-to-video-WITH-AUDIO: the runner muxes H.264 at
+      // a fixed 24 fps with 32 kHz stereo AAC, which is why `fpsOptions` offers
+      // that one value rather than letting the form ask for a rate the entry
+      // script has no flag to accept.
+      // The DiT arrives pre-quantized, so nothing is converted on first render.
+      {
+        id: 'fasth3_dense_datafree_mlx_int4',
+        name: 'FastH3 Preview v1 Dense Data-Free MLX INT4 (video + audio, ~89 GB download, 36+ GB RAM, 4-step)',
+        repo: 'MrMofer/FastVideo-FastH3-4-step-Preview-v1-Dense-DataFree-MLX-INT4',
+        revision: '4c8c3e54da8cd667b5db10f6074b4cb9b7559f15',
+        runtime: 'fastvideo',
+        fastvideoFamily: 'fasth3',
+        supportedModes: ['text'],
+        defaultWidth: 832,
+        defaultHeight: 480,
+        defaultFrames: 124,
+        frameOptions: [...FASTH3_OUTPUT_PROFILE.frameOptions],
+        fpsOptions: [...FASTH3_OUTPUT_PROFILE.fpsOptions],
+        resolutionStep: FASTH3_OUTPUT_PROFILE.resolutionStep,
+        resolutionOptions: FASTH3_OUTPUT_PROFILE.resolutionOptions.map((preset) => ({ ...preset })),
+        memoryGb: 36,
+        steps: 4,
+        guidance: 1.0,
+        samplerLocked: true,
+        samplerNote: 'FastH3 Preview v1 is a 4-step DMD2 model. This export is dense-attention only — it does not support VSA. Renders video with audio at a fixed 24 fps.',
+        // mlx_fasth3.py takes no --negative-prompt, exposes no way to mute the
+        // joint audio track, and PortOS never passes it a tiling flag. Declaring
+        // each `false` is what removes the control from the form rather than
+        // offering a knob whose value is silently dropped at the argv boundary.
+        supportsNegativePrompt: false,
+        supportsTiling: false,
+        supportsDisableAudio: false,
       },
     ]))))),
     cuda: applyMiniMaxH3MemoryProfiles(applyVideoDraftDecoders(applyVideoSpeedProfiles(applyVideoFinishProfiles(applyVideoDisclosures([

--- a/server/lib/mediaModels.test.js
+++ b/server/lib/mediaModels.test.js
@@ -137,10 +137,52 @@ describe('mediaModels registry', () => {
     expect(ltx25.repoFiles).toContain(
       'text_encoders/gemma4-12b-with-proj-ltx-2.5-bf16.safetensors',
     );
+    // Summed from the six pinned `repoFiles` at the pinned revision — the set
+    // PortOS actually downloads, not the 200 GB repo total. The review DATE is
+    // read from the module so a routine re-check of the disclosure facts
+    // doesn't turn this assertion red.
+    const { VIDEO_DISCLOSURE_REVIEWED_AT } = await import('./videoDisclosure.js');
     expect(ltx25.disclosure).toMatchObject({
-      estimatedDownloadGb: 72.1,
-      reviewedAt: '2026-08-30',
+      estimatedDownloadGb: 71.1,
+      reviewedAt: VIDEO_DISCLOSURE_REVIEWED_AT,
     });
+  });
+
+  it('ships FastH3 on the existing fastvideo runtime with H3 output limits', async () => {
+    const { loadMediaModels, FASTH3_OUTPUT_PROFILE } = await import('./mediaModels.js');
+    // MLX-only, so read the shipped macOS catalog rather than this platform's
+    // filtered list.
+    const fasth3 = loadMediaModels().video.mlx.find((m) => m.id === 'fasth3_dense_datafree_mlx_int4');
+    expect(fasth3).toMatchObject({
+      repo: 'MrMofer/FastVideo-FastH3-4-step-Preview-v1-Dense-DataFree-MLX-INT4',
+      revision: '4c8c3e54da8cd667b5db10f6074b4cb9b7559f15',
+      // NOT a new BYOV runtime: a new id would have no venv, no install button
+      // and no status probe. FastH3 is another family on `fastvideo`.
+      runtime: 'fastvideo',
+      fastvideoFamily: 'fasth3',
+      supportedModes: ['text'],
+      defaultWidth: 832,
+      defaultHeight: 480,
+      defaultFrames: 124,
+      steps: 4,
+      samplerLocked: true,
+    });
+    // FastH3 is a distilled MiniMax H3, so it decodes only 17n+5 frame counts
+    // and always muxes 24 fps. Without these the picker offers LTX's generic
+    // 8k+1 grid and a 16/30 fps choice the runner silently overrides.
+    expect(fasth3.frameOptions).toEqual([...FASTH3_OUTPUT_PROFILE.frameOptions]);
+    expect(fasth3.frameOptions.every((f) => (f - 5) % 17 === 0)).toBe(true);
+    expect(fasth3.frameOptions).toContain(fasth3.defaultFrames);
+    expect(fasth3.fpsOptions).toEqual([24]);
+    expect(fasth3.resolutionStep).toBe(32);
+    // Each control mlx_fasth3.py has no flag for must be declared unsupported,
+    // or the form offers a knob whose value dies at the argv boundary.
+    expect(fasth3.supportsNegativePrompt).toBe(false);
+    expect(fasth3.supportsTiling).toBe(false);
+    expect(fasth3.supportsDisableAudio).toBe(false);
+    // The MiniMax H3 Community License travels with the distilled weights, so
+    // the row carries the same territory gate as the other H3 entries.
+    expect(fasth3.termsGate?.id).toBe('minimax-h3-community-license-2026-08-02');
   });
 
   it('ships MiniMax H3 as a pinned, keyframe-capable 128 GB BYOV profile', async () => {

--- a/server/lib/videoDisclosure.js
+++ b/server/lib/videoDisclosure.js
@@ -27,7 +27,7 @@ import { ServerError } from './errorHandler.js';
 
 // Every shipped disclosure was checked against its upstream source on this
 // date. Bump it (and re-check) whenever an entry below changes.
-export const VIDEO_DISCLOSURE_REVIEWED_AT = '2026-08-30';
+export const VIDEO_DISCLOSURE_REVIEWED_AT = '2026-09-02';
 
 // License descriptors reused across entries. `url` points at the primary text
 // of the license, or at the model card when the card declares a custom license
@@ -240,7 +240,7 @@ export const VIDEO_MODEL_DISCLOSURES = Object.freeze({
       modelCardUrl: hfModelCard('Lightricks/LTX-2.5'),
       weightsLicense: LTX_2X_WEIGHTS,
       runtimeLicense: RUNTIME_LICENSE.ltx25_cuda,
-      estimatedDownloadGb: 72.1,
+      estimatedDownloadGb: 71.1,
       reviewedAt: VIDEO_DISCLOSURE_REVIEWED_AT,
     },
   },
@@ -317,13 +317,16 @@ export const VIDEO_MODEL_DISCLOSURES = Object.freeze({
       reviewedAt: VIDEO_DISCLOSURE_REVIEWED_AT,
     },
   },
+  // The FastMetal repos bundle their own text encoder and VAE beside the MLX
+  // DiT, and the entries declare no `repoFiles`, so the download is the whole
+  // snapshot — several times the DiT-only size their display names quote.
   fastmetal_1_3b_qad: {
     shippedRepo: 'FastVideo/FastMetal-1.3B-QAD',
     disclosure: {
       modelCardUrl: hfModelCard('FastVideo/FastMetal-1.3B-QAD'),
       weightsLicense: APACHE_2,
       runtimeLicense: RUNTIME_LICENSE.fastvideo,
-      estimatedDownloadGb: 3.5,
+      estimatedDownloadGb: 13.4,
       reviewedAt: VIDEO_DISCLOSURE_REVIEWED_AT,
     },
   },
@@ -333,7 +336,7 @@ export const VIDEO_MODEL_DISCLOSURES = Object.freeze({
       modelCardUrl: hfModelCard('FastVideo/FastMetal-5B-QAD'),
       weightsLicense: APACHE_2,
       runtimeLicense: RUNTIME_LICENSE.fastvideo,
-      estimatedDownloadGb: 10.2,
+      estimatedDownloadGb: 19.5,
       reviewedAt: VIDEO_DISCLOSURE_REVIEWED_AT,
     },
   },
@@ -343,9 +346,27 @@ export const VIDEO_MODEL_DISCLOSURES = Object.freeze({
       modelCardUrl: hfModelCard('FastVideo/FastMetal-14B-QAD'),
       weightsLicense: APACHE_2,
       runtimeLicense: RUNTIME_LICENSE.fastvideo,
-      estimatedDownloadGb: 25.4,
+      estimatedDownloadGb: 42.3,
       reviewedAt: VIDEO_DISCLOSURE_REVIEWED_AT,
     },
+  },
+  // FastH3 Preview v1 Dense / Data-Free, packed for MLX. Same MiniMax H3
+  // weights lineage as the entries above — its `conversion_manifest.json`
+  // names FastVideo/…-Dense-DataFree @ f624f08c as the source — so it carries
+  // the same license and the same territory gate. The repo is self-contained:
+  // the quantized DiT ships beside the vae / audio_vae / text_encoder /
+  // tokenizer the MLX pipeline loads, which is why the whole snapshot is the
+  // download figure.
+  fasth3_dense_datafree_mlx_int4: {
+    shippedRepo: 'MrMofer/FastVideo-FastH3-4-step-Preview-v1-Dense-DataFree-MLX-INT4',
+    disclosure: {
+      modelCardUrl: hfModelCard('MrMofer/FastVideo-FastH3-4-step-Preview-v1-Dense-DataFree-MLX-INT4'),
+      weightsLicense: MINIMAX_H3_WEIGHTS,
+      runtimeLicense: RUNTIME_LICENSE.fastvideo,
+      estimatedDownloadGb: 89.3,
+      reviewedAt: VIDEO_DISCLOSURE_REVIEWED_AT,
+    },
+    termsGate: MINIMAX_H3_TERMS_GATE,
   },
   // Legacy CUDA entry. It carries no `repo` because its diffusers helper
   // resolves LTX-Video 0.9.5 directly, so its weights license stays Unknown.

--- a/server/services/videoGen/renderArgs.js
+++ b/server/services/videoGen/renderArgs.js
@@ -553,6 +553,22 @@ export const assertRenderModeContract = ({
   if (err) throw err;
 };
 
+// Which FastVideo entry script a `fastvideo` row renders through. The runtime
+// is shared (one venv, one checkout, one progress protocol) but the entry
+// scripts are not interchangeable: FastMetal drives the distilled Wan exports
+// through mlx_wan_prompt_to_video.py, while FastH3 drives a pre-quantized MLX
+// DiT through mlx_fasth3.py, which has no --fps/--guidance/--negative-prompt
+// /--image-path and is text-to-video-with-audio only.
+//
+// Read off the registry entry rather than matched against an id list here, so
+// a peer-synced or user-added FastH3 row routes correctly without an edit to
+// this file — the same "execution facts live on the entry" convention
+// `samplerLocked` and `supportedModes` already use. An absent/unknown value
+// means FastMetal, which is what every pre-#5860 row is.
+export const FASTVIDEO_FAMILIES = Object.freeze(['fastmetal', 'fasth3']);
+export const fastvideoFamily = (model) =>
+  (FASTVIDEO_FAMILIES.includes(model?.fastvideoFamily) ? model.fastvideoFamily : 'fastmetal');
+
 // Build args for the FastVideo MLX helper on Apple Silicon.
 export const buildFastVideoArgs = ({
   model, fastvideoModelPath, prompt, negativePrompt, width, height,
@@ -560,10 +576,13 @@ export const buildFastVideoArgs = ({
 }) => {
   assertByovRuntimeInstalled('fastvideo');
   assertRenderModeContract({ model, mode, sourceImagePath });
+  const family = fastvideoFamily(model);
+  const modelRoot = fastvideoModelPath || model.repo;
   const args = [
     FASTVIDEO_HELPER_SCRIPT,
     '--repo-dir', FASTVIDEO_REPO_DIR,
-    '--model-root', fastvideoModelPath || model.repo,
+    '--family', family,
+    '--model-root', modelRoot,
     '--prompt', prompt,
     '--width', String(width),
     '--height', String(height),
@@ -574,6 +593,12 @@ export const buildFastVideoArgs = ({
     '--seed', String(seed),
     '--output', outputPath,
   ];
+  // The shipped FastH3 checkpoint is a self-contained snapshot: the quantized
+  // MLX DiT sits beside the vae/audio_vae/text_encoder/tokenizer the pipeline
+  // loads, so model-root IS the checkpoint. Stated explicitly rather than left
+  // to the helper's "defaults to model-root" fallback, so the two paths become
+  // separately addressable the day a row ships the DiT as its own download.
+  if (family === 'fasth3') args.push('--mlx-checkpoint', modelRoot);
   if (negativePrompt) args.push('--negative-prompt', negativePrompt);
   if (sourceImagePath) args.push('--image', sourceImagePath);
   return { bin: FASTVIDEO_VENV_PYTHON, args };

--- a/server/services/videoGen/renderArgsFastVideo.test.js
+++ b/server/services/videoGen/renderArgsFastVideo.test.js
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// The `fastvideo` runtime is a BYO-venv checkout that does not exist on CI, so
+// the install assertion is stubbed. Everything else under test is pure argv
+// construction. Paths are fixtures, never a real install's layout.
+vi.mock('./runtimes.js', async (importOriginal) => ({
+  ...(await importOriginal()),
+  assertByovRuntimeInstalled: vi.fn(),
+  FASTVIDEO_VENV_PYTHON: '/fixture/fastvideo/.venv/bin/python3',
+  FASTVIDEO_HELPER_SCRIPT: '/fixture/scripts/generate_fastvideo.py',
+  FASTVIDEO_REPO_DIR: '/fixture/fastvideo',
+}));
+
+const { buildFastVideoArgs, fastvideoFamily } = await import('./renderArgs.js');
+
+const fastmetal = {
+  id: 'fastmetal_5b_qad',
+  name: 'Example FastMetal Profile',
+  runtime: 'fastvideo',
+  repo: 'example-org/example-fastmetal',
+  supportedModes: ['text', 'image'],
+};
+const fasth3 = {
+  id: 'fasth3_dense_datafree_mlx_int4',
+  name: 'Example FastH3 Profile',
+  runtime: 'fastvideo',
+  fastvideoFamily: 'fasth3',
+  repo: 'example-org/example-fasth3',
+  supportedModes: ['text'],
+};
+
+const base = {
+  prompt: 'a paper boat on a puddle',
+  width: 832,
+  height: 480,
+  numFrames: 124,
+  fps: 24,
+  steps: 4,
+  guidance: 1,
+  seed: 2026,
+  mode: 'text',
+  outputPath: '/fixture/out/render.mp4',
+};
+
+const flagValue = (args, flag) => args[args.indexOf(flag) + 1];
+
+describe('fastvideoFamily', () => {
+  it('defaults to fastmetal for every pre-#5860 row', () => {
+    expect(fastvideoFamily(fastmetal)).toBe('fastmetal');
+    expect(fastvideoFamily({})).toBe('fastmetal');
+    expect(fastvideoFamily(null)).toBe('fastmetal');
+  });
+
+  it('reads the declared family off the entry', () => {
+    expect(fastvideoFamily(fasth3)).toBe('fasth3');
+  });
+
+  it('falls back to fastmetal for an unknown family rather than forwarding it', () => {
+    // The helper's argparse would reject an unknown --family, turning a
+    // hand-edited or peer-synced row into a crash instead of a render.
+    expect(fastvideoFamily({ fastvideoFamily: 'vsa' })).toBe('fastmetal');
+  });
+});
+
+describe('buildFastVideoArgs', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('routes a FastMetal row through the fastmetal family with no MLX checkpoint', () => {
+    const { bin, args } = buildFastVideoArgs({
+      ...base, model: fastmetal, fastvideoModelPath: '/fixture/cache/fastmetal',
+    });
+
+    expect(bin).toBe('/fixture/fastvideo/.venv/bin/python3');
+    expect(flagValue(args, '--family')).toBe('fastmetal');
+    expect(flagValue(args, '--model-root')).toBe('/fixture/cache/fastmetal');
+    expect(args).not.toContain('--mlx-checkpoint');
+  });
+
+  it('routes a FastH3 row through the fasth3 family, pointing both paths at the snapshot', () => {
+    // The shipped pack is self-contained: the quantized DiT sits beside the
+    // VAEs / text encoder the pipeline loads, so model-root IS the checkpoint.
+    const { args } = buildFastVideoArgs({
+      ...base, model: fasth3, fastvideoModelPath: '/fixture/cache/fasth3',
+    });
+
+    expect(flagValue(args, '--family')).toBe('fasth3');
+    expect(flagValue(args, '--model-root')).toBe('/fixture/cache/fasth3');
+    expect(flagValue(args, '--mlx-checkpoint')).toBe('/fixture/cache/fasth3');
+  });
+
+  it('passes the pinned render controls through for FastH3', () => {
+    const { args } = buildFastVideoArgs({ ...base, model: fasth3, fastvideoModelPath: '/fixture/cache/fasth3' });
+
+    expect(flagValue(args, '--width')).toBe('832');
+    expect(flagValue(args, '--height')).toBe('480');
+    expect(flagValue(args, '--num-frames')).toBe('124');
+    expect(flagValue(args, '--steps')).toBe('4');
+    expect(flagValue(args, '--seed')).toBe('2026');
+    expect(flagValue(args, '--output')).toBe('/fixture/out/render.mp4');
+  });
+
+  it('falls back to the repo id when the snapshot path is unresolved', () => {
+    const { args } = buildFastVideoArgs({ ...base, model: fasth3, fastvideoModelPath: null });
+
+    expect(flagValue(args, '--model-root')).toBe('example-org/example-fasth3');
+    expect(flagValue(args, '--mlx-checkpoint')).toBe('example-org/example-fasth3');
+  });
+
+  it('refuses an image-mode render against a text-only FastH3 row', () => {
+    // mlx_fasth3.py is text-to-video-with-audio only; an i2v request must fail
+    // here rather than reach a child process that has no --image-path flag.
+    expect(() => buildFastVideoArgs({
+      ...base, model: fasth3, mode: 'image', sourceImagePath: '/fixture/first.png',
+    })).toThrowError(/mode/i);
+  });
+});


### PR DESCRIPTION
## Summary

Adds **FastH3 Preview v1 Dense / Data-Free** — a 4-step distilled MiniMax H3 that renders muxed video **and audio** — to the macOS Video Gen catalog.

It rides the **existing `fastvideo` BYOV runtime** rather than adding one, so it inherits that runtime's install banner, streamed installer, status probe and per-model download badge with no new UI. The checkpoint is pre-quantized, so a first render converts nothing locally.

### One runtime, two entry scripts

FastMetal renders through `mlx_wan_prompt_to_video.py`; FastH3 renders through `mlx_fasth3.py`, which names the same concepts differently (`--steps`, not `--num-inference-steps`) and has no `--fps` / `--guidance` / `--negative-prompt` / `--image-path` at all. A new `fastvideoFamily` field on the registry entry selects between them, defaulting to FastMetal so every existing row is unchanged.

### Wired into the form, not just the catalog

Because the entry script has no flag for them, the row declares `supportsNegativePrompt` / `supportsTiling` / `supportsDisableAudio` false and pins `fpsOptions` to the 24 fps it always muxes — so the form drops those controls instead of offering knobs whose values die at the argv boundary. It is a distilled H3, so it also carries H3's 17n+5 VAE frame grid, 32px edge rounding, and the MiniMax H3 Community License territory gate the other H3 entries carry.

### Which checkpoint, and why not the ones the issue named

The issue specified FastVideo's own INT6 (default) / INT8 / INT4 MLX packs. **Those three repos publish a model card and a conversion manifest but no weights** — `mlx_h3_dit.safetensors` returns 404 on `resolve/main` for all three, and the tree listing agrees (5 small files, `usedStorage: 0`). Rows against them would be three guaranteed-broken download buttons, so they are not shipped.

What ships instead is `MrMofer/FastVideo-FastH3-4-step-Preview-v1-Dense-DataFree-MLX-INT4` (pinned `4c8c3e54`, 89.3 GB), whose `conversion_manifest.json` names the same source (`FastVideo/…-Dense-DataFree` @ `f624f08c`), the same converter commit `cf6a00b9`, MLX 0.32.2, 1464 tensors, `vsa_capable: false`. It is **self-contained** — the quantized DiT ships beside the `vae/`, `audio_vae/`, `text_encoder/`, `tokenizer/` the pipeline loads — so there is no two-download layout to build, and the `mlxCheckpoint` seam the issue sketched would have had no caller. MrMofer is already a shipped repacker in this catalog (`ltx25_mlx_q8`; the `ltx25` runtime is their fork).

### Disclosure re-check

Bumping `VIDEO_DISCLOSURE_REVIEWED_AT` obliges a re-check of every entry, which turned up four wrong `estimatedDownloadGb` figures. The three FastMetal rows quoted their DiT-only size while declaring no `repoFiles`, so PortOS actually pulls the whole snapshot: **3.5→13.4, 10.2→19.5, 25.4→42.3 GB**. LTX-2.5 CUDA's pinned six-file set sums to **71.1**, not 72.1. Every other entry's license and size verified unchanged against its live model card and pinned file listing.

## Test plan

- `cd server && npx vitest run` — **1852 files / 37620 tests pass**, 0 failures.
- `cd client && npx vitest run` — **10801 tests pass**, 0 failures.
- `python3 scripts/generate_fastvideo_test.py` — 9 pass. Covers both argv shapes, the per-family entry-script resolution, and a pin on the exact pre-split FastMetal argv.
- New `server/services/videoGen/renderArgsFastVideo.test.js` — family routing, the `--mlx-checkpoint` pairing, the unknown-family fallback, and the image-mode refusal.
- New `scripts/migrations/333-*.test.js` — idempotency, CUDA bucket untouched, no re-add of a user-deleted row, and that an upgraded install receives the same frame/fps/capability limits a fresh seed gets.
- Verified against the **real pinned FastVideo checkout**: the FastH3 argv this helper emits parses cleanly under `~/.portos/fastvideo/examples/inference/basic/mlx_fasth3.py`'s own argparse.
- Verified end to end that `getVideoModels()` lists the row as `hardwareCompatibility: available`, that `getVideoRuntimeStatus('fastvideo')` resolves it to the `INSTALL_FASTVIDEO` installer, and that an upgraded install (migration output loaded in isolation) still gets the licence terms gate via `applyVideoDisclosures`.

**Not verified: an actual render.** This machine has 48 GB of free disk against an 89.3 GB snapshot and 48 GB of unified memory against a 66.7 GB bf16 Qwen3-VL text encoder, so the model could not be downloaded or run here. Upstream records a passing 832x480 / 124-frame generation with the full H3 VAE on an M4 Max.

Closes #5860