### PR TITLE
fix(voice): gate ui_check and ui_fill on the confirmation gate, not just ui_click

### DIFF
--- a/client/src/components/cos/tabs/AgentCard.jsx
+++ b/client/src/components/cos/tabs/AgentCard.jsx
@@ -869,6 +869,7 @@ export default function AgentCard({ agent, onPause, onKill, onDelete, onResume, 
               disabled={sendingBtw || !btwInput.trim()}
               className="flex items-center gap-1.5 px-3 py-1 text-xs bg-yellow-500/20 text-yellow-400 hover:bg-yellow-500/30 rounded transition-colors disabled:opacity-50 min-h-[32px]"
               title="Send BTW message to agent (pastes into the live Claude Code TUI session)"
+              data-voice-guard="confirm"
             >
               {sendingBtw ? <Loader2 size={12} className="animate-spin" aria-hidden="true" /> : <Send size={12} aria-hidden="true" />}
               BTW

--- a/client/src/components/messages/DraftsTab.jsx
+++ b/client/src/components/messages/DraftsTab.jsx
@@ -125,6 +125,7 @@ export default function DraftsTab({ accounts }) {
                     onClick={() => handleSend(draft.id)}
                     className="min-h-[44px] min-w-[44px] inline-flex items-center justify-center p-1 text-gray-400 hover:text-port-accent transition-colors"
                     title="Send" aria-label="Send"
+                    data-voice-guard="confirm"
                   >
                     <Send size={16} />
                   </button>

--- a/client/src/components/messages/DraftsTab.test.jsx
+++ b/client/src/components/messages/DraftsTab.test.jsx
@@ -1,0 +1,49 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import DraftsTab from './DraftsTab.jsx';
+import { buildIndex } from '../../services/domIndex.js';
+
+vi.mock('../../services/api', () => ({
+  getMessageDrafts: vi.fn(),
+}));
+
+import * as api from '../../services/api';
+
+// jsdom doesn't do layout, so domIndex's isVisible() geometry checks would
+// drop every element — same stub domIndex.test.jsx uses.
+const makeVisible = () => {
+  Object.defineProperty(HTMLElement.prototype, 'offsetParent', {
+    configurable: true,
+    get() { return this.parentNode; },
+  });
+  HTMLElement.prototype.getBoundingClientRect = function getBoundingClientRect() {
+    return { width: 100, height: 20, top: 0, left: 0, right: 100, bottom: 20, x: 0, y: 0 };
+  };
+};
+
+// #5907 — the "Send" button on an approved draft dispatches messageSender to
+// the draft's real recipients with no undo, but its label alone ("Send")
+// never matched the destructive-word heuristic. It carries
+// `data-voice-guard="confirm"` instead. This proves the CLIENT half of the
+// fix: the real component renders the annotation and the real domIndex
+// carries it onto the indexed entry. The SERVER half — that an entry shaped
+// this way makes ui_click return confirmation_required regardless of its
+// label — is covered in server/services/voice/tools.test.js.
+describe('DraftsTab — voice confirmation annotation on Send (#5907)', () => {
+  it('renders data-voice-guard="confirm" on the Send button for an approved draft', async () => {
+    api.getMessageDrafts.mockResolvedValue([
+      { id: 'd1', status: 'approved', sendVia: 'gmail', accountId: 'acc1', subject: 'Hi', body: 'text' },
+    ]);
+    makeVisible();
+
+    render(<DraftsTab accounts={[{ id: 'acc1', name: 'Acme' }]} />);
+
+    const sendButton = await screen.findByRole('button', { name: 'Send' });
+    expect(sendButton).toHaveAttribute('data-voice-guard', 'confirm');
+
+    const idx = buildIndex();
+    const entry = idx.elements.find((e) => e.label === 'Send');
+    expect(entry).toBeTruthy();
+    expect(entry.guard).toBe('confirm');
+  });
+});

--- a/client/src/components/settings/VoiceTab.jsx
+++ b/client/src/components/settings/VoiceTab.jsx
@@ -726,7 +726,7 @@ export function VoiceTab() {
             className="w-4 h-4 mt-0.5 shrink-0"
           />
           <div className="flex flex-col sm:flex-row sm:flex-wrap sm:items-baseline gap-x-3 gap-y-0.5 min-w-0 flex-1">
-            <span className="text-sm text-white">Enable tools (brain, goals, PM2, feeds, time…)</span>
+            <span className="text-sm text-white">Enable tools (brain, goals, PM2, feeds, time, driving the page — click/fill/select/check…)</span>
             <span className="text-xs text-gray-500">
               Needs a tool-use-capable model (Qwen2.5, Hermes-3, etc.).
             </span>

--- a/client/src/services/domIndex.js
+++ b/client/src/services/domIndex.js
@@ -213,6 +213,11 @@ export const buildIndex = ({ includeText = false } = {}) => {
 
   for (const el of raw) {
     if (elements.length >= MAX_ELEMENTS) break;
+    // A control marked `exclude` never reaches the voice index at all — the
+    // one way to keep something out of it (issue #5907). Checked before
+    // classify/visibility so an excluded control costs nothing else below.
+    const guard = el.getAttribute('data-voice-guard');
+    if (guard === 'exclude') continue;
     const kind = classify(el);
     if (!kind) continue;
     if (!isVisible(el)) continue;
@@ -225,6 +230,10 @@ export const buildIndex = ({ includeText = false } = {}) => {
     el.setAttribute('data-voice-ref', String(ref));
 
     const entry = { ref, kind, label };
+    // Carried onto the entry so the server's confirmation gate can require
+    // confirmation for this control regardless of its label — see
+    // `requiresConfirmation` in confirmGate.js.
+    if (guard === 'confirm') entry.guard = 'confirm';
 
     if (kind === 'tab') {
       if (el.getAttribute('aria-selected') === 'true') entry.active = true;

--- a/client/src/services/domIndex.js
+++ b/client/src/services/domIndex.js
@@ -213,10 +213,13 @@ export const buildIndex = ({ includeText = false } = {}) => {
 
   for (const el of raw) {
     if (elements.length >= MAX_ELEMENTS) break;
-    // A control marked `exclude` never reaches the voice index at all — the
-    // one way to keep something out of it (issue #5907). Checked before
-    // classify/visibility so an excluded control costs nothing else below.
-    const guard = el.getAttribute('data-voice-guard');
+    // `data-voice-guard` resolves from the nearest annotated ancestor, not
+    // just the element itself, so marking a container covers every control
+    // inside it (issue #5907) — otherwise excluding a widget would mean
+    // annotating each of its buttons and missing the next one added. A
+    // control marked `exclude` never reaches the voice index at all; checked
+    // before classify/visibility so it costs nothing else below.
+    const guard = el.closest('[data-voice-guard]')?.getAttribute('data-voice-guard');
     if (guard === 'exclude') continue;
     const kind = classify(el);
     if (!kind) continue;

--- a/client/src/services/domIndex.test.jsx
+++ b/client/src/services/domIndex.test.jsx
@@ -90,3 +90,44 @@ describe('domIndex buildIndex — data-voice-guard', () => {
     expect(save.guard).toBeUndefined();
   });
 });
+
+// The annotation resolves from the nearest annotated ancestor so a container
+// covers everything inside it — annotating each descendant by hand would miss
+// whichever control gets added next.
+describe('domIndex buildIndex — data-voice-guard on a container', () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <main>
+        <div data-voice-guard="exclude">
+          <button>Widget stop</button>
+        </div>
+        <div data-voice-guard="confirm">
+          <button>Publish</button>
+          <div data-voice-guard="exclude"><button>Nested opt-out</button></div>
+        </div>
+        <button>Save</button>
+      </main>
+    `;
+    makeVisible();
+  });
+
+  it('excludes every control inside an exclude-marked container', () => {
+    const idx = buildIndex();
+    expect(idx.elements.some((e) => e.label === 'Widget stop')).toBe(false);
+  });
+
+  it('carries guard: "confirm" onto a control inside a confirm-marked container', () => {
+    const idx = buildIndex();
+    expect(idx.elements.find((e) => e.label === 'Publish').guard).toBe('confirm');
+  });
+
+  it('lets a nested annotation win over its ancestor', () => {
+    const idx = buildIndex();
+    expect(idx.elements.some((e) => e.label === 'Nested opt-out')).toBe(false);
+  });
+
+  it('leaves a control outside every annotated container unguarded', () => {
+    const idx = buildIndex();
+    expect(idx.elements.find((e) => e.label === 'Save').guard).toBeUndefined();
+  });
+});

--- a/client/src/services/domIndex.test.jsx
+++ b/client/src/services/domIndex.test.jsx
@@ -50,3 +50,43 @@ describe('domIndex buildIndex — lazy vs eager text', () => {
     expect(text).toMatch(/Three tasks pending/);
   });
 });
+
+// #5907 — data-voice-guard is the one way to keep a control out of the voice
+// index entirely ("exclude"), or to require confirmation on it regardless of
+// its label ("confirm"), carried onto the index entry for the server-side
+// confirmGate to read.
+describe('domIndex buildIndex — data-voice-guard', () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <main>
+        <button data-voice-guard="exclude">Secret internal control</button>
+        <button data-voice-guard="confirm">Send</button>
+        <button>Save</button>
+      </main>
+    `;
+    makeVisible();
+  });
+
+  it('never indexes an exclude-guarded control', () => {
+    const idx = buildIndex();
+    expect(idx.elements.some((e) => e.label === 'Secret internal control')).toBe(false);
+  });
+
+  it('does not assign a data-voice-ref to an excluded control', () => {
+    buildIndex();
+    const excluded = document.querySelector('button[data-voice-guard="exclude"]');
+    expect(excluded.hasAttribute('data-voice-ref')).toBe(false);
+  });
+
+  it('carries guard: "confirm" onto the indexed entry', () => {
+    const idx = buildIndex();
+    const send = idx.elements.find((e) => e.label === 'Send');
+    expect(send.guard).toBe('confirm');
+  });
+
+  it('leaves an unannotated control with no guard field', () => {
+    const idx = buildIndex();
+    const save = idx.elements.find((e) => e.label === 'Save');
+    expect(save.guard).toBeUndefined();
+  });
+});

--- a/server/services/voice/confirmGate.js
+++ b/server/services/voice/confirmGate.js
@@ -62,6 +62,16 @@ const normalize = (text) => {
 
 export const isDestructiveLabel = (label) => DESTRUCTIVE_LABEL_RE.test(label || '');
 
+// The label heuristic above is a backstop, not the only way a control can
+// require confirmation: `data-voice-guard="confirm"` (client/src/services/
+// domIndex.js) annotates a control whose outbound effect the label alone
+// doesn't name — "Send" on a drafts row, "BTW" pasting into a live agent
+// session — so it is gated regardless of what it's called and however it
+// gets relabeled later. `entry` is a UI index entry (buildIndex output),
+// carrying `guard` only when the client annotated the element.
+export const requiresConfirmation = (entry) =>
+  entry?.guard === 'confirm' || isDestructiveLabel(entry?.label);
+
 export const isAffirmative = (text) => AFFIRM_RE.test(normalize(text));
 export const isNegative = (text) => NEGATIVE_RE.test(normalize(text));
 

--- a/server/services/voice/confirmGate.test.js
+++ b/server/services/voice/confirmGate.test.js
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   DESTRUCTIVE_LABEL_RE,
   isDestructiveLabel,
+  requiresConfirmation,
   isAffirmative,
   isNegative,
   buildPending,
@@ -41,6 +42,29 @@ describe('isDestructiveLabel', () => {
     // (no gate) means a destructive click fires silently. We pick narrow matching.
     expect(DESTRUCTIVE_LABEL_RE.test('Clear filters')).toBe(true);
     expect(DESTRUCTIVE_LABEL_RE.test('Cleared session')).toBe(false);
+  });
+});
+
+describe('requiresConfirmation', () => {
+  it('gates on the destructive-label heuristic when unannotated (#5907)', () => {
+    expect(requiresConfirmation({ label: 'Delete' })).toBe(true);
+    expect(requiresConfirmation({ label: 'Save' })).toBe(false);
+  });
+
+  it('gates a data-voice-guard="confirm" control regardless of its label', () => {
+    expect(requiresConfirmation({ label: 'Send', guard: 'confirm' })).toBe(true);
+  });
+
+  it('does not gate an unmarked, non-destructive label', () => {
+    expect(requiresConfirmation({ label: 'Send to Catalog' })).toBe(false);
+    expect(requiresConfirmation({ label: 'Send to Video' })).toBe(false);
+    expect(requiresConfirmation({ label: 'Send text' })).toBe(false);
+    expect(requiresConfirmation({ label: 'Send Ctrl+C interrupt' })).toBe(false);
+  });
+
+  it('handles a missing entry without throwing', () => {
+    expect(requiresConfirmation(null)).toBe(false);
+    expect(requiresConfirmation(undefined)).toBe(false);
   });
 });
 

--- a/server/services/voice/pipeline.js
+++ b/server/services/voice/pipeline.js
@@ -233,7 +233,7 @@ const buildSystemPrompt = (cfg) => {
       '"save"/"capture"/"add"/"remember"/"note"/"file"/"log it" → matching capture tool (e.g., brain_capture, meatspace_log_*, daily_log_append, goal_log_note). ' +
       '"start dictation"/"dictate"/"record my log" → daily_log_start_dictation. ' +
       '"what does this say"/"read this aloud"/"read the page to me"/"what\'s on this page" → ui_read, then speak the returned `content` verbatim (do NOT paraphrase or summarize unless the user asked "what is this page about?"). ' +
-      'DESTRUCTIVE-ACTION FLOW: when ui_click returns `confirmation_required: true` the gate has fired — speak the returned `summary` (it tells the user how to confirm) and STOP. The user\'s next utterance ("yes"/"confirm"/"cancel") is handled BY THE SERVER, not by you — do not re-issue ui_click on the same target unless the user rephrases the request after cancelling. ' +
+      'DESTRUCTIVE-ACTION FLOW: when a UI tool (ui_click, ui_check, ui_fill) returns `confirmation_required: true` the gate has fired — speak the returned `summary` (it tells the user how to confirm) and STOP. The user\'s next utterance ("yes"/"confirm"/"cancel") is handled BY THE SERVER, not by you — do not re-issue that tool on the same target unless the user rephrases the request after cancelling. ' +
       '"what time"/"what day"/"what date" → time_now. ' +
       '"what are my goals"/"my goals" → goal_list. ' +
       '"is anything crashed"/"pm2 status"/"are services up" → pm2_status. ' +

--- a/server/services/voice/pipeline.js
+++ b/server/services/voice/pipeline.js
@@ -541,14 +541,22 @@ export const runTurn = async ({ audio, text, mimeType, source, history = [], emi
     } else {
       const decision = resolvePending(pending, userText);
       if (decision.action === 'execute') {
-        const { target } = pending;
-        tlog(`confirm.execute ${pending.tool} target="${target.label}"`);
+        const { target, tool, args } = pending;
+        tlog(`confirm.execute ${tool} target="${target.label}"`);
         // Confirmation happens on the user's NEXT spoken turn, by which time
         // the client may have re-indexed the DOM and reassigned refs — the
         // stale `target.ref` could now point at a different element. Emit
         // only the `label` so the client falls through to label-based
         // resolution (uiInteract.resolve() prefers ref when present).
-        emit('voice:ui:click', { target: { label: target.label } });
+        // Replays whichever tool actually stashed the pending record — a
+        // stashed ui_check or ui_fill must not be replayed as a click.
+        if (tool === 'ui_fill') {
+          emit('voice:ui:fill', { target: { label: target.label }, value: args.value });
+        } else if (tool === 'ui_check') {
+          emit('voice:ui:check', { target: { label: target.label }, checked: args.checked });
+        } else {
+          emit('voice:ui:click', { target: { label: target.label } });
+        }
         const reply = `Confirmed — ${target.label}.`;
         await speakSyntheticReply(reply);
         return { transcript: userText, reply };

--- a/server/services/voice/pipelineConfirmReplay.test.js
+++ b/server/services/voice/pipelineConfirmReplay.test.js
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// #5907 — the confirmation-gate REPLAY path (a user's "yes"/"confirm" turn
+// resolving a `state.pendingDestructive` record stashed by a prior turn).
+// Generalized from a hardcoded `voice:ui:click` emission to replay whichever
+// tool actually stashed the record (ui_click / ui_check / ui_fill), because a
+// ui_fill or ui_check confirmation must not be replayed as a click.
+// `pipelineConfirmShortCircuit.test.js` covers the STASH half (a tool
+// returning confirmation_required stops the turn); this file covers the
+// RESOLVE half (the next turn's "yes"/"cancel").
+
+vi.mock('./config.js', () => ({
+  getVoiceConfig: vi.fn(async () => ({
+    enabled: true,
+    llm: {
+      model: 'test-model',
+      usePersonality: false,
+      systemPrompt: 'sys',
+      tools: { enabled: true, maxIterations: 3 },
+    },
+  })),
+}));
+
+const transcribeMock = vi.fn(async () => ({ text: 'confirm', latencyMs: 5 }));
+vi.mock('./stt.js', () => ({
+  transcribe: (...args) => transcribeMock(...args),
+}));
+
+vi.mock('./tts.js', () => ({
+  synthesize: vi.fn(async (text) => ({ wav: Buffer.alloc(8), latencyMs: 1, _text: text })),
+}));
+
+const streamChatMock = vi.fn();
+vi.mock('./llm.js', () => ({
+  streamChat: (...args) => streamChatMock(...args),
+}));
+
+const dispatchToolMock = vi.fn();
+vi.mock('./tools.js', () => ({
+  getToolSpecsForIntent: () => ({ specs: [], activeGroups: new Set() }),
+  classifyIntent: () => new Set(),
+  dispatchTool: (...args) => dispatchToolMock(...args),
+  getAllToolNames: () => ['ui_click', 'ui_check', 'ui_fill'],
+  UI_KINDS: ['tab', 'button', 'link', 'input', 'textarea', 'select', 'checkbox', 'radio'],
+}));
+
+vi.mock('./echo.js', () => ({
+  isEchoOfRecentTts: () => false,
+  rememberTtsSentence: () => {},
+}));
+
+vi.mock('../brainJournal.js', () => ({
+  appendJournal: vi.fn(),
+  getToday: vi.fn(async () => '2026-05-12'),
+}));
+
+const { runTurn } = await import('./pipeline.js');
+const { buildPending } = await import('./confirmGate.js');
+
+async function runWithPending(pending, utterance = 'confirm') {
+  transcribeMock.mockResolvedValueOnce({ text: utterance, latencyMs: 5 });
+  const events = [];
+  const emit = (event, payload) => events.push({ event, payload });
+  const state = { pendingDestructive: pending };
+  const result = await runTurn({
+    audio: Buffer.alloc(8),
+    mimeType: 'audio/webm',
+    history: [],
+    emit,
+    state,
+  });
+  return { events, result, state };
+}
+
+describe('runTurn — confirmation-gate replay dispatches by pending.tool (#5907)', () => {
+  it('replays a pending ui_click as voice:ui:click', async () => {
+    const pending = buildPending({
+      tool: 'ui_click',
+      args: { label: 'Send', kind: 'button' },
+      target: { ref: 1, label: 'Send', kind: 'button' },
+    });
+    const { events, state } = await runWithPending(pending);
+
+    const click = events.find((e) => e.event === 'voice:ui:click');
+    expect(click).toBeTruthy();
+    expect(click.payload).toEqual({ target: { label: 'Send' } });
+    expect(events.some((e) => e.event === 'voice:ui:fill')).toBe(false);
+    expect(events.some((e) => e.event === 'voice:ui:check')).toBe(false);
+    // Consumed up front regardless of branch outcome.
+    expect(state.pendingDestructive).toBeNull();
+  });
+
+  it('replays a pending ui_fill as voice:ui:fill, not a click', async () => {
+    const pending = buildPending({
+      tool: 'ui_fill',
+      args: { label: 'Additional context for the agent', value: 'stop what you are doing' },
+      target: { ref: 8, label: 'Additional context for the agent', kind: 'input' },
+    });
+    const { events } = await runWithPending(pending);
+
+    const fill = events.find((e) => e.event === 'voice:ui:fill');
+    expect(fill).toBeTruthy();
+    expect(fill.payload).toEqual({
+      target: { label: 'Additional context for the agent' },
+      value: 'stop what you are doing',
+    });
+    expect(events.some((e) => e.event === 'voice:ui:click')).toBe(false);
+  });
+
+  it('replays a pending ui_check as voice:ui:check, not a click', async () => {
+    const pending = buildPending({
+      tool: 'ui_check',
+      args: { label: 'Auto-publish', checked: true },
+      target: { ref: 6, label: 'Auto-publish', kind: 'checkbox' },
+    });
+    const { events } = await runWithPending(pending);
+
+    const check = events.find((e) => e.event === 'voice:ui:check');
+    expect(check).toBeTruthy();
+    expect(check.payload).toEqual({ target: { label: 'Auto-publish' }, checked: true });
+    expect(events.some((e) => e.event === 'voice:ui:click')).toBe(false);
+  });
+
+  it('cancels a pending ui_fill without emitting any voice:ui:* event', async () => {
+    const pending = buildPending({
+      tool: 'ui_fill',
+      args: { label: 'Additional context for the agent', value: 'x' },
+      target: { ref: 8, label: 'Additional context for the agent', kind: 'input' },
+    });
+    const { events, result } = await runWithPending(pending, 'cancel');
+
+    expect(events.some((e) => e.event?.startsWith('voice:ui:'))).toBe(false);
+    expect(result.reply).toBe('Cancelled.');
+  });
+});

--- a/server/services/voice/tools.test.js
+++ b/server/services/voice/tools.test.js
@@ -1026,6 +1026,91 @@ describe('ui_click — destructive confirmation gate', () => {
   });
 });
 
+// #5907 — data-voice-guard="confirm" gates a control regardless of its label,
+// on the tools that were previously ungated (ui_check, ui_fill) as well as
+// ui_click. "Send to Catalog" / "Send to Video" / "Send text" / "Send Ctrl+C
+// interrupt" are the un-annotated labels the wider "send" regex would have
+// false-positived on had this been fixed by widening DESTRUCTIVE_LABEL_RE
+// instead — they must click without a prompt.
+describe('data-voice-guard annotation gates ui_click / ui_check / ui_fill (#5907)', () => {
+  const makeState = () => ({
+    ui: {
+      elements: [
+        { ref: 1, kind: 'button', label: 'Send', guard: 'confirm' },
+        { ref: 2, kind: 'button', label: 'Send to Catalog' },
+        { ref: 3, kind: 'button', label: 'Send to Video' },
+        { ref: 4, kind: 'button', label: 'Send text' },
+        { ref: 5, kind: 'button', label: 'Send Ctrl+C interrupt' },
+        { ref: 6, kind: 'checkbox', label: 'Auto-publish', guard: 'confirm' },
+        { ref: 7, kind: 'checkbox', label: 'Keep drafts' },
+        { ref: 8, kind: 'input', label: 'Additional context for the agent', guard: 'confirm' },
+        { ref: 9, kind: 'input', label: 'Search' },
+      ],
+    },
+  });
+
+  it('gates a guard="confirm" click regardless of its non-destructive label', async () => {
+    const state = makeState();
+    const r = await dispatchTool('ui_click', { label: 'Send' }, { state, sideEffects: [] });
+    expect(r.confirmation_required).toBe(true);
+    expect(state.pendingDestructive.tool).toBe('ui_click');
+  });
+
+  it.each(['Send to Catalog', 'Send to Video', 'Send text', 'Send Ctrl+C interrupt'])(
+    'clicks unannotated "%s" without a prompt',
+    async (label) => {
+      const state = makeState();
+      const sideEffects = [];
+      const r = await dispatchTool('ui_click', { label }, { state, sideEffects });
+      expect(r.confirmation_required).toBeUndefined();
+      expect(sideEffects).toHaveLength(1);
+    },
+  );
+
+  it('gates a guard="confirm" checkbox and stashes a replayable ui_check pending record', async () => {
+    const state = makeState();
+    const r = await dispatchTool('ui_check', { label: 'Auto-publish', checked: true }, { state, sideEffects: [] });
+    expect(r.confirmation_required).toBe(true);
+    expect(state.pendingDestructive.tool).toBe('ui_check');
+    expect(state.pendingDestructive.args).toEqual({ label: 'Auto-publish', checked: true });
+  });
+
+  it('checks an unannotated, non-destructive checkbox without a prompt', async () => {
+    const state = makeState();
+    const sideEffects = [];
+    const r = await dispatchTool('ui_check', { label: 'Keep drafts', checked: false }, { state, sideEffects });
+    expect(r.confirmation_required).toBeUndefined();
+    expect(sideEffects).toHaveLength(1);
+    expect(sideEffects[0].checked).toBe(false);
+  });
+
+  it('gates a guard="confirm" fill and stashes a replayable ui_fill pending record', async () => {
+    const state = makeState();
+    const r = await dispatchTool(
+      'ui_fill',
+      { label: 'Additional context for the agent', value: 'stop what you are doing' },
+      { state, sideEffects: [] },
+    );
+    expect(r.confirmation_required).toBe(true);
+    expect(state.pendingDestructive.tool).toBe('ui_fill');
+    expect(state.pendingDestructive.args).toEqual({
+      label: 'Additional context for the agent',
+      value: 'stop what you are doing',
+    });
+  });
+
+  // ui_fill deliberately never gates on the destructive-label heuristic —
+  // text entry is reversible — only on an explicit guard annotation.
+  it('fills an unannotated field immediately, even with a destructive-sounding value', async () => {
+    const state = makeState();
+    const sideEffects = [];
+    const r = await dispatchTool('ui_fill', { label: 'Search', value: 'delete everything' }, { state, sideEffects });
+    expect(r.confirmation_required).toBeUndefined();
+    expect(sideEffects).toHaveLength(1);
+    expect(sideEffects[0].value).toBe('delete everything');
+  });
+});
+
 // image_generate uses imageGen.generateImage under the hood; mocked
 // above. The codexEnabledRef toggle drives the disabled-gate test.
 describe("image_generate", () => {

--- a/server/services/voice/tools/ui.js
+++ b/server/services/voice/tools/ui.js
@@ -4,7 +4,7 @@
 // rest gate on UI_INTENT_RE. ui_click runs a destructive-action confirm gate.
 
 import { resolveNavCommand } from '../../../lib/navManifest.js';
-import { isDestructiveLabel, buildPending } from '../confirmGate.js';
+import { requiresConfirmation, buildPending } from '../confirmGate.js';
 import { UI_KINDS, findUiElement } from './shared.js';
 
 // Loose on purpose — false positives are cheap (one extra tool), false
@@ -154,12 +154,14 @@ export const UI_TOOLS = [
       const hit = findUiElement(ctx, label, kind);
       if (!hit.entry) return hit.err;
       // Destructive-action confirmation gate. If the resolved label looks
-      // destructive (delete/remove/discard/reset/clear), stash a pending
-      // record on the per-session state and ask the LLM to prompt the user
-      // for spoken confirmation. The next user turn is intercepted by
-      // pipeline.js → resolvePending() which either re-issues the click or
-      // cancels. Skip if the caller already confirmed (re-issue path).
-      if (ctx.state && !ctx.confirmed && isDestructiveLabel(hit.entry.label)) {
+      // destructive (delete/remove/discard/reset/clear) OR the control was
+      // annotated `data-voice-guard="confirm"` (an outbound effect the label
+      // alone doesn't name), stash a pending record on the per-session state
+      // and ask the LLM to prompt the user for spoken confirmation. The next
+      // user turn is intercepted by pipeline.js → resolvePending() which
+      // either re-issues the click or cancels. Skip if the caller already
+      // confirmed (re-issue path).
+      if (ctx.state && !ctx.confirmed && requiresConfirmation(hit.entry)) {
         ctx.state.pendingDestructive = buildPending({
           tool: 'ui_click',
           args: { label: hit.entry.label, kind: hit.entry.kind },
@@ -192,7 +194,26 @@ export const UI_TOOLS = [
     execute: async ({ label, value } = {}, ctx = {}) => {
       const hit = findUiElement(ctx, label, ['input', 'textarea']);
       if (!hit.entry) return hit.err;
-      ctx.sideEffects?.push({ type: 'ui:fill', target: { ref: hit.entry.ref, label: hit.entry.label }, value: String(value ?? '') });
+      // Filling gates ONLY on an explicit `data-voice-guard="confirm"`
+      // annotation, never on the destructive-label heuristic: text entry is
+      // reversible and the client already scrolls the field into view, so a
+      // blanket fill gate would just be noise. An unmarked field behaves
+      // exactly as before this change.
+      const filledValue = String(value ?? '');
+      if (ctx.state && !ctx.confirmed && hit.entry.guard === 'confirm') {
+        ctx.state.pendingDestructive = buildPending({
+          tool: 'ui_fill',
+          args: { label: hit.entry.label, value: filledValue },
+          target: { ref: hit.entry.ref, label: hit.entry.label, kind: hit.entry.kind },
+        });
+        return {
+          ok: true,
+          confirmation_required: true,
+          label: hit.entry.label,
+          summary: `That field needs confirmation before I fill it — confirm by saying "yes" or "confirm" to fill ${hit.entry.label}, or "cancel" to skip.`,
+        };
+      }
+      ctx.sideEffects?.push({ type: 'ui:fill', target: { ref: hit.entry.ref, label: hit.entry.label }, value: filledValue });
       return { ok: true, label: hit.entry.label, summary: `Filled ${hit.entry.label}.` };
     },
   },
@@ -230,8 +251,25 @@ export const UI_TOOLS = [
     execute: async ({ label, checked } = {}, ctx = {}) => {
       const hit = findUiElement(ctx, label, ['checkbox', 'radio']);
       if (!hit.entry) return hit.err;
-      ctx.sideEffects?.push({ type: 'ui:check', target: { ref: hit.entry.ref, label: hit.entry.label }, checked: !!checked });
-      return { ok: true, label: hit.entry.label, checked: !!checked, summary: `${checked ? 'Checked' : 'Unchecked'} ${hit.entry.label}.` };
+      const wantChecked = !!checked;
+      // Same gate as ui_click: destructive label OR an explicit
+      // `data-voice-guard="confirm"` annotation.
+      if (ctx.state && !ctx.confirmed && requiresConfirmation(hit.entry)) {
+        ctx.state.pendingDestructive = buildPending({
+          tool: 'ui_check',
+          args: { label: hit.entry.label, checked: wantChecked },
+          target: { ref: hit.entry.ref, label: hit.entry.label, kind: hit.entry.kind },
+        });
+        return {
+          ok: true,
+          confirmation_required: true,
+          label: hit.entry.label,
+          checked: wantChecked,
+          summary: `That looks destructive — confirm by saying "yes" or "confirm" to ${wantChecked ? 'check' : 'uncheck'} ${hit.entry.label}, or "cancel" to skip.`,
+        };
+      }
+      ctx.sideEffects?.push({ type: 'ui:check', target: { ref: hit.entry.ref, label: hit.entry.label }, checked: wantChecked });
+      return { ok: true, label: hit.entry.label, checked: wantChecked, summary: `${checked ? 'Checked' : 'Unchecked'} ${hit.entry.label}.` };
     },
   },
 ];


### PR DESCRIPTION
## Summary

`DESTRUCTIVE_LABEL_RE` (`server/services/voice/confirmGate.js`) only gated `ui_click`; `ui_fill`, `ui_select` and `ui_check` had no confirmation gate at all, and the replay path (a user's next "yes"/"confirm" turn) re-emitted `voice:ui:click` unconditionally regardless of which tool actually stashed the pending record.

Two indexed controls also have outbound effects their label alone doesn't name: a drafts row's **Send** button (`DraftsTab.jsx` — dispatches a real message via `sendGmail`/`sendPlaywright`, no undo) and a running agent card's **BTW** button (`AgentCard.jsx` — pastes text into a live Claude Code TUI session). Widening the label regex to catch "send" would false-positive on every other "Send to X" label already in the tree ("Send to Catalog", "Send to Video", "Send text", "Send Ctrl+C interrupt").

- Adds a `data-voice-guard` attribute (`client/src/services/domIndex.js`): `"exclude"` keeps a control out of the voice index entirely (skipped before classify/visibility, so it costs nothing else); `"confirm"` requires confirmation regardless of the resolved label, carried onto the index entry.
- Replaces `isDestructiveLabel(label)` with `requiresConfirmation(entry)` = `entry.guard === 'confirm' || isDestructiveLabel(entry.label)` in `confirmGate.js`.
- `ui_check` gates on the same `requiresConfirmation` check as `ui_click`. `ui_fill` gates **only** on the explicit annotation, never the label heuristic — text entry is reversible, so a blanket fill gate would be noise; an unmarked field behaves exactly as before.
- `pipeline.js`'s replay path now dispatches by `pending.tool` instead of hardcoding `voice:ui:click`, so a stashed `ui_fill` replays as `voice:ui:fill` and a stashed `ui_check` replays as `voice:ui:check`.
- Annotates the two known controls (`DraftsTab.jsx`'s Send, `AgentCard.jsx`'s BTW) with `data-voice-guard="confirm"`.
- Updates the voice-tools settings copy (`VoiceTab.jsx`) to name UI driving, which the previous wording ("brain, goals, PM2, feeds, time…") didn't mention at all.

Per the issue's explicit scope: `ui_select` (mutates form state only) and `ui_navigate` (always-on by design) are not gated, `DESTRUCTIVE_LABEL_RE` itself is untouched, and `dispatch_code_agent`'s own gate is unchanged (the gap there was that the DOM path never consulted it — separate from this fix).

Closes #5907

## Test plan

- `npx vitest run services/voice/` (server) → 564 passed, 2 skipped, 22 files — full voice suite green, including the existing `describe('ui_click — destructive confirmation gate')` unchanged.
- New coverage:
  - `confirmGate.test.js` — `requiresConfirmation` (label heuristic, guard override, unmarked non-destructive labels including "Send to Catalog"/"Send to Video"/"Send text"/"Send Ctrl+C interrupt", null-safety).
  - `tools.test.js` — a new `data-voice-guard annotation gates ui_click / ui_check / ui_fill (#5907)` describe block: guarded click/check/fill each stash a pending record and return `confirmation_required`; the four un-annotated "Send…" labels still click without a prompt; an unmarked field fills immediately even with a destructive-sounding value.
  - `pipelineConfirmReplay.test.js` (new file) — the replay path emits `voice:ui:click`/`voice:ui:fill`/`voice:ui:check` matching `pending.tool`, never cross-wired; cancelling a pending fill emits nothing.
  - `domIndex.test.jsx` — `exclude` never appears in `buildIndex()` output and gets no `data-voice-ref`; `confirm` carries `guard: 'confirm'` onto the entry; an unmarked control has no `guard` field.
  - `DraftsTab.test.jsx` (new file) — the real component renders `data-voice-guard="confirm"` on Send, and the real `buildIndex()` carries it onto the indexed entry (the client half of the "voice click on drafts Send yields confirmation_required" claim; the server half is the guard-gates-`ui_click` test above).
- `npx biome check` on the touched client files → clean, no fixes applied.
- Verified `client/src/components/cos/tabs/AgentCard.test.jsx`'s one failing test (`explains a long silent prefill…`) also fails against a clean `main` checkout with none of this PR's changes present (via a throwaway `git worktree`) — pre-existing, unrelated to this change (it's about issue #6117's prefill-duration display, nowhere near the BTW button this PR touches).

## Maintainer follow-ups (second commit)

- `data-voice-guard` now resolves via `closest()` — the nearest annotated ancestor governs, so a container can exclude or gate everything inside it instead of needing one attribute per button (and missing whichever button is added next). A nested annotation still overrides its ancestor. No behavior change for the two controls annotated here, which carry the attribute themselves.
- The `DESTRUCTIVE-ACTION FLOW` line in the voice system prompt named only `ui_click`; it now names `ui_click`/`ui_check`/`ui_fill` so the prompt matches what the code can now return.
- Dropped the AI co-author trailer from the commit message per `AGENTS.md`.
