### PR TITLE
fix: contain throwing onRunStarted hook in emitRunStarted so TUI PTY runs can't orphan (#6002)

### DIFF
--- a/server/services/runner.js
+++ b/server/services/runner.js
@@ -244,11 +244,16 @@ export async function resolveRunCwd({ runId, workspacePath, label, startTime = D
  * run tracking sees TUI runs as active.
  */
 export function emitRunStarted({ runId, provider, model }) {
-  runnerConfig.hooks?.onRunStarted?.({
-    runId,
-    provider: provider?.name || provider?.id,
-    model: model ?? provider?.defaultModel,
-  });
+  // Fire-and-forget lifecycle notification — a throwing hook must not take
+  // down the already-registered PTY run (same orphaned-run shape as #5792).
+  safeSettle(
+    () => runnerConfig.hooks?.onRunStarted?.({
+      runId,
+      provider: provider?.name || provider?.id,
+      model: model ?? provider?.defaultModel,
+    }),
+    `Run ${runId} onRunStarted hook`,
+  );
 }
 
 /**

--- a/server/services/runner.test.js
+++ b/server/services/runner.test.js
@@ -1205,6 +1205,25 @@ describe('emitRunStarted — payload-flattening contract', () => {
       model: 'gpt-4',
     })).not.toThrow();
   });
+
+  it('contains a throwing onRunStarted hook instead of rejecting the TUI spawn path (#6002)', () => {
+    // emitRunStarted fires after the PTY is already registered in the
+    // active-run map (tuiPromptRunner.js), so a throw here would reject the
+    // spawn with a live PTY and no terminal settlement — the same orphaned
+    // shape #5792 closed for the CLI path.
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    setAIToolkit(fakeToolkit(), {
+      dataDir: '/tmp/test-runner',
+      hooks: { onRunStarted: () => { throw new Error('tui started hook boom'); } },
+    });
+    expect(() => emitRunStarted({
+      runId: 'r-tui-throw',
+      provider: { name: 'codex', defaultModel: 'gpt-5' },
+      model: 'gpt-4o',
+    })).not.toThrow();
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('onRunStarted hook threw during recovery'));
+    errorSpy.mockRestore();
+  });
 });
 
 describe('executeCliRun — workspace validation (#3180)', () => {


### PR DESCRIPTION
## Summary
- Routes the `onRunStarted` hook call inside `emitRunStarted()` (`server/services/runner.js`) through the existing `safeSettle` wrapper, so a throwing hook is logged but can never reject the caller.
- `emitRunStarted` fires from the TUI spawn path (`server/services/tuiPromptRunner.js`) after the PTY is already registered in the active-run map; previously a hook throw rejected the spawn with a live PTY and no terminal settlement — the same orphaned-child shape #5792 closed for the CLI path.
- Signature and call site unchanged; payload-flattening logic untouched.

## Test plan
- New test in `server/services/runner.test.js` ("contains a throwing onRunStarted hook instead of rejecting the TUI spawn path (#6002)"): verified it **fails** against the unpatched helper (hook error propagates out of `emitRunStarted`) and **passes** with the fix (no throw, error logged via `safeSettle`).
- `npx vitest run services/runner.test.js services/tuiPromptRunner.test.js`: 139 passed.
- Full server suite (`cd server && npm test`): 1907 files passed / 1 skipped, 38487 tests passed / 24 skipped.

## Review note
- Local reviewer (mtplx, effort low) could not run: no model configured on the Settings → Code Reviewers page. Proceeding without a local-reviewer verdict; CI review requested instead.

Closes #6002
