### PR TITLE
Let the pr-reviewer coordinator release a fork PR's held CI run after it approves

### DIFF
--- a/server/services/issueWatcher.js
+++ b/server/services/issueWatcher.js
@@ -280,6 +280,34 @@ async function readPullRequest(ctx, number) {
   ], ctx);
 }
 
+// GitHub holds the workflow runs of a first-time fork contributor until a
+// maintainer clicks "Approve and run", so an approved external PR otherwise
+// sits at zero checks and never merges. CI is deliberately NOT started before
+// that point: an unreviewed or rejected PR must not spend runner minutes or
+// get a foothold on the runners. Only once the coordinator has posted its own
+// APPROVE on content it screened and reviewed does it approve the held runs
+// itself — and never when the PR edits a workflow file, since that run would
+// execute the contributor's workflow changes; those stay for a human.
+const WORKFLOW_PATH_RE = /^\.github\/workflows\//;
+const touchesWorkflowFiles = (pr) => (Array.isArray(pr?.files) ? pr.files : [])
+  .some((file) => WORKFLOW_PATH_RE.test(String(file?.path || '')));
+
+async function approveHeldWorkflowRuns(ctx, pr) {
+  if (touchesWorkflowFiles(pr)) return 0;
+  const runs = await runJson(apiArgs(ctx, `repos/${ctx.repoFullName}/actions/runs?head_sha=${pr.headRefOid}&status=action_required&per_page=20`), ctx);
+  const held = Array.isArray(runs?.workflow_runs) ? runs.workflow_runs : [];
+  let approved = 0;
+  for (const run of held) {
+    if (!Number.isInteger(run?.id)) continue;
+    const ok = await runGh(apiArgs(ctx, `repos/${ctx.repoFullName}/actions/runs/${run.id}/approve`, { method: 'POST' }), ctx)
+      .then(() => true)
+      .catch(() => false);
+    if (ok) approved += 1;
+  }
+  if (approved > 0) console.log(`✅ issue-watcher: approved ${approved} held workflow run(s) for PR #${pr.number}`);
+  return approved;
+}
+
 function sameNumberList(left, right) {
   const a = Array.isArray(left) ? left : [];
   const b = Array.isArray(right) ? right : [];
@@ -690,6 +718,9 @@ async function processPendingApprovals(app, ctx) {
       changed = true;
       continue;
     }
+    // A run GitHub is still holding for approval also shows up as no checks;
+    // this PR already carries the coordinator's APPROVE, so release it.
+    if (checkRollup.length === 0) await approveHeldWorkflowRuns(ctx, pr);
     // An empty rollup is ambiguous immediately after review: CI may simply not
     // have attached yet. A low-risk PR may skip CI only after two consecutive
     // scheduled observations see no checks. Active checks are never waived.
@@ -1037,6 +1068,7 @@ export async function processTaskOutput({ appId, success, payload, task, require
     }));
     if (!approved) continue;
     reviewed += 1;
+    await approveHeldWorkflowRuns(ctx, pr);
 
     const behindBy = await readBehindBy(ctx, pr);
     if (decision.rebaseRequired && (behindBy === null || behindBy > 0)) {

--- a/server/services/issueWatcher.test.js
+++ b/server/services/issueWatcher.test.js
@@ -91,9 +91,11 @@ function pullRequest(overrides = {}) {
 }
 
 function installDefaultGhMock({
-  pr = pullRequest(), issueRows = [[]], commentRows = [[]], reviews = [[]], issueDetails = {},
+  pr = pullRequest(), issueRows = [[]], commentRows = [[]], reviews = [[]], issueDetails = {}, heldRuns = [],
 } = {}) {
   execGhMock.mockImplementation(async (args) => {
+    if (args[0] === 'api' && args.some((arg) => String(arg).includes('/actions/runs?'))) return JSON.stringify({ workflow_runs: heldRuns });
+    if (args[0] === 'api' && args.some((arg) => String(arg).includes('/actions/runs/'))) return '';
     if (args[0] === 'api' && args.includes('repos/o/r') && !args.some((arg) => String(arg).includes('/issues'))
       && !args.some((arg) => String(arg).includes('/pulls/')) && !args.some((arg) => String(arg).includes('/compare/'))) {
       return JSON.stringify({ owner: { login: 'owner', type: 'User' }, default_branch: 'main' });
@@ -687,6 +689,72 @@ describe('processTaskOutput', () => {
     expect(followUp).toEqual({ skip: { reason: 'baselined' } });
     expect(mergePrMock).toHaveBeenCalledWith(APP.repoPath, 7);
     expect(apps.get(APP.id).issueWatcherState.approvedPullRequests).toEqual([]);
+  });
+
+  // GitHub holds a first-time fork contributor's workflow runs until a
+  // maintainer approves them. Left alone, an approved PR sits at zero checks
+  // for every sweep tick and is finally handed back as a notification — the
+  // exact hand-off the deterministic coordinator exists to make unnecessary.
+  // CI is released only AFTER the coordinator's own APPROVE, so an unreviewed
+  // or rejected PR never spends runner minutes.
+  it('approves a held workflow run after approving a fork PR, then merges once CI is green', async () => {
+    installDefaultGhMock({ pr: pullRequest({ statusCheckRollup: [] }), heldRuns: [{ id: 55 }] });
+    mergePrMock.mockResolvedValue({ success: true });
+    const payload = {
+      issueComments: [],
+      pullRequests: [{
+        number: 7, headSha: 'a'.repeat(40), verdict: 'approve', summary: 'Documentation-only and safe.', findings: [],
+        rebaseRequired: false, ciPolicy: 'required',
+      }],
+    };
+
+    const result = await processTaskOutput({ appId: APP.id, success: true, payload, task: { metadata } });
+
+    expect(result).toMatchObject({ reviewed: 1, merged: 0 });
+    const approveRun = execGhMock.mock.calls.find(([args]) => args.includes('repos/o/r/actions/runs/55/approve'));
+    expect(approveRun[0]).toContain('POST');
+    expect(mergePrMock).not.toHaveBeenCalled();
+
+    installDefaultGhMock({
+      pr: pullRequest({ statusCheckRollup: [{ conclusion: 'SUCCESS' }] }),
+      reviews: [[{ user: { login: 'owner' }, commit_id: 'a'.repeat(40), state: 'APPROVED' }]],
+    });
+    await buildTaskInput({ app: apps.get(APP.id) });
+    expect(mergePrMock).toHaveBeenCalledWith(APP.repoPath, 7);
+  });
+
+  it('does not release CI for a PR it did not approve', async () => {
+    installDefaultGhMock({ pr: pullRequest({ statusCheckRollup: [] }), heldRuns: [{ id: 55 }] });
+    const payload = {
+      issueComments: [],
+      pullRequests: [{
+        number: 7, headSha: 'a'.repeat(40), verdict: 'request_changes', summary: 'Needs work.', findings: [],
+        rebaseRequired: false, ciPolicy: 'required',
+      }],
+    };
+
+    await processTaskOutput({ appId: APP.id, success: true, payload, task: { metadata } });
+
+    expect(execGhMock.mock.calls.some(([args]) => args.some((arg) => String(arg).includes('/actions/runs')))).toBe(false);
+  });
+
+  it('leaves a held workflow run alone when the PR edits a workflow file', async () => {
+    installDefaultGhMock({
+      pr: pullRequest({ statusCheckRollup: [], files: [{ path: '.github/workflows/ci.yml' }] }),
+      heldRuns: [{ id: 55 }],
+    });
+    const payload = {
+      issueComments: [],
+      pullRequests: [{
+        number: 7, headSha: 'a'.repeat(40), verdict: 'approve', summary: 'CI tweak.', findings: [],
+        rebaseRequired: false, ciPolicy: 'required',
+      }],
+    };
+
+    const result = await processTaskOutput({ appId: APP.id, success: true, payload, task: { metadata } });
+
+    expect(result).toMatchObject({ reviewed: 1, merged: 0 });
+    expect(execGhMock.mock.calls.some(([args]) => args.some((arg) => String(arg).includes('/actions/runs/')))).toBe(false);
   });
 
   it('never waives an actively running check for a low-risk PR', async () => {


### PR DESCRIPTION
## Summary

On the live run of PR #5906 the pipeline completed all three stages and the deterministic coordinator posted its APPROVE, then parked on "CI or mergeability did not settle" every sweep. The PR's workflow run was in `action_required`: GitHub holds a first-time fork contributor's runs until a maintainer clicks "Approve and run", so an accepted PR still needed a human to finish the job.

- **The coordinator now approves the held workflow runs itself**, after its own APPROVE on screened, fingerprint-matched content, and again during the pending-merge sweep while the PR shows no checks. The next sweep merges on green as before.
- **CI is never started early.** A `request_changes` or `defer` verdict never touches the runs, so an unreviewed or rejected PR spends no runner minutes and gets no foothold on the runners.
- **PRs that edit `.github/workflows/` are never auto-released**, since that run would execute the contributor's workflow changes; those stay for a human.

Tests cover the approve-then-merge flow, the non-approve verdict, and the workflow-file guard.

## Test plan

- [x] `npx vitest run services/issueWatcher.test.js`
- [ ] Live: the next pending-merge sweep on PR #5906 approves its held run; CI attaches and the following sweep merges on green