### PR TITLE
fix CoS settings reset: stop treating valid state.json as corrupt

### DIFF
--- a/server/services/cosState.js
+++ b/server/services/cosState.js
@@ -153,7 +153,10 @@ function parseStateFile(content) {
  * recovery path so a recovered config is normalized identically.
  */
 function mergeStoredConfig(storedConfig) {
-  const persistedConfig = { ...(storedConfig || {}) };
+  // `isPlainObject` before the spread, not `|| {}`: spreading a string yields
+  // one key per character, so a `"config": "…"` in a hand-edited state file
+  // would merge character indices over DEFAULT_CONFIG instead of being ignored.
+  const persistedConfig = isPlainObject(storedConfig) ? { ...storedConfig } : {};
 
   // Migrate legacy split flags before merging defaults — DEFAULT_CONFIG.improvementEnabled = true
   // would otherwise shadow a v1 file that only set selfImprovementEnabled/appImprovementEnabled.
@@ -342,7 +345,7 @@ export async function readAgentsStateForSafetyCheck() {
   const agents = state?.agents;
   return {
     trusted,
-    agents: trusted && agents && typeof agents === 'object' && !Array.isArray(agents) ? agents : null,
+    agents: trusted && isPlainObject(agents) ? agents : null,
   };
 }
 

--- a/server/services/cosState.js
+++ b/server/services/cosState.js
@@ -8,7 +8,8 @@ import { readFile, writeFile, readdir, rm } from 'fs/promises';
 import { existsSync } from 'fs';
 import { join, dirname } from 'path';
 import { createFileWriteQueue } from '../lib/fileWriteQueue.js';
-import { ensureDirs, safeJSONParse, PATHS, atomicWrite } from '../lib/fileUtils.js';
+import { ensureDirs, safeJSONParse, readJSONFile, PATHS, atomicWrite } from '../lib/fileUtils.js';
+import { isPlainObject } from '../lib/objects.js';
 import { normalizeDomainAutonomy, getDomainMode } from '../lib/domainAutonomy.js';
 import { normalizeDomainBudgets } from '../lib/domainBudgets.js';
 import { createDefaultPersistentMindState, normalizePersistentMindState } from '../lib/persistentMind.js';
@@ -129,12 +130,128 @@ export async function ensureDirectories() {
   await ensureDirs([PATHS.data, PATHS.cos, AGENTS_DIR, REPORTS_DIR, SCRIPTS_DIR]);
 }
 
-function isValidJSON(str) {
-  if (!str || !str.trim()) return false;
-  const trimmed = str.trim();
-  if (!(trimmed.startsWith('{') && trimmed.endsWith('}'))) return false;
-  if (trimmed.includes('}{')) return false;
-  return true;
+/**
+ * Parse a persisted CoS state file, returning the object or `null` when the
+ * bytes are not a JSON object.
+ *
+ * Never front this with a structural heuristic. The one this replaced rejected
+ * any file containing the byte pair `}{` anywhere — a guess at a double-append
+ * corruption that fires on perfectly VALID JSON as soon as a stored string
+ * holds those two characters (an agent prompt quoting `{value}{ — project}`,
+ * a diff carrying JSX). Each false positive discarded the whole file and
+ * silently reset the user's config to DEFAULT_CONFIG. `JSON.parse` rejects a
+ * genuine `{…}{…}` concatenation on its own, so the guess protected nothing.
+ */
+function parseStateFile(content) {
+  const parsed = safeJSONParse(content, null, { allowArray: false, logError: true, context: 'CoS state' });
+  return isPlainObject(parsed) ? parsed : null;
+}
+
+/**
+ * Apply the stored config over DEFAULT_CONFIG, running the legacy-key
+ * migrations first. Shared by the normal load path and the corrupt-file
+ * recovery path so a recovered config is normalized identically.
+ */
+function mergeStoredConfig(storedConfig) {
+  const persistedConfig = { ...(storedConfig || {}) };
+
+  // Migrate legacy split flags before merging defaults — DEFAULT_CONFIG.improvementEnabled = true
+  // would otherwise shadow a v1 file that only set selfImprovementEnabled/appImprovementEnabled.
+  if (persistedConfig.improvementEnabled === undefined &&
+      (persistedConfig.selfImprovementEnabled !== undefined || persistedConfig.appImprovementEnabled !== undefined)) {
+    persistedConfig.improvementEnabled =
+      persistedConfig.selfImprovementEnabled || persistedConfig.appImprovementEnabled;
+  }
+
+  // Drop the retired `evaluationIntervalMs` key on read. CoS evaluation became
+  // event-driven (the periodic evaluateTasks() timer was removed), so the field
+  // no longer exists in DEFAULT_CONFIG or the (strict) update schema. Upgraded
+  // installs still carry it in state.json; stripping it here keeps GET /config
+  // from re-emitting a key the strict PUT schema would now reject on a full
+  // round-trip, and purges it from disk on the next saveState.
+  delete persistedConfig.evaluationIntervalMs;
+  // The global four-level autonomy preset was only a UI shortcut that rewrote
+  // independent capacity/work-generation fields. Domain guardrails now own the
+  // actual off/dry-run/execute policy, so do not keep re-emitting this inert key
+  // from upgraded state files. Per-job autonomyLevel remains a separate contract.
+  delete persistedConfig.autonomyLevel;
+  delete persistedConfig.comprehensiveAppImprovement;
+  delete persistedConfig.immediateExecution;
+
+  return {
+    ...DEFAULT_CONFIG,
+    ...persistedConfig,
+    persistentMindCapabilities: normalizePersistentMindCapabilities(persistedConfig.persistentMindCapabilities),
+    persistentMindProfile: normalizePersistentMindProfile(persistedConfig.persistentMindProfile),
+    persistentMindPrompt: normalizePersistentMindPrompt(persistedConfig.persistentMindPrompt),
+  };
+}
+
+// Mirror of the config slice as it was last persisted. state.json bundles the
+// user's durable settings with the agent records and Mind runtime state, so it
+// is rewritten constantly while the settings inside it are near-impossible to
+// reconstruct. `atomicWrite` already rules out a torn write; what remains is
+// disk-level damage or an out-of-tree editor — and when that lands, the
+// recovery below merges this file back in rather than dropping the user to
+// DEFAULT_CONFIG. Settings the user never touched are already the defaults, so
+// a missing sidecar loses nothing that wasn't already lost.
+export const CONFIG_BACKUP_FILE = join(PATHS.cos, 'config.last-known-good.json');
+
+// Serialized copy of what the sidecar already holds, so the common saveState
+// (an agent status tick, config untouched) stays a single file write.
+let lastConfigBackupJson = null;
+
+async function persistConfigBackup(config) {
+  if (!isPlainObject(config)) return;
+  // Serialize once and hand `atomicWrite` the string it would otherwise
+  // produce itself, so the changed-config save doesn't stringify twice.
+  const json = JSON.stringify(config, null, 2);
+  if (json === lastConfigBackupJson) return;
+  await atomicWrite(CONFIG_BACKUP_FILE, json)
+    .then(() => { lastConfigBackupJson = json; })
+    .catch((err) => console.error(`❌ Failed to back up CoS config: ${err.message}`));
+}
+
+// `readJSONFile` rather than a hand-rolled read: it carries the Windows
+// swap-window retry, so a read that lands between `atomicWrite`'s temp write
+// and its rename doesn't report "no sidecar" and drop the recovery below to
+// DEFAULT_CONFIG — the exact loss the sidecar exists to prevent.
+const readConfigBackup = () =>
+  readJSONFile(CONFIG_BACKUP_FILE, null, { allowArray: false, logError: true });
+
+/**
+ * Fall back to default state after an unreadable state.json, keeping the
+ * user's settings when the sidecar above can supply them. Backs the bad bytes
+ * up first (retaining the 3 most recent) so the loss is inspectable.
+ */
+async function recoverFromUnreadableState(content) {
+  console.log(`⚠️ Corrupted or empty state file at ${STATE_FILE}, returning default state`);
+  const backupPath = `${STATE_FILE}.corrupted.${Date.now()}`;
+  await writeFile(backupPath, content).catch(() => {});
+  console.log(`📝 Backed up corrupted state to ${backupPath}`);
+  // Cleanup old corrupted backups (keep only 3 most recent)
+  const cosDir = dirname(STATE_FILE);
+  const files = await readdir(cosDir).catch(() => []);
+  const corrupted = files
+    .filter(f => f.startsWith('state.json.corrupted.'))
+    .sort()
+    .reverse();
+  for (const old of corrupted.slice(3)) {
+    await rm(join(cosDir, old)).catch(() => {});
+  }
+  if (corrupted.length > 3) {
+    console.log(`🗑️ Cleaned up ${corrupted.length - 3} old corrupted state backups`);
+  }
+
+  const recovered = structuredClone(DEFAULT_STATE);
+  const savedConfig = await readConfigBackup();
+  if (savedConfig) {
+    // Already normalized when it was mirrored; re-merging costs nothing and
+    // covers a sidecar that was hand-edited or written by an older version.
+    recovered.config = mergeStoredConfig(savedConfig);
+    console.log(`♻️ Restored CoS config from ${CONFIG_BACKUP_FILE}`);
+  }
+  return recovered;
 }
 
 // In-memory state cache — avoids re-reading state.json from disk on every call.
@@ -177,69 +294,17 @@ export async function loadState() {
   }
 
   const content = await readFile(STATE_FILE, 'utf-8');
+  const state = parseStateFile(content);
 
-  if (!isValidJSON(content)) {
-    console.log(`⚠️ Corrupted or empty state file at ${STATE_FILE}, returning default state`);
-    const backupPath = `${STATE_FILE}.corrupted.${Date.now()}`;
-    await writeFile(backupPath, content).catch(() => {});
-    console.log(`📝 Backed up corrupted state to ${backupPath}`);
-    // Cleanup old corrupted backups (keep only 3 most recent)
-    const cosDir = dirname(STATE_FILE);
-    const files = await readdir(cosDir).catch(() => []);
-    const corrupted = files
-      .filter(f => f.startsWith('state.json.corrupted.'))
-      .sort()
-      .reverse();
-    for (const old of corrupted.slice(3)) {
-      await rm(join(cosDir, old)).catch(() => {});
-    }
-    if (corrupted.length > 3) {
-      console.log(`🗑️ Cleaned up ${corrupted.length - 3} old corrupted state backups`);
-    }
-    stateCache = structuredClone(DEFAULT_STATE);
-    return stateCache;
-  }
-
-  const state = safeJSONParse(content, null, { logError: true, context: 'CoS state' });
   if (!state) {
-    stateCache = structuredClone(DEFAULT_STATE);
+    stateCache = await recoverFromUnreadableState(content);
     return stateCache;
   }
-
-  // Migrate legacy split flags before merging defaults — DEFAULT_CONFIG.improvementEnabled = true
-  // would otherwise shadow a v1 file that only set selfImprovementEnabled/appImprovementEnabled.
-  const persistedConfig = state.config || {};
-  if (persistedConfig.improvementEnabled === undefined &&
-      (persistedConfig.selfImprovementEnabled !== undefined || persistedConfig.appImprovementEnabled !== undefined)) {
-    persistedConfig.improvementEnabled =
-      persistedConfig.selfImprovementEnabled || persistedConfig.appImprovementEnabled;
-  }
-
-  // Drop the retired `evaluationIntervalMs` key on read. CoS evaluation became
-  // event-driven (the periodic evaluateTasks() timer was removed), so the field
-  // no longer exists in DEFAULT_CONFIG or the (strict) update schema. Upgraded
-  // installs still carry it in state.json; stripping it here keeps GET /config
-  // from re-emitting a key the strict PUT schema would now reject on a full
-  // round-trip, and purges it from disk on the next saveState.
-  delete persistedConfig.evaluationIntervalMs;
-  // The global four-level autonomy preset was only a UI shortcut that rewrote
-  // independent capacity/work-generation fields. Domain guardrails now own the
-  // actual off/dry-run/execute policy, so do not keep re-emitting this inert key
-  // from upgraded state files. Per-job autonomyLevel remains a separate contract.
-  delete persistedConfig.autonomyLevel;
-  delete persistedConfig.comprehensiveAppImprovement;
-  delete persistedConfig.immediateExecution;
 
   stateCache = {
     ...DEFAULT_STATE,
     ...state,
-    config: {
-      ...DEFAULT_CONFIG,
-      ...persistedConfig,
-      persistentMindCapabilities: normalizePersistentMindCapabilities(persistedConfig.persistentMindCapabilities),
-      persistentMindProfile: normalizePersistentMindProfile(persistedConfig.persistentMindProfile),
-      persistentMindPrompt: normalizePersistentMindPrompt(persistedConfig.persistentMindPrompt),
-    },
+    config: mergeStoredConfig(state.config),
     stats: { ...DEFAULT_STATE.stats, ...state.stats },
     persistentMind: normalizePersistentMindState(state.persistentMind),
     agents: state.agents ?? {}
@@ -257,11 +322,8 @@ async function readStateForSafetyCheck() {
   await ensureDirectories();
   if (!existsSync(STATE_FILE)) return { trusted: true, state: null };
   const content = await readFile(STATE_FILE, 'utf-8');
-  if (!isValidJSON(content)) return { trusted: false, state: null };
-  const state = safeJSONParse(content, null, { logError: true, context: 'CoS state safety check' });
-  if (!state || typeof state !== 'object' || Array.isArray(state)) {
-    return { trusted: false, state: null };
-  }
+  const state = parseStateFile(content);
+  if (!state) return { trusted: false, state: null };
   return { trusted: true, state };
 }
 
@@ -288,6 +350,7 @@ export async function saveState(state) {
   await ensureDirectories();
   stateCache = state;
   await atomicWrite(STATE_FILE, state);
+  await persistConfigBackup(state.config);
 }
 
 // Resolve a single domain's autonomy mode (off | dry-run | execute) without

--- a/server/services/cosState.test.js
+++ b/server/services/cosState.test.js
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach, afterAll, vi } from 'vitest';
+import { mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { mockPathsDataRoot } from '../lib/mockPathsDataRoot.js';
+
+const { tempRoot, makeProxy, cleanup } = mockPathsDataRoot({ prefix: 'cos-state-test-' });
+
+vi.mock('../lib/fileUtils.js', async (importOriginal) => makeProxy(await importOriginal()));
+
+const COS_DIR = join(tempRoot, 'cos');
+const STATE_PATH = join(COS_DIR, 'state.json');
+
+afterAll(cleanup);
+
+// The module caches state in memory and remembers what it last mirrored to the
+// config sidecar, so every case needs a fresh module instance.
+const freshModule = async () => {
+  vi.resetModules();
+  return import('./cosState.js');
+};
+
+const writeState = (state) => writeFileSync(STATE_PATH, JSON.stringify(state, null, 2));
+
+beforeEach(() => {
+  rmSync(COS_DIR, { recursive: true, force: true });
+  mkdirSync(COS_DIR, { recursive: true });
+});
+
+describe('cosState persistence', () => {
+  // The regression: a `}{` heuristic declared VALID state files corrupt as soon
+  // as any stored string held that byte pair (a slashdo doc quoting
+  // `{value}{ — project|global}`, a diff carrying JSX), and the fallback reset
+  // every user setting to DEFAULT_CONFIG.
+  it('keeps user config when a stored string contains "}{"', async () => {
+    writeState({
+      running: false,
+      config: {
+        maxConcurrentAgents: 20,
+        maxConcurrentAgentsPerProject: 12,
+      },
+      agents: {
+        'agent-1': {
+          id: 'agent-1',
+          // Verbatim shape of the text that triggered the false positive.
+          prompt: 'Using saved defaults: --review-with={value}{, --review-iterations=…}{ — project|global}',
+        },
+      },
+    });
+
+    const { loadState } = await freshModule();
+    const state = await loadState();
+
+    expect(state.config.maxConcurrentAgents).toBe(20);
+    expect(state.config.maxConcurrentAgentsPerProject).toBe(12);
+    expect(state.agents['agent-1']).toBeDefined();
+    // A valid file is never treated as corrupt, so nothing is quarantined.
+    expect(readdirSync(COS_DIR).filter(f => f.startsWith('state.json.corrupted.'))).toHaveLength(0);
+  });
+
+  it('reports a "}{"-carrying state file as trusted to the update safety gate', async () => {
+    writeState({ agents: { 'agent-1': { id: 'agent-1', status: 'running', prompt: 'a }{ b' } } });
+
+    const { readAgentsStateForSafetyCheck } = await freshModule();
+
+    // `trusted: false` here would make the update gate treat a live agent as
+    // "records unreadable" and demand a manual state.json restore.
+    await expect(readAgentsStateForSafetyCheck()).resolves.toEqual({
+      trusted: true,
+      agents: { 'agent-1': { id: 'agent-1', status: 'running', prompt: 'a }{ b' } },
+    });
+  });
+
+  // Full round trip: save mirrors the config slice, and a state.json that is
+  // genuinely unreadable afterwards recovers those settings instead of
+  // dropping the user to DEFAULT_CONFIG.
+  it('recovers saved config when state.json becomes unreadable', async () => {
+    const saved = await freshModule();
+    const state = await saved.loadState();
+    state.config.maxConcurrentAgents = 20;
+    state.config.maxConcurrentAgentsPerProject = 12;
+    await saved.saveState(state);
+    expect(JSON.parse(readFileSync(saved.CONFIG_BACKUP_FILE, 'utf-8')).maxConcurrentAgents).toBe(20);
+
+    // A double-append: two complete objects concatenated. JSON.parse rejects it.
+    writeFileSync(STATE_PATH, `${JSON.stringify({ config: {} })}${JSON.stringify({ config: {} })}`);
+
+    const { loadState, DEFAULT_CONFIG } = await freshModule();
+    const recovered = await loadState();
+
+    expect(recovered.config.maxConcurrentAgents).toBe(20);
+    expect(recovered.config.maxConcurrentAgentsPerProject).toBe(12);
+    // Settings the sidecar doesn't carry still fall back to the shipped default.
+    expect(recovered.config.maxTotalProcesses).toBe(DEFAULT_CONFIG.maxTotalProcesses);
+    // Agent records are genuinely lost — but the bad bytes stay inspectable.
+    expect(recovered.agents).toEqual({});
+    expect(readdirSync(COS_DIR).filter(f => f.startsWith('state.json.corrupted.'))).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary

**Your CoS concurrency settings were reset by a false-positive corruption check, not by the update.** `loadState()` ran a hand-rolled `isValidJSON` heuristic before parsing that rejected any file containing the byte pair `}{` *anywhere* — a guess at a double-append corruption. It fires on perfectly **valid** JSON as soon as a stored string holds those two characters, which agent prompts and stored diffs of JSX routinely do. Each false positive made `loadState()` discard the whole state file and fall back to `DEFAULT_STATE`, silently resetting `maxConcurrentAgents`, `maxConcurrentAgentsPerProject`, domain autonomy, and the Mind grants. An update triggers a server restart, which is exactly when the file is re-read — so the reset looked like the update overwrote the settings.

Verified on the live install: three `state.json.corrupted.*` quarantine files in the last week, **all three of which parse as valid JSON**. The trigger text in each was ordinary stored content (a slashdo doc quoting `{value}{ — project|global}`, a diff carrying `{p.name}{cond && …}`).

- **Parse for real.** `JSON.parse` already rejects a genuine `{…}{…}` concatenation, so the heuristic protected nothing and cost real settings. It was a drifted fork of the shared `isValidJSON` in `server/lib/jsonIo.js` plus the extra clause; the fork is gone and both readers now share one parser.
- **Keep settings across a genuine corruption.** `saveState` now mirrors the config slice to `data/cos/config.last-known-good.json` (only when it changed, so the hot agent-status path stays a single write). When `state.json` really is unreadable, recovery merges that back in instead of dropping to `DEFAULT_CONFIG` — agent history is still lost, settings are not.
- The update path itself is clean: `scripts/setup-data.js` only copies *missing* files, so it never overwrote `data/cos/state.json`.

## Test plan

- `server/services/cosState.test.js` (new, 3 cases): a `}{`-carrying state file keeps user config and is never quarantined; the same file reads as `trusted` to the update safety gate; and a save → genuinely-unreadable-`state.json` → recover round trip restores the saved settings while still quarantining the bad bytes.
- All three fail on `main` with `expected 3 to be 20` — the reset itself — and pass with the fix.
- `cd server && npx vitest run <42 files referencing cosState>` — 1968 passing.

## Follow-ups filed

- #6181 — stop exporting `isValidJSON`, which exists only to be forked.
- #6182 — split durable CoS config out of `state.json`, which would make the sidecar unnecessary.