### PR TITLE
raise the Claude request timeout on a local daemon so a long prefill isn't retried forever

### DIFF
--- a/server/lib/cliChildEnv.js
+++ b/server/lib/cliChildEnv.js
@@ -61,6 +61,24 @@ import { isPublicReviewNoToolProfile, isPublicReviewRestrictedProfile } from './
 // provider.envVars still wins below.
 const CLAUDE_LOCAL_MAX_OUTPUT_TOKENS = '65536';
 
+// Claude Code cancels a request whose first byte has not arrived within 300s
+// (`API_TIMEOUT_MS` is the override) and paints `API error · Retrying in 0s ·
+// attempt 1/10`. Against a LOCAL daemon that ceiling is shorter than the
+// PREFILL: a public-review Stage 3 prompt inlines the whole screened envelope
+// and routinely runs to ~100K tokens (#6117), which a model server on this box
+// chews through in tens of minutes, not seconds. Every attempt was therefore
+// cancelled mid-prefill — the daemon logged `500 | 6m0s | POST /v1/messages` —
+// and the retry re-sent the same prompt, so a healthy run looked frozen at
+// attempt 1/10 forever while never emitting a token.
+//
+// `localPromptBudget.js` already predicts that prefill for the run card; this is
+// the harness half of the same fact. The ceiling exists to bound a retry storm,
+// not to budget a healthy run: a request that never answers still ends, because
+// the child prints nothing and the run's own supervision reaps it. Cloud Claude
+// answers in seconds and keeps the stock 300s. A value in provider.envVars still
+// wins below.
+const CLAUDE_LOCAL_API_TIMEOUT_MS = '3600000';
+
 /**
  * True for a Claude Code harness talking to a local OpenAI/Anthropic-compatible
  * daemon — `claude-ollama` and `claude-sglang` today, plus any renamed or
@@ -78,10 +96,27 @@ function isLocalBackedClaude(provider) {
   return !!localRuntimeNamespace(provider) && isClaudeCommand(provider?.command);
 }
 
+/**
+ * Every knob `claudeLocalEnvDefaults` composes for a local-backed Claude
+ * harness.
+ *
+ * Named once because the two public-review allowlists below have to let all of
+ * them through, and an allowlist that carries the wrapper's ENDPOINT but not its
+ * TUNING is the worst of both: the stage reaches the local daemon and then runs
+ * it on Claude Code's cloud-shaped ceilings. That is how Stage 3 — the stage
+ * carrying the ~100K-token review envelope — sat behind a 300s first-byte
+ * timeout it could never meet. Keep in lockstep with `claudeLocalEnvDefaults`;
+ * `cliChildEnv.test.js` fails when a knob it emits is missing from either list.
+ */
+const CLAUDE_LOCAL_TUNING_ENV_KEYS = [
+  'CLAUDE_CODE_MAX_OUTPUT_TOKENS', 'API_TIMEOUT_MS', 'MAX_THINKING_TOKENS',
+];
+
 function claudeLocalEnvDefaults(provider) {
   if (!isLocalBackedClaude(provider)) return {};
   return {
     CLAUDE_CODE_MAX_OUTPUT_TOKENS: CLAUDE_LOCAL_MAX_OUTPUT_TOKENS,
+    API_TIMEOUT_MS: CLAUDE_LOCAL_API_TIMEOUT_MS,
     // Claude Code omits the Anthropic-compatible `thinking` field when this is
     // zero, which Ollama maps to Qwen's non-thinking mode. Do not set a value
     // when enabled: Claude retains its normal adaptive budget.
@@ -160,7 +195,7 @@ const PUBLIC_REVIEW_ENV_KEYS = new Set([
   'SystemRoot', 'SystemDrive', 'ComSpec', 'PATHEXT', 'USERPROFILE', 'APPDATA',
   'LOCALAPPDATA', 'ProgramData', 'ProgramFiles', 'HOMEDRIVE', 'HOMEPATH',
   'ANTHROPIC_BASE_URL', 'ANTHROPIC_SMALL_FAST_MODEL',
-  'CLAUDE_CODE_MAX_OUTPUT_TOKENS', 'MAX_THINKING_TOKENS',
+  ...CLAUDE_LOCAL_TUNING_ENV_KEYS,
 ]);
 
 // A Claude CLI pointed at a LOCAL Anthropic-compatible runtime (the Ollama and
@@ -235,6 +270,10 @@ const PUBLIC_REVIEW_ACTIONS_ENV_KEYS = new Set([
   // The local Claude wrappers are eligible for this stage too; without the
   // endpoint they would talk to the cloud (or, with `--bare`, to nothing).
   'ANTHROPIC_BASE_URL', 'ANTHROPIC_SMALL_FAST_MODEL',
+  // ...and the tuning composed for that wrapper, for the reason spelled out on
+  // the constant. These are numeric harness knobs carrying no credential, so
+  // keeping them widens no boundary this list exists to hold.
+  ...CLAUDE_LOCAL_TUNING_ENV_KEYS,
 ]);
 
 export function buildPublicReviewActionsCliEnv(env = {}) {

--- a/server/lib/cliChildEnv.test.js
+++ b/server/lib/cliChildEnv.test.js
@@ -318,6 +318,31 @@ describe('buildCliChildEnv — public-review-actions profile', () => {
     expect(env).toMatchObject({ ANTHROPIC_BASE_URL: 'http://localhost:11434', ANTHROPIC_AUTH_TOKEN: 'ollama', ANTHROPIC_SMALL_FAST_MODEL: 'small:7b' });
     expect(env).not.toHaveProperty('GH_TOKEN');
   });
+
+  // An allowlist carrying the wrapper's ENDPOINT but not its TUNING is the worst
+  // of both: the stage reaches the local daemon and then runs it on Claude Code's
+  // cloud-shaped ceilings — a 32K output cap and a 300s first-byte timeout that a
+  // ~100K-token prefill can never meet. Derived from what composeProviderEnv
+  // actually emits rather than a copy of the key list, so a knob added to
+  // `claudeLocalEnvDefaults` and forgotten in an allowlist fails here.
+  it('lets every local-Claude tuning knob through both public-review allowlists', () => {
+    const envVars = { ANTHROPIC_BASE_URL: 'http://localhost:11434', ANTHROPIC_AUTH_TOKEN: 'ollama' };
+    // Maximally-configured so every conditional knob is emitted.
+    const provider = { command: 'claude', ollamaBacked: true, thinking: false, envVars };
+    const tuning = Object.keys(composeProviderEnv({ provider })).filter((key) => !(key in envVars));
+    expect(tuning.length).toBeGreaterThan(0);
+
+    for (const safetyProfile of [PUBLIC_REVIEW_EXECUTION_PROFILE, PUBLIC_REVIEW_ACTIONS_EXECUTION_PROFILE]) {
+      const env = buildCliChildEnv({
+        baseEnv: { PATH: '/usr/bin', GH_TOKEN: 'forge-secret' },
+        provider,
+        cwd: '/tmp/public-review',
+        safetyProfile,
+      });
+      for (const key of tuning) expect(env, `${safetyProfile} dropped ${key}`).toHaveProperty(key);
+      expect(env).not.toHaveProperty('GH_TOKEN');
+    }
+  });
 });
 
 describe('buildCliChildEnv — PWD pin and CLAUDECODE strip', () => {
@@ -390,6 +415,23 @@ describe('composeProviderEnv — delta for sites that do not spawn directly', ()
     expect(composeProviderEnv({
       provider: { command: 'opencode', ollamaBacked: true, envVars: {} },
     }).CLAUDE_CODE_MAX_OUTPUT_TOKENS).toBeUndefined();
+  });
+
+  // The 300s default is a first-byte deadline, and a local daemon spends longer
+  // than that PREFILLING a ~100K-token review envelope before it can emit one.
+  // Every attempt was cancelled mid-prefill and re-sent, so the run sat at
+  // `API error · Retrying … attempt 1/10` forever without ever being unhealthy.
+  it('raises the Claude request timeout past a local prefill, never for a cloud model', () => {
+    const localClaude = { command: '/usr/local/bin/claude', ollamaBacked: true, envVars: {} };
+    expect(composeProviderEnv({ provider: localClaude }).API_TIMEOUT_MS).toBe('3600000');
+    expect(composeProviderEnv({
+      provider: { ...localClaude, envVars: { API_TIMEOUT_MS: '900000' } },
+    }).API_TIMEOUT_MS).toBe('900000');
+
+    expect(composeProviderEnv({ provider: { command: 'claude', envVars: {} } }).API_TIMEOUT_MS).toBeUndefined();
+    expect(composeProviderEnv({
+      provider: { command: 'opencode', ollamaBacked: true, envVars: {} },
+    }).API_TIMEOUT_MS).toBeUndefined();
   });
 
   it('disables Claude/Ollama thinking when the provider requests it', () => {


### PR DESCRIPTION
## Summary

A pr-reviewer Stage 3 run on `qwen3-coder:30b` looked frozen at `API error · Retrying in 0s · attempt 1/10`. The model was healthy and the harness was launched correctly — it just never got to emit a token:

- The stage prompt inlines the whole screened review envelope: **97,759 tokens** (392 KB).
- A local model server prefills that in tens of minutes, not seconds (observed 88 → 48 tok/s, decaying as the KV grows).
- **Claude Code cancels a request whose first byte hasn't arrived in 300s.** Ollama logged `500 | 6m0s | POST /v1/messages`, twice.
- Each retry re-sent the same prompt, resuming from the cached prefix and creeping forward ~7K tokens per attempt — so a healthy run sat at attempt 1/10 indefinitely.

Two changes, both in `server/lib/cliChildEnv.js`:

- **Set `API_TIMEOUT_MS` for a local-backed Claude harness**, alongside the output ceiling `claudeLocalEnvDefaults` already composes. `localPromptBudget.js` (#6117) already predicts this prefill for the run card; this is the harness half of the same fact. Cloud Claude keeps the stock 300s, and `provider.envVars` still wins.
- **Stop the public-review allowlists from stripping that tuning.** Both carried the wrapper's `ANTHROPIC_BASE_URL` but dropped `CLAUDE_CODE_MAX_OUTPUT_TOKENS` / `MAX_THINKING_TOKENS`, so the one stage that carries the ~100K-token envelope reached the local daemon and then ran it on Claude Code's cloud-shaped ceilings. The key set is now named once and spread into both lists.

## Test plan

- `cd server && npm test -- cliChildEnv` — 46 pass.
- Each new test verified as a single-mutation probe: reverting only the `API_TIMEOUT_MS` default fails both new tests; reverting only the allowlist spread fails the lockstep test, naming the profile and the dropped key.
- The lockstep test derives the knobs from what `composeProviderEnv` actually emits rather than restating the key list, so a knob added to `claudeLocalEnvDefaults` and forgotten in an allowlist fails there instead of in a wedged live run.
- `npm test -- cliChildEnv providerVendors agentCliSpawning prReviewerSecurity opencodeConfig processEnv importScoping` — 248 pass.

## Follow-up (not in this PR)

The `claude-ollama*` providers carry no `numCtx`, so Ollama runs them at `-c 262144` with q8_0 KV and `-b 1024`, which is a large part of why prefill decays to ~48 tok/s. Worth a separate look.