### PR TITLE
fix: surface why pr-reviewer's on-demand Run found nothing to do

### DIFF
--- a/client/src/hooks/useOnDemandTaskToast.js
+++ b/client/src/hooks/useOnDemandTaskToast.js
@@ -24,6 +24,18 @@ const PARK_REASON_LABELS = {
   'no-detector': 'no work detector for this task'
 };
 
+// pr-reviewer's on-demand skip reasons (server: runPrReviewerSecurityPreflight in
+// cosTaskGenerator.js). An unlisted code falls back to the raw string rather than
+// the generic "nothing to do" — the reason IS the actionable detail here, since a
+// per-PR "Review this PR" trigger names a specific PR the maintainer wants reviewed.
+const PR_REVIEWER_REASON_LABELS = {
+  'parked': 'paused after repeated failures — it will retry on its normal cadence',
+  'no-external-open-prs': 'no open external pull requests to review',
+  'target-pull-request-not-reviewable': "that pull request isn't eligible right now (not open against the default branch, or authored by a trusted collaborator)",
+  'security-scan-report-pending': 'a security scan for this pull request is already in progress',
+  'security-guard-not-ready': "the local model-abuse classifier (Settings → Models → LLMs → Abuse Guard) isn't ready — finish or repair its setup, then try again",
+};
+
 /**
  * Global subscriber that toasts when a user-initiated on-demand task run
  * produced no work. The server emits `cos:schedule:on-demand-empty` ONLY for
@@ -64,6 +76,13 @@ export function useOnDemandTaskToast() {
       if (data?.outcome === 'idle') {
         if (data?.taskType === 'layered-intelligence' && data?.reason) {
           toast(`${task}${scope}: ${formatLiReason({ action: 'skipped', reason: data.reason })}.`, {
+            duration: 8000,
+            icon: '⚠️'
+          });
+          return;
+        }
+        if (data?.taskType === 'pr-reviewer' && data?.reason) {
+          toast(`${task}${scope}: ${PR_REVIEWER_REASON_LABELS[data.reason] || data.reason}.`, {
             duration: 8000,
             icon: '⚠️'
           });

--- a/client/src/hooks/useOnDemandTaskToast.test.jsx
+++ b/client/src/hooks/useOnDemandTaskToast.test.jsx
@@ -45,6 +45,28 @@ describe('useOnDemandTaskToast — idle outcome', () => {
     fire({ taskType: 'layered-intelligence', appName: 'App One', outcome: 'idle', reason: null });
     expect(toastSpy.mock.calls[0][0]).toMatch(/nothing to do right now/);
   });
+
+  it('surfaces the pr-reviewer skip reason (security guard not ready) instead of "nothing to do"', () => {
+    renderHook(() => useOnDemandTaskToast());
+    fire({ taskType: 'pr-reviewer', appName: 'PortOS', outcome: 'idle', reason: 'security-guard-not-ready' });
+    expect(toastSpy).toHaveBeenCalledTimes(1);
+    const [msg, opts] = toastSpy.mock.calls[0];
+    expect(msg).toMatch(/model-abuse classifier.*isn't ready/i);
+    expect(msg).not.toMatch(/nothing to do/);
+    expect(opts.icon).toBe('⚠️');
+  });
+
+  it('falls back to the raw reason string for an unglossed pr-reviewer code', () => {
+    renderHook(() => useOnDemandTaskToast());
+    fire({ taskType: 'pr-reviewer', appName: 'PortOS', outcome: 'idle', reason: 'some-future-code' });
+    expect(toastSpy.mock.calls[0][0]).toMatch(/some-future-code/);
+  });
+
+  it('falls back to the generic idle toast for a pr-reviewer idle result with no reason', () => {
+    renderHook(() => useOnDemandTaskToast());
+    fire({ taskType: 'pr-reviewer', appName: 'PortOS', outcome: 'idle', reason: null });
+    expect(toastSpy.mock.calls[0][0]).toMatch(/nothing to do right now/);
+  });
 });
 
 describe('useOnDemandTaskToast — transient outcome', () => {

--- a/server/services/cosTaskGenerator.js
+++ b/server/services/cosTaskGenerator.js
@@ -2101,34 +2101,39 @@ async function runPrReviewerSecurityPreflight(taskType, app, metadata, targetPul
   // A human "Run" is unaffected: applyOnDemandRunResets clears the park for a
   // USER-origin request before it reaches generation.
   if (taskSchedule && await taskSchedule.isPerpetualParkActive(taskType, app.id)) {
-    emitLog('info', `Skipping pr-reviewer for ${app.name}: parked until its recheck cadence`, { appId: app.id, analysisType: taskType });
-    return { skipped: true, reason: 'parked' };
+    const reason = 'parked';
+    emitLog('info', `Skipping pr-reviewer for ${app.name}: ${reason} until its recheck cadence`, { appId: app.id, analysisType: taskType });
+    return { skipped: true, reason };
   }
 
   const stages = metadata.pipeline?.stages;
   const securityStage = stages?.[0];
   const nextStage = stages?.[1];
   if (!securityStage || !nextStage) {
-    emitLog('warn', `Skipping pr-reviewer for ${app.name}: security pipeline requires an eligibility gate`, { appId: app.id, analysisType: taskType });
-    return { skipped: true };
+    const reason = 'pipeline-misconfigured';
+    emitLog('warn', `Skipping pr-reviewer for ${app.name}: ${reason} — security pipeline requires an eligibility gate`, { appId: app.id, analysisType: taskType });
+    return { skipped: true, reason };
   }
 
   const { listExternalOpenPullRequests, runPrReviewerSecurityScan, securityScanFingerprint } = await import('./prReviewerSecurity.js');
   const { writePublicReviewInputSnapshot } = await import('./modelAbuseGuard.js');
   let target = await listExternalOpenPullRequests(app);
   if (!target.ok) {
-    emitLog('warn', `Skipping pr-reviewer for ${app.name}: ${target.code || 'security-scan-target-unavailable'}`, { appId: app.id, analysisType: taskType });
-    return { skipped: true };
+    const reason = target.code || 'security-scan-target-unavailable';
+    emitLog('warn', `Skipping pr-reviewer for ${app.name}: ${reason}`, { appId: app.id, analysisType: taskType });
+    return { skipped: true, reason };
   }
   if (target.prs.length === 0) {
-    emitLog('info', `Skipping pr-reviewer for ${app.name}: no-external-open-prs`, { appId: app.id, analysisType: taskType });
-    return { skipped: true, reason: 'no-external-open-prs' };
+    const reason = 'no-external-open-prs';
+    emitLog('info', `Skipping pr-reviewer for ${app.name}: ${reason}`, { appId: app.id, analysisType: taskType });
+    return { skipped: true, reason };
   }
   if (targetPullRequest) {
     const scoped = target.prs.filter((pr) => pr.number === targetPullRequest);
     if (scoped.length === 0) {
-      emitLog('warn', `Skipping pr-reviewer for ${app.name}: target-pull-request-not-reviewable (#${targetPullRequest})`, { appId: app.id, analysisType: taskType });
-      return { skipped: true, reason: 'target-pull-request-not-reviewable' };
+      const reason = 'target-pull-request-not-reviewable';
+      emitLog('warn', `Skipping pr-reviewer for ${app.name}: ${reason} (#${targetPullRequest})`, { appId: app.id, analysisType: taskType });
+      return { skipped: true, reason };
     }
     // A maintainer pressed "Review this PR" on this row. The linked-open-issue
     // prerequisite exists to bound UNATTENDED spend on unsolicited PRs; an
@@ -2145,8 +2150,9 @@ async function runPrReviewerSecurityPreflight(taskType, app, metadata, targetPul
   const scanKey = securityScanFingerprint(target);
   const active = await findActiveSecurityScanTask(app.id, scanKey);
   if (active.unavailable) {
-    emitLog('warn', `Skipping pr-reviewer for ${app.name}: security-scan-task-state-unavailable`, { appId: app.id, analysisType: taskType });
-    return { skipped: true };
+    const reason = 'security-scan-task-state-unavailable';
+    emitLog('warn', `Skipping pr-reviewer for ${app.name}: ${reason}`, { appId: app.id, analysisType: taskType });
+    return { skipped: true, reason };
   }
   if (active.task) {
     emitLog('info', `Skipping pr-reviewer for ${app.name}: security-scan-report-pending`, { appId: app.id, analysisType: taskType, taskId: active.task.id });
@@ -2159,8 +2165,9 @@ async function runPrReviewerSecurityPreflight(taskType, app, metadata, targetPul
   });
   const reports = securityScanReports(scan);
   if (!scan.ok && !reports.length) {
-    emitLog('warn', `Skipping pr-reviewer for ${app.name}: ${scan.code || 'security-scan-not-passed'}`, { appId: app.id, analysisType: taskType });
-    return { skipped: true };
+    const reason = scan.code || 'security-scan-not-passed';
+    emitLog('warn', `Skipping pr-reviewer for ${app.name}: ${reason}`, { appId: app.id, analysisType: taskType });
+    return { skipped: true, reason };
   }
 
   const status = !scan.ok ? 'unavailable' : (scan.passed ? 'passed' : 'findings');
@@ -2169,8 +2176,9 @@ async function runPrReviewerSecurityPreflight(taskType, app, metadata, targetPul
     pullRequests: scan.ok ? (scan.reviewInputs || []) : [],
   });
   if (!snapshotWritten) {
-    emitLog('warn', `Skipping pr-reviewer for ${app.name}: public-review-input-snapshot-failed`, { appId: app.id, analysisType: taskType });
-    return { skipped: true };
+    const reason = 'public-review-input-snapshot-failed';
+    emitLog('warn', `Skipping pr-reviewer for ${app.name}: ${reason}`, { appId: app.id, analysisType: taskType });
+    return { skipped: true, reason };
   }
   const reviewOutput = buildSecurityScanPipelineOutput(scan, reports, status);
   // A partial/unavailable scan is never a usable allowlist. Keeping already
@@ -2423,6 +2431,14 @@ const transientVerdictKey = (taskType, appId) => `${taskType}:${appId || 'global
  * Record why a perpetual work gate skipped WITHOUT parking. `cli` is the forge
  * CLI whose probe failed (`gh` / `glab`), or null when no forge was involved.
  * Passing a null verdict clears any stale entry (the actionable / park paths).
+ *
+ * Also doubles as pr-reviewer's idle-skip reason channel: pr-reviewer is
+ * on-demand, not perpetual, so its preflight skip (churn park, no external PRs,
+ * a target PR that isn't reviewable, the security guard not being ready, …)
+ * reaches emitOnDemandEmpty as a plain 'idle' outcome with no channel of its own
+ * for WHY — the same gap this map already closes for 'transient'. The payload
+ * shape here is a free-form object (`{ ...verdict }`), so a `{ reason }` payload
+ * under the `taskType: 'pr-reviewer'` key needs no separate map or TTL logic.
  */
 export function recordPerpetualTransient(taskType, appId, verdict) {
   const key = transientVerdictKey(taskType, appId);
@@ -2478,6 +2494,9 @@ export async function emitOnDemandEmpty({ taskScheduleMod, request, targetApp, t
     const { getAppById } = await import('./apps.js');
     const app = await getAppById(appId).catch(() => null);
     reason = app?.layeredIntelligence?.lastRunReason || null;
+  }
+  if (outcome === 'idle' && request.taskType === 'pr-reviewer') {
+    reason = takePerpetualTransient('pr-reviewer', appId)?.reason ?? null;
   }
 
   // 'transient' says "the forge probe failed, try again shortly" — only true when
@@ -2862,6 +2881,13 @@ export async function generateManagedAppImprovementTaskForType(taskType, app, st
   if (taskType === 'pr-reviewer') ensurePrReviewerPipeline(metadata);
   initializePipelineMetadata(metadata);
   const securityPreflight = await runPrReviewerSecurityPreflight(taskType, app, metadata, targetPullRequest, taskSchedule);
+  // Record (or clear a stale) skip reason in the SAME call: clearing on a passed
+  // gate matters too, or an unrelated later idle outcome for this app (e.g. a
+  // downstream precondition skip below) could read back a reason that no longer
+  // applies.
+  if (taskType === 'pr-reviewer') {
+    recordPerpetualTransient('pr-reviewer', app.id, securityPreflight.skipped ? { reason: securityPreflight.reason || null } : null);
+  }
   if (securityPreflight.skipped) return null;
   if (!skipPreconditions && shouldSkipForPrecondition(metadata, app, taskType)) return null;
 

--- a/server/services/cosTaskGenerator.test.js
+++ b/server/services/cosTaskGenerator.test.js
@@ -1118,6 +1118,57 @@ describe('emitOnDemandEmpty', () => {
     }
   });
 
+  it("surfaces the pr-reviewer preflight's recorded skip reason on an idle outcome", async () => {
+    recordPerpetualTransient('pr-reviewer', 'app-1', { reason: 'security-guard-not-ready' });
+    const events = [];
+    const handler = (d) => events.push(d);
+    cosEvents.on('schedule:on-demand-empty', handler);
+    try {
+      await emitOnDemandEmpty({
+        taskScheduleMod: stubMod,
+        request: { id: 'req-pr-reviewer', taskType: 'pr-reviewer' },
+        targetApp: { id: 'app-1', name: 'PortOS' },
+        taskConfig: { type: 'on-demand', perpetual: false }
+      });
+    } finally {
+      cosEvents.off('schedule:on-demand-empty', handler);
+    }
+    expect(events[0]).toMatchObject({ taskType: 'pr-reviewer', outcome: 'idle', reason: 'security-guard-not-ready' });
+  });
+
+  it('consumes the pr-reviewer skip reason on read, so a stale one cannot be reported twice', async () => {
+    recordPerpetualTransient('pr-reviewer', 'app-1', { reason: 'no-external-open-prs' });
+    const first = [];
+    let handler = (d) => first.push(d);
+    cosEvents.on('schedule:on-demand-empty', handler);
+    try {
+      await emitOnDemandEmpty({
+        taskScheduleMod: stubMod,
+        request: { id: 'req-a', taskType: 'pr-reviewer' },
+        targetApp: { id: 'app-1', name: 'PortOS' },
+        taskConfig: { type: 'on-demand', perpetual: false }
+      });
+    } finally {
+      cosEvents.off('schedule:on-demand-empty', handler);
+    }
+    expect(first[0]).toMatchObject({ reason: 'no-external-open-prs' });
+
+    const second = [];
+    handler = (d) => second.push(d);
+    cosEvents.on('schedule:on-demand-empty', handler);
+    try {
+      await emitOnDemandEmpty({
+        taskScheduleMod: stubMod,
+        request: { id: 'req-b', taskType: 'pr-reviewer' },
+        targetApp: { id: 'app-1', name: 'PortOS' },
+        taskConfig: { type: 'on-demand', perpetual: false }
+      });
+    } finally {
+      cosEvents.off('schedule:on-demand-empty', handler);
+    }
+    expect(second[0]).toMatchObject({ reason: null });
+  });
+
   it('reads the LI last-run reason only for the layered-intelligence task type', () => {
     // Source-pinned (the behavioral read dynamic-imports the live app store):
     // the reason surfacing is gated on the LI task type + the 'idle' outcome and
@@ -1606,6 +1657,10 @@ describe('pr-reviewer security preflight wiring', () => {
     expect(preconditionAt, 'the ordinary stage gate must remain in the generator').toBeGreaterThan(-1);
     expect(preflightAt).toBeLessThan(preconditionAt);
     expect(promptAt, 'a passed preflight must select the current pipeline stage body').toBeGreaterThan(-1);
+    // The skip reason must be recorded before the `return null;` — otherwise a
+    // user-initiated "Review this PR" that hits the security guard, an unreviewable
+    // target PR, etc. reports the generic "nothing to do" toast instead of why.
+    expect(body).toContain("recordPerpetualTransient('pr-reviewer', app.id, securityPreflight.skipped ? { reason: securityPreflight.reason || null } : null)");
     expect(body).toContain('if (securityPreflight.skipped) return null;');
     expect(GEN_SRC).toContain('previousStageOutput');
     expect(GEN_SRC).toContain('security-scan-report-pending');
@@ -1626,7 +1681,8 @@ describe('pr-reviewer security preflight wiring', () => {
 
     expect(parkAt, 'a parked pr-reviewer must not regenerate').toBeGreaterThan(-1);
     expect(parkAt).toBeLessThan(scanAt);
-    expect(body).toContain("return { skipped: true, reason: 'parked' };");
+    expect(body).toContain("const reason = 'parked';");
+    expect(body).toContain('return { skipped: true, reason };');
   });
 
   it('narrows a targeted run before the fingerprint, the scan, and the stage-2 allowlist', () => {


### PR DESCRIPTION
## Summary

- Clicking "Review this PR" on a specific pull request always toasted a generic "nothing to do right now", even when the server knew exactly why the preflight skipped (e.g. the local model-abuse classifier isn't ready, the target PR isn't eligible, or a scan is already pending) — the reason was logged server-side and then discarded before reaching the client.
- `layered-intelligence` already has a `reason` channel for this same "idle" outcome; `pr-reviewer`'s preflight now records its skip reason through the existing transient-verdict map (keyed by `taskType:appId`, already used for the 'transient' outcome), and `emitOnDemandEmpty` reads it back for pr-reviewer's 'idle' outcome the same way.
- The toast hook glosses known reason codes into plain language (mirroring the existing `PARK_REASON_LABELS`/LI pattern) and falls back to the raw code for anything unglossed.

## Test plan

- `cd server && npx vitest run services/cosTaskGenerator.test.js` — 156 passed
- `cd client && npx vitest run src/hooks/useOnDemandTaskToast.test.jsx` — 14 passed
- Added coverage: pr-reviewer skip reason surfaces on the toast, falls back for an unknown code, consumes-on-read so a stale reason can't be reported twice, and the recorder is verified via the shared transient-verdict channel rather than a bespoke one.