### PR TITLE
fix: review complete FableLoom scenes before editorial approval

### DIFF
--- a/server/services/fableLoom/editorial.js
+++ b/server/services/fableLoom/editorial.js
@@ -206,7 +206,7 @@ const assertEditorialDependenciesUnchanged = (current, fingerprint, { code, mess
 };
 
 const seriesPlanDigest = (loom) => JSON.stringify({
-  storyArc: trimTo(loom.seriesPlan?.storyArc, 6000),
+  storyArc: loom.seriesPlan?.storyArc || '',
   plotPoints: asArray(loom.seriesPlan?.plotPoints),
   sideQuests: asArray(loom.seriesPlan?.sideQuests),
   deliveryOptions: loom.seriesPlan?.deliveryOptions || null,
@@ -216,7 +216,7 @@ const seriesPlanDigest = (loom) => JSON.stringify({
     id: episode.id,
     number: episode.number,
     title: episode.title,
-    synopsis: trimTo(episode.synopsis, 600),
+    synopsis: episode.synopsis || '',
     storyOutline: episode.storyOutline
       ? describeStoryOutlineForPrompt(episode.storyOutline)
       : '(missing)',
@@ -232,12 +232,14 @@ const exactGraphIdContract = (episode) => asArray(episode.nodes).flatMap((node) 
 const teleplayDigest = (loom) => asArray(loom.episodes).map((episode) => [
   `## Episode ${episode.number}: ${episode.title || 'Untitled'}`,
   `Episode id: ${episode.id}`,
-  episode.synopsis ? `Synopsis: ${trimTo(episode.synopsis, 600)}` : '',
+  episode.synopsis ? `Synopsis: ${episode.synopsis}` : '',
   episode.storyOutline
     ? `Beat outline:\n${describeStoryOutlineForPrompt(episode.storyOutline)}`
     : 'Beat outline: (missing)',
   episode.nodes.length
-    ? describeGraphForPrompt(episode, { proseLimit: 1000, participationMode: loom.participationMode })
+    // Whole-series editing and approval need each scene's payoff, not just its
+    // opening. The rendered-prompt budget below rejects oversized inputs.
+    ? describeGraphForPrompt(episode, { proseLimit: Infinity, participationMode: loom.participationMode })
     : '(no expanded teleplay scenes)',
   episode.nodes.length
     ? `Exact graph ids for patches (copy verbatim):\n${exactGraphIdContract(episode) || '(no transitions)'}`
@@ -1133,6 +1135,7 @@ export const __testing = {
   renderEditorialPrompt,
   sanitizeEvaluation,
   sanitizePlaythroughReview,
+  seriesPlanDigest,
   teleplayDigest,
   withCompletePlaythroughDigest,
 };

--- a/server/services/fableLoom/editorial.test.js
+++ b/server/services/fableLoom/editorial.test.js
@@ -157,6 +157,35 @@ describe('editorial prompt graph contract', () => {
     expect(digest).toContain('transition=take-left sourceNode=opening targetNode=left');
     expect(digest).toContain('transition=right-end sourceNode=right targetNode=ending');
   });
+
+  it('reviews complete narrative fields and rejects excess context instead of clipping their payoffs', async () => {
+    const loom = makeLoom();
+    loom.seriesPlan.storyArc = `${'The traveler follows the signal. '.repeat(220)}The beacon is their own warning.`;
+    const episode = loom.episodes[0];
+    episode.synopsis = `${'The two routes approach the beacon. '.repeat(25)}Both reveal who sent the warning.`;
+    const ending = episode.nodes.at(-1);
+    ending.prose = `${'The traveler climbs toward the light. '.repeat(40)}They recognize their own voice and turn the beacon off.`;
+    ending.videoPrompt = `${'Follow the traveler up the stairs. '.repeat(40)}End on the extinguished beacon.`;
+    const variables = {
+      seriesPlanJson: __testing.seriesPlanDigest(loom),
+      teleplayDigest: __testing.teleplayDigest(loom),
+    };
+    const plan = JSON.parse(variables.seriesPlanJson);
+    expect(plan.storyArc).toBe(loom.seriesPlan.storyArc);
+    expect(plan.episodes[0].synopsis).toBe(episode.synopsis);
+    expect(variables.teleplayDigest).toContain(episode.synopsis);
+    expect(variables.teleplayDigest).toContain(ending.prose);
+    expect(variables.teleplayDigest).toContain(ending.videoPrompt);
+
+    const rendered = Object.values(variables).join('\n\n');
+    const buildPromptFn = async () => rendered;
+    await expect(__testing.renderEditorialPrompt(
+      'fableloom-review-playthroughs', variables, rendered.length, { buildPromptFn },
+    )).resolves.toBe(rendered);
+    await expect(__testing.renderEditorialPrompt(
+      'fableloom-review-playthroughs', variables, rendered.length - 1, { buildPromptFn },
+    )).rejects.toMatchObject({ code: 'FABLELOOM_EDITORIAL_CONTEXT_TOO_LARGE' });
+  });
 });
 
 describe('applyFableLoomEditorialPatch', () => {


### PR DESCRIPTION
## Summary
FableLoom's editor and playthrough reviewer saw only the first 1,000 characters of each scene and shot, so an ending or consequence later in the scene could be omitted from a whole-story approval. Supply complete scene prose, video direction, episode synopses, and the series arc. The existing rendered-prompt budget still rejects inputs that exceed the selected model's context capacity.

## Test plan
- `cd server && npm test -- services/fableLoom/editorial.test.js services/fableLoom/editorialAutopilot.test.js lib/fableLoomPlaytest.test.js` — 46 tests passed.
- Added a regression covering narrative payoffs beyond the old clipping limits and rejection at the full rendered-prompt budget boundary.
- `git diff --check` passed.
