### PR TITLE
test: extract the shared VideoGen page mock harness

### DIFF
--- a/client/src/pages/VideoGen.composeWhileBusy.test.jsx
+++ b/client/src/pages/VideoGen.composeWhileBusy.test.jsx
@@ -1,152 +1,28 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { MemoryRouter } from 'react-router';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+
+import {
+  loadVideoGenPage,
+  renderVideoGenPage,
+  resetVideoGenMockState,
+  state,
+  videoGenModel,
+  videoGenStatus,
+  videoGenTermsGate,
+} from '../test/videoGenPageMocks.jsx';
 
 const TERMS_ID = 'minimax-h3-license-v1';
-const MODEL = {
-  id: 'h3-one',
-  name: 'MiniMax h3-one',
-  repo: 'example-org/h3-one',
-  revision: '1111111111111111111111111111111111111111',
-  runtime: 'minimax_h3',
-  supportedModes: ['text'],
-  defaultFrames: 124,
-  frameOptions: [124, 141],
-  fpsOptions: [24],
-  steps: 8,
-  guidance: 0,
-  samplerLocked: true,
-  supportsNegativePrompt: false,
-  supportsTiling: false,
-  supportsDisableAudio: false,
-  termsGate: {
-    id: TERMS_ID,
-    title: 'Terms for h3-one',
-    summary: 'This model is available only in its applicable territory.',
-    acknowledgement: `I am eligible and accept ${TERMS_ID}.`,
-    licenseUrl: 'https://example.com/license',
-  },
-};
+const MODEL = videoGenModel('h3-one', { termsGate: videoGenTermsGate(TERMS_ID) });
 
-const state = vi.hoisted(() => ({
-  generateVideo: vi.fn(),
-  attach: vi.fn(),
-  eventSourceRef: { current: null },
-}));
-
-vi.mock('../services/api', () => ({
-  // The page offers a federated render target (#4348); with no peer opted in
-  // as a media provider the picker renders nothing and every local path below
-  // is unchanged.
-  getInstances: vi.fn(async () => ({ peers: [] })),
-  getVideoGenStatus: vi.fn(async () => ({
-    connected: true,
-    pythonPath: '/opt/example/python3',
-    defaultModel: 'h3-one',
-    models: [MODEL],
-    byovRuntimes: [],
-    systemMemoryGb: 128,
-    backendDisclosures: [],
-  })),
-  generateVideo: (...args) => state.generateVideo(...args),
-  cancelVideoGen: vi.fn(async () => ({})),
-  listVideoHistory: vi.fn(async () => []),
-  deleteVideoHistoryItem: vi.fn(async () => ({})),
-  setVideoHidden: vi.fn(async () => ({})),
-  extractLastFrame: vi.fn(async () => ({})),
-  upscaleVideo: vi.fn(async () => ({})),
-  listImageGallery: vi.fn(async () => []),
-  patchSettingsSlice: vi.fn(async () => ({})),
-  getActiveVideoJob: vi.fn(async () => ({ activeJob: null })),
-  getSettings: vi.fn(async () => ({ imageGen: { grok: { enabled: false } } })),
-  getVideoGenRuntimeStatus: vi.fn(async () => ({ installed: true, ready: true, current: true })),
-  listLorasFull: vi.fn(async () => []),
-  getProviders: vi.fn(async () => ({ providers: [] })),
-  getVisionModels: vi.fn(async () => ({ models: [] })),
-}));
-
-vi.mock('../hooks/useModelDownloadStatus', () => ({
-  TEXT_ENCODER_DOWNLOAD_ID: '__text_encoder__',
-  useModelDownloadStatus: () => ({
-    extra: {},
-    loading: false,
-    statusError: null,
-    activeModelId: null,
-    progress: null,
-    lastError: null,
-    downloading: false,
-    repairing: false,
-    getStatus: () => ({ id: MODEL.id, repo: MODEL.repo, cached: true, sizeBytes: 100 }),
-    start: vi.fn(),
-    cancel: vi.fn(),
-    repair: vi.fn(),
-    refresh: vi.fn(),
-  }),
-}));
-
-vi.mock('../hooks/useMediaJobSse', () => ({
-  useMediaJobSse: () => ({ attach: state.attach, eventSourceRef: state.eventSourceRef }),
-}));
-vi.mock('../hooks/useMediaCompletionRefresh', () => ({ useMediaCompletionRefresh: vi.fn() }));
-vi.mock('../hooks/useMediaAnnotations', () => ({
-  useMediaAnnotations: () => ({ annotations: {}, updateAnnotation: vi.fn(), getCardProps: vi.fn(() => ({})) }),
-}));
-vi.mock('../hooks/usePreviewRoute', () => ({ default: () => [null, vi.fn()] }));
-vi.mock('../components/ui/Toast', () => ({
-  default: Object.assign(vi.fn(), { error: vi.fn(), success: vi.fn(), loading: vi.fn() }),
-}));
-
-vi.mock('../components/media/PromptEnhancer', () => ({
-  default: ({ disabled }) => (
-    <div data-testid="prompt-enhancer" data-disabled={disabled ? '1' : '0'}>Enhance with AI</div>
-  ),
-}));
-vi.mock('../components/media/PromptFromMedia', () => ({
-  default: ({ disabled }) => (
-    <div data-testid="prompt-from-media" data-disabled={disabled ? '1' : '0'}>Prompt from media</div>
-  ),
-}));
-vi.mock('../components/media/UniverseStylePicker', () => ({
-  default: ({ onChange }) => (
-    <button
-      type="button"
-      onClick={() => onChange({
-        id: 'u-1', name: 'Example Universe',
-        influences: { embrace: ['inky linework'], avoid: ['glossy'] },
-      })}
-    >
-      Use universe style
-    </button>
-  ),
-}));
-
-vi.mock('../components/Drawer', () => ({ default: () => null }));
-vi.mock('../components/settings/ImageGenTab', () => ({ ImageGenTab: () => null }));
-vi.mock('../components/settings/LocalSetupPanel', () => ({ default: () => null }));
-vi.mock('../components/install/RuntimeInstallModal', () => ({
-  default: ({ streamMethod }) => <div data-testid="runtime-install-modal" data-stream-method={streamMethod} />,
-}));
-vi.mock('../components/videoGen/FramePanel', () => ({ default: () => null }));
-vi.mock('../components/videoGen/KeyframePanel', () => ({ default: () => null }));
-vi.mock('../components/videoGen/AudioPanel', () => ({ default: () => null }));
-vi.mock('../components/videoGen/ExtendPanel', () => ({ default: () => null }));
-vi.mock('../components/videoGen/IcLoraPanel', () => ({ default: () => null }));
-vi.mock('../components/videoGen/AdvancedParamsPanel', () => ({ default: () => null }));
-vi.mock('../components/videoGen/RuntimeFingerprint', () => ({ default: () => null }));
-vi.mock('../components/videoGen/VideoGenGallery', () => ({ default: () => null }));
-vi.mock('../components/media/MediaPreview', () => ({ default: () => null }));
-vi.mock('../components/media/StylePresetPicker', () => ({ default: () => null }));
-vi.mock('../components/media/MediaJobsQueue', () => ({ default: () => null }));
-vi.mock('../components/imageGen/LoraPicker', () => ({ default: () => null }));
-vi.mock('../components/media/ResolutionField', () => ({ default: () => null }));
-
-const { default: VideoGen } = await import('./VideoGen.jsx');
+await loadVideoGenPage();
 
 describe('VideoGen compose-while-busy', () => {
   beforeEach(() => {
-    state.generateVideo.mockReset().mockReturnValue(new Promise(() => {}));
-    state.attach.mockReset().mockReturnValue(new Promise(() => {}));
-    state.eventSourceRef.current = null;
+    resetVideoGenMockState();
+    state.getVideoGenStatus.mockResolvedValue(videoGenStatus([MODEL]));
+    state.modelStatuses = { [MODEL.id]: { id: MODEL.id, repo: MODEL.repo, cached: true, sizeBytes: 100 } };
+    state.generateVideo.mockReturnValue(new Promise(() => {}));
+    state.attach.mockReturnValue(new Promise(() => {}));
     vi.stubGlobal('open', vi.fn());
     Object.defineProperty(globalThis.navigator, 'clipboard', {
       configurable: true,
@@ -155,33 +31,19 @@ describe('VideoGen compose-while-busy', () => {
   });
 
   it('starts runtime installation through the non-idempotent POST stream', async () => {
-    await act(async () => {
-      render(
-        <MemoryRouter initialEntries={['/media/video']}>
-          <VideoGen />
-        </MemoryRouter>,
-      );
-    });
+    await renderVideoGenPage();
 
     expect(screen.getByTestId('runtime-install-modal')).toHaveAttribute('data-stream-method', 'POST');
   });
 
   it('leaves Enhance with AI and Prompt from media usable so the next clip can be queued', async () => {
-    await act(async () => {
-      render(
-        <MemoryRouter initialEntries={['/media/video']}>
-          <VideoGen />
-        </MemoryRouter>,
-      );
-    });
+    await renderVideoGenPage();
 
     const prompt = await screen.findByLabelText('Prompt');
     fireEvent.change(prompt, { target: { value: 'a fox watches the rain' } });
     await waitFor(() => expect(screen.getByRole('button', { name: /^Generate$/ })).toBeEnabled());
 
-    await act(async () => {
-      fireEvent.click(screen.getByRole('button', { name: /^Generate$/ }));
-    });
+    fireEvent.click(screen.getByRole('button', { name: /^Generate$/ }));
     await waitFor(() => expect(screen.getByRole('button', { name: /Cancel/i })).toBeInTheDocument());
 
     expect(screen.getByTestId('prompt-enhancer')).toHaveAttribute('data-disabled', '0');
@@ -190,13 +52,7 @@ describe('VideoGen compose-while-busy', () => {
   });
 
   it('includes the selected universe style in the submitted video prompt', async () => {
-    await act(async () => {
-      render(
-        <MemoryRouter initialEntries={['/media/video']}>
-          <VideoGen />
-        </MemoryRouter>,
-      );
-    });
+    await renderVideoGenPage();
 
     fireEvent.click(screen.getByRole('button', { name: 'Use universe style' }));
     fireEvent.change(await screen.findByLabelText('Prompt'), { target: { value: 'a fox watches the rain' } });
@@ -207,13 +63,7 @@ describe('VideoGen compose-while-busy', () => {
   });
 
   it('submits an additional render to the server queue while another render is active', async () => {
-    await act(async () => {
-      render(
-        <MemoryRouter initialEntries={['/media/video']}>
-          <VideoGen />
-        </MemoryRouter>,
-      );
-    });
+    await renderVideoGenPage();
 
     const prompt = await screen.findByLabelText('Prompt');
     fireEvent.change(prompt, { target: { value: 'a fox watches the rain' } });
@@ -229,5 +79,4 @@ describe('VideoGen compose-while-busy', () => {
       prompt: 'a fox watches the rain',
     });
   });
-
 });

--- a/client/src/pages/VideoGen.federatedTarget.test.jsx
+++ b/client/src/pages/VideoGen.federatedTarget.test.jsx
@@ -1,32 +1,18 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { MemoryRouter } from 'react-router';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { act, fireEvent, screen, waitFor } from '@testing-library/react';
+
+import {
+  loadVideoGenPage,
+  renderVideoGenPage,
+  resetVideoGenMockState,
+  state,
+  videoGenModel,
+  videoGenStatus,
+  videoGenTermsGate,
+} from '../test/videoGenPageMocks.jsx';
 
 const TERMS_ID = 'minimax-h3-license-v1';
-const MODEL = {
-  id: 'h3-one',
-  name: 'MiniMax h3-one',
-  repo: 'example-org/h3-one',
-  revision: '1111111111111111111111111111111111111111',
-  runtime: 'minimax_h3',
-  supportedModes: ['text'],
-  defaultFrames: 124,
-  frameOptions: [124, 141],
-  fpsOptions: [24],
-  steps: 8,
-  guidance: 0,
-  samplerLocked: true,
-  supportsNegativePrompt: false,
-  supportsTiling: false,
-  supportsDisableAudio: false,
-  termsGate: {
-    id: TERMS_ID,
-    title: 'Terms for h3-one',
-    summary: 'This model is available only in its applicable territory.',
-    acknowledgement: `I am eligible and accept ${TERMS_ID}.`,
-    licenseUrl: 'https://example.com/license',
-  },
-};
+const MODEL = videoGenModel('h3-one', { termsGate: videoGenTermsGate(TERMS_ID) });
 
 // A peer opted in as a video provider, advertising one allowlisted model with a
 // verifiable freshness window — the shape `GET /api/instances` returns.
@@ -51,120 +37,21 @@ const PEER = {
   },
 };
 
-const state = vi.hoisted(() => ({
-  generateVideo: vi.fn(),
-  attach: vi.fn(),
-  eventSourceRef: { current: null },
-}));
-
-vi.mock('../services/api', () => ({
-  getInstances: vi.fn(async () => ({ peers: [PEER] })),
-  getVideoGenStatus: vi.fn(async () => ({
-    connected: true,
-    pythonPath: '/opt/example/python3',
-    defaultModel: 'h3-one',
-    models: [MODEL],
-    byovRuntimes: [],
-    systemMemoryGb: 128,
-    backendDisclosures: [],
-  })),
-  generateVideo: (...args) => state.generateVideo(...args),
-  cancelVideoGen: vi.fn(async () => ({})),
-  listVideoHistory: vi.fn(async () => []),
-  deleteVideoHistoryItem: vi.fn(async () => ({})),
-  setVideoHidden: vi.fn(async () => ({})),
-  extractLastFrame: vi.fn(async () => ({})),
-  upscaleVideo: vi.fn(async () => ({})),
-  listImageGallery: vi.fn(async () => []),
-  patchSettingsSlice: vi.fn(async () => ({})),
-  getActiveVideoJob: vi.fn(async () => ({ activeJob: null })),
-  getSettings: vi.fn(async () => ({ imageGen: { grok: { enabled: false } } })),
-  getVideoGenRuntimeStatus: vi.fn(async () => ({ installed: true, ready: true, current: true })),
-  listLorasFull: vi.fn(async () => []),
-  getProviders: vi.fn(async () => ({ providers: [] })),
-  getVisionModels: vi.fn(async () => ({ models: [] })),
-}));
-
-vi.mock('../hooks/useModelDownloadStatus', () => ({
-  TEXT_ENCODER_DOWNLOAD_ID: '__text_encoder__',
-  useModelDownloadStatus: () => ({
-    extra: {},
-    loading: false,
-    statusError: null,
-    activeModelId: null,
-    progress: null,
-    lastError: null,
-    downloading: false,
-    repairing: false,
-    getStatus: () => ({ id: MODEL.id, repo: MODEL.repo, cached: true, sizeBytes: 100 }),
-    start: vi.fn(),
-    cancel: vi.fn(),
-    repair: vi.fn(),
-    refresh: vi.fn(),
-  }),
-}));
-
-vi.mock('../hooks/useMediaJobSse', () => ({
-  useMediaJobSse: () => ({ attach: state.attach, eventSourceRef: state.eventSourceRef }),
-}));
-vi.mock('../hooks/useMediaCompletionRefresh', () => ({ useMediaCompletionRefresh: vi.fn() }));
-vi.mock('../hooks/useMediaAnnotations', () => ({
-  useMediaAnnotations: () => ({ annotations: {}, updateAnnotation: vi.fn(), getCardProps: vi.fn(() => ({})) }),
-}));
-vi.mock('../hooks/usePreviewRoute', () => ({ default: () => [null, vi.fn()] }));
-vi.mock('../components/ui/Toast', () => ({
-  default: Object.assign(vi.fn(), { error: vi.fn(), success: vi.fn(), loading: vi.fn() }),
-}));
-
-vi.mock('../components/media/PromptEnhancer', () => ({
-  default: ({ disabled }) => (
-    <div data-testid="prompt-enhancer" data-disabled={disabled ? '1' : '0'}>Enhance with AI</div>
-  ),
-}));
-vi.mock('../components/media/PromptFromMedia', () => ({
-  default: ({ disabled }) => (
-    <div data-testid="prompt-from-media" data-disabled={disabled ? '1' : '0'}>Prompt from media</div>
-  ),
-}));
-
-vi.mock('../components/Drawer', () => ({ default: () => null }));
-vi.mock('../components/settings/ImageGenTab', () => ({ ImageGenTab: () => null }));
-vi.mock('../components/settings/LocalSetupPanel', () => ({ default: () => null }));
-vi.mock('../components/install/RuntimeInstallModal', () => ({ default: () => null }));
-vi.mock('../components/videoGen/FramePanel', () => ({ default: () => null }));
-vi.mock('../components/videoGen/KeyframePanel', () => ({ default: () => null }));
-vi.mock('../components/videoGen/AudioPanel', () => ({ default: () => null }));
-vi.mock('../components/videoGen/ExtendPanel', () => ({ default: () => null }));
-vi.mock('../components/videoGen/IcLoraPanel', () => ({ default: () => null }));
-vi.mock('../components/videoGen/AdvancedParamsPanel', () => ({ default: () => null }));
-vi.mock('../components/videoGen/RuntimeFingerprint', () => ({ default: () => null }));
-vi.mock('../components/videoGen/VideoGenGallery', () => ({ default: () => null }));
-vi.mock('../components/media/MediaPreview', () => ({ default: () => null }));
-vi.mock('../components/media/StylePresetPicker', () => ({ default: () => null }));
-vi.mock('../components/media/UniverseStylePicker', () => ({ default: () => null }));
-vi.mock('../components/media/MediaJobsQueue', () => ({ default: () => null }));
-vi.mock('../components/imageGen/LoraPicker', () => ({ default: () => null }));
-vi.mock('../components/media/ResolutionField', () => ({ default: () => null }));
-
-
-const { default: VideoGen } = await import('./VideoGen.jsx');
+await loadVideoGenPage();
 
 const startRender = async (promptText = 'a fox watches the rain') => {
-  await act(async () => {
-    render(
-      <MemoryRouter initialEntries={['/media/video']}>
-        <VideoGen />
-      </MemoryRouter>,
-    );
-  });
+  await renderVideoGenPage();
   fireEvent.change(await screen.findByLabelText('Prompt'), { target: { value: promptText } });
 };
 
 describe('VideoGen federated render target', () => {
   beforeEach(() => {
-    state.generateVideo.mockReset().mockReturnValue(new Promise(() => {}));
-    state.attach.mockReset().mockReturnValue(new Promise(() => {}));
-    state.eventSourceRef.current = null;
+    resetVideoGenMockState();
+    state.peers = [PEER];
+    state.getVideoGenStatus.mockResolvedValue(videoGenStatus([MODEL]));
+    state.modelStatuses = { [MODEL.id]: { id: MODEL.id, repo: MODEL.repo, cached: true, sizeBytes: 100 } };
+    state.generateVideo.mockReturnValue(new Promise(() => {}));
+    state.attach.mockReturnValue(new Promise(() => {}));
   });
 
   // The whole point of the picker: a peer's model reaches the generate route as

--- a/client/src/pages/VideoGen.modelLoading.test.jsx
+++ b/client/src/pages/VideoGen.modelLoading.test.jsx
@@ -1,6 +1,14 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { act, render, screen, waitFor } from '@testing-library/react';
-import { MemoryRouter } from 'react-router';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { act, screen, waitFor } from '@testing-library/react';
+
+import {
+  loadVideoGenPage,
+  renderVideoGenPage,
+  resetVideoGenMockState,
+  state,
+  videoGenModel,
+  videoGenStatus,
+} from '../test/videoGenPageMocks.jsx';
 
 /**
  * The Model picker paints before /status lands.
@@ -11,147 +19,12 @@ import { MemoryRouter } from 'react-router';
  * placeholder, and a session-cached payload paints the real list immediately —
  * while every connectivity claim keeps waiting for the live probe.
  */
-const model = (id) => ({
-  id,
-  name: `Example ${id}`,
-  repo: `example-org/${id}`,
-  revision: '1111111111111111111111111111111111111111',
-  runtime: 'minimax_h3',
-  supportedModes: ['text'],
-  defaultFrames: 124,
-  frameOptions: [124, 141],
-  fpsOptions: [24],
-  steps: 8,
-  guidance: 0,
-  samplerLocked: true,
-  supportsNegativePrompt: false,
-  supportsTiling: false,
-  supportsDisableAudio: false,
-});
-const MODEL_ONE = model('example-one');
-const MODEL_TWO = model('example-two');
-const statusPayload = (overrides = {}) => ({
-  connected: true,
-  pythonPath: '/opt/example/python3',
-  defaultModel: MODEL_ONE.id,
-  models: [MODEL_ONE, MODEL_TWO],
-  byovRuntimes: [],
-  systemMemoryGb: 128,
-  backendDisclosures: [],
-  ...overrides,
-});
-const state = vi.hoisted(() => ({
-  modelStatuses: {},
-  generateVideo: vi.fn(),
-  startDownload: vi.fn(),
-  repairModel: vi.fn(),
-  attach: vi.fn(),
-  eventSourceRef: { current: null },
-  getVideoGenStatus: vi.fn(),
-  runtimeInstallComplete: null,
-}));
+const MODEL_ONE = videoGenModel('example-one');
+const MODEL_TWO = videoGenModel('example-two');
+const statusPayload = (overrides = {}) => videoGenStatus([MODEL_ONE, MODEL_TWO], overrides);
 
-vi.mock('../services/api', () => ({
-  // The page offers a federated render target (#4348); with no peer opted in
-  // as a media provider the picker renders nothing and every local path below
-  // is unchanged.
-  getInstances: vi.fn(async () => ({ peers: [] })),
-  getVideoGenStatus: (...args) => state.getVideoGenStatus(...args),
-  generateVideo: (...args) => state.generateVideo(...args),
-  cancelVideoGen: vi.fn(async () => ({})),
-  listVideoHistory: vi.fn(async () => []),
-  deleteVideoHistoryItem: vi.fn(async () => ({})),
-  setVideoHidden: vi.fn(async () => ({})),
-  extractLastFrame: vi.fn(async () => ({})),
-  upscaleVideo: vi.fn(async () => ({})),
-  listImageGallery: vi.fn(async () => []),
-  patchSettingsSlice: vi.fn(async () => ({})),
-  getActiveVideoJob: vi.fn(async () => ({ activeJob: null })),
-  getSettings: vi.fn(async () => ({ imageGen: { grok: { enabled: false } } })),
-  getVideoGenRuntimeStatus: vi.fn(async () => ({ installed: true, ready: true, current: true })),
-  listLorasFull: vi.fn(async () => []),
-  // The prompt-enhancement controls mount useProviderModels, which fetches the
-  // provider list from a mount effect. Unmocked it throws out of a passive
-  // effect — the tests still pass, but the unhandled rejection fails the run.
-  getProviders: vi.fn(async () => ({ providers: [] })),
-  getVisionModels: vi.fn(async () => ({ models: [] })),
-}));
-
-vi.mock('../components/media/PromptFromMedia', () => ({ default: () => null }));
-
-vi.mock('../hooks/useModelDownloadStatus', () => ({
-  TEXT_ENCODER_DOWNLOAD_ID: '__text_encoder__',
-  useModelDownloadStatus: () => ({
-    extra: {},
-    loading: false,
-    statusError: null,
-    activeModelId: null,
-    progress: null,
-    lastError: null,
-    downloading: false,
-    repairing: false,
-    getStatus: (id) => state.modelStatuses[id] || null,
-    start: state.startDownload,
-    cancel: vi.fn(),
-    repair: state.repairModel,
-    refresh: vi.fn(),
-  }),
-}));
-
-vi.mock('../hooks/useMediaJobSse', () => ({
-  useMediaJobSse: () => ({ attach: state.attach, eventSourceRef: state.eventSourceRef }),
-}));
-vi.mock('../hooks/useMediaCompletionRefresh', () => ({ useMediaCompletionRefresh: vi.fn() }));
-vi.mock('../hooks/useMediaAnnotations', () => ({
-  useMediaAnnotations: () => ({ annotations: {}, updateAnnotation: vi.fn(), getCardProps: vi.fn(() => ({})) }),
-}));
-vi.mock('../hooks/usePreviewRoute', () => ({ default: () => [null, vi.fn()] }));
-vi.mock('../components/ui/Toast', () => ({
-  default: Object.assign(vi.fn(), { error: vi.fn(), success: vi.fn(), loading: vi.fn() }),
-}));
-
-// Keep the policy-bearing controls real; replace unrelated, heavyweight page
-// surfaces so this is a focused orchestration test rather than a gallery/SSE
-// integration suite.
-vi.mock('../components/Drawer', () => ({ default: () => null }));
-vi.mock('../components/settings/ImageGenTab', () => ({ ImageGenTab: () => null }));
-vi.mock('../components/settings/LocalSetupPanel', () => ({ default: () => null }));
-vi.mock('../components/install/RuntimeInstallModal', () => ({
-  default: ({ onComplete }) => {
-    state.runtimeInstallComplete = onComplete;
-    return null;
-  },
-}));
-vi.mock('../components/videoGen/FramePanel', () => ({ default: () => null }));
-vi.mock('../components/videoGen/KeyframePanel', () => ({ default: () => null }));
-vi.mock('../components/videoGen/AudioPanel', () => ({ default: () => null }));
-vi.mock('../components/videoGen/ExtendPanel', () => ({ default: () => null }));
-vi.mock('../components/videoGen/IcLoraPanel', () => ({ default: () => null }));
-vi.mock('../components/videoGen/AdvancedParamsPanel', () => ({ default: () => null }));
-vi.mock('../components/videoGen/RuntimeFingerprint', () => ({ default: () => null }));
-vi.mock('../components/videoGen/VideoGenGallery', () => ({ default: () => null }));
-vi.mock('../components/media/MediaPreview', () => ({ default: () => null }));
-vi.mock('../components/media/StylePresetPicker', () => ({ default: () => null }));
-vi.mock('../components/media/UniverseStylePicker', () => ({ default: () => null }));
-vi.mock('../components/media/MediaJobsQueue', () => ({ default: () => null }));
-vi.mock('../components/imageGen/LoraPicker', () => ({ default: () => null }));
-vi.mock('../components/media/ResolutionField', () => ({ default: () => null }));
-
-
-const { default: VideoGen } = await import('./VideoGen.jsx');
+await loadVideoGenPage();
 const { VIDEO_GEN_STATUS_CACHE_KEY } = await import('../lib/videoGenStatusCache.js');
-
-const renderPage = async () => {
-  let view;
-  await act(async () => {
-    view = render(
-      <MemoryRouter initialEntries={['/media/video']}>
-        <VideoGen />
-      </MemoryRouter>,
-    );
-  });
-  return view;
-};
 
 // A /status call the test settles by hand, so the page can be asserted mid-probe.
 const deferredStatus = () => {
@@ -164,15 +37,14 @@ describe('VideoGen model picker while /status is in flight', () => {
   beforeEach(() => {
     localStorage.clear();
     sessionStorage.clear();
-    state.modelStatuses = {};
-    state.getVideoGenStatus.mockReset().mockResolvedValue(statusPayload());
-    state.eventSourceRef.current = null;
-    state.attach.mockReset().mockResolvedValue({ filename: 'example.mp4' });
+    resetVideoGenMockState();
+    state.getVideoGenStatus.mockResolvedValue(statusPayload());
+    state.attach.mockResolvedValue({ filename: 'example.mp4' });
   });
 
   it('keeps the Model field with a loading placeholder until the model list lands', async () => {
     const resolveStatus = deferredStatus();
-    await renderPage();
+    await renderVideoGenPage();
 
     const field = screen.getByLabelText('Model');
     expect(field).toBeDisabled();
@@ -185,7 +57,7 @@ describe('VideoGen model picker while /status is in flight', () => {
   });
 
   it('paints the cached model list on the next load instead of waiting for the probe', async () => {
-    const first = await renderPage();
+    const first = await renderVideoGenPage();
     await waitFor(() => expect(screen.getByLabelText('Model')).toHaveValue(MODEL_ONE.id));
     // Only the model-shaping slice is persisted — python health never is.
     expect(Object.keys(JSON.parse(sessionStorage.getItem(VIDEO_GEN_STATUS_CACHE_KEY))).sort())
@@ -193,7 +65,7 @@ describe('VideoGen model picker while /status is in flight', () => {
     first.unmount();
 
     const resolveStatus = deferredStatus();
-    await renderPage();
+    await renderVideoGenPage();
 
     const field = screen.getByLabelText('Model');
     expect(field).toBeEnabled();
@@ -211,7 +83,7 @@ describe('VideoGen model picker while /status is in flight', () => {
       missingPackages: ['torch'],
     })));
     const resolveStatus = deferredStatus();
-    await renderPage();
+    await renderVideoGenPage();
 
     expect(screen.getByLabelText('Model')).toHaveValue(MODEL_ONE.id);
     expect(screen.getByText('Checking…')).toBeInTheDocument();

--- a/client/src/pages/VideoGen.terms.test.jsx
+++ b/client/src/pages/VideoGen.terms.test.jsx
@@ -1,146 +1,22 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { MemoryRouter } from 'react-router';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { act, fireEvent, screen, waitFor } from '@testing-library/react';
+
+import {
+  loadVideoGenPage,
+  renderVideoGenPage,
+  resetVideoGenMockState,
+  state,
+  videoGenModel,
+  videoGenStatus,
+  videoGenTermsGate,
+} from '../test/videoGenPageMocks.jsx';
 
 const TERMS_ONE = 'minimax-h3-license-v1';
 const TERMS_TWO = 'minimax-h3-license-v2';
-const model = (id, termsId) => ({
-  id,
-  name: `MiniMax ${id}`,
-  repo: `example-org/${id}`,
-  revision: '1111111111111111111111111111111111111111',
-  runtime: 'minimax_h3',
-  supportedModes: ['text'],
-  defaultFrames: 124,
-  frameOptions: [124, 141],
-  fpsOptions: [24],
-  steps: 8,
-  guidance: 0,
-  samplerLocked: true,
-  supportsNegativePrompt: false,
-  supportsTiling: false,
-  supportsDisableAudio: false,
-  termsGate: {
-    id: termsId,
-    title: `Terms for ${id}`,
-    summary: 'This model is available only in its applicable territory.',
-    acknowledgement: `I am eligible and accept ${termsId}.`,
-    licenseUrl: 'https://example.com/license',
-  },
-});
-const H3_ONE = model('h3-one', TERMS_ONE);
-const H3_TWO = model('h3-two', TERMS_TWO);
+const H3_ONE = videoGenModel('h3-one', { termsGate: videoGenTermsGate(TERMS_ONE) });
+const H3_TWO = videoGenModel('h3-two', { termsGate: videoGenTermsGate(TERMS_TWO) });
 
-const state = vi.hoisted(() => ({
-  modelStatuses: {},
-  generateVideo: vi.fn(),
-  startDownload: vi.fn(),
-  repairModel: vi.fn(),
-  attach: vi.fn(),
-  eventSourceRef: { current: null },
-  getVideoGenStatus: vi.fn(),
-  runtimeInstallComplete: null,
-}));
-
-vi.mock('../services/api', () => ({
-  // The page offers a federated render target (#4348); with no peer opted in
-  // as a media provider the picker renders nothing and every local path below
-  // is unchanged.
-  getInstances: vi.fn(async () => ({ peers: [] })),
-  getVideoGenStatus: (...args) => state.getVideoGenStatus(...args),
-  generateVideo: (...args) => state.generateVideo(...args),
-  cancelVideoGen: vi.fn(async () => ({})),
-  listVideoHistory: vi.fn(async () => []),
-  deleteVideoHistoryItem: vi.fn(async () => ({})),
-  setVideoHidden: vi.fn(async () => ({})),
-  extractLastFrame: vi.fn(async () => ({})),
-  upscaleVideo: vi.fn(async () => ({})),
-  listImageGallery: vi.fn(async () => []),
-  patchSettingsSlice: vi.fn(async () => ({})),
-  getActiveVideoJob: vi.fn(async () => ({ activeJob: null })),
-  getSettings: vi.fn(async () => ({ imageGen: { grok: { enabled: false } } })),
-  getVideoGenRuntimeStatus: vi.fn(async () => ({ installed: true, ready: true, current: true })),
-  listLorasFull: vi.fn(async () => []),
-  // The prompt-enhancement controls mount useProviderModels, which fetches the
-  // provider list from a mount effect. Unmocked it throws out of a passive
-  // effect — the tests still pass, but the unhandled rejection fails the run.
-  getProviders: vi.fn(async () => ({ providers: [] })),
-  getVisionModels: vi.fn(async () => ({ models: [] })),
-}));
-
-vi.mock('../components/media/PromptFromMedia', () => ({ default: () => null }));
-
-vi.mock('../hooks/useModelDownloadStatus', () => ({
-  TEXT_ENCODER_DOWNLOAD_ID: '__text_encoder__',
-  useModelDownloadStatus: () => ({
-    extra: {},
-    loading: false,
-    statusError: null,
-    activeModelId: null,
-    progress: null,
-    lastError: null,
-    downloading: false,
-    repairing: false,
-    getStatus: (id) => state.modelStatuses[id] || null,
-    start: state.startDownload,
-    cancel: vi.fn(),
-    repair: state.repairModel,
-    refresh: vi.fn(),
-  }),
-}));
-
-vi.mock('../hooks/useMediaJobSse', () => ({
-  useMediaJobSse: () => ({ attach: state.attach, eventSourceRef: state.eventSourceRef }),
-}));
-vi.mock('../hooks/useMediaCompletionRefresh', () => ({ useMediaCompletionRefresh: vi.fn() }));
-vi.mock('../hooks/useMediaAnnotations', () => ({
-  useMediaAnnotations: () => ({ annotations: {}, updateAnnotation: vi.fn(), getCardProps: vi.fn(() => ({})) }),
-}));
-vi.mock('../hooks/usePreviewRoute', () => ({ default: () => [null, vi.fn()] }));
-vi.mock('../components/ui/Toast', () => ({
-  default: Object.assign(vi.fn(), { error: vi.fn(), success: vi.fn(), loading: vi.fn() }),
-}));
-
-// Keep the policy-bearing controls real; replace unrelated, heavyweight page
-// surfaces so this is a focused orchestration test rather than a gallery/SSE
-// integration suite.
-vi.mock('../components/Drawer', () => ({ default: () => null }));
-vi.mock('../components/settings/ImageGenTab', () => ({ ImageGenTab: () => null }));
-vi.mock('../components/settings/LocalSetupPanel', () => ({ default: () => null }));
-vi.mock('../components/install/RuntimeInstallModal', () => ({
-  default: ({ onComplete }) => {
-    state.runtimeInstallComplete = onComplete;
-    return null;
-  },
-}));
-vi.mock('../components/videoGen/FramePanel', () => ({ default: () => null }));
-vi.mock('../components/videoGen/KeyframePanel', () => ({ default: () => null }));
-vi.mock('../components/videoGen/AudioPanel', () => ({ default: () => null }));
-vi.mock('../components/videoGen/ExtendPanel', () => ({ default: () => null }));
-vi.mock('../components/videoGen/IcLoraPanel', () => ({ default: () => null }));
-vi.mock('../components/videoGen/AdvancedParamsPanel', () => ({ default: () => null }));
-vi.mock('../components/videoGen/RuntimeFingerprint', () => ({ default: () => null }));
-vi.mock('../components/videoGen/VideoGenGallery', () => ({ default: () => null }));
-vi.mock('../components/media/MediaPreview', () => ({ default: () => null }));
-vi.mock('../components/media/StylePresetPicker', () => ({ default: () => null }));
-vi.mock('../components/media/UniverseStylePicker', () => ({ default: () => null }));
-vi.mock('../components/media/MediaJobsQueue', () => ({ default: () => null }));
-vi.mock('../components/imageGen/LoraPicker', () => ({ default: () => null }));
-vi.mock('../components/media/ResolutionField', () => ({ default: () => null }));
-
-const { default: VideoGen } = await import('./VideoGen.jsx');
-
-const renderPage = async () => {
-  let view;
-  await act(async () => {
-    view = render(
-      <MemoryRouter initialEntries={['/media/video']}>
-        <VideoGen />
-      </MemoryRouter>,
-    );
-  });
-  return view;
-};
+await loadVideoGenPage();
 
 const prompt = () => screen.getByLabelText('Prompt');
 const generate = () => screen.getByRole('button', { name: /^Generate$/ });
@@ -149,32 +25,22 @@ const enqueue = () => screen.getByRole('button', { name: /Add to queue/ });
 describe('VideoGen MiniMax H3 orchestration', () => {
   beforeEach(() => {
     localStorage.clear();
+    resetVideoGenMockState();
     state.modelStatuses = {
       [H3_ONE.id]: { id: H3_ONE.id, repo: H3_ONE.repo, cached: true, sizeBytes: 100 },
       [H3_TWO.id]: { id: H3_TWO.id, repo: H3_TWO.repo, cached: true, sizeBytes: 100 },
     };
-    state.generateVideo.mockReset().mockResolvedValue({ jobId: 'job-1' });
-    state.startDownload.mockReset();
-    state.repairModel.mockReset().mockResolvedValue({ ok: true });
-    state.getVideoGenStatus.mockReset().mockResolvedValue({
-      connected: true,
-      pythonPath: '/opt/example/python3',
-      defaultModel: 'h3-one',
-      models: [H3_ONE, H3_TWO],
-      byovRuntimes: [],
-      systemMemoryGb: 128,
-      backendDisclosures: [],
-    });
-    state.runtimeInstallComplete = null;
-    state.eventSourceRef.current = null;
-    state.attach.mockReset().mockImplementation(async (_jobId, handlers) => {
+    state.generateVideo.mockResolvedValue({ jobId: 'job-1' });
+    state.repair.mockResolvedValue({ ok: true });
+    state.getVideoGenStatus.mockResolvedValue(videoGenStatus([H3_ONE, H3_TWO]));
+    state.attach.mockImplementation(async (_jobId, handlers) => {
       handlers.onComplete({ result: { filename: 'example.mp4' } });
       return { filename: 'example.mp4' };
     });
   });
 
   it('lets H3 generate and queue with no eligibility checkbox', async () => {
-    await renderPage();
+    await renderVideoGenPage();
 
     await waitFor(() => expect(screen.getByLabelText('Model')).toHaveValue(H3_ONE.id));
     expect(screen.queryByRole('checkbox', { name: /I am eligible/ })).toBeNull();
@@ -205,12 +71,12 @@ describe('VideoGen MiniMax H3 orchestration', () => {
 
   it('offers download without an eligibility acknowledgement', async () => {
     state.modelStatuses[H3_ONE.id] = { id: H3_ONE.id, repo: H3_ONE.repo, cached: false, sizeBytes: 0 };
-    await renderPage();
+    await renderVideoGenPage();
 
     const download = await screen.findByRole('button', { name: /Download/ });
     expect(download).toBeEnabled();
     fireEvent.click(download);
-    expect(state.startDownload).toHaveBeenCalledWith(H3_ONE.id);
+    expect(state.start).toHaveBeenCalledWith(H3_ONE.id);
   });
 
   it('offers integrity repair without an eligibility acknowledgement', async () => {
@@ -221,16 +87,16 @@ describe('VideoGen MiniMax H3 orchestration', () => {
       sizeBytes: 100,
       integrity: { status: 'bad', badFiles: [{ name: 'model.safetensors' }] },
     };
-    await renderPage();
+    await renderVideoGenPage();
 
     const repair = await screen.findByRole('button', { name: /Repair model/ });
     expect(repair).toBeEnabled();
     fireEvent.click(repair);
-    expect(state.repairModel).toHaveBeenCalledWith(H3_ONE.id);
+    expect(state.repair).toHaveBeenCalledWith(H3_ONE.id);
   });
 
   it('refreshes the model capability payload after runtime setup completes', async () => {
-    await renderPage();
+    await renderVideoGenPage();
     await waitFor(() => expect(screen.getByLabelText('Model')).toHaveValue(H3_ONE.id));
     const before = state.getVideoGenStatus.mock.calls.length;
 

--- a/client/src/pages/VideoGen.textEncoderAutoDownload.test.jsx
+++ b/client/src/pages/VideoGen.textEncoderAutoDownload.test.jsx
@@ -8,169 +8,47 @@
  * snap-to-stock on a model change) never does — those all reach the same
  * setTextEncoderId, and a ~57 GB pull must follow a click, not a restore.
  */
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { MemoryRouter } from 'react-router';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { act, fireEvent, screen, waitFor } from '@testing-library/react';
+
+import {
+  loadVideoGenPage,
+  renderVideoGenPage,
+  resetVideoGenMockState,
+  state,
+  videoGenModel,
+  videoGenStatus,
+  videoGenTermsGate,
+} from '../test/videoGenPageMocks.jsx';
 
 const TERMS_ID = 'minimax-h3-license-v1';
-const MODEL = {
-  id: 'h3-one',
-  name: 'MiniMax h3-one',
-  repo: 'example-org/h3-one',
-  revision: '1111111111111111111111111111111111111111',
-  runtime: 'minimax_h3',
-  supportedModes: ['text'],
-  defaultFrames: 124,
-  frameOptions: [124, 141],
-  fpsOptions: [24],
-  steps: 8,
-  guidance: 0,
-  samplerLocked: true,
-  supportsNegativePrompt: false,
-  supportsTiling: false,
-  supportsDisableAudio: false,
+const MODEL = videoGenModel('h3-one', {
   textEncoderOptions: [
     { id: 'stock', label: 'Stock', description: 'Ships with the model.', builtIn: true },
     { id: 'huihui-abliterated', label: 'Huihui abliterated', description: 'Abliterated.', builtIn: false, repo: 'example-org/abliterated', sizeBytes: 56962931632 },
   ],
-  termsGate: {
-    id: TERMS_ID,
-    title: 'Terms for h3-one',
-    summary: 'This model is available only in its applicable territory.',
-    acknowledgement: `I am eligible and accept ${TERMS_ID}.`,
-    licenseUrl: 'https://example.com/license',
-  },
-};
+  termsGate: videoGenTermsGate(TERMS_ID),
+});
 
-const state = vi.hoisted(() => ({
-  start: vi.fn(),
-  startWhenIdle: vi.fn(),
-  downloadStatus: { downloading: false, loading: false, cached: false },
-  queued: null,
-  history: [],
-  activeJob: null,
-  generateVideo: vi.fn(),
-  attach: vi.fn(),
-  eventSourceRef: { current: null },
-}));
-
-vi.mock('../services/api', () => ({
-  // The page offers a federated render target (#4348); with no peer opted in
-  // as a media provider the picker renders nothing and every local path below
-  // is unchanged.
-  getInstances: vi.fn(async () => ({ peers: [] })),
-  getVideoGenStatus: vi.fn(async () => ({
-    connected: true,
-    pythonPath: '/opt/example/python3',
-    defaultModel: 'h3-one',
-    models: [MODEL],
-    byovRuntimes: [],
-    systemMemoryGb: 128,
-    backendDisclosures: [],
-  })),
-  generateVideo: (...args) => state.generateVideo(...args),
-  cancelVideoGen: vi.fn(async () => ({})),
-  listVideoHistory: vi.fn(async () => state.history),
-  deleteVideoHistoryItem: vi.fn(async () => ({})),
-  setVideoHidden: vi.fn(async () => ({})),
-  extractLastFrame: vi.fn(async () => ({})),
-  upscaleVideo: vi.fn(async () => ({})),
-  listImageGallery: vi.fn(async () => []),
-  patchSettingsSlice: vi.fn(async () => ({})),
-  getActiveVideoJob: vi.fn(async () => ({ activeJob: state.activeJob })),
-  getSettings: vi.fn(async () => ({ imageGen: { grok: { enabled: false } } })),
-  getVideoGenRuntimeStatus: vi.fn(async () => ({ installed: true, ready: true, current: true })),
-  listLorasFull: vi.fn(async () => []),
-  getProviders: vi.fn(async () => ({ providers: [] })),
-  getVisionModels: vi.fn(async () => ({ models: [] })),
-}));
-
-vi.mock('../hooks/useModelDownloadStatus', () => ({
-  TEXT_ENCODER_DOWNLOAD_ID: '__text_encoder__',
-  textEncoderDownloadId: (id) => `__text_encoder_option__:${id}`,
-  useModelDownloadStatus: () => ({
-    extra: {},
-    loading: state.downloadStatus.loading,
-    statusError: null,
-    activeModelId: null,
-    progress: null,
-    lastError: null,
-    downloading: state.downloadStatus.downloading,
-    repairing: false,
-    getStatus: (id) => (String(id).startsWith('__text_encoder_option__:')
-      ? { id: 'huihui-abliterated', repo: 'example-org/abliterated', cached: state.downloadStatus.cached, sizeBytes: 0 }
-      : { id: MODEL.id, repo: MODEL.repo, cached: true, sizeBytes: 100 }),
-    start: state.start,
-    startWhenIdle: state.startWhenIdle,
-    queuedModelId: state.queued,
-    cancel: vi.fn(),
-    repair: vi.fn(),
-    refresh: vi.fn(),
-  }),
-}));
-
-vi.mock('../hooks/useMediaJobSse', () => ({
-  useMediaJobSse: () => ({ attach: state.attach, eventSourceRef: state.eventSourceRef }),
-}));
-vi.mock('../hooks/useMediaCompletionRefresh', () => ({ useMediaCompletionRefresh: vi.fn() }));
-vi.mock('../hooks/useMediaAnnotations', () => ({
-  useMediaAnnotations: () => ({ annotations: {}, updateAnnotation: vi.fn(), getCardProps: vi.fn(() => ({})) }),
-}));
-vi.mock('../hooks/usePreviewRoute', () => ({ default: () => [null, vi.fn()] }));
-vi.mock('../components/ui/Toast', () => ({
-  default: Object.assign(vi.fn(), { error: vi.fn(), success: vi.fn(), loading: vi.fn() }),
-}));
-
-vi.mock('../components/media/PromptEnhancer', () => ({
-  default: ({ disabled }) => (
-    <div data-testid="prompt-enhancer" data-disabled={disabled ? '1' : '0'}>Enhance with AI</div>
-  ),
-}));
-vi.mock('../components/media/PromptFromMedia', () => ({
-  default: ({ disabled }) => (
-    <div data-testid="prompt-from-media" data-disabled={disabled ? '1' : '0'}>Prompt from media</div>
-  ),
-}));
-
-vi.mock('../components/Drawer', () => ({ default: () => null }));
-vi.mock('../components/settings/ImageGenTab', () => ({ ImageGenTab: () => null }));
-vi.mock('../components/settings/LocalSetupPanel', () => ({ default: () => null }));
-vi.mock('../components/install/RuntimeInstallModal', () => ({ default: () => null }));
-vi.mock('../components/videoGen/FramePanel', () => ({ default: () => null }));
-vi.mock('../components/videoGen/KeyframePanel', () => ({ default: () => null }));
-vi.mock('../components/videoGen/AudioPanel', () => ({ default: () => null }));
-vi.mock('../components/videoGen/ExtendPanel', () => ({ default: () => null }));
-vi.mock('../components/videoGen/IcLoraPanel', () => ({ default: () => null }));
-vi.mock('../components/videoGen/AdvancedParamsPanel', () => ({ default: () => null }));
-vi.mock('../components/videoGen/RuntimeFingerprint', () => ({ default: () => null }));
-vi.mock('../components/videoGen/VideoGenGallery', () => ({ default: () => null }));
-vi.mock('../components/media/MediaPreview', () => ({ default: () => null }));
-vi.mock('../components/media/StylePresetPicker', () => ({ default: () => null }));
-vi.mock('../components/media/UniverseStylePicker', () => ({ default: () => null }));
-vi.mock('../components/media/MediaJobsQueue', () => ({ default: () => null }));
-vi.mock('../components/imageGen/LoraPicker', () => ({ default: () => null }));
-vi.mock('../components/media/ResolutionField', () => ({ default: () => null }));
-
-const { default: VideoGen } = await import('./VideoGen.jsx');
+await loadVideoGenPage();
 
 const SUBSTITUTE_ID = 'huihui-abliterated';
 const DOWNLOAD_ID = `__text_encoder_option__:${SUBSTITUTE_ID}`;
 
 const mountPage = async () => {
-  await act(async () => {
-    render(<MemoryRouter initialEntries={['/media/video']}><VideoGen /></MemoryRouter>);
-  });
+  await renderVideoGenPage();
   return screen.findByLabelText('Text encoder');
 };
 
 describe('VideoGen substitute text-encoder auto-download', () => {
   beforeEach(() => {
-    state.start.mockReset();
-    state.startWhenIdle.mockReset();
-    state.queued = null;
-    state.downloadStatus = { downloading: false, loading: false, cached: false };
-    state.history = [];
-    state.activeJob = null;
+    resetVideoGenMockState();
+    state.getVideoGenStatus.mockResolvedValue(videoGenStatus([MODEL]));
+    // The substitute is never resident: what these cases pin down is the
+    // request, and a cached encoder would short-circuit it.
+    state.getModelStatus = (id) => (String(id).startsWith('__text_encoder_option__:')
+      ? { id: SUBSTITUTE_ID, repo: 'example-org/abliterated', cached: false, sizeBytes: 0 }
+      : { id: MODEL.id, repo: MODEL.repo, cached: true, sizeBytes: 100 });
   });
 
   it('requests the pull when a substitute is selected', async () => {
@@ -202,7 +80,7 @@ describe('VideoGen substitute text-encoder auto-download', () => {
   });
 
   it('surfaces the queued state on the selected substitute', async () => {
-    state.queued = DOWNLOAD_ID;
+    state.queuedModelId = DOWNLOAD_ID;
     const select = await mountPage();
     await act(async () => {
       fireEvent.change(select, { target: { value: SUBSTITUTE_ID } });

--- a/client/src/test/videoGenPageMocks.jsx
+++ b/client/src/test/videoGenPageMocks.jsx
@@ -1,0 +1,249 @@
+/**
+ * Shared mock scaffold for the VideoGen page suites.
+ *
+ * Five suites (`pages/VideoGen.terms`, `.federatedTarget`, `.composeWhileBusy`,
+ * `.textEncoderAutoDownload`, `.modelLoading`) each used to carry a near-verbatim
+ * ~140-line copy of the same 25 `vi.mock` registrations, the same `state` object,
+ * the same model fixture and the same `renderPage()` helper. Every endpoint or
+ * hook the page started calling had to be added in five places, or four suites
+ * broke at once.
+ *
+ * **Importing this module registers the mocks** — that is the whole point, and it
+ * is what the vitest hoisting rules allow. `vi.mock` is hoisted to the top of the
+ * file it is written in, so these registrations run when this module is evaluated,
+ * which is while the importing test file's static imports are being resolved and
+ * therefore before its `await loadVideoGenPage()`. The relative specifiers resolve
+ * identically from here and from `pages/` (`src/test/../services/api` and
+ * `src/pages/../services/api` are the same module), so the mocked paths are the
+ * ones the page itself imports.
+ *
+ * Every mock reads through the exported `state`, so a suite varies behavior by
+ * assigning to it in `beforeEach` rather than by re-registering a mock. Call
+ * `resetVideoGenMockState()` first to get the documented defaults back.
+ */
+
+import { act, render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { vi } from 'vitest';
+
+/** Universe style the stub picker hands to the page when its button is clicked. */
+const DEFAULT_UNIVERSE_STYLE = {
+  id: 'u-1',
+  name: 'Example Universe',
+  influences: { embrace: ['inky linework'], avoid: ['glossy'] },
+};
+
+/**
+ * Every knob the five suites vary. Mutated in `beforeEach`; read lazily by the
+ * mock factories below, so a reassignment takes effect on the next render.
+ */
+export const state = {
+  /** `GET /api/instances` peers — a media-provider peer makes the target picker appear. */
+  peers: [],
+  /** `getVideoGenStatus`; a spy so a suite can defer it, count calls or vary the payload. */
+  getVideoGenStatus: vi.fn(),
+  generateVideo: vi.fn(),
+  attach: vi.fn(),
+  eventSourceRef: { current: null },
+  activeJob: null,
+  /** Cache-status entries keyed by download id, read by the default `getModelStatus`. */
+  modelStatuses: {},
+  /** Override to answer ids the map cannot (e.g. the `__text_encoder_option__:` prefix). */
+  getModelStatus: (id) => state.modelStatuses[id] ?? null,
+  start: vi.fn(),
+  startWhenIdle: vi.fn(),
+  queuedModelId: null,
+  repair: vi.fn(),
+  cancel: vi.fn(),
+  refresh: vi.fn(),
+  /** `RuntimeInstallModal`'s `onComplete`, captured so a suite can fire it. */
+  runtimeInstallComplete: null,
+  universeStyle: DEFAULT_UNIVERSE_STYLE,
+};
+
+const SPIES = ['getVideoGenStatus', 'generateVideo', 'attach', 'start', 'startWhenIdle', 'repair', 'cancel', 'refresh'];
+
+/** Restore every documented default, including fresh spies. Call it first in `beforeEach`. */
+export function resetVideoGenMockState() {
+  state.peers = [];
+  state.activeJob = null;
+  state.modelStatuses = {};
+  state.getModelStatus = (id) => state.modelStatuses[id] ?? null;
+  state.queuedModelId = null;
+  state.runtimeInstallComplete = null;
+  state.universeStyle = DEFAULT_UNIVERSE_STYLE;
+  state.eventSourceRef.current = null;
+  for (const key of SPIES) state[key].mockReset();
+}
+
+/** A video model as `GET /api/video-gen/status` reports it. */
+export const videoGenModel = (id, overrides = {}) => ({
+  id,
+  name: `MiniMax ${id}`,
+  repo: `example-org/${id}`,
+  revision: '1111111111111111111111111111111111111111',
+  runtime: 'minimax_h3',
+  supportedModes: ['text'],
+  defaultFrames: 124,
+  frameOptions: [124, 141],
+  fpsOptions: [24],
+  steps: 8,
+  guidance: 0,
+  samplerLocked: true,
+  supportsNegativePrompt: false,
+  supportsTiling: false,
+  supportsDisableAudio: false,
+  ...overrides,
+});
+
+/** The eligibility gate a territory-restricted model carries. */
+export const videoGenTermsGate = (termsId) => ({
+  id: termsId,
+  title: `Terms for ${termsId}`,
+  summary: 'This model is available only in its applicable territory.',
+  acknowledgement: `I am eligible and accept ${termsId}.`,
+  licenseUrl: 'https://example.com/license',
+});
+
+/** A `/status` payload over `models`; the first model is the default unless overridden. */
+export const videoGenStatus = (models, overrides = {}) => ({
+  connected: true,
+  pythonPath: '/opt/example/python3',
+  defaultModel: models[0]?.id ?? null,
+  models,
+  byovRuntimes: [],
+  systemMemoryGb: 128,
+  backendDisclosures: [],
+  ...overrides,
+});
+
+vi.mock('../services/api', () => ({
+  // The page offers a federated render target (#4348); with no peer opted in as
+  // a media provider the picker renders nothing and every local path is unchanged.
+  getInstances: vi.fn(async () => ({ peers: state.peers })),
+  getVideoGenStatus: (...args) => state.getVideoGenStatus(...args),
+  generateVideo: (...args) => state.generateVideo(...args),
+  cancelVideoGen: vi.fn(async () => ({})),
+  listVideoHistory: vi.fn(async () => []),
+  deleteVideoHistoryItem: vi.fn(async () => ({})),
+  setVideoHidden: vi.fn(async () => ({})),
+  extractLastFrame: vi.fn(async () => ({})),
+  upscaleVideo: vi.fn(async () => ({})),
+  listImageGallery: vi.fn(async () => []),
+  patchSettingsSlice: vi.fn(async () => ({})),
+  getActiveVideoJob: vi.fn(async () => ({ activeJob: state.activeJob })),
+  getSettings: vi.fn(async () => ({ imageGen: { grok: { enabled: false } } })),
+  getVideoGenRuntimeStatus: vi.fn(async () => ({ installed: true, ready: true, current: true })),
+  listLorasFull: vi.fn(async () => []),
+  // The prompt-enhancement controls mount useProviderModels, which fetches the
+  // provider list from a mount effect. Unmocked it throws out of a passive
+  // effect — the tests still pass, but the unhandled rejection fails the run.
+  getProviders: vi.fn(async () => ({ providers: [] })),
+  getVisionModels: vi.fn(async () => ({ models: [] })),
+}));
+
+vi.mock('../hooks/useModelDownloadStatus', () => ({
+  TEXT_ENCODER_DOWNLOAD_ID: '__text_encoder__',
+  textEncoderDownloadId: (id) => `__text_encoder_option__:${id}`,
+  useModelDownloadStatus: () => ({
+    extra: {},
+    loading: false,
+    statusError: null,
+    activeModelId: null,
+    progress: null,
+    lastError: null,
+    downloading: false,
+    repairing: false,
+    getStatus: (id) => state.getModelStatus(id),
+    start: state.start,
+    startWhenIdle: state.startWhenIdle,
+    queuedModelId: state.queuedModelId,
+    cancel: state.cancel,
+    repair: state.repair,
+    refresh: state.refresh,
+  }),
+}));
+
+vi.mock('../hooks/useMediaJobSse', () => ({
+  useMediaJobSse: () => ({ attach: state.attach, eventSourceRef: state.eventSourceRef }),
+}));
+vi.mock('../hooks/useMediaCompletionRefresh', () => ({ useMediaCompletionRefresh: vi.fn() }));
+vi.mock('../hooks/useMediaAnnotations', () => ({
+  useMediaAnnotations: () => ({ annotations: {}, updateAnnotation: vi.fn(), getCardProps: vi.fn(() => ({})) }),
+}));
+vi.mock('../hooks/usePreviewRoute', () => ({ default: () => [null, vi.fn()] }));
+vi.mock('../components/ui/Toast', () => ({
+  default: Object.assign(vi.fn(), { error: vi.fn(), success: vi.fn(), loading: vi.fn() }),
+}));
+
+// The prompt helpers stay observable rather than blanked: whether they remain
+// usable while a render is already in flight is itself one of the assertions.
+vi.mock('../components/media/PromptEnhancer', () => ({
+  default: ({ disabled }) => (
+    <div data-testid="prompt-enhancer" data-disabled={disabled ? '1' : '0'}>Enhance with AI</div>
+  ),
+}));
+vi.mock('../components/media/PromptFromMedia', () => ({
+  default: ({ disabled }) => (
+    <div data-testid="prompt-from-media" data-disabled={disabled ? '1' : '0'}>Prompt from media</div>
+  ),
+}));
+// Interactive so a suite can drive the style into the page; inert everywhere else.
+vi.mock('../components/media/UniverseStylePicker', () => ({
+  default: ({ onChange }) => (
+    <button type="button" onClick={() => onChange(state.universeStyle)}>Use universe style</button>
+  ),
+}));
+// Captures `onComplete` (the runtime-setup refresh) and exposes `streamMethod`.
+vi.mock('../components/install/RuntimeInstallModal', () => ({
+  default: ({ onComplete, streamMethod }) => {
+    state.runtimeInstallComplete = onComplete;
+    return <div data-testid="runtime-install-modal" data-stream-method={streamMethod} />;
+  },
+}));
+
+// Keep the policy-bearing controls real; replace unrelated, heavyweight page
+// surfaces so these stay focused orchestration tests rather than a gallery/SSE
+// integration suite.
+vi.mock('../components/Drawer', () => ({ default: () => null }));
+vi.mock('../components/settings/ImageGenTab', () => ({ ImageGenTab: () => null }));
+vi.mock('../components/settings/LocalSetupPanel', () => ({ default: () => null }));
+vi.mock('../components/videoGen/FramePanel', () => ({ default: () => null }));
+vi.mock('../components/videoGen/KeyframePanel', () => ({ default: () => null }));
+vi.mock('../components/videoGen/AudioPanel', () => ({ default: () => null }));
+vi.mock('../components/videoGen/ExtendPanel', () => ({ default: () => null }));
+vi.mock('../components/videoGen/IcLoraPanel', () => ({ default: () => null }));
+vi.mock('../components/videoGen/AdvancedParamsPanel', () => ({ default: () => null }));
+vi.mock('../components/videoGen/RuntimeFingerprint', () => ({ default: () => null }));
+vi.mock('../components/videoGen/VideoGenGallery', () => ({ default: () => null }));
+vi.mock('../components/media/MediaPreview', () => ({ default: () => null }));
+vi.mock('../components/media/StylePresetPicker', () => ({ default: () => null }));
+vi.mock('../components/media/MediaJobsQueue', () => ({ default: () => null }));
+vi.mock('../components/imageGen/LoraPicker', () => ({ default: () => null }));
+vi.mock('../components/media/ResolutionField', () => ({ default: () => null }));
+
+let VideoGen = null;
+
+/**
+ * Import the page under the mocks above. Every suite loads it dynamically at
+ * module scope so the registrations are in place first; the component is kept
+ * here so `renderVideoGenPage()` needs no argument.
+ */
+export async function loadVideoGenPage() {
+  ({ default: VideoGen } = await import('../pages/VideoGen.jsx'));
+  return VideoGen;
+}
+
+/** Mount the page on its own route, flushing the mount effects. */
+export async function renderVideoGenPage() {
+  if (!VideoGen) throw new Error('await loadVideoGenPage() at module scope before rendering');
+  let view;
+  await act(async () => {
+    view = render(
+      <MemoryRouter initialEntries={['/media/video']}>
+        <VideoGen />
+      </MemoryRouter>,
+    );
+  });
+  return view;
+}


### PR DESCRIPTION
## Summary

The five VideoGen page suites each carried a near-verbatim ~140-line copy of the same mock scaffolding: 25 `vi.mock` registrations for `services/api`, the media hooks and every heavyweight child component, plus a hoisted `state` object, a model fixture and a `renderPage()` helper. Any endpoint or hook the page started calling had to be added in five places, or four suites broke at once.

`client/src/test/videoGenPageMocks.jsx` now owns that scaffold:

- **Importing it registers the mocks.** vitest hoists `vi.mock` to the top of the file it is written in, so the registrations run while the importing suite's static imports resolve — before its `await loadVideoGenPage()`. The relative specifiers resolve to the same modules from `src/test/` as from `src/pages/`.
- **Every mock reads through the exported `state`**, so a suite varies behavior by assigning in `beforeEach` rather than by re-registering a mock. `resetVideoGenMockState()` restores the documented defaults.
- It also exports the `videoGenModel` / `videoGenTermsGate` / `videoGenStatus` fixtures, plus `loadVideoGenPage()` and `renderVideoGenPage()`.

The five suites keep their own fixtures, cases and assertions and drop to between 82 and 127 lines each: 1167 lines of test files become 518, plus one ~250-line harness (net -397).

Two mocks were unified rather than copied, since the variation was incidental to the assertions:

- `RuntimeInstallModal` now both captures `onComplete` (needed by `.terms`) and renders `data-stream-method` (needed by `.composeWhileBusy`).
- `PromptEnhancer` / `PromptFromMedia` are the observable stubs everywhere, including in the two suites that previously left `PromptEnhancer` real. Neither asserts anything about it.

No page or product code changed.

## Test plan

- `cd client && npx vitest run src/pages/VideoGen` — 5 files, 20 tests, all pre-existing assertions unchanged and passing.
- `cd client && npm test` — 831 files / 10145 tests green.
- `cd client && npm run lint` — clean.
- Repo-hygiene guards that scan the client tree with the new non-test `.jsx` staged (`a11yConventions`, `responsiveGridConventions`, `popoverClampConventions`, `storageConventions`, `pollingConventions`, `globalShadowConventions`, `preWrapClasses`) — green, as are `scripts/repo-scan-guards`, `scripts/ci-test-plan` and `scripts/catalog-merge-union`.

Closes #5836

https://claude.ai/code/session_011Hc9gMmfTAeWRv63pJBuqJ