### PR TITLE
refactor: move the video-model cache verify/repair engine into a service (#5711)

### DIFF
--- a/server/lib/mediaModels.js
+++ b/server/lib/mediaModels.js
@@ -24,8 +24,8 @@
  *       `MiniMaxAI/MiniMax-H3` ships three layouts totalling ~498 GB where the
  *       CUDA runner needs ~144 GB of them — since the download, cache-status,
  *       integrity-verify and repair paths all fan out from the same
- *       `modelDownloadTargets()` in routes/videoGen.js and would otherwise pull
- *       and checksum the lot.
+ *       `modelDownloadTargets()` in services/videoGen/modelCache.js and would
+ *       otherwise pull and checksum the lot.
  *       `offloadProfile` (optional, `minimax_h3_cuda` only) pins the weight
  *       offload recipe to one of `auto` / `bf16` / `int8-stream` / `int8-lean`
  *       instead of letting the runner size one from the card's own VRAM. Left

--- a/server/routes/videoGen.js
+++ b/server/routes/videoGen.js
@@ -45,20 +45,19 @@ import { cleanupMultipartTemp } from '../services/videoGen/prepareParams.js';
 import { submitVideoGenJob } from '../services/videoGen/submitJob.js';
 import { VIDEO_GEN_LOCAL_ONLY_FIELDS } from '../services/videoGen/requestFields.js';
 import { attachSseClient, cancelJob, listJobs } from '../services/mediaJobQueue/index.js';
-import { repoForModel, getTextEncoderRepo, isHfRepoId } from '../lib/mediaModels.js';
+import { getTextEncoderRepo, isHfRepoId } from '../lib/mediaModels.js';
 import {
-  IC_LORA_MODE_VALUES, icLoraSpecForMode, icLoraRepos, listIcLoraWeights,
+  IC_LORA_MODE_VALUES, icLoraSpecForMode, listIcLoraWeights,
   icLoraWeightCandidates, findCachedIcLoraWeight,
 } from '../lib/icLoraWeights.js';
+import { publicTextEncoderOption } from '../lib/videoTextEncoders.js';
+import { DRAFT_DECODE_IDS } from '../lib/videoDraftDecoders.js';
+import { repairModelCache, repairCachedFile, summarizeVerify } from '../lib/hfCache.js';
 import {
-  downloadableVideoTextEncoders, downloadableVideoTextEncoder, publicTextEncoderOption,
-} from '../lib/videoTextEncoders.js';
-import { DRAFT_DECODE_IDS, downloadableVideoDraftDecoders } from '../lib/videoDraftDecoders.js';
-import {
-  inspectModelCache, verifyModelCache, repairModelCache, repairCachedFile,
-  verifyCachedRepoFiles, repairCachedRepoFiles, summarizeVerify, aggregateVerifies,
-  isSafeHfRepoRelativePath,
-} from '../lib/hfCache.js';
+  modelDownloadTargets, textEncoderDownloadTarget, textEncoderDownloadTargets,
+  verifyDownloadTarget, repairDownloadTarget, reposToVerify,
+  repoCacheStatus, modelCacheStatus, icLoraSpecFromParam, textEncoderFromParam,
+} from '../services/videoGen/modelCache.js';
 import { startHfDownloadStream } from '../services/hfDownloadStream.js';
 import { openSseStream } from '../lib/sseDownload.js';
 import { saveUploadedGalleryVideo } from '../services/videoUpload.js';
@@ -531,142 +530,6 @@ router.get('/models', asyncHandler(async (_req, res) => {
   res.json(models);
 }));
 
-// Resolve the repo set an integrity scan should cover. A specific `modelId`
-// scopes to that model's repo; no modelId scans every model repo plus the
-// shared text encoder.
-// One definition of "a valid `only` list" for every download target this file
-// builds — model repos, their required weights, and the substitutable prompt
-// conditioners. `owner` is only used to name the offender in the error, so a
-// conditioner entry can pass its own registry id.
-const safeOnlyList = (owner, files, label) => {
-  const only = Array.isArray(files) ? files.filter((file) => typeof file === 'string' && file.length > 0) : [];
-  if (only.some((file) => !isSafeHfRepoRelativePath(file))) {
-    throw new ServerError(
-      `${owner} has an unsafe ${label} path. Use repo-relative POSIX filenames only.`,
-      { status: 500, code: 'VIDEO_MODEL_MISCONFIGURED' },
-    );
-  }
-  return only;
-};
-
-const videoModelLabel = (model) => `Video model "${model?.id}"`;
-
-const modelDownloadTargets = (model) => {
-  const repo = repoForModel(model);
-  if (!repo) return [];
-  // `repoFiles` narrows the model's OWN repo to an explicit file list, the way
-  // `requiredWeights[].files` already does for a secondary repo. It is required
-  // — not an optimization — whenever the model's repo is an aggregate that
-  // holds more than the one component set the runner loads: MiniMax H3 ships
-  // its diffusers layout, a second transformer partition and the original
-  // non-diffusers layout in one ~498 GB repo, so the default whole-snapshot
-  // target would pull 3.5x what the render path can use. Absent (every other
-  // model) still means "snapshot the repo".
-  const targets = [{
-    repo,
-    revision: model?.revision || null,
-    only: safeOnlyList(videoModelLabel(model), model?.repoFiles, 'repo-file'),
-  }];
-  for (const dep of Array.isArray(model?.requiredWeights) ? model.requiredWeights : []) {
-    if (typeof dep?.repo !== 'string') continue;
-    const only = safeOnlyList(videoModelLabel(model), dep.files, 'required-weight');
-    if (only.length > 0) targets.push({ repo: dep.repo, revision: dep.revision || null, only });
-  }
-  // The model's preview-fidelity decoder (#5423), when it declares one. Scoped
-  // to its pinned file for the same reason every other entry here is — and
-  // listed under the MODEL rather than as a standalone target, because it is
-  // useless without the checkpoint it decodes for, so the download badge that
-  // offers it belongs beside that model's own.
-  for (const decoder of downloadableVideoDraftDecoders([model])) {
-    targets.push({
-      repo: decoder.repo,
-      revision: decoder.revision || null,
-      only: safeOnlyList(`Draft decoder "${decoder.id}"`, decoder.files, 'weight-file'),
-    });
-  }
-  return targets;
-};
-
-// One download target per substitutable prompt conditioner. Each names an
-// explicit file list inside a repo that holds more than the loader can use —
-// quantizations and generation tails in a repack, or the language layers past
-// the conditioning depth in an upstream checkpoint — so these are ALWAYS scoped
-// to `only: entry.files`. A repo-wide snapshot would pull ~130 GB of unusable
-// variants for the repack and ~10 GB of never-built layers for the upstream one.
-const textEncoderDownloadTarget = (entry) => ({
-  repo: entry.repo,
-  revision: entry.revision || null,
-  only: safeOnlyList(`Text encoder "${entry.id}"`, entry.files, 'weight-file'),
-});
-// Paired with its entry so the status lane can project the registry fields
-// (label, size) alongside the cache verdict without a second lookup.
-const textEncoderDownloadTargets = () => downloadableVideoTextEncoders()
-  .map((entry) => ({ entry, target: textEncoderDownloadTarget(entry) }));
-
-const targetKey = (target) => `${target.repo}@${target.revision || 'latest'}::${target.only.join(',')}`;
-const targetVerifyOptions = (target, deep) => ({
-  deep,
-  ...(target.revision ? { revision: target.revision } : {}),
-});
-const verifyDownloadTarget = (target, { deep = false } = {}) => target.only.length > 0
-  ? verifyCachedRepoFiles(target.repo, target.only, targetVerifyOptions(target, deep))
-  : verifyModelCache(target.repo, targetVerifyOptions(target, deep));
-const repairDownloadTarget = (target, { deep = false } = {}) => target.only.length > 0
-  ? repairCachedRepoFiles(target.repo, target.only, targetVerifyOptions(target, deep))
-  : repairModelCache(target.repo, targetVerifyOptions(target, deep));
-
-const reposToVerify = (modelId) => {
-  if (modelId) {
-    const m = listVideoModels().find((x) => x.id === modelId);
-    return m ? modelDownloadTargets(m) : [];
-  }
-  const targets = listVideoModels().flatMap(modelDownloadTargets);
-  const enc = getTextEncoderRepo();
-  if (isHfRepoId(enc)) targets.push({ repo: enc, only: [] });
-  // Substitutable prompt conditioners are single pinned files the render path
-  // depends on, so an unscoped scan must reach them too — a truncated one
-  // otherwise only surfaces as a load failure minutes into a render.
-  targets.push(...textEncoderDownloadTargets().map(({ target }) => target));
-  // IC-LoRA remix weights are separate HF pulls that the render path depends
-  // on, so an unscoped integrity scan must cover them too — otherwise a
-  // corrupt IC weight only surfaces as a garbled render.
-  targets.push(...icLoraRepos().map((repo) => ({ repo, only: [] })));
-  return [...new Map(targets.map((target) => [targetKey(target), target])).values()];
-};
-
-// Per-model download status — see /api/image-gen/models/status for the
-// shape contract. We also surface the active text-encoder repo so the
-// video form can warn when the Gemma encoder isn't downloaded yet (a
-// surprise multi-GB pull on top of the model itself).
-// Cache + integrity for one HF repo, in the `{ cached, sizeBytes, integrity }`
-// shape every download badge consumes. The integrity check only runs for a repo
-// that's actually downloaded — a not-yet-cached repo gets the Download badge,
-// not a Repair banner. Shared by all three lanes of /models/status below so the
-// badge semantics can't drift between models, the encoder, and IC weights.
-const repoCacheStatus = async (repo) => {
-  const { cached, sizeBytes } = await inspectModelCache(repo);
-  return { cached, sizeBytes, integrity: cached ? summarizeVerify(await verifyModelCache(repo)) : null };
-};
-
-const modelCacheStatus = async (model, cache = null) => {
-  const targets = modelDownloadTargets(model);
-  if (targets.length === 0) return { repo: null, cached: null, sizeBytes: 0, integrity: null };
-  const readTarget = (target) => {
-    if (!cache) return verifyDownloadTarget(target);
-    const key = targetKey(target);
-    if (!cache.has(key)) cache.set(key, verifyDownloadTarget(target));
-    return cache.get(key);
-  };
-  const verifies = await Promise.all(targets.map(readTarget));
-  return {
-    repo: targets[0].repo,
-    requiredRepos: [...new Set(targets.map((target) => target.repo))],
-    cached: verifies.every((verify) => verify.status === 'ok'),
-    sizeBytes: verifies.reduce((sum, verify) => sum + (verify.sizeBytes || 0), 0),
-    integrity: aggregateVerifies(verifies),
-  };
-};
-
 router.get('/models/status', asyncHandler(async (_req, res) => {
   // Text encoder is shared across all video renders. A registry entry with
   // `localPath` (e.g. an LM Studio install) trumps the HF cache check, so
@@ -797,17 +660,6 @@ router.get('/models/:modelId/download', asyncHandler(async (req, res) => {
 // but are NOT listVideoModels() entries, so the model-id-keyed routes above
 // can't reach them. Keyed by the PortOS remix mode ('ic-control', …) so the
 // client uses the same identifier it puts in the render payload.
-const icLoraSpecFromParam = (mode) => {
-  const spec = icLoraSpecForMode(mode);
-  if (!spec) {
-    throw new ServerError(
-      `Unknown IC-LoRA remix mode: ${mode} (expected one of ${IC_LORA_MODE_VALUES.join(', ')})`,
-      { status: 404, code: 'IC_LORA_UNKNOWN_MODE' },
-    );
-  }
-  return spec;
-};
-
 // Download one IC weight. A spec with a `mirrorRepo` is fetched SINGLE-FILE and
 // only ever single-file: the official Ingredients repo is gated (an anonymous
 // pull 401s) and its un-gated mirror is the ~708 GB `DeepBeepMeep/LTX-2`
@@ -863,18 +715,6 @@ router.post('/ic-loras/:mode/repair', asyncHandler(async (req, res) => {
 // Distinct from the /text-encoder/* pair below, which is the SHARED LTX encoder
 // (one repo, install-wide, selected in the media-models registry). These are
 // per-model alternatives chosen per render.
-const textEncoderFromParam = (id) => {
-  const entry = downloadableVideoTextEncoder(id);
-  if (!entry) {
-    const known = downloadableVideoTextEncoders().map((e) => e.id);
-    throw new ServerError(
-      `Unknown text encoder: ${id}${known.length ? ` (expected one of ${known.join(', ')})` : ''}`,
-      { status: 404, code: 'VIDEO_TEXT_ENCODER_UNKNOWN' },
-    );
-  }
-  return entry;
-};
-
 // Always the entry's pinned file list, never a snapshot: these repos publish
 // more than the loader can read — INT8 ConvRot / NVFP4 quantizations and 50-63
 // generation tails in a repack, the language layers past the conditioning depth

--- a/server/services/videoGen/modelCache.js
+++ b/server/services/videoGen/modelCache.js
@@ -1,0 +1,186 @@
+/**
+ * Video Gen — HuggingFace cache verify/repair engine.
+ *
+ * Enumerates every weight / text-encoder / IC-LoRA repo a video model needs,
+ * keys them, runs shallow and deep integrity verification, and drives repair.
+ * No HTTP surface: the video-gen routes are the current callers, but the media
+ * job queue and maintenance scripts can reach the same answers without pulling
+ * in an Express router.
+ *
+ * Sits beside runtimes.js / runtimeInstaller.js, which answer the same
+ * "is this install ready to render" question from the Python side.
+ */
+
+import { ServerError } from '../../lib/errorHandler.js';
+import { repoForModel, getTextEncoderRepo, isHfRepoId } from '../../lib/mediaModels.js';
+import { IC_LORA_MODE_VALUES, icLoraSpecForMode, icLoraRepos } from '../../lib/icLoraWeights.js';
+import { downloadableVideoTextEncoders, downloadableVideoTextEncoder } from '../../lib/videoTextEncoders.js';
+import { downloadableVideoDraftDecoders } from '../../lib/videoDraftDecoders.js';
+import {
+  inspectModelCache, verifyModelCache, repairModelCache,
+  verifyCachedRepoFiles, repairCachedRepoFiles, summarizeVerify, aggregateVerifies,
+  isSafeHfRepoRelativePath,
+} from '../../lib/hfCache.js';
+// Through the local facade the routes already use, so a caller that mocks
+// `videoGen/local.js` sees one model registry across the route and this module.
+import { listVideoModels } from './local.js';
+
+// One definition of "a valid `only` list" for every download target this file
+// builds — model repos, their required weights, and the substitutable prompt
+// conditioners. `owner` is only used to name the offender in the error, so a
+// conditioner entry can pass its own registry id.
+const safeOnlyList = (owner, files, label) => {
+  const only = Array.isArray(files) ? files.filter((file) => typeof file === 'string' && file.length > 0) : [];
+  if (only.some((file) => !isSafeHfRepoRelativePath(file))) {
+    throw new ServerError(
+      `${owner} has an unsafe ${label} path. Use repo-relative POSIX filenames only.`,
+      { status: 500, code: 'VIDEO_MODEL_MISCONFIGURED' },
+    );
+  }
+  return only;
+};
+
+const videoModelLabel = (model) => `Video model "${model?.id}"`;
+
+export const modelDownloadTargets = (model) => {
+  const repo = repoForModel(model);
+  if (!repo) return [];
+  // `repoFiles` narrows the model's OWN repo to an explicit file list, the way
+  // `requiredWeights[].files` already does for a secondary repo. It is required
+  // — not an optimization — whenever the model's repo is an aggregate that
+  // holds more than the one component set the runner loads: MiniMax H3 ships
+  // its diffusers layout, a second transformer partition and the original
+  // non-diffusers layout in one ~498 GB repo, so the default whole-snapshot
+  // target would pull 3.5x what the render path can use. Absent (every other
+  // model) still means "snapshot the repo".
+  const targets = [{
+    repo,
+    revision: model?.revision || null,
+    only: safeOnlyList(videoModelLabel(model), model?.repoFiles, 'repo-file'),
+  }];
+  for (const dep of Array.isArray(model?.requiredWeights) ? model.requiredWeights : []) {
+    if (typeof dep?.repo !== 'string') continue;
+    const only = safeOnlyList(videoModelLabel(model), dep.files, 'required-weight');
+    if (only.length > 0) targets.push({ repo: dep.repo, revision: dep.revision || null, only });
+  }
+  // The model's preview-fidelity decoder (#5423), when it declares one. Scoped
+  // to its pinned file for the same reason every other entry here is — and
+  // listed under the MODEL rather than as a standalone target, because it is
+  // useless without the checkpoint it decodes for, so the download badge that
+  // offers it belongs beside that model's own.
+  for (const decoder of downloadableVideoDraftDecoders([model])) {
+    targets.push({
+      repo: decoder.repo,
+      revision: decoder.revision || null,
+      only: safeOnlyList(`Draft decoder "${decoder.id}"`, decoder.files, 'weight-file'),
+    });
+  }
+  return targets;
+};
+
+// One download target per substitutable prompt conditioner. Each names an
+// explicit file list inside a repo that holds more than the loader can use —
+// quantizations and generation tails in a repack, or the language layers past
+// the conditioning depth in an upstream checkpoint — so these are ALWAYS scoped
+// to `only: entry.files`. A repo-wide snapshot would pull ~130 GB of unusable
+// variants for the repack and ~10 GB of never-built layers for the upstream one.
+export const textEncoderDownloadTarget = (entry) => ({
+  repo: entry.repo,
+  revision: entry.revision || null,
+  only: safeOnlyList(`Text encoder "${entry.id}"`, entry.files, 'weight-file'),
+});
+// Paired with its entry so the status lane can project the registry fields
+// (label, size) alongside the cache verdict without a second lookup.
+export const textEncoderDownloadTargets = () => downloadableVideoTextEncoders()
+  .map((entry) => ({ entry, target: textEncoderDownloadTarget(entry) }));
+
+export const targetKey = (target) => `${target.repo}@${target.revision || 'latest'}::${target.only.join(',')}`;
+const targetVerifyOptions = (target, deep) => ({
+  deep,
+  ...(target.revision ? { revision: target.revision } : {}),
+});
+export const verifyDownloadTarget = (target, { deep = false } = {}) => target.only.length > 0
+  ? verifyCachedRepoFiles(target.repo, target.only, targetVerifyOptions(target, deep))
+  : verifyModelCache(target.repo, targetVerifyOptions(target, deep));
+export const repairDownloadTarget = (target, { deep = false } = {}) => target.only.length > 0
+  ? repairCachedRepoFiles(target.repo, target.only, targetVerifyOptions(target, deep))
+  : repairModelCache(target.repo, targetVerifyOptions(target, deep));
+
+// Resolve the repo set an integrity scan should cover. A specific `modelId`
+// scopes to that model's repo; no modelId scans every model repo plus the
+// shared text encoder.
+export const reposToVerify = (modelId) => {
+  if (modelId) {
+    const m = listVideoModels().find((x) => x.id === modelId);
+    return m ? modelDownloadTargets(m) : [];
+  }
+  const targets = listVideoModels().flatMap(modelDownloadTargets);
+  const enc = getTextEncoderRepo();
+  if (isHfRepoId(enc)) targets.push({ repo: enc, only: [] });
+  // Substitutable prompt conditioners are single pinned files the render path
+  // depends on, so an unscoped scan must reach them too — a truncated one
+  // otherwise only surfaces as a load failure minutes into a render.
+  targets.push(...textEncoderDownloadTargets().map(({ target }) => target));
+  // IC-LoRA remix weights are separate HF pulls that the render path depends
+  // on, so an unscoped integrity scan must cover them too — otherwise a
+  // corrupt IC weight only surfaces as a garbled render.
+  targets.push(...icLoraRepos().map((repo) => ({ repo, only: [] })));
+  return [...new Map(targets.map((target) => [targetKey(target), target])).values()];
+};
+
+// Cache + integrity for one HF repo, in the `{ cached, sizeBytes, integrity }`
+// shape every download badge consumes. The integrity check only runs for a repo
+// that's actually downloaded — a not-yet-cached repo gets the Download badge,
+// not a Repair banner. Shared by all three lanes of /models/status so the
+// badge semantics can't drift between models, the encoder, and IC weights.
+export const repoCacheStatus = async (repo) => {
+  const { cached, sizeBytes } = await inspectModelCache(repo);
+  return { cached, sizeBytes, integrity: cached ? summarizeVerify(await verifyModelCache(repo)) : null };
+};
+
+// Per-model download status — see /api/image-gen/models/status for the
+// shape contract.
+export const modelCacheStatus = async (model, cache = null) => {
+  const targets = modelDownloadTargets(model);
+  if (targets.length === 0) return { repo: null, cached: null, sizeBytes: 0, integrity: null };
+  const readTarget = (target) => {
+    if (!cache) return verifyDownloadTarget(target);
+    const key = targetKey(target);
+    if (!cache.has(key)) cache.set(key, verifyDownloadTarget(target));
+    return cache.get(key);
+  };
+  const verifies = await Promise.all(targets.map(readTarget));
+  return {
+    repo: targets[0].repo,
+    requiredRepos: [...new Set(targets.map((target) => target.repo))],
+    cached: verifies.every((verify) => verify.status === 'ok'),
+    sizeBytes: verifies.reduce((sum, verify) => sum + (verify.sizeBytes || 0), 0),
+    integrity: aggregateVerifies(verifies),
+  };
+};
+
+// Mode → IC-LoRA spec, keyed by the PortOS remix mode ('ic-control', …) the
+// client also puts in the render payload.
+export const icLoraSpecFromParam = (mode) => {
+  const spec = icLoraSpecForMode(mode);
+  if (!spec) {
+    throw new ServerError(
+      `Unknown IC-LoRA remix mode: ${mode} (expected one of ${IC_LORA_MODE_VALUES.join(', ')})`,
+      { status: 404, code: 'IC_LORA_UNKNOWN_MODE' },
+    );
+  }
+  return spec;
+};
+
+// Registry id → substitutable prompt-conditioner entry (lib/videoTextEncoders.js).
+export const textEncoderFromParam = (id) => {
+  const entry = downloadableVideoTextEncoder(id);
+  if (!entry) {
+    const known = downloadableVideoTextEncoders().map((e) => e.id);
+    throw new ServerError(
+      `Unknown text encoder: ${id}${known.length ? ` (expected one of ${known.join(', ')})` : ''}`,
+      { status: 404, code: 'VIDEO_TEXT_ENCODER_UNKNOWN' },
+    );
+  }
+  return entry;
+};

--- a/server/services/videoGen/modelCache.test.js
+++ b/server/services/videoGen/modelCache.test.js
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// Target-shaping contract for the HF cache engine (issue #5711). These three
+// behaviors used to be reachable only by driving /models/status, /models/verify
+// and /models/:id/repair, so a regression in how a download target is scoped or
+// keyed showed up as a wrong HTTP payload rather than a failing unit.
+
+vi.mock('../../lib/mediaModels.js', () => ({
+  repoForModel: vi.fn((m) => m.repo || null),
+  getTextEncoderRepo: vi.fn(() => 'org/text-encoder'),
+  isHfRepoId: vi.fn(() => true),
+}));
+
+vi.mock('../../lib/videoTextEncoders.js', () => ({
+  downloadableVideoTextEncoders: vi.fn(() => []),
+  downloadableVideoTextEncoder: vi.fn(() => null),
+}));
+
+vi.mock('../../lib/videoDraftDecoders.js', () => ({
+  downloadableVideoDraftDecoders: vi.fn(() => []),
+}));
+
+vi.mock('../../lib/icLoraWeights.js', () => ({
+  IC_LORA_MODE_VALUES: ['ic-control'],
+  icLoraSpecForMode: vi.fn(() => null),
+  icLoraRepos: vi.fn(() => []),
+}));
+
+vi.mock('./local.js', () => ({
+  listVideoModels: vi.fn(() => [
+    { id: 'wan_lightning', repo: 'org/wan-base', revision: 'a'.repeat(40) },
+  ]),
+}));
+
+import {
+  modelDownloadTargets, targetKey, reposToVerify,
+} from './modelCache.js';
+
+describe('videoGen model cache targets', () => {
+  it('scopes an unlisted model repo to a whole-repo snapshot', () => {
+    // No `repoFiles` means "snapshot the repo" — an empty `only` is what routes
+    // the target to verifyModelCache instead of verifyCachedRepoFiles.
+    expect(modelDownloadTargets({ id: 'ltx2', repo: 'org/ltx2' }))
+      .toEqual([{ repo: 'org/ltx2', revision: null, only: [] }]);
+  });
+
+  it('keys two targets that differ only by revision distinctly', () => {
+    // A collision here would let reposToVerify() dedupe away a pinned revision
+    // and report a stale repo as fresh.
+    const base = { repo: 'org/wan', only: ['model.safetensors'] };
+    expect(targetKey({ ...base, revision: 'a'.repeat(40) }))
+      .not.toBe(targetKey({ ...base, revision: 'b'.repeat(40) }));
+    expect(targetKey({ ...base, revision: null })).toBe(targetKey(base));
+  });
+
+  it('covers the shared text encoder alongside the model repos on an unscoped scan', () => {
+    expect(reposToVerify().map((t) => t.repo))
+      .toEqual(['org/wan-base', 'org/text-encoder']);
+    // Scoped to one model, only that model's repos are walked.
+    expect(reposToVerify('wan_lightning').map((t) => t.repo)).toEqual(['org/wan-base']);
+    expect(reposToVerify('nope')).toEqual([]);
+  });
+});

--- a/server/services/videoGen/modelCache.test.js
+++ b/server/services/videoGen/modelCache.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // Target-shaping contract for the HF cache engine (issue #5711). These three
 // behaviors used to be reachable only by driving /models/status, /models/verify
@@ -26,15 +26,18 @@ vi.mock('../../lib/icLoraWeights.js', () => ({
   icLoraRepos: vi.fn(() => []),
 }));
 
-vi.mock('./local.js', () => ({
-  listVideoModels: vi.fn(() => [
-    { id: 'wan_lightning', repo: 'org/wan-base', revision: 'a'.repeat(40) },
-  ]),
-}));
+vi.mock('./local.js', () => ({ listVideoModels: vi.fn() }));
 
-import {
-  modelDownloadTargets, targetKey, reposToVerify,
-} from './modelCache.js';
+import { modelDownloadTargets, targetKey, reposToVerify } from './modelCache.js';
+import { listVideoModels } from './local.js';
+
+const REV_A = 'a'.repeat(40);
+const REV_B = 'b'.repeat(40);
+const WAN = { id: 'wan_lightning', repo: 'org/wan-base', revision: REV_A };
+
+beforeEach(() => {
+  vi.mocked(listVideoModels).mockReturnValue([WAN]);
+});
 
 describe('videoGen model cache targets', () => {
   it('scopes an unlisted model repo to a whole-repo snapshot', () => {
@@ -44,12 +47,18 @@ describe('videoGen model cache targets', () => {
       .toEqual([{ repo: 'org/ltx2', revision: null, only: [] }]);
   });
 
-  it('keys two targets that differ only by revision distinctly', () => {
-    // A collision here would let reposToVerify() dedupe away a pinned revision
-    // and report a stale repo as fresh.
-    const base = { repo: 'org/wan', only: ['model.safetensors'] };
-    expect(targetKey({ ...base, revision: 'a'.repeat(40) }))
-      .not.toBe(targetKey({ ...base, revision: 'b'.repeat(40) }));
+  it('keeps two same-repo targets that differ only by revision', () => {
+    // The unscoped scan dedupes by targetKey. A collision there would drop one
+    // pinned revision and let a stale repo report as fresh, so two models on
+    // the same repo at different revisions must both survive.
+    vi.mocked(listVideoModels).mockReturnValue([WAN, { ...WAN, id: 'wan_pinned', revision: REV_B }]);
+    const wan = reposToVerify().filter((t) => t.repo === 'org/wan-base');
+    expect(wan.map((t) => t.revision)).toEqual([REV_A, REV_B]);
+    // …while an identical pair still collapses to one walk.
+    vi.mocked(listVideoModels).mockReturnValue([WAN, { ...WAN, id: 'wan_clone' }]);
+    expect(reposToVerify().filter((t) => t.repo === 'org/wan-base')).toHaveLength(1);
+    // No revision keys the same as an explicit null one.
+    const base = { repo: 'org/wan-base', only: [] };
     expect(targetKey({ ...base, revision: null })).toBe(targetKey(base));
   });
 


### PR DESCRIPTION
## Summary

Closes #5711.

`server/routes/videoGen.js` carried a complete HuggingFace-cache domain module between its route registrations: eleven module-scope helpers that enumerate every weight / text-encoder / IC-LoRA repo a video model needs, key them, run shallow and deep integrity verification, and drive repair. None of it touched `req`/`res`, so it could not be reused by the media job queue or a maintenance script without importing an Express router, and it padded the repo's most-edited route file with logic no HTTP reviewer needs to read.

That engine now lives in `server/services/videoGen/modelCache.js`, beside `runtimes.js` / `runtimeInstaller.js` which answer the same "is this install ready to render" question. The route file drops 169 lines and keeps only HTTP glue.

**Moved (verbatim):** `safeOnlyList`, `videoModelLabel`, `modelDownloadTargets`, `textEncoderDownloadTarget`, `textEncoderDownloadTargets`, `targetKey`, `targetVerifyOptions`, `verifyDownloadTarget`, `repairDownloadTarget`, `reposToVerify`, `repoCacheStatus`, `modelCacheStatus`, plus the pure param→spec resolvers `icLoraSpecFromParam` and `textEncoderFromParam`. `safeOnlyList`, `videoModelLabel` and `targetVerifyOptions` stay module-private.

**Deviation from the filed plan:** `textEncoderDownloadTarget` is exported rather than kept private — `GET /text-encoders/:id/download` and `POST /text-encoders/:id/repair` call it directly.

`listVideoModels` is imported through the existing `videoGen/local.js` facade (not `generateVideo.js`) so a caller mocking that facade sees one model registry across both the route and this module. Every affected handler keeps its exact body; imports with no remaining consumer were dropped from the route.

## Test plan

- New `server/services/videoGen/modelCache.test.js` (3 tests) pins behavior previously reachable only by driving three HTTP endpoints: a model with no `repoFiles` produces a whole-repo target; `reposToVerify()` keeps two same-repo targets pinned to different revisions while still collapsing an identical pair; an unscoped scan covers the shared text encoder alongside the model repos, and a scoped one does not.
  - Verified the revision test actually catches the regression it names: dropping `revision` from `targetKey` makes it fail.
- `server/routes/videoGen.test.js` + `videoGen.integrity.test.js` pass unchanged (190 tests) — the extraction is behavior-preserving.
- Full `cd server && npm test`: 37787 passed, 1 failure in `services/sprites/atlas.test.js` (a 10s timeout under parallel load, unrelated to this diff — passes standalone in 62s).
- Local `codex` review at medium effort, two rounds: round 1 raised the test-strength and a stale doc pointer in `server/lib/mediaModels.js`, both fixed in the second commit; round 2 reported NO FINDINGS.

https://claude.ai/code/session_01NyGKNa5BKxqqtbn2n3NE5o
