### PR TITLE
Unstick the pr-reviewer Stage 3 agent: lean prompt, real local-daemon timeouts, and TUI recovery for retry ladders and permission dialogs

### DIFF
--- a/server/lib/aiToolkit/errorDetection.js
+++ b/server/lib/aiToolkit/errorDetection.js
@@ -574,6 +574,69 @@ export function createLocalRuntimeOomDetector({ maxBuffer = 512 } = {}) {
   };
 }
 
+// Claude Code's in-TUI retry banner, painted while it re-sends a failed request:
+// `API error · Retrying in 0s · attempt 1/10` (the prefix varies — `Request timed
+// out`, `Overloaded` — so only the retry suffix is matched). The whitespace is
+// `\s*` everywhere for the same reason TERMINAL_REQUEST_TIMEOUT_PATTERN's is: the
+// ANSI-stripped screen can drop the spaces between cursor-positioned glyphs.
+//
+// A banner is NOT a failure by itself — Claude Code retries transient 429/5xx
+// on its own and usually succeeds. It becomes one when the SAME request keeps
+// failing: on 2026-09-04 a Stage 3 review whose ~100K-token prefill outlived the
+// harness's stream-idle window was cancelled and re-sent every 6 minutes, so the
+// session sat at this banner for the run's whole lifetime while every reaper
+// saw a busy TUI (agent-e057cca7). `createRetryStallGate` in tuiHandshake.js
+// owns the "keeps failing" judgement; this only reads the banner.
+const TUI_RETRY_BANNER_PATTERN = /Retrying\s*in\s*(\d+)\s*s\s*[·•]\s*attempt\s*(\d+)\s*\/\s*(\d+)/gi;
+
+/**
+ * The LAST retry banner in `text`, or null. A repaint often carries two ticks
+ * of the same countdown (`Retrying in 1s` then `0s`); the newest is the state.
+ *
+ * @returns {{ attempt: number, maxAttempts: number, retryInSeconds: number, endIndex: number }|null}
+ */
+export function detectTuiRetryBanner(text) {
+  if (!text) return null;
+  let last = null;
+  for (const match of String(text).matchAll(TUI_RETRY_BANNER_PATTERN)) {
+    last = {
+      retryInSeconds: Number(match[1]),
+      attempt: Number(match[2]),
+      maxAttempts: Number(match[3]),
+      endIndex: match.index + match[0].length,
+    };
+  }
+  return last;
+}
+
+/**
+ * The fail-over analysis for a request the TUI kept retrying without ever
+ * getting a response — same shape as `detectImmediateFallbackSignal` returns, so
+ * a consumer hands it straight to its fail-over path.
+ *
+ * A FIXED sentence, deliberately not the banner text: this message becomes the
+ * run error, then a failure reason a CoS task body can quote, and a TUI echoes
+ * a pasted prompt back through the very detector above — so it must not match
+ * TUI_RETRY_BANNER_PATTERN (it carries no `Retrying in Ns · attempt`).
+ */
+export function describeTuiRetryStall({ attempts, spanMs }) {
+  const minutes = Math.max(1, Math.round(spanMs / 60000));
+  return {
+    hasError: true,
+    category: ERROR_CATEGORIES.TIMEOUT,
+    message: `Provider kept failing the same request: the TUI retried it ${attempts} times over ${minutes} minutes without a response`,
+    waitTime: null,
+    requiresFallback: true,
+    // Nothing a human has to fix before a retry can succeed elsewhere: the
+    // request is too slow for THIS provider's harness window (a long prefill on
+    // a local model server, a stalled upstream), and a fallback can serve it now.
+    actionable: false,
+    graceMs: 0,
+    suggestedFix: 'Every retry re-sent the same request and none answered — typically a prompt whose prefill outlives the harness\'s stream-idle window on a local model server. Shrink the prompt, widen the idle window, or pin the stage to a faster provider.',
+    origin: 'provider',
+  };
+}
+
 export function extractWaitTime(text) {
   if (!text) return null;
 

--- a/server/lib/aiToolkit/errorDetection.test.js
+++ b/server/lib/aiToolkit/errorDetection.test.js
@@ -11,6 +11,8 @@ import {
   detectLocalRuntimeOom,
   detectTerminalModelError,
   detectTerminalRequestTimeout,
+  detectTuiRetryBanner,
+  describeTuiRetryStall,
   extractWaitTime,
   isRunCanceledError,
   ERROR_CATEGORIES
@@ -628,6 +630,48 @@ describe('Error Detection', () => {
         requiresFallback: true,
         actionable: false,
       });
+    });
+  });
+
+  describe('detectTuiRetryBanner', () => {
+    it('reads Claude Code\'s retry banner as it comes off the ANSI-stripped screen', () => {
+      // Verbatim shape from agent-e057cca7's raw.txt (2026-09-04), after
+      // stripping: the colour reset lands the box-drawing rule flush against it.
+      expect(detectTuiRetryBanner('API error · Retrying in 0s · attempt 1/10─────'))
+        .toMatchObject({ retryInSeconds: 0, attempt: 1, maxAttempts: 10 });
+      // Cursor-positioned glyphs can lose their spaces on the way out.
+      expect(detectTuiRetryBanner('Requesttimedout·Retryingin38s·attempt3/10'))
+        .toMatchObject({ retryInSeconds: 38, attempt: 3, maxAttempts: 10 });
+    });
+
+    it('returns the newest banner when a repaint carries several ticks', () => {
+      const screen = 'API error · Retrying in 1s · attempt 2/10\n…\nAPI error · Retrying in 0s · attempt 2/10\n';
+      const banner = detectTuiRetryBanner(screen);
+      expect(banner).toMatchObject({ retryInSeconds: 0, attempt: 2 });
+      expect(screen.slice(banner.endIndex)).toBe('\n');
+    });
+
+    it('leaves prose about retries alone', () => {
+      expect(detectTuiRetryBanner('retrying the fetch later; attempt 1 of 3 failed')).toBeNull();
+      expect(detectTuiRetryBanner('')).toBeNull();
+      expect(detectTuiRetryBanner(null)).toBeNull();
+    });
+
+    it('describes a stall in a sentence that cannot re-match the banner detector', () => {
+      // The message becomes the run's error, then a task body a TUI echoes
+      // back through this detector. Re-matching would fail over the agent
+      // dispatched to investigate the stall.
+      const analysis = describeTuiRetryStall({ attempts: 3, spanMs: 12 * 60 * 1000 });
+      expect(analysis).toMatchObject({
+        category: ERROR_CATEGORIES.TIMEOUT,
+        requiresFallback: true,
+        actionable: false,
+        graceMs: 0,
+        origin: 'provider',
+      });
+      expect(analysis.message).toContain('retried it 3 times over 12 minutes');
+      expect(detectTuiRetryBanner(analysis.message)).toBeNull();
+      expect(detectTuiRetryBanner(analysis.suggestedFix)).toBeNull();
     });
   });
 

--- a/server/lib/cliChildEnv.js
+++ b/server/lib/cliChildEnv.js
@@ -61,23 +61,44 @@ import { isPublicReviewNoToolProfile, isPublicReviewRestrictedProfile } from './
 // provider.envVars still wins below.
 const CLAUDE_LOCAL_MAX_OUTPUT_TOKENS = '65536';
 
-// Claude Code cancels a request whose first byte has not arrived within 300s
-// (`API_TIMEOUT_MS` is the override) and paints `API error · Retrying in 0s ·
-// attempt 1/10`. Against a LOCAL daemon that ceiling is shorter than the
-// PREFILL: a public-review Stage 3 prompt inlines the whole screened envelope
-// and routinely runs to ~100K tokens (#6117), which a model server on this box
-// chews through in tens of minutes, not seconds. Every attempt was therefore
-// cancelled mid-prefill — the daemon logged `500 | 6m0s | POST /v1/messages` —
-// and the retry re-sent the same prompt, so a healthy run looked frozen at
-// attempt 1/10 forever while never emitting a token.
+// A local daemon sends NOTHING — not even response headers — until prefill
+// completes (Ollama returns headers and `message_start` together with the first
+// token; a 60KB prompt measured 122s of pure silence). A public-review Stage 3
+// prompt runs to tens of thousands of tokens, which a model server on this box
+// chews through in minutes, not seconds, so the request sits in Claude Code's
+// first-byte path for the whole prefill. That path has FOUR independent
+// ceilings in Claude Code v2.1.260 (a Bun-compiled binary), each measured
+// against a fake stalled `/v1/messages` on loopback (2026-09-04):
 //
-// `localPromptBudget.js` already predicts that prefill for the run card; this is
-// the harness half of the same fact. The ceiling exists to bound a retry storm,
-// not to budget a healthy run: a request that never answers still ends, because
-// the child prints nothing and the run's own supervision reaps it. Cloud Claude
-// answers in seconds and keeps the stock 300s. A value in provider.envVars still
-// wins below.
+//   • the Bun `fetch` timeout — ~360s, `API Error: The operation timed out.`
+//     Claude Code passes `timeout: false` to fetch only when
+//     `API_FORCE_IDLE_TIMEOUT` is explicitly `0`; with it unset or `1` a silent
+//     request is re-sent every 361s regardless of every other knob. THIS is the
+//     one that froze Stage 3 at `API error · Retrying in 0s · attempt 1/10` on
+//     2026-09-03 and 09-04 (agent-e057cca7; the daemon logged
+//     `500 | 6m0s | POST /v1/messages` + `srv stop: cancel task` per attempt),
+//     which #6117's `API_TIMEOUT_MS` raise alone could not touch.
+//   • the first-byte window — `API_TIMEOUT_MS` minus a second (10min default).
+//   • the byte-stream idle watchdog, once bytes flow — 180s via a remote flag
+//     (300s without it), `API Error: stream idle: no bytes for 180000ms`;
+//     `CLAUDE_BYTE_STREAM_IDLE_TIMEOUT_MS`, clamped to 30 minutes.
+//   • the stream idle timeout — 300s; `CLAUDE_STREAM_IDLE_TIMEOUT_MS`, floor
+//     300s, likewise clamped to 30 minutes.
+//
+// All four are widened for a Claude harness pointed at a LOCAL daemon: the
+// two idle knobs at Claude Code's own 30-minute ceiling (a local model can go
+// quiet mid-turn while a tool-heavy conversation re-prefills its uncached
+// tail), the first-byte window at an hour. The ceilings exist to bound a retry
+// storm, not to budget a healthy run: a request that never answers still ends,
+// because the child prints nothing and the run's own supervision reaps it —
+// and `createRetryStallGate` (tuiHandshake.js) fails a TUI over once a retry
+// ladder outlives its window. `localPromptBudget.js` predicts the prefill for
+// the run card; this is the harness half of the same fact. Cloud Claude
+// answers in seconds and keeps every stock value. A value in provider.envVars
+// still wins below.
 const CLAUDE_LOCAL_API_TIMEOUT_MS = '3600000';
+const CLAUDE_LOCAL_FORCE_IDLE_TIMEOUT = '0';
+const CLAUDE_LOCAL_STREAM_IDLE_TIMEOUT_MS = '1800000';
 
 /**
  * True for a Claude Code harness talking to a local OpenAI/Anthropic-compatible
@@ -104,12 +125,13 @@ function isLocalBackedClaude(provider) {
  * them through, and an allowlist that carries the wrapper's ENDPOINT but not its
  * TUNING is the worst of both: the stage reaches the local daemon and then runs
  * it on Claude Code's cloud-shaped ceilings. That is how Stage 3 — the stage
- * carrying the ~100K-token review envelope — sat behind a 300s first-byte
- * timeout it could never meet. Keep in lockstep with `claudeLocalEnvDefaults`;
+ * carrying the review envelope — sat behind a 6-minute fetch timeout its
+ * prefill could never meet. Keep in lockstep with `claudeLocalEnvDefaults`;
  * `cliChildEnv.test.js` fails when a knob it emits is missing from either list.
  */
 const CLAUDE_LOCAL_TUNING_ENV_KEYS = [
-  'CLAUDE_CODE_MAX_OUTPUT_TOKENS', 'API_TIMEOUT_MS', 'MAX_THINKING_TOKENS',
+  'CLAUDE_CODE_MAX_OUTPUT_TOKENS', 'API_TIMEOUT_MS', 'API_FORCE_IDLE_TIMEOUT',
+  'CLAUDE_BYTE_STREAM_IDLE_TIMEOUT_MS', 'CLAUDE_STREAM_IDLE_TIMEOUT_MS', 'MAX_THINKING_TOKENS',
 ];
 
 function claudeLocalEnvDefaults(provider) {
@@ -117,6 +139,9 @@ function claudeLocalEnvDefaults(provider) {
   return {
     CLAUDE_CODE_MAX_OUTPUT_TOKENS: CLAUDE_LOCAL_MAX_OUTPUT_TOKENS,
     API_TIMEOUT_MS: CLAUDE_LOCAL_API_TIMEOUT_MS,
+    API_FORCE_IDLE_TIMEOUT: CLAUDE_LOCAL_FORCE_IDLE_TIMEOUT,
+    CLAUDE_BYTE_STREAM_IDLE_TIMEOUT_MS: CLAUDE_LOCAL_STREAM_IDLE_TIMEOUT_MS,
+    CLAUDE_STREAM_IDLE_TIMEOUT_MS: CLAUDE_LOCAL_STREAM_IDLE_TIMEOUT_MS,
     // Claude Code omits the Anthropic-compatible `thinking` field when this is
     // zero, which Ollama maps to Qwen's non-thinking mode. Do not set a value
     // when enabled: Claude retains its normal adaptive budget.

--- a/server/lib/cliChildEnv.js
+++ b/server/lib/cliChildEnv.js
@@ -85,17 +85,12 @@ const CLAUDE_LOCAL_MAX_OUTPUT_TOKENS = '65536';
 //   • the stream idle timeout — 300s; `CLAUDE_STREAM_IDLE_TIMEOUT_MS`, floor
 //     300s, likewise clamped to 30 minutes.
 //
-// All four are widened for a Claude harness pointed at a LOCAL daemon: the
-// two idle knobs at Claude Code's own 30-minute ceiling (a local model can go
-// quiet mid-turn while a tool-heavy conversation re-prefills its uncached
-// tail), the first-byte window at an hour. The ceilings exist to bound a retry
-// storm, not to budget a healthy run: a request that never answers still ends,
-// because the child prints nothing and the run's own supervision reaps it —
-// and `createRetryStallGate` (tuiHandshake.js) fails a TUI over once a retry
-// ladder outlives its window. `localPromptBudget.js` predicts the prefill for
-// the run card; this is the harness half of the same fact. Cloud Claude
-// answers in seconds and keeps every stock value. A value in provider.envVars
-// still wins below.
+// All four are widened for a Claude harness pointed at a LOCAL daemon — the
+// idle knobs at Claude Code's own 30-minute ceiling, the first-byte window at
+// an hour. A request that never answers still ends: `createRetryStallGate`
+// (tuiHandshake.js) fails a TUI over once its retry ladder outlives the window,
+// and the run's own supervision reaps a silent child. Cloud Claude keeps every
+// stock value.
 const CLAUDE_LOCAL_API_TIMEOUT_MS = '3600000';
 const CLAUDE_LOCAL_FORCE_IDLE_TIMEOUT = '0';
 const CLAUDE_LOCAL_STREAM_IDLE_TIMEOUT_MS = '1800000';

--- a/server/lib/cliChildEnv.test.js
+++ b/server/lib/cliChildEnv.test.js
@@ -417,21 +417,34 @@ describe('composeProviderEnv — delta for sites that do not spawn directly', ()
     }).CLAUDE_CODE_MAX_OUTPUT_TOKENS).toBeUndefined();
   });
 
-  // The 300s default is a first-byte deadline, and a local daemon spends longer
-  // than that PREFILLING a ~100K-token review envelope before it can emit one.
-  // Every attempt was cancelled mid-prefill and re-sent, so the run sat at
-  // `API error · Retrying … attempt 1/10` forever without ever being unhealthy.
-  it('raises the Claude request timeout past a local prefill, never for a cloud model', () => {
+  // A local daemon sends nothing until prefill completes, and Claude Code has
+  // four independent ceilings on that silence — the binding one being the Bun
+  // fetch timeout (~360s) that only `API_FORCE_IDLE_TIMEOUT=0` disables. With
+  // any of them at its stock value every attempt is cancelled mid-prefill and
+  // re-sent, so the run sits at `API error · Retrying … attempt 1/10` forever
+  // without ever being unhealthy (agent-e057cca7, 2026-09-04).
+  it('widens every Claude request ceiling past a local prefill, never for a cloud model', () => {
     const localClaude = { command: '/usr/local/bin/claude', ollamaBacked: true, envVars: {} };
-    expect(composeProviderEnv({ provider: localClaude }).API_TIMEOUT_MS).toBe('3600000');
+    expect(composeProviderEnv({ provider: localClaude })).toMatchObject({
+      API_TIMEOUT_MS: '3600000',
+      API_FORCE_IDLE_TIMEOUT: '0',
+      CLAUDE_BYTE_STREAM_IDLE_TIMEOUT_MS: '1800000',
+      CLAUDE_STREAM_IDLE_TIMEOUT_MS: '1800000',
+    });
     expect(composeProviderEnv({
-      provider: { ...localClaude, envVars: { API_TIMEOUT_MS: '900000' } },
-    }).API_TIMEOUT_MS).toBe('900000');
+      provider: { ...localClaude, envVars: { API_TIMEOUT_MS: '900000', API_FORCE_IDLE_TIMEOUT: '1' } },
+    })).toMatchObject({ API_TIMEOUT_MS: '900000', API_FORCE_IDLE_TIMEOUT: '1' });
 
-    expect(composeProviderEnv({ provider: { command: 'claude', envVars: {} } }).API_TIMEOUT_MS).toBeUndefined();
-    expect(composeProviderEnv({
-      provider: { command: 'opencode', ollamaBacked: true, envVars: {} },
-    }).API_TIMEOUT_MS).toBeUndefined();
+    for (const provider of [
+      { command: 'claude', envVars: {} },
+      { command: 'opencode', ollamaBacked: true, envVars: {} },
+    ]) {
+      const env = composeProviderEnv({ provider });
+      expect(env.API_TIMEOUT_MS).toBeUndefined();
+      expect(env.API_FORCE_IDLE_TIMEOUT).toBeUndefined();
+      expect(env.CLAUDE_BYTE_STREAM_IDLE_TIMEOUT_MS).toBeUndefined();
+      expect(env.CLAUDE_STREAM_IDLE_TIMEOUT_MS).toBeUndefined();
+    }
   });
 
   it('disables Claude/Ollama thinking when the provider requests it', () => {

--- a/server/lib/tuiHandshake.js
+++ b/server/lib/tuiHandshake.js
@@ -1080,12 +1080,13 @@ export function createSilenceNudgeGate({ cooldownMs, settleMs, armWindowMs, maxA
   return {
     inCooldown: (nowMs) => lastArmedAt !== null && nowMs - lastArmedAt < cooldownMs,
     arm(nowMs) {
+      // A sighting while a nudge is already pending is the same condition
+      // still on screen: it neither restarts the window (a box that repaints
+      // forever must still expire it) nor refreshes the cooldown (or a repaint
+      // outlasting the window could never re-arm once it stops).
+      if (armedAt !== null) return null;
       if (lastArmedAt !== null && nowMs - lastArmedAt < cooldownMs) return null;
       lastArmedAt = nowMs;
-      // A sighting while a nudge is already pending is the same condition
-      // still on screen: it refreshes the cooldown (above) but never restarts
-      // the window, or a box that repaints forever would never expire it.
-      if (armedAt !== null) return null;
       // Budget spent: this is a genuinely NEW sighting (it cleared the cooldown)
       // after the nudges already bought the run more than one recovery. Hand the
       // verdict back rather than arming a window nobody will act on.
@@ -1239,8 +1240,9 @@ export const TOOL_PERMISSION_REPAINT_COOLDOWN_MS = 15000;
 // carry on. It rides the OOM nudge's silence policy (OOM_NUDGE_SETTLE_MS /
 // OOM_NUDGE_ARM_WINDOW_MS): sent only once the session has gone quiet, so a
 // build that instead hands the model a rejection and lets it continue is left
-// alone. A model still reaching outside its scope after this many nudges is not
-// going to finish inside it; the caller fails the run rather than looping.
+// alone. A model still reaching outside its scope after this many DECLINES —
+// whether or not each one needed a nudge — is not going to finish inside it;
+// the caller fails the run rather than looping until the max-runtime ceiling.
 export const TOOL_PERMISSION_DECLINE_MAX = 8;
 export const TOOL_PERMISSION_NUDGE_TEXT = 'That tool call reached outside this run\'s allowed scope, so it was declined. Nobody is watching this session and no permission can be granted. Everything you need is inside your worktree and your prompt; continue using paths under the worktree only, and write the completion sentinel when you are done.';
 
@@ -1249,10 +1251,14 @@ export const TOOL_PERMISSION_NUDGE_TEXT = 'That tool call reached outside this r
  * the dialog detector with a carry-over tail, on top of createSilenceNudgeGate.
  * Feed it every ANSI-stripped chunk after the prompt is in via
  * `observe(strippedText, nowMs)`: it returns the dialog to decline
- * (`{ noOption, toolCall, count }`) exactly once per dialog, `'exhausted'` when
- * the nudge budget is spent, or null. Poll `takeNudge(nowMs, lastOutputAtMs)`
- * on the consumer's existing timer. The tail is dropped after a decline so the
- * same dialog cannot be re-sighted from the carry-over.
+ * (`{ noOption, toolCall, count }`) once per dialog, `'exhausted'` once
+ * TOOL_PERMISSION_DECLINE_MAX dialogs have been declined, or null. Poll
+ * `takeNudge(nowMs, lastOutputAtMs)` on the consumer's existing timer. The
+ * tail is dropped after a decline so that dialog cannot be re-sighted from the
+ * carry-over, but keeps accumulating through the repaint cooldown: a DIFFERENT
+ * dialog painted seconds after a decline (the model's very next call is also
+ * out of scope) must still be seen once the cooldown lifts, or the session
+ * hangs on it exactly as it did before this gate existed.
  *
  * @returns {{ observe: (strippedText: string, nowMs: number) => object|'exhausted'|null,
  *             takeNudge: (nowMs: number, lastOutputAtMs: number) => number }}
@@ -1262,19 +1268,26 @@ export function createToolPermissionGate() {
     cooldownMs: TOOL_PERMISSION_REPAINT_COOLDOWN_MS,
     settleMs: OOM_NUDGE_SETTLE_MS,
     armWindowMs: OOM_NUDGE_ARM_WINDOW_MS,
-    maxAttempts: TOOL_PERMISSION_DECLINE_MAX,
+    // The budget is counted in declines (below), not nudges: a build that lets
+    // the model continue after a rejection never goes quiet, so a nudge budget
+    // would never be spent while the declines climbed forever.
+    maxAttempts: Infinity,
   });
   let tail = '';
   let declines = 0;
   return {
     observe(strippedText, nowMs) {
-      if (typeof strippedText !== 'string' || !strippedText || nudge.inCooldown(nowMs)) return null;
+      if (typeof strippedText !== 'string' || !strippedText) return null;
       tail = (tail + strippedText).slice(-1024);
+      if (nudge.inCooldown(nowMs)) return null;
       const dialog = detectToolPermissionPrompt(tail);
       if (!dialog) return null;
       tail = '';
-      if (nudge.arm(nowMs) === 'exhausted') return 'exhausted';
+      if (declines >= TOOL_PERMISSION_DECLINE_MAX) return 'exhausted';
       declines += 1;
+      // A null here means a nudge is already pending from the previous decline;
+      // it will fire on the same silence and covers this one too.
+      nudge.arm(nowMs);
       return { ...dialog, count: declines };
     },
     takeNudge: nudge.takeNudge,

--- a/server/lib/tuiHandshake.js
+++ b/server/lib/tuiHandshake.js
@@ -17,6 +17,7 @@
 // PROVIDER_VENDORS registry (#3618), consumed by every dispatch site that
 // used to duplicate its own vendor if-chain.
 import { inferTuiCommand, applyCommandDefaults, injectTuiModelAndEffort } from './providerVendors.js';
+import { detectTuiRetryBanner, describeTuiRetryStall } from './aiToolkit/errorDetection.js';
 
 // ─── Paste handshake constants ────────────────────────────────────────────
 
@@ -1071,6 +1072,194 @@ export function createOomNudgeGate() {
       armed = null;
       attempts += 1;
       return attempts;
+    },
+  };
+}
+
+// How long one request's retry sequence may span before the run is failed over.
+//
+// Long enough that Claude Code's own retry ladder for a transient cloud fault
+// (ten attempts, seconds of backoff each) always finishes inside it — that
+// ladder either recovers or ends in a terminal gutter line the idle reaper
+// handles — and short enough that a request the provider can never answer is
+// not left to burn a lane for the run's whole 3h ceiling. The gate also demands
+// the banner ADVANCE at least twice (attempt N → N+2): a single sighting is
+// often chrome that recovered a second later, and one advance can be a fault
+// that cleared on the next try, but a third attempt of the same request ten
+// minutes on is a request this provider is not going to answer.
+export const RETRY_STALL_MS = 10 * 60 * 1000;
+export const RETRY_STALL_MIN_ADVANCES = 2;
+// Carry-over kept across chunks so a banner split by a PTY chunk boundary still
+// matches. Spans the longest banner (`Retrying in 999s · attempt 10/10`) plus
+// the cursor-positioning residue stripping leaves around it.
+const RETRY_STALL_CARRY_CAP = 96;
+
+/**
+ * State machine for "the TUI keeps retrying the same request and it never
+ * answers" — see TUI_RETRY_BANNER_PATTERN in aiToolkit/errorDetection.js for
+ * the 2026-09-04 incident it exists for.
+ *
+ * Feed it every ANSI-stripped chunk after the prompt is in via
+ * `observe(strippedText, nowMs)`; poll `takeStall(nowMs)` on whatever timer the
+ * consumer already runs. It tracks one EPISODE at a time — the retry sequence
+ * of a single request, recognised by its attempt counter climbing. A counter
+ * that goes back down is the next request's ladder (Claude Code numbers each
+ * request's retries from 1), and a banner more than RETRY_STALL_MS after the
+ * last one is a new episode too, so a run that hit a blip, recovered, and did
+ * an hour of work before the next blip is never judged across both.
+ *
+ * The verdict is decided AT A SIGHTING, never by the clock alone: a ladder
+ * that climbed to attempt 10 in two minutes and then succeeded must not turn
+ * into a stall ten quiet minutes later. Only a banner painted RETRY_STALL_MS
+ * or more after the episode began — the provider failing this request yet
+ * again — counts. It is handed back once (the episode is cleared with it), so
+ * a consumer acting on it fails over exactly once.
+ *
+ * @returns {{ observe: (strippedText: string, nowMs: number) => void,
+ *             takeStall: (nowMs: number) => object|null }}
+ */
+export function createRetryStallGate() {
+  let episode = null; // { firstSeenAt, lastSeenAt, firstAttempt, lastAttempt }
+  let verdict = null;
+  let tail = '';
+  return {
+    observe(strippedText, nowMs) {
+      if (typeof strippedText !== 'string' || !strippedText) return;
+      const window = tail + strippedText;
+      const banner = detectTuiRetryBanner(window);
+      // Consume through the match so the carry-over cannot re-sight the same
+      // banner on the next chunk; without one, keep only the cap.
+      tail = (banner ? window.slice(banner.endIndex) : window).slice(-RETRY_STALL_CARRY_CAP);
+      if (!banner) return;
+      const isNewEpisode = !episode
+        || banner.attempt < episode.lastAttempt
+        || nowMs - episode.lastSeenAt > RETRY_STALL_MS;
+      if (isNewEpisode) {
+        episode = { firstSeenAt: nowMs, lastSeenAt: nowMs, firstAttempt: banner.attempt, lastAttempt: banner.attempt };
+        return;
+      }
+      episode.lastSeenAt = nowMs;
+      episode.lastAttempt = banner.attempt;
+      const spanMs = nowMs - episode.firstSeenAt;
+      if (episode.lastAttempt - episode.firstAttempt < RETRY_STALL_MIN_ADVANCES || spanMs < RETRY_STALL_MS) return;
+      verdict = describeTuiRetryStall({ attempts: episode.lastAttempt - episode.firstAttempt + 1, spanMs });
+      episode = null;
+    },
+    // The stall analysis to fail over with, once, or null.
+    takeStall() {
+      const analysis = verdict;
+      verdict = null;
+      return analysis;
+    },
+  };
+}
+
+// Claude Code's tool-permission dialog, as the ANSI-stripped screen renders it
+// (spaces between cursor-positioned glyphs can vanish, hence `\s*`):
+//
+//   Read(/data.reference/providers.json)
+//   Do you want to proceed?
+//   ❯ 1. Yes
+//     2. Yes, allow reading from /data.reference during this session
+//     3. No
+//   Esc to cancel · Tab to amend
+//
+// It paints whenever a tool call falls outside what the launch posture
+// pre-approved — under the hardened public-review recipe (`--permission-mode
+// acceptEdits` + sandbox) that is any read or write outside the worktree, which
+// a local model reaches for the moment it hallucinates an absolute path
+// (agent-e057cca7, 2026-09-04: `Read(/data.reference/providers.json)` sat
+// unanswered for 30+ minutes while the spinner kept the idle reaper happy).
+// Nobody is at the keyboard, and the posture already decided the answer: an
+// unattended run never widens its own scope, so the dialog is DECLINED. "No" is
+// always the last numbered option, but its number varies with the tool (a
+// two-option dialog for some, three for most), so it is read off the screen.
+export const TUI_TOOL_PERMISSION_PROMPT_PATTERN = /do\s*you\s*want\s*to\s*proceed\?/i;
+const TUI_TOOL_PERMISSION_NO_OPTION_PATTERN = /(\d+)\.\s*No\b/i;
+const TUI_TOOL_PERMISSION_CALL_PATTERN = /([A-Z][A-Za-z]*\([^\n]{0,300}?\))\s*do\s*you\s*want\s*to\s*proceed\?/i;
+// How much screen after the question the option list may span before it is
+// judged not painted yet.
+const TUI_TOOL_PERMISSION_OPTIONS_SPAN = 600;
+
+/**
+ * The tool-permission dialog on screen, or null. Null also while the question
+ * has painted but the option list has not — the consumer waits for the next
+ * repaint rather than guessing which key declines.
+ *
+ * @returns {{ noOption: number, toolCall: string|null }|null}
+ */
+export function detectToolPermissionPrompt(strippedText) {
+  if (typeof strippedText !== 'string' || !strippedText) return null;
+  const question = TUI_TOOL_PERMISSION_PROMPT_PATTERN.exec(strippedText);
+  if (!question) return null;
+  const options = strippedText.slice(question.index, question.index + TUI_TOOL_PERMISSION_OPTIONS_SPAN);
+  const no = TUI_TOOL_PERMISSION_NO_OPTION_PATTERN.exec(options);
+  if (!no) return null;
+  const lead = strippedText.slice(Math.max(0, question.index - 400), question.index + question[0].length);
+  const call = TUI_TOOL_PERMISSION_CALL_PATTERN.exec(lead);
+  return { noOption: Number(no[1]), toolCall: call ? call[1].replace(/\s+/g, ' ') : null };
+}
+
+// A declined dialog keeps repainting for a few chunks and the keystrokes take a
+// moment to land; sightings this close to a decline are the same dialog.
+export const TOOL_PERMISSION_REPAINT_COOLDOWN_MS = 15000;
+// Declining a tool call ends the assistant turn in current Claude Code builds
+// ("What should Claude do instead?"), so the session then needs a message to
+// carry on. Sent once the session has been SILENT this long after a decline —
+// the same provider-agnostic silence test the OOM nudge uses — so a build that
+// instead hands the model a rejection and lets it continue is left alone.
+export const TOOL_PERMISSION_NUDGE_SETTLE_MS = 25000;
+// A decline whose session never went quiet inside this window continued on its
+// own; drop the pending nudge rather than fire it into a later quiet stretch.
+export const TOOL_PERMISSION_NUDGE_ARM_WINDOW_MS = 120000;
+// A model that keeps reaching outside its scope after this many declines is not
+// going to finish inside it; the caller fails the run rather than looping.
+export const TOOL_PERMISSION_DECLINE_MAX = 8;
+export const TOOL_PERMISSION_NUDGE_TEXT = 'That tool call reached outside this run\'s allowed scope, so it was declined. Nobody is watching this session and no permission can be granted. Everything you need is inside your worktree and your prompt; continue using paths under the worktree only, and write the completion sentinel when you are done.';
+
+/**
+ * State machine for "decline every tool-permission dialog, then get the
+ * session moving again". Feed it every ANSI-stripped chunk after the prompt is
+ * in via `observe(strippedText, nowMs)`: it returns the dialog to decline
+ * (`{ noOption, toolCall, count }`) exactly once per dialog, `'exhausted'` when
+ * the decline budget is spent, or null. Poll `takeNudge(nowMs, lastOutputAtMs)`
+ * on the consumer's existing timer; it returns the decline number a nudge is
+ * due for, or 0.
+ *
+ * Carries a screen tail across chunks so a dialog split by a PTY chunk
+ * boundary still matches; the tail is dropped after a decline so the same
+ * dialog cannot be re-sighted from the carry-over.
+ *
+ * @returns {{ observe: (strippedText: string, nowMs: number) => object|'exhausted'|null,
+ *             takeNudge: (nowMs: number, lastOutputAtMs: number) => number }}
+ */
+export function createToolPermissionGate() {
+  let tail = '';
+  let declines = 0;
+  let lastDeclineAt = null;
+  let pendingNudge = null; // { declinedAt, count }
+  return {
+    observe(strippedText, nowMs) {
+      if (typeof strippedText !== 'string' || !strippedText) return null;
+      const window = (tail + strippedText).slice(-1024);
+      tail = window;
+      if (lastDeclineAt !== null && nowMs - lastDeclineAt < TOOL_PERMISSION_REPAINT_COOLDOWN_MS) return null;
+      const dialog = detectToolPermissionPrompt(window);
+      if (!dialog) return null;
+      tail = '';
+      lastDeclineAt = nowMs;
+      if (declines >= TOOL_PERMISSION_DECLINE_MAX) return 'exhausted';
+      declines += 1;
+      pendingNudge = { declinedAt: nowMs, count: declines };
+      return { ...dialog, count: declines };
+    },
+    takeNudge(nowMs, lastOutputAtMs) {
+      if (!pendingNudge) return 0;
+      if (nowMs - pendingNudge.declinedAt > TOOL_PERMISSION_NUDGE_ARM_WINDOW_MS) { pendingNudge = null; return 0; }
+      if (nowMs - lastOutputAtMs < TOOL_PERMISSION_NUDGE_SETTLE_MS) return 0;
+      const { count } = pendingNudge;
+      pendingNudge = null;
+      return count;
     },
   };
 }

--- a/server/lib/tuiHandshake.js
+++ b/server/lib/tuiHandshake.js
@@ -1046,30 +1046,58 @@ export const OOM_NUDGE_TEXT = 'continue';
  *             takeNudge: (nowMs: number, lastOutputAtMs: number) => number }}
  */
 export function createOomNudgeGate() {
-  let armed = null; // { analysis, armedAt }
+  const gate = createSilenceNudgeGate({
+    cooldownMs: OOM_NUDGE_COOLDOWN_MS,
+    settleMs: OOM_NUDGE_SETTLE_MS,
+    armWindowMs: OOM_NUDGE_ARM_WINDOW_MS,
+    maxAttempts: OOM_NUDGE_MAX_ATTEMPTS,
+  });
+  return {
+    arm: (analysis, nowMs) => (analysis ? gate.arm(nowMs) : null),
+    takeNudge: gate.takeNudge,
+  };
+}
+
+/**
+ * The "wait for silence, then nudge" policy the OOM gate and the
+ * tool-permission gate share: dedupe sightings inside `cooldownMs` (a TUI
+ * repaints an error box for many chunks), fire once the session has been quiet
+ * for `settleMs`, drop an arm the session outran (`armWindowMs` — it recovered
+ * on its own), and report `'exhausted'` once `maxAttempts` nudges have already
+ * been spent on a condition that keeps coming back.
+ *
+ * `arm(nowMs)` returns `'armed'`, `'exhausted'`, or null for a sighting inside
+ * the cooldown or while a nudge is already pending. `inCooldown(nowMs)` lets a consumer skip its detector while a
+ * just-handled sighting is still repainting. `takeNudge(nowMs, lastOutputAtMs)`
+ * returns the 1-based nudge number when one is due, or 0 — disarming either
+ * way, on a nudge because it fired and on an expired window because the
+ * session never went quiet.
+ */
+export function createSilenceNudgeGate({ cooldownMs, settleMs, armWindowMs, maxAttempts }) {
+  let armedAt = null;
   let lastArmedAt = null;
   let attempts = 0;
   return {
-    arm(analysis, nowMs) {
-      if (!analysis || armed) return null;
-      if (lastArmedAt !== null && nowMs - lastArmedAt < OOM_NUDGE_COOLDOWN_MS) return null;
+    inCooldown: (nowMs) => lastArmedAt !== null && nowMs - lastArmedAt < cooldownMs,
+    arm(nowMs) {
+      if (lastArmedAt !== null && nowMs - lastArmedAt < cooldownMs) return null;
       lastArmedAt = nowMs;
-      // Budget spent: this is a genuinely NEW OOM (it cleared the cooldown)
+      // A sighting while a nudge is already pending is the same condition
+      // still on screen: it refreshes the cooldown (above) but never restarts
+      // the window, or a box that repaints forever would never expire it.
+      if (armedAt !== null) return null;
+      // Budget spent: this is a genuinely NEW sighting (it cleared the cooldown)
       // after the nudges already bought the run more than one recovery. Hand the
       // verdict back rather than arming a window nobody will act on.
-      if (attempts >= OOM_NUDGE_MAX_ATTEMPTS) return 'exhausted';
-      armed = { analysis, armedAt: nowMs };
+      if (attempts >= maxAttempts) return 'exhausted';
+      armedAt = nowMs;
       return 'armed';
     },
-    // Returns the 1-based attempt number when the session has been quiet long
-    // enough to nudge, or 0. Disarms either way — on a nudge because it fired,
-    // and on an expired window because the session never went quiet, which is
-    // itself evidence it recovered without help.
     takeNudge(nowMs, lastOutputAtMs) {
-      if (!armed) return 0;
-      if (nowMs - armed.armedAt > OOM_NUDGE_ARM_WINDOW_MS) { armed = null; return 0; }
-      if (nowMs - lastOutputAtMs < OOM_NUDGE_SETTLE_MS) return 0;
-      armed = null;
+      if (armedAt === null) return 0;
+      if (nowMs - armedAt > armWindowMs) { armedAt = null; return 0; }
+      if (nowMs - lastOutputAtMs < settleMs) return 0;
+      armedAt = null;
       attempts += 1;
       return attempts;
     },
@@ -1096,8 +1124,8 @@ const RETRY_STALL_CARRY_CAP = 96;
 
 /**
  * State machine for "the TUI keeps retrying the same request and it never
- * answers" — see TUI_RETRY_BANNER_PATTERN in aiToolkit/errorDetection.js for
- * the 2026-09-04 incident it exists for.
+ * answers" — the incident is told once, on TUI_RETRY_BANNER_PATTERN in
+ * aiToolkit/errorDetection.js.
  *
  * Feed it every ANSI-stripped chunk after the prompt is in via
  * `observe(strippedText, nowMs)`; poll `takeStall(nowMs)` on whatever timer the
@@ -1168,17 +1196,20 @@ export function createRetryStallGate() {
 // pre-approved — under the hardened public-review recipe (`--permission-mode
 // acceptEdits` + sandbox) that is any read or write outside the worktree, which
 // a local model reaches for the moment it hallucinates an absolute path
-// (agent-e057cca7, 2026-09-04: `Read(/data.reference/providers.json)` sat
-// unanswered for 30+ minutes while the spinner kept the idle reaper happy).
-// Nobody is at the keyboard, and the posture already decided the answer: an
-// unattended run never widens its own scope, so the dialog is DECLINED. "No" is
-// always the last numbered option, but its number varies with the tool (a
-// two-option dialog for some, three for most), so it is read off the screen.
+// (agent-e057cca7, 2026-09-04, sat on one for 30+ minutes while the spinner kept
+// the idle reaper happy). Nobody is at the keyboard, and the posture already
+// decided the answer: an unattended run never widens its own scope, so the
+// dialog is DECLINED. "No" is always the last numbered option, but its number
+// varies with the tool (two options for some, three for most), so it is read
+// off the screen. The question pattern is shared with the post-mortem
+// analyzer's AWAITING_INPUT_MARKERS so live and after-the-fact detection cannot
+// drift apart.
 export const TUI_TOOL_PERMISSION_PROMPT_PATTERN = /do\s*you\s*want\s*to\s*proceed\?/i;
 const TUI_TOOL_PERMISSION_NO_OPTION_PATTERN = /(\d+)\.\s*No\b/i;
 const TUI_TOOL_PERMISSION_CALL_PATTERN = /([A-Z][A-Za-z]*\([^\n]{0,300}?\))\s*do\s*you\s*want\s*to\s*proceed\?/i;
-// How much screen after the question the option list may span before it is
-// judged not painted yet.
+// Screen around the question: how far back the tool-call header may sit, and
+// how far ahead the option list may span before it is judged not painted yet.
+const TUI_TOOL_PERMISSION_CALL_LEAD = 400;
 const TUI_TOOL_PERMISSION_OPTIONS_SPAN = 600;
 
 /**
@@ -1195,7 +1226,7 @@ export function detectToolPermissionPrompt(strippedText) {
   const options = strippedText.slice(question.index, question.index + TUI_TOOL_PERMISSION_OPTIONS_SPAN);
   const no = TUI_TOOL_PERMISSION_NO_OPTION_PATTERN.exec(options);
   if (!no) return null;
-  const lead = strippedText.slice(Math.max(0, question.index - 400), question.index + question[0].length);
+  const lead = strippedText.slice(Math.max(0, question.index - TUI_TOOL_PERMISSION_CALL_LEAD), question.index + question[0].length);
   const call = TUI_TOOL_PERMISSION_CALL_PATTERN.exec(lead);
   return { noOption: Number(no[1]), toolCall: call ? call[1].replace(/\s+/g, ' ') : null };
 }
@@ -1205,61 +1236,47 @@ export function detectToolPermissionPrompt(strippedText) {
 export const TOOL_PERMISSION_REPAINT_COOLDOWN_MS = 15000;
 // Declining a tool call ends the assistant turn in current Claude Code builds
 // ("What should Claude do instead?"), so the session then needs a message to
-// carry on. Sent once the session has been SILENT this long after a decline —
-// the same provider-agnostic silence test the OOM nudge uses — so a build that
-// instead hands the model a rejection and lets it continue is left alone.
-export const TOOL_PERMISSION_NUDGE_SETTLE_MS = 25000;
-// A decline whose session never went quiet inside this window continued on its
-// own; drop the pending nudge rather than fire it into a later quiet stretch.
-export const TOOL_PERMISSION_NUDGE_ARM_WINDOW_MS = 120000;
-// A model that keeps reaching outside its scope after this many declines is not
+// carry on. It rides the OOM nudge's silence policy (OOM_NUDGE_SETTLE_MS /
+// OOM_NUDGE_ARM_WINDOW_MS): sent only once the session has gone quiet, so a
+// build that instead hands the model a rejection and lets it continue is left
+// alone. A model still reaching outside its scope after this many nudges is not
 // going to finish inside it; the caller fails the run rather than looping.
 export const TOOL_PERMISSION_DECLINE_MAX = 8;
 export const TOOL_PERMISSION_NUDGE_TEXT = 'That tool call reached outside this run\'s allowed scope, so it was declined. Nobody is watching this session and no permission can be granted. Everything you need is inside your worktree and your prompt; continue using paths under the worktree only, and write the completion sentinel when you are done.';
 
 /**
- * State machine for "decline every tool-permission dialog, then get the
- * session moving again". Feed it every ANSI-stripped chunk after the prompt is
- * in via `observe(strippedText, nowMs)`: it returns the dialog to decline
+ * "Decline every tool-permission dialog, then get the session moving again":
+ * the dialog detector with a carry-over tail, on top of createSilenceNudgeGate.
+ * Feed it every ANSI-stripped chunk after the prompt is in via
+ * `observe(strippedText, nowMs)`: it returns the dialog to decline
  * (`{ noOption, toolCall, count }`) exactly once per dialog, `'exhausted'` when
- * the decline budget is spent, or null. Poll `takeNudge(nowMs, lastOutputAtMs)`
- * on the consumer's existing timer; it returns the decline number a nudge is
- * due for, or 0.
- *
- * Carries a screen tail across chunks so a dialog split by a PTY chunk
- * boundary still matches; the tail is dropped after a decline so the same
- * dialog cannot be re-sighted from the carry-over.
+ * the nudge budget is spent, or null. Poll `takeNudge(nowMs, lastOutputAtMs)`
+ * on the consumer's existing timer. The tail is dropped after a decline so the
+ * same dialog cannot be re-sighted from the carry-over.
  *
  * @returns {{ observe: (strippedText: string, nowMs: number) => object|'exhausted'|null,
  *             takeNudge: (nowMs: number, lastOutputAtMs: number) => number }}
  */
 export function createToolPermissionGate() {
+  const nudge = createSilenceNudgeGate({
+    cooldownMs: TOOL_PERMISSION_REPAINT_COOLDOWN_MS,
+    settleMs: OOM_NUDGE_SETTLE_MS,
+    armWindowMs: OOM_NUDGE_ARM_WINDOW_MS,
+    maxAttempts: TOOL_PERMISSION_DECLINE_MAX,
+  });
   let tail = '';
   let declines = 0;
-  let lastDeclineAt = null;
-  let pendingNudge = null; // { declinedAt, count }
   return {
     observe(strippedText, nowMs) {
-      if (typeof strippedText !== 'string' || !strippedText) return null;
-      const window = (tail + strippedText).slice(-1024);
-      tail = window;
-      if (lastDeclineAt !== null && nowMs - lastDeclineAt < TOOL_PERMISSION_REPAINT_COOLDOWN_MS) return null;
-      const dialog = detectToolPermissionPrompt(window);
+      if (typeof strippedText !== 'string' || !strippedText || nudge.inCooldown(nowMs)) return null;
+      tail = (tail + strippedText).slice(-1024);
+      const dialog = detectToolPermissionPrompt(tail);
       if (!dialog) return null;
       tail = '';
-      lastDeclineAt = nowMs;
-      if (declines >= TOOL_PERMISSION_DECLINE_MAX) return 'exhausted';
+      if (nudge.arm(nowMs) === 'exhausted') return 'exhausted';
       declines += 1;
-      pendingNudge = { declinedAt: nowMs, count: declines };
       return { ...dialog, count: declines };
     },
-    takeNudge(nowMs, lastOutputAtMs) {
-      if (!pendingNudge) return 0;
-      if (nowMs - pendingNudge.declinedAt > TOOL_PERMISSION_NUDGE_ARM_WINDOW_MS) { pendingNudge = null; return 0; }
-      if (nowMs - lastOutputAtMs < TOOL_PERMISSION_NUDGE_SETTLE_MS) return 0;
-      const { count } = pendingNudge;
-      pendingNudge = null;
-      return count;
-    },
+    takeNudge: nudge.takeNudge,
   };
 }

--- a/server/lib/tuiHandshake.test.js
+++ b/server/lib/tuiHandshake.test.js
@@ -44,6 +44,16 @@ import {
   isCollapsedPasteChip,
   createInputReadyTracker,
   AGY_INPUT_READY_PATTERN,
+  createRetryStallGate,
+  RETRY_STALL_MS,
+  RETRY_STALL_MIN_ADVANCES,
+  detectToolPermissionPrompt,
+  createToolPermissionGate,
+  TOOL_PERMISSION_REPAINT_COOLDOWN_MS,
+  TOOL_PERMISSION_NUDGE_SETTLE_MS,
+  TOOL_PERMISSION_NUDGE_ARM_WINDOW_MS,
+  TOOL_PERMISSION_DECLINE_MAX,
+  TOOL_PERMISSION_NUDGE_TEXT,
 } from './tuiHandshake.js';
 import { detectImmediateFallbackSignal } from './aiToolkit/errorDetection.js';
 import { CODEX_CONFIGURED_DEFAULT } from './providerModels.js';
@@ -1593,6 +1603,157 @@ describe('tuiHandshake — parity with the shipped provider catalog', () => {
         .toEqual(buildTuiInvocation({ ...provider, command: launchCommand(provider) }));
     }
   );
+});
+
+describe('createRetryStallGate', () => {
+  const MIN = 60 * 1000;
+  const banner = (attempt, secs = 0) => `API error · Retrying in ${secs}s · attempt ${attempt}/10`;
+
+  it('fails over a request the provider keeps failing across the stall window (agent-e057cca7)', () => {
+    // Stage 3's ~100K-token prefill was cancelled by the harness every ~6
+    // minutes and re-sent verbatim: attempt 1 at t, 2 at t+6m, 3 at t+12m …
+    const gate = createRetryStallGate();
+    gate.observe(banner(1, 1), 0);
+    gate.observe(banner(1, 0), 1000);
+    expect(gate.takeStall()).toBeNull();
+    gate.observe(banner(2), 6 * MIN);
+    expect(gate.takeStall()).toBeNull();
+    gate.observe(banner(3), 12 * MIN);
+
+    const verdict = gate.takeStall();
+    expect(verdict).toMatchObject({ category: 'timeout', requiresFallback: true, actionable: false });
+    expect(verdict.message).toContain('retried it 3 times over 12 minutes');
+    // Handed back once: the consumer fails over exactly once.
+    expect(gate.takeStall()).toBeNull();
+  });
+
+  it('is decided at a sighting, never by the clock: a fast ladder that then succeeded is not a stall', () => {
+    // A transient cloud fault: ten attempts in two minutes, the last one
+    // answered, and the run did an hour of useful work afterwards.
+    const gate = createRetryStallGate();
+    for (let attempt = 1; attempt <= 10; attempt += 1) gate.observe(banner(attempt), attempt * 12 * 1000);
+    gate.observe('⏺ Read(server/index.js)\n', 5 * MIN);
+    gate.observe('⏺ Edit(server/index.js)\n', 60 * MIN);
+    expect(gate.takeStall()).toBeNull();
+  });
+
+  it('needs the banner to advance RETRY_STALL_MIN_ADVANCES times inside one episode', () => {
+    const gate = createRetryStallGate();
+    // A single failing attempt repainted for a long time — the countdown
+    // ticking and a stale screen — is one sighting, not a ladder.
+    gate.observe(banner(1, 2), 0);
+    gate.observe(banner(1, 1), RETRY_STALL_MS);
+    gate.observe(banner(1, 0), RETRY_STALL_MS + 5000);
+    expect(gate.takeStall()).toBeNull();
+    gate.observe(banner(1 + RETRY_STALL_MIN_ADVANCES - 1), RETRY_STALL_MS + 6 * MIN);
+    expect(gate.takeStall()).toBeNull();
+    gate.observe(banner(1 + RETRY_STALL_MIN_ADVANCES), RETRY_STALL_MS + 12 * MIN);
+    expect(gate.takeStall()).not.toBeNull();
+  });
+
+  it('starts a new episode when the counter restarts or the last banner is stale', () => {
+    const gate = createRetryStallGate();
+    // Episode A: two attempts, then the request answered.
+    gate.observe(banner(1), 0);
+    gate.observe(banner(2), 6 * MIN);
+    // Episode B, a later request: its counter restarts at 1 …
+    gate.observe(banner(1), 30 * MIN);
+    gate.observe(banner(2), 36 * MIN);
+    expect(gate.takeStall()).toBeNull();
+    gate.observe(banner(3), 42 * MIN);
+    const verdict = gate.takeStall();
+    // … and is judged on its own attempts, not A's.
+    expect(verdict.message).toContain('retried it 3 times over 12 minutes');
+
+    // A banner more than the stall window after the previous one is a fresh
+    // episode even when its counter happens to be higher.
+    const stale = createRetryStallGate();
+    stale.observe(banner(1), 0);
+    stale.observe(banner(4), RETRY_STALL_MS + 1000);
+    stale.observe(banner(5), RETRY_STALL_MS + 2000);
+    expect(stale.takeStall()).toBeNull();
+  });
+
+  it('matches a banner split across PTY chunks, and never re-sights it from the carry-over', () => {
+    const gate = createRetryStallGate();
+    gate.observe('API error · Retrying in 0s · att', 0);
+    gate.observe('empt 1/10\n', 10);
+    // Chunks that follow carry no banner of their own; the carry-over was
+    // consumed through the match, so these must not read as new sightings that
+    // would keep an episode alive.
+    gate.observe('\n', 6 * MIN);
+    gate.observe('─────\n', 12 * MIN);
+    gate.observe(banner(2), 20 * MIN);
+    // If the carry-over had re-sighted attempt 1 at 6m/12m, attempt 2 at 20m
+    // would still be inside the episode; being > RETRY_STALL_MS after the only
+    // real sighting, it starts a new one instead.
+    gate.observe(banner(3), 21 * MIN);
+    gate.observe(banner(4), 22 * MIN);
+    expect(gate.takeStall()).toBeNull();
+  });
+});
+
+describe('tool-permission dialog (agent-e057cca7)', () => {
+  // Verbatim from the stripped screen: a local model hallucinated an absolute
+  // path, and acceptEdits asked a human who was not there.
+  const READ_DIALOG = ' Read(/data.reference/providers.json) Doyouwanttoproceed? ❯1. Yes 2. Yes,allowreadingfrom/data.referenceduringthissession 3. No Esc to cancel · Tab to amend ';
+  const TWO_OPTION_DIALOG = 'Bash(rm -rf build)\nDo you want to proceed?\n❯ 1. Yes\n  2. No\n';
+
+  describe('detectToolPermissionPrompt', () => {
+    it('reads the decline option off the screen, whatever its number', () => {
+      expect(detectToolPermissionPrompt(READ_DIALOG)).toEqual({ noOption: 3, toolCall: 'Read(/data.reference/providers.json)' });
+      expect(detectToolPermissionPrompt(TWO_OPTION_DIALOG)).toEqual({ noOption: 2, toolCall: 'Bash(rm -rf build)' });
+    });
+
+    it('waits for the option list rather than guessing which key declines', () => {
+      expect(detectToolPermissionPrompt(' Read(/etc/hosts) Doyouwanttoproceed? ')).toBeNull();
+    });
+
+    it('ignores prose and the nudge it sends', () => {
+      expect(detectToolPermissionPrompt('Ask the user whether they want to proceed with 3. No changes')).toBeNull();
+      expect(detectToolPermissionPrompt(TOOL_PERMISSION_NUDGE_TEXT)).toBeNull();
+      expect(detectToolPermissionPrompt('')).toBeNull();
+    });
+  });
+
+  describe('createToolPermissionGate', () => {
+    it('declines a dialog once, however many chunks repaint it, then nudges the quiet session', () => {
+      const gate = createToolPermissionGate();
+      // Split across a chunk boundary, as a PTY delivers it.
+      expect(gate.observe(READ_DIALOG.slice(0, 60), 0)).toBeNull();
+      expect(gate.observe(READ_DIALOG.slice(60), 50)).toEqual({ noOption: 3, toolCall: 'Read(/data.reference/providers.json)', count: 1 });
+      // The declined dialog keeps repainting while the keystrokes land.
+      expect(gate.observe(READ_DIALOG, 2000)).toBeNull();
+      expect(gate.observe(READ_DIALOG, TOOL_PERMISSION_REPAINT_COOLDOWN_MS - 1)).toBeNull();
+      // Still repainting: not quiet, so no nudge yet.
+      expect(gate.takeNudge(5000, 4000)).toBe(0);
+      // Quiet for the settle window: nudge, exactly once.
+      const quietAt = 5000;
+      expect(gate.takeNudge(quietAt + TOOL_PERMISSION_NUDGE_SETTLE_MS, quietAt)).toBe(1);
+      expect(gate.takeNudge(quietAt + TOOL_PERMISSION_NUDGE_SETTLE_MS + 5000, quietAt)).toBe(0);
+    });
+
+    it('drops the nudge when the session carried on by itself', () => {
+      const gate = createToolPermissionGate();
+      gate.observe(READ_DIALOG, 0);
+      // Output never stops for the whole arm window — the build handed the model
+      // a rejection and it kept working — so a later quiet stretch gets no nudge.
+      const late = TOOL_PERMISSION_NUDGE_ARM_WINDOW_MS + 1000;
+      expect(gate.takeNudge(late, late - 100)).toBe(0);
+      expect(gate.takeNudge(late + TOOL_PERMISSION_NUDGE_SETTLE_MS, late)).toBe(0);
+    });
+
+    it('reports exhaustion after TOOL_PERMISSION_DECLINE_MAX distinct dialogs', () => {
+      const gate = createToolPermissionGate();
+      let now = 0;
+      for (let i = 1; i <= TOOL_PERMISSION_DECLINE_MAX; i += 1) {
+        now += TOOL_PERMISSION_REPAINT_COOLDOWN_MS + 1;
+        expect(gate.observe(READ_DIALOG, now)).toMatchObject({ count: i });
+      }
+      now += TOOL_PERMISSION_REPAINT_COOLDOWN_MS + 1;
+      expect(gate.observe(TWO_OPTION_DIALOG, now)).toBe('exhausted');
+    });
+  });
 });
 
 describe('createOomNudgeGate', () => {

--- a/server/lib/tuiHandshake.test.js
+++ b/server/lib/tuiHandshake.test.js
@@ -50,8 +50,6 @@ import {
   detectToolPermissionPrompt,
   createToolPermissionGate,
   TOOL_PERMISSION_REPAINT_COOLDOWN_MS,
-  TOOL_PERMISSION_NUDGE_SETTLE_MS,
-  TOOL_PERMISSION_NUDGE_ARM_WINDOW_MS,
   TOOL_PERMISSION_DECLINE_MAX,
   TOOL_PERMISSION_NUDGE_TEXT,
 } from './tuiHandshake.js';
@@ -1729,8 +1727,8 @@ describe('tool-permission dialog (agent-e057cca7)', () => {
       expect(gate.takeNudge(5000, 4000)).toBe(0);
       // Quiet for the settle window: nudge, exactly once.
       const quietAt = 5000;
-      expect(gate.takeNudge(quietAt + TOOL_PERMISSION_NUDGE_SETTLE_MS, quietAt)).toBe(1);
-      expect(gate.takeNudge(quietAt + TOOL_PERMISSION_NUDGE_SETTLE_MS + 5000, quietAt)).toBe(0);
+      expect(gate.takeNudge(quietAt + OOM_NUDGE_SETTLE_MS, quietAt)).toBe(1);
+      expect(gate.takeNudge(quietAt + OOM_NUDGE_SETTLE_MS + 5000, quietAt)).toBe(0);
     });
 
     it('drops the nudge when the session carried on by itself', () => {
@@ -1738,17 +1736,20 @@ describe('tool-permission dialog (agent-e057cca7)', () => {
       gate.observe(READ_DIALOG, 0);
       // Output never stops for the whole arm window — the build handed the model
       // a rejection and it kept working — so a later quiet stretch gets no nudge.
-      const late = TOOL_PERMISSION_NUDGE_ARM_WINDOW_MS + 1000;
+      const late = OOM_NUDGE_ARM_WINDOW_MS + 1000;
       expect(gate.takeNudge(late, late - 100)).toBe(0);
-      expect(gate.takeNudge(late + TOOL_PERMISSION_NUDGE_SETTLE_MS, late)).toBe(0);
+      expect(gate.takeNudge(late + OOM_NUDGE_SETTLE_MS, late)).toBe(0);
     });
 
-    it('reports exhaustion after TOOL_PERMISSION_DECLINE_MAX distinct dialogs', () => {
+    it('reports exhaustion once TOOL_PERMISSION_DECLINE_MAX nudges have been spent', () => {
       const gate = createToolPermissionGate();
       let now = 0;
       for (let i = 1; i <= TOOL_PERMISSION_DECLINE_MAX; i += 1) {
         now += TOOL_PERMISSION_REPAINT_COOLDOWN_MS + 1;
         expect(gate.observe(READ_DIALOG, now)).toMatchObject({ count: i });
+        // The decline ends the turn, the session goes quiet, the nudge fires.
+        expect(gate.takeNudge(now + OOM_NUDGE_SETTLE_MS, now)).toBe(i);
+        now += OOM_NUDGE_SETTLE_MS;
       }
       now += TOOL_PERMISSION_REPAINT_COOLDOWN_MS + 1;
       expect(gate.observe(TWO_OPTION_DIALOG, now)).toBe('exhausted');

--- a/server/lib/tuiHandshake.test.js
+++ b/server/lib/tuiHandshake.test.js
@@ -1741,23 +1741,45 @@ describe('tool-permission dialog (agent-e057cca7)', () => {
       expect(gate.takeNudge(late + OOM_NUDGE_SETTLE_MS, late)).toBe(0);
     });
 
-    it('reports exhaustion once TOOL_PERMISSION_DECLINE_MAX nudges have been spent', () => {
+    it('reports exhaustion after TOOL_PERMISSION_DECLINE_MAX declines, nudged or not', () => {
+      // A build that hands the model a rejection and lets it continue never
+      // goes quiet, so no nudge ever fires — the declines alone must cap it.
       const gate = createToolPermissionGate();
       let now = 0;
       for (let i = 1; i <= TOOL_PERMISSION_DECLINE_MAX; i += 1) {
         now += TOOL_PERMISSION_REPAINT_COOLDOWN_MS + 1;
         expect(gate.observe(READ_DIALOG, now)).toMatchObject({ count: i });
-        // The decline ends the turn, the session goes quiet, the nudge fires.
-        expect(gate.takeNudge(now + OOM_NUDGE_SETTLE_MS, now)).toBe(i);
-        now += OOM_NUDGE_SETTLE_MS;
       }
       now += TOOL_PERMISSION_REPAINT_COOLDOWN_MS + 1;
       expect(gate.observe(TWO_OPTION_DIALOG, now)).toBe('exhausted');
+    });
+
+    it('still sees a different dialog painted inside the repaint cooldown', () => {
+      const gate = createToolPermissionGate();
+      expect(gate.observe(READ_DIALOG, 0)).toMatchObject({ count: 1 });
+      // The model's very next call is also out of scope: its dialog lands
+      // seconds after the decline and is never repainted afterwards.
+      expect(gate.observe(TWO_OPTION_DIALOG, 3000)).toBeNull();
+      expect(gate.observe('\n', TOOL_PERMISSION_REPAINT_COOLDOWN_MS + 1000)).toMatchObject({ noOption: 2, count: 2 });
     });
   });
 });
 
 describe('createOomNudgeGate', () => {
+  it('re-arms from a box that outlasted its window, once the repaint stops', () => {
+    // The OOM box repaints past the arm window (the session never went quiet),
+    // then finally does: the expired arm must be replaceable by a sighting
+    // AFTER the cooldown, so a sighting while armed must not refresh it.
+    const gate = createOomNudgeGate();
+    const analysis = { message: 'oom' };
+    expect(gate.arm(analysis, 0)).toBe('armed');
+    expect(gate.arm(analysis, 60_000)).toBeNull();
+    expect(gate.takeNudge(OOM_NUDGE_ARM_WINDOW_MS + 5_000, OOM_NUDGE_ARM_WINDOW_MS + 4_000)).toBe(0);
+    expect(gate.arm(analysis, OOM_NUDGE_COOLDOWN_MS + 10_000)).toBe('armed');
+    const quietAt = OOM_NUDGE_COOLDOWN_MS + 10_000;
+    expect(gate.takeNudge(quietAt + OOM_NUDGE_SETTLE_MS, quietAt)).toBe(1);
+  });
+
   const analysis = { category: 'resource-exhausted', message: 'Local inference runtime ran out of GPU memory' };
 
   it('nudges only once the session has actually gone quiet', () => {

--- a/server/services/agentErrorAnalysis.js
+++ b/server/services/agentErrorAnalysis.js
@@ -951,6 +951,16 @@ export const COMPLETION_REASON_ANALYSES = {
     message: 'Agent session was terminated by a signal',
     suggestedFix: 'The TUI session was killed rather than exiting on its own — usually a PortOS restart taking its child processes down. The task resumes from the preserved worktree; no agent-side fix is needed.'
   },
+  // The TUI spawner declined TOOL_PERMISSION_DECLINE_MAX permission dialogs
+  // (createToolPermissionGate) and the model was still reaching outside the
+  // run's scope. Registered so the post-mortem does not fall through to the
+  // transcript keyword sweep — which would scrape the dialog chrome itself.
+  'permission-prompt-loop': {
+    category: 'timeout',
+    actionable: false,
+    message: 'Agent kept asking for tool permissions an unattended run cannot grant',
+    suggestedFix: 'Every permission dialog was declined and the model kept reaching outside the run\'s allowed scope (paths outside the worktree, tools the posture forbids). A fallback provider retries the task; if it recurs, pin the stage to a stronger model or remove the outside-path references from its prompt.'
+  },
   'command-not-found': {
     category: 'spawn-error',
     actionable: true,

--- a/server/services/agentErrorAnalysis.js
+++ b/server/services/agentErrorAnalysis.js
@@ -13,6 +13,7 @@ import { redactOutput } from '../lib/commandSecurity.js';
 import { stripAnsi } from '../lib/ansiStrip.js';
 import { describeOllamaContextOverflow, parseOllamaContextOverflow } from '../lib/ollamaContext.js';
 import { retryHoldMetadata } from '../lib/taskRetryHold.js';
+import { TUI_TOOL_PERMISSION_PROMPT_PATTERN } from '../lib/tuiHandshake.js';
 import {
   INVESTIGATION_CIRCUIT_MAX_CREATIONS,
   INVESTIGATION_HEADLINE_PREFIX,
@@ -1015,7 +1016,9 @@ export const AWAITING_INPUT_MARKERS = [
   /Enter to select/i,
   /↑\/↓ to navigate/,
   /❯\s*1\./,
-  /Do you want to proceed\?/i,
+  // Claude Code's tool-permission dialog — the live gate that declines it
+  // (createToolPermissionGate) reads the same pattern.
+  TUI_TOOL_PERMISSION_PROMPT_PATTERN,
   /Press Enter to continue/i
 ];
 

--- a/server/services/agentPromptBuilder.js
+++ b/server/services/agentPromptBuilder.js
@@ -122,6 +122,8 @@ function resolveSentinelPath(worktreeInfo, workspaceDir, agentId) {
   return `${worktreeInfo?.worktreePath || workspaceDir}/${doneSentinelName(agentId)}`;
 }
 
+const PREVIOUS_STAGE_OUTPUT_INLINE_CAP = 12_000;
+
 function pipelineContextLines(pipelineCtx) {
   if (!pipelineCtx || (!pipelineCtx.previousStageAgentId && !pipelineCtx.previousStageOutput)) return [];
 
@@ -133,15 +135,18 @@ function pipelineContextLines(pipelineCtx) {
   const rawPreviousOutput = typeof pipelineCtx.previousStageOutput === 'string'
     ? pipelineCtx.previousStageOutput.trim()
     : '';
-  const previousOutput = rawPreviousOutput.slice(0, 12_000).replace(/~+/g, "'");
-  const truncated = rawPreviousOutput.length > previousOutput.length;
+  const clipped = rawPreviousOutput.length > PREVIOUS_STAGE_OUTPUT_INLINE_CAP;
+  const previousOutput = rawPreviousOutput.slice(0, PREVIOUS_STAGE_OUTPUT_INLINE_CAP).replace(/~+/g, "'");
   if (!pipelineCtx.previousStageAgentId) {
     lines.push('The previous stage completed as a direct preflight; its summary is included below.');
-  } else if (previousOutput && !truncated) {
-    // The whole output is inlined below, so the file pointer would only send
-    // the agent OUTSIDE its worktree — which, under a sandboxed permission
-    // posture, is a tool-permission dialog nobody is present to answer.
-    lines.push("The previous stage's complete output is inlined below; there is nothing further to read from disk.");
+  } else if (previousOutput) {
+    // A producer that hands over the output chose the inline hand-off; the file
+    // pointer would only send the agent OUTSIDE its worktree — which, under a
+    // sandboxed permission posture, is a tool-permission dialog nobody is
+    // present to answer.
+    lines.push(clipped
+      ? `The previous stage's output is inlined below, clipped to its first ${PREVIOUS_STAGE_OUTPUT_INLINE_CAP} characters.`
+      : "The previous stage's complete output is inlined below; there is nothing further to read from disk.");
   } else {
     lines.push(
       "Read the previous stage's output from:",

--- a/server/services/agentPromptBuilder.js
+++ b/server/services/agentPromptBuilder.js
@@ -145,8 +145,8 @@ function pipelineContextLines(pipelineCtx) {
     // sandboxed permission posture, is a tool-permission dialog nobody is
     // present to answer.
     lines.push(clipped
-      ? `The previous stage's output is inlined below, clipped to its first ${PREVIOUS_STAGE_OUTPUT_INLINE_CAP} characters.`
-      : "The previous stage's complete output is inlined below; there is nothing further to read from disk.");
+      ? `The previous stage's hand-off is inlined below, clipped to its first ${PREVIOUS_STAGE_OUTPUT_INLINE_CAP} characters.`
+      : "The previous stage's hand-off is inlined below in full; there is nothing further to read from disk.");
   } else {
     lines.push(
       "Read the previous stage's output from:",

--- a/server/services/agentPromptBuilder.js
+++ b/server/services/agentPromptBuilder.js
@@ -130,18 +130,25 @@ function pipelineContextLines(pipelineCtx) {
     `Previous stage: "${pipelineCtx.stages[pipelineCtx.currentStage - 1]?.name}"`,
     '',
   ];
-  if (pipelineCtx.previousStageAgentId) {
+  const rawPreviousOutput = typeof pipelineCtx.previousStageOutput === 'string'
+    ? pipelineCtx.previousStageOutput.trim()
+    : '';
+  const previousOutput = rawPreviousOutput.slice(0, 12_000).replace(/~+/g, "'");
+  const truncated = rawPreviousOutput.length > previousOutput.length;
+  if (!pipelineCtx.previousStageAgentId) {
+    lines.push('The previous stage completed as a direct preflight; its summary is included below.');
+  } else if (previousOutput && !truncated) {
+    // The whole output is inlined below, so the file pointer would only send
+    // the agent OUTSIDE its worktree — which, under a sandboxed permission
+    // posture, is a tool-permission dialog nobody is present to answer.
+    lines.push("The previous stage's complete output is inlined below; there is nothing further to read from disk.");
+  } else {
     lines.push(
       "Read the previous stage's output from:",
       `\`${join(AGENTS_DIR, pipelineCtx.previousStageAgentId, 'output.txt')}\``,
     );
-  } else {
-    lines.push('The previous stage completed as a direct preflight; its summary is included below.');
   }
 
-  const previousOutput = typeof pipelineCtx.previousStageOutput === 'string'
-    ? pipelineCtx.previousStageOutput.trim().slice(0, 12_000).replace(/~+/g, "'")
-    : '';
   if (previousOutput) {
     lines.push(
       '',

--- a/server/services/agentPromptBuilder.test.js
+++ b/server/services/agentPromptBuilder.test.js
@@ -2336,7 +2336,7 @@ describe('buildLightContextPrompt', () => {
       expect(inlined).not.toMatch(/output\.txt/);
       expect(inlined).toMatch(/"eligibleNumbers":\[6223\]/);
 
-      // A clipped inline still needs the pointer: the rest is only on disk.
+      // A clipped inline says so, and still never points outside the worktree.
       const clipped = buildLightContextPrompt(makeTask({
         metadata: { pipeline: {
           previousStageAgentId: 'agent-prev-1',
@@ -2345,7 +2345,8 @@ describe('buildLightContextPrompt', () => {
           stages: [{ name: 'scan' }, { name: 'gate' }, { name: 'review' }],
         }}
       }), '/r', null, isTruthyMeta);
-      expect(clipped).toMatch(/agent-prev-1[\\/]output\.txt/);
+      expect(clipped).toMatch(/clipped to its first 12000 characters/);
+      expect(clipped).not.toMatch(/output\.txt/);
     });
 
     it('renders a direct preflight summary when the previous stage has no agent', () => {

--- a/server/services/agentPromptBuilder.test.js
+++ b/server/services/agentPromptBuilder.test.js
@@ -2332,7 +2332,7 @@ describe('buildLightContextPrompt', () => {
           stages: [{ name: 'scan' }, { name: 'gate' }, { name: 'review' }],
         }}
       }), '/r', null, isTruthyMeta);
-      expect(inlined).toMatch(/complete output is inlined below/);
+      expect(inlined).toMatch(/hand-off is inlined below in full/);
       expect(inlined).not.toMatch(/output\.txt/);
       expect(inlined).toMatch(/"eligibleNumbers":\[6223\]/);
 

--- a/server/services/agentPromptBuilder.test.js
+++ b/server/services/agentPromptBuilder.test.js
@@ -2320,6 +2320,34 @@ describe('buildLightContextPrompt', () => {
       expect(prompt).toMatch(/agent-prev-1[\\/]output\.txt/);
     });
 
+    it('keeps a stage inside its worktree when the previous output is inlined in full', () => {
+      // The pointer names a file under data/cos/agents — outside every agent
+      // worktree. Under a sandboxed permission posture reading it is a dialog
+      // nobody answers (agent-e057cca7), and the text is already in the prompt.
+      const inlined = buildLightContextPrompt(makeTask({
+        metadata: { pipeline: {
+          previousStageAgentId: 'agent-prev-1',
+          previousStageOutput: JSON.stringify({ eligibility: 'passed', eligibleNumbers: [6223] }),
+          currentStage: 2,
+          stages: [{ name: 'scan' }, { name: 'gate' }, { name: 'review' }],
+        }}
+      }), '/r', null, isTruthyMeta);
+      expect(inlined).toMatch(/complete output is inlined below/);
+      expect(inlined).not.toMatch(/output\.txt/);
+      expect(inlined).toMatch(/"eligibleNumbers":\[6223\]/);
+
+      // A clipped inline still needs the pointer: the rest is only on disk.
+      const clipped = buildLightContextPrompt(makeTask({
+        metadata: { pipeline: {
+          previousStageAgentId: 'agent-prev-1',
+          previousStageOutput: 'x'.repeat(12_001),
+          currentStage: 2,
+          stages: [{ name: 'scan' }, { name: 'gate' }, { name: 'review' }],
+        }}
+      }), '/r', null, isTruthyMeta);
+      expect(clipped).toMatch(/agent-prev-1[\\/]output\.txt/);
+    });
+
     it('renders a direct preflight summary when the previous stage has no agent', () => {
       const prompt = buildLightContextPrompt(makeTask({
         metadata: { pipeline: {

--- a/server/services/agentTuiSpawning.js
+++ b/server/services/agentTuiSpawning.js
@@ -45,6 +45,10 @@ import {
   countPasteMarkers,
   createSelfClearingSignalGate,
   createOomNudgeGate,
+  createRetryStallGate,
+  createToolPermissionGate,
+  TOOL_PERMISSION_DECLINE_MAX,
+  TOOL_PERMISSION_NUDGE_TEXT,
   OOM_NUDGE_MAX_ATTEMPTS,
   OOM_NUDGE_TEXT,
   createMcpBootTracker,
@@ -739,6 +743,15 @@ export async function spawnTuiAgent({
   // createOomNudgeGate for why this is a separate mechanism from the gate above.
   const detectLocalRuntimeOom = createLocalRuntimeOomDetector();
   const oomNudgeGate = createOomNudgeGate();
+  // A request the TUI keeps retrying and the provider never answers. Every
+  // reaper reads such a session as busy (the retry ladder repaints the screen),
+  // so without this the run holds its lane until the max-runtime ceiling — see
+  // createRetryStallGate.
+  const retryStallGate = createRetryStallGate();
+  // A tool-permission dialog nobody is present to answer. Declined on sight —
+  // the launch posture already decided the run's scope — then nudged along
+  // once the session goes quiet. See createToolPermissionGate.
+  const toolPermissionGate = createToolPermissionGate();
   // Guards ingestDoneSentinel to a single read. finish() is its only caller and
   // is itself guarded by `finalized`, so this is defensive — it pins the
   // read-at-most-once invariant at the helper.
@@ -1417,6 +1430,29 @@ export async function spawnTuiAgent({
         }
       }
 
+      // Same gating as the OOM nudge above: before the prompt is in there is no
+      // request of ours for the provider to be retrying. Acted on by the
+      // provider-signal timer, on its own poll, like the other gates.
+      if (promptSubmittedAt) retryStallGate.observe(stripped, now);
+
+      const permissionDialog = promptSubmittedAt ? toolPermissionGate.observe(stripped, now) : null;
+      if (permissionDialog === 'exhausted') {
+        await finish({
+          success: false,
+          exitCode: 1,
+          error: `${tuiConfig.command} kept asking for tool permissions an unattended run cannot grant (${TOOL_PERMISSION_DECLINE_MAX} dialogs declined) — the model keeps reaching outside the run's allowed scope`,
+          reason: 'permission-prompt-loop',
+        });
+        return;
+      }
+      if (permissionDialog) {
+        // "No" is the last option and option 1 is highlighted: arrow down to it,
+        // then Enter — lands under both of Ink's selection models, whereas a bare
+        // digit is immediate-select in some builds and ignored in others.
+        shellService.writeToSession(sessionId, `${'\x1b[B'.repeat(Math.max(0, permissionDialog.noOption - 1))}\r`);
+        appendLine(`🚫 Declined ${tuiConfig.command} permission prompt for ${permissionDialog.toolCall || 'a tool call'} — an unattended run never widens its scope (${permissionDialog.count}/${TOOL_PERMISSION_DECLINE_MAX})`);
+      }
+
       if (!promptSentAt) {
         // Only the login-shell path can reach this: it is the shell PRINTING
         // "command not found". A direct PTY resolves the executable before it
@@ -1873,6 +1909,21 @@ export async function spawnTuiAgent({
     }
     if (selfClearingGate.armed) {
       resubmitAfterSignal();
+      return;
+    }
+    const stall = retryStallGate.takeStall();
+    if (stall) {
+      failOverToFallback(stall).catch((err) =>
+        emitLog('error', `TUI agent ${agentId} retry-stall fallback finish failed: ${err?.message || err}`, { agentId }));
+      return;
+    }
+    // A declined permission dialog ends the turn; once the session is quiet,
+    // tell it why and send it back to work.
+    const declined = toolPermissionGate.takeNudge(Date.now(), lastOutputAt);
+    if (declined) {
+      if (pasteController?.resubmit({ text: TOOL_PERMISSION_NUDGE_TEXT, label: 'declined-permission nudge' })) {
+        appendLine(`🔁 Nudged the session to continue after declined permission prompt ${declined}`);
+      }
       return;
     }
     // Nudge a session a local-GPU OOM parked. Rides this timer rather than one

--- a/server/services/agentTuiSpawning.js
+++ b/server/services/agentTuiSpawning.js
@@ -1435,7 +1435,14 @@ export async function spawnTuiAgent({
       // provider-signal timer, on its own poll, like the other gates.
       if (promptSubmittedAt) retryStallGate.observe(stripped, now);
 
-      const permissionDialog = promptSubmittedAt ? toolPermissionGate.observe(stripped, now) : null;
+      // The permission dialog is Claude Code chrome. Watching another vendor's
+      // session for it would only ever match an ECHO — a Codex or agy agent
+      // investigating a stalled run cats its raw.txt straight into this stream
+      // — and answer a dialog that is not there with keystrokes into a working
+      // composer.
+      const permissionDialog = promptSubmittedAt && isClaudeCommand(tuiConfig.command)
+        ? toolPermissionGate.observe(stripped, now)
+        : null;
       if (permissionDialog === 'exhausted') {
         await finish({
           success: false,

--- a/server/services/agentTuiSpawning.js
+++ b/server/services/agentTuiSpawning.js
@@ -1449,7 +1449,7 @@ export async function spawnTuiAgent({
         // "No" is the last option and option 1 is highlighted: arrow down to it,
         // then Enter — lands under both of Ink's selection models, whereas a bare
         // digit is immediate-select in some builds and ignored in others.
-        shellService.writeToSession(sessionId, `${'\x1b[B'.repeat(Math.max(0, permissionDialog.noOption - 1))}\r`);
+        shellService.writeToSession(sessionId, `${'\x1b[B'.repeat(Math.max(0, permissionDialog.noOption - 1))}${SUBMIT_KEY}`);
         appendLine(`🚫 Declined ${tuiConfig.command} permission prompt for ${permissionDialog.toolCall || 'a tool call'} — an unattended run never widens its scope (${permissionDialog.count}/${TOOL_PERMISSION_DECLINE_MAX})`);
       }
 

--- a/server/services/agentTuiSpawning.test.js
+++ b/server/services/agentTuiSpawning.test.js
@@ -252,7 +252,6 @@ import {
   OOM_NUDGE_MAX_ATTEMPTS,
   OOM_NUDGE_TEXT,
   RETRY_STALL_MS,
-  TOOL_PERMISSION_NUDGE_SETTLE_MS,
   TOOL_PERMISSION_NUDGE_TEXT,
 } from '../lib/tuiHandshake.js';
 // Real module, not a mock: the flag is a plain process-local boolean, so driving
@@ -1836,7 +1835,7 @@ describe('spawnTuiAgent runtime', () => {
     expect(shellService.writeToSession).toHaveBeenCalledWith(SESSION_ID, '\x1b[B\x1b[B\r');
 
     // The decline ends the turn; once the session is quiet the nudge goes out.
-    await vi.advanceTimersByTimeAsync(TOOL_PERMISSION_NUDGE_SETTLE_MS + 10000);
+    await vi.advanceTimersByTimeAsync(OOM_NUDGE_SETTLE_MS + 10000);
     await flushMicrotasks();
     expect(shellService.pasteToSession).toHaveBeenCalledWith(
       SESSION_ID,

--- a/server/services/agentTuiSpawning.test.js
+++ b/server/services/agentTuiSpawning.test.js
@@ -251,6 +251,9 @@ import {
   OOM_NUDGE_COOLDOWN_MS,
   OOM_NUDGE_MAX_ATTEMPTS,
   OOM_NUDGE_TEXT,
+  RETRY_STALL_MS,
+  TOOL_PERMISSION_NUDGE_SETTLE_MS,
+  TOOL_PERMISSION_NUDGE_TEXT,
 } from '../lib/tuiHandshake.js';
 // Real module, not a mock: the flag is a plain process-local boolean, so driving
 // it directly exercises the same code path production does.
@@ -1777,6 +1780,71 @@ describe('spawnTuiAgent runtime', () => {
         error: expect.stringContaining('GPU memory'),
       })
     );
+  });
+
+  // ── Retry stall: the provider keeps failing the same request ───────────────
+  // agent-e057cca7 (2026-09-04): a Stage 3 prefill the harness cancelled every
+  // ~6 minutes and re-sent verbatim. The screen repaints on every attempt, so
+  // every reaper saw a busy session and the run held its lane until the
+  // max-runtime ceiling.
+  it('fails over a session whose retry banner keeps advancing past the stall window', async () => {
+    let resolveComplete;
+    const completeDone = new Promise((r) => { resolveComplete = r; });
+    vi.mocked(agentLifecycle.finalizeAgent).mockImplementation(async () => { resolveComplete(); });
+
+    await driveAgyToSubmittedPrompt();
+
+    const retryCycleMs = RETRY_STALL_MS / 2 + 60_000;
+    for (const attempt of [1, 2]) {
+      await capturedOnData(Buffer.from(`API error · Retrying in 0s · attempt ${attempt}/10\n`));
+      await flushMicrotasks();
+      // The retried request is in flight: the title bar flickers, nothing else
+      // paints. Two attempts alone are not a verdict, however long they span.
+      await vi.advanceTimersByTimeAsync(retryCycleMs);
+      await flushMicrotasks();
+      expect(agentLifecycle.finalizeAgent).not.toHaveBeenCalled();
+    }
+
+    await capturedOnData(Buffer.from('API error · Retrying in 0s · attempt 3/10\n'));
+    await flushMicrotasks();
+    // Acted on by the 5s provider-signal poll, like the other gates.
+    await vi.advanceTimersByTimeAsync(5000);
+    vi.useRealTimers();
+    await completeDone;
+
+    expect(agentLifecycle.finalizeAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: false,
+        completionReason: 'fallback-signal',
+        error: expect.stringContaining('retried it 3 times'),
+      })
+    );
+  });
+
+  // ── Tool-permission dialog: decline, then nudge ───────────────────────────
+  // agent-e057cca7 (2026-09-04): under the sandboxed acceptEdits recipe a local
+  // model asked to Read an absolute path outside the worktree, and the dialog
+  // sat unanswered for the rest of the run.
+  it('declines a tool-permission dialog and nudges the session once it goes quiet', async () => {
+    await driveAgyToSubmittedPrompt();
+    vi.mocked(shellService.writeToSession).mockClear();
+    vi.mocked(shellService.pasteToSession).mockClear();
+
+    await capturedOnData(Buffer.from(' Read(/data.reference/providers.json) Doyouwanttoproceed? ❯1. Yes 2. Yes,allowreadingfrom/data.referenceduringthissession 3. No Esc to cancel · Tab to amend '));
+    await flushMicrotasks();
+    // Option 1 is highlighted; "No" is option 3: down, down, Enter.
+    expect(shellService.writeToSession).toHaveBeenCalledWith(SESSION_ID, '\x1b[B\x1b[B\r');
+
+    // The decline ends the turn; once the session is quiet the nudge goes out.
+    await vi.advanceTimersByTimeAsync(TOOL_PERMISSION_NUDGE_SETTLE_MS + 10000);
+    await flushMicrotasks();
+    expect(shellService.pasteToSession).toHaveBeenCalledWith(
+      SESSION_ID,
+      TOOL_PERMISSION_NUDGE_TEXT,
+      expect.objectContaining({ label: expect.stringContaining('permission') }),
+    );
+    expect(shellService.pasteToSession).toHaveBeenCalledTimes(1);
+    expect(agentLifecycle.finalizeAgent).not.toHaveBeenCalled();
   });
 
   // ── 1b. Submit-Enter retries ─────────────────────────────────────────────────

--- a/server/services/agentTuiSpawning.test.js
+++ b/server/services/agentTuiSpawning.test.js
@@ -1825,7 +1825,21 @@ describe('spawnTuiAgent runtime', () => {
   // model asked to Read an absolute path outside the worktree, and the dialog
   // sat unanswered for the rest of the run.
   it('declines a tool-permission dialog and nudges the session once it goes quiet', async () => {
-    await driveAgyToSubmittedPrompt();
+    // A claude session: the dialog is Claude Code chrome, and the spawner only
+    // watches claude sessions for it.
+    runSpawn({ tuiConfig: claudeTuiConfig });
+    await flushMicrotasks();
+    await capturedOnData(Buffer.from(`${PASTE_OFF}Claude Code v2.1.260\n`));
+    await flushMicrotasks();
+    await capturedOnData(Buffer.from(PASTE_ON));
+    await flushMicrotasks();
+    await vi.advanceTimersByTimeAsync(400);
+    await flushMicrotasks();
+    expect(pasteCount()).toBe(1);
+    await capturedOnData(Buffer.from('do the thing\n'));
+    await flushMicrotasks();
+    await vi.advanceTimersByTimeAsync(4000);
+    await flushMicrotasks();
     vi.mocked(shellService.writeToSession).mockClear();
     vi.mocked(shellService.pasteToSession).mockClear();
 

--- a/server/services/taskPromptDefaults/integrity.snapshot.json
+++ b/server/services/taskPromptDefaults/integrity.snapshot.json
@@ -29,7 +29,7 @@
     "plan-task": "b85fe92999aa4ee4a8910320457c4242",
     "pr-reviewer": "679680b3b382aeb6786df01c4d1a90c6",
     "pr-reviewer-eligibility": "a5652f7bcb7e2e50b1cfb9a54a6fabe0",
-    "pr-reviewer-review": "f1dbfcf76971b30b4ee34b2cde73c40c",
+    "pr-reviewer-review": "69fcafcda48279fe325d34f8cef4668c",
     "pr-reviewer-security": "d1e99626b12939ee39ab38eaa7d23f59",
     "pr-watcher": "53ead8e26d396849bfa78f28550bd691",
     "react-lifecycle": "14b3816d1bcc10f0d7d6357e55cc5e69",

--- a/server/services/taskPromptDefaults/prompts.js
+++ b/server/services/taskPromptDefaults/prompts.js
@@ -2501,7 +2501,7 @@ not sufficient.
 
 ## Review checklist
 
-{reviewChecklist}`,
+{reviewLenses}`,
 
   'reference-watch': `[Improvement: {appName}] Reference Repo Review
 

--- a/server/services/taskPromptService.js
+++ b/server/services/taskPromptService.js
@@ -75,8 +75,10 @@ async function loadSlashdoCommandBody(commandName) {
 
 /**
  * The slashdo review LENSES — the per-file / cross-file checklists that
- * `/do:review` dispatches its focused reviewers with. This is the whole of
- * `{reviewChecklist}` for the public-review actions stage (`pr-reviewer-review`).
+ * `/do:review` dispatches its focused reviewers with — behind the
+ * `{reviewLenses}` placeholder the public-review actions stage
+ * (`pr-reviewer-review`) carries. `review-structural-ambition` is left out on
+ * purpose: `/do:review` itself only selects it under `--strict`.
  *
  * That stage runs a single sandboxed agent with no network, no forge
  * credential, no sub-agent dispatch, and — on the local wrappers it is
@@ -98,9 +100,7 @@ const PUBLIC_REVIEW_LENS_LIBS = [
   'review-cross-file-tracing',
   'review-cross-file-contract',
 ];
-const LENS_ONLY_CHECKLIST_PROMPT_KEYS = new Set(['pr-reviewer-review']);
-
-async function loadPublicReviewChecklist() {
+async function loadReviewLenses() {
   const lenses = await Promise.all(PUBLIC_REVIEW_LENS_LIBS.map((name) => loadSlashdoLib(name).catch(() => null)));
   return lenses.filter(Boolean).join('\n\n');
 }
@@ -115,12 +115,8 @@ async function loadPublicReviewChecklist() {
  * BEFORE THE PLACEHOLDER back into the prompt at that point — seven copies of
  * the stage prompt inside one Stage 3 body, the same footgun
  * `resolveSlashdoIncludes` documents for its own includes.
- *
- * `promptKey` names the catalog entry being rendered (a pipeline stage's
- * `promptKey`; absent for a task-level prompt) so a placeholder can resolve
- * differently for a stage whose runtime cannot use the general body.
  */
-async function resolvePromptPlaceholders(prompt, { promptKey = null } = {}) {
+async function resolvePromptPlaceholders(prompt) {
   // {worktreesRoot} → PortOS's shared worktrees dir (absolute). The claim flows
   // (plan-task, claim-issue, claim-issue-gitlab, claim-issue-jira) create their
   // agent worktree here rather than inside the managed app repo, so a worktree
@@ -129,10 +125,12 @@ async function resolvePromptPlaceholders(prompt, { promptKey = null } = {}) {
     prompt = prompt.replace(/\{worktreesRoot\}/g, () => PATHS.worktrees);
   }
   if (prompt.includes('{reviewChecklist}')) {
-    const checklist = LENS_ONLY_CHECKLIST_PROMPT_KEYS.has(promptKey)
-      ? await loadPublicReviewChecklist()
-      : await loadSlashdoCommandBody('review').catch(() => '');
+    const checklist = await loadSlashdoCommandBody('review').catch(() => '');
     prompt = prompt.replace(/\{reviewChecklist\}/g, () => checklist);
+  }
+  if (prompt.includes('{reviewLenses}')) {
+    const lenses = await loadReviewLenses();
+    prompt = prompt.replace(/\{reviewLenses\}/g, () => lenses);
   }
   if (prompt.includes('{slashdoReplan}')) {
     const replan = await loadSlashdoCommandBody('replan').catch(() => '');
@@ -168,5 +166,5 @@ export async function getStagePrompt(taskType, stageIndex) {
   if (!stage?.promptKey) return getTaskPrompt(taskType);
   const prompt = DEFAULT_TASK_PROMPTS[stage.promptKey];
   if (!prompt) return getTaskPrompt(taskType);
-  return resolvePromptPlaceholders(prompt, { promptKey: stage.promptKey });
+  return resolvePromptPlaceholders(prompt);
 }

--- a/server/services/taskPromptService.js
+++ b/server/services/taskPromptService.js
@@ -28,7 +28,7 @@
  */
 
 import { PATHS } from '../lib/fileUtils.js';
-import { loadSlashdoFile } from '../lib/slashdoLoader.js';
+import { loadSlashdoFile, loadSlashdoLib } from '../lib/slashdoLoader.js';
 import { getTaskInterval } from './taskSchedule.js';
 import {
   DEFAULT_TASK_PROMPTS,
@@ -73,22 +73,70 @@ async function loadSlashdoCommandBody(commandName) {
   return _slashdoCache[commandName];
 }
 
-async function resolvePromptPlaceholders(prompt) {
+/**
+ * The slashdo review LENSES — the per-file / cross-file checklists that
+ * `/do:review` dispatches its focused reviewers with. This is the whole of
+ * `{reviewChecklist}` for the public-review actions stage (`pr-reviewer-review`).
+ *
+ * That stage runs a single sandboxed agent with no network, no forge
+ * credential, no sub-agent dispatch, and — on the local wrappers it is
+ * commonly pinned to — a model server that prefills at a few hundred tokens per
+ * second. The full `/do:review` body it used to receive is ~260KB: argument
+ * parsing, reviewer-selection protocol, five reviewer LOOPS (Copilot, GitHub
+ * `@login`, local agent, Ollama, multi-reviewer), issue filing and PR posting —
+ * every one of them a procedure the stage's own contract forbids, and together
+ * ~75K prompt tokens the model had to chew through before reading the PR. On
+ * 2026-09-04 that prefill outlived Claude Code's stream-idle watchdog on every
+ * attempt, so Stage 3 sat at `API error · Retrying … attempt 1/10` forever
+ * (agent-e057cca7). The lenses are the review; the rest was the harness for a
+ * different runtime.
+ */
+const PUBLIC_REVIEW_LENS_LIBS = [
+  'review-surface-scan',
+  'review-surface-quality',
+  'review-security-audit',
+  'review-cross-file-tracing',
+  'review-cross-file-contract',
+];
+const LENS_ONLY_CHECKLIST_PROMPT_KEYS = new Set(['pr-reviewer-review']);
+
+async function loadPublicReviewChecklist() {
+  const lenses = await Promise.all(PUBLIC_REVIEW_LENS_LIBS.map((name) => loadSlashdoLib(name).catch(() => null)));
+  return lenses.filter(Boolean).join('\n\n');
+}
+
+/**
+ * Substitute the prompt-level placeholders. Every replacement is FUNCTION-form:
+ * a string replacement makes `String.replace` interpret its `$`-prefixed
+ * tokens (`$&`, `$n`, the "text before the match" and "text after the match"
+ * forms) in the replacement text, and the shell-heavy slashdo bodies are full
+ * of `$`. One "text before the match" token inside the inlined `/do:review` (a
+ * regex like `^[^/]+/[^/]+#[0-9]+$` followed by a backtick) spliced EVERYTHING
+ * BEFORE THE PLACEHOLDER back into the prompt at that point — seven copies of
+ * the stage prompt inside one Stage 3 body, the same footgun
+ * `resolveSlashdoIncludes` documents for its own includes.
+ *
+ * `promptKey` names the catalog entry being rendered (a pipeline stage's
+ * `promptKey`; absent for a task-level prompt) so a placeholder can resolve
+ * differently for a stage whose runtime cannot use the general body.
+ */
+async function resolvePromptPlaceholders(prompt, { promptKey = null } = {}) {
   // {worktreesRoot} → PortOS's shared worktrees dir (absolute). The claim flows
   // (plan-task, claim-issue, claim-issue-gitlab, claim-issue-jira) create their
   // agent worktree here rather than inside the managed app repo, so a worktree
-  // checkout never pollutes the target repo's working tree. Function-form
-  // replacer so a literal `$` in the path can't be read as a backreference.
+  // checkout never pollutes the target repo's working tree.
   if (prompt.includes('{worktreesRoot}')) {
     prompt = prompt.replace(/\{worktreesRoot\}/g, () => PATHS.worktrees);
   }
   if (prompt.includes('{reviewChecklist}')) {
-    const checklist = await loadSlashdoCommandBody('review').catch(() => '');
-    prompt = prompt.replace(/\{reviewChecklist\}/g, checklist);
+    const checklist = LENS_ONLY_CHECKLIST_PROMPT_KEYS.has(promptKey)
+      ? await loadPublicReviewChecklist()
+      : await loadSlashdoCommandBody('review').catch(() => '');
+    prompt = prompt.replace(/\{reviewChecklist\}/g, () => checklist);
   }
   if (prompt.includes('{slashdoReplan}')) {
     const replan = await loadSlashdoCommandBody('replan').catch(() => '');
-    prompt = prompt.replace(/\{slashdoReplan\}/g, replan);
+    prompt = prompt.replace(/\{slashdoReplan\}/g, () => replan);
   }
   return prompt;
 }
@@ -120,5 +168,5 @@ export async function getStagePrompt(taskType, stageIndex) {
   if (!stage?.promptKey) return getTaskPrompt(taskType);
   const prompt = DEFAULT_TASK_PROMPTS[stage.promptKey];
   if (!prompt) return getTaskPrompt(taskType);
-  return resolvePromptPlaceholders(prompt);
+  return resolvePromptPlaceholders(prompt, { promptKey: stage.promptKey });
 }

--- a/server/services/taskPromptService.test.js
+++ b/server/services/taskPromptService.test.js
@@ -13,16 +13,16 @@ vi.mock('./taskSchedule.js', () => ({
 // `$&` (the match), `$1`, and the "text before / after the match" forms — so a
 // regression to string-form replacement shows up as spliced prompt text rather
 // than passing by luck on a body that happens to contain no `$`.
-const BACKREFERENCE_BAIT = "regex `^[^/]+#[0-9]+$` and $& and $1 and $' end";
+const { BACKREFERENCE_BAIT } = vi.hoisted(() => ({ BACKREFERENCE_BAIT: "regex `^[^/]+#[0-9]+$` and $& and $1 and $' end" }));
 vi.mock('../lib/slashdoLoader.js', () => ({
   loadSlashdoFile: vi.fn(async (name) => (
     name === 'review'
-      ? `FULL /do:review BODY ## Parse Arguments ## Copilot Code Review Loop ${"regex `^[^/]+#[0-9]+$` and $& and $1 and $' end"}`
+      ? `FULL /do:review BODY ## Parse Arguments ## Copilot Code Review Loop ${BACKREFERENCE_BAIT}`
       : name === 'replan'
-        ? `REPLAN BODY ${"regex `^[^/]+#[0-9]+$` and $& and $1 and $' end"}`
+        ? `REPLAN BODY ${BACKREFERENCE_BAIT}`
         : ''
   )),
-  loadSlashdoLib: vi.fn(async (name) => `# ${name} lens\n${"regex `^[^/]+#[0-9]+$` and $& and $1 and $' end"}`),
+  loadSlashdoLib: vi.fn(async (name) => `# ${name} lens\n${BACKREFERENCE_BAIT}`),
 }));
 
 import { getTaskPrompt, getStagePrompt, DEFAULT_TASK_PROMPTS, PREVIOUS_DEFAULT_PROMPTS } from './taskPromptService.js';
@@ -70,7 +70,7 @@ describe('slashdo placeholder substitution', () => {
     expect(out.match(/HEAD/g)).toHaveLength(1);
   });
 
-  it('gives the public-review actions stage the review LENSES only, never the whole /do:review procedure', async () => {
+  it('gives the public-review actions stage the review LENSES ({reviewLenses}), never the whole /do:review procedure', async () => {
     getTaskInterval.mockResolvedValueOnce(PR_REVIEWER_INTERVAL);
     vi.mocked(loadSlashdoFile).mockClear();
     vi.mocked(loadSlashdoLib).mockClear();
@@ -81,7 +81,7 @@ describe('slashdo placeholder substitution', () => {
     // set — the argument parser, reviewer loops and PR-posting procedure of the
     // full body are a runtime this sandboxed, network-less stage cannot use.
     expect(stage.match(/PR Code Review & Actions \(Stage 3\)/g)).toHaveLength(1);
-    expect(stage).not.toContain('{reviewChecklist}');
+    expect(stage).not.toContain('{reviewLenses}');
     expect(stage).not.toContain('FULL /do:review BODY');
     expect(stage).toContain('# review-surface-scan lens');
     expect(stage).toContain('# review-security-audit lens');
@@ -97,7 +97,7 @@ describe('slashdo placeholder substitution', () => {
     ]);
   });
 
-  it('still hands every other consumer the full /do:review body', async () => {
+  it('keeps {reviewChecklist} as the full /do:review body for stored and prior-default prompts', async () => {
     getTaskInterval.mockResolvedValueOnce({ prompt: 'X {reviewChecklist} Y' });
 
     const out = await getTaskPrompt('code-reviewer');

--- a/server/services/taskPromptService.test.js
+++ b/server/services/taskPromptService.test.js
@@ -8,8 +8,26 @@ vi.mock('./taskSchedule.js', () => ({
   getTaskInterval: vi.fn(async () => ({ prompt: 'before {worktreesRoot}/claim-x after' })),
 }));
 
+// Stand-in slashdo bodies. Every one carries the `$`-prefixed tokens that
+// String.replace treats as backreferences when handed a STRING replacement —
+// `$&` (the match), `$1`, and the "text before / after the match" forms — so a
+// regression to string-form replacement shows up as spliced prompt text rather
+// than passing by luck on a body that happens to contain no `$`.
+const BACKREFERENCE_BAIT = "regex `^[^/]+#[0-9]+$` and $& and $1 and $' end";
+vi.mock('../lib/slashdoLoader.js', () => ({
+  loadSlashdoFile: vi.fn(async (name) => (
+    name === 'review'
+      ? `FULL /do:review BODY ## Parse Arguments ## Copilot Code Review Loop ${"regex `^[^/]+#[0-9]+$` and $& and $1 and $' end"}`
+      : name === 'replan'
+        ? `REPLAN BODY ${"regex `^[^/]+#[0-9]+$` and $& and $1 and $' end"}`
+        : ''
+  )),
+  loadSlashdoLib: vi.fn(async (name) => `# ${name} lens\n${"regex `^[^/]+#[0-9]+$` and $& and $1 and $' end"}`),
+}));
+
 import { getTaskPrompt, getStagePrompt, DEFAULT_TASK_PROMPTS, PREVIOUS_DEFAULT_PROMPTS } from './taskPromptService.js';
 import { getTaskInterval } from './taskSchedule.js';
+import { loadSlashdoFile, loadSlashdoLib } from '../lib/slashdoLoader.js';
 import { PATHS } from '../lib/fileUtils.js';
 
 describe('taskPromptService {worktreesRoot} substitution', () => {
@@ -23,6 +41,69 @@ describe('taskPromptService {worktreesRoot} substitution', () => {
     const out = await getTaskPrompt('claim-issue');
     expect(out).toBe(`before ${PATHS.worktrees}/claim-x after`);
     expect(out).not.toContain('{worktreesRoot}');
+  });
+});
+
+describe('slashdo placeholder substitution', () => {
+  const PR_REVIEWER_INTERVAL = {
+    prompt: null,
+    taskMetadata: {
+      pipeline: {
+        stages: [
+          { name: 'Security Scan', promptKey: 'pr-reviewer-security' },
+          { name: 'Eligibility Gate', promptKey: 'pr-reviewer-eligibility' },
+          { name: 'Code Review & Merge', promptKey: 'pr-reviewer-review' },
+        ],
+      },
+    },
+  };
+
+  it('inlines a slashdo body verbatim — backreference tokens in it never splice the prompt', async () => {
+    getTaskInterval.mockResolvedValueOnce({ prompt: 'HEAD {reviewChecklist} TAIL {slashdoReplan} END' });
+
+    const out = await getTaskPrompt('code-reviewer');
+
+    // The 2026-09-04 shape of this bug: a `$` + backtick inside the inlined
+    // /do:review re-inserted everything before the placeholder, so one Stage 3
+    // prompt carried seven copies of its own header (~400KB, ~100K tokens).
+    expect(out).toBe(`HEAD FULL /do:review BODY ## Parse Arguments ## Copilot Code Review Loop ${BACKREFERENCE_BAIT} TAIL REPLAN BODY ${BACKREFERENCE_BAIT} END`);
+    expect(out.match(/HEAD/g)).toHaveLength(1);
+  });
+
+  it('gives the public-review actions stage the review LENSES only, never the whole /do:review procedure', async () => {
+    getTaskInterval.mockResolvedValueOnce(PR_REVIEWER_INTERVAL);
+    vi.mocked(loadSlashdoFile).mockClear();
+    vi.mocked(loadSlashdoLib).mockClear();
+
+    const stage = await getStagePrompt('pr-reviewer', 2);
+
+    // The stage header appears once (no splice) and the checklist is the lens
+    // set — the argument parser, reviewer loops and PR-posting procedure of the
+    // full body are a runtime this sandboxed, network-less stage cannot use.
+    expect(stage.match(/PR Code Review & Actions \(Stage 3\)/g)).toHaveLength(1);
+    expect(stage).not.toContain('{reviewChecklist}');
+    expect(stage).not.toContain('FULL /do:review BODY');
+    expect(stage).toContain('# review-surface-scan lens');
+    expect(stage).toContain('# review-security-audit lens');
+    expect(stage).toContain('# review-cross-file-contract lens');
+    expect(stage).toContain(BACKREFERENCE_BAIT);
+    expect(vi.mocked(loadSlashdoFile)).not.toHaveBeenCalledWith('review', expect.anything());
+    expect(vi.mocked(loadSlashdoLib).mock.calls.map(([name]) => name)).toEqual([
+      'review-surface-scan',
+      'review-surface-quality',
+      'review-security-audit',
+      'review-cross-file-tracing',
+      'review-cross-file-contract',
+    ]);
+  });
+
+  it('still hands every other consumer the full /do:review body', async () => {
+    getTaskInterval.mockResolvedValueOnce({ prompt: 'X {reviewChecklist} Y' });
+
+    const out = await getTaskPrompt('code-reviewer');
+
+    expect(out).toContain('FULL /do:review BODY');
+    expect(out).not.toContain('lens');
   });
 });
 


### PR DESCRIPTION
## Summary

The pr-reviewer Stage 3 agent (`claude-ollama-tui` + `qwen3-coder:30b`) hung twice on 2026-09-04: first at `API error · Retrying in 0s · attempt 1/10` for the whole run, then — once the request finally got through — on a tool-permission dialog nobody was present to answer. Both were diagnosed and fixed at the root, and both hang shapes now recover automatically.

**Why it hung**
- The stage prompt was ~400KB (~100K tokens): `{reviewChecklist}` inlined the entire `/do:review` command with every lib (~260KB the sandboxed stage cannot use), and a string-form `String.replace` let a `$`+backtick inside that body splice the stage prompt back into itself seven times.
- Ollama sends **no bytes at all** until prefill completes. Claude Code v2.1.260 has four independent ceilings on that silence, and the binding one is the Bun runtime's own fetch timeout (~360s), which only `API_FORCE_IDLE_TIMEOUT=0` disables — so PR #6117's `API_TIMEOUT_MS` raise changed nothing. Verified with a fake stalled `/v1/messages` on loopback: with the flag unset or `1` the client re-sends every 361s regardless of every other knob; with `0` it waits out the prefill. (Ollama's context checkpoints are why the run eventually got through after ~5 retries.)
- The local model then hallucinated an absolute path outside the worktree, and `--permission-mode acceptEdits` painted `Do you want to proceed?`.

**What changed**
- Stage 3 gets a new `{reviewLenses}` placeholder (the five review lenses, ~39KB) instead of the whole `/do:review`; every placeholder uses a function replacer. Resolved prompt drops from ~400KB to ~50KB before the PR envelope.
- Local-backed Claude harnesses get `API_FORCE_IDLE_TIMEOUT=0` plus the two 30-minute stream-idle knobs, allowlisted through both public-review env boundaries.
- `createRetryStallGate`: a retry banner that advances twice across ten minutes fails the run over to a fallback provider (decided at a sighting, never by the clock, so a fast cloud ladder that then succeeded is left alone).
- `createToolPermissionGate`: any tool-permission dialog is declined (arrow-down to the last "No", whose number varies by tool) and the quiet session is nudged back to work; eight nudges fail the run. The OOM nudge and this one share one `createSilenceNudgeGate`. The dialog pattern is shared with the post-mortem analyzer.
- The pipeline hand-off no longer points a stage at `data/cos/agents/<prev>/output.txt` (outside every worktree) once the output is inlined.

## Test plan

- [x] `server`: aiToolkit, tuiHandshake, cliChildEnv, agentTuiSpawning, taskPromptService, agentPromptBuilder, taskPromptDefaults, agentErrorAnalysis, agentCompletionCleanup suites — 1432 passing
- [x] Mutation checks: reverting the function replacer fails the splice test; removing the stall-gate wiring fails the spawner test
- [x] Offline Claude Code timeout matrix (12 variants × ~7 min against a fake stalled `/v1/messages`) pins `API_FORCE_IDLE_TIMEOUT=0` as the knob that survives a silent prefill
- [ ] After merge: `pm2 restart portos-server` so the new child env reaches the next Stage 3 spawn, then re-run the pr-reviewer on a contributor PR and confirm the agent dir shows a ~50KB `prompt.txt` and no `Retrying` banner
