### PR TITLE
fix: surface the render child's own cause on an ordinary nonzero exit

### DIFF
--- a/server/services/videoGen/generateVideoHelpers.js
+++ b/server/services/videoGen/generateVideoHelpers.js
@@ -13,6 +13,7 @@ import { broadcastSse } from '../../lib/sseUtils.js';
 import { generateThumbnail, optimizeForStreaming } from '../../lib/ffmpeg.js';
 import { formatBytes } from '../../lib/fileUtils.js';
 import { renderTimingFields } from '../../lib/renderTiming.js';
+import { scrubSecretTokens } from '../../lib/secretText.js';
 import { videoGenEvents } from './events.js';
 
 /**
@@ -393,6 +394,30 @@ export function describeSignalDeath(signal, { fingerprint = null } = {}) {
   const cause = SIGNAL_DEATH_CAUSES[signal] || `Killed by signal ${signal}`;
   const fp = formatRuntimeFingerprint(fingerprint);
   return fp ? `${cause} [runtime: ${fp}]` : cause;
+}
+
+/**
+ * Pick the cause text for an ordinary (no signal, no missing-module match)
+ * nonzero exit — the gap that otherwise reports only `Exit code N` with
+ * nothing else to go on (issue #6281). `stdoutText`/`stderrText` come from
+ * two `createOutputTail()` instances in `spawnWatch.js` fed ONLY the lines
+ * neither the child's own STATUS:/STAGE:/RUNTIME:/SPEEDPROFILE: protocol nor
+ * `PYTHON_NOISE_RE` claimed, so a progress bar, a dependency warning, or a
+ * STAGE marker can never win over the real cause — and each tail already caps
+ * itself by a char budget, so this can never surface an unbounded traceback.
+ * stderr wins over stdout (a raised exception normally lands there); a Python
+ * traceback also prints its exception message LAST, so the tail's most recent
+ * line is almost always that message rather than a stack frame above it.
+ * Returns null when neither tail collected anything, so the caller can fall
+ * back to the bare exit-code message.
+ * @param {object} opts
+ * @param {string} [opts.stdoutText]
+ * @param {string} [opts.stderrText]
+ * @returns {string|null}
+ */
+export function pickExitDiagnostic({ stdoutText = '', stderrText = '' } = {}) {
+  const chosen = (stderrText || stdoutText || '').trim();
+  return chosen ? scrubSecretTokens(chosen) : null;
 }
 
 /**

--- a/server/services/videoGen/generateVideoHelpers.test.js
+++ b/server/services/videoGen/generateVideoHelpers.test.js
@@ -3,7 +3,7 @@ import { writeFileSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { EventEmitter } from 'events';
-import { makeVideoGenLineHandler, isWatchdogSuccess, finalizeGeneratedVideo, parseByteProgress, formatBytes, formatDownloadMessage, describeSignalDeath, formatRuntimeFingerprint, describeRenderConditioning, isPromptEncodingMetalWatchdog, planPromptEncodingRetry, DEFAULT_GEMMA_MAX_LENGTH, RETRY_GEMMA_MAX_LENGTH, bufferChildExit, RENDER_INPUTS_VERSION } from './generateVideoHelpers.js';
+import { makeVideoGenLineHandler, isWatchdogSuccess, finalizeGeneratedVideo, parseByteProgress, formatBytes, formatDownloadMessage, describeSignalDeath, pickExitDiagnostic, formatRuntimeFingerprint, describeRenderConditioning, isPromptEncodingMetalWatchdog, planPromptEncodingRetry, DEFAULT_GEMMA_MAX_LENGTH, RETRY_GEMMA_MAX_LENGTH, bufferChildExit, RENDER_INPUTS_VERSION } from './generateVideoHelpers.js';
 
 describe('parseByteProgress', () => {
   it('parses single byte value (e.g., "2.5G")', () => {
@@ -478,6 +478,34 @@ describe('describeSignalDeath (#3101 signal → actionable cause)', () => {
   it('omits the fingerprint suffix entirely when nothing is known (no empty brackets)', () => {
     expect(describeSignalDeath('SIGSEGV', { fingerprint: null })).not.toMatch(/runtime:/);
     expect(describeSignalDeath('SIGSEGV', { fingerprint: {} })).not.toMatch(/runtime:/);
+  });
+});
+
+describe('pickExitDiagnostic (#6281 — explain an ordinary nonzero exit)', () => {
+  it('returns null when neither tail collected anything', () => {
+    expect(pickExitDiagnostic({})).toBeNull();
+    expect(pickExitDiagnostic({ stdoutText: '', stderrText: '' })).toBeNull();
+  });
+
+  it('prefers stderr over stdout — a raised exception normally lands there', () => {
+    const result = pickExitDiagnostic({
+      stdoutText: 'some stdout noise',
+      stderrText: 'RuntimeError: CUDA out of memory',
+    });
+    expect(result).toBe('RuntimeError: CUDA out of memory');
+  });
+
+  it('falls back to stdout when stderr collected nothing', () => {
+    const result = pickExitDiagnostic({ stdoutText: 'AssertionError: shape mismatch', stderrText: '' });
+    expect(result).toBe('AssertionError: shape mismatch');
+  });
+
+  it('scrubs a credential-shaped token before it can reach the job record or UI', () => {
+    const result = pickExitDiagnostic({
+      stderrText: 'Auth failed for token sk-abcdefghijklmnopqrstuvwx while loading weights',
+    });
+    expect(result).not.toMatch(/sk-abcdefghijklmnopqrstuvwx/);
+    expect(result).toMatch(/\[REDACTED\]/);
   });
 });
 

--- a/server/services/videoGen/local.test.js
+++ b/server/services/videoGen/local.test.js
@@ -3415,6 +3415,114 @@ describe('generateVideo — BYOV missing-python-module failure path (#1833 regre
   });
 });
 
+// ── an ordinary nonzero exit that is neither a missing module nor a death
+// signal (#6281) — before this, handleChildClose's fallback reported only a
+// bare `Exit code N`, discarding whatever the child actually printed. ────────
+describe('generateVideo — ordinary nonzero exit surfaces a cause instead of a bare exit code (#6281)', () => {
+  const spawnDrivenChild = async () => {
+    vi.resetModules();
+    const { spawnDetached } = await import('../../lib/detachedSpawn.js');
+    let stderrData;
+    let stdoutData;
+    let closeListener;
+    vi.mocked(spawnDetached).mockImplementationOnce(async () => {
+      const proc = {
+        pid: 5281,
+        exitCode: null,
+        signalCode: null,
+        killed: false,
+        stdout: { on: (event, fn) => { if (event === 'data') stdoutData = fn; } },
+        stderr: { on: (event, fn) => { if (event === 'data') stderrData = fn; } },
+        on(event, fn) { if (event === 'close') closeListener = fn; return proc; },
+        off() { return proc; },
+        kill: vi.fn(),
+      };
+      return proc;
+    });
+    const { generateVideo: gv } = await import('./local.js');
+    const { videoGenEvents: events } = await import('./events.js');
+    await gv({
+      jobId: 'ordinary-nonzero-exit',
+      pythonPath: '/usr/bin/python3',
+      modelId: 'ltx2_unified',
+      prompt: 'a clip',
+      width: 512, height: 512, numFrames: 25, fps: 24,
+      mode: 'text',
+    });
+    return {
+      stderr: (text) => stderrData?.(Buffer.from(text)),
+      stdout: (text) => stdoutData?.(Buffer.from(text)),
+      close: (code) => closeListener?.(code, null),
+      failed: () => new Promise((resolve) => events.once('failed', resolve)),
+    };
+  };
+
+  it('reports the traceback\'s exception line, not just the exit code', async () => {
+    const child = await spawnDrivenChild();
+    const failed = child.failed();
+    child.stderr(
+      'Traceback (most recent call last):\n'
+      + '  File "generate_ltx2.py", line 214, in <module>\n'
+      + '    raise RuntimeError("disk quota exceeded while writing checkpoint cache")\n'
+      + 'RuntimeError: disk quota exceeded while writing checkpoint cache\n',
+    );
+    child.close(1);
+
+    const evt = await failed;
+    expect(evt.error).toMatch(/^Exit code 1: /);
+    expect(evt.error).toMatch(/RuntimeError: disk quota exceeded while writing checkpoint cache/);
+  });
+
+  it('still captures the cause when the final line has no trailing newline (flushed on close)', async () => {
+    const child = await spawnDrivenChild();
+    const failed = child.failed();
+    // Split across two chunks with nothing to terminate the second — only
+    // stderrReader.flush() (called inside handleChildClose, before this
+    // fallback runs) can surface it.
+    child.stderr('RuntimeError: disk quota exce');
+    child.stderr('eded mid-write');
+    child.close(1);
+
+    const evt = await failed;
+    expect(evt.error).toMatch(/RuntimeError: disk quota exceeded mid-write/);
+  });
+
+  it('ignores STATUS:/STAGE: protocol lines and tqdm-style noise, keeping only the real cause', async () => {
+    const child = await spawnDrivenChild();
+    const failed = child.failed();
+    child.stderr(
+      'STATUS:loading checkpoint\n'
+      + '  45%|####5     | 45/100 [00:12<00:15]\n'
+      + 'RuntimeError: shape mismatch on conditioning tensor\n',
+    );
+    child.close(1);
+
+    const evt = await failed;
+    expect(evt.error).toMatch(/RuntimeError: shape mismatch on conditioning tensor/);
+    expect(evt.error).not.toMatch(/STATUS:loading checkpoint/);
+    expect(evt.error).not.toMatch(/45\/100/);
+  });
+
+  it('falls back to stdout when stderr contributed nothing', async () => {
+    const child = await spawnDrivenChild();
+    const failed = child.failed();
+    child.stdout('AssertionError: unexpected tensor shape (3, 512, 512)\n');
+    child.close(1);
+
+    const evt = await failed;
+    expect(evt.error).toMatch(/AssertionError: unexpected tensor shape/);
+  });
+
+  it('falls back to the bare exit code when neither stream printed anything useful', async () => {
+    const child = await spawnDrivenChild();
+    const failed = child.failed();
+    child.close(7);
+
+    const evt = await failed;
+    expect(evt.error).toBe('Exit code 7');
+  });
+});
+
 describe('resolveVideoModel — live registry lookup (#2124 no-restart add)', () => {
   it('resolves a model id through the live getVideoModels() list', async () => {
     const { resolveVideoModel } = await import('./local.js');

--- a/server/services/videoGen/spawnWatch.js
+++ b/server/services/videoGen/spawnWatch.js
@@ -6,7 +6,7 @@ import { readFile } from 'fs/promises';
 import { join } from 'path';
 import { PATHS, rmGuarded } from '../../lib/fileUtils.js';
 import { spawnDetached } from '../../lib/detachedSpawn.js';
-import { createLineReader } from '../../lib/streamLines.js';
+import { createLineReader, createOutputTail } from '../../lib/streamLines.js';
 import { claimHeavyLocalJob } from '../../lib/heavyJobClaim.js';
 import { prepareLocalMemory, gpuBlockersMessage } from '../localMemory.js';
 import { ServerError } from '../../lib/errorHandler.js';
@@ -22,6 +22,7 @@ import {
   isWatchdogSuccess,
   describeSignalDeath,
   planPromptEncodingRetry,
+  pickExitDiagnostic,
   bufferChildExit,
 } from './generateVideoHelpers.js';
 import {
@@ -248,6 +249,15 @@ export async function spawnAndWatchVideo({
       stderrTail.push(raw);
       if (stderrTail.length > STDERR_TAIL_LINES) stderrTail.shift();
     };
+    // Separate, char-budget-bounded tails (issue #6281) fed only the lines the
+    // readers below already decided are worth raw-logging — i.e. neither the
+    // STATUS:/STAGE:/RUNTIME:/SPEEDPROFILE: protocol nor PYTHON_NOISE_RE
+    // claimed them. Kept apart from `stderrTail` above, which the Metal-retry
+    // sniffer needs UNFILTERED (it greps for the STAGE:encode-prompt markers
+    // this pair deliberately excludes). Used to explain an ordinary nonzero
+    // exit that matches neither a missing module nor a death signal.
+    const stdoutDiagTail = createOutputTail();
+    const stderrDiagTail = createOutputTail();
 
     // The python child's STATUS:/STAGE:/DOWNLOAD:/tqdm → SSE-frame parser lives
     // in generateVideoHelpers.js so it can be unit-tested without a real child.
@@ -277,6 +287,7 @@ export async function spawnAndWatchVideo({
       // Some runtimes don't print the result JSON but do log the final
       // decode+mux line right before they should exit — treat it the same way.
       if (MUXING_DONE_RE.test(line)) armCompletionWatchdog();
+      stdoutDiagTail.remember(line);
       console.log(`🐍-out [${jobId.slice(0, 8)}] ${line}`);
     });
     const stderrReader = createLineReader((raw) => {
@@ -287,7 +298,10 @@ export async function spawnAndWatchVideo({
         const m = raw.match(MODULE_NOT_FOUND_RE);
         if (m) missingPyModule = m[1];
       }
-      if (!handleLine(raw)) console.log(`🐍 [${jobId.slice(0, 8)}] ${raw.trim()}`);
+      if (!handleLine(raw)) {
+        stderrDiagTail.remember(raw);
+        console.log(`🐍 [${jobId.slice(0, 8)}] ${raw.trim()}`);
+      }
     }, { splitRe: /[\n\r]+/ });
 
     proc.stdout.on('data', (chunk) => {
@@ -369,7 +383,11 @@ export async function spawnAndWatchVideo({
               fingerprint: await pickDeathFingerprint({ emitted: job.runtime, runtimeId: model.runtime }),
             });
           } else {
-            reason = `Exit code ${code}`;
+            const diagnostic = pickExitDiagnostic({
+              stdoutText: stdoutDiagTail.text(),
+              stderrText: stderrDiagTail.text(),
+            });
+            reason = diagnostic ? `Exit code ${code}: ${diagnostic}` : `Exit code ${code}`;
           }
           console.log(`❌ Video generation failed [${jobId.slice(0, 8)}]: ${reason}`);
           broadcastSse(job, { type: 'error', error: `Generation failed: ${reason}` });


### PR DESCRIPTION
## Summary

Closes #6281.

`spawnWatch.js#handleChildClose()`'s fallback branch reported only a bare `Exit code N` whenever a video-gen child exited nonzero with no death signal and no `ModuleNotFoundError` match — discarding whatever the child actually printed to explain why.

## What this adds

- Two new `createOutputTail()` instances (`stdoutDiagTail`/`stderrDiagTail`) in `spawnAndWatchVideo`, fed only the lines neither the child's own STATUS:/STAGE:/RUNTIME:/SPEEDPROFILE: protocol nor `PYTHON_NOISE_RE` already claimed as noise — the same gate `stdoutReader`/`stderrReader` already use to decide what's worth raw-logging. A progress bar, a dependency warning, or a STAGE marker can therefore never win over the real cause, and each tail's own char budget means this can never surface an unbounded traceback.
- `generateVideoHelpers.js#pickExitDiagnostic()`: picks between the two tails (stderr first — a raised exception normally lands there; a Python traceback also prints its exception message LAST, so the tail's most recent line is almost always that message rather than a stack frame above it) and scrubs credential-shaped tokens via the existing `scrubSecretTokens()` before the reason can reach the job record or the UI.
- The fallback branch now reports `Exit code N: <cause>` when a cause was found, falling back to the bare `Exit code N` exactly as before when neither stream printed anything useful — terminal messages still carry the exit code either way.
- Kept separate from the existing `stderrTail` array, which the Metal-retry sniffer needs UNFILTERED (it greps for the `STAGE:encode-prompt` markers this pair deliberately excludes).

Cross-platform by construction: no traceback-format assumptions, just the last bounded window of otherwise-unrecognized output.

Clean-room implementation from the issue's own description; the referenced Phosphene commit was not opened.

## Test plan

- `cd server && npx vitest run services/videoGen/local.test.js services/videoGen/generateVideoHelpers.test.js` — 359 passed, 8 skipped (unrelated), 0 failed.
- New tests added per the issue's acceptance criteria:
  - `pickExitDiagnostic` unit tests (null when empty, stderr-over-stdout preference, stdout fallback, credential scrubbing) in `generateVideoHelpers.test.js`.
  - A new `generateVideo — ordinary nonzero exit surfaces a cause instead of a bare exit code (#6281)` describe block in `local.test.js`: a realistic multi-line traceback, a final line split across two chunks with no trailing newline (flushed on close), STATUS:/tqdm noise correctly excluded from the reported cause, a stdout-only fallback, and the bare-exit-code fallback when neither stream printed anything.
  - Existing missing-module, cancellation, signal-death, and one-shot Metal-retry process-boundary tests were left untouched and still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)