### PR TITLE
fix app update activity log wrapping git-pull stat output on mobile

### DIFF
--- a/client/src/components/apps/ActivityLog.jsx
+++ b/client/src/components/apps/ActivityLog.jsx
@@ -18,13 +18,17 @@ export default function ActivityLog({ steps, error, completed }) {
         const cfg = STATUS_CONFIG[s.status] || STATUS_CONFIG.running;
         const Icon = cfg.icon;
         return (
-          <div key={s.step} className={`flex items-start gap-2 px-2 py-1 rounded ${cfg.bg}`}>
+          <div key={s.step} className={`flex min-w-0 items-start gap-2 px-2 py-1 rounded ${cfg.bg}`}>
             <span className={`shrink-0 mt-0.5 ${cfg.color}`}>
               {s.status === 'running' ? <BrailleSpinner text="" className="text-xs" /> : Icon && <Icon size={14} />}
             </span>
-            <span className="text-xs text-gray-300">
+            <span className="min-w-0 text-xs text-gray-300">
               <span className="font-mono text-white">{s.step}</span>
-              {s.message && <span className="ml-2 text-gray-400">{s.message}</span>}
+              {s.message && (
+                <span className="mt-1 block max-h-40 overflow-y-auto overflow-x-hidden whitespace-pre-wrap break-words font-mono text-[11px] text-gray-400">
+                  {s.message}
+                </span>
+              )}
             </span>
           </div>
         );


### PR DESCRIPTION
## Summary
- The app-update progress log (Apps > Git tab > "Updating...") rendered the `git pull` diffstat output as one unbroken inline span, so on a phone it collapsed into an unreadable wall of squished text instead of wrapping per file.
- `client/src/components/apps/ActivityLog.jsx`: render a step's `message` as a wrapped, scrollable monospace block (`whitespace-pre-wrap break-words`, capped height with vertical scroll) instead of an inline `<span>`, and let the row shrink (`min-w-0`) so it doesn't force horizontal overflow.

## Test plan
- `npx vitest run src/components/apps/tabs/RepositorySourcePanel.test.jsx` — passes (9/9)
- `npx vitest run src/responsiveGridConventions.test.js src/popoverClampConventions.test.js` — passes