### PR TITLE
chore(deps): clear the qs moderate advisories and refresh patch-level pins

### DIFF
--- a/autofixer/package-lock.json
+++ b/autofixer/package-lock.json
@@ -600,9 +600,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "es-define-property": "^1.0.1",

--- a/autofixer/package.json
+++ b/autofixer/package.json
@@ -13,6 +13,6 @@
   "overrides": {
     "path-to-regexp": "8.4.2",
     "body-parser": "2.3.0",
-    "qs": "6.15.3"
+    "qs": "6.16.0"
   }
 }

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -16,7 +16,7 @@
         "@xterm/addon-fit": "0.11.0",
         "@xterm/addon-web-links": "0.12.0",
         "@xterm/xterm": "6.0.0",
-        "lucide-react": "1.37.0",
+        "lucide-react": "1.40.0",
         "react": "19.2.8",
         "react-dom": "19.2.8",
         "react-router": "8.3.1",
@@ -25,12 +25,12 @@
         "three": "0.185.1"
       },
       "devDependencies": {
-        "@biomejs/biome": "2.5.11",
+        "@biomejs/biome": "2.5.12",
         "@tailwindcss/postcss": "4.3.3",
         "@testing-library/dom": "10.4.1",
         "@testing-library/jest-dom": "7.0.1",
         "@testing-library/react": "16.3.3",
-        "@testing-library/user-event": "14.6.6",
+        "@testing-library/user-event": "14.6.7",
         "@vitejs/plugin-react": "6.1.1",
         "jsdom": "30.0.1",
         "rollup-plugin-visualizer": "7.1.1",
@@ -250,9 +250,9 @@
       }
     },
     "node_modules/@biomejs/biome": {
-      "version": "2.5.11",
-      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.11.tgz",
-      "integrity": "sha512-Tj0dnkLPdW0ASjHfj2D/ZkkvPU2wrFmnE1jWTD2xzV1ycapV1DutbYXk4NDnR3rYTi1ZCbNFD4G2gRMEY65WaA==",
+      "version": "2.5.12",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.12.tgz",
+      "integrity": "sha512-Lw4VHZRebrReBBnlHa12JQjnIBm3JJAA55PDB9LbBVBF0q4RYphm6KfmIjqtPhf61MxZ5Q9KoK8R8x+7per5Aw==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "bin": {
@@ -266,20 +266,20 @@
         "url": "https://opencollective.com/biome"
       },
       "optionalDependencies": {
-        "@biomejs/cli-darwin-arm64": "2.5.11",
-        "@biomejs/cli-darwin-x64": "2.5.11",
-        "@biomejs/cli-linux-arm64": "2.5.11",
-        "@biomejs/cli-linux-arm64-musl": "2.5.11",
-        "@biomejs/cli-linux-x64": "2.5.11",
-        "@biomejs/cli-linux-x64-musl": "2.5.11",
-        "@biomejs/cli-win32-arm64": "2.5.11",
-        "@biomejs/cli-win32-x64": "2.5.11"
+        "@biomejs/cli-darwin-arm64": "2.5.12",
+        "@biomejs/cli-darwin-x64": "2.5.12",
+        "@biomejs/cli-linux-arm64": "2.5.12",
+        "@biomejs/cli-linux-arm64-musl": "2.5.12",
+        "@biomejs/cli-linux-x64": "2.5.12",
+        "@biomejs/cli-linux-x64-musl": "2.5.12",
+        "@biomejs/cli-win32-arm64": "2.5.12",
+        "@biomejs/cli-win32-x64": "2.5.12"
       }
     },
     "node_modules/@biomejs/cli-darwin-arm64": {
-      "version": "2.5.11",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.11.tgz",
-      "integrity": "sha512-6SGZxoKbXvUjMn1t6A98HqWISPnGNbYs0R/Rt2JarmXBSev+lva4QxUMWEBX9lX1Wo1XTJ78uk5xVDtG58SRZg==",
+      "version": "2.5.12",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.12.tgz",
+      "integrity": "sha512-lCRY1rwgNeWNgTr4DI/u6ZwXTRwRLHAvbaio1YLLGS+4r1nhvB2ssyPqIpfUSmRveNfv0fn/N58C7CAdK2XVrg==",
       "cpu": [
         "arm64"
       ],
@@ -294,9 +294,9 @@
       }
     },
     "node_modules/@biomejs/cli-darwin-x64": {
-      "version": "2.5.11",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.11.tgz",
-      "integrity": "sha512-nYkXY7tLBEgnGbYapDKAyKzgt44ZEyG+AKalvTXtCWKYgepI9dw327q+cVgedxm+Udi1ZzHKUyZrIusHi/KQbw==",
+      "version": "2.5.12",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.12.tgz",
+      "integrity": "sha512-vhPgwnh+6tN3ArdAXuET99xaNbFt7CG82Bqn+omHVLC5xdVx45JsYjGPmUIGNzjDek5XdNCP1HKksK7fn8+3bQ==",
       "cpu": [
         "x64"
       ],
@@ -311,9 +311,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64": {
-      "version": "2.5.11",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.11.tgz",
-      "integrity": "sha512-3PVLSTD9RR73rvVPt5G3T1gc+ycggWEGfTD7RvzzbtcDPD27NxgxBbAFfpm7DXJKW6VLHWE1lLMGvFt2Qxjcow==",
+      "version": "2.5.12",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.12.tgz",
+      "integrity": "sha512-2gp8aVwXYKdAtmBfRFCUuyDMcfN1ahHqUkGfLYrZlNRFmryMATLVvJgWKvyA8wu4Rwn5OSxM1UcUmOuOFNGeBQ==",
       "cpu": [
         "arm64"
       ],
@@ -331,9 +331,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64-musl": {
-      "version": "2.5.11",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.11.tgz",
-      "integrity": "sha512-qhyZUMyCbWYFV2bAwRNVvfMVZ+hv7WYl6mossGrxC+uiQQXhvsuWWU8zz6jYX0mChZd9MgQZbm4vozTmG/5iGw==",
+      "version": "2.5.12",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.12.tgz",
+      "integrity": "sha512-couHYjFLL5uuI8ne6zhT7KwEsXo5YP7ry/2xmEqah7qanu0YmfDi3mwJg47YXSuv/NpZj22CZzcRH/5c4gjPSQ==",
       "cpu": [
         "arm64"
       ],
@@ -351,9 +351,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64": {
-      "version": "2.5.11",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.11.tgz",
-      "integrity": "sha512-JOytptlsgM33B2MMFUg8iBrb4IKpbD5JnJrSeYiaFEeAj4vuXx0iQSQZ4qK7sqyMtfjZxxPdNdMZZVL4y/mFyA==",
+      "version": "2.5.12",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.12.tgz",
+      "integrity": "sha512-SnvOs3TSTiuia4SQOUNe1aWC9RT4+YkjcKnOhL/nsKOV0k5ycgBkDzF0lUxKn1V7Q8CLTRq6iV23ZAivHomRoA==",
       "cpu": [
         "x64"
       ],
@@ -371,9 +371,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64-musl": {
-      "version": "2.5.11",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.11.tgz",
-      "integrity": "sha512-oRRlrchG5EfrEL/EmtT1qUjSNHk3/5LGeZhQqADBBAJF1b1ET6964xEKe7aGlGARzDfza8H/seEsFJl7S6Ql9w==",
+      "version": "2.5.12",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.12.tgz",
+      "integrity": "sha512-8A0oDW58/w9f/PQNYuq0sGUZtGtGrkNF4Z6n0PUoXpLCshi85vtKTv1XSznQawhdE4MXJ8ufpzHXyLFe87M/+w==",
       "cpu": [
         "x64"
       ],
@@ -391,9 +391,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-arm64": {
-      "version": "2.5.11",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.11.tgz",
-      "integrity": "sha512-e49E6K9hzH/ohJNx8Y26mY8HaV4I4ZViIeoqhKsmoXLKHhQnMeBAVqCgsGf2Wa3lXlS7RkporDXMHHWkzvZzFw==",
+      "version": "2.5.12",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.12.tgz",
+      "integrity": "sha512-b9vtoZFsuZt1pdjNwJvXl0f+BpayRzV008uS2+JpmwIKdSE2qdu4A/l04FESwLoou5g2E/Qlec0xwJydZplH+A==",
       "cpu": [
         "arm64"
       ],
@@ -408,9 +408,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-x64": {
-      "version": "2.5.11",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.11.tgz",
-      "integrity": "sha512-QSQr/KjOgXA7OzXJUWS+oguKyAZ3Q0l/lnlDGbu397eKo83atuWUjBPJrsqbKNF6CARGw8XXJLGzpHC8Ryhd4Q==",
+      "version": "2.5.12",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.12.tgz",
+      "integrity": "sha512-B1R/l+CwEpKFSuqiwePzPNRk1EiJN8kc0UhdafNz6MZN9v5OFP9HYP1irptvWzHrwVI4blVNGMbxc5zt70m3IA==",
       "cpu": [
         "x64"
       ],
@@ -2459,9 +2459,9 @@
       }
     },
     "node_modules/@testing-library/user-event": {
-      "version": "14.6.6",
-      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.6.tgz",
-      "integrity": "sha512-Jbs9FpkkIDw8FgSc6kOVsOv8JuuqGAL7J4X1oot77JxAoDlkNn2GRkd0aYRVuQ+pVQAiHWVkE4rX/dkF5fBiCw==",
+      "version": "14.6.7",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.7.tgz",
+      "integrity": "sha512-MPCpX8bxe8zS+JmmTwLp8jd0dy1rAm60Te/SL8JrQM3qvQJcBOs1d7IefJMyZzqM3EWBrDn/LWDt1BCGu4ASfg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5117,9 +5117,9 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "1.37.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.37.0.tgz",
-      "integrity": "sha512-LPsB4rD1TD6wZu1djKOf9vUnS1jTNaHbolXebXDgiTdb6jeA1agIJhJsIybCmjKmQClcOaal1o1OaiYahEftyQ==",
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.40.0.tgz",
+      "integrity": "sha512-MaG+8WnOXkDWz9XeElj7TnQ890tTZUB0a36i03aRRCKGWE6e7jJpmdCvtxxuxcjjdqyN6m4sL6qlHVuSUDtYgg==",
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -6153,9 +6153,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.26",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
-      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+      "version": "8.5.27",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.27.tgz",
+      "integrity": "sha512-79Iho8QeYyooJ8e9lCRyTVlyTAkS/kXBYKff6TMzS3kEWGQ8Ds5UEtXpGrSUDLUWok6QTvxeYy0GO8fopHnaSA==",
       "funding": [
         {
           "type": "opencollective",
@@ -6172,7 +6172,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.17",
+        "nanoid": "^3.3.18",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/client/package.json
+++ b/client/package.json
@@ -27,7 +27,7 @@
     "@xterm/addon-fit": "0.11.0",
     "@xterm/addon-web-links": "0.12.0",
     "@xterm/xterm": "6.0.0",
-    "lucide-react": "1.37.0",
+    "lucide-react": "1.40.0",
     "react": "19.2.8",
     "react-dom": "19.2.8",
     "react-router": "8.3.1",
@@ -36,12 +36,12 @@
     "three": "0.185.1"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.5.11",
+    "@biomejs/biome": "2.5.12",
     "@tailwindcss/postcss": "4.3.3",
     "@testing-library/dom": "10.4.1",
     "@testing-library/jest-dom": "7.0.1",
     "@testing-library/react": "16.3.3",
-    "@testing-library/user-event": "14.6.6",
+    "@testing-library/user-event": "14.6.7",
     "@vitejs/plugin-react": "6.1.1",
     "jsdom": "30.0.1",
     "rollup-plugin-visualizer": "7.1.1",
@@ -53,6 +53,7 @@
     "socket.io-parser": "4.2.7",
     "ws": "8.21.3",
     "nanoid": "3.3.18",
-    "three": "0.185.1"
+    "three": "0.185.1",
+    "postcss": "8.5.27"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -520,9 +520,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
-      "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.7.0.tgz",
+      "integrity": "sha512-BGFsyJd5mpXp3rK6jIdADLNgpJUK1jnjzvYF8lK+VyDab9JAmqN0YOKDdP17HlgKb2+ehPgDc8EtnRLbGCAMhA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/package.json
+++ b/package.json
@@ -54,6 +54,6 @@
     "follow-redirects": "1.16.0",
     "js-yaml": "4.3.1",
     "ws": "8.21.3",
-    "ip-address": "10.5.0"
+    "ip-address": "10.7.0"
   }
 }

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -23,7 +23,7 @@
         "sharp": "0.35.4",
         "socket.io": "4.8.3",
         "socket.io-client": "4.8.3",
-        "undici": "8.10.0",
+        "undici": "8.10.1",
         "ws": "8.21.3",
         "zod": "4.5.4"
       },
@@ -2811,9 +2811,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
-      "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.7.0.tgz",
+      "integrity": "sha512-BGFsyJd5mpXp3rK6jIdADLNgpJUK1jnjzvYF8lK+VyDab9JAmqN0YOKDdP17HlgKb2+ehPgDc8EtnRLbGCAMhA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -3980,9 +3980,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.26",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
-      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+      "version": "8.5.27",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.27.tgz",
+      "integrity": "sha512-79Iho8QeYyooJ8e9lCRyTVlyTAkS/kXBYKff6TMzS3kEWGQ8Ds5UEtXpGrSUDLUWok6QTvxeYy0GO8fopHnaSA==",
       "dev": true,
       "funding": [
         {
@@ -4000,7 +4000,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.17",
+        "nanoid": "^3.3.18",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -4109,9 +4109,9 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.15.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "es-define-property": "^1.0.1",
@@ -4869,9 +4869,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "8.10.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
-      "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
+      "version": "8.10.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.1.tgz",
+      "integrity": "sha512-YQ3WlbqjYMmNpdvDH64jAgLjxuAR9+649calDWhbshYaeQGO2bR4nI94ORJmwI3J9YhoKQnpyGOK+0zlWS5N5Q==",
       "license": "MIT",
       "engines": {
         "node": ">=22.19.0"

--- a/server/package.json
+++ b/server/package.json
@@ -36,7 +36,7 @@
     "sharp": "0.35.4",
     "socket.io": "4.8.3",
     "socket.io-client": "4.8.3",
-    "undici": "8.10.0",
+    "undici": "8.10.1",
     "ws": "8.21.3",
     "zod": "4.5.4"
   },
@@ -52,14 +52,14 @@
     "js-yaml": "4.3.1",
     "tar": "7.5.22",
     "engine.io": "6.6.9",
-    "qs": "6.15.3",
+    "qs": "6.16.0",
     "sharp": "0.35.4",
     "socket.io-parser": "4.2.7",
     "protobufjs": "7.6.5",
     "@protobufjs/utf8": "1.1.2",
     "ws": "8.21.3",
-    "ip-address": "10.5.0",
-    "postcss": "8.5.26",
+    "ip-address": "10.7.0",
+    "postcss": "8.5.27",
     "nanoid": "3.3.18"
   }
 }


### PR DESCRIPTION
## Summary

- **Security:** the `qs` override sat at `6.15.3`, the top of the vulnerable range for **GHSA-x5fp-wj9c-mxmx** (array-limit bypass via bracket-key comma parsing) and **GHSA-4mjr-xmp4-gh2g** (DoS via attacker-controlled `isBuffer`). Bumped to `6.16.0`, the first fixed release, in `server/` and `autofixer/`. `npm audit` now reports **0 vulnerabilities** in all four workspaces (it was 4 moderate in `server/`, 3 in `autofixer/`).
- **Currency pass:** `undici` 8.10.0 → 8.10.1, `postcss` override 8.5.26 → 8.5.27, `ip-address` override 10.5.0 → 10.7.0 (root + server kept in parity), `@biomejs/biome` 2.5.11 → 2.5.12, `@testing-library/user-event` 14.6.6 → 14.6.7, `lucide-react` 1.37.0 → 1.40.0.
- `client/` also gains the `postcss` pin: `dependency-overrides.test.js` requires every tracked lockfile to *resolve* a pinned package to its pin, so bumping it in `server/` alone left client's tree drifting at 8.5.26.

No open Dependabot/Renovate PRs to land first — all five open PRs are human-authored, and `.github/dependabot.yml` already covers all four npm directories.

### Deliberately left alone

- `js-yaml` (4→5), `protobufjs` (7→8), `nanoid` (3→6) — each override is a security *floor* on a transitive dependency whose consumer still asks for the old major. Forcing the major would break the consumer for no audit benefit; none of the current pins is vulnerable.
- `node-pty` (1.2.0-beta.15) and `jsdom` (30.0.1) are intentionally pinned ahead of their `latest` dist-tags.

## Test plan

- `npm audit` across root, `server/`, `client/`, `autofixer/` — 0 vulnerabilities each (was 4 + 3 moderate).
- `cd server && npm test` — 38301 passed, 1 skipped.
- `cd client && npm test` — 10145 passed, 1 skipped.
- `cd client && npm run build` and `npm run lint` (biome 2.5.12) — both clean.
- `npm run smoke` — server survived the boot window and shut down gracefully.