### PR TITLE
Raise MeatSpace log-row icon buttons to the 44px tap-target floor

### DIFF
--- a/client/src/a11yConventions.test.js
+++ b/client/src/a11yConventions.test.js
@@ -32,6 +32,9 @@
  *   6. An `<img>` with no `alt`, which is announced by its `src` — a hashed
  *      filename or a blob URL. `alt=""` is the correct spelling for a
  *      decorative image and passes; only the omission is the bug.
+ *   7. An icon-only `<button>` in the MeatSpace health-logging tree sized to
+ *      its bare icon (`p-1` around a 12-14px glyph = a 22px target) instead of
+ *      the 44px floor the rest of the app enforces.
  *
  * Scoped to git-tracked `.jsx` under `client/src` so an untracked scratch file
  * can't fail the suite.
@@ -742,17 +745,24 @@ function findButtonBody(src, openEnd) {
   return closeIdx === -1 ? null : src.slice(openEnd, closeIdx);
 }
 
-// Is this <button> node an icon-only button with nothing to name it? Named
-// rather than inlined in the rule so the `selfClosing` it reads is testable:
-// this rule scans UNMASKED source, where a comment survives to the end of the
-// tag — `<button /* pause */>` ends in `*/>`, which the old `endsWith('/>')`
-// re-derivation called self-closing, skipping a button that has a body and
-// needs a name.
-function isUnnamedIconOnlyButton(src, { tag, contentStart, selfClosing }) {
+// Is this <button> node one whose entire body is an icon? Named rather than
+// inlined in the rule so the `selfClosing` it reads is testable: these rules
+// scan UNMASKED source, where a comment survives to the end of the tag —
+// `<button /* pause */>` ends in `*/>`, which the old `endsWith('/>')`
+// re-derivation called self-closing, skipping a button that has a body.
+//
+// Two rules ask about the same shape for different reasons: the naming rule
+// wants the ones with nothing to announce, the touch-target rule wants all of
+// them (an aria-label makes a 22px button announceable, not tappable).
+function isIconOnlyButton(src, { contentStart, selfClosing }) {
   if (selfClosing) return false; // no body to judge
-  if (/\baria-label\s*=/.test(tag) || /\baria-labelledby\s*=/.test(tag)) return false;
   const body = findButtonBody(src, contentStart);
   return body !== null && isIconOnlyBody(body);
+}
+
+function isUnnamedIconOnlyButton(src, node) {
+  if (/\baria-label\s*=/.test(node.tag) || /\baria-labelledby\s*=/.test(node.tag)) return false;
+  return isIconOnlyButton(src, node);
 }
 
 // Tailwind `h-`/`w-`/`min-h-`/`min-w-` token → px, for both an arbitrary
@@ -3254,5 +3264,55 @@ describe('a11y conventions', () => {
       }
     }
     expect(offenders, `Close button under the 44px touch-target minimum — add min-h-[44px] min-w-[44px] + flex items-center justify-center (see Drawer.jsx:106):\n${offenders.join('\n')}`).toEqual([]);
+  });
+
+  it("meets the 44px touch-target minimum on the MeatSpace log-row icon buttons (#5703)", () => {
+    // The MeatSpace tabs are the app's most phone-centric surface — a drink or
+    // a nicotine entry is logged one-handed — and their inline row controls
+    // kept shipping as a bare `p-1`/`p-1.5` around a 12-14px icon: a 22-26px
+    // target, half the floor everywhere else. Save and Cancel sit adjacent in
+    // the edit rows, so a mis-tap commits or discards the wrong edit.
+    //
+    // The fix grows the invisible box (`min-h-[44px] min-w-[44px]` +
+    // `inline-flex items-center justify-center`), never the icon: icon size is
+    // what sets the log row's density, and growing it would reflow the tables.
+    //
+    // Two scopings, both deliberate. `components/meatspace/` rather than the
+    // whole tree: the same shape survives in a handful of desktop-first views,
+    // and widening here would turn one regression guard into a tree-wide sweep.
+    // And only the `p-0.5`/`p-1`/`p-1.5` shape, rather than every icon button
+    // missing an explicit min: one that reaches 44px through generous padding
+    // (`p-3` around a 20px glyph), or that carries no padding class at all, is a
+    // different question, and folding it in would make the guard report dozens
+    // of controls this change never looked at.
+    const TIGHT_PADDING = /(?:^|\s)p-(?:0\.5|1|1\.5)(?:\s|$)/;
+    const offendersIn = (file, src) => {
+      const out = [];
+      for (const node of forEachOpeningTag(src, "button")) {
+        if (!isIconOnlyButton(src, node)) continue;
+        const cls = node.tag.match(/className\s*=\s*"([^"]*)"/);
+        if (!cls) continue; // dynamic className — reviewed by hand, not scanned here
+        if (!TIGHT_PADDING.test(cls[1])) continue;
+        if (hasFortyFourMinTouchTarget(cls[1])) continue;
+        out.push(`${file}:${lineOf(src, node.index)}`);
+      }
+      return out;
+    };
+
+    // Probe first: a green run has to mean "no offenders", not "the matcher
+    // stopped recognizing the shape it was written for".
+    const probe = (cls) => offendersIn("probe.jsx", `<button aria-label="Save" className="${cls}"><Check size={14} /></button>`);
+    expect(probe("p-1 text-port-success")).toEqual(["probe.jsx:1"]);
+    expect(probe("min-h-[44px] min-w-[44px] inline-flex items-center justify-center p-1")).toEqual([]);
+    // …and that the padding scoping is a scoping, not an accident: a roomier
+    // button is out of this rule's remit even though it declares no min either.
+    expect(probe("p-2 text-port-success")).toEqual([]);
+
+    const offenders = [];
+    for (const file of trackedJsxFiles()) {
+      if (!file.startsWith("src/components/meatspace/")) continue;
+      offenders.push(...offendersIn(file, rawSourceOf(file)));
+    }
+    expect(offenders, `MeatSpace icon-only <button> under the 44px touch-target minimum — add min-h-[44px] min-w-[44px] inline-flex items-center justify-center and leave the icon size alone:\n${offenders.join("\n")}`).toEqual([]);
   });
 });

--- a/client/src/a11yConventions.test.js
+++ b/client/src/a11yConventions.test.js
@@ -3308,11 +3308,15 @@ describe('a11y conventions', () => {
     // button is out of this rule's remit even though it declares no min either.
     expect(probe("p-2 text-port-success")).toEqual([]);
 
+    // The prefix is `trackedJsxFiles()`'s path shape (`git ls-files src` run
+    // from client/), not this file's location — assert the filter really
+    // selected the tree, so a change to the walker's path shape fails loudly
+    // here instead of turning the rule into a vacuous pass over zero files.
+    const scanned = trackedJsxFiles().filter((file) => file.startsWith("src/components/meatspace/"));
+    expect(scanned.length, "no MeatSpace sources matched — has trackedJsxFiles() changed its path shape?").toBeGreaterThan(20);
+
     const offenders = [];
-    for (const file of trackedJsxFiles()) {
-      if (!file.startsWith("src/components/meatspace/")) continue;
-      offenders.push(...offendersIn(file, rawSourceOf(file)));
-    }
+    for (const file of scanned) offenders.push(...offendersIn(file, rawSourceOf(file)));
     expect(offenders, `MeatSpace icon-only <button> under the 44px touch-target minimum — add min-h-[44px] min-w-[44px] inline-flex items-center justify-center and leave the icon size alone:\n${offenders.join("\n")}`).toEqual([]);
   });
 });

--- a/client/src/components/meatspace/post/MemoryBuilder.jsx
+++ b/client/src/components/meatspace/post/MemoryBuilder.jsx
@@ -293,7 +293,7 @@ export default function MemoryBuilder({ onBack, onSelectItem, onReviewItem = onS
                   <button
                     onClick={() => requestDelete(item.id)}
                     aria-label={`Delete ${item.title}`}
-                    className="p-1.5 text-gray-500 hover:text-port-error transition-colors"
+                    className="min-h-[44px] min-w-[44px] inline-flex items-center justify-center p-1.5 text-gray-500 hover:text-port-error transition-colors"
                   >
                     <Trash2 size={14} />
                   </button>

--- a/client/src/components/meatspace/post/MemoryPractice.jsx
+++ b/client/src/components/meatspace/post/MemoryPractice.jsx
@@ -981,9 +981,9 @@ function SpeedRunLine({ line, index, onResult }) {
             {line.text}
           </span>
           {marked === null && (
-            <div className="flex gap-1 shrink-0">
-              <button onClick={() => mark(true)} aria-label={`Mark line ${index + 1} correct`} className="p-1 text-port-success hover:bg-port-success/10 rounded"><Check size={14} /></button>
-              <button onClick={() => mark(false)} aria-label={`Mark line ${index + 1} incorrect`} className="p-1 text-port-error hover:bg-port-error/10 rounded"><X size={14} /></button>
+            <div className="flex gap-2 shrink-0">
+              <button onClick={() => mark(true)} aria-label={`Mark line ${index + 1} correct`} className="min-h-[44px] min-w-[44px] inline-flex items-center justify-center p-1 text-port-success hover:bg-port-success/10 rounded"><Check size={14} /></button>
+              <button onClick={() => mark(false)} aria-label={`Mark line ${index + 1} incorrect`} className="min-h-[44px] min-w-[44px] inline-flex items-center justify-center p-1 text-port-error hover:bg-port-error/10 rounded"><X size={14} /></button>
             </div>
           )}
         </div>

--- a/client/src/components/meatspace/post/MorseProgressPanel.jsx
+++ b/client/src/components/meatspace/post/MorseProgressPanel.jsx
@@ -174,7 +174,7 @@ export default function MorseProgressPanel({ refreshKey = 0 }) {
           ))}
           <button
             onClick={() => load(days)}
-            className="p-1 text-gray-500 hover:text-port-accent transition-colors"
+            className="min-h-[44px] min-w-[44px] inline-flex items-center justify-center p-1 text-gray-500 hover:text-port-accent transition-colors"
             aria-label="Refresh progress"
           >
             <RefreshCw size={12} className={loading ? 'animate-spin' : ''} />

--- a/client/src/components/meatspace/post/MorseTrainer.jsx
+++ b/client/src/components/meatspace/post/MorseTrainer.jsx
@@ -548,7 +548,7 @@ export default function MorseTrainer({ mode = null, onSelectMode, onExitMode, on
       <div className="flex items-center gap-3">
         <button
           onClick={onBack}
-          className="p-1.5 text-gray-400 hover:text-white bg-port-card border border-port-border rounded-lg transition-colors"
+          className="min-h-[44px] min-w-[44px] inline-flex items-center justify-center p-1.5 text-gray-400 hover:text-white bg-port-card border border-port-border rounded-lg transition-colors"
           aria-label="Back"
         >
           <ArrowLeft size={16} />

--- a/client/src/components/meatspace/post/WordplayTrainer.jsx
+++ b/client/src/components/meatspace/post/WordplayTrainer.jsx
@@ -421,7 +421,7 @@ export default function WordplayTrainer({ onBack, onContinue, config, onConfigUp
     return (
       <div className="max-w-2xl mx-auto space-y-6 px-4">
         <div className="flex items-center gap-3">
-          <button aria-label="Back" onClick={onBack} className="p-1.5 hover:bg-port-card rounded-lg transition-colors">
+          <button aria-label="Back" onClick={onBack} className="min-h-[44px] min-w-[44px] inline-flex items-center justify-center p-1.5 hover:bg-port-card rounded-lg transition-colors">
             <ArrowLeft size={20} className="text-gray-400" />
           </button>
           <h2 className="text-xl font-bold text-white">Wordplay Training</h2>
@@ -676,7 +676,7 @@ function ModeHeader({ modeInfo, onBack }) {
   const Icon = modeInfo?.icon || Link;
   return (
     <div className="flex items-center gap-3">
-      <button aria-label="Back" onClick={onBack} className="p-1.5 hover:bg-port-card rounded-lg transition-colors">
+      <button aria-label="Back" onClick={onBack} className="min-h-[44px] min-w-[44px] inline-flex items-center justify-center p-1.5 hover:bg-port-card rounded-lg transition-colors">
         <ArrowLeft size={20} className="text-gray-400" />
       </button>
       <div className={`p-1.5 rounded-lg ${modeInfo?.bgColor || 'bg-purple-500/20'}`}>

--- a/client/src/components/meatspace/tabs/AlcoholTab.jsx
+++ b/client/src/components/meatspace/tabs/AlcoholTab.jsx
@@ -384,10 +384,10 @@ export default function AlcoholTab() {
                       aria-label="Drink button ABV percent"
                       className="w-16 px-2 py-1.5 bg-port-bg border border-port-border rounded-lg text-xs text-white text-right"
                     />
-                    <button onClick={saveEditButton} className="p-1.5 text-port-success hover:text-port-success/80" title="Save" aria-label="Save">
+                    <button onClick={saveEditButton} className="min-h-[44px] min-w-[44px] inline-flex items-center justify-center p-1.5 text-port-success hover:text-port-success/80" title="Save" aria-label="Save">
                       <Check size={14} />
                     </button>
-                    <button onClick={cancelEditButton} className="p-1.5 text-gray-500 hover:text-gray-300" title="Cancel" aria-label="Cancel">
+                    <button onClick={cancelEditButton} className="min-h-[44px] min-w-[44px] inline-flex items-center justify-center p-1.5 text-gray-500 hover:text-gray-300" title="Cancel" aria-label="Cancel">
                       <X size={14} />
                     </button>
                   </>
@@ -396,7 +396,7 @@ export default function AlcoholTab() {
                     <span className="flex-1 text-xs text-gray-300">{drink.name}</span>
                     <span className="text-xs text-gray-500">{drink.oz}oz</span>
                     <span className="text-xs text-gray-500">{drink.abv}%</span>
-                    <button onClick={() => startEditButton(idx)} className="p-1.5 text-gray-600 hover:text-port-accent" title="Edit" aria-label="Edit">
+                    <button onClick={() => startEditButton(idx)} className="min-h-[44px] min-w-[44px] inline-flex items-center justify-center p-1.5 text-gray-600 hover:text-port-accent" title="Edit" aria-label="Edit">
                       <Pencil size={12} />
                     </button>
                     {isConfirming(`btn:${idx}`) ? (
@@ -409,7 +409,7 @@ export default function AlcoholTab() {
                         onCancel={cancelDelete}
                       />
                     ) : (
-                      <button onClick={() => requestDelete(`btn:${idx}`)} className="p-1.5 text-gray-600 hover:text-port-error" title="Remove" aria-label="Remove">
+                      <button onClick={() => requestDelete(`btn:${idx}`)} className="min-h-[44px] min-w-[44px] inline-flex items-center justify-center p-1.5 text-gray-600 hover:text-port-error" title="Remove" aria-label="Remove">
                         <Trash2 size={12} />
                       </button>
                     )}
@@ -658,17 +658,17 @@ export default function AlcoholTab() {
                               {computeStdDrinks(toOz(parseFloat(editForm.oz), editVolumeUnit), parseFloat(editForm.abv), parseInt(editForm.count) || 1)}
                             </td>
                             <td className="px-3 py-1.5 text-right">
-                              <div className="flex items-center justify-end gap-1">
+                              <div className="flex items-center justify-end gap-2">
                                 <button
                                   onClick={saveEdit}
-                                  className="p-1 text-port-success hover:text-port-success/80 transition-colors"
+                                  className="min-h-[44px] min-w-[44px] inline-flex items-center justify-center p-1 text-port-success hover:text-port-success/80 transition-colors"
                                   title="Save" aria-label="Save"
                                 >
                                   <Check size={14} />
                                 </button>
                                 <button
                                   onClick={cancelEdit}
-                                  className="p-1 text-gray-500 hover:text-gray-300 transition-colors"
+                                  className="min-h-[44px] min-w-[44px] inline-flex items-center justify-center p-1 text-gray-500 hover:text-gray-300 transition-colors"
                                   title="Cancel" aria-label="Cancel"
                                 >
                                   <X size={14} />
@@ -684,10 +684,10 @@ export default function AlcoholTab() {
                             <td className="px-3 py-1.5 text-right text-gray-300">{drink.count > 1 ? drink.count : 1}</td>
                             <td className="px-3 py-1.5 text-right text-gray-400">{stdDrinks}</td>
                             <td className="px-3 py-1.5 text-right">
-                              <div className="flex items-center justify-end gap-1">
+                              <div className="flex items-center justify-end gap-2">
                                 <button
                                   onClick={() => startEdit(entry.date, idx, drink)}
-                                  className="p-1 text-gray-600 hover:text-port-accent transition-colors"
+                                  className="min-h-[44px] min-w-[44px] inline-flex items-center justify-center p-1 text-gray-600 hover:text-port-accent transition-colors"
                                   title="Edit drink" aria-label="Edit drink"
                                 >
                                   <Pencil size={12} />
@@ -704,7 +704,7 @@ export default function AlcoholTab() {
                                 ) : (
                                   <button
                                     onClick={() => requestDelete(key)}
-                                    className="p-1 text-gray-600 hover:text-port-error transition-colors"
+                                    className="min-h-[44px] min-w-[44px] inline-flex items-center justify-center p-1 text-gray-600 hover:text-port-error transition-colors"
                                     title="Remove drink" aria-label="Remove drink"
                                   >
                                     <Trash2 size={12} />

--- a/client/src/components/meatspace/tabs/BodyTab.jsx
+++ b/client/src/components/meatspace/tabs/BodyTab.jsx
@@ -222,10 +222,10 @@ export default function BodyTab() {
                       <td className="py-1.5 px-2 text-right font-mono text-gray-300">{formatSph(exam.rightCylinder)}</td>
                       <td className="py-1.5 px-2 text-right font-mono text-gray-300">{exam.rightAxis != null ? `${exam.rightAxis}\u00B0` : '\u2014'}</td>
                       <td className="py-1.5 px-2 text-right">
-                        <div className="flex items-center justify-end gap-1">
+                        <div className="flex items-center justify-end gap-2">
                           <button
                             onClick={() => startEditEye(exam, realIdx)}
-                            className="p-1 text-gray-600 hover:text-port-accent transition-colors"
+                            className="min-h-[44px] min-w-[44px] inline-flex items-center justify-center p-1 text-gray-600 hover:text-port-accent transition-colors"
                             title="Edit" aria-label="Edit"
                           >
                             <Pencil size={12} />
@@ -241,7 +241,7 @@ export default function BodyTab() {
                           ) : (
                             <button
                               onClick={() => requestDelete(realIdx)}
-                              className="p-1 text-gray-600 hover:text-port-error transition-colors"
+                              className="min-h-[44px] min-w-[44px] inline-flex items-center justify-center p-1 text-gray-600 hover:text-port-error transition-colors"
                               title="Delete" aria-label="Delete"
                             >
                               <Trash2 size={12} />

--- a/client/src/components/meatspace/tabs/CalendarTab.jsx
+++ b/client/src/components/meatspace/tabs/CalendarTab.jsx
@@ -197,7 +197,7 @@ export default function CalendarTab() {
               </div>
               <button
                 onClick={() => handleRemoveActivity(i)}
-                className="opacity-40 sm:opacity-0 sm:group-hover:opacity-100 focus-visible:opacity-100 transition-opacity text-gray-600 hover:text-port-error p-0.5"
+                className="min-h-[44px] min-w-[44px] inline-flex items-center justify-center opacity-40 sm:opacity-0 sm:group-hover:opacity-100 focus-visible:opacity-100 transition-opacity text-gray-600 hover:text-port-error p-0.5"
                 title="Remove activity" aria-label="Remove activity"
               >
                 <Trash2 size={12} />

--- a/client/src/components/meatspace/tabs/NicotineTab.jsx
+++ b/client/src/components/meatspace/tabs/NicotineTab.jsx
@@ -269,14 +269,14 @@ export default function NicotineTab() {
                       aria-label="Product button milligrams per unit"
                       step="0.1"
                     />
-                    <button aria-label="Save" onClick={saveEditButton} className="p-1.5 text-port-success hover:text-white"><Check size={14} /></button>
-                    <button aria-label="Cancel" onClick={cancelEditButton} className="p-1.5 text-gray-500 hover:text-white"><X size={14} /></button>
+                    <button aria-label="Save" onClick={saveEditButton} className="min-h-[44px] min-w-[44px] inline-flex items-center justify-center p-1.5 text-port-success hover:text-white"><Check size={14} /></button>
+                    <button aria-label="Cancel" onClick={cancelEditButton} className="min-h-[44px] min-w-[44px] inline-flex items-center justify-center p-1.5 text-gray-500 hover:text-white"><X size={14} /></button>
                   </>
                 ) : (
                   <>
                     <span className="flex-1 text-xs text-gray-300">{btn.name}</span>
                     <span className="text-xs text-gray-500">{btn.mgPerUnit}mg</span>
-                    <button aria-label="Edit" onClick={() => startEditButton(idx)} className="p-1.5 text-gray-600 hover:text-port-accent"><Pencil size={12} /></button>
+                    <button aria-label="Edit" onClick={() => startEditButton(idx)} className="min-h-[44px] min-w-[44px] inline-flex items-center justify-center p-1.5 text-gray-600 hover:text-port-accent"><Pencil size={12} /></button>
                     {isConfirming(`btn:${idx}`) ? (
                       <ConfirmButtonPair
                         prompt="Remove?"
@@ -287,7 +287,7 @@ export default function NicotineTab() {
                         onCancel={cancelDelete}
                       />
                     ) : (
-                      <button aria-label="Delete" onClick={() => requestDelete(`btn:${idx}`)} className="p-1.5 text-gray-600 hover:text-port-error"><Trash2 size={12} /></button>
+                      <button aria-label="Delete" onClick={() => requestDelete(`btn:${idx}`)} className="min-h-[44px] min-w-[44px] inline-flex items-center justify-center p-1.5 text-gray-600 hover:text-port-error"><Trash2 size={12} /></button>
                     )}
                   </>
                 )}
@@ -491,9 +491,9 @@ export default function NicotineTab() {
                               {Math.round(parseFloat(editForm.mgPerUnit || 0) * (parseInt(editForm.count, 10) || 1) * 100) / 100}mg
                             </td>
                             <td className="px-3 py-1.5 text-right">
-                              <div className="flex items-center justify-end gap-1">
-                                <button aria-label="Save" onClick={saveEdit} className="p-1 text-port-success hover:text-port-success/80"><Check size={14} /></button>
-                                <button aria-label="Cancel" onClick={cancelEdit} className="p-1 text-gray-500 hover:text-gray-300"><X size={14} /></button>
+                              <div className="flex items-center justify-end gap-2">
+                                <button aria-label="Save" onClick={saveEdit} className="min-h-[44px] min-w-[44px] inline-flex items-center justify-center p-1 text-port-success hover:text-port-success/80"><Check size={14} /></button>
+                                <button aria-label="Cancel" onClick={cancelEdit} className="min-h-[44px] min-w-[44px] inline-flex items-center justify-center p-1 text-gray-500 hover:text-gray-300"><X size={14} /></button>
                               </div>
                             </td>
                           </>
@@ -504,8 +504,8 @@ export default function NicotineTab() {
                             <td className="px-3 py-1.5 text-right text-gray-300">{item.count > 1 ? item.count : 1}</td>
                             <td className="px-3 py-1.5 text-right text-white font-medium">{itemTotal}mg</td>
                             <td className="px-3 py-1.5 text-right">
-                              <div className="flex items-center justify-end gap-1">
-                                <button aria-label="Edit" onClick={() => startEdit(entry.date, idx, item)} className="p-1 text-gray-600 hover:text-port-accent"><Pencil size={12} /></button>
+                              <div className="flex items-center justify-end gap-2">
+                                <button aria-label="Edit" onClick={() => startEdit(entry.date, idx, item)} className="min-h-[44px] min-w-[44px] inline-flex items-center justify-center p-1 text-gray-600 hover:text-port-accent"><Pencil size={12} /></button>
                                 {isConfirming(key) ? (
                                   <ConfirmButtonPair
                                     prompt="Remove?"
@@ -516,7 +516,7 @@ export default function NicotineTab() {
                                     onCancel={cancelDelete}
                                   />
                                 ) : (
-                                  <button aria-label="Delete" onClick={() => requestDelete(key)} className="p-1 text-gray-600 hover:text-port-error"><Trash2 size={12} /></button>
+                                  <button aria-label="Delete" onClick={() => requestDelete(key)} className="min-h-[44px] min-w-[44px] inline-flex items-center justify-center p-1 text-gray-600 hover:text-port-error"><Trash2 size={12} /></button>
                                 )}
                               </div>
                             </td>

--- a/client/src/components/meatspace/tabs/calendar/LifeEventsPanel.jsx
+++ b/client/src/components/meatspace/tabs/calendar/LifeEventsPanel.jsx
@@ -76,14 +76,14 @@ export default function LifeEventsPanel({ events, onAdd, onToggle, onRemove }) {
                   <span className="text-[10px] text-gray-600">{event.type}</span>
                   <button
                     onClick={() => onToggle(event.id, !event.enabled)}
-                    className="text-gray-500 hover:text-white transition-colors p-0.5"
+                    className="min-h-[44px] min-w-[44px] inline-flex items-center justify-center text-gray-500 hover:text-white transition-colors p-0.5"
                     title={event.enabled ? 'Disable' : 'Enable'} aria-label={event.enabled ? 'Disable' : 'Enable'}
                   >
                     {event.enabled ? <Eye size={12} /> : <EyeOff size={12} />}
                   </button>
                   <button
                     onClick={() => onRemove(event.id)}
-                    className="opacity-40 sm:opacity-0 sm:group-hover:opacity-100 focus-visible:opacity-100 transition-opacity text-gray-600 hover:text-port-error p-0.5"
+                    className="min-h-[44px] min-w-[44px] inline-flex items-center justify-center opacity-40 sm:opacity-0 sm:group-hover:opacity-100 focus-visible:opacity-100 transition-opacity text-gray-600 hover:text-port-error p-0.5"
                     title="Remove" aria-label="Remove"
                   >
                     <Trash2 size={12} />

--- a/client/src/components/media/PromptFromMedia.jsx
+++ b/client/src/components/media/PromptFromMedia.jsx
@@ -357,7 +357,7 @@ function PromptResultField({ label, value, negative, onCopy, onApply, applyLabel
       <div className="flex items-center justify-between">
         <span className="text-[11px] uppercase tracking-wide text-gray-500">{label}</span>
         <div className="flex items-center gap-1">
-          <button type="button" onClick={onCopy} className="p-1 rounded text-gray-400 hover:text-white hover:bg-port-border/50" aria-label={`Copy ${label}`}>
+          <button type="button" onClick={onCopy} className="min-h-[44px] min-w-[44px] inline-flex items-center justify-center p-1 rounded text-gray-400 hover:text-white hover:bg-port-border/50" aria-label={`Copy ${label}`}>
             <Copy className="w-3.5 h-3.5" />
           </button>
           <button

--- a/client/src/components/settings/LocalLlmTab.jsx
+++ b/client/src/components/settings/LocalLlmTab.jsx
@@ -1070,7 +1070,7 @@ export function LocalLlmTab({ view }) {
       <div className="bg-port-card border border-port-border rounded-xl p-4 sm:p-6 space-y-4">
         <div className="flex items-center justify-between">
           <h2 className="text-sm font-medium text-gray-300">Local LLM Backends</h2>
-          <button onClick={loadStatus} disabled={loading} className="p-1.5 text-gray-400 hover:text-white transition-colors" title="Refresh" aria-label="Refresh local LLM status">
+          <button onClick={loadStatus} disabled={loading} className="min-h-[44px] min-w-[44px] inline-flex items-center justify-center p-1.5 text-gray-400 hover:text-white transition-colors" title="Refresh" aria-label="Refresh local LLM status">
             <RefreshCw size={14} className={loading ? 'animate-spin' : ''} />
           </button>
         </div>

--- a/client/src/components/sharing/ConflictsTab.jsx
+++ b/client/src/components/sharing/ConflictsTab.jsx
@@ -104,7 +104,7 @@ function ConflictEntry({ entry, onResolved }) {
             className="px-2 py-1 rounded border border-port-border text-gray-400 hover:text-white text-[11px]">
             Discard
           </button>
-          <button type="button" onClick={remove} disabled={busy} className="p-1 text-gray-500 hover:text-port-error" title="Remove entry" aria-label="Remove entry">
+          <button type="button" onClick={remove} disabled={busy} className="min-h-[44px] min-w-[44px] inline-flex items-center justify-center p-1 text-gray-500 hover:text-port-error" title="Remove entry" aria-label="Remove entry">
             <Trash2 size={13} />
           </button>
         </div>

--- a/client/src/components/wiki/tabs/GraphTab.jsx
+++ b/client/src/components/wiki/tabs/GraphTab.jsx
@@ -227,7 +227,7 @@ export default function GraphTab({ vaultId }) {
         >
           Reset
         </button>
-        <button onClick={loadGraph} aria-label="Refresh" className="p-1.5 rounded bg-port-card border border-port-border text-gray-400 hover:text-white">
+        <button onClick={loadGraph} aria-label="Refresh" className="min-h-[44px] min-w-[44px] inline-flex items-center justify-center p-1.5 rounded bg-port-card border border-port-border text-gray-400 hover:text-white">
           <RefreshCw size={14} />
         </button>
       </div>

--- a/client/src/components/wiki/tabs/LogTab.jsx
+++ b/client/src/components/wiki/tabs/LogTab.jsx
@@ -82,7 +82,7 @@ export default function LogTab({ vaultId, allNotes }) {
         <div className="flex items-center gap-2 text-xs text-gray-500">
           <span>{entries.length} entries</span>
           {log.modifiedAt && <span>Updated {timeAgo(log.modifiedAt)}</span>}
-          <button onClick={loadLog} aria-label="Refresh" className="p-1 rounded hover:bg-port-card text-gray-500 hover:text-white">
+          <button onClick={loadLog} aria-label="Refresh" className="min-h-[44px] min-w-[44px] inline-flex items-center justify-center p-1 rounded hover:bg-port-card text-gray-500 hover:text-white">
             <RefreshCw size={12} />
           </button>
         </div>

--- a/client/src/pages/Loops.jsx
+++ b/client/src/pages/Loops.jsx
@@ -395,7 +395,7 @@ export default function Loops() {
         <div className="flex items-center gap-3 text-xs text-gray-400">
           {runningCount > 0 && <span className="text-port-success">{runningCount} active</span>}
           <span>{loops.length} total</span>
-          <button onClick={fetchLoops} className="p-1 rounded hover:bg-port-border" title="Refresh" aria-label="Refresh">
+          <button onClick={fetchLoops} className="min-h-[44px] min-w-[44px] inline-flex items-center justify-center p-1 rounded hover:bg-port-border" title="Refresh" aria-label="Refresh">
             <RefreshCw size={14} />
           </button>
         </div>

--- a/client/src/pages/Review.jsx
+++ b/client/src/pages/Review.jsx
@@ -740,11 +740,11 @@ function ReviewItem({ item, config, idScope, isEditing, onComplete, onDismiss, o
               rows={2}
               className="w-full bg-port-bg border border-port-border rounded px-2 py-1 text-sm text-gray-300 focus:outline-none focus:border-port-accent resize-none"
             />
-            <div className="flex gap-1">
-              <button onClick={() => onSaveEdit(item.id, editTitle.trim(), editDescription.trim())} aria-label="Save" className="p-1 text-port-success hover:text-port-success/80" title="Save">
+            <div className="flex gap-2">
+              <button onClick={() => onSaveEdit(item.id, editTitle.trim(), editDescription.trim())} aria-label="Save" className="min-h-[44px] min-w-[44px] inline-flex items-center justify-center p-1 text-port-success hover:text-port-success/80" title="Save">
                 <Check size={16} />
               </button>
-              <button onClick={onCancelEdit} aria-label="Cancel" className="p-1 text-gray-500 hover:text-white" title="Cancel">
+              <button onClick={onCancelEdit} aria-label="Cancel" className="min-h-[44px] min-w-[44px] inline-flex items-center justify-center p-1 text-gray-500 hover:text-white" title="Cancel">
                 <X size={16} />
               </button>
             </div>


### PR DESCRIPTION
## Summary

- Raises every icon-only `<button>` in `client/src/components/meatspace/` that was styled `p-0.5`/`p-1`/`p-1.5` from a 22-26px hit area to the 44px floor the rest of the app enforces, by adding `min-h-[44px] min-w-[44px] inline-flex items-center justify-center`. **Icon sizes are unchanged** — growing the glyph would change the log tables' density; growing the invisible box does not.
- Widens the action rows that hold two of those targets from `gap-1` to `gap-2` so adjacent Save/Cancel no longer butt up against each other (nicotine + alcohol edit rows, the eye-exam row, the memory speed-run row).
- Applies the same fix to the seven single controls the audit named outside MeatSpace: `settings/LocalLlmTab.jsx`, `wiki/tabs/GraphTab.jsx`, `wiki/tabs/LogTab.jsx`, `sharing/ConflictsTab.jsx`, `media/PromptFromMedia.jsx`, `pages/Loops.jsx`, `pages/Review.jsx`.
- Also fixes Review's inline **Save**, which sits directly beside the named Cancel. The issue's acceptance grep missed it because `<button[^>]*` stops at the `>` inside an arrow function — the same blind spot hid four more controls in `NicotineTab.jsx`, which are fixed here too. Re-running the grep without that prefix is what produced the final offender list.
- New regression guard in `client/src/a11yConventions.test.js`, which already owned the 44px close-button scan. `isIconOnlyButton` is split out of `isUnnamedIconOnlyButton` so the naming rule and the touch-target rule read one definition of the shape (an aria-label makes a 22px button announceable, not tappable).

### Deliberately out of scope

The `LocalLlmTab.jsx` edit is the two tap-target attributes on one line, so it stays trivially rebaseable under the pending component split (#5720). The guard is scoped to `components/meatspace/` and to the tight-padding shape — icon buttons that reach 44px through generous padding, or that carry no padding class at all, are a different question and a handful survive in desktop-first views; widening the rule here would turn one regression guard into a tree-wide sweep.

## Test plan

- `cd client && npx vitest run src/a11yConventions.test.js` — 50 passed, including the new rule. It probes itself against a synthetic offender before scanning, and asserts the file filter actually selected the tree, so a green run means "none left" rather than "matcher went blind" or "scanned zero files".
- `cd client && npx vitest run src/components/meatspace src/components/settings/LocalLlmTab src/components/wiki/tabs src/components/sharing/ConflictsTab src/components/media/PromptFromMedia src/pages/Loops src/pages/Review` — 551 passed. `PostDrillConfig.test.jsx` hit five 5s hook timeouts in the batch run; it passes 41/41 in isolation and the file is untouched by this change (this worktree lives under `data/`, which the suite walks).
- `cd client && npm run lint` — clean.
- Issue acceptance grep returns nothing; the broadened grep (no `<button[^>]*` prefix) leaves only two `<div>` padding wrappers in `calendar/LifeGrid.jsx`, which are not controls.

Closes #5703
