### PR TITLE
feat: offer OpenCode, Kimi and MTPLX as code reviewers

### DIFF
--- a/client/src/components/cos/constants.js
+++ b/client/src/components/cos/constants.js
@@ -290,8 +290,11 @@ export const REVIEWER_OPTIONS = [
   { value: 'codex', label: 'Codex', description: 'Codex CLI reviews the PR diff (optional model tier on Models → Code Reviewers)' },
   { value: 'grok', label: 'Grok', description: 'Grok Build CLI (grok) reviews the PR diff' },
   { value: 'cursor', label: 'Cursor Agent', description: 'Cursor Agent CLI (cursor-agent) reviews the PR diff' },
+  { value: 'opencode', label: 'OpenCode', description: 'OpenCode CLI reviews the PR diff (optional provider/model on Models → Code Reviewers)' },
+  { value: 'kimi', label: 'Kimi', description: 'Kimi CLI reviews the PR diff (optional model on Models → Code Reviewers)' },
   { value: 'lmstudio', label: 'LM Studio', description: 'Local LM Studio model reviews the diff (set model on AI Providers)' },
-  { value: 'ollama', label: 'Ollama', description: 'Local Ollama model reviews the diff (set model on AI Providers)' }
+  { value: 'ollama', label: 'Ollama', description: 'Local Ollama model reviews the diff (set model on AI Providers)' },
+  { value: 'mtplx', label: 'MTPLX', description: 'Local MTPLX model reviews the diff (set model on AI Providers)' }
 ];
 // The display label for a reviewer token — the one place UI copy turns a
 // reviewer slug into prose, so a roster addition renders everywhere without a

--- a/client/src/hooks/useReviewerModelOptions.js
+++ b/client/src/hooks/useReviewerModelOptions.js
@@ -1,8 +1,15 @@
 import { useEffect, useMemo, useState } from 'react';
 import * as api from '../services/api';
-import { filterSelectableModels, selectableModelsForProvider, isAntigravityProvider, isGrokBuildCli, antigravityModelEffortLevels } from '../utils/providers';
-import { LOCAL_LLM_REVIEWERS, MODEL_SELECTABLE_REVIEWERS } from '../components/cos/constants';
+import { filterSelectableModels, selectableModelsForProvider, isAntigravityProvider, isGrokBuildCli, isKimiProvider, antigravityModelEffortLevels } from '../utils/providers';
+import { MODEL_SELECTABLE_REVIEWERS } from '../components/cos/constants';
 import { reviewerEffortLevels, normalizeReviewerSlug } from '../lib/reviewerPins';
+import { LOCAL_LLM_BACKENDS } from '../lib/localLlmBackends';
+
+// Local backends whose installed-model list `/api/local-llm/status` actually
+// probes — the same roster the Runtimes/Model Library views render a catalog for,
+// reused so the two can't drift. `mtplx` is a local backend but is NOT in it: its
+// listing runs the `mtplx` wrapper, so it stays catalog-sourced and free-text.
+const PROBED_LOCAL_BACKENDS = LOCAL_LLM_BACKENDS.map((b) => b.id);
 
 /**
  * Selectable model ids per model-taking reviewer, for `ReviewerPicker`'s Model
@@ -13,9 +20,12 @@ import { reviewerEffortLevels, normalizeReviewerSlug } from '../lib/reviewerPins
  * Two sources, because the two reviewer kinds are different things:
  * - `lmstudio` / `ollama` ids come from `/api/local-llm/status`, so they reflect
  *   what's actually installed rather than a provider's stale stored `models`.
- * - `codex` / `claude` / `antigravity` / `grok` / `cursor` tiers come from the provider
- *   catalog (`/api/providers`) — these are CLI reviewers, not local backends, so
- *   there's nothing to probe.
+ * - Every other reviewer's tiers come from the provider catalog
+ *   (`/api/providers`). That includes `mtplx`: its installed checkpoints live
+ *   behind `/api/local-llm/mtplx/status`, which INVOKES the `mtplx` wrapper (a
+ *   several-hundred-MB venv bootstrap on a cold version — see
+ *   `server/lib/mtplxRuntime.js`), and a picker mount must never pay that. The
+ *   shipped provider's catalog plus a free-text field is the honest trade.
  *
  * The `claude` list spans BOTH usage modes: the `claude-code` provider tiers and
  * the installed Ollama ids (an Ollama-backed `claude` CLI, where `--model` selects
@@ -27,7 +37,8 @@ import { reviewerEffortLevels, normalizeReviewerSlug } from '../lib/reviewerPins
  * catalog can enumerate. Consumers render a `<datalist>` for those.
  *
  * `unavailable` distinguishes "backend is down" from "backend has no models" so
- * the empty state can say the useful thing. Absent = not a local backend.
+ * the empty state can say the useful thing. Absent = not probed (every reviewer
+ * outside PROBED_LOCAL_BACKENDS, `mtplx` included).
  * `loaded` flips once both fetches settle, so a consumer can tell "no options
  * yet" from "genuinely no options" (an empty list is a real answer, not a
  * pre-fetch placeholder).
@@ -121,6 +132,17 @@ export default function useReviewerModelOptions() {
       // regardless because grok, like every CLI reviewer, is free-text.
       grok: providerTiers((p) => p.id === 'grok-cli', isGrokBuildCli),
       cursor: providerTiers((p) => p.id === 'cursor-cli', (p) => p.id === 'cursor-tui'),
+      // Legitimately empty, for grok's documented reason: the shipped kimi
+      // provider carries only the configured-default sentinel, which
+      // `filterSelectableModels` strips. Free-text keeps the cell usable.
+      kimi: providerTiers((p) => p.id === 'kimi-cli', isKimiProvider),
+      // Deliberately NOT sourced from the `opencode-<backend>` presets. Those
+      // enumerate ids that only resolve under the `OPENCODE_CONFIG_CONTENT` a
+      // PortOS-spawned provider injects, and the reviewer runs a bare `opencode`
+      // against the user's OWN config — so listing them would offer picks that
+      // silently fail. `opencode -m` takes a `provider/model` id the user types.
+      opencode: [],
+      mtplx: providerTiers((p) => p.id === 'mtplx'),
     };
 
     const defaultModels = {
@@ -131,6 +153,9 @@ export default function useReviewerModelOptions() {
       antigravity: providerDefault(isAntigravityProvider),
       grok: providerDefault((p) => p.id === 'grok-cli', isGrokBuildCli),
       cursor: providerDefault((p) => p.id === 'cursor-cli', (p) => p.id === 'cursor-tui'),
+      kimi: providerDefault((p) => p.id === 'kimi-cli', isKimiProvider),
+      opencode: null,
+      mtplx: providerDefault((p) => p.id === 'mtplx'),
     };
 
     // The agy provider's RAW catalog — one id per effort tier
@@ -155,8 +180,11 @@ export default function useReviewerModelOptions() {
       optionsByReviewer,
       defaultModels,
       modelEffortLevels,
-      // A local backend's id list is authoritative (we probed it), so keep those
-      // pickers a closed `<select>`. Every CLI reviewer is free-text: `claude` for
+      // A PROBED backend's id list is authoritative, so keep those pickers a closed
+      // `<select>`. Gated on PROBED_LOCAL_BACKENDS rather than LOCAL_LLM_REVIEWERS
+      // because `mtplx` is a local backend we deliberately do NOT probe here — a
+      // closed select over its stored catalog would forbid a checkpoint the user
+      // has actually pulled. Every CLI reviewer is free-text too: `claude` for
       // the Ollama-backed / Bedrock-form cases above, `codex`/`antigravity`/`grok`/`cursor`
       // because their catalogs are stored snapshots that can lag a newly-released
       // tier — grok's shipped catalog holds no real id at all, so a typed id is the
@@ -164,7 +192,7 @@ export default function useReviewerModelOptions() {
       // server splits it). Derived from the rosters so a reviewer added to either
       // one can't silently default to the wrong control.
       freeText: Object.fromEntries(
-        MODEL_SELECTABLE_REVIEWERS.map((r) => [r, !LOCAL_LLM_REVIEWERS.includes(r)])
+        MODEL_SELECTABLE_REVIEWERS.map((r) => [r, !PROBED_LOCAL_BACKENDS.includes(r)])
       ),
       unavailable: {
         lmstudio: localStatus?.lmstudio?.available === false,

--- a/client/src/hooks/useReviewerModelOptions.test.jsx
+++ b/client/src/hooks/useReviewerModelOptions.test.jsx
@@ -29,6 +29,7 @@ const providers = [
   { id: 'grok-tui', type: 'tui', command: 'grok', models: ['stale-tui-id'] },
   { id: 'grok-cli', type: 'cli', command: 'grok', models: ['grok-configured-default', 'grok-code-fast-1'] },
   { id: 'cursor-cli', type: 'cli', command: 'cursor-agent', models: ['auto', 'gpt-5'] },
+  { id: 'mtplx', type: 'api', models: ['mtplx-qwen38-27b-optimized-speed'], defaultModel: 'mtplx-qwen38-27b-optimized-speed' },
 ];
 
 describe('useReviewerModelOptions', () => {
@@ -44,6 +45,21 @@ describe('useReviewerModelOptions', () => {
     for (const reviewer of MODEL_SELECTABLE_REVIEWERS) {
       expect(Array.isArray(result.current.optionsByReviewer[reviewer])).toBe(true);
     }
+  });
+
+  // A closed `<select>` is only honest for a backend whose installed list we
+  // actually probed. `mtplx` is a local backend we deliberately do NOT probe (its
+  // listing runs the `mtplx` wrapper, a cold-version venv bootstrap), so it must
+  // stay free-text — otherwise the user could not pin a checkpoint they pulled.
+  it('keeps every unprobed reviewer free-text, local backends included', async () => {
+    const { result } = renderHook(() => useReviewerModelOptions());
+    await waitFor(() => expect(result.current.loaded).toBe(true));
+    expect(result.current.freeText.lmstudio).toBe(false);
+    expect(result.current.freeText.ollama).toBe(false);
+    for (const reviewer of ['mtplx', 'opencode', 'kimi']) {
+      expect(result.current.freeText[reviewer], reviewer).toBe(true);
+    }
+    expect(result.current.optionsByReviewer.mtplx).toEqual(['mtplx-qwen38-27b-optimized-speed']);
   });
 
   it('publishes concrete provider defaults without exposing configured-default sentinels', async () => {

--- a/client/src/lib/reviewerPins.js
+++ b/client/src/lib/reviewerPins.js
@@ -27,16 +27,18 @@ import {
  * unaffected.
  */
 
-// CLI reviewers whose binary takes a `--model <id>` tier. Mirror of
+// CLI reviewers whose binary takes a model id. Mirror of
 // MODEL_CAPABLE_CLI_REVIEWERS (`antigravity` runs `agy --model <id>`, `grok` runs
-// `grok --model <id>`, and Cursor runs `cursor-agent --model <id>` — `grok` takes
-// a model but no effort at all, so this roster is deliberately wider than
-// EFFORT_SELECTABLE_REVIEWERS below; Cursor takes both, but carries its effort
-// INSIDE the model id rather than as a separate flag).
-export const MODEL_CAPABLE_CLI_REVIEWERS = ['codex', 'claude', 'antigravity', 'grok', 'cursor'];
+// `grok --model <id>`, Cursor runs `cursor-agent --model <id>`, and `opencode`
+// runs `opencode run -m <provider/model>` — the server owns which flag spells it,
+// see `reviewerModelFlag`). This roster is deliberately wider than
+// EFFORT_SELECTABLE_REVIEWERS below: `grok`/`opencode`/`kimi` take a model but no
+// pickable effort, and Cursor takes both while carrying its effort INSIDE the
+// model id rather than as a separate flag.
+export const MODEL_CAPABLE_CLI_REVIEWERS = ['codex', 'claude', 'antigravity', 'grok', 'cursor', 'opencode', 'kimi'];
 
 // The local-LLM backends, which take both a model and an effort.
-export const LOCAL_LLM_REVIEWERS = ['lmstudio', 'ollama'];
+export const LOCAL_LLM_REVIEWERS = ['lmstudio', 'ollama', 'mtplx'];
 
 // Every reviewer whose model the user can pick per row in ReviewerPicker — the
 // model-capable CLIs plus the local-LLM backends. Mirror of
@@ -70,6 +72,7 @@ export const REVIEWER_EFFORT_LEVELS = Object.freeze({
   grok: GROK_EFFORT_LEVELS,
   lmstudio: LOCAL_LLM_EFFORT_LEVELS,
   ollama: LOCAL_LLM_EFFORT_LEVELS,
+  mtplx: LOCAL_LLM_EFFORT_LEVELS,
 });
 
 // Every reviewer whose effort the user can pick per row in ReviewerPicker.

--- a/docs/features/product-surfaces.md
+++ b/docs/features/product-surfaces.md
@@ -72,7 +72,7 @@ Submit tasks, manage durable autonomous agents, schedule recurring automations, 
 | **AI Providers & Model Runner** | `/ai` | Multi-provider configuration supporting CLI agents (Claude Code, Codex, Antigravity, OpenCode), cloud APIs (OpenAI, Anthropic, Gemini, Grok), and local endpoints (Ollama, LM Studio, vLLM, SGLang). | [Claude on Ollama](./claude-ollama.md) |
 | **Prompt Manager** | `/prompts` | Reusable prompt template library, variable substitution engine, prompt versioning, and auto-upgrade migrations. | [Prompt Manager](./prompt-manager.md) |
 | **Runs & Run Events Ledger** | `/cos/runs`, `/cos/run-events` | Comprehensive ledger of past and in-flight AI runs, lifecycle event replay, and orphaned process recovery. | — |
-| **Code Reviewers** | `/settings/code-reviewers` | Configurable multi-reviewer chain (Codex, Claude, Copilot, Ollama) with stop conditions, max rounds, and dispute workflows. | — |
+| **Code Reviewers** | `/settings/code-reviewers` | Configurable multi-reviewer chain (Copilot, Claude, Antigravity, Codex, Grok, Cursor, OpenCode, Kimi, LM Studio, Ollama, MTPLX) with stop conditions, max rounds, per-reviewer model/effort pins, and dispute workflows. | — |
 
 ---
 

--- a/server/lib/reviewerConfig.js
+++ b/server/lib/reviewerConfig.js
@@ -1183,10 +1183,11 @@ export function buildReviewWithArgs(reviewers, {
 } = {}) {
   const users = normalizeReviewUsernames(usernames);
   const keyed = resolveKeyedReviewers(reviewers, users.length > 0);
+  const configured = [...keyed, ...users.map(u => `@${u}`)];
   // PortOS-only reviewers are dropped rather than emitted — see the doc comment
   // above and `splitSlashdoReviewerTokens`. The surrounding prompt still names the
   // full reviewer list and the Local Reviewer Procedure that runs them.
-  const combined = splitSlashdoReviewerTokens([...keyed, ...users.map(u => `@${u}`)]).flagTokens;
+  const combined = splitSlashdoReviewerTokens(configured).flagTokens;
   const optSet = optionalReviewerSet(optionalReviewers);
   const maxLookup = reviewerMaxRoundsLookup(reviewerMaxRounds);
   const modelLookup = reviewerModelLookup(reviewerModels);
@@ -1194,7 +1195,14 @@ export function buildReviewWithArgs(reviewers, {
   // The lone-default-copilot suppression only applies when copilot carries NO
   // per-entry suffix — a `copilot~opt` / `copilot~max=2` / `copilot~effort=high` list must still
   // emit the flag to carry that suffix.
-  const isDefaultOnly = combined.length === 1 && combined[0] === DEFAULT_REVIEWER
+  //
+  // Measured against the CONFIGURED list, not the emitted one. Suppressing the
+  // flag hands `--review-with` to the host's saved slashdo defaults, which name
+  // some other reviewer set — right for a run that asked for nothing but the
+  // default copilot, wrong for `[lmstudio, copilot]`, where the user chose this
+  // pair and only lmstudio's slug is unemittable. Reading the filtered list here
+  // would silently swap copilot out for whatever `.slashdo.json` happens to say.
+  const isDefaultOnly = configured.length === 1 && configured[0] === DEFAULT_REVIEWER
     && !optSet.has(DEFAULT_REVIEWER) && maxLookup.get(DEFAULT_REVIEWER) === undefined
     && effortLookup.get(DEFAULT_REVIEWER) === undefined;
   const hasNonCopilot = combined.some(r => !r.startsWith('@') && r !== DEFAULT_REVIEWER);

--- a/server/lib/reviewerConfig.js
+++ b/server/lib/reviewerConfig.js
@@ -16,26 +16,38 @@ import { ANTIGRAVITY_COMMAND } from './antigravity.js';
 import { CURSOR_COMMAND } from './cursor.js';
 
 // Reviewer choices for the Review Loop. `copilot` requests a native GitHub
-// Copilot review; `claude`/`antigravity`/`codex`/`grok`/`cursor` instruct the review-loop
-// follow-up agent to invoke the named CLI to critique the PR diff; `lmstudio`/`ollama`
-// route the diff through PortOS's local code-review endpoint
-// (`POST /api/code-review/local`) which runs the configured local LLM model.
+// Copilot review; `claude`/`antigravity`/`codex`/`grok`/`cursor`/`opencode`/`kimi`
+// instruct the review-loop follow-up agent to invoke the named CLI to critique the
+// PR diff; `lmstudio`/`ollama`/`mtplx` route the diff through PortOS's local
+// code-review endpoint (`POST /api/code-review/local`) which runs the configured
+// local LLM model.
+//
+// The roster deliberately covers EVERY coding-agent vendor PortOS can already
+// spawn (`PROVIDER_VENDORS` in providerVendors.js) plus every OpenAI-compatible
+// local backend it manages, so the provider a user is told is their best local
+// coding agent is also selectable as their reviewer. `opencode` is the one CLI
+// whose model flag is `-m` rather than `--model` (see REVIEWER_MODEL_FLAGS), and
+// `opencode`/`kimi`/`mtplx` — like `lmstudio` — have no slashdo counterpart, so
+// they are PORTOS_ONLY_REVIEWERS.
 // Mirrored in client/src/components/cos/constants.js → REVIEWER_OPTIONS.
-export const REVIEWER_VALUES = ['copilot', 'claude', 'antigravity', 'codex', 'grok', 'cursor', 'lmstudio', 'ollama'];
+export const REVIEWER_VALUES = ['copilot', 'claude', 'antigravity', 'codex', 'grok', 'cursor', 'opencode', 'kimi', 'lmstudio', 'ollama', 'mtplx'];
 export const REVIEWER_ALIASES = { gemini: 'antigravity', 'cursor-agent': 'cursor' };
 export const DEFAULT_REVIEWER = 'copilot';
 export const DEFAULT_REVIEWERS = ['copilot'];
 // Reviewers that resolve to a local-LLM backend (rather than a CLI or GitHub
 // bot). Used by the code-review endpoint, settings panel, and prompt builder
 // to gate model-id resolution.
-export const LOCAL_LLM_REVIEWERS = ['lmstudio', 'ollama'];
+export const LOCAL_LLM_REVIEWERS = ['lmstudio', 'ollama', 'mtplx'];
 // Reviewers PortOS serves ITSELF, with no counterpart in slashdo's reviewer
-// vocabulary: `lmstudio` runs through `POST /api/code-review/local`, which takes
-// its model in the request body. slashdo has no such slug, so it can neither
-// carry a `[<model>]` bracket nor appear in a `--review-with` list (an unknown
-// value aborts the command). One constant so a future addition can't be fixed
-// in one of those two places and missed in the other.
-export const PORTOS_ONLY_REVIEWERS = ['lmstudio'];
+// vocabulary (`copilot`/`codex`/`agy`/`claude`/`grok`/`cursor`/`ollama`/`@login`):
+// `lmstudio`/`mtplx` run through `POST /api/code-review/local`, which takes their
+// model in the request body, and `opencode`/`kimi` are CLIs PortOS's own review
+// procedure spawns. slashdo has no such slug, so none can carry a `[<model>]`
+// bracket or appear in a `--review-with` list (an unknown value aborts the
+// command). One constant so a future addition can't be fixed in one of those two
+// places and missed in the other — `splitSlashdoReviewerTokens` is the shared
+// partition every emitter goes through.
+export const PORTOS_ONLY_REVIEWERS = ['lmstudio', 'mtplx', 'opencode', 'kimi'];
 // CLI reviewers whose binary accepts a `--model <id>` tier the user can pin on
 // the Code Review Defaults panel (stored as a `<reviewer>Model` settings scalar,
 // e.g. `codexModel` / `claudeModel` / `antigravityModel`). The review-loop
@@ -51,11 +63,15 @@ export const PORTOS_ONLY_REVIEWERS = ['lmstudio'];
 // for one list. `cursor` runs `cursor-agent --model <id>` and DOES take an
 // effort — but as a parameter of the model id (`gpt-5[effort=max]`), not a flag,
 // so its pin rides this roster's `--model` rather than an `--effort` argv.
+// `opencode` runs `opencode run -m <provider/model>` and `kimi` runs
+// `kimi --model <id>`; neither offers a pickable effort, so they widen this roster
+// past EFFORT_SELECTABLE_REVIEWERS the same way `grok` does. `reviewerModelFlag`
+// owns which of `--model`/`-m` each one spells.
 // Copilot/local-LLM reviewers are excluded — the former has no CLI, the latter
 // get their model injected server-side by `POST /api/code-review/local`. Add a
 // reviewer here when its CLI gains model selection; the `<reviewer>Model`
 // settings scalar is generated from this roster (codeReviewSettingsSchema).
-export const MODEL_CAPABLE_CLI_REVIEWERS = ['codex', 'claude', 'antigravity', 'grok', 'cursor'];
+export const MODEL_CAPABLE_CLI_REVIEWERS = ['codex', 'claude', 'antigravity', 'grok', 'cursor', 'opencode', 'kimi'];
 // Every reviewer whose model the user can PICK in the UI: the model-capable CLIs
 // above (threaded into the follow-up prompt as `<reviewer> --model <id>`) plus the
 // local-LLM backends (whose id is injected server-side by
@@ -80,7 +96,29 @@ export const REVIEWER_CLI_BINARIES = {
   codex: 'codex',
   grok: 'grok',
   cursor: CURSOR_COMMAND,
+  opencode: 'opencode',
+  kimi: 'kimi',
 };
+
+// The `--model` flag a CLI reviewer's binary actually spells. Only a reviewer
+// that deviates from `--model` appears; `reviewerModelFlag` supplies the default
+// for the rest. `opencode` takes its model as `opencode run -m <provider/model>`
+// (mirroring `opencodeCliArgs` in providerVendors.js) — rendering `--model`
+// there would have the follow-up agent probe for a flag that is not the
+// documented one.
+const REVIEWER_MODEL_FLAGS = { opencode: '-m' };
+
+/**
+ * The flag a CLI reviewer's pinned model must be passed with (`--model` unless
+ * that reviewer's binary spells it differently). Accepts the `gemini` alias.
+ *
+ * @param {string} reviewer - reviewer slug
+ * @returns {string}
+ */
+export function reviewerModelFlag(reviewer) {
+  const slug = typeof reviewer === 'string' ? reviewer.trim().toLowerCase() : '';
+  return REVIEWER_MODEL_FLAGS[REVIEWER_ALIASES[slug] ?? slug] || '--model';
+}
 
 /**
  * Is this reviewer a CLI the agent spawns itself? Derived by EXCLUSION rather
@@ -865,7 +903,7 @@ export function buildReviewerEffortNote(reviewers, reviewerEfforts = {}, { revie
       // a model-only pin is not this sentence's business.
       if (!normalizeReviewerEffort(efforts[r], r)) return null;
       const model = reviewerModelArg(r, models[r], efforts[r]);
-      return model ? `\`${binary} --model ${model}\`` : null;
+      return model ? `\`${binary} ${reviewerModelFlag(r)} ${model}\`` : null;
     })
     .filter(Boolean);
   if (!entries.length) return '';
@@ -889,6 +927,32 @@ const REVIEW_LOOP_SLASHDO_EXAMPLES_MD = ['/do:pr', '/do:next', '/do:review', '/d
  * by a round-trip test, so a grammar change can't silently mis-slug here.
  */
 export const reviewerTokenSlug = (token) => String(token).split('[')[0].split('~')[0].trim().toLowerCase();
+
+/**
+ * Partition emitted `--review-with` tokens into the ones slashdo can parse and
+ * the ones PortOS serves itself.
+ *
+ * slashdo's parser ABORTS the whole command on an unknown `--review-with` value,
+ * so a PORTOS_ONLY_REVIEWERS slug in that flag doesn't degrade the run — it kills
+ * it, and the PR the invocation existed to open never gets created. Every emitter
+ * of that flag therefore drops those slugs and names them separately, alongside
+ * the Local Reviewer Procedure that actually runs them.
+ *
+ * An `@login` entry is always a valid slashdo reviewer. `portosOnly` is reported
+ * by BARE slug — the `[<model>]`/`~<suffix>` decoration is slashdo grammar, and
+ * these reviewers never reach a slashdo parser.
+ *
+ * @param {string[]} tokens - emitted reviewer tokens (decorated or bare)
+ * @returns {{flagTokens: string[], portosOnly: string[]}}
+ */
+export function splitSlashdoReviewerTokens(tokens) {
+  const trimmed = (Array.isArray(tokens) ? tokens : []).map(t => String(t).trim()).filter(Boolean);
+  const isSlashdoToken = t => t.startsWith('@') || !PORTOS_ONLY_REVIEWERS.includes(reviewerTokenSlug(t));
+  return {
+    flagTokens: trimmed.filter(isSlashdoToken),
+    portosOnly: [...new Set(trimmed.filter(t => !isSlashdoToken(t)).map(reviewerTokenSlug))],
+  };
+}
 
 /**
  * Prose block pinning a claim prompt's reviewer list against slashdo's SAVED
@@ -924,11 +988,7 @@ export function buildReviewerPinNote(reviewersCsv) {
   // unless PortOS serves it itself. Emitting a PORTOS_ONLY_REVIEWERS slug in a
   // `--review-with` list would abort the command outright, so it is dropped from
   // the flag text and named separately with the procedure that DOES run it.
-  const tokens = csv.split(',').map(t => t.trim()).filter(Boolean);
-  const flagTokens = tokens.filter(t => t.startsWith('@') || !PORTOS_ONLY_REVIEWERS.includes(reviewerTokenSlug(t)));
-  // Named by bare slug: the `[<model>]`/`~<suffix>` decoration is slashdo
-  // grammar, and these reviewers never reach a slashdo parser.
-  const portosOnly = [...new Set(tokens.filter(t => !flagTokens.includes(t)).map(reviewerTokenSlug))];
+  const { flagTokens, portosOnly } = splitSlashdoReviewerTokens(csv.split(','));
 
   return [
     '## Reviewer pin — use the reviewers PortOS configured',
@@ -1092,6 +1152,11 @@ export function buildReviewersCsv(reviewers, usernames = [], optionalReviewers =
  *   effort DOES force the flag on (otherwise the suffix — the whole point — would be
  *   dropped with the flag).
  *
+ * - A `PORTOS_ONLY_REVIEWERS` slug (`lmstudio`/`mtplx`/`opencode`/`kimi`) is
+ *   DROPPED from the emitted list: slashdo aborts on an unknown `--review-with`
+ *   value, so emitting one would kill the whole invocation rather than degrade
+ *   it. With nothing left to name, no flag is emitted at all.
+ *
  * Everything past `reviewers` is an options object: the two reviewer-name lists
  * (`usernames` / `optionalReviewers`) and the three per-reviewer lookup maps
  * (`reviewerMaxRounds` / `reviewerModels` / `reviewerEfforts`) are same-shaped.
@@ -1118,7 +1183,10 @@ export function buildReviewWithArgs(reviewers, {
 } = {}) {
   const users = normalizeReviewUsernames(usernames);
   const keyed = resolveKeyedReviewers(reviewers, users.length > 0);
-  const combined = [...keyed, ...users.map(u => `@${u}`)];
+  // PortOS-only reviewers are dropped rather than emitted — see the doc comment
+  // above and `splitSlashdoReviewerTokens`. The surrounding prompt still names the
+  // full reviewer list and the Local Reviewer Procedure that runs them.
+  const combined = splitSlashdoReviewerTokens([...keyed, ...users.map(u => `@${u}`)]).flagTokens;
   const optSet = optionalReviewerSet(optionalReviewers);
   const maxLookup = reviewerMaxRoundsLookup(reviewerMaxRounds);
   const modelLookup = reviewerModelLookup(reviewerModels);
@@ -1129,9 +1197,11 @@ export function buildReviewWithArgs(reviewers, {
   const isDefaultOnly = combined.length === 1 && combined[0] === DEFAULT_REVIEWER
     && !optSet.has(DEFAULT_REVIEWER) && maxLookup.get(DEFAULT_REVIEWER) === undefined
     && effortLookup.get(DEFAULT_REVIEWER) === undefined;
-  const hasNonCopilot = keyed.some(r => r !== DEFAULT_REVIEWER);
+  const hasNonCopilot = combined.some(r => !r.startsWith('@') && r !== DEFAULT_REVIEWER);
   const parts = [];
-  if (!isDefaultOnly) parts.push(`--review-with ${combined.map(t => markSuffixes(t, optSet, maxLookup, modelLookup, effortLookup)).join(',')}`);
+  // Nothing slashdo can parse (a list of PortOS-only reviewers): emit no flag at
+  // all rather than a bare `--review-with`.
+  if (!isDefaultOnly && combined.length) parts.push(`--review-with ${combined.map(t => markSuffixes(t, optSet, maxLookup, modelLookup, effortLookup)).join(',')}`);
   if (combined.length >= 2) {
     if (stopMode === 'on-findings') parts.push('--review-stop-on-findings');
     else if (stopMode === 'on-clean') parts.push('--review-stop-on-clean');

--- a/server/lib/reviewerConfig.test.js
+++ b/server/lib/reviewerConfig.test.js
@@ -29,6 +29,9 @@ import {
   resolveReviewerConfig,
   resolveClaimReviewerConfig,
   reviewerTokenSlug,
+  reviewerModelFlag,
+  splitSlashdoReviewerTokens,
+  PORTOS_ONLY_REVIEWERS,
 } from './reviewerConfig.js';
 // The Zod half of the old cosValidation.js — these cases assert that a reviewer
 // pin survives the schema that persists it, so they need both modules.
@@ -94,6 +97,47 @@ describe('reviewerConfig reviewer CLI binaries', () => {
     expect(LOCAL_LLM_REVIEWERS.some(isCliReviewer)).toBe(false);
   });
 
+  // Every coding-agent CLI PortOS can spawn is selectable as a reviewer, so the
+  // provider a user is told is their best local agent can also review their code.
+  it('covers the OpenCode and Kimi CLIs, naming their own binaries', () => {
+    for (const slug of ['opencode', 'kimi']) {
+      expect(REVIEWER_VALUES).toContain(slug);
+      expect(isCliReviewer(slug)).toBe(true);
+      expect(reviewerCliBinary(slug)).toBe(slug);
+      expect(MODEL_CAPABLE_CLI_REVIEWERS).toContain(slug);
+    }
+  });
+
+  // `opencode run -m <provider/model>` — rendering `--model` would send the
+  // follow-up agent probing for a flag OpenCode does not document.
+  it('spells the model flag the way each CLI does', () => {
+    expect(reviewerModelFlag('opencode')).toBe('-m');
+    for (const slug of ['codex', 'claude', 'antigravity', 'gemini', 'grok', 'cursor', 'kimi']) {
+      expect(reviewerModelFlag(slug)).toBe('--model');
+    }
+  });
+
+  // MTPLX is an OpenAI-compatible local server, so it reviews through
+  // `POST /api/code-review/local` like lmstudio/ollama — never as a spawned CLI.
+  it('treats mtplx as a local-LLM backend, not a CLI', () => {
+    expect(LOCAL_LLM_REVIEWERS).toContain('mtplx');
+    expect(isCliReviewer('mtplx')).toBe(false);
+    expect(reviewerCliBinary('mtplx')).toBeNull();
+    expect(reviewerEffortLevels('mtplx')).toEqual(LOCAL_LLM_EFFORT_LEVELS);
+  });
+
+  // slashdo's `--review-with` vocabulary is copilot/codex/agy/claude/grok/cursor/
+  // ollama/@login. Anything else aborts the command, so PortOS's own reviewers
+  // must never reach that flag.
+  it('classifies every reviewer slashdo cannot parse as PortOS-only', () => {
+    expect([...PORTOS_ONLY_REVIEWERS].sort()).toEqual(['kimi', 'lmstudio', 'mtplx', 'opencode']);
+    const { flagTokens, portosOnly } = splitSlashdoReviewerTokens([
+      'ollama[qwen2.5:7b]~max=1', 'opencode', '@octocat', 'mtplx~effort=high', 'codex',
+    ]);
+    expect(flagTokens).toEqual(['ollama[qwen2.5:7b]~max=1', '@octocat', 'codex']);
+    expect(portosOnly).toEqual(['opencode', 'mtplx']);
+  });
+
   // slashdoInvocation keeps its own copy of the roster to decide which slashdo
   // `lib/*` includes a reviewer needs. Two hand-maintained lists of the same
   // reviewers drift the moment one gains a member — the `grok` addition is the
@@ -129,7 +173,7 @@ describe('per-reviewer reasoning effort (reviewerEfforts)', () => {
 
   it('EFFORT_SELECTABLE_REVIEWERS is exactly the reviewers with a non-empty ladder', () => {
     expect([...EFFORT_SELECTABLE_REVIEWERS].sort())
-      .toEqual(['antigravity', 'claude', 'codex', 'cursor', 'grok', 'lmstudio', 'ollama']);
+      .toEqual(['antigravity', 'claude', 'codex', 'cursor', 'grok', 'lmstudio', 'mtplx', 'ollama']);
     for (const reviewer of REVIEWER_VALUES) {
       expect(EFFORT_SELECTABLE_REVIEWERS.includes(reviewer))
         .toBe((reviewerEffortLevels(reviewer) || []).length > 0);

--- a/server/lib/slashdoInvocation.js
+++ b/server/lib/slashdoInvocation.js
@@ -85,15 +85,21 @@ export const SLASHDO_REVIEWER_INCLUDE_NAMES = Object.freeze(Object.values(SLASHD
 /**
  * Reviewer slugs that drive slashdo's shared local-agent (spawnable CLI) loop.
  *
+ * PortOS-only CLI reviewers (`opencode`, `kimi`) are members too: slashdo has no
+ * slug for them, but the include they'd need is the same generic spawn-a-CLI
+ * review procedure, and pruning it would leave PortOS's own inlined CLI Reviewer
+ * Procedure with nothing to point at. `lmstudio`/`mtplx` sit in
+ * LOCAL_MODEL_REVIEWERS for the same reason.
+ *
  * Kept here rather than imported from reviewerConfig.js, whose importer
  * cosValidation.js imports THIS module — an import back would be a cycle.
  * Exported so reviewerConfig.test.js can pin it against `REVIEWER_CLI_BINARIES`
  * (whose keys are the same roster); a reviewer added to one and not the other
  * is a drift the test catches.
  */
-export const LOCAL_AGENT_REVIEWERS = new Set(['claude', 'codex', 'antigravity', 'grok', 'cursor']);
+export const LOCAL_AGENT_REVIEWERS = new Set(['claude', 'codex', 'antigravity', 'grok', 'cursor', 'opencode', 'kimi']);
 /** Reviewer slugs that drive slashdo's local-model (Ollama-style) loop. */
-const LOCAL_MODEL_REVIEWERS = new Set(['ollama', 'lmstudio']);
+const LOCAL_MODEL_REVIEWERS = new Set(['ollama', 'lmstudio', 'mtplx']);
 
 /**
  * Which reviewer-variant includes a run can never reach, given its resolved

--- a/server/lib/validation.test.js
+++ b/server/lib/validation.test.js
@@ -1559,11 +1559,20 @@ describe('validation.js', () => {
         .toBe('--review-with ollama[qwen2.5:7b]~opt~max=1');
     });
 
-    it('never brackets copilot, a @username, or lmstudio (no slashdo slug takes one)', () => {
-      // lmstudio's model rides in the /api/code-review/local request body instead.
+    it('never brackets copilot or a @username, and drops a PortOS-only reviewer entirely', () => {
+      // lmstudio has no slashdo slug at all: emitting it would abort the command
+      // (unknown --review-with value), so it is dropped from the flag rather than
+      // bracketed. Its model rides in the /api/code-review/local request body.
       expect(buildReviewWithArgs(['copilot', 'lmstudio'], { usernames: ['Bot'], reviewerModels: {
         copilot: 'x', lmstudio: 'local-a', '@Bot': 'y',
-      } })).toBe('--review-with copilot,lmstudio,@Bot');
+      } })).toBe('--review-with copilot,@Bot');
+    });
+
+    it('emits no flag at all when every configured reviewer is PortOS-only', () => {
+      // `--review-with` with an empty value is as fatal to slashdo as an unknown
+      // slug; the surrounding prompt still names the reviewers and the Local
+      // Reviewer Procedure that runs them.
+      expect(buildReviewWithArgs(['mtplx', 'opencode'])).toBe('');
     });
 
     it('does not let a stray copilot pin force the suppressed lone-default flag on', () => {

--- a/server/lib/validation.test.js
+++ b/server/lib/validation.test.js
@@ -1568,6 +1568,13 @@ describe('validation.js', () => {
       } })).toBe('--review-with copilot,@Bot');
     });
 
+    it('still emits the copilot flag when a PortOS-only reviewer rides alongside it', () => {
+      // Suppression hands `--review-with` to the host's saved slashdo defaults.
+      // That is right for a bare default copilot (#2507) and wrong here: the user
+      // chose this pair, and only lmstudio's slug is unemittable.
+      expect(buildReviewWithArgs(['lmstudio', 'copilot'])).toBe('--review-with copilot');
+    });
+
     it('emits no flag at all when every configured reviewer is PortOS-only', () => {
       // `--review-with` with an empty value is as fatal to slashdo as an unknown
       // slug; the surrounding prompt still names the reviewers and the Local

--- a/server/routes/codeReview.js
+++ b/server/routes/codeReview.js
@@ -49,15 +49,16 @@ router.get('/defaults', asyncHandler(async (_req, res) => {
 }))
 
 // POST /api/code-review/local — run a single review pass against the
-// configured local-LLM backend (LM Studio or Ollama) and return the findings
+// configured local-LLM backend (LM Studio, Ollama, or MTPLX) and return the findings
 // text the agent will act on. Synchronous: keeps the agent's `curl` step
 // simple — one request, one body back.
 router.post('/local', asyncHandler(async (req, res) => {
   const body = validateRequest(localReviewRequestSchema, req.body)
   const settings = await getSettings()
-  const configured = body.backend === 'lmstudio'
-    ? settings.codeReview?.lmstudioModel
-    : settings.codeReview?.ollamaModel
+  // Keyed off the roster's `<reviewer>Model` scalar rather than a per-backend
+  // branch, so a backend added to LOCAL_LLM_REVIEWERS reads its own configured
+  // model instead of silently inheriting another backend's.
+  const configured = settings.codeReview?.[`${body.backend}Model`]
   const model = body.model || configured
   // Per-request effort wins over the panel default; absent in both = omit the
   // field entirely so the model reasons however it normally would. The stored

--- a/server/routes/codeReview.test.js
+++ b/server/routes/codeReview.test.js
@@ -142,6 +142,26 @@ describe('POST /api/code-review/local', () => {
     )
   })
 
+  // The old lmstudio-or-else ternary handed every non-lmstudio backend the
+  // OLLAMA model id, so a third backend would have reviewed with the wrong model.
+  it('reads each backend\'s own configured model scalar', async () => {
+    settingsSvc.getSettings.mockResolvedValue({
+      codeReview: { ollamaModel: 'ollama-model', mtplxModel: 'mtplx-model' },
+    })
+    codeReviewSvc.runLocalCodeReview.mockResolvedValue({
+      ok: true, backend: 'mtplx', model: 'mtplx-model', findings: 'No findings.',
+    })
+
+    const res = await request(makeApp())
+      .post('/api/code-review/local')
+      .send({ backend: 'mtplx', diff: 'diff --git a b' })
+
+    expect(res.status).toBe(200)
+    expect(codeReviewSvc.runLocalCodeReview).toHaveBeenCalledWith(
+      expect.objectContaining({ backend: 'mtplx', model: 'mtplx-model' }),
+    )
+  })
+
   it('passes the caller-supplied model through when present', async () => {
     settingsSvc.getSettings.mockResolvedValue({
       codeReview: { ollamaModel: 'settings-model' },

--- a/server/services/codeReview.js
+++ b/server/services/codeReview.js
@@ -1,5 +1,5 @@
 /**
- * Local-LLM code review backend for the Review Loop's `lmstudio` / `ollama`
+ * Local-LLM code review backend for the Review Loop's `lmstudio` / `ollama` / `mtplx`
  * reviewer kinds. The follow-up agent (a CLI like Claude / Antigravity / Codex)
  * POSTs the PR diff to `/api/code-review/local`; we feed it through the
  * configured backend's OpenAI-compatible `/v1/chat/completions` endpoint with
@@ -42,14 +42,24 @@ import { getSettings, settingsEvents } from './settings.js'
 import { getBaseUrl as getLmStudioBaseUrl } from './lmStudioManager.js'
 import { getBaseUrl as getOllamaBaseUrl } from './ollamaManager.js'
 
-// Both LM Studio (`:1234`) and Ollama (`:11434`) ship OpenAI-compatible
-// `/v1/chat/completions`. Resolve through each manager's live `getBaseUrl()`
-// so a runtime `updateConfig({ baseUrl })` from the local-LLM tab takes
-// effect here too — otherwise the catalog UI and the reviewer would silently
-// desync when a user relocates their LM Studio install.
+// LM Studio (`:1234`), Ollama (`:11434`) and MTPLX (`:8000/v1`) all ship
+// OpenAI-compatible `/v1/chat/completions`. Resolve through each manager's live
+// endpoint accessor so a runtime `updateConfig({ baseUrl })` from the local-LLM
+// tab — or an MTPLX daemon relaunched on another port — takes effect here too;
+// otherwise the catalog UI and the reviewer would silently desync when a user
+// relocates their install.
+//
+// Every entry is awaited at the call site, which lets MTPLX's stay a DYNAMIC
+// import. That is deliberate: `mtplxServerManager.js` pulls in the managed-daemon
+// watcher and its PM2/filesystem graph, and this module is imported by the agent
+// spawn path — a static import would put that whole graph behind every one of its
+// importers (and did break suites that partially mock `lib/fileUtils.js`). The
+// review request is a one-off HTTP call, so paying the resolve lazily costs
+// nothing.
 const BACKEND_BASE_URLS = {
   lmstudio: () => getLmStudioBaseUrl(),
   ollama: () => getOllamaBaseUrl(),
+  mtplx: async () => (await import('./mtplxServerManager.js')).getMtplxServerEndpoint(),
 }
 
 export function isLocalLlmReviewer(backend) {
@@ -208,7 +218,7 @@ export async function resolveReviewLoopOptions(metadata, { normalize }) {
  * Per-reviewer CLI-binary install probe, keyed by reviewer slug (e.g.
  * `{ claude: true, antigravity: false, codex: true, grok: false, cursor: true }`). Only CLI
  * reviewers (`isCliReviewer`) are probed — `copilot` is a GitHub API review
- * and `lmstudio`/`ollama` route through `/api/code-review/local`, neither has
+ * and `lmstudio`/`ollama`/`mtplx` route through `/api/code-review/local`, neither has
  * a binary to find.
  *
  * TTL-cached (`authGate.js`'s inline Map+expiresAt pattern) rather than
@@ -276,7 +286,7 @@ async function runToolFreeLocalCompletion({ backend, model, messages, effort, ti
   // Local runtime records are normalized to the OpenAI `/v1` root, while the
   // legacy backend managers return the host root. Keep both forms compatible
   // with the one endpoint suffix below.
-  const baseUrl = String(requestedBaseUrl || BACKEND_BASE_URLS[backend]())
+  const baseUrl = String(requestedBaseUrl || await BACKEND_BASE_URLS[backend]())
     .replace(/\/+$/, '')
     .replace(/\/v\d+$/i, '')
   const body = {
@@ -317,7 +327,7 @@ async function runToolFreeLocalCompletion({ backend, model, messages, effort, ti
  * for surfacing the text findings to the agent driving the review loop.
  *
  * @param {Object} opts
- * @param {'lmstudio'|'ollama'} opts.backend
+ * @param {'lmstudio'|'ollama'|'mtplx'} opts.backend
  * @param {string} opts.model - Installed model id (e.g. `qwen2.5-coder:7b`).
  * @param {string} opts.diff - Unified diff text to review.
  * @param {string} [opts.effort] - Reasoning effort (`low`/`medium`/`high`), sent

--- a/server/services/codeReview.test.js
+++ b/server/services/codeReview.test.js
@@ -165,6 +165,9 @@ describe('codeReview helpers', () => {
         antigravityModel: 'gemini-3.6-flash',
         grokModel: 'grok-code-fast-1',
         cursorModel: null,
+        opencodeModel: null,
+        kimiModel: null,
+        mtplxModel: null,
         ...NO_EFFORTS,
       })
     })
@@ -200,8 +203,8 @@ describe('codeReview helpers', () => {
       const probed = []
       commandExistsMock.impl = async (binary) => { probed.push(binary); return binary !== 'agy' }
       const out = await getReviewerCliInstalled()
-      expect(out).toEqual({ claude: true, antigravity: false, codex: true, grok: true, cursor: true })
-      expect(probed.sort()).toEqual(['agy', 'claude', 'codex', 'cursor-agent', 'grok'])
+      expect(out).toEqual({ claude: true, antigravity: false, codex: true, grok: true, cursor: true, opencode: true, kimi: true })
+      expect(probed.sort()).toEqual(['agy', 'claude', 'codex', 'cursor-agent', 'grok', 'kimi', 'opencode'])
     })
 
     it('caches the result within the TTL — a second call does not re-probe', async () => {
@@ -209,7 +212,7 @@ describe('codeReview helpers', () => {
       commandExistsMock.impl = async () => { calls += 1; return true }
       await getReviewerCliInstalled()
       await getReviewerCliInstalled()
-      expect(calls).toBe(5) // one probe per CLI reviewer, only on the first call
+      expect(calls).toBe(7) // one probe per CLI reviewer, only on the first call
     })
 
     it('probes with the longer 15s timeout these heavier agentic CLIs need', async () => {

--- a/server/services/promptSections/reviewLifecycle.js
+++ b/server/services/promptSections/reviewLifecycle.js
@@ -2,7 +2,7 @@
  * Review-loop, CI-gate, and merge prompt sections.
  */
 
-import { DEFAULT_REVIEWER, DEFAULT_REVIEW_STOP_MODE, LOCAL_LLM_REVIEWERS, MODEL_CAPABLE_CLI_REVIEWERS, describeReviewerCli, isCliReviewer, reviewerCliBinary, normalizeReviewUsernames, normalizeOptionalReviewers, normalizeReviewerMaxRounds, reviewerEffortArgs, reviewerModelArg, resolveKeyedReviewers, buildReviewWithArgs, prioritizeToolFreeReviewers } from '../../lib/reviewerConfig.js';
+import { DEFAULT_REVIEWER, DEFAULT_REVIEW_STOP_MODE, LOCAL_LLM_REVIEWERS, MODEL_CAPABLE_CLI_REVIEWERS, describeReviewerCli, isCliReviewer, reviewerCliBinary, normalizeReviewUsernames, normalizeOptionalReviewers, normalizeReviewerMaxRounds, reviewerEffortArgs, reviewerModelArg, reviewerModelFlag, resolveKeyedReviewers, buildReviewWithArgs, prioritizeToolFreeReviewers } from '../../lib/reviewerConfig.js';
 import { oversizedBodyPointer } from '../../lib/slashdoInvocation.js';
 import { detectForgeCli } from '../../lib/gitForge.js';
 import { shellQuote } from '../../lib/shellQuote.js';
@@ -256,7 +256,10 @@ export function buildReviewLoopFollowUpSection(metadata = {}, { verbose = false,
         // reasoning effort INSIDE the model id — `gpt-5[effort=max]` — so the
         // pinned pair must render as ONE `--model`, never a `--effort` cursor
         // rejects. Every other reviewer gets the id back verbatim.
-        flags.push(`--model ${reviewerModelArg(r, reviewerModelMap[r], reviewerEffortMap[r])}`);
+        // `reviewerModelFlag` because the flag itself is per-CLI: `opencode`
+        // spells it `-m`, everyone else `--model`. Rendering the wrong one sends
+        // the follow-up agent probing for a flag its reviewer does not document.
+        flags.push(`${reviewerModelFlag(r)} ${reviewerModelArg(r, reviewerModelMap[r], reviewerEffortMap[r])}`);
       }
       const effortArgs = reviewerEffortArgs(r, reviewerEffortMap[r]);
       if (effortArgs.length) flags.push(effortArgs.join(' '));
@@ -366,6 +369,17 @@ export function buildReviewLoopFollowUpSection(metadata = {}, { verbose = false,
   // `model: "…"` placeholder would have the agent send the literal ellipsis, and
   // the route's `body.model || configured` prefers that truthy junk over the
   // install default — turning a pinned-effort review into a model-not-found error.
+  // The `backend` value the agent must send. Derived from the reviewers THIS run
+  // configured rather than a fixed `<lmstudio|ollama>` placeholder: naming a
+  // backend that isn't in the list is a 400 from the route's `z.enum`, and a
+  // single configured backend needs no substitution step at all.
+  const localLlmBackends = LOCAL_LLM_REVIEWERS.filter(r => reviewers.includes(r));
+  const localLlmBackendToken = localLlmBackends.length === 1
+    ? localLlmBackends[0]
+    : `<${localLlmBackends.join('|')}>`;
+  const localLlmBackendNote = localLlmBackends.length === 1
+    ? ''
+    : ` Substitute the active reviewer name for \`${localLlmBackendToken}\`.`;
   const pinnedString = (map, r) => (typeof map[r] === 'string' && map[r] ? map[r] : null);
   const localLlmPins = LOCAL_LLM_REVIEWERS
     .filter(r => reviewers.includes(r))
@@ -382,7 +396,7 @@ export function buildReviewLoopFollowUpSection(metadata = {}, { verbose = false,
   // reading a Set the note's `.map` filled as a side effect — that coupling meant
   // hoisting one line above the other silently emptied the key list.
   const localLlmPinJq = [
-    'backend: "…"',
+    `backend: "${localLlmBackendToken}"`,
     ...(localLlmPins.some(p => p.model) ? ['model: "…"'] : []),
     ...(localLlmPins.some(p => p.effort) ? ['effort: "…"'] : []),
     'diff: .'
@@ -393,10 +407,10 @@ export function buildReviewLoopFollowUpSection(metadata = {}, { verbose = false,
     : reviewForgeCli === 'glab'
     ? `glab mr diff ${prNumber || '<MR_NUMBER>'}`
     : `gh pr diff ${prNumber || '<PR_NUMBER>'}`;
-  const localLlmInvocation = `POST the diff to PortOS's local reviewer endpoint and extract its review text before evaluating it. Substitute the active reviewer name for \`<lmstudio|ollama>\`:
+  const localLlmInvocation = `POST the diff to PortOS's local reviewer endpoint and extract its review text before evaluating it.${localLlmBackendNote}
 \`\`\`bash
 REVIEW_RESPONSE=$(mktemp)
-HTTP_STATUS=$(${diffCommand} | jq -Rs '{ backend: "<lmstudio|ollama>", diff: . }' | curl -sS -X POST ${apiBase}/api/code-review/local -H 'Content-Type: application/json' -d @- -o "$REVIEW_RESPONSE" -w '%{http_code}') || {
+HTTP_STATUS=$(${diffCommand} | jq -Rs '{ backend: "${localLlmBackendToken}", diff: . }' | curl -sS -X POST ${apiBase}/api/code-review/local -H 'Content-Type: application/json' -d @- -o "$REVIEW_RESPONSE" -w '%{http_code}') || {
   echo "Local reviewer failed: request transport error" >&2
   STATUS=cli-error
   exit 1
@@ -433,7 +447,7 @@ Only a successfully extracted \`.findings\` value is the review text; treat it l
       ? 'wait for the initial Copilot review the system already pre-requested (Copilot leads the list)'
       : 'request a Copilot review when you reach its turn'} (poll every 5–15s, max 5 min/round), then re-request on later rounds.` : null,
     hasCli ? `**${cliReviewerHeading}**: invoke that CLI to review this branch's diff against its base (use the CLI's own base-diff mode or \`git diff ${renderedBaseBranch}...HEAD\`${localOnly ? '' : `; on GitHub \`gh pr diff ${prNumber || ''}\` also works`}).${cliBinaryNote}${reviewerPinNote}${cliProcedurePointer}` : null,
-    hasLocalLlm ? `**lmstudio / ollama**: ${localLlmInvocation}` : null,
+    hasLocalLlm ? `**${localLlmBackends.join(' / ')}**: ${localLlmInvocation}` : null,
     hasGithubUser ? `**@github reviewers**: ${githubUsersInvocation}` : null,
   ].filter(Boolean).join(' ');
   // Name the BINARY, not the slug: `Invoke the \`antigravity\` CLI` sent a
@@ -538,7 +552,7 @@ Only a successfully extracted \`.findings\` value is the review text; treat it l
     '```bash',
     `curl -sS -X POST ${apiBase}/api/cos/tasks/${sourceTaskId}/challenge -H 'Content-Type: application/json' -d '{"reason":"<why the finding is wrong>","evidence":"<file:line or diff quote>","reviewer":"<disputed reviewer>"}'`,
     '```',
-    `A \`409\` (\`CHALLENGE_EXHAUSTED\` = the one challenge is spent, or \`CHALLENGE_BUDGET_EXHAUSTED\` = the task is out of retry budget) means you can't dispute — then fix the finding or, if genuinely blocked, ${localOnly ? 'stop without pushing or opening a PR/MR' : 'post a PR comment and stop'}. After filing, RE-CHECK: re-run the disputed reviewer (or another configured reviewer) against the current diff, then resolve — overturned → \`POST .../challenge/resolve\` with \`{"outcome":"upheld"}\` and continue to ${localOnly ? 'the PR/MR creation step' : 'merge'}; confirmed → fix it, or send \`{"outcome":"escalated"}\` to hand the dispute to the user.` + (hasLocalLlm ? ' For a local reviewer you may instead POST `{"recheck":{"backend":"<lmstudio|ollama>","diff":"<unified diff>"}}` and let the server re-run it and auto-derive the outcome.' : ''),
+    `A \`409\` (\`CHALLENGE_EXHAUSTED\` = the one challenge is spent, or \`CHALLENGE_BUDGET_EXHAUSTED\` = the task is out of retry budget) means you can't dispute — then fix the finding or, if genuinely blocked, ${localOnly ? 'stop without pushing or opening a PR/MR' : 'post a PR comment and stop'}. After filing, RE-CHECK: re-run the disputed reviewer (or another configured reviewer) against the current diff, then resolve — overturned → \`POST .../challenge/resolve\` with \`{"outcome":"upheld"}\` and continue to ${localOnly ? 'the PR/MR creation step' : 'merge'}; confirmed → fix it, or send \`{"outcome":"escalated"}\` to hand the dispute to the user.` + (hasLocalLlm ? ` For a local reviewer you may instead POST \`{"recheck":{"backend":"${localLlmBackendToken}","diff":"<unified diff>"}}\` and let the server re-run it and auto-derive the outcome.` : ''),
   ].join('\n');
   // Per-reviewer round caps. This prompt drives the loop in PROSE (it isn't
   // slashdo parsing a `~max=<n>` suffix), so a configured cap only binds if it's

--- a/server/services/promptSections/reviewLifecycle.test.js
+++ b/server/services/promptSections/reviewLifecycle.test.js
@@ -57,3 +57,37 @@ describe('reviewLifecycle agent-facing API origin', () => {
     expect(section).toContain('http://127.0.0.1:5555/api/cos/tasks/task-example/challenge');
   });
 });
+
+describe('reviewLifecycle reviewer invocation details', () => {
+  beforeEach(() => {
+    getHttpsEnabledAtBoot.mockReturnValue({ value: false, initialized: true });
+  });
+
+  // The route validates `backend` against a z.enum of the local-LLM reviewers, so
+  // a leftover `<lmstudio|ollama>` placeholder in a run configured for MTPLX is a
+  // 400 the agent has to guess its way out of.
+  it('names the local backend this run actually configured', () => {
+    const section = buildReviewLoopFollowUpSection({ ...metadata, reviewLoopReviewers: ['mtplx'] });
+    expect(section).toContain('backend: "mtplx"');
+    expect(section).not.toContain('<lmstudio|ollama>');
+    expect(section).not.toContain('Substitute the active reviewer name');
+  });
+
+  it('keeps a substitution placeholder when several local backends are configured', () => {
+    const section = buildReviewLoopFollowUpSection({ ...metadata, reviewLoopReviewers: ['ollama', 'mtplx'] });
+    expect(section).toContain('backend: "<ollama|mtplx>"');
+    expect(section).toContain('Substitute the active reviewer name');
+  });
+
+  // `opencode run -m <provider/model>`: rendering `--model` here had agents
+  // probing for a flag OpenCode does not document.
+  it('renders each CLI reviewer\'s own model flag', () => {
+    const section = buildReviewLoopFollowUpSection({
+      ...metadata,
+      reviewLoopReviewers: ['opencode', 'codex'],
+      reviewLoopReviewerModels: { opencode: 'mtplx/qwen38', codex: 'gpt-5.6-sol' },
+    });
+    expect(section).toContain('`opencode -m mtplx/qwen38 …`');
+    expect(section).toContain('`codex --model gpt-5.6-sol …`');
+  });
+});


### PR DESCRIPTION
## Summary

The Code Reviewers roster only covered `copilot`/`claude`/`antigravity`/`codex`/`grok`/`cursor`/`lmstudio`/`ollama`, so the coding agent a user is told is their best local option could not be picked as the reviewer that critiques their diff. This widens it to **every vendor PortOS can already spawn plus every OpenAI-compatible local backend it manages**.

### New reviewers

- **`opencode`** and **`kimi`** join the CLI reviewers — binary, install probe, and a per-reviewer model pin each. OpenCode spells its model flag `-m`, not `--model`, so `reviewerModelFlag()` now owns that per-CLI detail and the review-loop prompt renders `opencode -m <provider/model>` instead of sending the follow-up agent probing for a flag OpenCode does not document.
- **`mtplx`** joins the local-LLM reviewers, reviewing through `POST /api/code-review/local` alongside LM Studio and Ollama. Its base URL resolves through the live daemon endpoint, imported lazily so the managed-daemon graph stays off every importer of `codeReview.js`.

Every roster-derived surface follows automatically: the `<reviewer>Model` / `<reviewer>Effort` settings scalars, the install probe, the ReviewerPicker rows, and the `⌘K`-adjacent pickers.

### Bug fixed along the way

A reviewer PortOS serves itself has no slashdo slug, and **slashdo aborts on an unknown `--review-with` value** — so emitting one killed the whole `/do:pr` invocation and the PR it existed to open. `buildReviewWithArgs` now drops those slugs through `splitSlashdoReviewerTokens` (the partition `buildReviewerPinNote` already used), emitting no flag when nothing slashdo-parseable is left. The lone-default-copilot suppression is measured against the **configured** list, not the filtered one — otherwise `[lmstudio, copilot]` would suppress the flag and hand reviewer selection to the host's saved `.slashdo.json` defaults.

### Also

- The local reviewer's `curl` recipe names the backend the run actually configured instead of a fixed `<lmstudio|ollama>` placeholder that the route's `z.enum` would have rejected.
- The route reads each backend's own `<reviewer>Model` scalar rather than falling through to Ollama's — the old two-arm ternary would have handed MTPLX the Ollama model id.
- The picker keeps MTPLX **free-text**: listing its checkpoints means invoking the `mtplx` wrapper, which bootstraps a several-hundred-megabyte venv on a cold version — not something a picker mount may pay. `PROBED_LOCAL_BACKENDS` reuses the `LOCAL_LLM_BACKENDS` roster so the two can't drift.

## Test plan

- `cd server && npm test` — 37,892 passing
- `cd client && npm test` — 10,079 passing
- `cd client && npm run build` — clean

New coverage: reviewer roster/binary/model-flag contracts and the slashdo partition (`reviewerConfig.test.js`), the flag-emission cases including `[lmstudio, copilot]` (`validation.test.js`), the derived local-backend token and per-CLI model flag in the prompt (`reviewLifecycle.test.js`), per-backend model scalar resolution (`routes/codeReview.test.js`), and free-text-vs-closed-select for an unprobed local backend (`useReviewerModelOptions.test.jsx`).
