### PR TITLE
deps: drop the direct three-stdlib dependency (#5683)

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -22,8 +22,7 @@
         "react-router": "8.3.1",
         "recharts": "3.10.1",
         "socket.io-client": "4.8.3",
-        "three": "0.185.1",
-        "three-stdlib": "2.36.1"
+        "three": "0.185.1"
       },
       "devDependencies": {
         "@biomejs/biome": "2.5.11",

--- a/client/package.json
+++ b/client/package.json
@@ -33,8 +33,7 @@
     "react-router": "8.3.1",
     "recharts": "3.10.1",
     "socket.io-client": "4.8.3",
-    "three": "0.185.1",
-    "three-stdlib": "2.36.1"
+    "three": "0.185.1"
   },
   "devDependencies": {
     "@biomejs/biome": "2.5.11",

--- a/client/src/hooks/useClonedGltf.jsx
+++ b/client/src/hooks/useClonedGltf.jsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { useAnimations, useGLTF } from '@react-three/drei';
-import { SkeletonUtils } from 'three-stdlib';
+import * as SkeletonUtils from 'three/examples/jsm/utils/SkeletonUtils.js';
 
 const preserveAnimations = (animations) => animations;
 

--- a/client/src/hooks/useClonedGltf.test.jsx
+++ b/client/src/hooks/useClonedGltf.test.jsx
@@ -1,9 +1,16 @@
 import { renderHook } from '@testing-library/react';
+import {
+  Bone,
+  BufferGeometry,
+  Group,
+  MeshBasicMaterial,
+  Skeleton,
+  SkinnedMesh,
+} from 'three';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import useClonedGltf, { GltfPrimitive } from './useClonedGltf.jsx';
 
 const mocks = vi.hoisted(() => ({
-  clone: vi.fn(),
   useAnimations: vi.fn(),
   useGLTF: vi.fn(),
 }));
@@ -13,20 +20,43 @@ vi.mock('@react-three/drei', () => ({
   useGLTF: mocks.useGLTF,
 }));
 
-vi.mock('three-stdlib', () => ({
-  SkeletonUtils: { clone: mocks.clone },
-}));
+// A minimal rigged GLTF scene: Group > SkinnedMesh > Bone("Root") > Bone("Spine").
+// SkeletonUtils.clone is the only thing that rebinds a clone's skeleton to the
+// CLONED bones; a plain Object3D.clone leaves the copy driven by the cached
+// original's skeleton, which is the "second mount renders blank" failure the
+// hook exists to avoid.
+const buildRiggedScene = () => {
+  const root = new Group();
+  root.name = 'source';
+  const rootBone = new Bone();
+  rootBone.name = 'Root';
+  const spineBone = new Bone();
+  spineBone.name = 'Spine';
+  rootBone.add(spineBone);
+  const mesh = new SkinnedMesh(new BufferGeometry(), new MeshBasicMaterial());
+  mesh.name = 'Body';
+  mesh.add(rootBone);
+  mesh.bind(new Skeleton([rootBone, spineBone]));
+  root.add(mesh);
+  return root;
+};
+
+const findSkinnedMesh = (scene) => {
+  let found = null;
+  scene.traverse((node) => {
+    if (node.isSkinnedMesh) found = node;
+  });
+  return found;
+};
 
 describe('useClonedGltf', () => {
   beforeEach(() => {
-    mocks.clone.mockReset();
     mocks.useAnimations.mockReset();
     mocks.useGLTF.mockReset();
   });
 
   it('clones the cached scene and binds transformed animations to the clone', () => {
-    const sourceScene = { name: 'source' };
-    const clonedScene = { name: 'clone' };
+    const sourceScene = buildRiggedScene();
     const sourceAnimations = [{ name: 'Walk' }];
     const transformedAnimations = [{ name: 'Walk-in-place' }];
     const transformAnimations = vi.fn(() => transformedAnimations);
@@ -36,24 +66,41 @@ describe('useClonedGltf', () => {
       names: ['Walk-in-place'],
     };
     mocks.useGLTF.mockReturnValue({ scene: sourceScene, animations: sourceAnimations });
-    mocks.clone.mockReturnValue(clonedScene);
     mocks.useAnimations.mockReturnValue(animationState);
 
     const { result, rerender } = renderHook(() => (
       useClonedGltf('/example.glb', transformAnimations)
     ));
 
-    expect(mocks.clone).toHaveBeenCalledWith(sourceScene);
+    const { scene } = result.current;
+    // A real clone, not the drei-cached scene handed straight back.
+    expect(scene).not.toBe(sourceScene);
+    expect(scene.name).toBe('source');
+
+    // The rig survived, and every bone the clone is skinned to belongs to the
+    // clone's own hierarchy — never the source's.
+    const sourceMesh = findSkinnedMesh(sourceScene);
+    const clonedMesh = findSkinnedMesh(scene);
+    expect(clonedMesh).not.toBe(sourceMesh);
+    expect(clonedMesh.skeleton).not.toBe(sourceMesh.skeleton);
+    expect(clonedMesh.skeleton.bones.map((bone) => bone.name)).toEqual(['Root', 'Spine']);
+    for (const bone of clonedMesh.skeleton.bones) {
+      expect(sourceMesh.skeleton.bones).not.toContain(bone);
+      expect(scene.getObjectById(bone.id)).toBe(bone);
+    }
+
     expect(transformAnimations).toHaveBeenCalledWith(sourceAnimations);
-    expect(mocks.useAnimations).toHaveBeenCalledWith(transformedAnimations, clonedScene);
+    expect(mocks.useAnimations).toHaveBeenCalledWith(transformedAnimations, scene);
     expect(result.current).toEqual({
-      scene: clonedScene,
+      scene,
       animations: transformedAnimations,
       ...animationState,
     });
 
+    // Memoized on the cached scene: a rerender must not re-clone, or every
+    // render would rebuild the rig and drop the running animation actions.
     rerender();
-    expect(mocks.clone).toHaveBeenCalledTimes(1);
+    expect(result.current.scene).toBe(scene);
     expect(transformAnimations).toHaveBeenCalledTimes(1);
   });
 

--- a/docs/DEPS.md
+++ b/docs/DEPS.md
@@ -59,7 +59,7 @@ Before removing a Tier 3 candidate, run a transitive-dep check (`npm ls <pkg>`).
 | `recharts` | 1 | KEEP | charts | |
 | `socket.io-client` | 1 | KEEP | realtime client | |
 | `three` | 1 | KEEP | 3D | |
-| `three-stdlib` | 1 | KEEP | CyberCity 3D | Community-maintained Three.js utilities used by the client renderer |
+| `three-stdlib` | — | REMOVED (direct) | 3D avatars | 2026-09-02 → `three/examples/jsm/utils/SkeletonUtils.js` (issue #5683). The sole direct import was `SkeletonUtils.clone`, which `three` itself ships. Still in the tree transitively via `@react-three/drei`, so this is a manifest cleanup, not a supply-chain reduction — the win is one fewer pin to Dependabot-bump and the removal of a pinned-vs-`^` drift surface against drei's own request |
 | **Client devDeps** | | | | |
 | `@biomejs/biome` | 1 | KEEP | linting | Replaced the whole eslint stack 2026-08-04; native binary, 0 regular deps + 8 platform optionals (1 installed) |
 | `eslint` | — | REMOVED | linting | 2026-08-04 → `@biomejs/biome`. 53 packages were reachable only via `eslint` itself (incl. the `file-entry-cache → flat-cache → keyv` chain); 110 net once the plugin subtrees and orphaned `typescript` go too. `minimatch` and `brace-expansion` left the tree with it (both now 0 occurrences in every lockfile), so neither needs an override pin — do not re-add one |


### PR DESCRIPTION
## Summary

`client/src/hooks/useClonedGltf.jsx` imported exactly one symbol from `three-stdlib` — `SkeletonUtils` — and `three` itself ships that module at `three/examples/jsm/utils/SkeletonUtils.js`, a path the client already imports from (`client/src/lib/threejsEnvironment.js`). This takes it from `three` and drops the direct pin.

Honest scoping: this is **not** a supply-chain reduction. `three-stdlib` stays in the tree transitively via `@react-three/drei`. The win is narrower and real — one fewer direct pin to maintain and Dependabot-bump, one fewer manifest row, and the removal of a drift surface: `client/package.json` pinned `three-stdlib@2.36.1` while drei requests `^2.35.6`, so a bump could have produced two `SkeletonUtils` implementations operating on the same GLTF cache.

- `client/src/hooks/useClonedGltf.jsx` — `import * as SkeletonUtils from 'three/examples/jsm/utils/SkeletonUtils.js'`. A namespace import because `three`'s copy exports `clone` as a bare named export rather than a `SkeletonUtils` object; the call site is unchanged.
- `client/package.json` — `three-stdlib` removed from `dependencies`. The `three` entry in `overrides` is untouched: it is what keeps drei, fiber, and the surviving transitive `three-stdlib` on one `three` copy.
- `client/package-lock.json` — regenerated. `three-stdlib@2.36.1` is still resolved, but now only because `@react-three/drei` requires it; `three@0.185.1` is still a single deduped copy.
- `docs/DEPS.md` — the `three-stdlib` row moved to the `REMOVED` style used by the `eslint` / `sax` rows, recording that it survives transitively.

The three remaining `three-stdlib` mentions under `client/src/components/openworld/` are comments explaining why drei's `<Line>` is avoided. They describe drei's *bundled* copy and are still accurate, so they stay.

## Test plan

`client/src/hooks/useClonedGltf.test.jsx` previously mocked `three-stdlib` away entirely, so it could not have noticed the swap being wired up wrongly. It now exercises the **real** `SkeletonUtils` against a minimal rigged scene (`Group > SkinnedMesh > Bone > Bone`) and asserts the returned scene is a distinct object whose skinned mesh is rebound to the clone's own bones — mocking only drei's `useGLTF` / `useAnimations`.

Verified it fails on both plausible regressions before being accepted:

| Injected regression | Result |
| --- | --- |
| `import SkeletonUtils from '...'` (default import) | `TypeError: Cannot read properties of undefined (reading 'clone')` |
| `gltf.scene.clone()` (shallow `Object3D.clone`) | `AssertionError: expected Skeleton not to be Skeleton` — the copy would stay driven by the cached original's skeleton, the "next mount renders blank" failure the hook exists to avoid |

Also run:

- `cd client && npm test` — 866 files passed, 1 skipped; 10801 tests passed, 2 skipped.
- `cd client && npm run lint` — 2442 files checked, clean.
- `cd client && npm run build` — succeeded; the `vendor-three` chunk still builds.
- Lockfile check: root `dependencies` no longer lists `three-stdlib`; only `@react-three/drei` requires it, and `three` resolves to one copy.

No server code touched.

Closes #5683
