### PR TITLE
close the PromptManager variable race that the #6189 fix only relocated

### DIFF
--- a/client/src/pages/PromptManager.test.jsx
+++ b/client/src/pages/PromptManager.test.jsx
@@ -524,6 +524,10 @@ describe('PromptManager variable editing', () => {
 
   it('keeps the saved variable open in the editor and confirms with a toast', async () => {
     await openVariable();
+    // Re-stub AFTER the mount load, so only the post-save refetch carries the
+    // extra sibling — staging it with mockResolvedValueOnce instead would bake
+    // in an assumption about how many times the page loads before the save.
+    getPromptVariables.mockResolvedValue({ variables: { ...VARIABLES, 'aside-voice': { name: 'Aside Voice', content: 'wink' } } });
 
     fireEvent.change(contentBox(), { target: { value: 'stay dry' } });
     fireEvent.click(saveButton());
@@ -532,8 +536,12 @@ describe('PromptManager variable editing', () => {
     expect(savePromptVariable).toHaveBeenCalledWith(
       'tone-guide', expect.objectContaining({ content: 'stay dry' }), { silent: true },
     );
-    // The refetch below returns the pre-save fixture; the editor must NOT be
-    // re-hydrated from it, deselected, or blanked.
+    // The refetch still carries the PRE-save content, so the editor must NOT be
+    // re-hydrated from it, deselected, or blanked. The toast fires BEFORE that
+    // refetch, so waiting on it asserts ahead of the very state change under
+    // test — the sibling above is what makes the refresh's arrival observable,
+    // and #6023 slips through this test unnoticed without it (#6189).
+    await screen.findByText('Aside Voice');
     expect(currentSearch()).toContain('var=tone-guide');
     expect(screen.getByText('Edit: tone-guide')).toBeTruthy();
     expect(contentBox().value).toBe('stay dry');
@@ -557,12 +565,17 @@ describe('PromptManager variable editing', () => {
     expect(createPromptVariable).toHaveBeenCalledWith(
       expect.objectContaining({ key: 'aside-voice', content: 'wink' }), { silent: true },
     );
-    // The URL selection and the editor's hydration from the post-create
-    // refetch are separate effects, so `var=aside-voice` landing in the URL
-    // does not prove the editor has content yet. Wait on the value — the last
-    // thing to settle — and the URL assertion comes along for free.
-    await waitFor(() => expect(contentBox().value).toBe('wink'));
-    expect(currentSearch()).toContain('var=aside-voice');
+    // Both halves in ONE barrier: neither settles last on its own (#6189).
+    // The post-create refetch re-runs the hydration effect while the selection
+    // is still null, which resets the form to BLANK — the URL adopts the new key
+    // only afterwards, and re-hydrating from the refetched record is a further
+    // commit still. So waiting on the URL alone reads a blanked textarea. But
+    // waiting on the textarea alone is a barrier already open, since it holds
+    // 'wink' from the typing above, leaving the URL as the racing read instead.
+    await waitFor(() => {
+      expect(currentSearch()).toContain('var=aside-voice');
+      expect(contentBox().value).toBe('wink');
+    });
     expect(screen.getByText('Edit: aside-voice')).toBeTruthy();
   });
 


### PR DESCRIPTION
Follow-up to #6194, which shipped the one-line fix #6189 prescribed. That fix does not close the race, and the second test #6189 flagged as "also worth checking" was left untouched and is blind to the regression it guards.

## Summary

- **`selects the created variable in the URL`** — #6194 made it wait on `contentBox().value`, then read the URL synchronously. The textarea already holds `'wink'` from the `fireEvent.change` earlier in the test (it is the user's own draft, not the refetched record), so that barrier resolves on its first check — before the create has even settled — and `currentSearch()` becomes the unguarded racing read. Neither half settles last on its own: the post-create refetch re-runs the hydration effect while the selection is still `null`, blanking the form, and `setSelectedVar` runs only after `await loadData()`. Both assertions now sit inside one `waitFor`; the pair is the settled state under either interleaving.
- **`keeps the saved variable open in the editor`** — waits on `toast.success`, which `saveVariable()` fires *before* the refetch whose harmlessness is the whole point of the test, so it asserted on pre-refetch state. The post-save refetch now returns a sibling the list did not have, giving the refresh an observable arrival to wait on.

Test-only. No change to `client/src/pages/PromptManager.jsx`.

## Test plan

- `cd client && npx vitest run src/pages/PromptManager.test.jsx` → 71/71 pass.
- **Race closed:** resolve the mocked `getPromptVariables` refetch behind `setTimeout(…, 30)`. The version on `main` fails with `expected '?tab=variables' to contain 'var=aside-voice'`; this branch passes.
- **Original flake reproduced deterministically** (even on a many-core box): sample `contentBox().value` at the first DOM mutation where the URL contains `var=aside-voice` — which is what RTL's MutationObserver-driven `waitFor` does. It reads `""`, the CI signature from #6189.
- **Bypass probe on the second test:** re-inject the #6023 regression by dropping the `varHydratedRef.current !== selectedVar` guard in `PromptManager.jsx`. On `main` the test still **passes**; on this branch it fails with `expected 'stay wry' to be 'stay dry'`. Guard restored afterwards.
- Full client suite run: the only failures are pre-existing load flakes in `loadingSkeletons.test.jsx`, `Layout.test.jsx` and `TaskAddForm.test.jsx` (a different set on each run, 3 then 9); all four files pass in isolation alongside `PromptManager.test.jsx`.

Closes #6197
Refs #6189