### PR TITLE
fix: resolve Codex Windows shim for model refresh

### DIFF
--- a/server/lib/aiToolkit/providers.js
+++ b/server/lib/aiToolkit/providers.js
@@ -1384,7 +1384,14 @@ export function createProviderService(config = {}) {
      */
     async _fetchCodexModels(provider) {
       const bin = provider?.command || 'codex';
-      const { command, args } = prepareWindowsSafeSpawn(bin, ['app-server']);
+      // On Windows, npm places a POSIX `codex` stub beside its runnable
+      // `codex.cmd` shim. `spawn('codex')` can select the former (or fail to
+      // resolve it entirely), even though the provider passed its capability
+      // check. Resolve the extension-bearing shim before the safe cmd.exe
+      // wrapper below, matching the other CLI probes in this module.
+      const childEnv = { ...process.env, ...provider?.envVars };
+      const resolvedBin = resolveWindowsExecutable(bin, process.platform === 'win32', childEnv) || bin;
+      const { command, args } = prepareWindowsSafeSpawn(resolvedBin, ['app-server']);
       return new Promise((resolve, reject) => {
         let settled = false;
         let child;
@@ -1407,7 +1414,7 @@ export function createProviderService(config = {}) {
         try {
           child = spawn(command, args, {
             stdio: ['pipe', 'pipe', 'pipe'],
-            env: { ...process.env, ...provider?.envVars },
+            env: childEnv,
             windowsHide: true,
           });
         } catch (err) {

--- a/server/lib/aiToolkit/providers.test.js
+++ b/server/lib/aiToolkit/providers.test.js
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { chmod, mkdtemp, rm, writeFile } from 'fs/promises';
 import { tmpdir } from 'os';
-import { join } from 'path';
+import { delimiter, join } from 'path';
 import { createProviderService, isOllamaBackedProvider } from './providers.js';
 
 // Temp dir, NOT a cwd-rooted one — see providerStatus.test.js (#3823).
@@ -1451,6 +1451,27 @@ rl.on('line', (line) => {
       const updated = await providerService.refreshProviderModels('codex-tui');
       expect(updated, 'the id clause on the TUI arm matches').not.toBeNull();
       expect(updated.models).toEqual(['gpt-6-astra', 'gpt-5.6-sol']);
+    });
+
+    it.skipIf(process.platform !== 'win32')('resolves the Windows codex.cmd shim before refreshing', async () => {
+      const fakeCodex = await writeFakeCodex({ data: [{ id: 'gpt-6-astra' }] });
+      const shimDir = await mkdtemp(join(tmpdir(), 'portos-codex-shim-'));
+      const previousPath = process.env.PATH;
+      try {
+        const shim = join(shimDir, 'codex.cmd');
+        await writeFile(shim, `@echo off\r\nnode "${fakeCodex}" %*\r\n`);
+        process.env.PATH = `${shimDir}${delimiter}${previousPath || ''}`;
+
+        const p = await providerService.createProvider({
+          name: 'Codex TUI', type: 'tui', command: 'codex',
+          models: ['gpt-5.3-codex-spark'], defaultModel: 'gpt-5.3-codex-spark',
+        });
+        const updated = await providerService.refreshProviderModels(p.id);
+        expect(updated.models).toEqual(['gpt-6-astra']);
+      } finally {
+        process.env.PATH = previousPath;
+        await rm(shimDir, { recursive: true, force: true });
+      }
     });
 
     it('reports a failed codex app-server probe as a refresh failure, leaving the stored list intact', async () => {


### PR DESCRIPTION
## Summary
- Resolve the Windows `codex.cmd` shim before fetching Codex’s account model catalog.
- Preserve the Windows-safe command wrapper and add a regression test for a PATH-resolved npm shim.

## Test plan
- `npm test --prefix server -- providers.test.js`