### PR TITLE
Reuse one record restore path for video Remix

### DIFF
--- a/client/src/hooks/useMediaPreviewActions.js
+++ b/client/src/hooks/useMediaPreviewActions.js
@@ -77,9 +77,24 @@ export default function useMediaPreviewActions({ onCleanComplete = null } = {}) 
   // params), videos go to /media/video (with video-shaped params — frames,
   // fps, tiling, etc.). Video remix lands the user in 'text' mode with all
   // params filled; they can switch to image/extend mode and pick a source.
+  //
+  // Videos hand over the RECORD ID (`?remix=<id>`), not a render-settings
+  // bundle (#6290). A field-by-field URL is a second restore implementation
+  // that has to be extended every time a render field is added, and it fell
+  // behind the in-page one: `textEncoderId`, `speedProfileId`, `draftDecode`
+  // and the LoRA arrays were all missing here, so remixing the same clip from
+  // Media History silently returned those controls to stock while remixing it
+  // from the Video Gen gallery restored them. The id lets /media/video resolve
+  // the record from its own history load and reuse `applyRemix` — the single
+  // restore implementation. The field bundle below stays for records with no
+  // id (and keeps previously-issued links working), but is not extended.
   const handleRemix = useCallback((item) => {
     if (!item) return;
     if (item.kind === 'video') {
+      if (item.id != null && item.id !== '') {
+        navigate(`/media/video?remix=${encodeURIComponent(item.id)}`);
+        return;
+      }
       const params = new URLSearchParams();
       if (item.prompt && item.prompt !== '(no prompt)') params.set('prompt', item.prompt);
       if (item.negativePrompt) params.set('negativePrompt', item.negativePrompt);

--- a/client/src/hooks/useMediaPreviewActions.test.jsx
+++ b/client/src/hooks/useMediaPreviewActions.test.jsx
@@ -48,13 +48,6 @@ describe('useMediaPreviewActions.handleRemix', () => {
     expect([...params.keys()]).toEqual(['remix']);
   });
 
-  it('percent-encodes a record id so an id with URL punctuation survives the handoff', () => {
-    const { result } = renderHook(() => useMediaPreviewActions());
-    result.current.handleRemix({ kind: 'video', id: 'vid 1&x=2' });
-    const { params } = parseNav();
-    expect(params.get('remix')).toBe('vid 1&x=2');
-  });
-
   // Records that never got an id (and links already out in the wild) keep the
   // legacy field bundle. It is deliberately not extended with new fields.
   it('falls back to the legacy field bundle for a video with no record id', () => {

--- a/client/src/hooks/useMediaPreviewActions.test.jsx
+++ b/client/src/hooks/useMediaPreviewActions.test.jsx
@@ -22,7 +22,42 @@ const parseNav = () => {
 describe('useMediaPreviewActions.handleRemix', () => {
   beforeEach(() => navigate.mockReset());
 
-  it('sends a video back to /media/video with prompt and render settings', () => {
+  // #6290: a saved video hands over its RECORD ID, not a render-settings
+  // bundle. The bundle was a second restore implementation that had to be
+  // extended for every new render field and wasn't — it silently dropped the
+  // conditioner, speed profile, draft decode and LoRAs — so the same clip came
+  // back with different settings from History than from the Video Gen gallery.
+  // Enumerating fields here again would re-open exactly that drift.
+  it('sends a saved video back to /media/video by record id, with no settings bundle', () => {
+    const { result } = renderHook(() => useMediaPreviewActions());
+    result.current.handleRemix({
+      kind: 'video',
+      id: 'vid-1',
+      prompt: 'a fox in rain',
+      negativePrompt: 'blurry',
+      modelId: 'ltx2-dev',
+      width: 768,
+      height: 512,
+      numFrames: 121,
+      fps: 24,
+      raw: { seed: 42, steps: 8, guidanceScale: 3, tiling: 'none', disableAudio: true },
+    });
+    const { path, params } = parseNav();
+    expect(path).toBe('/media/video');
+    expect(params.get('remix')).toBe('vid-1');
+    expect([...params.keys()]).toEqual(['remix']);
+  });
+
+  it('percent-encodes a record id so an id with URL punctuation survives the handoff', () => {
+    const { result } = renderHook(() => useMediaPreviewActions());
+    result.current.handleRemix({ kind: 'video', id: 'vid 1&x=2' });
+    const { params } = parseNav();
+    expect(params.get('remix')).toBe('vid 1&x=2');
+  });
+
+  // Records that never got an id (and links already out in the wild) keep the
+  // legacy field bundle. It is deliberately not extended with new fields.
+  it('falls back to the legacy field bundle for a video with no record id', () => {
     const { result } = renderHook(() => useMediaPreviewActions());
     result.current.handleRemix({
       kind: 'video',
@@ -37,6 +72,7 @@ describe('useMediaPreviewActions.handleRemix', () => {
     });
     const { path, params } = parseNav();
     expect(path).toBe('/media/video');
+    expect(params.get('remix')).toBeNull();
     expect(params.get('prompt')).toBe('a fox in rain');
     expect(params.get('negativePrompt')).toBe('blurry');
     expect(params.get('modelId')).toBe('ltx2-dev');
@@ -51,7 +87,7 @@ describe('useMediaPreviewActions.handleRemix', () => {
     expect(params.get('disableAudio')).toBe('1');
   });
 
-  it('skips the (no prompt) placeholder so a remixed clip does not seed that literal', () => {
+  it('skips the (no prompt) placeholder so an id-less remixed clip does not seed that literal', () => {
     const { result } = renderHook(() => useMediaPreviewActions());
     result.current.handleRemix({ kind: 'video', prompt: '(no prompt)', width: 512, height: 512 });
     const { params } = parseNav();

--- a/client/src/hooks/useVideoGenForm.js
+++ b/client/src/hooks/useVideoGenForm.js
@@ -545,6 +545,27 @@ export function useVideoGenForm({
     [availableLoras, loraFamily],
   );
 
+  // `applyRemix` resolves each restored LoRA's DISPLAY NAME out of the installed
+  // library at apply time, falling back to the raw filename. The cross-page
+  // Remix handoff (#6290) can apply before that library has landed — the page
+  // fetches the LoRA list and the history list as independent mount effects with
+  // no ordering — so re-resolve once it arrives, or the picker sits on
+  // `lora-example-v7.safetensors` for the session. Filename and scale (what the
+  // payload is built from) are untouched; only the label is filled in.
+  useEffect(() => {
+    if (!availableLoras.length) return;
+    setSelectedLoras((prev) => {
+      let changed = false;
+      const next = prev.map((selected) => {
+        const name = availableLoras.find((l) => l.filename === selected.filename)?.name;
+        if (!name || name === selected.name) return selected;
+        changed = true;
+        return { ...selected, name };
+      });
+      return changed ? next : prev;
+    });
+  }, [availableLoras]);
+
   // Installed video LoRAs bucketed by family, regardless of the selected model.
   // One pass instead of one filter per family, and the source for the
   // "why is the picker gone" hint below.

--- a/client/src/pages/VideoGen.jsx
+++ b/client/src/pages/VideoGen.jsx
@@ -452,6 +452,14 @@ export default function VideoGen() {
   // otherwise replay it over a form the user has been editing the whole time.
   const remixHandoffId = searchParams.get('remix');
   const settledRemixHandoffRef = useRef(null);
+  // The restore waits on a history round trip, so unlike the old URL bundle
+  // (applied synchronously on mount) there is a window in which the form still
+  // holds the page defaults and is about to be replaced wholesale. Announce it
+  // and hold Generate: rendering here would spend GPU time on the defaults while
+  // the user believes they are looking at the clip's settings.
+  // Only Retry puts `historyLoad` back to 'loading' after it has settled, and
+  // that is exactly a re-pending handoff — so the two conditions are enough.
+  const remixHandoffPending = !!remixHandoffId && historyLoad === 'loading';
   // null while nothing is wrong; otherwise 'error' (the history fetch failed,
   // retryable) or 'missing' (history loaded and holds no such record).
   const [remixHandoffProblem, setRemixHandoffProblem] = useState(null);
@@ -970,7 +978,7 @@ export default function VideoGen() {
   // A federated render answers to the PEER’s readiness, not to this machine’s
   // runtime gates — none of the local probes below describe the hardware it
   // will actually run on.
-  const canEnqueue = prompt.trim() && (remoteTarget.isRemote
+  const canEnqueue = prompt.trim() && !remixHandoffPending && (remoteTarget.isRemote
     ? remoteBlocked === null
     : (isGrok || isFal || isReactor || (!notConnected && !extendModeBlocked
       && !a2vModeBlocked && !icLoraModeBlocked && !byovGateBlocked
@@ -1123,6 +1131,11 @@ export default function VideoGen() {
               would be the worst outcome here: the user pressed Remix, landed on
               a form holding whatever it held before, and would start a render
               with the wrong settings believing they were the clip's. */}
+          {remixHandoffPending && (
+            <p role="status" className="rounded-lg border border-port-border bg-port-bg px-3 py-2 text-xs text-gray-400">
+              Restoring this render's settings — the form below is about to be replaced with them.
+            </p>
+          )}
           {remixHandoffProblem && (
             <div
               role="status"

--- a/client/src/pages/VideoGen.jsx
+++ b/client/src/pages/VideoGen.jsx
@@ -442,11 +442,18 @@ export default function VideoGen() {
   // The ref (not the stripped param) is what makes this one-shot: the strip is
   // an async router update, so a completion refresh landing in the same tick
   // would otherwise re-apply the handoff over edits the user has since made.
+  // It records the settled ID rather than a boolean, so a SECOND handoff
+  // arriving on the same mount is still honored.
   const remixHandoffId = searchParams.get('remix');
-  const remixHandoffAppliedRef = useRef(false);
+  const settledRemixHandoffRef = useRef(null);
   // null while nothing is wrong; otherwise 'error' (the history fetch failed,
   // retryable) or 'missing' (history loaded and holds no such record).
   const [remixHandoffProblem, setRemixHandoffProblem] = useState(null);
+  // Set when the fetch failed under a pending handoff. The restore then waits
+  // for an explicit Retry instead of riding in on the next background refresh:
+  // a render completing minutes later would otherwise replay the handoff over
+  // a form the user has been editing since the banner appeared.
+  const [remixHandoffBlocked, setRemixHandoffBlocked] = useState(false);
   const consumeRemixHandoff = useCallback(() => {
     setSearchParams((prev) => {
       const next = new URLSearchParams(prev);
@@ -455,18 +462,23 @@ export default function VideoGen() {
     }, { replace: true });
   }, [setSearchParams]);
   useEffect(() => {
-    if (!remixHandoffId || remixHandoffAppliedRef.current) return;
+    // No handoff in the URL — including right after this one consumed its own.
+    // Clearing the settled id here is what lets the NEXT handoff through, even
+    // when it names the same record.
+    if (!remixHandoffId) { settledRemixHandoffRef.current = null; return; }
+    if (settledRemixHandoffRef.current === remixHandoffId || remixHandoffBlocked) return;
     // Still fetching: say nothing. Reporting "no such record" here would be a
     // lie every time the page is opened faster than the history round trip.
     if (historyLoad === 'loading') return;
     if (historyLoad === 'error') {
-      // Keep the param so Retry can resolve it once the fetch succeeds, and
-      // leave the ref unset so the retry actually re-runs this effect.
+      // Keep the param so Retry can resolve it, and leave the handoff unsettled
+      // so that retry actually re-runs this effect.
       setRemixHandoffProblem('error');
+      setRemixHandoffBlocked(true);
       return;
     }
     const record = history.find((v) => String(v.id) === remixHandoffId);
-    remixHandoffAppliedRef.current = true;
+    settledRemixHandoffRef.current = remixHandoffId;
     if (record) {
       applyRemix(record);
       setRemixHandoffProblem(null);
@@ -474,21 +486,21 @@ export default function VideoGen() {
       setRemixHandoffProblem('missing');
     }
     consumeRemixHandoff();
-  }, [remixHandoffId, historyLoad, history, applyRemix, consumeRemixHandoff]);
+  }, [remixHandoffId, historyLoad, history, remixHandoffBlocked, applyRemix, consumeRemixHandoff]);
   // Back to 'loading' first, so a retry that fails again still moves the state
-  // ('loading' → 'error') and re-runs the effect above. Re-setting 'error' onto
-  // 'error' is a no-op React bails on, which would leave the banner dismissed
-  // after a second failure.
+  // ('loading' → 'error') and re-runs the effect above.
   const retryRemixHandoff = useCallback(() => {
     setHistoryLoad('loading');
     setRemixHandoffProblem(null);
+    setRemixHandoffBlocked(false);
     refreshHistory();
   }, [refreshHistory]);
   const dismissRemixHandoff = useCallback(() => {
-    remixHandoffAppliedRef.current = true;
+    settledRemixHandoffRef.current = remixHandoffId;
     setRemixHandoffProblem(null);
+    setRemixHandoffBlocked(false);
     consumeRemixHandoff();
-  }, [consumeRemixHandoff]);
+  }, [remixHandoffId, consumeRemixHandoff]);
 
   // Finish a draft (#3696): same restore as Remix, but switched to the delivery
   // model the draft's registry entry declares. Prefill only — the user presses

--- a/client/src/pages/VideoGen.jsx
+++ b/client/src/pages/VideoGen.jsx
@@ -340,13 +340,26 @@ export default function VideoGen() {
   // sentinel rather than `history.length` — the Remix handoff below has to tell
   // "history is still in flight / failed to load" apart from "history loaded
   // and has no such record", and an empty array is a legitimate loaded state.
+  //
+  // The mount fetch and the completion refresh share this one sentinel, so the
+  // handoff also needs to know whether ANOTHER fetch is still running before it
+  // trusts an 'error': a transient failure on a background refresh must not
+  // strand a handoff that the in-flight mount fetch is about to satisfy. The
+  // count is a ref because only the effects read it, and they run after commit.
   const [historyLoad, setHistoryLoad] = useState('loading');
-  const refreshHistory = useCallback(() => listVideoHistory()
-    .then((items) => {
-      setHistory(Array.isArray(items) ? items : []);
-      setHistoryLoad('loaded');
-    })
-    .catch(() => setHistoryLoad('error')), []);
+  const historyInFlightRef = useRef(0);
+  // `silent` — this page owns the failure UI (the Remix banner below, and the
+  // gallery simply staying empty), so the shared toast would double it.
+  const refreshHistory = useCallback(() => {
+    historyInFlightRef.current += 1;
+    return listVideoHistory({ silent: true })
+      .then((items) => {
+        setHistory(Array.isArray(items) ? items : []);
+        setHistoryLoad('loaded');
+      })
+      .catch(() => setHistoryLoad('error'))
+      .finally(() => { historyInFlightRef.current -= 1; });
+  }, []);
   useMediaCompletionRefresh({ onVideoCompleted: refreshHistory });
   useEffect(() => { refreshHistory(); }, [refreshHistory]);
 
@@ -452,17 +465,18 @@ export default function VideoGen() {
   // otherwise replay it over a form the user has been editing the whole time.
   const remixHandoffId = searchParams.get('remix');
   const settledRemixHandoffRef = useRef(null);
+  // null while nothing is wrong; otherwise 'error' (the history fetch failed,
+  // retryable) or 'missing' (history loaded and holds no such record).
+  const [remixHandoffProblem, setRemixHandoffProblem] = useState(null);
   // The restore waits on a history round trip, so unlike the old URL bundle
   // (applied synchronously on mount) there is a window in which the form still
   // holds the page defaults and is about to be replaced wholesale. Announce it
   // and hold Generate: rendering here would spend GPU time on the defaults while
-  // the user believes they are looking at the clip's settings.
-  // Only Retry puts `historyLoad` back to 'loading' after it has settled, and
-  // that is exactly a re-pending handoff — so the two conditions are enough.
-  const remixHandoffPending = !!remixHandoffId && historyLoad === 'loading';
-  // null while nothing is wrong; otherwise 'error' (the history fetch failed,
-  // retryable) or 'missing' (history loaded and holds no such record).
-  const [remixHandoffProblem, setRemixHandoffProblem] = useState(null);
+  // the user believes they are looking at the clip's settings. The window runs
+  // from the parameter appearing until the handoff either restores (which strips
+  // it) or reports a problem — which also covers the wait on a sibling fetch
+  // below, with no second sentinel. Retry re-enters it by clearing the problem.
+  const remixHandoffPending = !!remixHandoffId && !remixHandoffProblem;
   const consumeRemixHandoff = useCallback(() => {
     setSearchParams((prev) => {
       const next = new URLSearchParams(prev);
@@ -480,6 +494,12 @@ export default function VideoGen() {
     // lie every time the page is opened faster than the history round trip.
     // Any banner still up belongs to a previous handoff, so it goes.
     if (historyLoad === 'loading') { setRemixHandoffProblem(null); return; }
+    // The sentinel is shared with the completion refresh, so an 'error' may
+    // belong to a background fetch that failed alongside the one this handoff is
+    // actually waiting on. Keep waiting while any fetch is still running, or a
+    // transient blip on the sibling would strand a handoff the in-flight request
+    // is about to satisfy.
+    if (historyLoad === 'error' && historyInFlightRef.current > 0) return;
     settledRemixHandoffRef.current = remixHandoffId;
     if (historyLoad === 'error') {
       // Keep the param in the URL — Retry resolves this same handoff.

--- a/client/src/pages/VideoGen.jsx
+++ b/client/src/pages/VideoGen.jsx
@@ -463,6 +463,10 @@ export default function VideoGen() {
     }, { replace: true });
   }, [setSearchParams]);
   useEffect(() => {
+    // The retry-block belongs to ONE handoff. Once the URL moves off it — the
+    // param was consumed, or another record arrived — it is spent, so the same
+    // record can be handed over again later and resolve normally.
+    if (blockedRemixHandoffId && blockedRemixHandoffId !== remixHandoffId) setBlockedRemixHandoffId(null);
     // No handoff in the URL — including right after this one consumed its own.
     // Clearing the settled id here is what lets the NEXT handoff through, even
     // when it names the same record.

--- a/client/src/pages/VideoGen.jsx
+++ b/client/src/pages/VideoGen.jsx
@@ -449,11 +449,12 @@ export default function VideoGen() {
   // null while nothing is wrong; otherwise 'error' (the history fetch failed,
   // retryable) or 'missing' (history loaded and holds no such record).
   const [remixHandoffProblem, setRemixHandoffProblem] = useState(null);
-  // Set when the fetch failed under a pending handoff. The restore then waits
-  // for an explicit Retry instead of riding in on the next background refresh:
-  // a render completing minutes later would otherwise replay the handoff over
-  // a form the user has been editing since the banner appeared.
-  const [remixHandoffBlocked, setRemixHandoffBlocked] = useState(false);
+  // The handoff id whose fetch failed. That restore then waits for an explicit
+  // Retry instead of riding in on the next background refresh: a render
+  // completing minutes later would otherwise replay it over a form the user has
+  // been editing since the banner appeared. Holding the ID rather than a flag
+  // keeps the block on that one handoff — a later one resolves normally.
+  const [blockedRemixHandoffId, setBlockedRemixHandoffId] = useState(null);
   const consumeRemixHandoff = useCallback(() => {
     setSearchParams((prev) => {
       const next = new URLSearchParams(prev);
@@ -466,15 +467,16 @@ export default function VideoGen() {
     // Clearing the settled id here is what lets the NEXT handoff through, even
     // when it names the same record.
     if (!remixHandoffId) { settledRemixHandoffRef.current = null; return; }
-    if (settledRemixHandoffRef.current === remixHandoffId || remixHandoffBlocked) return;
+    if (settledRemixHandoffRef.current === remixHandoffId || blockedRemixHandoffId === remixHandoffId) return;
     // Still fetching: say nothing. Reporting "no such record" here would be a
     // lie every time the page is opened faster than the history round trip.
-    if (historyLoad === 'loading') return;
+    // Any banner still up belongs to a previous handoff, so it goes.
+    if (historyLoad === 'loading') { setRemixHandoffProblem(null); return; }
     if (historyLoad === 'error') {
       // Keep the param so Retry can resolve it, and leave the handoff unsettled
       // so that retry actually re-runs this effect.
       setRemixHandoffProblem('error');
-      setRemixHandoffBlocked(true);
+      setBlockedRemixHandoffId(remixHandoffId);
       return;
     }
     const record = history.find((v) => String(v.id) === remixHandoffId);
@@ -486,19 +488,19 @@ export default function VideoGen() {
       setRemixHandoffProblem('missing');
     }
     consumeRemixHandoff();
-  }, [remixHandoffId, historyLoad, history, remixHandoffBlocked, applyRemix, consumeRemixHandoff]);
+  }, [remixHandoffId, historyLoad, history, blockedRemixHandoffId, applyRemix, consumeRemixHandoff]);
   // Back to 'loading' first, so a retry that fails again still moves the state
   // ('loading' → 'error') and re-runs the effect above.
   const retryRemixHandoff = useCallback(() => {
     setHistoryLoad('loading');
     setRemixHandoffProblem(null);
-    setRemixHandoffBlocked(false);
+    setBlockedRemixHandoffId(null);
     refreshHistory();
   }, [refreshHistory]);
   const dismissRemixHandoff = useCallback(() => {
     settledRemixHandoffRef.current = remixHandoffId;
     setRemixHandoffProblem(null);
-    setRemixHandoffBlocked(false);
+    setBlockedRemixHandoffId(null);
     consumeRemixHandoff();
   }, [remixHandoffId, consumeRemixHandoff]);
 

--- a/client/src/pages/VideoGen.jsx
+++ b/client/src/pages/VideoGen.jsx
@@ -439,22 +439,22 @@ export default function VideoGen() {
   // decode and LoRAs. `history` is the unfiltered load, so a hidden record
   // resolves too.
   //
-  // The ref (not the stripped param) is what makes this one-shot: the strip is
-  // an async router update, so a completion refresh landing in the same tick
-  // would otherwise re-apply the handoff over edits the user has since made.
-  // It records the settled ID rather than a boolean, so a SECOND handoff
-  // arriving on the same mount is still honored.
+  // One ref carries the whole "has this handoff been dealt with?" question, and
+  // it holds the handoff ID rather than a boolean, so a SECOND handoff arriving
+  // on the same mount is still honored. It is what makes the restore one-shot —
+  // not the stripped parameter, which lands on an async router update a
+  // completion refresh in the same tick could beat, re-applying the handoff over
+  // edits the user has made since.
+  //
+  // A FAILED fetch settles the handoff too, deliberately: the restore then waits
+  // for the explicit Retry (which clears the ref) instead of riding in on the
+  // next background refresh, since a render completing minutes later would
+  // otherwise replay it over a form the user has been editing the whole time.
   const remixHandoffId = searchParams.get('remix');
   const settledRemixHandoffRef = useRef(null);
   // null while nothing is wrong; otherwise 'error' (the history fetch failed,
   // retryable) or 'missing' (history loaded and holds no such record).
   const [remixHandoffProblem, setRemixHandoffProblem] = useState(null);
-  // The handoff id whose fetch failed. That restore then waits for an explicit
-  // Retry instead of riding in on the next background refresh: a render
-  // completing minutes later would otherwise replay it over a form the user has
-  // been editing since the banner appeared. Holding the ID rather than a flag
-  // keeps the block on that one handoff — a later one resolves normally.
-  const [blockedRemixHandoffId, setBlockedRemixHandoffId] = useState(null);
   const consumeRemixHandoff = useCallback(() => {
     setSearchParams((prev) => {
       const next = new URLSearchParams(prev);
@@ -463,28 +463,22 @@ export default function VideoGen() {
     }, { replace: true });
   }, [setSearchParams]);
   useEffect(() => {
-    // The retry-block belongs to ONE handoff. Once the URL moves off it — the
-    // param was consumed, or another record arrived — it is spent, so the same
-    // record can be handed over again later and resolve normally.
-    if (blockedRemixHandoffId && blockedRemixHandoffId !== remixHandoffId) setBlockedRemixHandoffId(null);
     // No handoff in the URL — including right after this one consumed its own.
     // Clearing the settled id here is what lets the NEXT handoff through, even
     // when it names the same record.
     if (!remixHandoffId) { settledRemixHandoffRef.current = null; return; }
-    if (settledRemixHandoffRef.current === remixHandoffId || blockedRemixHandoffId === remixHandoffId) return;
+    if (settledRemixHandoffRef.current === remixHandoffId) return;
     // Still fetching: say nothing. Reporting "no such record" here would be a
     // lie every time the page is opened faster than the history round trip.
     // Any banner still up belongs to a previous handoff, so it goes.
     if (historyLoad === 'loading') { setRemixHandoffProblem(null); return; }
+    settledRemixHandoffRef.current = remixHandoffId;
     if (historyLoad === 'error') {
-      // Keep the param so Retry can resolve it, and leave the handoff unsettled
-      // so that retry actually re-runs this effect.
+      // Keep the param in the URL — Retry resolves this same handoff.
       setRemixHandoffProblem('error');
-      setBlockedRemixHandoffId(remixHandoffId);
       return;
     }
     const record = history.find((v) => String(v.id) === remixHandoffId);
-    settledRemixHandoffRef.current = remixHandoffId;
     if (record) {
       applyRemix(record);
       setRemixHandoffProblem(null);
@@ -492,19 +486,18 @@ export default function VideoGen() {
       setRemixHandoffProblem('missing');
     }
     consumeRemixHandoff();
-  }, [remixHandoffId, historyLoad, history, blockedRemixHandoffId, applyRemix, consumeRemixHandoff]);
+  }, [remixHandoffId, historyLoad, history, applyRemix, consumeRemixHandoff]);
   // Back to 'loading' first, so a retry that fails again still moves the state
   // ('loading' → 'error') and re-runs the effect above.
   const retryRemixHandoff = useCallback(() => {
+    settledRemixHandoffRef.current = null;
     setHistoryLoad('loading');
     setRemixHandoffProblem(null);
-    setBlockedRemixHandoffId(null);
     refreshHistory();
   }, [refreshHistory]);
   const dismissRemixHandoff = useCallback(() => {
     settledRemixHandoffRef.current = remixHandoffId;
     setRemixHandoffProblem(null);
-    setBlockedRemixHandoffId(null);
     consumeRemixHandoff();
   }, [remixHandoffId, consumeRemixHandoff]);
 

--- a/client/src/pages/VideoGen.jsx
+++ b/client/src/pages/VideoGen.jsx
@@ -336,9 +336,17 @@ export default function VideoGen() {
   // after `previewItems` below so the resolver can match against it.
   const [showHidden, setShowHidden] = useState(false);
 
-  const refreshHistory = useCallback(() => {
-    listVideoHistory().then((items) => setHistory(Array.isArray(items) ? items : [])).catch(() => {});
-  }, []);
+  // 'loading' until the first fetch settles, then 'loaded' or 'error'. A
+  // sentinel rather than `history.length` — the Remix handoff below has to tell
+  // "history is still in flight / failed to load" apart from "history loaded
+  // and has no such record", and an empty array is a legitimate loaded state.
+  const [historyLoad, setHistoryLoad] = useState('loading');
+  const refreshHistory = useCallback(() => listVideoHistory()
+    .then((items) => {
+      setHistory(Array.isArray(items) ? items : []);
+      setHistoryLoad('loaded');
+    })
+    .catch(() => setHistoryLoad('error')), []);
   useMediaCompletionRefresh({ onVideoCompleted: refreshHistory });
   useEffect(() => { refreshHistory(); }, [refreshHistory]);
 
@@ -422,6 +430,65 @@ export default function VideoGen() {
     applyRemix(raw);
     window.scrollTo({ top: 0, behavior: 'smooth' });
   }, [applyRemix]);
+
+  // Cross-page Remix (#6290). Media History (and every other MediaPreview
+  // surface) hands this page a RECORD ID rather than a render-settings bundle,
+  // so the restore runs through the same `applyRemix` the in-page gallery uses
+  // — one implementation that knows every field the record carries, instead of
+  // a URL enumeration that silently dropped the encoder, speed profile, draft
+  // decode and LoRAs. `history` is the unfiltered load, so a hidden record
+  // resolves too.
+  //
+  // The ref (not the stripped param) is what makes this one-shot: the strip is
+  // an async router update, so a completion refresh landing in the same tick
+  // would otherwise re-apply the handoff over edits the user has since made.
+  const remixHandoffId = searchParams.get('remix');
+  const remixHandoffAppliedRef = useRef(false);
+  // null while nothing is wrong; otherwise 'error' (the history fetch failed,
+  // retryable) or 'missing' (history loaded and holds no such record).
+  const [remixHandoffProblem, setRemixHandoffProblem] = useState(null);
+  const consumeRemixHandoff = useCallback(() => {
+    setSearchParams((prev) => {
+      const next = new URLSearchParams(prev);
+      next.delete('remix');
+      return next;
+    }, { replace: true });
+  }, [setSearchParams]);
+  useEffect(() => {
+    if (!remixHandoffId || remixHandoffAppliedRef.current) return;
+    // Still fetching: say nothing. Reporting "no such record" here would be a
+    // lie every time the page is opened faster than the history round trip.
+    if (historyLoad === 'loading') return;
+    if (historyLoad === 'error') {
+      // Keep the param so Retry can resolve it once the fetch succeeds, and
+      // leave the ref unset so the retry actually re-runs this effect.
+      setRemixHandoffProblem('error');
+      return;
+    }
+    const record = history.find((v) => String(v.id) === remixHandoffId);
+    remixHandoffAppliedRef.current = true;
+    if (record) {
+      applyRemix(record);
+      setRemixHandoffProblem(null);
+    } else {
+      setRemixHandoffProblem('missing');
+    }
+    consumeRemixHandoff();
+  }, [remixHandoffId, historyLoad, history, applyRemix, consumeRemixHandoff]);
+  // Back to 'loading' first, so a retry that fails again still moves the state
+  // ('loading' → 'error') and re-runs the effect above. Re-setting 'error' onto
+  // 'error' is a no-op React bails on, which would leave the banner dismissed
+  // after a second failure.
+  const retryRemixHandoff = useCallback(() => {
+    setHistoryLoad('loading');
+    setRemixHandoffProblem(null);
+    refreshHistory();
+  }, [refreshHistory]);
+  const dismissRemixHandoff = useCallback(() => {
+    remixHandoffAppliedRef.current = true;
+    setRemixHandoffProblem(null);
+    consumeRemixHandoff();
+  }, [consumeRemixHandoff]);
 
   // Finish a draft (#3696): same restore as Remix, but switched to the delivery
   // model the draft's registry entry declares. Prefill only — the user presses
@@ -1041,6 +1108,42 @@ export default function VideoGen() {
 
       <form onSubmit={handleGenerate} className="grid grid-cols-1 lg:grid-cols-[3fr_2fr] gap-4">
         <div className="bg-port-card border border-port-border rounded-xl p-4 space-y-3">
+          {/* A cross-page Remix that could not be restored (#6290). Silence
+              would be the worst outcome here: the user pressed Remix, landed on
+              a form holding whatever it held before, and would start a render
+              with the wrong settings believing they were the clip's. */}
+          {remixHandoffProblem && (
+            <div
+              role="status"
+              className="rounded-lg border border-port-warning/40 bg-port-warning/10 px-3 py-3 text-xs text-port-warning flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2"
+            >
+              <div>
+                {remixHandoffProblem === 'error'
+                  ? "Couldn't load your render history, so this clip's settings weren't restored."
+                  : 'That render is no longer in your history, so its settings could not be restored.'}
+                {' '}The form still holds its previous values.
+              </div>
+              <div className="flex items-center gap-2 self-start sm:self-auto">
+                {remixHandoffProblem === 'error' && (
+                  <button
+                    type="button"
+                    onClick={retryRemixHandoff}
+                    className="whitespace-nowrap inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-port-accent text-white text-xs font-medium hover:bg-port-accent/80"
+                  >
+                    <RefreshCw className="w-3.5 h-3.5" />
+                    Retry
+                  </button>
+                )}
+                <button
+                  type="button"
+                  onClick={dismissRemixHandoff}
+                  className="text-gray-400 hover:text-gray-200 text-xs"
+                >
+                  Dismiss
+                </button>
+              </div>
+            </div>
+          )}
           {!isGrok && !isFal && !isReactor && byovRuntimeMissing && (
             <div className="rounded-lg border border-port-warning/40 bg-port-warning/10 px-3 py-3 text-xs text-port-warning flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
               <div>

--- a/client/src/pages/VideoGen.remix.test.jsx
+++ b/client/src/pages/VideoGen.remix.test.jsx
@@ -171,6 +171,23 @@ describe('VideoGen cross-page Remix handoff', () => {
     expect(restored.chunkPrompts).toEqual([]);
   });
 
+  it('labels a restored LoRA even when the library lands after the record does', async () => {
+    // The page fetches history and the LoRA library as independent mount
+    // effects. A cross-page Remix restores as soon as HISTORY settles, so on
+    // this ordering the names have nothing to resolve against yet — and a
+    // one-shot resolve would leave the picker showing the raw filename.
+    let settleLoras;
+    state.listLorasFull.mockReturnValue(new Promise((resolve) => { settleLoras = resolve; }));
+    await renderVideoGenPage(`/media/video?remix=${RECORD.id}`);
+    await waitFor(() => expect(screen.getByLabelText('Prompt')).toHaveValue(RECORD.prompt));
+
+    await act(async () => { settleLoras([LORA]); });
+
+    await waitFor(() => expect(state.loraPicker?.selected).toEqual([
+      { filename: LORA.filename, name: LORA.name, scale: 0.7 },
+    ]));
+  });
+
   it('says nothing about a missing record while the history fetch is still in flight', async () => {
     let settleHistory;
     state.listVideoHistory.mockReturnValue(new Promise((resolve) => { settleHistory = resolve; }));

--- a/client/src/pages/VideoGen.remix.test.jsx
+++ b/client/src/pages/VideoGen.remix.test.jsx
@@ -122,6 +122,11 @@ describe('VideoGen cross-page Remix handoff', () => {
     state.attach.mockResolvedValue({ filename: 'example.mp4' });
     state.availableLoras = [LORA];
     state.listVideoHistory.mockResolvedValue([RECORD, LEGACY_RECORD]);
+    // Every weight cached — a ready install. Without this the Generate button
+    // is disabled by the weights gate no matter what, which would let the
+    // "held while the handoff is pending" assertion pass for the wrong reason.
+    state.getModelStatus = () => ({ cached: true });
+    state.modelDownloadExtra = { textEncoder: { cached: true } };
   });
 
   it('restores the same settings from a History handoff as from the in-page gallery', async () => {
@@ -198,9 +203,18 @@ describe('VideoGen cross-page Remix handoff', () => {
     expect(screen.queryByText(/no longer in your history/)).toBeNull();
     expect(screen.queryByText(/Couldn't load your render history/)).toBeNull();
 
+    // It IS announced, and Generate is held: the form still shows the page
+    // defaults and is about to be replaced wholesale, so a render started here
+    // would spend GPU time on the wrong settings under the clip's name.
+    screen.getByText(/Restoring this render's settings/);
+    fireEvent.change(screen.getByLabelText('Prompt'), { target: { value: 'anything at all' } });
+    expect(screen.getByRole('button', { name: /Generate/ })).toBeDisabled();
+
     await act(async () => { settleHistory([RECORD]); });
     await waitFor(() => expect(screen.getByLabelText('Prompt')).toHaveValue(RECORD.prompt));
     expect(screen.queryByText(/no longer in your history/)).toBeNull();
+    expect(screen.queryByText(/Restoring this render's settings/)).toBeNull();
+    expect(screen.getByRole('button', { name: /Generate/ })).toBeEnabled();
   });
 
   it('offers a retry when the history fetch fails, and restores once it succeeds', async () => {

--- a/client/src/pages/VideoGen.remix.test.jsx
+++ b/client/src/pages/VideoGen.remix.test.jsx
@@ -1,0 +1,217 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { act, cleanup, fireEvent, screen, waitFor } from '@testing-library/react';
+
+import {
+  loadVideoGenPage,
+  renderVideoGenPage,
+  resetVideoGenMockState,
+  state,
+  videoGenModel,
+  videoGenModelContext,
+  videoGenStatus,
+} from '../test/videoGenPageMocks.jsx';
+
+/**
+ * Cross-page Remix restores exactly what in-page Remix restores (#6290).
+ *
+ * Media History used to hand /media/video a field-by-field URL bundle built by
+ * `useMediaPreviewActions`, a second restore implementation that fell behind the
+ * page's own `applyRemix`: the conditioner, speed profile, draft decode and the
+ * LoRA arrays were all missing from it, so the same saved clip came back with
+ * stock/Quality/Full/no-LoRA settings from History and with its real settings
+ * from the gallery — a different render at a different compute cost. The handoff
+ * is now the RECORD ID, resolved here against the page's own history load and
+ * replayed through the one restore implementation.
+ */
+const MODEL = videoGenModel('example-ltx', {
+  name: 'Example LTX',
+  runtime: 'ltx2',
+  supportedModes: ['text', 'image'],
+  defaultFrames: 121,
+  frameOptions: [121, 241],
+  fpsOptions: [24],
+  samplerLocked: false,
+  supportsNegativePrompt: true,
+  supportsTiling: true,
+  supportsDisableAudio: true,
+  textEncoderOptions: [
+    { id: 'stock', label: 'Stock conditioner', builtIn: true },
+    { id: 'example-substitute', label: 'Example substitute' },
+  ],
+  speedProfiles: [{ id: 'turbo', label: 'Turbo', steps: 4, guidance: 1 }],
+  draftDecodeOptions: [{ id: 'example-draft', label: 'Example draft decoder' }],
+});
+
+const LORA = { filename: 'lora-example.safetensors', name: 'Example LoRA', loraCompatKey: 'ltx-video' };
+
+/**
+ * A saved render carrying every field the old URL bundle dropped. `hidden` is
+ * deliberate: History can open a hidden record, so the lookup has to run against
+ * the unfiltered load rather than the gallery's visible slice.
+ */
+const RECORD = {
+  id: 'vid-example-1',
+  filename: 'example.mp4',
+  prompt: 'a paper boat on a canal',
+  negativePrompt: 'blurry',
+  modelId: MODEL.id,
+  width: 768,
+  height: 512,
+  numFrames: 121,
+  fps: 24,
+  seed: 42,
+  steps: 12,
+  guidanceScale: 3,
+  tiling: 'none',
+  disableAudio: true,
+  textEncoderId: 'example-substitute',
+  speedProfileId: 'turbo',
+  draftDecode: 'example-draft',
+  loraFilenames: [LORA.filename],
+  loraScales: [0.7],
+  chainedFrom: ['vid-example-a', 'vid-example-b'],
+  chunkPrompts: ['the boat launches', 'the boat sinks'],
+  hidden: true,
+};
+
+/** A record from before the optional render fields existed. */
+const LEGACY_RECORD = {
+  id: 'vid-legacy-1',
+  filename: 'legacy.mp4',
+  prompt: 'a kite over a field',
+  modelId: MODEL.id,
+  width: 768,
+  height: 512,
+  numFrames: 121,
+  fps: 24,
+};
+
+await loadVideoGenPage();
+
+/**
+ * Everything the restore is responsible for, read off the live form: the
+ * controls the page renders itself, plus the sampler/LoRA props it hands the
+ * panels. One reading, so the two entry paths are compared on identical terms.
+ */
+const readRestoredForm = () => ({
+  prompt: screen.getByLabelText('Prompt').value,
+  negativePrompt: screen.getByLabelText('Negative Prompt').value,
+  modelId: screen.getByLabelText('Model').value,
+  textEncoderId: screen.getByLabelText('Text encoder').value,
+  loras: (state.loraPicker?.selected || []).map((l) => `${l.filename}@${l.scale}`),
+  numFrames: state.advancedParams?.numFrames,
+  fps: state.advancedParams?.fps,
+  seed: state.advancedParams?.seed,
+  steps: state.advancedParams?.steps,
+  guidanceScale: state.advancedParams?.guidanceScale,
+  speedProfileId: state.advancedParams?.speedProfileId,
+  draftDecode: state.advancedParams?.draftDecode,
+  tiling: state.advancedParams?.tiling,
+  disableAudio: state.advancedParams?.disableAudio,
+  chunks: state.advancedParams?.chunks,
+  chunkPrompts: state.advancedParams?.chunkPrompts,
+});
+
+describe('VideoGen cross-page Remix handoff', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    sessionStorage.clear();
+    resetVideoGenMockState();
+    state.getVideoGenStatus.mockResolvedValue(videoGenStatus([MODEL]));
+    state.getVideoGenModelContext.mockResolvedValue(videoGenModelContext([MODEL]));
+    state.attach.mockResolvedValue({ filename: 'example.mp4' });
+    state.availableLoras = [LORA];
+    state.listVideoHistory.mockResolvedValue([RECORD, LEGACY_RECORD]);
+  });
+
+  it('restores the same settings from a History handoff as from the in-page gallery', async () => {
+    await renderVideoGenPage(`/media/video?remix=${RECORD.id}`);
+    await waitFor(() => expect(screen.getByLabelText('Prompt')).toHaveValue(RECORD.prompt));
+    const fromHistory = readRestoredForm();
+
+    // The exact fields the old URL bundle dropped. Asserted by name as well as
+    // by the equality below, so a regression that broke BOTH paths together
+    // still fails this test rather than comparing two blank forms.
+    expect(fromHistory.textEncoderId).toBe('example-substitute');
+    expect(fromHistory.speedProfileId).toBe('turbo');
+    expect(fromHistory.draftDecode).toBe('example-draft');
+    expect(fromHistory.loras).toEqual(['lora-example.safetensors@0.7']);
+    expect(fromHistory.chunks).toBe(2);
+    expect(fromHistory.chunkPrompts).toEqual(RECORD.chunkPrompts);
+
+    cleanup();
+    await renderVideoGenPage();
+    await act(async () => { state.galleryProps.onRemix(RECORD); });
+    await waitFor(() => expect(screen.getByLabelText('Prompt')).toHaveValue(RECORD.prompt));
+
+    expect(readRestoredForm()).toEqual(fromHistory);
+  });
+
+  it('resets the optional controls to their sentinels for a legacy record', async () => {
+    await renderVideoGenPage(`/media/video?remix=${LEGACY_RECORD.id}`);
+    await waitFor(() => expect(screen.getByLabelText('Prompt')).toHaveValue(LEGACY_RECORD.prompt));
+
+    const restored = readRestoredForm();
+    expect(restored.textEncoderId).toBe('stock');
+    expect(restored.speedProfileId).toBe('quality');
+    expect(restored.draftDecode).toBe('full');
+    expect(restored.loras).toEqual([]);
+    expect(restored.steps).toBe('');
+    expect(restored.guidanceScale).toBe('');
+    expect(restored.chunks).toBe(1);
+  });
+
+  it('says nothing about a missing record while the history fetch is still in flight', async () => {
+    let settleHistory;
+    state.listVideoHistory.mockReturnValue(new Promise((resolve) => { settleHistory = resolve; }));
+    await renderVideoGenPage(`/media/video?remix=${RECORD.id}`);
+
+    // The pending fetch is not evidence of anything — claiming the record is
+    // gone here would fire on every load that beats the round trip.
+    expect(screen.queryByText(/no longer in your history/)).toBeNull();
+    expect(screen.queryByText(/Couldn't load your render history/)).toBeNull();
+
+    await act(async () => { settleHistory([RECORD]); });
+    await waitFor(() => expect(screen.getByLabelText('Prompt')).toHaveValue(RECORD.prompt));
+    expect(screen.queryByText(/no longer in your history/)).toBeNull();
+  });
+
+  it('offers a retry when the history fetch fails, and restores once it succeeds', async () => {
+    state.listVideoHistory.mockRejectedValueOnce(new Error('offline'));
+    await renderVideoGenPage(`/media/video?remix=${RECORD.id}`);
+
+    // A failed fetch is not a missing record — the settings may be perfectly
+    // intact on disk, so the notice has to be the retryable one.
+    await screen.findByText(/Couldn't load your render history/);
+    expect(screen.queryByText(/no longer in your history/)).toBeNull();
+
+    state.listVideoHistory.mockResolvedValue([RECORD]);
+    await act(async () => { fireEvent.click(screen.getByRole('button', { name: 'Retry' })); });
+
+    await waitFor(() => expect(screen.getByLabelText('Prompt')).toHaveValue(RECORD.prompt));
+    expect(screen.queryByText(/Couldn't load your render history/)).toBeNull();
+  });
+
+  it('reports an actionable missing-record state when the load holds no such record', async () => {
+    state.listVideoHistory.mockResolvedValue([LEGACY_RECORD]);
+    await renderVideoGenPage('/media/video?remix=vid-deleted');
+
+    await screen.findByText(/no longer in your history/);
+    expect(screen.queryByRole('button', { name: 'Retry' })).toBeNull();
+
+    await act(async () => { fireEvent.click(screen.getByRole('button', { name: 'Dismiss' })); });
+    expect(screen.queryByText(/no longer in your history/)).toBeNull();
+  });
+
+  it('does not replay the consumed handoff over the edits that follow it', async () => {
+    await renderVideoGenPage(`/media/video?remix=${RECORD.id}`);
+    await waitFor(() => expect(screen.getByLabelText('Prompt')).toHaveValue(RECORD.prompt));
+
+    fireEvent.change(screen.getByLabelText('Prompt'), { target: { value: 'a paper boat at dusk' } });
+    // The completion refresh re-fetches history — the handoff must not ride
+    // along with it and overwrite what the user has typed since.
+    await act(async () => { await state.completionRefresh.onVideoCompleted(); });
+
+    expect(screen.getByLabelText('Prompt')).toHaveValue('a paper boat at dusk');
+  });
+});

--- a/client/src/pages/VideoGen.remix.test.jsx
+++ b/client/src/pages/VideoGen.remix.test.jsx
@@ -147,8 +147,16 @@ describe('VideoGen cross-page Remix handoff', () => {
     expect(readRestoredForm()).toEqual(fromHistory);
   });
 
-  it('resets the optional controls to their sentinels for a legacy record', async () => {
-    await renderVideoGenPage(`/media/video?remix=${LEGACY_RECORD.id}`);
+  it('clears the optional controls when a legacy record follows a configured one', async () => {
+    // The configured record first, so every control under test holds a
+    // NON-default value. Asserting the sentinels on a freshly mounted form
+    // would pass even if the restore stopped clearing them at all.
+    await renderVideoGenPage(`/media/video?remix=${RECORD.id}`);
+    await waitFor(() => expect(screen.getByLabelText('Prompt')).toHaveValue(RECORD.prompt));
+    expect(readRestoredForm().speedProfileId).toBe('turbo');
+
+    // A second handoff arriving in place, with the page already mounted.
+    await act(async () => { state.navigate(`/media/video?remix=${LEGACY_RECORD.id}`); });
     await waitFor(() => expect(screen.getByLabelText('Prompt')).toHaveValue(LEGACY_RECORD.prompt));
 
     const restored = readRestoredForm();
@@ -156,9 +164,11 @@ describe('VideoGen cross-page Remix handoff', () => {
     expect(restored.speedProfileId).toBe('quality');
     expect(restored.draftDecode).toBe('full');
     expect(restored.loras).toEqual([]);
+    expect(restored.negativePrompt).toBe('');
     expect(restored.steps).toBe('');
     expect(restored.guidanceScale).toBe('');
     expect(restored.chunks).toBe(1);
+    expect(restored.chunkPrompts).toEqual([]);
   });
 
   it('says nothing about a missing record while the history fetch is still in flight', async () => {
@@ -200,12 +210,19 @@ describe('VideoGen cross-page Remix handoff', () => {
     // The banner can sit for as long as the user leaves it there, and the form
     // is live the whole time. A render finishing in the background re-fetches
     // history — the stranded handoff must not ride in on it and wipe the form.
-    fireEvent.change(screen.getByLabelText('Prompt'), { target: { value: 'a kite over a field' } });
-    state.listVideoHistory.mockResolvedValue([RECORD]);
+    fireEvent.change(screen.getByLabelText('Prompt'), { target: { value: 'a half-typed idea' } });
+    state.listVideoHistory.mockResolvedValue([RECORD, LEGACY_RECORD]);
     await act(async () => { await state.completionRefresh.onVideoCompleted(); });
 
-    expect(screen.getByLabelText('Prompt')).toHaveValue('a kite over a field');
+    expect(screen.getByLabelText('Prompt')).toHaveValue('a half-typed idea');
     expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
+
+    // The wait belongs to THAT handoff, not to the page: a different record
+    // arriving afterwards must resolve against the history that has since
+    // loaded rather than inherit the stranded one's block.
+    await act(async () => { state.navigate(`/media/video?remix=${LEGACY_RECORD.id}`); });
+    await waitFor(() => expect(screen.getByLabelText('Prompt')).toHaveValue(LEGACY_RECORD.prompt));
+    expect(screen.queryByText(/Couldn't load your render history/)).toBeNull();
   });
 
   it('reports an actionable missing-record state when the load holds no such record', async () => {

--- a/client/src/pages/VideoGen.remix.test.jsx
+++ b/client/src/pages/VideoGen.remix.test.jsx
@@ -217,6 +217,23 @@ describe('VideoGen cross-page Remix handoff', () => {
     expect(screen.getByRole('button', { name: /Generate/ })).toBeEnabled();
   });
 
+  it('keeps waiting when a background refresh fails beside the fetch it is waiting on', async () => {
+    // The mount fetch and the completion refresh write one shared load
+    // sentinel. A blip on the background one must not strand the handoff and
+    // leave "couldn't load your history" sitting over a gallery that loaded.
+    let settleMount;
+    state.listVideoHistory.mockReturnValueOnce(new Promise((resolve) => { settleMount = resolve; }));
+    await renderVideoGenPage(`/media/video?remix=${RECORD.id}`);
+
+    state.listVideoHistory.mockRejectedValueOnce(new Error('transient'));
+    await act(async () => { await state.completionRefresh.onVideoCompleted(); });
+    expect(screen.queryByText(/Couldn't load your render history/)).toBeNull();
+
+    await act(async () => { settleMount([RECORD]); });
+    await waitFor(() => expect(screen.getByLabelText('Prompt')).toHaveValue(RECORD.prompt));
+    expect(screen.queryByText(/Couldn't load your render history/)).toBeNull();
+  });
+
   it('offers a retry when the history fetch fails, and restores once it succeeds', async () => {
     state.listVideoHistory.mockRejectedValueOnce(new Error('offline'));
     await renderVideoGenPage(`/media/video?remix=${RECORD.id}`);

--- a/client/src/pages/VideoGen.remix.test.jsx
+++ b/client/src/pages/VideoGen.remix.test.jsx
@@ -223,6 +223,12 @@ describe('VideoGen cross-page Remix handoff', () => {
     await act(async () => { state.navigate(`/media/video?remix=${LEGACY_RECORD.id}`); });
     await waitFor(() => expect(screen.getByLabelText('Prompt')).toHaveValue(LEGACY_RECORD.prompt));
     expect(screen.queryByText(/Couldn't load your render history/)).toBeNull();
+
+    // And the block is spent, not permanent: the record whose fetch failed is
+    // restorable once it is handed over again against a history that loaded.
+    await act(async () => { state.navigate(`/media/video?remix=${RECORD.id}`); });
+    await waitFor(() => expect(screen.getByLabelText('Prompt')).toHaveValue(RECORD.prompt));
+    expect(screen.queryByText(/Couldn't load your render history/)).toBeNull();
   });
 
   it('reports an actionable missing-record state when the load holds no such record', async () => {

--- a/client/src/pages/VideoGen.remix.test.jsx
+++ b/client/src/pages/VideoGen.remix.test.jsx
@@ -192,6 +192,22 @@ describe('VideoGen cross-page Remix handoff', () => {
     expect(screen.queryByText(/Couldn't load your render history/)).toBeNull();
   });
 
+  it('waits for Retry rather than restoring from a background refresh after a failure', async () => {
+    state.listVideoHistory.mockRejectedValueOnce(new Error('offline'));
+    await renderVideoGenPage(`/media/video?remix=${RECORD.id}`);
+    await screen.findByText(/Couldn't load your render history/);
+
+    // The banner can sit for as long as the user leaves it there, and the form
+    // is live the whole time. A render finishing in the background re-fetches
+    // history — the stranded handoff must not ride in on it and wipe the form.
+    fireEvent.change(screen.getByLabelText('Prompt'), { target: { value: 'a kite over a field' } });
+    state.listVideoHistory.mockResolvedValue([RECORD]);
+    await act(async () => { await state.completionRefresh.onVideoCompleted(); });
+
+    expect(screen.getByLabelText('Prompt')).toHaveValue('a kite over a field');
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
+  });
+
   it('reports an actionable missing-record state when the load holds no such record', async () => {
     state.listVideoHistory.mockResolvedValue([LEGACY_RECORD]);
     await renderVideoGenPage('/media/video?remix=vid-deleted');

--- a/client/src/test/videoGenPageMocks.jsx
+++ b/client/src/test/videoGenPageMocks.jsx
@@ -23,7 +23,7 @@
  */
 
 import { act, render } from '@testing-library/react';
-import { MemoryRouter } from 'react-router';
+import { MemoryRouter, useNavigate } from 'react-router';
 import { vi } from 'vitest';
 
 /** Universe style the stub picker hands to the page when its button is clicked. */
@@ -80,6 +80,12 @@ export const state = {
   completionRefresh: null,
   /** `listLorasFull` — the installed library the LoRA picker resolves names against. */
   availableLoras: [],
+  /**
+   * The mounted router's `navigate`, for a suite that needs a SECOND in-place
+   * navigation — a URL handoff arriving while the page is already mounted,
+   * which is a different code path from a fresh mount on that URL.
+   */
+  navigate: null,
 };
 
 const SPIES = ['getVideoGenStatus', 'getVideoGenModelContext', 'generateVideo', 'attach', 'start', 'startWhenIdle', 'repair', 'cancel', 'refresh', 'listVideoHistory'];
@@ -99,6 +105,7 @@ export function resetVideoGenMockState() {
   state.galleryProps = null;
   state.completionRefresh = null;
   state.availableLoras = [];
+  state.navigate = null;
   for (const key of SPIES) state[key].mockReset();
   state.listVideoHistory.mockResolvedValue([]);
 }
@@ -273,6 +280,12 @@ vi.mock('../components/media/ResolutionField', () => ({ default: () => null }));
 
 let VideoGen = null;
 
+/** Publishes the router's `navigate` on `state`. Renders nothing. */
+function NavigateProbe() {
+  state.navigate = useNavigate();
+  return null;
+}
+
 /**
  * Import the page under the mocks above. Every suite loads it dynamically at
  * module scope so the registrations are in place first; the component is kept
@@ -293,6 +306,7 @@ export async function renderVideoGenPage(entry = '/media/video') {
   await act(async () => {
     view = render(
       <MemoryRouter initialEntries={[entry]}>
+        <NavigateProbe />
         <VideoGen />
       </MemoryRouter>,
     );

--- a/client/src/test/videoGenPageMocks.jsx
+++ b/client/src/test/videoGenPageMocks.jsx
@@ -1,12 +1,12 @@
 /**
  * Shared mock scaffold for the VideoGen page suites.
  *
- * Five suites (`pages/VideoGen.terms`, `.federatedTarget`, `.composeWhileBusy`,
- * `.textEncoderAutoDownload`, `.modelLoading`) each used to carry a near-verbatim
- * ~140-line copy of the same 25 `vi.mock` registrations, the same `state` object,
- * the same model fixture and the same `renderPage()` helper. Every endpoint or
- * hook the page started calling had to be added in five places, or four suites
- * broke at once.
+ * Six suites (`pages/VideoGen.terms`, `.federatedTarget`, `.composeWhileBusy`,
+ * `.textEncoderAutoDownload`, `.modelLoading`, `.remix`) each used to carry a
+ * near-verbatim ~140-line copy of the same 25 `vi.mock` registrations, the same
+ * `state` object, the same model fixture and the same `renderPage()` helper.
+ * Every endpoint or hook the page started calling had to be added in five
+ * places, or four suites broke at once.
  *
  * **Importing this module registers the mocks** — that is the whole point, and it
  * is what the vitest hoisting rules allow. `vi.mock` is hoisted to the top of the
@@ -34,7 +34,7 @@ const DEFAULT_UNIVERSE_STYLE = {
 };
 
 /**
- * Every knob the five suites vary. Mutated in `beforeEach`; read lazily by the
+ * Every knob the suites vary. Mutated in `beforeEach`; read lazily by the
  * mock factories below, so a reassignment takes effect on the next render.
  */
 export const state = {
@@ -64,9 +64,25 @@ export const state = {
   /** `RuntimeInstallModal`'s `onComplete`, captured so a suite can fire it. */
   runtimeInstallComplete: null,
   universeStyle: DEFAULT_UNIVERSE_STYLE,
+  /** `GET /api/video-gen/history`; a spy so a suite can defer it, reject it, or seed records. */
+  listVideoHistory: vi.fn(),
+  /**
+   * Last props handed to the panels below, captured by mocks that still render
+   * NOTHING — the five older suites assert over the DOM, so a probe element
+   * here would change what they see. The Remix suite reads the restored
+   * sampler/LoRA values and drives the in-page Remix through
+   * `galleryProps.onRemix`, which is the page's real gallery handler.
+   */
+  advancedParams: null,
+  loraPicker: null,
+  galleryProps: null,
+  /** `useMediaCompletionRefresh`'s options, so a suite can fire a completion refresh. */
+  completionRefresh: null,
+  /** `listLorasFull` — the installed library the LoRA picker resolves names against. */
+  availableLoras: [],
 };
 
-const SPIES = ['getVideoGenStatus', 'getVideoGenModelContext', 'generateVideo', 'attach', 'start', 'startWhenIdle', 'repair', 'cancel', 'refresh'];
+const SPIES = ['getVideoGenStatus', 'getVideoGenModelContext', 'generateVideo', 'attach', 'start', 'startWhenIdle', 'repair', 'cancel', 'refresh', 'listVideoHistory'];
 
 /** Restore every documented default, including fresh spies. Call it first in `beforeEach`. */
 export function resetVideoGenMockState() {
@@ -78,7 +94,13 @@ export function resetVideoGenMockState() {
   state.runtimeInstallComplete = null;
   state.universeStyle = DEFAULT_UNIVERSE_STYLE;
   state.eventSourceRef.current = null;
+  state.advancedParams = null;
+  state.loraPicker = null;
+  state.galleryProps = null;
+  state.completionRefresh = null;
+  state.availableLoras = [];
   for (const key of SPIES) state[key].mockReset();
+  state.listVideoHistory.mockResolvedValue([]);
 }
 
 /** A video model as `GET /api/video-gen/status` reports it. */
@@ -143,7 +165,7 @@ vi.mock('../services/api', () => ({
   getVideoGenModelContext: (...args) => state.getVideoGenModelContext(...args),
   generateVideo: (...args) => state.generateVideo(...args),
   cancelVideoGen: vi.fn(async () => ({})),
-  listVideoHistory: vi.fn(async () => []),
+  listVideoHistory: (...args) => state.listVideoHistory(...args),
   deleteVideoHistoryItem: vi.fn(async () => ({})),
   setVideoHidden: vi.fn(async () => ({})),
   extractLastFrame: vi.fn(async () => ({})),
@@ -153,7 +175,7 @@ vi.mock('../services/api', () => ({
   getActiveVideoJob: vi.fn(async () => ({ activeJob: state.activeJob })),
   getSettings: vi.fn(async () => ({ imageGen: { grok: { enabled: false } } })),
   getVideoGenRuntimeStatus: vi.fn(async () => ({ installed: true, ready: true, current: true })),
-  listLorasFull: vi.fn(async () => []),
+  listLorasFull: vi.fn(async () => state.availableLoras),
   // The prompt-enhancement controls mount useProviderModels, which fetches the
   // provider list from a mount effect. Unmocked it throws out of a passive
   // effect — the tests still pass, but the unhandled rejection fails the run.
@@ -186,7 +208,9 @@ vi.mock('../hooks/useModelDownloadStatus', () => ({
 vi.mock('../hooks/useMediaJobSse', () => ({
   useMediaJobSse: () => ({ attach: state.attach, eventSourceRef: state.eventSourceRef }),
 }));
-vi.mock('../hooks/useMediaCompletionRefresh', () => ({ useMediaCompletionRefresh: vi.fn() }));
+vi.mock('../hooks/useMediaCompletionRefresh', () => ({
+  useMediaCompletionRefresh: (options) => { state.completionRefresh = options; },
+}));
 vi.mock('../hooks/useMediaAnnotations', () => ({
   useMediaAnnotations: () => ({ annotations: {}, updateAnnotation: vi.fn(), getCardProps: vi.fn(() => ({})) }),
 }));
@@ -232,13 +256,19 @@ vi.mock('../components/videoGen/KeyframePanel', () => ({ default: () => null }))
 vi.mock('../components/videoGen/AudioPanel', () => ({ default: () => null }));
 vi.mock('../components/videoGen/ExtendPanel', () => ({ default: () => null }));
 vi.mock('../components/videoGen/IcLoraPanel', () => ({ default: () => null }));
-vi.mock('../components/videoGen/AdvancedParamsPanel', () => ({ default: () => null }));
+vi.mock('../components/videoGen/AdvancedParamsPanel', () => ({
+  default: (props) => { state.advancedParams = props; return null; },
+}));
 vi.mock('../components/videoGen/RuntimeFingerprint', () => ({ default: () => null }));
-vi.mock('../components/videoGen/VideoGenGallery', () => ({ default: () => null }));
+vi.mock('../components/videoGen/VideoGenGallery', () => ({
+  default: (props) => { state.galleryProps = props; return null; },
+}));
 vi.mock('../components/media/MediaPreview', () => ({ default: () => null }));
 vi.mock('../components/media/StylePresetPicker', () => ({ default: () => null }));
 vi.mock('../components/media/MediaJobsQueue', () => ({ default: () => null }));
-vi.mock('../components/imageGen/LoraPicker', () => ({ default: () => null }));
+vi.mock('../components/imageGen/LoraPicker', () => ({
+  default: (props) => { state.loraPicker = props; return null; },
+}));
 vi.mock('../components/media/ResolutionField', () => ({ default: () => null }));
 
 let VideoGen = null;
@@ -253,13 +283,16 @@ export async function loadVideoGenPage() {
   return VideoGen;
 }
 
-/** Mount the page on its own route, flushing the mount effects. */
-export async function renderVideoGenPage() {
+/**
+ * Mount the page on its own route, flushing the mount effects. `entry` overrides
+ * the location so a suite can exercise a URL handoff (`/media/video?remix=<id>`).
+ */
+export async function renderVideoGenPage(entry = '/media/video') {
   if (!VideoGen) throw new Error('await loadVideoGenPage() at module scope before rendering');
   let view;
   await act(async () => {
     view = render(
-      <MemoryRouter initialEntries={['/media/video']}>
+      <MemoryRouter initialEntries={[entry]}>
         <VideoGen />
       </MemoryRouter>,
     );

--- a/client/src/test/videoGenPageMocks.jsx
+++ b/client/src/test/videoGenPageMocks.jsx
@@ -53,6 +53,8 @@ export const state = {
   activeJob: null,
   /** Cache-status entries keyed by download id, read by the default `getModelStatus`. */
   modelStatuses: {},
+  /** `useModelDownloadStatus().extra` — carries the SHARED text encoder's cache status. */
+  modelDownloadExtra: {},
   /** Override to answer ids the map cannot (e.g. the `__text_encoder_option__:` prefix). */
   getModelStatus: (id) => state.modelStatuses[id] ?? null,
   start: vi.fn(),
@@ -97,6 +99,7 @@ export function resetVideoGenMockState() {
   state.peers = [];
   state.activeJob = null;
   state.modelStatuses = {};
+  state.modelDownloadExtra = {};
   state.getModelStatus = (id) => state.modelStatuses[id] ?? null;
   state.queuedModelId = null;
   state.runtimeInstallComplete = null;
@@ -197,7 +200,7 @@ vi.mock('../hooks/useModelDownloadStatus', () => ({
   TEXT_ENCODER_DOWNLOAD_ID: '__text_encoder__',
   textEncoderDownloadId: (id) => `__text_encoder_option__:${id}`,
   useModelDownloadStatus: () => ({
-    extra: {},
+    extra: state.modelDownloadExtra,
     loading: false,
     statusError: null,
     activeModelId: null,

--- a/client/src/test/videoGenPageMocks.jsx
+++ b/client/src/test/videoGenPageMocks.jsx
@@ -78,8 +78,10 @@ export const state = {
   galleryProps: null,
   /** `useMediaCompletionRefresh`'s options, so a suite can fire a completion refresh. */
   completionRefresh: null,
-  /** `listLorasFull` — the installed library the LoRA picker resolves names against. */
+  /** The library `listLorasFull` resolves to by default; the LoRA picker reads names from it. */
   availableLoras: [],
+  /** `listLorasFull`; a spy so a suite can defer it and land the library AFTER history. */
+  listLorasFull: vi.fn(),
   /**
    * The mounted router's `navigate`, for a suite that needs a SECOND in-place
    * navigation — a URL handoff arriving while the page is already mounted,
@@ -88,7 +90,7 @@ export const state = {
   navigate: null,
 };
 
-const SPIES = ['getVideoGenStatus', 'getVideoGenModelContext', 'generateVideo', 'attach', 'start', 'startWhenIdle', 'repair', 'cancel', 'refresh', 'listVideoHistory'];
+const SPIES = ['getVideoGenStatus', 'getVideoGenModelContext', 'generateVideo', 'attach', 'start', 'startWhenIdle', 'repair', 'cancel', 'refresh', 'listVideoHistory', 'listLorasFull'];
 
 /** Restore every documented default, including fresh spies. Call it first in `beforeEach`. */
 export function resetVideoGenMockState() {
@@ -108,6 +110,7 @@ export function resetVideoGenMockState() {
   state.navigate = null;
   for (const key of SPIES) state[key].mockReset();
   state.listVideoHistory.mockResolvedValue([]);
+  state.listLorasFull.mockImplementation(async () => state.availableLoras);
 }
 
 /** A video model as `GET /api/video-gen/status` reports it. */
@@ -182,7 +185,7 @@ vi.mock('../services/api', () => ({
   getActiveVideoJob: vi.fn(async () => ({ activeJob: state.activeJob })),
   getSettings: vi.fn(async () => ({ imageGen: { grok: { enabled: false } } })),
   getVideoGenRuntimeStatus: vi.fn(async () => ({ installed: true, ready: true, current: true })),
-  listLorasFull: vi.fn(async () => state.availableLoras),
+  listLorasFull: (...args) => state.listLorasFull(...args),
   // The prompt-enhancement controls mount useProviderModels, which fetches the
   // provider list from a mount effect. Unmocked it throws out of a passive
   // effect — the tests still pass, but the unhandled rejection fails the run.


### PR DESCRIPTION
## Summary

Remixing the same saved clip from Media History and from the Video Gen gallery produced **different renders**. The cross-page path built a field-by-field URL bundle in `useMediaPreviewActions` — a second restore implementation that had to be extended for every new render field, and wasn't. It carried no `textEncoderId`, `speedProfileId`, `draftDecode` or LoRA arrays, so a History Remix silently returned those controls to stock/Quality/Full/no-LoRA while the in-page `applyRemix` restored the record: different conditioning, different compute cost.

- **Saved videos hand over `?remix=<record-id>`.** `VideoGen` resolves it against the history load it already does (hidden records included) and replays it through `applyRemix`, so current records have exactly one restore implementation. The legacy field-based URL reader stays for id-less callers and links already issued, and is not extended further.
- **The lookup distinguishes three states a naive `find` collapses**: a pending fetch stays silent and announces itself, a failed fetch offers a Retry, and only a successful load with no match reports the record as missing.
- **Generate is held while a handoff is still resolving.** The old bundle applied synchronously on mount; this one waits on a fetch, and rendering in that window would spend GPU time on the page defaults under the clip's name.
- **The handoff is one-shot and scoped to its own id**, so a completion refresh can't replay it over later edits, a stranded handoff waits for the explicit Retry rather than riding in on a background refresh minutes later, and a second handoff on the same mount still resolves.
- A restored LoRA's label is re-resolved when the library lands, since the page fetches the LoRA list and the history list as unordered mount effects.

Closes #6290

## Test plan

- `client/src/pages/VideoGen.remix.test.jsx` (new, 9 cases): the History handoff and the in-page gallery restore *identically* from the same record; a legacy record following a configured one clears the optional controls; the in-flight window is announced and holds Generate; a background failure beside the fetch being waited on doesn't strand the handoff; Retry restores; a missing record reports actionably; the consumed handoff isn't replayed over later edits; a LoRA label resolves when the library lands late.
- `client/src/hooks/useMediaPreviewActions.test.jsx`: the video handoff carries the record id and *no other params* (which is what stops the field bundle being re-added); id-less records still get the legacy bundle.
- Each new guard was verified by mutation — removing it fails the test that covers it.
- `cd client && npm test`: green. Twelve unrelated files time out at 5s under parallel load on this machine and all pass in isolation.