### PR TITLE
fix(cos): start the PR page's Resolve & merge agent immediately

### DIFF
--- a/client/src/components/apps/tabs/PullRequestsTab.jsx
+++ b/client/src/components/apps/tabs/PullRequestsTab.jsx
@@ -45,7 +45,7 @@ const ACTION_KINDS = {
     field: 'agentAction',
     queued: result => result.task && { taskId: result.task.id, status: result.task.status },
     title: (forgeLabel, number, appName) =>
-      `Queue a CoS agent to resolve and merge ${forgeLabel} request #${number} for ${appName}`,
+      `Start a CoS agent now to resolve and merge ${forgeLabel} request #${number} for ${appName}`,
     matches: (task, appId, number) => task.metadata?.app === appId
       && Number(task.metadata?.reviewLoopPRNumber) === number,
   },
@@ -272,12 +272,26 @@ export default function PullRequestsTab({ appId, appName }) {
         },
       };
     });
-    toast.success(result.duplicate ? already : queued);
+    // The `queued` toast text may be a function of the response, for an action
+    // that reports whether an agent actually STARTED (resolve dispatches
+    // immediately) rather than only that a task was persisted.
+    const duplicate = result.duplicate === true;
+    const message = duplicate ? already
+      : (typeof queued === 'function' ? queued(result) : queued);
+    // Queued-but-not-started is not a failure — it just isn't running yet (no
+    // agent slots, daemon stopped) — but it is not a success claim either, so it
+    // gets the neutral toast. A duplicate stays a success: something is already
+    // on it.
+    if (!duplicate && result.started === false) toast(message);
+    else toast.success(message);
   };
 
   const handleResolve = pullRequest => queueAction('resolve', pullRequest, {
     call: () => api.resolveAppPullRequest(appId, pullRequest.number),
-    queued: `Queued an agent to resolve and merge ${forgeLabel} #${pullRequest.number}`,
+    queued: result => (result.started
+      ? `Started an agent to resolve and merge ${forgeLabel} #${pullRequest.number}`
+      : `Queued an agent to resolve and merge ${forgeLabel} #${pullRequest.number}`
+        + (result.queueReason ? ` — ${result.queueReason}` : '')),
     already: `An agent is already resolving ${forgeLabel} #${pullRequest.number}`,
   });
 
@@ -334,7 +348,7 @@ export default function PullRequestsTab({ appId, appName }) {
 
       <div className="px-3 py-2 text-xs text-gray-500 bg-port-card border border-port-border rounded-lg space-y-1">
         <p>
-          Resolve and merge queues a PortOS agent to inspect feedback, fix the branch, wait for checks, and merge when the forge allows it. It uses the configured Code Review Defaults.
+          Resolve and merge starts a PortOS agent right away to inspect feedback, fix the branch, wait for checks, and merge when the forge allows it. It uses the configured Code Review Defaults.
         </p>
         {(data?.pullRequests || []).some(pullRequest => pullRequest.reviewEligible) && (
           <p>

--- a/client/src/components/apps/tabs/PullRequestsTab.test.jsx
+++ b/client/src/components/apps/tabs/PullRequestsTab.test.jsx
@@ -15,7 +15,15 @@ const { socketHandlers, socketMock } = vi.hoisted(() => {
   return { socketHandlers: handlers, socketMock: mock };
 });
 
+const { toastMock } = vi.hoisted(() => {
+  const fn = vi.fn();
+  fn.success = vi.fn();
+  fn.error = vi.fn();
+  return { toastMock: fn };
+});
+
 vi.mock('../../../services/socket', () => ({ default: socketMock }));
+vi.mock('../../ui/Toast', () => ({ default: toastMock }));
 vi.mock('../../../services/api', () => ({
   getAppPullRequests: vi.fn(),
   resolveAppPullRequest: vi.fn(),
@@ -76,6 +84,8 @@ beforeEach(() => {
   api.resolveAppPullRequest.mockResolvedValue({
     task: { id: 'task-1', status: 'pending' },
     duplicate: false,
+    started: true,
+    queueReason: null,
   });
   api.reviewAppPullRequest.mockResolvedValue({
     requestId: 'demand-abc',
@@ -110,6 +120,36 @@ describe('PullRequestsTab', () => {
     fireEvent.click(await screen.findByRole('button', { name: /Resolve & merge/ }));
 
     await waitFor(() => expect(api.resolveAppPullRequest).toHaveBeenCalledWith('app-1', 17));
+    expect(await screen.findByRole('link', { name: /Queued/ })).toBeInTheDocument();
+  });
+
+  // The server starts the follow-up on the click, so the toast must say so —
+  // and must NOT claim an agent is on it when the dispatch was refused.
+  it('reports that the resolve agent started', async () => {
+    await renderTab();
+
+    fireEvent.click(await screen.findByRole('button', { name: /Resolve & merge/ }));
+
+    await waitFor(() => expect(toastMock.success).toHaveBeenCalledWith(
+      expect.stringContaining('Started an agent to resolve and merge'),
+    ));
+  });
+
+  it('surfaces why a resolve task is queued but not yet running', async () => {
+    api.resolveAppPullRequest.mockResolvedValue({
+      task: { id: 'task-1', status: 'pending' },
+      duplicate: false,
+      started: false,
+      queueReason: 'No available agent slots (3/3)',
+    });
+    await renderTab();
+
+    fireEvent.click(await screen.findByRole('button', { name: /Resolve & merge/ }));
+
+    await waitFor(() => expect(toastMock).toHaveBeenCalledWith(
+      expect.stringContaining('No available agent slots (3/3)'),
+    ));
+    expect(toastMock.success).not.toHaveBeenCalled();
     expect(await screen.findByRole('link', { name: /Queued/ })).toBeInTheDocument();
   });
 

--- a/server/routes/apps/pullRequests.js
+++ b/server/routes/apps/pullRequests.js
@@ -7,7 +7,8 @@
  *
  * Neither POST route merges a user's PR directly. `/resolve` queues PortOS's
  * existing review-loop follow-up, which owns fetching feedback, fixing the
- * branch, waiting for checks, and merging. `/review` queues the `pr-reviewer`
+ * branch, waiting for checks, and merging — and starts it immediately, because
+ * pressing the button is the approval. `/review` queues the `pr-reviewer`
  * scheduled task narrowed to a single request, so the security-scan → review
  * pipeline that normally sweeps every external PR can be pointed at one.
  */
@@ -181,8 +182,9 @@ router.get('/:id/pull-requests', loadApp, asyncHandler(async (req, res) => {
 }));
 
 // POST /api/apps/:id/pull-requests/:number/resolve — queue the existing review
-// loop against a freshly-read open PR/MR. Re-reading before queueing prevents a
-// closed or replaced request from being attached to an agent by stale UI data.
+// loop against a freshly-read open PR/MR and start it now. Re-reading before
+// queueing prevents a closed or replaced request from being attached to an agent
+// by stale UI data.
 router.post('/:id/pull-requests/:number/resolve', loadApp, asyncHandler(async (req, res) => {
   const app = req.loadedApp;
   const { number } = validateRequest(pullRequestParamsSchema, req.params);
@@ -258,6 +260,11 @@ router.post('/:id/pull-requests/:number/resolve', loadApp, asyncHandler(async (r
     ...reviewOptions,
     reviewers,
     optionalReviewers,
+    // This button IS the user's approval — start the agent now instead of leaving
+    // the follow-up as a pending system task the autonomous dequeue only picks up
+    // while CoS auto-run is in `execute` and under its daily budget (which is why
+    // it had to be started by hand from the task page).
+    dispatch: 'immediate',
   });
   if (!task) {
     throw new ServerError('Could not queue the pull-request resolve agent', {
@@ -266,13 +273,23 @@ router.post('/:id/pull-requests/:number/resolve', loadApp, asyncHandler(async (r
     });
   }
 
-  console.log(`🚀 Queued PR resolve agent ${task.id} for app ${app.id} request #${number}`);
+  // `started` false means the task is persisted and queued but nothing is running
+  // it yet (no agent slots, daemon stopped/paused, runner unreachable) — report the
+  // reason rather than letting the UI claim an agent is on it. A duplicate has no
+  // dispatch of its own: whatever is already queued owns the run.
+  const started = task.dispatch?.started === true;
+  const queueReason = task.dispatch?.reason ?? null;
+  console.log(started
+    ? `🚀 Started PR resolve agent for task ${task.id} (app ${app.id} request #${number})`
+    : `⏳ Queued PR resolve task ${task.id} for app ${app.id} request #${number}${queueReason ? ` — ${queueReason}` : ''}`);
   res.status(task.duplicate ? 200 : 202).json({
     appId: app.id,
     appName: app.name,
     pullRequest: { ...pullRequest, agentAction: { taskId: task.id, status: task.status } },
     task: taskResponse(task),
     duplicate: task.duplicate === true,
+    started,
+    queueReason,
   });
 }));
 

--- a/server/routes/apps/pullRequests.test.js
+++ b/server/routes/apps/pullRequests.test.js
@@ -82,6 +82,7 @@ describe('app pull-request routes', () => {
       id: 'sys-rl-1',
       status: 'pending',
       description: '[Review Loop] Resolve and merge PR #17 for Widget (https://github.com/acme/widget/pull/17)',
+      dispatch: { started: true, reason: null },
     });
     listExternalOpenPullRequests.mockResolvedValue({
       ok: true,
@@ -151,6 +152,52 @@ describe('app pull-request routes', () => {
       duplicate: false,
       pullRequest: { agentAction: { taskId: 'sys-rl-1', status: 'pending' } },
     });
+  });
+
+  // Pressing the button IS the approval. Without an immediate dispatch the
+  // follow-up is an auto-approved SYSTEM task, which the dequeue only spawns while
+  // CoS auto-run is in `execute` and under budget — so it sat pending until the
+  // user pressed Run now on the task page.
+  it('starts the follow-up immediately instead of leaving it for the autonomous queue', async () => {
+    const response = await request(app).post('/api/apps/app-001/pull-requests/17/resolve');
+
+    expect(response.status).toBe(202);
+    expect(spawnReviewLoopFollowUp).toHaveBeenCalledWith(expect.objectContaining({ dispatch: 'immediate' }));
+    expect(response.body).toMatchObject({ started: true, queueReason: null });
+  });
+
+  it('reports why the agent has not started yet rather than claiming one is running', async () => {
+    spawnReviewLoopFollowUp.mockResolvedValue({
+      id: 'sys-rl-1',
+      status: 'pending',
+      description: '[Review Loop] Resolve and merge PR #17 for Widget',
+      dispatch: { started: false, reason: 'No available agent slots (3/3)' },
+    });
+
+    const response = await request(app).post('/api/apps/app-001/pull-requests/17/resolve');
+
+    expect(response.status).toBe(202);
+    expect(response.body).toMatchObject({
+      started: false,
+      queueReason: 'No available agent slots (3/3)',
+      task: { id: 'sys-rl-1', status: 'pending' },
+    });
+  });
+
+  // The service returns the already-queued task when the store rejects the write
+  // as a duplicate (the window between the route's own scan and the persist).
+  it('reports a duplicate the task store rejected', async () => {
+    spawnReviewLoopFollowUp.mockResolvedValue({
+      id: 'sys-rl-existing',
+      status: 'pending',
+      description: '[Review Loop] Resolve and merge PR #17 for Widget',
+      duplicate: true,
+    });
+
+    const response = await request(app).post('/api/apps/app-001/pull-requests/17/resolve');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({ duplicate: true, started: false, task: { id: 'sys-rl-existing' } });
   });
 
   it('keeps a forge-controlled title out of autonomous task instructions', async () => {

--- a/server/services/agentWorktreeCleanup.js
+++ b/server/services/agentWorktreeCleanup.js
@@ -17,7 +17,7 @@
 import { existsSync } from 'fs';
 import { join } from 'path';
 import { emitLog } from './cosEvents.js';
-import { addTask, updateTask } from './cos.js';
+import { addTask, forceSpawnTask, updateTask } from './cos.js';
 import * as git from './git.js';
 import { removeWorktree, classifyWorktreeDirt } from './worktreeManager.js';
 import { isTruthyMeta } from './agentState.js';
@@ -812,8 +812,29 @@ export async function releaseRetryHold({ agentId, task, success, agentMetadata }
  * The follow-up task uses an isolated worktree attached to the existing PR branch
  * through its canonical `reviewLoopPRBranch`, so it can fix-and-push without
  * trampling concurrent agents.
+ *
+ * `dispatch` decides WHO starts the task:
+ *   `'queue'`     (default) — the autonomous lane. The task is persisted and the
+ *                 ordinary `tasks:changed` dequeue picks it up, which is correct
+ *                 for a follow-up spawned by cleanup/prWatcher: the run that
+ *                 produced the PR was itself autonomous, so its continuation
+ *                 belongs under the CoS auto-run gate and daily action budget.
+ *   `'immediate'` — an explicit human action (the app PR page's "Resolve &
+ *                 merge"). The dequeue's Priority-2 tier only spawns
+ *                 auto-approved system tasks while CoS auto-run is in `execute`
+ *                 and under budget, so a queued follow-up would sit `pending`
+ *                 until the user pressed Run now on the task page — the whole
+ *                 point of the button was not having to. This suppresses the
+ *                 automatic dequeue and force-spawns the task instead (same path
+ *                 as that Run now button), reporting the outcome as `dispatch`.
+ *
+ * Returns the follow-up task, or — when an equivalent follow-up was already
+ * queued — that existing task with `duplicate: true`. `dispatch: 'immediate'`
+ * additionally stamps `dispatch: { started, reason }` so the caller can say
+ * whether an agent actually started or the task is still waiting (no slots,
+ * daemon stopped, …) rather than guessing.
  */
-export async function spawnReviewLoopFollowUp({ originalAgentId, originalTask, prUrl, prBranch, sourceWorkspace, prCompletion = PR_COMPLETIONS.REVIEW_THEN_MERGE, reviewers = DEFAULT_REVIEWERS, usernames = [], optionalReviewers = [], reviewerMaxRounds = {}, reviewStopMode = DEFAULT_REVIEW_STOP_MODE, reviewerApplies = false, reviewerModels = null, reviewerEfforts = null, leaveOpen = false }) {
+export async function spawnReviewLoopFollowUp({ originalAgentId, originalTask, prUrl, prBranch, sourceWorkspace, prCompletion = PR_COMPLETIONS.REVIEW_THEN_MERGE, reviewers = DEFAULT_REVIEWERS, usernames = [], optionalReviewers = [], reviewerMaxRounds = {}, reviewStopMode = DEFAULT_REVIEW_STOP_MODE, reviewerApplies = false, reviewerModels = null, reviewerEfforts = null, leaveOpen = false, dispatch = 'queue' }) {
   if (!prUrl || !prBranch) return null;
   if (prCompletion === PR_COMPLETIONS.LEAVE_OPEN) return null;
 
@@ -973,11 +994,44 @@ export async function spawnReviewLoopFollowUp({ originalAgentId, originalTask, p
     section: 'pending'
   };
 
-  await addTask(followUpTask, 'internal', { raw: true });
+  // An immediate dispatch owns the spawn, so the automatic dequeue is suppressed:
+  // otherwise it races this force-spawn for the same task and whichever loses
+  // reports a bogus failure for a run that did start (see the `suppressDequeue`
+  // contract on cos.js's `tasks:changed` listener).
+  const immediate = dispatch === 'immediate';
+  const persisted = await addTask(followUpTask, 'internal', { raw: true, suppressDequeue: immediate });
+
+  // A duplicate rejection persisted NOTHING under `followUpTaskId` — an equivalent
+  // follow-up is already queued under a different id. Return THAT record so a
+  // caller reports (and force-spawns) the task that actually exists instead of the
+  // id we just minted, which `forceSpawnTask` would answer with "Task not found".
+  if (persisted?.duplicate) {
+    emitLog('info', `🔁 ${kind.label} follow-up for PR ${prUrl} matched already-queued task ${persisted.id}`, {
+      taskId: persisted.id, prUrl, prBranch, sourceAgentId: originalAgentId, sourceTaskId: originalTask?.id
+    });
+    return persisted;
+  }
+
   emitLog('info', `🔁 Spawned ${kind.label} follow-up task ${followUpTaskId} (${kind.reviewers}) for PR ${prUrl}`, {
     taskId: followUpTaskId, prUrl, prBranch, sourceAgentId: originalAgentId, sourceTaskId: originalTask?.id
   });
-  return followUpTask;
+  if (!immediate) return followUpTask;
+
+  // A throw here would 500 an explicit user request whose task IS already
+  // persisted — report it the same way a refusal is reported instead.
+  const spawn = await forceSpawnTask(followUpTaskId).catch(err => ({ error: err.message }));
+  if (spawn?.error) {
+    // The task stays `pending` and keeps its place in the queue — say why it has
+    // not started rather than letting the caller claim an agent is running.
+    emitLog('warn', `⏳ ${kind.label} follow-up ${followUpTaskId} queued but not started — ${spawn.error}`, {
+      taskId: followUpTaskId, prUrl
+    });
+    return { ...followUpTask, dispatch: { started: false, reason: spawn.error } };
+  }
+  emitLog('info', `⚡ Started ${kind.label} follow-up ${followUpTaskId} immediately for PR ${prUrl}`, {
+    taskId: followUpTaskId, prUrl
+  });
+  return { ...followUpTask, dispatch: { started: true, reason: null } };
 }
 
 /**

--- a/server/services/cleanupAgentWorktree.test.js
+++ b/server/services/cleanupAgentWorktree.test.js
@@ -39,6 +39,7 @@ vi.mock('./cos.js', () => ({
   addTask: vi.fn().mockResolvedValue(undefined),
   emitLog: vi.fn(),
   getTaskById: vi.fn().mockResolvedValue(null),
+  forceSpawnTask: vi.fn().mockResolvedValue({ success: true }),
   getAgent: vi.fn().mockResolvedValue(null),
   getAgentRecord: vi.fn().mockResolvedValue(null)
 }));
@@ -227,7 +228,7 @@ import { existsSync as existsSyncMock } from 'fs';
 // They used to be pulled through the `subAgentSpawner.js` barrel, which was
 // retired in #3450.
 import { cleanupAgentWorktree, spawnMergeRecoveryTask, spawnReviewLoopFollowUp, resolveResumePointer, resolveTaskResumePatch, recordTaskResumePointer, releaseRetryHold, resumePointerMetadata } from './agentWorktreeCleanup.js';
-import { getAgent, getAgentRecord, getTaskById, addTask, updateTask } from './cos.js';
+import { getAgent, getAgentRecord, getTaskById, addTask, forceSpawnTask, updateTask } from './cos.js';
 import { removeWorktree } from './worktreeManager.js';
 import { PATHS } from '../lib/fileUtils.js';
 import * as git from './git.js';
@@ -657,7 +658,7 @@ describe('cleanupAgentWorktree - PR-creation path', () => {
     expect(addTask).toHaveBeenCalledTimes(1);
     const [followUp, taskType, opts] = addTask.mock.calls[0];
     expect(taskType).toBe('internal');
-    expect(opts).toEqual({ raw: true });
+    expect(opts).toEqual({ raw: true, suppressDequeue: false });
     expect(followUp.metadata.reviewLoopFollowUp).toBe(true);
     expect(followUp.metadata.reviewLoopPRUrl).toBe('https://github.com/test/repo/pull/42');
     expect(followUp.metadata.reviewLoopPRBranch).toBe('cos/task-abc123');
@@ -1640,6 +1641,7 @@ describe('spawnReviewLoopFollowUp', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     addTask.mockResolvedValue({ id: 'sys-rl-x' });
+    forceSpawnTask.mockResolvedValue({ success: true });
   });
 
   it('should not spawn when prUrl is missing', async () => {
@@ -1703,6 +1705,59 @@ describe('spawnReviewLoopFollowUp', () => {
       prUrl: 'https://github.com/o/r/pull/9', prBranch: 'cos/task-1/agent-1', sourceWorkspace: '/ws'
     });
     expect(addTask.mock.calls[0][0].metadata.app).toBe('example-app');
+  });
+
+  // Dispatch ownership: an autonomous follow-up belongs to the auto-run-gated
+  // dequeue, while an explicitly requested one must not wait for it.
+  it('leaves the spawn to the dequeue by default', async () => {
+    const result = await spawnReviewLoopFollowUp({
+      originalAgentId: 'agent-1',
+      originalTask: { id: 'task-1', metadata: {}, description: 'X' },
+      prUrl: 'https://github.com/o/r/pull/9', prBranch: 'cos/task-1/agent-1', sourceWorkspace: '/ws'
+    });
+    expect(addTask.mock.calls[0][2]).toMatchObject({ raw: true, suppressDequeue: false });
+    expect(forceSpawnTask).not.toHaveBeenCalled();
+    expect(result.dispatch).toBeUndefined();
+  });
+
+  it('force-spawns an immediate dispatch and suppresses the racing dequeue', async () => {
+    const result = await spawnReviewLoopFollowUp({
+      originalAgentId: null,
+      originalTask: { id: 'app-pr-widget-9', metadata: { app: 'widget' }, description: 'Resolve and merge PR #9 for Widget' },
+      prUrl: 'https://github.com/o/r/pull/9', prBranch: 'fix/save', sourceWorkspace: '/ws',
+      dispatch: 'immediate'
+    });
+    const [followUp, taskType, opts] = addTask.mock.calls[0];
+    expect(taskType).toBe('internal');
+    expect(opts).toMatchObject({ raw: true, suppressDequeue: true });
+    expect(forceSpawnTask).toHaveBeenCalledWith(followUp.id);
+    expect(result.dispatch).toEqual({ started: true, reason: null });
+  });
+
+  it('reports why an immediate dispatch did not start, leaving the task queued', async () => {
+    forceSpawnTask.mockResolvedValue({ error: 'No available agent slots (3/3)' });
+    const result = await spawnReviewLoopFollowUp({
+      originalAgentId: null,
+      originalTask: { id: 'app-pr-widget-9', metadata: { app: 'widget' }, description: 'Resolve and merge PR #9 for Widget' },
+      prUrl: 'https://github.com/o/r/pull/9', prBranch: 'fix/save', sourceWorkspace: '/ws',
+      dispatch: 'immediate'
+    });
+    expect(result.dispatch).toEqual({ started: false, reason: 'No available agent slots (3/3)' });
+  });
+
+  // A duplicate rejection persists nothing under the id we just minted, so
+  // force-spawning it would answer 'Task not found' for a follow-up that is in
+  // fact already queued. Report the record that exists instead.
+  it('returns the already-queued task on a duplicate rejection instead of force-spawning a phantom id', async () => {
+    addTask.mockResolvedValue({ id: 'sys-rl-existing', status: 'pending', duplicate: true });
+    const result = await spawnReviewLoopFollowUp({
+      originalAgentId: null,
+      originalTask: { id: 'app-pr-widget-9', metadata: { app: 'widget' }, description: 'Resolve and merge PR #9 for Widget' },
+      prUrl: 'https://github.com/o/r/pull/9', prBranch: 'fix/save', sourceWorkspace: '/ws',
+      dispatch: 'immediate'
+    });
+    expect(result).toMatchObject({ id: 'sys-rl-existing', duplicate: true });
+    expect(forceSpawnTask).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Summary

Pressing **Resolve & merge** on an app's Pull Requests tab queued the review-loop follow-up as an auto-approved *system* task and then left it to the CoS dequeue. That tier (`spawnDequeuePriority2AutoApproved`) only spawns system tasks while CoS auto-run is in `execute` **and** under its daily action budget — so on any other setting the task sat `pending` until it was started by hand from the task page, which is exactly what the button existed to avoid.

The click is the approval, so `/resolve` now dispatches the follow-up itself through the same force-spawn path as the task list's **Run now** button (`cos.forceSpawnTask`), suppressing the racing dequeue via `suppressDequeue` — the pattern `cosJobRoutes.js` already uses for a manually triggered job.

When the spawn genuinely can't proceed (no agent slots, daemon stopped/paused, runner unreachable) the task stays queued in place and the response reports the reason instead of claiming an agent is on it; the tab's toast then says *"Started an agent to…"* or names what it's waiting for.

Also fixes a related silent gap found while wiring this: a follow-up the task store rejected as a duplicate persisted nothing under the id the service had minted, so callers reported (and would have force-spawned) a task that did not exist. The service now returns the already-queued record with `duplicate: true`.

### Changes

- `server/services/agentWorktreeCleanup.js` — `spawnReviewLoopFollowUp` gains `dispatch: 'queue' | 'immediate'`. `queue` (default) keeps the autonomous lane exactly as it was; `immediate` suppresses the dequeue, force-spawns, and reports `dispatch: { started, reason }`. Duplicate rejections return the existing task.
- `server/routes/apps/pullRequests.js` — `/resolve` passes `dispatch: 'immediate'` and surfaces `started` + `queueReason` in the response.
- `client/src/components/apps/tabs/PullRequestsTab.jsx` — toast/tooltip/help text report what actually happened; a queued-but-not-started result gets the neutral toast with its reason.

Autonomous follow-ups (worktree cleanup, `prWatcher` escalation) are untouched — the run that produced their PR was itself autonomous, so its continuation stays under the auto-run gate and budget.

## Test plan

- `server/services/cleanupAgentWorktree.test.js` — default dispatch leaves the spawn to the dequeue (`suppressDequeue: false`, no force-spawn); immediate dispatch suppresses the dequeue and force-spawns the new task id; a refused spawn reports its reason with the task still queued; a duplicate rejection returns the queued record instead of force-spawning a phantom id.
- `server/routes/apps/pullRequests.test.js` — the route requests an immediate dispatch and reports `started: true`; a refused dispatch reports `started: false` + `queueReason`; a store-rejected duplicate is reported as such.
- `client/src/components/apps/tabs/PullRequestsTab.test.jsx` — "Started an agent…" on success; the waiting reason surfaced on the neutral toast with the row still showing Queued.
- Full server suite: 38,426 passed / 14 skipped. Full client suite: 10,161 passed / 2 skipped. `biome lint` clean.

https://claude.ai/code/session_01JErGn4inLCwQiWtXc99m2o