### PR TITLE
fix: relabel claim override field as "Extra context"

### DIFF
--- a/client/src/components/apps/tabs/IssuesTab.jsx
+++ b/client/src/components/apps/tabs/IssuesTab.jsx
@@ -600,7 +600,7 @@ export default function IssuesTab({ appId, appName }) {
         )}
         <div className="space-y-1">
           <label htmlFor={overrideContextId} className="block text-xs text-gray-400">
-            Override context or instructions <span className="text-gray-600">(optional)</span>
+            Extra context <span className="text-gray-600">(optional)</span>
           </label>
           <textarea
             id={overrideContextId}

--- a/client/src/components/apps/tabs/IssuesTab.test.jsx
+++ b/client/src/components/apps/tabs/IssuesTab.test.jsx
@@ -347,7 +347,7 @@ describe('IssuesTab', () => {
     await renderTab();
 
     await screen.findByText('Crash on save');
-    fireEvent.change(screen.getByLabelText(/Override context or instructions/), {
+    fireEvent.change(screen.getByLabelText(/Extra context/), {
       target: { value: 'Prefer a small, focused fix and add a regression test.' }
     });
     fireEvent.click(screen.getByRole('button', { name: /Claim/ }));


### PR DESCRIPTION
## Summary
- The claim-agent panel's override field is labeled "Override context or instructions", but the value is appended as extra context alongside the claim instructions rather than replacing them.
- Relabeled it to "Extra context" for accuracy.

## Test plan
- `npx vitest run src/components/apps/tabs/IssuesTab.test.jsx` — 37 passed.