### PR TITLE
fix: stop exporting isValidJSON from jsonIo.js — inline it into safeJSONParse

### DIFF
--- a/server/lib/agentSentinel.js
+++ b/server/lib/agentSentinel.js
@@ -91,11 +91,12 @@ export function parseSentinelPayload(contents) {
   if (!trimmed) return { summary: '', payload: null };
 
   // Only a JSON OBJECT counts as structured. `safeJSONParse` with allowArray:false
-  // returns the object, or null for a plain markdown summary / bare JSON
-  // scalar/array / malformed content — so a legacy sentinel round-trips as text
-  // (repo convention: reuse safeJSONParse, no bare try/catch).
+  // rejects a root array and returns null for malformed content, but still parses
+  // a bare scalar (`"42"`, `"true"`) — so guard for a genuine object here too, or
+  // a legacy sentinel that happens to be a lone number/string/bool would crash on
+  // the `'payload' in parsed` check below instead of round-tripping as text.
   const parsed = safeJSONParse(trimmed, null, { allowArray: false });
-  if (parsed) {
+  if (parsed && typeof parsed === 'object') {
     const summary = typeof parsed.summary === 'string' ? parsed.summary : '';
     const payload = 'payload' in parsed ? parsed.payload : null;
     return { summary, payload };

--- a/server/lib/fileUtils.test.js
+++ b/server/lib/fileUtils.test.js
@@ -33,7 +33,6 @@ import {
   ensureDir,
   pathExists,
   expandHome,
-  isValidJSON,
   listDirectoryByExtension,
   safeJSONParse,
   safeJSONLParse,
@@ -127,56 +126,6 @@ async function withUnreadableFile(err, fn) {
 }
 
 describe('fileUtils', () => {
-  describe('isValidJSON', () => {
-    it('should return true for valid JSON object', () => {
-      expect(isValidJSON('{"key": "value"}')).toBe(true);
-    });
-
-    it('should return true for valid JSON array when allowed', () => {
-      expect(isValidJSON('[1, 2, 3]')).toBe(true);
-    });
-
-    it('should return false for JSON array when not allowed', () => {
-      expect(isValidJSON('[1, 2, 3]', { allowArray: false })).toBe(false);
-    });
-
-    it('should return false for empty string', () => {
-      expect(isValidJSON('')).toBe(false);
-    });
-
-    it('should return false for whitespace-only string', () => {
-      expect(isValidJSON('   ')).toBe(false);
-    });
-
-    it('should return false for null', () => {
-      expect(isValidJSON(null)).toBe(false);
-    });
-
-    it('should return false for undefined', () => {
-      expect(isValidJSON(undefined)).toBe(false);
-    });
-
-    it('should return false for string not starting with { or [', () => {
-      expect(isValidJSON('hello')).toBe(false);
-    });
-
-    it('should return false for incomplete object (missing end)', () => {
-      expect(isValidJSON('{"key":')).toBe(false);
-    });
-
-    it('should return false for incomplete array (missing end)', () => {
-      expect(isValidJSON('[1, 2')).toBe(false);
-    });
-
-    it('should handle whitespace around valid JSON', () => {
-      expect(isValidJSON('  {"key": "value"}  ')).toBe(true);
-    });
-
-    it('should handle nested objects', () => {
-      expect(isValidJSON('{"outer": {"inner": "value"}}')).toBe(true);
-    });
-  });
-
   describe('safeJSONParse', () => {
     it('should parse valid JSON object', () => {
       const result = safeJSONParse('{"key": "value"}', {});
@@ -223,6 +172,23 @@ describe('fileUtils', () => {
       expect(result).toEqual({});
     });
 
+    it('should still reject a root array under allowArray: false when defaultValue is not an array', () => {
+      const result = safeJSONParse('["a", "b"]', { fallback: true }, { allowArray: false });
+      expect(result).toEqual({ fallback: true });
+    });
+
+    it('should parse a top-level scalar string', () => {
+      expect(safeJSONParse('"hello"', null)).toBe('hello');
+    });
+
+    it('should parse a top-level scalar number', () => {
+      expect(safeJSONParse('123', null)).toBe(123);
+    });
+
+    it('should parse a top-level scalar boolean', () => {
+      expect(safeJSONParse('true', null)).toBe(true);
+    });
+
     it('should log warning when logError is true', () => {
       const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
       safeJSONParse('invalid', {}, { logError: true });
@@ -245,7 +211,6 @@ describe('fileUtils', () => {
     });
 
     it('should handle syntax error in structurally valid JSON', () => {
-      // Passes structural check but fails JSON.parse
       const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
       const result = safeJSONParse('{"key": undefined}', { fallback: true }, { logError: true });
       expect(result).toEqual({ fallback: true });

--- a/server/lib/hostShutdown.js
+++ b/server/lib/hostShutdown.js
@@ -122,13 +122,13 @@ export async function writeHostShutdownMarker({ agentIds = [], signal = null } =
  * `agentIds` is ALWAYS an array of non-empty strings — that's the one field
  * with a production consumer, and boot recovery runs before everything else, so
  * a truncated/garbled marker has to degrade to "no agents were interrupted"
- * rather than throw. `allowArray: false` does the rest of the shape check:
- * `readJSONFile` already rejects an unparseable file AND any root that isn't a
- * `{…}` object, so a falsy result is the only failure left to test for.
+ * rather than throw. `allowArray: false` only rejects an unparseable file or a
+ * root array; a bare JSON scalar (a truncated/garbled marker) still parses, so
+ * this also checks `typeof raw === 'object'` before treating it as a marker.
  */
 export async function readHostShutdownMarker() {
   const raw = await readJSONFile(hostShutdownMarkerPath(), null, { logError: false, allowArray: false });
-  if (!raw) return null;
+  if (!raw || typeof raw !== 'object') return null;
   return { ...raw, agentIds: Array.isArray(raw.agentIds) ? raw.agentIds.filter(isNonEmptyString) : [] };
 }
 

--- a/server/lib/jsonIo.js
+++ b/server/lib/jsonIo.js
@@ -11,34 +11,6 @@ const WIN_RETRY_DELAY_MS = 10;
 const WIN_READ_LOCK_CODES = ['EPERM', 'EACCES', 'EBUSY'];
 
 /**
- * Check if a string is potentially valid JSON.
- * Performs quick structural validation before parsing.
- *
- * @param {string} str - String to validate
- * @param {Object} options - Validation options
- * @param {boolean} [options.allowArray=true] - Allow array JSON (default: true)
- * @returns {boolean} True if the string appears to be valid JSON
- *
- * @example
- * isValidJSON('{"key": "value"}') // true
- * isValidJSON('[1, 2, 3]') // true
- * isValidJSON('') // false
- * isValidJSON('{"incomplete":') // false
- */
-export function isValidJSON(str, { allowArray = true } = {}) {
-  if (!str || !str.trim()) return false;
-  const trimmed = str.trim();
-
-  // Check for basic JSON structure (object or array)
-  const isObject = trimmed.startsWith('{') && trimmed.endsWith('}');
-  const isArray = trimmed.startsWith('[') && trimmed.endsWith(']');
-
-  if (!isObject && !(allowArray && isArray)) return false;
-
-  return true;
-}
-
-/**
  * Index of the first JSON array token in `str`, or -1 when it holds none.
  *
  * Split out of `extractJSONArray` so a caller can tell "found an array" from "found
@@ -97,17 +69,22 @@ export function safeJSONParse(str, defaultValue = null, { allowArray = true, log
     str = extractJSONArray(str);
   }
 
-  if (!isValidJSON(str, { allowArray })) {
+  if (!str || !str.trim()) {
     if (logError && str) {
       console.warn(`Invalid JSON${context ? ` in ${context}` : ''}: empty or malformed content`);
     }
     return defaultValue;
   }
 
-  // Attempt actual parse - the validation above catches structural issues
-  // but syntax errors like trailing commas still need handling
   try {
-    return JSON.parse(str);
+    const parsed = JSON.parse(str);
+    if (!allowArray && Array.isArray(parsed)) {
+      if (logError) {
+        console.warn(`Invalid JSON${context ? ` in ${context}` : ''}: array not allowed`);
+      }
+      return defaultValue;
+    }
+    return parsed;
   } catch (err) {
     if (logError) {
       console.warn(`Failed to parse JSON${context ? ` in ${context}` : ''}: ${err.message}`);

--- a/server/scripts/migrateWritersRoomToDB.js
+++ b/server/scripts/migrateWritersRoomToDB.js
@@ -189,7 +189,10 @@ export async function migrateWritersRoomToDB() {
     const content = await readFile(manifestPath, 'utf-8').catch(() => null);
     if (content === null) continue;
     const manifest = safeJSONParse(content, null, { allowArray: false, logError: true, context: manifestPath });
-    if (!manifest) continue; // corrupted manifest — skip, leave on disk untouched
+    // `allowArray: false` only rejects a root array — a bare JSON scalar
+    // still parses, so also guard for a genuine object before treating the
+    // manifest as valid.
+    if (!manifest || typeof manifest !== 'object') continue; // corrupted manifest — skip, leave on disk untouched
     if (await importWork(manifest)) workCount += 1;
     importedManifestPaths.push(manifestPath);
   }

--- a/server/services/digital-twin-analysis.js
+++ b/server/services/digital-twin-analysis.js
@@ -411,7 +411,10 @@ export function parseTraitsResponse(response) {
   }
 
   const parsed = safeJSONParse(jsonStr, null, { allowArray: false });
-  if (!parsed) {
+  // A fenced ```json block can wrap a bare scalar (e.g. the model responds
+  // with just `42`) — `allowArray: false` only rejects a root array, so guard
+  // for a genuine object before treating it as a traits response.
+  if (!parsed || typeof parsed !== 'object') {
     return { error: 'Failed to parse traits response - invalid JSON', rawResponse: response };
   }
 

--- a/server/services/meatspacePostMorse.js
+++ b/server/services/meatspacePostMorse.js
@@ -52,11 +52,15 @@ function clampLevel(level) {
 }
 
 async function loadMorseProgress() {
-  const data = await readJSONFile(
+  const raw = await readJSONFile(
     MORSE_FILE,
     { kochLevel: null, settings: null, rounds: [] },
     { allowArray: false },
   );
+  // `allowArray: false` only rejects a root array — a bare JSON scalar
+  // (corrupted file) still parses, and the field assignments below would
+  // throw on one, so fall back to a fresh object rather than that scalar.
+  const data = raw && typeof raw === 'object' ? raw : { kochLevel: null, settings: null, rounds: [] };
   if (!Array.isArray(data.rounds)) data.rounds = [];
   // Preserve the "never set" sentinel: anything that isn't a real number stays
   // null so adopt-once keeps working across older/partial files.

--- a/server/services/pipeline/editorialAnalysis.js
+++ b/server/services/pipeline/editorialAnalysis.js
@@ -151,7 +151,11 @@ function sanitizeAnalysis(parsed) {
 async function loadSnapshot(issueId) {
   const content = await tryReadFile(snapshotPath(issueId));
   if (content === null) return null;
-  return safeJSONParse(content, null, { allowArray: false, logError: true, context: snapshotPath(issueId) });
+  const parsed = safeJSONParse(content, null, { allowArray: false, logError: true, context: snapshotPath(issueId) });
+  // `allowArray: false` only rejects a root array — a bare JSON scalar
+  // (corrupted snapshot) still parses, and callers spread this into a
+  // response object, so guard for a genuine object here.
+  return parsed && typeof parsed === 'object' ? parsed : null;
 }
 
 async function saveSnapshot(snapshot) {

--- a/server/services/pipeline/foundationJudge.js
+++ b/server/services/pipeline/foundationJudge.js
@@ -323,7 +323,11 @@ export function residualFindings(dimensions) {
 async function loadSnapshot(seriesId) {
   const content = await tryReadFile(snapshotPath(seriesId));
   if (content === null) return null;
-  return safeJSONParse(content, null, { allowArray: false, logError: true, context: snapshotPath(seriesId) });
+  const parsed = safeJSONParse(content, null, { allowArray: false, logError: true, context: snapshotPath(seriesId) });
+  // `allowArray: false` only rejects a root array — a bare JSON scalar
+  // (corrupted snapshot) still parses, and callers spread this into a
+  // response object, so guard for a genuine object here.
+  return parsed && typeof parsed === 'object' ? parsed : null;
 }
 
 async function saveSnapshot(snapshot) {

--- a/server/services/pipeline/perspectiveRewrite.js
+++ b/server/services/pipeline/perspectiveRewrite.js
@@ -171,7 +171,11 @@ export function sanitizeAnalysis(parsed) {
 async function loadDoc(issueId) {
   const content = await tryReadFile(docPath(issueId));
   if (content === null) return null;
-  return safeJSONParse(content, null, { allowArray: false, logError: true, context: docPath(issueId) });
+  const parsed = safeJSONParse(content, null, { allowArray: false, logError: true, context: docPath(issueId) });
+  // `allowArray: false` only rejects a root array — a bare JSON scalar
+  // (corrupted doc) still parses, and callers spread this into a response
+  // object, so guard for a genuine object here.
+  return parsed && typeof parsed === 'object' ? parsed : null;
 }
 
 async function saveDoc(doc) {

--- a/server/services/pipeline/pipelineJudge.js
+++ b/server/services/pipeline/pipelineJudge.js
@@ -175,7 +175,11 @@ export function sanitizeJudge(parsed) {
 async function loadSnapshot(issueId) {
   const content = await tryReadFile(snapshotPath(issueId));
   if (content === null) return null;
-  return safeJSONParse(content, null, { allowArray: false, logError: true, context: snapshotPath(issueId) });
+  const parsed = safeJSONParse(content, null, { allowArray: false, logError: true, context: snapshotPath(issueId) });
+  // `allowArray: false` only rejects a root array — a bare JSON scalar
+  // (corrupted snapshot) still parses, and callers spread this into a
+  // response object, so guard for a genuine object here.
+  return parsed && typeof parsed === 'object' ? parsed : null;
 }
 
 async function saveSnapshot(snapshot) {

--- a/server/services/pipeline/readerPanel.js
+++ b/server/services/pipeline/readerPanel.js
@@ -48,7 +48,11 @@ const snapshotPath = (seriesId) => join(panelDir(), `${seriesId}.json`);
 async function loadSnapshot(seriesId) {
   const content = await tryReadFile(snapshotPath(seriesId));
   if (content === null) return null;
-  return safeJSONParse(content, null, { allowArray: false, logError: true, context: snapshotPath(seriesId) });
+  const parsed = safeJSONParse(content, null, { allowArray: false, logError: true, context: snapshotPath(seriesId) });
+  // `allowArray: false` only rejects a root array — a bare JSON scalar
+  // (corrupted snapshot) still parses, and callers spread this into a
+  // response object, so guard for a genuine object here.
+  return parsed && typeof parsed === 'object' ? parsed : null;
 }
 
 async function saveSnapshot(snapshot) {

--- a/server/services/pipeline/seriesReview.js
+++ b/server/services/pipeline/seriesReview.js
@@ -572,9 +572,13 @@ async function clearSnapshot(seriesId) {
 export async function getSeriesReview(seriesId) {
   assertValidSeriesId(seriesId);
   const content = await tryReadFile(snapshotPath(seriesId));
-  const verdict = content === null
+  const parsed = content === null
     ? null
     : safeJSONParse(content, null, { allowArray: false, logError: true, context: snapshotPath(seriesId) });
+  // `allowArray: false` only rejects a root array — a bare JSON scalar
+  // (corrupt snapshot) still parses, so guard for a genuine object before
+  // treating it as a verdict.
+  const verdict = parsed && typeof parsed === 'object' ? parsed : null;
   const [fix, review, currentHash] = await Promise.all([
     getFixAvailability(),
     // `null` = the findings store couldn't be read (distinct from a store with no

--- a/server/services/writersRoom/evaluator.js
+++ b/server/services/writersRoom/evaluator.js
@@ -145,7 +145,11 @@ async function loadAnalysis(workId, id) {
     throw err;
   });
   if (content === null) return null;
-  return safeJSONParse(content, null, { allowArray: false, logError: true, context: analysisPath(workId, id) });
+  const parsed = safeJSONParse(content, null, { allowArray: false, logError: true, context: analysisPath(workId, id) });
+  // `allowArray: false` only rejects a root array — a bare JSON scalar
+  // (corrupted analysis) still parses, and callers spread this into a
+  // response object, so guard for a genuine object here.
+  return parsed && typeof parsed === 'object' ? parsed : null;
 }
 
 async function saveAnalysis(workId, snapshot) {
@@ -247,7 +251,9 @@ async function migrateLegacyAnalyses(workId) {
     const content = await tryReadFile(path);
     if (content === null) return null;
     const parsed = safeJSONParse(content, null, { allowArray: false, logError: true, context: path });
-    return parsed ? { id, snapshot: parsed } : null;
+    // `allowArray: false` only rejects a root array — a bare JSON scalar
+    // (corrupted legacy file) still parses, so also guard the shape here.
+    return parsed && typeof parsed === 'object' ? { id, snapshot: parsed } : null;
   }))).filter(Boolean);
 
   const latestPerKind = new Map();

--- a/server/services/writersRoom/polish.js
+++ b/server/services/writersRoom/polish.js
@@ -213,7 +213,11 @@ async function loadSnapshot(workId, id) {
     throw err;
   });
   if (content === null) return null;
-  return safeJSONParse(content, null, { allowArray: false, logError: true, context: snapshotPath(workId, id) });
+  const parsed = safeJSONParse(content, null, { allowArray: false, logError: true, context: snapshotPath(workId, id) });
+  // `allowArray: false` only rejects a root array — a bare JSON scalar
+  // (corrupted snapshot) still parses, and callers use this as a manifest,
+  // so guard for a genuine object here.
+  return parsed && typeof parsed === 'object' ? parsed : null;
 }
 
 export async function getSnapshot(workId, id) {

--- a/server/services/writersRoom/store.js
+++ b/server/services/writersRoom/store.js
@@ -78,7 +78,9 @@ function makeFileBackend() {
     // pre-#1017 file behavior) so listWorks can drop the work without masking
     // the issue and direct callers get an actionable error, not a raw SyntaxError.
     const parsed = safeJSONParse(content, null, { allowArray: false, logError: true, context: path });
-    if (parsed === null) {
+    // `allowArray: false` only rejects a root array — a bare JSON scalar
+    // (corrupted manifest) still parses, so also check the shape here.
+    if (parsed === null || typeof parsed !== 'object') {
       console.warn(`⚠️ wr: corrupted manifest at ${path} (work ${workId})`);
       throw new ServerError(`Corrupted writers-room manifest for ${workId}`, {
         status: 500, code: 'CORRUPTED_MANIFEST', context: { workId },


### PR DESCRIPTION
## Summary
- Inline `isValidJSON`'s structural pre-check into `safeJSONParse`'s existing try/catch, dropping the standalone export — it had zero in-tree callers outside `jsonIo.js`/its own test, and existed only to invite exactly the kind of fork that corrupted CoS state (see issue for the `cosState.js` history).
- `Array.isArray(parsed)` is now checked **after** `JSON.parse`, preserving the `allowArray: false` contract while fixing a residual false-negative: a valid top-level scalar (`"str"`, `123`, `true`) now parses instead of being refused.
- Several existing callers implicitly relied on `allowArray: false` meaning "object or nothing." Since a bare scalar now parses under that option, audited every `allowArray: false` call site and guarded the ones that would otherwise crash (write onto a primitive) or silently manufacture a wrong-shaped object (spreading a corrupted scalar into a response).

## Test plan
- `cd server && npm test` — full suite green (1927 files, 38926 tests passed).
- `server/lib/fileUtils.test.js` — replaced the `isValidJSON` describe block with `safeJSONParse` cases proving a top-level scalar now parses and a root array is still refused under `allowArray: false`.
- Local review pass (antigravity) surfaced 3 concrete regressions from the loosened scalar contract; fixed all 3 plus additional sites found in a follow-up sweep of every `allowArray: false` caller.

Closes #6181