### PR TITLE
fix: close two ImageGen object-URL leaks the unmount sweep can't catch (#5722)

### DIFF
--- a/client/src/pages/ImageGen.jsx
+++ b/client/src/pages/ImageGen.jsx
@@ -38,6 +38,7 @@ import { useMediaCompletionRefresh } from '../hooks/useMediaCompletionRefresh';
 import { useMediaAnnotations } from '../hooks/useMediaAnnotations';
 import { useAutoRefetch } from '../hooks/useAutoRefetch';
 import usePreviewRoute from '../hooks/usePreviewRoute';
+import useMounted from '../hooks/useMounted';
 import {
   Image as ImageIcon, Sparkles, Download, RefreshCw, Settings as SettingsIcon,
   AlertTriangle, X, Film,
@@ -178,6 +179,13 @@ export default function ImageGen() {
   const [initImage, setInitImage] = useState({ source: null, file: null, name: null, previewUrl: null });
   const initImagePreviewRef = useRef(initImage.previewUrl);
   initImagePreviewRef.current = initImage.previewUrl;
+  // Both upload handlers AWAIT EXIF normalization before they mint their object
+  // URL, so an unmount during that await would run the cleanup sweep below and
+  // the handler would then resume to create a url nothing is left to revoke.
+  // (The init image is the live leak: the reference handler mints inside a state
+  // updater React skips once unmounted — an implementation detail to guard
+  // against, not to rely on.)
+  const mountedRef = useMounted();
   const [initImageStrength, setInitImageStrength] = useState(0.4);
   // Visual gallery picker target: null (closed), { kind: 'init' }, or
   // { kind: 'reference', slot: i }. The search/browse alternative to the plain
@@ -543,6 +551,7 @@ export default function ImageGen() {
     const raw = e.target.files?.[0];
     if (!raw) return;
     const file = await normalizeImageOrientation(raw);
+    if (!mountedRef.current) return;
     revokeIfBlob(initImagePreviewRef.current);
     setInitImage({ source: 'upload', file, name: file.name, previewUrl: URL.createObjectURL(file) });
     // Default the output resolution to the uploaded image's dimensions, clamped
@@ -574,6 +583,7 @@ export default function ImageGen() {
     const raw = e.target.files?.[0];
     if (!raw) return;
     const file = await normalizeImageOrientation(raw);
+    if (!mountedRef.current) return;
     setReferenceImages((prev) => {
       const next = [...prev];
       revokeIfBlob(next[slotIndex]?.previewUrl);

--- a/client/src/pages/ImageGen.jsx
+++ b/client/src/pages/ImageGen.jsx
@@ -584,10 +584,15 @@ export default function ImageGen() {
     if (!raw) return;
     const file = await normalizeImageOrientation(raw);
     if (!mountedRef.current) return;
+    // Mint the url OUTSIDE the updater. StrictMode invokes a functional updater
+    // twice in dev, and a url created inside it on the discarded pass is never
+    // stored — so it can never be revoked. (The revoke stays inside, where it
+    // can read the authoritative `prev`; revoking twice is a no-op.)
+    const previewUrl = URL.createObjectURL(file);
     setReferenceImages((prev) => {
       const next = [...prev];
       revokeIfBlob(next[slotIndex]?.previewUrl);
-      next[slotIndex] = { file, previewUrl: URL.createObjectURL(file), strength: next[slotIndex]?.strength ?? 1.0 };
+      next[slotIndex] = { file, previewUrl, strength: next[slotIndex]?.strength ?? 1.0 };
       return next;
     });
   };

--- a/client/src/pages/ImageGen.objectUrls.test.jsx
+++ b/client/src/pages/ImageGen.objectUrls.test.jsx
@@ -1,0 +1,235 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+
+// Codex is i2i-capable and declares no input-image cap, so the form offers the
+// init image plus all four reference slots without needing a FLUX.2 install.
+const MODEL = { id: 'dev', name: 'FLUX.1 Dev', runner: 'mflux', steps: 20, guidance: 3.5 };
+
+const state = vi.hoisted(() => ({ created: [], revoked: [], fileSeq: 0 }));
+
+const nextFile = () => new File(['x'], `photo-${++state.fileSeq}.jpg`, { type: 'image/jpeg' });
+
+// Interactive stubs for the three pickers that own the object-URL lifecycle.
+// Each exposes the page's own handler as a button plus the previewUrl it is
+// currently rendering, so a test can assert the page never leaves a REVOKED
+// url wired to a live <img src>.
+vi.mock('../components/imageGen/InitImagePicker', () => ({
+  default: ({ initImage, onPick, onClear, onBrowse }) => (
+    <div>
+      <button type="button" onClick={() => onPick({ target: { files: [nextFile()] } })}>pick-init</button>
+      <button type="button" onClick={onClear}>clear-init</button>
+      <button type="button" onClick={onBrowse}>browse-init</button>
+      <span data-testid="init-url">{initImage.previewUrl || ''}</span>
+    </div>
+  ),
+}));
+vi.mock('../components/imageGen/ReferenceImagePicker', () => ({
+  default: ({ referenceImages, onPick, onClear }) => (
+    <div>
+      {referenceImages.map((slot, i) => (
+        <div key={i}>
+          <button type="button" onClick={() => onPick(i, { target: { files: [nextFile()] } })}>{`pick-ref-${i}`}</button>
+          <button type="button" onClick={() => onClear(i)}>{`clear-ref-${i}`}</button>
+          <span data-testid={`ref-url-${i}`}>{slot.previewUrl || ''}</span>
+        </div>
+      ))}
+    </div>
+  ),
+}));
+vi.mock('../components/imageGen/GalleryImagePicker', () => ({
+  default: ({ open, onSelect }) => (open
+    ? <button type="button" onClick={() => onSelect({ filename: 'gallery-pick.png' })}>gallery-select</button>
+    : null),
+}));
+
+vi.mock('../services/api', () => ({
+  getInstances: vi.fn(async () => ({ peers: [] })),
+  getImageGenStatus: vi.fn(async () => ({ connected: true, mode: 'codex' })),
+  generateImage: vi.fn(async () => ({ jobId: 'job-1' })),
+  generateImageMultipart: vi.fn(async () => ({})),
+  listImageModels: vi.fn(async () => [MODEL]),
+  listLorasFull: vi.fn(async () => []),
+  listImageGallery: vi.fn(async () => []),
+  cancelImageGen: vi.fn(async () => ({})),
+  deleteImage: vi.fn(async () => ({})),
+  setImageHidden: vi.fn(async () => ({})),
+  cleanGalleryImage: vi.fn(async () => ({})),
+  getActiveImageJob: vi.fn(async () => ({ activeJob: null })),
+  getSettings: vi.fn(async () => ({ imageGen: { mode: 'codex' } })),
+  buildFormData: vi.fn(() => new FormData()),
+  listMediaJobs: vi.fn(async () => ({ jobs: [] })),
+  regenerateGalleryImage: vi.fn(async () => ({})),
+  getRegenAvailability: vi.fn(async () => ({ available: false })),
+  removeImageWatermark: vi.fn(async () => ({})),
+  getFlux2Status: vi.fn(async () => ({ installed: false, ready: false })),
+}));
+
+vi.mock('../hooks/useImageGenProgress', () => ({
+  useImageGenProgress: () => ({ progress: null, begin: vi.fn(), end: vi.fn(), resume: vi.fn() }),
+}));
+vi.mock('../hooks/useMediaJobSse', () => ({
+  useMediaJobSse: () => ({ attach: vi.fn(), eventSourceRef: { current: null } }),
+}));
+vi.mock('../hooks/useModelDownloadStatus', () => ({
+  useModelDownloadStatus: () => ({
+    getStatus: () => ({ cached: true }), start: vi.fn(), cancel: vi.fn(), repair: vi.fn(), refresh: vi.fn(),
+    downloading: false, repairing: false, progress: null, lastError: null, activeModelId: null, extra: {}, loading: false, statusError: null,
+  }),
+}));
+vi.mock('../hooks/useHfTokenStatus', () => ({ useHfTokenStatus: () => ({ present: true, refresh: vi.fn() }) }));
+vi.mock('../hooks/useAgyModels', () => ({ useAgyModels: () => ({ models: [], error: null }) }));
+vi.mock('../hooks/useMediaCompletionRefresh', () => ({ useMediaCompletionRefresh: vi.fn() }));
+vi.mock('../hooks/useMediaAnnotations', () => ({
+  useMediaAnnotations: () => ({ annotations: {}, updateAnnotation: vi.fn(), getCardProps: vi.fn(() => ({})) }),
+}));
+vi.mock('../hooks/useAutoRefetch', () => ({ useAutoRefetch: vi.fn() }));
+vi.mock('../hooks/usePreviewRoute', () => ({ default: () => [null, vi.fn()] }));
+vi.mock('../components/ui/Toast', () => ({
+  default: Object.assign(vi.fn(), { error: vi.fn(), success: vi.fn(), loading: vi.fn() }),
+}));
+vi.mock('../components/media/PromptEnhancer', () => ({ default: () => null }));
+vi.mock('../components/media/PromptFromMedia', () => ({ default: () => null }));
+vi.mock('../components/media/UniverseStylePicker', () => ({ default: () => null }));
+vi.mock('../components/media/StylePresetPicker', () => ({ default: () => null }));
+vi.mock('../components/media/MediaPreview', () => ({ default: () => null }));
+vi.mock('../components/media/MediaJobsQueue', () => ({ default: () => null }));
+vi.mock('../components/media/ResolutionField', () => ({ default: () => null }));
+vi.mock('../components/Drawer', () => ({ default: () => null }));
+vi.mock('../components/settings/ImageGenTab', () => ({ ImageGenTab: () => null }));
+vi.mock('../components/imageGen/Flux2InstallModal', () => ({ default: () => null }));
+vi.mock('../components/imageGen/LoraPicker', () => ({ default: () => null }));
+
+const { default: ImageGen } = await import('./ImageGen.jsx');
+
+const mount = async () => {
+  let result;
+  await act(async () => {
+    result = render(
+      <MemoryRouter initialEntries={['/media/image']}>
+        <ImageGen />
+      </MemoryRouter>,
+    );
+  });
+  return result;
+};
+
+const click = async (name) => {
+  await act(async () => { fireEvent.click(screen.getByRole('button', { name })); });
+};
+
+// Blob URLs created but not yet revoked — what a real tab would still be
+// pinning the underlying File for.
+const liveUrls = () => state.created.filter((u) => !state.revoked.includes(u));
+
+describe('ImageGen object-URL lifecycle', () => {
+  let origCreate;
+  let origRevoke;
+  let origCreateImageBitmap;
+
+  beforeEach(() => {
+    state.created = [];
+    state.revoked = [];
+    state.fileSeq = 0;
+    origCreate = URL.createObjectURL;
+    origRevoke = URL.revokeObjectURL;
+    origCreateImageBitmap = window.createImageBitmap;
+    URL.createObjectURL = vi.fn(() => {
+      const url = `blob:portos/${state.created.length + 1}`;
+      state.created.push(url);
+      return url;
+    });
+    URL.revokeObjectURL = vi.fn((url) => { state.revoked.push(url); });
+    // The page EXIF-normalizes uploads through createImageBitmap; jsdom has no
+    // decoder, and the page's own `.catch` falls back to the original File.
+    window.createImageBitmap = vi.fn(() => Promise.reject(new Error('no decoder')));
+  });
+
+  afterEach(() => {
+    URL.createObjectURL = origCreate;
+    URL.revokeObjectURL = origRevoke;
+    window.createImageBitmap = origCreateImageBitmap;
+  });
+
+  // The leak this file exists for: navigating away from /image-gen with images
+  // still selected must not pin their Files for the rest of the tab's life.
+  it('revokes every blob URL it created when the page unmounts', async () => {
+    const { unmount } = await mount();
+    await click('pick-init');
+    await click('pick-ref-0');
+    await click('pick-ref-1');
+
+    await waitFor(() => expect(state.created).toHaveLength(3));
+    expect(state.revoked).toEqual([]);
+
+    await act(async () => { unmount(); });
+
+    expect(liveUrls()).toEqual([]);
+    // Each url revoked exactly once — a double revoke would mean the unmount
+    // sweep and a per-action handler are both claiming the same url.
+    for (const url of state.created) {
+      expect(state.revoked.filter((u) => u === url)).toHaveLength(1);
+    }
+  });
+
+  // Replacing keeps reclaiming immediately, and the url left rendered must be
+  // the LIVE one — a revoked url wired to an <img src> renders a broken image.
+  it('revokes the replaced url on both the init image and a reference slot, never the live one', async () => {
+    await mount();
+    await click('pick-init');
+    await click('pick-ref-0');
+    await waitFor(() => expect(state.created).toHaveLength(2));
+    const [firstInit, firstRef] = state.created;
+
+    await click('pick-init');
+    await click('pick-ref-0');
+    await waitFor(() => expect(state.created).toHaveLength(4));
+    const [, , secondInit, secondRef] = state.created;
+
+    expect(state.revoked).toContain(firstInit);
+    expect(state.revoked).toContain(firstRef);
+    expect(state.revoked).not.toContain(secondInit);
+    expect(state.revoked).not.toContain(secondRef);
+    expect(screen.getByTestId('init-url')).toHaveTextContent(secondInit);
+    expect(screen.getByTestId('ref-url-0')).toHaveTextContent(secondRef);
+  });
+
+  // Clearing reclaims immediately, and the later unmount must not re-revoke a
+  // url the clear already released.
+  it('revokes on clear and does not revoke again at unmount', async () => {
+    const { unmount } = await mount();
+    await click('pick-init');
+    await click('pick-ref-0');
+    await waitFor(() => expect(state.created).toHaveLength(2));
+
+    await click('clear-init');
+    await click('clear-ref-0');
+    expect(liveUrls()).toEqual([]);
+
+    await act(async () => { unmount(); });
+    expect(state.revoked).toHaveLength(2);
+  });
+
+  // `revokeIfBlob` exists for exactly this: gallery previews are plain
+  // `/data/...` paths the whole app shares. Revoking one is a no-op on the
+  // blob registry but would be a bug the moment it were passed to revoke.
+  it('never revokes a gallery /data/ preview url', async () => {
+    const { unmount } = await mount();
+    await click('pick-init');
+    await waitFor(() => expect(state.created).toHaveLength(1));
+    const [blobUrl] = state.created;
+
+    // Swap the upload for a gallery pick: the blob is reclaimed, the
+    // `/data/...` path that replaces it is not a revoke candidate.
+    await click('browse-init');
+    await click('gallery-select');
+
+    await waitFor(() => expect(screen.getByTestId('init-url')).toHaveTextContent('/data/images/gallery-pick.png'));
+    expect(state.revoked).toEqual([blobUrl]);
+
+    await act(async () => { unmount(); });
+
+    expect(state.revoked).toEqual([blobUrl]);
+    expect(URL.revokeObjectURL).not.toHaveBeenCalledWith(expect.stringContaining('/data/'));
+  });
+});

--- a/client/src/pages/ImageGen.objectUrls.test.jsx
+++ b/client/src/pages/ImageGen.objectUrls.test.jsx
@@ -1,5 +1,5 @@
 import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
 
 // Codex is i2i-capable and declares no input-image cap, so the form offers the
@@ -122,33 +122,43 @@ const click = async (name) => {
 // pinning the underlying File for.
 const liveUrls = () => state.created.filter((u) => !state.revoked.includes(u));
 
+// jsdom ships none of these, so restoring means DELETING the property again —
+// assigning `undefined` back would leave an own property that later files see
+// as "present but broken".
+const stub = (host, key, value) => {
+  const had = Object.prototype.hasOwnProperty.call(host, key);
+  const prev = host[key];
+  host[key] = value;
+  return () => { if (had) host[key] = prev; else delete host[key]; };
+};
+
 describe('ImageGen object-URL lifecycle', () => {
-  let origCreate;
-  let origRevoke;
-  let origCreateImageBitmap;
+  let restore = [];
 
   beforeEach(() => {
     state.created = [];
     state.revoked = [];
     state.fileSeq = 0;
-    origCreate = URL.createObjectURL;
-    origRevoke = URL.revokeObjectURL;
-    origCreateImageBitmap = window.createImageBitmap;
-    URL.createObjectURL = vi.fn(() => {
-      const url = `blob:portos/${state.created.length + 1}`;
-      state.created.push(url);
-      return url;
-    });
-    URL.revokeObjectURL = vi.fn((url) => { state.revoked.push(url); });
-    // The page EXIF-normalizes uploads through createImageBitmap; jsdom has no
-    // decoder, and the page's own `.catch` falls back to the original File.
-    window.createImageBitmap = vi.fn(() => Promise.reject(new Error('no decoder')));
+    restore = [
+      stub(URL, 'createObjectURL', vi.fn(() => {
+        const url = `blob:portos/${state.created.length + 1}`;
+        state.created.push(url);
+        return url;
+      })),
+      stub(URL, 'revokeObjectURL', vi.fn((url) => { state.revoked.push(url); })),
+      // The page EXIF-normalizes uploads through createImageBitmap; jsdom has
+      // no decoder, and the page's own `.catch` falls back to the original File.
+      stub(window, 'createImageBitmap', vi.fn(() => Promise.reject(new Error('no decoder')))),
+    ];
   });
 
   afterEach(() => {
-    URL.createObjectURL = origCreate;
-    URL.revokeObjectURL = origRevoke;
-    window.createImageBitmap = origCreateImageBitmap;
+    // Unmount anything a test left mounted BEFORE the stubs go away: the
+    // global cleanup in src/test/setup.js runs after this hook, and the
+    // unmount sweep it triggers would reach a deleted revokeObjectURL.
+    cleanup();
+    restore.forEach((undo) => undo());
+    restore = [];
   });
 
   // The leak this file exists for: navigating away from /image-gen with images
@@ -156,20 +166,44 @@ describe('ImageGen object-URL lifecycle', () => {
   it('revokes every blob URL it created when the page unmounts', async () => {
     const { unmount } = await mount();
     await click('pick-init');
-    await click('pick-ref-0');
-    await click('pick-ref-1');
+    // Every slot, not just the first: a sweep that walked a truncated list
+    // would still pass on a two-slot sample.
+    for (let i = 0; i < 4; i += 1) await click(`pick-ref-${i}`);
 
-    await waitFor(() => expect(state.created).toHaveLength(3));
+    await waitFor(() => expect(state.created).toHaveLength(5));
     expect(state.revoked).toEqual([]);
 
     await act(async () => { unmount(); });
 
     expect(liveUrls()).toEqual([]);
-    // Each url revoked exactly once — a double revoke would mean the unmount
-    // sweep and a per-action handler are both claiming the same url.
-    for (const url of state.created) {
-      expect(state.revoked.filter((u) => u === url)).toHaveLength(1);
-    }
+  });
+
+  // Each pick handler awaits (EXIF normalization) BEFORE it mints its url, so
+  // an unmount mid-await would otherwise resume past the sweep and create one
+  // nothing owns — a leak the steady-state test above cannot see.
+  it('creates no object URL for a pick that resolves after the page unmounted', async () => {
+    // One deferred normalization per pick — release ALL of them, or a handler
+    // left suspended would fake a pass.
+    const pending = [];
+    window.createImageBitmap = vi.fn(() => new Promise((_, reject) => {
+      pending.push(() => reject(new Error('no decoder')));
+    }));
+
+    const { unmount } = await mount();
+    await click('pick-init');
+    await click('pick-ref-0');
+    expect(pending).toHaveLength(2);
+    expect(state.created).toEqual([]);
+
+    await act(async () => { unmount(); });
+    // Let the suspended handlers resume all the way through their `.catch`
+    // fallback to the point where they would mint a url.
+    await act(async () => {
+      pending.forEach((fail) => fail());
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    expect(state.created).toEqual([]);
   });
 
   // Replacing keeps reclaiming immediately, and the url left rendered must be
@@ -230,6 +264,5 @@ describe('ImageGen object-URL lifecycle', () => {
     await act(async () => { unmount(); });
 
     expect(state.revoked).toEqual([blobUrl]);
-    expect(URL.revokeObjectURL).not.toHaveBeenCalledWith(expect.stringContaining('/data/'));
   });
 });

--- a/client/src/pages/ImageGen.objectUrls.test.jsx
+++ b/client/src/pages/ImageGen.objectUrls.test.jsx
@@ -1,5 +1,6 @@
 import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
 import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { StrictMode } from 'react';
 import { MemoryRouter } from 'react-router';
 
 // Codex is i2i-capable and declares no input-image cap, so the form offers the
@@ -102,14 +103,15 @@ vi.mock('../components/imageGen/LoraPicker', () => ({ default: () => null }));
 
 const { default: ImageGen } = await import('./ImageGen.jsx');
 
-const mount = async () => {
+const mount = async ({ strict = false } = {}) => {
+  const tree = (
+    <MemoryRouter initialEntries={['/media/image']}>
+      <ImageGen />
+    </MemoryRouter>
+  );
   let result;
   await act(async () => {
-    result = render(
-      <MemoryRouter initialEntries={['/media/image']}>
-        <ImageGen />
-      </MemoryRouter>,
-    );
+    result = render(strict ? <StrictMode>{tree}</StrictMode> : tree);
   });
   return result;
 };
@@ -226,6 +228,22 @@ describe('ImageGen object-URL lifecycle', () => {
     expect(state.revoked).not.toContain(secondRef);
     expect(screen.getByTestId('init-url')).toHaveTextContent(secondInit);
     expect(screen.getByTestId('ref-url-0')).toHaveTextContent(secondRef);
+  });
+
+  // The app renders under StrictMode (client/src/main.jsx), which invokes a
+  // functional state updater TWICE in dev. A url minted inside the updater is
+  // created on both passes but only one is kept, so the other is unreachable
+  // and can never be revoked — a leak on every single reference pick.
+  it('mints exactly one url per pick under StrictMode', async () => {
+    const { unmount } = await mount({ strict: true });
+    await click('pick-init');
+    await click('pick-ref-0');
+
+    await waitFor(() => expect(screen.getByTestId('ref-url-0')).not.toHaveTextContent(''));
+    expect(state.created).toHaveLength(2);
+
+    await act(async () => { unmount(); });
+    expect(liveUrls()).toEqual([]);
   });
 
   // Clearing reclaims immediately, and the later unmount must not re-revoke a

--- a/client/src/pages/ImageGen.objectUrls.test.jsx
+++ b/client/src/pages/ImageGen.objectUrls.test.jsx
@@ -128,7 +128,7 @@ const liveUrls = () => state.created.filter((u) => !state.revoked.includes(u));
 // assigning `undefined` back would leave an own property that later files see
 // as "present but broken".
 const stub = (host, key, value) => {
-  const had = Object.prototype.hasOwnProperty.call(host, key);
+  const had = Object.hasOwn(host, key);
   const prev = host[key];
   host[key] = value;
   return () => { if (had) host[key] = prev; else delete host[key]; };


### PR DESCRIPTION
## Summary

Closes #5722.

The issue reported that `ImageGen` never revokes its picked init/reference image blob URLs on unmount. That specific claim turned out to be **stale** — an unmount sweep (`previewUrlsRef` + an empty-deps cleanup) has been in `client/src/pages/ImageGen.jsx` since June and does revoke whatever is live at unmount. Nothing pinned it, though, which is why an audit read the page as leaking.

Writing that regression test surfaced **two real leaks the sweep cannot catch**, both fixed here:

1. **Post-unmount creation.** Both upload handlers `await` EXIF normalization *before* calling `URL.createObjectURL`. Navigating away mid-upload runs the unmount sweep first; the handler then resumes and mints a blob URL with no owner left to revoke it, pinning a full-resolution photo for the rest of the tab's life. Both handlers now re-check the shared `useMounted()` guard before creating. (Used the repo's mandated hook rather than a hand-rolled `useRef(true)` — `client/src/hooks/mountedRefConventions.test.js` rejects the hand-roll.)

2. **StrictMode double-mint.** `handlePickReferenceImage` created its url *inside* the functional `setReferenceImages` updater. The app renders under `React.StrictMode`, which invokes an updater twice in development, so every reference pick created two urls and kept one — the discarded one unreachable from state and unrevocable by any path. The url is now minted before the updater, which also makes the updater pure as React requires. The revoke stays inside, where it can read the authoritative `prev`; revoking the same url twice is a no-op.

No changes to the replace/clear revoke paths or the gallery picker — those were already correct.

### Test coverage

New `client/src/pages/ImageGen.objectUrls.test.jsx` pins six invariants: unmount revokes every live url across all four reference slots; a pick that resolves *after* unmount creates no url at all; exactly one url per pick under StrictMode; a replaced url is reclaimed while the one left rendered is not; a cleared url is not revoked again at unmount; and a gallery `/data/...` preview is never passed to `revokeObjectURL`.

Each assertion was mutation-verified — removing the corresponding guard or sweep makes that test fail.

## Test plan

- `cd client && npm test` — 810 files passed, 1 skipped, 0 failed. No `act()` warnings.
- Mutation checks (each reverted after):
  - remove the unmount sweep → unmount test fails
  - remove the `useMounted` guards → post-unmount test fails (`created` non-empty)
  - move `createObjectURL` back inside the updater → StrictMode test fails (3 urls, expected 2)

## Remaining (not in scope here)

A local review round also flagged a narrow race outside this issue's scope: two overlapping init-image picks (the user re-picking before the first EXIF normalization resolves) both read the same stale previous url, both mint one, and last-write-wins leaves one orphan. Fixing it needs a per-pick sequence token rather than a mounted flag. Filed separately rather than widened into this PR.

https://claude.ai/code/session_01NyGKNa5BKxqqtbn2n3NE5o
