### PR TITLE
fix: keep a throwing onRunStarted hook from crashing the server on CLI run spawn (#5792)

### DIFF
--- a/server/services/runner.js
+++ b/server/services/runner.js
@@ -408,6 +408,20 @@ export async function executeCliRun({ runId, provider, prompt, workspacePath, sc
     env: childEnv
   });
 
+  // Claim the child's 'error' event in the SAME tick as spawn(). Everything
+  // between here and the terminal handlers below — stdin delivery, the
+  // external-run registration, the onRunStarted hook — can throw, and a throw
+  // there leaves a live registered child whose 'error' has no listener; Node
+  // re-throws an unhandled ChildProcess 'error' and kills the server process.
+  // Buffer until the real handler is wired, then replay it exactly once
+  // (same shape as `spawnDirectly` in agentCliSpawning.js).
+  let pendingSpawnError = null;
+  let handleSpawnError = null;
+  childProcess.on('error', (err) => {
+    if (handleSpawnError) handleSpawnError(err);
+    else pendingSpawnError = err;
+  });
+
   // Guard the stdin pipe BEFORE writing: a child that exits before reading it
   // (bad flag, missing CLI) emits EPIPE, and an unlistened stream 'error' out
   // here crashes the server. The 'error'/'close' handlers below settle the run.
@@ -422,8 +436,13 @@ export async function executeCliRun({ runId, provider, prompt, workspacePath, sc
   // stopRun/isRunActive/deleteRun account for this host-spawned child process.
   toolkit.services.runner.registerExternalRun(runId, childProcess);
 
-  // Call hooks
-  runnerConfig.hooks?.onRunStarted?.({ runId, provider: provider.name, model: provider.defaultModel });
+  // Call hooks — isolated like every other hook invocation here: a throw would
+  // otherwise reject executeCliRun with the child already spawned and
+  // registered, leaving the run permanently non-terminal.
+  safeSettle(
+    () => runnerConfig.hooks?.onRunStarted?.({ runId, provider: provider.name, model: provider.defaultModel }),
+    `Run ${runId} onRunStarted hook`,
+  );
 
   // Set timeout (default 5 min, guard against undefined which would fire immediately)
   const effectiveTimeout = timeout ?? provider.timeout ?? 300000;
@@ -573,13 +592,18 @@ export async function executeCliRun({ runId, provider, prompt, workspacePath, sc
     return finalizationPromise;
   };
 
-  childProcess.on('error', (err) => {
+  handleSpawnError = (err) => {
     void finalizeOnce({ exitCode: -1, spawnError: err });
-  });
+  };
 
   childProcess.on('close', (code, signal) => {
     void finalizeOnce({ exitCode: code, signal });
   });
+
+  // A failed spawn emits 'error' and commonly 'close' after it; finalizeOnce
+  // is idempotent, so replaying the buffered error here settles the run and
+  // the later 'close' is a no-op.
+  if (pendingSpawnError) handleSpawnError(pendingSpawnError);
 
   return runId;
 }

--- a/server/services/runner.test.js
+++ b/server/services/runner.test.js
@@ -669,6 +669,76 @@ describe('executeCliRun — stdin pipe containment (#5655)', () => {
   });
 });
 
+describe('executeCliRun — spawn-site error containment (#5792)', () => {
+  const provider = {
+    id: 'codex', command: 'codex', args: [],
+    defaultModel: 'codex-configured-default', timeout: 5000,
+  };
+
+  it('contains a throwing onRunStarted instead of orphaning the spawned child', async () => {
+    // Pre-fix, onRunStarted was the one hook invocation in runner.js not routed
+    // through safeSettle: a throw rejected executeCliRun with the child already
+    // spawned and registered, and the terminal 'error'/'close' handlers ~150
+    // lines below never got wired.
+    const child = makeChild();
+    spawn.mockReturnValue(child);
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    setAIToolkit(fakeToolkit(), {
+      dataDir: '/tmp/test-runner',
+      hooks: { onRunStarted: () => { throw new Error('started hook boom'); } },
+    });
+
+    const onComplete = vi.fn();
+    await expect(executeCliRun({
+      runId: 'run-started-hook-throws', provider, prompt: 'test prompt',
+      workspacePath: TEST_WORKSPACE, onComplete,
+    })).resolves.toBe('run-started-hook-throws');
+
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('onRunStarted hook threw during recovery'));
+
+    // The run is still fully wired: its terminal handler settles the caller.
+    child.emit('close', 0);
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(onComplete).toHaveBeenCalledTimes(1);
+    expect(onComplete.mock.calls[0][0]).toMatchObject({ success: true });
+    errorSpy.mockRestore();
+  });
+
+  it('replays an error emitted before setup finishes into the terminal handler exactly once', async () => {
+    // An unlistened 'error' on a ChildProcess is re-thrown by Node and kills the
+    // server process, so the listener is claimed in the same tick as spawn() and
+    // buffered until the real handler exists. onRunStarted fires inside that
+    // window, which makes it a faithful stand-in for the racing child.
+    const child = makeChild();
+    spawn.mockReturnValue(child);
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    setAIToolkit(fakeToolkit(), {
+      dataDir: '/tmp/test-runner',
+      hooks: {
+        onRunStarted: () => {
+          child.emit('error', Object.assign(new Error('spawn ENOENT'), { code: 'ENOENT' }));
+        },
+      },
+    });
+
+    const onComplete = vi.fn();
+    await executeCliRun({
+      runId: 'run-early-spawn-error', provider, prompt: 'test prompt',
+      workspacePath: TEST_WORKSPACE, onComplete,
+    });
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(onComplete).toHaveBeenCalledTimes(1);
+    expect(onComplete.mock.calls[0][0]).toMatchObject({ success: false, errorCategory: 'spawn_error' });
+
+    // Node commonly follows a failed spawn's 'error' with 'close'; the run stays settled once.
+    child.emit('close', null);
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(onComplete).toHaveBeenCalledTimes(1);
+    errorSpy.mockRestore();
+  });
+});
+
 describe('executeCliRun — close handler crash guard', () => {
   // Drive a codex run whose first write (output) succeeds and second write
   // (metadata) rejects, so the close handler's recovery path runs. Returns the


### PR DESCRIPTION
## Summary

`executeCliRun` (`server/services/runner.js`) spawns the CLI child, delivers stdin, registers the run in the toolkit's external-run registry, and then fires the `onRunStarted` lifecycle hook — all roughly 150 lines *before* the child's `'error'` listener is registered.

`onRunStarted` was the one hook invocation in that file not routed through the existing `safeSettle` wrapper. A throwing hook therefore rejected `executeCliRun` with a live child already registered as an active run and no terminal settlement, and a subsequent `'error'` on that orphan landed on nothing — Node re-throws an unhandled `ChildProcess` `'error'`, which kills the server process along with every other run on it.

Two changes, both established patterns already in this codebase:

1. The `onRunStarted` call at the spawn site now goes through `safeSettle`, matching every other hook invocation in `runner.js`.
2. The child's `'error'` event is claimed in the same tick as `spawn()` and buffered until the real terminal handler exists, then replayed into it exactly once — the `pendingSpawnError` / `handleSpawnError` shape already proven in `spawnDirectly` (`server/services/agentCliSpawning.js`). `finalizeOnce` is idempotent, so the `'close'` Node commonly emits after a failed spawn stays a no-op.

Follow-on to the stdin-pipe containment work in #5655; separate hazard.

## Test plan

Two new tests in `server/services/runner.test.js` (`executeCliRun — spawn-site error containment`), both verified to fail against the unpatched `runner.js` and pass with the fix:

- A throwing `onRunStarted` no longer rejects `executeCliRun`; the throw is logged and the run's terminal handler still settles the caller with `success: true` on close.
- An `'error'` emitted during the setup window (from inside `onRunStarted`, before the real handler is wired) reaches the terminal handler exactly once as `errorCategory: 'spawn_error'`, and a following `'close'` does not settle it a second time.

Full server suite: `cd server && npm test` — **Test Files 1888 passed | 1 skipped (1889)**, Tests 38088 passed | 14 skipped.

Closes #5792
