### PR TITLE
feat(video-gen): render FastH3 from FastVideo's own checkpoint by converting its DiT locally

### DIFF
--- a/data.reference/media-models.json
+++ b/data.reference/media-models.json
@@ -677,6 +677,255 @@
         }
       },
       {
+        "id": "fasth3_dense_datafree_int8",
+        "name": "FastH3 Preview v1 Dense Data-Free — MLX INT8 (highest fidelity) (video + audio, ~144 GB download, 48+ GB RAM, 4-step)",
+        "repo": "FastVideo/FastVideo-FastH3-4-step-Preview-v1-Dense-DataFree",
+        "revision": "f624f08c6c279ab43534c003e556fc5b295b6558",
+        "runtime": "fastvideo",
+        "fastvideoFamily": "fasth3",
+        "fastvideoMlxFormat": "int8",
+        "supportedModes": [
+          "text"
+        ],
+        "defaultWidth": 832,
+        "defaultHeight": 480,
+        "defaultFrames": 124,
+        "frameOptions": [
+          107,
+          124,
+          141,
+          158,
+          175,
+          192,
+          209,
+          226,
+          243,
+          260,
+          277,
+          294,
+          311,
+          328,
+          345,
+          362
+        ],
+        "fpsOptions": [
+          24
+        ],
+        "resolutionStep": 32,
+        "resolutionOptions": [
+          {
+            "label": "832x480 (16:9 FastH3 default)",
+            "w": 832,
+            "h": 480
+          },
+          {
+            "label": "1280x720 (16:9 HD)",
+            "w": 1280,
+            "h": 720
+          }
+        ],
+        "memoryGb": 48,
+        "steps": 4,
+        "guidance": 1,
+        "samplerLocked": true,
+        "samplerNote": "FastH3 Preview v1 is a 4-step DMD2 model. This is FastVideo's own dense-attention checkpoint — it does not support VSA, whose routing weights the MLX runtime drops. The first render converts its transformer to an MLX INT8 DiT (a few minutes, once), after which the 66 GB bf16 transformer can be deleted. Renders video with audio at a fixed 24 fps.",
+        "supportsNegativePrompt": false,
+        "supportsTiling": false,
+        "supportsDisableAudio": false,
+        "disclosure": {
+          "modelCardUrl": "https://huggingface.co/FastVideo/FastVideo-FastH3-4-step-Preview-v1-Dense-DataFree",
+          "weightsLicense": {
+            "name": "MiniMax H3 Community License",
+            "url": "https://huggingface.co/MiniMaxAI/MiniMax-H3/blob/6818f6c32d12b210915e44ad56a4228c2608f160/LICENSE"
+          },
+          "runtimeLicense": {
+            "name": "Apache-2.0",
+            "url": "https://github.com/hao-ai-lab/FastVideo/blob/main/LICENSE"
+          },
+          "estimatedDownloadGb": 144,
+          "reviewedAt": "2026-09-02"
+        },
+        "termsGate": {
+          "id": "minimax-h3-community-license-2026-08-02",
+          "title": "MiniMax H3 eligibility and terms",
+          "summary": "MiniMax grants use only in its Applicable Territory. The license excludes the European Union, United Kingdom, Republic of Korea, and United States of America.",
+          "acknowledgement": "I confirm I am in the Applicable Territory and agree to the MiniMax H3 Community License and its Acceptable Use Policy.",
+          "licenseUrl": "https://huggingface.co/MiniMaxAI/MiniMax-H3/blob/6818f6c32d12b210915e44ad56a4228c2608f160/LICENSE",
+          "excludedTerritories": [
+            "European Union",
+            "United Kingdom",
+            "Republic of Korea",
+            "United States of America"
+          ]
+        }
+      },
+      {
+        "id": "fasth3_dense_datafree_int6",
+        "name": "FastH3 Preview v1 Dense Data-Free — MLX INT6 (upstream default) (video + audio, ~144 GB download, 42+ GB RAM, 4-step)",
+        "repo": "FastVideo/FastVideo-FastH3-4-step-Preview-v1-Dense-DataFree",
+        "revision": "f624f08c6c279ab43534c003e556fc5b295b6558",
+        "runtime": "fastvideo",
+        "fastvideoFamily": "fasth3",
+        "fastvideoMlxFormat": "int6",
+        "supportedModes": [
+          "text"
+        ],
+        "defaultWidth": 832,
+        "defaultHeight": 480,
+        "defaultFrames": 124,
+        "frameOptions": [
+          107,
+          124,
+          141,
+          158,
+          175,
+          192,
+          209,
+          226,
+          243,
+          260,
+          277,
+          294,
+          311,
+          328,
+          345,
+          362
+        ],
+        "fpsOptions": [
+          24
+        ],
+        "resolutionStep": 32,
+        "resolutionOptions": [
+          {
+            "label": "832x480 (16:9 FastH3 default)",
+            "w": 832,
+            "h": 480
+          },
+          {
+            "label": "1280x720 (16:9 HD)",
+            "w": 1280,
+            "h": 720
+          }
+        ],
+        "memoryGb": 42,
+        "steps": 4,
+        "guidance": 1,
+        "samplerLocked": true,
+        "samplerNote": "FastH3 Preview v1 is a 4-step DMD2 model. This is FastVideo's own dense-attention checkpoint — it does not support VSA, whose routing weights the MLX runtime drops. The first render converts its transformer to an MLX INT6 DiT (a few minutes, once), after which the 66 GB bf16 transformer can be deleted. Renders video with audio at a fixed 24 fps.",
+        "supportsNegativePrompt": false,
+        "supportsTiling": false,
+        "supportsDisableAudio": false,
+        "disclosure": {
+          "modelCardUrl": "https://huggingface.co/FastVideo/FastVideo-FastH3-4-step-Preview-v1-Dense-DataFree",
+          "weightsLicense": {
+            "name": "MiniMax H3 Community License",
+            "url": "https://huggingface.co/MiniMaxAI/MiniMax-H3/blob/6818f6c32d12b210915e44ad56a4228c2608f160/LICENSE"
+          },
+          "runtimeLicense": {
+            "name": "Apache-2.0",
+            "url": "https://github.com/hao-ai-lab/FastVideo/blob/main/LICENSE"
+          },
+          "estimatedDownloadGb": 144,
+          "reviewedAt": "2026-09-02"
+        },
+        "termsGate": {
+          "id": "minimax-h3-community-license-2026-08-02",
+          "title": "MiniMax H3 eligibility and terms",
+          "summary": "MiniMax grants use only in its Applicable Territory. The license excludes the European Union, United Kingdom, Republic of Korea, and United States of America.",
+          "acknowledgement": "I confirm I am in the Applicable Territory and agree to the MiniMax H3 Community License and its Acceptable Use Policy.",
+          "licenseUrl": "https://huggingface.co/MiniMaxAI/MiniMax-H3/blob/6818f6c32d12b210915e44ad56a4228c2608f160/LICENSE",
+          "excludedTerritories": [
+            "European Union",
+            "United Kingdom",
+            "Republic of Korea",
+            "United States of America"
+          ]
+        }
+      },
+      {
+        "id": "fasth3_dense_datafree_int4",
+        "name": "FastH3 Preview v1 Dense Data-Free — MLX INT4 (smallest) (video + audio, ~144 GB download, 36+ GB RAM, 4-step)",
+        "repo": "FastVideo/FastVideo-FastH3-4-step-Preview-v1-Dense-DataFree",
+        "revision": "f624f08c6c279ab43534c003e556fc5b295b6558",
+        "runtime": "fastvideo",
+        "fastvideoFamily": "fasth3",
+        "fastvideoMlxFormat": "int4",
+        "supportedModes": [
+          "text"
+        ],
+        "defaultWidth": 832,
+        "defaultHeight": 480,
+        "defaultFrames": 124,
+        "frameOptions": [
+          107,
+          124,
+          141,
+          158,
+          175,
+          192,
+          209,
+          226,
+          243,
+          260,
+          277,
+          294,
+          311,
+          328,
+          345,
+          362
+        ],
+        "fpsOptions": [
+          24
+        ],
+        "resolutionStep": 32,
+        "resolutionOptions": [
+          {
+            "label": "832x480 (16:9 FastH3 default)",
+            "w": 832,
+            "h": 480
+          },
+          {
+            "label": "1280x720 (16:9 HD)",
+            "w": 1280,
+            "h": 720
+          }
+        ],
+        "memoryGb": 36,
+        "steps": 4,
+        "guidance": 1,
+        "samplerLocked": true,
+        "samplerNote": "FastH3 Preview v1 is a 4-step DMD2 model. This is FastVideo's own dense-attention checkpoint — it does not support VSA, whose routing weights the MLX runtime drops. The first render converts its transformer to an MLX INT4 DiT (a few minutes, once), after which the 66 GB bf16 transformer can be deleted. Renders video with audio at a fixed 24 fps.",
+        "supportsNegativePrompt": false,
+        "supportsTiling": false,
+        "supportsDisableAudio": false,
+        "disclosure": {
+          "modelCardUrl": "https://huggingface.co/FastVideo/FastVideo-FastH3-4-step-Preview-v1-Dense-DataFree",
+          "weightsLicense": {
+            "name": "MiniMax H3 Community License",
+            "url": "https://huggingface.co/MiniMaxAI/MiniMax-H3/blob/6818f6c32d12b210915e44ad56a4228c2608f160/LICENSE"
+          },
+          "runtimeLicense": {
+            "name": "Apache-2.0",
+            "url": "https://github.com/hao-ai-lab/FastVideo/blob/main/LICENSE"
+          },
+          "estimatedDownloadGb": 144,
+          "reviewedAt": "2026-09-02"
+        },
+        "termsGate": {
+          "id": "minimax-h3-community-license-2026-08-02",
+          "title": "MiniMax H3 eligibility and terms",
+          "summary": "MiniMax grants use only in its Applicable Territory. The license excludes the European Union, United Kingdom, Republic of Korea, and United States of America.",
+          "acknowledgement": "I confirm I am in the Applicable Territory and agree to the MiniMax H3 Community License and its Acceptable Use Policy.",
+          "licenseUrl": "https://huggingface.co/MiniMaxAI/MiniMax-H3/blob/6818f6c32d12b210915e44ad56a4228c2608f160/LICENSE",
+          "excludedTerritories": [
+            "European Union",
+            "United Kingdom",
+            "Republic of Korea",
+            "United States of America"
+          ]
+        }
+      },
+      {
         "id": "fasth3_dense_datafree_mlx_int4",
         "name": "FastH3 Preview v1 Dense Data-Free MLX INT4 (video + audio, ~89 GB download, 36+ GB RAM, 4-step)",
         "repo": "MrMofer/FastVideo-FastH3-4-step-Preview-v1-Dense-DataFree-MLX-INT4",

--- a/data.reference/media-models.json
+++ b/data.reference/media-models.json
@@ -691,7 +691,6 @@
         "defaultHeight": 480,
         "defaultFrames": 124,
         "frameOptions": [
-          107,
           124,
           141,
           158,
@@ -705,8 +704,7 @@
           294,
           311,
           328,
-          345,
-          362
+          345
         ],
         "fpsOptions": [
           24
@@ -774,7 +772,6 @@
         "defaultHeight": 480,
         "defaultFrames": 124,
         "frameOptions": [
-          107,
           124,
           141,
           158,
@@ -788,8 +785,7 @@
           294,
           311,
           328,
-          345,
-          362
+          345
         ],
         "fpsOptions": [
           24
@@ -857,7 +853,6 @@
         "defaultHeight": 480,
         "defaultFrames": 124,
         "frameOptions": [
-          107,
           124,
           141,
           158,
@@ -871,8 +866,7 @@
           294,
           311,
           328,
-          345,
-          362
+          345
         ],
         "fpsOptions": [
           24
@@ -939,7 +933,6 @@
         "defaultHeight": 480,
         "defaultFrames": 124,
         "frameOptions": [
-          107,
           124,
           141,
           158,
@@ -953,8 +946,7 @@
           294,
           311,
           328,
-          345,
-          362
+          345
         ],
         "fpsOptions": [
           24

--- a/docs/research/2026-08-28-fasth3-vsa-datafree.md
+++ b/docs/research/2026-08-28-fasth3-vsa-datafree.md
@@ -89,4 +89,15 @@ is**: the bf16 snapshot is 144 GB and the converted DiT another 11–22 GB.
 Conditioning was half the wall clock and recomputes identical embeddings every
 run, so PortOS now passes `--prompt-cache-dir`; upstream digests each entry over
 its cache version, the model root and the prompt, so one shared directory is
-safe across models.
+safe across models. Re-running the same prompt on a warm cache took conditioning
+from **307.0s to 0.003s** (621s to 336s end to end) and produced a **byte-identical
+MP4** — so the saving costs nothing in output.
+
+The conversion path was verified against the upstream snapshot directly: its
+bf16 `transformer/` converted to an MLX INT6 DiT in **21.9s**, peak 19.4 GiB,
+1464 arrays — the tensor count the repack's own conversion manifest records —
+and rendered from that checkpoint. Denoise peaks at 19.6 GiB on INT6 against
+14.9 GiB on INT4.
+
+Renders are deterministic at a fixed seed: two runs at seed 2026 produced
+byte-identical files.

--- a/docs/research/2026-08-28-fasth3-vsa-datafree.md
+++ b/docs/research/2026-08-28-fasth3-vsa-datafree.md
@@ -47,3 +47,46 @@ the CUDA kernel through MPS.
 - [FastVideo VSA backend documentation](https://github.com/hao-ai-lab/FastVideo/tree/main/docs/attention/vsa)
 
 Issue: [#5351](https://github.com/atomantic/PortOS/issues/5351)
+
+## Addendum, 2026-09-02: the weights are there; the runtime is still dense
+
+The VSA-DataFree repo does publish full weights — the DiT is under
+`transformer/`, in the diffusers shard layout, beside the `vae/`, `audio_vae/`,
+`text_encoder/` and `tokenizer/` the pipeline loads. An earlier read that looked
+for a top-level checkpoint file found none and concluded the repo was a stub.
+That conclusion was wrong about the weights, and it does not change the verdict:
+FastVideo's MLX H3 runtime is dense-only, and its converter *drops* the VSA
+routing projections by name — `_IGNORED_DENSE_KEY_PARTS = ("attn.to_gate_compress",)`
+in `fastvideo/mlx_runtime/minimax_h3.py`, on the stated grounds that "the MLX
+path is dense, so retaining these weights wastes about 3.6 GiB without affecting
+a single output value." Converting the VSA student would therefore load it with
+the mechanism it was distilled around deleted. VSA-DataFree stays a CUDA target.
+
+**Dense-DataFree is the Apple Silicon checkpoint.**
+`FastVideo/FastVideo-FastH3-4-step-Preview-v1-Dense-DataFree` @ `f624f08c` is the
+one FastVideo's own MPS guide converts, and PortOS now ships it at all three MLX
+DiT formats. FastVideo's three pre-converted MLX repos (`…-MLX-INT4/INT6/INT8`)
+are still weightless as of this date — `usedStorage: 0`, five small files each —
+so the local conversion is not an optimization, it is the only path to them.
+
+### Measured on an M5 Max, 128 GB
+
+832x480, 124 frames, 4 steps, INT4 DiT, full H3 VAE, dense attention:
+
+| phase | seconds | peak GiB |
+| --- | --- | --- |
+| conditioning (streamed bf16 Qwen3-VL) | 307.0 | 1.8 |
+| denoise (4 steps) | 229.3 | 14.9 |
+| video decode (tiled) | 83.0 | 11.2 |
+| audio decode | 2.8 | 2.4 |
+| mux | 1.5 | — |
+
+Output: 5.17 s of 832x480 H.264 at 24 fps with synchronized 32 kHz stereo AAC,
+subjectively coherent across the clip. Peak memory is ~15 GiB — the published
+36 GB floor is conservative, and 128 GB is not the binding constraint. **Disk
+is**: the bf16 snapshot is 144 GB and the converted DiT another 11–22 GB.
+
+Conditioning was half the wall clock and recomputes identical embeddings every
+run, so PortOS now passes `--prompt-cache-dir`; upstream digests each entry over
+its cache version, the model root and the prompt, so one shared directory is
+safe across models.

--- a/scripts/generate_fastvideo.py
+++ b/scripts/generate_fastvideo.py
@@ -19,6 +19,7 @@ entry script rejects instead of silently rendering through the wrong pipeline.
 """
 
 import argparse
+import hashlib
 import os
 import re
 import subprocess
@@ -136,6 +137,10 @@ def parse_args() -> argparse.Namespace:
                    help="Which FastVideo entry script and argv shape to use")
     p.add_argument("--model-root", required=True, help="HF model snapshot path")
     p.add_argument("--mlx-checkpoint", default=None, help="MLX checkpoint path (defaults to model-root)")
+    p.add_argument("--mlx-format", choices=MLX_DIT_FORMATS, default=None,
+                   help="convert this snapshot's transformer/ to an MLX DiT of this format on first use")
+    p.add_argument("--prompt-cache-dir", default=None,
+                   help="reusable FastH3 prompt-embedding cache (default: a shared dir under the repo)")
     p.add_argument("--prompt", required=True)
     p.add_argument("--negative-prompt", default="")
     p.add_argument("--width", type=int, required=True)
@@ -184,6 +189,107 @@ def find_entry_script(repo_dir: Path, family: str = "fastmetal") -> Path:
     if found:
         return found[0]
     raise FileNotFoundError(f"Could not find {glob_name} under {repo_dir}")
+
+
+# FastVideo publishes FastH3 as a bf16 diffusers snapshot: the DiT lives under
+# `transformer/` beside the vae / audio_vae / text_encoder / tokenizer the
+# pipeline loads. mlx_fasth3.py does not read that DiT -- it wants a
+# pre-quantized `mlx_h3_dit` directory. `--mlx-format` bridges the two by
+# running FastVideo's own converter once, so a row can point at the upstream
+# checkpoint instead of depending on a third party having published a repack.
+MLX_DIT_FORMATS = ("int8", "int6", "int4")
+_CONVERTER_SCRIPT = ("scripts", "checkpoint_conversion", "convert_minimax_h3_mlx.py")
+_MLX_CHECKPOINT_FILES = ("mlx_h3_dit.safetensors", "mlx_h3_dit.json")
+
+
+def mlx_checkpoint_root(model_root: Path) -> Path:
+    """Where DiTs converted from `model_root` are cached.
+
+    Keyed by the SNAPSHOT, not by the repo id -- an HF cache path ends in the
+    commit sha, so two revisions of one repo cannot collide on a converted
+    checkpoint. Kept outside the HF cache because `hf` prunes by blob and has no
+    idea these files belong to that snapshot.
+    """
+    parts = [part for part in (model_root.parent.parent.name, model_root.name) if part]
+    label = re.sub(r"[^A-Za-z0-9._-]+", "-", "-".join(parts)).strip("-") or "snapshot"
+    # The readable half is for whoever reads the directory listing; the digest is
+    # what carries identity. A --model-root outside the HF cache can share both
+    # its own name and its grandparent's with an unrelated snapshot, and two
+    # snapshots resolving to ONE converted DiT would render the wrong weights
+    # without any error to notice.
+    digest = hashlib.sha256(str(model_root).encode("utf-8")).hexdigest()[:12]
+    return Path.home() / ".portos" / "fastvideo" / "mlx-checkpoints" / f"{label}-{digest}"
+
+
+def is_converted(checkpoint_dir: Path) -> bool:
+    return all((checkpoint_dir / name).is_file() for name in _MLX_CHECKPOINT_FILES)
+
+
+def ensure_mlx_checkpoint(repo_dir: Path, model_root: Path, fmt: str, env: dict) -> Path:
+    """Return the converted MLX DiT for `fmt`, converting it if it is missing."""
+    out_base = mlx_checkpoint_root(model_root)
+    out_dir = out_base / fmt
+    if is_converted(out_dir):
+        return out_dir
+    transformer = model_root / "transformer"
+    if not transformer.is_dir():
+        raise FileNotFoundError(
+            f"{model_root} has no transformer/ to convert to MLX {fmt}. Download the "
+            f"full FastH3 snapshot, or point --mlx-checkpoint at a converted DiT.")
+    converter = repo_dir.joinpath(*_CONVERTER_SCRIPT)
+    if not converter.is_file():
+        raise FileNotFoundError(f"Could not find {converter}")
+    print(f"STATUS:converting the FastH3 DiT to MLX {fmt} — one time, into {out_dir}",
+          file=sys.stderr, flush=True)
+    out_base.mkdir(parents=True, exist_ok=True)
+    proc = subprocess.Popen(
+        [sys.executable, str(converter),
+         "--model-root", str(transformer),
+         "--out", str(out_base),
+         "--formats", fmt],
+        stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True,
+        env=env, cwd=str(repo_dir),
+    )
+    assert proc.stdout is not None
+    for raw in proc.stdout:
+        line = raw.rstrip()
+        if line:
+            print(f"STATUS:{line}", file=sys.stderr, flush=True)
+    code = proc.wait()
+    if code != 0:
+        raise RuntimeError(f"FastH3 MLX conversion exited with code {code}")
+    if not is_converted(out_dir):
+        raise RuntimeError(f"FastH3 MLX conversion finished but {out_dir} is incomplete")
+    # The bf16 transformer is dead weight for rendering once this exists, but it
+    # is the user's download: name it, do not delete it.
+    print(f"STATUS:MLX {fmt} DiT ready — {transformer} is no longer needed to render and can be deleted",
+          file=sys.stderr, flush=True)
+    return out_dir
+
+
+def resolve_prompt_cache_dir(args) -> Path:
+    """Where FastH3 caches its conditioning embeddings.
+
+    Streaming the bf16 Qwen3-VL conditioner is HALF the wall clock of a 124-frame
+    render (307s of 621s measured on an M5 Max), and it produces the same
+    embeddings every time. Upstream digests the cache entry over its own cache
+    version, the model root AND the prompt, so one shared directory cannot serve
+    a stale entry across models or across a conditioner change.
+    """
+    if args.prompt_cache_dir:
+        return Path(args.prompt_cache_dir)
+    return Path.home() / ".portos" / "fastvideo" / "prompt-cache"
+
+
+def build_child_env(repo_dir: Path) -> dict:
+    """Environment shared by the conversion child and the inference child."""
+    env = os.environ.copy()
+    env["PYTHONPATH"] = f"{str(repo_dir)}:{env.get('PYTHONPATH', '')}".rstrip(":")
+    # Mirrors train_mflux_lora.py's M5 Metal-watchdog mitigation. Preserve an
+    # explicit caller override, but make the validated safe value the default
+    # for the sustained denoise child of either family.
+    env.setdefault("AGX_RELAX_CDM_CTXSTORE_TIMEOUT", "1")
+    return env
 
 
 # mlx_fasth3.py always muxes H.264 at 24 fps with 32 kHz stereo AAC and exposes
@@ -246,7 +352,8 @@ def build_command(args, entry_script: Path, model_root: Path, mlx_checkpoint: Pa
     if args.fps and args.fps != FASTH3_NATIVE_FPS:
         print(f"STATUS:FastH3 always writes {FASTH3_NATIVE_FPS} fps — ignoring the requested {args.fps} fps",
               file=sys.stderr, flush=True)
-    cmd = common + ["--steps", str(args.steps)] + tail
+    cmd = common + ["--steps", str(args.steps),
+                    "--prompt-cache-dir", str(resolve_prompt_cache_dir(args))] + tail
     if args.fast:
         cmd.append("--fast")
     return cmd
@@ -273,18 +380,26 @@ def main() -> int:
         return 1
 
     model_root = Path(args.model_root).resolve()
-    mlx_checkpoint = Path(args.mlx_checkpoint).resolve() if args.mlx_checkpoint else model_root
+    env = build_child_env(repo_dir)
+    # Precedence: an explicit path always wins, so a row that ships a
+    # pre-quantized DiT never triggers a conversion it does not need.
+    if args.mlx_checkpoint:
+        mlx_checkpoint = Path(args.mlx_checkpoint).resolve()
+    elif args.mlx_format:
+        try:
+            mlx_checkpoint = ensure_mlx_checkpoint(repo_dir, model_root, args.mlx_format, env)
+        except (FileNotFoundError, RuntimeError) as err:
+            print(f"❌ {err}", file=sys.stderr)
+            return 1
+    else:
+        mlx_checkpoint = model_root
 
     cmd = build_command(args, entry_script, model_root, mlx_checkpoint)
+    if args.family == "fasth3":
+        resolve_prompt_cache_dir(args).mkdir(parents=True, exist_ok=True)
 
     print(f"🎬 fastvideo {args.family} generate {args.width}x{args.height} frames={args.num_frames} steps={args.steps} seed={args.seed}", file=sys.stderr, flush=True)
 
-    env = os.environ.copy()
-    env["PYTHONPATH"] = f"{str(repo_dir)}:{env.get('PYTHONPATH', '')}".rstrip(":")
-    # Mirrors train_mflux_lora.py's M5 Metal-watchdog mitigation. Preserve an
-    # explicit caller override, but make the validated safe value the default
-    # for the sustained denoise child of either family.
-    env.setdefault("AGX_RELAX_CDM_CTXSTORE_TIMEOUT", "1")
     print(
         f"STATUS:watchdog mitigation · AGX_RELAX_CDM_CTXSTORE_TIMEOUT={env['AGX_RELAX_CDM_CTXSTORE_TIMEOUT']}",
         file=sys.stderr,

--- a/scripts/generate_fastvideo.py
+++ b/scripts/generate_fastvideo.py
@@ -139,8 +139,10 @@ def parse_args() -> argparse.Namespace:
     p.add_argument("--mlx-checkpoint", default=None, help="MLX checkpoint path (defaults to model-root)")
     p.add_argument("--mlx-format", choices=MLX_DIT_FORMATS, default=None,
                    help="convert this snapshot's transformer/ to an MLX DiT of this format on first use")
+    p.add_argument("--mlx-checkpoint-cache-dir", default=None,
+                   help="root for converted MLX DiTs (default: a shared dir under ~/.portos/fastvideo)")
     p.add_argument("--prompt-cache-dir", default=None,
-                   help="reusable FastH3 prompt-embedding cache (default: a shared dir under the repo)")
+                   help="reusable FastH3 prompt-embedding cache (default: a shared dir under ~/.portos/fastvideo)")
     p.add_argument("--prompt", required=True)
     p.add_argument("--negative-prompt", default="")
     p.add_argument("--width", type=int, required=True)
@@ -198,11 +200,16 @@ def find_entry_script(repo_dir: Path, family: str = "fastmetal") -> Path:
 # running FastVideo's own converter once, so a row can point at the upstream
 # checkpoint instead of depending on a third party having published a repack.
 MLX_DIT_FORMATS = ("int8", "int6", "int4")
+# PortOS declares both of these roots in server/services/videoGen/runtimes.js and
+# passes them as flags. These defaults exist only so the script runs standalone,
+# the same role --repo-dir's fallback plays.
+MLX_CHECKPOINT_CACHE = Path.home() / ".portos" / "fastvideo" / "mlx-checkpoints"
+PROMPT_CACHE = Path.home() / ".portos" / "fastvideo" / "prompt-cache"
 _CONVERTER_SCRIPT = ("scripts", "checkpoint_conversion", "convert_minimax_h3_mlx.py")
 _MLX_CHECKPOINT_FILES = ("mlx_h3_dit.safetensors", "mlx_h3_dit.json")
 
 
-def mlx_checkpoint_root(model_root: Path) -> Path:
+def mlx_checkpoint_root(model_root: Path, base: Path | None = None) -> Path:
     """Where DiTs converted from `model_root` are cached.
 
     Keyed by the SNAPSHOT, not by the repo id -- an HF cache path ends in the
@@ -218,16 +225,17 @@ def mlx_checkpoint_root(model_root: Path) -> Path:
     # snapshots resolving to ONE converted DiT would render the wrong weights
     # without any error to notice.
     digest = hashlib.sha256(str(model_root).encode("utf-8")).hexdigest()[:12]
-    return Path.home() / ".portos" / "fastvideo" / "mlx-checkpoints" / f"{label}-{digest}"
+    return (base or MLX_CHECKPOINT_CACHE) / f"{label}-{digest}"
 
 
 def is_converted(checkpoint_dir: Path) -> bool:
     return all((checkpoint_dir / name).is_file() for name in _MLX_CHECKPOINT_FILES)
 
 
-def ensure_mlx_checkpoint(repo_dir: Path, model_root: Path, fmt: str, env: dict) -> Path:
+def ensure_mlx_checkpoint(repo_dir: Path, model_root: Path, fmt: str, env: dict,
+                          base: Path | None = None) -> Path:
     """Return the converted MLX DiT for `fmt`, converting it if it is missing."""
-    out_base = mlx_checkpoint_root(model_root)
+    out_base = mlx_checkpoint_root(model_root, base)
     out_dir = out_base / fmt
     if is_converted(out_dir):
         return out_dir
@@ -242,20 +250,13 @@ def ensure_mlx_checkpoint(repo_dir: Path, model_root: Path, fmt: str, env: dict)
     print(f"STATUS:converting the FastH3 DiT to MLX {fmt} — one time, into {out_dir}",
           file=sys.stderr, flush=True)
     out_base.mkdir(parents=True, exist_ok=True)
-    proc = subprocess.Popen(
+    code = run_child(
         [sys.executable, str(converter),
          "--model-root", str(transformer),
          "--out", str(out_base),
          "--formats", fmt],
-        stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True,
-        env=env, cwd=str(repo_dir),
+        env, repo_dir, lambda line: f"STATUS:{line}",
     )
-    assert proc.stdout is not None
-    for raw in proc.stdout:
-        line = raw.rstrip()
-        if line:
-            print(f"STATUS:{line}", file=sys.stderr, flush=True)
-    code = proc.wait()
     if code != 0:
         raise RuntimeError(f"FastH3 MLX conversion exited with code {code}")
     if not is_converted(out_dir):
@@ -276,9 +277,26 @@ def resolve_prompt_cache_dir(args) -> Path:
     version, the model root AND the prompt, so one shared directory cannot serve
     a stale entry across models or across a conditioner change.
     """
-    if args.prompt_cache_dir:
-        return Path(args.prompt_cache_dir)
-    return Path.home() / ".portos" / "fastvideo" / "prompt-cache"
+    return Path(args.prompt_cache_dir) if args.prompt_cache_dir else PROMPT_CACHE
+
+
+def run_child(cmd: list, env: dict, cwd: Path, transform) -> int:
+    """Spawn a child, stream its merged output through `transform`, return its code.
+
+    Shared by the conversion child and the inference child so their stream
+    handling cannot drift: both fold stderr into stdout and re-emit line by
+    line on THIS process's stderr, which is the channel PortOS parses.
+    """
+    proc = subprocess.Popen(
+        cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True,
+        env=env, cwd=str(cwd),
+    )
+    assert proc.stdout is not None
+    for raw in proc.stdout:
+        line = raw.rstrip()
+        if line:
+            print(transform(line), file=sys.stderr, flush=True)
+    return proc.wait()
 
 
 def build_child_env(repo_dir: Path) -> dict:
@@ -387,7 +405,9 @@ def main() -> int:
         mlx_checkpoint = Path(args.mlx_checkpoint).resolve()
     elif args.mlx_format:
         try:
-            mlx_checkpoint = ensure_mlx_checkpoint(repo_dir, model_root, args.mlx_format, env)
+            mlx_checkpoint = ensure_mlx_checkpoint(
+                repo_dir, model_root, args.mlx_format, env,
+                Path(args.mlx_checkpoint_cache_dir) if args.mlx_checkpoint_cache_dir else None)
         except (FileNotFoundError, RuntimeError) as err:
             print(f"❌ {err}", file=sys.stderr)
             return 1
@@ -395,8 +415,11 @@ def main() -> int:
         mlx_checkpoint = model_root
 
     cmd = build_command(args, entry_script, model_root, mlx_checkpoint)
-    if args.family == "fasth3":
-        resolve_prompt_cache_dir(args).mkdir(parents=True, exist_ok=True)
+    # The child writes into this directory but will not create it. Keyed off the
+    # argv rather than a second family test, so it cannot disagree with the one
+    # branch in build_command that decides the flag is passed at all.
+    if "--prompt-cache-dir" in cmd:
+        Path(cmd[cmd.index("--prompt-cache-dir") + 1]).mkdir(parents=True, exist_ok=True)
 
     print(f"🎬 fastvideo {args.family} generate {args.width}x{args.height} frames={args.num_frames} steps={args.steps} seed={args.seed}", file=sys.stderr, flush=True)
 

--- a/scripts/generate_fastvideo.py
+++ b/scripts/generate_fastvideo.py
@@ -18,6 +18,8 @@ from the checkpoint, so a mis-tagged registry row fails on an argument the
 entry script rejects instead of silently rendering through the wrong pipeline.
 """
 
+from __future__ import annotations
+
 import argparse
 import hashlib
 import os
@@ -283,9 +285,11 @@ def resolve_prompt_cache_dir(args) -> Path:
 def run_child(cmd: list, env: dict, cwd: Path, transform) -> int:
     """Spawn a child, stream its merged output through `transform`, return its code.
 
-    Shared by the conversion child and the inference child so their stream
-    handling cannot drift: both fold stderr into stdout and re-emit line by
-    line on THIS process's stderr, which is the channel PortOS parses.
+    For the CONVERSION child only. The inference child in main() runs its own
+    loop because it also drives a heartbeat thread and a phase state machine,
+    and shares stderr with that thread — it needs one write per line, which
+    print() does not give. Conversion finishes before the heartbeat starts, so
+    there is no concurrent writer here.
     """
     proc = subprocess.Popen(
         cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True,

--- a/scripts/generate_fastvideo_test.py
+++ b/scripts/generate_fastvideo_test.py
@@ -10,7 +10,9 @@ from __future__ import annotations
 
 import importlib.util
 import io
+import shutil
 import sys
+import tempfile
 import unittest
 from contextlib import redirect_stderr
 from pathlib import Path
@@ -47,6 +49,7 @@ def make_args(**overrides):
         fast=False,
         enhance_prompt=False,
         refine=False,
+        prompt_cache_dir="/fixture/prompt-cache",
     )
     for key, value in overrides.items():
         setattr(args, key, value)
@@ -126,6 +129,22 @@ class BuildCommandTest(unittest.TestCase):
         _, quiet = self.build(family="fasth3", fps=self.helper.FASTH3_NATIVE_FPS)
         self.assertNotIn("fps", quiet)
 
+    def test_fasth3_reuses_conditioning_through_a_prompt_cache(self):
+        # Streaming the bf16 Qwen3-VL conditioner is half the wall clock of a
+        # 124-frame render, and it recomputes the same embeddings every time.
+        cmd, _ = self.build(family="fasth3")
+        self.assertEqual(self.flag(cmd, "--prompt-cache-dir"), "/fixture/prompt-cache")
+
+    def test_fasth3_falls_back_to_a_shared_cache_dir(self):
+        cmd, _ = self.build(family="fasth3", prompt_cache_dir=None)
+        self.assertTrue(self.flag(cmd, "--prompt-cache-dir").endswith("prompt-cache"))
+
+    def test_fastmetal_is_not_handed_a_prompt_cache_flag(self):
+        # mlx_wan_prompt_to_video.py has no such flag; passing it would turn
+        # every FastMetal render into an argparse error.
+        cmd, _ = self.build(family="fastmetal")
+        self.assertNotIn("--prompt-cache-dir", cmd)
+
     def test_fasth3_still_forwards_fast_mode(self):
         cmd, _ = self.build(family="fasth3", fast=True)
         self.assertIn("--fast", cmd)
@@ -162,6 +181,71 @@ class EntryScriptTest(unittest.TestCase):
             with self.assertRaises(FileNotFoundError) as ctx:
                 self.helper.find_entry_script(repo, "fasth3")
             self.assertIn("mlx_fasth3.py", str(ctx.exception))
+
+
+class MlxCheckpointTest(unittest.TestCase):
+    """The convert-on-first-use path for FastVideo's own bf16 FastH3 snapshot."""
+
+    def setUp(self):
+        self.helper = load_helper()
+
+    def test_the_cache_key_is_the_snapshot_not_the_repo(self):
+        # Two revisions of one repo must not collide on a converted DiT, so the
+        # key carries the commit sha an HF cache path ends in.
+        root = self.helper.mlx_checkpoint_root
+        older = root(Path("/hfcache/models--Org--Repo/snapshots/aaaa1111"))
+        newer = root(Path("/hfcache/models--Org--Repo/snapshots/bbbb2222"))
+        self.assertNotEqual(older, newer)
+        self.assertIn("models--Org--Repo", str(older))
+        self.assertIn("aaaa1111", str(older))
+        # Outside the HF cache: hf prunes by blob and would not know these
+        # converted files belong to that snapshot.
+        self.assertNotIn("/hfcache/models--Org--Repo", str(older))
+
+    def test_two_roots_sharing_a_readable_name_still_get_their_own_checkpoint(self):
+        # A hand-placed --model-root can share both its own name and its
+        # grandparent's with an unrelated snapshot. Collapsing those onto one
+        # converted DiT would render the wrong weights with nothing to notice.
+        first = self.helper.mlx_checkpoint_root(Path("/srv/a/models/snapshot"))
+        second = self.helper.mlx_checkpoint_root(Path("/srv/b/models/snapshot"))
+        self.assertNotEqual(first, second)
+        self.assertIn("snapshot", first.name)
+        # Stable across calls, so a second render reuses the first conversion.
+        self.assertEqual(first, self.helper.mlx_checkpoint_root(Path("/srv/a/models/snapshot")))
+
+    def test_a_directory_missing_either_file_is_not_converted(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp) / "int4"
+            out.mkdir()
+            self.assertFalse(self.helper.is_converted(out))
+            (out / "mlx_h3_dit.safetensors").write_text("")
+            self.assertFalse(self.helper.is_converted(out))
+            (out / "mlx_h3_dit.json").write_text("")
+            self.assertTrue(self.helper.is_converted(out))
+
+    def test_an_already_converted_format_is_reused_without_a_transformer(self):
+        # The steady state after the user deletes the 66 GB bf16 transformer:
+        # rendering must keep working off the converted DiT alone.
+        with tempfile.TemporaryDirectory() as tmp:
+            model_root = Path(tmp) / "models--Org--Repo" / "snapshots" / "abc123"
+            model_root.mkdir(parents=True)
+            out = self.helper.mlx_checkpoint_root(model_root) / "int6"
+            out.mkdir(parents=True)
+            for name in ("mlx_h3_dit.safetensors", "mlx_h3_dit.json"):
+                (out / name).write_text("")
+            try:
+                resolved = self.helper.ensure_mlx_checkpoint(Path(tmp), model_root, "int6", {})
+                self.assertEqual(resolved, out)
+            finally:
+                shutil.rmtree(self.helper.mlx_checkpoint_root(model_root), ignore_errors=True)
+
+    def test_a_snapshot_without_a_transformer_fails_loudly(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            model_root = Path(tmp) / "models--Org--Repo" / "snapshots" / "def456"
+            model_root.mkdir(parents=True)
+            with self.assertRaises(FileNotFoundError) as ctx:
+                self.helper.ensure_mlx_checkpoint(Path(tmp), model_root, "int4", {})
+            self.assertIn("transformer", str(ctx.exception))
 
 
 if __name__ == "__main__":

--- a/scripts/generate_fastvideo_test.py
+++ b/scripts/generate_fastvideo_test.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 import importlib.util
 import io
-import shutil
 import sys
 import tempfile
 import unittest
@@ -50,6 +49,7 @@ def make_args(**overrides):
         enhance_prompt=False,
         refine=False,
         prompt_cache_dir="/fixture/prompt-cache",
+        mlx_checkpoint_cache_dir=None,
     )
     for key, value in overrides.items():
         setattr(args, key, value)
@@ -227,24 +227,22 @@ class MlxCheckpointTest(unittest.TestCase):
         # The steady state after the user deletes the 66 GB bf16 transformer:
         # rendering must keep working off the converted DiT alone.
         with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp) / "mlx-checkpoints"
             model_root = Path(tmp) / "models--Org--Repo" / "snapshots" / "abc123"
             model_root.mkdir(parents=True)
-            out = self.helper.mlx_checkpoint_root(model_root) / "int6"
+            out = self.helper.mlx_checkpoint_root(model_root, base) / "int6"
             out.mkdir(parents=True)
             for name in ("mlx_h3_dit.safetensors", "mlx_h3_dit.json"):
                 (out / name).write_text("")
-            try:
-                resolved = self.helper.ensure_mlx_checkpoint(Path(tmp), model_root, "int6", {})
-                self.assertEqual(resolved, out)
-            finally:
-                shutil.rmtree(self.helper.mlx_checkpoint_root(model_root), ignore_errors=True)
+            resolved = self.helper.ensure_mlx_checkpoint(Path(tmp), model_root, "int6", {}, base)
+            self.assertEqual(resolved, out)
 
     def test_a_snapshot_without_a_transformer_fails_loudly(self):
         with tempfile.TemporaryDirectory() as tmp:
             model_root = Path(tmp) / "models--Org--Repo" / "snapshots" / "def456"
             model_root.mkdir(parents=True)
             with self.assertRaises(FileNotFoundError) as ctx:
-                self.helper.ensure_mlx_checkpoint(Path(tmp), model_root, "int4", {})
+                self.helper.ensure_mlx_checkpoint(Path(tmp), model_root, "int4", {}, Path(tmp) / "cache")
             self.assertIn("transformer", str(ctx.exception))
 
 

--- a/scripts/migrations/334-fasth3-upstream-source-mlx.js
+++ b/scripts/migrations/334-fasth3-upstream-source-mlx.js
@@ -65,13 +65,14 @@ export default {
     const { ok, config, entries: mlxEntries, path } = await readMediaRegistry({ rootDir, bucket: VIDEO_BUCKET_MLX });
     if (!ok) return;
 
-    let changed = false;
+    let added = 0;
+    let repaired = false;
     const present = new Set(mlxEntries.map((entry) => entry?.id));
     for (const entry of NEW_ENTRIES) {
       if (present.has(entry.id)) continue;
       mlxEntries.push(structuredClone(entry));
       present.add(entry.id);
-      changed = true;
+      added += 1;
     }
     // Repair the row 333 shipped, but only while it still holds 333's exact
     // list — a user who edited their own frame options keeps them.
@@ -80,7 +81,7 @@ export default {
       && repack.frameOptions.length === MIGRATION_333_FRAME_OPTIONS.length
       && repack.frameOptions.every((frames, i) => frames === MIGRATION_333_FRAME_OPTIONS[i])) {
       repack.frameOptions = [...FRAME_OPTIONS];
-      changed = true;
+      repaired = true;
     }
 
     const shipped = readVideoBucket(config?._shippedDefaults?.video, VIDEO_BUCKET_MLX);
@@ -88,13 +89,19 @@ export default {
       for (const entry of NEW_ENTRIES) {
         if (!shipped.includes(entry.id)) {
           shipped.push(entry.id);
-          changed = true;
+          added = Math.max(added, 1);
         }
       }
     }
-    if (changed) {
+    if (added > 0 || repaired) {
       await writeMediaRegistry(path, config);
-      console.log('📝 data/media-models.json: added the upstream FastH3 Dense Data-Free MLX models');
+      // Say which of the two things actually happened — an upgrade that only
+      // repaired the frame grid did not add anything.
+      const what = [
+        added > 0 ? `added ${added} upstream FastH3 Dense Data-Free MLX model(s)` : null,
+        repaired ? 'repaired the FastH3 repack frame options' : null,
+      ].filter(Boolean).join('; ');
+      console.log(`📝 data/media-models.json: ${what}`);
     }
   },
 };

--- a/scripts/migrations/334-fasth3-upstream-source-mlx.js
+++ b/scripts/migrations/334-fasth3-upstream-source-mlx.js
@@ -1,0 +1,99 @@
+/**
+ * Add FastVideo's own FastH3 Dense / Data-Free snapshot to existing macOS video
+ * registries, at all three MLX DiT formats. Fresh installs receive them from
+ * data.reference/media-models.json.
+ *
+ * Migration 333 shipped a third-party repack because FastVideo's MLX repos
+ * publish no weights (they still do not). These rows point at the upstream bf16
+ * diffusers snapshot instead and declare `fastvideoMlxFormat`, which is what
+ * makes the helper run FastVideo's own converter on the snapshot's transformer/
+ * before the first render. One download serves all three rows.
+ */
+
+import { readFile } from 'fs/promises';
+import { join } from 'path';
+import { atomicWrite } from '../../server/lib/fileUtils.js';
+import { VIDEO_BUCKET_MLX, readVideoBucket } from '../../server/lib/mediaModelBuckets.js';
+
+const REL_PATH = 'data/media-models.json';
+
+// H3's video VAE decodes only 17n+5 frame counts, and FastH3 is a distilled H3.
+// Inlined rather than imported from lib/mediaModels.js: a migration must keep
+// writing the values it shipped with, not whatever the live constant becomes
+// three releases later.
+const FRAME_OPTIONS = [107, 124, 141, 158, 175, 192, 209, 226, 243, 260, 277, 294, 311, 328, 345, 362];
+const RESOLUTION_OPTIONS = [
+  { label: '832x480 (16:9 FastH3 default)', w: 832, h: 480 },
+  { label: '1280x720 (16:9 HD)', w: 1280, h: 720 },
+];
+
+const NEW_ENTRIES = [
+  { format: 'int8', memoryGb: 48, label: 'INT8 (highest fidelity)' },
+  { format: 'int6', memoryGb: 42, label: 'INT6 (upstream default)' },
+  { format: 'int4', memoryGb: 36, label: 'INT4 (smallest)' },
+].map(({ format, memoryGb, label }) => ({
+  id: `fasth3_dense_datafree_${format}`,
+  name: `FastH3 Preview v1 Dense Data-Free — MLX ${label} (video + audio, ~144 GB download, ${memoryGb}+ GB RAM, 4-step)`,
+  repo: 'FastVideo/FastVideo-FastH3-4-step-Preview-v1-Dense-DataFree',
+  revision: 'f624f08c6c279ab43534c003e556fc5b295b6558',
+  runtime: 'fastvideo',
+  fastvideoFamily: 'fasth3',
+  fastvideoMlxFormat: format,
+  supportedModes: ['text'],
+  defaultWidth: 832,
+  defaultHeight: 480,
+  defaultFrames: 124,
+  frameOptions: [...FRAME_OPTIONS],
+  fpsOptions: [24],
+  resolutionStep: 32,
+  resolutionOptions: RESOLUTION_OPTIONS.map((preset) => ({ ...preset })),
+  memoryGb,
+  steps: 4,
+  guidance: 1,
+  samplerLocked: true,
+  samplerNote: `FastH3 Preview v1 is a 4-step DMD2 model. This is FastVideo's own dense-attention checkpoint — it does not support VSA, whose routing weights the MLX runtime drops. The first render converts its transformer to an MLX ${format.toUpperCase()} DiT (a few minutes, once), after which the 66 GB bf16 transformer can be deleted. Renders video with audio at a fixed 24 fps.`,
+  supportsNegativePrompt: false,
+  supportsTiling: false,
+  supportsDisableAudio: false,
+}));
+
+export default {
+  async up({ rootDir }) {
+    const path = join(rootDir, REL_PATH);
+    const raw = await readFile(path, 'utf-8').catch((err) => {
+      if (err.code === 'ENOENT') return null;
+      throw err;
+    });
+    if (raw == null) return;
+    let config;
+    try {
+      config = JSON.parse(raw);
+    } catch (err) {
+      throw new Error(`Cannot migrate ${REL_PATH}: invalid JSON (${err.message})`, { cause: err });
+    }
+    const mlxEntries = readVideoBucket(config?.video, VIDEO_BUCKET_MLX);
+    if (!Array.isArray(mlxEntries)) return;
+
+    let changed = false;
+    const present = new Set(mlxEntries.map((entry) => entry?.id));
+    for (const entry of NEW_ENTRIES) {
+      if (present.has(entry.id)) continue;
+      mlxEntries.push(structuredClone(entry));
+      present.add(entry.id);
+      changed = true;
+    }
+    const shipped = readVideoBucket(config?._shippedDefaults?.video, VIDEO_BUCKET_MLX);
+    if (Array.isArray(shipped)) {
+      for (const entry of NEW_ENTRIES) {
+        if (!shipped.includes(entry.id)) {
+          shipped.push(entry.id);
+          changed = true;
+        }
+      }
+    }
+    if (changed) {
+      await atomicWrite(path, `${JSON.stringify(config, null, 2)}\n`);
+      console.log(`📝 ${REL_PATH}: added the upstream FastH3 Dense Data-Free MLX models`);
+    }
+  },
+};

--- a/scripts/migrations/334-fasth3-upstream-source-mlx.js
+++ b/scripts/migrations/334-fasth3-upstream-source-mlx.js
@@ -10,18 +10,21 @@
  * before the first render. One download serves all three rows.
  */
 
-import { readFile } from 'fs/promises';
-import { join } from 'path';
-import { atomicWrite } from '../../server/lib/fileUtils.js';
 import { VIDEO_BUCKET_MLX, readVideoBucket } from '../../server/lib/mediaModelBuckets.js';
+import { readMediaRegistry, writeMediaRegistry } from './_lib.js';
 
-const REL_PATH = 'data/media-models.json';
+// H3's video VAE decodes only 17n+5 frame counts, and the MLX pipeline refuses
+// anything outside 5-15 s at 24 fps, so the grid is 124..345. Inlined rather
+// than imported from lib/mediaModels.js: a migration must keep writing the
+// values it shipped with, not whatever the live constant becomes three releases
+// later.
+const FRAME_OPTIONS = [124, 141, 158, 175, 192, 209, 226, 243, 260, 277, 294, 311, 328, 345];
 
-// H3's video VAE decodes only 17n+5 frame counts, and FastH3 is a distilled H3.
-// Inlined rather than imported from lib/mediaModels.js: a migration must keep
-// writing the values it shipped with, not whatever the live constant becomes
-// three releases later.
-const FRAME_OPTIONS = [107, 124, 141, 158, 175, 192, 209, 226, 243, 260, 277, 294, 311, 328, 345, 362];
+// What migration 333 wrote. Its two extra ends — 107 (4.46 s) and 362 (15.08 s)
+// — sit outside the pipeline's window and raise instead of rendering, so an
+// install that already ran 333 carries a picker with a broken value at each end.
+const MIGRATION_333_FRAME_OPTIONS = [107, 124, 141, 158, 175, 192, 209, 226, 243, 260, 277, 294, 311, 328, 345, 362];
+const REPACK_ID = 'fasth3_dense_datafree_mlx_int4';
 const RESOLUTION_OPTIONS = [
   { label: '832x480 (16:9 FastH3 default)', w: 832, h: 480 },
   { label: '1280x720 (16:9 HD)', w: 1280, h: 720 },
@@ -43,10 +46,10 @@ const NEW_ENTRIES = [
   defaultWidth: 832,
   defaultHeight: 480,
   defaultFrames: 124,
-  frameOptions: [...FRAME_OPTIONS],
+  frameOptions: FRAME_OPTIONS,
   fpsOptions: [24],
   resolutionStep: 32,
-  resolutionOptions: RESOLUTION_OPTIONS.map((preset) => ({ ...preset })),
+  resolutionOptions: RESOLUTION_OPTIONS,
   memoryGb,
   steps: 4,
   guidance: 1,
@@ -59,20 +62,8 @@ const NEW_ENTRIES = [
 
 export default {
   async up({ rootDir }) {
-    const path = join(rootDir, REL_PATH);
-    const raw = await readFile(path, 'utf-8').catch((err) => {
-      if (err.code === 'ENOENT') return null;
-      throw err;
-    });
-    if (raw == null) return;
-    let config;
-    try {
-      config = JSON.parse(raw);
-    } catch (err) {
-      throw new Error(`Cannot migrate ${REL_PATH}: invalid JSON (${err.message})`, { cause: err });
-    }
-    const mlxEntries = readVideoBucket(config?.video, VIDEO_BUCKET_MLX);
-    if (!Array.isArray(mlxEntries)) return;
+    const { ok, config, entries: mlxEntries, path } = await readMediaRegistry({ rootDir, bucket: VIDEO_BUCKET_MLX });
+    if (!ok) return;
 
     let changed = false;
     const present = new Set(mlxEntries.map((entry) => entry?.id));
@@ -82,6 +73,16 @@ export default {
       present.add(entry.id);
       changed = true;
     }
+    // Repair the row 333 shipped, but only while it still holds 333's exact
+    // list — a user who edited their own frame options keeps them.
+    const repack = mlxEntries.find((entry) => entry?.id === REPACK_ID);
+    if (repack && Array.isArray(repack.frameOptions)
+      && repack.frameOptions.length === MIGRATION_333_FRAME_OPTIONS.length
+      && repack.frameOptions.every((frames, i) => frames === MIGRATION_333_FRAME_OPTIONS[i])) {
+      repack.frameOptions = [...FRAME_OPTIONS];
+      changed = true;
+    }
+
     const shipped = readVideoBucket(config?._shippedDefaults?.video, VIDEO_BUCKET_MLX);
     if (Array.isArray(shipped)) {
       for (const entry of NEW_ENTRIES) {
@@ -92,8 +93,8 @@ export default {
       }
     }
     if (changed) {
-      await atomicWrite(path, `${JSON.stringify(config, null, 2)}\n`);
-      console.log(`📝 ${REL_PATH}: added the upstream FastH3 Dense Data-Free MLX models`);
+      await writeMediaRegistry(path, config);
+      console.log('📝 data/media-models.json: added the upstream FastH3 Dense Data-Free MLX models');
     }
   },
 };

--- a/scripts/migrations/334-fasth3-upstream-source-mlx.test.js
+++ b/scripts/migrations/334-fasth3-upstream-source-mlx.test.js
@@ -62,13 +62,42 @@ describe('334-fasth3-upstream-source-mlx migration', () => {
     }
   });
 
-  it('leaves the pre-converted repack row from migration 333 in place', async () => {
+  it('leaves the pre-converted repack row from migration 333 otherwise in place', async () => {
     write({ video: { mlx: [{ id: 'fasth3_dense_datafree_mlx_int4', repo: 'MrMofer/x' }] } });
 
     await migration.up({ rootDir });
 
     const packed = read().video.mlx.find((m) => m.id === 'fasth3_dense_datafree_mlx_int4');
     expect(packed).toEqual({ id: 'fasth3_dense_datafree_mlx_int4', repo: 'MrMofer/x' });
+  });
+
+  it('drops the two out-of-window frame counts migration 333 shipped', async () => {
+    // 107 is 4.46 s and 362 is 15.08 s at FastH3's fixed 24 fps; the pipeline
+    // refuses both, so they were a broken value at each end of the picker.
+    write({
+      video: {
+        mlx: [{
+          id: 'fasth3_dense_datafree_mlx_int4',
+          frameOptions: [107, 124, 141, 158, 175, 192, 209, 226, 243, 260, 277, 294, 311, 328, 345, 362],
+        }],
+      },
+    });
+
+    await migration.up({ rootDir });
+
+    const packed = read().video.mlx.find((m) => m.id === 'fasth3_dense_datafree_mlx_int4');
+    expect(packed.frameOptions).not.toContain(107);
+    expect(packed.frameOptions).not.toContain(362);
+    expect(packed.frameOptions.every((f) => f / 24 >= 5 && f / 24 <= 15)).toBe(true);
+  });
+
+  it('keeps a user own frame options rather than overwriting them', async () => {
+    write({ video: { mlx: [{ id: 'fasth3_dense_datafree_mlx_int4', frameOptions: [124, 141] }] } });
+
+    await migration.up({ rootDir });
+
+    expect(read().video.mlx.find((m) => m.id === 'fasth3_dense_datafree_mlx_int4').frameOptions)
+      .toEqual([124, 141]);
   });
 
   it('leaves the CUDA bucket untouched', async () => {

--- a/scripts/migrations/334-fasth3-upstream-source-mlx.test.js
+++ b/scripts/migrations/334-fasth3-upstream-source-mlx.test.js
@@ -1,0 +1,104 @@
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import migration from './334-fasth3-upstream-source-mlx.js';
+
+const NEW_IDS = ['fasth3_dense_datafree_int8', 'fasth3_dense_datafree_int6', 'fasth3_dense_datafree_int4'];
+const SOURCE_REPO = 'FastVideo/FastVideo-FastH3-4-step-Preview-v1-Dense-DataFree';
+
+describe('334-fasth3-upstream-source-mlx migration', () => {
+  let rootDir;
+  let registryFile;
+
+  beforeEach(() => {
+    rootDir = join(tmpdir(), `portos-test-334-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(join(rootDir, 'data'), { recursive: true });
+    registryFile = join(rootDir, 'data', 'media-models.json');
+  });
+
+  afterEach(() => {
+    rmSync(rootDir, { recursive: true, force: true });
+  });
+
+  const write = (config) => writeFileSync(registryFile, JSON.stringify(config, null, 2));
+  const read = () => JSON.parse(readFileSync(registryFile, 'utf-8'));
+
+  it('skips gracefully when media-models.json does not exist', async () => {
+    await expect(migration.up({ rootDir })).resolves.toBeUndefined();
+  });
+
+  it('adds all three format rows to an existing MLX registry and its shipped list', async () => {
+    write({
+      video: { mlx: [{ id: 'fastmetal_1_3b_qad', name: 'FastMetal 1.3B' }], cuda: [] },
+      _shippedDefaults: { video: { mlx: ['fastmetal_1_3b_qad'] } },
+    });
+
+    await migration.up({ rootDir });
+
+    const updated = read();
+    for (const id of NEW_IDS) {
+      const entry = updated.video.mlx.find((m) => m.id === id);
+      expect(entry).toBeDefined();
+      // All three rows are ONE download differing only by a local conversion,
+      // so they must name the same pinned snapshot.
+      expect(entry.repo).toBe(SOURCE_REPO);
+      expect(entry.revision).toMatch(/^[0-9a-f]{40}$/);
+      // The row rides the EXISTING fastvideo runtime; `fastvideoFamily` routes
+      // it to the FastH3 entry script and `fastvideoMlxFormat` is what makes
+      // the helper convert the snapshot's bf16 transformer before rendering.
+      expect(entry.runtime).toBe('fastvideo');
+      expect(entry.fastvideoFamily).toBe('fasth3');
+      expect(entry.fastvideoMlxFormat).toBe(id.split('_').pop());
+      // The UI reads its frame/fps/capability limits straight off the entry, so
+      // an upgraded install must receive them too — not just a fresh seed.
+      expect(entry.frameOptions.every((f) => (f - 5) % 17 === 0)).toBe(true);
+      expect(entry.frameOptions).toContain(entry.defaultFrames);
+      expect(entry.fpsOptions).toEqual([24]);
+      expect(entry.supportsNegativePrompt).toBe(false);
+      expect(entry.supportsTiling).toBe(false);
+      expect(entry.supportsDisableAudio).toBe(false);
+      expect(updated._shippedDefaults.video.mlx).toContain(id);
+    }
+  });
+
+  it('leaves the pre-converted repack row from migration 333 in place', async () => {
+    write({ video: { mlx: [{ id: 'fasth3_dense_datafree_mlx_int4', repo: 'MrMofer/x' }] } });
+
+    await migration.up({ rootDir });
+
+    const packed = read().video.mlx.find((m) => m.id === 'fasth3_dense_datafree_mlx_int4');
+    expect(packed).toEqual({ id: 'fasth3_dense_datafree_mlx_int4', repo: 'MrMofer/x' });
+  });
+
+  it('leaves the CUDA bucket untouched', async () => {
+    write({ video: { mlx: [], cuda: [{ id: 'ltx_video' }] } });
+
+    await migration.up({ rootDir });
+
+    expect(read().video.cuda.map((m) => m.id)).toEqual(['ltx_video']);
+  });
+
+  it('is idempotent when run multiple times', async () => {
+    write({ video: { mlx: [{ id: 'fastmetal_1_3b_qad' }] } });
+
+    await migration.up({ rootDir });
+    const firstPass = readFileSync(registryFile, 'utf-8');
+    await migration.up({ rootDir });
+
+    expect(readFileSync(registryFile, 'utf-8')).toBe(firstPass);
+  });
+
+  it('does not re-add a row the user deleted from the shipped list only', async () => {
+    write({
+      video: { mlx: [{ id: NEW_IDS[0], name: 'edited by user', runtime: 'fastvideo' }] },
+      _shippedDefaults: { video: { mlx: NEW_IDS } },
+    });
+
+    await migration.up({ rootDir });
+
+    expect(read().video.mlx.filter((m) => m.id === NEW_IDS[0])).toEqual([
+      { id: NEW_IDS[0], name: 'edited by user', runtime: 'fastvideo' },
+    ]);
+  });
+});

--- a/server/lib/huggingfaceModel.js
+++ b/server/lib/huggingfaceModel.js
@@ -84,13 +84,14 @@ const detectVideoRuntime = (blob) => {
   if (/fastvideo|fastmetal|fasth3/i.test(blob)) {
     // FastH3 needs more than the venv: the row also has to declare
     // `fastvideoFamily: 'fasth3'` (a different entry script and argv shape),
-    // and the published packs are split across a components repo and a DiT
-    // pack — neither of which a single-repo self-service add can express. Say
-    // that instead of pointing at an install script that would not fix it.
+    // and an upstream bf16 snapshot additionally needs `fastvideoMlxFormat` or
+    // its DiT never becomes loadable — neither of which a self-service add,
+    // which only knows a repo id, can infer. Say that instead of pointing at
+    // an install script that would not fix it.
     if (/fasth3/i.test(blob)) {
       return {
         runtime: 'fastvideo',
-        refusal: 'needs a FastH3 registry row (its own entry script, and for the split packs a second download) that the self-service add flow cannot express — use the shipped FastH3 entry in Video Gen, or add it to data/media-models.json by hand',
+        refusal: 'needs a FastH3 registry row (its own entry script, and for an upstream snapshot the MLX format to convert its transformer to) that the self-service add flow cannot express — use a shipped FastH3 entry in Video Gen, or add it to data/media-models.json by hand',
       };
     }
     return { runtime: 'fastvideo', installHint: 'INSTALL_FASTVIDEO=1 bash scripts/setup-image-video.sh' };

--- a/server/lib/mediaModels.js
+++ b/server/lib/mediaModels.js
@@ -134,13 +134,19 @@ const h3FrameGrid = (min, max) => {
 
 // FastH3 Preview v1's output contract (#5860). It is a distilled MiniMax H3, so
 // it inherits H3's 17n+5 VAE frame grid and 32px edge rounding — but NOT H3's
+// full frame range: the MLX pipeline hard-refuses anything outside 5-15 s at its
+// fixed 24 fps ("H3 generates 5-15 s at 24 fps", resolve_geometry in
+// fastvideo/mlx_runtime/minimax_h3_pipeline.py), so the grid is clamped to
+// 120..360 frames. The unclamped 107..362 this shipped with put a too-short AND
+// a too-long value at the two ends of the picker, each of which reached the
+// runtime and raised instead of rendering.
 // canvas: the MLX FastH3 entry point is validated at 832x480 (its own default,
 // and the resolution upstream's conversion manifest records a passing 124-frame
 // generation at), and its docstring documents 1280x720 as the other supported
 // request. `resolutionOptions` are presets rather than a whitelist, so a custom
 // size still resolves through `resolutionStep`.
 export const FASTH3_OUTPUT_PROFILE = Object.freeze({
-  frameOptions: h3FrameGrid(107, 362),
+  frameOptions: h3FrameGrid(124, 345),
   fpsOptions: Object.freeze([24]),
   resolutionStep: 32,
   resolutionOptions: Object.freeze([
@@ -164,7 +170,7 @@ const FASTH3_SOURCE_FORMATS = Object.freeze([
   Object.freeze({ format: 'int4', memoryGb: 36, label: 'INT4 (smallest)' }),
 ]);
 
-export const fastH3SourceEntries = () => FASTH3_SOURCE_FORMATS.map(({ format, memoryGb, label }) => ({
+const FASTH3_SOURCE_ENTRIES = FASTH3_SOURCE_FORMATS.map(({ format, memoryGb, label }) => ({
   id: `fasth3_dense_datafree_${format}`,
   name: `FastH3 Preview v1 Dense Data-Free — MLX ${label} (video + audio, ~144 GB download, ${memoryGb}+ GB RAM, 4-step)`,
   repo: FASTH3_SOURCE_REPO,
@@ -678,7 +684,7 @@ const DEFAULT_REGISTRY = {
       // FastVideo's own FastH3 Dense / Data-Free snapshot, converted to MLX on
       // this machine. Listed before the third-party repack below because it is
       // the upstream checkpoint the repack is derived from.
-      ...fastH3SourceEntries(),
+      ...FASTH3_SOURCE_ENTRIES,
       // FastH3 Preview v1 Dense / Data-Free, packed for MLX (#5860). Same
       // `fastvideo` venv and checkout as FastMetal above, but a different entry
       // script and argv shape — `fastvideoFamily` is what routes it, see

--- a/server/lib/mediaModels.js
+++ b/server/lib/mediaModels.js
@@ -149,6 +149,50 @@ export const FASTH3_OUTPUT_PROFILE = Object.freeze({
   ]),
 });
 
+// The upstream FastH3 source snapshot (#5860 follow-up). FastVideo's own MLX
+// repos publish a model card and a conversion manifest but still no weights, so
+// the checkpoint PortOS points at is the bf16 diffusers snapshot the converter
+// documents as its input: one repo, whose `transformer/` becomes an MLX DiT on
+// this machine. That is a per-format local step, not a per-format download —
+// the three rows below share ONE snapshot and differ only in the format the
+// helper converts it to, which is the knob that maps to the user's RAM.
+export const FASTH3_SOURCE_REPO = 'FastVideo/FastVideo-FastH3-4-step-Preview-v1-Dense-DataFree';
+export const FASTH3_SOURCE_REVISION = 'f624f08c6c279ab43534c003e556fc5b295b6558';
+const FASTH3_SOURCE_FORMATS = Object.freeze([
+  Object.freeze({ format: 'int8', memoryGb: 48, label: 'INT8 (highest fidelity)' }),
+  Object.freeze({ format: 'int6', memoryGb: 42, label: 'INT6 (upstream default)' }),
+  Object.freeze({ format: 'int4', memoryGb: 36, label: 'INT4 (smallest)' }),
+]);
+
+export const fastH3SourceEntries = () => FASTH3_SOURCE_FORMATS.map(({ format, memoryGb, label }) => ({
+  id: `fasth3_dense_datafree_${format}`,
+  name: `FastH3 Preview v1 Dense Data-Free — MLX ${label} (video + audio, ~144 GB download, ${memoryGb}+ GB RAM, 4-step)`,
+  repo: FASTH3_SOURCE_REPO,
+  revision: FASTH3_SOURCE_REVISION,
+  runtime: 'fastvideo',
+  fastvideoFamily: 'fasth3',
+  fastvideoMlxFormat: format,
+  supportedModes: ['text'],
+  defaultWidth: 832,
+  defaultHeight: 480,
+  defaultFrames: 124,
+  frameOptions: [...FASTH3_OUTPUT_PROFILE.frameOptions],
+  fpsOptions: [...FASTH3_OUTPUT_PROFILE.fpsOptions],
+  resolutionStep: FASTH3_OUTPUT_PROFILE.resolutionStep,
+  resolutionOptions: FASTH3_OUTPUT_PROFILE.resolutionOptions.map((preset) => ({ ...preset })),
+  memoryGb,
+  steps: 4,
+  guidance: 1.0,
+  samplerLocked: true,
+  samplerNote: `FastH3 Preview v1 is a 4-step DMD2 model. This is FastVideo's own dense-attention checkpoint — it does not support VSA, whose routing weights the MLX runtime drops. The first render converts its transformer to an MLX ${format.toUpperCase()} DiT (a few minutes, once), after which the 66 GB bf16 transformer can be deleted. Renders video with audio at a fixed 24 fps.`,
+  // Same argv boundary as the repack row below: mlx_fasth3.py has no
+  // --negative-prompt, no way to mute the joint audio track, and PortOS never
+  // hands it a tiling flag.
+  supportsNegativePrompt: false,
+  supportsTiling: false,
+  supportsDisableAudio: false,
+}));
+
 // The MLX entry's output profile: the shared canvas above PLUS the upgrade
 // machinery migration 267 and `upgradeMiniMaxH3OutputControls` key off (the id,
 // the repo it was checked against, and the frame list it supersedes). That
@@ -631,6 +675,10 @@ const DEFAULT_REGISTRY = {
         samplerLocked: true,
         samplerNote: 'FastMetal models are DMD2-distilled 3-step models with affine INT8 quantization.',
       },
+      // FastVideo's own FastH3 Dense / Data-Free snapshot, converted to MLX on
+      // this machine. Listed before the third-party repack below because it is
+      // the upstream checkpoint the repack is derived from.
+      ...fastH3SourceEntries(),
       // FastH3 Preview v1 Dense / Data-Free, packed for MLX (#5860). Same
       // `fastvideo` venv and checkout as FastMetal above, but a different entry
       // script and argv shape — `fastvideoFamily` is what routes it, see

--- a/server/lib/mediaModels.test.js
+++ b/server/lib/mediaModels.test.js
@@ -216,6 +216,28 @@ describe('mediaModels registry', () => {
     }
   });
 
+  it('offers FastH3 only frame counts its pipeline will accept', async () => {
+    const { loadMediaModels, FASTH3_OUTPUT_PROFILE } = await import('./mediaModels.js');
+    // mlx_fasth3.py renders at a fixed 24 fps and resolve_geometry hard-refuses
+    // anything outside 5-15 s, so a frame count off that window reaches the
+    // runtime and RAISES rather than rendering. 107 and 362 both did.
+    const FPS = 24;
+    for (const frames of FASTH3_OUTPUT_PROFILE.frameOptions) {
+      expect((frames - 5) % 17).toBe(0);
+      expect(frames / FPS).toBeGreaterThanOrEqual(5);
+      expect(frames / FPS).toBeLessThanOrEqual(15);
+    }
+    expect(FASTH3_OUTPUT_PROFILE.frameOptions).not.toContain(107);
+    expect(FASTH3_OUTPUT_PROFILE.frameOptions).not.toContain(362);
+    // Every shipped FastH3 row, not just the profile constant.
+    const rows = loadMediaModels().video.mlx.filter((m) => m.fastvideoFamily === 'fasth3');
+    expect(rows.length).toBeGreaterThan(1);
+    for (const row of rows) {
+      expect(row.frameOptions).toEqual([...FASTH3_OUTPUT_PROFILE.frameOptions]);
+      expect(row.frameOptions).toContain(row.defaultFrames);
+    }
+  });
+
   it('ships MiniMax H3 as a pinned, keyframe-capable 128 GB BYOV profile', async () => {
     const { loadMediaModels } = await import('./mediaModels.js');
     // H3 is an Apple-silicon MLX runtime, so inspect the shipped macOS catalog

--- a/server/lib/mediaModels.test.js
+++ b/server/lib/mediaModels.test.js
@@ -185,6 +185,37 @@ describe('mediaModels registry', () => {
     expect(fasth3.termsGate?.id).toBe('minimax-h3-community-license-2026-08-02');
   });
 
+  it('ships the upstream FastH3 snapshot at three MLX formats off ONE pinned download', async () => {
+    const { loadMediaModels, FASTH3_SOURCE_REPO, FASTH3_SOURCE_REVISION, FASTH3_OUTPUT_PROFILE } = await import('./mediaModels.js');
+    const { FASTVIDEO_MLX_FORMATS } = await import('../services/videoGen/renderArgs.js');
+    const rows = loadMediaModels().video.mlx.filter((m) => m.repo === FASTH3_SOURCE_REPO);
+    expect(rows.map((m) => m.id)).toEqual([
+      'fasth3_dense_datafree_int8', 'fasth3_dense_datafree_int6', 'fasth3_dense_datafree_int4',
+    ]);
+    // The three rows differ ONLY by a local conversion of one snapshot, so a
+    // row on a different revision would quietly double a 144 GB download.
+    expect(new Set(rows.map((m) => m.revision))).toEqual(new Set([FASTH3_SOURCE_REVISION]));
+    // Each format must be distinct AND one the converter publishes — a repeated
+    // or misspelled value silently gives two rows the same DiT, or a row whose
+    // format the helper's argparse rejects at render time.
+    const formats = rows.map((m) => m.fastvideoMlxFormat);
+    expect(new Set(formats).size).toBe(rows.length);
+    for (const format of formats) expect(FASTVIDEO_MLX_FORMATS).toContain(format);
+    for (const row of rows) {
+      // Still a FastH3 family row on the existing fastvideo runtime.
+      expect(row.runtime).toBe('fastvideo');
+      expect(row.fastvideoFamily).toBe('fasth3');
+      // Same H3 output contract and same argv boundary as the repack row.
+      expect(row.frameOptions).toEqual([...FASTH3_OUTPUT_PROFILE.frameOptions]);
+      expect(row.fpsOptions).toEqual([24]);
+      expect(row.supportsNegativePrompt).toBe(false);
+      expect(row.supportsTiling).toBe(false);
+      expect(row.supportsDisableAudio).toBe(false);
+      // The MiniMax H3 Community License travels with the distilled weights.
+      expect(row.termsGate?.id).toBe('minimax-h3-community-license-2026-08-02');
+    }
+  });
+
   it('ships MiniMax H3 as a pinned, keyframe-capable 128 GB BYOV profile', async () => {
     const { loadMediaModels } = await import('./mediaModels.js');
     // H3 is an Apple-silicon MLX runtime, so inspect the shipped macOS catalog

--- a/server/lib/videoDisclosure.js
+++ b/server/lib/videoDisclosure.js
@@ -350,6 +350,22 @@ export const VIDEO_MODEL_DISCLOSURES = Object.freeze({
       reviewedAt: VIDEO_DISCLOSURE_REVIEWED_AT,
     },
   },
+  // FastVideo's own FastH3 Dense / Data-Free snapshot — the checkpoint the
+  // repack below is converted FROM, so same weights, same license, same
+  // territory gate. The three rows share one 144 GB download: the format in the
+  // id names a LOCAL conversion of the snapshot's transformer/, not a separate
+  // repo, which is why they all quote the same figure.
+  ...Object.fromEntries(['int8', 'int6', 'int4'].map((format) => [`fasth3_dense_datafree_${format}`, {
+    shippedRepo: 'FastVideo/FastVideo-FastH3-4-step-Preview-v1-Dense-DataFree',
+    disclosure: {
+      modelCardUrl: hfModelCard('FastVideo/FastVideo-FastH3-4-step-Preview-v1-Dense-DataFree'),
+      weightsLicense: MINIMAX_H3_WEIGHTS,
+      runtimeLicense: RUNTIME_LICENSE.fastvideo,
+      estimatedDownloadGb: 144.0,
+      reviewedAt: VIDEO_DISCLOSURE_REVIEWED_AT,
+    },
+    termsGate: MINIMAX_H3_TERMS_GATE,
+  }])),
   // FastH3 Preview v1 Dense / Data-Free, packed for MLX. Same MiniMax H3
   // weights lineage as the entries above — its `conversion_manifest.json`
   // names FastVideo/…-Dense-DataFree @ f624f08c as the source — so it carries

--- a/server/services/videoGen/renderArgs.js
+++ b/server/services/videoGen/renderArgs.js
@@ -50,6 +50,8 @@ import {
   FASTVIDEO_VENV_PYTHON,
   FASTVIDEO_HELPER_SCRIPT,
   FASTVIDEO_REPO_DIR,
+  FASTVIDEO_MLX_CHECKPOINT_DIR,
+  FASTVIDEO_PROMPT_CACHE_DIR,
   LTX25_CUDA_VENV_PYTHON,
   LTX25_CUDA_HELPER_SCRIPT,
   WAN22_CUDA_VENV_PYTHON,
@@ -574,6 +576,10 @@ export const fastvideoFamily = (model) =>
 // directory instead. A row that names one of these formats is pointing at that
 // upstream snapshot and wants the helper to run FastVideo's own converter once;
 // a row that omits it already ships the quantized DiT beside its model root.
+// Mirrors MLX_DIT_FORMATS in scripts/generate_fastvideo.py, itself the
+// converter's own format list. Kept in sync by hand — the helper's argparse
+// `choices=` is the enforcement; this list is what lets the server reject a
+// bad value before queueing a render.
 export const FASTVIDEO_MLX_FORMATS = Object.freeze(['int8', 'int6', 'int4']);
 export const fastvideoMlxFormat = (model) =>
   (FASTVIDEO_MLX_FORMATS.includes(model?.fastvideoMlxFormat) ? model.fastvideoMlxFormat : null);
@@ -610,8 +616,11 @@ export const buildFastVideoArgs = ({
   // vae/audio_vae/text_encoder/tokenizer IS its own checkpoint, and says so
   // explicitly rather than leaning on the helper's default-to-model-root.
   if (family === 'fasth3') {
+    // Conditioning is half the wall clock of a render and recomputes identical
+    // embeddings every time, so every FastH3 row reuses one cache.
+    args.push('--prompt-cache-dir', FASTVIDEO_PROMPT_CACHE_DIR);
     const mlxFormat = fastvideoMlxFormat(model);
-    if (mlxFormat) args.push('--mlx-format', mlxFormat);
+    if (mlxFormat) args.push('--mlx-format', mlxFormat, '--mlx-checkpoint-cache-dir', FASTVIDEO_MLX_CHECKPOINT_DIR);
     else args.push('--mlx-checkpoint', modelRoot);
   }
   if (negativePrompt) args.push('--negative-prompt', negativePrompt);

--- a/server/services/videoGen/renderArgs.js
+++ b/server/services/videoGen/renderArgs.js
@@ -569,6 +569,15 @@ export const FASTVIDEO_FAMILIES = Object.freeze(['fastmetal', 'fasth3']);
 export const fastvideoFamily = (model) =>
   (FASTVIDEO_FAMILIES.includes(model?.fastvideoFamily) ? model.fastvideoFamily : 'fastmetal');
 
+// FastVideo publishes FastH3 as a bf16 diffusers snapshot whose DiT sits under
+// `transformer/`, but mlx_fasth3.py loads a pre-quantized `mlx_h3_dit`
+// directory instead. A row that names one of these formats is pointing at that
+// upstream snapshot and wants the helper to run FastVideo's own converter once;
+// a row that omits it already ships the quantized DiT beside its model root.
+export const FASTVIDEO_MLX_FORMATS = Object.freeze(['int8', 'int6', 'int4']);
+export const fastvideoMlxFormat = (model) =>
+  (FASTVIDEO_MLX_FORMATS.includes(model?.fastvideoMlxFormat) ? model.fastvideoMlxFormat : null);
+
 // Build args for the FastVideo MLX helper on Apple Silicon.
 export const buildFastVideoArgs = ({
   model, fastvideoModelPath, prompt, negativePrompt, width, height,
@@ -593,12 +602,18 @@ export const buildFastVideoArgs = ({
     '--seed', String(seed),
     '--output', outputPath,
   ];
-  // The shipped FastH3 checkpoint is a self-contained snapshot: the quantized
-  // MLX DiT sits beside the vae/audio_vae/text_encoder/tokenizer the pipeline
-  // loads, so model-root IS the checkpoint. Stated explicitly rather than left
-  // to the helper's "defaults to model-root" fallback, so the two paths become
-  // separately addressable the day a row ships the DiT as its own download.
-  if (family === 'fasth3') args.push('--mlx-checkpoint', modelRoot);
+  // Two FastH3 checkpoint layouts, and the row is what distinguishes them.
+  // An upstream FastVideo snapshot carries the bf16 DiT under `transformer/`
+  // and declares a target format, so the helper converts once and owns the
+  // resulting path — passing --mlx-checkpoint here would pin the wrong
+  // directory. A repack that already ships `mlx_h3_dit.safetensors` beside the
+  // vae/audio_vae/text_encoder/tokenizer IS its own checkpoint, and says so
+  // explicitly rather than leaning on the helper's default-to-model-root.
+  if (family === 'fasth3') {
+    const mlxFormat = fastvideoMlxFormat(model);
+    if (mlxFormat) args.push('--mlx-format', mlxFormat);
+    else args.push('--mlx-checkpoint', modelRoot);
+  }
   if (negativePrompt) args.push('--negative-prompt', negativePrompt);
   if (sourceImagePath) args.push('--image', sourceImagePath);
   return { bin: FASTVIDEO_VENV_PYTHON, args };

--- a/server/services/videoGen/renderArgsFastVideo.test.js
+++ b/server/services/videoGen/renderArgsFastVideo.test.js
@@ -9,6 +9,8 @@ vi.mock('./runtimes.js', async (importOriginal) => ({
   FASTVIDEO_VENV_PYTHON: '/fixture/fastvideo/.venv/bin/python3',
   FASTVIDEO_HELPER_SCRIPT: '/fixture/scripts/generate_fastvideo.py',
   FASTVIDEO_REPO_DIR: '/fixture/fastvideo',
+  FASTVIDEO_MLX_CHECKPOINT_DIR: '/fixture/fastvideo/mlx-checkpoints',
+  FASTVIDEO_PROMPT_CACHE_DIR: '/fixture/fastvideo/prompt-cache',
 }));
 
 const { buildFastVideoArgs, fastvideoFamily, fastvideoMlxFormat } = await import('./renderArgs.js');
@@ -98,6 +100,9 @@ describe('buildFastVideoArgs', () => {
     expect(flagValue(args, '--family')).toBe('fasth3');
     expect(flagValue(args, '--model-root')).toBe('/fixture/cache/fasth3');
     expect(flagValue(args, '--mlx-checkpoint')).toBe('/fixture/cache/fasth3');
+    // It already holds a quantized DiT, so it must never trigger a conversion.
+    expect(args).not.toContain('--mlx-format');
+    expect(args).not.toContain('--mlx-checkpoint-cache-dir');
   });
 
   it('passes the pinned render controls through for FastH3', () => {
@@ -151,19 +156,24 @@ describe('buildFastVideoArgs — upstream FastH3 snapshot', () => {
       ...base, model: fasth3Source, fastvideoModelPath: '/fixture/models/fasth3-source',
     });
     expect(flagValue(args, '--mlx-format')).toBe('int6');
-    // The converted DiT lands in a helper-owned cache, NOT beside the snapshot,
-    // so pinning --mlx-checkpoint here would point the pipeline at the bf16
-    // diffusers layout it cannot load.
+    // The converted DiT lands under a SERVER-declared cache root, not beside the
+    // snapshot, so pinning --mlx-checkpoint here would point the pipeline at the
+    // bf16 diffusers layout it cannot load.
     expect(args).not.toContain('--mlx-checkpoint');
+    expect(flagValue(args, '--mlx-checkpoint-cache-dir')).toBe('/fixture/fastvideo/mlx-checkpoints');
     expect(flagValue(args, '--model-root')).toBe('/fixture/models/fasth3-source');
   });
 
-  it('still pins the checkpoint for a pre-converted row, and never asks to convert', () => {
-    const { args } = buildFastVideoArgs({
-      ...base, model: fasth3, fastvideoModelPath: '/fixture/models/fasth3-packed',
-    });
-    expect(flagValue(args, '--mlx-checkpoint')).toBe('/fixture/models/fasth3-packed');
-    expect(args).not.toContain('--mlx-format');
+  it('reuses one server-declared prompt cache for every FastH3 row', () => {
+    // Conditioning is half a render's wall clock and recomputes identical
+    // embeddings, so both layouts must get the flag — and FastMetal must not,
+    // since mlx_wan_prompt_to_video.py would reject it.
+    for (const model of [fasth3, fasth3Source]) {
+      const { args } = buildFastVideoArgs({ ...base, model, fastvideoModelPath: '/fixture/cache/fasth3' });
+      expect(flagValue(args, '--prompt-cache-dir')).toBe('/fixture/fastvideo/prompt-cache');
+    }
+    const { args } = buildFastVideoArgs({ ...base, model: fastmetal, fastvideoModelPath: '/fixture/cache/fastmetal' });
+    expect(args).not.toContain('--prompt-cache-dir');
   });
 
   it('never asks FastMetal to convert, even if a row mislabels a format', () => {

--- a/server/services/videoGen/renderArgsFastVideo.test.js
+++ b/server/services/videoGen/renderArgsFastVideo.test.js
@@ -11,7 +11,7 @@ vi.mock('./runtimes.js', async (importOriginal) => ({
   FASTVIDEO_REPO_DIR: '/fixture/fastvideo',
 }));
 
-const { buildFastVideoArgs, fastvideoFamily } = await import('./renderArgs.js');
+const { buildFastVideoArgs, fastvideoFamily, fastvideoMlxFormat } = await import('./renderArgs.js');
 
 const fastmetal = {
   id: 'fastmetal_5b_qad',
@@ -26,6 +26,18 @@ const fasth3 = {
   runtime: 'fastvideo',
   fastvideoFamily: 'fasth3',
   repo: 'example-org/example-fasth3',
+  supportedModes: ['text'],
+};
+
+// The upstream FastVideo snapshot: same family, but its DiT is bf16 under
+// transformer/, so the row names the MLX format the helper must convert to.
+const fasth3Source = {
+  id: 'fasth3_dense_datafree_int6',
+  name: 'Example FastH3 Source Profile',
+  runtime: 'fastvideo',
+  fastvideoFamily: 'fasth3',
+  fastvideoMlxFormat: 'int6',
+  repo: 'example-org/example-fasth3-source',
   supportedModes: ['text'],
 };
 
@@ -112,5 +124,54 @@ describe('buildFastVideoArgs', () => {
     expect(() => buildFastVideoArgs({
       ...base, model: fasth3, mode: 'image', sourceImagePath: '/fixture/first.png',
     })).toThrowError(/mode/i);
+  });
+});
+
+describe('fastvideoMlxFormat', () => {
+  it('is null for a row that already ships a quantized DiT', () => {
+    expect(fastvideoMlxFormat(fasth3)).toBeNull();
+    expect(fastvideoMlxFormat({})).toBeNull();
+    expect(fastvideoMlxFormat(null)).toBeNull();
+  });
+
+  it('reads the declared format off the entry', () => {
+    expect(fastvideoMlxFormat(fasth3Source)).toBe('int6');
+  });
+
+  it('rejects a format the converter does not publish', () => {
+    // A hand-edited or peer-synced row naming e.g. "fp8" must not reach the
+    // helper's argparse, which would reject it and turn a render into a crash.
+    expect(fastvideoMlxFormat({ ...fasth3Source, fastvideoMlxFormat: 'fp8' })).toBeNull();
+  });
+});
+
+describe('buildFastVideoArgs — upstream FastH3 snapshot', () => {
+  it('asks the helper to convert, and does not pin a checkpoint path', () => {
+    const { args } = buildFastVideoArgs({
+      ...base, model: fasth3Source, fastvideoModelPath: '/fixture/models/fasth3-source',
+    });
+    expect(flagValue(args, '--mlx-format')).toBe('int6');
+    // The converted DiT lands in a helper-owned cache, NOT beside the snapshot,
+    // so pinning --mlx-checkpoint here would point the pipeline at the bf16
+    // diffusers layout it cannot load.
+    expect(args).not.toContain('--mlx-checkpoint');
+    expect(flagValue(args, '--model-root')).toBe('/fixture/models/fasth3-source');
+  });
+
+  it('still pins the checkpoint for a pre-converted row, and never asks to convert', () => {
+    const { args } = buildFastVideoArgs({
+      ...base, model: fasth3, fastvideoModelPath: '/fixture/models/fasth3-packed',
+    });
+    expect(flagValue(args, '--mlx-checkpoint')).toBe('/fixture/models/fasth3-packed');
+    expect(args).not.toContain('--mlx-format');
+  });
+
+  it('never asks FastMetal to convert, even if a row mislabels a format', () => {
+    const { args } = buildFastVideoArgs({
+      ...base, model: { ...fastmetal, fastvideoMlxFormat: 'int4' },
+      fastvideoModelPath: '/fixture/models/fastmetal',
+    });
+    expect(args).not.toContain('--mlx-format');
+    expect(args).not.toContain('--mlx-checkpoint');
   });
 });

--- a/server/services/videoGen/runtimes.js
+++ b/server/services/videoGen/runtimes.js
@@ -112,6 +112,14 @@ export const MINIMAX_H3_CUDA_OFFLOAD_PROFILES = Object.freeze([
 export const FASTVIDEO_VENV_PYTHON = join(homedir(), '.portos', 'fastvideo', '.venv', 'bin', 'python3');
 export const FASTVIDEO_HELPER_SCRIPT = join(PATHS.root, 'scripts', 'generate_fastvideo.py');
 export const FASTVIDEO_REPO_DIR = join(homedir(), '.portos', 'fastvideo');
+// FastH3's two derived-artifact roots, declared here for the same reason the
+// H3 shim and prompt-embedding roots above are: the server owns WHERE they
+// live so it can name, report and reclaim them, and the helper owns only the
+// layout underneath. Both are plain caches the user can delete at any time —
+// but the converted DiT is multi-GB per (snapshot, format), so leaving PortOS
+// with no name for it is what makes it unreclaimable.
+export const FASTVIDEO_MLX_CHECKPOINT_DIR = join(homedir(), '.portos', 'fastvideo', 'mlx-checkpoints');
+export const FASTVIDEO_PROMPT_CACHE_DIR = join(homedir(), '.portos', 'fastvideo', 'prompt-cache');
 
 // LTX-2.5 on CUDA — the official Lightricks ltx-core / ltx-pipelines runtime.
 export const LTX25_CUDA_REPO_DIR = join(homedir(), '.portos', 'ltx-2.5-cuda');


### PR DESCRIPTION
## Summary

- **PortOS now points at FastVideo's own FastH3 checkpoint**, not a third-party repack. PR #5867 concluded the upstream repos were weightless; they are not — the DiT lives under `transformer/` in the diffusers shard layout, which is exactly what FastVideo's own MPS guide converts before rendering. What was actually missing was a conversion step.
- **`--mlx-format` adds one.** A row declaring it points at the upstream snapshot, and the helper runs FastVideo's `convert_minimax_h3_mlx.py` once into a cache keyed by the snapshot path, so two revisions can't collide on one DiT and a second render reuses the first conversion. Rows without it keep passing an explicit `--mlx-checkpoint`, so the existing repack row is untouched.
- Ships the snapshot at **all three formats (int8/int6/int4)** — one 144 GB download differing only by that local step, which is the knob that maps to the user's RAM.
- **Dense, not VSA.** The MLX runtime drops `attn.to_gate_compress` by name because its attention is dense, so converting the VSA student would load it with the mechanism it was distilled around deleted. VSA-DataFree stays a CUDA target.

### Two fixes found by actually running it

- **Frame picker offered two values that always fail.** `mlx_fasth3.py` refuses anything outside 5–15s at its fixed 24 fps, but the shipped grid ran 107..362 — so the *first* and *last* entries (107 = 4.46s, 362 = 15.08s) reached the runtime and raised `H3 generates 5-15 s at 24 fps` instead of rendering. Clamped to 124..345; migration 334 repairs installs that already ran 333, but only while the row still holds 333's exact list.
- **Conditioning was recomputed every render.** Streaming the bf16 Qwen3-VL conditioner was 307s of a 621s render and produces identical embeddings each time, so PortOS now passes `--prompt-cache-dir`. Upstream digests each entry over its cache version, the model root and the prompt, so one shared directory is safe across models.

The two derived-artifact roots are declared in `runtimes.js` and passed as flags, matching the `MINIMAX_H3_PROMPT_EMBEDDING_CACHE_DIR` sibling — the converted DiT is multi-GB per (snapshot, format), so a root the server can't name is one it can't reclaim.

## Test plan

Verified end to end on an M5 Max / 128 GB, against the real upstream checkpoint:

- Downloaded FastVideo's actual 66 GB bf16 `transformer/` @ `f624f08c` and converted it to an MLX INT6 DiT in **21.9s** — 1464 arrays, matching the tensor count upstream's own conversion manifest records.
- Rendered from that converted checkpoint through the exact argv `buildFastVideoArgs` emits: 832x480, 124 frames, H.264 @ 24 fps + synchronized 32 kHz stereo AAC.
- Confirmed a second render **reuses** the cached DiT (zero reconversions) and hits the prompt cache (conditioning 307.0s → **0.003s**), producing a **byte-identical** MP4 — the cache costs nothing in output.
- Confirmed the `run_child` refactor is behavior-preserving: a render through it is byte-identical to one through the pre-refactor path.
- Re-verified today that FastVideo's three pre-converted MLX repos are still weightless (`usedStorage: 0`), so the local conversion is the only path to them.

Suites: `server` 1855 files / 37661 tests and `client` 867 files / 10803 tests — the only failures were parallel-load timeouts (`imageGen.multipart`, `peerSyncAuthIntegration`, `settings.secretsStrip`, `trellis2NormalBake`, `LocalLlmTab`), all passing in isolation and none touching these files. `scripts/generate_fastvideo_test.py`: 17 pass.