### PR TITLE
Make the /api/sync category parity test read the real getSupportedCategories

### DIFF
--- a/server/routes/dataSync.js
+++ b/server/routes/dataSync.js
@@ -46,8 +46,10 @@ const router = Router();
 
 // MUST stay in sync with dataSync.getSupportedCategories() — a category
 // registered in the service but absent here 400s before its snapshot/apply
-// handler can run (the latent bug #730 hit for `storyBuilder`).
-const categoryParam = z.enum(['goals', 'character', 'digitalTwin', 'meatspace', 'universe', 'pipeline', 'mediaCollections', 'videoHistory', 'storyBuilder', 'usage']);
+// handler can run (the latent bug #730 hit for `storyBuilder`). Exported so
+// dataSync.test.js can assert that parity against the REAL service export in
+// both directions, instead of re-typing this list (#5705).
+export const categoryParam = z.enum(['goals', 'character', 'digitalTwin', 'meatspace', 'universe', 'pipeline', 'mediaCollections', 'videoHistory', 'storyBuilder', 'usage']);
 
 // Categories whose payload is the user's own person rather than their creative
 // work — `digitalTwin` alone carries identity, chronotype, longevity markers,

--- a/server/routes/dataSync.test.js
+++ b/server/routes/dataSync.test.js
@@ -11,11 +11,16 @@ vi.mock('../services/sharing/tombstoneGc.js', () => ({
   getSweepStatus: vi.fn(),
   TOMBSTONE_GRACE_MS: 24 * 60 * 60 * 1000,
 }));
-vi.mock('../services/dataSync.js', () => ({
+// The three I/O entry points are stubbed so the route test never touches real
+// stores — but `getSupportedCategories` delegates to the REAL export (#5705).
+// It is a pure `Object.keys(CATEGORIES)` with no I/O, and it is the source of
+// truth the route's hand-maintained `categoryParam` enum has to match; a stub
+// would make the parity tests below compare the route to a copy of itself.
+vi.mock('../services/dataSync.js', async () => ({
   getChecksum: vi.fn(),
   getSnapshot: vi.fn(),
   applyRemote: vi.fn(),
-  getSupportedCategories: vi.fn(() => []),
+  getSupportedCategories: (await vi.importActual('../services/dataSync.js')).getSupportedCategories,
 }));
 
 // Stub only the two leaves the REAL peer-pull gate reads — the peer registry
@@ -31,14 +36,19 @@ vi.mock('../services/instances.js', async () => ({
   getPeers: async () => peers,
 }));
 let settings = {};
-vi.mock('../services/settings.js', () => ({
+// Spreads the real module rather than listing one export: pulling the real
+// `getSupportedCategories` above loads the whole dataSync graph, which reaches
+// modules importing other settings exports — a hand-listed stub would break
+// again the next time that graph grows an import.
+vi.mock('../services/settings.js', async () => ({
+  ...(await vi.importActual('../services/settings.js')),
   getSettings: async () => settings,
 }));
 
 import { sweepTombstones, getSweepStatus } from '../services/sharing/tombstoneGc.js';
-import { getChecksum, getSnapshot } from '../services/dataSync.js';
+import { getChecksum, getSnapshot, applyRemote, getSupportedCategories } from '../services/dataSync.js';
 import { PEER_INSTANCE_ID_HEADER, __resetPullWarnThrottleForTests } from '../services/sharing/peerPullAuthorization.js';
-import dataSyncRoutes from './dataSync.js';
+import dataSyncRoutes, { categoryParam } from './dataSync.js';
 
 const PEER_ID = 'peer-a-instance-id';
 // Obviously-fake peer record. `fullSync` stands in for "the user ticked every
@@ -153,22 +163,41 @@ describe('GET /api/sync/:category/checksum — forPeer scoping', () => {
     expect(res.status).toBe(200);
     expect(getChecksum).toHaveBeenCalledWith('universe', { forPeerId: undefined });
   });
+});
 
-  // The category enum is hand-maintained and MUST cover every category the
-  // service supports (a missing one 400s before the snapshot handler runs —
-  // the latent bug #730 hit for `storyBuilder`). Assert each known snapshot
-  // category is accepted (non-400) so a future addition that forgets the enum
-  // is caught here.
-  it.each([
-    'goals', 'character', 'digitalTwin', 'meatspace',
-    'universe', 'pipeline', 'mediaCollections', 'videoHistory', 'storyBuilder', 'usage',
-  ])('accepts the %s category (enum parity with getSupportedCategories)', async (category) => {
-    // Identified as a configured peer so the PII categories clear the pull gate
+// The route's `categoryParam` enum is hand-maintained and has to match
+// `dataSync.getSupportedCategories()` exactly. Drift in either direction is a
+// live bug: a service category missing from the enum 400s before its handler
+// can run (#730 hit that for `storyBuilder`), and an enum entry the service
+// retired lets a request through to a 404 at the service. Both directions are
+// asserted against the REAL export here — the earlier version of this suite
+// stubbed it and iterated a hardcoded copy of the enum, so it compared the
+// route to itself and could not catch either (#5705).
+describe('/api/sync/:category — enum parity with getSupportedCategories()', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    settings = {};
+    // A configured, fully-shared peer so the PII categories clear the pull gate
     // (#5663) and this stays a test of the ENUM, not of authorization.
+    setPeers(allowedPeer());
+    __resetPullWarnThrottleForTests();
+    getChecksum.mockResolvedValue({ checksum: 'abc' });
+  });
+
+  it('matches the service category list exactly', () => {
+    // Symmetric on purpose: a missing entry also trips the sweep below, but
+    // only this gives a stale entry (a category the service retired, which now
+    // reaches a 404 at the service) a failure at all — and it names the drift
+    // in the diff instead of as N route errors.
+    expect([...categoryParam.options].sort()).toEqual([...getSupportedCategories()].sort());
+  });
+
+  it.each(getSupportedCategories())('serves a checksum for the %s category', async (category) => {
     const res = await request(buildApp())
       .get(`/api/sync/${category}/checksum`)
       .set(PEER_INSTANCE_ID_HEADER, PEER_ID);
-    expect(res.status).not.toBe(400);
+    expect(res.status).toBe(200);
+    expect(getChecksum).toHaveBeenCalledWith(category, { forPeerId: undefined });
   });
 });
 
@@ -278,10 +307,9 @@ describe('GET /api/sync/:category — peer-pull authorization', () => {
   });
 
   it('leaves the write direction alone — apply is gated by its schema-version check, not this', async () => {
-    const { applyRemote } = await import('../services/dataSync.js');
     applyRemote.mockResolvedValue({ applied: true, count: 1 });
     const res = await request(buildApp()).post('/api/sync/digitalTwin/apply').send({ data: { a: 1 } });
     expect(res.status).toBe(200);
-    expect(applyRemote).toHaveBeenCalled();
+    expect(applyRemote).toHaveBeenCalledWith('digitalTwin', { a: 1 }, { portosMeta: undefined });
   });
 });

--- a/server/services/sharing/privacyNeverFederates.test.js
+++ b/server/services/sharing/privacyNeverFederates.test.js
@@ -43,12 +43,17 @@ describe('privacy records never federate (ADR 2026-08-08, #2148)', () => {
     expect([...NON_RECORD_SCHEMA_CATEGORIES].filter(mentionsPrivacy)).toEqual([]);
   });
 
+  // Explicit timeout: the lazy import below resolves the whole dataSync
+  // service graph INSIDE the test body, which costs most of the default 10s
+  // cap on a loaded machine and made this guard flake. Widening the cap keeps
+  // the laziness (and the isolation it buys the two assertions above) without
+  // the false red.
   it('declares no privacy dataSync snapshot category', async () => {
     // Imported lazily: dataSync pulls a broad service graph, and the two
     // assertions above must still run if that import ever gets heavier.
     const { getSupportedCategories } = await import('../dataSync.js');
     expect(getSupportedCategories().filter(mentionsPrivacy)).toEqual([]);
-  });
+  }, 30000);
 
   it('gives no privacy table a sync cursor or tombstone column', () => {
     // Sanity: if the filter ever matches nothing the assertions below are


### PR DESCRIPTION
## Summary

- The `/api/sync` category "parity with `getSupportedCategories`" test mocked that export to return `[]` and then iterated a hardcoded copy of the route's own Zod enum — it compared the route to itself. The #730 regression it exists to catch (a category registered in `dataSync.CATEGORIES` but forgotten in `categoryParam`, which 400s before the handler runs) produced a green suite.
- The service mock now delegates `getSupportedCategories` to the real module via `vi.importActual`. The three I/O entry points stay stubbed, so the route test still never touches a store.
- `categoryParam` is exported from `server/routes/dataSync.js` so the test compares the two lists symmetrically rather than re-typing one. That also covers the previously unguarded direction: an enum entry the service retired, which reaches a 404 at the service.
- Per-category cases are generated from the real list, and the assertion moves from `not.toBe(400)` — which a 500 from a broken handler also satisfies — to the actual contract (200 plus the exact `getChecksum` arguments).
- The apply verb parses the same enum as the reads, so it gets no second per-category sweep; its existing case is tightened to assert the exact `applyRemote` arguments instead of only that it was called.

### Rolled in

Pulling the real export loads the whole `dataSync` service graph, so the `settings.js` mock spreads the real module instead of listing one export — a hand-listed stub breaks again the next time that graph grows an import. The same graph is why `privacyNeverFederates.test.js` gets an explicit timeout: its lazy `import('../dataSync.js')` runs inside the test body and was already flaking against the default 10s cap.

## Test plan

- `cd server && npm test` — 37715 passing. The two failures in `services/sprites/atlas.test.js` are pre-existing: verified reproducing on a clean `origin/main` checkout outside the worktree (7 failures there, 6 on this branch), and untouched by this diff.
- Bypass probes, run against the fixed test and then reverted:
  - Added a category to `CATEGORIES` in `server/services/dataSync.js` without adding it to `categoryParam` — 2 failures (`matches the service category list exactly` and the generated checksum case for it). The old test passed this.
  - Added a category to `categoryParam` that the service does not support — `matches the service category list exactly` fails. Previously unguarded.
- Reviewed locally with `agy --effort medium`; its two substantive findings (use a symmetric list assertion, drop the duplicated apply sweep) are applied above.

Closes #5705
