### PR TITLE
fix: try each transcript spool until one yields a payload, not the first that exists

### DIFF
--- a/server/services/agentFinalization.js
+++ b/server/services/agentFinalization.js
@@ -1067,13 +1067,23 @@ export async function finalizeAgent({
   return { success, prVerdict: effectivePrVerdict };
 }
 
-// Tail of the agent's raw PTY spool scanned by the transcript rescue. The
-// deliverable, when printed, is the LAST thing the model emits, and a reasoner
-// envelope is a few KB at most — but a repaint-heavy TUI spends most of its
-// bytes on escape sequences, so the window is generous relative to the payload.
-// Bounded for the same reason RAW_TAIL_ANALYSIS_BYTES is: raw.txt has no upper
+// Tail of the agent's transcript scanned by the rescue. The deliverable, when
+// printed, is the LAST thing the model emits, and a reasoner envelope is a few
+// KB at most — but a repaint-heavy TUI spends most of its bytes on escape
+// sequences, so the window is generous relative to the payload. Bounded for the
+// same reason RAW_TAIL_ANALYSIS_BYTES is: neither transcript file has an upper
 // size limit on a long run.
 const TRANSCRIPT_RESCUE_TAIL_BYTES = 256 * 1024;
+
+// Transcript spools, in the order the rescue reads them. A PTY/TUI run spools
+// its terminal to raw.txt; a direct CLI run (every public-review stage, and any
+// cli-typed provider) has ONLY output.txt, so reading raw.txt alone made the
+// tool-free Eligibility Gate's printed JSON invisible and a valid decision was
+// rejected as eligibility-response-invalid. Each source is tried until one
+// yields a payload rather than stopping at the first that merely EXISTS: a
+// repaint-heavy raw.txt can interleave the answer past reconstruction while the
+// parsed output.txt beside it still holds it intact.
+const TRANSCRIPT_RESCUE_FILES = ['raw.txt', 'output.txt'];
 
 /**
  * Recover a programmatic-I/O deliverable the agent PRINTED to its terminal
@@ -1097,17 +1107,14 @@ async function rescueTranscriptPayload({ agentId, taskType }) {
     const isPayload = await getTaskOutputPayloadPredicate(taskType);
     if (!isPayload) return null;
     const { PATHS, readFileTail } = await import('../lib/fileUtils.js');
-    // A PTY/TUI run spools its terminal to raw.txt; a direct CLI run (every
-    // public-review stage, and any cli-typed provider) has only output.txt.
-    // Reading raw.txt alone made the tool-free Eligibility Gate's printed JSON
-    // invisible, so a valid decision was rejected as eligibility-response-invalid.
-    const agentDir = join(PATHS.cosAgents, agentId);
-    const transcript = await readFileTail(join(agentDir, 'raw.txt'), TRANSCRIPT_RESCUE_TAIL_BYTES)
-      || await readFileTail(join(agentDir, 'output.txt'), TRANSCRIPT_RESCUE_TAIL_BYTES);
-    if (!transcript) return null;
     const { extractSentinelPayloadFromTranscript } = await import('../lib/agentSentinel.js');
-    const { payload } = await extractSentinelPayloadFromTranscript(transcript, isPayload);
-    return payload ?? null;
+    for (const file of TRANSCRIPT_RESCUE_FILES) {
+      const transcript = await readFileTail(join(PATHS.cosAgents, agentId, file), TRANSCRIPT_RESCUE_TAIL_BYTES);
+      if (!transcript) continue;
+      const { payload } = await extractSentinelPayloadFromTranscript(transcript, isPayload);
+      if (payload != null) return payload;
+    }
+    return null;
   } catch (err) {
     emitLog('warn', `⚠️ Transcript payload rescue failed for ${agentId} (${taskType}): ${err.message}`, { agentId });
     return null;

--- a/server/services/agentFinalization.transcriptRescue.test.js
+++ b/server/services/agentFinalization.transcriptRescue.test.js
@@ -3,7 +3,8 @@
  * TUI instead of writing to `.agent-done` (#3640).
  *
  * Drives the real `dispatchTaskOutputHookOnce` against an on-disk agent dir
- * (raw.txt spool) and an on-disk workspace, so the "sentinel absent" branch and
+ * (the raw.txt PTY spool a TUI run writes, and the output.txt a CLI/direct run
+ * writes instead) and an on-disk workspace, so the "sentinel absent" branch and
  * the tail read are exercised end to end rather than stubbed.
  */
 import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -79,7 +80,7 @@ const printedTranscript = (answer = REASONER_ANSWER, { echoSchema = false } = {}
 ].join('');
 
 let agentId = 0;
-const setupRun = ({ transcript, sentinel = null, spool = 'raw.txt' }) => {
+const setupRun = ({ transcript, sentinel = null, spool = 'raw.txt', output = null }) => {
   agentId += 1;
   const id = `agent-${agentId}`;
   const agentDir = join(TEMP_ROOT, 'cos/agents', id);
@@ -87,6 +88,9 @@ const setupRun = ({ transcript, sentinel = null, spool = 'raw.txt' }) => {
   mkdirSync(agentDir, { recursive: true });
   mkdirSync(workspace, { recursive: true });
   if (transcript !== null) writeFileSync(join(agentDir, spool), transcript);
+  // `output` writes a SECOND spool beside `transcript`, for the cases where a
+  // run has both files and only one of them carries the deliverable.
+  if (output !== null) writeFileSync(join(agentDir, 'output.txt'), output);
   // The sentinel filename is scoped to the agent instance (doneSentinelName).
   if (sentinel !== null) writeFileSync(join(workspace, `.agent-done-${id}`), sentinel);
   return { agentId: id, workspacePath: workspace };
@@ -199,5 +203,28 @@ describe('printed-payload transcript rescue (#3640)', () => {
     const hook = await runDispatch({ transcript: null });
 
     expect(hook).toHaveBeenCalledWith(expect.objectContaining({ payload: null }));
+  });
+
+  // Both spools exist: a TUI run whose repaint-mangled raw.txt yields nothing
+  // must still reach the parsed output.txt beside it, so stopping at the first
+  // file that merely EXISTS is not enough.
+  it('falls through to output.txt when raw.txt holds no deliverable', async () => {
+    const hook = await runDispatch({
+      transcript: printedTranscript('{"tokens": 1200, "cost": 0.03}'),
+      output: printedTranscript(),
+    });
+
+    expect(hook).toHaveBeenCalledWith(expect.objectContaining({
+      payload: { analysis: 'Nothing worth proposing this cycle.', proposal: null, pause: null },
+    }));
+  });
+
+  it('prefers the raw PTY spool over output.txt when both carry a deliverable', async () => {
+    const hook = await runDispatch({
+      transcript: printedTranscript('{"analysis": "from raw spool", "proposal": null}'),
+      output: printedTranscript('{"analysis": "from parsed output", "proposal": null}'),
+    });
+
+    expect(hook.mock.calls[0][0].payload.analysis).toBe('from raw spool');
   });
 });


### PR DESCRIPTION
## Summary

Follow-up hardening on `159b8ed41`, which taught the printed-payload rescue to read `output.txt` as well as `raw.txt`.

- **The rescue stopped at the first spool it could READ, not the first that held a payload.** It only fell through to `output.txt` when `raw.txt` was absent or empty.
- A TUI run has **both** files. A `raw.txt` whose repaints interleaved the model's answer past reconstruction ends the rescue there — the parsed `output.txt` beside it, which usually holds the same answer intact, is never consulted, and the output hook is handed a `null` payload.
- Now the spools are walked in order and the first that yields a payload the owning hook's own shape predicate accepts wins. `raw.txt` stays first, so a TUI run that already worked is unchanged, and the CLI-only case `159b8ed41` fixed is unchanged too.

### Investigation context

Filed from the `eligibility-response-invalid` investigation on `app-improve-portos-default-pr-reviewer-mtkv9emn`. Root cause confirmed: the tool-free Eligibility Gate ran headless (direct CLI), printed a complete and correct decision envelope as its final message per its own system prompt, and finalize found no `.agent-done` and no `raw.txt` — so the hook received `null` and scored the run invalid. `159b8ed41` (a concurrently-dispatched sibling agent) shipped that fix ~4 minutes ahead of this branch; this PR carries only the delta that survived the rebase.

## Test plan

- `cd server && npm test` — full server suite green (1878 files / 37854 tests) before the rebase; `agentFinalization`, `prReviewerPipeline`, `agentCliSpawning`, `agentTuiSpawning` (11 files / 319 tests) re-run green after it.
- Two new cases in `agentFinalization.transcriptRescue.test.js`: fall-through when `raw.txt` holds no deliverable, and `raw.txt` precedence when both spools carry one.
- Verified offline that the failing run's real `output.txt` extracts to the exact expected eligibility payload via `extractSentinelPayloadFromTranscript` + `isEligibilityPayload`.