### PR TITLE
Keep a long record name readable in detail-page headings

### DIFF
--- a/client/src/components/agents/AgentDetail.jsx
+++ b/client/src/components/agents/AgentDetail.jsx
@@ -123,7 +123,9 @@ export default function AgentDetail() {
             {agent.avatar?.emoji || '🤖'}
           </div>
           <div className="flex-1 min-w-0">
-            <h1 className="text-xl font-bold text-white truncate">{agent.name}</h1>
+            <h1 className="line-clamp-2 break-words text-xl font-bold text-white" title={agent.name}>
+              {agent.name}
+            </h1>
             {agent.description && (
               <p className="text-sm text-gray-400 truncate">{agent.description}</p>
             )}

--- a/client/src/components/apps/AppDetailView.jsx
+++ b/client/src/components/apps/AppDetailView.jsx
@@ -312,7 +312,12 @@ export default function AppDetailView() {
           </Link>
           <div className="flex-1 min-w-0">
             <div className="flex flex-wrap items-center gap-3">
-              <h1 className="text-xl font-bold text-white truncate">{app.name}</h1>
+              <h1
+                className="min-w-0 line-clamp-2 break-words text-xl font-bold text-white"
+                title={app.name}
+              >
+                {app.name}
+              </h1>
               {NON_PM2_TYPES.has(app.type) ? (
                 <span className="px-1.5 py-0.5 bg-port-accent/20 text-port-accent text-xs rounded">
                   {getAppTypeLabel(app.type)}

--- a/client/src/components/apps/AppDetailView.test.jsx
+++ b/client/src/components/apps/AppDetailView.test.jsx
@@ -114,6 +114,26 @@ describe('AppDetailView app-removal socket handling', () => {
   });
 });
 
+describe('AppDetailView header title', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    socketHandlers.clear();
+  });
+
+  // A truncated h1 is the ONLY place the app name appears on this route, and
+  // clipped text is neither selectable nor expandable — the tooltip is the sole
+  // access path to the rest of a long name on a phone (#5694).
+  it('exposes the full app name through the heading title attribute', async () => {
+    const longName = 'Example Application With A Deliberately Very Long Managed App Name For Wrapping';
+    api.getApp.mockResolvedValue({ ...APP, name: longName });
+
+    renderDetail();
+
+    const heading = await screen.findByRole('heading', { name: longName });
+    expect(heading).toHaveAttribute('title', longName);
+  });
+});
+
 describe('AppDetailView managed-app feature tabs', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/client/src/headingTruncationConventions.test.js
+++ b/client/src/headingTruncationConventions.test.js
@@ -1,0 +1,130 @@
+/**
+ * A detail page's `<h1>` is the only place the record's name appears on that
+ * route, so truncating it away leaves the value unreachable.
+ *
+ * `truncate` is `overflow:hidden; text-overflow:ellipsis; white-space:nowrap`.
+ * At a 360px viewport, after the back link, icon, badges and action buttons
+ * sharing the header row, the heading gets roughly 150-180px — about fifteen
+ * characters. A series named "Season 2 — The Reclamation Arc (draft)" renders
+ * as "Season 2 — The…", and because the clipped text is neither selectable nor
+ * expandable there is no way to read the rest on a phone. Desktop would at
+ * least surface a native tooltip if `title` were set; it wasn't (issue #5694).
+ *
+ * The rule: an `<h1>` that renders a DYNAMIC value (its children contain a JSX
+ * expression) and clips it with an unprefixed `truncate` must also carry a
+ * `title` attribute, so the full value stays reachable. The tree's fix is to
+ * drop `truncate` for `line-clamp-2 break-words` AND set `title` — two clamped
+ * lines plus a tooltip — but the guard polices the reachability half only, so a
+ * page that has a genuine reason to keep one ellipsised line stays legal as
+ * long as the value can still be read.
+ *
+ * Deliberately NOT flagged:
+ *  - A heading whose children are a STATIC string (`<h1 …>Media Gen</h1>`).
+ *    Nothing is lost when a title the code itself wrote gets clipped, and the
+ *    page's nav entry carries the same words.
+ *  - `line-clamp-*`, which wraps rather than clipping to one line.
+ *  - A variant-prefixed `md:truncate`, which leaves the phone — the viewport
+ *    that actually runs out of room — unclipped.
+ *  - `h2` and below: a section heading labels content that is itself on screen,
+ *    not the record's only identifier.
+ *
+ * Scoped to git-tracked non-test sources; comments are masked first so a doc
+ * block quoting example markup is documentation, not markup.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { trackedSourceFiles } from './test/trackedFiles.js';
+import { lineOf, maskComments } from './test/classNameScan.js';
+
+const CLIENT_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+// Unprefixed only — the base variant is the phone. `line-clamp-2` never matches:
+// the token boundary in front of `truncate` rules out a longer enclosing word.
+const TRUNCATE_TOKEN = /(?:^|[\s'"`{])truncate(?=[\s'"`}]|$)/;
+const TITLE_ATTR = /(?:^|\s)title\s*=/;
+
+/**
+ * Walk an `<h1` opening tag to its closing `>`, ignoring any `>` that sits
+ * inside a nested JSX expression or a quoted string — `title={a > b}` and a
+ * `className={`…`}` template both put one there.
+ */
+function readOpenTag(source, start) {
+  let i = start;
+  let depth = 0;
+  let quote = null;
+  while (i < source.length) {
+    const ch = source[i];
+    if (quote) {
+      if (ch === '\\') i += 1;
+      else if (ch === quote) quote = null;
+    } else if (ch === '"' || ch === "'" || ch === '`') quote = ch;
+    else if (ch === '{') depth += 1;
+    else if (ch === '}') depth -= 1;
+    else if (ch === '>' && depth === 0) return { attrs: source.slice(start, i), end: i + 1 };
+    i += 1;
+  }
+  return null;
+}
+
+function violationsIn(rawSource, file) {
+  const source = maskComments(rawSource);
+  const found = [];
+  const opener = /<h1(?=[\s/>])/g;
+  let match;
+  while ((match = opener.exec(source))) {
+    const tag = readOpenTag(source, match.index + 3);
+    if (!tag) break;
+    opener.lastIndex = tag.end;
+    const close = source.indexOf('</h1>', tag.end);
+    const children = close === -1 ? '' : source.slice(tag.end, close);
+    // A heading with no interpolation renders a string the code itself wrote.
+    if (!children.includes('{')) continue;
+    if (!TRUNCATE_TOKEN.test(tag.attrs)) continue;
+    if (TITLE_ATTR.test(tag.attrs)) continue;
+    found.push(`${file}:${lineOf(source, match.index)} — <h1${tag.attrs.replace(/\s+/g, ' ')}>`);
+  }
+  return found;
+}
+
+const findViolations = (file) =>
+  violationsIn(readFileSync(join(CLIENT_ROOT, file), 'utf8'), file);
+
+describe('detail-heading truncation conventions', () => {
+  const files = trackedSourceFiles(CLIENT_ROOT);
+
+  it('scans a populated client tree', () => {
+    expect(files.length).toBeGreaterThan(100);
+  });
+
+  // Without this the suite would still pass if the detector silently stopped
+  // matching anything — a green tree-wide guard proves nothing on its own.
+  it('flags a truncated dynamic heading and clears every safe form', () => {
+    const flagged = (markup) => violationsIn(markup, 'probe.jsx').length;
+    expect(flagged('<h1 className="text-xl font-bold truncate">{record.name}</h1>')).toBe(1);
+    expect(flagged('<h1 className="truncate">#{issue.number} — {issue.title}</h1>')).toBe(1);
+    // A tooltip keeps the full value reachable, whatever the clipping style.
+    expect(flagged('<h1 className="truncate" title={record.name}>{record.name}</h1>')).toBe(0);
+    expect(flagged('<h1 title={n} className="truncate">{n}</h1>')).toBe(0);
+    // The tree's canonical fix: wrap over two lines instead of clipping.
+    expect(flagged('<h1 className="line-clamp-2 break-words" title={n}>{n}</h1>')).toBe(0);
+    expect(flagged('<h1 className="line-clamp-2 break-words">{n}</h1>')).toBe(0);
+    // A static heading loses nothing it doesn't already say elsewhere.
+    expect(flagged('<h1 className="truncate">Media Gen</h1>')).toBe(0);
+    // A variant-prefixed clip leaves the phone alone.
+    expect(flagged('<h1 className="md:truncate">{n}</h1>')).toBe(0);
+    // A `>` inside an attribute expression must not end the tag early.
+    expect(flagged('<h1 className={n.length > 3 ? "truncate" : "x"}>{n}</h1>')).toBe(1);
+    expect(flagged('<h1 className={n.length > 3 ? "truncate" : "x"} title={n}>{n}</h1>')).toBe(0);
+    // Section headings are out of scope.
+    expect(flagged('<h2 className="truncate">{n}</h2>')).toBe(0);
+    // Example markup inside a doc block is documentation, not markup.
+    expect(violationsIn('// <h1 className="truncate">{record.name}</h1>', 'probe.jsx')).toEqual([]);
+  });
+
+  it('never clips a dynamic page title out of reach', () => {
+    expect(files.flatMap((file) => findViolations(file))).toEqual([]);
+  });
+});

--- a/client/src/pages/BrainScanReport.jsx
+++ b/client/src/pages/BrainScanReport.jsx
@@ -70,8 +70,13 @@ export default function BrainScanReport() {
             <ArrowLeft size={14} /> Brain Links
           </Link>
           <div className="flex items-center gap-2">
-            <FileText className="text-port-accent" size={24} />
-            <h1 className="truncate text-xl font-semibold text-white">{data.link.title}</h1>
+            <FileText className="shrink-0 text-port-accent" size={24} />
+            <h1
+              className="min-w-0 line-clamp-2 break-words text-xl font-semibold text-white"
+              title={data.link.title}
+            >
+              {data.link.title}
+            </h1>
           </div>
           <p className="mt-1 break-all text-xs text-gray-500">{data.link.url}</p>
         </div>

--- a/client/src/pages/CatalogIngredient.jsx
+++ b/client/src/pages/CatalogIngredient.jsx
@@ -482,7 +482,10 @@ export default function CatalogIngredient() {
             <Sparkles className="w-6 h-6 text-port-accent mt-1 flex-shrink-0" aria-hidden="true" />
             <div className="min-w-0">
               <div className="flex items-center gap-2 flex-wrap">
-                <h1 className="text-2xl font-bold text-white truncate">
+                <h1
+                  className="min-w-0 line-clamp-2 break-words text-2xl font-bold text-white"
+                  title={record.name || '(untitled)'}
+                >
                   {record.name || '(untitled)'}
                 </h1>
                 <span className={`text-[10px] uppercase tracking-wider px-2 py-0.5 rounded border ${badgeClass}`}>

--- a/client/src/pages/CatalogIngredient.test.jsx
+++ b/client/src/pages/CatalogIngredient.test.jsx
@@ -129,6 +129,18 @@ beforeEach(() => {
 });
 
 describe('CatalogIngredient — character sheet', () => {
+  // The h1 is the ONLY place the ingredient's name appears on this route, and
+  // clipped text is neither selectable nor expandable — the tooltip is the sole
+  // access path to the rest of a long name on a phone (#5694).
+  it('exposes the full record name through the heading title attribute', async () => {
+    const longName = 'Augusta Ada King, Countess of Lovelace, Analytical Engine Programmer and Mathematician';
+    getCatalogIngredientDetails.mockImplementation(async () => detailsOf({ ...CHAR_FIXTURE, name: longName }));
+    renderPage();
+
+    const heading = await screen.findByRole('heading', { name: longName });
+    expect(heading.getAttribute('title')).toBe(longName);
+  });
+
   it('requires confirmation before detaching media', async () => {
     detachCatalogIngredientMedia.mockResolvedValue({});
     getCatalogIngredientDetails.mockImplementation(async () => ({

--- a/client/src/pages/CreativeCommissionDetail.jsx
+++ b/client/src/pages/CreativeCommissionDetail.jsx
@@ -340,7 +340,12 @@ export default function CreativeCommissionDetail() {
             <Sparkles className="w-6 h-6 text-port-accent shrink-0" />
             <div className="min-w-0">
               <div className="flex items-center gap-2 flex-wrap">
-                <h1 className="text-xl font-semibold text-gray-100 truncate">{commission.name}</h1>
+                <h1
+                  className="min-w-0 line-clamp-2 break-words text-xl font-semibold text-gray-100"
+                  title={commission.name}
+                >
+                  {commission.name}
+                </h1>
                 <span className={`text-[10px] uppercase px-1.5 py-0.5 rounded ${commission.enabled ? 'bg-port-success/20 text-port-success' : 'bg-gray-700 text-gray-400'}`}>
                   {commission.enabled ? 'Active' : 'Paused'}
                 </span>

--- a/client/src/pages/CreativeDirectorDetail.jsx
+++ b/client/src/pages/CreativeDirectorDetail.jsx
@@ -240,7 +240,7 @@ export default function CreativeDirectorDetail() {
           <div className="flex items-center gap-3 min-w-0">
             <Link to="/creative-director" className="text-port-text-muted hover:text-port-text"><ArrowLeft className="w-4 h-4" /></Link>
             <div className="min-w-0">
-              <h1 className="text-xl font-semibold truncate">{project.name}</h1>
+              <h1 className="line-clamp-2 break-words text-xl font-semibold" title={project.name}>{project.name}</h1>
               <div className="text-xs text-port-text-muted truncate">
                 {project.id} • status: <span className="text-port-text">{project.status}</span>
               </div>

--- a/client/src/pages/Game.jsx
+++ b/client/src/pages/Game.jsx
@@ -391,7 +391,7 @@ export default function Game() {
           </Link>
           <Gamepad2 className="h-6 w-6 shrink-0 text-port-accent" aria-hidden="true" />
           <div className="min-w-0">
-            <h1 className="truncate text-xl font-bold text-white">{game.name}</h1>
+            <h1 className="line-clamp-2 break-words text-xl font-bold text-white" title={game.name}>{game.name}</h1>
             <p className="truncate text-xs text-gray-400">{app?.name || 'Managed app unavailable'}</p>
           </div>
         </div>

--- a/client/src/pages/PipelineIssue.jsx
+++ b/client/src/pages/PipelineIssue.jsx
@@ -331,7 +331,12 @@ export default function PipelineIssue() {
         </div>
 
         <div className="flex items-center justify-between gap-3 flex-wrap">
-          <h1 className="text-xl font-bold text-white truncate">#{issue.number} — {issue.title}</h1>
+          <h1
+            className="min-w-0 line-clamp-2 break-words text-xl font-bold text-white"
+            title={`#${issue.number} — ${issue.title}`}
+          >
+            #{issue.number} — {issue.title}
+          </h1>
           <div className="flex items-center gap-2 flex-wrap">
             <ArcRolePicker
               issue={issue}

--- a/client/src/pages/PipelineManuscriptEditor.jsx
+++ b/client/src/pages/PipelineManuscriptEditor.jsx
@@ -773,8 +773,13 @@ export default function PipelineManuscriptEditor() {
             <Link to={`/pipeline/series/${seriesId}`} className="inline-flex items-center gap-1 text-sm text-gray-400 hover:text-white">
               <ArrowLeft size={14} /> Series
             </Link>
-            <FileText className="w-5 h-5 text-port-accent ml-2" />
-            <h1 className="text-xl font-bold text-white truncate">{series?.name || 'Manuscript'}</h1>
+            <FileText className="w-5 h-5 shrink-0 text-port-accent ml-2" />
+            <h1
+              className="min-w-0 line-clamp-2 break-words text-xl font-bold text-white"
+              title={series?.name || 'Manuscript'}
+            >
+              {series?.name || 'Manuscript'}
+            </h1>
 
             <div className="ml-auto flex items-center gap-2 flex-wrap">
               {/* View-mode toggle: Live (Grammarly) vs Review (annotated). */}

--- a/client/src/pages/PipelineSeries.jsx
+++ b/client/src/pages/PipelineSeries.jsx
@@ -231,8 +231,13 @@ export default function PipelineSeries() {
             <Link to="/pipeline" className="inline-flex items-center gap-1 text-sm text-gray-400 hover:text-white">
               <ArrowLeft size={14} /> All Series
             </Link>
-            <WorkflowIcon className="w-5 h-5 text-port-accent ml-2" />
-            <h1 className="text-xl font-bold text-white truncate">{series.name || 'Untitled series'}</h1>
+            <WorkflowIcon className="w-5 h-5 shrink-0 text-port-accent ml-2" />
+            <h1
+              className="min-w-0 line-clamp-2 break-words text-xl font-bold text-white"
+              title={series.name || 'Untitled series'}
+            >
+              {series.name || 'Untitled series'}
+            </h1>
             {series.writersRoomWorkId ? (
               <Link
                 to={`/writers-room/works/${encodeURIComponent(series.writersRoomWorkId)}`}

--- a/scripts/ci-test-plan.js
+++ b/scripts/ci-test-plan.js
@@ -271,11 +271,12 @@ const structuralTestsFor = (changedFiles, trackedSet) => {
   // Both `.js` and `.jsx`: the StrictMode mounted-ref bug the first guard covers
   // reached its widest blast radius through a plain-`.js` hook (`useAsyncAction`),
   // so a `.jsx`-only trigger would miss the case that matters most, and the
-  // responsive-grid, popover-clamp, and safe-storage guards read class strings
-  // and storage accesses out of both extensions. None of these files has a source
-  // sibling or imports an app module, so nothing else selects them — without this
-  // entry they only ever run on a full suite.
+  // responsive-grid, popover-clamp, safe-storage, and heading-truncation guards
+  // read class strings, storage accesses, and JSX markup out of both extensions.
+  // None of these files has a source sibling or imports an app module, so nothing
+  // else selects them — without this entry they only ever run on a full suite.
   if (changedFiles.some((path) => /^client\/src\/.*\.jsx?$/.test(path))) {
+    add('client/src/headingTruncationConventions.test.js');
     add('client/src/hooks/mountedRefConventions.test.js');
     add('client/src/popoverClampConventions.test.js');
     add('client/src/responsiveGridConventions.test.js');

--- a/scripts/repo-scan-guards.test.js
+++ b/scripts/repo-scan-guards.test.js
@@ -38,6 +38,7 @@ const STRUCTURALLY_SELECTED = new Map([
   // client/src/**.jsx (a11y) or .js/.jsx (mounted-ref) file changes, which is
   // the only way either can start failing.
   ['client/src/a11yConventions.test.js', 'structuralTestsFor: client/src/**.jsx'],
+  ['client/src/headingTruncationConventions.test.js', 'structuralTestsFor: client/src/**.js(x)'],
   ['client/src/hooks/mountedRefConventions.test.js', 'structuralTestsFor: client/src/**.js(x)'],
   ['client/src/popoverClampConventions.test.js', 'structuralTestsFor: client/src/**.js(x)'],
   ['client/src/responsiveGridConventions.test.js', 'structuralTestsFor: client/src/**.js(x)'],


### PR DESCRIPTION
## Summary

- Ten detail pages clipped the record's user-supplied name with `truncate` on the page `<h1>`. At 360px the heading gets roughly 150-180px after the back link, icon, badges and action buttons sharing the row — about fifteen characters — and clipped text is neither selectable nor expandable. The `<h1>` is the only place the name appears on those routes and none carried a `title`, so the full value was unreachable on a phone and on desktop hover alike.
- Replaced `truncate` with `line-clamp-2 break-words` and added `title={<the same expression>}` on `AgentDetail`, `AppDetailView`, `BrainScanReport`, `CatalogIngredient`, `CreativeCommissionDetail`, `CreativeDirectorDetail`, `Game`, `PipelineIssue`, `PipelineManuscriptEditor` and `PipelineSeries`. Two clamped lines plus a native tooltip; `break-words` keeps a long unspaced id from widening the row.
- Added `min-w-0` to the headings that are direct flex children, so the clamp engages instead of pushing the action buttons off-screen, and `shrink-0` to the three leading icons that the now-wrapping heading no longer shields from the row's shrink.
- Left the three static-string truncations (`LocalLlmPlayground`, `MediaGen`, `Shell`) alone — nothing is lost when a heading the code itself wrote gets clipped.

## Test plan

- New `client/src/headingTruncationConventions.test.js`, a tree-wide guard in the existing `*Conventions.test.js` family: an `<h1>` rendering a dynamic value and clipping it with an unprefixed `truncate` must carry a `title`. Verified it flags all ten pre-fix sites (stash the source changes → the guard reports exactly those ten) and clears static headings, `line-clamp-*`, and variant-prefixed `md:truncate`. Carries a bypass probe so a silently-inert detector can't pass green.
- Extended `client/src/pages/CatalogIngredient.test.jsx` and `client/src/components/apps/AppDetailView.test.jsx` with a render using an ~85-character name, asserting the heading's `title` equals the full name.
- `cd client && npx vitest run` — 868 files / 10826 tests pass. One pre-existing load-related flake in `src/pages/ChiefOfStaff.test.jsx` (untouched by this change) passes on an isolated re-run.
- `cd client && npx biome lint --error-on-warnings src` — clean.
- Acceptance grep returns only the three static cases:
  `grep -rnE '<h1[^>]*className="[^"]*\btruncate\b' client/src --include='*.jsx' | grep -v test | grep -v 'title='`

Closes #5694
