### PR TITLE
refactor: name the sidebar section groups instead of slicing SECTION_ORDER (#5692)

### DIFF
--- a/client/src/components/Layout.jsx
+++ b/client/src/components/Layout.jsx
@@ -356,10 +356,19 @@ const SECTION_PRESENTATION = {
   POST: { icon: Zap, defaultTo: '/post/launcher' },
 };
 
-const SECTION_ORDER = [
+// Sidebar grouping is declared, never derived from array positions. The first
+// two lists are the alphabetical run of sections, split around the Goals row;
+// the third is the intentionally-last bucket that renders below the "More"
+// divider, so it is NOT alphabetical relative to the other two and can only be
+// declared. Adding a section means putting its name in the list it belongs to —
+// there are no indices to keep in sync.
+export const SECTIONS_BEFORE_GOALS = [
   'Brain', 'Calendar', 'Chief of Staff', 'Comms', 'Create', 'Dev Tools',
-  'Health', 'Models', 'Settings', 'Identity', 'POST',
 ];
+export const SECTIONS_AFTER_GOALS = ['Health', 'Models', 'Settings'];
+export const SECTIONS_BELOW_MORE = ['Identity', 'POST'];
+
+const SECTION_ORDER = [...SECTIONS_BEFORE_GOALS, ...SECTIONS_AFTER_GOALS, ...SECTIONS_BELOW_MORE];
 
 // These rows have no PortOS route, so a NAV_COMMANDS entry would be dishonest.
 // Keep them visibly marked as local-only instead of smuggling structural route
@@ -410,11 +419,11 @@ const navItems = [
   ...mainRows,
   { separator: true, localOnly: true },
   { ...appsCommand, dynamic: 'apps', defaultTo: appsCommand.to, children: [] },
-  ...SECTION_ORDER.slice(0, 6).map((section) => sectionRows[section]),
+  ...SECTIONS_BEFORE_GOALS.map((section) => sectionRows[section]),
   goalsRow,
-  ...SECTION_ORDER.slice(6, 9).map((section) => sectionRows[section]),
+  ...SECTIONS_AFTER_GOALS.map((section) => sectionRows[section]),
   { moreLabel: true, localOnly: true },
-  ...SECTION_ORDER.slice(9).map((section) => sectionRows[section]),
+  ...SECTIONS_BELOW_MORE.map((section) => sectionRows[section]),
 ];
 
 const SIDEBAR_KEY = 'portos-sidebar-collapsed';

--- a/client/src/components/Layout.test.jsx
+++ b/client/src/components/Layout.test.jsx
@@ -501,16 +501,20 @@ describe('Layout — isFullWidthRoute classification', () => {
 describe('Layout — sidebar section grouping', () => {
   const alphabetical = (list) => [...list].sort((a, b) => a.localeCompare(b));
 
-  it.each([
-    ['SECTIONS_BEFORE_GOALS', SECTIONS_BEFORE_GOALS],
-    ['SECTIONS_AFTER_GOALS', SECTIONS_AFTER_GOALS],
-  ])('%s stays alphabetical', (_name, list) => {
-    expect(list).toEqual(alphabetical(list));
+  // The two lists are one alphabetical run split by the standalone Goals row, so
+  // splicing that row's label back in at the split point must re-form a sorted
+  // list. That pins BOTH the ordering within each list and where the split sits:
+  // moving a section across the Goals boundary lands it out of order here, which
+  // per-list sort checks would happily accept.
+  it('reads as one alphabetical run through the standalone Goals row', () => {
+    const goalsLabel = NAV_COMMANDS.find((command) => command.path === '/goals/list').label;
+    const run = [...SECTIONS_BEFORE_GOALS, goalsLabel, ...SECTIONS_AFTER_GOALS];
+    expect(run).toEqual(alphabetical(run));
   });
 
-  // SECTIONS_BELOW_MORE is deliberately NOT alphabetical relative to the other
-  // two — it is the below-the-fold bucket — so it is exempt from the sort check
-  // but still has to be disjoint and complete.
+  // SECTIONS_BELOW_MORE is deliberately NOT part of that run — it is the
+  // below-the-fold bucket — so it is exempt from the sort check but still has to
+  // be disjoint and complete.
   it('groups every presented section exactly once', () => {
     const grouped = [...SECTIONS_BEFORE_GOALS, ...SECTIONS_AFTER_GOALS, ...SECTIONS_BELOW_MORE];
     expect(new Set(grouped).size).toBe(grouped.length);

--- a/client/src/components/Layout.test.jsx
+++ b/client/src/components/Layout.test.jsx
@@ -87,7 +87,13 @@ vi.mock('../services/api', () => ({
 import { __resetInstanceFeatureCache } from '../hooks/useInstanceFeatures.js';
 
 import { NAV_COMMANDS } from '../../../server/lib/navManifest.js';
-import Layout, { isFullWidthRoute, NAV_PRESENTATION } from './Layout';
+import Layout, {
+  isFullWidthRoute,
+  NAV_PRESENTATION,
+  SECTIONS_BEFORE_GOALS,
+  SECTIONS_AFTER_GOALS,
+  SECTIONS_BELOW_MORE,
+} from './Layout';
 
 const LocationProbe = () => {
   const location = useLocation();
@@ -484,5 +490,40 @@ describe('Layout — isFullWidthRoute classification', () => {
     ['/songbook', true], ['/', false],
   ])('%s -> %s', (pathname, expected) => {
     expect(isFullWidthRoute(pathname)).toBe(expected);
+  });
+});
+
+// The sidebar's section grouping used to be three numeric slices into a single
+// flat SECTION_ORDER array, so inserting a section at its alphabetical position
+// silently pushed a real section (e.g. Settings) past the "More" divider with
+// nothing to catch it. The groups are named lists now; this locks the two
+// invariants that made the slices fragile.
+describe('Layout — sidebar section grouping', () => {
+  const alphabetical = (list) => [...list].sort((a, b) => a.localeCompare(b));
+
+  it.each([
+    ['SECTIONS_BEFORE_GOALS', SECTIONS_BEFORE_GOALS],
+    ['SECTIONS_AFTER_GOALS', SECTIONS_AFTER_GOALS],
+  ])('%s stays alphabetical', (_name, list) => {
+    expect(list).toEqual(alphabetical(list));
+  });
+
+  // SECTIONS_BELOW_MORE is deliberately NOT alphabetical relative to the other
+  // two — it is the below-the-fold bucket — so it is exempt from the sort check
+  // but still has to be disjoint and complete.
+  it('groups every presented section exactly once', () => {
+    const grouped = [...SECTIONS_BEFORE_GOALS, ...SECTIONS_AFTER_GOALS, ...SECTIONS_BELOW_MORE];
+    expect(new Set(grouped).size).toBe(grouped.length);
+
+    // `Main` (Dashboard/Review/Eidoverse plus the dynamic Apps row) and `Goals`
+    // render as standalone top-level rows, not as collapsible section groups.
+    const UNGROUPED_SECTIONS = new Set(['Main', 'Goals']);
+    const sectionByPath = new Map(NAV_COMMANDS.map((command) => [command.path, command.section]));
+    const presented = new Set(
+      Object.keys(NAV_PRESENTATION)
+        .map((path) => sectionByPath.get(path))
+        .filter((section) => section && !UNGROUPED_SECTIONS.has(section)),
+    );
+    expect(alphabetical([...presented])).toEqual(alphabetical(grouped));
   });
 });


### PR DESCRIPTION
## Summary

The sidebar built its section list by slicing a flat `SECTION_ORDER` array at literal indices `6` and `9` to decide what renders before the Goals row, after it, and below the "More" divider. Those literals encoded alphabetical facts about the array's current contents, so obeying the "sidebar nav is alphabetical" convention for a new section — inserting its name at the right position — silently relocated a real section past the divider unless the reader also noticed and bumped both bounds. Inserting `Finance` after `Dev Tools`, for example, pushed `Settings` below "More". Nothing in the suite caught it.

Grouping is declared now:

- `SECTIONS_BEFORE_GOALS`, `SECTIONS_AFTER_GOALS`, and `SECTIONS_BELOW_MORE` are three named, exported lists.
- `SECTION_ORDER` is derived from their concatenation, so section-row construction is unchanged.
- `navItems` maps each named list instead of slicing — no numeric `slice(` over `SECTION_ORDER` remains.

The below-"More" bucket stays a separate list rather than a computed split because it is a deliberate below-the-fold group that is not alphabetical relative to the other two, so it can only be declared, not derived. Rendered sidebar order is byte-identical.

Two new `Layout.test.jsx` cases lock the invariants the slices used to hide:

- **Ordering and split point** — splicing the Goals row's own label back in between the two lists must re-form an alphabetically sorted run. This pins both the order within each list and where the Goals boundary sits; a per-list sort check alone would accept a section moved across that boundary.
- **Coverage** — the three lists are disjoint and together cover every section that has a presented row and is not one of the standalone top-level rows.

## Test plan

- `cd client && npm test` — 866 files / 10803 tests passed, 1 skipped.
- `cd server && npm test` — 1853 files / 37631 tests passed, 14 skipped. Run in full because `navManifest.test.js` is server-side and scrapes the sidebar list.
- Verified each new assertion fails on the regression it claims, then reverted the probe:
  - reordering `SECTIONS_AFTER_GOALS` to `['Health', 'Settings', 'Models']` → alphabetical-run test fails.
  - moving `Settings` to the end of `SECTIONS_BEFORE_GOALS` (both lists still individually sorted) → alphabetical-run test fails.
  - dropping `Settings` from every list → coverage test fails.
- Confirmed the rendered section sequence (`Brain … Dev Tools`, Goals, `Health, Models, Settings`, "More", `Identity, POST`) is identical to what the old slice bounds produced.

Closes #5692

