### PR TITLE
feat(eidoverse): let a hosted world name its PortOS host and describe itself

### DIFF
--- a/server/lib/eidoverseWorldDesign.js
+++ b/server/lib/eidoverseWorldDesign.js
@@ -16,6 +16,11 @@ export const EIDOVERSE_MAX_LIVE_ENTITIES = 48;
 export const EIDOVERSE_LIBRARY_MODEL_ROOT = 'eidoverse/assets/models/';
 export const EIDOVERSE_MANAGED_PREFIX = 'portos-design-v2-';
 export const EIDOVERSE_PROJECTION_PREFIX = `${EIDOVERSE_MANAGED_PREFIX}signal-`;
+// The world's self-description rides on one managed convention entity rather
+// than a world-scope singleton: a `meta` slot on WorldState would be a protocol
+// amendment, while this replays, forks, and degrades gracefully on a host that
+// has never heard of PortOS.
+export const EIDOVERSE_META_ENTITY_ID = `${EIDOVERSE_MANAGED_PREFIX}meta`;
 
 export const EIDOVERSE_SOURCE_KEYS = Object.freeze([
   'apps',

--- a/server/services/eidoverseHost.js
+++ b/server/services/eidoverseHost.js
@@ -29,10 +29,13 @@ const forwardedHeaders = (req, protocol, targetHost, targetPort) => ({
 
 const requestPathname = (url) => String(url || '').split('?')[0].replace(/\/+$/, '') || '/';
 
-const writePlainText = (res, status, body) => {
+// Node suppresses the body of a HEAD response itself, so every writer here can
+// pass one unconditionally.
+const writePlainText = (res, status, body, headers = {}) => {
   res.writeHead(status, {
     'content-type': 'text/plain; charset=utf-8',
     'content-length': Buffer.byteLength(body),
+    ...headers,
   });
   res.end(body);
 };
@@ -43,7 +46,7 @@ const writePlainText = (res, status, body) => {
  */
 const serveHostDescriptor = async (req, res) => {
   if (req.method !== 'GET' && req.method !== 'HEAD') {
-    writePlainText(res, 405, 'The PortOS host descriptor is read-only.');
+    writePlainText(res, 405, 'The PortOS host descriptor is read-only.', { allow: 'GET, HEAD' });
     return;
   }
   // Deferred import: this bridge is constructed from the always-loaded settings
@@ -66,7 +69,7 @@ const serveHostDescriptor = async (req, res) => {
     'content-length': Buffer.byteLength(body),
     'cache-control': 'no-store',
   });
-  res.end(req.method === 'HEAD' ? undefined : body);
+  res.end(body);
 };
 
 const writeBadGateway = (res) => {

--- a/server/services/eidoverseHost.js
+++ b/server/services/eidoverseHost.js
@@ -8,6 +8,7 @@ import { ServerError } from '../lib/errorHandler.js';
 import { EIDOVERSE_PORT } from './eidoverse.js';
 
 const BAD_GATEWAY_BODY = 'Eidoverse Worlds is not running.';
+const HOST_DESCRIPTOR_PATH = '/host';
 
 // Where a conflicting listener would sit. A local squatter almost always claims
 // loopback — Docker publishes to 127.0.0.1, dev servers bind localhost — and
@@ -25,6 +26,48 @@ const forwardedHeaders = (req, protocol, targetHost, targetPort) => ({
   'x-forwarded-host': req.headers.host || '',
   'x-forwarded-proto': protocol,
 });
+
+const requestPathname = (url) => String(url || '').split('?')[0].replace(/\/+$/, '') || '/';
+
+const writePlainText = (res, status, body) => {
+  res.writeHead(status, {
+    'content-type': 'text/plain; charset=utf-8',
+    'content-length': Buffer.byteLength(body),
+  });
+  res.end(body);
+};
+
+/**
+ * Terminate `GET /host` at the bridge. Runs outside the Express lifecycle, so a
+ * rejected read is caught here rather than crashing the process.
+ */
+const serveHostDescriptor = async (req, res) => {
+  if (req.method !== 'GET' && req.method !== 'HEAD') {
+    writePlainText(res, 405, 'The PortOS host descriptor is read-only.');
+    return;
+  }
+  // Deferred import: this bridge is constructed from the always-loaded settings
+  // route, while `/host` is a rare request. A static edge would drag the world
+  // config graph into every suite that reaches this module (server/AGENTS.md,
+  // "Import scoping").
+  const descriptor = await import('./eidoverseWorld.js')
+    .then(({ readEidoverseHostDescriptor }) => readEidoverseHostDescriptor())
+    .catch((error) => {
+      console.error(`❌ Eidoverse host descriptor failed: ${error.message}`);
+      return null;
+    });
+  if (!descriptor) {
+    writePlainText(res, 503, 'The PortOS host descriptor is unavailable.');
+    return;
+  }
+  const body = JSON.stringify(descriptor);
+  res.writeHead(200, {
+    'content-type': 'application/json; charset=utf-8',
+    'content-length': Buffer.byteLength(body),
+    'cache-control': 'no-store',
+  });
+  res.end(req.method === 'HEAD' ? undefined : body);
+};
 
 const writeBadGateway = (res) => {
   if (res.headersSent) {
@@ -89,6 +132,15 @@ export function createEidoverseHost({
   };
 
   const handleHttp = (req, res) => {
+    if (requestPathname(req.url) === HOST_DESCRIPTOR_PATH) {
+      // Nothing holds this promise, and a client that hung up mid-write makes
+      // `res` throw — so own the rejection here rather than killing the process.
+      serveHostDescriptor(req, res).catch((error) => {
+        console.error(`❌ Eidoverse host descriptor response failed: ${error.message}`);
+        res.destroy();
+      });
+      return;
+    }
     const upstream = httpRequest({
       hostname: targetHost,
       port: targetPort,

--- a/server/services/eidoverseHost.test.js
+++ b/server/services/eidoverseHost.test.js
@@ -1,8 +1,22 @@
 import { once } from 'node:events';
 import { createServer } from 'node:http';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { WebSocket, WebSocketServer } from 'ws';
 import { createEidoverseHost } from './eidoverseHost.js';
+
+// The bridge reaches the world config through a deferred `await import()`, so
+// the stub stands in for the whole config graph without loading it here.
+const HOST_DESCRIPTOR = Object.freeze({
+  id: 'hst_0123456789ab',
+  kind: 'portos',
+  label: 'Luminous Systems Garden',
+  version: '9.9.9',
+  caps: { eido: false },
+});
+const readEidoverseHostDescriptor = vi.fn(async () => HOST_DESCRIPTOR);
+vi.mock('./eidoverseWorld.js', () => ({
+  readEidoverseHostDescriptor: (...args) => readEidoverseHostDescriptor(...args),
+}));
 
 const bridges = [];
 const upstreamServers = [];
@@ -108,6 +122,58 @@ describe('Eidoverse host bridge', () => {
     client.close();
     await once(client, 'close');
     webSocketClients.pop();
+  });
+
+  it('answers GET /host itself, so the descriptor never reaches the sequencer', async () => {
+    const upstreamRequests = [];
+    const upstreamPort = await listen(createServer((req, res) => {
+      upstreamRequests.push(req.url);
+      res.writeHead(200);
+      res.end('sequencer');
+    }));
+    const bridge = createEidoverseHost({
+      targetPort: upstreamPort,
+      listenHost: '127.0.0.1',
+      listenPort: 0,
+      certDir: null,
+    });
+    bridges.push(bridge);
+
+    const host = await bridge.start();
+    const response = await fetch(`http://127.0.0.1:${host.port}/host?probe=1`);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).toBe('application/json; charset=utf-8');
+    expect(await response.json()).toEqual(HOST_DESCRIPTOR);
+    // A forwarded request would have shown up here; the whole point is that it
+    // does not, so the upstream checkout needs no change to serve this.
+    expect(upstreamRequests).toEqual([]);
+  });
+
+  it('refuses to write through the descriptor path, and reports an unreadable descriptor honestly', async () => {
+    const upstreamRequests = [];
+    const upstreamPort = await listen(createServer((req, res) => {
+      upstreamRequests.push(req.url);
+      res.writeHead(200);
+      res.end('sequencer');
+    }));
+    const bridge = createEidoverseHost({
+      targetPort: upstreamPort,
+      listenHost: '127.0.0.1',
+      listenPort: 0,
+      certDir: null,
+    });
+    bridges.push(bridge);
+
+    const host = await bridge.start();
+    const posted = await fetch(`http://127.0.0.1:${host.port}/host`, { method: 'POST' });
+    expect(posted.status).toBe(405);
+
+    readEidoverseHostDescriptor.mockRejectedValueOnce(new Error('config unreadable'));
+    const failed = await fetch(`http://127.0.0.1:${host.port}/host`);
+    expect(failed.status).toBe(503);
+    // Neither the refusal nor the failure may fall through to the sequencer.
+    expect(upstreamRequests).toEqual([]);
   });
 
   // A managed app on PortOS's reserved :5563 bound 127.0.0.1 explicitly while

--- a/server/services/eidoverseWorld.js
+++ b/server/services/eidoverseWorld.js
@@ -15,9 +15,10 @@ import { atomicWrite, dataPath, ensureDir, readJSONFile } from '../lib/fileUtils
 import { createMutex } from '../lib/asyncMutex.js';
 import { ServerError } from '../lib/errorHandler.js';
 import { canonicalStringify } from '../lib/objects.js';
-import { getSelf, ensureSelf } from './instances.js';
+import { getSelf, ensureSelf, getInstanceId } from './instances.js';
 import { getInstanceFeatures } from './instanceFeatures.js';
 import { getEidoverseStatus, EIDOVERSE_PORT } from './eidoverse.js';
+import { getCurrentVersion } from './updateChecker.js';
 import {
   EIDOVERSE_ASSET_SLOTS_BY_DISTRICT,
   EIDOVERSE_ASSET_RECIPE_VERSION,
@@ -37,6 +38,7 @@ import {
 } from './eidoverseWorldProjection.js';
 import {
   collectEidoverseWorldSources,
+  eidoverseHostId,
   projectedJiraTickets,
   projectedStorage,
 } from './eidoverseWorldSources.js';
@@ -438,6 +440,33 @@ export async function ensureEidoverseWorldConfig() {
     applyConfigDefaults(state, fallback);
     return configFromState(state);
   });
+}
+
+/**
+ * Who hosts this world? Answered by the PortOS bridge on `GET /host`, so the
+ * upstream Eidoverse checkout stays untouched — and hung on the world's own
+ * meta entity, so a fork of the log carries it too.
+ *
+ * Anyone who can reach the door reads this, so it carries a non-reversible
+ * install digest and the operator-chosen world title only — never a hostname,
+ * tailnet/MagicDNS name, LAN or public address, OS username, or home path.
+ * Config reads only: the bridge must not have to open a world connection.
+ */
+export async function readEidoverseHostDescriptor() {
+  const [state, instanceId, version] = await Promise.all([
+    loadState(),
+    getInstanceId(),
+    getCurrentVersion(),
+  ]);
+  return {
+    id: eidoverseHostId(instanceId),
+    kind: 'portos',
+    label: safeText(state.recipe?.name, DEFAULT_EIDOVERSE_PROJECTION_RECIPE.name, 120),
+    version,
+    // The `eido:` resolver/export path is unimplemented upstream, so a visiting
+    // client must not assume this host can serve one.
+    caps: { eido: false },
+  };
 }
 
 export async function updateEidoverseWorldConfig(patch) {
@@ -1603,11 +1632,13 @@ export async function projectEidoverseWorld({ signal } = {}) {
     const lockedConfig = await resolveAndLockAssets(config, { signal });
     const presence = await ensureCosPresenceInternal({ fresh: true, signal });
     const source = await collectEidoverseWorldSources({ signal });
+    const hostId = eidoverseHostId(await getInstanceId());
     throwIfAborted(signal);
     const plan = buildProjectionPlan({
       source,
       recipe: lockedConfig.recipe,
       currentState: presence.snapshot?.state || {},
+      meta: { title: lockedConfig.design.name, hostId },
     });
     await applyProjectionPlan(presence, plan, {
       signal,

--- a/server/services/eidoverseWorld.runtime.test.js
+++ b/server/services/eidoverseWorld.runtime.test.js
@@ -1,3 +1,4 @@
+import { homedir, hostname, userInfo } from 'node:os';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
@@ -635,6 +636,44 @@ describe('Eidoverse private-world lifecycle', () => {
 
     await expect(pending).rejects.toMatchObject({ name: 'AbortError' });
     resolveAppStatuses([]);
+  });
+
+  // Anyone who can reach the Eidoverse door reads this payload, so a field
+  // naming the machine, its network, or its operator would leak on every join.
+  it('names its host opaquely on GET /host, and carries no machine identity', async () => {
+    const descriptor = await world.readEidoverseHostDescriptor();
+
+    expect(Object.keys(descriptor).sort()).toEqual(['caps', 'id', 'kind', 'label', 'version']);
+    expect(descriptor).toMatchObject({
+      id: expect.stringMatching(/^hst_[0-9a-f]{12}$/),
+      kind: 'portos',
+      label: world.DEFAULT_EIDOVERSE_PROJECTION_RECIPE.name,
+      version: expect.any(String),
+      caps: { eido: false },
+    });
+
+    const serialized = JSON.stringify(descriptor);
+    for (const identity of [hostname(), hostname().split('.')[0], homedir(), userInfo().username]) {
+      if (identity) expect(serialized).not.toContain(identity);
+    }
+    expect(serialized).not.toContain(mocks.self.instanceId);
+    expect(serialized).not.toContain(mocks.self.name);
+    expect(serialized).not.toMatch(/\d{1,3}(?:\.\d{1,3}){3}|\.ts\.net|\/Users\/|\/home\//);
+    // Stable across reads: the id is a digest of this install, not a nonce.
+    expect((await world.readEidoverseHostDescriptor()).id).toBe(descriptor.id);
+  });
+
+  // The label is the operator's, not a constant: a renamed world has to reach
+  // the door, or `GET /host` and the world's own meta entity disagree.
+  it('serves the operator-chosen world title as the host descriptor label', async () => {
+    const recipe = structuredClone(world.DEFAULT_EIDOVERSE_PROJECTION_RECIPE);
+    recipe.name = 'Example Systems Garden';
+    const updated = await world.updateEidoverseWorldConfig({ recipe });
+
+    const descriptor = await world.readEidoverseHostDescriptor();
+    expect(descriptor.label).toBe('Example Systems Garden');
+    // The same string the projection hangs on the world's meta entity.
+    expect(updated.design.name).toBe(descriptor.label);
   });
 
   // The world says who hosts it. A live projection has to actually supply that

--- a/server/services/eidoverseWorld.runtime.test.js
+++ b/server/services/eidoverseWorld.runtime.test.js
@@ -46,6 +46,7 @@ vi.mock('../lib/fileUtils.js', async (importActual) => {
 vi.mock('./instances.js', () => ({
   getSelf: vi.fn(async () => mocks.self),
   ensureSelf: vi.fn(async () => mocks.self),
+  getInstanceId: vi.fn(async () => mocks.self?.instanceId ?? 'unknown-instance'),
   getPeers: vi.fn(async () => []),
 }));
 
@@ -634,6 +635,24 @@ describe('Eidoverse private-world lifecycle', () => {
 
     await expect(pending).rejects.toMatchObject({ name: 'AbortError' });
     resolveAppStatuses([]);
+  });
+
+  // The world says who hosts it. A live projection has to actually supply that
+  // meta, or the reconciliation sweep deletes the carrier on the next run.
+  it('plants the world meta entity, naming its host opaquely and never by machine', async () => {
+    await world.projectEidoverseWorld();
+
+    const metaComp = mocks.sent.find(({ verb, args }) => (
+      verb === 'comp' && args?.id === 'portos-design-v2-meta' && args?.type === 'portos'
+    ));
+    expect(metaComp?.args.data).toMatchObject({
+      kind: 'world-meta',
+      managedBy: 'portos',
+      designVersion: 2,
+      meta: { title: expect.any(String), hostId: expect.stringMatching(/^hst_[0-9a-f]{12}$/) },
+    });
+    expect(JSON.stringify(metaComp.args.data)).not.toContain(mocks.self.instanceId);
+    expect(JSON.stringify(metaComp.args.data)).not.toContain(mocks.self.name);
   });
 
   it('preflights and locks recipe assets before completing a V2 reconciliation', async () => {

--- a/server/services/eidoverseWorld.test.js
+++ b/server/services/eidoverseWorld.test.js
@@ -1,25 +1,12 @@
-import { homedir, hostname, userInfo } from 'node:os';
-import { afterAll, describe, expect, it, vi } from 'vitest';
-import { cleanupTempDataRoots, lazyTempDataRoot, makePathsProxy } from '../lib/mockPathsDataRoot.js';
-
-// `readEidoverseHostDescriptor` reads world config and the local identity off
-// disk. Re-root both at a scratch tree so the descriptor under test is the
-// shipped default rather than whatever this machine happens to hold.
-vi.mock('../lib/fileUtils.js', async (importOriginal) => makePathsProxy(await importOriginal(), {
-  dataRoot: () => lazyTempDataRoot('portos-eidoverse-world-'),
-}));
-
-const {
+import { describe, expect, it } from 'vitest';
+import {
   buildProjectionPlan,
   DEFAULT_EIDOVERSE_PROJECTION_RECIPE,
   projectedJiraTickets,
   projectedStorage,
-  readEidoverseHostDescriptor,
-} = await import('./eidoverseWorld.js');
-const { eidoverseProjectionRecipeSchema } = await import('../lib/validation.js');
-const { EIDOVERSE_META_ENTITY_ID } = await import('../lib/eidoverseWorldDesign.js');
-
-afterAll(cleanupTempDataRoots);
+} from './eidoverseWorld.js';
+import { eidoverseProjectionRecipeSchema } from '../lib/validation.js';
+import { EIDOVERSE_META_ENTITY_ID, EIDOVERSE_WORLD_DESIGN_VERSION } from '../lib/eidoverseWorldDesign.js';
 
 const APP_FALLBACK = DEFAULT_EIDOVERSE_PROJECTION_RECIPE.assetRecipe.slots.app.fallback;
 
@@ -773,7 +760,7 @@ describe('Eidoverse world self-description', () => {
     expect(entity.comp.portos).toMatchObject({
       managedBy: 'portos',
       kind: 'world-meta',
-      designVersion: DEFAULT_EIDOVERSE_PROJECTION_RECIPE.version,
+      designVersion: EIDOVERSE_WORLD_DESIGN_VERSION,
       meta: { title: 'Example Garden', hostId: 'hst_0123456789ab' },
     });
     // No record contents ride along — the payload is identity, not data.
@@ -824,34 +811,5 @@ describe('Eidoverse world self-description', () => {
       verb: 'remove',
       args: { id: EIDOVERSE_META_ENTITY_ID },
     });
-  });
-});
-
-describe('Eidoverse host descriptor', () => {
-  // Anyone who can reach the door reads this payload, so a field naming the
-  // machine, its network, or its operator would leak on every join.
-  it('names the host opaquely and carries no machine, network, or account identity', async () => {
-    const descriptor = await readEidoverseHostDescriptor();
-
-    expect(Object.keys(descriptor).sort()).toEqual(['caps', 'id', 'kind', 'label', 'version']);
-    expect(descriptor.id).toMatch(/^hst_[0-9a-f]{12}$/);
-    expect(descriptor.kind).toBe('portos');
-    expect(descriptor.label).toBe(DEFAULT_EIDOVERSE_PROJECTION_RECIPE.name);
-    expect(descriptor.caps).toEqual({ eido: false });
-    expect(typeof descriptor.version).toBe('string');
-
-    const serialized = JSON.stringify(descriptor);
-    for (const identity of [hostname(), hostname().split('.')[0], homedir(), userInfo().username]) {
-      if (identity) expect(serialized).not.toContain(identity);
-    }
-    expect(serialized).not.toMatch(/\d{1,3}(?:\.\d{1,3}){3}|\.ts\.net|\/Users\/|\/home\//);
-  });
-
-  it('gives the same install the same opaque id on every read', async () => {
-    const [first, second] = await Promise.all([
-      readEidoverseHostDescriptor(),
-      readEidoverseHostDescriptor(),
-    ]);
-    expect(second.id).toBe(first.id);
   });
 });

--- a/server/services/eidoverseWorld.test.js
+++ b/server/services/eidoverseWorld.test.js
@@ -1,11 +1,25 @@
-import { describe, expect, it } from 'vitest';
-import {
+import { homedir, hostname, userInfo } from 'node:os';
+import { afterAll, describe, expect, it, vi } from 'vitest';
+import { cleanupTempDataRoots, lazyTempDataRoot, makePathsProxy } from '../lib/mockPathsDataRoot.js';
+
+// `readEidoverseHostDescriptor` reads world config and the local identity off
+// disk. Re-root both at a scratch tree so the descriptor under test is the
+// shipped default rather than whatever this machine happens to hold.
+vi.mock('../lib/fileUtils.js', async (importOriginal) => makePathsProxy(await importOriginal(), {
+  dataRoot: () => lazyTempDataRoot('portos-eidoverse-world-'),
+}));
+
+const {
   buildProjectionPlan,
   DEFAULT_EIDOVERSE_PROJECTION_RECIPE,
   projectedJiraTickets,
   projectedStorage,
-} from './eidoverseWorld.js';
-import { eidoverseProjectionRecipeSchema } from '../lib/validation.js';
+  readEidoverseHostDescriptor,
+} = await import('./eidoverseWorld.js');
+const { eidoverseProjectionRecipeSchema } = await import('../lib/validation.js');
+const { EIDOVERSE_META_ENTITY_ID } = await import('../lib/eidoverseWorldDesign.js');
+
+afterAll(cleanupTempDataRoots);
 
 const APP_FALLBACK = DEFAULT_EIDOVERSE_PROJECTION_RECIPE.assetRecipe.slots.app.fallback;
 
@@ -746,5 +760,98 @@ describe('Eidoverse PortOS projection plan', () => {
     expect(plan.operations).toContainEqual(expect.objectContaining({
       layer: 'reconciliation', verb: 'remove', args: { id: 'portos-projection-app-retired' },
     }));
+  });
+});
+
+describe('Eidoverse world self-description', () => {
+  it('hangs the world title, host id, and design version on one managed meta entity', () => {
+    const meta = { title: 'Example Garden', hostId: 'hst_0123456789ab' };
+    const plan = buildProjectionPlan({ source: emptySources(), meta });
+    const state = snapshotFromPlan(plan);
+    const entity = state.entities[EIDOVERSE_META_ENTITY_ID];
+
+    expect(entity.comp.portos).toMatchObject({
+      managedBy: 'portos',
+      kind: 'world-meta',
+      designVersion: DEFAULT_EIDOVERSE_PROJECTION_RECIPE.version,
+      meta: { title: 'Example Garden', hostId: 'hst_0123456789ab' },
+    });
+    // No record contents ride along — the payload is identity, not data.
+    expect(Object.keys(entity.comp.portos.meta).sort()).toEqual(['hostId', 'title']);
+    expect(plan.summary.infrastructureCount)
+      .toBe(buildProjectionPlan({ source: emptySources() }).summary.infrastructureCount + 1);
+  });
+
+  it('creates the meta entity once and reconciles it like every other managed entity', () => {
+    const meta = { title: 'Example Garden', hostId: 'hst_0123456789ab' };
+    const first = buildProjectionPlan({ source: emptySources(), meta });
+    const currentState = snapshotFromPlan(first, { foldModelDefaults: true });
+
+    const second = buildProjectionPlan({ source: emptySources(), meta, currentState });
+    expect(second.operations.filter(({ args }) => args?.id === EIDOVERSE_META_ENTITY_ID)).toEqual([]);
+
+    const renamed = buildProjectionPlan({
+      source: emptySources(),
+      meta: { ...meta, title: 'Renamed Garden' },
+      currentState,
+    });
+    expect(renamed.operations.filter(({ args }) => args?.id === EIDOVERSE_META_ENTITY_ID))
+      .toEqual([{
+        layer: 'infrastructure',
+        verb: 'comp',
+        args: {
+          id: EIDOVERSE_META_ENTITY_ID,
+          type: 'portos',
+          data: expect.objectContaining({ meta: { title: 'Renamed Garden', hostId: meta.hostId } }),
+        },
+      }]);
+  });
+
+  // A managed entity the plan no longer wants is swept by the reconciliation
+  // pass — which is what makes a world reset take the meta carrier with it.
+  it('sweeps the meta entity away when the world no longer declares one', () => {
+    const withMeta = buildProjectionPlan({
+      source: emptySources(),
+      meta: { title: 'Example Garden', hostId: 'hst_0123456789ab' },
+    });
+    const plan = buildProjectionPlan({
+      source: emptySources(),
+      currentState: snapshotFromPlan(withMeta, { foldModelDefaults: true }),
+    });
+
+    expect(plan.operations).toContainEqual({
+      layer: 'reconciliation',
+      verb: 'remove',
+      args: { id: EIDOVERSE_META_ENTITY_ID },
+    });
+  });
+});
+
+describe('Eidoverse host descriptor', () => {
+  // Anyone who can reach the door reads this payload, so a field naming the
+  // machine, its network, or its operator would leak on every join.
+  it('names the host opaquely and carries no machine, network, or account identity', async () => {
+    const descriptor = await readEidoverseHostDescriptor();
+
+    expect(Object.keys(descriptor).sort()).toEqual(['caps', 'id', 'kind', 'label', 'version']);
+    expect(descriptor.id).toMatch(/^hst_[0-9a-f]{12}$/);
+    expect(descriptor.kind).toBe('portos');
+    expect(descriptor.label).toBe(DEFAULT_EIDOVERSE_PROJECTION_RECIPE.name);
+    expect(descriptor.caps).toEqual({ eido: false });
+    expect(typeof descriptor.version).toBe('string');
+
+    const serialized = JSON.stringify(descriptor);
+    for (const identity of [hostname(), hostname().split('.')[0], homedir(), userInfo().username]) {
+      if (identity) expect(serialized).not.toContain(identity);
+    }
+    expect(serialized).not.toMatch(/\d{1,3}(?:\.\d{1,3}){3}|\.ts\.net|\/Users\/|\/home\//);
+  });
+
+  it('gives the same install the same opaque id on every read', async () => {
+    const [first, second] = await Promise.all([
+      readEidoverseHostDescriptor(),
+      readEidoverseHostDescriptor(),
+    ]);
+    expect(second.id).toBe(first.id);
   });
 });

--- a/server/services/eidoverseWorldProjection.js
+++ b/server/services/eidoverseWorldProjection.js
@@ -11,6 +11,7 @@ import {
   EIDOVERSE_DISTRICTS_V2,
   EIDOVERSE_MANAGED_PREFIX,
   EIDOVERSE_MAX_LIVE_ENTITIES,
+  EIDOVERSE_META_ENTITY_ID,
   EIDOVERSE_PROJECTION_PREFIX,
   EIDOVERSE_WORLD_DESIGN_V1,
   EIDOVERSE_WORLD_DESIGN_V2,
@@ -51,6 +52,9 @@ const DISTRICT_ASSET_SLOT = Object.freeze({
   federation: 'peer',
   activity: 'activity',
 });
+// Just off the nexus and clear of every nexus->district path lane, whose first
+// node sits at 27% of the district anchor.
+const META_ENTITY_POS = Object.freeze([2.4, 0.08, 2.4]);
 const DISTRICT_SCALE = Object.freeze({
   nexus: 1.15,
   apps: 1.1,
@@ -308,7 +312,7 @@ function equal(valueA, valueB) {
  * intentionally exported so recipe changes can be tested without a live
  * Eidoverse process and so future renderers can reuse the same projection.
  */
-export function buildProjectionPlan({ source = {}, recipe = DEFAULT_EIDOVERSE_PROJECTION_RECIPE, currentState = {} }) {
+export function buildProjectionPlan({ source = {}, recipe = DEFAULT_EIDOVERSE_PROJECTION_RECIPE, currentState = {}, meta = null }) {
   const effectiveRecipe = mergeRecipe(recipe);
   const stateEntities = currentState?.entities && typeof currentState.entities === 'object'
     ? currentState.entities
@@ -457,6 +461,44 @@ export function buildProjectionPlan({ source = {}, recipe = DEFAULT_EIDOVERSE_PR
       removed += delta.removed;
       pathNodeCount += 1;
     });
+  }
+
+  // The world's own title, its host, and the design it was built from. Placed
+  // in the managed set so reconciliation keeps it and a world reset sweeps it
+  // away with every other `portos-design-v2-` entity.
+  let metaEntityCount = 0;
+  if (meta) {
+    const delta = upsertModel({
+      operations,
+      stateEntities,
+      desiredIds,
+      id: EIDOVERSE_META_ENTITY_ID,
+      lib: assetPathFor(effectiveRecipe, null, 'district'),
+      pos: META_ENTITY_POS,
+      yaw: 0,
+      scale: 0.2,
+      collide: null,
+      component: {
+        schemaVersion: 1,
+        managedBy: 'portos',
+        designVersion: EIDOVERSE_WORLD_DESIGN_VERSION,
+        kind: 'world-meta',
+        label: 'World identity',
+        route: '/eidoverse',
+        status: 'active',
+        // World title and host identity only — never a record, a machine name,
+        // an address, or a filesystem path.
+        meta: {
+          title: safeText(meta.title, 'PortOS world', 120),
+          hostId: safeText(meta.hostId, '', 64) || null,
+        },
+      },
+      layer: 'infrastructure',
+    });
+    created += delta.created;
+    updated += delta.updated;
+    removed += delta.removed;
+    metaEntityCount = 1;
   }
 
   const liveEntityLimit = Math.min(
@@ -639,7 +681,7 @@ export function buildProjectionPlan({ source = {}, recipe = DEFAULT_EIDOVERSE_PR
       designVersion: EIDOVERSE_WORLD_DESIGN_VERSION,
       liveEntityCount,
       maxLiveEntities: liveEntityLimit,
-      infrastructureCount: districts.length + pathNodeCount,
+      infrastructureCount: districts.length + pathNodeCount + metaEntityCount,
       districtCounts,
       sourceAvailability,
       truncated: Object.keys(droppedBySource).length > 0,

--- a/server/services/eidoverseWorldProjection.js
+++ b/server/services/eidoverseWorldProjection.js
@@ -489,7 +489,7 @@ export function buildProjectionPlan({ source = {}, recipe = DEFAULT_EIDOVERSE_PR
         // World title and host identity only — never a record, a machine name,
         // an address, or a filesystem path.
         meta: {
-          title: safeText(meta.title, 'PortOS world', 120),
+          title: safeText(meta.title, effectiveRecipe.name, 120),
           hostId: safeText(meta.hostId, '', 64) || null,
         },
       },

--- a/server/services/eidoverseWorldSources.js
+++ b/server/services/eidoverseWorldSources.js
@@ -31,10 +31,19 @@ const safeText = (value, fallback = '', max = 160) => {
   return clean ? clean.slice(0, max) : fallback;
 };
 
-const opaqueId = (namespace, value, fallback) => {
+const opaqueDigest = (namespace, value, fallback) => {
   const source = safeText(value, fallback, 256);
-  return `${namespace}-${createHash('sha256').update(`${namespace}:${source}`).digest('hex').slice(0, 12)}`;
+  return createHash('sha256').update(`${namespace}:${source}`).digest('hex').slice(0, 12);
 };
+
+const opaqueId = (namespace, value, fallback) => `${namespace}-${opaqueDigest(namespace, value, fallback)}`;
+
+/**
+ * The install's public host identity. Anyone who can reach the Eidoverse door
+ * reads this, so it is a one-way digest of the federation instance id — never
+ * the hostname, tailnet name, address, OS user, or a filesystem path.
+ */
+export const eidoverseHostId = (instanceId) => `hst_${opaqueDigest('hst', instanceId, 'unknown-instance')}`;
 
 const coarseStatus = (value) => {
   const status = String(value || '').toLowerCase();


### PR DESCRIPTION
## Summary

A visiting client could not tell which install hosts the world it just joined, and the world log carried nothing about the world itself — no title, no founding install — so a fork of the log carried none of it either. Both answers now come from the PortOS side, with **no change to the upstream Eidoverse sequencer**.

**Host descriptor — served by the PortOS bridge.** `createEidoverseHost` already terminates every request before it reaches the sequencer, so it answers `GET /host` itself and never forwards it:

```jsonc
{ "id": "hst_<opaque>", "kind": "portos", "label": "<operator-chosen world title>", "version": "<PortOS version>", "caps": { "eido": false } }
```

The id is a one-way digest of the federation instance id — the same `opaqueId` discipline `eidoverseWorldSources.js` already applies to projected records — and the label is the operator's world title from Eidoverse world config. **The payload deliberately has no field for a hostname, tailnet/MagicDNS name, LAN or public address, OS username, or home-directory path**, because anyone who can reach the door can read it. A non-GET/HEAD request gets `405` with `Allow: GET, HEAD`; an unreadable config gets `503`. Neither falls through to the sequencer.

**World self-description — a convention entity, not a protocol amendment.** The projection plan now plants one managed `portos-design-v2-meta` entity carrying `comp {type: 'portos', data: {meta: {title, hostId}}}`. Because it is part of the plan's desired set, it is created once, reconciled like every other managed entity, and swept away with them by the reconciliation pass on a world reset. It replays and forks correctly, and degrades gracefully on a host that has never heard of PortOS. A world-scope `meta` slot on `WorldState` would be cleaner but is a protocol amendment; deliberately not pursued here.

The bridge reaches the world config through a deferred `await import()`: it is constructed from the always-loaded settings route while `/host` is a rare request, so a static edge would drag the config graph into every suite that reaches it (`server/AGENTS.md`, "Import scoping").

## Test plan

- `server/services/eidoverseHost.test.js` — `GET /host` is answered at the bridge and the upstream stub records **zero** forwarded requests; `POST /host` is `405`; an unreadable descriptor is `503`; neither reaches the sequencer.
- `server/services/eidoverseWorld.runtime.test.js` — the descriptor's key set is exactly `{id, kind, label, version, caps}`, its id matches `hst_<12 hex>` and is stable across reads, and the serialized payload contains none of this process's `hostname()`, `homedir()`, or `userInfo().username`, no dotted-quad, no `.ts.net`, and no home path. An operator-renamed world reaches `GET /host`. A live `projectEidoverseWorld()` actually plants the meta entity, and its component contains neither the raw instance id nor the instance name.
- `server/services/eidoverseWorld.test.js` — the meta entity carries only `{title, hostId}` under `meta`, is a no-op on a second plan against its own state, emits exactly one `comp` op when the title changes, and is swept by the reconciliation pass when the world no longer declares one.
- Full suites green: server 1948 files / 39,285 tests; client 840 files / 10,325 tests.

Closes #6246