### PR TITLE
fix: surface fal.ai/reactor.inc video backends when only FAL_KEY/REACTOR_API_KEY env vars are set

### DIFF
--- a/client/src/pages/VideoGen.backendSwitch.test.jsx
+++ b/client/src/pages/VideoGen.backendSwitch.test.jsx
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+
+import {
+  loadVideoGenPage,
+  renderVideoGenPage,
+  resetVideoGenMockState,
+  state,
+  videoGenModel,
+  videoGenModelContext,
+  videoGenStatus,
+} from '../test/videoGenPageMocks.jsx';
+
+const MODEL = videoGenModel('local-model');
+
+await loadVideoGenPage();
+
+describe('VideoGen backend switch — fal.ai/reactor.inc usability', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    resetVideoGenMockState();
+    state.getVideoGenModelContext.mockResolvedValue(videoGenModelContext([MODEL]));
+  });
+
+  // A key configured only via the FAL_KEY/REACTOR_API_KEY env var (no
+  // Settings-form entry) still makes the server's isVideoModeUsable() report
+  // true — GET /status must reflect that so the switcher appears without the
+  // client ever reading `videoGen.fal.apiKey` / `videoGen.reactor.apiKey`
+  // off the settings object.
+  it('shows fal.ai and reactor.inc once /status reports them usable, with no settings key stored', async () => {
+    state.getVideoGenStatus.mockResolvedValue(videoGenStatus([MODEL], {
+      falEnabled: true,
+      reactorEnabled: true,
+    }));
+    await renderVideoGenPage();
+
+    await waitFor(() => expect(screen.getByRole('group', { name: 'Video generation backend' })).toBeInTheDocument());
+    expect(screen.getByRole('button', { name: 'fal.ai' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Reactor.inc' })).toBeInTheDocument();
+  });
+
+  it('hides the switch entirely when neither backend is usable', async () => {
+    state.getVideoGenStatus.mockResolvedValue(videoGenStatus([MODEL], {
+      falEnabled: false,
+      reactorEnabled: false,
+    }));
+    await renderVideoGenPage();
+
+    await waitFor(() => expect(screen.getByLabelText('Model')).toHaveValue(MODEL.id));
+    expect(screen.queryByRole('group', { name: 'Video generation backend' })).toBeNull();
+  });
+});

--- a/client/src/pages/VideoGen.jsx
+++ b/client/src/pages/VideoGen.jsx
@@ -118,9 +118,11 @@ export default function VideoGen() {
   const openSettings = () => setSearchParams(prev => { const n = new URLSearchParams(prev); n.set('settings', '1'); return n; });
   const closeSettings = () => {
     setSearchParams(prev => { const n = new URLSearchParams(prev); n.delete('settings'); return n; });
-    // The drawer hosts the Grok enable toggle — re-read it so the
-    // Local/Grok backend switch appears/disappears without a reload.
+    // The drawer hosts the Grok enable toggle plus the fal.ai/reactor.inc API
+    // key fields — re-read both so the backend switch appears/disappears
+    // without a reload.
     refreshGrokEnabled();
+    refreshStatus();
   };
 
   // Episode Composer (#6228) — multi-scene continuous-video authoring, opened
@@ -166,23 +168,20 @@ export default function VideoGen() {
   // user enabled Grok in Settings → Image Gen (one toggle covers image +
   // video). 'local' keeps every existing flow untouched.
   const [grokEnabled, setGrokEnabled] = useState(false);
-  // fal.ai queue REST video backend (#6213) — surfaced only when an API key is
-  // configured (Settings → Video Gen, or the FAL_KEY env var).
-  const [falEnabled, setFalEnabled] = useState(false);
-  // reactor.inc fast-h3 video backend (#6214) — same usability gate shape as
-  // fal.ai above.
-  const [reactorEnabled, setReactorEnabled] = useState(false);
+  // fal.ai (#6213) / reactor.inc (#6214) usability comes off GET /status
+  // instead of the raw settings object — the server-side `isVideoModeUsable`
+  // it's computed from also honors the FAL_KEY/REACTOR_API_KEY env vars, which
+  // the client can't see, so a key set only via env var (no Settings-form
+  // entry) still surfaces the backend switcher below.
+  const falEnabled = status?.falEnabled === true;
+  const reactorEnabled = status?.reactorEnabled === true;
   // The jobId of the render this tab's Generate button currently owns —
   // threaded into cancelVideoGen so cancellation is job-scoped.
   const activeJobIdRef = useRef(null);
   const models = useMemo(() => modelContext?.models || [], [modelContext]);
   const refreshGrokEnabled = useCallback(() => {
     getSettings({ silent: true })
-      .then((sv) => {
-        setGrokEnabled(sv?.imageGen?.grok?.enabled === true);
-        setFalEnabled(Boolean(sv?.videoGen?.fal?.apiKey));
-        setReactorEnabled(Boolean(sv?.videoGen?.reactor?.apiKey));
-      })
+      .then((sv) => setGrokEnabled(sv?.imageGen?.grok?.enabled === true))
       .catch(() => {});
   }, []);
   useEffect(() => { refreshGrokEnabled(); }, [refreshGrokEnabled]);

--- a/server/routes/videoGen.js
+++ b/server/routes/videoGen.js
@@ -44,6 +44,7 @@ import {
 import { cleanupMultipartTemp } from '../services/videoGen/prepareParams.js';
 import { submitVideoGenJob } from '../services/videoGen/submitJob.js';
 import { resolveReactorApiKey, mintReactorToken } from '../services/videoGen/reactor.js';
+import { isVideoModeUsable, VIDEO_GEN_MODE } from '../services/videoGen/modes.js';
 import { VIDEO_GEN_LOCAL_ONLY_FIELDS } from '../services/videoGen/requestFields.js';
 import { attachSseClient, cancelJob, listJobs } from '../services/mediaJobQueue/index.js';
 import { getTextEncoderRepo, isHfRepoId } from '../lib/mediaModels.js';
@@ -489,6 +490,14 @@ router.get('/status', asyncHandler(async (_req, res) => {
     // wakes the display, re-introducing the exact GPU-watchdog contention the
     // sleep is there to avoid.
     displaySleepOnRender: isDisplaySleepEnabled(s.videoGen),
+    // Backend usability for the two metered-API video providers (#6213/#6214).
+    // Computed server-side through the SAME resolver `isVideoModeUsable` uses
+    // to gate an actual render, so a key set only via FAL_KEY/REACTOR_API_KEY
+    // env var (no Settings-form entry) still surfaces the backend switcher —
+    // the client can't see env vars, and re-deriving "has a key" from the
+    // settings object alone missed that case entirely.
+    falEnabled: isVideoModeUsable(s, VIDEO_GEN_MODE.FAL),
+    reactorEnabled: isVideoModeUsable(s, VIDEO_GEN_MODE.REACTOR),
   });
 }));
 

--- a/server/routes/videoGen.test.js
+++ b/server/routes/videoGen.test.js
@@ -445,6 +445,52 @@ describe('videoGen routes', () => {
       expect(off.body.displaySleepOnRender).toBe(false);
     });
 
+    // #6304-follow-up — falEnabled/reactorEnabled must reflect the SAME
+    // resolver a render is gated on (isVideoModeUsable), which honors the
+    // FAL_KEY/REACTOR_API_KEY env vars. Re-deriving "has a key" from the raw
+    // settings object client-side missed the env-var case entirely, so a key
+    // set only via env var never surfaced the backend switcher.
+    it('reports fal/reactor usable when a settings key is stored', async () => {
+      const { getSettings } = await import('../services/settings.js');
+      getSettings.mockResolvedValueOnce({
+        imageGen: { local: { pythonPath: '/usr/bin/python3' } },
+        videoGen: { fal: { apiKey: 'settings-fal-key' }, reactor: { apiKey: 'settings-reactor-key' } },
+      });
+      const r = await request(app).get('/api/video-gen/status');
+      expect(r.body.falEnabled).toBe(true);
+      expect(r.body.reactorEnabled).toBe(true);
+    });
+
+    it('reports fal/reactor usable from FAL_KEY/REACTOR_API_KEY env vars with no settings key', async () => {
+      const prevFal = process.env.FAL_KEY;
+      const prevReactor = process.env.REACTOR_API_KEY;
+      process.env.FAL_KEY = 'env-fal-key';
+      process.env.REACTOR_API_KEY = 'env-reactor-key';
+      try {
+        const r = await request(app).get('/api/video-gen/status');
+        expect(r.body.falEnabled).toBe(true);
+        expect(r.body.reactorEnabled).toBe(true);
+      } finally {
+        if (prevFal === undefined) delete process.env.FAL_KEY; else process.env.FAL_KEY = prevFal;
+        if (prevReactor === undefined) delete process.env.REACTOR_API_KEY; else process.env.REACTOR_API_KEY = prevReactor;
+      }
+    });
+
+    it('reports fal/reactor unusable when neither a settings key nor an env var is present', async () => {
+      const prevFal = process.env.FAL_KEY;
+      const prevReactor = process.env.REACTOR_API_KEY;
+      delete process.env.FAL_KEY;
+      delete process.env.REACTOR_API_KEY;
+      try {
+        const r = await request(app).get('/api/video-gen/status');
+        expect(r.body.falEnabled).toBe(false);
+        expect(r.body.reactorEnabled).toBe(false);
+      } finally {
+        if (prevFal !== undefined) process.env.FAL_KEY = prevFal;
+        if (prevReactor !== undefined) process.env.REACTOR_API_KEY = prevReactor;
+      }
+    });
+
     it('passes each model entry through with its registry disclosure block', async () => {
       videoGenService.listVideoModels.mockReturnValueOnce([
         {


### PR DESCRIPTION
## Summary

- `GET /api/video-gen/status` now reports `falEnabled`/`reactorEnabled` via the same `isVideoModeUsable()` resolver a render is gated on, which checks the `FAL_KEY`/`REACTOR_API_KEY` env vars as well as the settings-stored key.
- The Video Gen page previously re-derived usability from the raw `GET /api/settings` response alone, checking only `videoGen.fal.apiKey`/`videoGen.reactor.apiKey` — so a key configured only via env var (as the Settings UI's own copy explicitly invites: "or set the FAL_KEY environment variable instead") never surfaced the fal.ai/Reactor.inc backend switcher on the Video Gen page, even though a render using that mode would have worked fine server-side.
- Closing the Settings drawer now also refreshes `/status`, so toggling the key there updates the switcher without a reload.

## Test plan

- Added 3 server tests (`server/routes/videoGen.test.js`) covering: settings-key-only, env-var-only, and neither-present cases for the new `falEnabled`/`reactorEnabled` fields.
- Added `client/src/pages/VideoGen.backendSwitch.test.jsx` covering the switcher appearing/hiding based on `/status`, independent of the settings object.
- `cd server && NODE_ENV=test npx vitest run routes/videoGen.test.js services/videoGen` — 872 passed.
- `cd client && npx vitest run src/pages/VideoGen` — 35 passed.