### PR TITLE
fix: build the FLUX.2 venv from a system Python, never PortOS's own venv

### DIFF
--- a/server/lib/pythonSetup.js
+++ b/server/lib/pythonSetup.js
@@ -121,6 +121,21 @@ const PYTHON_CANDIDATES = IS_WIN
       '/usr/bin/python3',
     ];
 
+// PortOS's own managed venvs — the first three PYTHON_CANDIDATES entries on
+// both platforms. Fine as a pip-install target (detectPython/detectPythonSync),
+// but never a valid BASE to create a *different* venv from: a venv created
+// from another venv can fail with the base's own pyvenv.cfg pointing at an
+// interpreter path that no longer resolves (e.g. after a Homebrew point-release
+// upgrade prunes the old versioned keg the app venv was built against). See
+// detectVenvBasePythonSync below.
+const APP_MANAGED_VENV_PYTHONS = new Set(PYTHON_CANDIDATES.slice(0, 3));
+
+// PYTHON_CANDIDATES minus the app-managed venvs — the fallback pool for
+// picking a base interpreter to CREATE a venv from, as opposed to
+// PYTHON_CANDIDATES' own ordering, which is tuned for "which interpreter can
+// we pip packages into" (detectPython/detectPythonSync).
+const NON_APP_MANAGED_CANDIDATES = PYTHON_CANDIDATES.filter((p) => !APP_MANAGED_VENV_PYTHONS.has(p));
+
 export async function probePythonArch(pythonPath) {
   const { stdout } = await execFileAsync(pythonPath, [
     '-c', 'import platform; print(platform.machine())'
@@ -173,10 +188,17 @@ export function detectPythonSync() {
 // uv/python.org standalone builds are the reverse: externally-managed (so a bad
 // pip target) but a perfect venv base.
 //
-// So this prefers standalone builds and only falls back to detectPythonSync's
-// answer when there are none — a conda-based venv still beats no venv at all,
-// and the setup script's own import check reports it when it can't work.
-export function detectVenvBasePythonSync() {
+// So this prefers standalone builds and only falls back to a non-app-managed
+// PYTHON_CANDIDATES entry (a conda-based venv still beats no venv at all, and
+// the setup script's own import check reports it when it can't work) — and,
+// as a true last resort with nothing non-app-managed anywhere, PortOS's own
+// managed venv rather than nothing.
+//
+// Deliberately excludes `data/python/venv` / `~/.portos/venv` /
+// `~/.pixie-forge/venv` from every tier above the last: building a venv FROM
+// one of those has its own failure mode independent of the conda/DLL issue
+// above — see APP_MANAGED_VENV_PYTHONS.
+export function venvBaseCandidatesSync() {
   const standalone = [
     ...uvPythonCandidates(),
     ...(IS_WIN
@@ -190,7 +212,20 @@ export function detectVenvBasePythonSync() {
         ]
       : []),
   ];
-  return standalone.find((p) => existsSync(p)) || detectPythonSync();
+  const seen = new Set();
+  return [...standalone, ...NON_APP_MANAGED_CANDIDATES].filter((p) => {
+    if (seen.has(p) || !existsSync(p)) return false;
+    seen.add(p);
+    return true;
+  });
+}
+
+export function detectVenvBasePythonSync() {
+  // detectPythonSync's own PYTHON_CANDIDATES sweep will find an app-managed
+  // venv when nothing else exists — exactly the "beats no venv" last resort
+  // this needs — and its PATH fallback carries the WindowsApps-alias filter,
+  // which a hand-rolled whichFirstSync() call here would have to duplicate.
+  return venvBaseCandidatesSync()[0] || detectPythonSync();
 }
 
 export async function detectPython() {
@@ -646,12 +681,17 @@ export function isAllowedPython(pythonPath) {
 
 // Idempotent: if the venv exists, returns its python path without recreating.
 // Windows venvs put the interpreter at Scripts\python.exe, POSIX at bin/python3.
-export async function createVenv(basePython, targetDir) {
+// `clear: true` passes `--clear` to rebuild over a directory a prior failed
+// attempt left in a partial/broken state, e.g. when retrying venv creation
+// against a different base after the first base silently failed to
+// materialize the interpreter.
+export async function createVenv(basePython, targetDir, { clear = false } = {}) {
   const venvPython = IS_WIN
     ? join(targetDir, 'Scripts', 'python.exe')
     : join(targetDir, 'bin', 'python3');
-  if (existsSync(venvPython)) return venvPython;
-  await execFileAsync(basePython, ['-m', 'venv', targetDir], safeChildProcessOptions({ timeout: 120_000 }));
+  if (!clear && existsSync(venvPython)) return venvPython;
+  const args = ['-m', 'venv', ...(clear ? ['--clear'] : []), targetDir];
+  await execFileAsync(basePython, args, safeChildProcessOptions({ timeout: 120_000 }));
   if (!existsSync(venvPython)) {
     throw new Error(`Venv created but interpreter missing at ${venvPython}`);
   }
@@ -818,7 +858,13 @@ export function installFlux2Venv(onLog) {
 
   const promise = (async () => {
     stage('detect', 'Looking for system Python…');
-    const basePython = await detectPython();
+    // The base to CREATE the FLUX.2 venv from — deliberately not detectPython(),
+    // which ranks PortOS's own already-provisioned image-gen venv first and is
+    // answering a different question ("which interpreter can we pip into").
+    // Building a venv from an already-provisioned venv is fragile — its
+    // pyvenv.cfg can pin an interpreter path a later system upgrade removes.
+    const baseCandidates = venvBaseCandidatesSync();
+    const basePython = detectVenvBasePythonSync();
     if (!basePython) {
       onLog({ type: 'error', message: 'No system Python 3 found. Install Python 3.10+ and try again.' });
       return { ok: false, stage: 'detect' };
@@ -827,11 +873,26 @@ export function installFlux2Venv(onLog) {
 
     stage('venv', `Creating FLUX.2 venv at ${FLUX2_VENV_DEFAULT}…`);
     const targetDir = FLUX2_VENV_DEFAULT.replace(IS_WIN ? /\\Scripts\\python\.exe$/ : /\/bin\/python3$/, '');
-    const venvPython = await createVenv(basePython, targetDir).catch((err) => {
-      onLog({ type: 'error', message: `venv creation failed: ${err.message}` });
+    const venvFallback = baseCandidates.find((p) => p !== basePython);
+    let venvPython = await createVenv(basePython, targetDir).catch((err) => {
+      log(`venv creation failed against ${basePython}: ${err.message}`);
       return null;
     });
-    if (!venvPython) return { ok: false, stage: 'venv' };
+    if (killed) return { ok: false, stage: 'venv', cancelled: true };
+    if (!venvPython && venvFallback) {
+      log(`Retrying venv creation with ${venvFallback}…`);
+      venvPython = await createVenv(venvFallback, targetDir, { clear: true }).catch((err) => {
+        log(`venv creation also failed against ${venvFallback}: ${err.message}`);
+        return null;
+      });
+    }
+    if (!venvPython) {
+      onLog({
+        type: 'error',
+        message: 'venv creation failed. Try INSTALL_FLUX2=1 FLUX2_FORCE_REINSTALL=1 bash scripts/setup-image-video.sh',
+      });
+      return { ok: false, stage: 'venv' };
+    }
     if (killed) return { ok: false, stage: 'venv', cancelled: true };
 
     stage('upgrade-pip', 'Upgrading pip + wheel + setuptools…');

--- a/server/lib/pythonSetup.test.js
+++ b/server/lib/pythonSetup.test.js
@@ -407,6 +407,54 @@ describe('detectVenvBasePythonSync', () => {
     const { detectVenvBasePythonSync } = await loadModule();
     expect(detectVenvBasePythonSync()).toBeNull();
   });
+
+  it('never picks PortOS\'s own image-gen venv as a venv-creation base when a system Python is also present (#5980)', async () => {
+    // Regression: PYTHON_CANDIDATES ranks `data/python/venv` first because it's
+    // the best PIP TARGET (non-externally-managed) — but building a *second*
+    // venv from an already-provisioned venv is what broke on some Homebrew
+    // point-release upgrades. An app-managed venv present alongside a system
+    // Python must not win.
+    mockState.presentPaths.add('/data/python/venv/bin/python3');
+    mockState.presentPaths.add('/opt/homebrew/bin/python3');
+    const { detectVenvBasePythonSync, detectPythonSync } = await loadModule();
+    expect(detectVenvBasePythonSync()).toBe('/opt/homebrew/bin/python3');
+    // detectPythonSync (the pip-target picker) is unchanged: it still prefers
+    // the app-managed venv for installing packages.
+    expect(detectPythonSync()).toBe('/data/python/venv/bin/python3');
+  });
+
+  it('excludes all three app-managed venvs, not just the image-gen one', async () => {
+    mockState.presentPaths.add('/Users/test/.portos/venv/bin/python3');
+    mockState.presentPaths.add('/Users/test/.pixie-forge/venv/bin/python3');
+    mockState.presentPaths.add('/usr/bin/python3');
+    const { detectVenvBasePythonSync } = await loadModule();
+    expect(detectVenvBasePythonSync()).toBe('/usr/bin/python3');
+  });
+
+  it('falls back to an app-managed venv only when nothing non-app-managed exists anywhere', async () => {
+    mockState.presentPaths.add('/data/python/venv/bin/python3');
+    const { detectVenvBasePythonSync } = await loadModule();
+    expect(detectVenvBasePythonSync()).toBe('/data/python/venv/bin/python3');
+  });
+});
+
+describe('venvBaseCandidatesSync', () => {
+  beforeEach(resetState);
+
+  it('orders standalone builds first, excludes app-managed venvs, and lists every present fallback for retry', async () => {
+    mockState.presentPaths.add('/data/python/venv/bin/python3');
+    mockState.presentPaths.add('/opt/miniconda3/bin/python3');
+    mockState.presentPaths.add('/opt/homebrew/bin/python3');
+    const { venvBaseCandidatesSync } = await loadModule();
+    expect(venvBaseCandidatesSync()).toEqual(['/opt/miniconda3/bin/python3', '/opt/homebrew/bin/python3']);
+  });
+
+  it('returns an empty list when only app-managed venvs exist', async () => {
+    mockState.presentPaths.add('/data/python/venv/bin/python3');
+    mockState.presentPaths.add('/Users/test/.portos/venv/bin/python3');
+    const { venvBaseCandidatesSync } = await loadModule();
+    expect(venvBaseCandidatesSync()).toEqual([]);
+  });
 });
 
 describe('isFlux2VenvHealthy', () => {


### PR DESCRIPTION
## Summary

`installFlux2Venv()` picked its base interpreter via `detectPython()`, which ranks PortOS's own already-provisioned image-gen venv (`data/python/venv`) first — correct for "which interpreter can we pip into," but venv-from-venv creation is fragile: the child venv's `pyvenv.cfg` can pin an interpreter path that a later system change (e.g. a Homebrew point-release upgrade pruning the old versioned keg) removes, leaving venv creation looking like it succeeded while the interpreter never materializes.

- Excludes `data/python/venv`, `~/.portos/venv`, and `~/.pixie-forge/venv` from the venv-creation base picker (`detectVenvBasePythonSync()` and the new `venvBaseCandidatesSync()`) at every tier above the final "beats no venv at all" last resort. This also benefits the two other existing callers of `detectVenvBasePythonSync()` (`setupScriptRunner.js`, `modelAbuseGuard.js`).
- `installFlux2Venv()`'s detect stage now uses the corrected picker instead of `detectPython()`.
- Adds a one-shot retry (rebuilding with `--clear`) against the next non-app-managed candidate if the first venv-creation attempt fails, before surfacing a terminal error.
- The venv-stage error now includes the same actionable shell fallback (`INSTALL_FLUX2=1 FLUX2_FORCE_REINSTALL=1 bash scripts/setup-image-video.sh`) the verify stage already surfaces, so the modal gives the user something to try instead of just Close.

Closes #5980

## Test plan
- `cd server && npx vitest run lib/pythonSetup.test.js` — 41/41 passing, including new coverage for the corrected base-interpreter selection (app-managed exclusion, all-three-excluded, last-resort fallback) and `venvBaseCandidatesSync()`.
- `npx vitest run lib/setupScriptRunner.test.js services/modelAbuseGuard.test.js routes/videoGen.test.js routes/imageGen.test.js routes/midiRuntime.test.js` — all callers of the touched exports, 322/322 passing.
- Full server suite: 1890 files / 38185 tests passing, 0 failing.
- Two rounds of local `claude --effort low` review against the branch diff; all findings from round 1 (a WindowsApps-alias filter regression, a dead fallback expression, a missing cancel check between retry attempts) applied and verified fixed in round 2, with no new issues.

https://claude.ai/code/session_011LR2zm1Bdr8mkvCuJcWJ39