### PR TITLE
Honor an explicit --review-with in slashdoArgs over task reviewer defaults

### DIFF
--- a/server/lib/slashdoInvocation.js
+++ b/server/lib/slashdoInvocation.js
@@ -76,6 +76,232 @@ export const SLASHDO_REVIEWER_INCLUDE_NAMES = Object.freeze(Object.values(SLASHD
 export const LOCAL_AGENT_REVIEWERS = new Set(['claude', 'codex', 'antigravity', 'grok', 'cursor', 'opencode', 'kimi']);
 /** Reviewer slugs that drive slashdo's local-model (Ollama-style) loop. */
 const LOCAL_MODEL_REVIEWERS = new Set(['ollama', 'lmstudio', 'mtplx']);
+/**
+ * slashdo's own `--review-with` reviewer vocabulary, mapped to the PortOS slug
+ * `unreachableReviewerIncludes` is keyed by. slashdo spells antigravity `agy`
+ * and accepts `gemini`/`antigravity` as aliases for it; `cursor-agent` is an
+ * alias for `cursor`. PortOS stores the long names.
+ *
+ * Kept local rather than imported from `reviewerConfig.js` for the same reason
+ * `LOCAL_AGENT_REVIEWERS` is: `cosValidation.js` (which re-exports that module)
+ * imports THIS one, so the arrow can only point one way.
+ *
+ * Deliberately NOT the full `REVIEWER_VALUES` roster — a `PORTOS_ONLY_REVIEWERS`
+ * slug (`lmstudio`/`mtplx`/`opencode`/`kimi`) has no slashdo counterpart and
+ * aborts the command, so seeing one in an explicit flag means the argument was
+ * hand-written against a grammar we don't own. That falls through to the
+ * unresolvable branch, which prunes nothing.
+ */
+const SLASHDO_REVIEWER_SLUGS = Object.freeze({
+  copilot: 'copilot',
+  codex: 'codex',
+  claude: 'claude',
+  grok: 'grok',
+  cursor: 'cursor',
+  'cursor-agent': 'cursor',
+  agy: 'antigravity',
+  gemini: 'antigravity',
+  antigravity: 'antigravity',
+  ollama: 'ollama',
+});
+
+/** Reviewer slugs slashdo rejects a `[<model>]` bracket on. */
+const BRACKET_FREE_SLASHDO_REVIEWERS = new Set(['copilot']);
+const REVIEW_WITH_FLAG = '--review-with';
+/** slashdo's explicit "no external reviewer this run" tombstone. */
+const REVIEW_WITH_NONE = 'none';
+/**
+ * Shell constructs whose expansion we cannot see. A value carrying one is not a
+ * reviewer list we can resolve — the agent's shell decides what it becomes.
+ */
+const UNEXPANDABLE_VALUE_RE = /[$`\\]/;
+/** GitHub login charset plus the optional `[bot]` App suffix, per slashdo. */
+const REVIEWER_LOGIN_RE = /^[A-Za-z0-9][A-Za-z0-9-]*(?:\[bot\])?$/;
+const ENTRY_MAX_RE = /^max=\d+$/;
+const ENTRY_EFFORT_RE = /^effort=(?:low|medium|high|xhigh|max)$/;
+
+/** The sentinel for "an explicit flag is there, but we can't read it safely". */
+const UNRESOLVED_REVIEW_WITH = Object.freeze({ explicit: true, unresolved: true, reviewers: Object.freeze([]), usernames: Object.freeze([]) });
+
+/**
+ * Split a free-form argument string into argv-style tokens, honoring single and
+ * double quotes so a bracketed model id with spaces (`agy[Gemini 3.5 Flash]`)
+ * survives as one token.
+ * @param {string} args
+ * @returns {string[]|null} null when a quote is left open (nothing safe to read)
+ */
+function tokenizeSlashdoArgs(args) {
+  const tokens = [];
+  let current = '';
+  let started = false;
+  let quote = null;
+  for (const ch of args) {
+    if (quote) {
+      if (ch === quote) quote = null;
+      else current += ch;
+      continue;
+    }
+    if (ch === '"' || ch === "'") { quote = ch; started = true; continue; }
+    if (/\s/.test(ch)) {
+      if (started) { tokens.push(current); current = ''; started = false; }
+      continue;
+    }
+    current += ch;
+    started = true;
+  }
+  if (quote) return null;
+  if (started) tokens.push(current);
+  return tokens;
+}
+
+/**
+ * Split a `--review-with` value on the commas BETWEEN entries — never on one
+ * inside a `[<model>]` bracket, whose value is free-form.
+ * @param {string} value
+ * @returns {string[]|null} null when a bracket is left open
+ */
+function splitReviewerEntries(value) {
+  const entries = [];
+  let current = '';
+  let depth = 0;
+  for (const ch of value) {
+    if (ch === '[') depth += 1;
+    else if (ch === ']') { depth -= 1; if (depth < 0) return null; }
+    if (ch === ',' && depth === 0) { entries.push(current); current = ''; continue; }
+    current += ch;
+  }
+  if (depth !== 0) return null;
+  entries.push(current);
+  return entries;
+}
+
+/**
+ * Strip slashdo's per-entry `~` suffixes (`~opt`, `~max=<n>`, `~effort=<level>`)
+ * off an entry and return the bare slug/login. Suffixes are matched only OUTSIDE
+ * the outermost brackets, because a model id may itself contain a `~`.
+ *
+ * The suffix VALUES are deliberately discarded: they ride the explicit argument
+ * verbatim into the invocation, so PortOS never re-emits them. This only has to
+ * decide whether the entry is one slashdo would accept.
+ *
+ * @param {string} entry
+ * @returns {string|null} the suffix-free token, or null when a suffix is one
+ *   slashdo would reject (unknown, repeated, or malformed)
+ */
+function stripEntrySuffixes(entry) {
+  const open = entry.indexOf('[');
+  const close = entry.lastIndexOf(']');
+  if (open !== -1 && close < open) return null;
+  const tilde = entry.indexOf('~', close === -1 ? 0 : close + 1);
+  if (tilde === -1) return entry;
+  const seen = new Set();
+  for (const suffix of entry.slice(tilde + 1).split('~')) {
+    const kind = suffix === 'opt' ? 'opt'
+      : ENTRY_MAX_RE.test(suffix) ? 'max'
+        : ENTRY_EFFORT_RE.test(suffix) ? 'effort' : null;
+    if (!kind || seen.has(kind)) return null;
+    seen.add(kind);
+  }
+  return entry.slice(0, tilde);
+}
+
+/**
+ * Resolve one suffix-free `--review-with` entry to the PortOS reviewer slug (or
+ * `@login`) it names.
+ * @param {string} token
+ * @returns {{reviewer: string}|{username: string}|null} null when slashdo itself
+ *   would reject the entry, or when it names something PortOS can't map
+ */
+function resolveReviewerEntry(token) {
+  if (!token) return null;
+  if (token.startsWith('@')) {
+    const login = token.slice(1);
+    // slashdo rejects `@login[…]`; `[bot]` is part of the login, not a model.
+    return REVIEWER_LOGIN_RE.test(login) ? { username: login } : null;
+  }
+  const open = token.indexOf('[');
+  if (open !== -1 && !token.endsWith(']')) return null;
+  const slug = (open === -1 ? token : token.slice(0, open)).toLowerCase();
+  const reviewer = SLASHDO_REVIEWER_SLUGS[slug];
+  if (!reviewer) return null;
+  if (open !== -1 && BRACKET_FREE_SLASHDO_REVIEWERS.has(reviewer)) return null;
+  return { reviewer };
+}
+
+/**
+ * The reviewer contract an EXPLICIT `--review-with` in a task's `slashdoArgs`
+ * declares (#6261).
+ *
+ * slashdo's own precedence puts a typed flag above every saved or inherited
+ * default (`lib/review-config-defaults.md`), and PortOS passes `slashdoArgs`
+ * through verbatim — so when that flag is present it, not `resolveReviewerConfig`,
+ * is what the run will actually use. Pruning the body or pinning a `--review-with`
+ * from task metadata instead is how a prompt ends up requesting one reviewer,
+ * omitting its loop, and instructing the agent to use another.
+ *
+ * Three outcomes, and the caller must treat them differently:
+ * - `null` — no explicit flag; the metadata/defaults contract governs as before.
+ * - `{ unresolved: true }` — a flag is there but this parser can't safely read it
+ *   (an open quote or bracket, a shell expansion, a slug or suffix outside
+ *   slashdo's grammar, conflicting repeats). Preserve the arguments and prune and
+ *   pin NOTHING: a grammar we don't fully own is exactly the case where guessing
+ *   drops the loop the run needs.
+ * - `{ none: true }` or a resolved `{ reviewers, usernames }` — the explicit
+ *   selection, already mapped to PortOS slugs.
+ *
+ * Suffix values (`~opt` / `~max=<n>` / `~effort=<level>`) and `[<model>]` brackets
+ * are validated but not returned: they travel in the verbatim argument, so
+ * re-emitting them would state the same pin twice.
+ *
+ * @param {unknown} args - the task's raw `metadata.slashdoArgs`
+ * @returns {{explicit: true, unresolved?: true, none?: true, reviewers: string[],
+ *   usernames: string[]}|null}
+ */
+export function parseExplicitReviewWith(args) {
+  if (typeof args !== 'string' || !args.includes(REVIEW_WITH_FLAG)) return null;
+  const tokens = tokenizeSlashdoArgs(args);
+  if (!tokens) return UNRESOLVED_REVIEW_WITH;
+
+  const values = [];
+  for (let i = 0; i < tokens.length; i += 1) {
+    const token = tokens[i];
+    if (token === REVIEW_WITH_FLAG) {
+      const next = tokens[i + 1];
+      // A missing value, or the next flag where the value should be.
+      if (next === undefined || next.startsWith('-')) return UNRESOLVED_REVIEW_WITH;
+      values.push(next);
+      i += 1;
+    } else if (token.startsWith(`${REVIEW_WITH_FLAG}=`)) {
+      values.push(token.slice(REVIEW_WITH_FLAG.length + 1));
+    }
+    // Anything else starting with the same prefix (`--review-with-foo`) is a
+    // different flag — not ours to read.
+  }
+  if (!values.length) return null;
+  // Repeats are outside slashdo's documented grammar unless they agree.
+  if (new Set(values).size > 1) return UNRESOLVED_REVIEW_WITH;
+
+  const value = values[0];
+  if (!value || UNEXPANDABLE_VALUE_RE.test(value)) return UNRESOLVED_REVIEW_WITH;
+  if (value.toLowerCase() === REVIEW_WITH_NONE) {
+    return { explicit: true, none: true, reviewers: [], usernames: [] };
+  }
+
+  const entries = splitReviewerEntries(value);
+  if (!entries) return UNRESOLVED_REVIEW_WITH;
+  const reviewers = [];
+  const usernames = [];
+  for (const entry of entries) {
+    const bare = stripEntrySuffixes(entry.trim());
+    const resolved = bare === null ? null : resolveReviewerEntry(bare);
+    if (!resolved) return UNRESOLVED_REVIEW_WITH;
+    if (resolved.username) {
+      if (!usernames.some(u => u.toLowerCase() === resolved.username.toLowerCase())) usernames.push(resolved.username);
+    } else if (!reviewers.includes(resolved.reviewer)) reviewers.push(resolved.reviewer);
+  }
+  return { explicit: true, none: false, reviewers, usernames };
+}
+
 
 /**
  * Which reviewer-variant includes a run can never reach, given its resolved
@@ -388,7 +614,12 @@ export function oversizedBodyPointer(bodyPath, body) {
  * @param {string|null} [opts.bodyPath=null] - absolute path to a resolved copy of
  *   `body`. Pass only when the host has file tools.
  * @param {string} [opts.reviewWith=''] - reviewer CSV to pin (`codex,copilot`).
- *   Required when `body` had reviewer variants pruned out of it.
+ *   Required when `body` had reviewer variants pruned out of it AND the invocation
+ *   does not already carry its own `--review-with` (see `explicitReviewWith`).
+ * @param {boolean} [opts.explicitReviewWith=false] - the invocation's own arguments
+ *   carry an explicit `--review-with`, and `body` was pruned to match it (#6261).
+ *   Mutually exclusive with `reviewWith`: restating the value PortOS already passes
+ *   verbatim would emit every `~opt` / `~max=` / `~effort=` suffix twice.
  * @param {string} [opts.reviewerEffortNote=''] - the per-reviewer reasoning-effort
  *   instruction (`buildReviewerEffortNote`). Non-empty only when `reviewWith` is
  *   NOT emitted: a pinned CSV carries each effort as slashdo's `~effort=<level>`
@@ -404,6 +635,7 @@ export function buildSlashdoSection(resolved, body = null, {
   reviewWith = '',
   reviewerEffortNote = '',
   includeTaskContext = false,
+  explicitReviewWith = false,
 } = {}) {
   if (!resolved) return '';
 
@@ -426,7 +658,16 @@ export function buildSlashdoSection(resolved, body = null, {
       '```'
     );
   }
-  if (reviewWith) {
+  if (explicitReviewWith) {
+    // The invocation above already carries the flag verbatim, so the pin points AT
+    // it rather than repeating it: slashdo's own precedence puts an explicit flag
+    // above every saved default, and restating the value would emit each
+    // per-reviewer suffix a second time.
+    lines.push(
+      '',
+      'The `--review-with` value in the invocation above is authoritative for this run: the procedure you were given carries ONLY the reviewer loops that value can reach (the rest were omitted as unreachable). Do not substitute a different reviewer from a saved slashdo default.'
+    );
+  } else if (reviewWith) {
     lines.push(
       '',
       `Run this workflow with \`--review-with ${reviewWith}\` — the procedure you were given carries ONLY those reviewers' loops (the others were omitted as unreachable). Do not substitute a different reviewer from a saved slashdo default.`

--- a/server/lib/slashdoInvocation.test.js
+++ b/server/lib/slashdoInvocation.test.js
@@ -9,6 +9,7 @@ import {
   canTypeSlashCommands,
   resolveOwnsPrWorkflow,
   isValidSlashdoCommand,
+  parseExplicitReviewWith,
   resolveSlashdoInvocation,
   resolveSlashdoStyle,
   slashdoSkillName,
@@ -393,5 +394,59 @@ describe('bundled command context budget', () => {
     expect(Object.keys(bundle.files).length).toBeGreaterThan(0);
     expect(bundle.body.length).toBeLessThan(eager.length / 4);
     expect(eager).not.toMatch(/^!read /m);
+  });
+});
+
+// slashdo's `--review-with` grammar is the one thing PortOS re-parses rather than
+// owns, and the whole point of the parser is that anything it can't read falls
+// through to "prune and pin nothing". A prompt-level test can't cheaply pin that
+// matrix — and a mis-read entry is invisible there, since the wrong answer is a
+// well-formed prompt naming the wrong reviewer.
+describe('parseExplicitReviewWith', () => {
+  it('reads no flag as no explicit selection', () => {
+    expect(parseExplicitReviewWith('--issues 42')).toBeNull();
+    expect(parseExplicitReviewWith('')).toBeNull();
+    expect(parseExplicitReviewWith(undefined)).toBeNull();
+    // A different flag that merely shares the prefix is not ours to read.
+    expect(parseExplicitReviewWith('--review-with-nothing x')).toBeNull();
+  });
+
+  it.each([
+    ['spaced form', '--review-with ollama', ['ollama'], []],
+    ['equals form', '--review-with=codex,claude', ['codex', 'claude'], []],
+    ['slashdo agy slug and its aliases', '--review-with agy,gemini,antigravity', ['antigravity'], []],
+    ['cursor-agent alias', '--review-with cursor-agent', ['cursor'], []],
+    ['suffixes and a model bracket', '--review-with agy[gemini-3.8-flash]~opt~max=1~effort=medium', ['antigravity'], []],
+    ['a quoted model id containing spaces', '--review-with "agy[Gemini 3.5 Flash (High)]~opt"', ['antigravity'], []],
+    ['a @login, bot suffix included', '--review-with codex,@review-bot[bot]', ['codex'], ['review-bot[bot]']],
+    ['repeats that agree', '--review-with codex --review-with codex', ['codex'], []],
+  ])('resolves %s', (_label, args, reviewers, usernames) => {
+    expect(parseExplicitReviewWith(args)).toEqual({ explicit: true, none: false, reviewers, usernames });
+  });
+
+  it.each(['--review-with none', '--review-with NONE', '--review-with=none'])('reads %s as the opt-out tombstone', (args) => {
+    expect(parseExplicitReviewWith(args)).toEqual({ explicit: true, none: true, reviewers: [], usernames: [] });
+  });
+
+  it.each([
+    ['a missing value', '--review-with'],
+    ['the next flag where the value should be', '--review-with --merge'],
+    ['a shell expansion we cannot see through', '--review-with $REVIEWER'],
+    ['an unterminated quote', '--review-with "codex'],
+    ['an unterminated model bracket', '--review-with codex[a --merge'],
+    ['a slug slashdo has no counterpart for', '--review-with lmstudio'],
+    ['a slug outside the grammar entirely', '--review-with some-future-reviewer'],
+    ['a bracket on a reviewer that takes none', '--review-with copilot[x]'],
+    ['an unknown per-entry suffix', '--review-with codex~bogus'],
+    ['a repeated per-entry suffix', '--review-with codex~max=1~max=2'],
+    ['a non-integer round cap', '--review-with codex~max=two'],
+    ['an effort outside the ladder', '--review-with codex~effort=turbo'],
+    ['the tombstone mixed with real slugs', '--review-with none,codex'],
+    ['repeats that disagree', '--review-with codex --review-with claude'],
+    ['a malformed login', '--review-with @-nope'],
+  ])('refuses to guess at %s', (_label, args) => {
+    expect(parseExplicitReviewWith(args)).toEqual({
+      explicit: true, unresolved: true, reviewers: [], usernames: [],
+    });
   });
 });

--- a/server/services/agentPromptBuilder.test.js
+++ b/server/services/agentPromptBuilder.test.js
@@ -3622,6 +3622,91 @@ describe('buildAgentPrompt — slashdo prompt-size controls', () => {
       expect(skipped).not.toContain('multi-reviewer-loop');
     });
   });
+
+  // slashdo puts an explicit `--review-with` above every saved or inherited
+  // default (lib/review-config-defaults.md), and PortOS passes `slashdoArgs`
+  // through verbatim — so the flag in the invocation is what the run WILL use.
+  // Pruning the body (or pinning a reviewer) from task metadata instead is how a
+  // prompt requests one reviewer, omits its loop, and names another. #6261.
+  describe('an explicit --review-with in slashdoArgs', () => {
+    const skipArg = () => vi.mocked(loadSlashdoFile).mock.calls.at(-1)[1].skipIncludes;
+
+    it('prunes for the explicit flag, not for the task metadata behind it', async () => {
+      const prompt = await buildAgentPrompt(
+        slashdoTask({ slashdoArgs: '--review-with ollama', reviewers: ['codex'] }),
+        {}, '/r', null, isTruthyMeta,
+        { providerType: 'cli', providerId: 'codex' });
+      const skipped = skipArg();
+      // The reviewer the run will actually invoke keeps its loop…
+      expect(skipped).not.toContain('ollama-review-loop');
+      // …and the metadata reviewer's is what drops out.
+      expect(skipped).toContain('local-agent-review-loop');
+      // Naming codex here would tell the agent to use a reviewer whose loop was
+      // just pruned away.
+      expect(prompt).not.toContain('--review-with codex');
+    });
+
+    it('preserves an explicit `none` opt-out inherited from Code Review Defaults', async () => {
+      vi.mocked(getCodeReviewDefaults).mockResolvedValue({ reviewers: ['codex'] });
+      const prompt = await buildAgentPrompt(
+        slashdoTask({ slashdoArgs: '--review-with none' }), {}, '/r', null, isTruthyMeta,
+        { providerType: 'cli', providerId: 'codex' });
+      expect(prompt).toContain('--review-with none');
+      // `none` sets REVIEW_AGENTS=[] with no fallback, so no loop is reachable.
+      expect(skipArg()).toEqual(expect.arrayContaining([
+        'copilot-review-loop', 'github-reviewer-loop', 'local-agent-review-loop',
+        'ollama-review-loop', 'multi-reviewer-loop',
+      ]));
+      expect(prompt).not.toContain('--review-with codex');
+    });
+
+    it('states each suffix exactly once — in the invocation, not again as a pin', async () => {
+      const args = '--review-with agy[gemini-3.8-flash]~opt~max=1~effort=medium';
+      const prompt = await buildAgentPrompt(
+        // The metadata names a DIFFERENT loop variant, so a metadata-derived pin
+        // would both prune away agy's loop and add a second set of suffixes.
+        slashdoTask({ slashdoArgs: args, reviewers: ['ollama'], reviewerEfforts: { ollama: 'high' } }),
+        {}, '/r', null, isTruthyMeta,
+        { providerType: 'cli', providerId: 'codex' });
+      expect(prompt).not.toContain('--review-with ollama');
+      expect(skipArg()).not.toContain('local-agent-review-loop');
+      expect(prompt.split('~effort=').length - 1).toBe(1);
+      expect(prompt.split('~max=').length - 1).toBe(1);
+      expect(prompt.split('~opt').length - 1).toBe(1);
+    });
+
+    it('reads the equals form the same as the spaced one', async () => {
+      const prompt = await buildAgentPrompt(
+        slashdoTask({ slashdoArgs: '--review-with=ollama', reviewers: ['codex'] }),
+        {}, '/r', null, isTruthyMeta,
+        { providerType: 'cli', providerId: 'codex' });
+      expect(skipArg()).not.toContain('ollama-review-loop');
+      expect(skipArg()).toContain('local-agent-review-loop');
+      expect(prompt).not.toContain('--review-with codex');
+    });
+
+    it('prunes and pins NOTHING when the explicit value cannot be safely read', async () => {
+      vi.mocked(getCodeReviewDefaults).mockResolvedValue({ reviewers: ['codex'] });
+      const prompt = await buildAgentPrompt(
+        // A slug outside the grammar PortOS mirrors: guessing which loop it needs
+        // is how the run loses the one it reaches.
+        slashdoTask({ slashdoArgs: '--review-with some-future-reviewer' }),
+        {}, '/r', null, isTruthyMeta,
+        { providerType: 'cli', providerId: 'codex' });
+      expect(skipArg()).toEqual([]);
+      expect(prompt).toContain('--review-with some-future-reviewer');
+      expect(prompt).not.toContain('--review-with codex');
+    });
+
+    it('leaves the metadata contract in charge when the args name no reviewer', async () => {
+      const prompt = await buildAgentPrompt(
+        slashdoTask({ slashdoArgs: '--issues 42', reviewers: ['codex'] }),
+        {}, '/r', null, isTruthyMeta,
+        { providerType: 'cli', providerId: 'codex' });
+      expect(prompt).toContain('--review-with codex');
+      expect(skipArg()).toContain('copilot-review-loop');
+    });
+  });
 });
 
 describe('getAppWorkspace — tilde expansion (#3180)', () => {

--- a/server/services/promptSections/slashdo.js
+++ b/server/services/promptSections/slashdo.js
@@ -3,65 +3,61 @@
  */
 
 import { loadSlashdoFile, loadSlashdoBundle, writeResolvedSlashdoBody } from '../../lib/slashdoLoader.js';
-import { resolveSlashdoInvocation, buildSlashdoSection, unreachableReviewerIncludes, SLASHDO_INLINE_BUDGET_CHARS } from '../../lib/slashdoInvocation.js';
+import { resolveSlashdoInvocation, buildSlashdoSection, unreachableReviewerIncludes, parseExplicitReviewWith, SLASHDO_REVIEWER_INCLUDE_NAMES, SLASHDO_INLINE_BUDGET_CHARS } from '../../lib/slashdoInvocation.js';
 import { DEFAULT_REVIEWER, resolveReviewerConfig, buildReviewerEffortNote, buildReviewersCsv } from '../../lib/validation.js';
 
 /**
- * Fold a slashdo-backed task's invocation + procedure into its description (#3089).
+ * The ONE reviewer contract a slashdo invocation runs under — resolved before the
+ * body is pruned, before a `--review-with` is pinned, and before any per-reviewer
+ * effort instruction is emitted (#6261).
  *
- * A task that names a bundled workflow persists only the BARE command
- * (`metadata.slashdoCommand`) because the form's provider select defaults to
- * "Auto" — the concrete shape (`/do:x`, `/do-x`, or an Agent Skill selected by
- * name) is only knowable here, once the scheduler has picked a provider.
+ * There are two sources, and slashdo's own precedence
+ * (`lib/review-config-defaults.md`) puts them in this order:
  *
- * The command body travels with the prompt for every provider, not just the
- * skill-style ones: PortOS ships slashdo as a submodule and only surfaces it as
- * slash commands via the repo-local `.claude/commands/do/` symlinks, which don't
- * exist in the managed-app workspaces most CoS tasks run in.
+ * 1. **An explicit `--review-with` in the task's `slashdoArgs`.** PortOS passes
+ *    those arguments through verbatim, so a typed flag is what the run WILL use —
+ *    above task metadata, above the install's Code Review Defaults, above
+ *    slashdo's own saved defaults. Prune for exactly it, and pin nothing: the
+ *    invocation already carries the value, suffixes and all.
+ * 2. **Task metadata + Code Review Defaults**, via `resolveReviewerConfig`. This is
+ *    the historical path, and it still owns every invocation that names no flag.
  *
- * File-tool hosts receive slashdo's deferred bundle: an entrypoint and supporting
- * files read only at the relevant phase. API providers receive an eager body.
- * Oversized bodies without references still use the existing file pointer.
+ * Deriving `skipIncludes` from (2) while (1) rides the invocation is the bug this
+ * function exists to make impossible: the prompt requested one reviewer, omitted
+ * its loop, and instructed the agent to use another. `--review-with none` was the
+ * worst case — an explicit opt-out silently overridden by an inherited default.
  *
- * Pruning is only sound if the run then uses the reviewers we pruned FOR, so the
- * section emits an explicit `--review-with` pin alongside a pruned body —
- * otherwise the agent could resolve a different reviewer from slashdo's own saved
- * defaults and find that loop missing. No explicit pin ⇒ no prune.
+ * An explicit flag PortOS cannot safely read (`{ unresolved: true }` — an open
+ * quote or bracket, a shell expansion, a slug or suffix outside the grammar we
+ * mirror) preserves the arguments and prunes and pins NOTHING. A fat prompt costs
+ * tokens; a prompt missing the loop the run actually reaches costs the run.
  *
- * The reviewers, usernames, and optional-reviewers are resolved through the SAME
- * three helpers as the inline `/do:pr` completion path further down
- * (`normalizeReviewers` / `resolveReviewUsernames` / `resolveOptionalReviewers`),
- * so what we prune for is exactly what the rest of the prompt resolves — legacy
- * single-`reviewer` tasks and defaults-inherited `optionalReviewers` included.
+ * This deliberately does NOT touch the completion workflow's own reviewer
+ * resolution further down the prompt — that is a separate `/do:pr` invocation with
+ * its own arguments, and an explicit flag on THIS one says nothing about it.
  *
- * The one case that does NOT authorize pruning is a resolved lone `copilot` that
- * nothing named explicitly (no task pin, no username reviewers, not marked
- * optional): `pickCodeReviewDefaults` and `normalizeReviewers` both fall back to
- * `['copilot']`, so that value can't be told apart from an unconfigured install —
- * and pinning `--review-with copilot` where Copilot review isn't enabled is the
- * #2507 stall. This mirrors `buildReviewWithArgs`'s lone-default suppression,
- * including its exemption for an explicitly-optional copilot.
- *
- * Applied to the description (on a COPY — the stored task is untouched) rather
- * than emitted as its own template slot, because the briefing template renders
- * `{{task.description}}`: a new `{{slashdoSection}}` placeholder would be
- * silently dropped by every install whose customized template predates it.
- *
- * @returns {Promise<Object>} the task, or a copy carrying the invocation
+ * @param {Object} task - the CoS task (reads `metadata.slashdoArgs` + reviewer pins)
+ * @param {Object} [opts]
+ * @param {Object|null} [opts.codeReviewDefaults]
+ * @param {string[]|null} [opts.defaultReviewers]
+ * @returns {{skipIncludes: string[], reviewWith: string, reviewerEffortNote: string,
+ *   explicitReviewWith: boolean}}
  */
-export async function applySlashdoInvocation(task, {
-  providerId = null, providerCommand = null, leanMode = false, hasFileTools = false,
-  defaultReviewers = null, codeReviewDefaults = null,
-} = {}) {
-  const command = task.metadata?.slashdoCommand;
-  const resolved = resolveSlashdoInvocation({
-    command,
-    args: task.metadata?.slashdoArgs || '',
-    providerId,
-    providerCommand,
-    leanMode,
-  });
-  if (!resolved) return task;
+function resolveSlashdoReviewContract(task, { codeReviewDefaults = null, defaultReviewers = null } = {}) {
+  const explicit = parseExplicitReviewWith(task.metadata?.slashdoArgs);
+  if (explicit) {
+    // The explicit flag owns reviewers, models, efforts and suffixes alike, so
+    // there is no pin and no effort prose to emit — both would restate (or
+    // contradict) what the invocation already says.
+    const skipIncludes = explicit.unresolved
+      ? []
+      : explicit.none
+        // `none` sets REVIEW_AGENTS=[] with no fallback, so every reviewer loop is
+        // provably unreachable — the strongest form of "causes no reviewer call".
+        ? [...SLASHDO_REVIEWER_INCLUDE_NAMES]
+        : unreachableReviewerIncludes({ reviewers: explicit.reviewers, usernames: explicit.usernames });
+    return { skipIncludes, reviewWith: '', reviewerEffortNote: '', explicitReviewWith: skipIncludes.length > 0 };
+  }
 
   // Resolved through the SAME three helpers the inline `/do:pr` completion path
   // uses below (`taskReviewers` / `taskReviewerUsernames` / `taskOptionalReviewers`),
@@ -110,6 +106,67 @@ export async function applySlashdoInvocation(task, {
     ? []
     : unreachableReviewerIncludes({ reviewers: resolvedReviewers, usernames: resolvedUsernames });
 
+  const reviewWith = skipIncludes.length
+    ? buildReviewersCsv(resolvedReviewers, resolvedUsernames, resolvedOptional, resolvedMaxRounds, resolvedModels, resolvedEfforts)
+    : '';
+  // Gated on the PIN, not on pruning. When `reviewWith` is emitted, each token
+  // carries `~effort=<level>` and slashdo's loop applies it — the note would only
+  // have the agent pass the flag twice. When nothing is pinned, the workflow
+  // resolves reviewers itself and the note is the pin's only route to the CLI it
+  // spawns (the `/do:pr` completion step further down is a different invocation
+  // entirely, and for a slashdo-backed task usually isn't reached).
+  const reviewerEffortNote = buildReviewerEffortNote(resolvedReviewers, resolvedEfforts, { reviewWith, reviewerModels: resolvedModels });
+  return { skipIncludes, reviewWith, reviewerEffortNote, explicitReviewWith: false };
+}
+
+/**
+ * Fold a slashdo-backed task's invocation + procedure into its description (#3089).
+ *
+ * A task that names a bundled workflow persists only the BARE command
+ * (`metadata.slashdoCommand`) because the form's provider select defaults to
+ * "Auto" — the concrete shape (`/do:x`, `/do-x`, or an Agent Skill selected by
+ * name) is only knowable here, once the scheduler has picked a provider.
+ *
+ * The command body travels with the prompt for every provider, not just the
+ * skill-style ones: PortOS ships slashdo as a submodule and only surfaces it as
+ * slash commands via the repo-local `.claude/commands/do/` symlinks, which don't
+ * exist in the managed-app workspaces most CoS tasks run in.
+ *
+ * File-tool hosts receive slashdo's deferred bundle: an entrypoint and supporting
+ * files read only at the relevant phase. API providers receive an eager body.
+ * Oversized bodies without references still use the existing file pointer.
+ *
+ * Pruning is only sound if the run then uses the reviewers we pruned FOR, so the
+ * body, the emitted pin, and the effort instruction all come from ONE resolved
+ * reviewer contract — `resolveSlashdoReviewContract` above, which puts an explicit
+ * `--review-with` in the invocation's own arguments ahead of task metadata and the
+ * install defaults, exactly as slashdo does.
+ *
+ * Applied to the description (on a COPY — the stored task is untouched) rather
+ * than emitted as its own template slot, because the briefing template renders
+ * `{{task.description}}`: a new `{{slashdoSection}}` placeholder would be
+ * silently dropped by every install whose customized template predates it.
+ *
+ * @returns {Promise<Object>} the task, or a copy carrying the invocation
+ */
+export async function applySlashdoInvocation(task, {
+  providerId = null, providerCommand = null, leanMode = false, hasFileTools = false,
+  defaultReviewers = null, codeReviewDefaults = null,
+} = {}) {
+  const command = task.metadata?.slashdoCommand;
+  const resolved = resolveSlashdoInvocation({
+    command,
+    args: task.metadata?.slashdoArgs || '',
+    providerId,
+    providerCommand,
+    leanMode,
+  });
+  if (!resolved) return task;
+
+  const {
+    skipIncludes, reviewWith, reviewerEffortNote, explicitReviewWith,
+  } = resolveSlashdoReviewContract(task, { codeReviewDefaults, defaultReviewers });
+
   const options = { stripFrontmatter: true, skipIncludes };
   const bundle = hasFileTools ? await loadSlashdoBundle(command, options) : null;
   let body = hasFileTools ? bundle?.body : await loadSlashdoFile(command, options);
@@ -131,16 +188,6 @@ export async function applySlashdoInvocation(task, {
       })
     : null;
 
-  const reviewWith = skipIncludes.length
-    ? buildReviewersCsv(resolvedReviewers, resolvedUsernames, resolvedOptional, resolvedMaxRounds, resolvedModels, resolvedEfforts)
-    : '';
-  // Gated on the PIN, not on pruning. When `reviewWith` is emitted, each token
-  // carries `~effort=<level>` and slashdo's loop applies it — the note would only
-  // have the agent pass the flag twice. When nothing is pinned, the workflow
-  // resolves reviewers itself and the note is the pin's only route to the CLI it
-  // spawns (the `/do:pr` completion step further down is a different invocation
-  // entirely, and for a slashdo-backed task usually isn't reached).
-  const reviewerEffortNote = buildReviewerEffortNote(resolvedReviewers, resolvedEfforts, { reviewWith, reviewerModels: resolvedModels });
   // Plan-only supplies destination/approval flags as slashdo args, so preserve
   // the task description bridge that those flags would otherwise suppress.
   const includeTaskContext = task.metadata?.planOnly === true || task.metadata?.planOnly === 'true';
@@ -149,6 +196,7 @@ export async function applySlashdoInvocation(task, {
     reviewWith,
     reviewerEffortNote,
     includeTaskContext,
+    explicitReviewWith,
   });
   return { ...task, description: `${task.description}\n\n${section}` };
 }


### PR DESCRIPTION
## Summary

A CoS task can carry `metadata.slashdoArgs: '--review-with ollama'` alongside a different reviewer selection in task metadata or Code Review Defaults. `applySlashdoInvocation` passed the arguments through verbatim but derived `skipIncludes` and its own `--review-with` pin from `resolveReviewerConfig` — so the built prompt could **request one reviewer, omit that reviewer's loop from the pruned procedure, and then instruct the agent to use another**. An explicit `--review-with none` opt-out was overridden the same way.

- **One reviewer contract, resolved first.** `resolveSlashdoReviewContract` (in `server/services/promptSections/slashdo.js`) decides the contract before the body is pruned, before a pin is emitted, and before any effort instruction — matching slashdo's own precedence, which puts a typed flag above every saved or inherited default.
- **New parser** `parseExplicitReviewWith` (`server/lib/slashdoInvocation.js`) mirrors slashdo's grammar: spaced and `=` forms, the `none` tombstone, free-form `[<model>]` brackets, and the `~opt` / `~max=<n>` / `~effort=<level>` suffixes chainable in any order and matched only outside brackets, plus `@login` with the optional `[bot]` suffix.
- **Unreadable expressions prune and pin nothing.** A shell expansion, an open quote or bracket, an unknown slug, or a malformed/repeated suffix returns an explicit unresolved sentinel: the arguments are preserved and nothing is pruned. A fat prompt costs tokens; a prompt missing the loop the run reaches costs the run.
- **Suffixes appear exactly once.** With an explicit flag the section points at the invocation's own value instead of restating it, so no `~opt` / `~max=` / `~effort=` is emitted twice.
- **Explicit `none` prunes every reviewer loop** and emits no pin and no effort prose — it sets `REVIEW_AGENTS=[]` with no fallback, so none is reachable.

The completion workflow's own `/do:pr` reviewer resolution is deliberately untouched — that is a separate invocation with its own arguments.

## Test plan

- `server/lib/slashdoInvocation.test.js` — focused input matrix for the parser: resolvable forms (spaced, equals, `agy`/`gemini`/`cursor-agent` aliases, bracketed model with spaces, `@login[bot]`, agreeing repeats), the `none` tombstone, and 15 unreadable expressions that must fall through to the safe sentinel.
- `server/services/agentPromptBuilder.test.js` — six prompt-level boundary cases: explicit flag beats task metadata, `none` survives an inherited default, suffixes stated once, the equals form, an unreadable value prunes nothing, and the metadata path still governs when the args name no reviewer. Five of the six fail on `main`; the sixth is the non-regression guard for the unchanged path.
- Full `cd server && npm test`: 39,354 passed. One unrelated timeout in `routes/settings.secretsStrip.test.js` under parallel load — passes in isolation and this branch touches no settings route.

Closes #6261