### PR TITLE
fix(post): prevent horizontal scrolling for time column in drill review

### DIFF
--- a/client/src/components/meatspace/post/PostSessionResults.test.jsx
+++ b/client/src/components/meatspace/post/PostSessionResults.test.jsx
@@ -52,6 +52,7 @@ describe('PostSessionResults drill breakdown', () => {
 
     expect(within(container.querySelector('table')).getAllByText('123')).not.toHaveLength(0);
     expect(container.querySelector('.lucide-chevron-up')).toBeInTheDocument();
+    expect(container.querySelector('.lg\\:col-span-2')).toBeInTheDocument();
   });
 
   it('leaves non-digit-span drills collapsed by default', () => {

--- a/client/src/components/meatspace/post/PostSessionSummary.jsx
+++ b/client/src/components/meatspace/post/PostSessionSummary.jsx
@@ -143,7 +143,7 @@ export default function PostSessionSummary({ drillResults = [], sessionScore = 0
               (result.score || 0) >= 50 ? 'text-port-warning' : 'text-port-error';
 
             return (
-              <div key={i}>
+              <div key={i} className={isExpanded ? 'lg:col-span-2' : ''}>
                 <button
                   onClick={() => setExpandedDrill(isExpanded ? null : i)}
                   className="w-full flex items-center justify-between hover:bg-port-bg/50 rounded px-1 py-1 transition-colors"


### PR DESCRIPTION
## Summary
When reviewing POST test drill results (such as Digit Span / number sequences), the breakdown grid uses `lg:grid-cols-2`, constraining the drill container to ~400px. As a result, the review table inside `TableShell` overflowed horizontally, hiding the rightmost `Time` column and requiring horizontal scrolling.

## Changes
- In `PostSessionSummary.jsx`, add `className={isExpanded ? 'lg:col-span-2' : ''}` to the drill item container so that expanded drills span the full 2-column width, providing ample room for the question review table without horizontal scrolling.
- Added test coverage in `PostSessionResults.test.jsx` asserting `lg:col-span-2` is applied to expanded drill rows.