### PR TITLE
drop print-only flags from the attachable Claude review argv

### DIFF
--- a/server/lib/providerVendors.js
+++ b/server/lib/providerVendors.js
@@ -590,6 +590,38 @@ const CLAUDE_PUBLIC_REVIEW_ACTIONS_ARGS = [
   ...CLAUDE_PUBLIC_REVIEW_COMMON_ARGS,
 ];
 
+// Flags Claude Code accepts ONLY alongside `--print`, mapped to whether they
+// consume the following argv entry as their value. The posture arrays above are
+// written for the headless launch, so an attachable (`tui: true`) recipe has to
+// drop them — the CLI refuses to start at all otherwise:
+//
+//   Error: --no-session-persistence can only be used with --print mode.
+//
+// That is a 3-second exit(1) before the prompt is ever pasted, and it burned all
+// three retries of a Stage 3 pr-reviewer run. Worse, the only thing in the PTY
+// transcript by then was the shell's echo of the argv, so the failure analyzer
+// classified the run off `--mcp-config '{"mcpServers":{}}'` and filed "MCP server
+// error" for what was a flag-compatibility bug (agent-a12b1837).
+//
+// Filtered rather than conditionally spread so a print-only flag added to ANY
+// posture set is dropped for the attachable recipe automatically.
+const CLAUDE_PRINT_ONLY_ARGS = new Map([
+  ['--no-session-persistence', false],
+  ['--output-format', true],
+]);
+
+function dropPrintOnlyArgs(args) {
+  const kept = [];
+  for (let i = 0; i < args.length; i += 1) {
+    if (!CLAUDE_PRINT_ONLY_ARGS.has(args[i])) {
+      kept.push(args[i]);
+      continue;
+    }
+    if (CLAUDE_PRINT_ONLY_ARGS.get(args[i])) i += 1; // also skip its value
+  }
+  return kept;
+}
+
 const claudePublicReviewSpawnArgsFor = (postureArgs) => (provider, ctx) => claudePublicReviewArgs(postureArgs, provider, ctx);
 
 function claudePublicReviewArgs(postureArgs, provider, {
@@ -600,7 +632,7 @@ function claudePublicReviewArgs(postureArgs, provider, {
 } = {}) {
   const providerId = provider?.id || 'claude-code';
   const args = [
-    ...postureArgs,
+    ...(tui ? dropPrintOnlyArgs(postureArgs) : postureArgs),
     ...(tui ? [] : ['--print', '--output-format', 'stream-json', '--verbose', '--include-partial-messages']),
   ];
   if (systemPromptFile) args.push('--append-system-prompt-file', systemPromptFile);
@@ -645,7 +677,8 @@ const CLAUDE = {
       spawnArgs: claudePublicReviewSpawnArgsFor(CLAUDE_PUBLIC_REVIEW_ACTIONS_ARGS),
       matchProvider: matchClaudeBinary,
       // The only posture/vendor pairing that may run as an ATTACHABLE session.
-      // `claudePublicReviewArgs` drops only the headless output flags for
+      // `claudePublicReviewArgs` drops only the flags that REQUIRE `--print`
+      // (the headless output set plus CLAUDE_PRINT_ONLY_ARGS) for
       // `tui: true`; every enforcement flag above (`--permission-mode
       // acceptEdits`, the `--settings` sandbox JSON, `--disallowedTools`, and
       // the shared no-MCP/no-chrome/no-slash-command set) is still emitted, so
@@ -888,7 +921,8 @@ export function supportsPublicReviewActionsProvider(provider) {
  * declares none, which is fine for a `--print` child and useless in a PTY. An
  * interactive session requires a recipe that has been reviewed for it and says
  * so with `tui: true` — the recipe still owns the argv (`spawnArgs(provider,
- * { ...ctx, tui: true })`), it just drops the headless output flags.
+ * { ...ctx, tui: true })`), it just drops the flags that only work under
+ * `--print`.
  *
  * `no-tool` is structurally excluded: an interactive session for a reasoner
  * with no tools buys nothing and widens the boundary for free, so no row

--- a/server/lib/providerVendors.publicReview.test.js
+++ b/server/lib/providerVendors.publicReview.test.js
@@ -313,7 +313,7 @@ describe('public-review provider postures', () => {
 
   // #6062 — Stage 3 may run as an ATTACHABLE session so an operator can watch
   // and steer the longest, least predictable stage in the pipeline. `tui: true`
-  // is a per-recipe opt-in, and it drops ONLY the headless output flags.
+  // is a per-recipe opt-in, and it drops ONLY the flags that require `--print`.
   it('keeps every Claude actions enforcement flag when the recipe is built for a TUI session', () => {
     const claudeTui = { id: 'claude-tui', type: 'tui', command: 'claude', args: ['--dangerously-skip-permissions'] };
     const headless = buildVendorSpawnConfig(claudeTui, {
@@ -333,7 +333,7 @@ describe('public-review provider postures', () => {
       '--settings', headless.args[headless.args.indexOf('--settings') + 1],
       '--disallowedTools', 'WebFetch,WebSearch',
       '--strict-mcp-config', '--mcp-config', '{"mcpServers":{}}',
-      '--no-chrome', '--no-session-persistence', '--disable-slash-commands',
+      '--no-chrome', '--disable-slash-commands',
       '--model', 'sonnet',
     ]));
     // Nothing inside the session can lift the sandbox: the only lever is
@@ -343,13 +343,17 @@ describe('public-review provider postures', () => {
     // A saved skip-permissions arg is still ignored — provider.args is never
     // forwarded on this path, headless or attachable.
     expect(tui.args).not.toContain('--dangerously-skip-permissions');
-    // …and ONLY the headless output flags are gone.
-    expect(headless.args).toEqual(expect.arrayContaining(['--print', '--output-format', 'stream-json', '--verbose', '--include-partial-messages']));
-    for (const flag of ['--print', '--output-format', 'stream-json', '--verbose', '--include-partial-messages']) {
+    // …and ONLY the flags that require `--print` are gone. `--no-session-persistence`
+    // is in the SHARED posture set rather than the headless output block, and
+    // leaving it on the attachable argv made the CLI exit(1) at parse time
+    // ("can only be used with --print mode") — three seconds in, before the
+    // prompt was pasted, on every retry of a Stage 3 pr-reviewer run.
+    const printOnly = ['--print', '--output-format', 'stream-json', '--verbose', '--include-partial-messages', '--no-session-persistence'];
+    expect(headless.args).toEqual(expect.arrayContaining(printOnly));
+    for (const flag of printOnly) {
       expect(tui.args).not.toContain(flag);
     }
-    expect(headless.args.filter((a) => !['--print', '--output-format', 'stream-json', '--verbose', '--include-partial-messages'].includes(a)))
-      .toEqual(tui.args);
+    expect(headless.args.filter((a) => !printOnly.includes(a))).toEqual(tui.args);
   });
 
   it('declares attachability per recipe, and never for the tool-free postures', () => {

--- a/server/services/agentErrorAnalysis.js
+++ b/server/services/agentErrorAnalysis.js
@@ -196,6 +196,35 @@ export const ERROR_PATTERNS = [
       suggestedFix: 'The CLI failed while loading its own config (for codex, `~/.codex/config.toml`), before the prompt was read — every retry fails the same way until the file parses. Check it for a syntax error or a key this CLI version no longer accepts.'
     })
   },
+  {
+    // The CLI rejected the ARGV PortOS built, before reading the prompt — a flag
+    // that is unknown, or (the common one) legal only in another mode. Same Tier
+    // 1 blast radius as a bad config file: every retry dies identically in a few
+    // seconds, so it belongs up here with the other pre-prompt rejections.
+    //
+    // Registering it also stops a subtler failure. A TUI run that dies this
+    // early has NOTHING in its transcript but the shell's echo of the argv, so
+    // the loose sweep below classifies the run off PortOS's own launch flags —
+    // `--mcp-config '{"mcpServers":{}}'` filed a Stage 3 pr-reviewer run as
+    // "MCP server error" three times running while the real line, one row down,
+    // read `--no-session-persistence can only be used with --print mode`
+    // (agent-a12b1837). The flag name is echoed because it is PortOS-authored
+    // argv, never user data.
+    pattern: /(?:^|\n|\bError:\s*)(--[a-z0-9][a-z0-9-]*)\s+(?:can only be used with\s+([^\n]{1,80})|is (?:not a known|an unknown|not a valid)[^\n]{0,60})/i,
+    category: 'cli-config-invalid',
+    actionable: true,
+    origin: 'runner', // fully structured — the CLI's own argv rejection
+    escalation: 'Correct the flag set PortOS builds for this provider/posture in server/lib/providerVendors.js, then approve the retry.',
+    extract: (match) => {
+      const flag = match[1];
+      const requires = redactFailureSnippet(match[2] || '').replace(/[.,;]+$/, '').slice(0, CONFIG_EXPECTED_MAX_CHARS);
+      return {
+        message: `Provider CLI rejected the flag ${flag}`,
+        suggestedFix: `The CLI exited while parsing its arguments, before the prompt was delivered, so every retry fails identically.${requires ? ` It reports that \`${flag}\` only works with ${requires}.` : ''} PortOS builds this argv itself — fix the posture/vendor recipe in server/lib/providerVendors.js (an attachable \`tui: true\` recipe must drop every flag that requires \`--print\`), not the provider record.`,
+        rejectedCliFlag: flag
+      };
+    }
+  },
 
   // ===== API & Authentication Errors =====
   {
@@ -509,7 +538,18 @@ export const ERROR_PATTERNS = [
     }
   },
   {
-    pattern: /MCP.?(?:server|connection|error)|mcp.?(?:failed|timeout)/i,
+    // `MCP` as a standalone WORD followed by error prose on the same line. The
+    // previous shape — `MCP.?(?:server|connection|error)` — treated `.` as "any
+    // character", so it matched the `"mcpServers"` key inside the empty
+    // `--mcp-config '{"mcpServers":{}}'` object PortOS puts on every Claude
+    // public-review argv. That is the OPPOSITE of an MCP failure (it is how
+    // PortOS says "load no MCP servers at all"), and a run that died before
+    // producing anything but its own echoed command line was filed as an MCP
+    // outage three times running (agent-a12b1837). So: `\b…\b` rejects
+    // `mcpServers`, the `(?![-\w])` rejects the `--mcp-config` /
+    // `--strict-mcp-config` flag spellings, and the lookahead demands actual
+    // failure prose nearby rather than a mere mention.
+    pattern: /\bmcp\b(?![-\w])(?=[^\n]{0,120}\b(?:error|errored|failed|failure|unavailable|disconnected|refused|crashed|timed out|timeout|not (?:available|running|found|connected))\b)/i,
     category: 'mcp-error',
     actionable: false,
     extract: () => ({

--- a/server/services/agentErrorAnalysis.test.js
+++ b/server/services/agentErrorAnalysis.test.js
@@ -206,6 +206,45 @@ describe('analyzeAgentFailure — ERROR_PATTERNS classification', () => {
     expect(analysis.actionable).toBe(true);
   });
 
+  // Real incident (agent-a12b1837): the attachable Stage 3 pr-reviewer recipe
+  // carried `--no-session-persistence`, which Claude Code accepts only under
+  // `--print`. The CLI exited at argv-parse time — three seconds in, before the
+  // prompt was pasted — so the ONLY thing in the PTY transcript was the shell's
+  // echo of PortOS's own launch command, and the loose MCP sweep classified the
+  // run off `--mcp-config '{"mcpServers":{}}'` as an "MCP server error". Three
+  // retries, three bogus diagnoses. Both halves are asserted here: the flag
+  // rejection is recognised, and the echoed argv alone is not an MCP failure.
+  it('classifies a CLI argv rejection as cli-config-invalid and names the flag', () => {
+    const echoedArgv = "claude --permission-mode acceptEdits --settings '{\"sandbox\":{\"enabled\":true}}' "
+      + "--disallowedTools 'WebFetch,WebSearch' --strict-mcp-config --mcp-config '{\"mcpServers\":{}}' "
+      + '--no-chrome --no-session-persistence --disable-slash-commands --model qwen3-coder:30b --bare; exit $?';
+    const output = [echoedArgv, 'Error: --no-session-persistence can only be used with --print mode.'].join('\n');
+
+    const analysis = analyzeAgentFailure(output, { id: 't' }, 'qwen3-coder:30b', { completionReason: 'shell-exit' });
+
+    expect(analysis.category).toBe('cli-config-invalid');
+    expect(analysis.actionable).toBe(true);
+    expect(analysis.origin).toBe('runner');
+    expect(analysis.rejectedCliFlag).toBe('--no-session-persistence');
+    expect(analysis.suggestedFix).toContain('--print mode');
+    expect(analysis.suggestedFix).toContain('providerVendors.js');
+  });
+
+  it('does not read PortOS\'s own empty --mcp-config argv as an MCP outage', () => {
+    // The echoed launch line WITHOUT the rejection under it — nothing here is a
+    // failure, so it must fall through to the generic bucket rather than being
+    // filed as an MCP server error off the `"mcpServers"` key or the flag names.
+    const echoedArgv = "claude --strict-mcp-config --mcp-config '{\"mcpServers\":{}}' --no-chrome "
+      + '--disable-slash-commands --model qwen3-coder:30b --bare; exit $?';
+
+    expect(analyzeAgentFailure(withLead(echoedArgv), { id: 't' }, 'x').category).not.toBe('mcp-error');
+  });
+
+  it('still classifies a genuine MCP server failure', () => {
+    const analysis = analyzeAgentFailure(withLead('MCP server "notes" failed to connect: connection refused'), { id: 't' }, 'x');
+    expect(analysis.category).toBe('mcp-error');
+  });
+
   it('classifies a 404 model-not-found error as actionable', () => {
     const analysis = analyzeAgentFailure(withLead('API Error: 404 - model: claude-4-ultra not found'), { id: 't' }, 'claude-4-ultra');
     expect(analysis.category).toBe('model-not-found');

--- a/server/services/agentTuiSpawning.js
+++ b/server/services/agentTuiSpawning.js
@@ -236,8 +236,8 @@ export function buildTuiSpawnConfig(provider, model, {
   // generic assembly below — that path forwards `provider.args` and applies
   // `applyCommandDefaults`, either of which can hand a contributor-controlled
   // review a saved `--dangerously-skip-permissions`. `tui: true` tells the
-  // recipe to drop only its headless output flags and keep every enforcement
-  // flag. Fail closed when the pairing declares no attachable recipe: the
+  // recipe to drop only the flags that require `--print` and keep every
+  // enforcement flag. Fail closed when the pairing declares no attachable recipe: the
   // caller is supposed to have asked `supportsTuiPublicReviewPosture` first, so
   // reaching this is a routing bug and must not silently open a PTY whose
   // posture is decorative.


### PR DESCRIPTION
## Summary

The Stage 3 pr-reviewer agent failed three times in a row with a bogus `mcp-error` diagnosis. Two independent bugs:

- **Real cause**: the attachable (`tui: true`) Claude sandboxed-actions recipe kept `--no-session-persistence`, which Claude Code accepts only under `--print`. The CLI exited(1) at argv-parse time — three seconds in, before the prompt was ever pasted — so every retry died identically. `claudePublicReviewArgs` now filters a declared print-only set for the attachable recipe, so a print-only flag added to any posture array is dropped automatically.
- **Why it was misdiagnosed**: with nothing in the PTY transcript but the shell's echo of PortOS's own launch command, the failure analyzer's `mcp-error` sweep matched `--mcp-config '{"mcpServers":{}}'`. Its `MCP.?(?:server|…)` shape treated `.` as any character, so the `"mcpServers"` key — PortOS saying "load **no** MCP servers" — read as an MCP outage.

Two analyzer changes so this class diagnoses itself:

- A CLI argv rejection (`--flag can only be used with --print mode`, unknown-flag wording) is now `cli-config-invalid` alongside the config-load rejections — same pre-prompt blast radius, same Tier 1 fix — and names the flag plus the recipe file to edit.
- The `mcp-error` pattern requires `MCP` as a standalone word with failure prose nearby, so neither `mcpServers` nor the `--mcp-config` / `--strict-mcp-config` flag spellings can match.

## Test plan

- `analyzeAgentFailure` re-run against the real failing transcript now returns `cli-config-invalid` / "Provider CLI rejected the flag --no-session-persistence" instead of "MCP server error".
- New regression tests in `agentErrorAnalysis.test.js`: the argv rejection is classified and names the flag; the echoed launch line alone is not an MCP outage; a genuine MCP server failure still classifies.
- `providerVendors.publicReview.test.js` updated — `--no-session-persistence` joins the set the attachable recipe drops, and the exact set-difference assertion still pins that nothing else is lost.
- Full server suite green: 1927 files, 38917 tests.