### PR TITLE
test: make three QuotaBurn negative assertions outlive the timers they disprove

### DIFF
--- a/client/src/pages/QuotaBurn.jsx
+++ b/client/src/pages/QuotaBurn.jsx
@@ -35,7 +35,7 @@ export const SAVE_DEBOUNCE_MS = 500;
 
 // How often to re-ask while a family's quota scrape is still running. A scrape
 // is a 10-20s PTY spawn, so this is a handful of polls, not a busy loop.
-const PENDING_POLL_MS = 4000;
+export const PENDING_POLL_MS = 4000;
 
 const EMPTY_CATALOG = { jobTypes: [], apps: [], universes: [], imageModes: [], providers: [] };
 

--- a/client/src/pages/QuotaBurn.test.jsx
+++ b/client/src/pages/QuotaBurn.test.jsx
@@ -2,8 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Route, Routes } from 'react-router';
-import QuotaBurn, { SAVE_DEBOUNCE_MS } from './QuotaBurn';
-import { sleep } from '../utils/sleep';
+import QuotaBurn, { PENDING_POLL_MS, SAVE_DEBOUNCE_MS } from './QuotaBurn';
 
 vi.mock('../services/api', () => ({
   getQuotaBurn: vi.fn(),
@@ -88,6 +87,10 @@ const renderPage = (path = '/devtools/quota-burn') => render(
 
 const setupSaveUser = () => userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
 const flushSave = () => act(async () => { await vi.advanceTimersByTimeAsync(SAVE_DEBOUNCE_MS); });
+// Past the debounce/poll window rather than up to its edge, so a "did not
+// happen" assertion runs AFTER the moment the thing would have happened.
+const pastSaveWindow = () => act(async () => { await vi.advanceTimersByTimeAsync(SAVE_DEBOUNCE_MS + 100); });
+const pastPollWindow = () => act(async () => { await vi.advanceTimersByTimeAsync(PENDING_POLL_MS + 100); });
 
 // Mirrors UNSAVED_PATCH_KEY in the page — the session-scoped stash holding a
 // patch the server never accepted.
@@ -127,12 +130,14 @@ describe('QuotaBurn page', () => {
       expect(await screen.findByText(/reading quota…/)).toBeInTheDocument();
       expect(screen.getByLabelText(/Run the quota-burn loop automatically/)).toBeInTheDocument();
 
-      await act(async () => {
-        await vi.advanceTimersByTimeAsync(4000);
-      });
+      await pastPollWindow();
 
       expect(await screen.findByText(/62% left/)).toBeInTheDocument();
       expect(screen.queryByText(/reading quota…/)).not.toBeInTheDocument();
+      // Positive control for 'does NOT poll when nothing is pending': the poll
+      // DOES fire inside this window, so that test's silence means the guard
+      // held rather than that the window was too short to observe anything.
+      expect(api.getQuotaBurn).toHaveBeenCalledTimes(2);
     } finally {
       vi.useRealTimers();
     }
@@ -190,10 +195,14 @@ describe('QuotaBurn page', () => {
   });
 
   it('does NOT poll when nothing is pending', async () => {
+    // Past a full poll interval, not the 100ms of wall clock this used to
+    // wait: a re-arming timer first fires at PENDING_POLL_MS, so a shorter
+    // window passed whether or not `enabled: anyPending` was there at all.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
     renderPage();
     await screen.findByText(/62% left/);
     // One load on mount, and no timer re-arming behind it.
-    await sleep(100);
+    await pastPollWindow();
     expect(api.getQuotaBurn).toHaveBeenCalledTimes(1);
   });
 
@@ -670,20 +679,26 @@ describe('QuotaBurn save races', () => {
   it('ignores a stash that is not a patch object', async () => {
     // A hand-edited or older-build entry must not be replayed — the PUT body is
     // an object, and anything else 400s the save the restore should rescue.
+    // Past the save debounce: a replayed stash PUTs at SAVE_DEBOUNCE_MS, so
+    // the 100ms of wall clock this used to wait passed with the shape guard
+    // deleted. 'restores a stashed patch on the next visit' is the positive
+    // control that a well-formed stash DOES save inside this same window.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
     globalThis.sessionStorage.setItem(STASH_KEY, '"not-a-patch"');
     renderPage();
 
     expect(await screen.findByText(/62% left/)).toBeInTheDocument();
-    await sleep(100);
+    await pastSaveWindow();
     expect(api.saveQuotaBurn).not.toHaveBeenCalled();
   });
 
   it('ignores an empty stash rather than announcing a restore of nothing', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
     globalThis.sessionStorage.setItem(STASH_KEY, '{}');
     renderPage();
 
     expect(await screen.findByText(/62% left/)).toBeInTheDocument();
-    await sleep(100);
+    await pastSaveWindow();
     expect(api.saveQuotaBurn).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Summary

Three QuotaBurn tests proved "X did not happen" by sleeping 100ms of real wall clock and then asserting a mock was never called — but both things they guard fire *later* than that. The pending-quota poll first ticks at `PENDING_POLL_MS` (4000ms), and a replayed stash PUTs at `SAVE_DEBOUNCE_MS` (500ms). All three passed against the broken implementation they name, so they were a green light over an unguarded path that also cost ~300ms of real time per run.

- All three now run on `vi.useFakeTimers({ shouldAdvanceTime: true })` and advance past the real window inside `act()`.
- `PENDING_POLL_MS` is exported from `QuotaBurn.jsx` (next to the already-exported `SAVE_DEBOUNCE_MS`) so the tests advance past the real interval instead of a copied literal that can drift. The existing pending-poll test's hardcoded `4000` now reads the same constant.
- The last `await sleep(...)` is gone from the file; the import went with it. The `sleep` util itself still has other callers and is untouched.
- **Positive controls:** the two the plan called for already existed in the file — `renders immediately while a family's quota is still being read, then polls it in` and `restores a stashed patch on the next visit and re-saves it`. Rather than add duplicates of the same product outcome (root `AGENTS.md`, "Value Over Assertion Count"), the poll one now also pins `getQuotaBurn` to 2 calls, making it an explicit control that the advanced window is long enough to observe the call at all.
- The plan suggested a nested `describe` with a shared `beforeEach`; the three tests live in two different describes and the file's established pattern is a per-test inline `vi.useFakeTimers(...)` under a top-level `afterEach(() => vi.useRealTimers())`. Kept the file's pattern instead of relocating tests.

## Test plan

- `cd client && npm test -- src/pages/QuotaBurn.test.jsx` — 55 passed, no `act()` warnings.
- Mutation probes confirming each negative now fails against the implementation it names:
  - Drop `enabled: anyPending` from the `useAutoRefetch` call → `does NOT poll when nothing is pending` fails (1 failed / 54 passed).
  - Swap the `readStashedPatch()` shape guard for a raw session read → `ignores a stash that is not a patch object` and `ignores an empty stash rather than announcing a restore of nothing` both fail (2 failed / 53 passed).
  - Both probes reverted; the branch contains neither.
- `npx eslint src/pages/QuotaBurn.jsx src/pages/QuotaBurn.test.jsx` — clean.

Closes #5696
