### PR TITLE
Advance the pr-reviewer pipeline when a directly-spawned stage completes

### DIFF
--- a/server/services/agentCliSpawning.js
+++ b/server/services/agentCliSpawning.js
@@ -879,6 +879,23 @@ export async function spawnDirectly({
       directPrClaimVerified = prClaimWasVerified(finalized?.prVerdict);
       noChangesToShip = finalized?.prVerdict?.noChangesToShip === true;
     } finally {
+      // Advance a staged pipeline exactly as the runner/TUI path does through
+      // runAgentCompletionCleanup. This path only ever ran finalize + worktree
+      // cleanup, so a stage that spawned directly — every public-review stage,
+      // any cli-typed provider — completed without queuing its successor: the
+      // pr-reviewer Eligibility Gate recorded its decision and the pipeline
+      // simply stopped. Before the worktree goes, since a stage precondition
+      // may read it. Lazy import for the same module-cycle reason as
+      // cleanupWorktreeFn; sanctioned try/catch — this is a child 'close'
+      // handler, not a request.
+      if (task?.metadata?.pipeline) {
+        try {
+          const { handlePipelineProgression } = await import('./agentCompletionCleanup.js');
+          await handlePipelineProgression(task, agentId, cleanupSuccess);
+        } catch (err) {
+          console.error(`❌ Pipeline progression failed for ${agentId}: ${err.message}`);
+        }
+      }
       const directPrCompletion = resolvePrCompletion(task.metadata);
       const directReviewLoopFollowUp = isTruthyMetaFn(task.metadata?.reviewLoopFollowUp);
       const reviewOptions = await resolveReviewLoopOptions(task.metadata, { normalize: normalizeReviewers, isTruthyMeta: isTruthyMetaFn });

--- a/server/services/agentCliSpawning.test.js
+++ b/server/services/agentCliSpawning.test.js
@@ -56,6 +56,9 @@ vi.mock('./agentFinalization.js', () => ({
   finalizeAgent: vi.fn().mockResolvedValue(undefined),
   releaseAgentLane: vi.fn(),
 }));
+vi.mock('./agentCompletionCleanup.js', () => ({
+  handlePipelineProgression: vi.fn().mockResolvedValue(undefined),
+}));
 vi.mock('./agentState.js', () => ({
   activeAgents: new Map(),
   userTerminatedAgents: new Set(),
@@ -1141,6 +1144,41 @@ describe('stream error containment', () => {
   // didn't have, and hand its worktree to cleanup, discarding the state a resume
   // needs. The run is abandoned instead, leaving the record `running` for the
   // next boot's orphan sweep to reconcile from the host-shutdown marker.
+  describe('pipeline progression on close', () => {
+    // The runner/TUI completion path advances a staged pipeline through
+    // runAgentCompletionCleanup; this direct path only ran finalize + worktree
+    // cleanup, so every directly-spawned stage (all public-review stages)
+    // completed without queuing its successor.
+    it('advances the pipeline before the worktree is cleaned up', async () => {
+      const { handlePipelineProgression } = await import('./agentCompletionCleanup.js');
+      handlePipelineProgression.mockClear();
+      const order = [];
+      handlePipelineProgression.mockImplementation(async () => { order.push('pipeline'); });
+      minimalArgs.cleanupWorktreeFn.mockImplementation(async () => { order.push('worktree'); });
+      const task = { id: 'task-1', description: 'stage', metadata: { pipeline: { status: 'running', currentStage: 1, stages: [{}, {}, {}] } } };
+
+      const spawnPromise = spawnDirectly({ ...minimalArgs, task });
+      await new Promise((r) => setTimeout(r, 10));
+      fakeProcess.emit('close', 0);
+      await spawnPromise.catch(() => {});
+      await new Promise((r) => setTimeout(r, 30));
+
+      expect(handlePipelineProgression).toHaveBeenCalledWith(task, 'agent-test', true);
+      expect(order).toEqual(['pipeline', 'worktree']);
+    });
+
+    it('does not touch pipeline progression for an ordinary task', async () => {
+      const { handlePipelineProgression } = await import('./agentCompletionCleanup.js');
+      handlePipelineProgression.mockClear();
+      const spawnPromise = spawnDirectly(minimalArgs);
+      await new Promise((r) => setTimeout(r, 10));
+      fakeProcess.emit('close', 0);
+      await spawnPromise.catch(() => {});
+      await new Promise((r) => setTimeout(r, 30));
+      expect(handlePipelineProgression).not.toHaveBeenCalled();
+    });
+  });
+
   describe('host restart (#3202)', () => {
     // The outer beforeEach re-sets implementations but not call history, and the
     // mocks are module-scoped — clear so "was it called" reads only this test.


### PR DESCRIPTION
## Summary

Sixth batch from the live run of the pr-reviewer pipeline on PR #5906. Stage 2 now completes with an accepted eligibility decision (`eligibility-evaluated`, PR #5906 eligible under the maintainer-targeted waiver), but Stage 3 was never queued.

- **The direct-spawn close handler never advanced a pipeline.** The runner/TUI completion path goes through `runAgentCompletionCleanup`, which calls `handlePipelineProgression`; the direct CLI path only ran finalize and worktree cleanup. Every public-review stage spawns directly, so the pipeline stopped after the gate. The direct path now advances the pipeline before the worktree is discarded (tests pin the call and its ordering, and that an ordinary task is untouched).

Driving `handlePipelineProgression` against the completed live task offline queued the Stage 3 task correctly, which is what the live path now does.

## Test plan

- [x] `npx vitest run services/agentCliSpawning.test.js`
- [ ] Live: Stage 3 (Code Review & Merge) spawns after the next Stage 2 completion