### PR TITLE
Make voice fine-tuning lifecycle tests deterministic, and fix the cancelled-run outcome they exposed

### DIFF
--- a/scripts/ci-test-plan.js
+++ b/scripts/ci-test-plan.js
@@ -87,6 +87,13 @@ const WINDOWS_RISK_RULES = [
   /^server\/services\/(?:shell|pm2|appBuilder)\b/,
   /^server\/services\/agentTuiSpawning(?:\.test)?\.js$/,
   /^server\/services\/autonomousJobs\/execution\.shellSpawn/,
+  // The voice fine-tuning service spawns a real Python trainer and settles the
+  // job from its `close`/`error` events, so its assertions are the child-process
+  // contract, not platform-independent logic. Nothing here was Windows-tagged,
+  // so the shard only saw it on a full-matrix run — which is where it failed,
+  // with an interpreter-startup budget mistaken for a state-machine defect
+  // (#6268).
+  /^server\/services\/voice\/fineTuning(?:\.test)?\.js$/,
   /^server\/routes\/apps\//,
   /^server\/routes\/scaffoldVite\.js$/,
 ];
@@ -138,6 +145,7 @@ export const WINDOWS_CONTRACT_TESTS = [
   'server/services/agentTuiSpawning.test.js',
   'server/services/agentImportCycles.test.js',
   'server/services/twinImportCycles.test.js',
+  'server/services/voice/fineTuning.test.js',
 ];
 
 // Contract guards that run on EVERY plan, whatever the impact scope selects.

--- a/server/services/voice/fineTuning.js
+++ b/server/services/voice/fineTuning.js
@@ -44,6 +44,11 @@ const JOB_RECORD_FILE = 'job.json';
 // built from a caller-supplied id.
 const JOB_ID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
+// A user cancel is recorded by `cancelFineTuningJob` and, when the abort reaches
+// the child before the caller returns, by the child's terminal handler. One
+// shape so whichever writes first leaves the same record.
+const CANCELLED_OUTCOME = Object.freeze({ status: 'cancelled', error: 'Cancelled by user' });
+
 const jobRecordPath = (profileId, jobId) =>
   join(profileArtifactDirectory(profileId), 'fine-tune', jobId, JOB_RECORD_FILE);
 
@@ -271,25 +276,27 @@ export async function startFineTuningJob({
     }
   });
 
-  child.on('close', (code) => {
+  // Only the FIRST terminal event may write the outcome. An aborted spawn fires
+  // BOTH — `error` with an AbortError, then `close(null, 'SIGTERM')` — and
+  // `cancelFineTuningJob` records 'cancelled' synchronously before either
+  // arrives, so an unguarded `error` handler lands a user cancel on disk (and in
+  // the next status poll) as 'failed'.
+  const settle = (outcome) => {
     if (jobState.status === 'running') {
-      if (code === 0) {
-        jobState.status = 'completed';
-        jobState.progress = 100;
-      } else {
-        jobState.status = abortController.signal.aborted ? 'cancelled' : 'failed';
-        jobState.error = abortController.signal.aborted ? 'Cancelled by user' : `Process exited with code ${code}`;
-      }
-      jobState.completedAt = new Date().toISOString();
+      Object.assign(jobState, outcome, { completedAt: new Date().toISOString() });
     }
     finalizeJob(jobState);
+  };
+
+  child.on('close', (code) => {
+    if (code === 0) return settle({ status: 'completed', progress: 100 });
+    settle(abortController.signal.aborted
+      ? CANCELLED_OUTCOME
+      : { status: 'failed', error: `Process exited with code ${code}` });
   });
 
   child.on('error', (err) => {
-    jobState.status = 'failed';
-    jobState.error = err.message;
-    jobState.completedAt = new Date().toISOString();
-    finalizeJob(jobState);
+    settle(abortController.signal.aborted ? CANCELLED_OUTCOME : { status: 'failed', error: err.message });
   });
 
   return {
@@ -323,8 +330,7 @@ export function cancelFineTuningJob(jobId) {
   }
   if (job.status === 'running') {
     job.controller.abort();
-    job.status = 'cancelled';
-    job.completedAt = new Date().toISOString();
+    Object.assign(job, CANCELLED_OUTCOME, { completedAt: new Date().toISOString() });
   }
   return { ok: true, jobId, status: job.status };
 }

--- a/server/services/voice/fineTuning.js
+++ b/server/services/voice/fineTuning.js
@@ -288,11 +288,15 @@ export async function startFineTuningJob({
     finalizeJob(jobState);
   };
 
-  child.on('close', (code) => {
+  child.on('close', (code, signal) => {
     if (code === 0) return settle({ status: 'completed', progress: 100 });
-    settle(abortController.signal.aborted
-      ? CANCELLED_OUTCOME
-      : { status: 'failed', error: `Process exited with code ${code}` });
+    if (abortController.signal.aborted) return settle(CANCELLED_OUTCOME);
+    // A killed child reports a null code — an OOM reap during a long training
+    // run is the likely cause, so name the signal rather than "code null".
+    settle({
+      status: 'failed',
+      error: code === null ? `Process terminated by signal ${signal}` : `Process exited with code ${code}`,
+    });
   });
 
   child.on('error', (err) => {

--- a/server/services/voice/fineTuning.test.js
+++ b/server/services/voice/fineTuning.test.js
@@ -1,16 +1,33 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { EventEmitter } from 'node:events';
 import { mkdtemp, rm, mkdir, writeFile, readFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { SSE_CLEANUP_DELAY_MS } from '../../lib/sseUtils.js';
+import { PY_TEST_TIMEOUT_MS, resolveTestPython } from '../../lib/testHelper.js';
 
 let voiceProfilesRoot = '';
 const queryMock = vi.fn();
+
+// Both overrides default to null = "use the real thing", so one suite can hold
+// the deterministic state-machine cases AND the single runner-boundary case
+// that must exercise actual spawn wiring (vi.mock is per-FILE and hoisted, so
+// a runtime switch is the only way to have both).
+let spawnOverride = null;
+let pythonOverride = null;
 
 vi.mock('../../lib/db.js', () => ({ query: (...args) => queryMock(...args) }));
 vi.mock('../../lib/paths.js', async () => {
   const actual = await vi.importActual('../../lib/paths.js');
   return { ...actual, PATHS: { ...actual.PATHS, get voiceProfiles() { return voiceProfilesRoot; } } };
+});
+vi.mock('../../lib/childProcess.js', async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, spawn: (...args) => (spawnOverride ? spawnOverride(...args) : actual.spawn(...args)) };
+});
+vi.mock('./qwen3TtsRuntime.js', async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, resolveQwen3Python: async () => pythonOverride ?? actual.resolveQwen3Python() };
 });
 
 const {
@@ -45,11 +62,13 @@ const PROFILE = {
 beforeEach(async () => {
   voiceProfilesRoot = await mkdtemp(join(tmpdir(), 'portos-voice-profiles-'));
   queryMock.mockReset();
+  spawnOverride = null;
+  pythonOverride = null;
 });
 
 afterEach(async () => {
-  // maxRetries absorbs the ENOTEMPTY race with a job.json write still in flight
-  // from a child that exited as the test ended.
+  // Every case drains its job record first (see `drainJobRecord`); maxRetries
+  // stays as a backstop for a case that never started a run at all.
   await rm(voiceProfilesRoot, { recursive: true, force: true, maxRetries: 5, retryDelay: 20 });
 });
 
@@ -61,13 +80,86 @@ const seedSourceAudio = async () => {
 
 const jobRecordPath = (jobId) => join(voiceProfilesRoot, PROFILE.id, 'fine-tune', jobId, 'job.json');
 
-// The sidecar is rewritten from the child's terminal handler, so every test that
-// outlives a run waits for that write instead of racing the temp-dir teardown.
-const waitForTerminalJobRecord = (jobId) => vi.waitFor(async () => {
-  const record = JSON.parse(await readFile(jobRecordPath(jobId), 'utf8'));
-  expect(record.status).not.toBe('running');
+/**
+ * A child-process double whose frames the TEST decides, so lifecycle assertions
+ * are driven by the state machine rather than by however long a real Python
+ * interpreter needs to start on a contended CI worker (#6268).
+ *
+ * It models node's abort contract exactly — `error` with an AbortError on the
+ * next tick, then `close(null, 'SIGTERM')` — because that ordering is what
+ * decides whether a cancelled job settles as 'cancelled' or 'failed'.
+ */
+const createScriptedChild = ({ signal } = {}) => {
+  const child = new EventEmitter();
+  child.stdout = new EventEmitter();
+  child.kill = vi.fn();
+  // Frames mirror the runner's stdout contract (scripts/qwen3_tts_runner.py);
+  // the runner-boundary case below is what keeps that mirror honest.
+  child.emitFrames = (...frames) => {
+    for (const frame of frames) {
+      child.stdout.emit('data', Buffer.from(`${JSON.stringify(frame)}\n`));
+    }
+  };
+  child.exit = (code = 0) => child.emit('close', code, null);
+  signal?.addEventListener('abort', () => {
+    child.kill('SIGTERM');
+    process.nextTick(() => {
+      const err = new Error('The operation was aborted');
+      err.name = 'AbortError';
+      child.emit('error', err);
+      child.emit('close', null, 'SIGTERM');
+    });
+  }, { once: true });
+  return child;
+};
+
+const checkpointFrame = (step) => ({
+  stage: 'checkpoint',
+  step,
+  checkpoint: `checkpoint-${step}.safetensors`,
+  checkpoint_path: `/scripted/checkpoint-${step}.safetensors`,
+  sample_wav: `/scripted/sample-step-${step}.wav`,
+  loss: 0.42,
+});
+
+/** Install a scripted child and hand the test the handle spawn will return. */
+const useScriptedRunner = () => {
+  pythonOverride = '/scripted/python';
+  let child = null;
+  spawnOverride = (_command, _args, options) => {
+    child = createScriptedChild(options);
+    return child;
+  };
+  // The job's spawn happens inside startFineTuningJob, so resolve lazily.
+  return () => child;
+};
+
+/**
+ * Wait for the run's terminal sidecar AND for the per-job write chain behind it
+ * to drain, so the temp-dir teardown never races an in-flight `atomicWrite`.
+ *
+ * A terminal status alone is not proof: `persistJob` snapshots at QUEUE time, so
+ * a checkpoint write queued before the terminal one can serialize an already
+ * terminal status. The finalize write is the last the chain can take (`close`
+ * only fires once stdout is done), so bytes that stop changing mean drained.
+ */
+const drainJobRecord = async (jobId, { timeout = 5_000 } = {}) => {
+  const record = await vi.waitFor(async () => {
+    const parsed = JSON.parse(await readFile(jobRecordPath(jobId), 'utf8'));
+    expect(parsed.status).not.toBe('running');
+    return parsed;
+  }, { timeout, interval: 20 });
+
+  let previous = null;
+  await vi.waitFor(async () => {
+    const bytes = await readFile(jobRecordPath(jobId), 'utf8');
+    const prior = previous;
+    previous = bytes;
+    expect(bytes).toBe(prior);
+  }, { timeout, interval: 20 });
+
   return record;
-}, { timeout: 5_000, interval: 20 });
+};
 
 describe('fineTuning', () => {
   it('validates dataset readiness and checks source recordings', async () => {
@@ -83,25 +175,39 @@ describe('fineTuning', () => {
   it('runs fine tuning lifecycle, emits checkpoints, and promotes checkpoint', async () => {
     queryMock.mockResolvedValue({ rows: [{ data: PROFILE }] });
     await seedSourceAudio();
+    const scripted = useScriptedRunner();
 
     const startRes = await startFineTuningJob({
       profileId: PROFILE.id,
       epochs: 2,
       checkpointInterval: 20,
     });
-    expect(startRes).toMatchObject({
-      jobId: expect.any(String),
-      status: 'running',
-    });
+    expect(startRes).toMatchObject({ jobId: expect.any(String), status: 'running' });
 
-    await vi.waitFor(async () => {
-      expect((await getFineTuningJobStatus(startRes.jobId, PROFILE.id)).status).toBe('completed');
-    }, { timeout: 5_000, interval: 20 });
+    const child = scripted();
+    child.emitFrames(
+      { stage: 'init', total_steps: 100 },
+      { stage: 'training', step: 20, total_steps: 100, loss: 1.2, progress: 20 },
+      checkpointFrame(20),
+      checkpointFrame(100),
+      { stage: 'completed', total_steps: 100 },
+    );
+    child.exit(0);
 
-    await waitForTerminalJobRecord(startRes.jobId);
+    const record = await drainJobRecord(startRes.jobId);
+    expect(record.status).toBe('completed');
+
     const status = await getFineTuningJobStatus(startRes.jobId, PROFILE.id);
     expect(status.status).toBe('completed');
-    expect(status.checkpoints.length).toBeGreaterThan(0);
+    expect(status.progress).toBe(100);
+    expect(status.step).toBe(20);
+    expect(status.checkpoints).toHaveLength(2);
+    expect(status.checkpoints[0]).toMatchObject({
+      id: 'checkpoint-20.safetensors',
+      step: 20,
+      checkpointPath: '/scripted/checkpoint-20.safetensors',
+      sampleWav: '/scripted/sample-step-20.wav',
+    });
 
     const promoteRes = await promoteCheckpoint({
       profileId: PROFILE.id,
@@ -111,46 +217,66 @@ describe('fineTuning', () => {
     expect(promoteRes).toMatchObject({
       kind: 'fine-tuned',
       approval: { status: 'approved' },
+      inference: { checkpointPath: '/scripted/checkpoint-20.safetensors' },
     });
   });
 
-  it('cancels an active fine tuning job', async () => {
+  it('settles a cancelled job as cancelled even though the abort also fires an error', async () => {
     queryMock.mockResolvedValue({ rows: [{ data: PROFILE }] });
     await seedSourceAudio();
+    const scripted = useScriptedRunner();
 
-    const startRes = await startFineTuningJob({
-      profileId: PROFILE.id,
-      epochs: 50,
-    });
+    const startRes = await startFineTuningJob({ profileId: PROFILE.id, epochs: 50 });
+    scripted().emitFrames(checkpointFrame(50));
 
     const cancelRes = cancelFineTuningJob(startRes.jobId);
-    expect(cancelRes).toMatchObject({
-      ok: true,
-      jobId: startRes.jobId,
-      status: 'cancelled',
-    });
-    await waitForTerminalJobRecord(startRes.jobId);
+    expect(cancelRes).toMatchObject({ ok: true, jobId: startRes.jobId, status: 'cancelled' });
+    // The abort has to reach the child, or a cancelled run leaves an orphaned
+    // trainer burning the machine for the rest of its epochs.
+    expect(scripted().kill).toHaveBeenCalled();
+
+    // The AbortError arrives AFTER cancel wrote 'cancelled'. Without the
+    // first-terminal-event guard it overwrites the outcome with 'failed', both
+    // in memory and in the sidecar the operator reads after a restart.
+    const record = await drainJobRecord(startRes.jobId);
+    expect(record.status).toBe('cancelled');
+    expect(record.error).toBe('Cancelled by user');
+    expect(record.checkpoints).toHaveLength(1);
+    expect((await getFineTuningJobStatus(startRes.jobId, PROFILE.id)).status).toBe('cancelled');
+  });
+
+  it('records a non-zero exit as failed with its exit code', async () => {
+    queryMock.mockResolvedValue({ rows: [{ data: PROFILE }] });
+    await seedSourceAudio();
+    const scripted = useScriptedRunner();
+
+    const { jobId } = await startFineTuningJob({ profileId: PROFILE.id, epochs: 2 });
+    scripted().exit(3);
+
+    const record = await drainJobRecord(jobId);
+    expect(record.status).toBe('failed');
+    expect(record.error).toBe('Process exited with code 3');
   });
 
   it('persists a job.json sidecar beside the checkpoints when the run finishes', async () => {
     queryMock.mockResolvedValue({ rows: [{ data: PROFILE }] });
     await seedSourceAudio();
+    const scripted = useScriptedRunner();
 
     const { jobId } = await startFineTuningJob({
       profileId: PROFILE.id,
       epochs: 2,
       checkpointInterval: 20,
     });
-    await vi.waitFor(async () => {
-      expect((await getFineTuningJobStatus(jobId, PROFILE.id)).status).toBe('completed');
-    }, { timeout: 5_000, interval: 20 });
+    scripted().emitFrames(checkpointFrame(100), { stage: 'completed', total_steps: 100 });
+    scripted().exit(0);
 
-    const record = await waitForTerminalJobRecord(jobId);
+    const record = await drainJobRecord(jobId);
 
     expect(record.status).toBe('completed');
     expect(record.id).toBe(jobId);
     expect(record.profileId).toBe(PROFILE.id);
-    expect(record.checkpoints.length).toBeGreaterThan(0);
+    expect(record.checkpoints).toHaveLength(1);
     expect(record.completedAt).toEqual(expect.any(String));
     // Runtime-only handles must never reach disk.
     expect(record.controller).toBeUndefined();
@@ -160,19 +286,17 @@ describe('fineTuning', () => {
   it('promotes a checkpoint from the sidecar after a restart drops the in-memory job', async () => {
     queryMock.mockResolvedValue({ rows: [{ data: PROFILE }] });
     await seedSourceAudio();
+    const scripted = useScriptedRunner();
 
     const { jobId } = await startFineTuningJob({
       profileId: PROFILE.id,
       epochs: 2,
       checkpointInterval: 20,
     });
-    const status = await vi.waitFor(async () => {
-      const current = await getFineTuningJobStatus(jobId, PROFILE.id);
-      expect(current.status).toBe('completed');
-      expect(current.checkpoints.length).toBeGreaterThan(0);
-      return current;
-    }, { timeout: 5_000, interval: 20 });
-    await waitForTerminalJobRecord(jobId);
+    scripted().emitFrames(checkpointFrame(100), { stage: 'completed', total_steps: 100 });
+    scripted().exit(0);
+    const record = await drainJobRecord(jobId);
+    expect(record.checkpoints.length).toBeGreaterThan(0);
 
     // A restart loses `activeJobs` entirely; the sidecar is the only record left.
     vi.resetModules();
@@ -182,7 +306,7 @@ describe('fineTuning', () => {
     const promoted = await restarted.promoteCheckpoint({
       profileId: PROFILE.id,
       jobId,
-      checkpointId: status.checkpoints[0].id,
+      checkpointId: record.checkpoints[0].id,
     });
     expect(promoted).toMatchObject({ kind: 'fine-tuned', approval: { status: 'approved' } });
   });
@@ -190,13 +314,16 @@ describe('fineTuning', () => {
   it('reports an unreadable job record as an error rather than a missing job', async () => {
     queryMock.mockResolvedValue({ rows: [{ data: PROFILE }] });
     await seedSourceAudio();
+    const scripted = useScriptedRunner();
 
     const { jobId } = await startFineTuningJob({
       profileId: PROFILE.id,
       epochs: 2,
       checkpointInterval: 20,
     });
-    await waitForTerminalJobRecord(jobId);
+    scripted().emitFrames({ stage: 'completed', total_steps: 100 });
+    scripted().exit(0);
+    await drainJobRecord(jobId);
     await writeFile(jobRecordPath(jobId), '{ truncated');
 
     // A corrupt record must not read as "no such job" — the checkpoints it
@@ -218,31 +345,66 @@ describe('fineTuning', () => {
     try {
       queryMock.mockResolvedValue({ rows: [{ data: PROFILE }] });
       await seedSourceAudio();
+      const scripted = useScriptedRunner();
 
       const { jobId } = await startFineTuningJob({
         profileId: PROFILE.id,
         epochs: 2,
         checkpointInterval: 20,
       });
+      scripted().emitFrames(checkpointFrame(100), { stage: 'completed', total_steps: 100 });
+      scripted().exit(0);
+      await drainJobRecord(jobId);
+
       // Without a profileId the in-memory map is the only lookup source, so this
       // resolving proves the entry is still resident.
-      await vi.waitFor(async () => {
-        expect((await getFineTuningJobStatus(jobId)).status).toBe('completed');
-      }, { timeout: 5_000, interval: 20 });
-      await waitForTerminalJobRecord(jobId);
+      expect((await getFineTuningJobStatus(jobId)).status).toBe('completed');
 
-      // The eviction timer is only scheduled once the child process closes, and
-      // the sidecar can already read terminal before that (a checkpoint write
-      // queued earlier serializes after the "completed" frame set the status).
-      // Advancing once would then fire nothing, so keep advancing until the
-      // in-memory entry is actually gone.
-      await vi.waitFor(async () => {
-        await vi.advanceTimersByTimeAsync(SSE_CLEANUP_DELAY_MS + 100);
-        await expect(getFineTuningJobStatus(jobId)).rejects.toThrow(/not found/i);
-      }, { timeout: 5_000, interval: 20 });
+      await vi.advanceTimersByTimeAsync(SSE_CLEANUP_DELAY_MS + 100);
+      await expect(getFineTuningJobStatus(jobId)).rejects.toThrow(/not found/i);
       expect((await getFineTuningJobStatus(jobId, PROFILE.id)).status).toBe('completed');
     } finally {
       vi.useRealTimers();
     }
   });
+});
+
+// One boundary case keeps the scripted frames above honest: it runs the actual
+// Python runner through the real spawn, so a rename in either the runner's
+// stdout contract or the arguments it is handed fails here.
+describe.skipIf(!resolveTestPython())('fineTuning runner boundary', () => {
+  it('drives the real Qwen3 runner from spawn to a terminal sidecar', async () => {
+    queryMock.mockResolvedValue({ rows: [{ data: PROFILE }] });
+    await seedSourceAudio();
+    // Windows ships a `python` Store-alias stub that resolves but cannot run, so
+    // take the interpreter the shared helper proved executable.
+    pythonOverride = resolveTestPython();
+
+    const { jobId } = await startFineTuningJob({
+      profileId: PROFILE.id,
+      epochs: 2,
+      checkpointInterval: 20,
+    });
+
+    // A real interpreter's wall time tracks machine load, not the assertion, so
+    // both budgets come from the repository's Python-shelling allowance rather
+    // than a fixed inner deadline (#6268). The poll is strictly below the
+    // vitest budget so a genuinely stuck run reports the status it observed
+    // instead of producing a bare test timeout.
+    const record = await drainJobRecord(jobId, { timeout: Math.floor(PY_TEST_TIMEOUT_MS * 0.75) });
+    expect(record.status).toBe('completed');
+    expect(record.checkpoints.length).toBeGreaterThan(0);
+    // Same projection the scripted frames assert, mapped off the runner's own
+    // snake_case stdout keys.
+    expect(record.checkpoints[0]).toMatchObject({
+      id: expect.stringMatching(/^checkpoint-\d+\.safetensors$/),
+      step: expect.any(Number),
+      checkpointPath: expect.stringContaining('checkpoint-'),
+      sampleWav: expect.stringContaining('sample-step-'),
+    });
+
+    const status = await getFineTuningJobStatus(jobId, PROFILE.id);
+    expect(status.status).toBe('completed');
+    expect(status.progress).toBe(100);
+  }, PY_TEST_TIMEOUT_MS);
 });

--- a/server/services/voice/fineTuning.test.js
+++ b/server/services/voice/fineTuning.test.js
@@ -100,7 +100,7 @@ const createScriptedChild = ({ signal } = {}) => {
       child.stdout.emit('data', Buffer.from(`${JSON.stringify(frame)}\n`));
     }
   };
-  child.exit = (code = 0) => child.emit('close', code, null);
+  child.exit = (code = 0, signal = null) => child.emit('close', code, signal);
   signal?.addEventListener('abort', () => {
     child.kill('SIGTERM');
     process.nextTick(() => {
@@ -150,7 +150,7 @@ const drainJobRecord = async (jobId, { timeout = 5_000 } = {}) => {
     return parsed;
   }, { timeout, interval: 20 });
 
-  let previous = null;
+  let previous = await readFile(jobRecordPath(jobId), 'utf8');
   await vi.waitFor(async () => {
     const bytes = await readFile(jobRecordPath(jobId), 'utf8');
     const prior = previous;
@@ -245,17 +245,26 @@ describe('fineTuning', () => {
     expect((await getFineTuningJobStatus(startRes.jobId, PROFILE.id)).status).toBe('cancelled');
   });
 
-  it('records a non-zero exit as failed with its exit code', async () => {
+  it('reports an abnormal exit by its code, or by the signal that killed it', async () => {
     queryMock.mockResolvedValue({ rows: [{ data: PROFILE }] });
     await seedSourceAudio();
     const scripted = useScriptedRunner();
 
-    const { jobId } = await startFineTuningJob({ profileId: PROFILE.id, epochs: 2 });
+    const exited = await startFineTuningJob({ profileId: PROFILE.id, epochs: 2 });
     scripted().exit(3);
+    expect(await drainJobRecord(exited.jobId)).toMatchObject({
+      status: 'failed',
+      error: 'Process exited with code 3',
+    });
 
-    const record = await drainJobRecord(jobId);
-    expect(record.status).toBe('failed');
-    expect(record.error).toBe('Process exited with code 3');
+    // A killed child reports a null code; "exited with code null" tells the
+    // operator nothing about an OOM reap partway through a long run.
+    const killed = await startFineTuningJob({ profileId: PROFILE.id, epochs: 2 });
+    scripted().exit(null, 'SIGKILL');
+    expect(await drainJobRecord(killed.jobId)).toMatchObject({
+      status: 'failed',
+      error: 'Process terminated by signal SIGKILL',
+    });
   });
 
   it('persists a job.json sidecar beside the checkpoints when the run finishes', async () => {


### PR DESCRIPTION
## Summary

Windows server shard 3/3 failed on `services/voice/fineTuning.test.js > runs fine tuning lifecycle…` with the job still `running` after a fixed 5-second inner poll. Every lifecycle case launched the real Python runner, so the deadline was measuring interpreter startup under CI contention, not the state machine.

- **State-machine cases now drive a scripted child-process double** — frames, exit code, and node's abort ordering under test control. Lifecycle, checkpoint, promotion, cancellation, sidecar, restart-recovery and eviction assertions are unchanged in strength and no longer depend on process timing. The cancellation case no longer leaves a 2500-step trainer running to be killed at teardown.
- **One boundary case still spawns the real runner** so the scripted frames stay honest against `scripts/qwen3_tts_runner.py`. It takes the repository's Python-shelling budget (`PY_TEST_TIMEOUT_MS`) with a strictly smaller inner poll, so a genuinely stuck run reports the status it observed instead of a bare vitest timeout.
- **Every case drains the job's write chain before teardown** rather than letting the temp-dir removal retry through an in-flight `atomicWrite`.

Making the abort path deterministic surfaced two real defects in the subprocess boundary, both fixed here:

- **A cancelled run persisted as `failed`.** An aborted spawn fires *both* terminal events — `error` with an `AbortError`, then `close(null, 'SIGTERM')` — and the `error` handler overwrote the `cancelled` state that `cancelFineTuningJob` had just written. The operator's next status poll, and the `job.json` sidecar after a restart, both reported `failed`. Both handlers now share one guard: the first terminal event writes the outcome, later ones only finalize.
- **A killed trainer reported "Process exited with code null".** A child killed by a signal has no exit code, so an OOM reap partway through a long run said nothing useful. It now names the signal.

Finally, the service is now tagged in `WINDOWS_RISK_RULES` and its suite added to the Windows contract baseline (`scripts/ci-test-plan.js`). It was untagged, so the Windows shard only saw it on a full-matrix run — which is why the failure landed on `main` rather than on the PR that introduced it.

## Test plan

- `cd server && npm test` — 1958 files / 39366 tests pass.
- `npx vitest run services/voice/fineTuning.test.js` — 9 pass; the 8 scripted cases run in ~27–49 ms each (previously ~5 s of real-process wall time each), and the real-runner boundary case still exercises actual spawn wiring.
- Bypass probe: reverting the `error`-handler guard alone fails `settles a cancelled job as cancelled…` and nothing else, confirming that assertion is not vacuous.
- `npx vitest run routes/voice.test.js services/voice/` — 621 pass, so the route layer sees no behavior change.
- `npx vitest run ../scripts/ci-test-plan.test.js ../scripts/run-ci-tests.test.js` — 40 pass. A diff touching only `server/services/voice/fineTuning.js` now plans `windows: true, mode: related` and selects `fineTuning.test.js`; this PR itself plans a full matrix, so the Windows shard that originally failed runs here.

Closes #6268
