### PR TITLE
stop the CoS runner rebuilding OpenCode's config from an identity-only provider view

### DIFF
--- a/server/lib/cliChildEnv.js
+++ b/server/lib/cliChildEnv.js
@@ -120,6 +120,18 @@ function claudeLocalEnvDefaults(provider) {
  * @returns {object} a fresh object holding only these layers
  */
 export function composeProviderEnv({ before = null, provider = null, model = null, extra = null, safetyProfile = null } = {}) {
+  // `authOnly` marks an identity-only view of a provider — `cliProviderAuthDescriptor`'s
+  // `{ id, command, <local marker> }`, with no `envVars`, `models`, `defaultModel`,
+  // or `thinking`. It exists so the CoS runner can keep that provider's ambient
+  // auth allowlist (`buildSafeCliBaseEnv`, which still receives it); it is NOT a
+  // record to generate env from. Every generator below sits ABOVE `before` in
+  // layer order, so running one on a partial view overwrites the complete value
+  // PortOS already composed and POSTed. That is how a runner-owned OpenCode
+  // agent lost its declared-models map: rebuilt empty from the descriptor,
+  // `--model ollama/<id>` stopped resolving, and OpenCode silently fell back to
+  // the first model in its own catalog (a hosted OpenCode Zen model) instead of
+  // the local model the run was dispatched with.
+  if (provider?.authOnly) return { ...(before || {}), ...(extra || {}) };
   return {
     ...(before || {}),
     ...claudeLocalEnvDefaults(provider),

--- a/server/lib/cliChildEnv.test.js
+++ b/server/lib/cliChildEnv.test.js
@@ -549,7 +549,31 @@ describe('buildCliChildEnv — per-call-site composition', () => {
     });
   });
 
+  it('cos-runner/index.js: an auth-only descriptor never regenerates a layer over the POSTed delta', () => {
+    // The full two-hop shape every runner-owned spawn really takes: PortOS
+    // composes the delta from the FULL provider record, then POSTs it alongside
+    // `cliProviderAuthDescriptor`'s identity-only view. Regenerating any layer
+    // from that partial view lands ABOVE `before`, so it replaces the complete
+    // value with a worse one — the OpenCode config rebuilt with an empty models
+    // map, which stops `--model ollama/<id>` resolving and drops the run onto
+    // OpenCode's own catalog. Asserted on the composed env, not on one key, so
+    // a future generative layer added to composeProviderEnv is covered too.
+    const envVars = composeProviderEnv({ provider: OLLAMA_OPENCODE, model: 'qwen3-coder:30b' });
+    const env = buildCliChildEnv({
+      baseEnv: { PATH: '/usr/bin' },
+      before: envVars,
+      provider: cliProviderAuthDescriptor(OLLAMA_OPENCODE),
+      cwd: '/workspace',
+    });
+
+    expect(declaredModels(env)).toContain('qwen3-coder:30b');
+    expect(env).toEqual({ ...envVars, PATH: '/usr/bin', PWD: '/workspace' });
+  });
+
   it('retains ambient auth for the selected provider when the runner supplies its descriptor', () => {
+    // The descriptor's other half: inert for composition (above), but still the
+    // input `buildSafeCliBaseEnv` picks the ambient-auth allowlist from — which
+    // is the whole reason the runner is POSTed one.
     const provider = { id: 'codex', command: 'codex', envVars: { OPENAI_API_KEY: 'not serialized' } };
     const env = buildCliChildEnv({
       baseEnv: { PATH: '/usr/bin', OPENAI_API_KEY: 'ambient-key' },

--- a/server/lib/processEnv.js
+++ b/server/lib/processEnv.js
@@ -72,6 +72,15 @@ const LOCAL_PROVIDER_MARKERS = ['ollamaBacked', 'mtplxBacked', 'llamaBacked', 'v
  * in another process. Provider envVars are deliberately excluded: those may
  * contain credentials and are already carried separately when explicitly
  * configured.
+ *
+ * The result is stamped `authOnly` because it is a PARTIAL view — an identity,
+ * not a provider record. Its consumer (the CoS runner) hands it to
+ * `buildCliChildEnv`, which feeds `provider` to two different contracts:
+ * `buildSafeCliBaseEnv`, which wants exactly this identity, and
+ * `composeProviderEnv`, which otherwise treats it as authoritative and
+ * regenerates every per-provider env layer from it. Regenerating from a partial
+ * view over an already-composed delta produces a WORSE value that still wins by
+ * layer order — see the `authOnly` short-circuit in `cliChildEnv.js`.
  */
 export function cliProviderAuthDescriptor(provider) {
   if (!provider || typeof provider !== 'object') return null;
@@ -81,7 +90,7 @@ export function cliProviderAuthDescriptor(provider) {
   for (const marker of LOCAL_PROVIDER_MARKERS) {
     if (provider[marker] === true) descriptor[marker] = true;
   }
-  return Object.keys(descriptor).length ? descriptor : null;
+  return Object.keys(descriptor).length ? { ...descriptor, authOnly: true } : null;
 }
 
 function cliProviderAuthRule(provider) {


### PR DESCRIPTION
## Summary

**Every runner-owned OpenCode agent was silently running on a hosted OpenCode Zen model instead of the local model it was dispatched with.** Reported against `agent-eac37dd4`, which was launched on `opencode-ollama-tui` / `qwen3-coder:30b` and ran on Zen's default.

The cause is a second, non-idempotent env-composition pass over a partial provider view:

- PortOS composes the CLI child-env delta from the **full** provider record and POSTs it to the CoS runner as `before`, alongside `cliProviderAuthDescriptor`'s identity-only view — `{ id, command, ollamaBacked }`, no `envVars`, no `models`, no `defaultModel`.
- The runner re-runs `buildCliChildEnv` with that partial view as `provider`. Every generative layer in `composeProviderEnv` sits **above** `before`, so the rebuild overwrote the complete value it was layered onto.
- For an OpenCode wrapper that meant `OPENCODE_CONFIG_CONTENT` rebuilt with an **empty** models map. `--model ollama/<id>` then resolved to nothing, and OpenCode fell back to the first model in its own catalog rather than failing — so the run looked healthy while answering from the wrong model.

Reproduced directly: with the good config, `opencode models` lists the ten `ollama/*` ids; with the rebuilt one it lists only the hosted `opencode/*` catalog.

The fix is at the seam, not in the OpenCode builder. `cliProviderAuthDescriptor` now stamps `authOnly: true`, and `composeProviderEnv` short-circuits on it — an identity-only view contributes no env at all. `buildSafeCliBaseEnv` still receives the descriptor, since selecting that provider's ambient-auth allowlist is the whole reason it is POSTed. Guarding here rather than inside `buildOpencodeEnvVars` also covers the next generative layer added to `composeProviderEnv`, instead of special-casing the one symptom that surfaced.

Both runner call sites (`/spawn` and `/spawn-tui`) are fixed by the same change, so headless runner-CLI OpenCode agents were affected too, not just the TUI path.

## Test plan

- New `cliChildEnv.test.js` case drives the real two-hop shape — compose from the full record, then re-layer with the descriptor — and asserts the whole composed env equals the POSTed delta (plus `PATH`/`PWD`), so a future generative layer is covered rather than just `OPENCODE_CONFIG_CONTENT`. Verified it **fails** without the fix.
- The pre-existing ambient-auth test is kept as the descriptor's other half: inert for composition, still the input the auth allowlist is picked from.
- Full server suite: 1917 files / 38708 tests passing.