### PR TITLE
feat: add rigging clip compatibility contracts

### DIFF
--- a/data.reference/rigging/README.md
+++ b/data.reference/rigging/README.md
@@ -1,0 +1,15 @@
+# Rigging clip library
+
+`data/rigging/clips/` is a **file-primary** library of animation-bearing GLB
+files that you own or are licensed to use. PortOS creates this empty directory
+from `data.reference/` during `npm run setup:data`; it does not bundle clip
+assets here.
+
+Drop a `.glb` file containing animation clips into this directory. A later
+retarget job will inspect its skeleton and refuse a partial or unrecognized
+mapping rather than producing a broken animation.
+
+Only use assets whose license permits your intended use. Good places to find
+your own compatible CC0 source material include the [Kenney asset library]
+(https://kenney.nl/assets) and other sources that expressly label the specific
+asset CC0. Verify the license for each file before adding it.

--- a/server/services/dataManager.js
+++ b/server/services/dataManager.js
@@ -116,6 +116,7 @@ export const CATEGORIES = {
   'rapid-reader-library': { label: 'Rapid Reader Shelf', description: 'Saved books for Rapid Reader — pasted and URL-imported prose kept on this machine, not regenerable', archivable: false, deletable: false },
   'repos': { label: 'Cloned Repos', description: 'Git repositories cloned by agents', archivable: false, deletable: true, purgeScope: 'category' },
   'review': { label: 'Review', description: 'Review hub items', archivable: true, deletable: true, purgeScope: 'category' },
+  'rigging': { label: 'Rigging Clip Library', description: 'User-dropped animation-bearing GLB source files for retargeting — the only copy of assets you supplied', archivable: false, deletable: false },
   'runs': { label: 'AI Runs', description: 'Agent run logs and outputs', archivable: true, deletable: true, purgeScope: 'category' },
   'screenshots': { label: 'Screenshots', description: 'Task-related screenshots', archivable: true, deletable: true, purgeScope: 'category' },
   'settings': { label: 'Settings', description: 'Per-feature settings files', archivable: true, deletable: false },

--- a/server/services/rigging/clipCapabilities.js
+++ b/server/services/rigging/clipCapabilities.js
@@ -1,0 +1,26 @@
+/** Shared vocabulary only; procedural Three.js clip definitions remain separate. */
+export const COS_STATE_CLIP_VOCABULARY = {
+  sleeping: ['sleeping', 'sleep', 'sit', 'sitting'],
+  thinking: ['idle', 'thinking'],
+  coding: ['coding', 'typing', 'work'],
+  investigating: ['investigating', 'investigate', 'scan', 'look'],
+  reviewing: ['reviewing', 'review', 'yes', 'nod'],
+  planning: ['planning', 'plan', 'thumbsup'],
+  ideating: ['ideating', 'idea', 'dance'],
+  speaking: ['speaking', 'talk', 'wave'],
+};
+
+const key = (value) => String(value || '').trim().toLowerCase();
+
+/** Reports exactly which CoS states a real clip roster supports. */
+export function buildClipCoverage(clipNames, vocabulary = COS_STATE_CLIP_VOCABULARY) {
+  const availableClips = [...new Set((Array.isArray(clipNames) ? clipNames : []).filter((name) => typeof name === 'string' && name.trim()))];
+  const byKey = new Map(availableClips.map((name) => [key(name), name]));
+  const coverageByState = Object.fromEntries(Object.entries(vocabulary).map(([state, candidates]) => {
+    const clip = (Array.isArray(candidates) ? candidates : []).map((candidate) => byKey.get(key(candidate))).find(Boolean) || null;
+    return [state, { covered: Boolean(clip), clip }];
+  }));
+  const coveredStates = Object.keys(coverageByState).filter((state) => coverageByState[state].covered);
+  const missingStates = Object.keys(coverageByState).filter((state) => !coverageByState[state].covered);
+  return { availableClips, coverageByState, coveredStates, missingStates, complete: missingStates.length === 0 };
+}

--- a/server/services/rigging/clipLibrary.js
+++ b/server/services/rigging/clipLibrary.js
@@ -1,0 +1,38 @@
+import { basename, extname, join } from 'path';
+import { dataPath, ensureDir, listDirectoryByExtension } from '../../lib/fileUtils.js';
+
+/**
+ * User-owned clip files are file-primary: they are externally supplied binary
+ * assets, travel with the install's data backup, and need no record graph or
+ * search index until a retarget job references one.
+ */
+export const CLIP_LIBRARY_DIR = dataPath('rigging', 'clips');
+export const CLIP_SOURCE_EXTENSIONS = ['.glb'];
+
+export function clipSourceLabel(filename) {
+  const name = basename(String(filename || ''));
+  const extension = extname(name);
+  return extension ? name.slice(0, -extension.length) : name;
+}
+
+/** List locally dropped animation-bearing GLB files, newest first. */
+export async function listClipSources({ directory = CLIP_LIBRARY_DIR } = {}) {
+  await ensureDir(directory);
+  const entries = await listDirectoryByExtension(directory, {
+    extensions: CLIP_SOURCE_EXTENSIONS,
+    mapEntry: (filename, path, stats) => ({
+      filename,
+      label: clipSourceLabel(filename),
+      path,
+      sizeBytes: stats.size,
+      updatedAt: stats.mtime.toISOString(),
+    }),
+  });
+  return entries.sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+}
+
+/** Resolve a library filename without accepting path traversal or extensions. */
+export function resolveClipSource(filename, { directory = CLIP_LIBRARY_DIR } = {}) {
+  if (typeof filename !== 'string' || !/^[a-z0-9][a-z0-9-]*\.glb$/i.test(filename)) return null;
+  return join(directory, filename);
+}

--- a/server/services/rigging/clipLibrary.js
+++ b/server/services/rigging/clipLibrary.js
@@ -1,5 +1,5 @@
-import { basename, extname, join } from 'path';
-import { dataPath, ensureDir, listDirectoryByExtension } from '../../lib/fileUtils.js';
+import { basename, extname } from 'path';
+import { dataPath, ensureDir, listDirectoryByExtension, makePathResolver } from '../../lib/fileUtils.js';
 
 /**
  * User-owned clip files are file-primary: they are externally supplied binary
@@ -32,7 +32,4 @@ export async function listClipSources({ directory = CLIP_LIBRARY_DIR } = {}) {
 }
 
 /** Resolve a library filename without accepting path traversal or extensions. */
-export function resolveClipSource(filename, { directory = CLIP_LIBRARY_DIR } = {}) {
-  if (typeof filename !== 'string' || !/^[a-z0-9][a-z0-9-]*\.glb$/i.test(filename)) return null;
-  return join(directory, filename);
-}
+export const resolveClipSource = makePathResolver(() => CLIP_LIBRARY_DIR, { extensions: CLIP_SOURCE_EXTENSIONS });

--- a/server/services/rigging/rigging.test.js
+++ b/server/services/rigging/rigging.test.js
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { buildClipCoverage } from './clipCapabilities.js';
+import { reduceBoneMapping, SKELETON_BONE_MAPPINGS } from './skeletonMapping.js';
+
+describe('rigging skeleton compatibility', () => {
+  const cc3Bones = Object.values(SKELETON_BONE_MAPPINGS.cc3);
+
+  it('maps a recognized Mixamo source onto a complete CC3 target', () => {
+    const sourceBones = Object.values(SKELETON_BONE_MAPPINGS.mixamo);
+    const result = reduceBoneMapping({ sourceBones, targetBones: cc3Bones, skeletonHint: 'cc3' });
+    expect(result).toMatchObject({ ok: true, skeletonHint: 'cc3', unmappedBones: [] });
+    expect(result.mappings).toHaveLength(sourceBones.length);
+    expect(result.mappings[0]).toMatchObject({ sourceBone: 'mixamorig:Hips', targetBone: 'CC_Base_Hip', joint: 'hips' });
+  });
+
+  it('refuses an unknown target convention and names every source bone', () => {
+    expect(reduceBoneMapping({ sourceBones: ['Hips', 'MysteryJoint'], targetBones: cc3Bones, skeletonHint: 'unknown' }))
+      .toEqual({ ok: false, reason: 'unrecognized-skeleton', mappings: [], unmappedBones: ['Hips', 'MysteryJoint'] });
+  });
+
+  it('refuses a partial match rather than retargeting only the compatible bones', () => {
+    const result = reduceBoneMapping({ sourceBones: ['mixamorig:Hips', 'mixamorig:Head'], targetBones: ['CC_Base_Hip'], skeletonHint: 'cc3' });
+    expect(result).toEqual({ ok: false, reason: 'partial-match', mappings: [], unmappedBones: ['mixamorig:Head'] });
+  });
+});
+
+describe('clip capability report', () => {
+  it('reports covered and missing states without treating a partial roster as complete', () => {
+    const result = buildClipCoverage(['Idle', 'Wave', 'Dance']);
+    expect(result.coverageByState.thinking).toEqual({ covered: true, clip: 'Idle' });
+    expect(result.coverageByState.speaking).toEqual({ covered: true, clip: 'Wave' });
+    expect(result.coverageByState.coding).toEqual({ covered: false, clip: null });
+    expect(result).toMatchObject({ complete: false, missingStates: expect.arrayContaining(['coding']) });
+  });
+});

--- a/server/services/rigging/skeletonMapping.js
+++ b/server/services/rigging/skeletonMapping.js
@@ -1,0 +1,59 @@
+/** Canonical joints deliberately shared by the two declared avatar conventions. */
+const JOINTS = ['hips', 'spine', 'chest', 'neck', 'head', 'leftUpperArm', 'leftLowerArm', 'leftHand', 'rightUpperArm', 'rightLowerArm', 'rightHand', 'leftUpperLeg', 'leftLowerLeg', 'leftFoot', 'rightUpperLeg', 'rightLowerLeg', 'rightFoot'];
+
+export const SKELETON_BONE_MAPPINGS = {
+  cc3: {
+    hips: 'CC_Base_Hip', spine: 'CC_Base_Spine', chest: 'CC_Base_Spine02', neck: 'CC_Base_NeckTwist01', head: 'CC_Base_Head',
+    leftUpperArm: 'CC_Base_L_Upperarm', leftLowerArm: 'CC_Base_L_Forearm', leftHand: 'CC_Base_L_Hand',
+    rightUpperArm: 'CC_Base_R_Upperarm', rightLowerArm: 'CC_Base_R_Forearm', rightHand: 'CC_Base_R_Hand',
+    leftUpperLeg: 'CC_Base_L_Thigh', leftLowerLeg: 'CC_Base_L_Calf', leftFoot: 'CC_Base_L_Foot',
+    rightUpperLeg: 'CC_Base_R_Thigh', rightLowerLeg: 'CC_Base_R_Calf', rightFoot: 'CC_Base_R_Foot',
+  },
+  mixamo: {
+    hips: 'mixamorig:Hips', spine: 'mixamorig:Spine', chest: 'mixamorig:Spine2', neck: 'mixamorig:Neck', head: 'mixamorig:Head',
+    leftUpperArm: 'mixamorig:LeftArm', leftLowerArm: 'mixamorig:LeftForeArm', leftHand: 'mixamorig:LeftHand',
+    rightUpperArm: 'mixamorig:RightArm', rightLowerArm: 'mixamorig:RightForeArm', rightHand: 'mixamorig:RightHand',
+    leftUpperLeg: 'mixamorig:LeftUpLeg', leftLowerLeg: 'mixamorig:LeftLeg', leftFoot: 'mixamorig:LeftFoot',
+    rightUpperLeg: 'mixamorig:RightUpLeg', rightLowerLeg: 'mixamorig:RightLeg', rightFoot: 'mixamorig:RightFoot',
+  },
+};
+
+const normalizeBoneName = (name) => String(name || '').replace(/[^a-z0-9]/gi, '').toLowerCase();
+const semanticByNormalizedName = new Map(
+  Object.entries(SKELETON_BONE_MAPPINGS).flatMap(([, mapping]) => Object.entries(mapping)
+    .flatMap(([joint, bone]) => [[normalizeBoneName(joint), joint], [normalizeBoneName(bone), joint]])),
+);
+
+export function knownSkeletonHint(hint) {
+  return Object.hasOwn(SKELETON_BONE_MAPPINGS, hint) ? hint : 'unknown';
+}
+
+/**
+ * Builds an all-or-nothing mapping. Every source bone must be understood and
+ * represented by the declared target convention; otherwise callers get a
+ * deterministic unmapped list and must refuse the retarget.
+ */
+export function reduceBoneMapping({ sourceBones, targetBones, skeletonHint } = {}) {
+  const sources = [...new Set((Array.isArray(sourceBones) ? sourceBones : []).filter((bone) => typeof bone === 'string' && bone))];
+  const targetHint = knownSkeletonHint(skeletonHint);
+  const targetSet = new Set(Array.isArray(targetBones) ? targetBones : []);
+  if (targetHint === 'unknown') return { ok: false, reason: 'unrecognized-skeleton', mappings: [], unmappedBones: sources };
+
+  const mapping = SKELETON_BONE_MAPPINGS[targetHint];
+  const mappings = [];
+  const unmappedBones = [];
+  for (const sourceBone of sources) {
+    const joint = semanticByNormalizedName.get(normalizeBoneName(sourceBone));
+    const targetBone = joint && mapping[joint];
+    if (!targetBone || !targetSet.has(targetBone)) {
+      unmappedBones.push(sourceBone);
+      continue;
+    }
+    mappings.push({ sourceBone, targetBone, joint });
+  }
+  return unmappedBones.length
+    ? { ok: false, reason: 'partial-match', mappings: [], unmappedBones }
+    : { ok: true, skeletonHint: targetHint, mappings, unmappedBones: [] };
+}
+
+export const REQUIRED_RETARGET_JOINTS = JOINTS;

--- a/server/services/rigging/skeletonMapping.js
+++ b/server/services/rigging/skeletonMapping.js
@@ -19,10 +19,11 @@ export const SKELETON_BONE_MAPPINGS = {
 };
 
 const normalizeBoneName = (name) => String(name || '').replace(/[^a-z0-9]/gi, '').toLowerCase();
-const semanticByNormalizedName = new Map(
-  Object.entries(SKELETON_BONE_MAPPINGS).flatMap(([, mapping]) => Object.entries(mapping)
-    .flatMap(([joint, bone]) => [[normalizeBoneName(joint), joint], [normalizeBoneName(bone), joint]])),
-);
+const semanticByNormalizedName = new Map([
+  ...JOINTS.map((joint) => [normalizeBoneName(joint), joint]),
+  ...Object.values(SKELETON_BONE_MAPPINGS).flatMap((mapping) => Object.entries(mapping)
+    .map(([joint, bone]) => [normalizeBoneName(bone), joint])),
+]);
 
 export function knownSkeletonHint(hint) {
   return Object.hasOwn(SKELETON_BONE_MAPPINGS, hint) ? hint : 'unknown';


### PR DESCRIPTION
## Summary
- add a file-primary, user-owned GLB clip library contract and setup-data documentation
- add strict CC3/Mixamo mapping reduction that refuses unknown or partial matches
- report actual CoS clip coverage for later selector and fallback work

## Tests
- `cd server && npm test -- rigging.test.js`

Closes #5892