### PR TITLE
Reconcile .env.example with the environment variables the server reads, and guard the drift

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,15 +25,18 @@ PGPASSWORD=portos
 # Loopback HTTP port spawned when HTTPS is active so local curl skips the cert (default: 5553)
 # PORTOS_HTTP_PORT=5553
 
+# Port the Express server listens on (server/index.js; default: 5555 from lib/ports.js)
+# PORT=5555
+
+# VNC port the Remote Desktop broker connects to on this machine
+# (remoteDesktop.js; default: 5900). A non-numeric or out-of-range value falls
+# back to the default rather than failing.
+# PORTOS_VNC_PORT=5900
+
 # pm2 restarts portos-server when its RSS crosses this (memory-leak safety valve).
 # Default 4G fits small installs; raise it on a big-RAM workstation so a long
 # session / heavy SSE load doesn't cause spurious restarts (e.g. 32G on 128 GB).
 # PORTOS_SERVER_MAX_MEMORY=32G
-
-# Same ceiling for the Vite dev server (portos-ui). Default 1G — a dev server that
-# transforms modules on demand should sit well under that; raise it only if a huge
-# client tree makes Vite restart during normal editing.
-# PORTOS_UI_MAX_MEMORY=2G
 
 # Override the base URLs advertised to clients (auto-derived from PORTOS_HOST/PORT if unset)
 # PORTOS_API_URL=https://my-machine.ts.net:5555
@@ -69,6 +72,12 @@ PGPASSWORD=portos
 # Chief of Staff runner endpoint (used when CoS runs as a separate process)
 # COS_RUNNER_URL=http://localhost:5558
 
+# Eidoverse world server endpoints (eidoverseWorld.js). The WebSocket URL defaults
+# to ws://127.0.0.1:<eidoverse port>/ws; the HTTP URL is derived from it unless set.
+# Point these at another host only when the world runs off-box.
+# EIDOVERSE_WS_URL=ws://127.0.0.1:8940/ws
+# EIDOVERSE_HTTP_URL=http://127.0.0.1:8940/
+
 # Active local LLM backend: "ollama" or "lmstudio" (chosen at setup time; managed in Settings → Local LLMs)
 # LLM_BACKEND=ollama
 
@@ -95,6 +104,11 @@ PGPASSWORD=portos
 
 # Maximum Grok image-generation runtime in milliseconds (default: 1200000 / 20 minutes)
 # GROK_TIMEOUT_MS=1200000
+
+# Maximum Grok VIDEO runtime in milliseconds (videoGen/grok.js; default: 1800000 /
+# 30 minutes). Video takes longer than an image, so this cap is separate from
+# GROK_TIMEOUT_MS — keep it above the 20-minute cloud-lane idle watchdog.
+# GROK_VIDEO_TIMEOUT_MS=1800000
 
 # Maximum Antigravity image-generation runtime in milliseconds (default: 1200000 / 20 minutes)
 # AGY_IMAGEGEN_TIMEOUT_MS=1200000
@@ -141,6 +155,11 @@ PGPASSWORD=portos
 # because a bare `bash` often resolves to WSL, which can't see drive paths.
 # PORTOS_BASH=/bin/bash
 
+# Python interpreter scripts/setup-image-video.sh uses as the venv base
+# (setupScriptRunner.js). An explicit value always wins; on Windows PortOS
+# otherwise auto-detects one, avoiding a conda base whose venv can't load torch.
+# PYTHON_BIN=/usr/bin/python3
+
 # Shell binary for interactive PTY sessions (the Shell page, agent TUI shells).
 # Auto-detected if unset: on Windows PowerShell 7, else Windows PowerShell, else
 # cmd.exe (last, because it can't reach another drive by anything you'd type —
@@ -171,8 +190,28 @@ PGPASSWORD=portos
 # Ollama context window size passed to new model loads (default: 32768)
 # OLLAMA_NUM_CTX=32768
 
+# Slotstream model cache directory override (slotstreamModels.js; default:
+# ~/.slotstream/models). The binary always lives in ~/.slotstream/bin.
+# SLOTSTREAM_MODEL_DIR=/path/to/slotstream/models
+
+# Abort a speculative-decoding model download after this many milliseconds with
+# no bytes received (specDecodeModels.js; default: 1200000 / 20 minutes). Raise
+# it for a slow Hugging Face/CDN handshake; a download still receiving bytes is
+# never cut off by this.
+# SPEC_DECODE_IDLE_STALL_MS=1200000
+
 # Video process grace period after output completion in milliseconds (default: 40000)
 # VIDEOGEN_COMPLETION_WATCHDOG_MS=40000
+
+# FFLF/ltx2 stage-2 pixel-frame budget (videoGen/renderArgs.js). Unset, PortOS
+# scales it to detected unified memory. Raise it on a big-memory box; lower it if
+# a render OOMs. This is the single cap both the worker and the client honour.
+# FFLF_LTX2_PIXEL_BUDGET=8000000
+
+# Megapixel ceiling for a local image regeneration render (imageGen/regen.js;
+# default: 2.0). The result is upscaled back to the source's exact dimensions, so
+# this bounds compute, not output size. Raise it on a high-memory machine.
+# PORTOS_REGEN_MAX_MP=2.0
 
 # Terminate an idle queued video job after this many milliseconds (default: 1800000 / 30 minutes)
 # MEDIA_JOB_WATCHDOG_VIDEO_MS=1800000
@@ -207,14 +246,41 @@ PGPASSWORD=portos
 # Automatic LoRA checkpoint resumes allowed after soft stalls (default: 2; 0 disables)
 # LORA_TRAIN_STALL_MAX_AUTO_RESUMES=2
 
+# Cap LoRA training quantization at this bit width (loraTraining/runtimes.js).
+# Only 8 or 4 are honoured; anything else is ignored and the memory-derived tier
+# stands. Set it to force a smaller quant on a machine whose auto-tier OOMs.
+# LORA_TRAIN_MAX_QUANT_BITS=4
+
 # Ingredient catalog revisions retained per ingredient (default: 50)
 # CATALOG_REVISION_RETENTION=50
 
 # LM Studio model id auto-installed for voice tool calling (default: built-in fallback chain)
 # PORTOS_VOICE_DEFAULT_TOOL_MODEL=lmstudio-community/Qwen2.5-3B-Instruct-GGUF
 
+# Signal Desktop install directory read by Signal sync (signalSync.js; default:
+# ~/Library/Application Support/Signal). SIGNAL_CONFIG_PATH and SIGNAL_DB_PATH are
+# derived from it, so relocating a Signal install usually only needs this one.
+# SIGNAL_DIR=/path/to/signal
+
 # Signal sync config file path (default: SIGNAL_DIR/config.json)
 # SIGNAL_CONFIG_PATH=/path/to/signal/config.json
+
+# Signal sync SQLCipher database path (default: SIGNAL_DIR/sql/db.sqlite)
+# SIGNAL_DB_PATH=/path/to/signal/sql/db.sqlite
+
+# Test/CI hook that supplies the "Signal Safe Storage" password instead of
+# shelling out to the macOS keychain (signalSync.js). Leave unset on a real
+# install — PortOS reads the keychain itself, and this would put a live
+# credential in a plaintext file.
+# SIGNAL_KEYCHAIN_PASSWORD=fake-keychain-password
+
+# macOS Contacts (AddressBook) directory read by contact sync (contactsSync.js;
+# default: ~/Library/Application Support/AddressBook)
+# CONTACTS_AB_ROOT=/path/to/AddressBook
+
+# macOS Messages database read by iMessage sync (imessageSync.js; default:
+# ~/Library/Messages/chat.db)
+# IMESSAGE_CHAT_DB=/path/to/chat.db
 
 # Privacy Center PII Vault encryption key — 32 bytes, hex (64 chars) or base64.
 # Auto-generated and appended to .env on the first vault write if unset. Back

--- a/scripts/ci-test-plan.js
+++ b/scripts/ci-test-plan.js
@@ -179,6 +179,9 @@ export const ALWAYS_RUN_TESTS = [
   'scripts/repo-scan-guards.test.js',
   'scripts/tailnet-identity-leak.test.js',
   'server/dependency-overrides.test.js',
+  // Whole-tree scanner: any server file can add a `process.env` read, and
+  // `.env.example` itself is not a scope the selector routes to a runner.
+  'server/envExampleDrift.test.js',
   'server/lib/generatedManifests.test.js',
   'server/lib/qwenAgentParsers.test.js',
   'server/lib/testDataIsolation.guards.test.js',

--- a/server/envExampleDrift.test.js
+++ b/server/envExampleDrift.test.js
@@ -1,0 +1,231 @@
+/**
+ * Repo-wide guard: `.env.example` and the variables the server actually reads
+ * must not drift apart (#5706).
+ *
+ * ## Why this exists
+ *
+ * `.env.example` is the only discovery surface a fresh install has for "what can
+ * I configure". Every one of these variables is read lazily at first use with a
+ * silent fallback, so an undocumented one is invisible: the feature just quietly
+ * uses its default and nothing ever says otherwise. That made the file rot in
+ * both directions before this guard existed —
+ *
+ *   - FORWARD drift: `signalSync.js` reads `SIGNAL_DIR`, `SIGNAL_CONFIG_PATH` and
+ *     `SIGNAL_DB_PATH` in one three-line block, and only the middle one was
+ *     documented — so a user relocating a Signal install configured half of it.
+ *   - REVERSE drift: `.env.example` still advertised `PORTOS_UI_MAX_MEMORY` long
+ *     after #5322 made the Vite ceiling a fixed constant. Setting it did nothing.
+ *
+ * Both directions are checked below.
+ *
+ * ## The rule
+ *
+ * 1. Every `process.env.NAME` read in tracked, non-test server runtime source
+ *    appears as a `NAME=` line in `.env.example` — commented out is fine, that is
+ *    how the whole file documents an optional override.
+ * 2. Every `NAME=` documented in `.env.example` is mentioned somewhere in the
+ *    tracked code PortOS actually runs — any language, anywhere in the repo.
+ *
+ * ## Allowlist
+ *
+ * `INHERITED_ENV` below is the one escape hatch, and it is a *category* list with
+ * a reason per entry rather than a snapshot of today's diff — so it keeps meaning
+ * something as the tree grows. An entry belongs there only if a user would never
+ * put it in `.env`: the OS provides it, a toolchain (npm, PM2, Hugging Face, XDG)
+ * injects it, or it exists purely for the test harness. A new *product* setting
+ * is not an allowlist entry; document it in `.env.example` instead.
+ *
+ * ## What this guard CANNOT see
+ *
+ *   - `process.env['NAME']` / `process.env[dynamicKey]` — only the dotted form is
+ *     matched. Write `process.env.NAME` and this guard covers you.
+ *   - A destructured read (`const { FOO } = process.env`, or a helper taking an
+ *     `env` object, as `interactiveShellResolver.js` does with `PORTOS_SHELL`).
+ *     Forward drift on those shapes goes unnoticed; the reverse check still
+ *     covers them because it matches the bare name anywhere in the source.
+ *   - Anything outside the server RUNTIME tree in the forward direction. Both
+ *     `scripts/` and `server/scripts/` are standalone CLIs — CI plumbing
+ *     (`CI_SHARD`, `GITHUB_SHA`, …) and one-off dev explorers (`MAZE_SEED`, …)
+ *     that document their own env in their file headers and would be noise in a
+ *     user-facing example file. They stay a reverse-only surface.
+ *   - A reference to a name in prose. The reverse direction matches bare names,
+ *     so a variable nothing reads any more still counts as alive while a code
+ *     COMMENT mentions it. `.md` files are excluded from that surface for the
+ *     same reason, but an in-code comment cannot be told from a real read here.
+ *
+ * String and comment CONTENT is blanked before the forward scan (`blankLiterals`
+ * from `lib/sourceScan.js`), so a `process.env.X` written inside a code sample
+ * PortOS *generates* for someone else — `routes/apps/viteTls.js` emits exactly
+ * that for a user's vite config — is correctly not treated as a PortOS setting.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'child_process';
+import { readFileSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+import { blankLiterals } from './lib/sourceScan.js';
+
+const SERVER_ROOT = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = dirname(SERVER_ROOT);
+const ENV_EXAMPLE = join(REPO_ROOT, '.env.example');
+
+/**
+ * Names a user never sets in `.env`, with the reason each is exempt. Grouped by
+ * category on purpose — see the Allowlist note in the header before adding one.
+ */
+const INHERITED_ENV = {
+  // Provided by the operating system / shell.
+  HOME: 'OS-provided home directory',
+  PATH: 'OS-provided executable search path',
+  PWD: 'OS-provided working directory',
+  USER: 'OS-provided account name',
+  TZ: 'OS/pm2-provided timezone (ecosystem.config.cjs pins it to UTC)',
+  LOCALAPPDATA: 'Windows-provided per-user app data root',
+  ProgramFiles: 'Windows-provided install root',
+  SystemDrive: 'Windows-provided system drive letter',
+  DYLD_LIBRARY_PATH: 'macOS dynamic-loader path, passed through to child processes',
+  LD_LIBRARY_PATH: 'Linux dynamic-loader path, passed through to child processes',
+  XDG_CACHE_HOME: 'XDG base-directory spec, set by the desktop environment',
+
+  // Injected by a toolchain PortOS runs under.
+  NODE_ENV: 'set by the launcher (pm2) and forced to "test" by vitest.config.js',
+  npm_config_cache: 'injected by npm when it runs a script',
+  npm_lifecycle_event: 'injected by npm when it runs a script',
+  PM2_HOME: 'injected by pm2',
+  PM2_ID: 'injected by pm2',
+  pm_exec_path: 'injected by pm2',
+  pm_id: 'injected by pm2',
+  BUN_INSTALL: 'set by the Bun installer; PortOS only reads it to find the binary',
+  HF_HOME: 'Hugging Face toolchain convention, shared with the Python side',
+  HF_HUB_CACHE: 'Hugging Face toolchain convention, shared with the Python side',
+
+  // Test-harness only — setting any of these on a real install is meaningless.
+  VITEST: 'set by the vitest runner',
+  VITEST_FAST: 'opt-in fast-suite selector, CI/local test runs only',
+  TEST_DB_OK: 'test-harness flag for the DB-backed suites',
+  PGTESTDATABASE: 'test-harness override naming portos_test',
+  PORTOS_REQUIRE_DB: 'CI flag that turns a skipped DB suite into a failure',
+  PORTOS_TEST_PYTHON: 'test-harness interpreter override',
+  PORTOS_TEST_QUIET: 'test-harness log silencer',
+};
+
+/**
+ * `git ls-files --stage`, minus gitlinks. `--stage` so the mode is visible:
+ * `lib/slashdo` is a submodule, and git lists that gitlink as one path that is a
+ * DIRECTORY on disk (mode 160000), which would blow the reader up. Its contents
+ * are not tracked in this repo anyway.
+ */
+const trackedFiles = (...args) => execFileSync('git', ['ls-files', '--stage', ...args], {
+  cwd: REPO_ROOT,
+  encoding: 'utf8',
+  maxBuffer: 64 * 1024 * 1024,
+}).split('\n').filter(Boolean).flatMap((line) => {
+  const [meta, path] = line.split('\t');
+  return meta.startsWith('160000 ') ? [] : [path];
+});
+
+/** Tracked, non-test server RUNTIME modules — the forward-scan surface. */
+const serverRuntimeSources = () => trackedFiles('server').filter((f) => (
+  /\.(?:js|mjs|cjs)$/.test(f) && !f.includes('.test.') && !f.startsWith('server/scripts/')
+));
+
+// Everything a variable can reach the running system through. Deliberately wide
+// — a false "this is dead" would block CI over a real setting — but `.md` and
+// other prose is left out so a doc mention alone cannot keep a dead key alive.
+const CODE_EXT = /\.(?:js|mjs|cjs|ts|tsx|jsx|sh|ps1|bat|cmd|py|rb|swift|yml|yaml|json|toml|sql|html|npmrc)$/;
+
+/**
+ * Tracked code PortOS actually runs — the reverse-scan surface. Extensionless
+ * files are kept (an executable shim like `server/lib/agentGuard/bin/pm2` is
+ * exactly the kind of place a variable is consumed). Two things are not: tests,
+ * which exercise the code rather than being it — this very file names
+ * `PORTOS_UI_MAX_MEMORY` in its header and would otherwise vouch for the dead
+ * key it was written to catch — and `.env.example`, which would document itself.
+ */
+const runtimeCodeSources = () => trackedFiles().filter((f) => (
+  f !== '.env.example' && !f.includes('.test.') && (CODE_EXT.test(f) || !f.includes('.'))
+));
+
+const ENV_READ = /process\.env\.([A-Za-z_$][A-Za-z0-9_$]*)/g;
+
+/**
+ * Every `process.env.NAME` read in one file's source, literals blanked first.
+ * Most of the tree never touches `process.env`, and blanking is the expensive
+ * step, so skip it entirely for a file with nothing to find — this guard is on
+ * the always-run CI list and pays that cost on every PR.
+ */
+export function envReadsIn(src) {
+  if (!src.includes('process.env.')) return [];
+  return [...blankLiterals(src).matchAll(ENV_READ)].map((m) => m[1]);
+}
+
+// A key line is `NAME=`, optionally commented and optionally behind a platform
+// label — `# Windows: PORTOS_SHELL=…` documents PORTOS_SHELL just as well.
+const ENV_KEY_LINE = /^[ \t]*(?:#[ \t]*)?(?:[A-Za-z][A-Za-z0-9 ]*:[ \t]*)?([A-Za-z_][A-Za-z0-9_]*)=/gm;
+
+/** Every variable `.env.example` documents, commented or not. */
+export function documentedKeys(text) {
+  return [...text.matchAll(ENV_KEY_LINE)].map((m) => m[1]);
+}
+
+describe('.env.example stays in sync with the environment the server reads (#5706)', () => {
+  it('scans a real tree', () => {
+    // A broken `git ls-files` (wrong cwd, detached checkout) would otherwise let
+    // both directions below pass by comparing two empty sets.
+    expect(serverRuntimeSources().length).toBeGreaterThan(500);
+    expect(runtimeCodeSources().length).toBeGreaterThan(500);
+    expect(documentedKeys(readFileSync(ENV_EXAMPLE, 'utf8')).length).toBeGreaterThan(50);
+  });
+
+  it('extracts reads and documented keys from the shapes that matter', () => {
+    expect(envReadsIn('const a = process.env.FOO || 1;')).toEqual(['FOO']);
+    // Bracket access is a known blind spot — pinned so the limitation in the
+    // header stays true rather than quietly becoming wrong.
+    expect(envReadsIn("const a = process.env['FOO'];")).toEqual([]);
+    // A sample PortOS generates for someone ELSE's config is not a PortOS setting.
+    expect(envReadsIn('const line = `const D = process.env.FOO;`;')).toEqual([]);
+    expect(envReadsIn('// legacy: process.env.FOO\nconst a = process.env.BAR;')).toEqual(['BAR']);
+
+    expect(documentedKeys('# FOO=bar\n')).toEqual(['FOO']);
+    expect(documentedKeys('FOO=bar\n')).toEqual(['FOO']);
+    expect(documentedKeys('# Windows: FOO=C:\\bar\n')).toEqual(['FOO']);
+    expect(documentedKeys('# Prose about FOO=bar in a sentence\n')).toEqual([]);
+  });
+
+  it('documents every environment variable the server reads', () => {
+    const documented = new Set(documentedKeys(readFileSync(ENV_EXAMPLE, 'utf8')));
+    const undocumented = new Map();
+
+    for (const file of serverRuntimeSources()) {
+      for (const name of envReadsIn(readFileSync(join(REPO_ROOT, file), 'utf8'))) {
+        // hasOwn, not `in`: `process.env.constructor` would otherwise hit
+        // Object.prototype and silently skip enforcement.
+        if (documented.has(name) || Object.hasOwn(INHERITED_ENV, name)) continue;
+        if (!undocumented.has(name)) undocumented.set(name, file);
+      }
+    }
+
+    // Sorted `NAME (first read here)` lines so a failure says what to add and where.
+    expect([...undocumented].sort().map(([n, f]) => `${n} (${f})`)).toEqual([]);
+  });
+
+  it('documents nothing the code has stopped reading', () => {
+    // Bare-name match, not `process.env.NAME`: a variable can legitimately reach
+    // the code destructured, through an `env` object, or via a shell script, and
+    // this direction only needs to know that SOMETHING still knows the name.
+    // One alternation over the documented names per file — `\b` makes the longer
+    // name win, so PORTOS_HOST never counts as a sighting of PORT — and the scan
+    // stops as soon as every name has been accounted for.
+    const dead = new Set(documentedKeys(readFileSync(ENV_EXAMPLE, 'utf8')));
+    const anyName = new RegExp(`\\b(?:${[...dead].join('|')})\\b`, 'g');
+
+    for (const file of runtimeCodeSources()) {
+      if (dead.size === 0) break;
+      const src = readFileSync(join(REPO_ROOT, file), 'utf8');
+      for (const [name] of src.matchAll(anyName)) dead.delete(name);
+    }
+
+    expect([...dead].sort()).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- `.env.example` had drifted from what the server actually reads, in both directions. Every one of these variables is read lazily with a silent fallback, so an undocumented one is invisible — the feature just uses its default and nothing says otherwise.
- **Documented 16 missing variables**, each with a one-line comment naming its reading module and its default. The clearest gap: `signalSync.js` reads `SIGNAL_DIR`, `SIGNAL_CONFIG_PATH` and `SIGNAL_DB_PATH` in one three-line block and only the middle one was documented, so relocating a Signal install configured half of it.
- **Removed one dead variable.** `PORTOS_UI_MAX_MEMORY` was still advertised long after #5322 made the Vite ceiling a fixed constant — setting it did nothing.
- **Added `server/envExampleDrift.test.js`**, a guard for both directions, registered in `ALWAYS_RUN_TESTS` (any server file can add a `process.env` read, and `.env.example` is not a scope the CI selector routes anywhere).

Beyond the 13 variables the issue named, the same scan also turned up `PORT`, `PYTHON_BIN` and `SLOTSTREAM_MODEL_DIR`; all three are documented here too.

### How the guard avoids false positives

- The forward scan blanks string and comment content first, so the `process.env.X` inside a vite config PortOS *generates for a user* is not mistaken for a PortOS setting.
- `INHERITED_ENV` is a category allowlist with a reason per entry — OS-, toolchain- and test-harness-provided names a user would never put in `.env` — rather than a snapshot of today's diff, so it keeps meaning something as the tree grows.
- The reverse scan is deliberately wide (every tracked code file, any language, anywhere in the repo) because a false "this is dead" would block CI over a real setting. Prose and test files are excluded so a doc mention cannot vouch for a key nothing reads.
- Known blind spots are stated in the file header and pinned by fixture assertions, so they cannot quietly become wrong.

All added values are placeholders. No real host, path, or credential appears anywhere in the diff.

## Test plan

- `cd server && npx vitest run envExampleDrift.test.js` — passes in both directions (~0.5s).
- Bypass probe: temporarily adding an undocumented `process.env.PORTOS_PROBE_UNDOCUMENTED` read and a `# PORTOS_PROBE_DEAD_VAR=` line makes the guard fail on exactly those two, naming the file for the first. Both probes reverted.
- `cd server && npm test` — 37,674 passing. The 17 failures are pre-existing 10-second timeout flakes from running a large suite in a worktree under `data/`; all 9 affected files pass when run on their own.
- `scripts/repo-scan-guards.test.js` and `scripts/ci-test-plan.test.js` confirm the new scanner is registered.

Closes #5706
