### PR TITLE
fix: enable object-anchored Eidoverse labels in PortOS

### DIFF
--- a/client/src/components/eidoverse/EidoverseWorldDrawer.jsx
+++ b/client/src/components/eidoverse/EidoverseWorldDrawer.jsx
@@ -132,11 +132,11 @@ export default function EidoverseWorldDrawer({
           <select id="eidoverse-label-visibility" className={fieldClass} value={labelVisibility}
             onChange={(event) => onLabelVisibilityChange(event.target.value)}>
             <option value="nearby">Nearby — respect each object's label mode</option>
-            <option value="all-nearby">All nearby — include inspect-only objects</option>
-            <option value="off">Off — inspect selected objects only</option>
+            <option value="all-nearby">All nearby — label objects within 60 metres</option>
+            <option value="off">Off — hide floating labels</option>
           </select>
         </label>
-        <p className="mt-2 text-xs text-gray-400">Saved in this browser; changing visibility does not rewrite the world. Object details remain available with labels off.</p>
+        <p className="mt-2 text-xs text-gray-400">Labels appear above objects in the world. Click or tap a label to learn what it represents. Saved in this browser; turning labels off keeps already-open details available.</p>
         {!frameConnection?.capabilities?.labelPreferences && (
           <p className="mt-1 text-xs text-gray-400">The preference will apply when a compatible renderer connects.</p>
         )}

--- a/client/src/hooks/useEidoverseFrame.js
+++ b/client/src/hooks/useEidoverseFrame.js
@@ -11,7 +11,8 @@ import { safeReadStorage, safeWriteStorage } from '../lib/safeStorage';
 const PREFERENCE_KEY = 'portos-eidoverse-label-visibility';
 const readPreference = () => {
   const stored = safeReadStorage(PREFERENCE_KEY);
-  return EIDOVERSE_LABEL_PREFERENCES.includes(stored) ? stored : 'nearby';
+  // PortOS opts into world annotations; the standalone framework defaults off.
+  return EIDOVERSE_LABEL_PREFERENCES.includes(stored) ? stored : 'all-nearby';
 };
 
 export default function useEidoverseFrame(hostUrl, objects = []) {

--- a/client/src/hooks/useEidoverseFrame.test.jsx
+++ b/client/src/hooks/useEidoverseFrame.test.jsx
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import { MemoryRouter, useLocation } from 'react-router';
 import useEidoverseFrame from './useEidoverseFrame';
-import { safeRemoveStorage } from '../lib/safeStorage';
+import { safeRemoveStorage, safeWriteStorage } from '../lib/safeStorage';
 
 const hostUrl = 'https://world.example.com/';
 const objects = [{ id: 'portos-design-v2-signal-app-example', route: '/apps' }];
@@ -36,7 +36,7 @@ describe('hosted Eidoverse frame navigation', () => {
     fireEvent.load(frame);
     const [hello, origin] = post.mock.calls.at(-1);
     expect(origin).toBe('https://world.example.com');
-    expect(hello).toMatchObject({ type: 'portos:connect', version: 1, labelVisibility: 'nearby' });
+    expect(hello).toMatchObject({ type: 'portos:connect', version: 1, labelVisibility: 'all-nearby' });
     expect(Object.keys(hello).sort()).toEqual(['capabilities', 'labelVisibility', 'nonce', 'type', 'version']);
     const navigation = { type: 'eidoverse:navigate', version: 1, nonce: hello.nonce, entityId: objects[0].id, route: '/apps' };
     send(source, navigation); // No handshake yet.
@@ -75,6 +75,15 @@ describe('hosted Eidoverse frame navigation', () => {
     send(source, { ...ready, nonce: nextHello.nonce });
     send(source, { ...navigation, nonce: nextHello.nonce });
     expect(screen.getByLabelText('Route')).toHaveTextContent('/apps');
+  });
+
+  it('preserves an explicit saved opt-out when a new renderer connects', () => {
+    safeWriteStorage('portos-eidoverse-label-visibility', 'off');
+    mount();
+    const iframe = screen.getByTitle('Test renderer');
+    const post = vi.spyOn(iframe.contentWindow, 'postMessage').mockImplementation(() => {});
+    fireEvent.load(iframe);
+    expect(post.mock.calls.at(-1)[0]).toMatchObject({ type: 'portos:connect', labelVisibility: 'off' });
   });
 
   it('marks an unresponsive older renderer unsupported without waiting in production time', () => {

--- a/docs/features/eidoverse.md
+++ b/docs/features/eidoverse.md
@@ -444,8 +444,15 @@ section route. Only the fixed source-section routes (plus `/eidoverse`) are
 allowed. URLs, query strings, encoded/relative paths, record payloads, and
 unknown entities cannot navigate. No URL proxy is exposed.
 
+The Eidoverse framework leaves object labels off by default. PortOS explicitly enables
+them through its trusted frame session, defaulting to `all-nearby` when this browser
+has no saved preference. Existing saved choices, including `off`, are preserved.
+Labels are positioned over their objects; clicking or tapping one opens its semantic
+name and description, with Open in PortOS supplied only by our fork. The old detached
+object dropdown and armed inspection buttons are removed.
+
 Floating-label preference is browser-only: `nearby` respects authored modes,
-`all-nearby` includes inspect-only objects within the renderer's bounded range,
+`all-nearby` includes authored inspect-only objects within 60 metres,
 and `off` hides floating labels while keeping selected-object details accessible.
 PortOS sends `portos:label-preference` with `version`, `nonce`, and
 `labelVisibility` only after the frame advertises V1 preference support. A

--- a/scripts/eidoverse-frame-acceptance.mjs
+++ b/scripts/eidoverse-frame-acceptance.mjs
@@ -64,7 +64,7 @@ const SEED = {
   pin: { label: { name: 'Example Goals', visibility: 'always' }, portos: { route: '/goals/list' } },
   url: { label: { name: 'Elsewhere', visibility: 'always' }, portos: { route: 'https://evil.example/goals/list' } },
   query: { label: { name: 'Queried', visibility: 'always' }, portos: { route: '/goals/list?steal=1' } },
-  plain: { label: { name: 'Bench', visibility: 'always' } },
+  plain: { label: { name: 'Bench', visibility: 'inspect' } },
 };
 // The saved projection legend PortOS would hold for that world.
 const LEGEND = [{ id: 'pin', route: '/goals/list' }];
@@ -209,24 +209,26 @@ async function main() {
     if (!frame) throw new Error('renderer frame is gone');
     return frame;
   };
-  const panel = () => renderer().locator('details').filter({ hasText: 'Inspect objects' });
-  await panel().waitFor({ timeout: 90000 });
+  const panel = () => renderer().locator('.ew-object-detail');
+  await renderer().getByRole('group', { name: 'World object labels' }).waitFor({ timeout: 90000 });
 
   console.log('\n— C. a synthetic scene, and the one action it may offer —');
   await renderer().evaluate(async (seed) => {
-    const [{ state, hydrate }, { entities }, { THREE, camera, scene }, { tickObjectLabels }] = await Promise.all([
-      import('/lib/state.js'), import('/lib/world.js'), import('/lib/core.js'), import('/lib/objectlabels.js')]);
+    const [{ hydrate }, { entities }, { THREE, camera, scene }, { tickObjectLabels }, { emptyState, foldEntry }] = await Promise.all([
+      import('/lib/state.js'), import('/lib/world.js'), import('/lib/core.js'), import('/lib/objectlabels.js'), import('/shared/fold.js')]);
     camera.position.set(0, 2, 8); camera.lookAt(0, 1, 0); camera.updateMatrixWorld();
-    const snapshot = structuredClone(state.st);
-    snapshot.entities = {};
+    const snapshot = emptyState();
+    let seq = 0;
     for (const [id, comp] of Object.entries(seed)) {
-      snapshot.entities[id] = { id, lib: 'missing.glb', pos: [0, 0, 0], comp };
+      const fold = (verb, args) => foldEntry(snapshot, { verb, args, seq: ++seq, actor: 'fixture', ts: seq });
+      fold('spawn', { id, lib: 'missing.glb', pos: [0, 0, 0] });
+      for (const [type, data] of Object.entries(comp)) fold('comp', { id, type, data });
     }
     hydrate(snapshot);
     let index = 0;
     for (const id of Object.keys(seed)) {
       const mesh = new THREE.Mesh(new THREE.BoxGeometry(0.4, 1, 0.4), new THREE.MeshBasicMaterial());
-      mesh.position.set((index - 1.5) * 0.5, 0, 0);
+      mesh.position.set((index - 1.5) * 8, 0, 0);
       index += 1;
       scene.add(mesh);
       mesh.updateMatrixWorld();
@@ -238,11 +240,25 @@ async function main() {
     window.sent = [];
     WebSocket.prototype.send = function record(data) { window.sent.push(String(data)); return send.call(this, data); };
   }, SEED);
-  await panel().getByText('Inspect objects', { exact: true }).click();
   const open = panel().getByRole('button', { name: 'Open in PortOS' });
-  const select = (id) => panel().getByLabel('Choose object to inspect').selectOption(id);
+  const pointAt = (id) => renderer().evaluate(async (target) => {
+    const { entities } = await import('/lib/world.js');
+    const { camera } = await import('/lib/core.js');
+    const object = entities.get(target);
+    camera.position.set(object.position.x, 2, 4);
+    camera.lookAt(object.position.x, 0.5, 0);
+    camera.updateMatrixWorld();
+    window.labelTick(window.labelClock = Math.max(performance.now() + 1000, (window.labelClock || 0) + 101));
+  }, id);
+  const select = async (id) => {
+    await pointAt(id);
+    await renderer().getByRole('button', { name: `About ${SEED[id].label.name}`, exact: true }).click();
+  };
   await select('pin');
   check('a projected object offers Open in PortOS', await open.count() === 1);
+  await page.evaluate(([version, session]) => window.post({
+    type: 'portos:label-preference', version, nonce: session, labelVisibility: 'all-nearby',
+  }), [EIDOVERSE_FRAME_VERSION, nonce]);
   for (const id of ['url', 'query', 'plain']) {
     await select(id);
     check(`"${id}" offers no action — its component names no route PortOS knows`, await open.count() === 0);
@@ -274,27 +290,26 @@ async function main() {
     String(await page.evaluate(() => window.navigates().length)));
 
   console.log('\n— E. label preference is browser-only, and rides the session —');
-  const preference = () => panel().getByLabel('Object labels', { exact: true }).inputValue();
   const post = (message) => page.evaluate((value) => window.post(value), message);
-  const plaques = () => renderer().evaluate(() => [...document.querySelectorAll('body > div > span')]
-    .filter((element) => element.style.position === 'absolute' && element.style.display !== 'none').length);
-  await renderer().evaluate(() => window.labelTick(performance.now() + 2000));
-  check('nearby shows the authored plaques', await plaques() > 0, String(await plaques()));
+  const plaques = () => renderer().locator('.ew-object-labels button:visible').count();
+  await post({ type: 'portos:label-preference', version: EIDOVERSE_FRAME_VERSION, nonce, labelVisibility: 'nearby' });
+  await pointAt('plain');
+  check('nearby hides an unselected inspect-only object', await plaques() === 0);
+  await pointAt('pin');
+  check('nearby shows authored landmark labels', await plaques() > 0, String(await plaques()));
   await post({ type: 'portos:label-preference', version: EIDOVERSE_FRAME_VERSION, nonce, labelVisibility: 'all-nearby' });
-  check('all-nearby reaches the renderer', await until(async () => await preference() === 'all'), await preference());
-  await post({ type: 'portos:label-preference', version: EIDOVERSE_FRAME_VERSION, nonce, labelVisibility: 'off' });
-  const wentOff = await until(async () => await preference() === 'off');
-  await renderer().evaluate(() => window.labelTick(performance.now() + 4000));
-  check('off hides every floating plaque', wentOff && await plaques() === 0,
-    `${await preference()} / ${await plaques()} plaques`);
+  await pointAt('plain');
+  check('all-nearby reveals the inspect-only object', await until(async () => await plaques() > 0));
   await select('pin');
+  await post({ type: 'portos:label-preference', version: EIDOVERSE_FRAME_VERSION, nonce, labelVisibility: 'off' });
+  check('off hides every floating label', await until(async () => await plaques() === 0));
   check('off still leaves selected-object details readable',
-    /Entity: pin/.test(await panel().innerText()) && await open.count() === 1);
+    await panel().getByRole('heading', { name: 'Example Goals', exact: true }).count() === 1 && await open.count() === 1);
 
   console.log('\n— F. repeated refresh, and no world write —');
   await post({ type: 'portos:label-preference', version: EIDOVERSE_FRAME_VERSION, nonce, labelVisibility: 'nearby' });
-  await until(async () => await preference() === 'nearby');
-  await renderer().evaluate(() => window.labelTick(performance.now() + 6000));
+  await pointAt('pin');
+  await until(async () => await plaques() > 0);
   const before = await plaques();
   for (let round = 1; round <= 3; round += 1) {
     await renderer().evaluate((step) => window.labelTick(performance.now() + 6000 + step * 500), round);


### PR DESCRIPTION
## Summary

PortOS explicitly enables the refactored Eidoverse renderer's object-anchored labels for browsers without a saved preference. Existing saved choices, including Off, are preserved. World controls explain clicking labels in the scene and the 60-metre All nearby range; already-open object details remain usable when labels are hidden.

The framework defaults to labels off. Its generic rendering change is upstream draft anima-research/eidoverse-worlds#168; the trusted PortOS preference/navigation adapter stays in atomantic/eidoverse-worlds#9. This change builds on #6322's merged origin-handshake repair.

The external frame acceptance harness now activates actual label buttons, checks inspect-only visibility through the rendered result, and constructs fixtures through Eidoverse's real fold instead of inventing IDs on entity values.

## Test plan

- Focused client page and frame-hook suites: 30 passed, including preserving an explicit saved opt-out.
- Biome lint passed on the changed client files; acceptance script syntax check passed.
- Companion label, real-fold DOM, frame receiver and fold conformance tests passed.
- Real Chrome synthetic-world checks covered object-anchored labels, mouse/keyboard descriptions, narrow layout and default-off rendering. A real cross-origin parent/renderer check also passed through PortOS's proxy: initially disabled labels were enabled by the trusted handshake, navigation reached the validated destination, and Off preserved selected details. After deployment, the live PortOS scene was verified with labels over objects and clickable descriptions. The external Playwright acceptance script was updated but not rerun in this task.
