### PR TITLE
wrap the CoS task card action rail below the body on phones

### DIFF
--- a/client/src/components/cos/tabs/TaskItem.jsx
+++ b/client/src/components/cos/tabs/TaskItem.jsx
@@ -402,7 +402,12 @@ export default function TaskItem({ task, agent = null, isSystem, spawning = fals
           : requiresApproval ? 'border-yellow-500/50' : 'border-port-border'
       }`}
     >
-      <div className="flex items-start gap-3">
+      {/* The icon rail and the task body cannot share a row on a phone: up to
+          five 44px targets leave the body ~120px wide, so the task id breaks a
+          few characters per line and every badge lands on its own row. The
+          16rem basis on the body is what forces the rail onto its own wrapped
+          line under `sm`; `sm:flex-nowrap` puts them back on one row above it. */}
+      <div className="flex items-start gap-3 flex-wrap sm:flex-nowrap">
         {/* Drag handle - only show for user tasks. */}
         {dragHandleProps && !isSystem && (
           <button
@@ -430,9 +435,9 @@ export default function TaskItem({ task, agent = null, isSystem, spawning = fals
         >
           {statusIcons[displayStatus]}
         </button>
-        <div className="flex-1 min-w-0">
+        <div className="flex-1 basis-64 min-w-0">
           <div className="flex items-center gap-2 mb-1 flex-wrap">
-            <span className="text-sm font-mono text-gray-500">{task.id}</span>
+            <span className="text-sm font-mono text-gray-500 min-w-0 break-words">{task.id}</span>
             {task.metadata?.app && apps?.find(a => a.id === task.metadata.app)?.name && (
               <span className="px-1.5 py-0.5 text-xs bg-port-accent/20 text-port-accent rounded shrink-0" title={task.metadata.app}>
                 {apps.find(a => a.id === task.metadata.app).name}
@@ -733,7 +738,7 @@ export default function TaskItem({ task, agent = null, isSystem, spawning = fals
         {/* Action buttons. Keep the delete confirmation here, next to the trash
             icon, rather than at the bottom of the card — a task with a lot of
             context would otherwise push the confirm row far below the fold. */}
-        <div className="flex items-center gap-2 shrink-0">
+        <div className="flex flex-wrap items-center justify-end gap-1 sm:gap-2 shrink-0 ml-auto">
           {!editing && (
             isConfirming(task.id) ? (
               <ConfirmButtonPair

--- a/client/src/components/cos/tabs/TaskItem.jsx
+++ b/client/src/components/cos/tabs/TaskItem.jsx
@@ -405,8 +405,13 @@ export default function TaskItem({ task, agent = null, isSystem, spawning = fals
       {/* The icon rail and the task body cannot share a row on a phone: up to
           five 44px targets leave the body ~120px wide, so the task id breaks a
           few characters per line and every badge lands on its own row. The
-          16rem basis on the body is what forces the rail onto its own wrapped
-          line under `sm`; `sm:flex-nowrap` puts them back on one row above it. */}
+          rail's `basis-full` under `sm` is what drops it onto its own wrapped
+          line, leaving the handle, the status glyph and the body together on the
+          first; `sm:basis-auto` + `sm:flex-nowrap` put them back on one row above
+          it. Sizing the BODY instead (a `basis-64` that pushes the rail off the
+          line) reads the same at 390px but strands the two 16px glyphs alone on
+          row 1 once they no longer fit beside it — at 360px and below, and at
+          390px on any row that also carries a drag handle. */}
       <div className="flex items-start gap-3 flex-wrap sm:flex-nowrap">
         {/* Drag handle - only show for user tasks. */}
         {dragHandleProps && !isSystem && (
@@ -435,7 +440,7 @@ export default function TaskItem({ task, agent = null, isSystem, spawning = fals
         >
           {statusIcons[displayStatus]}
         </button>
-        <div className="flex-1 basis-64 min-w-0">
+        <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2 mb-1 flex-wrap">
             <span className="text-sm font-mono text-gray-500 min-w-0 break-words">{task.id}</span>
             {task.metadata?.app && apps?.find(a => a.id === task.metadata.app)?.name && (
@@ -738,7 +743,7 @@ export default function TaskItem({ task, agent = null, isSystem, spawning = fals
         {/* Action buttons. Keep the delete confirmation here, next to the trash
             icon, rather than at the bottom of the card — a task with a lot of
             context would otherwise push the confirm row far below the fold. */}
-        <div className="flex flex-wrap items-center justify-end gap-1 sm:gap-2 shrink-0 ml-auto">
+        <div className="flex flex-wrap items-center justify-end gap-1 sm:gap-2 shrink-0 ml-auto basis-full sm:basis-auto">
           {!editing && (
             isConfirming(task.id) ? (
               <ConfirmButtonPair


### PR DESCRIPTION
## Summary

The task cards on Chief of Staff → Tasks were unusable on a phone: the five 44px action targets and the task body shared one flex row, leaving the body ~120px wide. The task id broke a few characters per line, every badge (`PortOS`, `~4m`, `50%`, `AUTO`) landed on its own row, and both clamped text blocks showed two truncated fragments.

- The action rail now carries `basis-full sm:basis-auto`, so under `sm` it wraps onto its own full-width line (right-aligned) while the drag handle, status glyph, and body stay together on the first.
- `sm:flex-nowrap` on the row keeps the desktop layout exactly as it was.
- The task id gets `min-w-0 break-words` so an id with no hyphens can't overflow the card.

Measured in Chrome: at a 390px viewport the body goes from ~120px to 252px wide (280px on a system task, which has no drag handle); 700px and 1200px are byte-identical to before.

Sizing the *body* instead (a `basis-64` that pushes the rail off the line) reads the same at 390px but strands the two 16px glyphs alone on row 1 at 360px and below — caught by the agy review pass and covered by the comment above the row.

## Test plan

- `client`: `src/components/cos` — 42 files / 567 tests pass
- `client`: `responsiveGridConventions.test.js`, `popoverClampConventions.test.js` pass
- `biome lint --error-on-warnings` clean on the changed file
- Layout verified in headless Chrome at 320 / 360 / 390 / 430 / 500 / 639 / 700 / 1200px, with and without a drag handle: the rail wraps below `sm` at every width, the handle and status glyph never orphan, and the row is unchanged at `sm` and above