### PR TITLE
fix: resolve ollama thinking support per model before sending reasoning_effort

### DIFF
--- a/server/services/codeReview.js
+++ b/server/services/codeReview.js
@@ -42,7 +42,10 @@ import {
 import { getSettings, settingsEvents } from './settings.js'
 import { getActiveProvider } from './providers.js'
 import { getBaseUrl as getLmStudioBaseUrl } from './lmStudioManager.js'
-import { getBaseUrl as getOllamaBaseUrl } from './ollamaManager.js'
+import {
+  getBaseUrl as getOllamaBaseUrl,
+  getModelCapabilities as getOllamaModelCapabilities,
+} from './ollamaManager.js'
 
 // LM Studio (`:1234`), Ollama (`:11434`) and MTPLX (`:8000/v1`) all ship
 // OpenAI-compatible `/v1/chat/completions`. Resolve through each manager's live
@@ -324,13 +327,42 @@ function adaptiveFence(content) {
 
 // Ollama translates the OpenAI-compatible `reasoning_effort` field into its
 // own `thinking` parameter, and a model that never implements thinking 400s
-// on the whole request rather than ignoring the field. There is no reliable
-// per-model "supports thinking" capability flag to probe ahead of time, so
-// this remembers which `backend:model` pairs have already 400'd on it — for
-// the life of the process — so a multi-round review loop pays the retry once
-// instead of on every round.
+// on the whole request rather than ignoring the field. Ollama's `/api/show`
+// DOES answer that per model, so `modelRejectsThinking` resolves it BEFORE
+// the request and simply omits the field — the 400-retry further down stays
+// as the fail-safe for a backend with no such probe (LM Studio, MTPLX) or a
+// probe that could not answer. Resolving ahead matters because every reviewer
+// invocation from a claim/PR run is its own short-lived `node` process: a
+// purely reactive downgrade re-uploads the entire diff on every single call,
+// since the in-process cache below never survives to the next one.
+//
+// This map remembers which `backend:model` pairs are known thinking-less —
+// for the life of the process — so a multi-round review loop inside ONE
+// process pays neither the probe nor the retry twice.
 const thinkingUnsupportedModels = new Map()
+const thinkingCacheKey = (backend, model) => `${backend}:${model}`
 export function __resetThinkingUnsupportedCache() { thinkingUnsupportedModels.clear() }
+
+/**
+ * Does this `backend:model` reject `reasoning_effort`?
+ *
+ * `true` only when we KNOW it does — a cached prior downgrade, or an
+ * authoritative capability list that omits `thinking`. Ollama reports `null`
+ * when the per-model probe failed and `[]` when the daemon answered without
+ * reporting any capabilities; both mean *unknown*, not *unsupported*, so they
+ * fall through to the request (and its 400-retry) rather than silently
+ * dropping a level the model does in fact accept.
+ */
+async function modelRejectsThinking(backend, model) {
+  const cacheKey = thinkingCacheKey(backend, model)
+  if (thinkingUnsupportedModels.get(cacheKey) === true) return true
+  if (backend !== 'ollama') return false
+  const capabilities = await getOllamaModelCapabilities(model).catch(() => null)
+  if (!Array.isArray(capabilities) || capabilities.length === 0) return false
+  if (capabilities.includes('thinking')) return false
+  thinkingUnsupportedModels.set(cacheKey, true)
+  return true
+}
 
 async function sendChatCompletion(baseUrl, { model, messages, timeoutMs }, effortForRequest) {
   const body = {
@@ -363,10 +395,11 @@ async function runToolFreeLocalCompletion({ backend, model, messages, effort, ti
     return { ok: false, error: `No model configured for ${backend} reviewer — set one on the Settings → Code Reviewers page.` }
   }
 
-  const cacheKey = `${backend}:${model}`
-  const effortUnsupportedCached = thinkingUnsupportedModels.get(cacheKey) === true
-  let resolvedEffort = effortUnsupportedCached ? null : (normalizeReviewerEffort(effort, backend) || null)
-  let effortUnsupported = effortUnsupportedCached
+  // Probe only when there is actually a level to drop — an unpinned effort
+  // sends no field either way, so a capability round-trip would buy nothing.
+  const requestedEffort = normalizeReviewerEffort(effort, backend) || null
+  let effortUnsupported = requestedEffort ? await modelRejectsThinking(backend, model) : false
+  let resolvedEffort = effortUnsupported ? null : requestedEffort
 
   // Local runtime records are normalized to the OpenAI `/v1` root, while the
   // legacy backend managers return the host root. Keep both forms compatible
@@ -379,7 +412,7 @@ async function runToolFreeLocalCompletion({ backend, model, messages, effort, ti
 
   if (!attempt.ok && attempt.status === 400 && resolvedEffort && /does not support thinking/i.test(attempt.text || '')) {
     console.warn(`⚠️ ${backend} model ${model} ignores reasoning_effort — retried without it`)
-    thinkingUnsupportedModels.set(cacheKey, true)
+    thinkingUnsupportedModels.set(thinkingCacheKey(backend, model), true)
     resolvedEffort = null
     effortUnsupported = true
     attempt = await sendChatCompletion(baseUrl, { model, messages, timeoutMs }, null)
@@ -419,9 +452,13 @@ async function runToolFreeLocalCompletion({ backend, model, messages, effort, ti
  * @param {string} opts.diff - Unified diff text to review.
  * @param {string} [opts.effort] - Reasoning effort (`low`/`medium`/`high`), sent
  *   as the OpenAI-compatible `reasoning_effort` field. Omitted from the body
- *   entirely when unset or not a level this backend accepts — a non-reasoning
- *   model would otherwise get a field it has no answer for, and `absent` is the
- *   only spelling of "use the model's own default".
+ *   entirely when unset, when it is not a level this backend accepts, or when
+ *   THIS MODEL does not support thinking — the decision is per model, not per
+ *   backend, because one ollama daemon serves both kinds. A non-reasoning model
+ *   would otherwise get a field it has no answer for (ollama 400s the whole
+ *   request), and `absent` is the only spelling of "use the model's own
+ *   default". The response carries `effortUnsupported: true` when a pinned
+ *   level was dropped for that reason.
  * @param {number} [opts.timeoutMs=120000] - 2 min default — LM Studio cold-
  *   load of a large coder model regularly exceeds 30s but rarely 2 min.
  * @param {string} [opts.baseUrl] - Validated local OpenAI-compatible base URL;

--- a/server/services/codeReview.test.js
+++ b/server/services/codeReview.test.js
@@ -21,7 +21,15 @@ vi.mock('./providers.js', () => ({
   getActiveProvider: () => Promise.resolve(mockedActiveProvider.current),
 }))
 vi.mock('./lmStudioManager.js', () => ({ getBaseUrl: () => 'http://localhost:1234' }))
-vi.mock('./ollamaManager.js', () => ({ getBaseUrl: () => 'http://localhost:11434' }))
+// Ollama's per-model `/api/show` capability probe, which the reviewer now
+// consults BEFORE attaching `reasoning_effort`. Default `null` = "probe could
+// not answer", the sentinel that keeps a test on the reactive 400-retry path;
+// individual tests set an authoritative array to drive the proactive one.
+const mockedOllamaCapabilities = { current: null }
+vi.mock('./ollamaManager.js', () => ({
+  getBaseUrl: () => 'http://localhost:11434',
+  getModelCapabilities: () => Promise.resolve(mockedOllamaCapabilities.current),
+}))
 // Reviewer-CLI-installed probe: stub the shared execFile-based helper so the
 // test controls per-binary results without touching the real PATH.
 const commandExistsMock = { impl: async () => true }
@@ -57,6 +65,7 @@ describe('codeReview helpers', () => {
     __resetCodeReviewDefaultsCache()
     __resetReviewerCliInstalledCache()
     __resetThinkingUnsupportedCache()
+    mockedOllamaCapabilities.current = null
     commandExistsMock.impl = async () => true
     vi.restoreAllMocks()
   })
@@ -692,6 +701,11 @@ describe('codeReview helpers', () => {
       error: { message: '"m" does not support thinking', type: 'invalid_request_error' },
     })
 
+    // Default happy response; tests asserting the retry sequence override it.
+    beforeEach(() => {
+      global.fetch = vi.fn().mockResolvedValue(mockJsonResponse({ choices: [{ message: { content: 'No findings.' } }] }))
+    })
+
     it('retries without reasoning_effort when the backend rejects thinking', async () => {
       global.fetch = vi.fn()
         .mockResolvedValueOnce(mockTextResponse(thinkingRejectedBody, { ok: false, status: 400 }))
@@ -746,6 +760,78 @@ describe('codeReview helpers', () => {
       const secondBody = JSON.parse(global.fetch.mock.calls[1][1].body)
       expect('reasoning_effort' in secondBody).toBe(false)
       expect(r).toMatchObject({ ok: true, claimant: null, suspicious: false, effort: null, effortUnsupported: true })
+    })
+
+    it('omits reasoning_effort on the FIRST request when /api/show reports no thinking capability', async () => {
+      // The reactive retry alone re-uploads the whole diff on every fresh
+      // process (a claim run spawns one `node` per review call), so the
+      // capability probe has to prevent the doomed request, not just recover.
+      mockedOllamaCapabilities.current = ['completion', 'tools']
+
+      const r = await runLocalCodeReview({ backend: 'ollama', model: 'probed-nonthinking', diff: 'd', effort: 'low' })
+
+      expect(global.fetch).toHaveBeenCalledTimes(1)
+      expect('reasoning_effort' in JSON.parse(global.fetch.mock.calls[0][1].body)).toBe(false)
+      expect(r).toMatchObject({ ok: true, effort: null, effortUnsupported: true })
+    })
+
+    it('still sends reasoning_effort when /api/show reports the thinking capability', async () => {
+      mockedOllamaCapabilities.current = ['completion', 'tools', 'thinking']
+
+      const r = await runLocalCodeReview({ backend: 'ollama', model: 'probed-thinking', diff: 'd', effort: 'low' })
+
+      expect(global.fetch).toHaveBeenCalledTimes(1)
+      expect(JSON.parse(global.fetch.mock.calls[0][1].body).reasoning_effort).toBe('low')
+      expect(r).toMatchObject({ ok: true, effort: 'low' })
+      expect('effortUnsupported' in r).toBe(false)
+    })
+
+    it('treats an empty capability list as unknown, not as "no thinking"', async () => {
+      // Ollama answers `[]` for a model it reports no capabilities for at all.
+      // Collapsing that into "unsupported" would silently strip a level a
+      // reasoning model does accept, so it must fall through to the request.
+      mockedOllamaCapabilities.current = []
+
+      const r = await runLocalCodeReview({ backend: 'ollama', model: 'no-caps-reported', diff: 'd', effort: 'low' })
+
+      expect(JSON.parse(global.fetch.mock.calls[0][1].body).reasoning_effort).toBe('low')
+      expect(r).toMatchObject({ ok: true, effort: 'low' })
+    })
+
+    it('falls back to the 400-retry when the capability probe cannot answer', async () => {
+      mockedOllamaCapabilities.current = null
+      global.fetch = vi.fn()
+        .mockResolvedValueOnce(mockTextResponse(thinkingRejectedBody, { ok: false, status: 400 }))
+        .mockResolvedValueOnce(mockJsonResponse({ choices: [{ message: { content: 'No findings.' } }] }))
+
+      const r = await runLocalCodeReview({ backend: 'ollama', model: 'unprobeable', diff: 'd', effort: 'low' })
+
+      expect(global.fetch).toHaveBeenCalledTimes(2)
+      expect(r).toMatchObject({ ok: true, effort: null, effortUnsupported: true })
+    })
+
+    it('does not probe capabilities when no effort is pinned', async () => {
+      // Nothing to drop, so the round-trip would be pure cost — and a model
+      // that legitimately reports no thinking must not be flagged as a
+      // downgrade when the caller never asked for a level.
+      mockedOllamaCapabilities.current = ['completion']
+
+      const r = await runLocalCodeReview({ backend: 'ollama', model: 'unpinned', diff: 'd' })
+
+      expect('reasoning_effort' in JSON.parse(global.fetch.mock.calls[0][1].body)).toBe(false)
+      expect(r).toMatchObject({ ok: true, effort: null })
+      expect('effortUnsupported' in r).toBe(false)
+    })
+
+    it('does not probe ollama capabilities for a non-ollama backend', async () => {
+      // LM Studio ignores an unknown field rather than 400-ing, and has no
+      // equivalent probe — sending the level is still the right default.
+      mockedOllamaCapabilities.current = ['completion']
+
+      const r = await runLocalCodeReview({ backend: 'lmstudio', model: 'm', diff: 'd', effort: 'low' })
+
+      expect(JSON.parse(global.fetch.mock.calls[0][1].body).reasoning_effort).toBe('low')
+      expect(r).toMatchObject({ ok: true, effort: 'low' })
     })
   })
 })


### PR DESCRIPTION
## Summary

A local reviewer pinned to `ollama[<non-thinking model>]~effort=low` sent `reasoning_effort` on its **first** request. Ollama translates that field into its own `thinking` parameter and hard-rejects the whole request with a 400 for a model that does not advertise thinking support.

PR #5960 added a reactive recovery (retry without the field), but the "this model has no thinking" memo lives in a process-local `Map` — and every reviewer invocation from a claim/PR run is its own short-lived `node` process. So the cache never survived to the next call, and **every** review re-uploaded the entire diff twice: once for a request that could never succeed.

Ollama's `/api/show` reports the capability set per model, and PortOS already reads it (`ollamaManager.getModelCapabilities`, cached). This resolves it *before* the request and omits `reasoning_effort` for a model lacking `thinking`, so the doomed request is never sent. The 400-retry stays as the fail-safe for a backend with no such probe (LM Studio, MTPLX) and for a probe that cannot answer.

Sentinel handling follows the repo's absent-vs-empty rule: `null` (probe failed) and `[]` (daemon answered reporting no capabilities) both mean *unknown*, not *unsupported*, so both fall through to the request rather than silently stripping a level a reasoning model does accept.

The probe is skipped entirely when no effort is pinned — nothing to drop, so a capability round-trip buys nothing. That also stops `effortUnsupported: true` being reported when the caller never asked for a level.

The `runLocalCodeReview` doc comment now states the omission is decided **per model**, not per backend, matching the behavior (this was called out in the issue as the contract the implementation had drifted from).

## Test plan

- `server/services/codeReview.test.js` — 6 new cases pinning the body shape both ways and the fall-through paths:
  - `reasoning_effort` absent on the **first** request when `/api/show` omits `thinking` (fails on `main`, passes here — one fetch, not two)
  - `reasoning_effort` present when `/api/show` reports `thinking`
  - `[]` capabilities treated as unknown → level still sent
  - probe unable to answer → reactive 400-retry still recovers
  - no effort pinned → no probe, no `effortUnsupported` flag
  - non-ollama backend → not probed, level still sent
- Full server suite green: **1896 files / 38311 tests passed**, 1 file + 14 tests skipped.
- Verified end-to-end against the live ollama daemon with the exact model that reproduced the bug: previously `ok:false` with `400 ... does not support thinking`; now `ok:true` with findings and **no** retry warning, confirming the first request was already correct.

Closes #6050