### PR TITLE
refactor: import summarizeSkillEvidence instead of re-copying it into meatspacePostStats (#5709)

### DIFF
--- a/server/services/meatspacePost.js
+++ b/server/services/meatspacePost.js
@@ -941,6 +941,9 @@ export function deriveTaskAvgResponseMs(task) {
   return Math.round(timed.reduce((sum, q) => sum + q.responseMs, 0) / timed.length);
 }
 
+// Normalizes a legacy training-log entry into the scored-task shape the
+// session pipeline uses. Stays private: its only cross-module consumer reaches
+// it through summarizeSkillEvidence below.
 function trainingEntryTask(entry) {
   const rawQuestionCount = Number(entry?.questionCount);
   const rawCorrectCount = Number(entry?.correctCount);
@@ -982,7 +985,10 @@ function skillEvidenceSessions(sessions, training) {
   ];
 }
 
-function summarizeSkillEvidence(sessions, training) {
+// Rolls sessions + training entries into per-drill count/accuracy/completion
+// means. Consumed by meatspacePostStats.js (getPostStats); declared here beside
+// deriveTaskAccuracy/deriveTaskCompletion, which it is built on.
+export function summarizeSkillEvidence(sessions, training) {
   const accuracyLists = {};
   const completionLists = {};
   const counts = {};

--- a/server/services/meatspacePostStats.js
+++ b/server/services/meatspacePostStats.js
@@ -5,63 +5,16 @@
  * callers name THIS module for the derived aggregates rather than reaching for
  * a re-export off the persistence service (issue #5690).
  */
-import { getPostSessions, deriveTaskAccuracy, deriveTaskCompletion } from './meatspacePost.js';
+import {
+  getPostSessions,
+  deriveTaskAccuracy,
+  deriveTaskCompletion,
+  summarizeSkillEvidence,
+} from './meatspacePost.js';
 import { getAllTrainingEntries } from './postTrainingLogStore.js';
 import { computePostStreaks, computeUnifiedStreak, recordDayKey, ymdShift } from '../lib/postStreak.js';
 import { todayInTimezone } from '../lib/timezone.js';
 import { getUserTimezone } from './userTimezone.js';
-
-function trainingEntryTask(entry) {
-  const rawQuestionCount = Number(entry?.questionCount);
-  const rawCorrectCount = Number(entry?.correctCount);
-  const questionCount = Number.isFinite(rawQuestionCount) && rawQuestionCount > 0 ? rawQuestionCount : 0;
-  const correctCount = Number.isFinite(rawCorrectCount)
-    ? Math.max(0, Math.min(questionCount, rawCorrectCount))
-    : 0;
-  const accuracy = typeof entry?.accuracy === 'number'
-    ? entry.accuracy
-    : questionCount > 0 ? correctCount / questionCount : null;
-  return {
-    id: entry?.id,
-    module: entry?.module,
-    type: entry?.drillType,
-    config: entry?.difficulty || {},
-    questions: Array.isArray(entry?.questions) ? entry.questions : [],
-    score: Number.isFinite(entry?.score) ? entry.score : (accuracy == null ? null : accuracy * 100),
-    accuracy,
-    completion: typeof entry?.completion === 'number' ? entry.completion : (questionCount > 0 ? 1 : null),
-    avgResponseMs: typeof entry?.avgResponseMs === 'number'
-      ? entry.avgResponseMs
-      : questionCount > 0 ? (entry?.totalMs || 0) / questionCount : null,
-    totalMs: entry?.totalMs || 0,
-    totalCount: questionCount,
-  };
-}
-
-function summarizeSkillEvidence(sessions, training) {
-  const accuracyLists = {};
-  const completionLists = {};
-  const counts = {};
-  const add = (task) => {
-    if (!task?.module || !task?.type) return;
-    const key = `${task.module}:${task.type}`;
-    counts[key] = (counts[key] || 0) + 1;
-    const accuracy = deriveTaskAccuracy(task);
-    if (accuracy != null) (accuracyLists[key] ||= []).push(accuracy);
-    const completion = deriveTaskCompletion(task);
-    if (completion != null) (completionLists[key] ||= []).push(completion);
-  };
-  for (const session of sessions) for (const task of session.tasks || []) add(task);
-  for (const entry of training) add(trainingEntryTask(entry));
-  const meanMap = (lists) => Object.fromEntries(
-    Object.entries(lists).map(([key, values]) => [key, values.reduce((sum, value) => sum + value, 0) / values.length]),
-  );
-  return {
-    evidenceByDrillCount: counts,
-    evidenceByDrillAccuracy: meanMap(accuracyLists),
-    evidenceByDrillCompletion: meanMap(completionLists),
-  };
-}
 
 export async function getPostStats(days = 30) {
   const atDate = new Date();


### PR DESCRIPTION
## Summary

- `meatspacePostStats.js` carried byte-identical copies of `trainingEntryTask` and `summarizeSkillEvidence` from `meatspacePost.js`. Verified identical by extracting and diffing both bodies before collapsing them — no behavioral divergence, so nothing had to be chosen between.
- `summarizeSkillEvidence` is now exported from `meatspacePost.js` and imported by the stats module. It is declared beside `deriveTaskAccuracy` / `deriveTaskCompletion`, the two helpers it is built on and that the stats module already imported.
- `trainingEntryTask` stays **private**. The issue's plan exported both, but once the duplicate `summarizeSkillEvidence` is gone nothing outside `meatspacePost.js` calls it — exporting it would add unused public surface. Its only cross-module consumer reaches it through `summarizeSkillEvidence`.
- The import edge is downward-only (`meatspacePostStats.js` -> `meatspacePost.js`), so the `#5690` layering guard in `meatspacePostImportCycles.test.js` still holds.

### Two notes where the issue's plan was out of date

- **No import cycle to worry about.** The issue said `meatspacePost.js` imports `getPostStats` back from the stats module. `#5690` already removed that edge, so this is a plain one-way import, not a cycle. No TDZ risk.
- **The proposed new test already exists.** The issue asked for a new `meatspacePostStats.test.js` covering a training entry with no `accuracy` but with `questionCount`/`correctCount`, asserted through `getPostStats().evidenceByDrillAccuracy`. `meatspacePostProgress.test.js:138` already does exactly that, through the same public boundary. Per the repo's test strategy ("do not add a test that duplicates a stronger boundary assertion") no duplicate file was added; that existing test is the guard, and it passing unchanged is the before/after equivalence proof the issue asked for.

## Test plan

- `cd server && npm test` — full suite. 10 failures, all pre-existing on `origin/main` in this environment (sprites/atlas, imageGen, trellis normal-bake, peerSync auth, settings secrets-strip, referenceRepos, setup-data-drift); confirmed by re-running the same suites on a detached `origin/main` checkout, where they fail identically. None touch MeatSpace POST.
- Targeted: `meatspacePost.test.js`, `meatspacePostProgress.test.js`, `meatspacePostImportCycles.test.js` — 192 passed, 0 failed. That covers the evidence aggregation, the training-entry derived-accuracy path through `getPostStats`, and the layering/cycle guard.
- `grep -c "function trainingEntryTask\|function summarizeSkillEvidence" server/services/meatspacePostStats.js` returns `0`.

Closes #5709
