### PR TITLE
Give pr-reviewer stages their own prompt and a tool-free completion contract

### DIFF
--- a/server/services/agentCompletionCleanup.js
+++ b/server/services/agentCompletionCleanup.js
@@ -149,6 +149,11 @@ export async function handlePipelineProgression(task, agentId, success) {
   if (publicReviewPostureForProfile(nextStage.executionProfile)) {
     for (const key of ['provider', 'providerId', 'model', 'effort']) delete nextTask.metadata[key];
   }
+  // The previous stage's agent payload must not travel: `description` above IS
+  // this stage's prompt, and addTask only promotes it to `metadata.prompt` when
+  // none is set — an inherited one made every stage after the first run on the
+  // stage before it's instructions.
+  delete nextTask.metadata.prompt;
   if (nextStage.model) nextTask.metadata.model = nextStage.model;
   if (nextStage.providerId) {
     nextTask.metadata.provider = nextStage.providerId;

--- a/server/services/agentCompletionCleanup.test.js
+++ b/server/services/agentCompletionCleanup.test.js
@@ -90,6 +90,17 @@ describe('handlePipelineProgression', () => {
     expect(nextTask.metadata.effort).toBe('xhigh');
   });
 
+  it('does not carry the previous stage prompt into the next stage task', async () => {
+    // addTask promotes a multi-line description to metadata.prompt only when
+    // none is set, so an inherited prompt made stage 1+ run on stage 0's text.
+    const task = { id: 't', taskType: 'user', metadata: { prompt: 'stage-0 instructions\nmore', context: 'note', pipeline: runningPipeline() } };
+    await handlePipelineProgression(task, 'agent-1', true);
+    const [nextTask] = addTask.mock.calls[0];
+    expect(nextTask.metadata).not.toHaveProperty('prompt');
+    expect(nextTask.metadata.context).toBe('note');
+    expect(nextTask.description).toBe('do stage work in {appName}');
+  });
+
   it('leaves effort unset when the next stage has no effort pin', async () => {
     const task = { id: 't', taskType: 'user', metadata: { pipeline: runningPipeline() } };
     await handlePipelineProgression(task, 'agent-1', true);

--- a/server/services/agentPromptBuilder.js
+++ b/server/services/agentPromptBuilder.js
@@ -28,7 +28,7 @@ import { buildCompactionSection, buildTaskBlock, reconcileSplitContext } from '.
 import { applySlashdoInvocation } from './promptSections/slashdo.js';
 import { manualForgeCli, resolveManualForgeCli } from './promptSections/forge.js';
 import { buildPlannerAttributionSection } from './promptSections/plannerAttribution.js';
-import { isPublicReviewNoToolProfile } from '../lib/agentExecutionProfiles.js';
+import { isPublicReviewNoToolProfile, isPublicReviewRestrictedProfile } from '../lib/agentExecutionProfiles.js';
 import {
   DISCARD_WORKTREE_NOTE,
   buildActionOutputCompletionSection,
@@ -414,6 +414,10 @@ export async function buildAgentPrompt(task, config, workspaceDir, worktreeInfo 
   // A tool-free public-review stage has no sentinel, API, or command to reach
   // for: its reply IS the deliverable. Wins over every other completion contract.
   const toolFreeReasoning = isPublicReviewNoToolProfile(task.metadata?.executionProfile);
+  // The sandboxed review stage has tools and a discarded worktree; its output
+  // is the JSON payload in the sentinel, not an API action — so it takes the
+  // programmatic-output contract ahead of the no-code one.
+  const sentinelPayloadOutput = isPublicReviewRestrictedProfile(task.metadata?.executionProfile) && !toolFreeReasoning;
   const noChangeSuccess = isTruthyMetaFn(task.metadata?.noChangeSuccess);
   const isWorktreeOnExistingBranch = isPrBranchWorktree(task, worktreeInfo);
   const worktreeCommitNote = worktreeInfo
@@ -518,6 +522,8 @@ After completing your work and before committing, ${simplifyInstruction}. Fix an
   // its output channel.
   const tuiCompletionSection = toolFreeReasoning
     ? buildToolFreeReasoningCompletionSection()
+    : sentinelPayloadOutput
+    ? buildProgrammaticOutputCompletionSection(sentinelPath)
     : noCodeOutput
     ? buildActionOutputCompletionSection({ isTui, sentinelPath })
     : discardWorktree
@@ -743,7 +749,7 @@ ${(() => {
   const bullet = buildCompletionGuidelineBullet({
     isReadOnly: isTruthyMetaFn(task.metadata?.readOnly), whenDone,
     isTui, tuiCompletionCommand, slashdoFree: isTui && !canRunSlashCommands,
-    worktreeInfo, willOpenPR, prCompletion, discardWorktree, noCodeOutput, noChangeSuccess,
+    worktreeInfo, willOpenPR, prCompletion, discardWorktree, noCodeOutput: noCodeOutput && !sentinelPayloadOutput, noChangeSuccess,
     leavePrOpen: leavesPrForHuman(task),
     isPrFollowUp: isReviewLoopFollowUp, claimFlow, toolFreeReasoning,
   });
@@ -757,7 +763,7 @@ ${(() => {
 ${noChangeSuccess ? `- **No-change audits may exit cleanly.** ${NO_CHANGE_AUDIT_GUIDANCE}` : ''}
 ${toolFreeReasoning
   ? `- **No git at all.** You have no tools; the Completion section above is the whole contract.`
-  : noCodeOutput
+  : noCodeOutput && !sentinelPayloadOutput
   ? `- **Do NOT commit, push, or open a PR.** This task changes no code — its result is delivered by the API call or command described above. Without this, a no-worktree task of this shape was told to \`/do:push\` **directly to the branch it is standing on**, which for a task running in the app's live checkout is its default branch.`
   : discardWorktree
   ? `- **Do NOT commit, push, or open a PR.** This worktree is discarded on exit — your only output is the completion sentinel (see the Completion section above).`
@@ -843,6 +849,7 @@ function buildLightContextSections(task, workspaceDir, worktreeInfo, isTruthyMet
   // tasks (queued before this flag existed) are recognized without a migration.
   const noCodeOutput = isTruthyMetaFn(task.metadata?.noCodeOutput) || !!task.metadata?.creativeDirector;
   const toolFreeReasoning = isPublicReviewNoToolProfile(task.metadata?.executionProfile);
+  const sentinelPayloadOutput = isPublicReviewRestrictedProfile(task.metadata?.executionProfile) && !toolFreeReasoning;
   const noChangeSuccess = isTruthyMetaFn(task.metadata?.noChangeSuccess);
   const isReviewLoopFollowUp = isTruthyMetaFn(task.metadata?.reviewLoopFollowUp);
   const isWorktreeOnExistingBranch = isPrBranchWorktree(task, worktreeInfo);
@@ -1018,7 +1025,7 @@ function buildLightContextSections(task, workspaceDir, worktreeInfo, isTruthyMet
     // No tools at all: the reply is the deliverable (see the full path's
     // tuiCompletionSection ternary for the same precedence).
     contractSections.push(buildToolFreeReasoningCompletionSection());
-  } else if (noCodeOutput) {
+  } else if (noCodeOutput && !sentinelPayloadOutput) {
     contractSections.push(buildActionOutputCompletionSection({
       isTui,
       sentinelPath: resolveSentinelPath(worktreeInfo, workspaceDir, agentId),

--- a/server/services/agentPromptBuilder.js
+++ b/server/services/agentPromptBuilder.js
@@ -28,6 +28,7 @@ import { buildCompactionSection, buildTaskBlock, reconcileSplitContext } from '.
 import { applySlashdoInvocation } from './promptSections/slashdo.js';
 import { manualForgeCli, resolveManualForgeCli } from './promptSections/forge.js';
 import { buildPlannerAttributionSection } from './promptSections/plannerAttribution.js';
+import { isPublicReviewNoToolProfile } from '../lib/agentExecutionProfiles.js';
 import {
   DISCARD_WORKTREE_NOTE,
   buildActionOutputCompletionSection,
@@ -38,6 +39,7 @@ import {
   NO_CHANGE_AUDIT_GUIDANCE,
   buildProgrammaticOutputCompletionSection,
   buildReadOnlyCompletionSection,
+  buildToolFreeReasoningCompletionSection,
   buildResumeSection,
   buildSentinelWriteSteps,
   buildTuiCompletionSection,
@@ -409,6 +411,9 @@ export async function buildAgentPrompt(task, config, workspaceDir, worktreeInfo 
   // `pending` BEFORE this flag existed (persisted across an upgrade) are still
   // recognized without a metadata migration.
   const noCodeOutput = isTruthyMetaFn(task.metadata?.noCodeOutput) || isCreativeDirectorTask;
+  // A tool-free public-review stage has no sentinel, API, or command to reach
+  // for: its reply IS the deliverable. Wins over every other completion contract.
+  const toolFreeReasoning = isPublicReviewNoToolProfile(task.metadata?.executionProfile);
   const noChangeSuccess = isTruthyMetaFn(task.metadata?.noChangeSuccess);
   const isWorktreeOnExistingBranch = isPrBranchWorktree(task, worktreeInfo);
   const worktreeCommitNote = worktreeInfo
@@ -511,7 +516,9 @@ After completing your work and before committing, ${simplifyInstruction}. Fix an
   // worktree disposal (`discardWorktree`) pick the reasoning-payload contract.
   // A task doing external work during the run must not be told the sentinel is
   // its output channel.
-  const tuiCompletionSection = noCodeOutput
+  const tuiCompletionSection = toolFreeReasoning
+    ? buildToolFreeReasoningCompletionSection()
+    : noCodeOutput
     ? buildActionOutputCompletionSection({ isTui, sentinelPath })
     : discardWorktree
       ? buildProgrammaticOutputCompletionSection(sentinelPath)
@@ -738,7 +745,7 @@ ${(() => {
     isTui, tuiCompletionCommand, slashdoFree: isTui && !canRunSlashCommands,
     worktreeInfo, willOpenPR, prCompletion, discardWorktree, noCodeOutput, noChangeSuccess,
     leavePrOpen: leavesPrForHuman(task),
-    isPrFollowUp: isReviewLoopFollowUp, claimFlow,
+    isPrFollowUp: isReviewLoopFollowUp, claimFlow, toolFreeReasoning,
   });
   return bullet ? `- ${bullet}` : '';
 })()}
@@ -748,7 +755,9 @@ ${(() => {
 - **NEVER use \`git stash\`** in any form (\`git stash push\`, \`git stash pop\`, etc.). This is a multi-agent system — stashing can silently destroy or corrupt another agent's or the user's in-progress work. Work around uncommitted changes instead. (Note: the backend may use \`--autostash\` in user-triggered pull operations — that is safe because those are single-user UI actions, not concurrent agent operations.)
 - **Only commit files YOU changed** for this task. Never use \`git add -A\` or \`git add .\` — always stage specific files by name.
 ${noChangeSuccess ? `- **No-change audits may exit cleanly.** ${NO_CHANGE_AUDIT_GUIDANCE}` : ''}
-${noCodeOutput
+${toolFreeReasoning
+  ? `- **No git at all.** You have no tools; the Completion section above is the whole contract.`
+  : noCodeOutput
   ? `- **Do NOT commit, push, or open a PR.** This task changes no code — its result is delivered by the API call or command described above. Without this, a no-worktree task of this shape was told to \`/do:push\` **directly to the branch it is standing on**, which for a task running in the app's live checkout is its default branch.`
   : discardWorktree
   ? `- **Do NOT commit, push, or open a PR.** This worktree is discarded on exit — your only output is the completion sentinel (see the Completion section above).`
@@ -833,6 +842,7 @@ function buildLightContextSections(task, workspaceDir, worktreeInfo, isTruthyMet
   // derive from a CD task's `creativeDirector` marker so pre-upgrade `pending`
   // tasks (queued before this flag existed) are recognized without a migration.
   const noCodeOutput = isTruthyMetaFn(task.metadata?.noCodeOutput) || !!task.metadata?.creativeDirector;
+  const toolFreeReasoning = isPublicReviewNoToolProfile(task.metadata?.executionProfile);
   const noChangeSuccess = isTruthyMetaFn(task.metadata?.noChangeSuccess);
   const isReviewLoopFollowUp = isTruthyMetaFn(task.metadata?.reviewLoopFollowUp);
   const isWorktreeOnExistingBranch = isPrBranchWorktree(task, worktreeInfo);
@@ -1004,7 +1014,11 @@ function buildLightContextSections(task, workspaceDir, worktreeInfo, isTruthyMet
   // matters in production — every `tui`/`cli` provider returns from the light
   // path above and never reaches the other two, so a fix applied only there is
   // no fix at all for anything a subscription-quota job can run.
-  if (noCodeOutput) {
+  if (toolFreeReasoning) {
+    // No tools at all: the reply is the deliverable (see the full path's
+    // tuiCompletionSection ternary for the same precedence).
+    contractSections.push(buildToolFreeReasoningCompletionSection());
+  } else if (noCodeOutput) {
     contractSections.push(buildActionOutputCompletionSection({
       isTui,
       sentinelPath: resolveSentinelPath(worktreeInfo, workspaceDir, agentId),

--- a/server/services/agentPromptBuilder.test.js
+++ b/server/services/agentPromptBuilder.test.js
@@ -281,6 +281,29 @@ describe('reconcileSplitContext', () => {
   });
 });
 
+describe('tool-free public-review stage completion', () => {
+  // The Eligibility Gate runs with every tool removed. The No-Code contract
+  // (deliver via an API call, then write the sentinel) sent the model narrating
+  // "I will now update PortOS" instead of printing the JSON envelope.
+  const gateTask = () => makeTask({
+    metadata: {
+      context: 'Security scan status: passed.', noCodeOutput: true, discardWorktree: true, openPR: false,
+      executionProfile: 'public-review-gate',
+    },
+  });
+
+  it('tells the model its reply is the deliverable and never mentions a sentinel or API action', () => {
+    const prompt = buildLightContextPrompt(gateTask(), '/repo', null, isTruthyMeta, {
+      providerId: 'claude-ollama', providerCommand: 'claude',
+    });
+    expect(prompt).toMatch(/## Completion \(Tool-Free Reasoning\)/);
+    expect(prompt).toMatch(/final message of this reply/);
+    expect(prompt).not.toMatch(/## Completion \(No Code Output\)/);
+    expect(prompt).not.toMatch(/\.agent-done/);
+    expect(prompt).not.toMatch(/API request or command/);
+  });
+});
+
 describe('no-code / API-action task completion (CD agents must NOT be told to /do:push)', () => {
   // A Creative Director agent's deliverable is an HTTP PATCH described in its
   // prompt, not a commit — so it must get the No-Code completion section, never

--- a/server/services/agentPromptBuilder.test.js
+++ b/server/services/agentPromptBuilder.test.js
@@ -304,6 +304,22 @@ describe('tool-free public-review stage completion', () => {
   });
 });
 
+describe('sandboxed public-review actions stage completion', () => {
+  // Stage 3 has tools and a discarded worktree; its deliverable is the JSON
+  // payload in the sentinel, which the No-Code contract explicitly disclaims.
+  it('gets the programmatic-output sentinel contract, not the API-action one', () => {
+    const task = makeTask({
+      metadata: { noCodeOutput: true, discardWorktree: true, openPR: false, executionProfile: 'public-review-actions' },
+    });
+    const prompt = buildLightContextPrompt(task, '/repo', null, isTruthyMeta, {
+      providerId: 'codex-tui', providerCommand: 'codex',
+    });
+    expect(prompt).toMatch(/exact payload format described in your task instructions/);
+    expect(prompt).not.toMatch(/## Completion \(No Code Output\)/);
+    expect(prompt).not.toMatch(/## Completion \(Tool-Free Reasoning\)/);
+  });
+});
+
 describe('no-code / API-action task completion (CD agents must NOT be told to /do:push)', () => {
   // A Creative Director agent's deliverable is an HTTP PATCH described in its
   // prompt, not a commit — so it must get the No-Code completion section, never

--- a/server/services/cosTaskStore.js
+++ b/server/services/cosTaskStore.js
@@ -577,11 +577,17 @@ export async function addTask(taskData, taskType = 'user', { raw = false, ignore
   // NOTE and re-classifying a multi-line edit of it would overwrite the task's
   // real prompt. A producer that already wrote `metadata.prompt` wins over the
   // inference. See `server/lib/cosTaskPrompt.js` for the full contract.
-  const splitMetadata = splitTaskPromptFields(newTask.metadata);
-  if (splitMetadata !== newTask.metadata) newTask = { ...newTask, metadata: splitMetadata };
   // Markdown task rows are one-line records. Preserve every generated prompt
   // in the newline-safe metadata field before persistence, including raw
   // on-demand tasks that bypass the queue generator's normalization pass.
+  //
+  // This runs BEFORE the context reclassification below on purpose: a producer
+  // that hands over a multi-line description AND a multi-line context note (the
+  // pr-reviewer generator's security-scan summary) means the description is the
+  // prompt and the note is the note. Reclassifying first promoted the note to
+  // `prompt`, which then counted as an explicit producer prompt and silently
+  // discarded the stage instructions — Stage 2 ran with no gate rules and no
+  // output contract.
   if (typeof newTask.description === 'string' && newTask.description.includes('\n')) {
     newTask = {
       ...newTask,
@@ -594,6 +600,8 @@ export async function addTask(taskData, taskType = 'user', { raw = false, ignore
       },
     };
   }
+  const splitMetadata = splitTaskPromptFields(newTask.metadata);
+  if (splitMetadata !== newTask.metadata) newTask = { ...newTask, metadata: splitMetadata };
 
   // Add task to top or bottom based on position parameter
   if (taskData.position === 'top') {

--- a/server/services/cosTaskStore.test.js
+++ b/server/services/cosTaskStore.test.js
@@ -419,6 +419,30 @@ describe('cosTaskStore.addTask', () => {
       expect(reloaded.metadata.prompt).toBe(fullPrompt);
     });
 
+    it('keeps a multiline raw description as the prompt when a multiline context note rides along', async () => {
+      // The pr-reviewer generator hands over the stage instructions as the
+      // description and the security-scan summary as a multi-line context note.
+      // Reclassifying the note first made it the "explicit" prompt and dropped
+      // the instructions, so Stage 2 ran with no gate rules and no output contract.
+      const stagePrompt = '[Improvement: Example] PR Eligibility Gate (Stage 2)\n\n## Gate\n\nReturn JSON only.';
+      const scanNote = 'Security scan status: passed.\nReviewed 1 external pull request.';
+      const created = await addTask({
+        id: 'sys-stage-with-note',
+        status: 'pending',
+        priority: 'MEDIUM',
+        priorityValue: 2,
+        description: stagePrompt,
+        metadata: { context: scanNote },
+        section: 'pending',
+      }, 'internal', { raw: true });
+      expect(created.description).toBe('[Improvement: Example] PR Eligibility Gate (Stage 2)');
+      expect(created.metadata.prompt).toBe(stagePrompt);
+      expect(created.metadata.context).toBe(scanNote);
+      const reloaded = await getTaskById('sys-stage-with-note');
+      expect(reloaded.metadata.prompt).toBe(stagePrompt);
+      expect(reloaded.metadata.context).toBe(scanNote);
+    });
+
     it('preserves an explicitly empty prompt while normalizing a multiline raw description', async () => {
       const created = await addTask({
         id: 'sys-cleared-scheduled-prompt',

--- a/server/services/promptSections/completion.js
+++ b/server/services/promptSections/completion.js
@@ -45,7 +45,12 @@ export function buildCompletionGuidelineBullet({
   isReadOnly, isTui, tuiCompletionCommand, slashdoFree = false,
   worktreeInfo, willOpenPR, prCompletion = PR_COMPLETIONS.MERGE_ON_GREEN, discardWorktree = false, noCodeOutput = false,
   leavePrOpen = false, isPrFollowUp = false, claimFlow = false, noChangeSuccess = false, whenDone = null,
+  toolFreeReasoning = false,
 }) {
+  // Checked before every other contract: a tool-free stage cannot write a
+  // sentinel, call an API, or run a command, so any of the bullets below would
+  // send it chasing an output channel it does not have.
+  if (toolFreeReasoning) return TOOL_FREE_REASONING_BULLET;
   // A PR follow-up (review-loop or merge-only) already carries its own PRIMARY
   // OBJECTIVE section with the full procedure, and its cleanup runs with
   // `skipMerge`. The generic "your branch is merged back automatically" bullet
@@ -185,6 +190,23 @@ straight to your completion step and report that. If a PR is already **open**,
 finish/land that PR rather than opening a second one. Do NOT redo completed work,
 and do NOT revert its commits unless they are actually wrong.
 `;
+}
+
+const TOOL_FREE_REASONING_BULLET = '**You have no tools.** Do not try to run commands, read or write files, or call an API — none of that is available. Your entire deliverable is the final message of this reply: the exact JSON object described in your task instructions, and nothing after it. PortOS reads it from the transcript.';
+
+/**
+ * Completion block for a **tool-free reasoning** stage (pr-reviewer's
+ * Eligibility Gate). The CLI runs with every tool removed, so the sentinel and
+ * API-action contracts are impossible to satisfy; the only channel out is the
+ * reply itself, which PortOS parses for the task's JSON envelope.
+ */
+export function buildToolFreeReasoningCompletionSection() {
+  return [
+    '## Completion (Tool-Free Reasoning)',
+    TOOL_FREE_REASONING_BULLET,
+    '',
+    'Do not narrate a plan to apply the decision, and do not wait for anything after the JSON — the reply ends there.',
+  ].join('\n');
 }
 
 /**


### PR DESCRIPTION
## Summary

Fourth batch from the live run of the pr-reviewer pipeline on PR #5906 (after #5947, #5948, #5950). With Stage 2 authenticating, its transcript showed the model narrating "I will now proceed to update PortOS" instead of returning the JSON decision, and the prompt on disk contained only the scan context, not the gate instructions.

- **Pipeline stage tasks lost their instructions.** Since the #4153 prompt/note split, `addTask` reclassified the generator's multi-line security-scan context into `metadata.prompt` before promoting the multi-line description, so the description (the stage prompt) counted as superseded and was dropped. The description is promoted first now; a multi-line context stays the note. Test pins the pr-reviewer shape.
- **Every later stage inherited the previous stage's prompt.** The hand-off spread `metadata.prompt` into the next stage task, so its own description was never promoted either. The hand-off now drops the inherited prompt (test added).
- **The tool-free gate was told to deliver via an API call and a sentinel file**, neither of which it can produce. A tool-free public-review stage now gets a `Completion (Tool-Free Reasoning)` section on both prompt paths: the final message is the JSON, nothing else (test added on the light-context path the CLI/TUI providers use).

Offline check: the complete Stage 2 prompt against the Ollama-backed Claude wrapper (`gemma3:27b`) returns a valid envelope for #5906 with `eligible: true` under the maintainer-targeted waiver.

## Test plan

- [x] `npx vitest run services/cosTaskStore.test.js services/agentCompletionCleanup.test.js services/agentPromptBuilder.test.js services/promptSections`
- [ ] Live: re-run "Review this PR" on #5906 after the server restarts; Stage 2 records an eligibility decision and Stage 3 spawns