### PR TITLE
Fix the Prompt Guard helper crash that failed every pr-reviewer Stage 1 scan

### DIFF
--- a/client/src/lib/ports.parity.test.js
+++ b/client/src/lib/ports.parity.test.js
@@ -2,6 +2,7 @@
 import { describe, it, expect } from 'vitest';
 import { createRequire } from 'node:module';
 import { PORTS, DEFAULT_PEER_PORT } from './ports.js';
+import { PORTS as SERVER_PORTS } from '../../../server/lib/ports.js';
 
 const require = createRequire(import.meta.url);
 // ecosystem.config.cjs is the source of truth for every PortOS port.
@@ -12,6 +13,12 @@ describe('client/src/lib/ports.js mirror parity', () => {
     for (const key of Object.keys(PORTS)) {
       expect(ecosystem.PORTS[key], `ecosystem.config.cjs is missing PORTS.${key}`).toBeDefined();
       expect(PORTS[key], `client mirror PORTS.${key} drifted`).toBe(ecosystem.PORTS[key]);
+    }
+  });
+
+  it('matches the server mirror in server/lib/ports.js for every mirrored port', () => {
+    for (const key of Object.keys(PORTS)) {
+      expect(PORTS[key], `server mirror PORTS.${key} drifted`).toBe(SERVER_PORTS[key]);
     }
   });
 

--- a/scripts/run_prompt_guard.py
+++ b/scripts/run_prompt_guard.py
@@ -76,8 +76,10 @@ def main() -> int:
                 return_attention_mask=True,
                 return_tensors="pt",
             )
+            # prepare_for_model returns unbatched [seq] tensors; the encoder
+            # indexes input_shape[1], so add the batch axis it expects.
             model_inputs = {
-                key: value
+                key: value.unsqueeze(0) if value.dim() == 1 else value
                 for key, value in encoded.items()
                 if key in {"input_ids", "attention_mask", "token_type_ids"}
             }

--- a/server/services/modelAbuseGuard.js
+++ b/server/services/modelAbuseGuard.js
@@ -60,6 +60,7 @@ const FALLBACK_GUARD_PYTHON = IS_WIN
   : join(homedir(), '.portos', 'venv-prompt-guard', 'bin', 'python3');
 const HELPER_SCRIPT = join(PATHS.root, 'scripts', 'run_prompt_guard.py');
 const RUNTIME_PROBE_TIMEOUT_MS = 30_000;
+const STDERR_TAIL_CHARS = 2_000;
 const MAX_SCAN_TIMEOUT_MS = 10 * 60 * 1000;
 const MAX_INSTALL_EVENT_CHARS = 300;
 const MAX_PUBLIC_REVIEW_SNAPSHOT_CHARS = MODEL_ABUSE_GUARD_MAX_INPUT_CHARS * 3;
@@ -317,10 +318,18 @@ function probeScript() {
   return `${imports}; print('{"ready":true}')`;
 }
 
-async function isRuntimeReady(pythonPath) {
+// A benign sentence the helper must classify end to end before the guard
+// reports ready. Importing the packages proves the venv, not the classifier:
+// a helper that loads the model and then dies on the first window (the
+// unbatched-tensor bug that failed every Stage 1 scan on transformers 4.57)
+// passed the import probe and only surfaced as a bare
+// `security-guard-process-failed` at scan time.
+const RUNTIME_CANARY_TEXT = 'The quick brown fox jumps over the lazy dog.';
+
+async function isRuntimeReady(pythonPath, modelDir = null) {
   if (!pythonPath) return false;
-  if (cachedRuntime?.pythonPath === pythonPath && cachedRuntime.ready === true) return true;
-  const ready = await execFileAsync(
+  if (cachedRuntime?.pythonPath === pythonPath && cachedRuntime.modelDir === modelDir && cachedRuntime.ready === true) return true;
+  const importsReady = await execFileAsync(
     pythonPath,
     ['-c', probeScript()],
     safeChildProcessOptions({
@@ -330,8 +339,17 @@ async function isRuntimeReady(pythonPath) {
     }),
   ).then(({ stdout }) => stdout.trim().split(/\r?\n/).pop() === '{"ready":true}')
     .catch(() => false);
-  if (ready) cachedRuntime = { pythonPath, ready: true };
+  const ready = importsReady && (!modelDir || await canaryPasses(pythonPath, modelDir));
+  if (ready) cachedRuntime = { pythonPath, modelDir, ready: true };
   return ready;
+}
+
+async function canaryPasses(pythonPath, modelDir) {
+  const result = await runClassifier({ pythonPath, modelDir, content: RUNTIME_CANARY_TEXT, timeoutMs: RUNTIME_PROBE_TIMEOUT_MS })
+    .catch(() => ({ ok: false }));
+  if (!result.ok) return false;
+  const verdict = normalizeModelAbuseGuardResult(result.parsed, { minBenignScore: MODEL_ABUSE_GUARD_MIN_BENIGN_SCORE });
+  return verdict.ok === true && verdict.safe === true;
 }
 
 /**
@@ -349,7 +367,7 @@ export async function getModelAbuseGuardStatus() {
   const modelCached = Array.isArray(files);
   const venvReady = Boolean(pythonPath);
   const pythonAvailable = Boolean(detectVenvBasePythonSync());
-  const runtimeReady = await isRuntimeReady(pythonPath);
+  const runtimeReady = await isRuntimeReady(pythonPath, modelCached && files[0] ? dirname(files[0]) : null);
   const { stages, ready } = modelAbuseGuardStageReadiness({
     huggingfaceTokenPresent,
     pythonAvailable,
@@ -438,6 +456,7 @@ export function cancelModelAbuseGuardInstall() {
 function runClassifier({ pythonPath, modelDir, content, timeoutMs }) {
   return new Promise((resolve) => {
     let stdout = '';
+    let stderr = '';
     let stderrSize = 0;
     let settled = false;
     let timer = null;
@@ -466,6 +485,9 @@ function runClassifier({ pythonPath, modelDir, content, timeoutMs }) {
     proc.stdout.on('data', appendStdout);
     proc.stderr.on('data', (chunk) => {
       stderrSize += chunk.length;
+      // Keep only a bounded tail: the helper never echoes its input, and the
+      // last line is the `Prompt Guard failed: <reason>` the operator needs.
+      stderr = (stderr + chunk.toString()).slice(-STDERR_TAIL_CHARS);
       if (stderrSize > MODEL_ABUSE_GUARD_MAX_OUTPUT_CHARS) {
         proc.kill('SIGTERM');
         finish({ ok: false, code: 'security-guard-output-too-large' });
@@ -476,6 +498,8 @@ function runClassifier({ pythonPath, modelDir, content, timeoutMs }) {
     proc.on('close', (code) => {
       if (settled) return;
       if (code !== 0) {
+        const reason = stderr.trim().split('\n').filter(Boolean).pop() || 'no stderr';
+        console.error(`❌ Prompt Guard helper exited with code ${code}: ${reason.slice(0, 300)}`);
         finish({ ok: false, code: 'security-guard-process-failed' });
         return;
       }


### PR DESCRIPTION
## Summary

- **Every pr-reviewer run on this install failed in the security preflight** with a bare `security-guard-process-failed`. The Prompt Guard helper passed `prepare_for_model`'s unbatched `[seq]` tensors straight to DeBERTa, which indexes `input_shape[1]` and raised `tuple index out of range` on the first window (transformers 4.57). `scripts/run_prompt_guard.py` now adds the batch axis.
- **The Node boundary logs the helper's last stderr line** on a non-zero exit (bounded tail), so the operator sees the reason instead of only a code.
- **The readiness probe now classifies a benign canary sentence** when the model is cached. Importing the packages only proved the venv; a helper that loads the model and dies on the first window reported ready and failed only at scan time. The Abuse Guard page now reports not-ready for that case, and the scan log names the cause.

Follow-up to #5932, which left the live run on PR #5906 unverified. Further pipeline fixes from that run land separately.

## Test plan

- [x] Reproduced the crash with the checked-in helper against the cached model; the patched helper returns `LABEL_0` for benign text and `LABEL_1` for an injection sample
- [x] With the old helper in place, `getModelAbuseGuardStatus()` now reports `ready: false` and logs `Prompt Guard helper exited with code 1: Prompt Guard failed: tuple index out of range`; with the fix it reports ready and `runModelAbuseScan` passes clean content through both layers
- [x] `cd server && npx vitest run services/modelAbuseGuard.test.js`