### PR TITLE
refactor: break the cos.js re-export import cycle (#5684)

### DIFF
--- a/server/services/agentImportCycles.test.js
+++ b/server/services/agentImportCycles.test.js
@@ -473,6 +473,25 @@ describe('agent lifecycle cluster — no static import cycles (#2837)', () => {
     expect(graph.get('agents.js')).toContain('agentOrchestrator.js');
   });
 
+  it('keeps cos.js out of every static import cycle (#5684)', () => {
+    // cos.js re-exports cosState/cosTaskStore for backward compat with
+    // `import * as cos`. Two leaf services used to reach THROUGH that barrel for
+    // one symbol each (memoryEmbeddings -> getConfig, character -> getAllTasks),
+    // and because cos.js transitively reaches the CoS tool registry -> voice
+    // tools -> askService -> both of those leaves, each one-symbol forward closed
+    // a 7-module ring. Both now import the DECLARING module, which is the same
+    // rule the transition-caller guard above enforces for the agent cluster.
+    const offending = findCycles(graph).filter(cycle => cycle.split(' -> ').includes('cos.js'));
+    expect(offending, `cos.js is back in a static import cycle:\n${offending.join('\n')}`).toEqual([]);
+
+    // Name the two back-edges directly, so a reintroduced one-symbol import of
+    // the barrel fails with the reason rather than as an opaque ring.
+    expect(graph.get('memoryEmbeddings.js'), 'memoryEmbeddings must import getConfig from cosState.js').not.toContain('cos.js');
+    expect(graph.get('memoryEmbeddings.js')).toContain('cosState.js');
+    expect(graph.get('character.js'), 'character must import getAllTasks from cosTaskStore.js').not.toContain('cos.js');
+    expect(graph.get('character.js')).toContain('cosTaskStore.js');
+  });
+
   it('no longer needs the dynamic-import workaround for handleOrphanedTask', () => {
     // The cycle-dodge this issue was filed for: agentLifecycle reached
     // agentManagement via `await import()` because agentManagement imported it back.

--- a/server/services/character.js
+++ b/server/services/character.js
@@ -17,7 +17,7 @@ import crypto from 'crypto';
 import path from 'path';
 import { atomicWrite, ensureDir, readJSONFile, PATHS, sleep } from '../lib/fileUtils.js';
 import * as jiraService from './jira.js';
-import * as cosService from './cos.js';
+import { getAllTasks } from './cosTaskStore.js';
 import { getBirthDateStrict } from './meatspace.js';
 import { getCharacterSkills } from './characterSkills.js';
 import { getCharacterMetrics } from './characterMetrics.js';
@@ -424,7 +424,7 @@ export async function syncJiraXP() {
 
 export async function syncTaskXP() {
   const character = await loadRawCharacter();
-  const { user: userTasks, cos: cosTasks } = await cosService.getAllTasks();
+  const { user: userTasks, cos: cosTasks } = await getAllTasks();
   let totalXP = 0;
   let taskCount = 0;
 

--- a/server/services/character.test.js
+++ b/server/services/character.test.js
@@ -33,7 +33,9 @@ const FAKE_METRICS = [{ id: 'recordsCreated', label: 'Records Created', unit: 'c
 // registries were handed the SAME one (the whole point of #2676's read-once contract).
 const FAKE_READ = vi.hoisted(() => vi.fn());
 vi.mock('./jira.js', () => ({}));
-vi.mock('./cos.js', () => ({}));
+// character.js reaches cosTaskStore for the one symbol it uses (getAllTasks); syncTaskXP
+// is not exercised here, so the stub only has to satisfy the static import.
+vi.mock('./cosTaskStore.js', () => ({ getAllTasks: async () => ({ user: { tasks: [] }, cos: { tasks: [] } }) }));
 vi.mock('./characterSkills.js', () => ({
   getCharacterSkills: vi.fn(async () => FAKE_SKILLS),
 }));

--- a/server/services/memoryEmbeddings.js
+++ b/server/services/memoryEmbeddings.js
@@ -7,7 +7,7 @@
 
 import { DEFAULT_MEMORY_CONFIG } from './memoryBackend.js';
 import { getProviderById } from './providers.js';
-import { getConfig as getCosConfig } from './cos.js';
+import { getConfig as getCosConfig } from './cosState.js';
 import { fetchWithTimeout } from '../lib/fetchWithTimeout.js';
 import { readResponseJson } from '../lib/readResponseJson.js';
 import { estimateTokens, CHARS_PER_TOKEN } from '../lib/contextBudget.js';

--- a/server/services/memoryEmbeddings.test.js
+++ b/server/services/memoryEmbeddings.test.js
@@ -5,7 +5,7 @@ const getCosConfig = vi.fn();
 const getProviderById = vi.fn();
 const summarizeForEmbedding = vi.fn();
 
-vi.mock('./cos.js', () => ({ getConfig: getCosConfig }));
+vi.mock('./cosState.js', () => ({ getConfig: getCosConfig }));
 vi.mock('./providers.js', () => ({ getProviderById }));
 // generateMemoryEmbedding dynamically imports this for over-budget records.
 vi.mock('./memorySummarizer.js', () => ({ summarizeForEmbedding }));


### PR DESCRIPTION
## Summary

`server/services/cos.js` doubles as a re-export barrel for `cosState` and `cosTaskStore`. Two leaf services reached *through* that barrel for one symbol each — `memoryEmbeddings.js` for `getConfig`, `character.js` for `getAllTasks` — and because `cos.js` transitively imports the CoS tool registry → voice tools → ask service (which reach back to both leaves), each one-symbol forward closed a 7-module static ESM cycle:

```
cos.js -> persistentMindAdapter.js -> cosToolRegistry.js -> voice/tools.js -> voice/tools/ask.js -> askService.js -> memoryEmbeddings.js -> cos.js
cos.js -> persistentMindAdapter.js -> cosToolRegistry.js -> voice/tools.js -> voice/tools/ask.js -> askService.js -> character.js -> cos.js
```

A static cycle is a live TDZ hazard — whichever module in the ring evaluates first sees `undefined` bindings from the others, so an innocuous new top-level `const` in any of the seven can become a boot-time crash. Neither symbol is even declared in `cos.js`; both are pure forwards.

Both consumers now import the module that **declares** the symbol, the same rule `agentImportCycles.test.js` already enforces for the agent cluster:

- `memoryEmbeddings.js` → `import { getConfig as getCosConfig } from './cosState.js'`
- `character.js` → `import { getAllTasks } from './cosTaskStore.js'` (the namespace import is gone; `syncTaskXP` was its only consumer)

The `cos.js` re-export blocks are deliberately left intact — many suites mock against them and external call sites use `import * as cos`, so retiring that surface is its own change (as `agentOrchestrator.js` already notes).

A static import-graph scan of `server/services` drops from **13 cycles to 11**, with none containing `cos.js`.

## Test plan

- New guard `agentImportCycles.test.js › keeps cos.js out of every static import cycle (#5684)` reuses the file's existing `buildStaticGraph()` / `findCycles()` and asserts (a) no cycle contains `cos.js`, and (b) neither leaf imports the barrel while both import the declaring module. **Verified it fails pre-fix** — reverting `memoryEmbeddings.js` to `./cos.js` reproduces the ring in the failure message.
- Retargeted the two stale mocks so they still substitute the real dependency: `memoryEmbeddings.test.js` now mocks `./cosState.js`, `character.test.js` mocks `./cosTaskStore.js` (a `getAllTasks` stub, since a named import needs the symbol present where the old namespace mock could be empty).
- `cd server && npm test` — **1853 files passed / 1 skipped, 37632 tests passed / 14 skipped**.
- Local reviewer pass (codex, read-only): no findings.

Closes #5684
