### PR TITLE
fix(mind): route delegated tasks to the repo that will hold the change

### DIFF
--- a/server/services/persistentMindTaskCapability.js
+++ b/server/services/persistentMindTaskCapability.js
@@ -19,6 +19,7 @@ import { antigravityBaseModels, effortLevelsForProvider, filterSelectableModels 
 import { PR_COMPLETIONS } from '../lib/prDisposition.js';
 import { sha256Text } from '../lib/fileUtils.js';
 import { MANAGED_ASSESSMENT_BACKENDS, localRuntimeKind } from '../lib/localProviderRuntime.js';
+import { PORTOS_APP_ID } from '../lib/appIdentity.js';
 import { resolveAppWorkTracker } from '../lib/workTracker.js';
 import { getActiveApps, getAppWorkTracker } from './apps.js';
 import { loadState } from './cosState.js';
@@ -159,6 +160,9 @@ const appCatalogEntry = async (app) => {
     id: app.id,
     name: String(app.name || app.id).slice(0, 100),
     planOnly: ISSUE_TRACKERS.has(tracker?.resolved),
+    // Only the baseline entry carries the flag, so the prompt catalog stays
+    // small and the mind has one unambiguous answer to "which repo is mine".
+    ...(app.id === PORTOS_APP_ID ? { self: true } : {}),
   };
 };
 
@@ -291,6 +295,15 @@ Use 'requiredValidation' only when the task's acceptance criteria require those
 workspace checks before queueing. Supported checks are 'dependencies',
 'engines', 'submodules', 'forge', and 'reviewers'. An omitted or empty list
 keeps absent dependencies advisory, which is appropriate for docs-only work.
+
+Choosing the app: pick the repository that will hold the change, not the subject
+the work is about. PortOS owns every integration it ships — the connector,
+projection, routes, UI, and settings for another app all live in the PortOS repo,
+whose catalog entry, when you are granted it, is marked 'self: true'. Target
+another app's repo only when the change must land in that repo's own source. When
+PortOS work looks like it needs something another project does not expose yet,
+still target PortOS: the task can establish from PortOS's own integration what is
+genuinely missing there before anyone proposes a change to that project.
 
 Configured choices (ids are authoritative; do not invent ids):
 ${JSON.stringify(promptCatalog)}

--- a/server/services/persistentMindTaskCapability.test.js
+++ b/server/services/persistentMindTaskCapability.test.js
@@ -45,6 +45,8 @@ vi.mock('./persistentMindWorkspacePreflight.js', () => ({
   assessPersistentMindWorkspaceReadiness: (...args) => mocks.assessWorkspaceReadiness(...args),
 }));
 
+const { PORTOS_APP_ID } = await import('../lib/appIdentity.js');
+
 const {
   buildPersistentMindTaskCapabilityPrompt,
   executePersistentMindTaskRequests,
@@ -121,6 +123,21 @@ describe('persistent mind CoS-task capability', () => {
     expect(prompt).toContain('Plan & File Issue');
     expect(prompt).toContain('planOnly');
     expect(prompt).not.toContain('command');
+  });
+
+  it('flags only the PortOS baseline app and tells the mind to route by owning repo', async () => {
+    mocks.apps = [
+      { id: PORTOS_APP_ID, name: 'PortOS', repoPath: '/example/portos' },
+      { id: 'managed-app', name: 'Managed App', repoPath: '/example/managed' },
+    ];
+    const catalog = await readPersistentMindTaskCatalog();
+    expect(catalog.apps).toEqual([
+      { id: PORTOS_APP_ID, name: 'PortOS', planOnly: false, self: true },
+      { id: 'managed-app', name: 'Managed App', planOnly: false },
+    ]);
+    const prompt = buildPersistentMindTaskCapabilityPrompt({ enabled: true, catalog });
+    expect(prompt).toContain('pick the repository that will hold the change');
+    expect(prompt).toContain("marked 'self: true'");
   });
 
   it('publishes only allowlisted task models and rejects a model outside the policy', async () => {


### PR DESCRIPTION
## Summary

The persistent mind picks one configured app — one repository — for every CoS agent task it queues, and the task-capability prompt only told it to "choose one configured app." Nothing said which repo *owns* a given piece of work, so work on a PortOS integration got routed to the app the integration is **about**.

That happened: a wake that wanted to extend PortOS's Eidoverse world support queued its task against the Eidoverse Worlds checkout. The agent there could not see PortOS's connector (`server/services/eidoverseWorld.js`), its projection layer (`eidoverseWorldProjection.js`), or its privacy-safe source adapters (`eidoverseWorldSources.js`), so it re-derived most of that work as "missing" and opened a docs-only PR against a fork of a third-party upstream. That PR has been closed with the reasoning recorded on it.

## What changed

- **The prompt states the routing rule.** Pick the repository that will hold the change, not the subject the work is about. PortOS owns every integration it ships — the connector, projection, routes, UI, and settings for another app all live in the PortOS repo. Another app's repo is the target only when the change must land in that repo's own source. When PortOS work looks like it needs something another project does not expose yet, the task still targets PortOS and establishes from PortOS's own integration what is genuinely missing before anyone proposes a change to that project.
- **The catalog marks the PortOS baseline entry `self: true`**, so the rule points at a concrete id rather than a name the mind has to recognize. Only that one entry carries the flag — the prompt catalog is bounded at 4 000 characters and drops apps past the limit, so an unconditional `"self":false` on every entry would spend budget to say nothing.

`self` reuses the existing `PORTOS_APP_ID` constant from `server/lib/appIdentity.js` rather than a second literal.

## Follow-up

The two host-identity items that are genuinely PortOS-side work — serving a privacy-safe host descriptor from the Eidoverse bridge, and giving the world a self-description entity — are filed as #6246, decision-complete. The two that belong to the Eidoverse sequencer itself are recorded upstream rather than here.

## Test plan

- New test in `server/services/persistentMindTaskCapability.test.js`: with the real baseline id plus a managed app in the catalog, only the baseline carries `self: true`, and the prompt carries the routing rule. Verified failing before the fix (`self: true` absent) and passing after.
- Full server suite green: 1 948 files, 39 276 tests, exit 0.
- Traced every consumer of the catalog shape — `server/routes/cosMindRoutes.js` and the client components under `client/src` all spread the entry and read named keys, so the extra optional key passes through untouched.
