### PR TITLE
perf: index human_activity_events on (source, happened_at) so timeline reads stop scanning (#5715)

### DIFF
--- a/server/lib/db.catalogDdlParity.test.js
+++ b/server/lib/db.catalogDdlParity.test.js
@@ -171,11 +171,34 @@ describe('catalog DDL parity (init-db.sql ↔ db.js ensureSchema)', () => {
     expect(sqlIdx.size).toBeGreaterThan(0);
   });
 
-  // The operator-action ledger (#5594) is a machine-local db-primary table that
-  // ships in BOTH sources. `human_activity_events` has no dedicated assertion here
-  // and that is a gap, not a precedent — a column or index added to one file only
-  // would leave every EXISTING install without it (init-db.sql runs on fresh
-  // provisioning alone), so pin columns and index names for this one explicitly.
+  // The operator-action ledger (#5594) and the human-activity timeline (#2150)
+  // are machine-local db-primary tables that ship in BOTH sources. A column or
+  // index added to one file only would leave every EXISTING install without it
+  // (init-db.sql runs on fresh provisioning alone), so pin columns and index
+  // names for both explicitly.
+  it('human_activity_events has the same columns and indexes in both files', () => {
+    const sqlBody = extractCreateTable(INIT_SQL, 'human_activity_events');
+    const jsBody = extractCreateTable(DB_JS, 'human_activity_events');
+    expect(sqlBody, 'init-db.sql missing CREATE TABLE human_activity_events').toBeTruthy();
+    expect(jsBody, 'db/schema/humanActivity.js missing CREATE TABLE human_activity_events').toBeTruthy();
+    expect([...new Set(extractColumnNames(sqlBody))].sort())
+      .toEqual([...new Set(extractColumnNames(jsBody))].sort());
+
+    const sqlIdx = extractIndexNames(INIT_SQL, 'idx_human_activity_');
+    const jsIdx = extractIndexNames(DB_JS, 'idx_human_activity_');
+    expect([...sqlIdx].sort()).toEqual([...jsIdx].sort());
+    // Name them: the dedupe index is the idempotency contract (ON CONFLICT
+    // (source, dedupe_key) DO NOTHING) and the two composites (#5715) are what
+    // keep a source-scoped timeline read off a full happened_at walk — dropping
+    // either from both files would otherwise read as a passing set match.
+    expect([...sqlIdx].sort()).toEqual([
+      'idx_human_activity_dedupe',
+      'idx_human_activity_happened',
+      'idx_human_activity_source_happened',
+      'idx_human_activity_source_kind_happened',
+    ]);
+  });
+
   it('user_action_events has the same columns and indexes in both files', () => {
     const sqlBody = extractCreateTable(INIT_SQL, 'user_action_events');
     const jsBody = extractCreateTable(DB_JS, 'user_action_events');

--- a/server/lib/db.catalogDdlParity.test.js
+++ b/server/lib/db.catalogDdlParity.test.js
@@ -106,18 +106,21 @@ function extractIndexNames(source, prefix = 'idx_catalog_') {
 }
 
 // Names alone can't catch an index that exists in both files under the same
-// name but over different columns (or a different sort order) — that ships a
-// fresh install an index the boot-time DDL never intended. Pair each name with
-// its normalized column list so the parity check compares definitions.
+// name but over different columns (or a different sort order, or having lost
+// its UNIQUE) — that ships a fresh install an index the boot-time DDL never
+// intended, and a dropped UNIQUE breaks the ON CONFLICT idempotency contract
+// the store relies on. Pair each name with its normalized definition so the
+// parity check compares shape, not just identity.
 function extractIndexDefs(source, prefix) {
   const out = new Map();
   const re = new RegExp(
-    `CREATE (?:UNIQUE )?INDEX IF NOT EXISTS\\s+(${prefix}\\w+)\\s+ON\\s+\\w+\\s*\\(([^)]*)\\)`,
+    `CREATE (UNIQUE )?INDEX IF NOT EXISTS\\s+(${prefix}\\w+)\\s+ON\\s+\\w+\\s*\\(([^)]*)\\)`,
     'gi',
   );
   let m;
   while ((m = re.exec(source)) !== null) {
-    out.set(m[1], m[2].replace(/\s+/g, ' ').trim().toLowerCase());
+    const cols = m[3].replace(/\s+/g, ' ').trim().toLowerCase();
+    out.set(m[2], `${m[1] ? 'unique ' : ''}(${cols})`);
   }
   return out;
 }
@@ -212,10 +215,10 @@ describe('catalog DDL parity (init-db.sql ↔ db.js ensureSchema)', () => {
     // happened_at walk — dropping either from both files, or silently losing
     // the DESC ordering, would otherwise read as a passing set match.
     const expected = {
-      idx_human_activity_dedupe: 'source, dedupe_key',
-      idx_human_activity_happened: 'happened_at',
-      idx_human_activity_source_happened: 'source, happened_at desc',
-      idx_human_activity_source_kind_happened: 'source, kind, happened_at desc',
+      idx_human_activity_dedupe: 'unique (source, dedupe_key)',
+      idx_human_activity_happened: '(happened_at)',
+      idx_human_activity_source_happened: '(source, happened_at desc)',
+      idx_human_activity_source_kind_happened: '(source, kind, happened_at desc)',
     };
     expect(Object.fromEntries(sqlIdx)).toEqual(expected);
     expect(Object.fromEntries(jsIdx)).toEqual(expected);

--- a/server/lib/db.catalogDdlParity.test.js
+++ b/server/lib/db.catalogDdlParity.test.js
@@ -105,6 +105,23 @@ function extractIndexNames(source, prefix = 'idx_catalog_') {
   return out;
 }
 
+// Names alone can't catch an index that exists in both files under the same
+// name but over different columns (or a different sort order) — that ships a
+// fresh install an index the boot-time DDL never intended. Pair each name with
+// its normalized column list so the parity check compares definitions.
+function extractIndexDefs(source, prefix) {
+  const out = new Map();
+  const re = new RegExp(
+    `CREATE (?:UNIQUE )?INDEX IF NOT EXISTS\\s+(${prefix}\\w+)\\s+ON\\s+\\w+\\s*\\(([^)]*)\\)`,
+    'gi',
+  );
+  let m;
+  while ((m = re.exec(source)) !== null) {
+    out.set(m[1], m[2].replace(/\s+/g, ' ').trim().toLowerCase());
+  }
+  return out;
+}
+
 function extractFunctionNames(source, prefix = 'update_catalog_') {
   const out = new Set();
   const re = new RegExp(`CREATE OR REPLACE FUNCTION\\s+(${prefix}\\w+)`, 'gi');
@@ -184,19 +201,24 @@ describe('catalog DDL parity (init-db.sql ↔ db.js ensureSchema)', () => {
     expect([...new Set(extractColumnNames(sqlBody))].sort())
       .toEqual([...new Set(extractColumnNames(jsBody))].sort());
 
-    const sqlIdx = extractIndexNames(INIT_SQL, 'idx_human_activity_');
-    const jsIdx = extractIndexNames(DB_JS, 'idx_human_activity_');
-    expect([...sqlIdx].sort()).toEqual([...jsIdx].sort());
-    // Name them: the dedupe index is the idempotency contract (ON CONFLICT
-    // (source, dedupe_key) DO NOTHING) and the two composites (#5715) are what
-    // keep a source-scoped timeline read off a full happened_at walk — dropping
-    // either from both files would otherwise read as a passing set match.
-    expect([...sqlIdx].sort()).toEqual([
-      'idx_human_activity_dedupe',
-      'idx_human_activity_happened',
-      'idx_human_activity_source_happened',
-      'idx_human_activity_source_kind_happened',
-    ]);
+    // Compare definitions, not just names: an index present in both files under
+    // the same name but over different columns would ship a fresh install
+    // something the boot-time DDL never intended.
+    const sqlIdx = extractIndexDefs(INIT_SQL, 'idx_human_activity_');
+    const jsIdx = extractIndexDefs(DB_JS, 'idx_human_activity_');
+    // Spell out the expected map: the dedupe index is the idempotency contract
+    // (ON CONFLICT (source, dedupe_key) DO NOTHING) and the two composites
+    // (#5715) are what keep a source-scoped timeline read off a full
+    // happened_at walk — dropping either from both files, or silently losing
+    // the DESC ordering, would otherwise read as a passing set match.
+    const expected = {
+      idx_human_activity_dedupe: 'source, dedupe_key',
+      idx_human_activity_happened: 'happened_at',
+      idx_human_activity_source_happened: 'source, happened_at desc',
+      idx_human_activity_source_kind_happened: 'source, kind, happened_at desc',
+    };
+    expect(Object.fromEntries(sqlIdx)).toEqual(expected);
+    expect(Object.fromEntries(jsIdx)).toEqual(expected);
   });
 
   it('user_action_events has the same columns and indexes in both files', () => {

--- a/server/lib/db/schema/humanActivity.js
+++ b/server/lib/db/schema/humanActivity.js
@@ -25,4 +25,21 @@ export const humanActivityDdl = [
     )`,
     `CREATE UNIQUE INDEX IF NOT EXISTS idx_human_activity_dedupe ON human_activity_events (source, dedupe_key)`,
     `CREATE INDEX IF NOT EXISTS idx_human_activity_happened ON human_activity_events (happened_at)`,
+    // Source-scoped timeline reads (#5715). The dominant shape is
+    // `WHERE source = $1 [AND kind = ...] ORDER BY happened_at DESC LIMIT n`
+    // (listEvents in services/humanActivity.js), which neither index above
+    // serves: the dedupe index leads on `source` but carries no ordering, and
+    // the `happened_at` index orders but must filter every row on `source` — so
+    // a low-volume source behind a high-volume one walks past a large number of
+    // non-matching rows before it can fill LIMIT. Two indexes, not one: the
+    // kind-filtered read is a distinct shape, and `(source, kind, happened_at)`
+    // does not efficiently serve the source-only query for a source with many
+    // kinds. Mirrors the composites `user_action_events` already ships.
+    //
+    // Deliberately NOT `CONCURRENTLY`: ensureSchema() runs this DDL as part of
+    // the boot sequence, and CREATE INDEX CONCURRENTLY cannot run inside a
+    // transaction block. The table is machine-local and the boot-time build is
+    // bounded, so the blocking build is the correct trade here.
+    `CREATE INDEX IF NOT EXISTS idx_human_activity_source_happened ON human_activity_events (source, happened_at DESC)`,
+    `CREATE INDEX IF NOT EXISTS idx_human_activity_source_kind_happened ON human_activity_events (source, kind, happened_at DESC)`,
 ];

--- a/server/lib/db/schema/schema.test.js
+++ b/server/lib/db/schema/schema.test.js
@@ -101,6 +101,20 @@ describe('db/schema barrel + composer (#2832)', () => {
     expect(firstTrigIdx).toBeGreaterThan(fnIdx);
   });
 
+  // #5715 — the source-scoped composites are the only indexes serving
+  // `WHERE source = $1 [AND kind = ...] ORDER BY happened_at DESC LIMIT n`.
+  // Pin both, including the DESC ordering, so a future rewrite of the DDL array
+  // can't silently drop one back to a sequential-ish index walk.
+  it('humanActivityDdl ships the source-scoped happened_at composites', () => {
+    const ddl = schema.humanActivityDdl.join('\n');
+    expect(ddl).toContain(
+      'CREATE INDEX IF NOT EXISTS idx_human_activity_source_happened ON human_activity_events (source, happened_at DESC)',
+    );
+    expect(ddl).toContain(
+      'CREATE INDEX IF NOT EXISTS idx_human_activity_source_kind_happened ON human_activity_events (source, kind, happened_at DESC)',
+    );
+  });
+
   it('buildAuditTriggers emits a DROP + CREATE pair per audited table', () => {
     const triggers = buildAuditTriggers();
     expect(triggers.length).toBe(auditedTables.length * 2);

--- a/server/scripts/init-db.sql
+++ b/server/scripts/init-db.sql
@@ -196,6 +196,10 @@ CREATE TABLE IF NOT EXISTS human_activity_events (
 );
 CREATE UNIQUE INDEX IF NOT EXISTS idx_human_activity_dedupe ON human_activity_events (source, dedupe_key);
 CREATE INDEX IF NOT EXISTS idx_human_activity_happened ON human_activity_events (happened_at);
+-- Source-scoped timeline reads (#5715) — see db/schema/humanActivity.js for why
+-- there are two composites and why neither uses CONCURRENTLY.
+CREATE INDEX IF NOT EXISTS idx_human_activity_source_happened ON human_activity_events (source, happened_at DESC);
+CREATE INDEX IF NOT EXISTS idx_human_activity_source_kind_happened ON human_activity_events (source, kind, happened_at DESC);
 
 -- Operator-action ledger (#5594) — the durable, filterable record of what the
 -- human actually did in PortOS. Machine-local like human_activity_events:

--- a/server/services/humanActivity.db.test.js
+++ b/server/services/humanActivity.db.test.js
@@ -12,7 +12,7 @@
  * rows this suite inserts.
  */
 import { describe, it, expect, afterAll } from 'vitest';
-import { checkHealth, ensureSchema, close, query } from '../lib/db.js';
+import { checkHealth, ensureSchema, close, query, withTransaction } from '../lib/db.js';
 import { requireDbOrSkip } from '../lib/dbTestGate.js';
 import { recordEvents, listEvents, getDaySummary, stripParticipantsForAccount } from './humanActivity.js';
 
@@ -236,5 +236,46 @@ describe.skipIf(!runDb)('stripParticipantsForAccount — send-as alias backfill 
     expect(calls).toHaveLength(1);
     const row = await fetchRow('alias-tx');
     expect(row.participants).toEqual([{ email: 'friend@x.io' }]);
+  });
+});
+
+// #5715 — the source-scoped composite is what keeps a low-volume source sitting
+// behind a high-volume one off a backwards walk of the whole `happened_at`
+// index. Assert the PLAN, not a timing: plan shape is deterministic in CI,
+// elapsed time is not.
+describe.skipIf(!runDb)('source-scoped read plan (#5715)', () => {
+  // On a near-empty shared test table a sequential scan is genuinely the
+  // cheapest plan, so an unmodified EXPLAIN would prove nothing about the index.
+  // Disabling seqscan for the transaction makes the choice Postgres faces on a
+  // real, large table — this composite vs. the plain `happened_at` index —
+  // observable here.
+  const explainWithoutSeqScan = (sql, params) => withTransaction(async (client) => {
+    await client.query('SET LOCAL enable_seqscan = off');
+    const res = await client.query(`EXPLAIN (FORMAT JSON) ${sql}`, params);
+    return JSON.stringify(res.rows[0]['QUERY PLAN']);
+  });
+
+  it('uses idx_human_activity_source_happened for a source-scoped newest-first read', async () => {
+    await recordEvents([mk({ dedupeKey: 'plan-1' }), mk({ dedupeKey: 'plan-2' })]);
+    const plan = await explainWithoutSeqScan(
+      `SELECT * FROM human_activity_events
+       WHERE source = $1
+       ORDER BY happened_at DESC
+       LIMIT 50`,
+      [SOURCE],
+    );
+    expect(plan).toContain('idx_human_activity_source_happened');
+  });
+
+  it('uses idx_human_activity_source_kind_happened when the read is also kind-scoped', async () => {
+    await recordEvents([mk({ dedupeKey: 'plan-kind-1' })]);
+    const plan = await explainWithoutSeqScan(
+      `SELECT * FROM human_activity_events
+       WHERE source = $1 AND kind = $2
+       ORDER BY happened_at DESC
+       LIMIT 50`,
+      [SOURCE, 'message.received'],
+    );
+    expect(plan).toContain('idx_human_activity_source_kind_happened');
   });
 });

--- a/server/services/humanActivity.db.test.js
+++ b/server/services/humanActivity.db.test.js
@@ -252,8 +252,21 @@ describe.skipIf(!runDb)('source-scoped read plan (#5715)', () => {
   const explainWithoutSeqScan = (sql, params) => withTransaction(async (client) => {
     await client.query('SET LOCAL enable_seqscan = off');
     const res = await client.query(`EXPLAIN (FORMAT JSON) ${sql}`, params);
-    return JSON.stringify(res.rows[0]['QUERY PLAN']);
+    return res.rows[0]['QUERY PLAN'][0].Plan;
   });
+
+  const planNodes = (node) => [node, ...(node.Plans || []).flatMap(planNodes)];
+
+  // The point of the composite is that the index supplies the ordering, so the
+  // LIMIT stops early. A bitmap scan feeding a Sort would still name the index
+  // while re-reading and sorting every matching row — the exact regression this
+  // pins — so assert an ordered Index Scan AND the absence of a Sort node.
+  const expectOrderedIndexScan = (plan, indexName) => {
+    const nodes = planNodes(plan);
+    expect(nodes.map((n) => n['Node Type'])).not.toContain('Sort');
+    expect(nodes.some((n) => /^Index (Only )?Scan$/.test(n['Node Type']) && n['Index Name'] === indexName))
+      .toBe(true);
+  };
 
   it('uses idx_human_activity_source_happened for a source-scoped newest-first read', async () => {
     await recordEvents([mk({ dedupeKey: 'plan-1' }), mk({ dedupeKey: 'plan-2' })]);
@@ -264,7 +277,7 @@ describe.skipIf(!runDb)('source-scoped read plan (#5715)', () => {
        LIMIT 50`,
       [SOURCE],
     );
-    expect(plan).toContain('idx_human_activity_source_happened');
+    expectOrderedIndexScan(plan, 'idx_human_activity_source_happened');
   });
 
   it('uses idx_human_activity_source_kind_happened when the read is also kind-scoped', async () => {
@@ -276,6 +289,6 @@ describe.skipIf(!runDb)('source-scoped read plan (#5715)', () => {
        LIMIT 50`,
       [SOURCE, 'message.received'],
     );
-    expect(plan).toContain('idx_human_activity_source_kind_happened');
+    expectOrderedIndexScan(plan, 'idx_human_activity_source_kind_happened');
   });
 });


### PR DESCRIPTION
## Summary

`human_activity_events` is the machine-local firehose fed by the iMessage, Signal, Gmail, Calendar, Spotify and YouTube syncs — on a real install one of the largest tables. Its only indexes were `UNIQUE (source, dedupe_key)` and a single-column `(happened_at)`, and neither serves the dominant read shape, `WHERE source = $1 [AND kind = …] ORDER BY happened_at DESC LIMIT n` (`listEvents` in `server/services/humanActivity.js`): the dedupe index leads on `source` but carries no ordering, and the `happened_at` index orders but must filter every row on `source`. A low-volume source (Calendar, Spotify) sitting behind a high-volume one therefore walks the `happened_at` index backwards past a large number of non-matching rows before it can fill `LIMIT`. The structurally identical `user_action_events` table already ships the equivalent composites, so this was drift rather than a deliberate trade.

Changes:

- **`server/lib/db/schema/humanActivity.js`** — appends `(source, happened_at DESC)` and `(source, kind, happened_at DESC)` to `humanActivityDdl`, after the existing statements so the executed order stays append-only. `ensureSchema()` runs this additive DDL on every boot, so existing installs pick both up without a `scripts/migrations/` entry (verified against an already-provisioned database — see the test plan).
- **`server/scripts/init-db.sql`** — mirrors both statements so a fresh SQL-path provision matches `ensureSchema()`.
- Two indexes rather than one: the kind-filtered read (`fetchWindow` in `twinEnrichment.js`, the kind-scoped list path) is a distinct shape, and `(source, kind, happened_at)` does not efficiently serve the source-only query for a source with many kinds.
- Not `CONCURRENTLY`: `ensureSchema()` runs inside the boot sequence and `CREATE INDEX CONCURRENTLY` cannot run in a transaction block. The table is machine-local and the boot-time build is bounded. The reasoning is recorded in a comment above the statements so a later reader does not "fix" it.

Also closes the parity gap `db.catalogDdlParity.test.js` documented in a comment: `human_activity_events` now has its own column + index assertion alongside `user_action_events`, comparing normalized index *definitions* (columns, sort order, and `UNIQUE`) rather than names alone, so an index added or altered in one DDL source only can no longer slip through.

## Test plan

- `cd server && npm test` — 1873 files / 37801 tests green. (One run hit an unrelated 10s timeout in `routes/settings.secretsStrip.test.js` under load; it passes in isolation and passed the other full runs, and is untouched by this diff.)
- `npx vitest run --config vitest.config.db.js services/humanActivity.db.test.js` against `portos_test` (never the real DB — the config forces `PGDATABASE=portos_test`): 15 tests green, including two new `EXPLAIN (FORMAT JSON)` plan tests. They run inside a transaction with `SET LOCAL enable_seqscan = off` — a near-empty test table would otherwise seq-scan and prove nothing — then walk the plan tree and assert an ordered `Index Scan`/`Index Only Scan` on the expected composite with no `Sort` node anywhere, so a bitmap-scan-plus-sort plan that merely mentions the index still fails.
- Both new assertions were verified to fail on broken code: dropping `DESC` from one `init-db.sql` statement fails the parity test, and dropping the composite from the database makes the planner fall back to `Index Scan Backward using idx_human_activity_happened`, which the plan test rejects.
- Confirmed the upgrade path reaches existing installs: `ensureSchema()` created both indexes on an already-provisioned `portos_test`, and `\d human_activity_events` lists all four.
- Local `codex` review ran two rounds; every finding was applied in this branch.

Closes #5715

https://claude.ai/code/session_01NyGKNa5BKxqqtbn2n3NE5o
