### PR TITLE
Summarize route-error details into one log line instead of a JSON blob

### DIFF
--- a/server/lib/errorHandler.js
+++ b/server/lib/errorHandler.js
@@ -127,11 +127,19 @@ const clampLogText = (value) => {
   return flat.length > LOG_DETAIL_MAX_CHARS ? `${flat.slice(0, LOG_DETAIL_MAX_CHARS)}…` : flat;
 };
 
+const describeObjectEntries = (obj) => Object.entries(obj).map(([k, v]) => `${k}=${v}`).join('; ');
+
 const describeDetailEntry = (entry) => {
   if (!entry || typeof entry !== 'object') return String(entry);
-  const { path, message } = entry;
-  if (path && message) return `${path}: ${message}`;
-  return String(message || path || '?');
+  // `validate`/`validateRequest` pre-join the Zod path, but a caller passing raw
+  // issues through would leave an array — render it as dot notation, not CSV.
+  const path = Array.isArray(entry.path) ? entry.path.join('.') : entry.path;
+  const { message } = entry;
+  // Nullish, not truthy: a `message` of `0`/`false` is still a message.
+  if (path != null && message != null) return `${path}: ${message}`;
+  if (path != null || message != null) return String(message ?? path);
+  // Not a Zod-shaped issue — name its own fields rather than logging a bare '?'.
+  return describeObjectEntries(entry) || '?';
 };
 
 /**
@@ -154,9 +162,7 @@ const summarizeDetails = (details) => {
     const elided = details.length - LOG_DETAIL_MAX_ENTRIES;
     return elided > 0 ? `${shown} (+${elided} more)` : shown;
   }
-  if (details && typeof details === 'object') {
-    return clampLogText(Object.entries(details).map(([k, v]) => `${k}=${v}`).join('; '));
-  }
+  if (details && typeof details === 'object') return clampLogText(describeObjectEntries(details));
   return clampLogText(details);
 };
 
@@ -186,8 +192,10 @@ export function asyncHandler(fn) {
       } else if (error.status >= 500) {
         console.error(logMsg, error.stack ? error.stack : '');
       } else {
-        const details = error.context?.details;
-        console.error(details ? `${logMsg}: ${summarizeDetails(details)}` : logMsg);
+        // An empty `[]`/`{}` is truthy but summarizes to nothing — gate on the
+        // summary so the line can't end in a dangling colon.
+        const summary = error.context?.details ? summarizeDetails(error.context.details) : '';
+        console.error(summary ? `${logMsg}: ${summary}` : logMsg);
       }
 
       return sendErrorResponse(res, error, { io });

--- a/server/lib/errorHandler.js
+++ b/server/lib/errorHandler.js
@@ -116,6 +116,50 @@ export function createServiceErrorMapper(statusMap, buildContext) {
   };
 }
 
+// Log-line budget for `error.context.details`. Five entries is enough to name
+// the offending fields on a typical 400; the char cap keeps a `pg_dump` stderr
+// blob (dbAdmin.js puts raw stderr in this field) from swallowing the log.
+const LOG_DETAIL_MAX_ENTRIES = 5;
+const LOG_DETAIL_MAX_CHARS = 300;
+
+const clampLogText = (value) => {
+  const flat = String(value).replace(/\s+/g, ' ').trim();
+  return flat.length > LOG_DETAIL_MAX_CHARS ? `${flat.slice(0, LOG_DETAIL_MAX_CHARS)}…` : flat;
+};
+
+const describeDetailEntry = (entry) => {
+  if (!entry || typeof entry !== 'object') return String(entry);
+  const { path, message } = entry;
+  if (path && message) return `${path}: ${message}`;
+  return String(message || path || '?');
+};
+
+/**
+ * Render `error.context.details` as ONE readable log line.
+ *
+ * `validateRequest` sets `details` to the full mapped Zod issue array and
+ * `dbAdmin` sets it to raw command stderr, so serializing it as JSON emitted a
+ * multi-KB escaped blob per sub-500 — against the single-line logging
+ * convention and unreadable in PM2 logs. The field/message pairs are the useful
+ * part of a 400, so summarize rather than drop: the first few entries, then a
+ * `(+N more)` count. The `(+N more)` suffix is appended AFTER the char clamp so
+ * a long first entry can't hide how much was elided.
+ *
+ * Logging only — `buildErrorEnvelope`/`sanitizeContext` still carry the full
+ * structured `details` in the HTTP response body.
+ */
+const summarizeDetails = (details) => {
+  if (Array.isArray(details)) {
+    const shown = clampLogText(details.slice(0, LOG_DETAIL_MAX_ENTRIES).map(describeDetailEntry).join('; '));
+    const elided = details.length - LOG_DETAIL_MAX_ENTRIES;
+    return elided > 0 ? `${shown} (+${elided} more)` : shown;
+  }
+  if (details && typeof details === 'object') {
+    return clampLogText(Object.entries(details).map(([k, v]) => `${k}=${v}`).join('; '));
+  }
+  return clampLogText(details);
+};
+
 export function asyncHandler(fn) {
   return (req, res, next) => {
     Promise.resolve(fn(req, res, next)).catch((err) => {
@@ -143,7 +187,7 @@ export function asyncHandler(fn) {
         console.error(logMsg, error.stack ? error.stack : '');
       } else {
         const details = error.context?.details;
-        console.error(details ? `${logMsg}: ${JSON.stringify(details)}` : logMsg);
+        console.error(details ? `${logMsg}: ${summarizeDetails(details)}` : logMsg);
       }
 
       return sendErrorResponse(res, error, { io });

--- a/server/lib/errorHandler.test.js
+++ b/server/lib/errorHandler.test.js
@@ -469,6 +469,72 @@ describe('errorHandler.js', () => {
       // status→code derivation still runs even without an io channel.
       expect(res.json.mock.calls[0][0].code).toBe('NOT_FOUND');
     });
+
+    // `validateRequest` sets `context.details` to the full mapped Zod issue
+    // array, so JSON.stringify-ing it emitted a multi-KB blob per 400 —
+    // against the single-line logging convention. The log line must summarize;
+    // the RESPONSE body must still carry every entry.
+    it('summarizes a long details array into one line without stringifying it', async () => {
+      const { req, res } = makeReqRes(null);
+      const details = Array.from({ length: 12 }, (_, i) => ({
+        path: `body.field${i}`,
+        message: 'Required'
+      }));
+
+      await asyncHandler(async () => {
+        throw new ServerError('Validation failed', {
+          status: 400,
+          code: 'VALIDATION_ERROR',
+          context: { details }
+        });
+      })(req, res, vi.fn());
+      await flushMicrotasks();
+
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+      const [line, ...extraArgs] = errorSpy.mock.calls[0];
+      expect(extraArgs).toEqual([]);
+      expect(line).not.toContain('\n');
+      expect(line).not.toContain('[{');
+      expect(line).not.toContain('"path"');
+      expect(line).toContain('body.field0: Required');
+      expect(line).toContain('body.field4: Required');
+      expect(line).not.toContain('body.field5');
+      expect(line).toContain('(+7 more)');
+
+      // Logging-only change: the envelope still carries the full array.
+      expect(res.json.mock.calls[0][0].context.details).toEqual(details);
+    });
+
+    // dbAdmin puts raw pg_dump/pg_restore stderr in the same field.
+    it('collapses a multi-line string details value to one truncated line', async () => {
+      const { req, res } = makeReqRes(null);
+      const details = `pg_dump: error: connection to server failed\n${'x'.repeat(500)}\ntrailing`;
+
+      await asyncHandler(async () => {
+        throw new ServerError('Export failed', { status: 400, context: { details } });
+      })(req, res, vi.fn());
+      await flushMicrotasks();
+
+      const line = errorSpy.mock.calls[0][0];
+      expect(line).not.toContain('\n');
+      expect(line).toContain('pg_dump: error: connection to server failed');
+      expect(line).not.toContain('trailing');
+      expect(line.endsWith('…')).toBe(true);
+    });
+
+    // The 500 branch logs the stack, not `details` — it must stay untouched.
+    it('leaves the 500 stack branch alone', async () => {
+      const { req, res } = makeReqRes(null);
+      const error = new ServerError('boom', { status: 500, context: { details: [{ path: 'a', message: 'b' }] } });
+
+      await asyncHandler(async () => { throw error; })(req, res, vi.fn());
+      await flushMicrotasks();
+
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+      const [line, stack] = errorSpy.mock.calls[0];
+      expect(line).not.toContain('a: b');
+      expect(stack).toBe(error.stack);
+    });
   });
 
   describe('sendErrorResponse', () => {

--- a/server/lib/errorHandler.test.js
+++ b/server/lib/errorHandler.test.js
@@ -522,6 +522,18 @@ describe('errorHandler.js', () => {
       expect(line.endsWith('…')).toBe(true);
     });
 
+    // `[]` and `{}` are truthy but summarize to nothing.
+    it('omits the details segment entirely when it summarizes to nothing', async () => {
+      const { req, res } = makeReqRes(null);
+
+      await asyncHandler(async () => {
+        throw new ServerError('Validation failed', { status: 400, context: { details: [] } });
+      })(req, res, vi.fn());
+      await flushMicrotasks();
+
+      expect(errorSpy.mock.calls[0][0]).toBe('❌ Route error [GET /api/thing]: Validation failed');
+    });
+
     // The 500 branch logs the stack, not `details` — it must stay untouched.
     it('leaves the 500 stack branch alone', async () => {
       const { req, res } = makeReqRes(null);


### PR DESCRIPTION
## Summary

- `asyncHandler`'s sub-500 branch serialized `error.context.details` as JSON, so every 400 emitted the full mapped Zod issue array on one unbroken multi-KB line — and a failed `dbAdmin` export dumped an entire escaped `pg_dump` stderr blob the same way. Both break the single-line logging convention and make PM2 logs unreadable exactly when someone is reading them.
- New private `summarizeDetails` in `server/lib/errorHandler.js` renders the first 5 `field: message` pairs plus a `(+N more)` count, collapses whitespace to a single line, and truncates at 300 chars.
- **Logging only.** `buildErrorEnvelope` / `sanitizeContext` are untouched, so the HTTP response body still carries the full structured `details`. A test pins that.
- Edge handling: an unjoined Zod `path` array renders as dot notation (not CSV), a non-Zod-shaped entry object lists its own `key=value` fields instead of a bare `?`, a falsy `message` (`0`/`false`) survives via nullish checks, and an empty `[]`/`{}` drops the details segment rather than leaving a dangling colon.

## Test plan

- `cd server && npm test -- errorHandler` — 50 passed.
- `cd server && npm test -- errorHandler validation` — 24 files / 1094 passed.
- Four new cases in `server/lib/errorHandler.test.js` against a spied `console.error`: a 12-entry Zod-shaped array logs one line with `path: message` pairs, no `[{` or `"path"`, and a `(+7 more)` suffix (and the response body still carries all 12); a multi-line 500-char string collapses and truncates with a trailing `…`; an empty array logs no details segment; the 500 stack branch is unaffected.
- Reverting the one-line change back to `JSON.stringify` turns the first two red — verified.

Closes #5719
