### PR TITLE
test: add known-answer vectors for signalCrypto key derivation

### DIFF
--- a/server/lib/signalCrypto.test.js
+++ b/server/lib/signalCrypto.test.js
@@ -15,9 +15,53 @@ import {
   SAFE_STORAGE_IV,
 } from './signalCrypto.js';
 
+// ---------------------------------------------------------------------------
+// Known-answer vectors (KAT)
+//
+// signalCrypto implements two formats it does NOT own — SQLCipher-4 and
+// Chromium's macOS OSCrypt/safeStorage — so "correct" means "matches what
+// SQLCipher / Signal Desktop actually wrote on disk", not "round-trips against
+// itself". Every value below was produced by an INDEPENDENT tool (the exact
+// command is quoted above each one) and pasted as a literal. Never regenerate
+// them with deriveSafeStorageKey/deriveSqlcipherKeys: a wrong constant would
+// then be applied to both halves and the assertion would pass anyway. Each
+// command was additionally cross-checked against `openssl kdf ... PBKDF2`.
+// ---------------------------------------------------------------------------
+
+// Inputs the vectors were generated from (also the inputs the assertions feed
+// back into the production functions).
+const KAT_KEYCHAIN_PASSWORD = 'a-random-keychain-password';
+const KAT_SQLCIPHER_PASSPHRASE = 'correct horse battery staple';
+const KAT_SQLCIPHER_SALT = Buffer.from('000102030405060708090a0b0c0d0e0f', 'hex');
+const KAT_RAW_KEY_HEX = 'a'.repeat(64);
+const KAT_RAW_KEY_SALT = Buffer.alloc(16, 9);
+
+const KAT = {
+  // python3 -c "import hashlib; print(hashlib.pbkdf2_hmac('sha1', b'a-random-keychain-password', b'saltysalt', 1003, 16).hex())"
+  safeStorageKey: '5f7c922c2a8d144bfd90534c281820ee',
+
+  // python3 -c "import hashlib; print(hashlib.pbkdf2_hmac('sha512', b'correct horse battery staple', bytes.fromhex('000102030405060708090a0b0c0d0e0f'), 256000, 32).hex())"
+  sqlcipherPassphraseEncKey: '2c6ee106931bbdc6ea7e33497f04526ccbe4fb541379d36a506a65eabed0d8e2',
+
+  // HMAC salt is the file salt XOR 0x3a → 3f3e3d3c3b3a39383736353433323130
+  // python3 -c "import hashlib; print(hashlib.pbkdf2_hmac('sha512', bytes.fromhex('2c6ee106931bbdc6ea7e33497f04526ccbe4fb541379d36a506a65eabed0d8e2'), bytes.fromhex('3f3e3d3c3b3a39383736353433323130'), 2, 32).hex())"
+  sqlcipherPassphraseHmacKey: 'cb8c37560a8a82af03be930057ace6a4115e87b6df6385b1df6c1edabd4a1813',
+
+  // Raw-key mode: encKey is the 32 bytes of 'a'.repeat(64) verbatim, file salt is
+  // 16 x 0x09 → HMAC salt 16 x 0x33.
+  // python3 -c "import hashlib; print(hashlib.pbkdf2_hmac('sha512', bytes.fromhex('aa'*16), bytes.fromhex('33'*16), 2, 32).hex())"
+  sqlcipherRawHmacKey: '3108bc4e02b717113520682a69e67022b92e37416c26b9ae904bb7ca3ae94182',
+};
+
 // Re-implement SQLCipher-4 *encryption* here so the decryptor can be verified
 // against a known-good round trip — no real Signal DB required. This mirrors the
 // exact page layout decryptSqlcipherDatabase expects.
+//
+// This deliberately reuses the PRODUCTION deriveSqlcipherKeys: the fixture must
+// be keyed identically to the decryptor for the round trip to mean anything. The
+// KAT block above is what makes that safe — it pins the derivation itself to an
+// externally computed answer, so a wrong constant can no longer cancel out
+// across both halves of this round trip.
 function encryptSqlcipherDatabase(plaintext, rawKeyHex, salt) {
   const { encKey, hmacKey } = deriveSqlcipherKeys(rawKeyHex, salt);
   const totalPages = plaintext.length / SQLCIPHER_PAGE_SIZE;
@@ -73,12 +117,10 @@ describe('signalCrypto — SQLCipher key derivation', () => {
   });
 
   it('derives a distinct HMAC key via the fast 2-round PBKDF2 over the salt XOR 0x3a', () => {
-    const hex = 'a'.repeat(64);
-    const salt = Buffer.alloc(16, 9);
-    const { encKey, hmacKey } = deriveSqlcipherKeys(hex, salt);
-    const hmacSalt = Buffer.from(salt.map((b) => b ^ 0x3a));
-    const expected = crypto.pbkdf2Sync(encKey, hmacSalt, 2, 32, 'sha512');
-    expect(hmacKey.equals(expected)).toBe(true);
+    const { encKey, hmacKey } = deriveSqlcipherKeys(KAT_RAW_KEY_HEX, KAT_RAW_KEY_SALT);
+    // Asserted against the externally generated vector, NOT a local re-derivation
+    // with the implementation's own constants.
+    expect(hmacKey.toString('hex')).toBe(KAT.sqlcipherRawHmacKey);
     expect(hmacKey.equals(encKey)).toBe(false);
   });
 
@@ -128,7 +170,7 @@ describe('signalCrypto — SQLCipher page decryption', () => {
 });
 
 describe('signalCrypto — Chromium safeStorage decryption', () => {
-  const password = 'a-random-keychain-password';
+  const password = KAT_KEYCHAIN_PASSWORD;
 
   function encryptSafeStorage(plaintextStr, prefix = 'v10') {
     const key = deriveSafeStorageKey(password);
@@ -167,5 +209,39 @@ describe('signalCrypto — Chromium safeStorage decryption', () => {
 
   it('reports an empty value', () => {
     expect(decryptSafeStorageValue(Buffer.alloc(0), password).reason).toBe('empty');
+  });
+});
+
+describe('signalCrypto — known-answer vectors', () => {
+  it('derives the Chromium safeStorage key (known-answer vector)', () => {
+    // Pins SAFE_STORAGE_SALT, SAFE_STORAGE_ITER_MACOS (1003), the SHA-1 digest
+    // and the 16-byte AES-128 key length — all invisible to a round-trip test.
+    expect(deriveSafeStorageKey(KAT_KEYCHAIN_PASSWORD).toString('hex')).toBe(KAT.safeStorageKey);
+  });
+
+  it('derives the SQLCipher-4 passphrase key with the slow KDF (known-answer vector)', () => {
+    // The only test that reaches the non-raw-key branch of deriveSqlcipherKeys.
+    // Pins SQLCIPHER_KDF_ITER (256000), the SHA-512 digest and the 32-byte key
+    // length; the HMAC half additionally pins the 0x3a salt mask.
+    const { encKey, hmacKey } = deriveSqlcipherKeys(KAT_SQLCIPHER_PASSPHRASE, KAT_SQLCIPHER_SALT);
+    expect(encKey.toString('hex')).toBe(KAT.sqlcipherPassphraseEncKey);
+    expect(hmacKey.toString('hex')).toBe(KAT.sqlcipherPassphraseHmacKey);
+  });
+
+  it('a wrong iteration count, digest, or salt mask fails the known-answer vectors (bypass probe)', () => {
+    // Proves the vectors are sensitive to the constants they guard — i.e. that
+    // they were not accidentally regenerated from the implementation.
+    const offByOne = crypto.pbkdf2Sync(KAT_KEYCHAIN_PASSWORD, 'saltysalt', 1002, 16, 'sha1');
+    expect(offByOne.toString('hex')).not.toBe(KAT.safeStorageKey);
+    const wrongDigest = crypto.pbkdf2Sync(KAT_KEYCHAIN_PASSWORD, 'saltysalt', 1003, 16, 'sha256');
+    expect(wrongDigest.toString('hex')).not.toBe(KAT.safeStorageKey);
+    const wrongMask = crypto.pbkdf2Sync(
+      Buffer.from(KAT_RAW_KEY_HEX, 'hex'),
+      Buffer.from(KAT_RAW_KEY_SALT.map((b) => b ^ 0x3b)),
+      2,
+      32,
+      'sha512',
+    );
+    expect(wrongMask.toString('hex')).not.toBe(KAT.sqlcipherRawHmacKey);
   });
 });


### PR DESCRIPTION
## Summary

`server/lib/signalCrypto.js` implements two wire formats it does not own — SQLCipher-4 page encryption and Chromium's macOS `safeStorage` blob. "Correct" therefore means *matches what SQLCipher / Signal Desktop actually wrote on disk*, but every decryption test built its fixture with a test-local encryptor that called the **production** derivation functions. A wrong PBKDF2 round count, digest, salt mask, or key length was applied symmetrically to both halves, so the round trip stayed green while a real Signal database would fail to open. The HMAC-key test compounded this by re-stating the implementation's own constants as its expectation, and the passphrase branch of `deriveSqlcipherKeys` (slow PBKDF2-SHA512 KDF) had no coverage at all.

This PR adds known-answer vectors as the anchor. No production behaviour changes — the diff is `server/lib/signalCrypto.test.js` only.

- **`KAT` block** of externally generated hex literals. Each carries the exact `python3 -c "import hashlib; ..."` command that produced it so a reviewer can re-derive it; each was additionally cross-checked against `openssl kdf ... PBKDF2`. The block's header comment states the rule that keeps it honest: never regenerate these with `deriveSafeStorageKey` / `deriveSqlcipherKeys`.
- **`derives the Chromium safeStorage key`** — pins `SAFE_STORAGE_SALT`, `SAFE_STORAGE_ITER_MACOS` (1003), the SHA-1 digest and the 16-byte AES-128 key length.
- **`derives the SQLCipher-4 passphrase key with the slow KDF`** — pins `SQLCIPHER_KDF_ITER` (256000), the SHA-512 digest and the 32-byte key length, and is the first test to execute the non-raw-key branch of `deriveSqlcipherKeys` at all. Its HMAC half also pins the `0x3a` salt mask.
- **Bypass probe** — asserts a 1002-round derivation, a SHA-256 derivation, and a `0x3b` salt mask each *fail* the vectors, proving the pasted values are sensitive to the constants they guard rather than having been quietly regenerated from the implementation.
- **Rewrote** the existing `derives a distinct HMAC key via the fast 2-round PBKDF2 over the salt XOR 0x3a` to assert against a pasted vector instead of re-deriving with `crypto.pbkdf2Sync` and the implementation's own arguments.
- **Documented** above `encryptSqlcipherDatabase` that it deliberately reuses the production derivation, and that the KAT block is what makes that safe.

Out of scope, per the issue: no real Signal database fixture (that would be user data), and no change to `signalCrypto.js`. No KAT revealed a wrong constant, so no follow-up bug issue was needed.

## Test plan

- `cd server && npm test -- signalCrypto` → 16 passed.
- `cd server && npm test` (full server suite) → 1878 files passed, 1 skipped; 37870 tests passed, 14 skipped.
- **Mutation-verified the acceptance criteria.** Each constant was flipped one at a time in `server/lib/signalCrypto.js`, the suite re-run, and the file restored:

  | mutation | result |
  | --- | --- |
  | `SAFE_STORAGE_ITER_MACOS` 1003 → 1002 | 1 failed |
  | `SQLCIPHER_KDF_ITER` 256000 → 255999 | 1 failed |
  | `SQLCIPHER_SALT_MASK` 0x3a → 0x3b | 2 failed |
  | `SAFE_STORAGE_SALT` `'saltysalt'` → `'saltysalx'` | 1 failed |
  | `SAFE_STORAGE_KEY_BYTES` 16 → 24 | 4 failed |
  | `SQLCIPHER_KEY_BYTES` 32 → 24 | 2 failed |
  | safeStorage digest `sha1` → `sha256` | 1 failed |

  Every one of these is invisible to the suite on `main` today. `git diff` against `server/lib/signalCrypto.js` is empty afterwards.

Closes #5723
