### PR TITLE
fix: classify a fork by owner alone, so renaming it doesn't disable fork detection

### DIFF
--- a/server/lib/gitRemote.js
+++ b/server/lib/gitRemote.js
@@ -151,10 +151,13 @@ export function classifyOriginRemote(originUrl, {
   const ownerMatchesUpstream = parsed.owner.toLowerCase() === upstreamOwner.toLowerCase();
   const repoMatchesUpstream = parsed.repo.toLowerCase() === upstreamRepo.toLowerCase();
   const isUpstream = isGithub && ownerMatchesUpstream && repoMatchesUpstream;
-  // Strict fork: same repo name, different owner, on GitHub. A renamed
-  // GitHub repo (different name) doesn't count — `gh repo sync` would fail
-  // and the fork-aware UI would mislead the user.
-  const isFork = isGithub && repoMatchesUpstream && !ownerMatchesUpstream;
+  // Fork: different owner than upstream, on GitHub — regardless of repo name.
+  // A renamed fork (`<owner>/PortOS` -> `<owner>/PortOS-Fork`) still IS the
+  // PortOS checkout; requiring the name to match `repoMatchesUpstream` made
+  // `isFork` silently go false on rename, taking the fork panel, the
+  // sync-fork route, and the divergence check with it while `git`/`gh repo
+  // sync` kept working fine through GitHub's slug redirect (#5931).
+  const isFork = isGithub && !ownerMatchesUpstream;
 
   return {
     hasOrigin: true,

--- a/server/lib/gitRemote.test.js
+++ b/server/lib/gitRemote.test.js
@@ -193,15 +193,27 @@ describe('getOriginInfo', () => {
     });
   });
 
-  it('does NOT classify as fork when the repo name differs (renamed/unrelated)', async () => {
-    // Someone might fork-and-rename, or point origin at an unrelated GitHub
-    // repo. Treating that as a fork would invoke `gh repo sync` and fail.
+  it('classifies as fork by owner alone, regardless of repo name (#5931)', async () => {
+    // A fork renamed on GitHub (`<owner>/PortOS` -> `<owner>/PortOS-Fork`) still IS the
+    // PortOS checkout — GitHub's slug redirect keeps `git`/`gh repo sync` working, and a
+    // strict repo-name match silently dropped the fork panel, the sync-fork route, and
+    // the divergence check the moment someone renamed. The tradeoff: an origin genuinely
+    // unrelated to PortOS also classifies as a fork now — an acceptable false positive
+    // whose failure mode is a clear `gh repo sync` error, not four silently missing
+    // features.
     execGit.mockResolvedValue({ stdout: 'git@github.com:alice/MyCustomOS.git\n', stderr: '', exitCode: 0 });
     const info = await getOriginInfo();
     expect(info.isGithub).toBe(true);
-    expect(info.isFork).toBe(false);
+    expect(info.isFork).toBe(true);
     expect(info.isUpstream).toBe(false);
     expect(info.fullName).toBe('alice/MyCustomOS');
+  });
+
+  it('classifies a renamed fork of PortOS itself as a fork', async () => {
+    execGit.mockResolvedValue({ stdout: 'git@github.com:alice/PortOS-Fork.git\n', stderr: '', exitCode: 0 });
+    const info = await getOriginInfo();
+    expect(info.isFork).toBe(true);
+    expect(info.isUpstream).toBe(false);
   });
 
   it('classifies upstream even when origin URL carries a port', async () => {


### PR DESCRIPTION
## Summary
- `classifyOriginRemote()` required both a different owner AND a matching repo name to classify an origin as a fork (`server/lib/gitRemote.js`).
- Renaming a fork on GitHub (`<owner>/PortOS` -> `<owner>/PortOS-Fork`) silently flips `isFork` to `false` — `git`/`gh repo sync` keep working through GitHub's slug redirect, but the fork panel, `POST /api/update/sync-fork`, the `FORK_SYNC_REQUIRED` update guard, and the divergence check all disappear with no warning.
- Drops the repo-name requirement: `isFork = isGithub && !ownerMatchesUpstream`. Any GitHub origin under an owner other than upstream now classifies as a fork.
- Tradeoff accepted deliberately, per the issue: a genuinely unrelated GitHub origin also classifies as a fork now — its failure mode is a clear `gh repo sync` error, not four silently missing features.

## Test plan
- [x] `gitRemote.test.js` — updated the case that used to assert `isFork: false` for a differently-named repo under a different owner (now `true`, matching the new intended behavior), added a renamed-fork-of-PortOS case.
- [x] `npx vitest run lib/gitRemote.test.js routes/update.test.js services/updateChecker.test.js services/updatePreflightParity.test.js` — 128/128 passing, no regressions in the four downstream consumers the issue named.

Closes #5931

🤖 Generated with [Claude Code](https://claude.com/claude-code)