### PR TITLE
docs: mark port 5564 as assigned to slotstream in PORTS reserved ranges (#6031)

### DIFF
--- a/docs/PORTS.md
+++ b/docs/PORTS.md
@@ -132,7 +132,7 @@ PortOS automatically detects ports from env vars:
 | Range | Purpose |
 |-------|---------|
 | 5553-5561 | PortOS core services (includes the `:5553` loopback mirror and the `portos-db` Docker container on `:5561`) |
-| 5562-5569 | Reserved for PortOS extensions. Assigned: 5562 whisper, 5563 Eidoverse bridge (on demand), 5568 llama-server. Unassigned but still reserved: 5564-5567, 5569 |
+| 5562-5569 | Reserved for PortOS extensions. Assigned: 5562 whisper, 5563 Eidoverse bridge (on demand), 5564 slotstream (on demand), 5568 llama-server. Unassigned but still reserved: 5565-5567, 5569 |
 | 5570-5599 | User applications — **put managed apps here** |
 
 > **A collision inside `5553-5569` is silent, not loud.** The natural assumption is


### PR DESCRIPTION
## Summary

Fixes the `5562-5569` reserved-ranges summary in `docs/PORTS.md` (line 135), which incorrectly listed port 5564 as unassigned. Port 5564 is allocated to `portos-slotstream` (`SLOTSTREAM: 5564` in `ecosystem.config.cjs` and `server/lib/ports.js`, plus the port table and on-demand notes in the same document — overlooked when #5815 added slotstream). The summary now lists `5564 slotstream (on demand)` as assigned and narrows the unassigned range to `5565-5567, 5569`.

## Test plan

- Verified port 5564 against the canonical sources before editing: `SLOTSTREAM: 5564` in both `ecosystem.config.cjs` and `server/lib/ports.js`.
- `npm test -- lib/ports.test.js` (server workspace): 7 passed.
- Self-reviewed the diff: one line in `docs/PORTS.md`, no other files touched.
- Local reviewer (mtplx, low effort) returned no verdict — no model is configured for the mtplx reviewer in this environment. Recorded as review-blocked per swarm protocol.

Closes #6031
