### PR TITLE
default the repo study brief to the link save note

### DIFF
--- a/client/src/components/QuickBrainCapture.jsx
+++ b/client/src/components/QuickBrainCapture.jsx
@@ -28,13 +28,12 @@ export default function QuickBrainCapture() {
   const isYoutube = useMemo(() => isYoutubeVideoUrl(input), [input]);
   // A bare repo URL is cloned on capture, which unlocks the two post-clone
   // agent opt-ins (malware scan / repo study).
-  const repoIntake = useRepoIntake(input);
-
   const [showAdvanced, setShowAdvanced] = useState(false);
   const [ingestOpts, setIngestOpts] = useState(defaultIngestOptions);
   const [agentPrompt, setAgentPrompt] = useState('');
   const [tagsInput, setTagsInput] = useState('');
   const [linkNote, setLinkNote] = useState('');
+  const repoIntake = useRepoIntake(input, linkNote);
 
   // Server-side defaults for the checkboxes, so a user who always wants audio
   // sets it once in settings instead of every capture.

--- a/client/src/components/QuickBrainCapture.test.jsx
+++ b/client/src/components/QuickBrainCapture.test.jsx
@@ -219,6 +219,32 @@ describe('QuickBrainCapture', () => {
       });
     });
 
+    it('defaults the study context to the save note when the study option is ticked', async () => {
+      renderWidget();
+      type(REPO);
+      fireEvent.change(screen.getByLabelText(/why are you saving this link/i), {
+        target: { value: 'Might be a good fit for the media pipeline' },
+      });
+      fireEvent.click(screen.getByLabelText('Study for app ideas'));
+
+      await waitFor(() => expect(screen.getByLabelText(/study context/i))
+        .toHaveValue('Might be a good fit for the media pipeline'));
+    });
+
+    it('does not overwrite a study context the user already edited', async () => {
+      renderWidget();
+      type(REPO);
+      fireEvent.click(screen.getByLabelText('Study for app ideas'));
+      await waitFor(() => expect(screen.getByLabelText('File study issues against')).toBeInTheDocument());
+      fireEvent.change(screen.getByLabelText(/study context/i), { target: { value: 'My own brief' } });
+      fireEvent.change(screen.getByLabelText(/why are you saving this link/i), {
+        target: { value: 'Unrelated save note' },
+      });
+
+      expect(screen.getByLabelText(/study context/i)).toHaveValue('My own brief');
+      await waitFor(() => expect(screen.getByLabelText('Provider')).toBeInTheDocument());
+    });
+
     it('sends a provider, model, and effort override with the repo study request', async () => {
       renderWidget();
       type(REPO);

--- a/client/src/components/brain/tabs/InboxTab.jsx
+++ b/client/src/components/brain/tabs/InboxTab.jsx
@@ -59,7 +59,7 @@ export default function InboxTab({ onRefresh, settings }) {
   const [creative, setCreative] = useLocalStorageBool('brain.captureCreative', false);
   // A bare repo URL is cloned on capture, which unlocks the two post-clone
   // agent opt-ins (malware scan / repo study) — shared with Quick Capture.
-  const repoIntake = useRepoIntake(inputText);
+  const repoIntake = useRepoIntake(inputText, linkNote);
   const [entries, setEntries] = useState([]);
   const [loading, setLoading] = useState(true);
   const [showNeedsReview, setShowNeedsReview] = useState(true);

--- a/client/src/hooks/useRepoIntake.js
+++ b/client/src/hooks/useRepoIntake.js
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import { useLocalStorageBool } from './useLocalStorageBool.js';
 import { useRepoStudyConfig } from './useRepoStudyConfig.js';
 import { parseBareUrl } from '../lib/bareUrl.js';
@@ -38,6 +38,10 @@ export function capturedRepo(text) {
 
 /**
  * @param {string} text the current capture text
+ * @param {string} [note] the "why are you saving this link?" note shown
+ *   alongside the repo opt-ins. When the user ticks "Study for app ideas" with
+ *   an empty study brief, it defaults to this note — the two boxes are almost
+ *   always asked and answered with the same text.
  * @returns {object} the `useRepoStudyConfig` shape plus `repo`, `options`,
  *   `toggle`, and `intakeFor`. `repo` is the parsed `{ host, owner, repo }`
  *   (null when the text isn't a bare repo URL) — both the panel and the host's
@@ -47,13 +51,26 @@ export function capturedRepo(text) {
  *   the SUBMITTED text so a sticky tick can't ride along on a capture the user
  *   retyped into a plain thought.
  */
-export function useRepoIntake(text) {
+export function useRepoIntake(text, note = '') {
   const [malwareScan, setMalwareScan] = useLocalStorageBool(STORAGE_KEYS.malwareScan, false);
   const [learn, setLearn] = useLocalStorageBool(STORAGE_KEYS.learn, false);
   const repo = useMemo(() => capturedRepo(text), [text]);
 
   const repoKey = repo ? `${repo.host}/${repo.owner}/${repo.repo}` : null;
   const study = useRepoStudyConfig({ enabled: Boolean(repo && learn), resetKey: repoKey });
+
+  // Defaults the study brief from the save note the first time "learn" is
+  // ticked on for this repo, rather than on every keystroke — once the user
+  // has their own text in the brief box, typing more in the note shouldn't
+  // clobber it.
+  const prevLearnRef = useRef(learn);
+  useEffect(() => {
+    if (learn && !prevLearnRef.current && !study.studyContext.trim() && note.trim()) {
+      study.setStudyContext(note.trim());
+    }
+    prevLearnRef.current = learn;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [learn, repoKey]);
 
   const options = useMemo(() => ({ malwareScan, learn }), [malwareScan, learn]);
   const setters = { malwareScan: setMalwareScan, learn: setLearn };


### PR DESCRIPTION
## Summary
- When pasting a GitHub/GitLab repo URL into Brain's capture boxes (Quick Capture and the Inbox), the "why are you saving this link?" note and the "study context" brief for the repo-study agent were two blank text areas shown side by side, even though users almost always answer both with the same text.
- The first time "Study for app ideas" is ticked for a repo, the study context now defaults to the save note (if the study brief is still empty). Once the user edits the study brief directly, further edits to the note no longer overwrite it.

## Test plan
- Added `QuickBrainCapture.test.jsx` cases covering the auto-fill on toggle and that a manually-edited brief isn't clobbered by later note edits.
- `npx vitest run` (client) — 824 files / 10095 tests passing.
- `npm run lint` (client, Biome) — clean.