### PR TITLE
fix: retry local code review without reasoning_effort when a model rejects thinking

### DIFF
--- a/server/scripts/run-local-code-review.mjs
+++ b/server/scripts/run-local-code-review.mjs
@@ -19,8 +19,12 @@ try {
     : runLocalCodeReview;
   const result = await review({ ...request, model, effort });
   process.stdout.write(`${JSON.stringify(result)}\n`);
-  if (!result.ok) process.exitCode = 1;
+  if (!result.ok) {
+    process.stderr.write(`${result.error}\n`);
+    process.exitCode = 1;
+  }
 } catch (err) {
   process.stdout.write(`${JSON.stringify({ ok: false, error: err.message })}\n`);
+  process.stderr.write(`${err.message}\n`);
   process.exitCode = 1;
 }

--- a/server/services/codeReview.js
+++ b/server/services/codeReview.js
@@ -364,9 +364,9 @@ async function runToolFreeLocalCompletion({ backend, model, messages, effort, ti
   }
 
   const cacheKey = `${backend}:${model}`
-  let resolvedEffort = normalizeReviewerEffort(effort, backend) || null
-  let effortUnsupported = thinkingUnsupportedModels.get(cacheKey) === true
-  if (effortUnsupported) resolvedEffort = null
+  const effortUnsupportedCached = thinkingUnsupportedModels.get(cacheKey) === true
+  let resolvedEffort = effortUnsupportedCached ? null : (normalizeReviewerEffort(effort, backend) || null)
+  let effortUnsupported = effortUnsupportedCached
 
   // Local runtime records are normalized to the OpenAI `/v1` root, while the
   // legacy backend managers return the host root. Keep both forms compatible

--- a/server/services/codeReview.js
+++ b/server/services/codeReview.js
@@ -322,6 +322,39 @@ function adaptiveFence(content) {
   return '`'.repeat(Math.max(3, ...(content.match(/`+/g) || ['']).map((run) => run.length + 1)))
 }
 
+// Ollama translates the OpenAI-compatible `reasoning_effort` field into its
+// own `thinking` parameter, and a model that never implements thinking 400s
+// on the whole request rather than ignoring the field. There is no reliable
+// per-model "supports thinking" capability flag to probe ahead of time, so
+// this remembers which `backend:model` pairs have already 400'd on it — for
+// the life of the process — so a multi-round review loop pays the retry once
+// instead of on every round.
+const thinkingUnsupportedModels = new Map()
+export function __resetThinkingUnsupportedCache() { thinkingUnsupportedModels.clear() }
+
+async function sendChatCompletion(baseUrl, { model, messages, timeoutMs }, effortForRequest) {
+  const body = {
+    model,
+    messages,
+    temperature: 0.2,
+    stream: false,
+    ...(effortForRequest ? { reasoning_effort: effortForRequest } : {}),
+  }
+  const response = await fetchWithTimeout(`${baseUrl}/v1/chat/completions`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  }, timeoutMs).catch((err) => ({ ok: false, _fetchError: err.message }))
+  if (response._fetchError !== undefined) {
+    return { ok: false, error: `request failed: ${response._fetchError}` }
+  }
+  if (!response.ok) {
+    const text = await response.text().catch(() => '')
+    return { ok: false, status: response.status, text }
+  }
+  return { ok: true, response }
+}
+
 async function runToolFreeLocalCompletion({ backend, model, messages, effort, timeoutMs, baseUrl: requestedBaseUrl = null }) {
   if (!isLocalLlmReviewer(backend)) {
     return { ok: false, error: `Unsupported reviewer backend: ${backend}` }
@@ -330,35 +363,34 @@ async function runToolFreeLocalCompletion({ backend, model, messages, effort, ti
     return { ok: false, error: `No model configured for ${backend} reviewer — set one on the Settings → Code Reviewers page.` }
   }
 
-  const resolvedEffort = normalizeReviewerEffort(effort, backend) || null
+  const cacheKey = `${backend}:${model}`
+  let resolvedEffort = normalizeReviewerEffort(effort, backend) || null
+  let effortUnsupported = thinkingUnsupportedModels.get(cacheKey) === true
+  if (effortUnsupported) resolvedEffort = null
+
   // Local runtime records are normalized to the OpenAI `/v1` root, while the
   // legacy backend managers return the host root. Keep both forms compatible
   // with the one endpoint suffix below.
   const baseUrl = String(requestedBaseUrl || await BACKEND_BASE_URLS[backend]())
     .replace(/\/+$/, '')
     .replace(/\/v\d+$/i, '')
-  const body = {
-    model,
-    messages,
-    temperature: 0.2,
-    stream: false,
-    ...(resolvedEffort ? { reasoning_effort: resolvedEffort } : {}),
-  }
-  const response = await fetchWithTimeout(`${baseUrl}/v1/chat/completions`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(body),
-  }, timeoutMs).catch((err) => ({ ok: false, _fetchError: err.message }))
 
-  if (response._fetchError !== undefined) {
-    return { ok: false, backend, model, error: `${backend} request failed: ${response._fetchError}` }
-  }
-  if (!response.ok) {
-    const text = await response.text().catch(() => '')
-    return { ok: false, backend, model, error: `${backend} API error ${response.status}: ${text.slice(0, 300)}` }
+  let attempt = await sendChatCompletion(baseUrl, { model, messages, timeoutMs }, resolvedEffort)
+
+  if (!attempt.ok && attempt.status === 400 && resolvedEffort && /does not support thinking/i.test(attempt.text || '')) {
+    console.warn(`⚠️ ${backend} model ${model} ignores reasoning_effort — retried without it`)
+    thinkingUnsupportedModels.set(cacheKey, true)
+    resolvedEffort = null
+    effortUnsupported = true
+    attempt = await sendChatCompletion(baseUrl, { model, messages, timeoutMs }, null)
   }
 
-  const data = await readResponseJson(response, { fallback: (raw) => ({ _nonJson: raw }) })
+  if (!attempt.ok) {
+    if (attempt.error) return { ok: false, backend, model, error: `${backend} ${attempt.error}` }
+    return { ok: false, backend, model, error: `${backend} API error ${attempt.status}: ${(attempt.text || '').slice(0, 300)}` }
+  }
+
+  const data = await readResponseJson(attempt.response, { fallback: (raw) => ({ _nonJson: raw }) })
   if (data?._nonJson !== undefined) {
     return { ok: false, backend, model, error: `${backend} returned a non-JSON response: ${data._nonJson.slice(0, 300)}` }
   }
@@ -366,7 +398,14 @@ async function runToolFreeLocalCompletion({ backend, model, messages, effort, ti
   if (!content || typeof content !== 'string') {
     return { ok: false, backend, model, error: `${backend} returned no content.` }
   }
-  return { ok: true, backend, model, effort: resolvedEffort, content: content.trim() }
+  return {
+    ok: true,
+    backend,
+    model,
+    effort: resolvedEffort,
+    ...(effortUnsupported ? { effortUnsupported: true } : {}),
+    content: content.trim(),
+  }
 }
 
 /**
@@ -420,7 +459,14 @@ export async function runLocalCodeReview({ backend, model, diff, effort = null, 
     ],
   })
   if (!result.ok) return result
-  return { ok: true, backend, model, effort: result.effort, findings: result.content }
+  return {
+    ok: true,
+    backend,
+    model,
+    effort: result.effort,
+    ...(result.effortUnsupported ? { effortUnsupported: true } : {}),
+    findings: result.content,
+  }
 }
 
 /**
@@ -495,6 +541,7 @@ export async function runLocalClaimCommentReview({ backend, model, comments, cur
     backend,
     model,
     effort: result.effort,
+    ...(result.effortUnsupported ? { effortUnsupported: true } : {}),
     claimant,
     suspicious: parsed.suspicious,
     reviewedCommentCount: normalizedComments.length,

--- a/server/services/codeReview.test.js
+++ b/server/services/codeReview.test.js
@@ -38,6 +38,7 @@ import {
   getReviewerCliInstalled,
   __resetCodeReviewDefaultsCache,
   __resetReviewerCliInstalledCache,
+  __resetThinkingUnsupportedCache,
 } from './codeReview.js'
 import { MODEL_SELECTABLE_REVIEWERS, EFFORT_SELECTABLE_REVIEWERS } from '../lib/cosValidation.js'
 
@@ -55,6 +56,7 @@ describe('codeReview helpers', () => {
     mockedActiveProvider.current = null
     __resetCodeReviewDefaultsCache()
     __resetReviewerCliInstalledCache()
+    __resetThinkingUnsupportedCache()
     commandExistsMock.impl = async () => true
     vi.restoreAllMocks()
   })
@@ -680,6 +682,70 @@ describe('codeReview helpers', () => {
       expect(await runLocalClaimCommentReview({ backend: 'ollama', model: 'example-model', comments: oversized }))
         .toMatchObject({ ok: false, error: expect.stringContaining('per-comment safety limit') })
       expect(global.fetch).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('reasoning_effort downgrade for backends that reject thinking', () => {
+    // Real ollama 400 body shape (server/services/codeReview.js's regex
+    // matches on the message text, not the JSON envelope).
+    const thinkingRejectedBody = JSON.stringify({
+      error: { message: '"m" does not support thinking', type: 'invalid_request_error' },
+    })
+
+    it('retries without reasoning_effort when the backend rejects thinking', async () => {
+      global.fetch = vi.fn()
+        .mockResolvedValueOnce(mockTextResponse(thinkingRejectedBody, { ok: false, status: 400 }))
+        .mockResolvedValueOnce(mockJsonResponse({ choices: [{ message: { content: 'No findings.' } }] }))
+
+      const r = await runLocalCodeReview({ backend: 'ollama', model: 'nonthinking-model', diff: 'd', effort: 'low' })
+
+      expect(global.fetch).toHaveBeenCalledTimes(2)
+      const secondBody = JSON.parse(global.fetch.mock.calls[1][1].body)
+      expect('reasoning_effort' in secondBody).toBe(false)
+      expect(r).toMatchObject({ ok: true, effort: null, effortUnsupported: true, findings: 'No findings.' })
+    })
+
+    it('does not retry a 400 that is unrelated to thinking', async () => {
+      global.fetch = vi.fn().mockResolvedValue(mockTextResponse('bad request: missing field', { ok: false, status: 400 }))
+
+      const r = await runLocalCodeReview({ backend: 'ollama', model: 'other-400-model', diff: 'd', effort: 'low' })
+
+      expect(global.fetch).toHaveBeenCalledTimes(1)
+      expect(r.ok).toBe(false)
+      expect(r.error).toMatch(/API error 400/)
+    })
+
+    it('caches the downgrade for the same backend+model across sequential calls', async () => {
+      global.fetch = vi.fn()
+        .mockResolvedValueOnce(mockTextResponse(thinkingRejectedBody, { ok: false, status: 400 }))
+        .mockResolvedValueOnce(mockJsonResponse({ choices: [{ message: { content: 'No findings.' } }] }))
+        .mockResolvedValueOnce(mockJsonResponse({ choices: [{ message: { content: 'No findings.' } }] }))
+
+      await runLocalCodeReview({ backend: 'ollama', model: 'cached-model', diff: 'd1', effort: 'low' })
+      const second = await runLocalCodeReview({ backend: 'ollama', model: 'cached-model', diff: 'd2', effort: 'low' })
+
+      expect(global.fetch).toHaveBeenCalledTimes(3)
+      const thirdBody = JSON.parse(global.fetch.mock.calls[2][1].body)
+      expect('reasoning_effort' in thirdBody).toBe(false)
+      expect(second).toMatchObject({ ok: true, effort: null, effortUnsupported: true })
+    })
+
+    it('runLocalClaimCommentReview benefits from the same retry-and-downgrade', async () => {
+      global.fetch = vi.fn()
+        .mockResolvedValueOnce(mockTextResponse(thinkingRejectedBody, { ok: false, status: 400 }))
+        .mockResolvedValueOnce(mockJsonResponse({ choices: [{ message: { content: '{"claimant":null,"suspicious":false}' } }] }))
+
+      const r = await runLocalClaimCommentReview({
+        backend: 'ollama',
+        model: 'claim-nonthinking-model',
+        comments: [{ login: 'alice', type: 'User', body: 'Taking this', createdAt: '2026-01-01T00:00:00Z' }],
+        effort: 'low',
+      })
+
+      expect(global.fetch).toHaveBeenCalledTimes(2)
+      const secondBody = JSON.parse(global.fetch.mock.calls[1][1].body)
+      expect('reasoning_effort' in secondBody).toBe(false)
+      expect(r).toMatchObject({ ok: true, claimant: null, suspicious: false, effort: null, effortUnsupported: true })
     })
   })
 })


### PR DESCRIPTION
## Summary

Ollama translates the OpenAI-compatible `reasoning_effort` field into its own `thinking` parameter, and a model that never implements thinking rejects the whole request with a 400 rather than ignoring the field. This made every tool-free local reviewer (`runToolFreeLocalCompletion` in `server/services/codeReview.js`) configured with an effort pin 100% unavailable against such a model — not degraded, just dead. The same helper backs the claim-comment gate (`runLocalClaimCommentReview`), so the misconfiguration was also silently skipping otherwise-claimable issues that had any public comments, shrinking the autonomous claim queue with no visible error.

## Changes

- `runToolFreeLocalCompletion` now retries once, without `reasoning_effort`, when it gets a 400 whose body matches `/does not support thinking/i` — but only when `reasoning_effort` was actually sent, so an unrelated 400 still fails immediately without a wasted retry.
- The downgrade is remembered per `backend:model` in a module-level `Map` for the life of the process, so a multi-round review loop pays the 400 once instead of on every round (`__resetThinkingUnsupportedCache` exported for tests).
- The downgrade is surfaced instead of hidden: a single-line `console.warn` (`⚠️ ollama model <model> ignores reasoning_effort — retried without it`) plus an `effortUnsupported: true` flag on the result, propagated through both `runLocalCodeReview` and `runLocalClaimCommentReview` as an additive field that existing callers can ignore.
- `server/scripts/run-local-code-review.mjs` now also writes a failed result's error string to stderr (in addition to the existing stdout JSON), so an unattended claim agent's log names the misconfiguration instead of showing an unexplained skipped candidate.

## Test plan

- Added `codeReview.test.js` cases covering all four scenarios from the issue: retries and succeeds when the backend rejects thinking; does not retry a 400 unrelated to thinking; caches the downgrade across sequential calls (3 fetches for 2 calls, not 4); `runLocalClaimCommentReview` benefits from the same retry.
- `cd server && npx vitest run codeReview` — 71/71 passing.
- Full server suite (`cd server && npm test`) — 1890 files / 38184 tests passing.

Closes #5960

https://claude.ai/code/session_01HrCezpkgyZtawoS5YniF5i