### PR TITLE
fix(video-gen): quote the real FastMetal download size in the picker

### DIFF
--- a/data.reference/media-models.json
+++ b/data.reference/media-models.json
@@ -588,7 +588,7 @@
       },
       {
         "id": "fastmetal_1_3b_qad",
-        "name": "FastMetal 1.3B QAD (~3.5 GB download, 8+ GB RAM, 3-step)",
+        "name": "FastMetal 1.3B QAD (~13.4 GB download, 8+ GB RAM, 3-step)",
         "repo": "FastVideo/FastMetal-1.3B-QAD",
         "runtime": "fastvideo",
         "supportedModes": [
@@ -618,7 +618,7 @@
       },
       {
         "id": "fastmetal_5b_qad",
-        "name": "FastMetal 5B QAD (~10 GB download, 16+ GB RAM, 3-step)",
+        "name": "FastMetal 5B QAD (~19.5 GB download, 16+ GB RAM, 3-step)",
         "repo": "FastVideo/FastMetal-5B-QAD",
         "runtime": "fastvideo",
         "supportedModes": [
@@ -648,8 +648,27 @@
       },
       {
         "id": "fastmetal_14b_qad",
-        "name": "FastMetal 14B QAD (~25 GB download, 36+ GB RAM, 3-step)",
+        "name": "FastMetal 14B QAD (~27.1 GB download, 36+ GB RAM, 3-step)",
         "repo": "FastVideo/FastMetal-14B-QAD",
+        "repoFiles": [
+          "model_index.json",
+          "mlx_dit.json",
+          "mlx_dit.safetensors",
+          "scheduler/scheduler_config.json",
+          "text_encoder/config.json",
+          "text_encoder/model.safetensors.index.json",
+          "text_encoder/model-00001-of-00005.safetensors",
+          "text_encoder/model-00002-of-00005.safetensors",
+          "text_encoder/model-00003-of-00005.safetensors",
+          "text_encoder/model-00004-of-00005.safetensors",
+          "text_encoder/model-00005-of-00005.safetensors",
+          "tokenizer/special_tokens_map.json",
+          "tokenizer/spiece.model",
+          "tokenizer/tokenizer.json",
+          "tokenizer/tokenizer_config.json",
+          "vae/config.json",
+          "vae/diffusion_pytorch_model.safetensors"
+        ],
         "runtime": "fastvideo",
         "supportedModes": [
           "text"
@@ -672,7 +691,7 @@
             "name": "Apache-2.0",
             "url": "https://github.com/hao-ai-lab/FastVideo/blob/main/LICENSE"
           },
-          "estimatedDownloadGb": 42.3,
+          "estimatedDownloadGb": 27.1,
           "reviewedAt": "2026-09-02"
         }
       },

--- a/scripts/migrations/336-fastmetal-download-size-names.js
+++ b/scripts/migrations/336-fastmetal-download-size-names.js
@@ -1,0 +1,54 @@
+/**
+ * Correct the FastMetal rows' download size where the user actually reads it.
+ *
+ * All three shipped names quoted the MLX DiT alone (~3.5 / ~10 / ~25 GB) while
+ * the entries pull a whole-repo snapshot that also carries a bundled T5 text
+ * encoder and VAE — 13.4 / 19.5 / 42.3 GB. #5860 fixed the disclosure panel's
+ * `estimatedDownloadGb` but shipped no migration, and left the NAME — the
+ * number shown in the picker before that panel is ever opened — untouched.
+ *
+ * This also narrows the 14B row with `repoFiles`, dropping the `ema/` copy of
+ * its DiT (14.14 GB the entry script never loads), which is why its corrected
+ * figure is 27.1 GB rather than the full 42.3 GB snapshot.
+ *
+ * Conservative customization rules (see `upgradeFastMetalDownloadSizes`):
+ * - only a row still pointing at the shipped repo is eligible;
+ * - the name changes only when it is byte-for-byte the prior shipped string;
+ * - `repoFiles` is added only when the row declares none;
+ * - a persisted `estimatedDownloadGb` changes only when it equals a value
+ *   PortOS itself shipped.
+ *
+ * Fresh installs receive all of this from data.reference/media-models.json.
+ */
+
+import { readMediaRegistry, writeMediaRegistry } from './_lib.js';
+import {
+  FASTMETAL_DOWNLOAD_SIZE_PROFILES,
+  upgradeFastMetalDownloadSizes,
+} from '../../server/lib/mediaModels.js';
+
+const REL_PATH = 'data/media-models.json';
+
+export default {
+  async up({ rootDir }) {
+    const { ok, config, entries, path } = await readMediaRegistry({ rootDir });
+    if (!ok) return;
+
+    const changedIds = [];
+    for (const profile of FASTMETAL_DOWNLOAD_SIZE_PROFILES) {
+      const entry = entries.find((model) => model?.id === profile.id);
+      if (!entry) continue;
+      const [upgraded] = upgradeFastMetalDownloadSizes([entry]);
+      if (upgraded === entry) continue;
+      Object.assign(entry, upgraded);
+      changedIds.push(profile.id);
+    }
+
+    if (changedIds.length === 0) {
+      console.log(`✅ ${REL_PATH}: FastMetal download sizes already current or customized`);
+      return;
+    }
+    await writeMediaRegistry(path, config);
+    console.log(`📝 ${REL_PATH}: corrected FastMetal download sizes on ${changedIds.length} row(s) — ${changedIds.join(', ')}`);
+  },
+};

--- a/scripts/migrations/336-fastmetal-download-size-names.test.js
+++ b/scripts/migrations/336-fastmetal-download-size-names.test.js
@@ -1,0 +1,148 @@
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import migration from './336-fastmetal-download-size-names.js';
+
+// The exact strings/values migration 314 and #5860 shipped. Spelled out rather
+// than imported so the test would fail if a profile's `oldName` ever drifted off
+// what installs actually carry — the whole guard rests on a byte-for-byte match.
+const OLD_1_3B = 'FastMetal 1.3B QAD (~3.5 GB download, 8+ GB RAM, 3-step)';
+const OLD_5B = 'FastMetal 5B QAD (~10 GB download, 16+ GB RAM, 3-step)';
+const OLD_14B = 'FastMetal 14B QAD (~25 GB download, 36+ GB RAM, 3-step)';
+
+const shippedRow = (id, name, repo, extra = {}) => ({ id, name, repo, runtime: 'fastvideo', ...extra });
+
+const shippedRegistry = () => ({
+  video: {
+    mlx: [
+      shippedRow('fastmetal_1_3b_qad', OLD_1_3B, 'FastVideo/FastMetal-1.3B-QAD'),
+      shippedRow('fastmetal_5b_qad', OLD_5B, 'FastVideo/FastMetal-5B-QAD'),
+      shippedRow('fastmetal_14b_qad', OLD_14B, 'FastVideo/FastMetal-14B-QAD'),
+    ],
+    cuda: [],
+  },
+});
+
+describe('336-fastmetal-download-size-names migration', () => {
+  let rootDir;
+  let registryFile;
+
+  beforeEach(() => {
+    rootDir = join(tmpdir(), `portos-test-336-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(join(rootDir, 'data'), { recursive: true });
+    registryFile = join(rootDir, 'data', 'media-models.json');
+  });
+
+  afterEach(() => {
+    rmSync(rootDir, { recursive: true, force: true });
+  });
+
+  const write = (config) => writeFileSync(registryFile, JSON.stringify(config, null, 2));
+  const read = () => JSON.parse(readFileSync(registryFile, 'utf-8'));
+  const rowsById = () => Object.fromEntries(read().video.mlx.map((m) => [m.id, m]));
+
+  it('skips gracefully when media-models.json does not exist', async () => {
+    await expect(migration.up({ rootDir })).resolves.toBeUndefined();
+  });
+
+  it('rewrites all three shipped names onto the size the download actually pulls', async () => {
+    write(shippedRegistry());
+
+    await migration.up({ rootDir });
+
+    const rows = rowsById();
+    expect(rows.fastmetal_1_3b_qad.name).toBe('FastMetal 1.3B QAD (~13.4 GB download, 8+ GB RAM, 3-step)');
+    expect(rows.fastmetal_5b_qad.name).toBe('FastMetal 5B QAD (~19.5 GB download, 16+ GB RAM, 3-step)');
+    expect(rows.fastmetal_14b_qad.name).toBe('FastMetal 14B QAD (~27.1 GB download, 36+ GB RAM, 3-step)');
+  });
+
+  it('narrows only the 14B row off its duplicated ema/ DiT', async () => {
+    write(shippedRegistry());
+
+    await migration.up({ rootDir });
+
+    const rows = rowsById();
+    expect(rows.fastmetal_1_3b_qad.repoFiles).toBeUndefined();
+    expect(rows.fastmetal_5b_qad.repoFiles).toBeUndefined();
+    // The root DiT is in; the `ema/` copy of it — 14.14 GB the entry script
+    // never loads — is what the narrowing exists to drop.
+    expect(rows.fastmetal_14b_qad.repoFiles).toContain('mlx_dit.safetensors');
+    expect(rows.fastmetal_14b_qad.repoFiles.some((f) => f.startsWith('ema/'))).toBe(false);
+    // The pipeline's other components must survive the narrowing, or the
+    // download completes and the render fails on a missing text encoder.
+    expect(rows.fastmetal_14b_qad.repoFiles).toEqual(expect.arrayContaining([
+      'model_index.json',
+      'text_encoder/model-00005-of-00005.safetensors',
+      'vae/diffusion_pytorch_model.safetensors',
+    ]));
+  });
+
+  it('repairs a stale persisted disclosure size from either shipped generation', async () => {
+    const config = shippedRegistry();
+    // Pre-#5860: the DiT-only figure. Post-#5860: the whole-snapshot figure the
+    // 14B row no longer pulls now that `ema/` is excluded.
+    config.video.mlx[0].disclosure = { estimatedDownloadGb: 3.5, reviewedAt: '2026-08-01' };
+    config.video.mlx[2].disclosure = { estimatedDownloadGb: 42.3, reviewedAt: '2026-09-02' };
+    write(config);
+
+    await migration.up({ rootDir });
+
+    const rows = rowsById();
+    expect(rows.fastmetal_1_3b_qad.disclosure.estimatedDownloadGb).toBe(13.4);
+    expect(rows.fastmetal_14b_qad.disclosure.estimatedDownloadGb).toBe(27.1);
+    // Everything else in the block is the user's/shipped provenance — untouched.
+    expect(rows.fastmetal_1_3b_qad.disclosure.reviewedAt).toBe('2026-08-01');
+  });
+
+  it('leaves a renamed, re-pointed, pre-narrowed or hand-estimated row alone', async () => {
+    write({
+      video: {
+        mlx: [
+          shippedRow('fastmetal_1_3b_qad', 'My tiny video model', 'FastVideo/FastMetal-1.3B-QAD'),
+          shippedRow('fastmetal_5b_qad', OLD_5B, 'example/FastMetal-5B-fork'),
+          shippedRow('fastmetal_14b_qad', OLD_14B, 'FastVideo/FastMetal-14B-QAD', {
+            repoFiles: ['mlx_dit.safetensors'],
+            disclosure: { estimatedDownloadGb: 31.2 },
+          }),
+        ],
+        cuda: [],
+      },
+    });
+
+    await migration.up({ rootDir });
+
+    const rows = rowsById();
+    expect(rows.fastmetal_1_3b_qad.name).toBe('My tiny video model');
+    // A forked repo gets nothing: PortOS has not measured what it pulls.
+    expect(rows.fastmetal_5b_qad.name).toBe(OLD_5B);
+    expect(rows.fastmetal_5b_qad.repoFiles).toBeUndefined();
+    // The name is still the untouched shipped string, so it IS corrected — but
+    // the owner's own narrowing and estimate are preserved.
+    expect(rows.fastmetal_14b_qad.name).toBe('FastMetal 14B QAD (~27.1 GB download, 36+ GB RAM, 3-step)');
+    expect(rows.fastmetal_14b_qad.repoFiles).toEqual(['mlx_dit.safetensors']);
+    expect(rows.fastmetal_14b_qad.disclosure.estimatedDownloadGb).toBe(31.2);
+  });
+
+  it('is idempotent — a second run rewrites nothing', async () => {
+    write(shippedRegistry());
+    await migration.up({ rootDir });
+    const afterFirst = readFileSync(registryFile, 'utf-8');
+
+    await migration.up({ rootDir });
+
+    expect(readFileSync(registryFile, 'utf-8')).toBe(afterFirst);
+  });
+
+  it('skips a row the user deleted without touching its siblings', async () => {
+    const config = shippedRegistry();
+    config.video.mlx = config.video.mlx.filter((m) => m.id !== 'fastmetal_5b_qad');
+    write(config);
+
+    await migration.up({ rootDir });
+
+    const rows = rowsById();
+    expect(rows.fastmetal_5b_qad).toBeUndefined();
+    expect(rows.fastmetal_14b_qad.name).toBe('FastMetal 14B QAD (~27.1 GB download, 36+ GB RAM, 3-step)');
+  });
+});

--- a/server/lib/mediaModels.js
+++ b/server/lib/mediaModels.js
@@ -345,6 +345,129 @@ export const upgradeMiniMaxH3OutputControls = (list) => {
   return upgradeMiniMaxH3DenoisingCount(withGeometry);
 };
 
+// FastMetal 14B ships its MLX DiT TWICE — `mlx_dit.safetensors` at the repo
+// root and an `ema/` copy of the same 14.14 GB tensor. The render path reads
+// only the root one: scripts/generate_fastvideo.py defaults `mlx_checkpoint`
+// to the model root for the fastmetal family and ALWAYS forwards it, so
+// mlx_wan_prompt_to_video.py takes `resolve_mlx_checkpoint`'s explicit branch
+// and loads `mlx_dit.json` + `mlx_dit.safetensors` from that one directory.
+// Nothing on that path names `ema/` — the `ema/*` entries in the entry
+// script's own `allow_patterns` belong to its download helper, which PortOS
+// bypasses by passing an explicit `--model-root`.
+//
+// Enumerating the loaded set therefore drops 14.14 GB from the pull without
+// changing a single byte the render path reads.
+//
+// Listed rather than expressed as an "everything but ema/" exclusion because
+// `repoFiles` is the only narrowing the download path has (see
+// `modelDownloadTargets`), and an explicit list is also what the cache
+// completeness check verifies. `.gitattributes` and `README.md` are omitted:
+// nothing loads them, and a file in this list that upstream later drops would
+// read as an incomplete download.
+const FASTMETAL_14B_REPO_FILES = Object.freeze([
+  'model_index.json',
+  'mlx_dit.json',
+  'mlx_dit.safetensors',
+  'scheduler/scheduler_config.json',
+  'text_encoder/config.json',
+  'text_encoder/model.safetensors.index.json',
+  ...shardFiles('text_encoder', 'model', 5),
+  'tokenizer/special_tokens_map.json',
+  'tokenizer/spiece.model',
+  'tokenizer/tokenizer.json',
+  'tokenizer/tokenizer_config.json',
+  'vae/config.json',
+  'vae/diffusion_pytorch_model.safetensors',
+]);
+
+// The three shipped FastMetal rows quote a download size in their DISPLAY NAME
+// that is only the MLX DiT, while the entries pull a whole-repo snapshot that
+// also carries a bundled T5 text encoder and VAE — so a user reading "~3.5 GB"
+// was handed a 13.4 GB pull (#5871). #5860 corrected `estimatedDownloadGb` in
+// the disclosure panel; the name is the number the user reads BEFORE opening
+// that panel, so it is what these profiles correct.
+//
+// `oldName` / `oldEstimatedDownloadGb` are the exact superseded SHIPPED values:
+// each rewrite fires only when the persisted value still matches one of them, so
+// a user's own rename or hand-tuned estimate survives untouched. Same shape as
+// MINIMAX_H3_OUTPUT_PROFILE's upgrade half — keyed on (id, shipped repo, prior
+// shipped value).
+//
+// `oldEstimatedDownloadGb` carries TWO generations because #5860 shipped no
+// migration: an install that persisted its disclosure before it still reads the
+// DiT-only figure, and one that seeded after reads the whole-snapshot figure the
+// 14B row no longer pulls.
+export const FASTMETAL_DOWNLOAD_SIZE_PROFILES = Object.freeze([
+  Object.freeze({
+    id: 'fastmetal_1_3b_qad',
+    shippedRepo: 'FastVideo/FastMetal-1.3B-QAD',
+    oldName: 'FastMetal 1.3B QAD (~3.5 GB download, 8+ GB RAM, 3-step)',
+    name: 'FastMetal 1.3B QAD (~13.4 GB download, 8+ GB RAM, 3-step)',
+    oldEstimatedDownloadGb: Object.freeze([3.5]),
+    estimatedDownloadGb: 13.4,
+  }),
+  Object.freeze({
+    id: 'fastmetal_5b_qad',
+    shippedRepo: 'FastVideo/FastMetal-5B-QAD',
+    oldName: 'FastMetal 5B QAD (~10 GB download, 16+ GB RAM, 3-step)',
+    name: 'FastMetal 5B QAD (~19.5 GB download, 16+ GB RAM, 3-step)',
+    oldEstimatedDownloadGb: Object.freeze([10.2]),
+    estimatedDownloadGb: 19.5,
+  }),
+  // The 14B repo ships the DiT twice — `mlx_dit.safetensors` and an `ema/` copy
+  // of it, 14.14 GB each — and the entry script loads only the root one, so
+  // `repoFiles` drops the `ema/` half. That makes this row's honest number the
+  // narrowed 27.1 GB pull rather than the 42.3 GB whole snapshot. Every name
+  // here quotes its `estimatedDownloadGb` verbatim — the whole bug was the two
+  // disagreeing, so they are not allowed to round apart.
+  Object.freeze({
+    id: 'fastmetal_14b_qad',
+    shippedRepo: 'FastVideo/FastMetal-14B-QAD',
+    oldName: 'FastMetal 14B QAD (~25 GB download, 36+ GB RAM, 3-step)',
+    name: 'FastMetal 14B QAD (~27.1 GB download, 36+ GB RAM, 3-step)',
+    oldEstimatedDownloadGb: Object.freeze([25.4, 42.3]),
+    estimatedDownloadGb: 27.1,
+    repoFiles: FASTMETAL_14B_REPO_FILES,
+  }),
+]);
+
+const upgradeFastMetalEntry = (entry, profile) => {
+  if (!isPlainObject(entry) || entry.id !== profile.id || entry.repo !== profile.shippedRepo) return entry;
+  let next = entry;
+  // Only the untouched shipped string is rewritten — a user rename is theirs.
+  if (next.name === profile.oldName) next = { ...next, name: profile.name };
+  // The file list is additive and only lands on a row that declares none: an
+  // entry already carrying `repoFiles` has a narrowing its owner chose.
+  if (profile.repoFiles && !Object.hasOwn(next, 'repoFiles')) {
+    next = { ...next, repoFiles: [...profile.repoFiles] };
+  }
+  // A row that persisted its disclosure before this correction keeps a stale
+  // size that would now contradict the name beside it. applyVideoDisclosures
+  // only fills an ABSENT block, so the stale one is corrected here — and only
+  // when it still equals a value PortOS itself shipped.
+  if (isPlainObject(next.disclosure)
+    && profile.oldEstimatedDownloadGb.includes(next.disclosure.estimatedDownloadGb)) {
+    next = {
+      ...next,
+      disclosure: { ...next.disclosure, estimatedDownloadGb: profile.estimatedDownloadGb },
+    };
+  }
+  return next;
+};
+
+/**
+ * Bring the shipped FastMetal rows onto the size their download actually pulls
+ * — in the display name and in any stale persisted disclosure — and narrow the
+ * 14B row off its duplicated `ema/` DiT.
+ *
+ * Load-time twin of migration 336: the registry cache is populated before
+ * migrations execute, so the boot that runs the migration still needs this.
+ */
+export const upgradeFastMetalDownloadSizes = (list) => {
+  if (!Array.isArray(list)) return list;
+  return list.map((entry) => FASTMETAL_DOWNLOAD_SIZE_PROFILES.reduce(upgradeFastMetalEntry, entry));
+};
+
 // Existing installs already persisted the shipped LTX-2.5 row before its A2V
 // duration contract was declared. Backfill only the untouched pinned model and
 // only absent keys: a user-repointed fork or an explicit local override remains
@@ -635,10 +758,12 @@ const DEFAULT_REGISTRY = {
         }],
       },
       // FastVideo FastMetal models — Hao AI Lab's distilled DMD2 Wan models
-      // with affine INT8 quantization on Apple Silicon MLX.
+      // with affine INT8 quantization on Apple Silicon MLX. The download size
+      // in each name is the WHOLE snapshot (bundled T5 text encoder and VAE
+      // included), not the MLX DiT alone — see FASTMETAL_DOWNLOAD_SIZE_PROFILES.
       {
         id: 'fastmetal_1_3b_qad',
-        name: 'FastMetal 1.3B QAD (~3.5 GB download, 8+ GB RAM, 3-step)',
+        name: 'FastMetal 1.3B QAD (~13.4 GB download, 8+ GB RAM, 3-step)',
         repo: 'FastVideo/FastMetal-1.3B-QAD',
         runtime: 'fastvideo',
         supportedModes: ['text'],
@@ -653,7 +778,7 @@ const DEFAULT_REGISTRY = {
       },
       {
         id: 'fastmetal_5b_qad',
-        name: 'FastMetal 5B QAD (~10 GB download, 16+ GB RAM, 3-step)',
+        name: 'FastMetal 5B QAD (~19.5 GB download, 16+ GB RAM, 3-step)',
         repo: 'FastVideo/FastMetal-5B-QAD',
         runtime: 'fastvideo',
         supportedModes: ['text'],
@@ -668,8 +793,10 @@ const DEFAULT_REGISTRY = {
       },
       {
         id: 'fastmetal_14b_qad',
-        name: 'FastMetal 14B QAD (~25 GB download, 36+ GB RAM, 3-step)',
+        name: 'FastMetal 14B QAD (~27.1 GB download, 36+ GB RAM, 3-step)',
         repo: 'FastVideo/FastMetal-14B-QAD',
+        // Drops the duplicated `ema/` DiT the entry script never loads (#5871).
+        repoFiles: [...FASTMETAL_14B_REPO_FILES],
         runtime: 'fastvideo',
         supportedModes: ['text'],
         defaultWidth: 1280,
@@ -1356,9 +1483,9 @@ const normalizeRegistry = (parsed) => {
   // model this install deleted — or a hand-edited typo — is dropped with a
   // warning instead of surfacing a Finish button targeting nothing.
   const videoEntries = (entries, { upgradeLegacyCudaLtx = false } = {}) => {
-    const normalized = backfillRuntime(upgradeLtx25AudioControls(
+    const normalized = backfillRuntime(upgradeFastMetalDownloadSizes(upgradeLtx25AudioControls(
       upgradeMiniMaxH3OutputControls(dropRetiredEntries(entries)),
-    ));
+    )));
     const upgraded = upgradeLegacyCudaLtx
       ? upgradeLtx25CudaMemoryFloor(upgradeLegacyCudaLtxRuntime(normalized))
       : normalized;

--- a/server/lib/mediaModels.test.js
+++ b/server/lib/mediaModels.test.js
@@ -56,6 +56,89 @@ describe('LTX-2.5 CUDA compatibility upgrade', () => {
   });
 });
 
+describe('FastMetal download size disclosure', () => {
+  // #5871: the name quoted the MLX DiT alone while the entry pulled the whole
+  // repo. The picker shows the NAME and the disclosure panel shows the number —
+  // the regression is the two disagreeing, so that is what this pins.
+  it('quotes the same download size in each shipped name as in its disclosure', async () => {
+    const { loadMediaModels } = await import('./mediaModels.js');
+    const rows = loadMediaModels().video.mlx.filter((m) => m.id.startsWith('fastmetal_'));
+    expect(rows).toHaveLength(3);
+    for (const row of rows) {
+      const quoted = row.name.match(/~([\d.]+) GB download/);
+      expect(quoted, `${row.id} name must quote a download size`).not.toBeNull();
+      const gb = row.disclosure.estimatedDownloadGb;
+      // Exact, not "close enough": a tolerance wide enough to be comfortable is
+      // also wide enough to re-admit the bug this pins (a name a GB off its own
+      // panel). If a name must round, the disclosure moves with it.
+      expect(Number(quoted[1]), `${row.id}: name says ${quoted[1]} GB, disclosure says ${gb} GB`).toBe(gb);
+    }
+  });
+
+  // 14.14 GB of the 14B repo is an `ema/` copy of the DiT the entry script
+  // never loads. Only the narrowed row may quote the smaller figure.
+  it('narrows the 14B row off its duplicated ema/ DiT', async () => {
+    const { loadMediaModels } = await import('./mediaModels.js');
+    const rows = loadMediaModels().video.mlx;
+    const fourteen = rows.find((m) => m.id === 'fastmetal_14b_qad');
+    expect(fourteen.repoFiles).toContain('mlx_dit.safetensors');
+    expect(fourteen.repoFiles.some((f) => f.startsWith('ema/'))).toBe(false);
+    // The unnarrowed siblings must NOT claim a subset they do not download.
+    for (const id of ['fastmetal_1_3b_qad', 'fastmetal_5b_qad']) {
+      expect(rows.find((m) => m.id === id).repoFiles).toBeUndefined();
+    }
+  });
+
+  // The path that actually bites a real install: the boot BEFORE migration 336
+  // runs still reads the registry off disk, so the loader — not just the
+  // migration — has to correct it. This is also what fails if someone later
+  // reorders `upgradeFastMetalDownloadSizes` after applyVideoDisclosures (which
+  // only fills an ABSENT block) or drops it from the videoEntries chain.
+  it('corrects a persisted stale registry on load, before the migration runs', async () => {
+    writeFileSync(registryFile, JSON.stringify({
+      video: {
+        mlx: [{
+          id: 'fastmetal_14b_qad',
+          name: 'FastMetal 14B QAD (~25 GB download, 36+ GB RAM, 3-step)',
+          repo: 'FastVideo/FastMetal-14B-QAD',
+          runtime: 'fastvideo',
+          disclosure: { estimatedDownloadGb: 42.3, reviewedAt: '2026-09-02' },
+        }],
+        cuda: [],
+      },
+    }, null, 2));
+
+    const { loadMediaModels } = await import('./mediaModels.js');
+    const row = loadMediaModels().video.mlx.find((m) => m.id === 'fastmetal_14b_qad');
+
+    expect(row.name).toBe('FastMetal 14B QAD (~27.1 GB download, 36+ GB RAM, 3-step)');
+    expect(row.disclosure.estimatedDownloadGb).toBe(27.1);
+    expect(row.repoFiles.some((f) => f.startsWith('ema/'))).toBe(false);
+  });
+
+  it('corrects a stale persisted row but leaves a renamed or re-pointed one alone', async () => {
+    const { upgradeFastMetalDownloadSizes } = await import('./mediaModels.js');
+    const shipped = {
+      id: 'fastmetal_14b_qad',
+      repo: 'FastVideo/FastMetal-14B-QAD',
+      name: 'FastMetal 14B QAD (~25 GB download, 36+ GB RAM, 3-step)',
+      disclosure: { estimatedDownloadGb: 42.3 },
+    };
+    const renamed = { ...shipped, name: 'My big video model' };
+    const fork = { ...shipped, repo: 'example/FastMetal-fork' };
+
+    const [upgraded, keptRename, keptFork] = upgradeFastMetalDownloadSizes([shipped, renamed, fork]);
+
+    expect(upgraded.name).toBe('FastMetal 14B QAD (~27.1 GB download, 36+ GB RAM, 3-step)');
+    expect(upgraded.disclosure.estimatedDownloadGb).toBe(27.1);
+    expect(upgraded.repoFiles.some((f) => f.startsWith('ema/'))).toBe(false);
+    expect(keptRename.name).toBe('My big video model');
+    // A rename does not forfeit the size correction the panel needs.
+    expect(keptRename.disclosure.estimatedDownloadGb).toBe(27.1);
+    expect(keptFork).toBe(fork);
+  });
+});
+
 describe('mediaModels registry', () => {
   it('seeds the registry file on first load', async () => {
     expect(existsSync(registryFile)).toBe(false);

--- a/server/lib/videoDisclosure.js
+++ b/server/lib/videoDisclosure.js
@@ -318,8 +318,10 @@ export const VIDEO_MODEL_DISCLOSURES = Object.freeze({
     },
   },
   // The FastMetal repos bundle their own text encoder and VAE beside the MLX
-  // DiT, and the entries declare no `repoFiles`, so the download is the whole
-  // snapshot — several times the DiT-only size their display names quote.
+  // DiT, so the download is several times the DiT-only size. The 1.3B and 5B
+  // rows declare no `repoFiles` and pull the whole snapshot; the 14B row does
+  // (#5871), dropping the duplicated `ema/` DiT, so its figure is the narrowed
+  // pull rather than the 42.3 GB the full snapshot would cost.
   fastmetal_1_3b_qad: {
     shippedRepo: 'FastVideo/FastMetal-1.3B-QAD',
     disclosure: {
@@ -346,7 +348,7 @@ export const VIDEO_MODEL_DISCLOSURES = Object.freeze({
       modelCardUrl: hfModelCard('FastVideo/FastMetal-14B-QAD'),
       weightsLicense: APACHE_2,
       runtimeLicense: RUNTIME_LICENSE.fastvideo,
-      estimatedDownloadGb: 42.3,
+      estimatedDownloadGb: 27.1,
       reviewedAt: VIDEO_DISCLOSURE_REVIEWED_AT,
     },
   },


### PR DESCRIPTION
## Summary

The three shipped FastMetal rows quoted a download size in their **display name** that was only the MLX DiT file, not what PortOS actually pulls. None declared `repoFiles`, so the download snapshots the whole repo — which also carries a bundled T5 text encoder and VAE. A user on a nearly-full disk picked "~3.5 GB" and 13.4 GB later the pull failed partway.

#5860 corrected `estimatedDownloadGb` so the **disclosure panel** is accurate. The name is the number the user reads in the picker *before* opening that panel, and it was still wrong.

| Row | Name said | Name now | Actually downloads |
| --- | --- | --- | --- |
| `fastmetal_1_3b_qad` | ~3.5 GB | **~13.4 GB** | 13.4 GB |
| `fastmetal_5b_qad` | ~10 GB | **~19.5 GB** | 19.5 GB |
| `fastmetal_14b_qad` | ~25 GB | **~27.1 GB** | 27.1 GB (narrowed, was 42.3 GB) |

Each name now quotes its own `estimatedDownloadGb` verbatim rather than rounding away from it — the two disagreeing is the whole bug, so they are not allowed to drift.

### The 14B row is narrowed rather than restated

`FastVideo/FastMetal-14B-QAD` ships its DiT **twice**: `mlx_dit.safetensors` at the root and an `ema/` copy of the same 14.14 GB tensor. Only the root one is ever read — `scripts/generate_fastvideo.py` defaults `mlx_checkpoint` to the model root for the `fastmetal` family and always forwards it, so `mlx_wan_prompt_to_video.py` takes `resolve_mlx_checkpoint`'s explicit branch and loads the DiT from that one directory. Nothing on that path names `ema/` (the `ema/*` entries in the entry script's own `allow_patterns` belong to its download helper, which PortOS bypasses with an explicit `--model-root`).

So the row declares `repoFiles` and drops the duplicate: 15 GB less to download, zero bytes of difference to the render path. That is the better fix the issue asked us to consider, rather than restating the larger number.

### Compatibility

Names are persisted per install, so migration `336-fastmetal-download-size-names` rewrites them, with a load-time twin (`upgradeFastMetalDownloadSizes`) for the boot that runs the migration — the registry cache is populated before migrations execute.

Every rewrite is guarded on a byte-for-byte match with a value PortOS itself shipped, so these are left alone: a user rename, a re-pointed fork, an entry that already declares its own `repoFiles`, and a hand-tuned `estimatedDownloadGb`.

The migration also repairs a **stale persisted `estimatedDownloadGb`**, which #5860 shipped no migration for — `oldEstimatedDownloadGb` carries both generations (`25.4` pre-#5860 and `42.3` post) so either vintage converges on 27.1.

An install that already pulled the full 14B snapshot keeps its `ema/` copy on disk; PortOS never deletes cached weights unasked.

## Test plan

- `server/lib/mediaModels.test.js` — asserts every FastMetal name and its disclosure quote the **same** number (exact equality, not a tolerance wide enough to re-admit the bug); asserts only the 14B row is narrowed and that no `ema/` path survives; asserts a stale **persisted** registry is corrected on load, which is the path that bites a real install on the boot before the migration runs. Verified failing when `upgradeFastMetalDownloadSizes` is removed from the `videoEntries` chain.
- `scripts/migrations/336-fastmetal-download-size-names.test.js` — the three rewrites, the narrowing, disclosure repair from both shipped generations, idempotence, a deleted row, and the four customization-preservation cases.
- Sizes verified against the live HuggingFace tree API for all three repos.
- Full server suite: **1897 files / 38322 tests passed**.

Follow-up filed as #6056 (collapse the six shipped-value-guarded registry upgraders into one declarative chain) — deliberately not done here, since it touches every upgrader.

Closes #5871

https://claude.ai/code/session_014HkS5yBXfiNQL2t2k6RPRb