### PR TITLE
test: fix ~3% flake in resetGitWorktreeSandbox worktree-listing assertion

### DIFF
--- a/server/lib/gitTestRepo.test.js
+++ b/server/lib/gitTestRepo.test.js
@@ -182,9 +182,15 @@ describe('resetGitWorktreeSandbox', () => {
 
     await resetGitWorktreeSandbox(dest, initialHead);
 
+    // Parse porcelain into worktree entries and assert only `dest` itself
+    // remains, rather than substring-matching 'wt-a'/'wt-b' against the raw
+    // listing — that substring can coincidentally appear inside dest's own
+    // random mkdtemp() suffix (~3.2% chance per prefix) and false-fail (#6059).
+    // Counting entries also sidesteps comparing absolute paths directly,
+    // which git can respell on Windows (see the assertPath test above, #6003).
     const listing = (await execGit(['worktree', 'list', '--porcelain'], dest)).stdout;
-    expect(listing).not.toContain('wt-a');
-    expect(listing).not.toContain('wt-b');
+    const worktreeEntries = listing.split(/\r?\n/).filter((line) => line.startsWith('worktree '));
+    expect(worktreeEntries).toHaveLength(1);
     expect((await execGit(['branch', '--format=%(refname:short)'], dest)).stdout.trim()).toBe('main');
     expect((await execGit(['rev-parse', 'HEAD'], dest)).stdout.trim()).toBe(initialHead);
   });


### PR DESCRIPTION
## Summary
- Fixes #6059
- The `resetGitWorktreeSandbox` test asserted `.not.toContain('wt-a'/'wt-b')` against the raw `git worktree list --porcelain` output, which always includes the parent sandbox's own entry. When that entry's random `mkdtemp()` suffix happens to start with the same letter as a child worktree's differentiator, the substring coincidentally appears inside the parent's own path and the assertion false-fails (~3.2% chance per prefix).
- Replaced the substring check with a parse of the porcelain output into worktree entries — mirroring the parsing `resetGitWorktreeSandbox` itself already does in `gitTestRepo.js` (which drops the first entry as always being the parent) — and asserts exactly 1 entry remains. This sidesteps both the collision and comparing full paths directly, which git can respell on Windows (see the `assertPath` test in this same file, #6003).

## Test plan
- `cd server && npx vitest run lib/gitTestRepo.test.js` → 10/10 passed.
- Forced the exact collision deterministically with a standalone script (parent sandbox created at a path ending in `wt-b-XXXXXX`): confirmed the old substring assertion fails in that scenario and the new entry-count assertion does not — proof the fix removes the flake rather than passing by luck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)