### PR TITLE
Restore the trailing newline on materialized pr-reviewer patches

### DIFF
--- a/server/services/modelAbuseGuard.js
+++ b/server/services/modelAbuseGuard.js
@@ -255,7 +255,11 @@ export async function materializePublicReviewPatches({ scanKey, workspacePath, a
     const filename = `PR-${pullRequest.number}.patch`;
     const relativePath = `${PUBLIC_REVIEW_PATCH_DIRNAME}/${filename}`;
     const destination = join(patchDir, filename);
-    await atomicWrite(destination, pullRequest.diff);
+    // The gh wrapper trims stdout, which drops the diff's final newline; git
+    // apply then rejects the file as "corrupt patch at line N". Restore it so
+    // the reviewer can apply the patch verbatim (the fingerprint is computed
+    // on the trimmed text upstream and is unaffected).
+    await atomicWrite(destination, pullRequest.diff.endsWith('\n') ? pullRequest.diff : `${pullRequest.diff}\n`);
     const restricted = await chmod(destination, 0o444).then(() => true).catch(() => false);
     if (!restricted) return false;
     patches.push({

--- a/server/services/modelAbuseGuard.materialize.test.js
+++ b/server/services/modelAbuseGuard.materialize.test.js
@@ -23,7 +23,8 @@ const pullRequests = [{
   headSha,
   title: 'docs: example change',
   body: '',
-  diff: 'diff --git a/README.md b/README.md\n+example\n',
+  // Trailing newline already stripped, as the gh wrapper's stdout trim leaves it.
+  diff: 'diff --git a/README.md b/README.md\n--- a/README.md\n+++ b/README.md\n@@ -1 +1 @@\n-old\n+example',
 }];
 
 let workspace;
@@ -45,7 +46,8 @@ describe('materializing the screened public-review snapshot', () => {
     expect(await materializePublicReviewPatches({ scanKey, workspacePath: workspace, allowedPullRequestNumbers: [42] })).toBe(true);
     const manifest = JSON.parse(await readFile(join(workspace, PUBLIC_REVIEW_PATCH_DIRNAME, PUBLIC_REVIEW_PATCH_MANIFEST_FILENAME), 'utf8'));
     expect(manifest.patches).toEqual([expect.objectContaining({ number: 42, headSha, path: `${PUBLIC_REVIEW_PATCH_DIRNAME}/PR-42.patch` })]);
-    expect(await readFile(join(workspace, PUBLIC_REVIEW_PATCH_DIRNAME, 'PR-42.patch'), 'utf8')).toBe(pullRequests[0].diff);
+    // git apply rejects a patch whose last line has no newline ("corrupt patch").
+    expect(await readFile(join(workspace, PUBLIC_REVIEW_PATCH_DIRNAME, 'PR-42.patch'), 'utf8')).toBe(`${pullRequests[0].diff}\n`);
     expect((await stat(join(workspace, PUBLIC_REVIEW_PATCH_DIRNAME, 'PR-42.patch'))).mode & 0o222).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary

Final batch from the live run of the pr-reviewer pipeline on PR #5906, which now completes all three stages and posts the coordinator's review.

- **Materialized patch files were missing their final newline.** The `gh pr diff` wrapper trims stdout, so `git apply --check` rejected the read-only patch copy as `corrupt patch at line N`; the Stage 3 reviewer had to repair the byte by hand and flagged it in its review. The patch file now always ends with a newline (the materialize test's fixture is trimmed the way the wrapper leaves it and asserts the restored byte).

## Test plan

- [x] `npx vitest run services/modelAbuseGuard.materialize.test.js`