### PR TITLE
fix: keep grok's weekly reset time from squeezing off mobile usage cards

### DIFF
--- a/client/src/pages/UsagePage.jsx
+++ b/client/src/pages/UsagePage.jsx
@@ -60,11 +60,11 @@ function UsageMeter({ limit }) {
           style={{ width: `${Math.min(100, Math.max(0, used))}%` }}
         />
       </div>
-      <div className="flex items-start justify-between gap-1 mt-0.5 sm:mt-1">
+      <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-0.5 sm:gap-1 mt-0.5 sm:mt-1">
         <span className="text-[9px] sm:text-xs text-gray-500">{used}% used</span>
         {limit.resetsAt && (
-          <span className="flex min-w-0 text-[9px] sm:text-xs text-gray-500 items-start justify-end gap-1 text-right leading-tight">
-            <Clock size={11} /> resets {formatResetsAt(limit.resetsAt)}
+          <span className="flex min-w-0 text-[9px] sm:text-xs text-gray-500 items-start sm:justify-end gap-1 sm:text-right leading-tight">
+            <Clock size={11} className="shrink-0" /> resets {formatResetsAt(limit.resetsAt)}
           </span>
         )}
       </div>

--- a/client/src/pages/UsagePage.test.jsx
+++ b/client/src/pages/UsagePage.test.jsx
@@ -244,6 +244,31 @@ describe('UsagePage provider reset times', () => {
     expect(reset.className.split(/\s+/)).not.toContain('hidden');
     expect(reset.textContent).not.toContain(resetsAt);
   });
+
+  it('gives the Grok weekly reset its own full-width row on the cramped mobile card', async () => {
+    // Grok shares a mobile grid cell with Codex, so its card is the narrowest —
+    // the reset row must stack under "% used" (flex-col) rather than squeeze
+    // onto the same line (flex-row), which was clipping/overlapping it.
+    const resetsAt = new Date(Date.now() + 2 * 24 * 60 * 60 * 1000 + 60_000).toISOString();
+    api.getProviderUsage.mockResolvedValue({
+      providers: [{
+        family: 'grok',
+        label: 'Grok',
+        supported: true,
+        limits: [{ key: 'weekly', label: 'Weekly', percentUsed: 8, percentRemaining: 92, resetsAt }],
+        activity: [],
+        approximate: true,
+        fetchedAt: new Date().toISOString()
+      }]
+    });
+
+    render(<MemoryRouter><UsagePage /></MemoryRouter>);
+
+    const reset = await screen.findByText(/resets .*\(in 2d\)/);
+    expect(reset.className.split(/\s+/)).not.toContain('hidden');
+    const row = reset.parentElement;
+    expect(row.className.split(/\s+/)).toEqual(expect.arrayContaining(['flex-col', 'sm:flex-row']));
+  });
 });
 
 // The provider-quota section reads every provider on mount, well after the page


### PR DESCRIPTION
## Summary
- Grok shares its mobile grid cell with Codex on the Subscription Usage page, making it the narrowest provider card (2-up grid below `sm`).
- The reset row packed `% used` and `resets <date>` onto a single flex-row line, which crowded out/could clip the reset text on that card width.
- Stack the row vertically (`flex-col`) below the `sm` breakpoint, switching to the existing side-by-side layout at `sm+`, so the weekly (and any other) reset time always renders on its own full-width line.

## Test plan
- [x] `client/src/pages/UsagePage.test.jsx` — added a regression test asserting the Grok weekly reset row stacks (`flex-col sm:flex-row`) and is never hidden
- [x] `npx vitest run src/pages/UsagePage.test.jsx` — 13/13 passing

https://claude.ai/code/session_01RF47iFw448BJZBDJvpdHNG