### PR TITLE
docs: fix app-wizard.md template list and scaffold endpoints table

### DIFF
--- a/docs/features/app-wizard.md
+++ b/docs/features/app-wizard.md
@@ -31,7 +31,7 @@ Scaffold a new project from template:
 ### Steps
 
 1. **Basic Info**: Name, description
-2. **Template**: Select template (vite+express, node-server, static)
+2. **Template**: Select template (portos-stack, vite-express, vite-react, express-api, ios-native, xcode-multiplatform)
 3. **Location**: Parent directory for new repo
 4. **Ports**: Allocate from available range
 5. **Git Setup**:
@@ -57,6 +57,8 @@ Scaffold a new project from template:
 | POST /api/apps | Register existing app |
 | POST /api/scaffold | Create new app from template |
 | GET /api/scaffold/templates | List available templates |
+| GET /api/scaffold/directories | Browse directories for the location picker |
+| POST /api/scaffold/templates/create | Create an app from a template (user-friendly wrapper around POST /api/scaffold) |
 | POST /api/detect/port | Detect process on port |
 | POST /api/detect/repo | Validate repo path, detect type |
 


### PR DESCRIPTION
## Summary
- Fixes #6033
- `docs/features/app-wizard.md` listed templates (`vite+express`, `node-server`, `static`) that no longer match `SCAFFOLD_TEMPLATES` in `server/lib/validation.js`, so following the docs to pick a template name fails validation in `POST /api/scaffold`.
- Updated the template list to the 6 real templates (`portos-stack`, `vite-express`, `vite-react`, `express-api`, `ios-native`, `xcode-multiplatform`) and added the 2 scaffold endpoints missing from the table (`GET /api/scaffold/directories`, `POST /api/scaffold/templates/create`), cross-checked against `server/routes/scaffold.js`.

## Test plan
- `cd server && npx vitest run routes/scaffold.test.js lib/validation.test.js` → 301/301 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)