### PR TITLE
Unblock pr-reviewer Stage 2: fix the spawn-setup chmod crash and stop forcing approval on every scanned PR

### DIFF
--- a/server/services/agentLifecycle.js
+++ b/server/services/agentLifecycle.js
@@ -279,10 +279,15 @@ async function runAgentSpawn(task) {
   // "in review" until the next daemon restart (issue #989). The release is a
   // no-op when the task carries no `metadata.app` or the marker is a real
   // `agent-*` id from a different live agent.
+  // The throwaway worktree this attempt cut (set once prepareAgentWorkspace
+  // returns one), so every setup failure after that point removes it. Without
+  // this each failed spawn left a full checkout behind: the task stayed pending
+  // and every retry cut another.
+  let spawnWorktree = null;
   const cleanupOnError = async (error) => {
     // The spawn-dedup guard is released by withSpawnDedupGuard's finally around
     // this whole body (see spawnAgentForTask) — cleanupOnError only owns the
-    // lane, tool-execution, claim, and app-review marker releases.
+    // lane, tool-execution, claim, app-review marker, and setup-worktree releases.
     release(agentId);
     errorExecution(toolExecution.id, { message: error });
     completeExecution(toolExecution.id, { success: false });
@@ -295,6 +300,14 @@ async function runAgentSpawn(task) {
     await releaseAppReviewMarker(task.metadata?.app).catch(err => {
       emitLog('warn', `Failed to release app review marker for ${task.metadata?.app}: ${err.message}`, { taskId: task.id });
     });
+    if (spawnWorktree) {
+      // No agent ever ran in it, so nothing in it is worth keeping.
+      const { removeWorktree } = await import('./worktreeManager.js');
+      const sourceWorkspace = task.metadata?.app ? await getAppWorkspace(task.metadata.app).catch(() => ROOT_DIR) : ROOT_DIR;
+      await removeWorktree(agentId, sourceWorkspace, spawnWorktree.branchName, { discardDirt: true }).catch((cleanupErr) => {
+        emitLog('warn', `Failed to remove the worktree of failed spawn ${agentId}: ${cleanupErr.message}`, { agentId, taskId: task.id });
+      });
+    }
   };
 
   // Acquire the federation lease BEFORE any spawn setup (issue #1563, addressing
@@ -528,6 +541,9 @@ async function runAgentSpawn(task) {
       return null;
     }
     const { workspacePath, resolvedAppName, worktreeInfo, jiraTicket, jiraBranchName, explicitWorktree } = prep;
+    if (worktreeInfo?.branchName && !worktreeInfo.existingBranch && !worktreeInfo.isPersistentWorktree) {
+      spawnWorktree = { branchName: worktreeInfo.branchName };
+    }
 
     if (publicReview) {
       const allowedPullRequestNumbers = publicReviewActions

--- a/server/services/agentLifecycle.postureGate.test.js
+++ b/server/services/agentLifecycle.postureGate.test.js
@@ -78,6 +78,7 @@ vi.mock('./agentWorktreeCleanup.js', () => ({
   cleanupAgentWorktree: vi.fn(),
   releaseRetryHold: vi.fn().mockResolvedValue({}),
 }));
+vi.mock('./worktreeManager.js', () => ({ removeWorktree: vi.fn().mockResolvedValue({ removed: true }) }));
 vi.mock('./agentCompletionCleanup.js', () => ({ runAgentCompletionCleanup: vi.fn() }));
 vi.mock('./agentSummaryExtraction.js', () => ({ extractFinalSummary: vi.fn() }));
 vi.mock('./agentManagement.js', () => ({ handleOrphanedTask: vi.fn() }));
@@ -108,6 +109,9 @@ vi.mock('./modelAbuseGuard.js', () => ({
 }));
 
 import { spawnAgentForTask } from './agentLifecycle.js';
+import { prepareAgentWorkspace } from './agentWorkspacePrep.js';
+import { materializePublicReviewInput } from './modelAbuseGuard.js';
+import { removeWorktree } from './worktreeManager.js';
 import { resolveAgentProviderAndModel } from './agentProviderResolution.js';
 import { updateTask } from './cos.js';
 import { spawningTasks, runnerAgents } from './agentState.js';
@@ -130,6 +134,32 @@ beforeEach(() => {
   runnerAgents.clear();
   vi.mocked(resolveAgentProviderAndModel).mockResolvedValue({
     ok: true, provider: CLAUDE_TUI, selectedModel: 'sonnet', modelSelection: {},
+  });
+});
+
+describe('spawn setup failure after the worktree exists', () => {
+  // Every failed Stage 2 spawn used to leave its checkout behind: the task
+  // stayed pending and each retry cut another worktree.
+  it('removes the worktree this attempt cut', async () => {
+    vi.mocked(prepareAgentWorkspace).mockResolvedValueOnce({
+      outcome: 'ready',
+      workspacePath: '/tmp/worktrees/agent-x',
+      worktreeInfo: { worktreePath: '/tmp/worktrees/agent-x', branchName: 'cos/task-public-review/agent-x' },
+    });
+    vi.mocked(materializePublicReviewInput).mockRejectedValueOnce(new Error('The "cb" argument must be of type function'));
+
+    await spawnAgentForTask({
+      id: 'task-public-review',
+      metadata: {
+        executionProfile: 'public-review-gate',
+        pipeline: { securityScan: { completed: true, status: 'passed', safePrCount: 1 }, reviewInputKey: 'a'.repeat(64) },
+      },
+    });
+
+    expect(removeWorktree).toHaveBeenCalledTimes(1);
+    const [, , branchName, options] = vi.mocked(removeWorktree).mock.calls[0];
+    expect(branchName).toBe('cos/task-public-review/agent-x');
+    expect(options).toEqual({ discardDirt: true });
   });
 });
 

--- a/server/services/cosTaskGenerator.js
+++ b/server/services/cosTaskGenerator.js
@@ -2124,7 +2124,6 @@ async function runPrReviewerSecurityPreflight(taskType, app, metadata, targetPul
   }
 
   const status = !scan.ok ? 'unavailable' : (scan.passed ? 'passed' : 'findings');
-  const requiresApproval = reports.length > 0;
   const snapshotWritten = await writePublicReviewInputSnapshot({
     scanKey: scan.scanKey || scanKey,
     pullRequests: scan.ok ? (scan.reviewInputs || []) : [],
@@ -2174,7 +2173,6 @@ async function runPrReviewerSecurityPreflight(taskType, app, metadata, targetPul
       findingCount: reports.filter((report) => !reportIsSafe(report)).length,
       reports,
       noActionsTaken: true,
-      requiresApproval,
       safePrCount: safeReports.length,
     },
   };
@@ -2220,9 +2218,14 @@ async function runPrReviewerSecurityPreflight(taskType, app, metadata, targetPul
     }
   }
 
-  // applyOnDemandConsent deliberately honors this marker, so a user-triggered
-  // run cannot silently bypass the human gate for external contributor PRs.
-  if (requiresApproval) metadata.requireApproval = true;
+  // No forced human approval here. The pipeline's own gates bound what an
+  // external PR can do: Stage 1 already screened it, the Eligibility Gate is
+  // tool-free, and Stage 3 runs sandboxed with the deterministic coordinator
+  // owning every forge mutation. Forcing approval on every scanned PR held
+  // the cheap tool-free gate behind a click on each run, including a targeted
+  // "Review this PR" the maintainer had just pressed. The schedule's own
+  // "Require approval" toggle (metadata.requireApproval from the interval
+  // config) still holds the run when the user asks for that.
   emitLog(
     status === 'passed' ? 'info' : 'warn',
     `pr-reviewer security scan ${status} for ${app.name}: ${reports.length} external PR(s)`,

--- a/server/services/modelAbuseGuard.js
+++ b/server/services/modelAbuseGuard.js
@@ -9,7 +9,8 @@
  * credentials, or network access.
  */
 
-import { chmod, existsSync } from 'node:fs';
+import { existsSync } from 'node:fs';
+import { chmod } from 'node:fs/promises';
 import { homedir, platform } from 'node:os';
 import { dirname, join } from 'node:path';
 import { execFile, spawn } from '../lib/childProcess.js';

--- a/server/services/modelAbuseGuard.materialize.test.js
+++ b/server/services/modelAbuseGuard.materialize.test.js
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtemp, readFile, rm, stat } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { PATHS } from '../lib/fileUtils.js';
+import {
+  materializePublicReviewInput,
+  materializePublicReviewPatches,
+  writePublicReviewInputSnapshot,
+  PUBLIC_REVIEW_INPUT_FILENAME,
+  PUBLIC_REVIEW_PATCH_DIRNAME,
+  PUBLIC_REVIEW_PATCH_MANIFEST_FILENAME,
+} from './modelAbuseGuard.js';
+
+// Runs against the real filesystem on purpose: the materializers were only ever
+// exercised through mocks, which is how a callback-style `chmod` from `node:fs`
+// (throws synchronously when called without a callback) shipped and failed every
+// Stage 2 spawn with "The \"cb\" argument must be of type function".
+const scanKey = 'a'.repeat(64);
+const headSha = 'b'.repeat(40);
+const pullRequests = [{
+  number: 42,
+  headSha,
+  title: 'docs: example change',
+  body: '',
+  diff: 'diff --git a/README.md b/README.md\n+example\n',
+}];
+
+let workspace;
+afterEach(async () => {
+  if (workspace) await rm(workspace, { recursive: true, force: true });
+  await rm(join(PATHS.cos, 'public-review-inputs', `${scanKey}.json`), { force: true });
+});
+
+describe('materializing the screened public-review snapshot', () => {
+  it('writes the input file and the patch set read-only into the workspace', async () => {
+    workspace = await mkdtemp(join(tmpdir(), 'portos-public-review-'));
+    expect(await writePublicReviewInputSnapshot({ scanKey, pullRequests })).toBe(true);
+
+    expect(await materializePublicReviewInput({ scanKey, workspacePath: workspace })).toBe(true);
+    const input = JSON.parse(await readFile(join(workspace, PUBLIC_REVIEW_INPUT_FILENAME), 'utf8'));
+    expect(input.pullRequests.map((pr) => pr.number)).toEqual([42]);
+    expect((await stat(join(workspace, PUBLIC_REVIEW_INPUT_FILENAME))).mode & 0o222).toBe(0);
+
+    expect(await materializePublicReviewPatches({ scanKey, workspacePath: workspace, allowedPullRequestNumbers: [42] })).toBe(true);
+    const manifest = JSON.parse(await readFile(join(workspace, PUBLIC_REVIEW_PATCH_DIRNAME, PUBLIC_REVIEW_PATCH_MANIFEST_FILENAME), 'utf8'));
+    expect(manifest.patches).toEqual([expect.objectContaining({ number: 42, headSha, path: `${PUBLIC_REVIEW_PATCH_DIRNAME}/PR-42.patch` })]);
+    expect(await readFile(join(workspace, PUBLIC_REVIEW_PATCH_DIRNAME, 'PR-42.patch'), 'utf8')).toBe(pullRequests[0].diff);
+    expect((await stat(join(workspace, PUBLIC_REVIEW_PATCH_DIRNAME, 'PR-42.patch'))).mode & 0o222).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Second batch from the live run of the pr-reviewer pipeline on PR #5906 (after #5947 fixed Stage 1).

- **Stage 2 never spawned**: `modelAbuseGuard.js` imported the callback `chmod` from `node:fs` and called it promise-style. Node throws synchronously (`The "cb" argument must be of type function`) before the `.catch` can run, so materializing the screened input into the worktree aborted every spawn since the three-stage pipeline landed. Only mocks had exercised the materializers; a new test runs them on a real temp workspace and checks both files land read-only.
- **Every run parked behind human approval**: the security preflight forced `requireApproval` whenever the scan covered any PR, holding the cheap tool-free Eligibility Gate behind a click even for a targeted "Review this PR" the maintainer had just pressed. The pipeline's own gates bound what an external PR can do (Stage 1 screen, tool-free Stage 2, sandboxed Stage 3 with the deterministic coordinator owning forge mutations), so that forced flag is gone. The schedule's own **Require approval** toggle still holds a run when the user asks for it.

## Test plan

- [x] `server/services/modelAbuseGuard.materialize.test.js` fails on the old import with the exact `cb` TypeError and passes with the fix
- [x] `npx vitest run services/prReviewerPipeline.test.js services/cosTaskGenerator.test.js services/prReviewerSecurity.test.js services/modelAbuseGuard.test.js`
- [ ] Live: re-run "Review this PR" on #5906 after the server restarts on this commit; Stage 2 must spawn on the Ollama-backed Claude wrapper and return an eligibility decision