### PR TITLE
docs: fix ARCHITECTURE.md directory tree (GOALS.md / GOALS_OPERATIONAL.md location)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -103,8 +103,6 @@ PortOS/
 │   ├── browser-config.json    # Browser CDP/health configuration
 │   ├── TASKS.md               # User task file
 │   ├── COS-TASKS.md           # System task file
-│   ├── GOALS.md               # Repository mission and goals
-│   ├── docs/GOALS_OPERATIONAL.md # Operational CoS goals
 │   ├── cos/                   # CoS state and agents
 │   │   ├── state.json         # Daemon state
 │   │   └── agents/            # Agent outputs
@@ -145,7 +143,9 @@ PortOS/
 │   └── agent-personalities/   # Agent personality configs
 │
 ├── docs/                      # Documentation
+│   └── GOALS_OPERATIONAL.md   # Operational CoS goals
 ├── .github/workflows/         # CI/CD
+├── GOALS.md                   # Repository mission and goals
 └── ecosystem.config.cjs       # PM2 configuration
 ```
 


### PR DESCRIPTION
## Summary
- Fixes #6032
- `docs/ARCHITECTURE.md`'s directory tree listed `GOALS.md` and `docs/GOALS_OPERATIONAL.md` as if they lived under `data/`. Neither does: `GOALS.md` is at the repo root, `docs/GOALS_OPERATIONAL.md` is under `docs/`.
- Corrected the tree to match the real layout. Checked the rest of the repo for other stale references to these paths under `data/` — none found.

## Test plan
- Documentation-only change, verified by direct filesystem inspection against what's written (`GOALS.md` at root, `docs/GOALS_OPERATIONAL.md` under `docs/`, no `data/GOALS.md` or `data/docs/GOALS_OPERATIONAL.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)