### PR TITLE
fix: flag a stale deployed build in AI provider investigation tasks

### DIFF
--- a/server/services/autoFixer.js
+++ b/server/services/autoFixer.js
@@ -6,6 +6,7 @@
  */
 
 import { isRunning } from './cos.js';
+import { getBootCommit, getInstallState } from './installState.js';
 import { fileInvestigationTask, __resetInvestigationCircuit } from './investigationTaskProducer.js';
 import { investigationFingerprint } from '../lib/investigationTasks.js';
 import { errorEvents } from '../lib/errorHandler.js';
@@ -532,8 +533,17 @@ async function createAIProviderInvestigationTask(error) {
   // Structured diagnostics ride on the task record so downstream telemetry can
   // break auto-fix outcomes out by tier / category / failure reason (#2328).
   const diagnostics = providerFixDiagnostics(error);
+  // A server that booted BEFORE the current checkout can keep reproducing a
+  // failure that is already fixed on disk — exactly what happened when a
+  // local-LLM playground timeout was filed a second time hours after its fix
+  // landed (#5771), costing a whole investigation agent to rediscover. Surface
+  // the boot-vs-HEAD gap in the task body so the agent checks that first.
+  // Skipped entirely when no boot commit was captured (tarball install, tests,
+  // any process that never called captureBootCommit): without it the comparison
+  // is meaningless, and skipping keeps this off the git/fs path in those cases.
+  const installState = getBootCommit() ? await getInstallState().catch(() => null) : null;
   // Build specialized context for AI provider errors
-  const context = buildAIProviderErrorContext(error, diagnostics);
+  const context = buildAIProviderErrorContext(error, diagnostics, installState);
 
   const taskData = {
     // Mirror the `|| 'Unknown'` fallbacks buildAIProviderErrorContext already
@@ -627,8 +637,12 @@ function shouldAutoFix(error) {
 
 /**
  * Build detailed context for AI provider execution errors
+ *
+ * @param {object} [installState] result of `getInstallState()`, when available —
+ *   only `runningStaleCode` / `bootCommit` / `currentCommit` are read, to warn
+ *   that the failing process predates the checkout being investigated.
  */
-function buildAIProviderErrorContext(error, diagnostics) {
+function buildAIProviderErrorContext(error, diagnostics, installState = null) {
   const ctx = error.context || {};
   const lines = [
     '# AI Provider Execution Failure',
@@ -643,6 +657,20 @@ function buildAIProviderErrorContext(error, diagnostics) {
     `- **Workspace:** ${ctx.workspaceName || ctx.workspacePath || 'N/A'}`,
     ''
   ];
+
+  // The running process is behind the on-disk checkout, so the failure may have
+  // been fixed since it booted. Named first (right under Run Details) because it
+  // changes what the whole investigation should do: read the diff before
+  // debugging, and restart rather than write code if the fix is already there.
+  if (installState?.runningStaleCode) {
+    const boot = (installState.bootCommit || '').slice(0, 7) || 'unknown';
+    const head = (installState.currentCommit || '').slice(0, 7) || 'unknown';
+    lines.push('## Deployed Build: STALE');
+    lines.push(`- **Booted at commit:** ${boot}`);
+    lines.push(`- **Checkout HEAD:** ${head}`);
+    lines.push(`- The running server started before the current checkout, so it does NOT include every fix on disk. Check \`git log ${boot}..${head}\` for a fix covering this failure before debugging it — if one exists, the remedy is a restart (\`npm run pm2:restart\`), not a code change.`);
+    lines.push('');
+  }
 
   // Fallback-tier diagnostics (issue #2328) — tells the investigating agent
   // which class of fix to try first before escalating to open-ended debugging.
@@ -693,12 +721,20 @@ function buildAIProviderErrorContext(error, diagnostics) {
   }
 
   lines.push('## Investigation Steps');
-  lines.push('1. Check if the AI provider is configured correctly in /devtools/providers');
-  lines.push('2. Verify API keys and endpoints are valid');
-  lines.push('3. Check server logs for additional context (pm2 logs portos-server)');
-  lines.push('4. If this is a CLI provider, verify the command is installed and accessible');
-  lines.push('5. Check for rate limiting or quota issues with the provider');
-  lines.push('6. Review the output tail for specific error messages');
+  const steps = [
+    'Check if the AI provider is configured correctly in /devtools/providers',
+    'Verify API keys and endpoints are valid',
+    'Check server logs for additional context (pm2 logs portos-server)',
+    'If this is a CLI provider, verify the command is installed and accessible',
+    'Check for rate limiting or quota issues with the provider',
+    'Review the output tail for specific error messages',
+  ];
+  // Numbered here rather than hardcoded so the stale-build step can lead the
+  // list without renumbering the rest by hand.
+  if (installState?.runningStaleCode) {
+    steps.unshift('Rule out the stale deployed build above — a fix already in the checkout only needs a restart');
+  }
+  steps.forEach((step, index) => lines.push(`${index + 1}. ${step}`));
 
   return lines.join('\n');
 }

--- a/server/services/autoFixer.test.js
+++ b/server/services/autoFixer.test.js
@@ -13,6 +13,15 @@ vi.mock('./cos.js', () => ({
   getAllTasks: vi.fn().mockResolvedValue({ user: { tasks: [] }, cos: { tasks: [] } }),
 }));
 
+// installState reaches out to git/fs; stub it so the stale-deployed-build
+// branch is driven from the test rather than from this checkout's real HEAD.
+vi.mock('./installState.js', () => ({
+  getBootCommit: vi.fn(() => null),
+  getInstallState: vi.fn(async () => null),
+}));
+
+const installState = await import('./installState.js');
+
 const cos = await import('./cos.js');
 const {
   noteFallbackHandled,
@@ -779,5 +788,78 @@ describe('autoFixer — escalateProviderFailure dedupe clears on task-creation f
     const second = await (await import('./autoFixer.js')).escalateProviderFailure(err);
     expect(second).toBeTruthy();
     expect(cos.addTask).toHaveBeenCalledTimes(2);
+  });
+});
+
+// A server still running code from before the current checkout can keep
+// reproducing a failure that is already fixed on disk — a local-LLM playground
+// timeout was filed a second time hours after #5771 fixed it, and the
+// investigation agent had to rediscover that from scratch. The task body now
+// says so up front.
+describe('autoFixer — stale deployed build in the investigation body', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    cos.addTask.mockClear();
+    cos.isRunning.mockReturnValue(false);
+    installState.getBootCommit.mockReturnValue(null);
+    installState.getInstallState.mockClear();
+    installState.getInstallState.mockResolvedValue(null);
+    clearPendingAutoFixTasks();
+    _resetAutoFixerForTests();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    clearPendingAutoFixTasks();
+    _resetAutoFixerForTests();
+  });
+
+  it('names the boot-vs-HEAD gap and leads the steps with ruling it out', async () => {
+    installState.getBootCommit.mockReturnValue('aaaaaaa1111111111111111111111111111111a');
+    installState.getInstallState.mockResolvedValue({
+      runningStaleCode: true,
+      bootCommit: 'aaaaaaa1111111111111111111111111111111a',
+      currentCommit: 'bbbbbbb2222222222222222222222222222222b',
+    });
+
+    emitProviderFailure({ provider: 'Ollama', model: 'm-1' });
+    await vi.advanceTimersByTimeAsync(5500);
+
+    const { context } = getPendingAutoFixTasks()[0];
+    expect(context).toContain('## Deployed Build: STALE');
+    expect(context).toContain('git log aaaaaaa..bbbbbbb');
+    expect(context).toContain('1. Rule out the stale deployed build');
+    // The pre-existing steps keep their order, just renumbered behind it.
+    expect(context).toContain('2. Check if the AI provider is configured correctly');
+    expect(context).toContain('7. Review the output tail for specific error messages');
+  });
+
+  it('omits the section — and never probes git — when the build is current', async () => {
+    installState.getBootCommit.mockReturnValue('aaaaaaa1111111111111111111111111111111a');
+    installState.getInstallState.mockResolvedValue({
+      runningStaleCode: false,
+      bootCommit: 'aaaaaaa1111111111111111111111111111111a',
+      currentCommit: 'aaaaaaa1111111111111111111111111111111a',
+    });
+
+    emitProviderFailure({ provider: 'Ollama', model: 'm-1' });
+    await vi.advanceTimersByTimeAsync(5500);
+
+    const { context } = getPendingAutoFixTasks()[0];
+    expect(context).not.toContain('Deployed Build');
+    expect(context).toContain('1. Check if the AI provider is configured correctly');
+  });
+
+  // No captured boot commit (tarball install, or any process that never called
+  // captureBootCommit) makes the comparison meaningless — skip the git/fs work
+  // entirely rather than filing an "unknown..unknown" section.
+  it('skips the install-state probe when no boot commit was captured', async () => {
+    installState.getBootCommit.mockReturnValue(null);
+
+    emitProviderFailure({ provider: 'Ollama', model: 'm-1' });
+    await vi.advanceTimersByTimeAsync(5500);
+
+    expect(installState.getInstallState).not.toHaveBeenCalled();
+    expect(getPendingAutoFixTasks()[0].context).not.toContain('Deployed Build');
   });
 });


### PR DESCRIPTION
## Summary

An investigation task was filed for an Ollama run that "failed" after 300s in the Local LLM Playground. The failure was not a provider failure at all — and it was not even a new bug: the exact misclassification had been fixed hours earlier in #5771. The running `portos-server` process had booted before that fix landed and never restarted, so it kept producing the old, uncategorized record:

```json
"error": "Timed out after 300000ms",
"errorCategory": "unknown",
"errorAnalysis": { "category": "unknown", "message": "<the model's own first line>" }
```

Current `main` handles that run correctly (the playground finalizes its own deadline with `reportFailure: false`, and `finalizeRunRecord` falls back to the stated error) — nothing there needed changing. What was missing is any signal that the *deployed build* was the reason a fixed bug reappeared, so diagnosing it meant rediscovering the whole fix from the run metadata.

Provider-failure investigation tasks now lead with a **Deployed Build: STALE** section whenever the process is running code older than the checkout — the boot and HEAD commits, the `git log <boot>..<head>` range to read, and the fact that the remedy may be a restart rather than a code change. The matching step is unshifted onto the Investigation Steps list, which is now numbered programmatically instead of by hand.

The install-state probe is skipped entirely when no boot commit was captured (tarball install, tests, any process that never called `captureBootCommit`), so this adds no git/fs work where the comparison would be meaningless anyway, and `getInstallState()` stays best-effort (`.catch(() => null)`).

## Test plan

- `server/services/autoFixer.test.js` — a stale boot-vs-HEAD gap renders the section, the `git log` range, and the leading step with the pre-existing steps renumbered behind it; a current build renders neither; no captured boot commit skips the probe entirely.
- `cd server && npx vitest run services/autoFixer.test.js services/runner.test.js services/localLlmPlayground.test.js services/investigationTaskProducer.test.js lib/errorHandler.test.js services/socket.test.js services/promptRunner.test.js services/agentErrorAnalysis.test.js services/localModelAgentBenchmark.test.js services/installState.test.js` — all passing.
