### PR TITLE
wait on the settled value in two client tests that asserted behind the wrong barrier

### DIFF
--- a/client/src/pages/Media3DDetail.test.jsx
+++ b/client/src/pages/Media3DDetail.test.jsx
@@ -75,7 +75,11 @@ describe('Media3DDetail', () => {
     expect(screen.getByAltText('Source image')).toBeInTheDocument();
     // The viewer's loaded scene has to reach the AR panel or its export button
     // stays permanently disabled — a prop chain no other assertion touches.
-    expect(await screen.findByTestId('ar-export-panel')).toHaveAttribute('data-has-scene', 'true');
+    // The panel mounts before the scene reaches it, so wait on the ATTRIBUTE:
+    // findByTestId resolves on the node and leaves the prop still in flight.
+    await waitFor(() =>
+      expect(screen.getByTestId('ar-export-panel')).toHaveAttribute('data-has-scene', 'true'),
+    );
   });
 
   it('surfaces the render error for a failed record', async () => {

--- a/client/src/pages/PromptManager.test.jsx
+++ b/client/src/pages/PromptManager.test.jsx
@@ -557,9 +557,13 @@ describe('PromptManager variable editing', () => {
     expect(createPromptVariable).toHaveBeenCalledWith(
       expect.objectContaining({ key: 'aside-voice', content: 'wink' }), { silent: true },
     );
-    await waitFor(() => expect(currentSearch()).toContain('var=aside-voice'));
+    // The URL selection and the editor's hydration from the post-create
+    // refetch are separate effects, so `var=aside-voice` landing in the URL
+    // does not prove the editor has content yet. Wait on the value — the last
+    // thing to settle — and the URL assertion comes along for free.
+    await waitFor(() => expect(contentBox().value).toBe('wink'));
+    expect(currentSearch()).toContain('var=aside-voice');
     expect(screen.getByText('Edit: aside-voice')).toBeTruthy();
-    expect(contentBox().value).toBe('wink');
   });
 
   it('confirms a delete with a toast', async () => {


### PR DESCRIPTION
## Summary

Two client tests cleared an async barrier that proves something *other* than what the next line asserts, so on a loaded 2-core CI runner the assertion ran against state still in flight. Each one has failed a full-suite client shard on an unrelated PR, and a losing shard cancels its siblings — so either turns the whole client matrix red.

- **`PromptManager` → "selects the created variable in the URL"** — the URL update and the editor's hydration from the post-create refetch are separate effects, so `var=aside-voice` landing in the URL does not mean the editor has content. Now waits on the value (the last thing to settle) and asserts the URL after.
- **`Media3DDetail` → "renders the mesh viewer and source image"** — the AR panel mounts before the viewer's loaded scene reaches it, so `findByTestId` resolves on the node with `data-has-scene` still `false`. Now waits on the attribute rather than the node.

Same shape as the `TracksManager` / `SongBookViewer` fixes: wait on the settled **state**, not on a node or a sibling observable that merely tends to arrive first.

Deliberately **not** touched: `PromptManager` → "keeps the saved variable open in the editor" reads `contentBox().value` synchronously after the save toast, but that assertion is that a later refetch does *not* blank the editor. Wrapping it in `waitFor` would weaken it into "eventually equals", which is the opposite of what it guards.

Closes #6189

## Test plan

- Repro before the fix: `npx vitest run src/pages/Media3DDetail.test.jsx src/pages/PromptManager.test.jsx` fails `expected '' to be 'wink'` — the exact CI signature. Either file alone passes.
- After the fix, the same pair run 3× → 84 passed each time.
- CI failures this addresses: run 33836053001 (PromptManager, then Media3DDetail on the re-run).
