### PR TITLE
fix: keep long tokens in wrapping <pre> blocks on screen (#5820)

### DIFF
--- a/client/src/components/brain/tabs/TrustTab.jsx
+++ b/client/src/components/brain/tabs/TrustTab.jsx
@@ -279,7 +279,7 @@ export default function TrustTab({ onRefresh }) {
                 {isExpanded && (
                   <div className="mt-3 p-3 bg-port-bg rounded-lg">
                     <h4 className="text-xs font-medium text-gray-400 mb-2">Full Classification Data</h4>
-                    <pre className="text-xs text-gray-300 overflow-x-auto whitespace-pre-wrap">
+                    <pre className="text-xs text-gray-300 overflow-x-auto whitespace-pre-wrap break-all">
                       {JSON.stringify({
                         id: entry.id,
                         capturedAt: entry.capturedAt,

--- a/client/src/components/cos/tabs/ResumeAgentModal.jsx
+++ b/client/src/components/cos/tabs/ResumeAgentModal.jsx
@@ -274,7 +274,7 @@ export default function ResumeAgentModal({ agent, taskType = 'user', providers, 
             <summary className="text-gray-400 cursor-pointer hover:text-white transition-colors">
               View context to be included
             </summary>
-            <pre className="mt-2 p-3 bg-port-bg border border-port-border rounded-lg text-gray-400 text-xs overflow-auto max-h-48 whitespace-pre-wrap">
+            <pre className="mt-2 p-3 bg-port-bg border border-port-border rounded-lg text-gray-400 text-xs overflow-auto max-h-48 whitespace-pre-wrap break-all">
               {initialContext}
             </pre>
           </details>

--- a/client/src/components/cos/tabs/schedule/PromptEditor.jsx
+++ b/client/src/components/cos/tabs/schedule/PromptEditor.jsx
@@ -66,7 +66,7 @@ export default function PromptEditor({ config, promptValue, setPromptValue, edit
             title="Click to edit prompt"
             aria-label="Edit prompt"
           >
-            <pre className="whitespace-pre-wrap">{promptValue || 'No prompt configured'}</pre>
+            <pre className="whitespace-pre-wrap break-words">{promptValue || 'No prompt configured'}</pre>
           </button>
         )}
       </div>
@@ -96,7 +96,7 @@ export default function PromptEditor({ config, promptValue, setPromptValue, edit
           ))}
         </div>
         <div className="bg-port-bg px-3 py-2 text-xs text-gray-400 font-mono max-h-64 overflow-y-auto">
-          <pre className="whitespace-pre-wrap">{stagePrompts[activeTab] || 'No prompt configured'}</pre>
+          <pre className="whitespace-pre-wrap break-words">{stagePrompts[activeTab] || 'No prompt configured'}</pre>
         </div>
       </div>
       <p className="text-xs text-gray-500 mt-2">Stage prompts use the default templates. Edit the main task prompt to override all stages with a single prompt.</p>

--- a/client/src/components/creative-director/OverviewTab.jsx
+++ b/client/src/components/creative-director/OverviewTab.jsx
@@ -256,14 +256,14 @@ export default function OverviewTab({ project, onProjectUpdate, onAsyncWorkQueue
       {project.styleSpec && (
         <section className="bg-port-card border border-port-border rounded p-4">
           <h2 className="text-sm font-semibold text-port-text-muted uppercase tracking-wide mb-2">Style spec</h2>
-          <pre className="whitespace-pre-wrap text-sm text-port-text font-mono">{project.styleSpec}</pre>
+          <pre className="whitespace-pre-wrap break-words text-sm text-port-text font-mono">{project.styleSpec}</pre>
         </section>
       )}
 
       {project.userStory && (
         <section className="bg-port-card border border-port-border rounded p-4">
           <h2 className="text-sm font-semibold text-port-text-muted uppercase tracking-wide mb-2">User-supplied story</h2>
-          <pre className="whitespace-pre-wrap text-sm text-port-text font-mono">{project.userStory}</pre>
+          <pre className="whitespace-pre-wrap break-words text-sm text-port-text font-mono">{project.userStory}</pre>
         </section>
       )}
 

--- a/client/src/components/creative-director/TreatmentTab.jsx
+++ b/client/src/components/creative-director/TreatmentTab.jsx
@@ -40,9 +40,9 @@ export default function TreatmentTab({ project }) {
                   {typeof s.imageStrength === 'number' && ` · str ${s.imageStrength}`}
                 </span>
               </div>
-              <pre className="whitespace-pre-wrap text-xs text-port-text-muted font-mono mt-2">{s.prompt}</pre>
+              <pre className="whitespace-pre-wrap break-words text-xs text-port-text-muted font-mono mt-2">{s.prompt}</pre>
               {s.negativePrompt && (
-                <pre className="whitespace-pre-wrap text-xs text-port-error/70 font-mono mt-1">neg: {s.negativePrompt}</pre>
+                <pre className="whitespace-pre-wrap break-words text-xs text-port-error/70 font-mono mt-1">neg: {s.negativePrompt}</pre>
               )}
             </div>
           ))}

--- a/client/src/components/digital-twin/ListEnrichment.jsx
+++ b/client/src/components/digital-twin/ListEnrichment.jsx
@@ -411,7 +411,7 @@ export default function ListEnrichment({
                 className="w-full px-4 py-3 bg-port-bg border border-port-border rounded-lg text-white font-mono text-sm resize-y focus:outline-hidden focus:border-port-accent"
               />
             ) : (
-              <pre className="p-4 bg-port-bg rounded-lg text-sm text-gray-300 whitespace-pre-wrap overflow-auto max-h-96">
+              <pre className="p-4 bg-port-bg rounded-lg text-sm text-gray-300 whitespace-pre-wrap break-words overflow-auto max-h-96">
                 {documentContent}
               </pre>
             )}

--- a/client/src/components/digital-twin/NextActionBanner.jsx
+++ b/client/src/components/digital-twin/NextActionBanner.jsx
@@ -246,7 +246,7 @@ export default function NextActionBanner({ gaps, status, traits, onRefresh }) {
             </p>
             {prompt && (
               <div className="relative mb-3">
-                <pre className="text-xs text-gray-300 bg-port-bg border border-port-border rounded-lg p-3 pr-10 whitespace-pre-wrap max-h-32 overflow-y-auto">
+                <pre className="text-xs text-gray-300 bg-port-bg border border-port-border rounded-lg p-3 pr-10 whitespace-pre-wrap break-words max-h-32 overflow-y-auto">
                   {prompt}
                 </pre>
                 <button
@@ -389,7 +389,7 @@ export default function NextActionBanner({ gaps, status, traits, onRefresh }) {
                 All enrichment questions answered. Copy this prompt into ChatGPT or Claude to dig deeper into <span className="text-white font-medium">{dimensionLabel}</span>:
               </p>
               <div className="relative">
-                <pre className="text-xs text-gray-300 bg-port-bg border border-port-border rounded-lg p-3 pr-10 whitespace-pre-wrap max-h-32 overflow-y-auto">
+                <pre className="text-xs text-gray-300 bg-port-bg border border-port-border rounded-lg p-3 pr-10 whitespace-pre-wrap break-words max-h-32 overflow-y-auto">
                   {buildContinuationPrompt(activeGap.dimension, activeGap)}
                 </pre>
                 <button

--- a/client/src/components/digital-twin/tabs/AvatarBioTab.jsx
+++ b/client/src/components/digital-twin/tabs/AvatarBioTab.jsx
@@ -263,7 +263,7 @@ export default function AvatarBioTab() {
                 <CopyButton getText={() => polished.content} />
               </div>
             </div>
-            <pre className="text-sm text-gray-300 whitespace-pre-wrap font-sans leading-relaxed">
+            <pre className="text-sm text-gray-300 whitespace-pre-wrap break-words font-sans leading-relaxed">
               {polished.content}
             </pre>
           </div>

--- a/client/src/components/digital-twin/tabs/DocumentsTab.jsx
+++ b/client/src/components/digital-twin/tabs/DocumentsTab.jsx
@@ -294,7 +294,7 @@ export default function DocumentsTab({ onRefresh }) {
                   placeholder="Write your soul document here..."
                 />
               ) : (
-                <pre className="p-4 text-sm text-gray-300 whitespace-pre-wrap font-mono">
+                <pre className="p-4 text-sm text-gray-300 whitespace-pre-wrap break-words font-mono">
                   {selectedDoc.content}
                 </pre>
               )}

--- a/client/src/components/digital-twin/tabs/EnrichTab.jsx
+++ b/client/src/components/digital-twin/tabs/EnrichTab.jsx
@@ -683,7 +683,7 @@ export default function EnrichTab({ onRefresh }) {
                         Save to Soul
                       </button>
                     </div>
-                    <pre className="p-3 bg-port-bg rounded-lg text-sm text-gray-300 whitespace-pre-wrap overflow-auto max-h-64">
+                    <pre className="p-3 bg-port-bg rounded-lg text-sm text-gray-300 whitespace-pre-wrap break-words overflow-auto max-h-64">
                       {writingAnalysis.suggestedContent}
                     </pre>
                   </div>

--- a/client/src/components/digital-twin/tabs/ExportTab.jsx
+++ b/client/src/components/digital-twin/tabs/ExportTab.jsx
@@ -280,7 +280,7 @@ export default function ExportTab({ onRefresh: _onRefresh }) {
 
         <div className="flex-1 overflow-auto p-4">
           {exportResult ? (
-            <pre className="text-sm text-gray-300 whitespace-pre-wrap font-mono">
+            <pre className="text-sm text-gray-300 whitespace-pre-wrap break-all font-mono">
               {typeof exportResult.content === 'string'
                 ? exportResult.content
                 : JSON.stringify(exportResult.content, null, 2)}

--- a/client/src/components/digital-twin/tabs/ImportTab.jsx
+++ b/client/src/components/digital-twin/tabs/ImportTab.jsx
@@ -566,7 +566,7 @@ export default function ImportTab() {
                       <summary className="text-sm text-port-accent cursor-pointer hover:text-white">
                         Preview content
                       </summary>
-                      <pre className="mt-2 p-3 bg-port-card rounded text-xs text-gray-300 overflow-x-auto whitespace-pre-wrap max-h-48 overflow-y-auto">
+                      <pre className="mt-2 p-3 bg-port-card rounded text-xs text-gray-300 overflow-x-auto whitespace-pre-wrap break-words max-h-48 overflow-y-auto">
                         {doc.content}
                       </pre>
                     </details>

--- a/client/src/components/pipeline/stages/ComicScriptStage.jsx
+++ b/client/src/components/pipeline/stages/ComicScriptStage.jsx
@@ -770,7 +770,7 @@ export default function ComicScriptStage({ issue, series, onStageUpdate, actions
             {showSource ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
             Full comic script (markdown source)
           </summary>
-          <pre className="px-3 py-2 text-xs text-gray-300 whitespace-pre-wrap font-mono border-t border-port-border">
+          <pre className="px-3 py-2 text-xs text-gray-300 whitespace-pre-wrap break-words font-mono border-t border-port-border">
             {script.output}
           </pre>
         </details>

--- a/client/src/components/settings/LocalLlmRuntimesView.jsx
+++ b/client/src/components/settings/LocalLlmRuntimesView.jsx
@@ -1082,7 +1082,7 @@ export default function LocalLlmRuntimesView() {
               {showLlamaLogs ? 'Hide server logs' : `View server logs (${llamaStatus.recentLogs.length} lines)`}
             </button>
             {showLlamaLogs && (
-              <pre className="text-[10px] text-gray-400 bg-port-bg border border-port-border/60 p-2.5 rounded max-h-40 overflow-y-auto font-mono whitespace-pre-wrap">
+              <pre className="text-[10px] text-gray-400 bg-port-bg border border-port-border/60 p-2.5 rounded max-h-40 overflow-y-auto font-mono whitespace-pre-wrap break-all">
                 {llamaStatus.recentLogs.join('\n')}
               </pre>
             )}

--- a/client/src/components/settings/LocalSetupPanel.jsx
+++ b/client/src/components/settings/LocalSetupPanel.jsx
@@ -267,7 +267,7 @@ export default function LocalSetupPanel({ pythonPath, onPythonPathChange, onPack
               )}
               {(installing || installLog.length > 0) && (
                 <pre
-                  className="mt-3 max-h-48 overflow-y-auto text-[11px] font-mono text-gray-400 bg-black/40 border border-port-border rounded p-2 whitespace-pre-wrap"
+                  className="mt-3 max-h-48 overflow-y-auto text-[11px] font-mono text-gray-400 bg-black/40 border border-port-border rounded p-2 whitespace-pre-wrap break-all"
                 >
                   {installLog.map((e, i) => (
                     <div key={i} className={e.kind === 'error' ? 'text-port-error' : e.kind === 'success' ? 'text-port-success' : ''}>

--- a/client/src/components/settings/ModelCapabilityTests.jsx
+++ b/client/src/components/settings/ModelCapabilityTests.jsx
@@ -492,7 +492,7 @@ function CapabilityTestDrawer({
           <>
             <div className="bg-port-bg border border-port-border rounded-lg p-3 space-y-2">
               <h3 className="text-xs font-medium text-gray-400">What PortOS will send</h3>
-              <pre className="text-[11px] text-gray-300 whitespace-pre-wrap font-mono leading-relaxed max-h-56 overflow-y-auto">{prompt}</pre>
+              <pre className="text-[11px] text-gray-300 whitespace-pre-wrap break-words font-mono leading-relaxed max-h-56 overflow-y-auto">{prompt}</pre>
             </div>
             <p className="text-xs text-gray-500 leading-snug">
               This runs <span className="text-gray-300 font-mono break-all">{modelId}</span> on{' '}
@@ -555,7 +555,7 @@ function CapabilityTestDrawer({
                   {result.output === undefined
                     ? <BrailleSpinner text="Loading the output" />
                     : (result.output.trim()
-                      ? <pre className="text-sm text-gray-200 whitespace-pre-wrap leading-relaxed font-sans">{result.output}</pre>
+                      ? <pre className="text-sm text-gray-200 whitespace-pre-wrap break-all leading-relaxed font-sans">{result.output}</pre>
                       : <p className="text-xs text-gray-500 italic">The model returned no text.</p>)}
                 </div>
               </div>
@@ -568,7 +568,7 @@ function CapabilityTestDrawer({
                 {result.transcript === undefined && liveLines.length === 0
                   ? <BrailleSpinner text="Loading the transcript" />
                   : (
-                    <pre className="text-[11px] font-mono text-gray-400 whitespace-pre-wrap leading-relaxed">
+                    <pre className="text-[11px] font-mono text-gray-400 whitespace-pre-wrap break-all leading-relaxed">
                       {result.transcript?.trim() || liveLines.join('\n') || 'No agent transcript for this test.'}
                     </pre>
                   )}

--- a/client/src/components/settings/MtplxServerCard.jsx
+++ b/client/src/components/settings/MtplxServerCard.jsx
@@ -230,7 +230,7 @@ export default function MtplxServerCard({
             {showLogs ? 'Hide server logs' : `View server logs (${status.recentLogs.length} lines)`}
           </button>
           {showLogs && (
-            <pre className="text-[10px] text-gray-400 bg-port-bg border border-port-border/60 p-2.5 rounded max-h-40 overflow-y-auto font-mono whitespace-pre-wrap">
+            <pre className="text-[10px] text-gray-400 bg-port-bg border border-port-border/60 p-2.5 rounded max-h-40 overflow-y-auto font-mono whitespace-pre-wrap break-all">
               {status.recentLogs.join('\n')}
             </pre>
           )}

--- a/client/src/components/settings/SlotstreamServerCard.jsx
+++ b/client/src/components/settings/SlotstreamServerCard.jsx
@@ -211,7 +211,7 @@ export default function SlotstreamServerCard({
             {showLogs ? 'Hide server logs' : `View server logs (${status.recentLogs.length} lines)`}
           </button>
           {showLogs && (
-            <pre className="text-[10px] text-gray-400 bg-port-bg border border-port-border/60 p-2.5 rounded max-h-40 overflow-y-auto font-mono whitespace-pre-wrap">
+            <pre className="text-[10px] text-gray-400 bg-port-bg border border-port-border/60 p-2.5 rounded max-h-40 overflow-y-auto font-mono whitespace-pre-wrap break-all">
               {status.recentLogs.join('\n')}
             </pre>
           )}

--- a/client/src/components/settings/VoiceTab.jsx
+++ b/client/src/components/settings/VoiceTab.jsx
@@ -411,7 +411,7 @@ export function VoiceTab() {
         </div>
         {faceTimeDirty && <p className="text-xs text-port-warning">Set and save both identity fields before FaceTime controls are available.</p>}
         {facetimeStatus && <ul className="text-xs text-gray-400">{Object.entries(facetimeStatus).map(([key, value]) => <li key={key}>{value.ok === 'ok' ? '✓' : '•'} {key}: {value.message}</li>)}</ul>}
-        {facetimeResult && <pre className="text-xs text-gray-400 whitespace-pre-wrap">{JSON.stringify(facetimeResult, null, 2)}</pre>}
+        {facetimeResult && <pre className="text-xs text-gray-400 whitespace-pre-wrap break-all">{JSON.stringify(facetimeResult, null, 2)}</pre>}
       </section>}
 
       <div className="flex items-start gap-3 bg-port-bg border border-port-border rounded-lg p-3">

--- a/client/src/components/wiki/tabs/BrowseTab.jsx
+++ b/client/src/components/wiki/tabs/BrowseTab.jsx
@@ -332,7 +332,7 @@ export default function BrowseTab({ vaultId, notes, rawNotes, allNotes, onRefres
                   />
                 ) : (
                   <div className="p-4 prose prose-invert prose-sm max-w-none">
-                    <pre className="whitespace-pre-wrap text-sm text-gray-300 font-mono leading-relaxed">
+                    <pre className="whitespace-pre-wrap break-words text-sm text-gray-300 font-mono leading-relaxed">
                       {selectedNote.body || selectedNote.content}
                     </pre>
                   </div>

--- a/client/src/components/writers-room/AnalysisHistory.jsx
+++ b/client/src/components/writers-room/AnalysisHistory.jsx
@@ -198,7 +198,7 @@ function FormatResult({ result, onApply }) {
           </button>
         )}
       </div>
-      <pre className="whitespace-pre-wrap font-serif text-gray-300 bg-port-bg border border-port-border rounded p-2 max-h-64 overflow-y-auto">{text}</pre>
+      <pre className="whitespace-pre-wrap break-words font-serif text-gray-300 bg-port-bg border border-port-border rounded p-2 max-h-64 overflow-y-auto">{text}</pre>
     </div>
   );
 }

--- a/client/src/pages/AIProviders.jsx
+++ b/client/src/pages/AIProviders.jsx
@@ -880,7 +880,7 @@ export default function AIProviders() {
 
           {runOutput && (
             <div className="bg-port-bg border border-port-border rounded-lg p-3 max-h-64 overflow-auto">
-              <pre className="text-sm text-gray-300 font-mono whitespace-pre-wrap">{runOutput}</pre>
+              <pre className="text-sm text-gray-300 font-mono whitespace-pre-wrap break-all">{runOutput}</pre>
             </div>
           )}
         </div>

--- a/client/src/pages/Browser.jsx
+++ b/client/src/pages/Browser.jsx
@@ -295,7 +295,7 @@ export default function BrowserPage() {
               <RefreshCw size={14} />
             </button>
           </div>
-          <pre className="p-3 text-xs text-gray-400 font-mono overflow-auto max-h-64 whitespace-pre-wrap">
+          <pre className="p-3 text-xs text-gray-400 font-mono overflow-auto max-h-64 whitespace-pre-wrap break-all">
             {logs || <BrailleSpinner text="Loading logs" />}
           </pre>
         </div>

--- a/client/src/pages/HistoryPage.jsx
+++ b/client/src/pages/HistoryPage.jsx
@@ -284,7 +284,7 @@ export function HistoryPage() {
                         <div>
                           <div className="text-xs text-gray-500 uppercase tracking-wide mb-2">Error</div>
                           <Banner tone="error" size="md">
-                            <pre className="text-sm font-mono whitespace-pre-wrap">
+                            <pre className="text-sm font-mono whitespace-pre-wrap break-all">
                               {entry.error}
                             </pre>
                           </Banner>
@@ -296,7 +296,7 @@ export function HistoryPage() {
                         <div>
                           <div className="text-xs text-gray-500 uppercase tracking-wide mb-2">Additional Details</div>
                           <div className="bg-port-card border border-port-border rounded-lg p-3">
-                            <pre className="text-xs text-gray-400 font-mono whitespace-pre-wrap">
+                            <pre className="text-xs text-gray-400 font-mono whitespace-pre-wrap break-all">
                               {JSON.stringify(
                                 Object.fromEntries(
                                   Object.entries(entry.details).filter(([k]) => !['command', 'output', 'runtime', 'exitCode'].includes(k))

--- a/client/src/pages/Loops.jsx
+++ b/client/src/pages/Loops.jsx
@@ -276,7 +276,7 @@ function LoopCard({ loop, onAction, expandedId, onToggle }) {
         <div className="border-t border-port-border">
           <div className="px-4 py-2 bg-port-bg/30">
             <div className="text-xs text-gray-500 mb-1">Prompt</div>
-            <pre className="text-xs text-gray-300 whitespace-pre-wrap font-mono">{loop.prompt}</pre>
+            <pre className="text-xs text-gray-300 whitespace-pre-wrap break-words font-mono">{loop.prompt}</pre>
           </div>
 
           {loop.history?.length > 0 && (

--- a/client/src/pages/PromptManager.jsx
+++ b/client/src/pages/PromptManager.jsx
@@ -755,7 +755,7 @@ export default function PromptManager() {
                 {preview && (
                   <div className="bg-port-card border border-port-border rounded-xl p-4">
                     <h4 className="text-sm font-medium text-gray-400 mb-2">Preview</h4>
-                    <pre className="text-sm text-gray-300 whitespace-pre-wrap bg-port-bg p-3 rounded max-h-64 overflow-auto">
+                    <pre className="text-sm text-gray-300 whitespace-pre-wrap break-words bg-port-bg p-3 rounded max-h-64 overflow-auto">
                       {preview}
                     </pre>
                   </div>
@@ -1012,7 +1012,7 @@ export default function PromptManager() {
                 {jobSkillPreview && (
                   <div className="bg-port-card border border-port-border rounded-xl p-4">
                     <h4 className="text-sm font-medium text-gray-400 mb-2">Effective Prompt Preview</h4>
-                    <pre className="text-sm text-gray-300 whitespace-pre-wrap bg-port-bg p-3 rounded max-h-64 overflow-auto">
+                    <pre className="text-sm text-gray-300 whitespace-pre-wrap break-words bg-port-bg p-3 rounded max-h-64 overflow-auto">
                       {jobSkillPreview}
                     </pre>
                   </div>

--- a/client/src/pages/RunnerPage.jsx
+++ b/client/src/pages/RunnerPage.jsx
@@ -507,7 +507,7 @@ ${prompt.trim()}`;
           className="bg-port-bg border border-port-border rounded-lg p-3 sm:p-4 h-64 sm:h-80 overflow-auto font-mono text-xs sm:text-sm"
         >
           {output ? (
-            <pre className="text-gray-300 whitespace-pre-wrap">{output}</pre>
+            <pre className="text-gray-300 whitespace-pre-wrap break-all">{output}</pre>
           ) : (
             <div className="text-gray-500">Output will appear here...</div>
           )}

--- a/client/src/preWrapClasses.test.js
+++ b/client/src/preWrapClasses.test.js
@@ -1,0 +1,157 @@
+/**
+ * Repo-wide: a wrapping `<pre>` also has to break unbroken tokens.
+ *
+ * `Layout`'s root shell is `w-full max-w-full overflow-x-hidden`, so a child
+ * wider than the viewport is CLIPPED rather than made scrollable — there is no
+ * scrollbar to recover the overflowing edge. `whitespace-pre-wrap` only wraps at
+ * *whitespace*, so a `<pre>` carrying it alone still runs off the clip edge the
+ * moment its content holds one unbroken token: an absolute path, a URL, a
+ * base64 blob, a minified JSON line, a stack frame (issue #5820, following the
+ * two no-wrap-class blocks fixed in #5675).
+ *
+ * The rule: a `<pre>` opener whose class tokens include `whitespace-pre-wrap`
+ * must also carry a break class. Which one depends on what the block renders,
+ * and the split is deliberate:
+ *
+ *  - **Machine output** — logs, command output, JSON dumps, stack traces, raw
+ *    model transcripts, API payloads — takes `break-all`, matching
+ *    `components/ui/ProcessLogLines.jsx`, the canonical log renderer. A 400-char
+ *    token there has no natural break point, and mid-token breaking is the only
+ *    thing that keeps its tail on screen.
+ *  - **Human-authored prose** — prompt templates, treatments, bios, user
+ *    stories, wiki bodies — takes `break-words`, which breaks a word only when
+ *    it cannot fit on a line of its own. Breaking mid-word on every line is
+ *    worse to read than the rare long token in prose.
+ *
+ * `components/cos/JobCard.jsx` shows both in one component: `job.lastOutput` is
+ * `break-all`, `job.promptTemplate` is `break-words`.
+ *
+ * Deliberately NOT the fix, and so not accepted by this guard:
+ *  - Relaxing `Layout`'s `overflow-x-hidden` — it is what stops one wide child
+ *    from giving the whole app a horizontal scrollbar. The fix belongs in the leaf.
+ *  - `overflow-x-auto` on the block — a horizontal scroller inside a card is
+ *    worse on touch, where a wrapped block keeps every character reachable at 360px.
+ *
+ * Deliberately out of scope: a `<pre>` with no wrap class at all (it is a
+ * horizontal scroller by default, which a few blocks legitimately want) and
+ * `<code>` spans.
+ *
+ * The opener is read as a whole tag rather than a line, because a JSX `<pre>`
+ * routinely splits its attributes across lines — a line-scoped grep silently
+ * passes over exactly those blocks. Every class token in the opener is pooled,
+ * across a conditional's branches too, so a block that supplies its break class
+ * from only one branch reads as covered; branch-precise checking would need the
+ * component actually rendered, and the regression this catches is the far more
+ * common one of a block with no break class on any path. Comments are masked
+ * first so this doc block quoting an example class string is documentation, not
+ * markup.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { trackedSourceFiles } from './test/trackedFiles.js';
+import { lineOf, maskComments, stringLiterals } from './test/classNameScan.js';
+
+const CLIENT_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+// `<pre` followed by whitespace, `>`, `/`, or `{` — so `<prefetch>` and a
+// `<pre>`-free identifier like `preview` are not openers.
+const PRE_OPENER = /<pre(?=[\s/>{])/g;
+const WRAP = 'whitespace-pre-wrap';
+// `break-all` breaks anywhere; `break-words` (and Tailwind v4's `wrap-anywhere`
+// / `break-anywhere`) break only when the word cannot fit alone. All three keep
+// the tail of a long token on screen, which is the property under test.
+const BREAKS = new Set(['break-all', 'break-words', 'break-anywhere', 'wrap-anywhere']);
+
+/**
+ * The full opening tag starting at `start`, quotes and `{…}` expressions
+ * balanced, so a `>` inside `className={cond ? 'a>b' : ''}` doesn't end it early.
+ */
+function openingTag(source, start) {
+  let i = start;
+  let depth = 0;
+  while (i < source.length) {
+    const ch = source[i];
+    if (ch === '"' || ch === "'" || ch === '`') {
+      const quote = ch;
+      i += 1;
+      while (i < source.length && source[i] !== quote) i += source[i] === '\\' ? 2 : 1;
+      i += 1;
+      continue;
+    }
+    if (ch === '{') depth += 1;
+    else if (ch === '}') depth -= 1;
+    else if (ch === '>' && depth === 0) return source.slice(start, i + 1);
+    i += 1;
+  }
+  return source.slice(start);
+}
+
+// Splits on everything a Tailwind class cannot contain — whitespace, but also
+// the quotes, braces and `$` of a template literal — so a class supplied through
+// an interpolated branch (`` `whitespace-pre-wrap ${dense ? "break-all" : ""}` ``)
+// is read as the token it renders to rather than as `"break-all"`.
+const classTokens = (tag) =>
+  stringLiterals(tag)
+    .flatMap(({ value }) => value.split(/[^A-Za-z0-9_:/[\].%-]+/))
+    .filter(Boolean);
+
+function violationsIn(rawSource, file) {
+  const source = maskComments(rawSource);
+  const found = [];
+  PRE_OPENER.lastIndex = 0;
+  let match;
+  while ((match = PRE_OPENER.exec(source))) {
+    const tag = openingTag(source, match.index);
+    const tokens = classTokens(tag);
+    if (!tokens.includes(WRAP)) continue;
+    if (tokens.some((token) => BREAKS.has(token))) continue;
+    found.push(`${file}:${lineOf(source, match.index)}`);
+  }
+  return found;
+}
+
+const findViolations = (file) =>
+  violationsIn(readFileSync(join(CLIENT_ROOT, file), 'utf8'), file);
+
+describe('<pre> wrap/break class conventions', () => {
+  const files = trackedSourceFiles(CLIENT_ROOT);
+
+  it('scans a populated client tree', () => {
+    expect(files.length).toBeGreaterThan(100);
+  });
+
+  // Without this the suite would still pass if the detector silently stopped
+  // matching anything — a green tree-wide guard proves nothing on its own.
+  it('flags a wrapping <pre> with no break class and clears every safe form', () => {
+    const flagged = (markup) => violationsIn(markup, 'probe.jsx').length;
+    expect(flagged('<pre className="text-xs whitespace-pre-wrap">{log}</pre>')).toBe(1);
+    expect(flagged('<pre className="whitespace-pre-wrap break-all">{log}</pre>')).toBe(0);
+    expect(flagged('<pre className="whitespace-pre-wrap break-words">{prose}</pre>')).toBe(0);
+    // A `<pre>` with no wrap class is a horizontal scroller by design.
+    expect(flagged('<pre className="text-xs font-mono">{log}</pre>')).toBe(0);
+    expect(flagged('<pre>{log}</pre>')).toBe(0);
+    // The opener routinely spans lines; a line-scoped scan would miss this one.
+    expect(flagged('<pre\n  className="p-2 font-mono whitespace-pre-wrap"\n>\n  {log}\n</pre>')).toBe(1);
+    expect(flagged('<pre\n  className="whitespace-pre-wrap break-all"\n>\n  {log}\n</pre>')).toBe(0);
+    // Both halves of a composed class string count as one token set.
+    expect(flagged('<pre className={`whitespace-pre-wrap ${dense ? "break-all" : "break-words"}`}>{x}</pre>')).toBe(0);
+    expect(flagged('<pre className={`whitespace-pre-wrap ${dense ? "text-xs" : "text-sm"}`}>{x}</pre>')).toBe(1);
+    // A `>` inside the class expression does not end the opening tag early — if
+    // it did, the scan would see no class tokens at all and report nothing.
+    expect(flagged('<pre className={n > 2 ? "whitespace-pre-wrap" : "text-xs"}>{x}</pre>')).toBe(1);
+    // Neither `overflow-x-auto` nor a max-height substitutes for a break class:
+    // the shell clips rather than scrolls, so the overflow is unreachable.
+    expect(flagged('<pre className="whitespace-pre-wrap overflow-x-auto max-h-48">{log}</pre>')).toBe(1);
+    // A sibling tag whose name merely starts with "pre" is not a <pre>.
+    expect(flagged('<preview className="whitespace-pre-wrap" />')).toBe(0);
+    // A doc comment quoting an example opener is not markup.
+    expect(violationsIn('// e.g. <pre className="whitespace-pre-wrap">', 'probe.jsx')).toEqual([]);
+  });
+
+  it('never leaves a wrapping <pre> able to overflow the clipped shell', () => {
+    expect(files.flatMap((file) => findViolations(file))).toEqual([]);
+  });
+});

--- a/scripts/ci-test-plan.js
+++ b/scripts/ci-test-plan.js
@@ -309,9 +309,9 @@ const structuralTestsFor = (changedFiles, trackedSet) => {
   // Both `.js` and `.jsx`: the StrictMode mounted-ref bug the first guard covers
   // reached its widest blast radius through a plain-`.js` hook (`useAsyncAction`),
   // so a `.jsx`-only trigger would miss the case that matters most, and the
-  // responsive-grid, popover-clamp, safe-storage, heading-truncation, and
-  // global-shadow guards read class strings, storage accesses, declarations, and
-  // JSX markup out of both extensions.
+  // responsive-grid, popover-clamp, pre-wrap/break, safe-storage,
+  // heading-truncation, and global-shadow guards read class strings, storage
+  // accesses, declarations, and JSX markup out of both extensions.
   // None of these files has a source sibling or imports an app module, so nothing
   // else selects them — without this entry they only ever run on a full suite.
   if (changedFiles.some((path) => /^client\/src\/.*\.jsx?$/.test(path))) {
@@ -320,6 +320,7 @@ const structuralTestsFor = (changedFiles, trackedSet) => {
     add('client/src/hooks/mountedRefConventions.test.js');
     add('client/src/pollingConventions.test.js');
     add('client/src/popoverClampConventions.test.js');
+    add('client/src/preWrapClasses.test.js');
     add('client/src/responsiveGridConventions.test.js');
     add('client/src/storageConventions.test.js');
   }

--- a/scripts/repo-scan-guards.test.js
+++ b/scripts/repo-scan-guards.test.js
@@ -43,6 +43,7 @@ const STRUCTURALLY_SELECTED = new Map([
   ['client/src/hooks/mountedRefConventions.test.js', 'structuralTestsFor: client/src/**.js(x)'],
   ['client/src/pollingConventions.test.js', 'structuralTestsFor: client/src/**.js(x)'],
   ['client/src/popoverClampConventions.test.js', 'structuralTestsFor: client/src/**.js(x)'],
+  ['client/src/preWrapClasses.test.js', 'structuralTestsFor: client/src/**.js(x)'],
   ['client/src/responsiveGridConventions.test.js', 'structuralTestsFor: client/src/**.js(x)'],
   ['client/src/storageConventions.test.js', 'structuralTestsFor: client/src/**.js(x)'],
   // `.ps1` is not in EXECUTABLE_RE, so touching one is an "unclassified changed


### PR DESCRIPTION
## Summary

`Layout`'s root shell is `overflow-x-hidden`, so a child wider than the viewport is **clipped**, not scrollable — there is no scrollbar to recover the overflowing edge. `whitespace-pre-wrap` only wraps at *whitespace*, so a `<pre>` carrying it alone still runs off that edge as soon as its content holds one unbroken token: an absolute path, a URL, a base64 blob, a minified JSON line, a stack frame.

#5675 fixed the two `<pre>` openers that had no wrap class at all, plus the two in `JobCard.jsx`. This is the remaining sweep: **35 blocks across 27 files**, each classified by what it renders, following the split `JobCard.jsx` established.

- **Machine output → `break-all`** (matching `components/ui/ProcessLogLines.jsx`, the canonical log renderer): llama.cpp / mtplx / slotstream server logs, the local-setup install log, runner and provider command output, browser logs, JSON dumps (`TrustTab`, `VoiceTab`, `HistoryPage` details), error traces, agent transcripts and raw model output in the capability tests, the resume-agent context blob, and the digital-twin export payload.
- **Human-authored prose → `break-words`** (breaks a word only when it cannot fit on a line of its own): prompt templates and previews (`PromptEditor`, `PromptManager`, `Loops`, `NextActionBanner`, the capability-test "what PortOS will send" panel), creative-director style specs / user stories / treatment prompts, the comic-script markdown source, digital-twin soul documents and bios, and wiki note bodies.

Nothing else changes: `Layout`'s `overflow-x-hidden` is untouched (it is what stops one wide child from giving the whole app a horizontal scrollbar), and no `overflow-x-auto` was added — a horizontal scroller inside a card is worse on touch than a block that keeps every character reachable at 360px.

New tree-wide guard `client/src/preWrapClasses.test.js` fails when any git-tracked non-test `<pre>` opener carries `whitespace-pre-wrap` without a break class, so blocks added later are covered too. It reads each **opening tag whole** rather than line by line — `LocalSetupPanel.jsx` splits its attributes across lines, and the line-scoped grep in the issue passed straight over it. It follows the existing convention-guard shape (`popoverClampConventions.test.js`) and reuses the shared `test/trackedFiles.js` + `test/classNameScan.js` helpers.

Closes #5820

## Test plan

- `client/src/preWrapClasses.test.js` — 3 cases: the tree is populated, a bypass probe asserting the detector flags the bug and clears every safe form (break class present, no wrap class at all, multi-line opener, interpolated class branches, a `>` inside the class expression, `overflow-x-auto` as a non-substitute, a `<preview>` tag, a doc comment quoting an example), and the tree-wide sweep.
- **Guard verified to fail pre-fix**: stripping `break-all` from `RunnerPage.jsx:510` and from the multi-line `LocalSetupPanel.jsx:269` opener turned the suite red naming both — including the one a line-scoped grep cannot see. Restored, green again.
- The issue's enumeration grep now returns no results.
- `cd client && npm test` — **Test Files 827 passed | 1 skipped (828)**, Tests 10110 passed | 2 skipped. (One earlier run had two unrelated `PostSessionLauncher` drill-selection flakes that pass in isolation and did not recur.)
- `cd client && npm run lint` — clean.
- Server suite not run: the change touches only `client/src`, which the server Vitest project does not glob.
