### PR TITLE
test: enforce clickableProps and img alt in the a11y conventions suite (#5680)

### DIFF
--- a/client/src/a11yConventions.test.js
+++ b/client/src/a11yConventions.test.js
@@ -24,6 +24,14 @@
  *      which passes no `label`. Such a toast collapses to a pill after
  *      COLLAPSE_AFTER_MS (so it stops covering the page), and the pill has no
  *      text of its own to name itself with.
+ *   5. A non-interactive element (`<div>`, `<li>`, `<tr>`, …) carrying an
+ *      `onClick` and nothing else. It takes no focus and Enter/Space do
+ *      nothing, so the affordance does not exist at all for a keyboard or
+ *      screen-reader user. `lib/a11yKeyboard.js`'s `clickableProps(handler)`
+ *      supplies the missing role, tab stop and Enter/Space handler.
+ *   6. An `<img>` with no `alt`, which is announced by its `src` — a hashed
+ *      filename or a blob URL. `alt=""` is the correct spelling for a
+ *      decorative image and passes; only the omission is the bug.
  *
  * Scoped to git-tracked `.jsx` under `client/src` so an untracked scratch file
  * can't fail the suite.
@@ -1817,6 +1825,132 @@ const PREEXISTING_SELECT_TEXTAREA_NAME_ALLOWLIST = new Set([
 // already carries — never a row here.
 const PREEXISTING_ANCHOR_NAME_ALLOWLIST = new Set([]);
 
+// --- keyboard activation on non-interactive elements ----------------------
+// A `<button>`/`<a>`/`<input>` activates from the keyboard on its own; a
+// `<div onClick>` does not — it takes no focus and Enter/Space do nothing, so
+// the affordance simply does not exist for a keyboard or screen-reader user.
+// `lib/a11yKeyboard.js`'s `clickableProps(handler)` is the repair (role +
+// tabIndex + an Enter/Space `onKeyDown`), and the tree already follows it
+// everywhere — which is exactly why the convention is worth pinning now, while
+// the rule lands green with no allowlist to erode.
+const CLICKABLE_HOST_TAGS = ['div', 'span', 'li', 'tr', 'td', 'section', 'article'];
+
+// An `onClick` whose entire body is `e.stopPropagation()` is a propagation
+// shim, not an activation target: it exists so a click on a drag handle nested
+// inside a clickable row never reaches the row (goals/GoalsListView.jsx's grip,
+// fableloom/LoomSceneMedia.jsx's `stopNodeActivation`). There is nothing for a
+// keyboard user to activate, and handing it a role plus a tab stop would ADD a
+// dead stop to the tab order.
+const PROPAGATION_SHIM_HANDLER = /^\(?\s*\w*\s*\)?\s*=>\s*\{?\s*\w+\s*\.\s*stopPropagation\(\)\s*;?\s*\}?$/;
+const BARE_IDENTIFIER = /^[A-Za-z_$][\w$]*$/;
+
+// Roles whose keyboard contract does NOT live on the element itself, so a tab
+// stop here would be the defect rather than the fix:
+//   - `presentation`/`none` take the element out of the a11y tree, exactly like
+//     `aria-hidden` — that is how the dismiss scrim under every Modal, Drawer
+//     and command palette is spelled, and the keyboard route out is the owning
+//     component's Esc handler, not a focusable backdrop.
+//   - `option` is focus-managed BY its composite parent (ARIA APG roving focus /
+//     aria-activedescendant): CmdKSearch.jsx's result rows are the worked
+//     example — the input owns the arrow keys and Enter, and making each row
+//     individually tabbable would break that.
+//   - `dialog`/`alertdialog` on a click-to-dismiss surface (media/MediaLightbox)
+//     is closed with Esc.
+// Deliberately only the roles the tree actually renders. The sibling
+// composite-child roles (`tab`, `menuitem`, `treeitem`, `row`, `gridcell`) are
+// the same argument and belong here the day one lands — but seeding them now
+// would exempt a `<div role="tab" onClick>` that has no parent managing focus
+// at all, which is the false negative this list is one bad guess away from.
+// `button` and `link` are excluded permanently: those promise activation ON the
+// element, which is the promise this rule exists to keep.
+const SELF_MANAGED_CLICK_ROLES = new Set([
+  'presentation', 'none', 'dialog', 'alertdialog', 'option',
+]);
+
+// Attribute NAMES written on an opening tag, reading quoted values and brace
+// expressions as opaque. `attributeValue`'s bare regex is right for the paired
+// -id lookups it serves, but a rule whose entire answer is "was this attribute
+// written at all" must not accept `title=" alt="` as an alt — the one shape
+// that would silently exempt the images this guard exists for.
+function tagAttributes(tag) {
+  const names = new Set();
+  // Every SPREAD expression on the tag, concatenated. `clickableProps` only
+  // does anything when its result is spread onto the element, so both narrowings
+  // matter: reading the raw tag would let a `title="clickableProps(x)"` stand in
+  // for spreading it, and reading every brace expression would accept an
+  // `onClick={() => clickableProps(select)}` that builds the props and drops
+  // them on the floor.
+  let spreads = '';
+  for (let i = 0; i < tag.length; i++) {
+    const char = tag[i];
+    if (char === '"' || char === "'" || char === '`') { i = skipString(tag, i); continue; }
+    if (char === '{') {
+      const end = matchingBraceEnd(tag, i);
+      if (end === -1) break;
+      const body = tag.slice(i + 1, end);
+      if (body.trimStart().startsWith('...')) spreads += `${body}\n`;
+      i = end;
+      continue;
+    }
+    const name = /^[A-Za-z_$][\w$:.-]*/.exec(tag.slice(i))?.[0];
+    if (!name) continue;
+    let after = i + name.length;
+    while (/\s/.test(tag[after])) after++;
+    if (tag[after] === '=') names.add(name);
+    i = after - 1;
+  }
+  return { names, spreads };
+}
+
+// The shim written inline, or hoisted to a named `const`/`let`/`var` arrow in
+// the same file. Resolution is by name across the whole file, which is only
+// sound while that name is declared once — two component scopes sharing a
+// `stop` would let one's shim exempt the other's real handler — so a name
+// declared more than once resolves to nothing and the element is reported.
+function isPropagationShim(src, handler) {
+  if (PROPAGATION_SHIM_HANDLER.test(handler)) return true;
+  if (!BARE_IDENTIFIER.test(handler)) return false;
+  const declarations = [...src.matchAll(new RegExp(`\\b(?:const|let|var)\\s+${handler}\\s*=\\s*([^;\\n]+)`, 'g'))];
+  return declarations.length === 1 && PROPAGATION_SHIM_HANDLER.test(declarations[0][1].trim());
+}
+
+function isKeyboardActivatable(src, tag) {
+  const { names, spreads } = tagAttributes(tag);
+  if (!names.has('onClick')) return true;
+  if (isPropagationShim(src, normalizedAttributeValue(attributeValue(tag, 'onClick')) ?? '')) return true;
+  // `clickableProps(` is the canonical spelling.
+  if (/\bclickableProps\s*\(/.test(spreads)) return true;
+  if (normalizedAttributeValue(attributeValue(tag, 'aria-hidden')) === 'true') return true;
+  const role = normalizedAttributeValue(attributeValue(tag, 'role'));
+  if (role !== null && SELF_MANAGED_CLICK_ROLES.has(role)) return true;
+  // The explicit triple is the escape hatch, so a surface with its own ARIA
+  // role is never forced through the helper. A PARTIAL triple is not one — a
+  // `role="button"` with no tab stop is announced as a button the keyboard can
+  // never reach, which is worse than the plain <div> it started as — and
+  // neither is `tabIndex={-1}`, which is programmatic focus only.
+  if (!names.has('role') || !names.has('tabIndex') || !names.has('onKeyDown')) return false;
+  return !(normalizedAttributeValue(attributeValue(tag, 'tabIndex')) ?? '').startsWith('-');
+}
+
+// Every non-interactive element in `src` carrying a mouse-only `onClick`. The
+// rule and its fixture probes both walk this, so a probe asks the rule's own
+// question instead of a copy that can drift green.
+function* mouseOnlyClickables(src) {
+  for (const name of CLICKABLE_HOST_TAGS) {
+    for (const node of forEachOpeningTag(src, name)) {
+      if (!isKeyboardActivatable(src, node.tag)) yield node;
+    }
+  }
+}
+
+// `alt=""` is the correct spelling for a decorative image and must pass, so the
+// rule asks only whether the attribute is written at all — never what it holds.
+function* imagesWithoutAlt(src) {
+  for (const node of forEachOpeningTag(src, 'img')) {
+    if (!tagAttributes(node.tag).names.has('alt')) yield node;
+  }
+}
+
 describe('a11y conventions', () => {
   // Modal.jsx IS the shared implementation; Drawer and Layout use the same
   // backdrop treatment for a slide-in panel / mobile nav scrim, both of which
@@ -1991,6 +2125,95 @@ describe('a11y conventions', () => {
       }
     }
     expect(offenders, `Icon-only <button> with no aria-label/aria-labelledby — title alone isn't touch-discoverable and isn't reliably read as the accessible name; see media/MediaCard.jsx's Annotate button for the convention:\n${offenders.join('\n')}`).toEqual([]);
+  });
+
+  it('keyboard-activates every clickable non-interactive element', () => {
+    // A mouse-only `onClick` on a <div>/<li>/<tr> is the most common way an
+    // otherwise-accessible view loses its keyboard users: the element never
+    // enters the tab order, so there is no keystroke that reaches the handler
+    // at all. Spread `clickableProps(handler)` from lib/a11yKeyboard.js
+    // alongside the existing onClick (components/IngredientPicker.jsx is the
+    // worked example) — or, for a surface with its own ARIA role, write
+    // role + tabIndex + onKeyDown out in full.
+    const offenders = [];
+    for (const file of trackedJsxFiles()) {
+      const src = maskedSourceOf(file);
+      for (const { name, index } of mouseOnlyClickables(src)) {
+        offenders.push(`${file}:${lineOf(src, index)} <${name}>`);
+      }
+    }
+    expect(offenders, `Non-interactive element with a mouse-only onClick — spread {...clickableProps(handler)} from lib/a11yKeyboard.js (see IngredientPicker.jsx), or write role + tabIndex + onKeyDown in full:\n${offenders.join('\n')}`).toEqual([]);
+  });
+
+  it('gives every <img> an alt attribute', () => {
+    // An <img> with no `alt` is announced by its src — a hashed filename or a
+    // blob URL — where an empty `alt=""` correctly removes a decorative image
+    // from the a11y tree entirely. Both are one keystroke apart, and only the
+    // omission is a bug, so the rule requires the attribute and says nothing
+    // about its value.
+    const offenders = [];
+    for (const file of trackedJsxFiles()) {
+      const src = maskedSourceOf(file);
+      for (const { index } of imagesWithoutAlt(src)) offenders.push(`${file}:${lineOf(src, index)}`);
+    }
+    expect(offenders, `<img> without an alt attribute — describe the image, or write alt="" if it is decorative:\n${offenders.join('\n')}`).toEqual([]);
+  });
+
+  it('reads activation and alt off the tag itself, and not out of a comment', () => {
+    // Both rules above are green against the whole tree, so nothing in the tree
+    // pins what they actually reject. These fixtures do: one probe per branch,
+    // so neither rule can go vacuously green.
+    const clickables = (src) => [...mouseOnlyClickables(src)].map(({ name }) => name);
+
+    expect(clickables('<div onClick={select}>Pick</div>')).toEqual(['div']);
+    expect(clickables('<div onClick={select} {...clickableProps(select)}>Pick</div>')).toEqual([]);
+    expect(clickables('<li onClick={select} role="option" tabIndex={0} onKeyDown={onKey}>Pick</li>')).toEqual([]);
+    expect(clickables('<div onClick={e => e.stopPropagation()}><GripVertical /></div>')).toEqual([]);
+    // The same shim hoisted to a named const — resolved out of the source, not
+    // pattern-matched off the tag, so `onClick={stopNodeActivation}` is not read
+    // as a real clickable.
+    expect(clickables('const stop = (event) => event.stopPropagation();\n<div onClick={stop}><Grip /></div>')).toEqual([]);
+    // …but a named handler that is NOT a shim stays reported, or the branch
+    // above would exempt every clickable that hoists its handler.
+    expect(clickables('const stop = (event) => onSelect(event);\n<div onClick={stop}>Pick</div>')).toEqual(['div']);
+    // A scrim is outside the a11y tree and dismissed with Esc by its owner;
+    // giving it a tab stop would put focus on an element AT is told to ignore.
+    expect(clickables('<div className="fixed inset-0" onClick={close} aria-hidden="true" />')).toEqual([]);
+    // A composite-widget row is focus-managed by its parent (ARIA APG), and a
+    // click-to-dismiss dialog surface closes on Esc.
+    expect(clickables('<div onClick={dispatch} role="option" aria-selected={focused}>Go</div>')).toEqual([]);
+    expect(clickables('<div role="dialog" aria-modal="true" onClick={onClose}>…</div>')).toEqual([]);
+    // A partial triple is not the escape hatch — a role with no tab stop is
+    // announced as a button the keyboard can never reach.
+    expect(clickables('<div onClick={select} role="button">Pick</div>')).toEqual(['div']);
+    // …and neither is a full triple whose tab stop is programmatic-focus-only.
+    expect(clickables('<div onClick={select} role="button" tabIndex={-1} onKeyDown={onKey}>Pick</div>')).toEqual(['div']);
+    // A <button> activates itself; reporting one would make the rule noise.
+    expect(clickables('<button onClick={select}>Pick</button>')).toEqual([]);
+
+    // Every exemption is read off attribute NAMES and SPREAD expressions, never
+    // off the raw tag text, so nothing quoted can forge one. Without this the
+    // rules are one stray string away from exempting the elements they exist
+    // for — and the string would be invisible in review.
+    expect(clickables('<div onClick={select} title="clickableProps(select)">Pick</div>')).toEqual(['div']);
+    // Nor can building the props without spreading them onto the element.
+    expect(clickables('<div onClick={() => clickableProps(select)}>Pick</div>')).toEqual(['div']);
+    expect(clickables('<div onClick={select} title=" role= tabIndex= onKeyDown=">Pick</div>')).toEqual(['div']);
+    // A name declared twice resolves to no shim: one component's
+    // `e.stopPropagation()` must not exempt another's real handler.
+    expect(clickables('const stop = (e) => e.stopPropagation();\nconst stop = (e) => onSelect(e);\n<div onClick={stop}>Pick</div>')).toEqual(['div']);
+
+    const unaltered = (src) => [...imagesWithoutAlt(src)].length;
+    expect(unaltered('<img src={url} className="w-8" />')).toBe(1);
+    expect(unaltered('<img src={url} alt="" />')).toBe(0);
+    expect(unaltered('<img src={url} alt={caption} />')).toBe(0);
+    expect(unaltered('<img src={url} title=" alt=" />')).toBe(1);
+
+    // Both rules read MASKED source, so a JSX example written in a comment —
+    // the shape lib/a11yKeyboard.js's own usage docblock is written in — cannot
+    // fail the suite.
+    expect(unaltered(maskComments('// <img src={url} />'))).toBe(0);
+    expect(clickables(maskComments('// <div onClick={select}>Pick</div>'))).toEqual([]);
   });
 
   // Every rule below asks the same question of every tracked file and differs


### PR DESCRIPTION
## Summary

Two accessibility conventions this repo already follows everywhere had no guard, so both were held up entirely by whoever reviewed the next PR:

- a non-interactive element (`div`/`span`/`li`/`tr`/`td`/`section`/`article`) carrying an `onClick` must also spread `clickableProps(handler)` from `client/src/lib/a11yKeyboard.js`, so it gets a role, a tab stop and an Enter/Space `onKeyDown`;
- every `<img>` must carry an `alt`.

Both now ship as rules in `client/src/a11yConventions.test.js`, alongside the four regression classes its preamble already enumerates (the preamble grows to six). The tree is already clean on both counts, so they land green with **no allowlist** — the cheapest moment to pin them.

**What the clickable rule accepts.** `{...clickableProps(handler)}` is the canonical spelling; an explicit `role` + `tabIndex` + `onKeyDown` triple is the escape hatch, so a surface with its own ARIA role is never forced through the helper. `role="button"` / `role="link"` are never exempt, a *partial* triple is not the escape hatch, and neither is a `tabIndex={-1}` that only takes programmatic focus.

**What it exempts**, each a shape where a tab stop would be the defect rather than the fix, and each pinned by a fixture probe:

- a propagation shim (`onClick={e => e.stopPropagation()}`, inline or hoisted to a named const) — a drag handle inside a clickable row activates nothing;
- an `aria-hidden="true"` dismiss scrim — outside the a11y tree, exited with the owner's Esc;
- a composite-widget child whose parent owns roving focus (`role="option"`, e.g. the command-palette result rows);
- a click-to-dismiss `role="dialog"` / `role="presentation"` surface.

The role list holds only the roles the tree actually renders; the sibling composite-child roles belong there the day one lands, rather than being seeded on a guess that would exempt a `<div role="tab" onClick>` with no parent managing focus at all.

**Scanner hygiene.** Exemptions and the `alt` check read attribute *names* and *spread* expressions off a small tag walker rather than the raw tag text, so neither a quoted `title=" alt="` nor a `title="clickableProps(x)"` nor an `onClick={() => clickableProps(select)}` that drops the props on the floor can forge one. Both rules read `maskedSourceOf`, so a JSX example written in a comment — the shape `a11yKeyboard.js`'s own usage docblock is written in — cannot fail the suite. `alt=""` passes: that is the correct spelling for a decorative image, and only the omission is the bug.

## Test plan

- `cd client && npx vitest run src/a11yConventions.test.js` — 49 passed. Both new rules report zero offenders against the current tree (125 `<img>` tags, 18 `clickableProps` call sites, 7 clickable elements matched and exempted through the four documented branches).
- Twelve fixture probes pin each branch of the clickable rule and four pin the `alt` rule, so neither can go vacuously green: a bare `<div onClick>` fails; `clickableProps` spread passes; the full triple passes; `tabIndex={-1}` fails; a partial triple fails; an inline and a hoisted `stopPropagation` shim pass while a non-shim named handler fails; a duplicate declaration of that name fails; scrim and composite-role and dialog cases pass; a `<button>` is never reported; quoted-attribute and non-spread forgeries fail; `<img>` without `alt` fails, `alt=""` / `alt={caption}` pass; a commented-out `<img>` / `<div onClick>` does not fail.
- `cd client && npm test` — 866 files / 10804 tests passed, 1 file / 2 tests skipped.

No production code changed; the diff is one test file.

Closes #5680
