### PR TITLE
fix: teach pr-reviewer Stage 3 the sandbox-protected .claude/ apply fallback

### DIFF
--- a/server/lib/providerVendors.js
+++ b/server/lib/providerVendors.js
@@ -500,6 +500,18 @@ const CLAUDE_PUBLIC_REVIEW_NO_TOOL_ARGS = [
 // tree and the empty domain allowlist denies every network request — in
 // `--print` mode a denied request is simply not executed, there is nobody to
 // approve it. The web tools are denied outright for the same reason.
+//
+// `sandbox.filesystem.allowWrite` (a real, current setting) does NOT reach a
+// PR that edits `.claude/skills`, `.claude/agents`, `.claude/commands`,
+// `.claude/hooks`, `.claude/workflows`, or `.mcp.json` — Claude Code's docs
+// state plainly that these are "protected paths" and "there is no way to
+// exempt one of them: an allowWrite entry ... doesn't lift the protection."
+// (docs.claude.com/en/docs/claude-code/sandboxing, "Protected paths"). The
+// only way to lift it is `sandbox.filesystem.disabled`, which turns off
+// filesystem isolation for every path — defeating the point of sandboxing an
+// untrusted PR's patch. So the Stage 3 review prompt (`pr-reviewer-review` in
+// taskPromptDefaults/prompts.js) is taught the `git apply --cached` +
+// index-verification fallback instead (#5963).
 const CLAUDE_SANDBOX_SETTINGS = JSON.stringify({
   sandbox: { enabled: true, autoAllowBashIfSandboxed: true, network: { allowedDomains: [] } },
 });

--- a/server/services/taskPromptDefaults.test.js
+++ b/server/services/taskPromptDefaults.test.js
@@ -1008,9 +1008,23 @@ describe('taskPromptDefaults integrity snapshot', () => {
     expect(current).toContain('.claude/agents');
     expect(current).toContain('.claude/commands');
     expect(current).toContain('.claude/hooks');
+    expect(current).toContain('.claude/workflows');
+    expect(current).toContain('.mcp.json');
     expect(current).toContain('git apply --cached -- <patch>');
     expect(current).toContain('git show :<path>');
-    expect(current).toContain('never by reading the\n   working-tree file');
+    // Reflow-tolerant: every whitespace run (including a line-wrap newline,
+    // wherever it happens to fall) matches `\s+`, so a harmless rewrap of this
+    // prose can't break the assertion.
+    expect(current).toMatch(/never\s+by\s+reading\s+the\s+working-tree\s+file/);
     expect(current).toContain('never `defer` for this reason alone');
+    // `git apply --check` performs no writes, so the fallback must gate on the
+    // real (write) `git apply` failing — not on `--check`, which the sandbox's
+    // write-only protection can never cause to fail (#5963 review finding).
+    expect(current).toContain('`--check` makes no filesystem writes');
+    expect(current).not.toContain('When `--check` fails ONLY on');
+    // A deleted protected file has no index blob left for `git show :<path>`
+    // to read — the fallback must verify absence instead.
+    expect(current).toContain('git ls-files --cached -- <path>');
+    expect(current).toContain('deleted protected file');
   });
 });

--- a/server/services/taskPromptDefaults.test.js
+++ b/server/services/taskPromptDefaults.test.js
@@ -992,4 +992,25 @@ describe('taskPromptDefaults integrity snapshot', () => {
     expect(PROMPT_VERSIONS[stageKey]).toBeUndefined();
     expect(PREVIOUS_DEFAULT_PROMPTS[stageKey]).toBeUndefined();
   });
+
+  // #5963: Claude Code's sandbox permanently denies working-tree writes under
+  // `.claude/skills`, `.claude/agents`, `.claude/commands`, `.claude/hooks`,
+  // `.claude/workflows`, and `.mcp.json` — no `sandbox.filesystem.allowWrite`
+  // setting can lift it (see the comment on CLAUDE_SANDBOX_SETTINGS in
+  // providerVendors.js). A patch touching only those paths (e.g. a docs-only
+  // skill edit) fails `git apply` in the working tree even though the review
+  // is otherwise clean, so Stage 3 must know the `git apply --cached` +
+  // index-verification fallback instead of guessing between `approve` and
+  // `defer`.
+  it('pr-reviewer-review teaches the git apply --cached fallback for sandbox-protected .claude/ paths', () => {
+    const current = DEFAULT_TASK_PROMPTS['pr-reviewer-review'];
+    expect(current).toContain('.claude/skills');
+    expect(current).toContain('.claude/agents');
+    expect(current).toContain('.claude/commands');
+    expect(current).toContain('.claude/hooks');
+    expect(current).toContain('git apply --cached -- <patch>');
+    expect(current).toContain('git show :<path>');
+    expect(current).toContain('never by reading the\n   working-tree file');
+    expect(current).toContain('never `defer` for this reason alone');
+  });
 });

--- a/server/services/taskPromptDefaults/integrity.snapshot.json
+++ b/server/services/taskPromptDefaults/integrity.snapshot.json
@@ -29,7 +29,7 @@
     "plan-task": "b85fe92999aa4ee4a8910320457c4242",
     "pr-reviewer": "679680b3b382aeb6786df01c4d1a90c6",
     "pr-reviewer-eligibility": "ba358b2bb9380e2b7d9117969607231f",
-    "pr-reviewer-review": "78e75a273c62e6530f1a98a8dad4821e",
+    "pr-reviewer-review": "d8ad0de83427da1dcc05d93d0009363b",
     "pr-reviewer-security": "d1e99626b12939ee39ab38eaa7d23f59",
     "pr-watcher": "53ead8e26d396849bfa78f28550bd691",
     "react-lifecycle": "14b3816d1bcc10f0d7d6357e55cc5e69",

--- a/server/services/taskPromptDefaults/integrity.snapshot.json
+++ b/server/services/taskPromptDefaults/integrity.snapshot.json
@@ -29,7 +29,7 @@
     "plan-task": "b85fe92999aa4ee4a8910320457c4242",
     "pr-reviewer": "679680b3b382aeb6786df01c4d1a90c6",
     "pr-reviewer-eligibility": "ba358b2bb9380e2b7d9117969607231f",
-    "pr-reviewer-review": "4b0621340de017adebf06229259ff22d",
+    "pr-reviewer-review": "78e75a273c62e6530f1a98a8dad4821e",
     "pr-reviewer-security": "d1e99626b12939ee39ab38eaa7d23f59",
     "pr-watcher": "53ead8e26d396849bfa78f28550bd691",
     "react-lifecycle": "14b3816d1bcc10f0d7d6357e55cc5e69",

--- a/server/services/taskPromptDefaults/prompts.js
+++ b/server/services/taskPromptDefaults/prompts.js
@@ -2391,24 +2391,32 @@ PR state and exact content fingerprint.
 1. Read the supplied envelope and evaluate every eligible PR exactly once.
    Preserve each exact numeric \`number\` and 40-character \`headSha\`.
 2. Read \`.portos-public-review/PORTOS_PUBLIC_REVIEW_PATCHES.json\` to map a PR
-   number to its patch. For each PR, run \`git apply --check -- <patch>\` and,
-   if it applies, \`git apply -- <patch>\` in the disposable worktree. Never
-   use \`--unsafe-paths\`, \`--3way\`, a remote ref, or a replacement patch.
+   number to its patch. For each PR, run \`git apply --check -- <patch>\` first.
+   \`--check\` makes no filesystem writes, so a failure there is a genuine
+   patch-application problem, never the sandbox's write protection below —
+   treat it as an unapplied patch under step 3. When \`--check\` succeeds, run
+   \`git apply -- <patch>\` in the disposable worktree. Never use
+   \`--unsafe-paths\`, \`--3way\`, a remote ref, or a replacement patch.
    The sandbox permanently denies working-tree writes under a small set of
    Claude Code-owned paths even inside this disposable worktree — for example
    \`.claude/skills\`, \`.claude/agents\`, \`.claude/commands\`, \`.claude/hooks\`,
    \`.claude/workflows\`, and \`.mcp.json\` — and no setting can lift that
-   protection from inside the sandbox. When \`git apply --check\` fails ONLY on
-   those protected paths (every other file in the patch applies cleanly),
-   apply the same patch to the index instead of the working tree with
-   \`git apply --cached -- <patch>\`, then verify each protected file's exact
-   content from the index with \`git show :<path>\` (never by reading the
-   working-tree file, which the sandbox refused to write) and confirm it
-   matches the patch hunk-for-hunk. That is a fully verified change, not
-   partial evidence — use \`approve\` when the indexed content is correct and
-   the rest of the review supports it, never \`defer\` for this reason alone.
-   If \`--check\` fails for any other reason, treat the PR as unapplied under
-   step 3 below.
+   protection from inside the sandbox. Because \`--check\` already confirmed
+   the patch applies cleanly, a working-tree \`git apply\` failure that names
+   only those protected paths is that write denial, not a bad patch: fall back
+   to applying the same patch to the index instead with
+   \`git apply --cached -- <patch>\`. For a modified or added protected file,
+   verify its exact content from the index with \`git show :<path>\` (never by
+   reading the working-tree file, which the sandbox refused to write) and
+   confirm it matches the patch hunk-for-hunk; for a deleted protected file,
+   confirm it is now absent from the index with
+   \`git ls-files --cached -- <path>\` (expect empty output) instead — \`git
+   show\` has no blob left to read once a path is removed from the index.
+   That is a fully verified change, not partial evidence — use \`approve\`
+   when the verified content is correct and the rest of the review supports
+   it, never \`defer\` for this reason alone. If the working-tree \`git apply\`
+   fails for any other reason, or on a file outside those protected paths,
+   treat the PR as unapplied under step 3 below.
 3. Inspect the resulting code and run the narrowest relevant existing tests,
    followed by broader tests when practical. Tests may take several minutes;
    completeness and trustworthy evidence matter more than throughput. If a

--- a/server/services/taskPromptDefaults/prompts.js
+++ b/server/services/taskPromptDefaults/prompts.js
@@ -2394,6 +2394,21 @@ PR state and exact content fingerprint.
    number to its patch. For each PR, run \`git apply --check -- <patch>\` and,
    if it applies, \`git apply -- <patch>\` in the disposable worktree. Never
    use \`--unsafe-paths\`, \`--3way\`, a remote ref, or a replacement patch.
+   The sandbox permanently denies working-tree writes under a small set of
+   Claude Code-owned paths even inside this disposable worktree — for example
+   \`.claude/skills\`, \`.claude/agents\`, \`.claude/commands\`, \`.claude/hooks\`,
+   \`.claude/workflows\`, and \`.mcp.json\` — and no setting can lift that
+   protection from inside the sandbox. When \`git apply --check\` fails ONLY on
+   those protected paths (every other file in the patch applies cleanly),
+   apply the same patch to the index instead of the working tree with
+   \`git apply --cached -- <patch>\`, then verify each protected file's exact
+   content from the index with \`git show :<path>\` (never by reading the
+   working-tree file, which the sandbox refused to write) and confirm it
+   matches the patch hunk-for-hunk. That is a fully verified change, not
+   partial evidence — use \`approve\` when the indexed content is correct and
+   the rest of the review supports it, never \`defer\` for this reason alone.
+   If \`--check\` fails for any other reason, treat the PR as unapplied under
+   step 3 below.
 3. Inspect the resulting code and run the narrowest relevant existing tests,
    followed by broader tests when practical. Tests may take several minutes;
    completeness and trustworthy evidence matter more than throughput. If a


### PR DESCRIPTION
## Summary

Claude Code's sandboxed Bash tool (`sandbox.filesystem`, used by PortOS's `pr-reviewer` pipeline Stage 3) permanently denies working-tree writes under a fixed set of Claude Code-owned paths — `.claude/skills`, `.claude/agents`, `.claude/commands`, `.claude/hooks`, `.claude/workflows`, and `.mcp.json` — even inside a disposable worktree. I confirmed against Claude Code's current documentation that no `sandbox.filesystem.allowWrite` setting can lift this: it's an explicitly documented "protected path" with "no way to exempt" it short of turning off filesystem isolation for every path (`sandbox.filesystem.disabled`), which would defeat the point of sandboxing an untrusted PR's patch.

On the live run of #5906 (a docs-only change to `.claude/skills/portos-socket-ui/SKILL.md`), Stage 3's `git apply` failed for that path even though the review was otherwise clean, and the reviewer had to guess a fallback (`defer`) rather than following a documented procedure.

This teaches the Stage 3 prompt (`pr-reviewer-review` in `server/services/taskPromptDefaults/prompts.js`) the fallback explicitly:

- `git apply --check` performs no filesystem writes, so it can never fail from the sandbox's write-only protection — the fallback must gate on the real (write) `git apply` failing, not `--check`. (Caught and fixed after a local review round found the original wording gated on `--check`, which meant the fallback could never actually fire.)
- When the real `git apply` fails naming only the protected paths (and `--check` already confirmed the patch applies cleanly), apply the same patch to the index instead with `git apply --cached`.
- Verify a modified/added protected file's content from the index with `git show :<path>`; verify a deleted protected file's absence with `git ls-files --cached` (there's no index blob left for `git show` to read once a path is removed).
- Treat this as a fully verified change — `approve` when it checks out, never `defer` for this reason alone.

Also adds an explanatory comment on `CLAUDE_SANDBOX_SETTINGS` in `server/lib/providerVendors.js` documenting why the settings-based route (option 1 in the issue) doesn't work, so a future reader doesn't retry it.

No `PROMPT_VERSIONS` bump is needed: `pr-reviewer-review` is a live-read, unversioned pipeline-stage body (confirmed by the existing `it.each` in `taskPromptDefaults.test.js` pinning it as such) — `getStagePrompt` always reads the current catalog body, so the fix reaches every install on the next dispatch. The prompt-integrity snapshot was regenerated to match.

## Test plan

- `cd server && npx vitest run services/taskPromptDefaults.test.js lib/providerVendors.publicReview.test.js services/taskPromptService.test.js` — 83 passed, including a new regression test asserting the fallback text (gate condition, deletion handling, all six protected paths) is present in the Stage 3 default prompt.
- Full server suite run (`npx vitest run`): 3 unrelated pre-existing failures/timeouts in `services/sprites/atlas.test.js` and `services/imessageSync.runSync.test.js` (confirmed unaffected by this diff — reproduced independently of this branch, in isolated runs, unrelated to `providerVendors.js`/`prompts.js`).
- Local review: `claude --effort low` reviewed the branch diff and found the `--check`-vs-real-apply gating bug plus the deleted-file/`git show` gap — both fixed in a follow-up commit; the test's line-wrap-sensitive assertion was also relaxed to a whitespace-tolerant regex per that review.

Closes #5963