### PR TITLE
fix: pin the three stack to vendor-three and guard chunk groups against dead packages (#5725)

### DIFF
--- a/client/src/test/viteChunkGroups.test.js
+++ b/client/src/test/viteChunkGroups.test.js
@@ -1,0 +1,55 @@
+import { existsSync, readdirSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { CHUNK_GROUPS } from '../../vite.chunkGroups.js';
+
+const CLIENT_DIR = resolve(import.meta.dirname, '../..');
+// Client deps install into client/node_modules; a few hoist to the repo root.
+const NODE_MODULES_DIRS = [
+  resolve(CLIENT_DIR, 'node_modules'),
+  resolve(CLIENT_DIR, '../node_modules'),
+].filter(existsSync);
+
+const isInstalled = (name) => NODE_MODULES_DIRS.some((dir) => (
+  name.endsWith('*')
+    ? readdirSync(dir).some((entry) => entry.startsWith(name.slice(0, -1)))
+    : existsSync(resolve(dir, name))
+));
+
+const groupNamed = (name) => CHUNK_GROUPS.find((group) => group.name === name);
+
+describe('vite chunk groups', () => {
+  // The regression: a group regex naming a package that is not installed matches
+  // nothing, so the named chunk quietly stops capturing what its comment claims.
+  // `vendor-three` shipped that way against the removed `three-fenestra` (#5725).
+  it('only names packages that are actually installed', () => {
+    const missing = CHUNK_GROUPS.flatMap(({ name, packages }) =>
+      packages.filter((pkg) => !isInstalled(pkg)).map((pkg) => `${name} -> ${pkg}`));
+    expect(NODE_MODULES_DIRS.length).toBeGreaterThan(0);
+    expect(missing).toEqual([]);
+  });
+
+  it('captures the whole three stack on both path separators', () => {
+    const { test } = groupNamed('vendor-three');
+    expect(test.test('/app/node_modules/three/build/three.module.js')).toBe(true);
+    expect(test.test('/app/node_modules/three-stdlib/index.js')).toBe(true);
+    expect(test.test('/app/node_modules/three-mesh-bvh/src/index.js')).toBe(true);
+    expect(test.test('C:\\app\\node_modules\\@react-three\\fiber\\index.js')).toBe(true);
+    // A `three`-prefixed package we do not depend on must not be swept in.
+    expect(test.test('/app/node_modules/three-globe/index.js')).toBe(false);
+  });
+
+  it('keeps package names from bleeding across the separator', () => {
+    // `react` must not swallow `react-router-dom` or a nested `react` copy's
+    // sibling; the trailing separator is what enforces a whole-segment match.
+    const { test } = groupNamed('vendor-react');
+    expect(test.test('/app/node_modules/react/index.js')).toBe(true);
+    expect(test.test('/app/node_modules/react-redux/index.js')).toBe(false);
+    // Family prefixes still match every member.
+    const charts = groupNamed('vendor-charts').test;
+    expect(charts.test('/app/node_modules/d3-scale/src/band.js')).toBe(true);
+    expect(charts.test('/app/node_modules/victory-vendor/d3-scale.js')).toBe(true);
+  });
+});

--- a/client/src/test/viteChunkGroups.test.js
+++ b/client/src/test/viteChunkGroups.test.js
@@ -1,4 +1,4 @@
-import { existsSync, readdirSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
 import { describe, expect, it } from 'vitest';
@@ -6,17 +6,34 @@ import { describe, expect, it } from 'vitest';
 import { CHUNK_GROUPS } from '../../vite.chunkGroups.js';
 
 const CLIENT_DIR = resolve(import.meta.dirname, '../..');
-// Client deps install into client/node_modules; a few hoist to the repo root.
-const NODE_MODULES_DIRS = [
-  resolve(CLIENT_DIR, 'node_modules'),
-  resolve(CLIENT_DIR, '../node_modules'),
-].filter(existsSync);
 
-const isInstalled = (name) => NODE_MODULES_DIRS.some((dir) => (
-  name.endsWith('*')
-    ? readdirSync(dir).some((entry) => entry.startsWith(name.slice(0, -1)))
-    : existsSync(resolve(dir, name))
-));
+// Resolve against the checked-in lockfiles, not an installed `node_modules`
+// tree: the lockfile is deterministic, covers nested (unflattened) transitive
+// dependencies the group regexes still match at any depth, and cannot be
+// satisfied by a stale directory left behind by an uninstalled package.
+const lockedPackageNames = () => {
+  const names = new Set();
+  for (const lockfile of ['package-lock.json', '../package-lock.json']) {
+    const file = resolve(CLIENT_DIR, lockfile);
+    if (!existsSync(file)) continue;
+    for (const key of Object.keys(JSON.parse(readFileSync(file, 'utf-8')).packages ?? {})) {
+      const marker = key.lastIndexOf('node_modules/');
+      if (marker !== -1) names.add(key.slice(marker + 'node_modules/'.length));
+    }
+  }
+  return [...names];
+};
+
+const LOCKED_PACKAGES = lockedPackageNames();
+
+const isInstalled = (name) => {
+  if (name.endsWith('*')) return LOCKED_PACKAGES.some((pkg) => pkg.startsWith(name.slice(0, -1)));
+  // A bare `@scope` entry stands for every package published under it.
+  if (name.startsWith('@') && !name.includes('/')) {
+    return LOCKED_PACKAGES.some((pkg) => pkg.startsWith(`${name}/`));
+  }
+  return LOCKED_PACKAGES.includes(name);
+};
 
 const groupNamed = (name) => CHUNK_GROUPS.find((group) => group.name === name);
 
@@ -27,7 +44,7 @@ describe('vite chunk groups', () => {
   it('only names packages that are actually installed', () => {
     const missing = CHUNK_GROUPS.flatMap(({ name, packages }) =>
       packages.filter((pkg) => !isInstalled(pkg)).map((pkg) => `${name} -> ${pkg}`));
-    expect(NODE_MODULES_DIRS.length).toBeGreaterThan(0);
+    expect(LOCKED_PACKAGES.length).toBeGreaterThan(0);
     expect(missing).toEqual([]);
   });
 
@@ -42,8 +59,8 @@ describe('vite chunk groups', () => {
   });
 
   it('keeps package names from bleeding across the separator', () => {
-    // `react` must not swallow `react-router-dom` or a nested `react` copy's
-    // sibling; the trailing separator is what enforces a whole-segment match.
+    // A declared name must match a whole path segment: `react` must not swallow
+    // `react-redux`. The trailing separator is what enforces that.
     const { test } = groupNamed('vendor-react');
     expect(test.test('/app/node_modules/react/index.js')).toBe(true);
     expect(test.test('/app/node_modules/react-redux/index.js')).toBe(false);

--- a/client/vite.chunkGroups.js
+++ b/client/vite.chunkGroups.js
@@ -1,0 +1,50 @@
+// Vendor chunk groups for rolldown's `output.codeSplitting.groups` (Vite 8).
+//
+// Declared as package NAMES rather than as hand-written regexes so the grouping
+// can be checked against what is actually installed. A group regex naming a
+// package nobody installs matches nothing and quietly stops guaranteeing
+// anything: `vendor-three` listed `three-fenestra` — removed from the tree when
+// `openworld/InteriorMappingMaterial.js` ported the material in — while the two
+// three-* packages that DO ship (`three-stdlib` and `three-mesh-bvh`, both pulled
+// in by @react-three/drei) fell outside the pattern, because `three` had to be
+// followed immediately by a path separator (#5725).
+//
+// Conventions for a `packages` entry:
+//   'three'        an exact package name
+//   '@xterm'       a scope — every package published under it
+//   'd3-*'         a family prefix — every `d3-<something>` package
+// `buildGroupTest` renders them back into the module-id regex rolldown matches
+// with. Use `[\\/]` (not `/`) for the separator so the regexes match on Windows.
+
+const PATH_SEP = '[\\\\/]';
+
+const escapeRegex = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+const packagePattern = (name) =>
+  name.endsWith('*')
+    ? `${escapeRegex(name.slice(0, -1))}[^\\\\/]+`
+    : escapeRegex(name);
+
+/** Module-id regex capturing every module published by one of `packages`. */
+const buildGroupTest = (packages) =>
+  new RegExp(`${PATH_SEP}node_modules${PATH_SEP}(${packages.map(packagePattern).join('|')})${PATH_SEP}`);
+
+export const CHUNK_GROUPS = [
+  // Core React dependencies
+  { name: 'vendor-react', packages: ['react', 'react-dom', 'react-router'] },
+  // Socket dependencies
+  { name: 'vendor-realtime', packages: ['socket.io-client'] },
+  // Drag and drop library (only used in CoS)
+  { name: 'vendor-dnd', packages: ['@dnd-kit'] },
+  // Icon library (largest dependency)
+  { name: 'vendor-icons', packages: ['lucide-react'] },
+  // 3D stack — only pulled into lazy 3D pages (CyberCity, avatars, BrainGraph).
+  // Naming it gives the ~1 MB chunk a stable identity instead of an opaque
+  // `OrbitControls-*.js`, and listing drei's own three-* dependencies pins them
+  // to that chunk instead of leaving their placement to the bundler's derivation.
+  { name: 'vendor-three', packages: ['three', 'three-stdlib', 'three-mesh-bvh', '@react-three'] },
+  // Charting (recharts) — lazy chart pages only
+  { name: 'vendor-charts', packages: ['recharts', 'd3-*', 'victory-*'] },
+  // Terminal emulator (xterm) — Shell page only
+  { name: 'vendor-term', packages: ['@xterm'] },
+].map((group) => ({ ...group, test: buildGroupTest(group.packages) }));

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -6,6 +6,7 @@ import { execFileSync } from 'child_process';
 import { resolve } from 'path';
 
 import { resolveBundleNodeEnv } from './vite.buildEnv.js';
+import { CHUNK_GROUPS } from './vite.chunkGroups.js';
 
 const ANALYZE_BUNDLE = process.env.ANALYZE === 'true';
 const CONFIG_DIR = import.meta.dirname;
@@ -171,29 +172,11 @@ export default defineConfig(({ command, mode }) => {
           // id matches `test` into a named chunk. This replaces the legacy
           // `rollupOptions.output.manualChunks` function (still accepted via
           // rolldown's compat layer, but slated to drop in a future Vite). The
-          // groups below reproduce the same four vendor chunks as before.
-          // Note: use `[\\/]` (not `/`) for the path separator so the regexes
-          // also match on Windows.
+          // groups themselves are declared as package names in
+          // `vite.chunkGroups.js`, so a group naming an uninstalled package fails
+          // a test instead of silently grouping nothing.
           codeSplitting: {
-            groups: [
-              // Core React dependencies
-              { name: 'vendor-react', test: /[\\/]node_modules[\\/](react|react-dom|react-router)[\\/]/ },
-              // Socket dependencies
-              { name: 'vendor-realtime', test: /[\\/]node_modules[\\/]socket\.io-client[\\/]/ },
-              // Drag and drop library (only used in CoS)
-              { name: 'vendor-dnd', test: /[\\/]node_modules[\\/]@dnd-kit[\\/]/ },
-              // Icon library (largest dependency)
-              { name: 'vendor-icons', test: /[\\/]node_modules[\\/]lucide-react[\\/]/ },
-              // 3D stack — only pulled into lazy 3D pages (CyberCity, avatars,
-              // BrainGraph). Naming it gives the ~1 MB chunk a stable identity
-              // instead of an opaque `OrbitControls-*.js` and guarantees a single
-              // shared chunk across all 3D consumers.
-              { name: 'vendor-three', test: /[\\/]node_modules[\\/](three|@react-three|three-fenestra)[\\/]/ },
-              // Charting (recharts) — lazy chart pages only
-              { name: 'vendor-charts', test: /[\\/]node_modules[\\/](recharts|d3-[^\\/]+|victory-[^\\/]+)[\\/]/ },
-              // Terminal emulator (xterm) — Shell page only
-              { name: 'vendor-term', test: /[\\/]node_modules[\\/]@xterm[\\/]/ },
-            ]
+            groups: CHUNK_GROUPS.map(({ name, test }) => ({ name, test }))
           }
         }
       },


### PR DESCRIPTION
## Summary

`client/vite.config.js`'s `vendor-three` code-splitting group matched
`/[\\/]node_modules[\\/](three|@react-three|three-fenestra)[\\/]/`:

- `three-fenestra` is gone. `client/src/components/openworld/InteriorMappingMaterial.js`
  ported the material in-house, and the package is in neither `client/package.json`
  nor the lockfile — so that alternative matched nothing.
- The two three-* packages that *do* ship — `three-stdlib` and `three-mesh-bvh`,
  both pulled in by `@react-three/drei` — did not match, because the pattern
  required a path separator immediately after `three`. Their placement in
  `vendor-three` was left to the bundler's derivation rather than declared, which
  is not what the group comment claimed.

Chunk groups now live in a new `client/vite.chunkGroups.js` as lists of package
names (with `@scope` and `family-*` forms), rendered back into the same
`[\\/]`-separated module-id regexes rolldown matches with — the separator class
is preserved, so Windows paths still match. `vite.config.js` maps them into
`build.rolldownOptions.output.codeSplitting.groups`.

Declaring names rather than regexes is what makes the guard test possible.
`client/src/test/viteChunkGroups.test.js` fails when a group names a package that
is not in the checked-in lockfiles — exactly the state `three-fenestra` had been
in. It resolves against `package-lock.json` rather than `node_modules` so the
check is deterministic and covers transitive dependencies npm may nest instead of
flatten (both `three-stdlib` and `three-mesh-bvh` are transitive).

### A correction to the issue text

The issue states `three-stdlib` is a direct dependency at `client/package.json:12`
and is imported by `client/src/hooks/useClonedGltf.jsx:3`. Verified against the
tree: neither is true today. `three-stdlib` is only a transitive dependency of
`@react-three/drei`, and `useClonedGltf.jsx` imports `SkeletonUtils` from
`three/examples/jsm/utils/SkeletonUtils.js`. The grouping defect itself is real,
which is what this PR fixes.

## Test plan

- `cd client && npm test` — 810 files / 10022 tests pass, including the 3 new ones.
- Guard test verified to actually fail: re-adding `three-fenestra` to the
  `vendor-three` package list produces
  `expected [ 'vendor-three -> three-fenestra' ] to deeply equal []`.
- `cd client && npm run lint` — clean.
- `cd client && ANALYZE=true npm run build` before and after. Every emitted vendor
  chunk keeps its previous content hash (`vendor-three`, `vendor-charts`,
  `vendor-dnd`, `vendor-icons`, `vendor-react`, `vendor-realtime`, `vendor-term`),
  so the change is byte-identical for the current dependency graph while pinning
  a placement that was previously only derived.
- `dist/bundle-report.html` confirms `three`, `three-stdlib`, `@react-three/fiber`
  and `@react-three/drei` all land in `vendor-three`, and that it stays a lazily
  loaded chunk — no eager entry gained the 3D stack. (`three-mesh-bvh` is in the
  module graph but fully tree-shaken, contributing no bytes; listing it pins it
  if a future drei feature pulls it in.)

Closes #5725

https://claude.ai/code/session_01NyGKNa5BKxqqtbn2n3NE5o
