### PR TITLE
Shard full CI runs, scope python sidecar changes, and stop rebase churn on sorted catalogs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -27,3 +27,18 @@
 *.woff2 binary
 *.ttf binary
 *.eot binary
+
+# Sorted catalogs and barrels: one line per module, so concurrent branches
+# conflict on the same insertion hunk. `union` keeps both sides;
+# scripts/catalog-merge-union.test.js catches a doubled or resurrected line
+# and pins this list to the barrel list in scripts/ci-test-plan.js. Rationale
+# and rules: AGENTS.md "Module Organization".
+server/lib/README.md merge=union
+server/lib/index.js merge=union
+client/src/lib/README.md merge=union
+client/src/lib/index.js merge=union
+client/src/hooks/README.md merge=union
+client/src/hooks/index.js merge=union
+client/src/utils/README.md merge=union
+client/src/utils/index.js merge=union
+client/src/services/README.md merge=union

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,13 @@ jobs:
       windows_mode: ${{ steps.plan.outputs.windows_mode }}
       windows_files: ${{ steps.plan.outputs.windows_files }}
       windows_sources: ${{ steps.plan.outputs.windows_sources }}
+      # JSON arrays of shard indexes — `[1]` for a scoped plan, `[1..n]` for a
+      # full one. Each leaf job builds its matrix from these, because a
+      # job-level `if` cannot read `matrix` and so cannot skip extra shards on
+      # its own. See FULL_SUITE_SHARDS in scripts/ci-test-plan.js.
+      server_shards: ${{ steps.plan.outputs.server_shards }}
+      client_shards: ${{ steps.plan.outputs.client_shards }}
+      windows_shards: ${{ steps.plan.outputs.windows_shards }}
       suite_reasons: ${{ steps.plan.outputs.suite_reasons }}
     steps:
       - uses: actions/checkout@v7
@@ -91,27 +98,36 @@ jobs:
           SMOKE_MODE: ${{ steps.plan.outputs.smoke }}
           WINDOWS_MODE: ${{ steps.plan.outputs.windows }}
           WINDOWS_TEST_MODE: ${{ steps.plan.outputs.windows_mode }}
+          SERVER_SHARDS: ${{ steps.plan.outputs.server_shards }}
+          CLIENT_SHARDS: ${{ steps.plan.outputs.client_shards }}
+          WINDOWS_SHARDS: ${{ steps.plan.outputs.windows_shards }}
           SUITE_REASONS: ${{ steps.plan.outputs.suite_reasons }}
         run: |
           {
             echo "### CI impact plan"
             echo
             echo "- Reason: \`${PLAN_REASON}\`"
-            echo "- Server tests: \`${SERVER_MODE}\`"
-            echo "- Client tests: \`${CLIENT_MODE}\`"
+            echo "- Server tests: \`${SERVER_MODE}\` (shards \`${SERVER_SHARDS}\`)"
+            echo "- Client tests: \`${CLIENT_MODE}\` (shards \`${CLIENT_SHARDS}\`)"
             echo "- DB tests: \`${DB_MODE}\`"
             echo "- Client lint: \`${LINT_MODE}\`"
             echo "- Client build: \`${BUILD_MODE}\`"
             echo "- Server smoke: \`${SMOKE_MODE}\`"
-            echo "- Windows server tests: \`${WINDOWS_MODE}\` (\`${WINDOWS_TEST_MODE}\`)"
+            echo "- Windows server tests: \`${WINDOWS_MODE}\` (\`${WINDOWS_TEST_MODE}\`, shards \`${WINDOWS_SHARDS}\`)"
             echo "- Suite selection reasons: \`${SUITE_REASONS}\`"
           } >> "$GITHUB_STEP_SUMMARY"
 
   server:
-    name: Server tests
+    # Sharded on a full plan — see docs/GITHUB_ACTIONS.md "Full-suite sharding".
+    # The matrix comes from the planner; once-only steps pin to shard 1, and the
+    # transform-artifact cache key carries the shard so parallel saves don't race.
+    name: Server tests (${{ matrix.shard }}/${{ strategy.job-total }})
     needs: impact
     if: needs.impact.outputs.server_mode != 'skip'
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        shard: ${{ fromJSON(needs.impact.outputs.server_shards) }}
     permissions:
       contents: read
       actions: write
@@ -226,7 +242,7 @@ jobs:
           path: |
             server/node_modules/.vite
             server/node_modules/.vitest
-          key: vitest-server-${{ runner.os }}-${{ hashFiles('server/package-lock.json', 'server/vitest.config.js', 'scripts/vitestCiPool.js') }}
+          key: vitest-server-${{ runner.os }}-${{ hashFiles('server/package-lock.json', 'server/vitest.config.js', 'scripts/vitestCiPool.js') }}-${{ matrix.shard }}of${{ strategy.job-total }}
           restore-keys: |
             vitest-server-${{ runner.os }}-${{ hashFiles('server/package-lock.json') }}-
             vitest-server-${{ runner.os }}-
@@ -240,6 +256,7 @@ jobs:
           CI_TEST_MODE: ${{ needs.impact.outputs.server_mode }}
           CI_TEST_FILES: ${{ needs.impact.outputs.server_files }}
           CI_TEST_SOURCES: ${{ needs.impact.outputs.server_sources }}
+          CI_SHARD: ${{ matrix.shard }}/${{ strategy.job-total }}
           # Keep successful-test output signal-dense. Developers can reproduce
           # locally without this flag when assertion context needs app logs.
           PORTOS_TEST_QUIET: 1
@@ -252,7 +269,7 @@ jobs:
       # backend. It does need the native rebuild (server boot loads node-pty),
       # which is why it lives on this job rather than a third installer.
       - name: Smoke-boot server
-        if: needs.impact.outputs.smoke == 'true'
+        if: needs.impact.outputs.smoke == 'true' && matrix.shard == 1
         run: npm run smoke
 
       - name: Cancel sibling CI jobs after failure
@@ -262,10 +279,14 @@ jobs:
         run: node scripts/cancel-current-ci-run.js
 
   client:
-    name: Client tests and build
+    # Sharded like the server job; lint, build, and the bundle budget run on shard 1.
+    name: Client tests and build (${{ matrix.shard }}/${{ strategy.job-total }})
     needs: impact
     if: needs.impact.outputs.client_mode != 'skip' || needs.impact.outputs.build == 'true' || needs.impact.outputs.lint_mode != 'skip'
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        shard: ${{ fromJSON(needs.impact.outputs.client_shards) }}
     permissions:
       contents: read
       actions: write
@@ -296,13 +317,13 @@ jobs:
           path: |
             client/node_modules/.vite
             client/node_modules/.vitest
-          key: vitest-client-${{ runner.os }}-${{ hashFiles('client/package-lock.json', 'client/vitest.config.js', 'scripts/vitestCiPool.js') }}
+          key: vitest-client-${{ runner.os }}-${{ hashFiles('client/package-lock.json', 'client/vitest.config.js', 'scripts/vitestCiPool.js') }}-${{ matrix.shard }}of${{ strategy.job-total }}
           restore-keys: |
             vitest-client-${{ runner.os }}-${{ hashFiles('client/package-lock.json') }}-
             vitest-client-${{ runner.os }}-
 
       - name: Lint client
-        if: needs.impact.outputs.lint_mode != 'skip'
+        if: needs.impact.outputs.lint_mode != 'skip' && matrix.shard == 1
         env:
           CI_LINT_MODE: ${{ needs.impact.outputs.lint_mode }}
           CI_LINT_FILES: ${{ needs.impact.outputs.lint_files }}
@@ -314,17 +335,18 @@ jobs:
           CI_TEST_MODE: ${{ needs.impact.outputs.client_mode }}
           CI_TEST_FILES: ${{ needs.impact.outputs.client_files }}
           CI_TEST_SOURCES: ${{ needs.impact.outputs.client_sources }}
+          CI_SHARD: ${{ matrix.shard }}/${{ strategy.job-total }}
         run: node scripts/run-ci-tests.js client
 
       - name: Build client
-        if: needs.impact.outputs.build == 'true'
+        if: needs.impact.outputs.build == 'true' && matrix.shard == 1
         run: npm run build --prefix client
 
       # The Scalar bundle budget can only be measured against a real build, and it
       # skips itself when client/dist is absent — so it runs here, not in the unit
       # test job. See client/src/pages/ApiExplorer.bundle.test.js.
       - name: Check API Explorer bundle budget
-        if: needs.impact.outputs.build == 'true'
+        if: needs.impact.outputs.build == 'true' && matrix.shard == 1
         run: npm run test --prefix client -- ApiExplorer.bundle
 
       - name: Cancel sibling CI jobs after failure
@@ -478,10 +500,14 @@ jobs:
         run: node scripts/cancel-current-ci-run.js
 
   windows-server:
-    name: Windows server unit tests
+    # Sharded like the server job.
+    name: Windows server unit tests (${{ matrix.shard }}/${{ strategy.job-total }})
     needs: impact
     if: needs.impact.outputs.windows == 'true'
     runs-on: windows-latest
+    strategy:
+      matrix:
+        shard: ${{ fromJSON(needs.impact.outputs.windows_shards) }}
     permissions:
       contents: read
       actions: write
@@ -581,7 +607,7 @@ jobs:
           path: |
             server/node_modules/.vite
             server/node_modules/.vitest
-          key: vitest-server-${{ runner.os }}-${{ hashFiles('server/package-lock.json', 'server/vitest.config.js', 'scripts/vitestCiPool.js') }}
+          key: vitest-server-${{ runner.os }}-${{ hashFiles('server/package-lock.json', 'server/vitest.config.js', 'scripts/vitestCiPool.js') }}-${{ matrix.shard }}of${{ strategy.job-total }}
           restore-keys: |
             vitest-server-${{ runner.os }}-${{ hashFiles('server/package-lock.json') }}-
             vitest-server-${{ runner.os }}-
@@ -594,6 +620,7 @@ jobs:
           CI_TEST_MODE: ${{ needs.impact.outputs.windows_mode }}
           CI_TEST_FILES: ${{ needs.impact.outputs.windows_files }}
           CI_TEST_SOURCES: ${{ needs.impact.outputs.windows_sources }}
+          CI_SHARD: ${{ matrix.shard }}/${{ strategy.job-total }}
           PORTOS_TEST_QUIET: 1
           PGPASSWORD: portos
         run: node scripts/run-ci-tests.js server

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -172,6 +172,8 @@ Any new file in `server/lib/`, `client/src/lib/`, `client/src/hooks/`, `client/s
 
 This is the one rule that keeps catalogs from rotting, and it is enforced: `server/lib/index.test.js` and its client counterparts fail when a non-test `.js` file is missing from either the barrel or the README.
 
+**These catalogs and barrels merge with git's `union` driver** (`.gitattributes`), because every branch inserts one sorted line into each and two concurrent branches routinely collide on the same hunk. Union keeps both sides, which is right for an insertion and wrong for an edit or deletion beside one — so after a rebase that touched a catalog, `scripts/catalog-merge-union.test.js` (always-run) fails on a doubled or resurrected row; keep one and move on. Never give a file with real code paths the `union` attribute; the guard rejects a `.js` that is not a pure re-export barrel.
+
 **Name collisions.** When two modules in one directory export the same identifier (e.g. `settingsUpdateInputSchema` in both `brainValidation.js` and `digitalTwinValidation.js`), the barrel uses `export * as <name>` namespace exports so callers reach for `brainValidation.settingsUpdateInputSchema` explicitly. Catch-all modules like `validation.js` stay flat. The collision-detector test fails if two flat-`export *` modules ever share an identifier, forcing namespace resolution where the conflict is introduced.
 
 Existing deep imports (`import { x } from '../lib/foo.js'`) keep working — the barrel exists for *discovery*, not to force a re-import. New code may use either form. The worked example for "barrel + documented exports" is `server/lib/aiToolkit/index.js`.

--- a/docs/GITHUB_ACTIONS.md
+++ b/docs/GITHUB_ACTIONS.md
@@ -216,7 +216,7 @@ The selected work is split across parallel jobs:
   restored and its trusted-rebuild mark checks out.
 - **Client tests and build** — affected client tests; production build whenever
   client source changed; client lint on the same install so Biome does not pay a
-  second `npm ci`.
+  second `npm ci`. Lint, build, and the bundle budget run on shard 1 only.
 - **DB tests** — provisions only the isolated `portos_test` database and runs
   the serial DB suite when database-sensitive files changed.
 - **Windows server tests** — the same server selection, but only on full CI
@@ -230,6 +230,47 @@ The selected work is split across parallel jobs:
 - **Full CI Gate** — published only when the plan chose the complete suite, and
   mirrors `CI Gate`'s result. This is the check the release workflow looks for;
   see "Reusing the release PR's CI run" below.
+
+### Full-suite sharding
+
+A full plan is the slow case: on the 4-vCPU public runners the client suite
+alone took ~10 minutes (jsdom setup per file dominates — the 868-file run
+spent 489 s in `environment` against 384 s in `tests` — and its worker cap is
+two, see `scripts/vitestCiPool.js`), the Windows server suite ~10 minutes
+(module import is several times slower there), and the Linux server suite ~6
+minutes. Roughly half of all PR runs went full, so most PRs waited on the
+longest of those.
+
+The three test-runner jobs are therefore matrices. The impact job emits
+`server_shards`, `client_shards`, and `windows_shards` — `[1]` for a scoped
+plan and `[1..n]` for a full one, sized by `FULL_SUITE_SHARDS` in
+`scripts/ci-test-plan.js` (client 3, Windows 3, server 2) — and each job builds
+its matrix from that output. The decision has to be made in the planner: a
+job-level `if` cannot read the `matrix` context, so a job cannot skip its own
+extra shards. `scripts/run-ci-tests.js` turns `CI_SHARD=<index>/<count>` into
+Vitest's `--shard`, which slices the file list by path hash — every shard is a
+fixed, disjoint subset, and their union is the complete suite. A scoped plan
+never shards (its handful of files would trip Vitest's shard-count guard) and
+passes no flag at all, so its invocation stays identical to a local
+`npm run test:ci`. Once-only steps — smoke boot, lint, the client build, the
+bundle budget — pin themselves to shard 1. `CI Gate` sees a matrix job as one
+`needs` result, so nothing downstream changes; public-repo runner minutes are
+free, so the fan-out costs only concurrency.
+
+`scripts/run-ci-tests.test.js` pins the wiring: every runner job builds its
+matrix from the planner, hands `CI_SHARD` to the runner, and gates its
+once-only steps on shard 1.
+
+### Python sidecar scripts
+
+`scripts/*.py` (the LTX-2, MiniMax, FastVideo, and download sidecars) used to
+be "unclassified changed files" and forced the complete matrix on every edit.
+Vitest's import graph cannot reach into them, but ~45 suites pin their
+contracts by reading the `.py` source as text (argparse flags, MLX pins, model
+paths). The planner now resolves the suites naming each changed script with
+`git grep` (`pythonReferencePattern`) and runs exactly them in `files` mode,
+failing closed to the full suite for a script nothing names. A `.py` outside
+`scripts/` is still unclassified.
 
 Targeted `files` plans run the planner's exact test files once. `related` plans
 run `vitest related` once with changed behavioral source paths and the cheap
@@ -332,6 +373,9 @@ aggregate diagnostics and cache post-steps can complete normally.
 - Barrel/catalog guards are added when reusable `lib`, `hooks`, or `utils`
   directories change, and catalog-only barrels are excluded from import-graph
   expansion. JSX changes include the global accessibility convention guard.
+- A `scripts/*.py` sidecar selects every test that names a python script
+  (`git grep`), in `files` mode, and falls back to the full suite when none do
+  — see "Python sidecar scripts" above.
 - A deleted executable source cannot be handed to `vitest related`, so that
   case fails closed to the complete suite.
 - Database adapters, DB scripts, and relevant migrations add the complete

--- a/docs/GITHUB_ACTIONS.md
+++ b/docs/GITHUB_ACTIONS.md
@@ -373,6 +373,11 @@ aggregate diagnostics and cache post-steps can complete normally.
 - Barrel/catalog guards are added when reusable `lib`, `hooks`, or `utils`
   directories change, and catalog-only barrels are excluded from import-graph
   expansion. JSX changes include the global accessibility convention guard.
+- Any server source change adds the two generated-manifest drift tests
+  (`generate-api-route-catalog`, `generate-prompt-stage-call-sites`). They
+  regenerate from the tree rather than importing what they scan, so no import
+  edge reaches them; before this rule a route added on a scoped plan could
+  merge with a stale catalog and turn every later full-plan PR red.
 - A `scripts/*.py` sidecar selects every test that names a python script
   (`git grep`), in `files` mode, and falls back to the full suite when none do
   — see "Python sidecar scripts" above.

--- a/scripts/catalog-merge-union.test.js
+++ b/scripts/catalog-merge-union.test.js
@@ -1,0 +1,107 @@
+/**
+ * Guard for the catalogs and barrels `.gitattributes` merges with `union`
+ * (rationale: AGENTS.md "Module Organization"). Union keeps both sides of a
+ * conflicting hunk — right for an insertion, wrong for an edit or deletion
+ * beside one — so this catches the doubled or resurrected line nothing else
+ * would, and pins the precondition: every `.js` listed is a pure re-export
+ * barrel, where two edits to one line cannot both be right silently.
+ *
+ * Always-run: a README is documentation to the impact planner, so nothing
+ * else would run this on a docs-only rebase.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { STRUCTURAL_BARRELS } from './ci-test-plan.js';
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+const CONFLICT_MARKER_RE = /^(?:<{7}|={7}|>{7})(?:\s|$)/m;
+const BARREL_LINE_RE = /^export (?:\*|\* as \w+|\{[^}]+\}) from '(\.\/[^']+)';$/;
+const CATALOG_ROW_RE = /^\|\s*`([^`]+)`/;
+
+/** Paths `.gitattributes` assigns `merge=union`, repo-relative. */
+export const unionMergedPaths = (gitattributes) => gitattributes
+  .split('\n')
+  .map((line) => line.trim())
+  .filter((line) => line && !line.startsWith('#') && /\smerge=union(?:\s|$)/.test(line))
+  .map((line) => line.split(/\s+/)[0]);
+
+const duplicates = (values) => {
+  const seen = new Set();
+  const doubled = new Set();
+  for (const value of values) (seen.has(value) ? doubled : seen).add(value);
+  return [...doubled];
+};
+
+/** Non-blank, non-comment barrel lines that are not a single `export … from './x'`. */
+export const nonBarrelLines = (lines) => lines
+  .filter((line) => line.trim() && !line.trim().startsWith('//') && !BARREL_LINE_RE.test(line));
+
+/**
+ * Re-export lines a barrel repeats verbatim. Keyed on the whole line: a hooks
+ * barrel legitimately re-exports one module twice (`default as useX`, then a
+ * named helper), and only an identical line is the doubled-insertion shape.
+ */
+export const duplicateBarrelLines = (lines) => duplicates(lines.filter((line) => BARREL_LINE_RE.test(line)));
+
+/** Backtick-named table rows a catalog README lists more than once. */
+export const duplicateCatalogRows = (lines) => duplicates(
+  lines.map((line) => CATALOG_ROW_RE.exec(line)?.[1]).filter(Boolean),
+);
+
+describe('union-merged catalogs and barrels', () => {
+  const paths = unionMergedPaths(readFileSync(join(REPO_ROOT, '.gitattributes'), 'utf8'));
+  const sources = new Map(paths.map((path) => [path, readFileSync(join(REPO_ROOT, path), 'utf8')]));
+  const lines = (path) => sources.get(path).split('\n');
+  const barrels = paths.filter((path) => path.endsWith('.js'));
+  const catalogs = paths.filter((path) => path.endsWith('.md'));
+
+  it('unions exactly the structural barrels and the catalog beside each', () => {
+    // One list in .gitattributes, one in the planner: a barrel missing from
+    // either loses union merging (daily conflicts return) or import-graph
+    // exclusion, and nothing else would notice.
+    expect(barrels.sort()).toEqual([...STRUCTURAL_BARRELS].sort());
+    for (const barrel of barrels) {
+      expect(catalogs, barrel).toContain(barrel.replace(/index\.js$/, 'README.md'));
+    }
+  });
+
+  it('detects the shapes it guards against', () => {
+    // Bypass probes: each detector must bite on a minimal bad input.
+    expect(unionMergedPaths('# c\nfoo.md merge=union\nbar.js text\nbaz.js  merge=union'))
+      .toEqual(['foo.md', 'baz.js']);
+    expect(duplicateBarrelLines(["export * from './a.js';", "export * as b from './b.js';", "export * from './a.js';"]))
+      .toEqual(["export * from './a.js';"]);
+    expect(duplicateBarrelLines(["export { default as useA } from './useA.js';", "export { helper } from './useA.js';"]))
+      .toEqual([]);
+    expect(nonBarrelLines(['// note', "export * from './a.js';", 'const leaked = 1;'])).toEqual(['const leaked = 1;']);
+    expect(duplicateCatalogRows(['| `a.js` | one |', '| `b.js` | two |', '| `a.js` | one again |'])).toEqual(['a.js']);
+  });
+
+  it('leaves no conflict markers behind', () => {
+    for (const [path, source] of sources) expect(source, path).not.toMatch(CONFLICT_MARKER_RE);
+  });
+
+  it('only ever unions pure re-export barrels, never a file with code paths', () => {
+    for (const path of barrels) {
+      expect(nonBarrelLines(lines(path)), `${path} carries lines a union merge cannot arbitrate — drop it from .gitattributes`)
+        .toEqual([]);
+    }
+  });
+
+  it('has no doubled barrel re-export after a union merge', () => {
+    for (const path of barrels) {
+      expect(duplicateBarrelLines(lines(path)), `${path} repeats a re-export line — a union merge kept a line both branches touched; keep one`)
+        .toEqual([]);
+    }
+  });
+
+  it('has no doubled catalog row after a union merge', () => {
+    for (const path of catalogs) {
+      expect(duplicateCatalogRows(lines(path)), `${path} lists a module twice — a union merge kept a row both branches touched; keep one`)
+        .toEqual([]);
+    }
+  });
+});

--- a/scripts/ci-base-sha.test.js
+++ b/scripts/ci-base-sha.test.js
@@ -5,6 +5,7 @@ import { fileURLToPath } from 'url';
 import { describe, expect, it } from 'vitest';
 
 import { resolveBaseSha } from './ci-base-sha.js';
+import { workflowJobs } from './lib/workflowJobs.js';
 
 const WORKFLOW = readFileSync(
   join(dirname(fileURLToPath(import.meta.url)), '..', '.github', 'workflows', 'ci.yml'),
@@ -16,23 +17,6 @@ const HEAD = 'b'.repeat(40);
 
 /** A merge-ref checkout: both parents resolve. */
 const mergeRefRevParse = (rev) => ({ 'HEAD^1': BASE, 'HEAD^2': HEAD }[rev] ?? null);
-
-/** Split the workflow into `jobs:` entries keyed by job id. */
-function workflowJobs(yaml) {
-  const body = yaml.slice(yaml.indexOf('\njobs:\n'));
-  const jobs = {};
-  let current = null;
-  for (const line of body.split('\n')) {
-    const header = line.match(/^ {2}([a-z][a-z0-9-]*):\s*$/);
-    if (header) {
-      current = header[1];
-      jobs[current] = [];
-      continue;
-    }
-    if (current) jobs[current].push(line);
-  }
-  return Object.fromEntries(Object.entries(jobs).map(([id, lines]) => [id, lines.join('\n')]));
-}
 
 describe('resolveBaseSha', () => {
   it('reads the base branch off the pull-request merge ref', () => {

--- a/scripts/ci-fail-fast.test.js
+++ b/scripts/ci-fail-fast.test.js
@@ -4,6 +4,8 @@ import { fileURLToPath } from 'url';
 
 import { describe, expect, it } from 'vitest';
 
+import { workflowJobs } from './lib/workflowJobs.js';
+
 const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 const WORKFLOW = readFileSync(join(REPO_ROOT, '.github/workflows/ci.yml'), 'utf8');
 const NON_LEAF_JOBS = new Set(['impact', 'gate', 'full-gate']);
@@ -26,23 +28,6 @@ const FAIL_FAST_STEP = [
   '          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}',
   '        run: node scripts/cancel-current-ci-run.js',
 ].join('\n');
-
-function workflowJobs(yaml) {
-  const jobsStart = yaml.indexOf('\njobs:\n');
-  const body = yaml.slice(jobsStart);
-  const jobs = {};
-  let current = null;
-  for (const line of body.split('\n')) {
-    const header = line.match(/^ {2}([a-z][a-z0-9-]*):\s*$/);
-    if (header) {
-      current = header[1];
-      jobs[current] = [];
-      continue;
-    }
-    if (current) jobs[current].push(line);
-  }
-  return Object.fromEntries(Object.entries(jobs).map(([id, lines]) => [id, lines.join('\n')]));
-}
 
 describe('ci.yml fail-fast cancellation contract', () => {
   const jobs = workflowJobs(WORKFLOW);

--- a/scripts/ci-test-plan.js
+++ b/scripts/ci-test-plan.js
@@ -10,6 +10,28 @@ const EXECUTABLE_RE = /\.(?:cjs|css|html|js|jsx|json|mjs|sql|ts|tsx|ya?ml)$/i;
 const MAX_CHANGED_CODE_FILES = 30;
 const MAX_TARGETED_TEST_FILES = 120;
 
+// Python sidecar scripts (`scripts/generate_ltx2.py`, …). Vitest's import graph
+// cannot reach into them, but their contracts are pinned by suites that read
+// the .py source as text, so main() finds the suites naming each changed script
+// with `git grep` and the plan runs exactly those — failing closed to the full
+// suite for a script nothing names.
+const PYTHON_SCRIPT_RE = /^scripts\/[^/]+\.py$/;
+/** `git grep -E` pattern for a test that names this one script. */
+export const pythonReferencePattern = (scriptPath) => (
+  `(^|[^A-Za-z0-9_])${scriptPath.slice(scriptPath.lastIndexOf('/') + 1).replace(/[.]/g, '\\.')}([^A-Za-z0-9_]|$)`
+);
+
+// Parallel runners per test job on a full plan. Decided here rather than in
+// ci.yml because a job-level `if` cannot read the matrix context, so the
+// planner must emit `[1]` for a scoped plan itself. Sizing rationale:
+// docs/GITHUB_ACTIONS.md "Full-suite sharding".
+export const FULL_SUITE_SHARDS = { server: 2, client: 3, windows: 3 };
+
+/** Matrix values for one runner: every shard on a full run, one otherwise. */
+export const shardIndexes = (mode, count) => (
+  mode === 'full' ? Array.from({ length: count }, (_, index) => index + 1) : [1]
+);
+
 const FULL_TRIGGER_RULES = [
   { re: /^\.github\/workflows\//, reason: 'workflow definition changed' },
   { re: /^(?:package|server\/package|client\/package|autofixer\/package)(?:-lock)?\.json$/, reason: 'dependency manifest changed' },
@@ -134,6 +156,9 @@ export const WINDOWS_CONTRACT_TESTS = [
 // what can reach it.
 export const ALWAYS_RUN_TESTS = [
   'scripts/agent-instructions-files.test.js',
+  // The union-merged catalogs are `.md` to the planner — documentation-only —
+  // so a rebase that doubled a row would otherwise never be re-checked.
+  'scripts/catalog-merge-union.test.js',
   'scripts/direct-invocation-drift.test.js',
   'scripts/ensure-deps.test.js',
   'scripts/node-version-drift.test.js',
@@ -208,7 +233,8 @@ const pathMatchesFeature = (path, feature) => {
 
 const isTestFile = (path) => TEST_FILE_RE.test(path);
 const isDocumentationOnly = (path) => DOCUMENTATION_RULES.some((rule) => rule.test(path));
-const isExecutable = (path) => EXECUTABLE_RE.test(path);
+const isPythonScript = (path) => PYTHON_SCRIPT_RE.test(path);
+const isExecutable = (path) => EXECUTABLE_RE.test(path) || isPythonScript(path);
 const isServerRunnerFile = (path) => RUNNER_ROOTS.server.some((root) => path.startsWith(root));
 const isClientRunnerFile = (path) => RUNNER_ROOTS.client.some((root) => path.startsWith(root));
 
@@ -299,12 +325,16 @@ const skippedRunner = () => ({ mode: 'skip', files: [], sources: [] });
 // contains no behavior; PR #5296 changed server/lib/index.js and consequently
 // selected 1,244 files / 27,491 tests. Behavioral source files in the same diff
 // still drive related-test selection normally.
-const isStructuralBarrel = (path) => [
+//
+// Also the set `.gitattributes` merges with `union` — scripts/catalog-merge-union.test.js
+// pins the two lists to each other.
+export const STRUCTURAL_BARRELS = [
   'server/lib/index.js',
   'client/src/lib/index.js',
   'client/src/hooks/index.js',
   'client/src/utils/index.js',
-].includes(path);
+];
+const isStructuralBarrel = (path) => STRUCTURAL_BARRELS.includes(path);
 
 /**
  * A route declaration is a safe, client-only subset of the App composition
@@ -354,6 +384,8 @@ export function buildCiTestPlan(changedFiles, {
   forceFull = false,
   forceFullReason = 'full CI requested',
   appRouteOnly = false,
+  // Changed python script → tracked test files naming it (see PYTHON_SCRIPT_RE).
+  pythonContractTests = {},
 } = {}) {
   const changed = uniqueSorted(changedFiles.filter(Boolean));
   const trackedSet = new Set(trackedFiles);
@@ -374,7 +406,7 @@ export function buildCiTestPlan(changedFiles, {
       windowsFiles: [],
       windowsSources: [],
     };
-    return { ...plan, suiteReasons: suiteReasonsFor(plan, { appRouteOnly }) };
+    return finishPlan(plan, { appRouteOnly });
   }
 
   const appCompositionChanged = changed.includes('client/src/App.jsx');
@@ -412,7 +444,7 @@ export function buildCiTestPlan(changedFiles, {
       windowsFiles: [],
       windowsSources: [],
     };
-    return { ...plan, suiteReasons: suiteReasonsFor(plan, { appRouteOnly }) };
+    return finishPlan(plan, { appRouteOnly });
   }
 
   const executable = relevant.filter(isExecutable);
@@ -442,13 +474,27 @@ export function buildCiTestPlan(changedFiles, {
     // the graph.
     return fullPlan(changed, `deleted executable source: ${deletedSources[0]}`, { appRouteOnly });
   }
-  const features = uniqueSorted(sourceFiles.map(featureDirectory).filter(Boolean));
-  const unscopedSources = sourceFiles.filter((path) => !featureDirectory(path));
+  // Python scripts never enter the import graph or a feature directory: their
+  // only selector is the per-script contract list, so they leave the JS-only
+  // scoping below.
+  const pythonSources = sourceFiles.filter(isPythonScript);
+  const jsSources = sourceFiles.filter((path) => !isPythonScript(path));
+  const features = uniqueSorted(jsSources.map(featureDirectory).filter(Boolean));
+  const unscopedSources = jsSources.filter((path) => !featureDirectory(path));
   const selectedTests = [
     ...directTests,
     ...structuralTestsFor(changed, trackedSet),
     ...alwaysRun,
   ];
+
+  for (const script of pythonSources) {
+    const pythonTests = (pythonContractTests[script] || [])
+      .filter((path) => trackedSet.has(path) && runnerForTest(path));
+    if (pythonTests.length === 0) {
+      return fullPlan(changed, `python script with no parsing contract: ${script}`, { appRouteOnly });
+    }
+    selectedTests.push(...pythonTests);
+  }
 
   for (const testFile of trackedFiles.filter(isTestFile)) {
     if (features.some((feature) => pathMatchesFeature(testFile, feature))) {
@@ -463,15 +509,15 @@ export function buildCiTestPlan(changedFiles, {
     return fullPlan(changed, 'targeted test set exceeded safety cap', { appRouteOnly });
   }
 
-  const hasServerSource = sourceFiles.some(isServerRunnerFile);
-  const hasClientSource = sourceFiles.some((path) => path.startsWith('client/'));
+  const hasServerSource = jsSources.some(isServerRunnerFile);
+  const hasClientSource = jsSources.some((path) => path.startsWith('client/'));
   const hasUnscopedServer = unscopedSources.some(isServerRunnerFile);
   const hasUnscopedClient = unscopedSources.some((path) => path.startsWith('client/'));
 
-  const serverSources = sourceFiles
+  const serverSources = jsSources
     .filter(isServerRunnerFile)
     .filter((path) => !isStructuralBarrel(path));
-  const clientSources = sourceFiles
+  const clientSources = jsSources
     .filter((path) => path.startsWith('client/'))
     .filter((path) => !isStructuralBarrel(path));
 
@@ -497,11 +543,13 @@ export function buildCiTestPlan(changedFiles, {
     ? (serverSources.length > 0 ? 'related' : 'files')
     : 'skip';
 
-  const plan = {
+  let reason = 'Vitest related-test fallback';
+  if (features.length) reason = `targeted features: ${features.join(', ')}`;
+  else if (jsSources.length === 0 && pythonSources.length > 0) reason = 'python script parsing contracts';
+
+  return finishPlan({
     full: false,
-    reason: features.length
-      ? `targeted features: ${features.join(', ')}`
-      : 'Vitest related-test fallback',
+    reason,
     changedFiles: changed,
     server,
     client,
@@ -518,12 +566,22 @@ export function buildCiTestPlan(changedFiles, {
     windowsMode,
     windowsFiles: windows ? windowsContractTests(trackedSet) : [],
     windowsSources: windowsMode === 'related' ? serverSources : [],
-  };
-  return { ...plan, suiteReasons: suiteReasonsFor(plan, { appRouteOnly }) };
+  }, { appRouteOnly });
 }
 
+/** The derived fields every plan carries: per-suite reasons and shard matrices. */
+const finishPlan = (plan, options) => ({
+  ...plan,
+  suiteReasons: suiteReasonsFor(plan, options),
+  shards: {
+    server: shardIndexes(plan.server.mode, FULL_SUITE_SHARDS.server),
+    client: shardIndexes(plan.client.mode, FULL_SUITE_SHARDS.client),
+    windows: shardIndexes(plan.windowsMode, FULL_SUITE_SHARDS.windows),
+  },
+});
+
 function fullPlan(changedFiles, reason, options) {
-  const plan = {
+  return finishPlan({
     full: true,
     reason,
     changedFiles,
@@ -537,14 +595,23 @@ function fullPlan(changedFiles, reason, options) {
     windowsMode: 'full',
     windowsFiles: [],
     windowsSources: [],
-  };
-  return { ...plan, suiteReasons: suiteReasonsFor(plan, options) };
+  }, options);
 }
 
 const gitLines = (args) => execFileSync('git', args, { encoding: 'utf8' })
   .split('\n')
   .map((line) => line.trim())
   .filter(Boolean);
+
+/** Tracked test files whose text matches `pattern`; `git grep` exit 1 is "none". */
+const gitGrepFiles = (pattern, pathspecs) => {
+  try {
+    return gitLines(['grep', '-l', '-E', pattern, '--', ...pathspecs]);
+  } catch (err) {
+    if (err.status === 1) return [];
+    throw err;
+  }
+};
 
 export function emitGitHubPlan(plan) {
   const outputs = {
@@ -565,6 +632,9 @@ export function emitGitHubPlan(plan) {
     windows_mode: plan.windowsMode,
     windows_files: JSON.stringify(plan.windowsFiles),
     windows_sources: JSON.stringify(plan.windowsSources),
+    server_shards: JSON.stringify(plan.shards.server),
+    client_shards: JSON.stringify(plan.shards.client),
+    windows_shards: JSON.stringify(plan.shards.windows),
     suite_reasons: JSON.stringify(plan.suiteReasons),
   };
 
@@ -606,11 +676,16 @@ function main() {
   const appDiff = forceFull || !changedFiles.includes('client/src/App.jsx')
     ? null
     : execFileSync('git', ['diff', '--unified=0', `${base}...HEAD`, '--', 'client/src/App.jsx'], { encoding: 'utf8' });
+  const pythonContractTests = Object.fromEntries(changedFiles.filter(isPythonScript).map((script) => [
+    script,
+    gitGrepFiles(pythonReferencePattern(script), ['*.test.js', '*.test.jsx']),
+  ]));
   emitGitHubPlan(buildCiTestPlan(changedFiles, {
     trackedFiles,
     forceFull,
     forceFullReason,
     appRouteOnly: isRouteOnlyAppDiff(appDiff),
+    pythonContractTests,
   }));
 }
 

--- a/scripts/ci-test-plan.js
+++ b/scripts/ci-test-plan.js
@@ -262,6 +262,15 @@ const structuralTestsFor = (changedFiles, trackedSet) => {
   if (changedFiles.some((path) => /^server\/lib\//.test(path))) {
     add('server/lib/index.test.js');
   }
+  // The generated-manifest drift tests regenerate from the tree and compare;
+  // they import neither the route modules nor the stage call sites they scan,
+  // so no import edge selects them. Without this rule a route added on a
+  // scoped plan merged with a stale catalog (#5898), and every later full-plan
+  // PR inherited the red drift test until someone committed a regeneration.
+  if (changedFiles.some((path) => /^server\/.*\.js$/.test(path) || /^server\/lib\/.*\.generated\.json$/.test(path))) {
+    add('scripts/generate-api-route-catalog.test.js');
+    add('scripts/generate-prompt-stage-call-sites.test.js');
+  }
   // The socket guard readdir-scans server/sockets/ rather than importing it, so
   // no import edge reaches it — a handler added there would otherwise only be
   // checked on a full suite.

--- a/scripts/ci-test-plan.test.js
+++ b/scripts/ci-test-plan.test.js
@@ -4,7 +4,10 @@ import {
   ALWAYS_RUN_TESTS,
   buildCiTestPlan,
   forceFullReasonFor,
+  FULL_SUITE_SHARDS,
   isRouteOnlyAppDiff,
+  pythonReferencePattern,
+  shardIndexes,
   splitByRunner,
   WINDOWS_CONTRACT_TESTS,
 } from './ci-test-plan.js';
@@ -380,6 +383,100 @@ describe('CI test impact planner', () => {
 
     expect(plan.full).toBe(true);
     expect(plan.reason).toMatch(/deleted executable source/);
+  });
+
+  it('runs the parsing contracts for a python sidecar script instead of the full suite', () => {
+    const tracked = [
+      ...TRACKED,
+      'scripts/generate_ltx2.py',
+      'scripts/_runner_common.py',
+      'scripts/generate_ltx2.test.js',
+      'server/services/videoGen/runtimes.test.js',
+      'client/src/lib/videoRenderPhase.test.js',
+    ];
+    const pythonContractTests = {
+      'scripts/_runner_common.py': [
+        'scripts/generate_ltx2.test.js',
+        'server/services/videoGen/runtimes.test.js',
+        'client/src/lib/videoRenderPhase.test.js',
+        'server/lib/deleted.test.js',
+      ],
+    };
+
+    const plan = buildCiTestPlan(['scripts/_runner_common.py'], { trackedFiles: tracked, pythonContractTests });
+
+    expect(plan).toMatchObject({
+      full: false,
+      reason: 'python script parsing contracts',
+      server: { mode: 'files', sources: [] },
+      client: { mode: 'files', sources: [] },
+      windows: false,
+      smoke: false,
+      db: false,
+    });
+    expect(plan.server.files).toEqual(expect.arrayContaining([
+      'scripts/generate_ltx2.test.js',
+      'server/services/videoGen/runtimes.test.js',
+      'server/services/taskPromptDefaults.test.js',
+    ]));
+    expect(plan.server.files).not.toContain('server/lib/deleted.test.js');
+    expect(plan.client.files).toEqual(['client/src/lib/videoRenderPhase.test.js']);
+
+    // A JS source in the same diff keeps its own import-graph selection; the
+    // python contracts ride along as explicit files.
+    const mixed = buildCiTestPlan(['scripts/_runner_common.py', 'server/services/auth.js'], {
+      trackedFiles: tracked,
+      pythonContractTests,
+    });
+    expect(mixed.reason).toBe('Vitest related-test fallback');
+    expect(mixed.server).toMatchObject({ mode: 'related', sources: ['server/services/auth.js'] });
+    expect(mixed.server.files).toContain('scripts/generate_ltx2.test.js');
+    expect(mixed.smoke).toBe(true);
+  });
+
+  it('fails closed to the full suite for a python script nothing pins', () => {
+    // Per script: a pinned sibling in the same diff does not vouch for the orphan.
+    const plan = buildCiTestPlan(['scripts/generate_ltx2.py', 'scripts/orphan.py'], {
+      trackedFiles: [...TRACKED, 'scripts/generate_ltx2.py', 'scripts/orphan.py', 'scripts/generate_ltx2.test.js'],
+      pythonContractTests: { 'scripts/generate_ltx2.py': ['scripts/generate_ltx2.test.js'] },
+    });
+    expect(plan.full).toBe(true);
+    expect(plan.reason).toMatch(/python script with no parsing contract: scripts\/orphan\.py/);
+    // A python file outside scripts/ is still an unclassified artifact.
+    const nested = buildCiTestPlan(['server/tools/helper.py'], { trackedFiles: TRACKED });
+    expect(nested.reason).toMatch(/unclassified/);
+  });
+
+  it('matches the way tests name one python script, not every one', () => {
+    const re = new RegExp(pythonReferencePattern('scripts/generate_ltx2.py'));
+    expect(re.test("join(SCRIPTS, 'generate_ltx2.py')")).toBe(true);
+    expect(re.test('readFileSync("scripts/generate_ltx2.py", "utf8")')).toBe(true);
+    expect(re.test('"generate_ltx2.py"')).toBe(true);
+    expect(re.test("'generate_ltx2_cuda.py'")).toBe(false);
+    expect(re.test("'my_generate_ltx2.py'")).toBe(false);
+    expect(re.test("'generate_ltx2.pyc'")).toBe(false);
+    expect(re.test("'generate_ltx2xpy'")).toBe(false);
+  });
+
+  it('fans a full plan out across the configured shards and leaves a scoped plan on one', () => {
+    expect(shardIndexes('full', 3)).toEqual([1, 2, 3]);
+    expect(shardIndexes('related', 3)).toEqual([1]);
+    expect(shardIndexes('files', 3)).toEqual([1]);
+    expect(shardIndexes('skip', 3)).toEqual([1]);
+    for (const [runner, count] of Object.entries(FULL_SUITE_SHARDS)) {
+      expect(count, runner).toBeGreaterThan(1);
+    }
+
+    const full = buildCiTestPlan(['server/vitest.config.js'], { trackedFiles: TRACKED });
+    expect(full.shards).toEqual({
+      server: shardIndexes('full', FULL_SUITE_SHARDS.server),
+      client: shardIndexes('full', FULL_SUITE_SHARDS.client),
+      windows: shardIndexes('full', FULL_SUITE_SHARDS.windows),
+    });
+    const scoped = buildCiTestPlan(['server/services/auth.js'], { trackedFiles: TRACKED });
+    expect(scoped.shards).toEqual({ server: [1], client: [1], windows: [1] });
+    const docsOnly = buildCiTestPlan(['docs/README.md'], { trackedFiles: TRACKED });
+    expect(docsOnly.shards).toEqual({ server: [1], client: [1], windows: [1] });
   });
 
   it('falls back to full CI for unknown artifacts and wide changes', () => {

--- a/scripts/ci-test-plan.test.js
+++ b/scripts/ci-test-plan.test.js
@@ -434,6 +434,27 @@ describe('CI test impact planner', () => {
     expect(mixed.smoke).toBe(true);
   });
 
+  it('runs the generated-manifest drift tests whenever a server source changes', () => {
+    const tracked = [
+      ...TRACKED,
+      'server/routes/settings.js',
+      'scripts/generate-api-route-catalog.test.js',
+      'scripts/generate-prompt-stage-call-sites.test.js',
+    ];
+    const drift = ['scripts/generate-api-route-catalog.test.js', 'scripts/generate-prompt-stage-call-sites.test.js'];
+
+    // A new route on a scoped plan is exactly the case that shipped a stale catalog.
+    const route = buildCiTestPlan(['server/routes/settings.js'], { trackedFiles: tracked });
+    expect(route.full).toBe(false);
+    expect(route.server.files).toEqual(expect.arrayContaining(drift));
+    // Any server module can add a literal stage-key call site.
+    const service = buildCiTestPlan(['server/services/auth.js'], { trackedFiles: tracked });
+    expect(service.server.files).toEqual(expect.arrayContaining(drift));
+    // A client-only change has nothing to regenerate.
+    const client = buildCiTestPlan(['client/src/lib/catalogLinks.js'], { trackedFiles: tracked });
+    expect(client.server.files).not.toEqual(expect.arrayContaining(drift));
+  });
+
   it('fails closed to the full suite for a python script nothing pins', () => {
     // Per script: a pinned sibling in the same diff does not vouch for the orphan.
     const plan = buildCiTestPlan(['scripts/generate_ltx2.py', 'scripts/orphan.py'], {

--- a/scripts/lib/workflowJobs.js
+++ b/scripts/lib/workflowJobs.js
@@ -1,0 +1,27 @@
+/**
+ * Split a GitHub Actions workflow file into its `jobs:` entries, keyed by job
+ * id, each as the raw YAML text of that job. Shared by the workflow-contract
+ * tests so the indentation-based slicing lives in one place.
+ *
+ * ZERO external dependencies — see githubOutput.js.
+ */
+
+/**
+ * @param {string} yaml - workflow source
+ * @returns {Record<string, string>} job id → job body
+ */
+export function workflowJobs(yaml) {
+  const body = yaml.slice(yaml.indexOf('\njobs:\n'));
+  const jobs = {};
+  let current = null;
+  for (const line of body.split('\n')) {
+    const header = line.match(/^ {2}([a-z][a-z0-9-]*):\s*$/);
+    if (header) {
+      current = header[1];
+      jobs[current] = [];
+      continue;
+    }
+    if (current) jobs[current].push(line);
+  }
+  return Object.fromEntries(Object.entries(jobs).map(([id, lines]) => [id, lines.join('\n')]));
+}

--- a/scripts/run-ci-tests.js
+++ b/scripts/run-ci-tests.js
@@ -25,6 +25,18 @@ export function relatedInputs(sourceFiles, selectedFiles) {
   return [...new Set([...sourceFiles, ...selectedFiles])];
 }
 
+/**
+ * Vitest selector flags for this runner's slice of a full suite. `CI_SHARD` is
+ * `<index>/<count>` from the job matrix (ci.yml). A single shard passes nothing,
+ * so the one-runner invocation stays identical to a local `npm run test:ci`.
+ */
+export function shardArgs(shard) {
+  if (!shard) return [];
+  const match = /^(\d+)\/(\d+)$/.exec(shard);
+  if (!match) throw new Error(`CI_SHARD must look like <index>/<count>, got "${shard}"`);
+  return match[2] === '1' ? [] : [`--shard=${shard}`];
+}
+
 export function recordVitestDuration(scope, label, startedAt) {
   const seconds = ((Date.now() - startedAt) / 1000).toFixed(1);
   const line = `⏱ ${scope} ${label}: ${seconds}s`;
@@ -80,7 +92,9 @@ function main() {
   }
 
   if (mode === 'full') {
-    process.exit(spawnNpm(scope, 'test:ci', [], 'full suite'));
+    const shard = shardArgs(process.env.CI_SHARD);
+    const label = shard.length ? `full suite shard ${process.env.CI_SHARD}` : 'full suite';
+    process.exit(spawnNpm(scope, 'test:ci', shard, label));
   }
 
   if (mode === 'files') {

--- a/scripts/run-ci-tests.test.js
+++ b/scripts/run-ci-tests.test.js
@@ -7,8 +7,51 @@ import {
   recordVitestDuration,
   relatedInputs,
   requiresSourceFiles,
+  shardArgs,
   toRunnerPath,
 } from './run-ci-tests.js';
+import { workflowJobs } from './lib/workflowJobs.js';
+
+const WORKFLOW = readFileSync(join(import.meta.dirname, '..', '.github', 'workflows', 'ci.yml'), 'utf8');
+
+describe('shardArgs', () => {
+  it('passes a slice selector only when the matrix actually split the suite', () => {
+    expect(shardArgs(undefined)).toEqual([]);
+    expect(shardArgs('')).toEqual([]);
+    expect(shardArgs('1/1')).toEqual([]);
+    expect(shardArgs('2/3')).toEqual(['--shard=2/3']);
+    expect(() => shardArgs('2')).toThrow(/<index>\/<count>/);
+  });
+});
+
+describe('ci.yml shard wiring', () => {
+  const runners = Object.entries(workflowJobs(WORKFLOW)).filter(([, body]) => body.includes('run-ci-tests.js'));
+
+  it('builds every test runner matrix from the planner and hands each slice to the runner', () => {
+    expect(runners.map(([id]) => id).sort()).toEqual(['client', 'server', 'windows-server']);
+    for (const [id, body] of runners) {
+      // The fan-out is decided by the impact job, never hardcoded here: a
+      // scoped plan must collapse to one runner, and a job-level `if` cannot
+      // read `matrix` to skip the extra shards itself.
+      expect(body, id).toMatch(/shard: \$\{\{ fromJSON\(needs\.impact\.outputs\.\w+_shards\) \}\}/);
+      expect(body, id).toContain('CI_SHARD: ${{ matrix.shard }}/${{ strategy.job-total }}');
+      // Shards race to save one immutable cache entry; without the shard in
+      // the key the winner's 1/n of the transform artifacts is all that persists.
+      expect(body, id).toMatch(/key: vitest-\w+-\$\{\{ runner\.os \}\}-\$\{\{ hashFiles\([^)]*\) \}\}-\$\{\{ matrix\.shard \}\}of\$\{\{ strategy\.job-total \}\}/);
+    }
+  });
+
+  it('runs once-only steps on the first shard alone', () => {
+    // Smoke boot, lint, the production build, and the bundle budget are not
+    // sharded work; on every shard they would triple the cost for no coverage.
+    for (const step of ['Smoke-boot server', 'Lint client', 'Build client', 'Check API Explorer bundle budget']) {
+      const start = WORKFLOW.indexOf(`- name: ${step}\n`);
+      expect(start, step).toBeGreaterThan(0);
+      const condition = WORKFLOW.slice(start).match(/\n {8}if: (.*)\n/)[1];
+      expect(condition, step).toMatch(/&& matrix\.shard == 1$/);
+    }
+  });
+});
 
 describe('toRunnerPath', () => {
   it('maps repo paths onto each workspace runner root', () => {

--- a/server/services/taskPromptDefaults/integrity.snapshot.json
+++ b/server/services/taskPromptDefaults/integrity.snapshot.json
@@ -1,177 +1,103 @@
 {
   "DEFAULT_TASK_PROMPTS": {
-    "security": "8e58c1305a391ac765b0b13ab9615eb3",
-    "code-quality": "c34792a374dd9868e6381557da582dc1",
-    "test-coverage": "0d8359170529da12cd63356610b2e220",
-    "performance": "672bd3958b12afb0f382bcebb6dc3b33",
     "accessibility": "372916803f32b82da38a5b2130a54baf",
-    "console-errors": "2b6ed595287f0742bed9ecba6788afe6",
-    "dependency-updates": "1d59f04bea630a85a3085829db8599e7",
-    "documentation": "246be4932c277fa0ec0ab365beb3baad",
-    "ui-bugs": "def9ad96bd74ab397233f234d79a1974",
-    "mobile-responsive": "16d8e7f63a673a2de48994c0ac08ef3d",
-    "ux": "e03d03fc7c16faa5b5db93be2896b9ad",
-    "data-safety": "86b07f51abdbcbe7016f840b5bb0cd9b",
-    "simplify": "2a048214d1dd3b75bee9ae1a38fa1589",
-    "module-hygiene": "3b7671cd44f719d4b2116b96a279e6d0",
     "api-contract": "cf02b10a5993baf473e0d320771f26b6",
-    "react-lifecycle": "14b3816d1bcc10f0d7d6357e55cc5e69",
-    "observability": "fdb4d77df5891cfb653a5da2553ecf8a",
-    "copy": "6a0959e898d37fb4d4d7445dfc8008c9",
-    "feature-ideas": "804f62f1dadadbfa8a0bcd4aff16b2e8",
-    "plan-feature": "87f71a894757f89354da4e2119e07118",
-    "plan-task": "b85fe92999aa4ee4a8910320457c4242",
+    "branch-cleanup": "8fdeb4acc2749816a47ca318b6602721",
+    "branch-reconcile": "16479f4b64395103fd222dc9608830b1",
     "claim-issue": "78325cbcfb0e5698018fcd16b3aa8b49",
     "claim-issue-gitlab": "bb83608738b6517f3f05df116994a6fd",
     "claim-issue-jira": "b14a5dde5519fda59c2ba1ae7a3d8989",
-    "code-reviewer-review": "27ded42013f28e7d327d8f1cc624aac1",
+    "code-quality": "c34792a374dd9868e6381557da582dc1",
     "code-reviewer-implement": "2e10cac7c1e1cd021d06bfddb5c1eaf2",
-    "error-handling": "9afba2e99b90a8d5771c75e7f0615d96",
-    "typing": "1f2758ce0bb62d789a21aec241549531",
-    "release-check": "5a82eec9f86ad05185ed77a42dbfd9d4",
-    "stash-cleanup": "1c12bac5aac6bb27008c40981e7db08c",
-    "repo-sync": "0a648d35d43b023b758226b9c709c8ea",
-    "user-action-review": "945a716d446d26a03e2805d28bd1ae16",
-    "jira-sprint-manager": "3e63c8a3bdf0d5a05a30faaa2dc07980",
+    "code-reviewer-review": "27ded42013f28e7d327d8f1cc624aac1",
+    "console-errors": "2b6ed595287f0742bed9ecba6788afe6",
+    "copy": "6a0959e898d37fb4d4d7445dfc8008c9",
+    "data-safety": "86b07f51abdbcbe7016f840b5bb0cd9b",
+    "dependency-updates": "1d59f04bea630a85a3085829db8599e7",
     "do-replan": "35660eb7b43e4259a6a9253ed288a1db",
-    "jira-status-report": "9d374a9d8ccb92c5c8fd0aa9899e79a5",
-    "branch-cleanup": "8fdeb4acc2749816a47ca318b6602721",
-    "branch-reconcile": "16479f4b64395103fd222dc9608830b1",
+    "documentation": "246be4932c277fa0ec0ab365beb3baad",
+    "error-handling": "9afba2e99b90a8d5771c75e7f0615d96",
+    "feature-ideas": "804f62f1dadadbfa8a0bcd4aff16b2e8",
     "issue-reconcile": "6f33db6ad0b57c36909229694b78891a",
+    "jira-sprint-manager": "3e63c8a3bdf0d5a05a30faaa2dc07980",
+    "jira-status-report": "9d374a9d8ccb92c5c8fd0aa9899e79a5",
+    "mobile-responsive": "16d8e7f63a673a2de48994c0ac08ef3d",
+    "module-hygiene": "3b7671cd44f719d4b2116b96a279e6d0",
+    "observability": "fdb4d77df5891cfb653a5da2553ecf8a",
+    "performance": "672bd3958b12afb0f382bcebb6dc3b33",
+    "plan-feature": "87f71a894757f89354da4e2119e07118",
+    "plan-task": "b85fe92999aa4ee4a8910320457c4242",
     "pr-reviewer": "679680b3b382aeb6786df01c4d1a90c6",
-    "pr-reviewer-security": "a993798467b8d773b0e44b3e3d303bd0",
     "pr-reviewer-eligibility": "7e35acefd33f05145544e2702d065bfd",
     "pr-reviewer-review": "76d1d8265d4d56ae6a4c00d64e8787a8",
-    "reference-watch": "e0e20754700fb08d5159b8437d9c260b",
+    "pr-reviewer-security": "a993798467b8d773b0e44b3e3d303bd0",
     "pr-watcher": "53ead8e26d396849bfa78f28550bd691",
-    "refresh-local-llm-catalog": "9741ca6a8419fcdea2743e3b64781a8b"
+    "react-lifecycle": "14b3816d1bcc10f0d7d6357e55cc5e69",
+    "reference-watch": "e0e20754700fb08d5159b8437d9c260b",
+    "refresh-local-llm-catalog": "9741ca6a8419fcdea2743e3b64781a8b",
+    "release-check": "5a82eec9f86ad05185ed77a42dbfd9d4",
+    "repo-sync": "0a648d35d43b023b758226b9c709c8ea",
+    "security": "8e58c1305a391ac765b0b13ab9615eb3",
+    "simplify": "2a048214d1dd3b75bee9ae1a38fa1589",
+    "stash-cleanup": "1c12bac5aac6bb27008c40981e7db08c",
+    "test-coverage": "0d8359170529da12cd63356610b2e220",
+    "typing": "1f2758ce0bb62d789a21aec241549531",
+    "ui-bugs": "def9ad96bd74ab397233f234d79a1974",
+    "user-action-review": "945a716d446d26a03e2805d28bd1ae16",
+    "ux": "e03d03fc7c16faa5b5db93be2896b9ad"
   },
   "PROMPT_VERSIONS": {
-    "do-replan": 2,
-    "feature-ideas": 11,
-    "plan-task": 18,
+    "accessibility": 2,
+    "api-contract": 1,
+    "branch-reconcile": 3,
     "claim-issue": 24,
     "claim-issue-gitlab": 22,
     "claim-issue-jira": 16,
-    "pr-reviewer": 4,
+    "code-quality": 3,
     "code-reviewer-a": 1,
     "code-reviewer-b": 1,
-    "reference-watch": 3,
-    "pr-watcher": 1,
-    "branch-reconcile": 3,
-    "issue-reconcile": 4,
-    "refresh-local-llm-catalog": 4,
-    "user-action-review": 1,
-    "plan-feature": 5,
-    "security": 2,
-    "code-quality": 3,
-    "test-coverage": 2,
-    "performance": 2,
-    "accessibility": 2,
     "console-errors": 2,
-    "error-handling": 2,
-    "typing": 2,
-    "dependency-updates": 4,
-    "documentation": 6,
-    "ui-bugs": 2,
-    "mobile-responsive": 2,
-    "ux": 1,
-    "data-safety": 1,
-    "simplify": 1,
-    "module-hygiene": 1,
-    "api-contract": 1,
-    "react-lifecycle": 1,
-    "observability": 1,
     "copy": 1,
-    "stash-cleanup": 2,
-    "repo-sync": 1,
-    "release-check": 13,
+    "data-safety": 1,
+    "dependency-updates": 4,
+    "do-replan": 2,
+    "documentation": 6,
+    "error-handling": 2,
+    "feature-ideas": 11,
+    "issue-reconcile": 4,
     "jira-sprint-manager": 1,
-    "jira-status-report": 1
+    "jira-status-report": 1,
+    "mobile-responsive": 2,
+    "module-hygiene": 1,
+    "observability": 1,
+    "performance": 2,
+    "plan-feature": 5,
+    "plan-task": 18,
+    "pr-reviewer": 4,
+    "pr-watcher": 1,
+    "react-lifecycle": 1,
+    "reference-watch": 3,
+    "refresh-local-llm-catalog": 4,
+    "release-check": 13,
+    "repo-sync": 1,
+    "security": 2,
+    "simplify": 1,
+    "stash-cleanup": 2,
+    "test-coverage": 2,
+    "typing": 2,
+    "ui-bugs": 2,
+    "user-action-review": 1,
+    "ux": 1
   },
   "REFERENCE_WATCH_AUDITED_VERSION": 3,
   "PREVIOUS_DEFAULT_PROMPTS": {
-    "do-replan": [
-      "59a57f1bb445138c30ab4fa23630c6f8"
+    "accessibility": [
+      "ce7377d0ac57cbf0526074cfb95e3803",
+      "b07cfe1e367411036ef1d4cc4b6e9d2e"
     ],
-    "feature-ideas": [
-      "abc098e3acf4eb6b9d1211680ec0440f",
-      "d67a9028aeb8bb8348453951f878501b",
-      "c6a399399245872401666d5c67c716cc",
-      "a4a4b4d7191ae58b82140295c3df5926",
-      "52b76c852fd00f15c50eb73ea0bc4340",
-      "5a0350fa6db8ac040fb638fdd4a31700",
-      "d076e19a6848f6452f4d1078b096ba4b",
-      "73cdc70f8d14fc909668054bbcee1259",
-      "0741418bd275b8953131155f8bc89460",
-      "d3282f16da29efe2d53595b3b34778bc"
-    ],
-    "plan-task": [
-      "4df36bed4974ff41f369c86828e7f94f",
-      "e7ff71a98468960cb4465741bd54e6aa",
-      "602b259b4d1a565a84219b3e244f0a7f",
-      "6bf6de4ca34035fcfbc09e8d98c66001",
-      "1197ece173b4fddb90f38710ee04661c",
-      "5d55c4255b557a495f79762a1deab8ba",
-      "5425306bf082b15b6a17f972557d4dd9",
-      "2189019880ee12a8ba4d7975e7afc646",
-      "dced853944c2cad8fc0c151dea71301a",
-      "8f5b69fd9336b17184e7f7989f97def5",
-      "808140457aff9ff344ddac426e0022ed",
-      "bbc5495a02102fd470d2a429eedfbe76",
-      "aa5d121b3cb25aa134e3a20e5f0186c6",
-      "2012a0da54bdbf441911a0eed05f0cb1",
-      "910802d67f3b5a785f068f4d90178543"
-    ],
-    "pr-reviewer": [
-      "9ceeed08f238b3787fc1201a0ce8e023",
-      "f64e5d8176a871304fa691df812cda61",
-      "add27b67daa6aa2c75717ac96a6bd625"
-    ],
-    "reference-watch": [
-      "f9322140bff7d3f603799c09ce468da9",
-      "722ca590fb4b6323c98850a176b9b309"
-    ],
-    "pr-watcher": [],
-    "claim-issue-jira": [
-      "496638ec099de9d57686a61a015a3c03",
-      "157cfc80c3d00bcbf3e97aae3998c372",
-      "4094d2a07cdc33179eedfaaecc2a6104",
-      "18de42dd948a14866df8acbc9668e368",
-      "3f5cc58943bc08cbbc00f836660ecdfc",
-      "97a3994ce4da2d2743bdffec110a7482",
-      "e3d1a2e884a2a49c306a586089f4f376",
-      "367c22d2587212c9c391f50d146948e8",
-      "927766326e492e4c9c2566534f465512",
-      "364ecf5feb38ec1f7ada50a7bcbf3199",
-      "52fd3506aad0b283be7234b608cf31ca",
-      "9d782972b20d6b721eb44d0673315cad",
-      "c66170bfcdee911f03e60261c4f503db",
-      "d5e2b6cf39c2acfebef9ee8e826a7e42",
-      "1407b5095c18524f02e6bf1ff45ad967"
-    ],
-    "claim-issue-gitlab": [
-      "fae92c45c89c65455930b4b06a1b88c4",
-      "271ad9c6efa9dce424103711292fd055",
-      "880dd7820ac90c689065e28cdca032fb",
-      "f85cef7bd97bd675c504655b673589d1",
-      "9a4f517a0af3200dcd54f71aa2b8d924",
-      "e01f8d7e6dd078ae94516e903ce864d1",
-      "c9888390df157b72741aafb9f2f9d8e4",
-      "d7b44882f4d47ae44d39989e29e5fe2b",
-      "4f323dddadb5c7f0047e35914ba80529",
-      "12d78a91126213f7c10e9a6725cdb464",
-      "8e8f795bb75e996b80992883983a3c08",
-      "da0a8fbb33ac274a3b2efd968e302a1a",
-      "d8fe2bf614b465ca46108ea3295d2ec5",
-      "7ff928b2560ed6bb1a96dbbc80142ed9",
-      "eed428fc96a8a58ee94d38e6e4896932",
-      "ed2c2c9c8cd6297340b3a92666cb2c5a",
-      "348ed6348b90dcc6eead03e06df049e9",
-      "1f9ec476dce71d04e588d17e72cd46c9",
-      "b5e24d2caefba4acc6fb09f6c09f2afd",
-      "745672581d766edff0ec585dd5b1ef5d",
-      "42fcfae41076d73b49050015fac0ae0e"
+    "branch-reconcile": [
+      "7ef2b5f7d8f05937d4912b26ad45f42e",
+      "ecb0621588a751b1383ecd89cf514382"
     ],
     "claim-issue": [
       "37949d1b1fa8d461a15658f8f4192d97",
@@ -198,31 +124,62 @@
       "9bf278ab141120625cd6faf854622f91",
       "688661e7e7b0b4b5af95288dd86a23e8"
     ],
-    "security": [
-      "b199739b21a8c45ed3778b2339ebf55f",
-      "d0f54c1fbe62d067b1a23ee0a9f3528c"
+    "claim-issue-gitlab": [
+      "fae92c45c89c65455930b4b06a1b88c4",
+      "271ad9c6efa9dce424103711292fd055",
+      "880dd7820ac90c689065e28cdca032fb",
+      "f85cef7bd97bd675c504655b673589d1",
+      "9a4f517a0af3200dcd54f71aa2b8d924",
+      "e01f8d7e6dd078ae94516e903ce864d1",
+      "c9888390df157b72741aafb9f2f9d8e4",
+      "d7b44882f4d47ae44d39989e29e5fe2b",
+      "4f323dddadb5c7f0047e35914ba80529",
+      "12d78a91126213f7c10e9a6725cdb464",
+      "8e8f795bb75e996b80992883983a3c08",
+      "da0a8fbb33ac274a3b2efd968e302a1a",
+      "d8fe2bf614b465ca46108ea3295d2ec5",
+      "7ff928b2560ed6bb1a96dbbc80142ed9",
+      "eed428fc96a8a58ee94d38e6e4896932",
+      "ed2c2c9c8cd6297340b3a92666cb2c5a",
+      "348ed6348b90dcc6eead03e06df049e9",
+      "1f9ec476dce71d04e588d17e72cd46c9",
+      "b5e24d2caefba4acc6fb09f6c09f2afd",
+      "745672581d766edff0ec585dd5b1ef5d",
+      "42fcfae41076d73b49050015fac0ae0e"
+    ],
+    "claim-issue-jira": [
+      "496638ec099de9d57686a61a015a3c03",
+      "157cfc80c3d00bcbf3e97aae3998c372",
+      "4094d2a07cdc33179eedfaaecc2a6104",
+      "18de42dd948a14866df8acbc9668e368",
+      "3f5cc58943bc08cbbc00f836660ecdfc",
+      "97a3994ce4da2d2743bdffec110a7482",
+      "e3d1a2e884a2a49c306a586089f4f376",
+      "367c22d2587212c9c391f50d146948e8",
+      "927766326e492e4c9c2566534f465512",
+      "364ecf5feb38ec1f7ada50a7bcbf3199",
+      "52fd3506aad0b283be7234b608cf31ca",
+      "9d782972b20d6b721eb44d0673315cad",
+      "c66170bfcdee911f03e60261c4f503db",
+      "d5e2b6cf39c2acfebef9ee8e826a7e42",
+      "1407b5095c18524f02e6bf1ff45ad967"
     ],
     "code-quality": [
       "62752723eba7a39aa94e010911923cc8",
       "b1cce8f89218844746746ceb576553c1"
     ],
-    "test-coverage": [
-      "ec70fb2b8e193b6a98bec2fbf337b190",
-      "c2b0f0dee5bc881239684e706ea88324"
-    ],
-    "performance": [
-      "c8224243c15f6897ee04be25d172f021",
-      "4fea5eb3585bdc150980934b289016bc"
-    ],
-    "accessibility": [
-      "ce7377d0ac57cbf0526074cfb95e3803",
-      "b07cfe1e367411036ef1d4cc4b6e9d2e"
+    "console-errors": [
+      "23b1a2e33cb414f27d4002b51d315e83",
+      "3e3f690729ead5e312927ae4bce330c0"
     ],
     "dependency-updates": [
       "020d66b93698341c556eca1eee851bee",
       "640a7c4214e6bdba2bbd5b9061d9d425",
       "3f461b1c111ba45b7fa5016883cfa54d",
       "7ed05444e2602f4895bdd1e5e0edcaa8"
+    ],
+    "do-replan": [
+      "59a57f1bb445138c30ab4fa23630c6f8"
     ],
     "documentation": [
       "b6540f4ba13832226fd0c85cf1955f99",
@@ -232,11 +189,70 @@
       "74aa8433896647e7815f9d6d9e4a56c8",
       "b375f95ae2274f03d06ba5ceff5705d8"
     ],
-    "ui-bugs": [
-      "01d2a7e034713195f33071f2c71a3c99"
+    "error-handling": [
+      "26225ac04f2f35feb61151b2e6474465"
+    ],
+    "feature-ideas": [
+      "abc098e3acf4eb6b9d1211680ec0440f",
+      "d67a9028aeb8bb8348453951f878501b",
+      "c6a399399245872401666d5c67c716cc",
+      "a4a4b4d7191ae58b82140295c3df5926",
+      "52b76c852fd00f15c50eb73ea0bc4340",
+      "5a0350fa6db8ac040fb638fdd4a31700",
+      "d076e19a6848f6452f4d1078b096ba4b",
+      "73cdc70f8d14fc909668054bbcee1259",
+      "0741418bd275b8953131155f8bc89460",
+      "d3282f16da29efe2d53595b3b34778bc"
+    ],
+    "issue-reconcile": [
+      "c57a39aaa118173a496f030f5878bfc1",
+      "c87d7adb57de208c069964760c9c6276",
+      "a30f5d76b980bc9016f576047c9d5bb1"
     ],
     "mobile-responsive": [
       "636bdc17fa39ed2f2e27623284c8e04c"
+    ],
+    "performance": [
+      "c8224243c15f6897ee04be25d172f021",
+      "4fea5eb3585bdc150980934b289016bc"
+    ],
+    "plan-feature": [
+      "9fbc2a2ded8f4533d1f0f6b9cb780b34",
+      "a707866783fd0d8c1037489f23ff66de",
+      "b20980c8eda2256060d09d4bca397244",
+      "3df6f0a46f2a524af1dc4f83dfdf0647"
+    ],
+    "plan-task": [
+      "4df36bed4974ff41f369c86828e7f94f",
+      "e7ff71a98468960cb4465741bd54e6aa",
+      "602b259b4d1a565a84219b3e244f0a7f",
+      "6bf6de4ca34035fcfbc09e8d98c66001",
+      "1197ece173b4fddb90f38710ee04661c",
+      "5d55c4255b557a495f79762a1deab8ba",
+      "5425306bf082b15b6a17f972557d4dd9",
+      "2189019880ee12a8ba4d7975e7afc646",
+      "dced853944c2cad8fc0c151dea71301a",
+      "8f5b69fd9336b17184e7f7989f97def5",
+      "808140457aff9ff344ddac426e0022ed",
+      "bbc5495a02102fd470d2a429eedfbe76",
+      "aa5d121b3cb25aa134e3a20e5f0186c6",
+      "2012a0da54bdbf441911a0eed05f0cb1",
+      "910802d67f3b5a785f068f4d90178543"
+    ],
+    "pr-reviewer": [
+      "9ceeed08f238b3787fc1201a0ce8e023",
+      "f64e5d8176a871304fa691df812cda61",
+      "add27b67daa6aa2c75717ac96a6bd625"
+    ],
+    "pr-watcher": [],
+    "reference-watch": [
+      "f9322140bff7d3f603799c09ce468da9",
+      "722ca590fb4b6323c98850a176b9b309"
+    ],
+    "refresh-local-llm-catalog": [
+      "525bd0077672bf2f8beec9c0124740c8",
+      "a9dce67bb9f0837ba904f3412b03637f",
+      "ca7324a0f2251a66b46ea534940c9da8"
     ],
     "release-check": [
       "655180dfbab22e11fab79072ac49c9d6",
@@ -252,38 +268,22 @@
       "64be10f6ac7bcf74d4fc257089fc179b",
       "644e5f2f6df1daf06f3792a81ba7a51a"
     ],
-    "branch-reconcile": [
-      "7ef2b5f7d8f05937d4912b26ad45f42e",
-      "ecb0621588a751b1383ecd89cf514382"
-    ],
-    "issue-reconcile": [
-      "c57a39aaa118173a496f030f5878bfc1",
-      "c87d7adb57de208c069964760c9c6276",
-      "a30f5d76b980bc9016f576047c9d5bb1"
-    ],
-    "refresh-local-llm-catalog": [
-      "525bd0077672bf2f8beec9c0124740c8",
-      "a9dce67bb9f0837ba904f3412b03637f",
-      "ca7324a0f2251a66b46ea534940c9da8"
-    ],
-    "plan-feature": [
-      "9fbc2a2ded8f4533d1f0f6b9cb780b34",
-      "a707866783fd0d8c1037489f23ff66de",
-      "b20980c8eda2256060d09d4bca397244",
-      "3df6f0a46f2a524af1dc4f83dfdf0647"
+    "security": [
+      "b199739b21a8c45ed3778b2339ebf55f",
+      "d0f54c1fbe62d067b1a23ee0a9f3528c"
     ],
     "stash-cleanup": [
       "f9de8b10937919ceb6656fbdb70179c4"
     ],
-    "console-errors": [
-      "23b1a2e33cb414f27d4002b51d315e83",
-      "3e3f690729ead5e312927ae4bce330c0"
-    ],
-    "error-handling": [
-      "26225ac04f2f35feb61151b2e6474465"
+    "test-coverage": [
+      "ec70fb2b8e193b6a98bec2fbf337b190",
+      "c2b0f0dee5bc881239684e706ea88324"
     ],
     "typing": [
       "d8fd1423cf2a523b528ed7d2d7a2bb55"
+    ],
+    "ui-bugs": [
+      "01d2a7e034713195f33071f2c71a3c99"
     ]
   }
 }

--- a/server/services/taskPromptDefaults/integrityHash.js
+++ b/server/services/taskPromptDefaults/integrityHash.js
@@ -47,9 +47,8 @@ export const hashPromptBody = (body, apiUrl = PORTOS_API_URL) => createHash('md5
   .digest('hex');
 
 /**
- * Build the full snapshot shape from the taskPromptDefaults exports. Key order
- * matches the committed integrity.snapshot.json so a regeneration produces a
- * clean diff.
+ * Build the full snapshot shape from the taskPromptDefaults exports. Keys are
+ * sorted (see sortedEntries) so a regeneration produces a clean, mergeable diff.
  */
 export const buildPromptIntegritySnapshot = ({
   DEFAULT_TASK_PROMPTS,
@@ -57,13 +56,21 @@ export const buildPromptIntegritySnapshot = ({
   REFERENCE_WATCH_AUDITED_VERSION,
   PREVIOUS_DEFAULT_PROMPTS,
 }, apiUrl = PORTOS_API_URL) => ({
-  DEFAULT_TASK_PROMPTS: Object.fromEntries(
+  DEFAULT_TASK_PROMPTS: sortedEntries(
     Object.entries(DEFAULT_TASK_PROMPTS).map(([key, body]) => [key, hashPromptBody(body, apiUrl)]),
   ),
-  PROMPT_VERSIONS,
+  PROMPT_VERSIONS: sortedEntries(Object.entries(PROMPT_VERSIONS)),
   REFERENCE_WATCH_AUDITED_VERSION,
-  PREVIOUS_DEFAULT_PROMPTS: Object.fromEntries(
+  PREVIOUS_DEFAULT_PROMPTS: sortedEntries(
     Object.entries(PREVIOUS_DEFAULT_PROMPTS)
       .map(([key, bodies]) => [key, bodies.map((body) => hashPromptBody(body, apiUrl))]),
   ),
 });
+
+// Sorted keys put unrelated additions on unrelated lines so parallel branches
+// merge cleanly (declaration order made every new prompt the last line of its
+// section — a conflict on every rebase). Byte order, not locale, so every
+// machine regenerates the same file.
+function sortedEntries(entries) {
+  return Object.fromEntries(entries.sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0)));
+}


### PR DESCRIPTION
## Summary

Full-plan PRs — about half of all PR runs — waited ~12 minutes. Measured on a green full run (2026-09-02):

| Job | Wall | Where the time goes |
|---|---|---|
| Client tests and build | 10.3 min | `environment 489s, setup 112s, import 119s, tests 384s` — jsdom setup per file, 2-worker cap |
| Windows server unit tests | 10.0 min | `import 679s, tests 812s` — module import is slow on the Windows runner |
| Server tests | 5.7 min | `import 555s, tests 395s` |

- **Shard the full suite across runners.** Each test job is now a matrix built from a planner output (`[1]` for a scoped plan, `[1..n]` for a full one: client 3, Windows 3, server 2). `run-ci-tests.js` turns `CI_SHARD` into Vitest's `--shard`, which slices files by path hash. Lint, build, bundle budget, and smoke boot pin to shard 1; the transform-artifact cache key carries the shard so parallel saves don't race. Expected full-plan wall time: ~4–5 min instead of ~12. Public-repo runner minutes are free.
- **Stop treating `scripts/*.py` as unclassified.** Two of the sampled full runs were python sidecar edits. The planner now `git grep`s the suites naming each changed script and runs only those, failing closed per script.
- **Rebase churn on derived files** (the second half of the ask). Audit of every checked-in derived artifact:
  - `apiRouteCatalog.generated.json` — already content-keyed (commit 61e3c8a78, 2026-09-01) ✔; socket catalog already removed ✔; `promptStageCallSites` keyed by stage ✔.
  - `taskPromptDefaults/integrity.snapshot.json` (40 commits in 2 weeks) — was written in declaration order, so every new prompt landed on the last line of its section and two branches adding prompts conflicted on the closing brace. Now sorted (byte order); the test compares with `toEqual`, so the contract is unchanged.
  - `server/lib/README.md` + `index.js` (218 / 101 commits in 2 weeks) and the client lib/hooks/utils/services catalogs — sorted one-line-per-module lists where concurrent branches insert at the same hunk. They now merge with git's `union` driver (verified: the same insert/insert shape conflicts without it, merges clean with it). A new always-run guard fails on a doubled or resurrected row, rejects a `.js` that is not a pure re-export barrel, and pins the `.gitattributes` list to the planner's barrel list.
- Per-suite speedups for the slowest files (primaryCheckoutGuard 78s on Windows, sprites atlas/walk, worktreeReap, ChiefOfStaff.test.jsx) are filed as #5902 rather than bundled here.

## Test plan

- [x] `scripts/` tree (352 files) + `taskPromptDefaults`, `lib/index`, `generatedManifests` green under the server runner
- [x] Planner dry run: `scripts/_runner_common.py` → 16 server files (15 always-run + 1 contract); `generate_ltx2.py` → 19 server / 1 client; `server/vitest.config.js` → full with shards `[1,2]`/`[1,2,3]`/`[1,2,3]`
- [x] `vitest run --shard=1/3` and `--shard=3/3` over `client/src/utils` run disjoint slices (19 / 18 files)
- [x] `merge=union` simulated on a scratch repo: insert/insert conflict without the attribute, clean rebase with it
- [x] ci.yml parses; `ci-base-sha`, `ci-fail-fast`, `pre-install-entrypoints`, `repo-scan-guards` contract tests pass
- [ ] This PR itself triggers a full plan (it touches `ci-test-plan.js`), so CI on it exercises the sharded matrix for real — compare the `⏱` lines in the job summaries against the table above

## Found while running this PR's own CI

- The first run went red on `generate-api-route-catalog.test.js`: `apiRouteCatalog.generated.json` on `main` was stale (the settings credentials route from #5898 landed without a regeneration; `main` has since caught up). The route-catalog and prompt-stage drift tests regenerate from the tree instead of importing what they scan, so the scoped planner never selected them for the PR that added the route — the stale file only surfaces on the next full-plan PR, which then has to carry a "regenerate" commit. This PR adds a structural rule so both drift tests run on every scoped server change.
- The second run went red on Windows only: `twinImportCycles.test.js` (#5687) compared POSIX keys against `path.relative` output, so every subdirectory edge was dropped on Windows. `main` has the same one-line fix now, so this branch carries none.
