### PR TITLE
fix: validate the video-history id on every route that touches a record (#5713)

### DIFF
--- a/server/routes/videoGen.js
+++ b/server/routes/videoGen.js
@@ -956,6 +956,25 @@ router.post('/cancel', asyncHandler(async (req, res) => {
   res.json({ ok: false, reason: 'no active or queued video render' });
 }));
 
+// The ONE contract every `/history/:id*` route resolves its record id through
+// (#5713) — GET, DELETE, visibility and prompt all name the same stored row, so
+// they share one schema instead of three (loose / strict / none).
+//
+// It stays looser than `historyIdSchema` below on purpose: that UUID check suits
+// ids this install MINTS, but entries also arrive from a caller-supplied
+// download id and from federated peers, so a `.guid()` gate here would 400 rows
+// that are legitimately in the list. The charset bound is the floor — every
+// legitimate id is `[A-Za-z0-9._-]+`, and a value carrying a path segment or a
+// `..` can no longer parse, so `safeUnder()` two modules away in historyOps is
+// defense in depth rather than the only thing standing between a hostile id and
+// an unlink loop.
+const historyRecordIdSchema = z.string().trim().min(1).max(200)
+  .regex(/^[A-Za-z0-9._-]+$/, 'invalid history id');
+const updatePromptSchema = z.object({ prompt: z.string().max(8000) });
+// `hidden` is required: reading an absent body as `false` turned a malformed
+// request into a silent unhide.
+const visibilitySchema = z.object({ hidden: z.boolean() });
+
 router.get('/history', asyncHandler(async (_req, res) => {
   res.json(await loadHistory());
 }));
@@ -966,18 +985,8 @@ router.get('/history', asyncHandler(async (_req, res) => {
 // `finalVideoId`, an EpisodeVideoStage final) has to ask the server which file
 // it points at. Before this route existed, every such surface pulled the WHOLE
 // history list to find one row.
-//
-// The id is validated loosely on purpose: `historyIdSchema`'s UUID check below
-// suits ids this install MINTS, but entries also arrive from a caller-supplied
-// download id and from federated peers, so a `.guid()` gate here would 400 rows
-// that are legitimately in the list. Nothing is interpolated into a path — the
-// value is only compared against stored ids — so a length-capped string is the
-// right bound.
-const historyLookupIdSchema = z.string().min(1).max(200);
-const updatePromptSchema = z.object({ prompt: z.string().max(8000) });
-
 router.get('/history/:id', asyncHandler(async (req, res) => {
-  const parsed = historyLookupIdSchema.safeParse(req.params.id);
+  const parsed = historyRecordIdSchema.safeParse(req.params.id);
   if (!parsed.success) failValidation(parsed);
   const entry = await getHistoryItem(parsed.data);
   if (!entry) throw new ServerError('Not found', { status: 404, code: 'NOT_FOUND' });
@@ -1005,15 +1014,21 @@ router.post('/upload', asyncHandler(async (req, res) => {
 }));
 
 router.delete('/history/:id', asyncHandler(async (req, res) => {
-  res.json(await deleteHistoryItem(req.params.id));
+  const parsed = historyRecordIdSchema.safeParse(req.params.id);
+  if (!parsed.success) failValidation(parsed);
+  res.json(await deleteHistoryItem(parsed.data));
 }));
 
 router.post('/history/:id/visibility', asyncHandler(async (req, res) => {
-  res.json(await setHistoryItemHidden(req.params.id, !!req.body?.hidden));
+  const parsedId = historyRecordIdSchema.safeParse(req.params.id);
+  if (!parsedId.success) failValidation(parsedId);
+  const body = visibilitySchema.safeParse(req.body ?? {});
+  if (!body.success) failValidation(body);
+  res.json(await setHistoryItemHidden(parsedId.data, body.data.hidden));
 }));
 
 router.patch('/history/:id/prompt', asyncHandler(async (req, res) => {
-  const parsedId = historyLookupIdSchema.safeParse(req.params.id);
+  const parsedId = historyRecordIdSchema.safeParse(req.params.id);
   if (!parsedId.success) failValidation(parsedId);
   const body = updatePromptSchema.safeParse(req.body ?? {});
   if (!body.success) failValidation(body);
@@ -1021,9 +1036,10 @@ router.patch('/history/:id/prompt', asyncHandler(async (req, res) => {
 }));
 
 // Render jobs use UUID history ids, while shared-gallery uploads use an
-// `upload-<uuid8>` id. These mutating operations only resolve a stored history
-// record and subsequently derive the path from its guarded filename, so both
-// known id forms are valid here.
+// `upload-<uuid8>` id. These operations derive a NEW artifact path from the
+// resolved record (an anchor frame, an upscale, a stitch output) rather than
+// merely reading or mutating the row, so they hold the tighter of the two
+// contracts and accept only the two id forms this install can mint.
 const historyIdSchema = z.string().regex(
   /^(?:[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}|upload-[a-f0-9]{8})$/i,
   'invalid history id',

--- a/server/routes/videoGen.test.js
+++ b/server/routes/videoGen.test.js
@@ -2559,14 +2559,25 @@ describe('videoGen routes', () => {
 
     it('decodes a percent-encoded id before looking it up', async () => {
       videoGenService.getHistoryItem.mockResolvedValueOnce(null);
-      await request(app).get(`/api/video-gen/history/${encodeURIComponent('a b/c')}`);
-      expect(videoGenService.getHistoryItem).toHaveBeenCalledWith('a b/c');
+      await request(app).get('/api/video-gen/history/a%2Eb-c');
+      expect(videoGenService.getHistoryItem).toHaveBeenCalledWith('a.b-c');
     });
 
     it('rejects an absurdly long id without touching the service', async () => {
       const r = await request(app).get(`/api/video-gen/history/${'x'.repeat(201)}`);
       expect(r.status).toBe(400);
       expect(videoGenService.getHistoryItem).not.toHaveBeenCalled();
+    });
+
+    // The lookup schema is deliberately looser than the UUID gate on
+    // /last-frame and /upscale, because history rows also arrive from a
+    // caller-supplied download id and from federated peers (#5713).
+    it('accepts a legitimate non-UUID federated id', async () => {
+      const entry = { id: 'dl-abc_123', filename: 'peer.mp4' };
+      videoGenService.getHistoryItem.mockResolvedValueOnce(entry);
+      const r = await request(app).get('/api/video-gen/history/dl-abc_123');
+      expect(r.status).toBe(200);
+      expect(videoGenService.getHistoryItem).toHaveBeenCalledWith('dl-abc_123');
     });
   });
 
@@ -2576,6 +2587,49 @@ describe('videoGen routes', () => {
       const r = await request(app).delete('/api/video-gen/history/abc');
       expect(r.status).toBe(200);
       expect(videoGenService.deleteHistoryItem).toHaveBeenCalledWith('abc');
+    });
+
+    it('deletes a legitimate non-UUID federated id', async () => {
+      videoGenService.deleteHistoryItem.mockResolvedValue({ ok: true });
+      const r = await request(app).delete('/api/video-gen/history/dl-abc_123');
+      expect(r.status).toBe(200);
+      expect(videoGenService.deleteHistoryItem).toHaveBeenCalledWith('dl-abc_123');
+    });
+
+    // The destructive verb shipped with NO id validation, so a value carrying a
+    // path segment reached deleteHistoryItem — which interpolates the id into
+    // nine `${id}-fN.jpg` thumbnail unlinks. Gate it at the boundary (#5713).
+    it('rejects an id carrying a path segment without touching the service', async () => {
+      const r = await request(app).delete(`/api/video-gen/history/${encodeURIComponent('../../etc/passwd')}`);
+      expect(r.status).toBe(400);
+      expect(r.body.code).toBe('VALIDATION_ERROR');
+      expect(videoGenService.deleteHistoryItem).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('POST /history/:id/visibility', () => {
+    it('forwards the requested hidden flag', async () => {
+      videoGenService.setHistoryItemHidden.mockResolvedValue({ ok: true, hidden: true });
+      const r = await request(app).post('/api/video-gen/history/abc/visibility').send({ hidden: true });
+      expect(r.status).toBe(200);
+      expect(videoGenService.setHistoryItemHidden).toHaveBeenCalledWith('abc', true);
+    });
+
+    // `!!req.body?.hidden` read a missing body as "unhide", so a malformed
+    // request silently un-hid the row instead of failing (#5713).
+    it('rejects a body without a boolean hidden rather than unhiding', async () => {
+      const r = await request(app).post('/api/video-gen/history/abc/visibility').send({});
+      expect(r.status).toBe(400);
+      expect(r.body.code).toBe('VALIDATION_ERROR');
+      expect(videoGenService.setHistoryItemHidden).not.toHaveBeenCalled();
+    });
+
+    it('rejects an id carrying a path segment', async () => {
+      const r = await request(app)
+        .post(`/api/video-gen/history/${encodeURIComponent('../../etc/passwd')}/visibility`)
+        .send({ hidden: true });
+      expect(r.status).toBe(400);
+      expect(videoGenService.setHistoryItemHidden).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## Summary

The same video-history record id was validated three different ways across five routes in one router, and two of them — `DELETE /history/:id` and `POST /history/:id/visibility`, the destructive/mutating pair — validated nothing at all. `deleteHistoryItem` interpolates that id into nine `${id}-fN.jpg` thumbnail paths, so the only guard between a malformed id and an unlink loop was `safeUnder()` two modules away.

- Renames `historyLookupIdSchema` → `historyRecordIdSchema`, moves it above the first `/history` route, and tightens it to `z.string().trim().min(1).max(200).regex(/^[A-Za-z0-9._-]+$/)`. This is a **charset** bound, not a UUID bound — the schema's original looseness exists because history rows also arrive from a caller-supplied download id and from federated peers, and a `.guid()` gate would 400 rows that are legitimately in the list. The charset keeps all of those while making a path-segment-bearing value structurally impossible, so `safeUnder()` becomes defense in depth rather than the only defense.
- Applies it to all four record routes: `GET`, `DELETE`, `POST .../visibility`, `PATCH .../prompt`, using the same `safeParse` + `failValidation` two-liner the sibling routes already used.
- Adds a body schema to `POST /history/:id/visibility` (`z.object({ hidden: z.boolean() })`), replacing `!!req.body?.hidden`, which read a missing body as "unhide" — a malformed request silently changed state instead of failing. The client already sends a real boolean (`apiImageVideo.js#setVideoHidden`), so no client change is needed.
- `historyIdSchema` (the strict UUID/`upload-` form) and its three consumers — `/last-frame/:id`, `/upscale/:id`, `/stitch` — are unchanged. Its comment is corrected: it said "these mutating operations", but delete/visibility are mutating too; what actually distinguishes them is that these three derive a *new* artifact path from the record.
- `server/services/videoGen/historyOps.js` is untouched — `safeUnder` stays.

## Test plan

`server/routes/videoGen.test.js`:

- `DELETE /api/video-gen/history/<encoded ../../etc/passwd>` → 400 `VALIDATION_ERROR`, service never called. The percent-encoded traversal **does** reach the handler (Express decodes at the param level, not before routing), so no substitute value was needed.
- `POST /history/:id/visibility` with `{}` → 400 `VALIDATION_ERROR` rather than a silent unhide; plus a matching path-segment id rejection and a success case pinning the boolean is forwarded.
- A legitimate non-UUID federated id (`dl-abc_123`) still passes both `GET` and `DELETE` — pins that the tightened charset did not break the case the loose schema exists to protect.
- The pre-existing "decodes a percent-encoded id" case used `a b/c`, which the new charset correctly rejects; it now uses `a%2Eb-c` → `a.b-c`, so it still proves decoding happens without asserting a value the contract now forbids.

Verified the three new guard tests **fail** against the pre-fix router and pass after.

`cd server && npm test`: **1877 files passed / 1 skipped, 37859 tests passed / 14 skipped**. No `test:db` run.

Local reviewer (optional) returned INCONCLUSIVE — the configured ollama model rejects the request with `does not support thinking`; a pre-existing environment issue, not a finding.

Closes #5713

https://claude.ai/code/session_01EaknNsdoxVfoFyRBGXUrDx
