### PR TITLE
test(loras): drain escaped sidecar writes before tearing down the temp root

### DIFF
--- a/server/services/loras.test.js
+++ b/server/services/loras.test.js
@@ -25,9 +25,33 @@ let lorasService;
 let civitaiLib;
 let atomicWriteHook;
 
+// Sidecar writes the service has enqueued but not yet finished (#6265).
+//
+// `listLoras()` heals a stale/absent `keyLayout` (and `fluxVariant`) by firing
+// `patchLoraSidecar(...).catch(() => {})` — deliberately fire-and-forget, so
+// listing never blocks or fails on a cache write. That promise outlives the
+// test that started it — two tests here were observed still holding a queued
+// write at teardown — so `afterEach` rm -rf's the temp root while a queued
+// read-modify-write is still walking it, and the next `beforeEach` calls
+// `vi.resetModules()` with that work in flight. Both races widen under load,
+// which matches #6265: the file passes on its own and read two just-written
+// sidecars as `{}` inside a contended full-suite shard.
+//
+// The queue itself is the only complete seam: every heal goes through
+// `createKeyedFileWriteQueue()` regardless of which `listLoras()` call site
+// started it, and the queued promise covers the whole stat → read → atomicWrite
+// cycle (hooking `atomicWrite` would miss a task that has not reached its write
+// yet). Wrapping the factory lets `afterEach` await exactly the work the test
+// started — a drain, not a sleep or a retry.
+const pendingSidecarWrites = new Set();
+const drainSidecarWrites = async () => {
+  while (pendingSidecarWrites.size) await Promise.all([...pendingSidecarWrites]);
+};
+
 beforeEach(async () => {
   tmpRoot = mkdtempSync(join(tmpdir(), 'portos-loras-test-'));
   tmpLoras = join(tmpRoot, 'loras');
+  pendingSidecarWrites.clear();
 
   vi.resetModules();
   vi.doMock('../lib/fileUtils.js', async () => {
@@ -40,17 +64,50 @@ beforeEach(async () => {
         : actual.atomicWrite(...args),
     };
   });
+  vi.doMock('../lib/fileWriteQueue.js', async () => {
+    const actual = await vi.importActual('../lib/fileWriteQueue.js');
+    return {
+      ...actual,
+      createKeyedFileWriteQueue: (...factoryArgs) => {
+        const queue = actual.createKeyedFileWriteQueue(...factoryArgs);
+        return (key, fn) => {
+          const write = queue(key, fn);
+          // Track a silenced copy: a rejected sidecar write is a real product
+          // outcome several tests assert on, and the drain must not re-throw it
+          // out of `afterEach`.
+          const tracked = write.catch(() => {});
+          pendingSidecarWrites.add(tracked);
+          tracked.finally(() => pendingSidecarWrites.delete(tracked));
+          return write; // callers still see the real resolve/reject
+        };
+      },
+    };
+  });
   // Stub settings so resolveCivitaiKey doesn't read the real data/settings.json.
   vi.doMock('./settings.js', () => ({
     getSettings: async () => ({}),
   }));
   lorasService = await import('./loras.js');
   civitaiLib = await import('../lib/civitai.js');
+
+  // Module identity at the read, asserted once per test. Every fixture below
+  // writes through the raw `tmpLoras` path while the service resolves its own
+  // `PATHS.loras` out of the mocked module — if those two ever diverge (a
+  // reused mock instance, a factory that did not re-run), the symptom is a
+  // silent empty read many tests later, because `readSidecar` collapses "wrong
+  // directory" into the same `null` it returns for "no sidecar". Fail here,
+  // naming both paths, instead.
+  const { PATHS } = await import('../lib/fileUtils.js');
+  expect(PATHS.loras).toBe(tmpLoras);
 });
 
-afterEach(() => {
+afterEach(async () => {
+  // Before removing the tree the writes are aimed at, and before the next
+  // `beforeEach` resets the module graph out from under them.
+  await drainSidecarWrites();
   atomicWriteHook = null;
   vi.doUnmock('../lib/fileUtils.js');
+  vi.doUnmock('../lib/fileWriteQueue.js');
   vi.doUnmock('./settings.js');
   rmSync(tmpRoot, { recursive: true, force: true });
 });
@@ -1228,11 +1285,11 @@ describe('LoRA key layout', () => {
     });
     const list = await lorasService.listLoras();
     expect(list.find((l) => l.filename === 'lora-comfy.safetensors').keyLayout).toBe('comfyui');
-    // Sidecar write is fire-and-forget; wait for it to complete.
-    await vi.waitFor(async () => {
-      const sidecar = JSON.parse(await fs.readFile(join(tmpLoras, 'lora-comfy.safetensors.metadata.json'), 'utf-8'));
-      expect(sidecar.keyLayout).toBe('comfyui');
-    });
+    // Sidecar write is fire-and-forget; drain the queue it was enqueued on
+    // rather than polling for the file to appear.
+    await drainSidecarWrites();
+    const sidecar = JSON.parse(await fs.readFile(join(tmpLoras, 'lora-comfy.safetensors.metadata.json'), 'utf-8'));
+    expect(sidecar.keyLayout).toBe('comfyui');
   });
 
   it('prefers the stored sidecar layout over re-reading the header', async () => {


### PR DESCRIPTION
## Summary

The full-CI Linux shard read two just-written LoRA sidecars back as `{}` while the same 71-test suite passed on its own. This makes that suite deterministic. **No production change** — no product-side mechanism was established, and the acceptance criteria gate a production change on documenting one.

### What the CI evidence actually says

The shard runs with `--bail=1`, so the five tests after the failure never ran — they report as pending, not passing. The evidence is therefore consistent with the whole `readTriggerWordsByFilename` block failing, not only the two-sidecar case.

### Confirmed mechanism: work escaping cleanup

`listLoras()` heals a stale or absent `keyLayout` by firing `patchLoraSidecar(...).catch(() => {})` — deliberately fire-and-forget, so listing never blocks or fails on a cache write. Instrumenting the sidecar write queue shows **two tests in this file still holding a queued read-modify-write when their `afterEach` runs**, one of them the test immediately preceding the CI failure. `afterEach` then removes the temp root out from under that in-flight task, and the next `beforeEach` calls `vi.resetModules()` while it is still executing inside the old module graph. Both races widen under a contended four-worker shard — which is where this appeared, and never in a focused run.

### Why it was undiagnosable

`readSidecar` collapses absent, unreadable, malformed, and wrong-directory into the same `null`; its one warning goes through `console.log`, which CI silences via `PORTOS_TEST_QUIET=1`. So the failure could only ever surface as `{} !== {...}`.

### Changes

- Wrap `createKeyedFileWriteQueue` in the suite's existing `vi.doMock` block so every enqueued sidecar write is tracked, and have `afterEach` await them before removing the tree. A drain of the actual promises — no sleep, no retry — covering every `listLoras()` call site rather than an audited list. The queue is the only complete seam: its promise spans the whole stat/read/write cycle, so hooking `atomicWrite` would miss a task that has not reached its write yet.
- Replace the one `vi.waitFor` poll on a backfill with that same drain, removing its timeout window.
- Assert once per test that the service's own `PATHS.loras` is the current temp dir. Fixtures write through the raw path while the service resolves the mocked one; a divergence now fails at the hook naming both paths instead of as a silent `{}` many tests later.

Production absent-sidecar behavior is untouched, and the tests keep the real filesystem boundary.

## Test plan

- `server/services/loras.test.js` — 71/71 pass; 15 consecutive CI-env runs (`CI=1 PORTOS_TEST_QUIET=1`) all green, plus 25 baseline runs before the change.
- Full local server suite (979 files, 20,127 tests) — LoRA suite green; the only failures are pre-existing Windows-environment ones (missing Python for the TTS suite, voice fine-tuning timing).
- Structural guards `testDataIsolation.guards`, `lib/testDataIsolation`, `timerCallbackConventions` — pass.
- Mechanism verified empirically by asserting `pendingSidecarWrites.size === 0` before the drain: two tests trip it without this change, none with it.

Closes #6265