### PR TITLE
Fix songbook transpose readout width collapsing mobile controls bar (#5999)

### DIFF
--- a/client/src/pages/SongBookViewer.jsx
+++ b/client/src/pages/SongBookViewer.jsx
@@ -945,7 +945,7 @@ export default function SongBookViewer() {
                 </button>
                 <span className="min-w-[3.5rem] text-center text-sm text-gray-300 font-mono" title="Transpose (semitones)" role="status" aria-live="polite" aria-atomic="true">
                   <span className="sr-only">Transpose </span>
-                  <span aria-hidden="true">{transpose > 0 ? `+${transpose}` : transpose}</span>
+                  <span>{transpose > 0 ? `+${transpose}` : transpose}</span>
                   <span className="sr-only"> semitones</span>
                 </span>
                 <button type="button" onClick={() => setTranspose(transpose + 1)} className={ctrlBtnClass} aria-label={`Transpose up (currently ${transpose > 0 ? '+' : ''}${transpose} semitones)`} title="Transpose up (])">

--- a/client/src/pages/SongBookViewer.jsx
+++ b/client/src/pages/SongBookViewer.jsx
@@ -944,7 +944,9 @@ export default function SongBookViewer() {
                   <Minus size={16} />
                 </button>
                 <span className="min-w-[3.5rem] text-center text-sm text-gray-300 font-mono" title="Transpose (semitones)" role="status" aria-live="polite" aria-atomic="true">
-                  Transpose {transpose > 0 ? `+${transpose}` : transpose} semitones
+                  <span className="sr-only">Transpose </span>
+                  <span aria-hidden="true">{transpose > 0 ? `+${transpose}` : transpose}</span>
+                  <span className="sr-only"> semitones</span>
                 </span>
                 <button type="button" onClick={() => setTranspose(transpose + 1)} className={ctrlBtnClass} aria-label={`Transpose up (currently ${transpose > 0 ? '+' : ''}${transpose} semitones)`} title="Transpose up (])">
                   <Plus size={16} />

--- a/client/src/pages/SongBookViewer.test.jsx
+++ b/client/src/pages/SongBookViewer.test.jsx
@@ -379,7 +379,7 @@ E|--3-----|`;
       expect(screen.getByRole('button', { name: /Transpose up \(currently 0 semitones\)/ })).toBeTruthy();
       // Visible offset stays numeric-only so the control keeps its compact width (#5999).
       const transposeStatus = statuses.find((status) => status.textContent === 'Transpose 0 semitones');
-      expect(transposeStatus.querySelector('[aria-hidden="true"]').textContent).toBe('0');
+      expect(transposeStatus.querySelector('span:not(.sr-only)').textContent).toBe('0');
 
       fireEvent.click(screen.getByRole('button', { name: /Transpose up \(currently 0/ }));
       expect(screen.getAllByRole('status').some((status) => status.textContent === 'Transpose +1 semitones')).toBe(true);

--- a/client/src/pages/SongBookViewer.test.jsx
+++ b/client/src/pages/SongBookViewer.test.jsx
@@ -377,6 +377,9 @@ E|--3-----|`;
       const statuses = screen.getAllByRole('status');
       expect(statuses.some((status) => status.textContent === 'Transpose 0 semitones')).toBe(true);
       expect(screen.getByRole('button', { name: /Transpose up \(currently 0 semitones\)/ })).toBeTruthy();
+      // Visible offset stays numeric-only so the control keeps its compact width (#5999).
+      const transposeStatus = statuses.find((status) => status.textContent === 'Transpose 0 semitones');
+      expect(transposeStatus.querySelector('[aria-hidden="true"]').textContent).toBe('0');
 
       fireEvent.click(screen.getByRole('button', { name: /Transpose up \(currently 0/ }));
       expect(screen.getAllByRole('status').some((status) => status.textContent === 'Transpose +1 semitones')).toBe(true);


### PR DESCRIPTION
## Summary
The Transpose live-region in `SongBookViewer` rendered the full 21-character sentence (`Transpose +1 semitones`) visibly, expanding to ~176px inside a `min-w-[3.5rem]` box and forcing the mobile (375px) controls bar into 4–5 wrapped rows. The visible readout now renders only the numeric offset (`0`, `+1`, `-2`) while the words "Transpose"/"semitones" move into `sr-only` child spans, so the control fits inline and the `role="status"` element's `textContent` still reads `Transpose 0 semitones` for assistive tech and existing tests.

One deviation from the issue's suggested snippet: the numeric span intentionally has **no** `aria-hidden` — hiding it would drop the number from the accessible name under `aria-atomic="true"`, so screen readers would announce only "Transpose semitones". Keeping it in the tree preserves the full announcement and the same `textContent`.

## Test plan
- `cd client && npx vitest run src/pages/SongBookViewer.test.jsx` — 66/66 pass, including the existing live-region assertions (`textContent === 'Transpose 0 semitones'` / `'Transpose +1 semitones'`) and a new assertion that the visible non-`sr-only` span renders the numeric offset (`0`).
- Local reviewer `mtplx` (low effort, 1 round): raised the `aria-hidden` announcement gap above; addressed, re-tested green.

Closes #5999
