### PR TITLE
Never let a delegated orchestration lane silently fall back onto the architect's provider

### DIFF
--- a/client/src/components/cos/tabs/TaskItem.jsx
+++ b/client/src/components/cos/tabs/TaskItem.jsx
@@ -679,6 +679,22 @@ export default function TaskItem({ task, agent = null, isSystem, spawning = fals
                   {/* Clamped: server-side auto-blocks write `blockedReason` from
                       LLM error analysis / raw stderr, which can run very long. */}
                   <div className="min-w-0 flex-1">
+                    {/* A fail-closed orchestration lane (#5993) reads as a bare
+                        "agent failed" without this: the reason sentence is long
+                        and gets clamped, so the two facts that make the fix
+                        obvious — WHICH role stopped and WHICH provider it wanted
+                        — get a headline of their own above the clamp. */}
+                    {task.metadata?.blockedCategory === 'orchestration-lane-unavailable' && task.metadata?.orchestrationLane?.role && (
+                      <div className="font-medium text-port-error mb-0.5">
+                        {`${task.metadata.orchestrationLane.role} lane unavailable`}
+                        {task.metadata.orchestrationLane.requestedProvider
+                          ? ` — ${task.metadata.orchestrationLane.requestedProvider}`
+                          : ''}
+                        {task.metadata.orchestrationLane.requestedModel
+                          ? ` / ${task.metadata.orchestrationLane.requestedModel}`
+                          : ''}
+                      </div>
+                    )}
                     <CollapsibleText
                       id={`task-blocker-${idScope}-${task.id}`}
                       text={task.metadata.blocker || task.metadata.blockedReason}

--- a/client/src/components/cos/tabs/TaskItem.test.jsx
+++ b/client/src/components/cos/tabs/TaskItem.test.jsx
@@ -828,3 +828,34 @@ describe('TaskItem editing a pin whose instance has left the registry (#4520)', 
     expect(api.updateCosTask.mock.calls[0][1].targetInstanceId).toBe('peer-instance-id');
   });
 });
+
+describe('TaskItem fail-closed orchestration lane (#5993)', () => {
+  const blockedOnLane = {
+    ...task,
+    id: 'orch-lane',
+    status: 'blocked',
+    metadata: {
+      blockedCategory: 'orchestration-lane-unavailable',
+      blockedReason: 'Orchestrated implementer lane stopped: provider "p-cheap" model "m-cheap" is unavailable — not authenticated (no implementer.fallbackProvider is configured).',
+      orchestrationLane: { role: 'implementer', requestedProvider: 'p-cheap', requestedModel: 'm-cheap' },
+    },
+  };
+
+  it('headlines the role and provider so the fix is obvious', () => {
+    render(<TaskItem task={blockedOnLane} onRefresh={vi.fn()} providers={providers} />);
+
+    expect(screen.getByText('implementer lane unavailable — p-cheap / m-cheap')).toBeInTheDocument();
+  });
+
+  it('adds no headline to an ordinary block', () => {
+    const ordinary = {
+      ...blockedOnLane,
+      id: 'ordinary-block',
+      metadata: { blockedReason: 'Max spawn attempts reached', blockedCategory: 'max-spawns' },
+    };
+    render(<TaskItem task={ordinary} onRefresh={vi.fn()} providers={providers} />);
+
+    expect(screen.queryByText(/lane unavailable/)).toBeNull();
+    expect(screen.getByText('Max spawn attempts reached')).toBeInTheDocument();
+  });
+});

--- a/server/lib/agentRunEvents.js
+++ b/server/lib/agentRunEvents.js
@@ -99,7 +99,14 @@ export const AGENT_RUN_EVENT_KINDS = Object.freeze([
   // `endTime` that no exit ever produced, and nothing would say where it came
   // from. Adding this kind is not an envelope shape change — older builds fold
   // unknown kinds as no-ops — so AGENT_RUN_EVENT_SCHEMA_VERSION stays at 1.
-  'run.reconciled'
+  'run.reconciled',
+  // A configured orchestration lane refused to substitute providers and stopped
+  // the run before it spawned (#5993). Its own kind because the durable record
+  // this ledger annotates does NOT exist for it — no run directory is created —
+  // so without this line the only trace of a fail-closed lane is a blocked task,
+  // and "the cheap tier was down" is indistinguishable from every other block.
+  // Carries no runId (there is no run); keyed by agentId via `runEventKey`.
+  'run.lane-refused'
 ]);
 
 /** All writeable kinds in the shared machine-local ledger. */
@@ -508,8 +515,9 @@ export function projectRunStates(events) {
  * Every non-terminal arm below is guarded by this: the ledger is read in append
  * order, but a late-arriving annotation (a stop request that raced the exit, a
  * reconnect logged after the process was already reaped) must not resurrect a
- * finished run as `running`. `run.finalized` is the only arm that may set a
- * terminal status, so once set it stays.
+ * finished run as `running`. Only `run.finalized` and `run.lane-refused` may set
+ * a terminal status — the second because a refused lane never spawned a process,
+ * so no finalize will ever arrive for it (#5993) — and once set it stays.
  */
 const isTerminal = (state) => state.status === 'completed' || state.status === 'failed';
 
@@ -534,6 +542,24 @@ const canObserveRunning = (state) => !isTerminal(state) && !state.paused;
 function applyKind(state, event) {
   const data = event.data ?? {};
   switch (event.kind) {
+    case 'run.lane-refused':
+      // Terminal, and the ONLY arm besides `run.finalized` allowed to say so:
+      // a refused lane never spawned a process, so no exit will ever arrive to
+      // finalize it, and leaving the projection `unknown` would read as "still
+      // being figured out" for a run that is definitively over. Guarded like
+      // every other arm so it can never overwrite a real verdict.
+      if (!isTerminal(state)) {
+        state.status = 'failed';
+        state.success = false;
+      }
+      state.endedAt = state.endedAt ?? event.at;
+      state.laneRefused = {
+        role: typeof data.role === 'string' ? data.role : null,
+        requestedProvider: typeof data.requestedProvider === 'string' ? data.requestedProvider : null,
+        requestedModel: typeof data.requestedModel === 'string' ? data.requestedModel : null,
+        reason: typeof data.reason === 'string' ? data.reason : null,
+      };
+      break;
     case 'run.spawned':
       // Guarded like every other non-terminal arm. A spawn should never follow a
       // finalize for the same run, but the ledger is a stream several
@@ -544,6 +570,10 @@ function applyKind(state, event) {
       state.startedAt = state.startedAt ?? event.at;
       if (typeof data.providerId === 'string') state.providerId = data.providerId;
       if (typeof data.model === 'string') state.model = data.model;
+      // The tier this run actually ran as, plus the same-role alternate it fell
+      // to, if any — so a diagnostic can show the split the user configured.
+      if (typeof data.orchestrationRole === 'string') state.orchestrationRole = data.orchestrationRole;
+      if (typeof data.laneSubstitutedFrom === 'string') state.laneSubstitutedFrom = data.laneSubstitutedFrom;
       break;
     case 'run.runner-recovered':
       // A survivor is still running — recovery is an annotation on a live run,

--- a/server/lib/agentRunEvents.test.js
+++ b/server/lib/agentRunEvents.test.js
@@ -560,3 +560,62 @@ describe('projectRunStates — run.reconciled (#4540)', () => {
     expect(state).toMatchObject({ reconciled: false, reconciledCount: 0 });
   });
 });
+
+describe('run.lane-refused — fail-closed orchestration lanes (#5993)', () => {
+  it('is terminal even though no run ever spawned', () => {
+    const event = buildRunEvent({
+      kind: 'run.lane-refused',
+      agentId: 'agent-1',
+      taskId: 'task-1',
+      at: AT,
+      data: { role: 'implementer', requestedProvider: 'p-cheap', requestedModel: 'm-cheap', reason: 'not authenticated' },
+    });
+    const [state] = projectRunStates([event]);
+    // Keyed by the agent: the refusal happens before a run id exists.
+    expect(state.id).toBe('agent:agent-1');
+    expect(state.status).toBe('failed');
+    expect(state.success).toBe(false);
+    expect(state.endedAt).toBe(AT);
+    expect(state.laneRefused).toEqual({
+      role: 'implementer',
+      requestedProvider: 'p-cheap',
+      requestedModel: 'm-cheap',
+      reason: 'not authenticated',
+    });
+  });
+
+  it('never talks a run that already reached a verdict back to failed', () => {
+    const finalized = buildRunEvent({
+      kind: 'run.finalized',
+      runId: 'run-1',
+      agentId: 'agent-2',
+      at: AT,
+      data: { exitCode: 0, success: true },
+    });
+    const refused = buildRunEvent({
+      kind: 'run.lane-refused',
+      runId: 'run-1',
+      agentId: 'agent-2',
+      at: '2026-08-18T12:05:00.000Z',
+      data: { role: 'reviewer', reason: 'down' },
+    });
+    const [state] = projectRunStates([finalized, refused]);
+    expect(state.status).toBe('completed');
+    expect(state.success).toBe(true);
+    expect(state.laneRefused.role).toBe('reviewer');
+  });
+
+  it('records the tier a spawned run actually ran as', () => {
+    const spawned = buildRunEvent({
+      kind: 'run.spawned',
+      runId: 'run-2',
+      agentId: 'agent-3',
+      at: AT,
+      data: { providerId: 'p-cheap-2', model: 'alt-m', orchestrationRole: 'architect', laneSubstitutedFrom: 'p-cheap' },
+    });
+    const [state] = projectRunStates([spawned]);
+    expect(state.orchestrationRole).toBe('architect');
+    expect(state.laneSubstitutedFrom).toBe('p-cheap');
+    expect(state.providerId).toBe('p-cheap-2');
+  });
+});

--- a/server/lib/cosValidation.js
+++ b/server/lib/cosValidation.js
@@ -141,7 +141,21 @@ const orchestrationRoleSchema = z.object({
   // walking the run-level fallback chain back onto the architect's provider.
   fallbackProvider: z.string().trim().min(1).max(120).optional(),
   fallbackModel: z.string().trim().min(1).max(300).optional(),
-}).strict();
+}).strict().superRefine((role, ctx) => {
+  // Reject here what `normalizeRoleAssignment` would silently drop, and what the
+  // resolver would refuse at spawn time. Accepting them returns 200 for a profile
+  // that is permanently inert (or that stops every run the first time its provider
+  // blinks), and the user finds out only when a task blocks days later.
+  if (role.fallbackProvider && !role.provider && !role.model) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, path: ['fallbackProvider'], message: 'fallbackProvider needs a provider or model pin on the same role to be an alternate to' });
+  }
+  if (role.fallbackModel && !role.fallbackProvider) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, path: ['fallbackModel'], message: 'fallbackModel needs a fallbackProvider on the same role' });
+  }
+  if (role.model && role.fallbackProvider && !role.fallbackModel) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, path: ['fallbackModel'], message: 'a role pinning a model must name the fallbackModel its fallbackProvider runs it as' });
+  }
+});
 
 export const orchestrationProfileSchema = z.object(
   Object.fromEntries(ORCHESTRATION_ROLES.map(role => [role, orchestrationRoleSchema.optional()]))

--- a/server/lib/cosValidation.js
+++ b/server/lib/cosValidation.js
@@ -136,6 +136,11 @@ const orchestrationRoleSchema = z.object({
   // Per-role reasoning effort. The architect's own rung for its planning pass;
   // for the implementer it is the DEFAULT a spec's `REASONING:` line overrides.
   effort: z.enum(EFFORT_LEVELS).optional(),
+  // The role's SAME-ROLE alternate (#5993) — the only provider swap a configured
+  // lane accepts. Without one, an unavailable lane stops the run rather than
+  // walking the run-level fallback chain back onto the architect's provider.
+  fallbackProvider: z.string().trim().min(1).max(120).optional(),
+  fallbackModel: z.string().trim().min(1).max(300).optional(),
 }).strict();
 
 export const orchestrationProfileSchema = z.object(

--- a/server/lib/cosValidation.test.js
+++ b/server/lib/cosValidation.test.js
@@ -280,3 +280,39 @@ describe('createCosTaskSchema isInvestigation (#6043)', () => {
     expect(parsed).not.toHaveProperty('investigationFingerprint');
   });
 });
+
+/**
+ * Same-role alternates (#5993). The schema rejects exactly what the normalizer
+ * would drop and what the resolver would refuse — a 200 on a permanently-inert
+ * profile is a configuration the user only discovers when a task blocks later.
+ */
+describe('cosValidation orchestration role alternates', () => {
+  const parseRole = (architect) => createCosTaskSchema.safeParse({
+    description: 'x',
+    orchestrationProfile: { architect },
+  });
+
+  it('accepts an alternate beside a provider pin', () => {
+    expect(parseRole({ provider: 'p-cheap', fallbackProvider: 'p-cheap-2' }).success).toBe(true);
+  });
+
+  it('accepts a model-pinned role whose alternate names its own model', () => {
+    expect(parseRole({
+      provider: 'p-cheap', model: 'm-cheap', fallbackProvider: 'p-cheap-2', fallbackModel: 'm-cheap-2',
+    }).success).toBe(true);
+  });
+
+  it('rejects an alternate with no pin to be an alternate to', () => {
+    expect(parseRole({ effort: 'high', fallbackProvider: 'p-cheap-2' }).success).toBe(false);
+  });
+
+  it('rejects a fallbackModel with no fallbackProvider', () => {
+    expect(parseRole({ provider: 'p-cheap', fallbackModel: 'm-cheap-2' }).success).toBe(false);
+  });
+
+  it('rejects a model-pinned role whose alternate has no model to run it as', () => {
+    // Accepting this would let the run silently land on the alternate's own
+    // default — the substitution the fail-closed lane exists to prevent.
+    expect(parseRole({ provider: 'p-cheap', model: 'm-cheap', fallbackProvider: 'p-cheap-2' }).success).toBe(false);
+  });
+});

--- a/server/lib/orchestrationProfile.js
+++ b/server/lib/orchestrationProfile.js
@@ -72,17 +72,29 @@ const trimmedString = (value, maxLength) => {
  * only a model inherits the run's provider, and a role that pins nothing at all
  * normalizes away entirely (null) rather than persisting an empty object that
  * would read as a configured-but-blank override.
+ *
+ * `fallbackProvider` / `fallbackModel` are the role's SAME-ROLE alternate
+ * (#5993): the only substitution a configured lane accepts when its provider is
+ * unavailable. It is deliberately per-role rather than the run-level
+ * `metadata.fallbackProvider`, because the run-level chain is what silently
+ * collapses a cheap cross-vendor lane back onto the architect's provider. A
+ * fallback pinned with no primary `provider` is dropped — there is nothing for
+ * it to be an alternate TO, and keeping it would read as a second pin.
  */
 function normalizeRoleAssignment(raw) {
   if (!isPlainObject(raw)) return null;
   const provider = trimmedString(raw.provider, MAX_PROVIDER_ID_LENGTH);
   const model = trimmedString(raw.model, MAX_MODEL_ID_LENGTH);
   const effort = EFFORT_LEVELS.includes(raw.effort) ? raw.effort : null;
+  const fallbackProvider = provider ? trimmedString(raw.fallbackProvider, MAX_PROVIDER_ID_LENGTH) : null;
+  const fallbackModel = fallbackProvider ? trimmedString(raw.fallbackModel, MAX_MODEL_ID_LENGTH) : null;
   if (!provider && !model && !effort) return null;
   return Object.freeze({
     ...(provider ? { provider } : {}),
     ...(model ? { model } : {}),
     ...(effort ? { effort } : {}),
+    ...(fallbackProvider ? { fallbackProvider } : {}),
+    ...(fallbackModel ? { fallbackModel } : {}),
   });
 }
 

--- a/server/lib/orchestrationProfile.js
+++ b/server/lib/orchestrationProfile.js
@@ -77,16 +77,21 @@ const trimmedString = (value, maxLength) => {
  * (#5993): the only substitution a configured lane accepts when its provider is
  * unavailable. It is deliberately per-role rather than the run-level
  * `metadata.fallbackProvider`, because the run-level chain is what silently
- * collapses a cheap cross-vendor lane back onto the architect's provider. A
- * fallback pinned with no primary `provider` is dropped — there is nothing for
- * it to be an alternate TO, and keeping it would read as a second pin.
+ * collapses a cheap cross-vendor lane back onto the architect's provider.
+ *
+ * It rides on a `provider` OR a `model` pin — the same pair the resolver treats
+ * as fail-closed. A MODEL-only role is fail-closed too (its model is what the
+ * generic chain would drop), so it needs the alternate just as much; dropping
+ * one there would leave the refusal telling the user to configure a field this
+ * normalizer discards. A fallback pinned beside neither is dropped: there is
+ * nothing for it to be an alternate TO, and keeping it would read as a lane.
  */
 function normalizeRoleAssignment(raw) {
   if (!isPlainObject(raw)) return null;
   const provider = trimmedString(raw.provider, MAX_PROVIDER_ID_LENGTH);
   const model = trimmedString(raw.model, MAX_MODEL_ID_LENGTH);
   const effort = EFFORT_LEVELS.includes(raw.effort) ? raw.effort : null;
-  const fallbackProvider = provider ? trimmedString(raw.fallbackProvider, MAX_PROVIDER_ID_LENGTH) : null;
+  const fallbackProvider = provider || model ? trimmedString(raw.fallbackProvider, MAX_PROVIDER_ID_LENGTH) : null;
   const fallbackModel = fallbackProvider ? trimmedString(raw.fallbackModel, MAX_MODEL_ID_LENGTH) : null;
   if (!provider && !model && !effort) return null;
   return Object.freeze({

--- a/server/lib/orchestrationProfile.test.js
+++ b/server/lib/orchestrationProfile.test.js
@@ -83,3 +83,53 @@ describe('role vocabulary', () => {
     expect([...ORCHESTRATION_ROLES]).toEqual(['architect', 'implementer', 'reviewer']);
   });
 });
+
+/**
+ * Same-role alternates (#5993). The alternate rides on the pin it substitutes
+ * for, so what the normalizer keeps has to match what the resolver treats as a
+ * fail-closed lane — otherwise a refusal names a field that was silently dropped.
+ */
+describe('same-role alternates', () => {
+  it('keeps a fallbackProvider + fallbackModel beside a provider pin', () => {
+    const profile = normalizeOrchestrationProfile({
+      implementer: { provider: 'p-cheap', model: 'm-cheap', fallbackProvider: 'p-cheap-2', fallbackModel: 'm-cheap-2' },
+    });
+    expect(profile.implementer).toEqual({
+      provider: 'p-cheap',
+      model: 'm-cheap',
+      fallbackProvider: 'p-cheap-2',
+      fallbackModel: 'm-cheap-2',
+    });
+  });
+
+  // A model-only role is fail-closed too — the generic chain would drop its model
+  // pin — so it must be able to carry the alternate the refusal points the user at.
+  it('keeps the alternate on a model-only role', () => {
+    const profile = normalizeOrchestrationProfile({
+      implementer: { model: 'm-cheap', fallbackProvider: 'p-cheap-2', fallbackModel: 'm-cheap-2' },
+    });
+    expect(profile.implementer).toEqual({
+      model: 'm-cheap',
+      fallbackProvider: 'p-cheap-2',
+      fallbackModel: 'm-cheap-2',
+    });
+  });
+
+  it('drops an alternate on a role that pins neither a provider nor a model', () => {
+    const profile = normalizeOrchestrationProfile({
+      implementer: { effort: 'high', fallbackProvider: 'p-cheap-2', fallbackModel: 'm-cheap-2' },
+    });
+    expect(profile.implementer).toEqual({ effort: 'high' });
+  });
+
+  it('drops a fallbackModel with no fallbackProvider to attach to', () => {
+    const profile = normalizeOrchestrationProfile({
+      implementer: { provider: 'p-cheap', fallbackModel: 'm-cheap-2' },
+    });
+    expect(profile.implementer).toEqual({ provider: 'p-cheap' });
+  });
+
+  it('does not make an alternate alone enough to persist a role', () => {
+    expect(normalizeOrchestrationProfile({ implementer: { fallbackProvider: 'p-cheap-2' } })).toBeNull();
+  });
+});

--- a/server/lib/taskBlockCategories.js
+++ b/server/lib/taskBlockCategories.js
@@ -60,12 +60,25 @@ export const PAUSED_BLOCKED_CATEGORIES = new Set([
  * categories stay reapable — they revive themselves in minutes, so one still
  * sitting there after 14 days IS stale.)
  */
+/**
+ * A fail-closed orchestration lane refused to substitute providers (#5993). Its
+ * own exported name because `agentLifecycle.js` stamps it and the sweep below
+ * exempts it — two string literals that must never drift apart.
+ */
+export const ORCHESTRATION_LANE_BLOCKED_CATEGORY = 'orchestration-lane-unavailable';
+
 export const USER_DECISION_BLOCKED_CATEGORIES = new Set([
   'user-terminated',      // user explicitly stopped the agent
   AGENT_PAUSED_CATEGORY,  // user paused; resumable on demand
   'challenge-escalation', // parked awaiting the user's arbitration
   'app-unresolved',
-  'workspace-invalid'
+  'workspace-invalid',
+  // Waiting on the same kind of fix as the two above: authenticate the lane's
+  // provider, pick another model for the role, or give it a fallbackProvider.
+  // Without the exemption the failure sweep retires it to `completed` with an
+  // `auto-expired` marker after 14 days — turning the loud, deliberate stop into
+  // exactly the silent success the fail-closed lane exists to prevent.
+  ORCHESTRATION_LANE_BLOCKED_CATEGORY
 ]);
 
 /**

--- a/server/lib/taskBlockCategories.js
+++ b/server/lib/taskBlockCategories.js
@@ -18,6 +18,14 @@
 import { AGENT_PAUSED_CATEGORY } from './taskPauseHold.js';
 
 /**
+ * A fail-closed orchestration lane refused to substitute providers (#5993). Its
+ * own exported name because three places key on it — `agentLifecycle.js` stamps
+ * it, and BOTH sets below list it — which is exactly the literal drift this
+ * module exists to prevent.
+ */
+export const ORCHESTRATION_LANE_BLOCKED_CATEGORY = 'orchestration-lane-unavailable';
+
+/**
  * Pauses a TIMER clears, not a person: the task carries a `cooldownUntil` and the
  * cooldown sweeper (`unblockExpiredCooldowns`, cosTaskGenerator.js) flips it back
  * to `pending` once that stamp passes.
@@ -46,7 +54,16 @@ export const TIMED_COOLDOWN_BLOCKED_CATEGORIES = new Set([
 export const PAUSED_BLOCKED_CATEGORIES = new Set([
   ...TIMED_COOLDOWN_BLOCKED_CATEGORIES,
   'app-unresolved',    // the task's app has no usable Repository Path
-  'workspace-invalid'  // the resolved workspace isn't a usable directory
+  'workspace-invalid', // the resolved workspace isn't a usable directory
+  // A fail-closed lane is a CONFIG pause of the same shape: the user authenticates
+  // the provider (or gives the role a fallbackProvider) and revives the task. It
+  // is not TIMED, so no cooldown sweeper picks it up. Listing it here is what
+  // keeps the resume pointer — without it a lane that blocked on a merely
+  // rate-limited provider would strip `existingBranch` / `resumeWorktreePath`,
+  // and the revived task would restart clean and orphan its predecessor's
+  // worktree. Before fail-closed that case stayed `pending` with its pointer
+  // intact, so omitting it here would be a NEW way to abandon work.
+  ORCHESTRATION_LANE_BLOCKED_CATEGORY
 ]);
 
 /**
@@ -60,24 +77,17 @@ export const PAUSED_BLOCKED_CATEGORIES = new Set([
  * categories stay reapable — they revive themselves in minutes, so one still
  * sitting there after 14 days IS stale.)
  */
-/**
- * A fail-closed orchestration lane refused to substitute providers (#5993). Its
- * own exported name because `agentLifecycle.js` stamps it and the sweep below
- * exempts it — two string literals that must never drift apart.
- */
-export const ORCHESTRATION_LANE_BLOCKED_CATEGORY = 'orchestration-lane-unavailable';
-
 export const USER_DECISION_BLOCKED_CATEGORIES = new Set([
   'user-terminated',      // user explicitly stopped the agent
   AGENT_PAUSED_CATEGORY,  // user paused; resumable on demand
   'challenge-escalation', // parked awaiting the user's arbitration
   'app-unresolved',
   'workspace-invalid',
-  // Waiting on the same kind of fix as the two above: authenticate the lane's
-  // provider, pick another model for the role, or give it a fallbackProvider.
-  // Without the exemption the failure sweep retires it to `completed` with an
-  // `auto-expired` marker after 14 days — turning the loud, deliberate stop into
-  // exactly the silent success the fail-closed lane exists to prevent.
+  // Waiting on the same kind of fix as the workspace blocks above: authenticate
+  // the lane's provider, pick another model for the role, or give it a
+  // fallbackProvider. Without the exemption the failure sweep retires it to
+  // `completed` with an `auto-expired` marker after 14 days — turning the loud,
+  // deliberate stop into exactly the silent success the lane exists to prevent.
   ORCHESTRATION_LANE_BLOCKED_CATEGORY
 ]);
 

--- a/server/services/agentLifecycle.js
+++ b/server/services/agentLifecycle.js
@@ -45,6 +45,7 @@ import { spawnAgentViaRunner, getRunnerHealth, classifyRunnerSpawnFailure, RUNNE
 import { MAX_TOTAL_SPAWNS, normalizeReviewers } from '../lib/validation.js';
 import { isInternalTaskId } from '../lib/taskParser.js';
 import { isRetryHeld } from '../lib/taskRetryHold.js';
+import { ORCHESTRATION_LANE_BLOCKED_CATEGORY } from '../lib/taskBlockCategories.js';
 import { ensureDir, PATHS, sleep, tryReadFile } from '../lib/fileUtils.js';
 import { createToolExecution, startExecution, completeExecution, errorExecution } from './toolStateMachine.js';
 import { determineLane, acquire, release } from './executionLanes.js';
@@ -425,7 +426,7 @@ async function runAgentSpawn(task) {
           metadata: {
             ...task.metadata,
             blockedReason: resolution.error,
-            blockedCategory: lane ? 'orchestration-lane-unavailable' : 'provider-config',
+            blockedCategory: lane ? ORCHESTRATION_LANE_BLOCKED_CATEGORY : 'provider-config',
             ...(lane ? { orchestrationLane: lane } : {}),
             blockedAt: new Date().toISOString()
           }

--- a/server/services/agentLifecycle.js
+++ b/server/services/agentLifecycle.js
@@ -411,16 +411,42 @@ async function runAgentSpawn(task) {
       // `in_progress` record clobbered to `blocked` — which outranks `in_progress`
       // in the claim-aware merge. Transient failures fall through, skip the block,
       // and stay pending to retry.
+      // A configured orchestration lane that refused to substitute providers
+      // (#5993) is its OWN terminal outcome, not a generic provider failure: the
+      // fix is specific to the role ("authenticate that CLI", "pick another model
+      // for the implementer", "give it a fallbackProvider"), and a run that
+      // stopped for it must never be reported as anything else. The structured
+      // detail rides along on the task metadata, the `agent:error` event, and the
+      // ledger below so each surface names the role and provider itself.
+      const lane = resolution.orchestrationLane || null;
       if (resolution.permanent) {
         await updateTask(task.id, {
           status: 'blocked',
           metadata: {
             ...task.metadata,
             blockedReason: resolution.error,
-            blockedCategory: 'provider-config',
+            blockedCategory: lane ? 'orchestration-lane-unavailable' : 'provider-config',
+            ...(lane ? { orchestrationLane: lane } : {}),
             blockedAt: new Date().toISOString()
           }
         }, task.taskType || 'user').catch(() => {});
+      }
+      // Recorded BEFORE cleanup so the ledger holds the reason even if cleanup
+      // throws. No runId exists — the run never spawned — so this is keyed by the
+      // agent id, which is exactly the `agent:<id>` fallback `runEventKey` has.
+      if (lane) {
+        await appendRunEvent({
+          kind: 'run.lane-refused',
+          agentId,
+          taskId: task.id,
+          eventId: `lane-refused:${agentId}:${lane.role}`,
+          data: {
+            role: lane.role,
+            requestedProvider: lane.requestedProvider,
+            requestedModel: lane.requestedModel,
+            reason: lane.reason,
+          },
+        });
       }
       await cleanupOnError(resolution.error);
       cosEvents.emit('agent:error', {
@@ -428,6 +454,7 @@ async function runAgentSpawn(task) {
         error: resolution.error,
         ...(resolution.providerId && { providerId: resolution.providerId }),
         ...(resolution.providerStatus && { providerStatus: resolution.providerStatus }),
+        ...(lane && { orchestrationLane: lane }),
       });
       return null;
     }
@@ -720,7 +747,8 @@ async function runAgentSpawn(task) {
       model: selectedModel,
       provider,
       workspacePath,
-      appName: resolvedAppName
+      appName: resolvedAppName,
+      orchestrationLane: resolution.orchestrationLane ?? null
     });
     const executionMode = !spawnHeadless ? (dispatchUseRunner ? 'runner-tui' : 'tui') : dispatchUseRunner ? 'runner' : 'direct';
 

--- a/server/services/agentLifecycle.test.js
+++ b/server/services/agentLifecycle.test.js
@@ -635,7 +635,11 @@ describe('runAgentSpawn source — permanent provider-config failure blocks the 
     const idx = AGENT_LIFECYCLE_SRC.indexOf('const resolution = await resolveAgentProviderAndModel(task)');
     const body = AGENT_LIFECYCLE_SRC.slice(idx, idx + RESOLUTION_FAILURE_WINDOW);
     expect(body, 'reads the structured lane detail').toMatch(/const lane = resolution\.orchestrationLane/);
-    expect(body, 'has its own block category').toMatch(/'orchestration-lane-unavailable'/);
+    // The category is referenced through the shared constant, not re-typed: the
+    // failure sweep exempts the same value, and two literals would drift.
+    expect(body, 'has its own block category').toMatch(/ORCHESTRATION_LANE_BLOCKED_CATEGORY/);
+    expect(AGENT_LIFECYCLE_SRC, 'takes the category from the shared module')
+      .toMatch(/import \{ ORCHESTRATION_LANE_BLOCKED_CATEGORY \} from '\.\.\/lib\/taskBlockCategories\.js';/);
     expect(body, 'carries the detail onto the task').toMatch(/orchestrationLane: lane/);
     expect(body, 'records the refusal in the ledger').toMatch(/kind: 'run\.lane-refused'/);
   });

--- a/server/services/agentLifecycle.test.js
+++ b/server/services/agentLifecycle.test.js
@@ -612,19 +612,46 @@ describe('runAgentSpawn source — app-review marker release (issue #989)', () =
 // re-dispatch. Without a block, the task stays pending and silently re-fails
 // forever. Pin that the permanent branch flips the task to blocked BEFORE the
 // lease is released, so a federated peer can't be clobbered.
+// Wide enough to cover the whole `if (!resolution.ok)` arm — its comments carry
+// the reasoning for the ordering these tests pin, so the window has to include
+// them rather than being trimmed to the statements.
+const RESOLUTION_FAILURE_WINDOW = 4000;
+
 describe('runAgentSpawn source — permanent provider-config failure blocks the task', () => {
   it('the resolution-failure path blocks a permanent failure with a provider-config reason', () => {
     const idx = AGENT_LIFECYCLE_SRC.indexOf('const resolution = await resolveAgentProviderAndModel(task)');
     expect(idx, 'resolution call must exist').toBeGreaterThan(-1);
-    const body = AGENT_LIFECYCLE_SRC.slice(idx, idx + 2000);
+    const body = AGENT_LIFECYCLE_SRC.slice(idx, idx + RESOLUTION_FAILURE_WINDOW);
     expect(body, 'gates the block on resolution.permanent').toMatch(/if\s*\(resolution\.permanent\)/);
     expect(body, 'flips the task to blocked').toMatch(/status:\s*'blocked'/);
-    expect(body, 'tags the block category').toMatch(/blockedCategory:\s*'provider-config'/);
+    expect(body, 'tags the block category').toMatch(/blockedCategory:[^\n]*'provider-config'/);
+  });
+
+  // A configured orchestration lane that refuses to substitute providers (#5993)
+  // is a DISTINCT terminal outcome: same block, its own category and structured
+  // detail, so the client can name the role and provider instead of showing a
+  // generic provider-config failure.
+  it('tags a refused orchestration lane with its own category and detail', () => {
+    const idx = AGENT_LIFECYCLE_SRC.indexOf('const resolution = await resolveAgentProviderAndModel(task)');
+    const body = AGENT_LIFECYCLE_SRC.slice(idx, idx + RESOLUTION_FAILURE_WINDOW);
+    expect(body, 'reads the structured lane detail').toMatch(/const lane = resolution\.orchestrationLane/);
+    expect(body, 'has its own block category').toMatch(/'orchestration-lane-unavailable'/);
+    expect(body, 'carries the detail onto the task').toMatch(/orchestrationLane: lane/);
+    expect(body, 'records the refusal in the ledger').toMatch(/kind: 'run\.lane-refused'/);
+  });
+
+  it('records the lane refusal BEFORE cleanup, so the reason survives a failing cleanup', () => {
+    const idx = AGENT_LIFECYCLE_SRC.indexOf('const resolution = await resolveAgentProviderAndModel(task)');
+    const body = AGENT_LIFECYCLE_SRC.slice(idx, idx + RESOLUTION_FAILURE_WINDOW);
+    const ledgerIdx = body.indexOf("kind: 'run.lane-refused'");
+    const cleanupIdx = body.indexOf('await cleanupOnError(resolution.error)');
+    expect(ledgerIdx, 'ledger append must exist').toBeGreaterThan(-1);
+    expect(ledgerIdx, 'ledger append must precede cleanup').toBeLessThan(cleanupIdx);
   });
 
   it('blocks BEFORE releasing the lease so a federated peer cannot be clobbered', () => {
     const idx = AGENT_LIFECYCLE_SRC.indexOf('const resolution = await resolveAgentProviderAndModel(task)');
-    const body = AGENT_LIFECYCLE_SRC.slice(idx, idx + 2000);
+    const body = AGENT_LIFECYCLE_SRC.slice(idx, idx + RESOLUTION_FAILURE_WINDOW);
     const permanentIdx = body.indexOf('if (resolution.permanent)');
     const cleanupIdx = body.indexOf('await cleanupOnError(resolution.error)');
     expect(permanentIdx, 'permanent block must exist').toBeGreaterThan(-1);

--- a/server/services/agentManagement.js
+++ b/server/services/agentManagement.js
@@ -623,7 +623,7 @@ async function requeuePausedTask({ task, taskType, overrides }) {
 // state owned by the spent task/run so the replacement gets a new retry budget,
 // lease, workspace pointer, and output-hook dispatch.
 const REPLACEMENT_RUNTIME_METADATA_KEYS = new Set([
-  'blockedReason', 'blockedCategory', 'blockedAt', 'blocker', 'failureCount',
+  'blockedReason', 'blockedCategory', 'blockedAt', 'blocker', 'orchestrationLane', 'failureCount',
   'lastErrorCategory', 'lastFailureAt', 'cooldownUntil', 'totalSpawnCount',
   'orphanRetryCount', 'lastOrphanedAt', 'lastOrphanedAgentId', 'worktreeBusyAttempts',
   LAST_SPAWNED_AT_KEY, 'interruptedByRestart', 'lastInterruptedAt', 'lastInterruptedAgentId',

--- a/server/services/agentProviderResolution.js
+++ b/server/services/agentProviderResolution.js
@@ -196,17 +196,26 @@ async function resolveOrdinaryProviderAndModel(task) {
     }
   }
   if (!provider) provider = await getActiveProvider();
-  // A lane that pins only a MODEL inherits the active provider — so when there
-  // is no active provider it is the LANE that has nowhere to run, and it says so
-  // in the lane's own shape. Falling through to the generic
-  // "No active AI provider configured" below would lose the role, leaving the
-  // client with nothing to name.
-  if (lane && !provider) {
+  // A lane that pins only a MODEL inherits whatever provider the task resolves
+  // to — so both ways that inheritance can fail are the LANE failing, and both
+  // say so in the lane's own shape rather than falling through.
+  //
+  // `userProviderMissing` is the one that bites: the `else` above continues on
+  // the active provider, which makes `providerSwapped` true below, which drops
+  // the lane's pinned model to that provider's default. That is the silent
+  // model-axis substitution the `no-model` refusal and the alternate's
+  // pass-through exemption exist to close, arriving on a path with no block, no
+  // `orchestrationLane`, and nothing naming the role. The other is simpler: no
+  // active provider at all, where the generic "No active AI provider configured"
+  // below would lose the role and leave the client nothing to name.
+  if (lane && (!provider || userProviderMissing)) {
     return laneUnavailable({
       role: laneRole,
-      requestedProvider: null,
+      requestedProvider: userProviderMissing ? userProviderId : null,
       requestedModel: lane.model || null,
-      reason: 'no active AI provider is configured for it to inherit',
+      reason: userProviderMissing
+        ? 'the provider pinned for this task is not configured on this install'
+        : 'no active AI provider is configured for it to inherit',
     });
   }
 

--- a/server/services/agentProviderResolution.js
+++ b/server/services/agentProviderResolution.js
@@ -253,12 +253,32 @@ async function resolveOrdinaryProviderAndModel(task) {
     if (lane) {
       const alternateId = lane.fallbackProvider;
       const alternate = alternateId ? await getProviderById(alternateId) : null;
-      if (!alternate || !isProviderAvailable(alternate.id)) {
+      // An `api`-type alternate is rejected HERE rather than left to the harness
+      // guard below. That guard computes its `permanent` flag from the lane's own
+      // (CLI) primary, so an api alternate reaching it returns a TRANSIENT failure
+      // with no lane detail — the task never blocks, never records the refusal,
+      // and re-dispatches into the same dead end forever. Silent re-failure is the
+      // behavior this whole path exists to end, so it cannot be the way it ends.
+      //
+      // A lane that pinned a MODEL also needs the alternate to name one. Without
+      // `fallbackModel` the pin belongs to the primary, the swap invalidates it,
+      // and the run silently lands on the alternate's own default — the same
+      // substitution this closes, moved from the provider axis to the model axis.
+      const alternateUnusable = !alternate ? 'missing'
+        : alternate.type === 'api' ? 'no-harness'
+        : !isProviderAvailable(alternate.id) ? 'unavailable'
+        : lane.model && !lane.fallbackModel ? 'no-model'
+        : null;
+      if (alternateUnusable) {
         const why = !alternateId
           ? `${status.message} (no ${laneRole}.fallbackProvider is configured)`
-          : !alternate
+          : alternateUnusable === 'missing'
             ? `${status.message}, and its ${laneRole}.fallbackProvider "${alternateId}" is not a configured provider`
-            : `${status.message}, and its ${laneRole}.fallbackProvider "${alternateId}" is also unavailable (${getProviderStatus(alternate.id).message})`;
+            : alternateUnusable === 'no-harness'
+              ? `${status.message}, and its ${laneRole}.fallbackProvider "${alternateId}" is an HTTP API provider with no file-writing harness`
+              : alternateUnusable === 'no-model'
+                ? `${status.message}, and its ${laneRole}.fallbackProvider "${alternateId}" was given no ${laneRole}.fallbackModel to run the pinned model "${lane.model}" on`
+                : `${status.message}, and its ${laneRole}.fallbackProvider "${alternateId}" is also unavailable (${getProviderStatus(alternate.id).message})`;
         return laneUnavailable({
           role: laneRole,
           requestedProvider: provider.id,

--- a/server/services/agentProviderResolution.js
+++ b/server/services/agentProviderResolution.js
@@ -18,7 +18,7 @@ import { getActiveProvider, getAllProviders, getProviderById } from './providers
 import { isProviderAvailable, getFallbackProvider, getProviderStatus } from './providerStatus.js';
 import { selectModelForRole, selectModelForTask } from './agentModelSelection.js';
 import { modelPinIsOffered } from '../lib/localProviderRuntime.js';
-import { PRIMARY_ORCHESTRATION_ROLE, roleAssignment } from '../lib/orchestrationProfile.js';
+import { PRIMARY_ORCHESTRATION_ROLE, isOrchestratedTask, roleAssignment } from '../lib/orchestrationProfile.js';
 import { publicReviewPostureForTask, resolvePublicReviewProvider } from './publicReviewProviderSelection.js';
 
 /**
@@ -397,7 +397,16 @@ async function resolveOrdinaryProviderAndModel(task) {
   const providerSwapped = userProviderMissing || provider.id !== directProviderId;
   const pinnedProviderId = userProviderId || directProviderId;
   const isUserPin = modelSelection.tier === 'user-specified' && !fallbackModelPin;
-  const isUserPinnedModel = isUserPin && !providerSwapped;
+  // A lane's own `fallbackModel` is as explicit as `metadata.model` — the user
+  // named THIS model FOR THIS alternate (#5993). The `models` list is a
+  // convenience enumeration the pass-through CLIs don't enforce, and whose alias
+  // forms already disagree across records (see the note below), so downgrading
+  // the pin to the alternate's default here would silently run the lane on a
+  // model nobody chose — the model-axis substitution the `no-model` refusal
+  // above exists to close, arriving one branch later.
+  const isLaneAlternateModel = Boolean(laneSubstitution)
+    && fallbackModelPin != null && fallbackModelPin === lane?.fallbackModel;
+  const isUserPinnedModel = (isUserPin && !providerSwapped) || isLaneAlternateModel;
   if (isUserPin && providerSwapped && !(provider.models || []).includes(selectedModel)) {
     // Handled here rather than left to the list check below, which can't fire at
     // all for a fallback provider that enumerates no `models`.
@@ -450,11 +459,14 @@ async function resolveOrdinaryProviderAndModel(task) {
     // What the run ledger records so `/cos/runs` can show the tier split really
     // happened (#5993): the role this run was dispatched as, the provider it
     // ACTUALLY ran on, and the one substitution — if any — the lane accepted.
-    // Absent on a `direct`-mode run, which has no roles to account for.
-    ...(roleAssign ? {
+    // Gated on the RUN being orchestrated, not on this role being pinned: a
+    // profile that pins only the cheap implementer/reviewer lanes and leaves the
+    // architect on the run default is a normal config, and it is exactly the run
+    // whose tier split is worth showing. Absent on a `direct`-mode run.
+    ...(isOrchestratedTask(task) ? {
       orchestrationLane: {
         role: laneRole,
-        requestedProvider: roleAssign.provider || directProviderId,
+        requestedProvider: roleAssign?.provider || directProviderId,
         providerId: provider.id,
         model: selectedModel,
         ...(laneSubstitution ? { substitution: laneSubstitution } : {}),

--- a/server/services/agentProviderResolution.js
+++ b/server/services/agentProviderResolution.js
@@ -112,6 +112,36 @@ async function resolvePublicReviewAgentProvider(task, posture) {
   return { ok: true, provider, selectedModel, modelSelection };
 }
 
+/**
+ * A configured orchestration lane refused to substitute providers (#5993).
+ *
+ * Shaped so every consumer reads one structure: the caller blocks the task with
+ * `error` as its reason, the `agent:error` event and the run ledger carry
+ * `orchestrationLane` verbatim, and the client names the role and provider from
+ * the same fields rather than re-parsing the sentence.
+ *
+ * Always PERMANENT. That is the point of a fail-closed lane: a rate-limited
+ * cheap provider that would recover in an hour is still a lane the user has to
+ * decide about, and quietly re-dispatching until it comes back is the silent
+ * behavior this replaces. Unblocking is one click once the CLI is authenticated
+ * or a `fallbackProvider` is configured; a lane that retried itself would spend
+ * the architect's budget with nobody watching.
+ */
+function laneUnavailable({ role, requestedProvider, requestedModel, reason }) {
+  const requested = requestedProvider
+    ? `its provider "${requestedProvider}"${requestedModel ? ` (model "${requestedModel}")` : ''} is unavailable`
+    : `its pinned model "${requestedModel}" has nothing to run on`;
+  return {
+    ok: false,
+    permanent: true,
+    error: `Orchestrated ${role} lane stopped — ${requested}: ${reason}. `
+      + `PortOS will not substitute another provider for a configured lane; authenticate or repair that provider, `
+      + `pick another model for the ${role} role, or configure ${role}.fallbackProvider.`,
+    providerId: requestedProvider || undefined,
+    orchestrationLane: { role, requestedProvider: requestedProvider || null, requestedModel: requestedModel || null, reason },
+  };
+}
+
 async function resolveOrdinaryProviderAndModel(task) {
   // A task can pin a specific provider via metadata.provider (e.g. a CoS job's
   // per-job AI override). Resolve it BEFORE the active-provider availability
@@ -126,19 +156,54 @@ async function resolveOrdinaryProviderAndModel(task) {
   // (availability, fallback swap, the model-pin invalidation a swap triggers)
   // rather than growing a second, subtly-different resolution path. Null on a
   // `direct` task, so the metadata pin stays authoritative as before.
-  const userProviderId = roleAssignment(task, PRIMARY_ORCHESTRATION_ROLE)?.provider || task.metadata?.provider;
+  //
+  // …with ONE exception, and it is the whole of #5993. An orchestrated run's
+  // roles exist BECAUSE they are different providers: the implementer lane is
+  // cheap and cross-vendor on purpose. Swapping a configured lane onto whatever
+  // is healthy spends the architect's premium tokens on mechanical editing —
+  // the exact cost orchestration was turned on to avoid — and collapses the
+  // vendor split with nobody told. So when the role carries an assignment at
+  // all, this lane is FAIL-CLOSED: the only substitution it accepts is the
+  // role's own `fallbackProvider`, and anything else stops the run loudly.
+  // `direct`-mode runs keep the pin → active → fallback chain untouched
+  // (`roleAssignment` returns null for every role on one).
+  const laneRole = PRIMARY_ORCHESTRATION_ROLE;
+  const lane = roleAssignment(task, laneRole);
+  const userProviderId = lane?.provider || task.metadata?.provider;
   let userProviderMissing = false;
   if (userProviderId) {
     const userProvider = await getProviderById(userProviderId);
     if (userProvider) {
       emitLog('info', `Using user-specified provider: ${userProviderId}`, { taskId: task.id });
       provider = userProvider;
+    } else if (lane?.provider) {
+      // A configured lane whose provider record does not exist is a config error
+      // that re-fails identically forever — never "use the active provider".
+      return laneUnavailable({
+        role: laneRole,
+        requestedProvider: userProviderId,
+        requestedModel: lane.model || null,
+        reason: 'no provider with that id is configured on this install',
+      });
     } else {
       userProviderMissing = true;
       emitLog('warn', `User-specified provider "${userProviderId}" not found, using active provider`, { taskId: task.id });
     }
   }
   if (!provider) provider = await getActiveProvider();
+  // A lane that pins only a MODEL inherits the active provider — so when there
+  // is no active provider it is the LANE that has nowhere to run, and it says so
+  // in the lane's own shape. Falling through to the generic
+  // "No active AI provider configured" below would lose the role, leaving the
+  // client with nothing to name.
+  if (lane && !provider) {
+    return laneUnavailable({
+      role: laneRole,
+      requestedProvider: null,
+      requestedModel: lane.model || null,
+      reason: 'no active AI provider is configured for it to inherit',
+    });
+  }
 
   if (!provider) {
     return { ok: false, error: 'No active AI provider configured' };
@@ -163,6 +228,9 @@ async function resolveOrdinaryProviderAndModel(task) {
   // Model" pin — it overrides the usual per-task model selection so the
   // user's chosen fallback provider+model pair is honored on agent runs.
   let fallbackModelPin = null;
+  // The one substitution a configured lane DID accept, recorded so the run
+  // ledger can show the tier really ran where the user said it could (#5993).
+  let laneSubstitution = null;
   const providerAvailable = isProviderAvailable(provider.id);
   if (!providerAvailable) {
     const status = getProviderStatus(provider.id);
@@ -172,36 +240,68 @@ async function resolveOrdinaryProviderAndModel(task) {
       reason: status.reason
     });
 
-    // Try to get a fallback provider (check task-level, then provider-level, then system default).
-    // getFallbackProvider indexes its providers arg by id, so pass a map — NOT the
-    // { activeProvider, providers: [...] } shape getAllProviders() returns (mirrors promptRunner.js).
-    const { providers: providerList = [] } = await getAllProviders();
-    const providersMap = Object.fromEntries(providerList.map((p) => [p.id, p]));
-    const taskFallbackId = task.metadata?.fallbackProvider;
-    const taskFallbackModel = task.metadata?.fallbackModel;
-    const fallbackResult = await getFallbackProvider(provider.id, providersMap, taskFallbackId, taskFallbackModel);
-
-    if (fallbackResult) {
-      emitLog('info', `Using fallback provider: ${fallbackResult.provider.id} (source: ${fallbackResult.source})`, {
+    // A configured lane never walks the GENERIC chain (#5993). Its only accepted
+    // substitution is the same-role alternate the user named on the role itself,
+    // and that alternate must be a real, currently-available provider — an
+    // alternate that is itself down is not a lane, it is the same silent
+    // collapse one hop later.
+    if (lane) {
+      const alternateId = lane.fallbackProvider;
+      const alternate = alternateId ? await getProviderById(alternateId) : null;
+      if (!alternate || !isProviderAvailable(alternate.id)) {
+        const why = !alternateId
+          ? `${status.message} (no ${laneRole}.fallbackProvider is configured)`
+          : !alternate
+            ? `${status.message}, and its ${laneRole}.fallbackProvider "${alternateId}" is not a configured provider`
+            : `${status.message}, and its ${laneRole}.fallbackProvider "${alternateId}" is also unavailable (${getProviderStatus(alternate.id).message})`;
+        return laneUnavailable({
+          role: laneRole,
+          requestedProvider: provider.id,
+          requestedModel: lane.model || null,
+          reason: why,
+        });
+      }
+      emitLog('info', `Orchestrated ${laneRole} lane using its same-role alternate ${alternate.id}`, {
         taskId: task.id,
         primaryProvider: provider.id,
-        fallbackProvider: fallbackResult.provider.id,
-        fallbackSource: fallbackResult.source
+        fallbackProvider: alternate.id,
+        fallbackSource: `orchestration-${laneRole}`,
       });
-      provider = fallbackResult.provider;
-      fallbackModelPin = fallbackResult.model || null;
+      laneSubstitution = { role: laneRole, from: provider.id, to: alternate.id, reason: status.message };
+      provider = alternate;
+      fallbackModelPin = lane.fallbackModel || null;
     } else {
-      const errorMsg = `Provider ${provider.id} unavailable (${status.message}) and no fallback available`;
-      // TRANSIENT, never permanent: a null fallback here can mean a configured
-      // CLI/TUI fallback is merely momentarily down (getFallbackProvider skips
-      // unavailable candidates), so blocking would strand a task that recovers
-      // when that fallback returns. Permanence is decided by PROVIDER TYPE where we
-      // can actually inspect it — the harness check below, reached once the
-      // provider is available again — not inferred from a transient unavailable +
-      // null-fallback combination. A down api provider with no viable path retries
-      // cheaply (it fails fast here, spawning no agent) and self-heals to a
-      // permanent block the moment it becomes reachable.
-      return { ok: false, error: errorMsg, providerId: provider.id, providerStatus: status };
+      // Try to get a fallback provider (check task-level, then provider-level, then system default).
+      // getFallbackProvider indexes its providers arg by id, so pass a map — NOT the
+      // { activeProvider, providers: [...] } shape getAllProviders() returns (mirrors promptRunner.js).
+      const { providers: providerList = [] } = await getAllProviders();
+      const providersMap = Object.fromEntries(providerList.map((p) => [p.id, p]));
+      const taskFallbackId = task.metadata?.fallbackProvider;
+      const taskFallbackModel = task.metadata?.fallbackModel;
+      const fallbackResult = await getFallbackProvider(provider.id, providersMap, taskFallbackId, taskFallbackModel);
+
+      if (fallbackResult) {
+        emitLog('info', `Using fallback provider: ${fallbackResult.provider.id} (source: ${fallbackResult.source})`, {
+          taskId: task.id,
+          primaryProvider: provider.id,
+          fallbackProvider: fallbackResult.provider.id,
+          fallbackSource: fallbackResult.source
+        });
+        provider = fallbackResult.provider;
+        fallbackModelPin = fallbackResult.model || null;
+      } else {
+        const errorMsg = `Provider ${provider.id} unavailable (${status.message}) and no fallback available`;
+        // TRANSIENT, never permanent: a null fallback here can mean a configured
+        // CLI/TUI fallback is merely momentarily down (getFallbackProvider skips
+        // unavailable candidates), so blocking would strand a task that recovers
+        // when that fallback returns. Permanence is decided by PROVIDER TYPE where we
+        // can actually inspect it — the harness check below, reached once the
+        // provider is available again — not inferred from a transient unavailable +
+        // null-fallback combination. A down api provider with no viable path retries
+        // cheaply (it fails fast here, spawning no agent) and self-heals to a
+        // permanent block the moment it becomes reachable.
+        return { ok: false, error: errorMsg, providerId: provider.id, providerStatus: status };
+      }
     }
   }
 
@@ -317,5 +417,23 @@ async function resolveOrdinaryProviderAndModel(task) {
     ...(modelSelection.learningReason && { learningReason: modelSelection.learningReason })
   });
 
-  return { ok: true, provider, selectedModel, modelSelection };
+  return {
+    ok: true,
+    provider,
+    selectedModel,
+    modelSelection,
+    // What the run ledger records so `/cos/runs` can show the tier split really
+    // happened (#5993): the role this run was dispatched as, the provider it
+    // ACTUALLY ran on, and the one substitution — if any — the lane accepted.
+    // Absent on a `direct`-mode run, which has no roles to account for.
+    ...(lane ? {
+      orchestrationLane: {
+        role: laneRole,
+        requestedProvider: lane.provider || directProviderId,
+        providerId: provider.id,
+        model: selectedModel,
+        ...(laneSubstitution ? { substitution: laneSubstitution } : {}),
+      },
+    } : {}),
+  };
 }

--- a/server/services/agentProviderResolution.js
+++ b/server/services/agentProviderResolution.js
@@ -168,7 +168,12 @@ async function resolveOrdinaryProviderAndModel(task) {
   // `direct`-mode runs keep the pin → active → fallback chain untouched
   // (`roleAssignment` returns null for every role on one).
   const laneRole = PRIMARY_ORCHESTRATION_ROLE;
-  const lane = roleAssignment(task, laneRole);
+  const roleAssign = roleAssignment(task, laneRole);
+  // Fail-closed applies only to a role that pinned WHERE it runs. A role
+  // carrying nothing but an `effort` rung has expressed no vendor or model
+  // preference to protect, so refusing to substitute for it would strand a run
+  // over a choice the user never made — it keeps the ordinary chain.
+  const lane = roleAssign?.provider || roleAssign?.model ? roleAssign : null;
   const userProviderId = lane?.provider || task.metadata?.provider;
   let userProviderMissing = false;
   if (userProviderId) {
@@ -426,10 +431,10 @@ async function resolveOrdinaryProviderAndModel(task) {
     // happened (#5993): the role this run was dispatched as, the provider it
     // ACTUALLY ran on, and the one substitution — if any — the lane accepted.
     // Absent on a `direct`-mode run, which has no roles to account for.
-    ...(lane ? {
+    ...(roleAssign ? {
       orchestrationLane: {
         role: laneRole,
-        requestedProvider: lane.provider || directProviderId,
+        requestedProvider: roleAssign.provider || directProviderId,
         providerId: provider.id,
         model: selectedModel,
         ...(laneSubstitution ? { substitution: laneSubstitution } : {}),

--- a/server/services/agentProviderResolution.test.js
+++ b/server/services/agentProviderResolution.test.js
@@ -695,3 +695,89 @@ describe('resolveAgentProviderAndModel — effort-only orchestration roles', () 
     });
   });
 });
+
+/**
+ * The same-role alternate is the ONE substitution a fail-closed lane accepts, so
+ * it has to clear every bar the primary would have: a real provider, currently
+ * available, with a file-writing harness, and — when the lane pinned a model — a
+ * model of its own to run. An alternate that fails any of these is not a lane,
+ * it is the same silent collapse one hop later.
+ */
+describe('resolveAgentProviderAndModel — what a same-role alternate must satisfy', () => {
+  const orchestrated = (architect) => ({
+    id: 'task-alt',
+    metadata: { orchestrationMode: 'orchestrated', orchestrationProfile: { architect } },
+  });
+
+  beforeEach(() => {
+    getProviderStatus.mockImplementation((id) => ({ message: `${id} down`, reason: 'down' }));
+  });
+
+  it('refuses an api-type alternate instead of leaking into the transient harness guard', async () => {
+    // The harness guard below computes `permanent` from the lane's CLI primary,
+    // so an api alternate reaching it returns a retryable failure with no lane
+    // detail — the task would never block and would re-fail forever.
+    getProviderById.mockImplementation(async (id) => (
+      id === 'p-cheap'
+        ? { id, type: 'cli', defaultModel: 'm-cheap' }
+        : { id, type: 'api', defaultModel: 'm-api' }
+    ));
+    isProviderAvailable.mockImplementation((id) => id !== 'p-cheap');
+
+    const r = await resolveAgentProviderAndModel(orchestrated({ provider: 'p-cheap', fallbackProvider: 'p-api' }));
+
+    expect(r.ok).toBe(false);
+    expect(r.permanent).toBe(true);
+    expect(r.orchestrationLane.role).toBe('architect');
+    expect(r.orchestrationLane.reason).toContain('no file-writing harness');
+  });
+
+  it('refuses when a model-pinned lane names an alternate with no fallbackModel', async () => {
+    getProviderById.mockImplementation(async (id) => ({ id, type: 'cli', defaultModel: `m-${id}` }));
+    isProviderAvailable.mockImplementation((id) => id !== 'p-cheap');
+
+    const r = await resolveAgentProviderAndModel(orchestrated({
+      provider: 'p-cheap',
+      model: 'm-cheap',
+      fallbackProvider: 'p-cheap-2',
+    }));
+
+    expect(r.ok).toBe(false);
+    expect(r.orchestrationLane.reason).toContain('no architect.fallbackModel');
+    expect(r.orchestrationLane.requestedModel).toBe('m-cheap');
+  });
+
+  it('lets a provider-only lane take an alternate that supplies its own default', async () => {
+    const alternate = { id: 'p-cheap-2', type: 'cli', models: ['alt-default'], defaultModel: 'alt-default' };
+    getProviderById.mockImplementation(async (id) => (
+      id === 'p-cheap' ? { id, type: 'cli', defaultModel: 'm-cheap' } : alternate
+    ));
+    isProviderAvailable.mockImplementation((id) => id === 'p-cheap-2');
+    selectModelForTask.mockResolvedValue({ model: 'alt-default', tier: 'medium', reason: 'default' });
+
+    const r = await resolveAgentProviderAndModel(orchestrated({ provider: 'p-cheap', fallbackProvider: 'p-cheap-2' }));
+
+    expect(r.ok).toBe(true);
+    expect(r.provider).toBe(alternate);
+    expect(r.orchestrationLane.substitution.to).toBe('p-cheap-2');
+  });
+
+  it('carries a model-pinned lane onto its alternate using the configured fallbackModel', async () => {
+    const alternate = { id: 'p-cheap-2', type: 'cli', models: ['alt-m'], defaultModel: 'alt-default' };
+    getProviderById.mockImplementation(async (id) => (
+      id === 'p-cheap' ? { id, type: 'cli', defaultModel: 'm-cheap' } : alternate
+    ));
+    isProviderAvailable.mockImplementation((id) => id === 'p-cheap-2');
+
+    const r = await resolveAgentProviderAndModel(orchestrated({
+      provider: 'p-cheap',
+      model: 'm-cheap',
+      fallbackProvider: 'p-cheap-2',
+      fallbackModel: 'alt-m',
+    }));
+
+    expect(r.ok).toBe(true);
+    // Never the alternate's own default — that is the substitution this closes.
+    expect(r.selectedModel).toBe('alt-m');
+  });
+});

--- a/server/services/agentProviderResolution.test.js
+++ b/server/services/agentProviderResolution.test.js
@@ -762,8 +762,13 @@ describe('resolveAgentProviderAndModel — what a same-role alternate must satis
     expect(r.orchestrationLane.substitution.to).toBe('p-cheap-2');
   });
 
+  // The alternate enumerates a DIFFERENT model on purpose: a provider's `models`
+  // list is a convenience enumeration the pass-through CLIs never enforce, so
+  // letting it downgrade the user's configured fallbackModel to the alternate's
+  // own default would re-open the model-axis substitution on the one path that
+  // is allowed to swap providers at all.
   it('carries a model-pinned lane onto its alternate using the configured fallbackModel', async () => {
-    const alternate = { id: 'p-cheap-2', type: 'cli', models: ['alt-m'], defaultModel: 'alt-default' };
+    const alternate = { id: 'p-cheap-2', type: 'cli', models: ['something-else'], defaultModel: 'alt-default' };
     getProviderById.mockImplementation(async (id) => (
       id === 'p-cheap' ? { id, type: 'cli', defaultModel: 'm-cheap' } : alternate
     ));
@@ -779,5 +784,34 @@ describe('resolveAgentProviderAndModel — what a same-role alternate must satis
     expect(r.ok).toBe(true);
     // Never the alternate's own default — that is the substitution this closes.
     expect(r.selectedModel).toBe('alt-m');
+  });
+});
+
+/**
+ * The run ledger's tier accounting keys off the RUN being orchestrated, not off
+ * the architect happening to be pinned — a profile that pins only the cheap
+ * implementer/reviewer lanes is a normal config, and its split is the one most
+ * worth showing.
+ */
+describe('resolveAgentProviderAndModel — orchestration accounting coverage', () => {
+  it('accounts for an orchestrated run whose profile pins no architect', async () => {
+    const provider = { id: 'p-active', type: 'cli', models: ['m-default'] };
+    getActiveProvider.mockResolvedValue(provider);
+
+    const r = await resolveAgentProviderAndModel({
+      id: 'task-no-architect',
+      metadata: {
+        orchestrationMode: 'orchestrated',
+        orchestrationProfile: { implementer: { provider: 'p-cheap' }, reviewer: { provider: 'p-cheap' } },
+      },
+    });
+
+    expect(r.ok).toBe(true);
+    expect(r.orchestrationLane).toEqual({
+      role: 'architect',
+      requestedProvider: 'p-active',
+      providerId: 'p-active',
+      model: 'm-default',
+    });
   });
 });

--- a/server/services/agentProviderResolution.test.js
+++ b/server/services/agentProviderResolution.test.js
@@ -657,3 +657,41 @@ describe('resolveAgentProviderAndModel — fail-closed orchestration lanes', () 
     expect(getFallbackProvider).toHaveBeenCalled();
   });
 });
+
+/**
+ * An `effort`-only role assignment pins a reasoning rung, not a vendor — there
+ * is no cross-vendor split for the fail-closed rule to protect, so it must not
+ * strand the run over a choice the user never made.
+ */
+describe('resolveAgentProviderAndModel — effort-only orchestration roles', () => {
+  const effortOnly = {
+    id: 'task-effort',
+    metadata: {
+      orchestrationMode: 'orchestrated',
+      orchestrationProfile: { architect: { effort: 'high' } },
+    },
+  };
+
+  it('keeps the generic fallback chain for a role that pins no provider or model', async () => {
+    const primary = { id: 'p1', type: 'cli' };
+    const fallback = { id: 'p2', type: 'cli', models: ['m-fb'] };
+    getActiveProvider.mockResolvedValue(primary);
+    isProviderAvailable.mockReturnValue(false);
+    getProviderStatus.mockReturnValue({ message: 'usage-limit', reason: 'limit' });
+    getAllProviders.mockResolvedValue({ providers: [primary, fallback] });
+    getFallbackProvider.mockResolvedValue({ provider: fallback, source: 'system', model: 'm-fb' });
+
+    const r = await resolveAgentProviderAndModel(effortOnly);
+
+    expect(r.ok).toBe(true);
+    expect(r.provider).toBe(fallback);
+    expect(getFallbackProvider).toHaveBeenCalled();
+    // Still accounted for — the run WAS dispatched as the architect role.
+    expect(r.orchestrationLane).toEqual({
+      role: 'architect',
+      requestedProvider: 'p1',
+      providerId: 'p2',
+      model: 'm-fb',
+    });
+  });
+});

--- a/server/services/agentProviderResolution.test.js
+++ b/server/services/agentProviderResolution.test.js
@@ -513,3 +513,147 @@ describe('orchestration profiles (#5992)', () => {
     expect(result.provider.id).toBe('p-pinned');
   });
 });
+
+/**
+ * Fail-closed orchestration lanes (#5993).
+ *
+ * The regression these exist for: a cheap cross-vendor implementer/architect
+ * lane silently becoming the expensive same-vendor lane. Every case below is a
+ * point where the generic pin → active → fallback chain WOULD have substituted
+ * a provider, and asserts it refuses instead.
+ */
+describe('resolveAgentProviderAndModel — fail-closed orchestration lanes', () => {
+  const orchestrated = (architect, extraMetadata = {}) => ({
+    id: 'task-orch',
+    metadata: {
+      orchestrationMode: 'orchestrated',
+      orchestrationProfile: { architect },
+      ...extraMetadata,
+    },
+  });
+
+  it('refuses to fall back to the active provider when the lane provider is not configured', async () => {
+    getProviderById.mockResolvedValue(null);
+    getActiveProvider.mockResolvedValue({ id: 'p-active', type: 'cli', defaultModel: 'm-active' });
+
+    const r = await resolveAgentProviderAndModel(orchestrated({ provider: 'p-cheap', model: 'm-cheap' }));
+
+    expect(r.ok).toBe(false);
+    expect(r.permanent).toBe(true);
+    expect(r.orchestrationLane).toEqual({
+      role: 'architect',
+      requestedProvider: 'p-cheap',
+      requestedModel: 'm-cheap',
+      reason: 'no provider with that id is configured on this install',
+    });
+    expect(r.error).toContain('architect');
+    expect(r.error).toContain('p-cheap');
+    expect(getActiveProvider).not.toHaveBeenCalled();
+  });
+
+  it('refuses the generic fallback chain when a lane provider is unavailable', async () => {
+    getProviderById.mockResolvedValue({ id: 'p-cheap', type: 'cli', defaultModel: 'm-cheap' });
+    isProviderAvailable.mockReturnValue(false);
+    getProviderStatus.mockReturnValue({ message: 'not authenticated', reason: 'auth' });
+
+    const r = await resolveAgentProviderAndModel(
+      // A run-level fallback is configured and must still be ignored: it is the
+      // exact silent collapse onto the architect's provider this closes.
+      orchestrated({ provider: 'p-cheap' }, { fallbackProvider: 'p-premium' }),
+    );
+
+    expect(r.ok).toBe(false);
+    expect(r.permanent).toBe(true);
+    expect(r.orchestrationLane.reason).toContain('not authenticated');
+    expect(r.orchestrationLane.reason).toContain('no architect.fallbackProvider is configured');
+    expect(getFallbackProvider).not.toHaveBeenCalled();
+  });
+
+  it('honors the same-role alternate and records the substitution', async () => {
+    const cheap = { id: 'p-cheap', type: 'cli', defaultModel: 'm-cheap' };
+    const alternate = { id: 'p-cheap-2', type: 'cli', models: ['alt-m'], defaultModel: 'alt-default' };
+    getProviderById.mockImplementation(async (id) => (id === 'p-cheap' ? cheap : alternate));
+    isProviderAvailable.mockImplementation((id) => id === 'p-cheap-2');
+    getProviderStatus.mockReturnValue({ message: 'rate limited', reason: 'limit' });
+
+    const r = await resolveAgentProviderAndModel(orchestrated({
+      provider: 'p-cheap',
+      fallbackProvider: 'p-cheap-2',
+      fallbackModel: 'alt-m',
+    }));
+
+    expect(r.ok).toBe(true);
+    expect(r.provider).toBe(alternate);
+    expect(r.selectedModel).toBe('alt-m');
+    expect(r.orchestrationLane).toEqual({
+      role: 'architect',
+      requestedProvider: 'p-cheap',
+      providerId: 'p-cheap-2',
+      model: 'alt-m',
+      substitution: { role: 'architect', from: 'p-cheap', to: 'p-cheap-2', reason: 'rate limited' },
+    });
+    expect(getFallbackProvider).not.toHaveBeenCalled();
+  });
+
+  it('refuses when the same-role alternate is itself unavailable', async () => {
+    getProviderById.mockImplementation(async (id) => ({ id, type: 'cli', defaultModel: `m-${id}` }));
+    isProviderAvailable.mockReturnValue(false);
+    getProviderStatus.mockImplementation((id) => ({ message: `${id} down`, reason: 'down' }));
+
+    const r = await resolveAgentProviderAndModel(orchestrated({
+      provider: 'p-cheap',
+      fallbackProvider: 'p-cheap-2',
+    }));
+
+    expect(r.ok).toBe(false);
+    expect(r.orchestrationLane.reason).toContain('p-cheap-2');
+    expect(r.orchestrationLane.reason).toContain('also unavailable');
+  });
+
+  it('refuses a model-only lane rather than inheriting a swapped provider', async () => {
+    getActiveProvider.mockResolvedValue(null);
+
+    const r = await resolveAgentProviderAndModel(orchestrated({ model: 'm-cheap' }));
+
+    expect(r.ok).toBe(false);
+    expect(r.permanent).toBe(true);
+    expect(r.orchestrationLane).toEqual({
+      role: 'architect',
+      requestedProvider: null,
+      requestedModel: 'm-cheap',
+      reason: 'no active AI provider is configured for it to inherit',
+    });
+  });
+
+  it('reports the lane a healthy orchestrated run actually ran on', async () => {
+    const cheap = { id: 'p-cheap', type: 'cli', models: ['m-default'] };
+    getProviderById.mockResolvedValue(cheap);
+
+    const r = await resolveAgentProviderAndModel(orchestrated({ provider: 'p-cheap' }));
+
+    expect(r.ok).toBe(true);
+    expect(r.orchestrationLane).toEqual({
+      role: 'architect',
+      requestedProvider: 'p-cheap',
+      providerId: 'p-cheap',
+      model: 'm-default',
+    });
+  });
+
+  it('leaves a direct-mode run on the generic fallback chain', async () => {
+    const primary = { id: 'p1', type: 'cli' };
+    const fallback = { id: 'p2', type: 'cli', models: ['m-fb'] };
+    getActiveProvider.mockResolvedValue(primary);
+    isProviderAvailable.mockReturnValue(false);
+    getProviderStatus.mockReturnValue({ message: 'usage-limit', reason: 'limit' });
+    getAllProviders.mockResolvedValue({ providers: [primary, fallback] });
+    getFallbackProvider.mockResolvedValue({ provider: fallback, source: 'system', model: 'm-fb' });
+
+    const r = await resolveAgentProviderAndModel({ id: 'task-direct-2', metadata: {} });
+
+    expect(r.ok).toBe(true);
+    expect(r.provider).toBe(fallback);
+    expect(r.orchestrationLane).toBeUndefined();
+    expect(getFallbackProvider).toHaveBeenCalled();
+  });
+});

--- a/server/services/agentProviderResolution.test.js
+++ b/server/services/agentProviderResolution.test.js
@@ -815,3 +815,51 @@ describe('resolveAgentProviderAndModel — orchestration accounting coverage', (
     });
   });
 });
+
+/**
+ * Both ways a model-only lane's provider inheritance can fail. The
+ * missing-task-pin case is the sharp one: it used to continue on the active
+ * provider, which counts as a provider swap and drops the lane's model to that
+ * provider's default — a silent substitution with no block and nothing naming
+ * the role.
+ */
+describe('resolveAgentProviderAndModel — a model-only lane with nothing to inherit', () => {
+  const modelOnly = {
+    id: 'task-model-only',
+    metadata: {
+      provider: 'p-gone',
+      orchestrationMode: 'orchestrated',
+      orchestrationProfile: { architect: { model: 'm-cheap' } },
+    },
+  };
+
+  it('refuses when the task-level provider pin names a missing record', async () => {
+    getProviderById.mockResolvedValue(null);
+    getActiveProvider.mockResolvedValue({ id: 'p-active', type: 'cli', models: ['m-active'], defaultModel: 'm-active' });
+    selectModelForTask.mockResolvedValue({ model: 'm-cheap', tier: 'user-specified', reason: 'orchestration-role-architect' });
+
+    const r = await resolveAgentProviderAndModel(modelOnly);
+
+    expect(r.ok).toBe(false);
+    expect(r.permanent).toBe(true);
+    expect(r.orchestrationLane).toEqual({
+      role: 'architect',
+      requestedProvider: 'p-gone',
+      requestedModel: 'm-cheap',
+      reason: 'the provider pinned for this task is not configured on this install',
+    });
+  });
+
+  it('still refuses when there is no active provider to inherit at all', async () => {
+    getActiveProvider.mockResolvedValue(null);
+
+    const r = await resolveAgentProviderAndModel({
+      ...modelOnly,
+      metadata: { ...modelOnly.metadata, provider: undefined },
+    });
+
+    expect(r.ok).toBe(false);
+    expect(r.orchestrationLane.requestedProvider).toBeNull();
+    expect(r.orchestrationLane.reason).toContain('no active AI provider');
+  });
+});

--- a/server/services/agentRunTracking.js
+++ b/server/services/agentRunTracking.js
@@ -25,8 +25,12 @@ const RUNS_DIR = PATHS.runs;
  * @param {{ id: string, name: string, defaultModel?: string }} options.provider
  * @param {string} options.workspacePath
  * @param {string} [options.appName] - Defaults to 'portos'.
+ * @param {{ role: string, requestedProvider?: string, providerId: string, model?: string,
+ *           substitution?: { role: string, from: string, to: string, reason?: string } }}
+ *   [options.orchestrationLane] - The tier this run was dispatched as, when the
+ *   task runs under an orchestration profile (#5993). Absent for `direct` runs.
  */
-export async function createAgentRun({ agentId, task, model, provider, workspacePath, appName }) {
+export async function createAgentRun({ agentId, task, model, provider, workspacePath, appName, orchestrationLane = null }) {
   const runId = uuidv4();
   const runDir = join(RUNS_DIR, runId);
 
@@ -49,6 +53,7 @@ export async function createAgentRun({ agentId, task, model, provider, workspace
     // Full prompt size (chars) for input-token estimation on completion —
     // `prompt` above is truncated for display.
     promptLength: (task.description || '').length,
+    ...(orchestrationLane ? { orchestrationLane } : {}),
     startTime: new Date().toISOString(),
     endTime: null,
     duration: null,
@@ -83,7 +88,12 @@ export async function createAgentRun({ agentId, task, model, provider, workspace
       model: metadata.model,
       workspacePath,
       workspaceName: metadata.workspaceName,
-      promptChars: metadata.promptLength
+      promptChars: metadata.promptLength,
+      // Orchestration accounting (#5993): the role, and — when the lane took its
+      // configured same-role alternate — the provider it was configured for. Both
+      // omitted on a `direct` run so the event shape is unchanged there.
+      ...(orchestrationLane?.role ? { orchestrationRole: orchestrationLane.role } : {}),
+      ...(orchestrationLane?.substitution?.from ? { laneSubstitutedFrom: orchestrationLane.substitution.from } : {}),
     }
   });
 

--- a/server/services/cosTaskStore.js
+++ b/server/services/cosTaskStore.js
@@ -751,7 +751,7 @@ async function writeTaskUpdate(taskId, updates, taskType, { now, suppressDequeue
   // agent record then read its own pause as spent and spawned a SECOND agent on a
   // fresh task. The clear belongs at the transition, not at one caller.
   if (updates.status && updates.status !== 'blocked' && tasks[taskIndex].status === 'blocked') {
-    for (const key of ['blocker', 'blockedReason', 'blockedCategory', 'blockedAt', 'failureCount', 'lastErrorCategory', 'lastFailureAt', ...PAUSE_METADATA_KEYS]) {
+    for (const key of ['blocker', 'blockedReason', 'blockedCategory', 'blockedAt', 'orchestrationLane', 'failureCount', 'lastErrorCategory', 'lastFailureAt', ...PAUSE_METADATA_KEYS]) {
       delete updatedMetadata[key];
     }
   }

--- a/server/services/cosTaskStore.test.js
+++ b/server/services/cosTaskStore.test.js
@@ -987,6 +987,23 @@ describe('cosTaskStore.updateTask', () => {
     expect(reopened.metadata.blockedCategory).toBeUndefined();
   });
 
+  // The structured detail of a refused orchestration lane (#5993) goes with it.
+  // The task record federates, so a stale lane naming a provider the task is no
+  // longer blocked on would travel to every peer alongside a running task.
+  it('clears the orchestration lane detail when the block ends', async () => {
+    await addTask({ description: 'lane', id: 'task-lane' }, 'user');
+    await updateTask('task-lane', {
+      status: 'blocked',
+      metadata: {
+        blockedReason: 'Orchestrated architect lane stopped',
+        blockedCategory: 'orchestration-lane-unavailable',
+        orchestrationLane: { role: 'architect', requestedProvider: 'p-cheap', requestedModel: null, reason: 'not authenticated' },
+      },
+    }, 'user');
+    const reopened = await updateTask('task-lane', { status: 'pending' }, 'user');
+    expect(reopened.metadata.orchestrationLane).toBeUndefined();
+  });
+
   // The pause hold goes with it, whatever un-blocked the task. `resumeAgent` is only
   // ONE of the paths back to pending — a dedupe revive, an autopilot re-dispatch, a
   // cooldown expiry and a human unblocking it all land here — and every one of them

--- a/server/services/cosTaskStore.test.js
+++ b/server/services/cosTaskStore.test.js
@@ -1195,6 +1195,25 @@ describe('cosTaskStore.updateTask', () => {
     expect(blocked.metadata.resumeWorktreePath).toBe('/w/agent-x');
   });
 
+  // Same CONFIG-pause shape (#5993): the user authenticates the lane's provider
+  // and revives the task. Stripping the pointer here would restart the revived
+  // task clean and orphan its predecessor's worktree — and before this block
+  // category existed, that same condition left the task pending with its pointer
+  // intact, so losing it would be a NEW way to abandon work.
+  it('keeps the resume pointer through a refused orchestration lane', async () => {
+    await addTask({ description: 'lane', id: 'task-lane-ptr' }, 'user');
+    await updateTask('task-lane-ptr', {
+      metadata: { existingBranch: 'cos/b', resumedFromAgentId: 'agent-x', resumeWorktreePath: '/w/agent-x' }
+    }, 'user');
+    const blocked = await updateTask('task-lane-ptr', {
+      status: 'blocked',
+      metadata: { blockedCategory: ORCHESTRATION_LANE_BLOCKED_CATEGORY }
+    }, 'user');
+    expect(blocked.metadata.existingBranch).toBe('cos/b');
+    expect(blocked.metadata.resumeWorktreePath).toBe('/w/agent-x');
+    expect(blocked.metadata.resumedFromAgentId).toBe('agent-x');
+  });
+
   // An `existingBranch` with no `resumedFromAgentId` beside it was never written
   // by the resume mechanism — it is the task's OWN configuration. A merge
   // follow-up is the producer: it exists to land the PR on that branch. Stripping

--- a/server/services/cosTaskStore.test.js
+++ b/server/services/cosTaskStore.test.js
@@ -118,6 +118,7 @@ import {
 } from './cosTaskStore.js';
 import { AGENT_PAUSED_CATEGORY, PAUSE_METADATA_KEYS, registerPauseReleaseAdapter, __resetPauseReleaseAdapter } from '../lib/taskPauseHold.js';
 import { MAX_TOTAL_SPAWNS } from '../lib/cosValidation.js';
+import { ORCHESTRATION_LANE_BLOCKED_CATEGORY } from '../lib/taskBlockCategories.js';
 
 const USER_FILE = join('/root', 'TASKS.md');
 const COS_FILE = join('/root', 'COS-TASKS.md');
@@ -1728,6 +1729,24 @@ describe('cosTaskStore — stale failure-artifact reaper (#2619)', () => {
       const after = await getUserTasks();
       expect(after.tasks.find(t => t.id === 'task-fresh').status).toBe('blocked');
       expect(after.tasks.find(t => t.id === 'task-stop').status).toBe('blocked');
+    });
+
+    // A fail-closed orchestration lane (#5993) stops the run ON PURPOSE and waits
+    // on a user config fix. Retiring it to `completed` after 14 days would convert
+    // that deliberate loud stop into the silent success the whole feature exists
+    // to prevent — so it is exempt like the other user-decision blocks.
+    it('leaves a refused orchestration lane for the user however long it sits', async () => {
+      await addTask({ description: 'lane blocked', id: 'task-lane-old', priority: 'LOW' }, 'user', { now: NOW });
+      await updateTask('task-lane-old', {
+        status: 'blocked',
+        metadata: { blockedCategory: ORCHESTRATION_LANE_BLOCKED_CATEGORY, blockedAt: daysAgo(90) },
+      }, 'user', { now: NOW });
+      const res = await sweepResolvedFailureTasks({ now: NOW });
+      expect(res.reaped).toBe(0);
+      const after = await getUserTasks();
+      const task = after.tasks.find(t => t.id === 'task-lane-old');
+      expect(task.status).toBe('blocked');
+      expect(task.metadata.resolution).toBeUndefined();
     });
 
     it('flips an investigation whose originating task has completed', async () => {

--- a/server/services/promptSections/orchestrationDoctrine.js
+++ b/server/services/promptSections/orchestrationDoctrine.js
@@ -34,9 +34,14 @@ function roleLine(task, role) {
   // The lane's ONE permitted substitution (#5993). Named here because the
   // architect otherwise has no way to know a lane is fail-closed, and would plan
   // around a fallback that does not exist.
-  const alternate = assignment?.fallbackProvider
+  // Gated on a provider/model pin — the SAME condition the resolver uses. An
+  // effort-only role stays on the ordinary fallback chain, so telling the
+  // architect its run would stop would be false (and reads as nonsense besides:
+  // the "target" there is a reasoning rung, not a provider).
+  const failClosed = Boolean(assignment?.provider || assignment?.model);
+  const alternate = failClosed && assignment.fallbackProvider
     ? ` If it is unavailable, the lane may use \`${assignment.fallbackProvider}\`${assignment.fallbackModel ? ` with model \`${assignment.fallbackModel}\`` : ''} — and nothing else.`
-    : (pins.length ? ' If it is unavailable, the run STOPS — no other provider is substituted for this lane.' : '');
+    : (failClosed ? ' If it is unavailable, the run STOPS — no other provider is substituted for this lane.' : '');
   return `- **${role}** — ${ROLE_DUTIES[role]}. Runs on ${target}.${alternate}`;
 }
 

--- a/server/services/promptSections/orchestrationDoctrine.js
+++ b/server/services/promptSections/orchestrationDoctrine.js
@@ -31,7 +31,13 @@ function roleLine(task, role) {
     assignment?.effort ? `default reasoning \`${assignment.effort}\`` : null,
   ].filter(Boolean);
   const target = pins.length ? pins.join(', ') : 'this run’s own provider and model';
-  return `- **${role}** — ${ROLE_DUTIES[role]}. Runs on ${target}.`;
+  // The lane's ONE permitted substitution (#5993). Named here because the
+  // architect otherwise has no way to know a lane is fail-closed, and would plan
+  // around a fallback that does not exist.
+  const alternate = assignment?.fallbackProvider
+    ? ` If it is unavailable, the lane may use \`${assignment.fallbackProvider}\`${assignment.fallbackModel ? ` with model \`${assignment.fallbackModel}\`` : ''} — and nothing else.`
+    : (pins.length ? ' If it is unavailable, the run STOPS — no other provider is substituted for this lane.' : '');
+  return `- **${role}** — ${ROLE_DUTIES[role]}. Runs on ${target}.${alternate}`;
 }
 
 /**

--- a/server/services/promptSections/orchestrationDoctrine.test.js
+++ b/server/services/promptSections/orchestrationDoctrine.test.js
@@ -46,3 +46,28 @@ describe('buildOrchestrationDoctrineSection', () => {
     expect(section).toMatch(/never rounded/);
   });
 });
+
+describe('fail-closed lane doctrine (#5993)', () => {
+  const orchestrated = (profile) => ({
+    metadata: { orchestrationMode: 'orchestrated', orchestrationProfile: profile },
+  });
+
+  it('tells the architect a pinned lane has no substitute', () => {
+    const section = buildOrchestrationDoctrineSection(orchestrated({ implementer: { provider: 'p-cheap' } }));
+    expect(section).toContain('the run STOPS — no other provider is substituted for this lane');
+  });
+
+  it('names the one alternate a lane may use', () => {
+    const section = buildOrchestrationDoctrineSection(orchestrated({
+      implementer: { provider: 'p-cheap', fallbackProvider: 'p-cheap-2', fallbackModel: 'm-cheap-2' },
+    }));
+    expect(section).toContain('the lane may use `p-cheap-2` with model `m-cheap-2` — and nothing else');
+    expect(section).not.toContain('the run STOPS — no other provider is substituted for this lane.\n- **implementer**');
+  });
+
+  it('says nothing about substitution for a role that pins nothing', () => {
+    const section = buildOrchestrationDoctrineSection(orchestrated({ architect: { provider: 'p1' } }));
+    expect(section).toContain('- **reviewer** —');
+    expect(section.split('\n').find(l => l.startsWith('- **reviewer**'))).not.toContain('STOPS');
+  });
+});

--- a/server/services/promptSections/orchestrationDoctrine.test.js
+++ b/server/services/promptSections/orchestrationDoctrine.test.js
@@ -71,3 +71,29 @@ describe('fail-closed lane doctrine (#5993)', () => {
     expect(section.split('\n').find(l => l.startsWith('- **reviewer**'))).not.toContain('STOPS');
   });
 });
+
+describe('the doctrine states fail-closed only for the lanes that are', () => {
+  const orchestrated = (profile) => ({
+    metadata: { orchestrationMode: 'orchestrated', orchestrationProfile: profile },
+  });
+  const roleLineFor = (section, role) => section.split('\n').find(l => l.startsWith(`- **${role}**`));
+
+  it('says nothing about substitution for an effort-only role', () => {
+    // That role stays on the ordinary fallback chain, so promising the architect
+    // the run would stop is false — and reads as nonsense, since its only "pin"
+    // is a reasoning rung rather than a provider.
+    const section = buildOrchestrationDoctrineSection(orchestrated({
+      implementer: { effort: 'high' },
+      architect: { provider: 'p1' },
+    }));
+    expect(roleLineFor(section, 'implementer')).not.toContain('STOPS');
+    expect(roleLineFor(section, 'architect')).toContain('STOPS');
+  });
+
+  it('names the alternate a model-only lane may use', () => {
+    const section = buildOrchestrationDoctrineSection(orchestrated({
+      implementer: { model: 'm-cheap', fallbackProvider: 'p-cheap-2', fallbackModel: 'm-cheap-2' },
+    }));
+    expect(roleLineFor(section, 'implementer')).toContain('the lane may use `p-cheap-2` with model `m-cheap-2` — and nothing else');
+  });
+});

--- a/server/services/promptSections/orchestrationDoctrine.test.js
+++ b/server/services/promptSections/orchestrationDoctrine.test.js
@@ -62,7 +62,7 @@ describe('fail-closed lane doctrine (#5993)', () => {
       implementer: { provider: 'p-cheap', fallbackProvider: 'p-cheap-2', fallbackModel: 'm-cheap-2' },
     }));
     expect(section).toContain('the lane may use `p-cheap-2` with model `m-cheap-2` — and nothing else');
-    expect(section).not.toContain('the run STOPS — no other provider is substituted for this lane.\n- **implementer**');
+    expect(section.split('\n').find(l => l.startsWith('- **implementer**'))).not.toContain('STOPS');
   });
 
   it('says nothing about substitution for a role that pins nothing', () => {


### PR DESCRIPTION
Closes #5993 (Phase 2 of #5991).

## Summary

An orchestrated CoS run splits into **architect / implementer / reviewer** roles precisely so the mechanical tiers can run on a different, cheaper vendor. The generic `pin → active → fallback` chain undid that: when a role's provider was missing or unavailable, resolution quietly swapped in whatever was healthy — usually the architect's own premium provider — spending exactly the budget orchestration was turned on to avoid, and collapsing the vendor split with nobody told.

A role that pins **a provider or a model** is now fail-closed. Its only accepted substitution is a same-role alternate the user configured on the role itself (new `fallbackProvider` / `fallbackModel`); anything else stops the run with a structured, permanent outcome naming the role, the provider it wanted, and why it could not run.

**Direct-mode runs are untouched** — `roleAssignment()` returns null for every role on one, so the old chain is byte-for-byte unchanged. An **effort-only role** is also untouched: it pins a reasoning rung, not a vendor, so there is no cross-vendor split to protect and stranding the run over it would be over-reach.

## What the refusal covers

Every way a pinned lane can fail to run where it was told to now returns the same structured `orchestrationLane` shape instead of a substitution:

| Situation | Before | Now |
|---|---|---|
| Lane's provider record doesn't exist | falls back to the active provider | refuses |
| Lane's provider unavailable, no alternate configured | walks the generic task/provider/system fallback chain | refuses |
| Alternate isn't a configured provider, or is itself unavailable | n/a | refuses |
| Alternate is an `api`-type provider (no file-writing harness) | transient failure, task re-dispatches forever | refuses |
| Model-pinned lane whose alternate names no `fallbackModel` | lands on the alternate's own default | refuses |
| Model-only lane, task-level provider pin names a missing record | continues on the active provider, model pin dropped to its default | refuses |
| Model-only lane, no active provider at all | generic "No active AI provider configured", role lost | refuses, naming the role |

The one accepted swap — a configured, available, harness-carrying same-role alternate — honors the lane's `fallbackModel` as an explicit pin rather than validating it against the alternate's `models` list. That list is a convenience enumeration the pass-through CLIs never enforce (and whose alias forms already disagree across provider records), so downgrading the pin there would have re-opened the same substitution on the model axis.

## How it surfaces

- **Task** blocks under its own `orchestration-lane-unavailable` category, carrying `metadata.orchestrationLane` (`role`, `requestedProvider`, `requestedModel`, `reason`).
- **CoS task card** headlines the role and provider above the reason text, so the fix is obvious (authenticate the CLI, pick another model, configure an alternate) instead of a bare "agent failed".
- **Run ledger** gains a `run.lane-refused` event. It needs its own kind because a refused lane never creates a run directory — without it, a fail-closed lane is indistinguishable from every other block. A run that *did* spawn now records the role it ran as and any alternate it fell to, so the tier split is visible in run diagnostics.
- **Architect prompt** states the rule per role, so it plans around the lanes it actually has rather than assuming a fallback exists.

The category sits in both `PAUSED_BLOCKED_CATEGORIES` (so the task keeps its `existingBranch` / `resumeWorktreePath` and resumes onto its predecessor's worktree after the user fixes the config) and `USER_DECISION_BLOCKED_CATEGORIES` (so the 14-day failure sweep doesn't retire a deliberate stop to `completed` with an `auto-expired` marker — which would be exactly the silent success this closes).

## Test plan

- `server/services/agentProviderResolution.test.js` — every refusal path above, the accepted alternate, the model pass-through, direct-mode and effort-only regression coverage, and the accounting shape.
- `server/lib/orchestrationProfile.test.js` — what the normalizer keeps and drops for the new fields.
- `server/lib/cosValidation.test.js` — the schema rejects the combinations the normalizer discards and the resolver refuses, so an inert profile can't be persisted with a 200.
- `server/lib/agentRunEvents.test.js` — `run.lane-refused` is terminal, agent-keyed (no run id exists), and can't overwrite a real verdict.
- `server/services/cosTaskStore.test.js` — the lane detail is cleared when the block ends, the resume pointer survives the block, and the failure sweep leaves it alone however long it sits.
- `server/services/promptSections/orchestrationDoctrine.test.js` — the doctrine states fail-closed only for the lanes that are.
- `client/src/components/cos/tabs/TaskItem.test.jsx` — the headline appears for a lane block and not for an ordinary one.

Full suites: server 38972 passed, client 10268 passed.