### PR TITLE
Offer the signed-in ChatGPT account's real model catalog in every Codex model picker

### DIFF
--- a/client/src/components/cos/AppProviderPin.jsx
+++ b/client/src/components/cos/AppProviderPin.jsx
@@ -1,5 +1,5 @@
 import ProviderModelSelector from '../ProviderModelSelector';
-import { filterSelectableModels } from '../../utils/providers';
+import { filterSelectableModels, providerModelList } from '../../utils/providers';
 import { providerPinPatch } from './constants';
 
 /**
@@ -48,7 +48,7 @@ export default function AppProviderPin({
   const selectedModel = model || '';
   const selectedProvider = providers?.find(p => p.id === selectedProviderId);
   const availableModels = selectedProvider
-    ? filterSelectableModels(selectedProvider.models || [selectedProvider.defaultModel])
+    ? filterSelectableModels(providerModelList(selectedProvider))
     : [];
   // Keep a pinned model visible even when it isn't in the provider's fetched list
   // (a stale or hand-typed model must not render as a blanked select).

--- a/client/src/components/cos/PersistentMindTaskModelAllowlistControls.jsx
+++ b/client/src/components/cos/PersistentMindTaskModelAllowlistControls.jsx
@@ -3,6 +3,7 @@ import * as api from '../../services/api';
 import {
   filterHardwareCompatibleProviderModels,
   filterSelectableModels,
+  providerModelList,
   selectableModelsForProvider,
 } from '../../utils/providers.js';
 import toast from '../ui/Toast';
@@ -14,10 +15,7 @@ const normalizeEntries = (value) => (Array.isArray(value) ? value : [])
 const modelId = (entry) => typeof entry === 'string' ? entry : entry?.id;
 
 const modelsFor = (provider) => filterHardwareCompatibleProviderModels(
-  filterSelectableModels(selectableModelsForProvider(
-    provider,
-    provider?.models?.length ? provider.models : [provider?.defaultModel],
-  )),
+  filterSelectableModels(selectableModelsForProvider(provider, providerModelList(provider))),
   provider,
 ).map(modelId).filter(Boolean);
 

--- a/client/src/components/cos/TaskAddForm.jsx
+++ b/client/src/components/cos/TaskAddForm.jsx
@@ -8,7 +8,7 @@ import { processScreenshotUploads, processAttachmentUploads } from '../../servic
 import { ATTACHMENT_ACCEPT } from '../../utils/fileUpload';
 import FilePickerButton from '../ui/FilePickerButton';
 import { formatBytes } from '../../utils/formatters';
-import { effectiveModelFor, effortAwareModelOptions, effortSurvivingModel, isTuiProvider, isCliProvider, isProcessProvider, isCodexProvider, isOpencodeLocalProvider, generationControlsFor, seedModelEffort } from '../../utils/providers';
+import { effectiveModelFor, effortAwareModelOptions, effortSurvivingModel, isTuiProvider, isCliProvider, isProcessProvider, isCodexProvider, isCodexSubscriptionProvider, isOpencodeLocalProvider, generationControlsFor, seedModelEffort, resolveProviderModelOptions, MODEL_SOURCE } from '../../utils/providers';
 import { DEFAULT_PR_COMPLETION, DEFAULT_REVIEWERS, DEFAULT_REVIEW_STOP_MODE, PR_COMPLETION_OPTIONS, prCompletionOption } from './constants';
 import { clickableProps } from '../../lib/a11yKeyboard';
 import { slashdoLabel } from '../../lib/slashdoCatalog';
@@ -406,11 +406,27 @@ export default function TaskAddForm({ providers, providersLoaded = true, apps, o
   // with the tier picked separately — a legacy suffixed id saved in a template
   // stays selectable as its own option.
   const selectedProvider = providers?.find(p => p.id === newTask.provider);
-  const availableModels = effortAwareModelOptions(selectedProvider, newTask.model);
+  // A Codex-subscription provider offers the SIGNED-IN ACCOUNT's catalog when one
+  // has been fetched, so a tier the plan cannot run is never queued (#6306); every
+  // other state falls back to the shipped list, and the note below says which.
+  const { models: availableModels, source: modelSource, unlistedSelection } =
+    resolveProviderModelOptions(selectedProvider, newTask.model);
+  const NO_ACCOUNT_MODELS_NOTE = 'Your signed-in ChatGPT account exposes no models.';
+  const modelSourceNote = (() => {
+    if (!isCodexSubscriptionProvider(selectedProvider)) return '';
+    if (modelSource === MODEL_SOURCE.account) return 'Models your signed-in ChatGPT account can run.';
+    // Reachable with a stored pin the account no longer lists — the select still
+    // renders that one option, so it must not be labelled as the bundled list.
+    if (modelSource === MODEL_SOURCE.accountEmpty) return NO_ACCOUNT_MODELS_NOTE;
+    return 'Showing PortOS\u2019s bundled list \u2014 the ChatGPT account catalog has not been loaded.';
+  })();
   const providerModelNote = (() => {
     if (!selectedProvider) return '';
+    if (modelSource === MODEL_SOURCE.accountEmpty) return NO_ACCOUNT_MODELS_NOTE;
     if (isTuiProvider(selectedProvider)) return `${selectedProvider.name} runs in an attachable terminal UI session.`;
-    if (isCodexProvider(selectedProvider)) return 'Codex uses the model configured in ~/.codex/config.toml.';
+    // PortOS passes `--model` on every Codex spawn (providerVendors.js#codexSpawnArgs),
+    // so ~/.codex/config.toml is NOT what picks the model here.
+    if (isCodexProvider(selectedProvider)) return 'PortOS runs Codex with the model it selects; no models are listed for this provider yet.';
     if (isCliProvider(selectedProvider)) return `${selectedProvider.name} uses its CLI configured default model.`;
     return 'No models are configured. PortOS will use the provider default.';
   })();
@@ -1179,9 +1195,16 @@ export default function TaskAddForm({ providers, providersLoaded = true, apps, o
                 >
                   <option value="">Select model...</option>
                   {availableModels.map(m => (
-                    <option key={m} value={m}>{m.replace('claude-', '').replace(/-\d+$/, '')}</option>
+                    <option key={m} value={m}>
+                      {unlistedSelection && m === newTask.model
+                        ? `${m} (not in account catalog)`
+                        : m.replace('claude-', '').replace(/-\d+$/, '')}
+                    </option>
                   ))}
                 </select>
+                {modelSourceNote && (
+                  <p className="mt-1 text-xs text-gray-400">{modelSourceNote}</p>
+                )}
               </div>
             ) : selectedProvider ? (
               <div className="flex-1 px-3 py-2 min-h-[44px] bg-port-bg border border-port-border rounded-lg text-xs text-gray-400 flex items-center">

--- a/client/src/components/cos/TaskAddForm.test.jsx
+++ b/client/src/components/cos/TaskAddForm.test.jsx
@@ -14,6 +14,9 @@ const api = vi.hoisted(() => ({
   applyCosTaskTemplate: vi.fn(),
   addCosTask: vi.fn(),
   getOrchestrationProfiles: vi.fn(),
+  // Declared so the render-path assertion below is real: the picker must read the
+  // cached catalog off the provider payload, never fetch one of its own (#6306).
+  getCodexModels: vi.fn(),
 }));
 
 // useAssignableInstances reads the instance registry straight off apiSystem, so
@@ -717,5 +720,78 @@ describe('TaskAddForm worktree/PR defaults', () => {
         );
       });
     });
+  });
+});
+
+// #6306: a Codex task must not be queued against a model the signed-in ChatGPT
+// account cannot run — and a cold/failed catalog must not empty the dropdown.
+describe('TaskAddForm Codex model catalog', () => {
+  const SHIPPED = ['gpt-6-astra', 'gpt-5.6-sol', 'gpt-5.4'];
+  const codexProvider = (codexModelCatalog) => ({
+    id: 'codex',
+    name: 'Codex CLI',
+    type: 'cli',
+    command: 'codex',
+    enabled: true,
+    models: SHIPPED,
+    codexModelCatalog,
+  });
+
+  const renderWithCodex = async (catalog) => {
+    const user = userEvent.setup();
+    render(
+      <TaskAddForm
+        providers={[codexProvider(catalog)]}
+        apps={[{ id: 'example-app', name: 'Example App', repoPath: 'example.com/repo' }]}
+        defaultApp="example-app"
+        onTaskAdded={vi.fn()}
+      />
+    );
+    await waitFor(() => expect(screen.getByLabelText('AI provider')).not.toBeDisabled());
+    await user.selectOptions(screen.getByLabelText('AI provider'), 'codex');
+    return user;
+  };
+
+  const modelValues = () =>
+    Array.from(screen.getByLabelText('AI model').querySelectorAll('option'))
+      .map((option) => option.value)
+      .filter(Boolean);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    api.getCosPopularTemplates.mockResolvedValue({ templates: [] });
+    api.getCodeReviewDefaults.mockResolvedValue(null);
+    api.getLocalLlmStatus.mockResolvedValue({ ollama: { models: [] }, lmstudio: { models: [] } });
+    api.getProviders.mockResolvedValue({ providers: [] });
+    api.getAppWorkTracker.mockResolvedValue({ resolved: 'github' });
+    api.getAppRepositorySources.mockResolvedValue({
+      issueTargets: { default: 'origin', canChoose: false, origin: { fullName: 'example-org/example-app' }, upstream: { fullName: 'example-org/example-app' } },
+    });
+    api.applyCosTaskTemplate.mockResolvedValue({ success: true });
+    api.getOrchestrationProfiles.mockResolvedValue({ profiles: [] });
+    apiSystem.getAssignableInstances.mockResolvedValue({ instances: [] });
+  });
+
+  it('offers the signed-in account catalog, and never fetches one from a render', async () => {
+    await renderWithCodex({ models: [{ id: 'gpt-5.4' }, { id: 'gpt-5.4-mini' }], fetchedAt: 1, error: null });
+
+    expect(modelValues()).toEqual(['gpt-5.4', 'gpt-5.4-mini']);
+    expect(screen.getByText(/signed-in ChatGPT account can run/i)).toBeInTheDocument();
+    // Rendering a picker must not be what starts `codex app-server`.
+    expect(api.getCodexModels).not.toHaveBeenCalled();
+  });
+
+  it('keeps the shipped list, and says so, when the catalog failed to load', async () => {
+    await renderWithCodex({ models: null, fetchedAt: null, error: { code: 'protocol', message: 'boom' } });
+
+    expect(modelValues()).toEqual(SHIPPED);
+    expect(screen.getByText(/bundled list/i)).toBeInTheDocument();
+  });
+
+  it('explains a successfully-read empty catalog instead of rendering a blank control', async () => {
+    await renderWithCodex({ models: [], fetchedAt: 1, error: null });
+
+    expect(screen.queryByLabelText('AI model')).not.toBeInTheDocument();
+    expect(screen.getByText(/exposes no models/i)).toBeInTheDocument();
   });
 });

--- a/client/src/hooks/useProviderModels.js
+++ b/client/src/hooks/useProviderModels.js
@@ -5,13 +5,16 @@ import {
   filterSelectableModels,
   isProviderHardwareCompatible,
   isProviderModelHardwareCompatible,
+  providerModelList,
   selectableModelsForProvider,
   withStaleAntigravityPin,
 } from '../utils/providers';
 
-// The provider's selectable model source: its `models` list, or — when that
-// list is empty (a cloud/manual provider configured with only a defaultModel,
-// where `[]` is truthy so `||` wouldn't fall through) — its defaultModel.
+// The provider's selectable model source, via the shared `providerModelList`:
+// a signed-in ChatGPT account's own catalog when one has been fetched, else the
+// provider's `models` list, else — when that list is empty (a cloud/manual
+// provider configured with only a defaultModel, where `[]` is truthy so `||`
+// wouldn't fall through) — its defaultModel.
 //
 // `withEffort` then applies any provider-specific rewrite — today that means
 // Antigravity lists BASE models (`gemini-3.6-flash`) rather than one row per
@@ -19,7 +22,7 @@ import {
 // control the suffixed ids are the ONLY way to express a tier: collapsing them
 // there would silently strip the capability rather than relocate it.
 const sourceModels = (provider, withEffort) => {
-  const models = provider?.models?.length ? provider.models : [provider?.defaultModel];
+  const models = providerModelList(provider);
   return withEffort ? selectableModelsForProvider(provider, models) : models;
 };
 

--- a/client/src/services/apiProviders.js
+++ b/client/src/services/apiProviders.js
@@ -73,8 +73,10 @@ export const cancelCodexLogin = (loginId, options) => request('/providers/codex/
 });
 export const codexLogout = (options) => request('/providers/codex/account/logout', { method: 'POST', ...options });
 // The models this subscription may run, from the app-server catalog (#5590).
-// Not yet called from a component: the Providers-page picker that consumes it is
-// #5591 (phase 3), which also ships the toggle that sets `textTransportEnabled`.
+// This is the LAZY read that may spawn `codex app-server` — call it only from an
+// explicit user action (the Providers page's refresh). Render paths read the
+// cached catalog off `codexModelCatalog` on the `GET /providers` payload instead
+// (#6306), which spawns nothing.
 // Resolves to { models, fetchedAt, error }. `models: null` means NEVER FETCHED
 // and `[]` means fetched-and-empty; when `error` is set the list is the
 // last-known-good one, so render that rather than emptying the picker.

--- a/client/src/utils/providers.js
+++ b/client/src/utils/providers.js
@@ -561,11 +561,36 @@ export const withStaleAntigravityPin = (provider, models, selectedModel) => {
  * @returns {string[]|null}
  */
 export const codexCatalogModelIds = (provider) => {
+  if (!isCodexSubscriptionProvider(provider)) return null;
   const catalog = provider?.codexModelCatalog;
   if (!catalog || catalog.error || !Array.isArray(catalog.models)) return null;
   return catalog.models
     .map((entry) => (typeof entry === 'string' ? entry : entry?.id))
     .filter((id) => typeof id === 'string' && id !== '');
+};
+
+/**
+ * The RAW model list a picker should read for a provider, before any
+ * sentinel/effort/hardware filtering: the signed-in ChatGPT account's own
+ * catalog when one has been fetched, otherwise the provider's configured
+ * `models` — falling back to its `defaultModel` when that list is empty (a
+ * cloud/manual provider configured with only a default; `[]` is truthy, so a
+ * bare `||` would leave such a picker empty).
+ *
+ * This is the single place the account catalog enters a picker, so a caller
+ * that reads `provider.models` directly is the one bug this exists to prevent
+ * (#6306). A successfully-read EMPTY catalog is returned as `[]` and must not
+ * fall through to `defaultModel`: the account really has no models, and
+ * offering its default would put back the un-runnable option.
+ *
+ * CLIENT-ONLY (no server mirror).
+ * @param {{models?:unknown[], defaultModel?:string}|null|undefined} provider
+ * @returns {unknown[]}
+ */
+export const providerModelList = (provider) => {
+  const catalog = codexCatalogModelIds(provider);
+  if (catalog) return catalog;
+  return provider?.models?.length ? provider.models : [provider?.defaultModel];
 };
 
 /** Where a picker's option list came from. */
@@ -602,7 +627,7 @@ export const resolveProviderModelOptions = (provider, selectedModel) => {
     filterSelectableModels(selectableModelsForProvider(provider, provider?.models)),
     selectedModel,
   );
-  const catalog = isCodexSubscriptionProvider(provider) ? codexCatalogModelIds(provider) : null;
+  const catalog = codexCatalogModelIds(provider);
   if (!catalog) return { models: shipped, source: MODEL_SOURCE.shipped, unlistedSelection: false };
   const models = filterSelectableModels(catalog);
   const unlistedSelection = !!selectedModel

--- a/client/src/utils/providers.js
+++ b/client/src/utils/providers.js
@@ -544,22 +544,93 @@ export const withStaleAntigravityPin = (provider, models, selectedModel) => {
 };
 
 /**
+ * The model ids in a signed-in ChatGPT account's catalog, or `null` when the
+ * catalog is not a SUCCESSFUL read.
+ *
+ * The server ships `{ models, fetchedAt, error }` on a Codex-subscription
+ * provider (`codexModelCatalog`), and all three states are distinct:
+ * `models: null` = never fetched, a set `error` = the last read failed (the
+ * list, if any, is only last-known-good), and `[]` = this account genuinely
+ * exposes no models. Only the last two of those are answers about the account,
+ * so a never-fetched or failed read collapses to `null` here and the caller
+ * keeps its shipped list — an offline or signed-out user must never be handed
+ * an empty dropdown.
+ *
+ * CLIENT-ONLY (no server mirror).
+ * @param {{codexModelCatalog?:{models?:unknown, error?:unknown}}|null|undefined} provider
+ * @returns {string[]|null}
+ */
+export const codexCatalogModelIds = (provider) => {
+  const catalog = provider?.codexModelCatalog;
+  if (!catalog || catalog.error || !Array.isArray(catalog.models)) return null;
+  return catalog.models
+    .map((entry) => (typeof entry === 'string' ? entry : entry?.id))
+    .filter((id) => typeof id === 'string' && id !== '');
+};
+
+/** Where a picker's option list came from. */
+export const MODEL_SOURCE = Object.freeze({
+  /** The provider's shipped/configured `models` array. */
+  shipped: 'shipped',
+  /** The signed-in ChatGPT account's own catalog. */
+  account: 'account',
+  /** The account was read successfully and exposes no models. */
+  accountEmpty: 'account-empty',
+});
+
+/**
+ * The option list for a picker, plus WHERE it came from.
+ *
+ * For a Codex-subscription provider whose account catalog has been fetched, the
+ * options are that account's real models — so a tier the plan cannot run is not
+ * selectable and cannot be queued against a worktree that would only fail later.
+ * Every other state (never fetched, failed read, non-Codex provider) falls back
+ * to the shipped list unchanged.
+ *
+ * ADDITIVE: a stored `selectedModel` the catalog no longer lists is retained as
+ * its own option and reported via `unlistedSelection`, so an existing task
+ * template renders what it actually holds instead of silently changing model.
+ *
+ * CLIENT-ONLY (no server mirror).
+ * @param {{id?:string, command?:string, models?:unknown[]}|null|undefined} provider
+ * @param {string|null|undefined} selectedModel
+ * @returns {{models: unknown[], source: string, unlistedSelection: boolean}}
+ */
+export const resolveProviderModelOptions = (provider, selectedModel) => {
+  const shipped = withStaleAntigravityPin(
+    provider,
+    filterSelectableModels(selectableModelsForProvider(provider, provider?.models)),
+    selectedModel,
+  );
+  const catalog = isCodexSubscriptionProvider(provider) ? codexCatalogModelIds(provider) : null;
+  if (!catalog) return { models: shipped, source: MODEL_SOURCE.shipped, unlistedSelection: false };
+  const models = filterSelectableModels(catalog);
+  const unlistedSelection = !!selectedModel
+    && !isConfiguredDefaultModel(selectedModel)
+    && !models.includes(selectedModel);
+  return {
+    models: unlistedSelection ? [...models, selectedModel] : models,
+    source: models.length > 0 ? MODEL_SOURCE.account : MODEL_SOURCE.accountEmpty,
+    unlistedSelection,
+  };
+};
+
+/**
  * The option list for a picker that renders an effort control but reads
  * `provider.models` directly (no `useProviderModels`): base models, sentinels
  * stripped, plus any legacy suffixed pin so the stored value stays visible.
  * The hook's own list is assembled from the same two primitives, so the two
- * paths can't drift.
+ * paths can't drift. Codex-subscription providers resolve through
+ * `resolveProviderModelOptions`, so every picker offers the same account-aware
+ * answer without each one reimplementing the fallback.
  *
  * CLIENT-ONLY (no server mirror).
  * @param {{id?:string, command?:string, models?:unknown[]}|null|undefined} provider
  * @param {string|null|undefined} selectedModel
  * @returns {unknown[]}
  */
-export const effortAwareModelOptions = (provider, selectedModel) => withStaleAntigravityPin(
-  provider,
-  filterSelectableModels(selectableModelsForProvider(provider, provider?.models)),
-  selectedModel,
-);
+export const effortAwareModelOptions = (provider, selectedModel) =>
+  resolveProviderModelOptions(provider, selectedModel).models;
 
 /**
  * The model a run will ACTUALLY use: the explicit pin, else the provider's own

--- a/client/src/utils/providers.test.js
+++ b/client/src/utils/providers.test.js
@@ -81,6 +81,7 @@ import {
   effortAwareModelOptions,
   resolveProviderModelOptions,
   codexCatalogModelIds,
+  providerModelList,
   MODEL_SOURCE,
   effectiveModelFor,
   effortSurvivingModel,
@@ -388,6 +389,20 @@ describe('Antigravity base-model split (server mirror)', () => {
       const agy = { id: 'antigravity-cli', command: 'agy', models: CATALOG, codexModelCatalog: { models: [], error: null } };
       expect(resolveProviderModelOptions(agy, '').source).toBe(MODEL_SOURCE.shipped);
       expect(codexCatalogModelIds({ codexModelCatalog: { models: null, error: null } })).toBeNull();
+    });
+
+    it('is the raw list every other picker reads, so none reimplements the fallback', () => {
+      // providerModelList is the ONE place the account catalog enters a picker —
+      // useProviderModels, AppProviderPin and the allowlist controls all read it.
+      expect(providerModelList(codex({ models: [{ id: 'gpt-5.4' }], fetchedAt: 1, error: null })))
+        .toEqual(['gpt-5.4']);
+      expect(providerModelList(codex({ models: null, fetchedAt: null, error: null }))).toEqual(SHIPPED);
+      // A successfully-read EMPTY catalog must NOT fall through to defaultModel:
+      // the account really has no models, and the default is one of them.
+      expect(providerModelList({ ...codex({ models: [], fetchedAt: 1, error: null }), models: [], defaultModel: 'gpt-6-astra' }))
+        .toEqual([]);
+      // Non-Codex providers keep the defaultModel fallback for an empty list.
+      expect(providerModelList({ id: 'x', models: [], defaultModel: 'only-default' })).toEqual(['only-default']);
     });
 
     it('is what effortAwareModelOptions returns, so every picker agrees', () => {

--- a/client/src/utils/providers.test.js
+++ b/client/src/utils/providers.test.js
@@ -79,6 +79,9 @@ import {
   selectableModelsForProvider,
   withStaleAntigravityPin,
   effortAwareModelOptions,
+  resolveProviderModelOptions,
+  codexCatalogModelIds,
+  MODEL_SOURCE,
   effectiveModelFor,
   effortSurvivingModel,
   seedModelEffort,
@@ -330,6 +333,66 @@ describe('Antigravity base-model split (server mirror)', () => {
       const codex = { id: 'codex', command: 'codex', models: ['gpt-5', 'gpt-5-mini'] };
       expect(effortAwareModelOptions(codex, 'gpt-5')).toEqual(['gpt-5', 'gpt-5-mini']);
       expect(effortAwareModelOptions(null, '')).toEqual([]);
+    });
+  });
+
+  // #6306: the CoS picker must offer the SIGNED-IN account's catalog, and must
+  // never be emptied by a cold cache or a failed read.
+  describe('resolveProviderModelOptions (Codex account catalog)', () => {
+    const SHIPPED = ['gpt-6-astra', 'gpt-5.6-sol', 'gpt-5.4'];
+    const codex = (codexModelCatalog) => ({
+      id: 'codex', name: 'Codex CLI', type: 'cli', command: 'codex', models: SHIPPED, codexModelCatalog,
+    });
+
+    it('offers the account catalog when one was fetched', () => {
+      const result = resolveProviderModelOptions(
+        codex({ models: [{ id: 'gpt-5.4' }, { id: 'gpt-5.4-mini' }], fetchedAt: 1, error: null }),
+        'gpt-5.4',
+      );
+      expect(result.models).toEqual(['gpt-5.4', 'gpt-5.4-mini']);
+      expect(result.source).toBe(MODEL_SOURCE.account);
+      expect(result.unlistedSelection).toBe(false);
+    });
+
+    it('keeps the shipped list for a never-fetched catalog and for a failed read', () => {
+      for (const catalog of [
+        undefined,
+        { models: null, fetchedAt: null, error: null },
+        { models: null, fetchedAt: null, error: { code: 'protocol', message: 'boom' } },
+        // A failed read hands back a LAST-KNOWN-GOOD list, which is not an answer
+        // about the account either — the shipped list stands.
+        { models: [{ id: 'gpt-5.4' }], fetchedAt: 1, error: { code: 'protocol', message: 'boom' } },
+      ]) {
+        const result = resolveProviderModelOptions(codex(catalog), '');
+        expect(result.models).toEqual(SHIPPED);
+        expect(result.source).toBe(MODEL_SOURCE.shipped);
+      }
+    });
+
+    it('reports a successfully-read empty catalog as its own state, not as shipped', () => {
+      const result = resolveProviderModelOptions(codex({ models: [], fetchedAt: 1, error: null }), '');
+      expect(result.models).toEqual([]);
+      expect(result.source).toBe(MODEL_SOURCE.accountEmpty);
+    });
+
+    it('retains a stored model the catalog no longer lists, flagged', () => {
+      const result = resolveProviderModelOptions(
+        codex({ models: [{ id: 'gpt-5.4' }], fetchedAt: 1, error: null }),
+        'gpt-6-astra',
+      );
+      expect(result.models).toEqual(['gpt-5.4', 'gpt-6-astra']);
+      expect(result.unlistedSelection).toBe(true);
+    });
+
+    it('leaves a non-subscription provider on its own catalog', () => {
+      const agy = { id: 'antigravity-cli', command: 'agy', models: CATALOG, codexModelCatalog: { models: [], error: null } };
+      expect(resolveProviderModelOptions(agy, '').source).toBe(MODEL_SOURCE.shipped);
+      expect(codexCatalogModelIds({ codexModelCatalog: { models: null, error: null } })).toBeNull();
+    });
+
+    it('is what effortAwareModelOptions returns, so every picker agrees', () => {
+      const provider = codex({ models: [{ id: 'gpt-5.4' }], fetchedAt: 1, error: null });
+      expect(effortAwareModelOptions(provider, '')).toEqual(resolveProviderModelOptions(provider, '').models);
     });
   });
 

--- a/server/routes/providers.codexAccount.test.js
+++ b/server/routes/providers.codexAccount.test.js
@@ -13,6 +13,7 @@ vi.mock('../services/codexAppServer.js', () => ({
   cancelCodexChatGptLogin: vi.fn(),
   codexLogout: vi.fn(),
   peekCodexAccountReadiness: vi.fn(() => null),
+  peekCodexModelCatalog: vi.fn(() => ({ models: null, fetchedAt: null, error: null })),
   listCodexModels: vi.fn(),
 }));
 vi.mock('../services/providerRuntimeInstaller.js', async (importOriginal) => ({
@@ -52,6 +53,7 @@ const appWith = (providers = [CODEX, CLAUDE]) => {
 beforeEach(() => {
   vi.clearAllMocks();
   codexAppServer.peekCodexAccountReadiness.mockReturnValue(null);
+  codexAppServer.peekCodexModelCatalog.mockReturnValue({ models: null, fetchedAt: null, error: null });
 });
 
 describe('GET /api/providers/codex/account', () => {
@@ -175,6 +177,30 @@ describe('GET /api/providers decorates the Codex cards', () => {
 
     expect(cards.codex.missingPrerequisites).toEqual([{ code: 'codexAccount', label: 'No ChatGPT account is signed in' }]);
     expect(cards['claude-code'].missingPrerequisites).toEqual([]);
+  });
+
+  it('publishes the model catalog as its three-state shape, on Codex cards only', async () => {
+    codexAppServer.peekCodexModelCatalog.mockReturnValue({
+      models: [{ id: 'gpt-5.6-terra' }],
+      fetchedAt: 1_700_000_000_000,
+      error: null,
+    });
+
+    const cards = byId(await request(appWith()).get('/api/providers'));
+
+    expect(cards.codex.codexModelCatalog.models).toEqual([{ id: 'gpt-5.6-terra' }]);
+    expect(cards['claude-code']).not.toHaveProperty('codexModelCatalog');
+    // Cache-only: rendering the list must not be what fetches a catalog.
+    expect(codexAppServer.listCodexModels).not.toHaveBeenCalled();
+  });
+
+  it('keeps a never-fetched catalog distinguishable from a fetched-empty one', async () => {
+    const cold = byId(await request(appWith()).get('/api/providers'));
+    expect(cold.codex.codexModelCatalog).toEqual({ models: null, fetchedAt: null, error: null });
+
+    codexAppServer.peekCodexModelCatalog.mockReturnValue({ models: [], fetchedAt: 1_700_000_000_000, error: null });
+    const empty = byId(await request(appWith()).get('/api/providers'));
+    expect(empty.codex.codexModelCatalog.models).toEqual([]);
   });
 
   it('does not turn an unknown verdict into a finding', async () => {

--- a/server/routes/providers.js
+++ b/server/routes/providers.js
@@ -26,6 +26,7 @@ import { isCodexSubscriptionProvider } from '../lib/codexAccount.js';
 import {
   cancelCodexChatGptLogin,
   peekCodexAccountReadiness,
+  peekCodexModelCatalog,
   codexLogout,
   listCodexModels,
   getCodexAccountReadiness,
@@ -189,13 +190,18 @@ export function createPortOSProviderRoutes(aiToolkit) {
     // `null` here means NOT PROBED, and the dedicated `/codex/account` fetch is
     // what fills it — a card renders "unknown", never "signed out", until then.
     const codexAccount = peekCodexAccountReadiness();
+    // Same cache-only contract, for the CoS/model pickers (#6306): the signed-in
+    // account's real catalog when one has been fetched, otherwise the three-state
+    // shape that tells the client to keep showing its shipped list. Rendering a
+    // picker must never be what starts `codex app-server`.
+    const codexModelCatalog = peekCodexModelCatalog();
     res.json({
       activeProvider: data.activeProvider,
       providers: data.providers.map((provider) => ({
         ...presentProvider(provider, capabilities),
         prerequisitesMet: prerequisites[provider.id]?.met ?? true,
         missingPrerequisites: prerequisites[provider.id]?.missing ?? [],
-        ...(isCodexSubscriptionProvider(provider) ? { codexAccount } : {}),
+        ...(isCodexSubscriptionProvider(provider) ? { codexAccount, codexModelCatalog } : {}),
       })),
       runnerAllowedCommands: RUNNER_ALLOWED_COMMANDS
     });

--- a/server/services/codexAppServer.js
+++ b/server/services/codexAppServer.js
@@ -110,6 +110,14 @@ const activeTurns = new Map();
  * account has no models".
  */
 let modelsCache = null;
+/**
+ * `{ code, message }` from the LAST `model/list` attempt, or `null` when the most
+ * recent attempt succeeded (or none has run). Cached beside — never inside —
+ * `modelsCache`, so a failed read stays distinguishable from a never-fetched
+ * one while the last-known-good list survives: a picker reading the peek can
+ * then say WHY it is showing the shipped list instead of the account's.
+ */
+let modelsError = null;
 /** `{ until, category, message }` while the TEXT transport is benched. */
 let textTransportBench = null;
 /** The empty scratch directory generic text turns run in. Created lazily. */
@@ -222,6 +230,7 @@ const handleNotification = (method, params) => {
   // completely as one PortOS started.
   if (params?.success !== false) {
     modelsCache = null;
+    modelsError = null;
     clearCodexTextTransportBench();
   }
   const loginId = typeof params?.loginId === 'string' ? params.loginId : null;
@@ -610,6 +619,7 @@ export async function codexLogout() {
   settleLogin('ended by sign-out');
   readinessCache = null;
   modelsCache = null;
+  modelsError = null;
   // Signing out invalidates whatever the bench was waiting on, and signing back
   // in must not inherit the previous account's cooldown.
   clearCodexTextTransportBench();
@@ -729,13 +739,15 @@ export async function listCodexModels({ fresh = false } = {}) {
       throw new Error(`model/list did not finish paginating within ${MODEL_LIST_MAX_PAGES} pages`);
     }
     modelsCache = { at: Date.now(), models };
+    modelsError = null;
     return { models, fetchedAt: modelsCache.at, error: null };
   } catch (err) {
     console.error(`❌ Codex model/list failed: ${err.message}`);
+    modelsError = { code: err.code || CODEX_ERROR_CODES.protocol, message: err.message };
     return {
       models: modelsCache ? modelsCache.models : null,
       fetchedAt: modelsCache ? modelsCache.at : null,
-      error: { code: err.code || CODEX_ERROR_CODES.protocol, message: err.message },
+      error: modelsError,
     };
   }
 }
@@ -743,6 +755,26 @@ export async function listCodexModels({ fresh = false } = {}) {
 /** The cached catalog without spawning anything. `null` = never fetched. */
 export function peekCodexModels() {
   return modelsCache ? { models: modelsCache.models, fetchedAt: modelsCache.at } : null;
+}
+
+/**
+ * The cached catalog as the three-state shape a picker needs, without spawning
+ * anything. `models: null` = NEVER FETCHED, `[]` = fetched and genuinely empty,
+ * and a populated array is this account's real catalog; `error` is set when the
+ * last attempt failed, in which case `models` is the last-known-good list (or
+ * `null` if there never was one). A caller must fall back to its shipped list
+ * for every state except a successful read — that is the whole point of keeping
+ * the three apart.
+ *
+ * CACHE-ONLY, like `peekCodexAccountReadiness`: this is what the providers list
+ * may call on a render path, where spawning `codex app-server` is forbidden.
+ */
+export function peekCodexModelCatalog() {
+  return {
+    models: modelsCache ? modelsCache.models : null,
+    fetchedAt: modelsCache ? modelsCache.at : null,
+    error: modelsError,
+  };
 }
 
 /** The catalog entry for `modelId`, or `null` when the catalog is unknown. */
@@ -988,6 +1020,7 @@ export async function stopCodexAppServer() {
   settleLogin(null);
   readinessCache = null;
   modelsCache = null;
+  modelsError = null;
 
   // The child goes down BEFORE any await. `teardown` decides whether to fail
   // live turns by comparing `connection` to the dying target, so `connection`
@@ -1035,6 +1068,7 @@ export function __resetCodexAppServer() {
   connectingTarget = null;
   activeTurns.clear();
   modelsCache = null;
+  modelsError = null;
   textTransportBench = null;
   textTurnCwd = null;
   creatingTextTurnCwd = null;

--- a/server/services/codexAppServer.turn.test.js
+++ b/server/services/codexAppServer.turn.test.js
@@ -29,6 +29,7 @@ const {
   listCodexModels,
   codexLogout,
   peekCodexModels,
+  peekCodexModelCatalog,
   runCodexTextTurn,
   stopCodexAppServer,
 } = await import('./codexAppServer.js');
@@ -474,6 +475,28 @@ describe('a catalog that will not stop paginating', () => {
     expect(result.models).toBeNull();
     expect(result.error.message).toMatch(/paginating/i);
     expect(peekCodexModels()).toBeNull();
+  });
+});
+
+describe('peekCodexModelCatalog', () => {
+  it('keeps never-fetched, fetched-empty, and failed apart for a picker', async () => {
+    // A picker that cannot tell these three apart either offers an empty
+    // dropdown to an offline user or claims a plan has no models (#6306).
+    expect(peekCodexModelCatalog()).toEqual({ models: null, fetchedAt: null, error: null });
+
+    const empty = listCodexModels();
+    await handshake();
+    await awaitRequest(child, 'model/list', { data: [] });
+    await empty;
+    expect(peekCodexModelCatalog()).toMatchObject({ models: [], error: null });
+    expect(peekCodexModelCatalog().fetchedAt).toEqual(expect.any(Number));
+
+    const failing = listCodexModels({ fresh: true });
+    await awaitRequest(child, 'model/list', (frame) => child.replyError(frame, { code: -32603, message: 'catalog unavailable' }));
+    await failing;
+    // The last-known-good list survives, and the error says it is not authoritative.
+    expect(peekCodexModelCatalog().models).toEqual([]);
+    expect(peekCodexModelCatalog().error.message).toMatch(/catalog unavailable/);
   });
 });
 


### PR DESCRIPTION
## Summary

- `GET /api/providers` now decorates a Codex-subscription card with `codexModelCatalog` — the cached `{ models, fetchedAt, error }` peek (`peekCodexModelCatalog()`), following the same cache-only contract as `codexAccount`, so rendering a picker never spawns `codex app-server`.
- `providerModelList()` in `client/src/utils/providers.js` is the single place that catalog enters a picker: the signed-in account's real models when a fetch succeeded, otherwise the provider's shipped list. `useProviderModels`, `AppProviderPin`, the persistent-mind allowlist controls, and the CoS task form all read it, so they can no longer disagree about the same provider.
- Three-state fallback preserved: `models: null` (never fetched) and a set `error` (failed read; the list is only last-known-good) both keep the shipped list, so a signed-out or offline user is never handed an empty dropdown. Only a successful `[]` means "this account exposes no models", and the form says so instead of rendering a blank control.
- Additive: a stored model the catalog no longer lists survives as its own option, flagged `(not in account catalog)`, so an existing task template does not silently change model.
- Replaces the "Codex uses the model configured in `~/.codex/config.toml`" note, untrue since `codexSpawnArgs` began passing `--model` unconditionally.

## Test plan

- `server/routes/providers.codexAccount.test.js` — the catalog rides the providers payload on Codex cards only, never-fetched stays distinguishable from fetched-empty, and listing providers does not call `listCodexModels`.
- `server/services/codexAppServer.turn.test.js` — `peekCodexModelCatalog()` keeps never-fetched / fetched-empty / failed apart, with the last-known-good list surviving a failure.
- `client/src/utils/providers.test.js` — all three catalog states resolve to the right options and source; a stored-but-unlisted model is retained and flagged; `providerModelList` is the shared raw list; a successful empty catalog does not fall through to `defaultModel`.
- `client/src/components/cos/TaskAddForm.test.jsx` — the account catalog is offered, a failed read keeps the shipped list with a note, an empty account explains itself, and no fetch is triggered from the render.
- `cd client && npm run lint`, `cd client && npx vitest run` (2287 passed), `cd server && npx vitest run` — the 4 files that failed under full-suite load all pass in isolation (known timeout flakes; different files failed on each run).

Closes #6306