### PR TITLE
Read the direct-CLI output spool when rescuing a printed pr-reviewer decision

### DIFF
--- a/server/services/agentFinalization.js
+++ b/server/services/agentFinalization.js
@@ -1097,7 +1097,13 @@ async function rescueTranscriptPayload({ agentId, taskType }) {
     const isPayload = await getTaskOutputPayloadPredicate(taskType);
     if (!isPayload) return null;
     const { PATHS, readFileTail } = await import('../lib/fileUtils.js');
-    const transcript = await readFileTail(join(PATHS.cosAgents, agentId, 'raw.txt'), TRANSCRIPT_RESCUE_TAIL_BYTES);
+    // A PTY/TUI run spools its terminal to raw.txt; a direct CLI run (every
+    // public-review stage, and any cli-typed provider) has only output.txt.
+    // Reading raw.txt alone made the tool-free Eligibility Gate's printed JSON
+    // invisible, so a valid decision was rejected as eligibility-response-invalid.
+    const agentDir = join(PATHS.cosAgents, agentId);
+    const transcript = await readFileTail(join(agentDir, 'raw.txt'), TRANSCRIPT_RESCUE_TAIL_BYTES)
+      || await readFileTail(join(agentDir, 'output.txt'), TRANSCRIPT_RESCUE_TAIL_BYTES);
     if (!transcript) return null;
     const { extractSentinelPayloadFromTranscript } = await import('../lib/agentSentinel.js');
     const { payload } = await extractSentinelPayloadFromTranscript(transcript, isPayload);

--- a/server/services/agentFinalization.transcriptRescue.test.js
+++ b/server/services/agentFinalization.transcriptRescue.test.js
@@ -79,14 +79,14 @@ const printedTranscript = (answer = REASONER_ANSWER, { echoSchema = false } = {}
 ].join('');
 
 let agentId = 0;
-const setupRun = ({ transcript, sentinel = null }) => {
+const setupRun = ({ transcript, sentinel = null, spool = 'raw.txt' }) => {
   agentId += 1;
   const id = `agent-${agentId}`;
   const agentDir = join(TEMP_ROOT, 'cos/agents', id);
   const workspace = join(TEMP_ROOT, 'workspaces', id);
   mkdirSync(agentDir, { recursive: true });
   mkdirSync(workspace, { recursive: true });
-  if (transcript !== null) writeFileSync(join(agentDir, 'raw.txt'), transcript);
+  if (transcript !== null) writeFileSync(join(agentDir, spool), transcript);
   // The sentinel filename is scoped to the agent instance (doneSentinelName).
   if (sentinel !== null) writeFileSync(join(workspace, `.agent-done-${id}`), sentinel);
   return { agentId: id, workspacePath: workspace };
@@ -114,6 +114,17 @@ describe('printed-payload transcript rescue (#3640)', () => {
 
     expect(hook).toHaveBeenCalledWith(expect.objectContaining({
       success: true,
+      payload: { analysis: 'Nothing worth proposing this cycle.', proposal: null, pause: null },
+    }));
+  });
+
+  it('reads output.txt when the run was a direct CLI spawn with no raw.txt spool', async () => {
+    // Every public-review stage spawns the CLI directly (stream-json to
+    // output.txt); only the PTY spawner writes raw.txt. Reading raw.txt alone
+    // rejected the tool-free Eligibility Gate's printed decision as invalid.
+    const hook = await runDispatch({ transcript: printedTranscript(), spool: 'output.txt' });
+
+    expect(hook).toHaveBeenCalledWith(expect.objectContaining({
       payload: { analysis: 'Nothing worth proposing this cycle.', proposal: null, pause: null },
     }));
   });


### PR DESCRIPTION
## Summary

Fifth batch from the live run of the pr-reviewer pipeline on PR #5906 (after #5947, #5948, #5950, #5952). Stage 2 now runs to completion and prints a valid eligibility envelope, but the output hook rejected it three times (`eligibility-response-invalid`) and blocked the task.

- **The transcript rescue only read `raw.txt`**, which the PTY/TUI spawner writes. Every public-review stage spawns its CLI directly and streams to `output.txt`, so the printed decision was never seen. The rescue now falls back to `output.txt` (test added on the real dispatch path with an on-disk agent dir).

Offline, the same transcript and live task record pass `prReviewerPipeline.processTaskOutput` with `action: eligibility-evaluated`.

## Test plan

- [x] `npx vitest run services/agentFinalization.transcriptRescue.test.js`
- [ ] Live: re-run "Review this PR" on #5906 after the server restarts; Stage 2 records the decision and Stage 3 spawns