### PR TITLE
chore: pin the five caret-ranged server dependencies to exact versions

### DIFF
--- a/docs/DEPS.md
+++ b/docs/DEPS.md
@@ -167,6 +167,12 @@ These exist purely to force-bump transitive deps; revisit if `npm audit` flags n
 
 **Not every compromised package warrants a pin.** A pin only helps when the installed version is *below* the top of its permitted range — otherwise there is nothing to force. The August 2026 `keyv` / `flat-cache` / `file-entry-cache` compromise deliberately got **no** pin: each range was already at its ceiling (highest published `keyv@4.x` *is* `4.5.4`, etc.), so a pin would have been a no-op, and the packages were removed outright instead. Check headroom (`npm view <pkg>@<major> version`) before adding an entry here.
 
+## Direct Dependency Pinning
+
+**Every direct dependency and devDependency, in every manifest, is an exact version — no `^`, `~`, `>=`, or `*`.** A caret range lets a fresh `npm install` (or any tree re-resolution: a Dependabot bump to a sibling package, `npm run setup`'s `npm install --no-save --prefix server`, `scripts/ensure-deps.js`'s clean-reinstall path) float past a version nobody reviewed — the same argument that already makes an override pin exact, applied to the packages this repo depends on directly. Upgrades arrive as reviewable Dependabot PRs instead.
+
+`server/dependency-overrides.test.js` enforces this across all four manifests, so a dependency added with a caret fails the suite rather than shipping.
+
 ## Install-Script Policy
 
 `ignore-scripts=true` is pinned in **every** workspace's own `.npmrc` (root, `client/`, `server/`, `autofixer/`, `browser/`) — not just the repo root. The list is not maintained by hand: `discoverWorkspaces()` in `scripts/trusted-rebuilds.js` globs every top-level directory carrying a `package.json`, and the test asserts each discovered one has the setting — so a workspace added later is caught rather than silently unguarded. npm resolves the project `.npmrc` from the *local prefix* and never walks up the directory tree, so a root-only setting does not cover `cd client && npm install` or `npm ci --prefix server` (what CI runs). Deleting any workspace `.npmrc` silently re-grants every dependency in that workspace an install-time code-execution slot — the vector the Shai-Hulud worm used.

--- a/server/dependency-overrides.test.js
+++ b/server/dependency-overrides.test.js
@@ -270,3 +270,50 @@ describe('dependency override parity across manifests (#2848)', () => {
     expect(drift).toEqual([]);
   });
 });
+
+// An exact npm version: `8.21.3`, or a prerelease like `node-pty@1.2.0-beta.15`.
+// Anything else — `^16.0.0`, `~1.17.1`, `>=5`, `*`, a git/file/npm-alias specifier —
+// lets a fresh install resolve somewhere nobody reviewed.
+const EXACT_VERSION = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/;
+
+const readDirectDeps = (rel) => {
+  const pkg = JSON.parse(readFileSync(join(REPO_ROOT, rel), 'utf8'));
+  return ['dependencies', 'devDependencies'].flatMap((block) =>
+    Object.entries(pkg[block] ?? {}).map(([name, range]) => ({ block, name, range }))
+  );
+};
+
+// The `overrides` blocks have always required an exact pin (see the comment on
+// MINIMUM_SAFE above: a range "lets npm resolve anywhere in the range on a fresh
+// install, which defeats the point of pinning"). The same argument applies to the
+// packages this repo depends on DIRECTLY, and until #5699 nothing enforced it —
+// six server dependencies had drifted to caret ranges. Any tree re-resolution
+// (`npm run setup`'s `npm install --no-save --prefix server`, a Dependabot bump to
+// a sibling, `scripts/ensure-deps.js`'s clean reinstall) would float them to a
+// newer release no human reviewed. Upgrades arrive as reviewable PRs instead.
+describe('direct dependency pinning (#5699)', () => {
+  it.each(MANIFESTS)('%s: pins every direct dependency to an exact version', (rel) => {
+    const ranged = readDirectDeps(rel)
+      .filter(({ range }) => !EXACT_VERSION.test(range))
+      .map(({ block, name, range }) => `${block}.${name}=${range}`);
+
+    expect(
+      ranged,
+      `${rel}: direct dependencies must be exact versions, not ranges (see docs/DEPS.md "Direct Dependency Pinning"): ${ranged.join(', ')}`
+    ).toEqual([]);
+  });
+
+  it('scans every manifest, so a clean result is not vacuous', () => {
+    const scanned = MANIFESTS.flatMap(readDirectDeps);
+    // ~49 entries across the four manifests today. A path or shape change that
+    // makes the loop iterate nothing would otherwise report a clean sweep.
+    expect(scanned.length).toBeGreaterThanOrEqual(40);
+    // And the matcher must actually reject the shapes this guard exists to catch,
+    // so a regex that accidentally accepts everything fails here rather than
+    // passing every manifest.
+    for (const range of ['^16.0.0', '~1.17.1', '>=8.10.0', '8.x', '*', 'latest']) {
+      expect(EXACT_VERSION.test(range), `${range} should not read as an exact pin`).toBe(false);
+    }
+    expect(EXACT_VERSION.test('1.2.0-beta.15')).toBe(true);
+  });
+});

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -9,12 +9,12 @@
       "version": "1.7.1",
       "dependencies": {
         "@cantoo/pdf-lib": "2.9.1",
-        "@googleapis/calendar": "^16.0.0",
-        "@googleapis/gmail": "^18.0.0",
+        "@googleapis/calendar": "16.0.0",
+        "@googleapis/gmail": "18.0.0",
         "@novnc/novnc": "1.7.0",
         "chokidar": "5.0.0",
         "express": "5.2.1",
-        "google-auth-library": "^11.0.2",
+        "google-auth-library": "11.0.2",
         "kokoro-js": "1.2.1",
         "node-pty": "1.2.0-beta.15",
         "pg": "8.23.0",
@@ -23,9 +23,9 @@
         "sharp": "0.35.4",
         "socket.io": "4.8.3",
         "socket.io-client": "4.8.3",
-        "undici": "^8.10.0",
+        "undici": "8.10.0",
         "ws": "8.21.3",
-        "zod": "^4.5.4"
+        "zod": "4.5.4"
       },
       "devDependencies": {
         "@vitest/coverage-v8": "4.1.11",

--- a/server/package.json
+++ b/server/package.json
@@ -22,12 +22,12 @@
   },
   "dependencies": {
     "@cantoo/pdf-lib": "2.9.1",
-    "@googleapis/calendar": "^16.0.0",
-    "@googleapis/gmail": "^18.0.0",
+    "@googleapis/calendar": "16.0.0",
+    "@googleapis/gmail": "18.0.0",
     "@novnc/novnc": "1.7.0",
     "chokidar": "5.0.0",
     "express": "5.2.1",
-    "google-auth-library": "^11.0.2",
+    "google-auth-library": "11.0.2",
     "kokoro-js": "1.2.1",
     "node-pty": "1.2.0-beta.15",
     "pg": "8.23.0",
@@ -36,9 +36,9 @@
     "sharp": "0.35.4",
     "socket.io": "4.8.3",
     "socket.io-client": "4.8.3",
-    "undici": "^8.10.0",
+    "undici": "8.10.0",
     "ws": "8.21.3",
-    "zod": "^4.5.4"
+    "zod": "4.5.4"
   },
   "devDependencies": {
     "@vitest/coverage-v8": "4.1.11",


### PR DESCRIPTION
## Summary

Five of the server's direct dependencies still used caret ranges while every other direct dependency in the root, client, and autofixer manifests was an exact version. Any tree re-resolution — `npm run setup`'s `npm install --no-save --prefix server`, a Dependabot bump to a sibling package, `scripts/ensure-deps.js`'s clean-reinstall path — could float them to a release nobody reviewed. That is the same argument the `overrides` blocks have always made for exact pins, applied to the packages this repo depends on directly.

- `server/package.json` — `@googleapis/calendar`, `@googleapis/gmail`, `google-auth-library`, `undici`, and `zod` pinned to the versions the lockfile already resolves (16.0.0, 18.0.0, 11.0.2, 8.10.0, 4.5.4). **No dependency is upgraded**: `undici` 8.10.1 and any newer `zod` stay separate reviewable bumps.
- `server/package-lock.json` regenerated with `npm install --package-lock-only`. The diff is confined to the manifest-mirror block at the top — no resolution moved, so the installed tree is byte-identical.
- `server/dependency-overrides.test.js` — new `direct dependency pinning` block asserts every `dependencies`/`devDependencies` value in all four manifests is an exact version, so a new dependency added with a caret fails the suite instead of shipping.
- `docs/DEPS.md` — documents the convention alongside the existing override-pin rules.

The issue also listed `pdf-lib`; that entry was replaced by the exact-pinned `@cantoo/pdf-lib@2.9.1` on `main` before this branch, so five ranges remained rather than six.

## Test plan

- `cd server && npx vitest run dependency-overrides.test.js` — 10 passed.
- Bypass probe: temporarily reverting `zod` to `^4.5.4` fails the new assertion with the offending entry named; restored before commit.
- `cd server && npx vitest run ../scripts/trusted-rebuilds.test.js ../scripts/run-ci-lint.test.js ../scripts/root-runtime-deps.test.js ../scripts/node-version-drift.test.js ../scripts/checkNpmVersion.test.js services/updateChecker.test.js services/installState.test.js` — all green.
- Resolution no-op verified by reading the regenerated lockfile: all five packages resolve to the same versions as before.
- `cd server && npm audit` — 4 moderate, identical to the same command on `main` (pre-existing, untouched by this change).

Closes #5699
