### PR TITLE
fix: click the download confirm button only once it is enabled

### DIFF
--- a/client/src/components/settings/LocalLlmLibraryView.test.jsx
+++ b/client/src/components/settings/LocalLlmLibraryView.test.jsx
@@ -66,6 +66,7 @@ import {
   upgradeLocalLlmBackend,
 } from '../../services/api';
 import socket from '../../services/socket';
+import { clickStartDownload } from '../../test/downloadPreflightConfirm.js';
 import LocalLlmLibraryView from './LocalLlmLibraryView.jsx';
 
 // A realistically long HF model id — the shape that got ellipsised to
@@ -166,7 +167,7 @@ describe('LocalLlmLibraryView Ollama auto-upgrade', () => {
     await renderLibrary();
     fireEvent.change(screen.getByLabelText('Install a Ollama model by id'), { target: { value: 'llama3.2' } });
     fireEvent.click(screen.getByRole('button', { name: 'Install' }));
-    fireEvent.click(await screen.findByRole('button', { name: 'Start download' }));
+    await clickStartDownload();
 
     expect(await screen.findByText('Upgrading Ollama')).toBeInTheDocument();
     expect(screen.getByText(/llama3.2 needs a newer Ollama/)).toBeInTheDocument();
@@ -248,7 +249,7 @@ describe('LocalLlmLibraryView installed models', () => {
     installLocalLlmModel.mockResolvedValue({ success: true });
     await renderLibrary();
     fireEvent.click(screen.getByRole('button', { name: `Redownload ${LONG_ID}` }));
-    fireEvent.click(await screen.findByRole('button', { name: 'Start download' }));
+    await clickStartDownload();
     await waitFor(() => expect(installLocalLlmModel).toHaveBeenCalledWith(
       'ollama',
       LONG_ID,
@@ -315,7 +316,7 @@ describe('LocalLlmLibraryView installed models', () => {
     );
     await waitFor(() => expect(screen.getByText(/Installed on LM Studio/)).toBeTruthy());
     fireEvent.click(screen.getByRole('button', { name: 'Redownload Qwen3.8 27B' }));
-    fireEvent.click(await screen.findByRole('button', { name: 'Start download' }));
+    await clickStartDownload();
     await waitFor(() => expect(installLocalLlmModel).toHaveBeenCalledWith(
       'lmstudio',
       'unsloth/Qwen3.8-27B-GGUF@UD-Q4_K_M',
@@ -418,7 +419,7 @@ describe('LocalLlmLibraryView recommendations', () => {
     await renderLibrary();
     expect(await screen.findByText('Qwen3.8 27B')).toBeTruthy();
     fireEvent.click(screen.getByRole('button', { name: /^Redownload$/ }));
-    fireEvent.click(await screen.findByRole('button', { name: 'Start download' }));
+    await clickStartDownload();
     await waitFor(() => expect(installLocalLlmModel).toHaveBeenCalledWith(
       'ollama',
       'hf.co/unsloth/Qwen3.8-27B-GGUF:UD-Q4_K_M',

--- a/client/src/components/settings/LocalLlmRuntimesView.test.jsx
+++ b/client/src/components/settings/LocalLlmRuntimesView.test.jsx
@@ -64,6 +64,7 @@ import {
   patchSettingsSlice,
 } from '../../services/api';
 import socket from '../../services/socket';
+import { clickStartDownload } from '../../test/downloadPreflightConfirm.js';
 import LocalLlmRuntimesView from './LocalLlmRuntimesView.jsx';
 import {
   appleGpuBudgetGib,
@@ -265,7 +266,7 @@ describe('LocalLlmRuntimesView runtime servers', () => {
 
     await renderRuntimes();
     fireEvent.click(screen.getByRole('button', { name: /Download default checkpoint/ }));
-    fireEvent.click(await screen.findByRole('button', { name: 'Start download' }));
+    await clickStartDownload();
 
     await waitFor(() => expect(toast.error).toHaveBeenCalledWith(expect.stringMatching(/no space left on device/)));
     expect(toast.success).not.toHaveBeenCalled();
@@ -280,7 +281,7 @@ describe('LocalLlmRuntimesView runtime servers', () => {
 
     await renderRuntimes();
     fireEvent.click(screen.getByRole('button', { name: /Download default checkpoint/ }));
-    fireEvent.click(await screen.findByRole('button', { name: 'Start download' }));
+    await clickStartDownload();
 
     // `null` (not a repo id the card invented) = MTPLX's own verified default.
     await waitFor(() => expect(pullMtplxModel).toHaveBeenCalledWith(null));
@@ -626,7 +627,7 @@ describe('LocalLlmRuntimesView llama-server management', () => {
     expect(screen.getByText(/Downloaded \(1\.1 GB\)/)).toBeInTheDocument();
     const downloadBtn = screen.getByRole('button', { name: /^Download$/ });
     fireEvent.click(downloadBtn);
-    fireEvent.click(await screen.findByRole('button', { name: 'Start download' }));
+    await clickStartDownload();
 
     await waitFor(() => {
       expect(downloadSpecDecodeModel).toHaveBeenCalledWith('qwen3.8-27b-dspark', 'model', { silent: true });
@@ -653,7 +654,7 @@ describe('LocalLlmRuntimesView llama-server management', () => {
     await renderRuntimes();
 
     fireEvent.click(await screen.findByRole('button', { name: /^Download$/ }));
-    fireEvent.click(await screen.findByRole('button', { name: 'Start download' }));
+    await clickStartDownload();
 
     await waitFor(() => {
       expect(toast.warning).toHaveBeenCalledWith(expect.stringMatching(/still running in the background/));

--- a/client/src/pages/Loras.test.jsx
+++ b/client/src/pages/Loras.test.jsx
@@ -6,6 +6,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
+import { clickStartDownload } from '../test/downloadPreflightConfirm.js';
 import Loras from './Loras';
 import {
   listLorasFull, deleteLoraFull, installLoraFromHuggingfaceStream, probeLoraEffect,
@@ -134,7 +135,7 @@ describe('Loras HuggingFace family picker', () => {
     const input = await screen.findByLabelText('HuggingFace LoRA URL');
     fireEvent.change(input, { target: { value: 'https://huggingface.co/Alissonerdx/CharacterSheet' } });
     fireEvent.submit(input.closest('form'));
-    fireEvent.click(await screen.findByRole('button', { name: 'Start download' }));
+    await clickStartDownload();
     expect(await screen.findByRole('button', { name: 'Install as Flux 2' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Install as Flux 1' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Install as LTX-Video' })).toBeInTheDocument();
@@ -191,7 +192,7 @@ describe('Loras suggestion card busy state', () => {
     // "Installing…", not have reverted to "Quick install" already.
     expect(await screen.findByRole('button', { name: 'Installing…' })).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Start download' }));
+    await clickStartDownload();
     expect(await screen.findByRole('button', { name: 'Installing…' })).toBeInTheDocument();
 
     resolveInstall({ name: 'lora-example.safetensors' });
@@ -247,7 +248,7 @@ describe('Loras video suggestion quick-install preflight', () => {
     }));
     expect(installLoraFromHuggingfaceStream).not.toHaveBeenCalled();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Start download' }));
+    await clickStartDownload();
     await waitFor(() => expect(installLoraFromHuggingfaceStream).toHaveBeenCalledWith(
       expect.objectContaining({ url: VIDEO_CARD.installUrl, family: VIDEO_CARD.runnerFamily, file: VIDEO_CARD.file }),
     ));

--- a/client/src/test/downloadPreflightConfirm.js
+++ b/client/src/test/downloadPreflightConfirm.js
@@ -1,0 +1,24 @@
+import { act, fireEvent, screen, waitFor } from '@testing-library/react';
+import { expect } from 'vitest';
+
+// DownloadPreflightConfirm renders its confirm button the instant the modal
+// opens — disabled, mid-`loading` — and only enables it once the preview()
+// promise settles the size/destination assessment (#6266). `findByRole`
+// matches a disabled button too, so `fireEvent.click(await
+// screen.findByRole('button', { name: 'Start download' }))` can land on the
+// still-disabled button under CPU contention and silently no-op. Wait for
+// enabled, not just present, before clicking — then settle with
+// `act(async () => {})`, because waiting the extra tick for "enabled" is
+// itself enough to leave the confirm handler's own promise chain (e.g. the
+// status reload a successful install kicks off) unflushed past whatever the
+// caller asserts next.
+export async function clickStartDownload(name = 'Start download') {
+  const button = await waitFor(() => {
+    const el = screen.getByRole('button', { name });
+    expect(el).toBeEnabled();
+    return el;
+  });
+  fireEvent.click(button);
+  await act(async () => {});
+  return button;
+}


### PR DESCRIPTION
## Summary
- `DownloadPreflightConfirm`'s "Start download" button renders the instant the modal opens — disabled, mid-loading — and only enables once the disk-preflight preview resolves.
- `findByRole` matches a disabled button too, so `fireEvent.click(await screen.findByRole('button', { name: 'Start download' }))` could land on the still-disabled button and silently no-op — no download starts, nothing downstream happens. That's what made `LocalLlmLibraryView.test.jsx`'s Ollama auto-upgrade banner test flake under the full client shard's CPU contention.
- Added `client/src/test/downloadPreflightConfirm.js` exporting `clickStartDownload()`, which waits for the button to be enabled (not just present) before clicking, then settles with `act(async () => {})` so a caller's next assertion doesn't race the confirm handler's own promise chain (e.g. the status reload a successful install kicks off).
- Applied the helper everywhere the client suite clicks that confirm button: `LocalLlmLibraryView.test.jsx`, `LocalLlmRuntimesView.test.jsx`, and `Loras.test.jsx` — all three shared the same latent race, confirmed by reproducing it with an injected preview delay before the fix and reverifying the fix holds with that same delay.

## Test plan
- Reproduced the race deterministically by adding an artificial delay to the mocked `previewLocalLlmDownload` — 4 tests failed the way CI described, confirming the disabled-button click theory.
- Reverted the delay, applied the fix, reran the same delayed-mock stress test — all pass.
- `npx vitest run` on the 3 affected files: 76/76 pass, 5 consecutive runs, no flake.
- Full client suite (`npx vitest run`): 10371 passed, 1 unrelated pre-existing flake in `MediaCollections.test.jsx` (passes in isolation, untouched by this change).

Closes #6266