### PR TITLE
test: fix flaky BrowseTab Save-button query racing the Edit transition

### DIFF
--- a/client/src/components/wiki/tabs/BrowseTab.test.jsx
+++ b/client/src/components/wiki/tabs/BrowseTab.test.jsx
@@ -104,11 +104,16 @@ describe('BrowseTab iCloud force save', () => {
     renderTab();
     fireEvent.click(screen.getByText('Example Source'));
     fireEvent.click(await screen.findByRole('button', { name: 'Edit' }));
+    // Clicking Edit swaps the button row for the Save/Cancel pair — under
+    // full-suite contention that re-render doesn't always land before the
+    // next synchronous query runs, so wait for it here rather than assuming
+    // it's already mounted at every clickSave() call site (#6051).
+    await screen.findByRole('button', { name: /Save/ });
   };
 
   const clickSave = async () => {
     const before = api.updateNote.mock.calls.length;
-    fireEvent.click(screen.getByRole('button', { name: /Save/ }));
+    fireEvent.click(await screen.findByRole('button', { name: /Save/ }));
     await waitFor(() => expect(api.updateNote.mock.calls.length).toBe(before + 1));
   };
 


### PR DESCRIPTION
## Summary
- `openEditor` and `clickSave` in `BrowseTab.test.jsx` used synchronous `getByRole`/`getByText` queries immediately after a `fireEvent.click` that triggers an async state transition (Edit → editable form with a Save button).
- Under full-suite CPU contention (multiple jsdom workers) this occasionally ran before React committed the new state, even though it reliably passed in isolation — a classic React Testing Library race, not a bug in the component itself (`BrowseTab.jsx`'s Edit→Save transition is a plain synchronous `setState`).
- Both helpers now `await screen.findByRole(...)` instead of a bare `getBy*`, so the query itself waits for the transition to settle.

## Test plan
- [x] `client/src/components/wiki/tabs/BrowseTab.test.jsx` — 8/8, re-run 5x for stability, plus the whole `wiki/` directory together

🤖 Generated with [Claude Code](https://claude.com/claude-code)