### PR TITLE
feat: add a disabled-by-default Slotstream AI Providers preset

### DIFF
--- a/client/src/utils/providers.test.js
+++ b/client/src/utils/providers.test.js
@@ -1138,7 +1138,7 @@ describe('supportsModelRefresh', () => {
       // provider — nothing here can enumerate that, and Models → Harnesses
       // ("Refresh models") is where their catalog comes from instead.
       'opencode-zen',
-      'openrouter', 'orcarouter',
+      'openrouter', 'orcarouter', 'slotstream',
     ]);
   });
 });

--- a/data.reference/providers.json
+++ b/data.reference/providers.json
@@ -596,6 +596,18 @@
       "enabled": false,
       "envVars": {}
     },
+    "slotstream": {
+      "id": "slotstream",
+      "name": "Slotstream (SSD-streaming MoE)",
+      "type": "api",
+      "endpoint": "http://127.0.0.1:5564/v1",
+      "apiKey": "",
+      "models": ["qwen3-235b-a22b-4bit", "gpt-oss-120b-mxfp4", "qwen3-30b-a3b-4bit"],
+      "defaultModel": "qwen3-235b-a22b-4bit",
+      "timeout": 300000,
+      "enabled": false,
+      "envVars": {}
+    },
     "nvidia-kimi": {
       "id": "nvidia-kimi",
       "name": "NVIDIA Kimi K2.5",

--- a/docs/features/product-surfaces.md
+++ b/docs/features/product-surfaces.md
@@ -194,7 +194,7 @@ Local AI model acceleration, multi-machine peer federation, storage classificati
 
 | Surface / Area | Route(s) | Key Capabilities & Workflows | Related Guides |
 |---|---|---|---|
-| **Local LLM Runtimes** | `/models/llms` | Management of local model servers: Ollama, LM Studio, vLLM, SGLang, and llama.cpp / llama-server. | [Claude on Ollama](./claude-ollama.md) |
+| **Local LLM Runtimes** | `/models/llms` | Management of local model servers: Ollama, LM Studio, vLLM, SGLang, llama.cpp / llama-server, MTPLX, and Slotstream (SSD-streaming MoE for checkpoints larger than RAM). | [Claude on Ollama](./claude-ollama.md), [MTPLX](./mtplx.md), [Slotstream](./slotstream.md) |
 | **Speculative Decoding** | `/models/llms` | Accelerated token generation using DSpark, DFlash 2, and MTPLX speculative drafting pairs. | [DFlash2 & DSpark](./dflash2.md), [MTPLX](./mtplx.md), [RTX 3090 vLLM](./qwen38-rtx3090.md), [SGLang Qwen](./sglang-qwen38.md) |
 | **Embeddings Management** | `/models/embeddings` | Local text embedding models (Nomic, Ollama) and pgvector semantic index configuration. | [STORAGE.md](../STORAGE.md) |
 | **LoRAs & Model Training** | `/models/loras`, `/models/training` | LoRA adapter discovery, Civitai downloads, image captioning, and local FLUX LoRA training dataset management. | — |

--- a/docs/features/slotstream.md
+++ b/docs/features/slotstream.md
@@ -72,18 +72,39 @@ same port would silently steal its traffic instead of failing loudly.
    progress over the `slotstream:download` socket event; the download resumes
    from a partial file if interrupted, and stalls (no bytes for 20 minutes by
    default) are abandoned rather than hung forever, resumable on the next
-   press. PortOS also accepts a plain Hugging Face `owner/name` outside the
-   curated list, as long as the repo is a Slotstream-loadable MoE checkpoint.
-   Nothing downloads without this explicit press.
+   press. Every downloaded file is checked against the hash Hugging Face
+   published for it (`expectedSha256` in `streamResumableDownload`) before it
+   counts as finished; a mismatch fails the install and removes the partial
+   file rather than leaving a silently corrupt checkpoint on disk. PortOS also
+   accepts a plain Hugging Face `owner/name` outside the curated list, as long
+   as the repo is a Slotstream-loadable MoE checkpoint. Nothing downloads
+   without this explicit press.
 3. **Start Slotstream** on the card, or **Save configuration** to store the
    choice for a later on-demand start without starting it now. Either way,
    Slotstream never fetches weights at start time — a start reads
    `~/.slotstream/models` (or `SLOTSTREAM_MODEL_DIR`, see below) and refuses
    with a clear message if nothing servable is cached, rather than trying to
    fetch the requested checkpoint.
-4. Point an `api`/`tui` provider at the Slotstream endpoint (or use the
-   `slotstream` preset if one exists in AI Providers) and use it for
-   supported tasks.
+4. Enable the **Slotstream (SSD-streaming MoE)** preset on **AI Providers** —
+   see below — or point any `api`/`tui` provider at the endpoint by hand, and
+   use it for supported tasks.
+
+## AI Providers preset
+
+`data.reference/providers.json` ships a `slotstream` preset (`api` type,
+`http://127.0.0.1:5564/v1`, **disabled by default** — the same
+consent-before-cost posture as the download itself) and migration 340 seeds it
+into existing installs. It offers the curated catalog's three checkpoint ids
+as candidate models, defaulting to the 235B-class headline case; whichever
+checkpoint is actually cached and started is what answers, regardless of which
+catalog id the request names.
+
+Unlike MTPLX, Slotstream gets no `opencode-slotstream` CLI/TUI wrapper: it is
+text-only, so it is not a valid CoS coding-agent runner. `isSlotstreamProvider`
+(`server/services/slotstreamServerManager.js`) recognizes any `api`/`tui`
+provider pointed at `PORTS.SLOTSTREAM` — including a hand-added one, not only
+this preset — so `ensureSlotstreamProviderReady` lazy-starts the runtime for
+it the same way.
 
 ## Memory plan
 

--- a/scripts/migrations/340-slotstream-provider.js
+++ b/scripts/migrations/340-slotstream-provider.js
@@ -1,0 +1,39 @@
+/**
+ * Ship a disabled Slotstream provider preset to existing installs.
+ *
+ * Slotstream is a separately managed local runtime (SSD-streaming MoE) —
+ * see docs/features/slotstream.md. It answers ordinary text tasks through its
+ * loopback OpenAI-compatible endpoint the same way MTPLX's API preset does
+ * (migration 272): text-only, so no CLI/TUI variant is registered — Slotstream
+ * is not a valid CoS coding-agent runner.
+ *
+ * This migration deliberately does not install Slotstream, download a
+ * checkpoint, start a daemon, or contact its endpoint. The preset is disabled
+ * by default. An install that already owns this id is left untouched,
+ * preserving refreshed models and local endpoint edits.
+ *
+ * Kept in lockstep with data.reference/providers.json and
+ * server/lib/aiToolkit/defaults/providers.sample.json. This frozen literal is
+ * the historical upgrade payload; later default changes require a new
+ * migration rather than rewriting this record.
+ */
+
+import { makeProviderSeedMigration } from './_lib.js';
+
+const SLOTSTREAM_API = {
+  id: 'slotstream',
+  name: 'Slotstream (SSD-streaming MoE)',
+  type: 'api',
+  endpoint: 'http://127.0.0.1:5564/v1',
+  apiKey: '',
+  models: ['qwen3-235b-a22b-4bit', 'gpt-oss-120b-mxfp4', 'qwen3-30b-a3b-4bit'],
+  defaultModel: 'qwen3-235b-a22b-4bit',
+  timeout: 300000,
+  enabled: false,
+  envVars: {},
+};
+
+export default makeProviderSeedMigration({
+  label: 'Slotstream',
+  defs: [SLOTSTREAM_API],
+});

--- a/scripts/migrations/340-slotstream-provider.test.js
+++ b/scripts/migrations/340-slotstream-provider.test.js
@@ -1,0 +1,70 @@
+/**
+ * Test for migration 340 — add the Slotstream provider preset to existing
+ * installs. The shared idempotent write shell is asserted in _lib.test.js;
+ * this test pins migration 340's frozen payload and its disabled-by-default,
+ * text-only contract (no CLI/TUI variant — see migration 272 for why MTPLX
+ * gets one and Slotstream does not).
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, mkdirSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import migration from './340-slotstream-provider.js';
+
+const writeJson = (path, value) => writeFileSync(path, JSON.stringify(value, null, 2) + '\n');
+const readJson = (path) => JSON.parse(readFileSync(path, 'utf-8'));
+
+describe('migration 340 — Slotstream provider', () => {
+  let rootDir;
+  let providersPath;
+
+  beforeEach(() => {
+    rootDir = mkdtempSync(join(tmpdir(), 'migration-340-'));
+    mkdirSync(join(rootDir, 'data'), { recursive: true });
+    providersPath = join(rootDir, 'data/providers.json');
+  });
+
+  afterEach(() => {
+    rmSync(rootDir, { recursive: true, force: true });
+  });
+
+  it('adds a disabled API preset without touching existing state', async () => {
+    writeJson(providersPath, {
+      activeProvider: 'claude-code',
+      providers: { 'claude-code': { id: 'claude-code', type: 'cli', command: 'claude' } },
+    });
+
+    await migration.up({ rootDir });
+
+    const out = readJson(providersPath);
+    const api = out.providers.slotstream;
+
+    expect(api).toMatchObject({
+      id: 'slotstream',
+      type: 'api',
+      endpoint: 'http://127.0.0.1:5564/v1',
+      models: ['qwen3-235b-a22b-4bit', 'gpt-oss-120b-mxfp4', 'qwen3-30b-a3b-4bit'],
+      defaultModel: 'qwen3-235b-a22b-4bit',
+      enabled: false,
+    });
+
+    // Text-only: no opencode-slotstream CLI/TUI wrapper, unlike MTPLX.
+    expect(out.providers['opencode-slotstream']).toBeUndefined();
+    expect(out.providers['opencode-slotstream-tui']).toBeUndefined();
+
+    expect(out.providers['claude-code']).toBeDefined();
+    expect(out.activeProvider).toBe('claude-code');
+  });
+
+  it('preserves an existing Slotstream provider instead of replacing its local edits', async () => {
+    const existing = {
+      id: 'slotstream', name: 'My Slotstream', type: 'api', endpoint: 'http://127.0.0.1:5564/v1', enabled: true,
+    };
+    writeJson(providersPath, { providers: { slotstream: existing } });
+
+    await migration.up({ rootDir });
+
+    expect(readJson(providersPath).providers.slotstream).toEqual(existing);
+  });
+});

--- a/server/lib/aiToolkit/defaults/providers.sample.json
+++ b/server/lib/aiToolkit/defaults/providers.sample.json
@@ -638,6 +638,19 @@
       "envVars": {},
       "secretEnvVars": []
     },
+    "slotstream": {
+      "id": "slotstream",
+      "name": "Slotstream (SSD-streaming MoE)",
+      "type": "api",
+      "endpoint": "http://127.0.0.1:5564/v1",
+      "apiKey": "",
+      "models": ["qwen3-235b-a22b-4bit", "gpt-oss-120b-mxfp4", "qwen3-30b-a3b-4bit"],
+      "defaultModel": "qwen3-235b-a22b-4bit",
+      "timeout": 300000,
+      "enabled": false,
+      "envVars": {},
+      "secretEnvVars": []
+    },
     "grok": {
       "id": "grok",
       "name": "xAI Grok",

--- a/server/lib/aiToolkit/internal/modelFetchers.test.js
+++ b/server/lib/aiToolkit/internal/modelFetchers.test.js
@@ -18,6 +18,7 @@ const SHIPPED_REFRESHABLE = [
   'antigravity-cli', 'antigravity-tui', 'cerebras', 'claude-code',
   'claude-code-bedrock', 'claude-ollama', 'claude-ollama-tui', 'cursor-cli',
   'cursor-tui', 'grok', 'lmstudio', 'mtplx', 'nvidia-kimi', 'ollama',
+  'slotstream',
   'opencode-llama-tui',
   'opencode-mtplx', 'opencode-mtplx-tui', 'opencode-ollama', 'opencode-ollama-tui',
   'opencode-orcarouter', 'opencode-orcarouter-tui', 'orcarouter',


### PR DESCRIPTION
## Summary

Closes #5816.

The rest of the issue's scope shipped independently while this was in flight (#6162 and its follow-ups): `slotstreamModelManager.js` already enumerates cached checkpoints, previews size/destination/free-disk and refuses before the first byte via the shared download-preflight helper (`assessDownloadPreflight`/`assertDownloadFits`), verifies each file's sha256 (`expectedSha256` in `streamResumableDownload`), and resumes across restart/cancel. The consent modal (`DownloadPreflightConfirm.jsx` via `useDownloadPreflightConfirm`) and the card UI (`SlotstreamServerCard.jsx`) already wire all of that up. The one piece the issue asked for that genuinely didn't exist yet was the **AI Providers preset itself**.

## What this adds

- `data.reference/providers.json` + `providers.sample.json`: a new `slotstream` `api`-type preset (`http://127.0.0.1:5564/v1`, **disabled by default**), modeled exactly on the existing `mtplx` preset. Text-only, so — per the issue — no `opencode-slotstream` CLI/TUI wrapper is registered, unlike MTPLX: Slotstream is not a valid CoS coding-agent runner.
- `scripts/migrations/340-slotstream-provider.js` (+ test): seeds the preset into existing installs via the same `makeProviderSeedMigration` factory migration 272 used for MTPLX. An install that already owns the `slotstream` id is left untouched.
- `docs/features/slotstream.md`: removes the "(or use the `slotstream` preset if one exists in AI Providers)" hedge now that it's real, documents the per-file hash verification under the download step, and adds a short **AI Providers preset** section.
- `docs/features/product-surfaces.md`: lists Slotstream (and MTPLX, which was missing too) under **Local LLM Runtimes**.
- Two existing tests hardcode the shipped-provider-id list this preset joins — every `api`-type provider gets a "Refresh models" button (`canRefreshModels` in `modelFetchers.js`), same as `mtplx`/`lmstudio`/`ollama`: `client/src/utils/providers.test.js` and `server/lib/aiToolkit/internal/modelFetchers.test.js`, both updated to include `slotstream`.

`models`/`defaultModel` use the three `SLOTSTREAM_CATALOG` checkpoint ids (`server/lib/slotstreamCatalog.js`) rather than a fabricated served-model name — whichever checkpoint is actually cached and started is what answers, regardless of which catalog id a request names.

## Test plan

- `npx vitest run scripts/migrations/340-slotstream-provider.test.js` — new migration test, green.
- Every test that derives its expectations from `providers.json`/`providers.sample.json` — `tuiHandshake.test.js`, `cliChildEnv.test.js`, `harnesses.test.js`, `bootstrapSequence.test.js`, `providerModels.test.js`, plus the two updated above — all green, confirming the new preset doesn't trip any shipped-catalog invariant beyond the two intentional list updates.
- `slotstreamServerManager.test.js` / `slotstreamModelManager.test.js` — unaffected, still green.
- Two unrelated pre-existing failures on this Windows dev machine (`aiToolkit/runner.test.js` — an `EBUSY` temp-file-cleanup race; `AIProviders.test.jsx` — a `waitFor` timing flake in a fully self-mocked test with no dependency on `providers.json`) were confirmed to reproduce **identically on a clean `main`** with none of this branch's changes applied, so they're not from this change — left untouched as out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)