### PR TITLE
docs: include required providerId in Execute AI Run curl example (#6030)

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -869,6 +869,7 @@ curl -X POST http://localhost:5555/api/apps \
 curl -X POST http://localhost:5555/api/runs \
   -H "Content-Type: application/json" \
   -d '{
+    "providerId": "claude-code",
     "prompt": "List all files in the current directory",
     "workspacePath": "/path/to/workspace"
   }'


### PR DESCRIPTION
## Summary

- `docs/API.md` "Execute AI Run" curl example now includes the required `"providerId"` field (`"claude-code"`, a real id from `server/lib/aiToolkit/defaults/providers.sample.json`; substitute any configured provider id from `GET /api/providers`).
- Verified against `server/lib/aiToolkit/routes/runs.js:34-36`, which rejects a missing `providerId` with HTTP 400. Docs-only change; no code touched.

Closes #6030

## Test plan

- Parsed the documented JSON payload — valid JSON with `providerId`, `prompt`, `workspacePath`.
- Ran `server/lib/aiToolkit/routes/runs.test.js` — 17/17 passed.
- `git diff --stat`: 1 file changed, 1 insertion (`docs/API.md`).
