### PR TITLE
Let the local Claude wrapper authenticate inside the pr-reviewer child environment

### DIFF
--- a/server/lib/cliChildEnv.js
+++ b/server/lib/cliChildEnv.js
@@ -142,10 +142,39 @@ const PUBLIC_REVIEW_ENV_KEYS = new Set([
   'CLAUDE_CODE_MAX_OUTPUT_TOKENS', 'MAX_THINKING_TOKENS',
 ]);
 
+// A Claude CLI pointed at a LOCAL Anthropic-compatible runtime (the Ollama and
+// SGLang wrappers) authenticates with a placeholder token that means nothing
+// outside that loopback endpoint, and its lean argv passes `--bare`, which
+// disables the keychain — so without the token the CLI exits "Not logged in"
+// before reading the prompt. Keep the credential only for a loopback base URL;
+// against any other host it is a real cloud credential and stays stripped.
+const LOCAL_ANTHROPIC_CREDENTIAL_KEYS = ['ANTHROPIC_AUTH_TOKEN', 'ANTHROPIC_API_KEY'];
+const LOOPBACK_HOSTNAMES = new Set(['localhost', '127.0.0.1', '::1', '[::1]']);
+
+function localAnthropicCredentialEnv(env) {
+  let hostname;
+  try {
+    hostname = new URL(env?.ANTHROPIC_BASE_URL).hostname.toLowerCase();
+  } catch {
+    return {};
+  }
+  if (!LOOPBACK_HOSTNAMES.has(hostname) && !hostname.startsWith('127.')) return {};
+  return Object.fromEntries(LOCAL_ANTHROPIC_CREDENTIAL_KEYS
+    .filter((key) => env[key] != null)
+    .map((key) => [key, env[key]]));
+}
+
+function allowlistEnv(env, keys) {
+  return {
+    ...Object.fromEntries(Object.entries(env || {}).filter(([key, value]) => (
+      value != null && (keys.has(key) || key.startsWith('LC_'))
+    ))),
+    ...localAnthropicCredentialEnv(env),
+  };
+}
+
 export function buildPublicReviewCliEnv(env = {}) {
-  return Object.fromEntries(Object.entries(env || {}).filter(([key, value]) => (
-    value != null && (PUBLIC_REVIEW_ENV_KEYS.has(key) || key.startsWith('LC_'))
-  )));
+  return allowlistEnv(env, PUBLIC_REVIEW_ENV_KEYS);
 }
 
 // The actions stage is allowed to use its vendor's own workspace sandbox for
@@ -161,12 +190,13 @@ const PUBLIC_REVIEW_ACTIONS_ENV_KEYS = new Set([
   'NVM_DIR', 'NVM_BIN',
   'SystemRoot', 'SystemDrive', 'ComSpec', 'PATHEXT', 'USERPROFILE', 'APPDATA',
   'LOCALAPPDATA', 'ProgramData', 'ProgramFiles', 'HOMEDRIVE', 'HOMEPATH',
+  // The local Claude wrappers are eligible for this stage too; without the
+  // endpoint they would talk to the cloud (or, with `--bare`, to nothing).
+  'ANTHROPIC_BASE_URL', 'ANTHROPIC_SMALL_FAST_MODEL',
 ]);
 
 export function buildPublicReviewActionsCliEnv(env = {}) {
-  return Object.fromEntries(Object.entries(env || {}).filter(([key, value]) => (
-    value != null && (PUBLIC_REVIEW_ACTIONS_ENV_KEYS.has(key) || key.startsWith('LC_'))
-  )));
+  return allowlistEnv(env, PUBLIC_REVIEW_ACTIONS_ENV_KEYS);
 }
 
 /**

--- a/server/lib/cliChildEnv.test.js
+++ b/server/lib/cliChildEnv.test.js
@@ -138,8 +138,11 @@ describe('buildCliChildEnv — public-review profile', () => {
       HOME: '/home/example',
       LC_ALL: 'C',
       ANTHROPIC_BASE_URL: 'http://127.0.0.1:11434',
+      // The wrapper's placeholder token authenticates only to the loopback
+      // runtime; `--bare` disables the keychain, so without it the CLI exits
+      // "Not logged in" (the live Stage 2 failure on the Ollama wrapper).
+      ANTHROPIC_AUTH_TOKEN: 'local-only',
     });
-    expect(env).not.toHaveProperty('ANTHROPIC_AUTH_TOKEN');
     expect(env).not.toHaveProperty('GH_TOKEN');
     expect(env).not.toHaveProperty('GITHUB_TOKEN');
     expect(env).not.toHaveProperty('AWS_SECRET_ACCESS_KEY');
@@ -166,12 +169,28 @@ describe('buildCliChildEnv — public-review profile', () => {
     });
 
     expect(env.ANTHROPIC_BASE_URL).toBe('http://127.0.0.1:11434');
-    expect(env).not.toHaveProperty('ANTHROPIC_AUTH_TOKEN');
+    expect(env.ANTHROPIC_AUTH_TOKEN).toBe('local-only');
     expect(env.PWD).toBe('/tmp/public-review');
     expect(env).not.toHaveProperty('GH_TOKEN');
     expect(env).not.toHaveProperty('AWS_PROFILE');
     expect(env).not.toHaveProperty('OPENAI_API_KEY');
     expect(env).not.toHaveProperty('CLAUDECODE');
+  });
+});
+
+describe('buildCliChildEnv — public-review profile, cloud endpoint', () => {
+  it('strips the Anthropic credential when the base URL is not loopback', () => {
+    const env = buildPublicReviewCliEnv({
+      PATH: '/usr/bin',
+      ANTHROPIC_BASE_URL: 'https://api.example.com',
+      ANTHROPIC_AUTH_TOKEN: 'cloud-secret',
+      ANTHROPIC_API_KEY: 'cloud-key',
+    });
+    expect(env.ANTHROPIC_BASE_URL).toBe('https://api.example.com');
+    expect(env).not.toHaveProperty('ANTHROPIC_AUTH_TOKEN');
+    expect(env).not.toHaveProperty('ANTHROPIC_API_KEY');
+    // No base URL at all means the cloud default — the credential stays out.
+    expect(buildPublicReviewCliEnv({ ANTHROPIC_API_KEY: 'cloud-key' })).not.toHaveProperty('ANTHROPIC_API_KEY');
   });
 });
 
@@ -212,6 +231,17 @@ describe('buildCliChildEnv — public-review-actions profile', () => {
     expect(env).not.toHaveProperty('ANTHROPIC_AUTH_TOKEN');
     expect(env).not.toHaveProperty('AWS_PROFILE');
     expect(env).not.toHaveProperty('PRIVATE_APP_SETTING');
+  });
+
+  it('keeps the local Claude wrapper endpoint and its placeholder token', () => {
+    const env = buildCliChildEnv({
+      baseEnv: { PATH: '/usr/bin', GH_TOKEN: 'forge-secret' },
+      provider: { envVars: { ANTHROPIC_BASE_URL: 'http://localhost:11434', ANTHROPIC_AUTH_TOKEN: 'ollama', ANTHROPIC_SMALL_FAST_MODEL: 'small:7b' } },
+      cwd: '/tmp/public-review-actions',
+      safetyProfile: PUBLIC_REVIEW_ACTIONS_EXECUTION_PROFILE,
+    });
+    expect(env).toMatchObject({ ANTHROPIC_BASE_URL: 'http://localhost:11434', ANTHROPIC_AUTH_TOKEN: 'ollama', ANTHROPIC_SMALL_FAST_MODEL: 'small:7b' });
+    expect(env).not.toHaveProperty('GH_TOKEN');
   });
 });
 


### PR DESCRIPTION
## Summary

Third batch from the live run of the pr-reviewer pipeline on PR #5906 (after #5947 and #5948). With Stage 2 finally spawning, its Claude child exited immediately with `Not logged in · Please run /login`.

- **Both public-review env allowlists stripped `ANTHROPIC_AUTH_TOKEN`.** The Ollama and SGLang Claude wrappers authenticate with a placeholder token that means nothing outside the loopback endpoint, and their lean argv passes `--bare`, which disables the keychain, so the child had no credential at all. The credential now survives only when `ANTHROPIC_BASE_URL` is a loopback host; for any other host it is a real cloud credential and stays stripped (new test pins that).
- **The actions allowlist gains `ANTHROPIC_BASE_URL` and `ANTHROPIC_SMALL_FAST_MODEL`** so the same wrappers can run Stage 3 against their local runtime instead of the cloud.

## Test plan

- [x] `npx vitest run lib/cliChildEnv.test.js lib/providerVendors.publicReview.test.js services/agentCliSpawning`
- [x] Composed the real `claude-ollama` provider's env for both postures: base URL, small-fast model, and token present; no forge, cloud, or SSH keys
- [ ] Live: Stage 2 on PR #5906 returns an eligibility decision after the server restarts on this commit