### PR TITLE
ci: initialize lib/slashdo submodule for its bundled adapter contracts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,7 @@ jobs:
       lint_files: ${{ steps.plan.outputs.lint_files }}
       build: ${{ steps.plan.outputs.build }}
       smoke: ${{ steps.plan.outputs.smoke }}
+      slashdo: ${{ steps.plan.outputs.slashdo }}
       windows: ${{ steps.plan.outputs.windows }}
       windows_mode: ${{ steps.plan.outputs.windows_mode }}
       windows_files: ${{ steps.plan.outputs.windows_files }}
@@ -96,6 +97,7 @@ jobs:
           LINT_MODE: ${{ steps.plan.outputs.lint_mode }}
           BUILD_MODE: ${{ steps.plan.outputs.build }}
           SMOKE_MODE: ${{ steps.plan.outputs.smoke }}
+          SLASHDO_MODE: ${{ steps.plan.outputs.slashdo }}
           WINDOWS_MODE: ${{ steps.plan.outputs.windows }}
           WINDOWS_TEST_MODE: ${{ steps.plan.outputs.windows_mode }}
           SERVER_SHARDS: ${{ steps.plan.outputs.server_shards }}
@@ -113,6 +115,7 @@ jobs:
             echo "- Client lint: \`${LINT_MODE}\`"
             echo "- Client build: \`${BUILD_MODE}\`"
             echo "- Server smoke: \`${SMOKE_MODE}\`"
+            echo "- Slashdo submodule: \`${SLASHDO_MODE}\`"
             echo "- Windows server tests: \`${WINDOWS_MODE}\` (\`${WINDOWS_TEST_MODE}\`, shards \`${WINDOWS_SHARDS}\`)"
             echo "- Suite selection reasons: \`${SUITE_REASONS}\`"
           } >> "$GITHUB_STEP_SUMMARY"
@@ -274,6 +277,16 @@ jobs:
       - name: Check server entry-point syntax
         run: node --check server/index.js
 
+      # The submodule ships no source into this checkout by default (see
+      # AGENTS.md "Slashdo Commands"), so the planner's `slashdo` output is
+      # the only signal that the selected tests need it — an unrelated scoped
+      # PR must not pay for the fetch. `CI_EXPECT_SLASHDO_SUBMODULE` below
+      # tells the two contract suites to fail instead of skip if this step
+      # somehow leaves the checkout without it.
+      - name: Initialize slashdo submodule
+        if: needs.impact.outputs.slashdo == 'true'
+        run: git submodule update --init lib/slashdo
+
       - name: Run server tests
         if: needs.impact.outputs.server_mode != 'skip'
         env:
@@ -281,6 +294,7 @@ jobs:
           CI_TEST_FILES: ${{ needs.impact.outputs.server_files }}
           CI_TEST_SOURCES: ${{ needs.impact.outputs.server_sources }}
           CI_SHARD: ${{ matrix.shard }}/${{ strategy.job-total }}
+          CI_EXPECT_SLASHDO_SUBMODULE: ${{ needs.impact.outputs.slashdo }}
           # Keep successful-test output signal-dense. Developers can reproduce
           # locally without this flag when assertion context needs app logs.
           PORTOS_TEST_QUIET: 1

--- a/docs/GITHUB_ACTIONS.md
+++ b/docs/GITHUB_ACTIONS.md
@@ -59,6 +59,23 @@ the scanner set from the tree and fails when a new scanner is added without
 being registered, either in `ALWAYS_RUN_TESTS` or in its own
 `STRUCTURALLY_SELECTED` map naming the selector that already reaches it.
 
+### The bundled `lib/slashdo` submodule
+
+`server/lib/slashdoLoader.test.js` and `server/lib/slashdoInvocation.test.js`
+carry contract suites that exercise the real bundled renderer in
+`lib/slashdo` (see AGENTS.md "Slashdo Commands"). A git diff reports only the
+gitlink pointer at that path, never the files inside it, so the planner can't
+detect a relevant change the way it does an ordinary source edit.
+`needsSlashdoSubmodule()` in `ci-test-plan.js` sets the `slashdo` output
+whenever the plan is full, the gitlink itself changed, or either contract
+suite (or the loader/adapter source it exercises) is selected. The `server`
+job's "Initialize slashdo submodule" step runs `git submodule update --init
+lib/slashdo` only when that output is true, so an unrelated scoped PR pays
+nothing for the fetch. When the output is true, the two contract suites fail
+the job instead of silently skipping if the submodule still isn't there
+(`CI_EXPECT_SLASHDO_SUBMODULE`); outside that signal — a local checkout, or a
+CI run that never needed it — they keep the documented skip.
+
 ### Vitest runner tuning
 
 On GitHub Actions, `CI=true` caps the server Vitest runner at `maxWorkers: 4`

--- a/scripts/ci-test-plan.js
+++ b/scripts/ci-test-plan.js
@@ -207,6 +207,30 @@ const DOCUMENTATION_RULES = [
   /\.(?:md|mdx|png|jpe?g|gif|webp|svg|ico)$/i,
 ];
 
+// The bundled slashdo submodule (see AGENTS.md "Slashdo Commands") ships no
+// source into the tree the planner scans — `git diff` reports only the gitlink
+// pointer at this path, never the files inside it — so it can't be detected the
+// way an ordinary source change is. The two contract suites below exercise the
+// real bundled renderer and only mean anything with the submodule checked out,
+// so CI initializes it (see ci.yml) exactly when one of them is set to run.
+export const SLASHDO_GITLINK_PATH = 'lib/slashdo';
+export const SLASHDO_CONTRACT_TEST_FILES = [
+  'server/lib/slashdoLoader.test.js',
+  'server/lib/slashdoInvocation.test.js',
+];
+const SLASHDO_CONTRACT_SOURCE_FILES = [
+  'server/lib/slashdoLoader.js',
+  'server/lib/slashdoInvocation.js',
+];
+
+/** Whether this plan's server job needs `lib/slashdo` initialized. */
+export const needsSlashdoSubmodule = (plan) => Boolean(
+  plan.full
+  || plan.changedFiles.includes(SLASHDO_GITLINK_PATH)
+  || plan.server.files.some((path) => SLASHDO_CONTRACT_TEST_FILES.includes(path))
+  || plan.server.sources.some((path) => SLASHDO_CONTRACT_SOURCE_FILES.includes(path))
+);
+
 const RUNNER_ROOTS = {
   server: [
     'server/',
@@ -603,6 +627,7 @@ export function buildCiTestPlan(changedFiles, {
 /** The derived fields every plan carries: per-suite reasons and shard matrices. */
 const finishPlan = (plan, options) => ({
   ...plan,
+  slashdo: needsSlashdoSubmodule(plan),
   suiteReasons: suiteReasonsFor(plan, options),
   shards: {
     server: shardIndexes(plan.server.mode, FULL_SUITE_SHARDS.server),
@@ -659,6 +684,7 @@ export function emitGitHubPlan(plan) {
     lint_files: JSON.stringify(plan.lint.files),
     build: plan.build,
     smoke: plan.smoke,
+    slashdo: plan.slashdo,
     windows: plan.windows,
     windows_mode: plan.windowsMode,
     windows_files: JSON.stringify(plan.windowsFiles),

--- a/scripts/ci-test-plan.js
+++ b/scripts/ci-test-plan.js
@@ -223,7 +223,26 @@ const SLASHDO_CONTRACT_SOURCE_FILES = [
   'server/lib/slashdoInvocation.js',
 ];
 
-/** Whether this plan's server job needs `lib/slashdo` initialized. */
+/**
+ * Whether this plan's server job needs `lib/slashdo` initialized.
+ *
+ * The `changedFiles` check is currently unreachable from `buildCiTestPlan`
+ * itself: `SLASHDO_GITLINK_PATH` has no recognized extension, so a real
+ * gitlink change already hits the "unclassified changed file" rule and forces
+ * `plan.full = true` first, which the `plan.full` clause above already
+ * covers. It stays as a direct, defense-in-depth check — independent of that
+ * incidental classification — and is what the unit tests below exercise
+ * against a hand-built plan.
+ *
+ * This only catches a literal edit to the two source files, not an indirect
+ * one: a shared dependency of `slashdoLoader.js`/`slashdoInvocation.js`
+ * changing would not set this, even though Vitest's real `related` selection
+ * can still transitively pull the contract tests in — in which case they run
+ * without the submodule and take the documented skip. In practice a
+ * sufficiently shared dependency changing also tends to select enough tests
+ * to exceed MAX_TARGETED_TEST_FILES and force a full plan, which does trigger
+ * this; a narrowly-shared one is the remaining gap.
+ */
 export const needsSlashdoSubmodule = (plan) => Boolean(
   plan.full
   || plan.changedFiles.includes(SLASHDO_GITLINK_PATH)

--- a/scripts/ci-test-plan.test.js
+++ b/scripts/ci-test-plan.test.js
@@ -6,8 +6,10 @@ import {
   forceFullReasonFor,
   FULL_SUITE_SHARDS,
   isRouteOnlyAppDiff,
+  needsSlashdoSubmodule,
   pythonReferencePattern,
   shardIndexes,
+  SLASHDO_GITLINK_PATH,
   splitByRunner,
   WINDOWS_CONTRACT_TESTS,
 } from './ci-test-plan.js';
@@ -31,6 +33,10 @@ const TRACKED = [
   'server/services/sprites/atlasLayout.js',
   'server/services/sprites/atlasLayout.test.js',
   'server/services/taskPromptDefaults.test.js',
+  'server/lib/slashdoLoader.js',
+  'server/lib/slashdoLoader.test.js',
+  'server/lib/slashdoInvocation.js',
+  'server/lib/slashdoInvocation.test.js',
   'server/lib/bufferedSpawn.test.js',
   'server/lib/platform.test.js',
   'server/lib/shellCd.test.js',
@@ -637,5 +643,80 @@ describe('CI test impact planner', () => {
     expect(plan.windows).toBe(true);
     expect(plan.windowsMode).toBe('files');
     expect(plan.windowsSources).toEqual([]);
+  });
+
+  describe('slashdo submodule initialization (#6263)', () => {
+    it('requests the submodule for a gitlink-only change, forced full by the unclassified path', () => {
+      const plan = buildCiTestPlan([SLASHDO_GITLINK_PATH], { trackedFiles: TRACKED });
+
+      expect(plan.full).toBe(true);
+      expect(plan.slashdo).toBe(true);
+    });
+
+    it('requests the submodule when the loader source changes, without forcing full CI', () => {
+      const plan = buildCiTestPlan(['server/lib/slashdoLoader.js'], { trackedFiles: TRACKED });
+
+      expect(plan.full).toBe(false);
+      expect(plan.server.mode).toBe('related');
+      expect(plan.server.sources).toContain('server/lib/slashdoLoader.js');
+      expect(plan.slashdo).toBe(true);
+    });
+
+    it('requests the submodule when only the adapter test file changes', () => {
+      const plan = buildCiTestPlan(['server/lib/slashdoInvocation.test.js'], { trackedFiles: TRACKED });
+
+      expect(plan.full).toBe(false);
+      expect(plan.server.files).toContain('server/lib/slashdoInvocation.test.js');
+      expect(plan.slashdo).toBe(true);
+    });
+
+    it('requests the submodule on an explicit full-CI request (nightly / release gate)', () => {
+      const plan = buildCiTestPlan(['docs/README.md'], { trackedFiles: TRACKED, forceFull: true });
+
+      expect(plan.slashdo).toBe(true);
+    });
+
+    it('does not request the submodule for an unrelated scoped change', () => {
+      const plan = buildCiTestPlan(['server/services/sprites/atlas.js'], { trackedFiles: TRACKED });
+
+      expect(plan.full).toBe(false);
+      expect(plan.slashdo).toBe(false);
+    });
+
+    it('never requests the submodule for a documentation-only change', () => {
+      const plan = buildCiTestPlan(['docs/GITHUB_ACTIONS.md'], { trackedFiles: TRACKED });
+
+      expect(plan.slashdo).toBe(false);
+    });
+  });
+});
+
+describe('needsSlashdoSubmodule', () => {
+  const basePlan = { full: false, changedFiles: [], server: { files: [], sources: [] } };
+
+  it('is false for a plan that touches neither the gitlink nor the adapter', () => {
+    expect(needsSlashdoSubmodule(basePlan)).toBe(false);
+  });
+
+  it('is true for a full plan even without an explicit slashdo change', () => {
+    expect(needsSlashdoSubmodule({ ...basePlan, full: true })).toBe(true);
+  });
+
+  it('is true when the gitlink path itself changed', () => {
+    expect(needsSlashdoSubmodule({ ...basePlan, changedFiles: [SLASHDO_GITLINK_PATH] })).toBe(true);
+  });
+
+  it('is true when a contract test file is selected', () => {
+    expect(needsSlashdoSubmodule({
+      ...basePlan,
+      server: { files: ['server/lib/slashdoLoader.test.js'], sources: [] },
+    })).toBe(true);
+  });
+
+  it('is true when a contract source file is selected', () => {
+    expect(needsSlashdoSubmodule({
+      ...basePlan,
+      server: { files: [], sources: ['server/lib/slashdoInvocation.js'] },
+    })).toBe(true);
   });
 });

--- a/server/envExampleDrift.test.js
+++ b/server/envExampleDrift.test.js
@@ -103,6 +103,7 @@ const INHERITED_ENV = {
   // Test-harness only — setting any of these on a real install is meaningless.
   VITEST: 'set by the vitest runner',
   VITEST_FAST: 'opt-in fast-suite selector, CI/local test runs only',
+  CI_EXPECT_SLASHDO_SUBMODULE: 'CI flag that turns a skipped slashdo adapter contract into a failure',
   TEST_DB_OK: 'test-harness flag for the DB-backed suites',
   PGTESTDATABASE: 'test-harness override naming portos_test',
   PORTOS_REQUIRE_DB: 'CI flag that turns a skipped DB suite into a failure',

--- a/server/lib/slashdoInvocation.test.js
+++ b/server/lib/slashdoInvocation.test.js
@@ -385,7 +385,15 @@ describe('unreachableReviewerIncludes', () => {
 describe('bundled command context budget', () => {
   it('keeps the better entrypoint small and preserves an eager procedure', async () => {
     const { existsSync } = await import('fs');
-    if (!existsSync(new URL('../../lib/slashdo/src/transformer.js', import.meta.url))) return;
+    if (!existsSync(new URL('../../lib/slashdo/src/transformer.js', import.meta.url))) {
+      // See slashdoLoader.test.js for why this fails rather than skips in CI
+      // when the submodule was expected: a return here would otherwise turn a
+      // failed "Initialize slashdo submodule" step into a silent pass.
+      if (process.env.CI_EXPECT_SLASHDO_SUBMODULE === 'true') {
+        throw new Error('lib/slashdo submodule is missing but this CI job expected it to be initialized');
+      }
+      return;
+    }
     const { loadSlashdoBundle } = await import('./slashdoLoader.js');
     const bundle = await loadSlashdoBundle('better', { stripFrontmatter: true });
     const eager = await loadSlashdoFile('better', { stripFrontmatter: true });

--- a/server/lib/slashdoInvocation.test.js
+++ b/server/lib/slashdoInvocation.test.js
@@ -15,6 +15,7 @@ import {
   unreachableReviewerIncludes,
 } from './slashdoInvocation.js';
 import { loadSlashdoFile } from './slashdoLoader.js';
+import { requireSlashdoSubmoduleInCi } from './testHelper.js';
 
 describe('isValidSlashdoCommand', () => {
   it('accepts bare command names', () => {
@@ -386,12 +387,7 @@ describe('bundled command context budget', () => {
   it('keeps the better entrypoint small and preserves an eager procedure', async () => {
     const { existsSync } = await import('fs');
     if (!existsSync(new URL('../../lib/slashdo/src/transformer.js', import.meta.url))) {
-      // See slashdoLoader.test.js for why this fails rather than skips in CI
-      // when the submodule was expected: a return here would otherwise turn a
-      // failed "Initialize slashdo submodule" step into a silent pass.
-      if (process.env.CI_EXPECT_SLASHDO_SUBMODULE === 'true') {
-        throw new Error('lib/slashdo submodule is missing but this CI job expected it to be initialized');
-      }
+      requireSlashdoSubmoduleInCi(false);
       return;
     }
     const { loadSlashdoBundle } = await import('./slashdoLoader.js');

--- a/server/lib/slashdoLoader.test.js
+++ b/server/lib/slashdoLoader.test.js
@@ -16,17 +16,11 @@ vi.mock('./fileUtils.js', async importOriginal => {
   } };
 });
 import { loadSlashdoLib, loadSlashdoFile, loadSlashdoBundle, writeResolvedSlashdoBody } from './slashdoLoader.js';
+import { requireSlashdoSubmoduleInCi } from './testHelper.js';
 
 const source = fileURLToPath(new URL('../../lib/slashdo/src', import.meta.url));
 const hasSubmodule = existsSync(join(source, 'transformer.js'));
-// CI sets this (see ci.yml "Initialize slashdo submodule") whenever the
-// selected test plan needs the real bundled renderer — a missing submodule
-// there means the init step failed silently, so this must fail the job
-// rather than quietly falling back to the fixture-only coverage below. A
-// local or intentionally minimal checkout (the flag unset) keeps skipping.
-if (process.env.CI_EXPECT_SLASHDO_SUBMODULE === 'true' && !hasSubmodule) {
-  throw new Error('lib/slashdo submodule is missing but this CI job expected it to be initialized');
-}
+requireSlashdoSubmoduleInCi(hasSubmodule);
 const write = (path, body) => {
   mkdirSync(dirname(path), { recursive: true });
   writeFileSync(path, body);

--- a/server/lib/slashdoLoader.test.js
+++ b/server/lib/slashdoLoader.test.js
@@ -19,6 +19,14 @@ import { loadSlashdoLib, loadSlashdoFile, loadSlashdoBundle, writeResolvedSlashd
 
 const source = fileURLToPath(new URL('../../lib/slashdo/src', import.meta.url));
 const hasSubmodule = existsSync(join(source, 'transformer.js'));
+// CI sets this (see ci.yml "Initialize slashdo submodule") whenever the
+// selected test plan needs the real bundled renderer — a missing submodule
+// there means the init step failed silently, so this must fail the job
+// rather than quietly falling back to the fixture-only coverage below. A
+// local or intentionally minimal checkout (the flag unset) keeps skipping.
+if (process.env.CI_EXPECT_SLASHDO_SUBMODULE === 'true' && !hasSubmodule) {
+  throw new Error('lib/slashdo submodule is missing but this CI job expected it to be initialized');
+}
 const write = (path, body) => {
   mkdirSync(dirname(path), { recursive: true });
   writeFileSync(path, body);

--- a/server/lib/testHelper.js
+++ b/server/lib/testHelper.js
@@ -404,3 +404,18 @@ export function resolveTestPython() {
     }
   }) || null;
 }
+
+/**
+ * Fail the CI job — rather than silently skip — when `lib/slashdo` was
+ * expected to be initialized but isn't (issue #6263). ci.yml sets
+ * `CI_EXPECT_SLASHDO_SUBMODULE` on the "Run server tests" step whenever the
+ * impact planner selected slashdo's bundled adapter contracts; a missing
+ * submodule there means the "Initialize slashdo submodule" step failed. With
+ * the env var unset — a local or intentionally minimal checkout — this is a
+ * no-op and the caller's own skip/early-return applies instead.
+ */
+export function requireSlashdoSubmoduleInCi(hasSubmodule) {
+  if (process.env.CI_EXPECT_SLASHDO_SUBMODULE === 'true' && !hasSubmodule) {
+    throw new Error('lib/slashdo submodule is missing but this CI job expected it to be initialized');
+  }
+}


### PR DESCRIPTION
## Summary
- `server/lib/slashdoLoader.test.js` and `server/lib/slashdoInvocation.test.js` exercise the real bundled slashdo renderer, but always skipped on CI because `.github/workflows/ci.yml` never initialized submodules — and a `git diff` reports only the gitlink pointer at `lib/slashdo`, never the files inside it, so the impact planner had no signal to detect a relevant change.
- `scripts/ci-test-plan.js` now derives a `slashdo` plan output (`needsSlashdoSubmodule`) that's true on a full-suite run, a gitlink change, or when either contract test file or its source (`slashdoLoader.js`/`slashdoInvocation.js`) is selected.
- The `server` job in CI initializes `lib/slashdo` only when that output is true, so an unrelated scoped PR pays nothing for the fetch.
- When the output is true, the two contract suites now fail the job (via a shared `requireSlashdoSubmoduleInCi` helper in `server/lib/testHelper.js`) instead of silently skipping if the submodule still isn't present. A local or intentionally minimal checkout keeps the documented skip.
- Documented the mechanism in `docs/GITHUB_ACTIONS.md`.

Closes #6263

## Test plan
- `cd server && npx vitest run ../scripts/ci-test-plan.test.js lib/slashdoLoader.test.js lib/slashdoInvocation.test.js lib/testHelper.test.js lib/index.test.js` — all pass.
- Manually initialized `lib/slashdo` locally and confirmed both contract suites run their real-renderer assertions (55/55 passing) instead of skipping.
- Manually removed the submodule content with `CI_EXPECT_SLASHDO_SUBMODULE=true` set and confirmed both suites fail loudly with a clear error, and confirmed they still skip quietly with the env var unset.
- Verified the new CI YAML parses and the new step lands in the right place in the `server` job.