### PR TITLE
Cap libvips threads and narrow compiled walk spans in the sprite test suites

### DIFF
--- a/server/services/sprites/atlas.test.js
+++ b/server/services/sprites/atlas.test.js
@@ -26,15 +26,9 @@ import {
   writeWalkFramePng,
 } from './spriteTestFixtures.js';
 
-capSharpThreads();
+const restoreSharpThreads = capSharpThreads();
+afterAll(restoreSharpThreads);
 const TEST_ROOT = mkdtempSync(join(tmpdir(), 'sprite-atlas-test-'));
-
-// The narrowest walk span a compile will accept: the walk track's registry row
-// declares a 6–16 frame range and `resolveTrackUniformity` refuses anything
-// outside it, so 6 is the floor — still enough for varyArm to vary the
-// silhouette and for a mid-strip index to exist. Tests that pin the production
-// 9-column grid keep WALK_PHASES instead (#6004).
-const NARROW_WALK_FRAMES = 6;
 
 vi.mock('../../lib/fileUtils.js', async (importOriginal) => {
   const actual = await importOriginal();
@@ -61,7 +55,9 @@ const records = await import('./records.js');
 const { lockReference, loadManifest } = await import('./reference.js');
 const { compileAtlas, getAtlasState, ATLAS_COLUMNS, DEFAULT_ATLAS_GEOMETRY } = await import('./atlas.js');
 const { SPRITE_DIRECTIONS } = await import('./prompts.js');
-const { WALK_PHASES, walkPhaseLabels, WALK_FPS } = await import('./walkPostprocess.js');
+const {
+  WALK_PHASES, walkPhaseLabels, WALK_FPS, WALK_MIN_FRAME_COUNT,
+} = await import('./walkPostprocess.js');
 const { buildAtlasGrid, compiledGridUpToDate } = await import('./atlasGrid.js');
 const { getAnimationTrack, SCANNER_TRACK, AMBIENT_TRACK } = await import('./animationTracks.js');
 // #3152 — `scanner`/`ambient` are seeded STORE rows, so the compiler's real table
@@ -71,6 +67,14 @@ const {
   animationTrackStorePath, animationTrackSeedPath,
 } = await import('./animationTrackStore.js');
 const EFFECTIVE_TRACKS = getEffectiveAnimationTracks();
+
+// The narrowest walk span a compile will accept: `resolveTrackUniformity`
+// refuses a direction outside the walk track's authoring range, so this tracks
+// the registry's floor rather than restating it — raising the floor adapts these
+// tests instead of breaking a dozen of them. Still wide enough for varyArm to
+// vary the silhouette and for a mid-strip index to exist; tests that pin the
+// production 9-column grid keep WALK_PHASES instead (#6004).
+const NARROW_WALK_FRAMES = WALK_MIN_FRAME_COUNT;
 
 let seq = 0;
 const newId = () => `atlas-char-${++seq}`;
@@ -677,13 +681,14 @@ describe('compileAtlas', () => {
     repartitioned.atlasSha256 = 'f'.repeat(64);
     repartitioned.geometry = {
       ...repartitioned.geometry,
-      // The same columns split differently — idle, a shortened walk, and a
-      // scanner span taking the rest — so the spans still tile the grid and only
-      // the SEMANTIC drift can be what triggers the recompile below.
+      // The same columns split differently — idle, a walk span one column
+      // short, and a scanner taking the column it gave up — so the spans still
+      // tile the grid at any walk width and only the SEMANTIC drift can be what
+      // triggers the recompile below.
       tracks: {
         idle: { start: 0, count: 1 },
-        walk: { start: 1, count: 3 },
-        scanner: { start: 4, count: NARROW_WALK_FRAMES - 3 },
+        walk: { start: 1, count: NARROW_WALK_FRAMES - 1 },
+        scanner: { start: NARROW_WALK_FRAMES, count: 1 },
       },
     };
     await writeFile(pointerAbs, JSON.stringify(repartitioned));

--- a/server/services/sprites/atlas.test.js
+++ b/server/services/sprites/atlas.test.js
@@ -19,13 +19,22 @@ import sharp from 'sharp';
 import { mkdir, writeFile, readFile, rm } from 'fs/promises';
 import { createHash } from 'crypto';
 import {
+  capSharpThreads,
   lockAllAnchors as lockAllAnchorsFixture,
   placeCandidate,
   trackSpan as fullSpan,
   writeWalkFramePng,
 } from './spriteTestFixtures.js';
 
+capSharpThreads();
 const TEST_ROOT = mkdtempSync(join(tmpdir(), 'sprite-atlas-test-'));
+
+// The narrowest walk span a compile will accept: the walk track's registry row
+// declares a 6–16 frame range and `resolveTrackUniformity` refuses anything
+// outside it, so 6 is the floor — still enough for varyArm to vary the
+// silhouette and for a mid-strip index to exist. Tests that pin the production
+// 9-column grid keep WALK_PHASES instead (#6004).
+const NARROW_WALK_FRAMES = 6;
 
 vi.mock('../../lib/fileUtils.js', async (importOriginal) => {
   const actual = await importOriginal();
@@ -271,10 +280,10 @@ async function finalizedAmbientPlace() {
   return id;
 }
 
-async function finalizedCharacter() {
+async function finalizedCharacter(walkOptions) {
   const id = newId();
   await lockAllAnchors(id);
-  await buildFinalizedWalkSet(id);
+  await buildFinalizedWalkSet(id, walkOptions);
   return id;
 }
 
@@ -334,14 +343,20 @@ describe('compileAtlas', () => {
   it('compiles an approved four-frame scanner span beside the walk span', async () => {
     const id = newId();
     await lockAllAnchors(id);
-    await buildFinalizedWalkSet(id, { frameCount: 12, fps: 10 });
+    // A narrow walk span: this test is about where the scanner span LANDS
+    // beside the walk span, and that placement is frame-count-parametric
+    // (atlasGrid.test.js pins the arithmetic). The 12-frame walk has its own
+    // test below, so a wide walk here only buys 48 more compiled cells (#6004).
+    await buildFinalizedWalkSet(id, { frameCount: NARROW_WALK_FRAMES, fps: 10 });
     await buildFinalizedScannerSet(id);
     const result = await compileAtlas(id);
     const manifest = JSON.parse(await readFile(join(TEST_ROOT, 'sprites', id, result.manifestPath), 'utf8'));
     expect(manifest.geometry.columns).toEqual([
-      'idle', ...walkPhaseLabels(12), 'scanner-00', 'scanner-01', 'scanner-02', 'scanner-03',
+      'idle', ...walkPhaseLabels(NARROW_WALK_FRAMES),
+      'scanner-00', 'scanner-01', 'scanner-02', 'scanner-03',
     ]);
-    expect(manifest.geometry.tracks.scanner).toMatchObject({ start: 13, count: 4, rows: 8 });
+    expect(manifest.geometry.tracks.scanner)
+      .toMatchObject({ start: NARROW_WALK_FRAMES + 1, count: 4, rows: 8 });
     expect(manifest.geometry.scannerFrameCount).toBe(4);
     expect(manifest.scannerSetSha256).toMatch(/^[0-9a-f]{64}$/);
     for (const row of manifest.directions) {
@@ -379,7 +394,7 @@ describe('compileAtlas', () => {
     it('still compiles an approved scanner set beside the walk span', async () => {
       const id = newId();
       await lockAllAnchors(id);
-      await buildFinalizedWalkSet(id, { frameCount: 12, fps: 10 });
+      await buildFinalizedWalkSet(id, { frameCount: NARROW_WALK_FRAMES, fps: 10 });
       await buildFinalizedScannerSet(id);
       await installUserStore();
 
@@ -388,9 +403,11 @@ describe('compileAtlas', () => {
       // Identical geometry to the compiled-row era: span order, column labels and
       // frame count all still resolve from the (now stored) row.
       expect(manifest.geometry.columns).toEqual([
-        'idle', ...walkPhaseLabels(12), 'scanner-00', 'scanner-01', 'scanner-02', 'scanner-03',
+        'idle', ...walkPhaseLabels(NARROW_WALK_FRAMES),
+        'scanner-00', 'scanner-01', 'scanner-02', 'scanner-03',
       ]);
-      expect(manifest.geometry.tracks.scanner).toMatchObject({ start: 13, count: 4, rows: 8 });
+      expect(manifest.geometry.tracks.scanner)
+        .toMatchObject({ start: NARROW_WALK_FRAMES + 1, count: 4, rows: 8 });
       expect(manifest.geometry.scannerFrameCount).toBe(4);
     });
 
@@ -430,7 +447,7 @@ describe('compileAtlas', () => {
     };
     const id = newId();
     await lockAllAnchors(id);
-    await buildFinalizedWalkSet(id, { frameCount: 8, fps: 10 });
+    await buildFinalizedWalkSet(id, { frameCount: NARROW_WALK_FRAMES, fps: 10 });
     await buildFinalizedScannerSet(id, {
       trackId,
       frameCount: 3,
@@ -441,9 +458,10 @@ describe('compileAtlas', () => {
     const first = await compileAtlas(id, { tracks: customTracks });
     const manifest = JSON.parse(await readFile(join(TEST_ROOT, 'sprites', id, first.manifestPath), 'utf8'));
     expect(manifest.geometry.columns).toEqual([
-      'idle', ...WALK_PHASES, 'jetpack-00', 'jetpack-01', 'jetpack-02',
+      'idle', ...walkPhaseLabels(NARROW_WALK_FRAMES), 'jetpack-00', 'jetpack-01', 'jetpack-02',
     ]);
-    expect(manifest.geometry.tracks.jetpack).toEqual({ start: 9, count: 3, rows: 8 });
+    expect(manifest.geometry.tracks.jetpack)
+      .toEqual({ start: NARROW_WALK_FRAMES + 1, count: 3, rows: 8 });
     expect(manifest.geometry.jetpackFrameCount).toBe(3);
     expect(manifest.trackSets.jetpack.setSha256).toMatch(/^[0-9a-f]{64}$/);
     for (const row of manifest.directions) {
@@ -549,6 +567,9 @@ describe('compileAtlas', () => {
     const id = newId();
     await lockAllAnchors(id);
     await buildFinalizedWalkSet(id, {
+      // The registry floor, still covering varyArm's full four-offset cycle —
+      // the widths still differ, which is the condition the guard below needs.
+      frameCount: NARROW_WALK_FRAMES,
       varyArm: true,
       alignment: { cellSize: 40, targetPivot: [20, 35] },
     });
@@ -579,7 +600,11 @@ describe('compileAtlas', () => {
   it('ignores a speck below the sole when grounding a compiled cell', async () => {
     const id = newId();
     await lockAllAnchors(id);
-    await buildFinalizedWalkSet(id, { speckFrames: [2], alignment: { cellSize: 40, targetPivot: [20, 35] } });
+    await buildFinalizedWalkSet(id, {
+      frameCount: NARROW_WALK_FRAMES,
+      speckFrames: [2],
+      alignment: { cellSize: 40, targetPivot: [20, 35] },
+    });
     const result = await compileAtlas(id);
     const manifest = JSON.parse(await readFile(join(TEST_ROOT, 'sprites', id, result.manifestPath), 'utf8'));
 
@@ -619,7 +644,7 @@ describe('compileAtlas', () => {
   });
 
   it('recompiles a set whose pointer still describes the pre-#2986 scanner grid', async () => {
-    const id = await finalizedCharacter();
+    const id = await finalizedCharacter({ frameCount: NARROW_WALK_FRAMES });
     const first = await compileAtlas(id);
 
     // Simulate a pointer written by the old compiler: same walk set, same cell
@@ -640,20 +665,25 @@ describe('compileAtlas', () => {
     const again = await compileAtlas(id);
     expect(again.created).toBe(true);
     expect(again.version).toBe(first.version + 1);
-    expect(again.geometry.columns).toEqual(['idle', ...WALK_PHASES]);
-    expect(again.geometry.widthPx).toBe(DEFAULT_ATLAS_GEOMETRY.cellSize * 9);
+    expect(again.geometry.columns).toEqual(['idle', ...walkPhaseLabels(NARROW_WALK_FRAMES)]);
+    expect(again.geometry.widthPx)
+      .toBe(DEFAULT_ATLAS_GEOMETRY.cellSize * (NARROW_WALK_FRAMES + 1));
 
     // A track-set change can leave the column list identical. Repartition the
     // now-current pointer and prove that semantic grid drift also versions.
     const repartitioned = JSON.parse(await readFile(pointerAbs, 'utf8'));
-    expect(repartitioned.geometry.tracks).toEqual({ idle: fullSpan(0, 1), walk: fullSpan(1, 8) });
+    expect(repartitioned.geometry.tracks)
+      .toEqual({ idle: fullSpan(0, 1), walk: fullSpan(1, NARROW_WALK_FRAMES) });
     repartitioned.atlasSha256 = 'f'.repeat(64);
     repartitioned.geometry = {
       ...repartitioned.geometry,
+      // The same columns split differently — idle, a shortened walk, and a
+      // scanner span taking the rest — so the spans still tile the grid and only
+      // the SEMANTIC drift can be what triggers the recompile below.
       tracks: {
         idle: { start: 0, count: 1 },
-        walk: { start: 1, count: 4 },
-        scanner: { start: 5, count: 4 },
+        walk: { start: 1, count: 3 },
+        scanner: { start: 4, count: NARROW_WALK_FRAMES - 3 },
       },
     };
     await writeFile(pointerAbs, JSON.stringify(repartitioned));
@@ -661,8 +691,9 @@ describe('compileAtlas', () => {
     const trackChanged = await compileAtlas(id);
     expect(trackChanged.created).toBe(true);
     expect(trackChanged.version).toBe(again.version + 1);
-    expect(trackChanged.geometry.columns).toEqual(['idle', ...WALK_PHASES]);
-    expect(trackChanged.geometry.tracks).toEqual({ idle: fullSpan(0, 1), walk: fullSpan(1, 8) });
+    expect(trackChanged.geometry.columns).toEqual(['idle', ...walkPhaseLabels(NARROW_WALK_FRAMES)]);
+    expect(trackChanged.geometry.tracks)
+      .toEqual({ idle: fullSpan(0, 1), walk: fullSpan(1, NARROW_WALK_FRAMES) });
   });
 
   it('stays idempotent for current and legacy geometry descriptors', async () => {
@@ -670,7 +701,7 @@ describe('compileAtlas', () => {
     // span, so a pointer written before it would compare unequal and re-run the
     // entire pixel pipeline on every compile, forever, for every existing
     // install. Absent must normalize to full height on the way in.
-    const id = await finalizedCharacter();
+    const id = await finalizedCharacter({ frameCount: NARROW_WALK_FRAMES });
     const first = await compileAtlas(id);
 
     const unchanged = await compileAtlas(id);
@@ -705,7 +736,7 @@ describe('compileAtlas', () => {
     // post-encode sha compare, so a test that only checked that would pass even
     // with the legacy fallback deleted — i.e. while the pixel pipeline ran in
     // full on every compile, which is the exact regression this guards.
-    const grid = buildAtlasGrid([{ id: 'walk', frameCount: WALK_PHASES.length }]);
+    const grid = buildAtlasGrid([{ id: 'walk', frameCount: NARROW_WALK_FRAMES }]);
     expect(compiledGridUpToDate(pointer.geometry, { ...DEFAULT_ATLAS_GEOMETRY, ...grid })).toBe(true);
 
     const withoutTracks = await compileAtlas(id);
@@ -778,7 +809,7 @@ describe('compileAtlas', () => {
   });
 
   it('refuses an unapproved direction', async () => {
-    const id = await finalizedCharacter();
+    const id = await finalizedCharacter({ frameCount: NARROW_WALK_FRAMES });
     const setAbs = join(TEST_ROOT, 'sprites', id, `walk/${id}-walk-set-v1.json`);
     const walkSet = JSON.parse(await readFile(setAbs, 'utf8'));
     walkSet.directions.north.status = 'rejected';
@@ -787,12 +818,13 @@ describe('compileAtlas', () => {
   });
 
   it('honors geometry overrides at normal and 2x source density', async () => {
-    const id = await finalizedCharacter();
+    const id = await finalizedCharacter({ frameCount: NARROW_WALK_FRAMES });
+    const columnCount = NARROW_WALK_FRAMES + 1;
     const normal = await compileAtlas(id, {
       geometry: { cellSize: 64, pivot: [32, 56], targetMaxHeight: 44, targetMaxWidth: 52 },
     });
     const normalMeta = await sharp(join(TEST_ROOT, 'sprites', id, normal.atlasPath)).metadata();
-    expect(normalMeta.width).toBe(64 * 9);
+    expect(normalMeta.width).toBe(64 * columnCount);
     expect(normalMeta.height).toBe(64 * 8);
 
     const dense = await compileAtlas(id, {
@@ -804,12 +836,12 @@ describe('compileAtlas', () => {
       },
     });
     const denseMeta = await sharp(join(TEST_ROOT, 'sprites', id, dense.atlasPath)).metadata();
-    expect(denseMeta.width).toBe(192 * 9);
+    expect(denseMeta.width).toBe(192 * columnCount);
     expect(denseMeta.height).toBe(192 * 8);
   });
 
   it('refuses an imported legacy walk set with an explicit code (not a tamper error)', async () => {
-    const id = await finalizedCharacter();
+    const id = await finalizedCharacter({ frameCount: NARROW_WALK_FRAMES });
     const setAbs = join(TEST_ROOT, 'sprites', id, `walk/${id}-walk-set-v1.json`);
     const walkSet = JSON.parse(await readFile(setAbs, 'utf8'));
     walkSet.selectionPath = `art-source/sprites/${id}/walk/${id}-walk-selection-v1.json`;
@@ -823,7 +855,7 @@ describe('compileAtlas', () => {
   // must still be refused for the directions that have NOT been re-derived —
   // and must name them, since the remedy is applied one direction at a time.
   it('names the directions still packaged by the source pipeline', async () => {
-    const id = await finalizedCharacter();
+    const id = await finalizedCharacter({ frameCount: NARROW_WALK_FRAMES });
     const setAbs = join(TEST_ROOT, 'sprites', id, `walk/${id}-walk-set-v1.json`);
     const walkSet = JSON.parse(await readFile(setAbs, 'utf8'));
     walkSet.directions.north.runManifest = `art-source/sprites/${id}/${walkSet.directions.north.runManifest}`;
@@ -836,7 +868,9 @@ describe('compileAtlas', () => {
   });
 
   it('self-heals a deleted atlas without overwriting an immutable version', async () => {
-    const id = await finalizedCharacter();
+    // Version bookkeeping only — no column assertions — so this compiles the
+    // narrow span three times rather than the full production grid (#6004).
+    const id = await finalizedCharacter({ frameCount: NARROW_WALK_FRAMES });
     const first = await compileAtlas(id);
     rmSync(join(TEST_ROOT, 'sprites', id, first.atlasPath));
     const again = await compileAtlas(id);
@@ -858,7 +892,7 @@ describe('compileAtlas', () => {
   });
 
   it('rejects geometry whose content bounds cannot fit the cell', async () => {
-    const id = await finalizedCharacter();
+    const id = await finalizedCharacter({ frameCount: NARROW_WALK_FRAMES });
     await expect(compileAtlas(id, { geometry: { cellSize: 64, targetMaxWidth: 64 } }))
       .rejects.toMatchObject({ status: 400, code: 'INVALID_GEOMETRY' });
   });

--- a/server/services/sprites/spriteTestFixtures.js
+++ b/server/services/sprites/spriteTestFixtures.js
@@ -20,6 +20,22 @@ import sharp from 'sharp';
 import { mkdir, writeFile } from 'fs/promises';
 import { SPRITE_DIRECTIONS } from './prompts.js';
 
+/**
+ * Cap libvips at one thread per call, for a suite whose images are all tiny.
+ *
+ * Every sprite fixture and every compiled atlas cell is a 40–192px image, so a
+ * Sharp call's cost is its per-call overhead, not its pixel count — and the
+ * thread pool's setup/join IS most of that overhead at this size. CI already
+ * saturates each runner with several Vitest workers, so the pool only
+ * oversubscribes the box on top of that; the sprite suites measured markedly
+ * less system time with it capped (#6004). Called explicitly by the suites that
+ * want it rather than run on import, so importing a fixture never silently
+ * reconfigures a worker that later runs an unrelated, image-heavy suite.
+ */
+export function capSharpThreads() {
+  sharp.concurrency(1);
+}
+
 // Sharp PNG encoding is the expensive part; the same raw pixels show up in
 // dozens of tests. Cache the encoded buffer per unique pixel config and
 // `writeFile` it — still a real PNG, just not re-encoded every time.

--- a/server/services/sprites/spriteTestFixtures.js
+++ b/server/services/sprites/spriteTestFixtures.js
@@ -22,18 +22,26 @@ import { SPRITE_DIRECTIONS } from './prompts.js';
 
 /**
  * Cap libvips at one thread per call, for a suite whose images are all tiny.
+ * Returns the restore function the caller MUST hand to `afterAll`.
  *
  * Every sprite fixture and every compiled atlas cell is a 40–192px image, so a
  * Sharp call's cost is its per-call overhead, not its pixel count — and the
  * thread pool's setup/join IS most of that overhead at this size. CI already
  * saturates each runner with several Vitest workers, so the pool only
  * oversubscribes the box on top of that; the sprite suites measured markedly
- * less system time with it capped (#6004). Called explicitly by the suites that
- * want it rather than run on import, so importing a fixture never silently
- * reconfigures a worker that later runs an unrelated, image-heavy suite.
+ * less system time with it capped (#6004).
+ *
+ * `sharp.concurrency` reaches past the module graph into libvips itself, so it
+ * is PROCESS state: Vitest resets the module registry between files but reuses
+ * the worker process, and an uncapped setting would otherwise stick to every
+ * later file in that worker — including the imageGen suites that raster
+ * 700–1200px images near their hook timeout. Hence the restore, and hence
+ * calling this from a suite rather than running it on import.
  */
 export function capSharpThreads() {
+  const previous = sharp.concurrency();
   sharp.concurrency(1);
+  return () => sharp.concurrency(previous);
 }
 
 // Sharp PNG encoding is the expensive part; the same raw pixels show up in

--- a/server/services/sprites/walk.test.js
+++ b/server/services/sprites/walk.test.js
@@ -15,8 +15,9 @@ import { tmpdir } from 'os';
 import { join } from 'path';
 import { mkdir, writeFile, readFile, rm } from 'fs/promises';
 import { createHash } from 'crypto';
-import { lockAllAnchors, expectCarriesCorrection } from './spriteTestFixtures.js';
+import { capSharpThreads, lockAllAnchors, expectCarriesCorrection } from './spriteTestFixtures.js';
 
+capSharpThreads();
 const TEST_ROOT = mkdtempSync(join(tmpdir(), 'sprite-walk-test-'));
 
 vi.mock('../../lib/fileUtils.js', async (importOriginal) => {

--- a/server/services/sprites/walk.test.js
+++ b/server/services/sprites/walk.test.js
@@ -17,7 +17,8 @@ import { mkdir, writeFile, readFile, rm } from 'fs/promises';
 import { createHash } from 'crypto';
 import { capSharpThreads, lockAllAnchors, expectCarriesCorrection } from './spriteTestFixtures.js';
 
-capSharpThreads();
+const restoreSharpThreads = capSharpThreads();
+afterAll(restoreSharpThreads);
 const TEST_ROOT = mkdtempSync(join(tmpdir(), 'sprite-walk-test-'));
 
 vi.mock('../../lib/fileUtils.js', async (importOriginal) => {


### PR DESCRIPTION
> **Status: needs a maintainer call before it goes anywhere.** #6004 — the issue this branch was claimed against — was closed as a dead end at 03:46Z while this work was in flight, and its remaining scope moved to #6180. Read the "Relationship to #6004 and #6180" section below before reviewing the diff. Merge is withheld regardless (see the review comments).

## Summary

Two independent reductions in what the sprite `atlas`/`walk` Vitest suites cost on a **contended** runner. No test is skipped, deleted, or weakened.

**1. Cap libvips threads (3 files, ~15 lines).** Both suites call a new `capSharpThreads()` fixture helper (`sharp.concurrency(1)`) and restore the previous value in `afterAll`. Every image these suites touch is 40–192px, where the libvips pool's setup/join is most of the call — which is the same finding #6165 recorded as "`sharp().stats()` costs ~4ms regardless of frame size — libvips pipeline setup, not pixels". CI already runs several Vitest workers per box, so the pool only oversubscribes it on top of that. The restore matters: `sharp.concurrency` is process state and Vitest reuses worker processes across files, so an uncapped setting would stick to every later file in that worker.

**2. Narrow the compiled walk span where the assertion is frame-count-parametric.** Scanner/jetpack span placement, hip-anchor registration, speck grounding, the pre-#2986 grid-drift recompile, idempotency, geometry overrides, self-heal versioning and the refusal paths now build the narrowest walk span the walk track's registry allows (`WALK_MIN_FRAME_COUNT`) instead of 8 or 12. Their expectations derive span starts and widths from that constant rather than hardcoding column indices, so they pin exactly the same arithmetic. The production 9×8 grid stays pinned, unchanged, by `compiles the 9×8 player atlas`, and the 12-frame variable-width case keeps its own dedicated test. This cuts both the cells each `compileAtlas` renders and the files each `buildFinalizedWalkSet` writes.

## What this branch independently confirmed, and what it rules out

Before writing either change, this run measured the two levers #6004 actually proposed. Both are no-ops, matching @Bryandero98's pass and the maintainer's Windows profiling:

- **Fixture frame size** — halving the 40×40 walk fixture to 24×24 left both suites' CPU time unchanged (and forced an assertion tolerance to be loosened, so it was reverted rather than shipped).
- **Atlas cell size** — halving `DEFAULT_ATLAS_GEOMETRY.cellSize` from 96 to 48 as a probe: 36.77s user CPU vs a 36.92s baseline. No change.

A compiled cell costs two Sharp calls (decode + premultiplied resize) whose price at these sizes is per-call overhead, not pixel count. What is left is the **number** of calls and the thread pool behind each one — which is what this branch attacks.

## Measurements

On an **idle** machine there is no change, because these suites are not CPU-bound when nothing else is running: `atlas` 4.68s → 4.63s, `walk` 3.55s → 3.81s. That is the honest result, and it is consistent with the 56s/53s Windows figures being a contention/small-file-I/O signal rather than an image-work one.

Under contention it is real. Two alternating A/B rounds of both suites on a deliberately loaded machine (load average 60–90), measuring CPU rather than wall clock:

| Round | Baseline user+sys | This branch | Δ |
|---|---|---|---|
| 1 | 48.7s + 34.2s = 82.9s | 36.4s + 20.7s = 57.1s | −31% |
| 2 | 47.1s + 30.6s = 77.7s | 32.5s + 17.3s = 49.8s | −36% |

System time roughly halves, which is the thread-pool oversubscription going away. Measured separately under the same load, `capSharpThreads()` alone accounts for most of the `walk` gain (12.25s → 8.40s user) and only a small part of the `atlas` gain (36.9s → 34.6s user); the span narrowing is what moves `atlas`.

This run stops at publication and does not watch CI, so it does not post the `⏱` job-summary line itself — read it off this PR's full-suite job and compare against `main`.

## Relationship to #6004 and #6180

- **#6004 is closed** (COMPLETED, resolved by #6165, remaining scope → #6180). Nothing here reopens it; the trailer is `Refs`, not `Closes`.
- **Change 1 (`capSharpThreads`) does not overlap #6180 at all.** It is three lines in `spriteTestFixtures.js` plus one call site per suite, touches no assertion, and is orthogonal to #6180's fixture hoist. If only one half of this PR is wanted, this is the half.
- **Change 2 (span narrowing) overlaps #6180's territory** — same two files, and #6180 explicitly scopes `compileAtlas` out as "the production work under test". It does not do what #6180 does (it builds *less*, rather than avoiding a rebuild), and the two compose — a hoisted prototype is cheaper to copy when it is narrower — but it will cost @Bryandero98 a rebase on a ~3,400-line test refactor if it lands first.

**Recommended call:** either take the whole branch now, before #6180's refactor starts in earnest, or ask for it to be cut down to change 1 and leave the span narrowing to be folded into #6180. Closing this outright is also a reasonable answer; the negative results above stand on their own either way and are the reason the fixture-shrink path is not being tried a fifth time.

## Test plan

- `cd server && npx vitest run services/sprites/` — 26 files, 713 passed, 1 skipped (pre-existing). Run on both a quiet and a heavily loaded machine, before and after rebasing onto current `main`.
- No test deleted, skipped, or `SKIP_HEAVY_INTEGRATION`-gated by this change; the assertion count is unchanged.

Refs #6004, #6180
