### PR TITLE
restart PortOS's PM2 apps when an update aborts between the delete and the start

### DIFF
--- a/scripts/update-headless-recovery.test.js
+++ b/scripts/update-headless-recovery.test.js
@@ -94,6 +94,12 @@ if (${stallDelete} && args.startsWith('delete')) {
     writeFileSync(join(bin, shim), `#!/bin/sh\n${npmBody}\n`);
     chmodSync(join(bin, shim), 0o755);
   }
+  // The success case is the only one that runs past trusted-rebuilds, so it
+  // reaches update.sh's ffmpeg step — which on a machine without ffmpeg would
+  // run a real `brew install`, or on Linux CI a passwordless `sudo apt-get
+  // install` that mutates the runner. update.sh only probes `command -v`.
+  writeFileSync(join(bin, 'ffmpeg'), '#!/bin/sh\nexit 0\n');
+  chmodSync(join(bin, 'ffmpeg'), 0o755);
   // A pm2 the recovery can still reach after safe_install wipes the local one.
   if (pm2OnPath) {
     writeFileSync(join(bin, 'pm2'), `#!/bin/sh\nprintf '%s\\n' "$*" >> ${JSON.stringify(calls)}\n`);
@@ -262,12 +268,20 @@ describe('update.ps1 headless-install guard', () => {
     expect([...new Set(exits.map(e => e.line))].sort()).toEqual([...SANCTIONED_EXITS].sort());
   });
 
-  it('forces the Resolve-Pm2Command result into an array', () => {
-    // PowerShell unrolls a single-element array into a bare string, and
-    // `$pm2 + @('start', …)` on a string concatenates into one garbage token
-    // instead of an argument list — so the PATH fallback would never start pm2.
+  it('keeps every Resolve-Pm2Command branch a plain array collected by @()', () => {
+    // `return` ENUMERATES an array into the output stream, so a single-element
+    // branch arrives as a bare string and `$pm2 + @('start', …)` concatenates
+    // into one garbage token — the PATH fallback would never start pm2. The
+    // call-site @() fixes that, but only if every branch returns a PLAIN array:
+    // a `,@(…)` wrapper emits the array as ONE stream item and @() nests rather
+    // than flattens it, so $CmdArgs[0] is an object[] instead of the executable.
     expect(ps1.some(line => line.includes('$pm2 = @(Resolve-Pm2Command)'))).toBe(true);
-    expect(ps1.some(line => line.includes("return ,@('pm2')"))).toBe(true);
+
+    const body = ps1.slice(lineOf('function Resolve-Pm2Command'), lineOf('function Restore-Pm2Apps'));
+    const returns = body.map(line => line.trim()).filter(line => line.startsWith('return'));
+    expect(returns.length).toBeGreaterThan(2);
+    expect(returns.filter(line => /return\s*,/.test(line)), 'a ,@() return nests instead of flattening').toEqual([]);
+    expect(returns.every(line => /^return\s+@\(/.test(line))).toBe(true);
   });
 
   it('arms the latch before the delete, not after', () => {

--- a/scripts/update-headless-recovery.test.js
+++ b/scripts/update-headless-recovery.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { spawn } from 'child_process';
-import { mkdirSync, writeFileSync, copyFileSync, readFileSync, existsSync, chmodSync } from 'fs';
+import { mkdirSync, writeFileSync, copyFileSync, readFileSync, existsSync, chmodSync, rmSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { makeGitSandbox, destroyGitSandbox, SKIP_HEAVY_INTEGRATION } from '../server/lib/gitTestRepo.js';
@@ -36,11 +36,12 @@ const STUB_SCRIPTS = [
  */
 async function makeSandbox({
   origin = true, failAfterDelete = true, npmShim = 'ok',
-  forceClean = false, pm2OnPath = false, healthy = true
+  forceClean = false, pm2OnPath = false, healthy = true, stallDelete = false
 } = {}) {
   const { scratch, repo } = await makeGitSandbox({ origin, prefix: 'portos-update-guard-' });
   const bin = join(scratch, 'bin');
   const calls = join(scratch, 'pm2-calls.log');
+  const releaseFile = join(scratch, 'pm2-delete-stalled');
 
   mkdirSync(bin, { recursive: true });
   mkdirSync(join(repo, 'scripts'), { recursive: true });
@@ -51,11 +52,22 @@ async function makeSandbox({
   writeFileSync(join(repo, 'package.json'), JSON.stringify({ name: 'sandbox', version: '0.0.0' }));
   writeFileSync(join(repo, 'ecosystem.config.cjs'), 'module.exports = { apps: [] };\n');
 
-  // Records every pm2 invocation the script makes, in order.
+  // Records every pm2 invocation the script makes, in order. When stallDelete is
+  // set the `delete` call logs and then BLOCKS until the test deletes the release
+  // file, so a signal can be delivered while the delete is still running — the
+  // window a latch armed after the delete would miss.
   writeFileSync(join(repo, 'node_modules', 'pm2', 'package.json'), JSON.stringify({ name: 'pm2', version: '0.0.0' }));
   writeFileSync(
     join(repo, 'node_modules', 'pm2', 'bin', 'pm2'),
-    `require('fs').appendFileSync(${JSON.stringify(calls)}, process.argv.slice(2).join(' ') + '\\n');\n`
+    `const fs = require('fs');
+const args = process.argv.slice(2).join(' ');
+fs.appendFileSync(${JSON.stringify(calls)}, args + '\\n');
+if (${stallDelete} && args.startsWith('delete')) {
+  const release = ${JSON.stringify(releaseFile)};
+  fs.writeFileSync(release, 'stalled');
+  while (fs.existsSync(release)) { try { require('child_process').execFileSync('sleep', ['0.05']); } catch { break; } }
+}
+`
   );
 
   writeFileSync(join(repo, 'scripts', 'trusted-rebuilds.js'), `process.exit(${failAfterDelete ? 1 : 0});\n`);
@@ -88,7 +100,7 @@ async function makeSandbox({
     chmodSync(join(bin, 'pm2'), 0o755);
   }
 
-  return { scratch, repo, bin, calls, forceClean };
+  return { scratch, repo, bin, calls, forceClean, releaseFile };
 }
 
 // The three runs share no state, so they go out concurrently rather than
@@ -106,14 +118,14 @@ function runUpdate(sandbox, { onStart } = {}) {
   });
 }
 
-// Resolves once the sandbox's pm2 log contains a matching call, so a test can
-// act at a precise point in the window instead of guessing at a delay.
-function waitForPm2Call(sandbox, prefix, timeoutMs = 30000) {
+// Resolves once a sentinel appears, so a test can act at a precise point in the
+// window instead of guessing at a delay.
+function waitForFile(path, timeoutMs = 30000) {
   const deadline = Date.now() + timeoutMs;
   return new Promise((resolve, reject) => {
     const poll = () => {
-      if (pm2Calls(sandbox).some(c => c.startsWith(prefix))) return resolve();
-      if (Date.now() > deadline) return reject(new Error(`timed out waiting for pm2 "${prefix}"`));
+      if (existsSync(path)) return resolve();
+      if (Date.now() > deadline) return reject(new Error(`timed out waiting for ${path}`));
       setTimeout(poll, 25);
     };
     poll();
@@ -187,15 +199,20 @@ describe.skipIf(process.platform === 'win32' || SKIP_HEAVY_INTEGRATION)('update.
     expect(results.pm2Wiped.status).not.toBe(0);
   });
 
-  it('restarts the apps when the update is killed mid-window', async () => {
-    // Without the TERM/INT/HUP traps bash runs NO exit trap for a fatal signal,
-    // so the apps would stay deleted.
-    const box = await makeSandbox({ npmShim: 'slow' });
+  it('restarts the apps when the update is killed during the delete itself', async () => {
+    // Two guards at once: without the TERM/INT/HUP traps bash runs NO exit trap
+    // for a fatal signal, and with the latch armed AFTER the delete the trap
+    // would see it unset — bash only runs a pending trap between statements, so
+    // a signal delivered while `pm2 delete` is still running lands here.
+    const box = await makeSandbox({ stallDelete: true });
     try {
       const result = await runUpdate(box, {
         onStart: (child) => {
-          waitForPm2Call(box, 'delete ecosystem.config.cjs')
-            .then(() => child.kill('SIGTERM'))
+          waitForFile(box.releaseFile)
+            .then(() => {
+              child.kill('SIGTERM');
+              rmSync(box.releaseFile, { force: true });
+            })
             .catch(() => child.kill('SIGKILL'));
         }
       });
@@ -236,13 +253,28 @@ describe('update.ps1 headless-install guard', () => {
   it('routes every fatal exit through the recovery', () => {
     const exits = ps1
       .map((line, i) => ({ line: line.trim(), number: i + 1 }))
-      .filter(({ line }) => /(^|[{;]\s*)exit\b/.test(line) || line.includes('[Environment]::Exit('));
+      .filter(({ line }) => /(^|[{;]\s*)exit\b/i.test(line) || /\[Environment\]::Exit\(/i.test(line));
 
     const offenders = exits.filter(({ line }) => !SANCTIONED_EXITS.includes(line));
     expect(offenders, `exit(s) bypassing Restore-Pm2Apps: ${JSON.stringify(offenders)}`).toEqual([]);
     // ...and both sanctioned exits must still be there, so the guard can't be
     // "satisfied" by deleting the exit inside Stop-UpdateScript.
     expect([...new Set(exits.map(e => e.line))].sort()).toEqual([...SANCTIONED_EXITS].sort());
+  });
+
+  it('forces the Resolve-Pm2Command result into an array', () => {
+    // PowerShell unrolls a single-element array into a bare string, and
+    // `$pm2 + @('start', …)` on a string concatenates into one garbage token
+    // instead of an argument list — so the PATH fallback would never start pm2.
+    expect(ps1.some(line => line.includes('$pm2 = @(Resolve-Pm2Command)'))).toBe(true);
+    expect(ps1.some(line => line.includes("return ,@('pm2')"))).toBe(true);
+  });
+
+  it('arms the latch before the delete, not after', () => {
+    const armed = lineOf('$script:Pm2AppsDown = $true');
+    const deleted = lineOf('pm2 delete ecosystem.config.cjs --silent');
+    expect(armed).toBeGreaterThan(-1);
+    expect(armed).toBeLessThan(deleted);
   });
 
   it('defines the recovery before every call site that depends on it', () => {

--- a/scripts/update-headless-recovery.test.js
+++ b/scripts/update-headless-recovery.test.js
@@ -1,0 +1,183 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { spawn } from 'child_process';
+import { mkdirSync, writeFileSync, copyFileSync, readFileSync, existsSync, chmodSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { makeGitSandbox, destroyGitSandbox, SKIP_HEAVY_INTEGRATION } from '../server/lib/gitTestRepo.js';
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const UPDATE_SH = join(REPO_ROOT, 'update.sh');
+
+// Everything update.sh shells out to between the pm2 delete and the pm2 start.
+// Stubbing them lets the success path run end to end offline, which is the only
+// way to prove the exit trap does NOT start the apps a second time.
+const STUB_SCRIPTS = [
+  'setup-data.js', 'setup-db.js', 'setup-browser.js', 'setup-ghostty.js',
+  'setup-cert.js', 'setup-guide.js', 'run-migrations.js',
+  'verify-server-health.js', 'print-access-url.js', 'open-ui-in-browser.js'
+];
+
+/**
+ * A throwaway checkout of update.sh with `npm`, `npx` and `pm2` shimmed, so the
+ * assertions below are what the script actually does to PM2 rather than a grep
+ * for the guard's source text. The rationale for the guard itself lives with it
+ * in update.sh.
+ *
+ * @param {{origin?: boolean, failInstall?: boolean, healthy?: boolean}} options
+ *   origin:false leaves the checkout with no upstream, so the git-pull step
+ *   fails before anything is deleted. failInstall fails the first step AFTER
+ *   the pm2 delete that does not also wipe node_modules (safe_install's retry
+ *   would delete the pm2 shim with it). healthy:false makes the health probe
+ *   report the restarted server never came back.
+ */
+async function makeSandbox({ origin = true, failInstall = true, healthy = true } = {}) {
+  const { scratch, repo } = await makeGitSandbox({ origin, prefix: 'portos-update-guard-' });
+  const bin = join(scratch, 'bin');
+  const calls = join(scratch, 'pm2-calls.log');
+
+  mkdirSync(bin, { recursive: true });
+  mkdirSync(join(repo, 'scripts'), { recursive: true });
+  mkdirSync(join(repo, 'node_modules', 'pm2', 'bin'), { recursive: true });
+
+  copyFileSync(UPDATE_SH, join(repo, 'update.sh'));
+  chmodSync(join(repo, 'update.sh'), 0o755);
+  writeFileSync(join(repo, 'package.json'), JSON.stringify({ name: 'sandbox', version: '0.0.0' }));
+  writeFileSync(join(repo, 'ecosystem.config.cjs'), 'module.exports = { apps: [] };\n');
+
+  // Records every pm2 invocation the script makes, in order.
+  writeFileSync(join(repo, 'node_modules', 'pm2', 'package.json'), JSON.stringify({ name: 'pm2', version: '0.0.0' }));
+  writeFileSync(
+    join(repo, 'node_modules', 'pm2', 'bin', 'pm2'),
+    `require('fs').appendFileSync(${JSON.stringify(calls)}, process.argv.slice(2).join(' ') + '\\n');\n`
+  );
+
+  writeFileSync(join(repo, 'scripts', 'trusted-rebuilds.js'), `process.exit(${failInstall ? 1 : 0});\n`);
+  for (const stub of STUB_SCRIPTS) {
+    writeFileSync(join(repo, 'scripts', stub), 'process.exit(0);\n');
+  }
+  writeFileSync(join(repo, 'scripts', 'verify-server-health.js'), `process.exit(${healthy ? 0 : 1});\n`);
+  // Non-zero means "the daemon is already ours", which skips the co-located
+  // `pm2 update` restart — the branch a healthy install takes.
+  writeFileSync(join(repo, 'scripts', 'pm2-daemon-refresh.js'), 'process.exit(1);\n');
+
+  // The workspaces safe_install cd's into, and the dependency it sanity-checks.
+  for (const ws of ['client', 'server', 'autofixer']) {
+    mkdirSync(join(repo, ws), { recursive: true });
+    writeFileSync(join(repo, ws, 'package.json'), JSON.stringify({ name: ws, version: '0.0.0' }));
+  }
+  mkdirSync(join(repo, 'client', 'node_modules', 'vite', 'bin'), { recursive: true });
+  writeFileSync(join(repo, 'client', 'node_modules', 'vite', 'bin', 'vite.js'), '');
+
+  // update.sh only ever calls these as bare commands, so a PATH shim covers
+  // every install and the slash-do refresh without touching the network.
+  for (const shim of ['npm', 'npx']) {
+    writeFileSync(join(bin, shim), '#!/bin/sh\nexit 0\n');
+    chmodSync(join(bin, shim), 0o755);
+  }
+
+  return { scratch, repo, bin, calls };
+}
+
+// The three runs share no state, so they go out concurrently rather than
+// serializing three full update scripts.
+function runUpdate(sandbox) {
+  return new Promise((resolve) => {
+    const child = spawn('bash', [join(sandbox.repo, 'update.sh')], {
+      cwd: sandbox.repo,
+      env: { ...process.env, PATH: `${sandbox.bin}:${process.env.PATH}` }
+    });
+    let stdout = '';
+    child.stdout.on('data', (d) => { stdout += d; });
+    child.stderr.on('data', () => {});
+    child.on('close', (status) => resolve({ status, stdout }));
+  });
+}
+
+const pm2Calls = (sandbox) =>
+  (existsSync(sandbox.calls) ? readFileSync(sandbox.calls, 'utf8') : '').split('\n').filter(Boolean);
+
+describe.skipIf(process.platform === 'win32' || SKIP_HEAVY_INTEGRATION)('update.sh headless-install guard', () => {
+  const sandboxes = {};
+  const results = {};
+
+  beforeAll(async () => {
+    const cases = {
+      failed: { failInstall: true },
+      clean: { failInstall: false },
+      preDelete: { origin: false },
+      unhealthy: { failInstall: true, healthy: false }
+    };
+    await Promise.all(Object.entries(cases).map(async ([name, options]) => {
+      sandboxes[name] = await makeSandbox(options);
+    }));
+    await Promise.all(Object.keys(cases).map(async (name) => {
+      results[name] = await runUpdate(sandboxes[name]);
+    }));
+  }, 180000);
+
+  afterAll(async () => {
+    await Promise.all(Object.values(sandboxes).map(box => destroyGitSandbox(box.scratch)));
+  });
+
+  it('restarts the PM2 apps it deleted when a later step aborts the update', () => {
+    const calls = pm2Calls(sandboxes.failed);
+    const deleteAt = calls.findIndex(c => c.startsWith('delete ecosystem.config.cjs'));
+    const startAt = calls.findIndex(c => c.startsWith('start ecosystem.config.cjs'));
+    expect(deleteAt, `pm2 calls were: ${JSON.stringify(calls)}`).toBeGreaterThan(-1);
+    expect(startAt, `pm2 calls were: ${JSON.stringify(calls)}`).toBeGreaterThan(deleteAt);
+  });
+
+  it('still reports the update as failed after recovering', () => {
+    expect(results.failed.status).not.toBe(0);
+    expect(results.failed.stdout).toContain('STEP:restart:warning:');
+  });
+
+  it('starts the apps exactly once on an update that succeeds', () => {
+    expect(results.clean.status, results.clean.stdout).toBe(0);
+    expect(pm2Calls(sandboxes.clean).filter(c => c.startsWith('start ecosystem.config.cjs'))).toHaveLength(1);
+    expect(results.clean.stdout).toContain('STEP:restart:done:');
+    expect(results.clean.stdout).not.toContain('STEP:restart:warning:');
+  });
+
+  it('does not claim a recovery the health probe never confirmed', () => {
+    expect(results.unhealthy.status).not.toBe(0);
+    expect(results.unhealthy.stdout).toContain('STEP:restart:error:');
+    expect(results.unhealthy.stdout).not.toContain('STEP:restart:warning:');
+  });
+
+  it('does not touch PM2 when the update aborts before the delete', () => {
+    expect(results.preDelete.status).not.toBe(0);
+    expect(pm2Calls(sandboxes.preDelete)).toEqual([]);
+  });
+});
+
+/**
+ * update.ps1 is the Windows half of the same bracket and cannot be executed
+ * here, so guard the invariant that makes its recovery reachable: every fatal
+ * exit between the pm2 delete and the successful start must route through
+ * Stop-UpdateScript. A future step added to that window with a bare `exit`
+ * would silently reintroduce the headless failure on Windows only.
+ */
+describe('update.ps1 headless-install guard', () => {
+  const ps1 = readFileSync(join(REPO_ROOT, 'update.ps1'), 'utf8').split('\n');
+  const lineOf = (needle) => ps1.findIndex(line => line.includes(needle));
+
+  it('routes every fatal exit in the delete→start window through the recovery', () => {
+    const deleteAt = lineOf('$script:Pm2AppsDown = $true');
+    // The latch is cleared in Restore-Pm2Apps too; the LAST clear is the real start.
+    const startedAt = ps1.findLastIndex(line => line.includes('$script:Pm2AppsDown = $false'));
+    expect(deleteAt).toBeGreaterThan(-1);
+    expect(startedAt).toBeGreaterThan(deleteAt);
+
+    const rawExits = ps1
+      .slice(deleteAt, startedAt)
+      .map((line, i) => ({ line: line.trim(), number: deleteAt + i + 1 }))
+      .filter(({ line }) => /(^|[{;]\s*)exit\b/.test(line));
+    expect(rawExits, `bare exit(s) skip Restore-Pm2Apps: ${JSON.stringify(rawExits)}`).toEqual([]);
+  });
+
+  it('installs the recovery before the delete that makes it necessary', () => {
+    expect(lineOf('function Restore-Pm2Apps')).toBeLessThan(lineOf('$script:Pm2AppsDown = $true'));
+    expect(lineOf('trap {')).toBeLessThan(lineOf('$script:Pm2AppsDown = $true'));
+  });
+});

--- a/scripts/update-headless-recovery.test.js
+++ b/scripts/update-headless-recovery.test.js
@@ -23,14 +23,21 @@ const STUB_SCRIPTS = [
  * for the guard's source text. The rationale for the guard itself lives with it
  * in update.sh.
  *
- * @param {{origin?: boolean, failInstall?: boolean, healthy?: boolean}} options
+ * @param {{origin?: boolean, failAfterDelete?: boolean, npmShim?: string,
+ *   forceClean?: boolean, pm2OnPath?: boolean, healthy?: boolean}} options
  *   origin:false leaves the checkout with no upstream, so the git-pull step
- *   fails before anything is deleted. failInstall fails the first step AFTER
- *   the pm2 delete that does not also wipe node_modules (safe_install's retry
- *   would delete the pm2 shim with it). healthy:false makes the health probe
- *   report the restarted server never came back.
+ *   fails before anything is deleted. failAfterDelete fails the first step AFTER
+ *   the pm2 delete that does not also wipe node_modules. npmShim picks whether
+ *   `npm`/`npx` succeed ('ok'), fail ('fail' — which makes safe_install wipe
+ *   node_modules first) or stall ('slow', so a signal can arrive mid-window).
+ *   forceClean makes safe_install wipe root node_modules regardless of the diff,
+ *   pm2OnPath supplies a fallback pm2 for when that wipe removes the local one,
+ *   and healthy:false makes the health probe report the server never came back.
  */
-async function makeSandbox({ origin = true, failInstall = true, healthy = true } = {}) {
+async function makeSandbox({
+  origin = true, failAfterDelete = true, npmShim = 'ok',
+  forceClean = false, pm2OnPath = false, healthy = true
+} = {}) {
   const { scratch, repo } = await makeGitSandbox({ origin, prefix: 'portos-update-guard-' });
   const bin = join(scratch, 'bin');
   const calls = join(scratch, 'pm2-calls.log');
@@ -51,7 +58,7 @@ async function makeSandbox({ origin = true, failInstall = true, healthy = true }
     `require('fs').appendFileSync(${JSON.stringify(calls)}, process.argv.slice(2).join(' ') + '\\n');\n`
   );
 
-  writeFileSync(join(repo, 'scripts', 'trusted-rebuilds.js'), `process.exit(${failInstall ? 1 : 0});\n`);
+  writeFileSync(join(repo, 'scripts', 'trusted-rebuilds.js'), `process.exit(${failAfterDelete ? 1 : 0});\n`);
   for (const stub of STUB_SCRIPTS) {
     writeFileSync(join(repo, 'scripts', stub), 'process.exit(0);\n');
   }
@@ -70,26 +77,46 @@ async function makeSandbox({ origin = true, failInstall = true, healthy = true }
 
   // update.sh only ever calls these as bare commands, so a PATH shim covers
   // every install and the slash-do refresh without touching the network.
+  const npmBody = { ok: 'exit 0', fail: 'exit 1', slow: 'sleep 2\nexit 0' }[npmShim];
   for (const shim of ['npm', 'npx']) {
-    writeFileSync(join(bin, shim), '#!/bin/sh\nexit 0\n');
+    writeFileSync(join(bin, shim), `#!/bin/sh\n${npmBody}\n`);
     chmodSync(join(bin, shim), 0o755);
   }
+  // A pm2 the recovery can still reach after safe_install wipes the local one.
+  if (pm2OnPath) {
+    writeFileSync(join(bin, 'pm2'), `#!/bin/sh\nprintf '%s\\n' "$*" >> ${JSON.stringify(calls)}\n`);
+    chmodSync(join(bin, 'pm2'), 0o755);
+  }
 
-  return { scratch, repo, bin, calls };
+  return { scratch, repo, bin, calls, forceClean };
 }
 
 // The three runs share no state, so they go out concurrently rather than
 // serializing three full update scripts.
-function runUpdate(sandbox) {
+function runUpdate(sandbox, { onStart } = {}) {
   return new Promise((resolve) => {
-    const child = spawn('bash', [join(sandbox.repo, 'update.sh')], {
-      cwd: sandbox.repo,
-      env: { ...process.env, PATH: `${sandbox.bin}:${process.env.PATH}` }
-    });
+    const env = { ...process.env, PATH: `${sandbox.bin}:${process.env.PATH}` };
+    if (sandbox.forceClean) env.PORTOS_FORCE_CLEAN_WORKSPACES = '.';
+    const child = spawn('bash', [join(sandbox.repo, 'update.sh')], { cwd: sandbox.repo, env });
     let stdout = '';
     child.stdout.on('data', (d) => { stdout += d; });
     child.stderr.on('data', () => {});
     child.on('close', (status) => resolve({ status, stdout }));
+    onStart?.(child);
+  });
+}
+
+// Resolves once the sandbox's pm2 log contains a matching call, so a test can
+// act at a precise point in the window instead of guessing at a delay.
+function waitForPm2Call(sandbox, prefix, timeoutMs = 30000) {
+  const deadline = Date.now() + timeoutMs;
+  return new Promise((resolve, reject) => {
+    const poll = () => {
+      if (pm2Calls(sandbox).some(c => c.startsWith(prefix))) return resolve();
+      if (Date.now() > deadline) return reject(new Error(`timed out waiting for pm2 "${prefix}"`));
+      setTimeout(poll, 25);
+    };
+    poll();
   });
 }
 
@@ -102,10 +129,13 @@ describe.skipIf(process.platform === 'win32' || SKIP_HEAVY_INTEGRATION)('update.
 
   beforeAll(async () => {
     const cases = {
-      failed: { failInstall: true },
-      clean: { failInstall: false },
+      failed: {},
+      clean: { failAfterDelete: false },
       preDelete: { origin: false },
-      unhealthy: { failInstall: true, healthy: false }
+      unhealthy: { healthy: false },
+      // The failure the guard's own comment names: both npm installs fail, and
+      // safe_install wiped root node_modules — pm2 included — on the way.
+      pm2Wiped: { npmShim: 'fail', forceClean: true, pm2OnPath: true }
     };
     await Promise.all(Object.entries(cases).map(async ([name, options]) => {
       sandboxes[name] = await makeSandbox(options);
@@ -145,6 +175,40 @@ describe.skipIf(process.platform === 'win32' || SKIP_HEAVY_INTEGRATION)('update.
     expect(results.unhealthy.stdout).not.toContain('STEP:restart:warning:');
   });
 
+  it('restarts through a pm2 the failed install did not delete', () => {
+    // safe_install wipes root node_modules (pm2 is a ROOT dependency) before it
+    // retries, so a recovery hardcoded to ./node_modules/pm2/bin/pm2 would be a
+    // no-op on the most likely failure of all.
+    const calls = pm2Calls(sandboxes.pm2Wiped);
+    const deleteAt = calls.findIndex(c => c.startsWith('delete ecosystem.config.cjs'));
+    const startAt = calls.findIndex(c => c.startsWith('start ecosystem.config.cjs'));
+    expect(deleteAt, `pm2 calls were: ${JSON.stringify(calls)}`).toBeGreaterThan(-1);
+    expect(startAt, `pm2 calls were: ${JSON.stringify(calls)}`).toBeGreaterThan(deleteAt);
+    expect(results.pm2Wiped.status).not.toBe(0);
+  });
+
+  it('restarts the apps when the update is killed mid-window', async () => {
+    // Without the TERM/INT/HUP traps bash runs NO exit trap for a fatal signal,
+    // so the apps would stay deleted.
+    const box = await makeSandbox({ npmShim: 'slow' });
+    try {
+      const result = await runUpdate(box, {
+        onStart: (child) => {
+          waitForPm2Call(box, 'delete ecosystem.config.cjs')
+            .then(() => child.kill('SIGTERM'))
+            .catch(() => child.kill('SIGKILL'));
+        }
+      });
+      const calls = pm2Calls(box);
+      const deleteAt = calls.findIndex(c => c.startsWith('delete ecosystem.config.cjs'));
+      const startAt = calls.findIndex(c => c.startsWith('start ecosystem.config.cjs'));
+      expect(startAt, `pm2 calls were: ${JSON.stringify(calls)}`).toBeGreaterThan(deleteAt);
+      expect(result.status).toBe(143);
+    } finally {
+      await destroyGitSandbox(box.scratch);
+    }
+  }, 120000);
+
   it('does not touch PM2 when the update aborts before the delete', () => {
     expect(results.preDelete.status).not.toBe(0);
     expect(pm2Calls(sandboxes.preDelete)).toEqual([]);
@@ -153,30 +217,39 @@ describe.skipIf(process.platform === 'win32' || SKIP_HEAVY_INTEGRATION)('update.
 
 /**
  * update.ps1 is the Windows half of the same bracket and cannot be executed
- * here, so guard the invariant that makes its recovery reachable: every fatal
- * exit between the pm2 delete and the successful start must route through
- * Stop-UpdateScript. A future step added to that window with a bare `exit`
- * would silently reintroduce the headless failure on Windows only.
+ * here, so guard the invariant that makes its recovery reachable: PowerShell's
+ * `exit` inside a function terminates the whole script WITHOUT raising a
+ * terminating error, bypassing both Stop-UpdateScript and the script-scope trap.
+ * So every fatal exit in the file must route through Stop-UpdateScript. Scanning
+ * the whole file rather than the delete→start line window is the point: the
+ * exit that actually caused this bug lives in Safe-Install, which is DEFINED
+ * above the delete and CALLED below it.
  */
 describe('update.ps1 headless-install guard', () => {
   const ps1 = readFileSync(join(REPO_ROOT, 'update.ps1'), 'utf8').split('\n');
   const lineOf = (needle) => ps1.findIndex(line => line.includes(needle));
 
-  it('routes every fatal exit in the delete→start window through the recovery', () => {
-    const deleteAt = lineOf('$script:Pm2AppsDown = $true');
-    // The latch is cleared in Restore-Pm2Apps too; the LAST clear is the real start.
-    const startedAt = ps1.findLastIndex(line => line.includes('$script:Pm2AppsDown = $false'));
-    expect(deleteAt).toBeGreaterThan(-1);
-    expect(startedAt).toBeGreaterThan(deleteAt);
+  // The only two script-terminating exits that may bypass the recovery: the one
+  // Stop-UpdateScript itself performs (after running it), and the final status.
+  const SANCTIONED_EXITS = ['exit $Code', 'exit $verifyFailed'];
 
-    const rawExits = ps1
-      .slice(deleteAt, startedAt)
-      .map((line, i) => ({ line: line.trim(), number: deleteAt + i + 1 }))
-      .filter(({ line }) => /(^|[{;]\s*)exit\b/.test(line));
-    expect(rawExits, `bare exit(s) skip Restore-Pm2Apps: ${JSON.stringify(rawExits)}`).toEqual([]);
+  it('routes every fatal exit through the recovery', () => {
+    const exits = ps1
+      .map((line, i) => ({ line: line.trim(), number: i + 1 }))
+      .filter(({ line }) => /(^|[{;]\s*)exit\b/.test(line) || line.includes('[Environment]::Exit('));
+
+    const offenders = exits.filter(({ line }) => !SANCTIONED_EXITS.includes(line));
+    expect(offenders, `exit(s) bypassing Restore-Pm2Apps: ${JSON.stringify(offenders)}`).toEqual([]);
+    // ...and both sanctioned exits must still be there, so the guard can't be
+    // "satisfied" by deleting the exit inside Stop-UpdateScript.
+    expect([...new Set(exits.map(e => e.line))].sort()).toEqual([...SANCTIONED_EXITS].sort());
   });
 
-  it('installs the recovery before the delete that makes it necessary', () => {
+  it('defines the recovery before every call site that depends on it', () => {
+    const definedAt = lineOf('function Stop-UpdateScript');
+    expect(definedAt).toBeGreaterThan(-1);
+    const firstCall = ps1.findIndex(line => line.includes('Stop-UpdateScript ') && !line.includes('function '));
+    expect(firstCall).toBeGreaterThan(definedAt);
     expect(lineOf('function Restore-Pm2Apps')).toBeLessThan(lineOf('$script:Pm2AppsDown = $true'));
     expect(lineOf('trap {')).toBeLessThan(lineOf('$script:Pm2AppsDown = $true'));
   });

--- a/server/lib/sglangQwenProject.js
+++ b/server/lib/sglangQwenProject.js
@@ -47,12 +47,15 @@ import { homedir } from 'os';
 import { join } from 'path';
 
 import {
-  PORTOS_ENV_PATH,
   projectDirIsSettled,
   readRecordedProjectDir,
   recordProjectDir,
   resolveRecordedProjectDir,
 } from './recordedProjectDir.js';
+// PORTOS_ENV_PATH is declared by portosEnv.js; recordedProjectDir.js imports it
+// for its own defaults but does not re-export it — and it cannot, because both
+// modules are `export *`'d from lib/index.js and a re-export would collide there.
+import { PORTOS_ENV_PATH } from './portosEnv.js';
 
 /** Operator override for where the compose project was created. */
 export const SGLANG_PROJECT_DIR_ENV = 'SGLANG_QWEN_PROJECT_DIR';

--- a/server/lib/vllmQwenProject.js
+++ b/server/lib/vllmQwenProject.js
@@ -45,12 +45,15 @@ import { homedir } from 'os';
 import { join } from 'path';
 
 import {
-  PORTOS_ENV_PATH,
   projectDirIsSettled,
   readRecordedProjectDir,
   recordProjectDir,
   resolveRecordedProjectDir,
 } from './recordedProjectDir.js';
+// PORTOS_ENV_PATH is declared by portosEnv.js; recordedProjectDir.js imports it
+// for its own defaults but does not re-export it — and it cannot, because both
+// modules are `export *`'d from lib/index.js and a re-export would collide there.
+import { PORTOS_ENV_PATH } from './portosEnv.js';
 
 /** Operator override for where the compose project was cloned. */
 export const VLLM_PROJECT_DIR_ENV = 'VLLM_QWEN_PROJECT_DIR';

--- a/update.ps1
+++ b/update.ps1
@@ -76,6 +76,94 @@ function Invoke-Logged {
     & $cmd @cmdRest >> $UpdateLog 2>&1
 }
 
+# Headless-install guard (mirrors update.sh). From the `pm2-stop` step below
+# until the closing `pm2 start` succeeds, PortOS's PM2 entries are DELETED — the
+# install has no server. Every step in between (npm install, setup-db,
+# migrations, the client build) can fail, and each of those failures exits this
+# script with the apps still deleted and nothing left running to notice: the
+# "update deleted portos-server and it never came back" failure. So restore the
+# apps on the way out instead of leaving the machine headless.
+#
+# This block sits here — above every fatal exit in the script, not beside the
+# delete it guards — because PowerShell's `exit` inside a function terminates the
+# whole script WITHOUT raising a terminating error, bypassing both the trap and
+# any later-defined helper. Safe-Install is defined above the delete and called
+# below it, so a guard defined between them could never catch its exit.
+#
+# Starting the pulled tree after a failed install can crash-loop, but a
+# crash-looping app the user can see beats a silently headless machine — and the
+# recovery only ever runs on a path that was already leaving PortOS down.
+$script:Pm2AppsDown = $false
+
+# Which pm2 the recovery can actually reach. It CANNOT assume this checkout's own
+# copy: Safe-Install wipes root node_modules whenever the pulled update touched
+# root package.json — which every release does, since the version bump lives
+# there — and pm2 is a ROOT dependency. So on the most likely failure of all
+# (both npm install attempts fail) the checkout's pm2 is already gone by the time
+# the recovery runs. Any pm2 CLI can drive the already-running daemon, so falling
+# back to one on PATH, or to npx, is fine for a recovery.
+function Resolve-Pm2Command {
+    if (Test-Path "$RootDir\node_modules\pm2\bin\pm2") {
+        return @('node', './node_modules/pm2/bin/pm2')
+    }
+    if (Get-Command pm2 -ErrorAction SilentlyContinue) {
+        return @('pm2')
+    }
+    $pinned = try { (Get-Content "$RootDir\package.json" -Raw | ConvertFrom-Json).dependencies.pm2 } catch { $null }
+    if ($pinned) { return @('npx', '--yes', "pm2@$pinned") }
+    return @('npx', '--yes', 'pm2')
+}
+
+function Restore-Pm2Apps {
+    if (-not $script:Pm2AppsDown) { return }
+    $script:Pm2AppsDown = $false
+    try {
+        $pm2 = Resolve-Pm2Command
+        Write-SafeHost "⚠️  Update is exiting with PortOS's apps deleted — restarting them so the install isn't left headless." -ForegroundColor Yellow
+        Step "restart" "running" "Update failed — restarting PortOS so it isn't left down..."
+        # `pm2 start` exiting 0 is not proof the server came back (same reason the
+        # verify step below exists) — and this path starts a HALF-INSTALLED tree, so
+        # a start that exits 0 and then crash-loops is the likely case here, not the
+        # edge case. Never claim a recovery the health probe doesn't confirm.
+        $startArgs = $pm2 + @('start', 'ecosystem.config.cjs')
+        Invoke-Logged @startArgs
+        if ($LASTEXITCODE -eq 0) { Invoke-Logged node scripts/verify-server-health.js }
+        if ($LASTEXITCODE -eq 0) {
+            $saveArgs = $pm2 + @('save')
+            Invoke-Logged @saveArgs
+            Step "restart" "warning" "Update failed, but PortOS was restarted"
+            Write-SafeHost "✅ PortOS is answering /api/system/health again after the failed update." -ForegroundColor Green
+        } else {
+            Step "restart" "error" "Update failed and PortOS is DOWN"
+            Write-SafeHost "❌ PortOS is not answering /api/system/health." -ForegroundColor Red
+            # Name the pm2 that actually exists — the checkout's copy may be the
+            # thing a failed install just deleted, so printing it would be a dead end.
+            Write-SafeHost "    Recover with: $($pm2 -join ' ') start ecosystem.config.cjs" -ForegroundColor Red
+        }
+    } catch {
+        # A throwing recovery must not replace the real update failure, and must
+        # not re-enter the trap below.
+        Write-SafeHost "❌ PortOS restart attempt failed: $($_.Exception.Message)" -ForegroundColor Red
+    }
+}
+
+# Every fatal exit in this script goes through here, so the recovery cannot be
+# forgotten at one of the call sites. Before the delete it is a no-op.
+function Stop-UpdateScript {
+    param([int]$Code = 1)
+    Restore-Pm2Apps
+    # Recovery must never turn a failed update into a reported success.
+    if ($Code -eq 0) { $Code = 1 }
+    exit $Code
+}
+
+# Backstop for a terminating error nobody converted into a Stop-UpdateScript
+# call; `break` rethrows so the script still exits non-zero.
+trap {
+    Restore-Pm2Apps
+    break
+}
+
 Write-SafeHost "===================================" -ForegroundColor Cyan
 Write-SafeHost "  PortOS Update" -ForegroundColor Cyan
 Write-SafeHost "===================================" -ForegroundColor Cyan
@@ -202,7 +290,7 @@ if ($currentBranch -ne "main") {
         Write-SafeHost "⚠️  On branch '$currentBranch' — switching to main for update" -ForegroundColor Yellow
     }
     Invoke-Logged git checkout main
-    if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+    if ($LASTEXITCODE -ne 0) { Stop-UpdateScript $LASTEXITCODE }
 }
 # Record main's pre-pull HEAD — captured AFTER any checkout so it's the commit
 # the installed node_modules was built from (main, which the rest of this script
@@ -211,7 +299,7 @@ if ($currentBranch -ne "main") {
 # the update brings is detected even when launched from another branch.
 $prePullSha = git rev-parse HEAD 2>$null
 Invoke-Logged git pull --rebase --autostash
-if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+if ($LASTEXITCODE -ne 0) { Stop-UpdateScript $LASTEXITCODE }
 Step "git-pull" "done" "Latest changes pulled"
 
 # Determine which workspaces' package.json this update touched, so Safe-Install
@@ -239,69 +327,11 @@ Write-SafeHost ""
 # contract, not whichever submodule commit happens to be newest upstream.
 Step "submodules" "running" "Synchronizing and updating submodules..."
 Invoke-Logged git submodule sync --recursive
-if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+if ($LASTEXITCODE -ne 0) { Stop-UpdateScript $LASTEXITCODE }
 Invoke-Logged git submodule update --init --recursive
-if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+if ($LASTEXITCODE -ne 0) { Stop-UpdateScript $LASTEXITCODE }
 Step "submodules" "done" "Submodules updated"
 Write-SafeHost ""
-
-# Headless-install guard (mirrors update.sh). From the `pm2-stop` step below
-# until the closing `pm2 start` succeeds, PortOS's PM2 entries are DELETED — the
-# install has no server. Every step in between (npm install, setup-db,
-# migrations, the client build) can fail, and each of those failures exits this
-# script with the apps still deleted and nothing left running to notice: the
-# "update deleted portos-server and it never came back" failure. So restore the
-# apps on the way out instead of leaving the machine headless.
-#
-# Starting the pulled tree after a failed install can crash-loop, but a
-# crash-looping app the user can see beats a silently headless machine — and the
-# recovery only ever runs on a path that was already leaving PortOS down.
-$script:Pm2AppsDown = $false
-
-function Restore-Pm2Apps {
-    if (-not $script:Pm2AppsDown) { return }
-    $script:Pm2AppsDown = $false
-    try {
-        Write-SafeHost "⚠️  Update is exiting with PortOS's apps deleted — restarting them so the install isn't left headless." -ForegroundColor Yellow
-        Step "restart" "running" "Update failed — restarting PortOS so it isn't left down..."
-        # `pm2 start` exiting 0 is not proof the server came back (same reason the
-        # verify step below exists) — and this path starts a HALF-INSTALLED tree, so
-        # a start that exits 0 and then crash-loops is the likely case here, not the
-        # edge case. Never claim a recovery the health probe doesn't confirm.
-        Invoke-Logged node ./node_modules/pm2/bin/pm2 start ecosystem.config.cjs
-        if ($LASTEXITCODE -eq 0) { Invoke-Logged node scripts/verify-server-health.js }
-        if ($LASTEXITCODE -eq 0) {
-            Invoke-Logged node ./node_modules/pm2/bin/pm2 save
-            Step "restart" "warning" "Update failed, but PortOS was restarted"
-            Write-SafeHost "✅ PortOS is answering /api/system/health again after the failed update." -ForegroundColor Green
-        } else {
-            Step "restart" "error" "Update failed and PortOS is DOWN"
-            Write-SafeHost "❌ PortOS is not answering /api/system/health." -ForegroundColor Red
-            Write-SafeHost "    Recover with: node ./node_modules/pm2/bin/pm2 start ecosystem.config.cjs" -ForegroundColor Red
-        }
-    } catch {
-        # A throwing recovery must not replace the real update failure, and must
-        # not re-enter the trap below.
-        Write-SafeHost "❌ PortOS restart attempt failed: $($_.Exception.Message)" -ForegroundColor Red
-    }
-}
-
-# Every fatal exit between the delete and the start goes through here, so the
-# recovery cannot be forgotten at one of the ten call sites.
-function Stop-UpdateScript {
-    param([int]$Code = 1)
-    Restore-Pm2Apps
-    # Recovery must never turn a failed update into a reported success.
-    if ($Code -eq 0) { $Code = 1 }
-    exit $Code
-}
-
-# Backstop for a terminating error nobody converted into a Stop-UpdateScript
-# call; `break` rethrows so the script still exits non-zero.
-trap {
-    Restore-Pm2Apps
-    break
-}
 
 # Remove ONLY PortOS's apps from the shared PM2 daemon — never `pm2 kill`, which
 # tears down the daemon and stops EVERY other project's apps on this machine.

--- a/update.ps1
+++ b/update.ps1
@@ -146,7 +146,7 @@ function Safe-Install {
 
     Pop-Location
     Write-SafeHost "❌ npm install failed for $Label after retry" -ForegroundColor Red
-    exit 1
+    Stop-UpdateScript 1
 }
 
 # Pull latest — always switch to main (detached HEAD or feature branch both
@@ -245,12 +245,71 @@ if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 Step "submodules" "done" "Submodules updated"
 Write-SafeHost ""
 
+# Headless-install guard (mirrors update.sh). From the `pm2-stop` step below
+# until the closing `pm2 start` succeeds, PortOS's PM2 entries are DELETED — the
+# install has no server. Every step in between (npm install, setup-db,
+# migrations, the client build) can fail, and each of those failures exits this
+# script with the apps still deleted and nothing left running to notice: the
+# "update deleted portos-server and it never came back" failure. So restore the
+# apps on the way out instead of leaving the machine headless.
+#
+# Starting the pulled tree after a failed install can crash-loop, but a
+# crash-looping app the user can see beats a silently headless machine — and the
+# recovery only ever runs on a path that was already leaving PortOS down.
+$script:Pm2AppsDown = $false
+
+function Restore-Pm2Apps {
+    if (-not $script:Pm2AppsDown) { return }
+    $script:Pm2AppsDown = $false
+    try {
+        Write-SafeHost "⚠️  Update is exiting with PortOS's apps deleted — restarting them so the install isn't left headless." -ForegroundColor Yellow
+        Step "restart" "running" "Update failed — restarting PortOS so it isn't left down..."
+        # `pm2 start` exiting 0 is not proof the server came back (same reason the
+        # verify step below exists) — and this path starts a HALF-INSTALLED tree, so
+        # a start that exits 0 and then crash-loops is the likely case here, not the
+        # edge case. Never claim a recovery the health probe doesn't confirm.
+        Invoke-Logged node ./node_modules/pm2/bin/pm2 start ecosystem.config.cjs
+        if ($LASTEXITCODE -eq 0) { Invoke-Logged node scripts/verify-server-health.js }
+        if ($LASTEXITCODE -eq 0) {
+            Invoke-Logged node ./node_modules/pm2/bin/pm2 save
+            Step "restart" "warning" "Update failed, but PortOS was restarted"
+            Write-SafeHost "✅ PortOS is answering /api/system/health again after the failed update." -ForegroundColor Green
+        } else {
+            Step "restart" "error" "Update failed and PortOS is DOWN"
+            Write-SafeHost "❌ PortOS is not answering /api/system/health." -ForegroundColor Red
+            Write-SafeHost "    Recover with: node ./node_modules/pm2/bin/pm2 start ecosystem.config.cjs" -ForegroundColor Red
+        }
+    } catch {
+        # A throwing recovery must not replace the real update failure, and must
+        # not re-enter the trap below.
+        Write-SafeHost "❌ PortOS restart attempt failed: $($_.Exception.Message)" -ForegroundColor Red
+    }
+}
+
+# Every fatal exit between the delete and the start goes through here, so the
+# recovery cannot be forgotten at one of the ten call sites.
+function Stop-UpdateScript {
+    param([int]$Code = 1)
+    Restore-Pm2Apps
+    # Recovery must never turn a failed update into a reported success.
+    if ($Code -eq 0) { $Code = 1 }
+    exit $Code
+}
+
+# Backstop for a terminating error nobody converted into a Stop-UpdateScript
+# call; `break` rethrows so the script still exits non-zero.
+trap {
+    Restore-Pm2Apps
+    break
+}
+
 # Remove ONLY PortOS's apps from the shared PM2 daemon — never `pm2 kill`, which
 # tears down the daemon and stops EVERY other project's apps on this machine.
 # The daemon itself is left alone here; whether it also needs an in-place reload
 # is decided in the restart step below, against the freshly installed pm2.
 Step "pm2-stop" "running" "Stopping PortOS apps..."
 Invoke-Logged node ./node_modules/pm2/bin/pm2 delete ecosystem.config.cjs --silent
+$script:Pm2AppsDown = $true
 $global:LASTEXITCODE = 0
 Step "pm2-stop" "done" "Apps stopped"
 Write-SafeHost ""
@@ -271,14 +330,14 @@ Safe-Install -Dir "autofixer" -Label "autofixer"
 # (vite 8 dropped the esbuild binary dependency that used to be the reason).
 Write-SafeHost "🔧 Rebuilding trusted native dependencies..." -ForegroundColor Yellow
 Invoke-Logged node scripts/trusted-rebuilds.js server
-if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+if ($LASTEXITCODE -ne 0) { Stop-UpdateScript $LASTEXITCODE }
 Write-SafeHost ""
 
 # Verify critical dependencies exist
 if (-not (Test-Path "client/node_modules/vite/bin/vite.js")) {
     Write-SafeHost "❌ Critical dependency missing: client/node_modules/vite" -ForegroundColor Red
     Write-SafeHost "   Try running: npm run install:all"
-    exit 1
+    Stop-UpdateScript 1
 }
 Step "npm-install" "done" "Dependencies installed"
 
@@ -287,11 +346,11 @@ Step "npm-install" "done" "Dependencies installed"
 # `npm run setup` and are idempotent.
 Step "setup" "running" "Running setup..."
 Invoke-Logged node scripts/setup-data.js
-if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+if ($LASTEXITCODE -ne 0) { Stop-UpdateScript $LASTEXITCODE }
 Invoke-Logged node scripts/setup-db.js
-if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+if ($LASTEXITCODE -ne 0) { Stop-UpdateScript $LASTEXITCODE }
 Invoke-Logged node scripts/setup-browser.js
-if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+if ($LASTEXITCODE -ne 0) { Stop-UpdateScript $LASTEXITCODE }
 Invoke-Logged node scripts/setup-ghostty.js
 Step "setup" "done" "Setup complete"
 Write-SafeHost ""
@@ -301,7 +360,7 @@ Write-SafeHost ""
 # failed update; setup-guide owns the shared human-readable next step.
 Step "network-setup" "running" "Checking Tailscale, MagicDNS, and HTTPS..."
 Invoke-Logged node scripts/setup-cert.js
-if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+if ($LASTEXITCODE -ne 0) { Stop-UpdateScript $LASTEXITCODE }
 $networkSummary = & {
     $ErrorActionPreference = 'Continue'
     & node scripts/setup-guide.js --summary 2>> $UpdateLog
@@ -318,7 +377,7 @@ Step "migrations" "running" "Running data migrations..."
 $migrationsScript = Join-Path $RootDir "scripts\run-migrations.js"
 if (Test-Path $migrationsScript) {
     Invoke-Logged node $migrationsScript
-    if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+    if ($LASTEXITCODE -ne 0) { Stop-UpdateScript $LASTEXITCODE }
 }
 Step "migrations" "done" "Migrations complete"
 
@@ -345,7 +404,7 @@ Write-SafeHost ""
 # Build UI assets for production serving
 Step "build" "running" "Building client..."
 Invoke-Logged npm run build
-if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+if ($LASTEXITCODE -ne 0) { Stop-UpdateScript $LASTEXITCODE }
 Step "build" "done" "Client built"
 Write-SafeHost ""
 
@@ -353,7 +412,7 @@ Write-SafeHost ""
 $Tag = (Get-Content package.json -Raw | ConvertFrom-Json).version
 if (-not $Tag) {
     Write-SafeHost "❌ Failed to determine package version from package.json" -ForegroundColor Red
-    exit 1
+    Stop-UpdateScript 1
 }
 $completedAt = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
 $markerObj = @{ version = $Tag; completedAt = $completedAt }
@@ -388,8 +447,9 @@ if ($LASTEXITCODE -ne 0) {
     if (Test-Path "$RootDir\data\update-complete.json") {
         Remove-Item -Force "$RootDir\data\update-complete.json"
     }
-    exit $LASTEXITCODE
+    Stop-UpdateScript $LASTEXITCODE
 }
+$script:Pm2AppsDown = $false
 Invoke-Logged node ./node_modules/pm2/bin/pm2 save
 $global:LASTEXITCODE = 0
 Step "restart" "done" "PortOS started"

--- a/update.ps1
+++ b/update.ps1
@@ -107,10 +107,7 @@ function Resolve-Pm2Command {
         return @('node', (Join-Path $RootDir 'node_modules/pm2/bin/pm2'))
     }
     if (Get-Command pm2 -ErrorAction SilentlyContinue) {
-        # `,` keeps PowerShell from unrolling this single-element array into a
-        # bare string — `$pm2 + @('start', …)` on a string concatenates into one
-        # garbage token instead of building an argument list.
-        return ,@('pm2')
+        return @('pm2')
     }
     $pinned = try { (Get-Content "$RootDir\package.json" -Raw | ConvertFrom-Json).dependencies.pm2 } catch { $null }
     if ($pinned) { return @('npx', '--yes', "pm2@$pinned") }
@@ -121,7 +118,12 @@ function Restore-Pm2Apps {
     if (-not $script:Pm2AppsDown) { return }
     $script:Pm2AppsDown = $false
     try {
-        # @() again at the call site, so no future branch can regress the shape.
+        # @() at the call site is what keeps the shape right: `return` ENUMERATES
+        # an array into the output stream, so a single-element branch would arrive
+        # as a bare string and `$pm2 + @('start', …)` would concatenate into one
+        # garbage token. @() collects the stream back into a flat array. Every
+        # branch must therefore return a PLAIN array — a `,@(…)` wrapper would
+        # emit the array as one item and @() would nest rather than flatten it.
         $pm2 = @(Resolve-Pm2Command)
         Write-SafeHost "⚠️  Update is exiting with PortOS's apps deleted — restarting them so the install isn't left headless." -ForegroundColor Yellow
         Step "restart" "running" "Update failed — restarting PortOS so it isn't left down..."

--- a/update.ps1
+++ b/update.ps1
@@ -104,10 +104,13 @@ $script:Pm2AppsDown = $false
 # back to one on PATH, or to npx, is fine for a recovery.
 function Resolve-Pm2Command {
     if (Test-Path "$RootDir\node_modules\pm2\bin\pm2") {
-        return @('node', './node_modules/pm2/bin/pm2')
+        return @('node', (Join-Path $RootDir 'node_modules/pm2/bin/pm2'))
     }
     if (Get-Command pm2 -ErrorAction SilentlyContinue) {
-        return @('pm2')
+        # `,` keeps PowerShell from unrolling this single-element array into a
+        # bare string — `$pm2 + @('start', …)` on a string concatenates into one
+        # garbage token instead of building an argument list.
+        return ,@('pm2')
     }
     $pinned = try { (Get-Content "$RootDir\package.json" -Raw | ConvertFrom-Json).dependencies.pm2 } catch { $null }
     if ($pinned) { return @('npx', '--yes', "pm2@$pinned") }
@@ -118,16 +121,18 @@ function Restore-Pm2Apps {
     if (-not $script:Pm2AppsDown) { return }
     $script:Pm2AppsDown = $false
     try {
-        $pm2 = Resolve-Pm2Command
+        # @() again at the call site, so no future branch can regress the shape.
+        $pm2 = @(Resolve-Pm2Command)
         Write-SafeHost "⚠️  Update is exiting with PortOS's apps deleted — restarting them so the install isn't left headless." -ForegroundColor Yellow
         Step "restart" "running" "Update failed — restarting PortOS so it isn't left down..."
         # `pm2 start` exiting 0 is not proof the server came back (same reason the
         # verify step below exists) — and this path starts a HALF-INSTALLED tree, so
         # a start that exits 0 and then crash-loops is the likely case here, not the
         # edge case. Never claim a recovery the health probe doesn't confirm.
-        $startArgs = $pm2 + @('start', 'ecosystem.config.cjs')
+        $ecosystem = Join-Path $RootDir 'ecosystem.config.cjs'
+        $startArgs = $pm2 + @('start', $ecosystem)
         Invoke-Logged @startArgs
-        if ($LASTEXITCODE -eq 0) { Invoke-Logged node scripts/verify-server-health.js }
+        if ($LASTEXITCODE -eq 0) { Invoke-Logged node (Join-Path $RootDir 'scripts/verify-server-health.js') }
         if ($LASTEXITCODE -eq 0) {
             $saveArgs = $pm2 + @('save')
             Invoke-Logged @saveArgs
@@ -138,7 +143,7 @@ function Restore-Pm2Apps {
             Write-SafeHost "❌ PortOS is not answering /api/system/health." -ForegroundColor Red
             # Name the pm2 that actually exists — the checkout's copy may be the
             # thing a failed install just deleted, so printing it would be a dead end.
-            Write-SafeHost "    Recover with: $($pm2 -join ' ') start ecosystem.config.cjs" -ForegroundColor Red
+            Write-SafeHost "    Recover with: $($pm2 -join ' ') start $ecosystem" -ForegroundColor Red
         }
     } catch {
         # A throwing recovery must not replace the real update failure, and must
@@ -338,8 +343,10 @@ Write-SafeHost ""
 # The daemon itself is left alone here; whether it also needs an in-place reload
 # is decided in the restart step below, against the freshly installed pm2.
 Step "pm2-stop" "running" "Stopping PortOS apps..."
-Invoke-Logged node ./node_modules/pm2/bin/pm2 delete ecosystem.config.cjs --silent
+# Arm the latch BEFORE the delete (see update.sh) so an interruption during the
+# delete itself still reaches the recovery.
 $script:Pm2AppsDown = $true
+Invoke-Logged node ./node_modules/pm2/bin/pm2 delete ecosystem.config.cjs --silent
 $global:LASTEXITCODE = 0
 Step "pm2-stop" "done" "Apps stopped"
 Write-SafeHost ""

--- a/update.sh
+++ b/update.sh
@@ -186,25 +186,55 @@ log ""
 # recovery only ever runs on a path that was already leaving PortOS down.
 PM2_APPS_DOWN=0
 
+# Which pm2 the recovery can actually reach. It CANNOT assume this checkout's
+# own copy: `safe_install .` wipes root node_modules whenever the pulled update
+# touched root package.json — which every release does, since the version bump
+# lives there — and pm2 is a ROOT dependency. So on the most likely failure of
+# all (both npm install attempts fail: offline, registry 5xx, ENOSPC) the
+# checkout's pm2 is already gone by the time the trap runs, and a hardcoded
+# ./node_modules/pm2/bin/pm2 would make the recovery a no-op exactly when it is
+# needed most. Prefer the local copy, fall back to a pm2 on PATH, then to npx at
+# the version package.json pins. Any pm2 CLI can drive the already-running
+# daemon, so a version difference is fine for a recovery.
+PM2_CMD=()
+resolve_pm2_cmd() {
+  if [ -f "$ROOT_DIR/node_modules/pm2/bin/pm2" ]; then
+    PM2_CMD=(node "$ROOT_DIR/node_modules/pm2/bin/pm2")
+  elif command -v pm2 >/dev/null 2>&1; then
+    PM2_CMD=(pm2)
+  else
+    local pinned
+    pinned=$(node -e 'const d=require("./package.json").dependencies||{}; process.stdout.write(typeof d.pm2 === "string" ? d.pm2 : "")' 2>/dev/null || echo "")
+    if [ -n "$pinned" ]; then
+      PM2_CMD=(npx --yes "pm2@$pinned")
+    else
+      PM2_CMD=(npx --yes pm2)
+    fi
+  fi
+}
+
 restore_pm2_apps_on_exit() {
   local status=$?
   trap - EXIT
   if [ "$PM2_APPS_DOWN" = "1" ]; then
     PM2_APPS_DOWN=0
+    resolve_pm2_cmd
     log "⚠️  Update is exiting (status $status) with PortOS's apps deleted — restarting them so the install isn't left headless."
     step "restart" "running" "Update failed — restarting PortOS so it isn't left down..."
     # `pm2 start` exiting 0 is not proof the server came back (same reason the
     # verify step below exists) — and this path starts a HALF-INSTALLED tree, so
     # a start that exits 0 and then crash-loops is the likely case here, not the
     # edge case. Never claim a recovery the health probe doesn't confirm.
-    if run node ./node_modules/pm2/bin/pm2 start ecosystem.config.cjs && run node scripts/verify-server-health.js; then
-      run node ./node_modules/pm2/bin/pm2 save || true
+    if run "${PM2_CMD[@]}" start ecosystem.config.cjs && run node scripts/verify-server-health.js; then
+      run "${PM2_CMD[@]}" save || true
       step "restart" "warning" "Update failed, but PortOS was restarted"
       log "✅ PortOS is answering /api/system/health again after the failed update."
     else
       step "restart" "error" "Update failed and PortOS is DOWN"
       log "❌ PortOS is not answering /api/system/health."
-      log "    Recover with: node ./node_modules/pm2/bin/pm2 start ecosystem.config.cjs"
+      # Name the pm2 that actually exists — the checkout's copy may be the thing
+      # a failed install just deleted, so printing it would be a dead-end hint.
+      log "    Recover with: ${PM2_CMD[*]} start ecosystem.config.cjs"
     fi
     # Recovery must never turn a failed update into a reported success.
     if [ "$status" -eq 0 ]; then status=1; fi

--- a/update.sh
+++ b/update.sh
@@ -215,7 +215,11 @@ resolve_pm2_cmd() {
 
 restore_pm2_apps_on_exit() {
   local status=$?
-  trap - EXIT
+  # Disarm every trap, not just EXIT: a second signal (Ctrl-C twice, an
+  # escalating killer) arriving while the recovery's own `pm2 start` and health
+  # probe are running would otherwise abort it mid-flight and leave the install
+  # headless — exactly the state this function exists to prevent.
+  trap - EXIT TERM INT HUP
   if [ "$PM2_APPS_DOWN" = "1" ]; then
     PM2_APPS_DOWN=0
     resolve_pm2_cmd

--- a/update.sh
+++ b/update.sh
@@ -173,12 +173,58 @@ run git submodule update --init --recursive
 step "submodules" "done" "Submodules updated"
 log ""
 
+# Headless-install guard. From the `pm2-stop` step below until the closing
+# `pm2 start` succeeds, PortOS's PM2 entries are DELETED — the install has no
+# server. Every step in between (npm install, setup-db, migrations, the client
+# build) can fail, and `set -e` would then exit with the apps still deleted and
+# nothing left running to notice: the "update deleted portos-server and it never
+# came back" failure. #5976 made this script SURVIVE pm2's tree-kill; it did not
+# cover the script exiting on its own. So trap the exit and put the apps back.
+#
+# Starting the pulled tree after a failed install can crash-loop, but a
+# crash-looping app the user can see beats a silently headless machine — and the
+# recovery only ever runs on a path that was already leaving PortOS down.
+PM2_APPS_DOWN=0
+
+restore_pm2_apps_on_exit() {
+  local status=$?
+  trap - EXIT
+  if [ "$PM2_APPS_DOWN" = "1" ]; then
+    PM2_APPS_DOWN=0
+    log "⚠️  Update is exiting (status $status) with PortOS's apps deleted — restarting them so the install isn't left headless."
+    step "restart" "running" "Update failed — restarting PortOS so it isn't left down..."
+    # `pm2 start` exiting 0 is not proof the server came back (same reason the
+    # verify step below exists) — and this path starts a HALF-INSTALLED tree, so
+    # a start that exits 0 and then crash-loops is the likely case here, not the
+    # edge case. Never claim a recovery the health probe doesn't confirm.
+    if run node ./node_modules/pm2/bin/pm2 start ecosystem.config.cjs && run node scripts/verify-server-health.js; then
+      run node ./node_modules/pm2/bin/pm2 save || true
+      step "restart" "warning" "Update failed, but PortOS was restarted"
+      log "✅ PortOS is answering /api/system/health again after the failed update."
+    else
+      step "restart" "error" "Update failed and PortOS is DOWN"
+      log "❌ PortOS is not answering /api/system/health."
+      log "    Recover with: node ./node_modules/pm2/bin/pm2 start ecosystem.config.cjs"
+    fi
+    # Recovery must never turn a failed update into a reported success.
+    if [ "$status" -eq 0 ]; then status=1; fi
+  fi
+  exit "$status"
+}
+trap restore_pm2_apps_on_exit EXIT
+# Turn a fatal signal into an ordinary exit so the EXIT trap above still runs
+# (bash does not run an EXIT trap for an untrapped fatal signal).
+trap 'exit 143' TERM
+trap 'exit 130' INT
+trap 'exit 129' HUP
+
 # Remove ONLY PortOS's apps from the shared PM2 daemon — never `pm2 kill`, which
 # tears down the daemon and stops EVERY other project's apps on this machine.
 # The daemon itself is left alone here; whether it also needs an in-place reload
 # is decided in the restart step below, against the freshly installed pm2.
 step "pm2-stop" "running" "Stopping PortOS apps..."
 run node ./node_modules/pm2/bin/pm2 delete ecosystem.config.cjs --silent || true
+PM2_APPS_DOWN=1
 step "pm2-stop" "done" "Apps stopped"
 log ""
 
@@ -354,6 +400,7 @@ if ! run node ./node_modules/pm2/bin/pm2 start ecosystem.config.cjs; then
   rm -f "$ROOT_DIR/data/update-complete.json"
   exit 1
 fi
+PM2_APPS_DOWN=0
 run node ./node_modules/pm2/bin/pm2 save || true
 step "restart" "done" "PortOS started"
 log ""

--- a/update.sh
+++ b/update.sh
@@ -253,8 +253,13 @@ trap 'exit 129' HUP
 # The daemon itself is left alone here; whether it also needs an in-place reload
 # is decided in the restart step below, against the freshly installed pm2.
 step "pm2-stop" "running" "Stopping PortOS apps..."
-run node ./node_modules/pm2/bin/pm2 delete ecosystem.config.cjs --silent || true
+# Arm the latch BEFORE the delete, not after: bash runs a pending signal trap
+# only between statements, so a TERM arriving while `pm2 delete` is still
+# running would otherwise reach the EXIT trap with the latch still 0 and skip
+# the recovery — the exact window the signal traps exist for. Recovering apps
+# that were never deleted is a harmless no-op restart on an already-failing path.
 PM2_APPS_DOWN=1
+run node ./node_modules/pm2/bin/pm2 delete ecosystem.config.cjs --silent || true
 step "pm2-stop" "done" "Apps stopped"
 log ""
 


### PR DESCRIPTION
## Summary

Updating PortOS from App Management could still delete `portos-server` and leave it down. #5976 fixed the update script being **tree-killed** by its own `pm2 delete`; it did not cover the script **exiting on its own**.

`update.sh` / `update.ps1` delete PortOS's PM2 entries at the `pm2-stop` step and don't start them again until the `restart` step ~170 lines later. Under `set -euo pipefail` (and each explicit `exit` on Windows), *any* failure in between — `npm install`, `setup-db`, migrations, the client build — exits with `portos-server` deleted and nothing left running to notice. The install stays headless until someone runs `pm2 start` by hand.

- **Trap the exit** (bash `EXIT` + `TERM`/`INT`/`HUP`) / **route every fatal exit through `Stop-UpdateScript`** (PowerShell), and restart the apps on the way out.
- **Confirm with `verify-server-health.js`**, the same probe the happy path uses — the recovery starts a half-installed tree, so a `pm2 start` that exits 0 and then crash-loops is the likely case, not the edge case. It never claims a recovery the probe didn't confirm, and the update still reports failure.
- **Resolve pm2 rather than hardcoding it.** `safe_install .` wipes root `node_modules` whenever the pull touched root `package.json` — every release, since the version bump lives there — and pm2 is a root dependency. On the most likely failure of all (both `npm install` attempts fail) the checkout's own pm2 is already gone. Falls back local → PATH → `npx` at the pinned version, and prints whichever one exists.
- **PowerShell:** the guard block sits above every fatal exit in the file, because `exit` inside a function ends the script without a terminating error — bypassing both `Stop-UpdateScript` and the `trap`. `Safe-Install`'s exit is defined above the delete but runs below it, so a guard placed beside the delete could never have caught it.
- **Arm the latch before the delete.** Bash runs a pending signal trap only between statements, so a `TERM` during `pm2 delete` would otherwise reach the trap with the latch unset.

## Test plan

`scripts/update-headless-recovery.test.js` runs the **real `update.sh`** in sandboxed git repos (shared `makeGitSandbox` helper) with `npm`/`npx`/`pm2` shimmed — assertions are on the recorded pm2 call sequence, not a grep for the guard's source:

- fails after the delete → a `start` follows the `delete`, exit status stays non-zero, `STEP:restart:warning:`
- succeeds → exactly **one** `start`, no recovery
- fails before the delete → PM2 untouched
- health probe fails → `STEP:restart:error:`, never a false success
- `npm install` fails after wiping root `node_modules` → recovery still starts pm2 via the PATH fallback
- `SIGTERM` delivered *during* the delete → recovery still runs, exit 143

`update.ps1` can't be executed here, so its guard is pinned structurally: every `exit` in the whole file must be one of the two sanctioned ones, the latch must be armed before the delete, and `Resolve-Pm2Command`'s result must be array-forced.

Each guard was verified by reverting it and confirming the matching test fails. Full server (38k) and client (10k) suites pass.

## Known, not fixed here

`updateExecutor` labels the failure `Update failed at step "restart"` because the recovery emits the last `STEP:` line. It has no live consumer — the server is already deleted whenever the recovery runs — and the fix belongs in `updateExecutor`, outside this diff.