### PR TITLE
fix: align model child navigation with manifest

### DIFF
--- a/client/src/components/Layout.jsx
+++ b/client/src/components/Layout.jsx
@@ -553,7 +553,8 @@ const EXACT_FULL_WIDTH_PATHS = [
   // OpenClaw lives under the Settings nav group; it's a full-bleed
   // chat surface (sidebar + message pane) that owns its own internal
   // scroll, so it needs the bare full-width main like the other
-  // Settings pages (/ai, /prompts, /settings/*).
+  // Full-width Settings pages (/prompts, /settings/*) and the Models Providers
+  // page at /ai.
   '/openclaw',
   '/prompts',
   '/review',

--- a/client/src/components/models/ModelsTabsHeader.jsx
+++ b/client/src/components/models/ModelsTabsHeader.jsx
@@ -1,4 +1,5 @@
-import RouteTabsHeader from '../ui/RouteTabsHeader';
+import { getSectionNavTabs } from '../../../../server/lib/navManifest.js';
+import SectionTabsHeader from '../ui/SectionTabsHeader';
 
 // Shared sub-nav for the top-level Models section.
 //
@@ -15,27 +16,14 @@ import RouteTabsHeader from '../ui/RouteTabsHeader';
 // Models is a gallery of generated meshes, and `/3d` is the render flow that
 // consumes the runtimes listed here.
 //
-// Playground keeps its own `/local-llm/playground` path — it predates this
-// section and the path is in ⌘K history — but it renders this header too, so
-// selecting it does not strand the user outside the tab bar.
+// Providers (`/ai`), Usage (`/devtools/usage`) and Playground
+// (`/local-llm/playground`) keep their legacy paths, but render this header too,
+// so selecting any Models destination does not strand the user outside the tab bar.
 //
-// Keep this list alphabetical by label, matching the sidebar convention.
-// RouteTabsHeader collapses a list this long to a `<select>` under `sm` on its
-// own — no per-section flag to remember.
-export const TABS = [
-  { id: '3d', label: '3D', to: '/models/3d' },
-  { id: 'code-reviewers', label: 'Code Reviewers', to: '/models/code-reviewers' },
-  { id: 'embeddings', label: 'Embeddings', to: '/models/embeddings' },
-  { id: 'harnesses', label: 'Harnesses', to: '/models/harnesses' },
-  { id: 'llms', label: 'LLMs', to: '/models/llms' },
-  { id: 'loras', label: 'LoRAs', to: '/models/loras' },
-  { id: 'media', label: 'Media', to: '/models/media' },
-  { id: 'performance', label: 'Performance', to: '/models/performance' },
-  { id: 'playground', label: 'Playground', to: '/local-llm/playground' },
-  { id: 'status', label: 'Status', to: '/models/status' },
-  { id: 'training', label: 'Training', to: '/models/training' },
-];
+// The manifest owns this list. Keep the export for page tests and callers that
+// need to enumerate the section, but never hand-maintain a second route list.
+export const TABS = getSectionNavTabs('Models');
 
 export default function ModelsTabsHeader({ activeTab }) {
-  return <RouteTabsHeader tabs={TABS} activeTab={activeTab} ariaLabel="Models sections" />;
+  return <SectionTabsHeader activeTab={activeTab} fallbackSection="Models" />;
 }

--- a/client/src/components/settings/SettingsTabsHeader.jsx
+++ b/client/src/components/settings/SettingsTabsHeader.jsx
@@ -1,36 +1,21 @@
-import RouteTabsHeader from '../ui/RouteTabsHeader';
+import { useLocation } from 'react-router';
+import { getNavSectionForPath, getSectionNavTabs } from '../../../../server/lib/navManifest.js';
+import SectionTabsHeader from '../ui/SectionTabsHeader';
 import { useInstanceFeatures } from '../../hooks/useInstanceFeatures.js';
 
-// Shared sub-nav for every page that lives under the sidebar's "Settings"
-// group. Settings.jsx hosts the in-Settings tabs (general/backup/etc.) and
-// the two standalone pages (Providers at /ai, Prompts at /prompts) host
-// themselves — but all three need the same tabbed header so users can hop
-// between them without going back to the sidebar.
+// Backward-compatible wrapper for the shared section child nav. Settings.jsx
+// hosts the in-Settings tabs (general/backup/etc.) and standalone pages such as
+// Prompts host themselves; the current route resolves the actual parent section
+// so a moved page does not keep rendering the old parent's tabs.
 //
-// Pass `activeTab` matching one of the TABS ids below. Internal Settings
-// pages use the `<tab>` slug; the standalone pages use `providers` / `prompts`.
-export const TABS = [
-  { id: 'ai-assignments', label: 'AI Assignments', to: '/settings/ai-assignments' },
-  { id: 'api-access', label: 'API Access', to: '/settings/api-access' },
-  { id: 'autofixer', label: 'Autofixer', to: '/settings/autofixer' },
-  { id: 'backup', label: 'Backup', to: '/settings/backup' },
-  { id: 'credentials', label: 'Credentials', to: '/settings/credentials' },
-  { id: 'database', label: 'Database', to: '/settings/database' },
-  { id: 'features', label: 'Features', to: '/settings/features' },
-  { id: 'general', label: 'General', to: '/settings/general' },
-  { id: 'mortalloom', label: 'MortalLoom', to: '/settings/mortalloom', feature: 'health' },
-  { id: 'openclaw', label: 'OpenClaw', to: '/openclaw', feature: 'openclaw' },
-  { id: 'orchestration', label: 'Orchestration', to: '/settings/orchestration' },
-  { id: 'prompts', label: 'Prompts', to: '/prompts' },
-  { id: 'providers', label: 'Providers', to: '/ai' },
-  { id: 'security', label: 'Security', to: '/settings/security' },
-  { id: 'sharing', label: 'Sharing', to: '/settings/sharing' },
-  { id: 'telegram', label: 'Telegram', to: '/settings/telegram' },
-  { id: 'voice', label: 'Voice', to: '/settings/voice' }
-];
+// The manifest owns this list. Keep the export for Settings tests and callers
+// that enumerate the section, but never hand-maintain a second route list.
+export const TABS = getSectionNavTabs('Settings');
 
 export default function SettingsTabsHeader({ activeTab }) {
+  const { pathname } = useLocation();
   const { isFeatureEnabled } = useInstanceFeatures();
-  const visibleTabs = TABS.filter((tab) => isFeatureEnabled(tab.feature));
-  return <RouteTabsHeader tabs={visibleTabs} activeTab={activeTab} ariaLabel="Settings sections" />;
+  const section = getNavSectionForPath(pathname) || 'Settings';
+  const visibleTabs = getSectionNavTabs(section).filter((tab) => isFeatureEnabled(tab.feature));
+  return <SectionTabsHeader tabs={visibleTabs} activeTab={activeTab} fallbackSection={section} />;
 }

--- a/client/src/components/ui/RouteTabsHeader.jsx
+++ b/client/src/components/ui/RouteTabsHeader.jsx
@@ -2,7 +2,7 @@ import { useNavigate } from 'react-router';
 import TabPills from './TabPills';
 
 // Above this many tabs, a phone-width pill row is a horizontal scroll nobody
-// finds the far end of. Six fits 375px; nine (Models) does not.
+// finds the far end of. Six fits 375px; larger sections such as Models do not.
 const MOBILE_DROPDOWN_THRESHOLD = 6;
 
 const selectIdFor = (ariaLabel) => `${String(ariaLabel || 'section').toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')}-select`;
@@ -16,8 +16,8 @@ const selectIdFor = (ariaLabel) => `${String(ariaLabel || 'section').toLowerCase
  * from ⌘K and voice — the URL is the source of truth for what is open
  * (`client/src/AGENTS.md`).
  *
- * Each section owns its own `TABS` array (`{ id, label, to }`) and passes it in;
- * the navigation shim is the same for all of them. Sections may include a tab
+ * Each section passes a `{ id, label, to }` tab list; section wrappers may
+ * derive that list from the shared nav manifest. Sections may include a tab
  * whose `to` lives outside their route prefix (Models → Playground) — the id
  * still selects it, so the host page passes its own `activeTab`.
  *

--- a/client/src/components/ui/SectionTabsHeader.jsx
+++ b/client/src/components/ui/SectionTabsHeader.jsx
@@ -1,0 +1,28 @@
+import { useLocation } from 'react-router';
+import { getNavSectionForPath, getSectionNavTabs } from '../../../../server/lib/navManifest.js';
+import RouteTabsHeader from './RouteTabsHeader';
+
+/**
+ * Shared section child navigation.
+ *
+ * The route's manifest entry owns the parent section, tab id, label, and
+ * destination. Resolving the section from the current path means a page can
+ * move between sidebar parents without carrying a second hard-coded header
+ * choice along with it. `fallbackSection` keeps standalone test renders and
+ * section indexes usable before a concrete tab route is available.
+ */
+export default function SectionTabsHeader({ activeTab, fallbackSection, tabs }) {
+  const { pathname } = useLocation();
+  const section = getNavSectionForPath(pathname) || fallbackSection;
+  const sectionTabs = tabs || (section ? getSectionNavTabs(section) : []);
+
+  if (!section || sectionTabs.length === 0) return null;
+
+  return (
+    <RouteTabsHeader
+      tabs={sectionTabs}
+      activeTab={activeTab}
+      ariaLabel={`${section} sections`}
+    />
+  );
+}

--- a/client/src/pages/AIProviders.jsx
+++ b/client/src/pages/AIProviders.jsx
@@ -11,7 +11,7 @@ import useLocalModels from '../hooks/useLocalModels';
 import { useAutoRefetch } from '../hooks/useAutoRefetch';
 import EmptyState from '../components/EmptyState';
 import Banner from '../components/ui/Banner';
-import SettingsTabsHeader from '../components/settings/SettingsTabsHeader';
+import ModelsTabsHeader from '../components/models/ModelsTabsHeader';
 import PageHeader from '../components/PageHeader';
 import PageSkeleton from '../components/ui/PageSkeleton';
 import OverflowMenu from '../components/ui/OverflowMenu';
@@ -661,7 +661,7 @@ export default function AIProviders() {
     return (
       <div className="flex flex-col h-full">
         <PageHeader icon={Bot} title="AI Providers" />
-        <SettingsTabsHeader activeTab="providers" />
+        <ModelsTabsHeader activeTab="providers" />
         <div className="flex-1 overflow-auto p-4">
           <PageSkeleton header="none" label="Loading providers" layout="grid" cards={4} />
         </div>
@@ -710,7 +710,7 @@ export default function AIProviders() {
         )}
       />
 
-      <SettingsTabsHeader activeTab="providers" />
+      <ModelsTabsHeader activeTab="providers" />
 
       <div className="flex-1 overflow-auto p-4 space-y-6">
 

--- a/client/src/pages/AIProviders.test.jsx
+++ b/client/src/pages/AIProviders.test.jsx
@@ -48,8 +48,8 @@ vi.mock('../services/socket', () => ({
 vi.mock('../hooks/useLocalModels', () => ({
   default: () => localModels.value,
 }));
-vi.mock('../components/settings/SettingsTabsHeader', () => ({
-  default: () => <div data-testid="settings-tabs-header" />,
+vi.mock('../components/models/ModelsTabsHeader', () => ({
+  default: ({ activeTab }) => <div data-testid="models-tabs-header" data-active-tab={activeTab} />,
 }));
 vi.mock('../components/install/RuntimeInstallModal', () => ({
   // `params` becomes the setup request's query string, so the test can assert
@@ -277,7 +277,15 @@ describe('AIProviders page load error handling', () => {
     expect(screen.getByRole('menuitem', { name: /Compare local models/ })).toHaveAttribute('href', '/models/performance');
   });
 
-  // The page hosts SettingsTabsHeader; before #5653 it also hand-rolled a
+  it('uses the Models child navigation after Providers moves out of Settings', async () => {
+    api.getProviders.mockResolvedValue({ providers: [], activeProvider: null });
+
+    renderPage();
+
+    expect(await screen.findByTestId('models-tabs-header')).toHaveAttribute('data-active-tab', 'providers');
+  });
+
+  // The page hosts ModelsTabsHeader; before #5653 it also hand-rolled a
   // `Settings` title bar above it, so every render stacked two h1s and pushed
   // the first provider card off a phone viewport.
   it('renders exactly one h1, naming the page rather than the settings section', async () => {

--- a/client/src/pages/Models.jsx
+++ b/client/src/pages/Models.jsx
@@ -36,8 +36,10 @@ const MediaModels = lazyWithReload(() => import('./MediaModels'));
  *   - **LoRAs** — installed image/video adapters.
  *   - **Media** — image/video checkpoints and the Hugging Face cache.
  *   - **Performance** — measured assessments and launch-tuning comparison.
+ *   - **Providers** — configured AI provider connections and model catalogs.
  *   - **Status** — residency plus the downloaded-model inventory.
  *   - **Training** — LoRA fine-tuning datasets and runs.
+ *   - **Usage** — provider quota and PortOS AI usage accounting.
  *
  * What deliberately stayed OUT is output rather than weights: Three.js Models is
  * a gallery of generated meshes, and `/3d` is the render flow that consumes the

--- a/client/src/pages/Models.test.jsx
+++ b/client/src/pages/Models.test.jsx
@@ -45,9 +45,9 @@ const PANEL_MARKER = {
   training: 'training panel',
 };
 
-// Playground is the one destination the header lists that this page does not
-// serve — it predates the section and keeps its own `/local-llm/playground` path.
-const EXTERNAL_TAB_IDS = ['playground'];
+// These destinations belong to Models in the sidebar but keep their own route
+// shells, so their pages render the shared header directly.
+const EXTERNAL_TAB_IDS = ['playground', 'providers', 'usage'];
 const ownTabs = TABS.filter((t) => !EXTERNAL_TAB_IDS.includes(t.id));
 
 const renderAt = (path) => render(
@@ -113,7 +113,7 @@ describe('Models', () => {
   });
 
   // The tab bar collapses to a `<select>` under `sm`, so every destination has to
-  // be reachable there too — nine tabs no longer fit a phone-width pill row.
+  // be reachable there too — this section is now too wide for a phone pill row.
   it('mirrors every destination into the mobile select', () => {
     renderAt('/models/performance');
     const select = screen.getByRole('combobox', { name: 'Models sections' });

--- a/client/src/pages/Settings.tabs.test.jsx
+++ b/client/src/pages/Settings.tabs.test.jsx
@@ -35,6 +35,10 @@ describe('Settings — Instance Features tab', () => {
     expect(TABS.some(t => t.id === 'code-reviewers')).toBe(false);
   });
 
+  it('does not list Providers after it moved to Models', () => {
+    expect(TABS.some(t => t.id === 'providers')).toBe(false);
+  });
+
   it('is listed in the settings sub-nav', () => {
     const tab = TABS.find(t => t.id === 'features');
     expect(tab?.to).toBe('/settings/features');

--- a/client/src/pages/UsagePage.jsx
+++ b/client/src/pages/UsagePage.jsx
@@ -10,6 +10,7 @@ import { useAsyncAction } from '../hooks/useAsyncAction';
 import { useAutoRefetch } from '../hooks/useAutoRefetch';
 import SubscriptionSavingsCard from '../components/usage/SubscriptionSavingsCard';
 import FleetUsageCard from '../components/usage/FleetUsageCard';
+import ModelsTabsHeader from '../components/models/ModelsTabsHeader';
 
 // How often to re-ask while a provider's quota reading is still being taken. A
 // CLI/TUI scrape is a 10-20s spawn, so this is a handful of polls, not a loop.
@@ -1031,6 +1032,7 @@ function InternalUsageMetrics() {
 export function UsagePage() {
   return (
     <div className="space-y-6">
+      <ModelsTabsHeader activeTab="usage" />
       <ProviderQuotaSection />
       <InternalUsageMetrics />
     </div>

--- a/client/src/pages/UsagePage.test.jsx
+++ b/client/src/pages/UsagePage.test.jsx
@@ -55,6 +55,7 @@ describe('UsagePage subscription savings', () => {
   it('renders the savings editor from the report payload', async () => {
     api.getUsage.mockResolvedValue({ ...usage, subscriptionSavings: savings });
     render(<MemoryRouter><UsagePage /></MemoryRouter>);
+    expect(screen.getByRole('tab', { name: 'Usage' })).toHaveAttribute('aria-selected', 'true');
     expect(await screen.findByText('Subscription vs. API Cost')).toBeInTheDocument();
   });
 

--- a/server/lib/navManifest.js
+++ b/server/lib/navManifest.js
@@ -1,6 +1,6 @@
 // Single source of truth for PortOS navigation. Consumed by the sidebar,
 // server/services/voice/tools.js#ui_navigate, and the Cmd+K palette.
-// Entry: { id, path, label, section, aliases?, keywords?, previousPaths?, preservePreviousPathSuffix? }.
+// Entry: { id, path, label, section, tabId?, aliases?, keywords?, previousPaths?, preservePreviousPathSuffix? }.
 // See AGENTS.md "Command Palette & Voice Nav" for the contract.
 //
 // `previousPaths` lists every path this page has ANSWERED TO BEFORE — including
@@ -84,8 +84,8 @@ const RAW_NAV_COMMANDS = [
   { id: 'nav.media.settings', path: '/media/image?settings=1', label: 'Media Gen Settings', section: 'Create', aliases: ['media-settings', 'image-gen-settings', 'sd-settings', 'video-gen-settings'] },
   { id: 'nav.writers-room', path: '/writers-room', label: 'Writers Room', section: 'Create', aliases: ['writers-room', 'writersroom', 'writer', 'write', 'studio', 'novel'], keywords: ['prose', 'screenplay', 'story', 'draft', 'manuscript', 'literary', 'novel', 'short story'] },
   { id: 'nav.writers-room.guide', path: '/writers-room/guide', label: 'Writers Room Guide', section: 'Create', aliases: ['writers-room-guide', 'writing-guide', 'writing-rules', 'word-count', 'length-targets'], keywords: ['microfiction', 'flash fiction', 'short story', 'novelette', 'novella', 'novel length', 'word count', 'character count', 'book length', 'craft', 'writing advice', 'emotional roadmap', 'documentation', 'help'] },
-  { id: 'nav.settings.prompts', path: '/prompts', label: 'Prompts', section: 'Settings', aliases: ['prompts'] },
-  { id: 'nav.settings.providers', path: '/ai', label: 'Providers', section: 'Models', aliases: ['providers', 'ai-providers'] },
+  { id: 'nav.settings.prompts', path: '/prompts', label: 'Prompts', section: 'Settings', tabId: 'prompts', aliases: ['prompts'] },
+  { id: 'nav.settings.providers', path: '/ai', label: 'Providers', section: 'Models', tabId: 'providers', aliases: ['providers', 'ai-providers'] },
   { id: 'nav.settings.fleet-llm', path: '/ai/fleet', label: 'Fleet LLM Setup', section: 'Settings', aliases: ['fleet-llm', 'gpu-host', 'remote-ai-provider'], keywords: ['3090', 'tailscale', 'vllm', 'qwen', 'coding model', 'dedicated host'] },
 
   { id: 'nav.brain.inbox', path: '/brain/inbox', label: 'Inbox', section: 'Brain', aliases: ['brain', 'brain-inbox', 'inbox'] },
@@ -168,7 +168,7 @@ const RAW_NAV_COMMANDS = [
   { id: 'nav.devtools.jira-reports', path: '/devtools/jira/reports', label: 'JIRA Reports', section: 'Dev Tools', feature: 'jira', aliases: ['jira-reports'] },
   { id: 'nav.devtools.quota-burn', path: '/devtools/quota-burn', label: 'Quota Burn', section: 'Dev Tools', aliases: ['quota-burn', 'burn-quota', 'quota'], keywords: ['subscription', 'usage', 'reset window', 'spend quota', 'claude', 'codex', 'grok', 'agy', 'burn'] },
   { id: 'nav.shell', path: '/shell', label: 'Shell', section: 'Dev Tools', aliases: ['shell', 'terminal'] },
-  { id: 'nav.devtools.usage', path: '/devtools/usage', label: 'Usage', section: 'Models', aliases: ['devtools-usage'] },
+  { id: 'nav.devtools.usage', path: '/devtools/usage', label: 'Usage', section: 'Models', tabId: 'usage', aliases: ['devtools-usage'] },
   { id: 'nav.devtools.video-download', path: '/devtools/video-download', label: 'Video Downloader', section: 'Dev Tools', aliases: ['video-download', 'video-downloader', 'download-video'], keywords: ['youtube', 'x.com', 'twitter', 'yt-dlp', 'download', 'clip'] },
   { id: 'nav.workspace-contexts', path: '/workspace-contexts', label: 'Workspaces', section: 'Dev Tools', aliases: ['workspaces', 'workspace-contexts', 'project-contexts', 'project-switcher'], keywords: ['project', 'context', 'switch project', 'branch', 'shell', 'tasks', 'restore', 'working context'] },
 
@@ -261,44 +261,44 @@ const RAW_NAV_COMMANDS = [
   { id: 'nav.post.wordplay.double-meaning', path: '/post/wordplay/double-meaning', label: 'Double Meaning', section: 'POST', aliases: ['wordplay-double-meaning', 'double-meaning', 'double meaning'], keywords: ['homonym', 'two meanings', 'pun'] },
   { id: 'nav.post.wordplay.idiom-twist', path: '/post/wordplay/idiom-twist', label: 'Idiom Twist', section: 'POST', aliases: ['wordplay-idiom-twist', 'idiom-twist', 'idiom twist'], keywords: ['idiom', 'phrase', 'twist', 'domain swap'] },
 
-  { id: 'nav.settings.ai-assignments', path: '/settings/ai-assignments', label: 'AI Assignments', section: 'Settings', aliases: ['ai-assignments', 'assignments', 'settings-ai-assignments', 'ai-inventory'], keywords: ['provider', 'model', 'pin', 'inventory', 'migration', 'llm'] },
-  { id: 'nav.settings.api-access', path: '/settings/api-access', label: 'API Access', section: 'Settings', aliases: ['api-access', 'settings-api-access', 'public-api', 'swagger', 'openapi'], keywords: ['rest', 'external', 'tts api', 'sdapi', 'voice api', 'docs', 'curl', 'expose', 'passwordless', 'auth gating'] },
+  { id: 'nav.settings.ai-assignments', path: '/settings/ai-assignments', label: 'AI Assignments', section: 'Settings', tabId: 'ai-assignments', aliases: ['ai-assignments', 'assignments', 'settings-ai-assignments', 'ai-inventory'], keywords: ['provider', 'model', 'pin', 'inventory', 'migration', 'llm'] },
+  { id: 'nav.settings.api-access', path: '/settings/api-access', label: 'API Access', section: 'Settings', tabId: 'api-access', aliases: ['api-access', 'settings-api-access', 'public-api', 'swagger', 'openapi'], keywords: ['rest', 'external', 'tts api', 'sdapi', 'voice api', 'docs', 'curl', 'expose', 'passwordless', 'auth gating'] },
   { id: 'nav.devtools.api-explorer', path: '/api-reference/catalog', label: 'API Explorer', section: 'Dev Tools', aliases: ['api-explorer', 'api-reference', 'swagger-ui', 'rest-reference'], keywords: ['openapi', 'rest', 'endpoints', 'routes', 'agent tools', 'contracts', 'developer docs'] },
-  { id: 'nav.settings.autofixer', path: '/settings/autofixer', label: 'Autofixer', section: 'Settings', aliases: ['autofixer', 'settings-autofixer', 'auto-fixer'], keywords: ['crash', 'fix', 'pm2', 'repair', 'ai provider', 'restart'] },
-  { id: 'nav.settings.backup', path: '/settings/backup', label: 'Backup', section: 'Settings', aliases: ['backup', 'settings-backup'] },
-  { id: 'nav.settings.credentials', path: '/settings/credentials', label: 'Credentials', section: 'Settings', aliases: ['settings-credentials', 'credentials', 'api-keys', 'tokens'], keywords: ['configured', 'unconfigured', 'env', 'huggingface', 'civitai', 'jira', 'datadog', 'telegram'] },
-  { id: 'nav.settings.database', path: '/settings/database', label: 'Database', section: 'Settings', aliases: ['settings-database', 'database'] },
-  { id: 'nav.settings.features', path: '/settings/features', label: 'Features', section: 'Settings', aliases: ['settings-features', 'instance-features', 'feature-usage'], keywords: ['enabled', 'disabled', 'instance', 'optional', 'participation', 'metrics', 'reminders'] },
-  { id: 'nav.settings.general', path: '/settings/general', label: 'General', section: 'Settings', aliases: ['settings', 'settings-general', 'general'] },
+  { id: 'nav.settings.autofixer', path: '/settings/autofixer', label: 'Autofixer', section: 'Settings', tabId: 'autofixer', aliases: ['autofixer', 'settings-autofixer', 'auto-fixer'], keywords: ['crash', 'fix', 'pm2', 'repair', 'ai provider', 'restart'] },
+  { id: 'nav.settings.backup', path: '/settings/backup', label: 'Backup', section: 'Settings', tabId: 'backup', aliases: ['backup', 'settings-backup'] },
+  { id: 'nav.settings.credentials', path: '/settings/credentials', label: 'Credentials', section: 'Settings', tabId: 'credentials', aliases: ['settings-credentials', 'credentials', 'api-keys', 'tokens'], keywords: ['configured', 'unconfigured', 'env', 'huggingface', 'civitai', 'jira', 'datadog', 'telegram'] },
+  { id: 'nav.settings.database', path: '/settings/database', label: 'Database', section: 'Settings', tabId: 'database', aliases: ['settings-database', 'database'] },
+  { id: 'nav.settings.features', path: '/settings/features', label: 'Features', section: 'Settings', tabId: 'features', aliases: ['settings-features', 'instance-features', 'feature-usage'], keywords: ['enabled', 'disabled', 'instance', 'optional', 'participation', 'metrics', 'reminders'] },
+  { id: 'nav.settings.general', path: '/settings/general', label: 'General', section: 'Settings', tabId: 'general', aliases: ['settings', 'settings-general', 'general'] },
   // Local-model management is its own top-level section (#4736), which grew to
   // cover every KIND of model this install manages (#4728) — image/video
   // checkpoints, LoRAs and their training datasets, embeddings, and the
   // image-to-3D runtimes. Several ids keep a `nav.settings.*` / `nav.media.*`
   // prefix: they are opaque and stored in palette history, so renaming them
   // would orphan those entries — only the path, label and section move.
-  { id: 'nav.models.3d', path: '/models/3d', label: '3D', section: 'Models', aliases: ['3d-runtimes', 'image-to-3d-runtimes', 'trellis-install', 'pixal3d-install'], keywords: ['trellis', 'pixal3d', 'install', 'repair', 'runtime', 'mesh', 'image to 3d', 'on-device'] },
-  { id: 'nav.models.code-reviewers', path: '/models/code-reviewers', label: 'Code Reviewers', section: 'Models', previousPaths: ['/settings/code-reviewers'], aliases: ['code-reviewers', 'settings-code-reviewers', 'code-review', 'review-defaults', 'reviewers'], keywords: ['review loop', 'reviewer chain', 'codex', 'copilot', 'ollama', 'stop mode', 'max rounds', 'defaults'] },
-  { id: 'nav.models.harnesses', path: '/models/harnesses', label: 'Harnesses', section: 'Models', aliases: ['harnesses', 'harness', 'agent-harnesses', 'coding-clis', 'cli-harnesses'], keywords: ['opencode', 'claude code', 'codex', 'antigravity', 'agy', 'grok', 'kimi', 'cursor', 'install cli', 'update cli', 'upgrade', 'version', 'refresh models'] },
-  { id: 'nav.settings.embeddings', path: '/models/embeddings', label: 'Embeddings', section: 'Models', previousPaths: ['/settings/embeddings'], aliases: ['settings-embeddings', 'embeddings', 'embedding'], keywords: ['vector', 'pgvector', 'semantic search', 'nomic', 'ollama', 'lm studio'] },
-  { id: 'nav.settings.local-llm', path: '/models/llms', label: 'LLMs', section: 'Models', previousPaths: ['/settings/local-llm'], aliases: ['local-llm', 'local-llms', 'llms', 'models-llms', 'ollama', 'lm-studio', 'lmstudio'], keywords: ['ollama', 'lm studio', 'local model', 'local llm', 'gguf', 'pull model', 'install model', 'migrate', 'switch backend', 'llama.cpp'] },
+  { id: 'nav.models.3d', path: '/models/3d', label: '3D', section: 'Models', tabId: '3d', aliases: ['3d-runtimes', 'image-to-3d-runtimes', 'trellis-install', 'pixal3d-install'], keywords: ['trellis', 'pixal3d', 'install', 'repair', 'runtime', 'mesh', 'image to 3d', 'on-device'] },
+  { id: 'nav.models.code-reviewers', path: '/models/code-reviewers', label: 'Code Reviewers', section: 'Models', tabId: 'code-reviewers', previousPaths: ['/settings/code-reviewers'], aliases: ['code-reviewers', 'settings-code-reviewers', 'code-review', 'review-defaults', 'reviewers'], keywords: ['review loop', 'reviewer chain', 'codex', 'copilot', 'ollama', 'stop mode', 'max rounds', 'defaults'] },
+  { id: 'nav.models.harnesses', path: '/models/harnesses', label: 'Harnesses', section: 'Models', tabId: 'harnesses', aliases: ['harnesses', 'harness', 'agent-harnesses', 'coding-clis', 'cli-harnesses'], keywords: ['opencode', 'claude code', 'codex', 'antigravity', 'agy', 'grok', 'kimi', 'cursor', 'install cli', 'update cli', 'upgrade', 'version', 'refresh models'] },
+  { id: 'nav.settings.embeddings', path: '/models/embeddings', label: 'Embeddings', section: 'Models', tabId: 'embeddings', previousPaths: ['/settings/embeddings'], aliases: ['settings-embeddings', 'embeddings', 'embedding'], keywords: ['vector', 'pgvector', 'semantic search', 'nomic', 'ollama', 'lm studio'] },
+  { id: 'nav.settings.local-llm', path: '/models/llms', label: 'LLMs', section: 'Models', tabId: 'llms', previousPaths: ['/settings/local-llm'], aliases: ['local-llm', 'local-llms', 'llms', 'models-llms', 'ollama', 'lm-studio', 'lmstudio'], keywords: ['ollama', 'lm studio', 'local model', 'local llm', 'gguf', 'pull model', 'install model', 'migrate', 'switch backend', 'llama.cpp'] },
   { id: 'nav.models.llms.abuse', path: '/models/llms/abuse', label: 'Abuse Guard', section: 'Models', aliases: ['abuse-guard', 'model-abuse', 'model-abuse-guard', 'prompt-guard', 'prompt guard'], keywords: ['classifier', 'prompt injection', 'security scan', 'llama prompt guard', 'install guard'] },
-  { id: 'nav.media.loras', path: '/models/loras', label: 'LoRAs', section: 'Models', previousPaths: ['/media/loras'], aliases: ['loras', 'lora', 'lora-manager', 'civitai'], keywords: ['lora', 'civitai', 'fine-tune', 'style adapter', 'realstagram', 'photoreal', 'flux lora'] },
-  { id: 'nav.media.training', path: '/models/training', label: 'Training', section: 'Models', previousPaths: ['/media/training', '/media/training/:datasetId'], aliases: ['training', 'lora-training', 'train-lora', 'datasets', 'character-lora'], keywords: ['fine-tune', 'dataset', 'caption', 'dreambooth', 'character consistency', 'train', 'flux lora'] },
-  { id: 'nav.media.models', path: '/models/media', label: 'Media', section: 'Models', previousPaths: ['/media/models', '/media-models'], aliases: ['media-models', 'image-models', 'video-models', 'huggingface'], keywords: ['hf cache', 'model storage', 'disk', 'add model', 'install model', 'custom model'] },
-  { id: 'nav.models.performance', path: '/models/performance', label: 'Performance', section: 'Models', aliases: ['model-performance', 'performance', 'assessments', 'model-assessments', 'benchmark-models', 'tuning'], keywords: ['measure', 'assessment', 'benchmark', 'throughput', 'chars per second', 'ttft', 'context', 'tuning', 'llama.cpp', 'mtplx', 'vllm', 'which model', 'fastest model'] },
+  { id: 'nav.media.loras', path: '/models/loras', label: 'LoRAs', section: 'Models', tabId: 'loras', previousPaths: ['/media/loras'], aliases: ['loras', 'lora', 'lora-manager', 'civitai'], keywords: ['lora', 'civitai', 'fine-tune', 'style adapter', 'realstagram', 'photoreal', 'flux lora'] },
+  { id: 'nav.media.training', path: '/models/training', label: 'Training', section: 'Models', tabId: 'training', previousPaths: ['/media/training', '/media/training/:datasetId'], aliases: ['training', 'lora-training', 'train-lora', 'datasets', 'character-lora'], keywords: ['fine-tune', 'dataset', 'caption', 'dreambooth', 'character consistency', 'train', 'flux lora'] },
+  { id: 'nav.media.models', path: '/models/media', label: 'Media', section: 'Models', tabId: 'media', previousPaths: ['/media/models', '/media-models'], aliases: ['media-models', 'image-models', 'video-models', 'huggingface'], keywords: ['hf cache', 'model storage', 'disk', 'add model', 'install model', 'custom model'] },
+  { id: 'nav.models.performance', path: '/models/performance', label: 'Performance', section: 'Models', tabId: 'performance', aliases: ['model-performance', 'performance', 'assessments', 'model-assessments', 'benchmark-models', 'tuning'], keywords: ['measure', 'assessment', 'benchmark', 'throughput', 'chars per second', 'ttft', 'context', 'tuning', 'llama.cpp', 'mtplx', 'vllm', 'which model', 'fastest model'] },
   // Absorbed the Dev Tools 'Model Resources' page (#4728), so its aliases and
   // keywords live here — 'model resources' and 'downloaded models' must keep
   // resolving after the fold.
-  { id: 'nav.models.status', path: '/models/status', label: 'Status', section: 'Models', previousPaths: ['/system-resources/models'], aliases: ['model-status', 'models-status', 'memory-management', 'resident-models', 'model-resources', 'loaded-models', 'downloaded-models', 'model-memory'], keywords: ['memory', 'resident', 'loaded', 'unload', 'ram', 'vram', 'free memory', 'what is loaded', 'ollama', 'lm studio', 'hugging face', 'lora', 'delete model', 'disk'] },
-  { id: 'nav.settings.local-llm-playground', path: '/local-llm/playground', label: 'Playground', section: 'Models', aliases: ['llm-playground', 'playground', 'model-playground', 'compare-models'], keywords: ['ollama', 'lm studio', 'compare', 'benchmark', 'chat', 'test model', 'ttft', 'tokens per second', 'local llm'] },
-  { id: 'nav.settings.mortalloom', path: '/settings/mortalloom', label: 'MortalLoom', section: 'Settings', feature: 'health', aliases: ['settings-mortalloom', 'mortalloom'] },
-  { id: 'nav.settings.openclaw', path: '/openclaw', label: 'OpenClaw', section: 'Settings', feature: 'openclaw', aliases: ['openclaw', 'settings-openclaw'], keywords: ['operator', 'chat', 'agent', 'runtime', 'sessions', 'streaming'] },
-  { id: 'nav.settings.orchestration', path: '/settings/orchestration', label: 'Orchestration Profiles', section: 'Settings', aliases: ['orchestration', 'orchestration-profiles', 'cos-orchestration', 'agent-roles'], keywords: ['orchestration', 'roles', 'architect', 'implementer', 'reviewer', 'profiles', 'cos', 'reasoning'] },
-  { id: 'nav.settings.security', path: '/settings/security', label: 'Security', section: 'Settings', aliases: ['settings-security', 'login-password', 'auth-password', 'password-settings'], keywords: ['password', 'login', 'auth', 'sign-in', 'lock', 'tailnet', 'sidecar'] },
+  { id: 'nav.models.status', path: '/models/status', label: 'Status', section: 'Models', tabId: 'status', previousPaths: ['/system-resources/models'], aliases: ['model-status', 'models-status', 'memory-management', 'resident-models', 'model-resources', 'loaded-models', 'downloaded-models', 'model-memory'], keywords: ['memory', 'resident', 'loaded', 'unload', 'ram', 'vram', 'free memory', 'what is loaded', 'ollama', 'lm studio', 'hugging face', 'lora', 'delete model', 'disk'] },
+  { id: 'nav.settings.local-llm-playground', path: '/local-llm/playground', label: 'Playground', section: 'Models', tabId: 'playground', aliases: ['llm-playground', 'playground', 'model-playground', 'compare-models'], keywords: ['ollama', 'lm studio', 'compare', 'benchmark', 'chat', 'test model', 'ttft', 'tokens per second', 'local llm'] },
+  { id: 'nav.settings.mortalloom', path: '/settings/mortalloom', label: 'MortalLoom', section: 'Settings', tabId: 'mortalloom', feature: 'health', aliases: ['settings-mortalloom', 'mortalloom'] },
+  { id: 'nav.settings.openclaw', path: '/openclaw', label: 'OpenClaw', section: 'Settings', tabId: 'openclaw', feature: 'openclaw', aliases: ['openclaw', 'settings-openclaw'], keywords: ['operator', 'chat', 'agent', 'runtime', 'sessions', 'streaming'] },
+  { id: 'nav.settings.orchestration', path: '/settings/orchestration', label: 'Orchestration Profiles', section: 'Settings', tabId: 'orchestration', aliases: ['orchestration', 'orchestration-profiles', 'cos-orchestration', 'agent-roles'], keywords: ['orchestration', 'roles', 'architect', 'implementer', 'reviewer', 'profiles', 'cos', 'reasoning'] },
+  { id: 'nav.settings.security', path: '/settings/security', label: 'Security', section: 'Settings', tabId: 'security', aliases: ['settings-security', 'login-password', 'auth-password', 'password-settings'], keywords: ['password', 'login', 'auth', 'sign-in', 'lock', 'tailnet', 'sidecar'] },
   { id: 'nav.capabilities', path: '/capabilities', label: 'Setup', section: 'Settings', aliases: ['setup', 'onboarding', 'walkthrough', 'capabilities', 'capability-map', 'integrations'], keywords: ['first run', 'status', 'setup', 'checklist', 'tailscale', 'https', 'dns', 'providers', 'connected systems', 'integrations', 'health overview'] },
-  { id: 'nav.settings.sharing', path: '/settings/sharing', label: 'Sharing', section: 'Settings', aliases: ['settings-sharing', 'sharing-settings'], keywords: ['display name', 'bio', 'attribution', 'identity', 'source'] },
-  { id: 'nav.settings.telegram', path: '/settings/telegram', label: 'Telegram', section: 'Settings', aliases: ['settings-telegram', 'telegram'] },
-  { id: 'nav.settings.voice', path: '/settings/voice', label: 'Voice', section: 'Settings', aliases: ['settings-voice', 'voice', 'voice-settings'], keywords: ['mic', 'microphone', 'speech', 'tts', 'whisper', 'kokoro'] },
+  { id: 'nav.settings.sharing', path: '/settings/sharing', label: 'Sharing', section: 'Settings', tabId: 'sharing', aliases: ['settings-sharing', 'sharing-settings'], keywords: ['display name', 'bio', 'attribution', 'identity', 'source'] },
+  { id: 'nav.settings.telegram', path: '/settings/telegram', label: 'Telegram', section: 'Settings', tabId: 'telegram', aliases: ['settings-telegram', 'telegram'] },
+  { id: 'nav.settings.voice', path: '/settings/voice', label: 'Voice', section: 'Settings', tabId: 'voice', aliases: ['settings-voice', 'voice', 'voice-settings'], keywords: ['mic', 'microphone', 'speech', 'tts', 'whisper', 'kokoro'] },
   { id: 'nav.settings.facetime', path: '/settings/voice', label: 'FaceTime Audio', section: 'Settings', feature: 'facetime', aliases: ['facetime', 'facetime-audio', 'call-settings'], keywords: ['facetime', 'audio call', 'call', 'hang up', 'blackhole'] },
   { id: 'nav.settings.call-host', path: '/voice/call-host', label: 'Call Host', section: 'Settings', feature: 'facetime', aliases: ['call-host', 'voice-call-host', 'facetime-call-host', 'audio-bridge', 'meeting-capture', 'capture-audio'], keywords: ['facetime', 'call audio', 'blackhole', 'bridge', 'attach', 'microphone', 'speaker', 'call host', 'meeting capture', 'transcribe meeting', 'record meeting'] },
 
@@ -339,6 +339,45 @@ export const NAV_COMMANDS = RAW_NAV_COMMANDS.map((cmd) => {
   return feature ? { ...cmd, feature } : cmd;
 });
 
+// `tabId` marks the destinations that participate in their section's shared
+// child navigation. It deliberately lives beside the route's section and
+// label, rather than in a page component, so moving a destination between
+// sidebar sections moves its child-nav entry with it. Commands without a
+// `tabId` are still valid navigation destinations, but are nested drill-downs
+// or workflow overlays rather than section-level tabs.
+export const getSectionNavTabs = (section) => NAV_COMMANDS
+  .filter((command) => command.section === section && command.tabId)
+  .sort((a, b) => a.label.localeCompare(b.label) || a.path.localeCompare(b.path))
+  .map(({ tabId, label, path, feature }) => ({
+    id: tabId,
+    label,
+    to: path,
+    ...(feature ? { feature } : {}),
+  }));
+
+const normalizedNavPath = (pathname) => {
+  const barePath = String(pathname || '').split(/[?#]/)[0];
+  if (!barePath || barePath === '/') return '/';
+  return barePath.replace(/\/+$/, '');
+};
+
+const pathContainsNavRoute = (pathname, routePath) => (
+  pathname === routePath || pathname.startsWith(`${routePath}/`)
+);
+
+// Find the section whose tab owns a routed page. Longest-match keeps nested
+// views (for example `/models/llms/abuse`) on their parent tab, and intentionally
+// ignores workflow commands such as `/ai/fleet` that do not carry a `tabId`.
+export const getNavSectionForPath = (pathname) => {
+  const normalizedPath = normalizedNavPath(pathname);
+  return NAV_COMMANDS
+    .filter((command) => command.tabId && pathContainsNavRoute(
+      normalizedPath,
+      normalizedNavPath(command.path),
+    ))
+    .sort((a, b) => normalizedNavPath(b.path).length - normalizedNavPath(a.path).length)[0]?.section || null;
+};
+
 // Every feature id this manifest gates on, for the registry-drift guard.
 export const NAV_FEATURE_IDS = [...new Set(NAV_COMMANDS.map((c) => c.feature).filter(Boolean))].sort();
 
@@ -350,8 +389,22 @@ for (const cmd of NAV_COMMANDS) {
   if (!cmd.path.startsWith('/')) {
     throw new Error(`navManifest: path must start with / — got "${cmd.path}" for ${cmd.id}`);
   }
+  if (cmd.tabId !== undefined && (typeof cmd.tabId !== 'string' || !cmd.tabId.trim())) {
+    throw new Error(`navManifest: tabId must be a non-empty string — got "${cmd.tabId}" for ${cmd.id}`);
+  }
   if (seenIds.has(cmd.id)) throw new Error(`navManifest: duplicate id ${cmd.id}`);
   seenIds.add(cmd.id);
+}
+
+const tabIdsBySection = new Map();
+for (const command of NAV_COMMANDS) {
+  if (!command.tabId) continue;
+  const sectionIds = tabIdsBySection.get(command.section) || new Set();
+  if (sectionIds.has(command.tabId)) {
+    throw new Error(`navManifest: duplicate tabId "${command.tabId}" in section ${command.section}`);
+  }
+  sectionIds.add(command.tabId);
+  tabIdsBySection.set(command.section, sectionIds);
 }
 
 // Alias collisions resolve to the first-declared entry; ordering is load-bearing.

--- a/server/lib/navManifest.test.js
+++ b/server/lib/navManifest.test.js
@@ -2,7 +2,15 @@ import { describe, it, expect } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { NAV_COMMANDS, NAV_FEATURE_IDS, SECTION_FEATURE, getNavAliasMap, resolveNavCommand } from './navManifest.js';
+import {
+  NAV_COMMANDS,
+  NAV_FEATURE_IDS,
+  SECTION_FEATURE,
+  getNavAliasMap,
+  getNavSectionForPath,
+  getSectionNavTabs,
+  resolveNavCommand,
+} from './navManifest.js';
 import { INSTANCE_FEATURE_IDS } from './instanceFeatureRegistry.js';
 import { PORTOS_APP_ID } from './appIdentity.js';
 
@@ -19,6 +27,8 @@ const SETTINGS_PAGE = path.join(REPO_ROOT, 'client/src/pages/Settings.jsx');
 //                   where the page's own tabs are the entries whose path is exactly
 //                   `<prefix>` or under `<prefix>/`; entries pointing elsewhere
 //                   (e.g. Settings' "Prompts" → /prompts) are cross-links, not tabs.
+//   kind 'section' — the header exports a generated `TABS` list sourced from
+//                   the nav manifest; `section` identifies the manifest group.
 //   kind 'switch' — the page has no tab array; its tabs are a `switch (<switchVar>)`
 //                   render-dispatch plus the `{ <switchVar> = '<id>' }` destructuring
 //                   default (POST). Reading the switch directly means the guard
@@ -35,8 +45,8 @@ const TABBED_PAGES = [
   { prefix: '/privacy', file: 'client/src/pages/Privacy.jsx', kind: 'ids', constName: 'TABS' },
   { prefix: '/messages', file: 'client/src/pages/Messages.jsx', kind: 'ids', constName: 'TABS' },
   { prefix: '/wiki', file: 'client/src/pages/Wiki.jsx', kind: 'ids', constName: 'TABS' },
-  { prefix: '/settings', file: 'client/src/components/settings/SettingsTabsHeader.jsx', kind: 'links', constName: 'TABS' },
-  { prefix: '/models', file: 'client/src/components/models/ModelsTabsHeader.jsx', kind: 'links', constName: 'TABS',
+  { prefix: '/settings', section: 'Settings', file: 'client/src/components/settings/SettingsTabsHeader.jsx', kind: 'section', constName: 'TABS' },
+  { prefix: '/models', section: 'Models', file: 'client/src/components/models/ModelsTabsHeader.jsx', kind: 'section', constName: 'TABS',
     nestedIdSources: [
       { parent: 'llms', file: 'client/src/components/settings/LocalLlmTab.jsx', constName: 'LLM_NAV_SUBROUTES' },
     ] },
@@ -104,13 +114,14 @@ function extractConstIds(filePath, constName) {
 }
 
 // The set of absolute tab paths a page serves under its own prefix.
-function extractTabPaths(filePath, { kind, constName, switchVar, prefix, nestedIdSources, allowBasePrefix }) {
+function extractTabPaths(filePath, { kind, constName, switchVar, prefix, section, nestedIdSources, allowBasePrefix }) {
   const src = fs.readFileSync(filePath, 'utf8');
   const nested = (nestedIdSources || []).flatMap(({ parent, file, constName: c }) =>
     extractConstIds(path.join(REPO_ROOT, file), c).map((id) => `${prefix}/${parent}/${id}`));
   if (kind === 'switch') {
     return [...extractSwitchTabs(src, switchVar).map((id) => `${prefix}/${id}`), ...nested];
   }
+  if (kind === 'section') return [...getSectionNavTabs(section).map((tab) => tab.to), ...nested];
   const block = extractConstArrayBlock(src, constName);
   if (kind === 'ids') {
     const ids = [...block.matchAll(/id:\s*['"]([^'"]+)['"]/g)].map((m) => `${prefix}/${m[1]}`);
@@ -161,6 +172,38 @@ describe('navManifest — persistent mind dashboard', () => {
   it('maps both former Mind Tools routes onto the embedded tools panel', () => {
     const tools = NAV_COMMANDS.find((command) => command.id === 'nav.cos.mind-tools');
     expect(tools?.previousPaths).toEqual(['/cos/tools', '/cos/mind/tools']);
+  });
+});
+
+describe('nav contract — generated section child navigation', () => {
+  const headers = [
+    ['Settings', 'client/src/components/settings/SettingsTabsHeader.jsx'],
+    ['Models', 'client/src/components/models/ModelsTabsHeader.jsx'],
+  ];
+
+  it.each(headers)('%s header reads its tabs from navManifest', (section, file) => {
+    const source = fs.readFileSync(path.join(REPO_ROOT, file), 'utf8');
+    expect(source).toMatch(new RegExp(`getSectionNavTabs\\(['"]${section}['"]\\)`));
+  });
+
+  it('keeps moved Providers and Usage destinations in the Models child nav', () => {
+    expect(getSectionNavTabs('Models').filter((tab) => ['providers', 'usage'].includes(tab.id))).toEqual([
+      { id: 'providers', label: 'Providers', to: '/ai' },
+      { id: 'usage', label: 'Usage', to: '/devtools/usage' },
+    ]);
+    expect(getSectionNavTabs('Settings').some((tab) => tab.id === 'providers')).toBe(false);
+  });
+
+  it.each([
+    ['/ai', 'Models'],
+    ['/ai/edit/example-provider', 'Models'],
+    ['/ai/fleet', 'Models'],
+    ['/devtools/usage', 'Models'],
+    ['/models/llms/abuse', 'Models'],
+    ['/settings/general', 'Settings'],
+    ['/prompts', 'Settings'],
+  ])('resolves %s to the %s section', (pathname, section) => {
+    expect(getNavSectionForPath(pathname)).toBe(section);
   });
 });
 
@@ -325,9 +368,17 @@ describe('nav contract — tabbed pages match their tab constants', () => {
       // section served at the bare prefix, e.g. /sharing → buckets) or anything
       // under `<prefix>/`. Compare on the bare path so deep-link query/hash
       // variants (e.g. /media/image?settings=1) normalize first.
+      const hasNestedSources = (page.nestedIdSources || []).length > 0;
       const navPaths = NAV_COMMANDS
-        .map((c) => c.path.split(/[?#]/)[0])
-        .filter((p) => p === prefix || p.startsWith(`${prefix}/`));
+        .filter((c) => {
+          const barePath = c.path.split(/[?#]/)[0];
+          if (page.section) {
+            return c.section === page.section
+              && (c.tabId || (hasNestedSources && (barePath === prefix || barePath.startsWith(`${prefix}/`))));
+          }
+          return barePath === prefix || barePath.startsWith(`${prefix}/`);
+        })
+        .map((c) => c.path.split(/[?#]/)[0]);
 
       // Read inside it() bodies (not at describe time) so a moved/renamed source
       // file surfaces as a focused test failure rather than aborting the entire
@@ -358,15 +409,15 @@ describe('nav contract — tabbed pages match their tab constants', () => {
 // Providers → /ai) point off /settings, so the `links` extractor already drops
 // them — the two filtered sets are therefore expected to match exactly.
 describe('nav contract — Settings tab bar header ↔ page switch parity', () => {
-  const SETTINGS_HEADER = 'client/src/components/settings/SettingsTabsHeader.jsx';
   const SETTINGS_PAGE = 'client/src/pages/Settings.jsx';
 
-  // Header tab ids that live under /settings/<id> (cross-links already filtered).
-  // Require the trailing slash so a hypothetical bare `to: '/settings'` index entry
-  // can't slice to '' and surface as a cryptic missing/orphan '' rather than a tab.
-  const headerTabIds = () => extractTabPaths(path.join(REPO_ROOT, SETTINGS_HEADER), {
-    kind: 'links', constName: 'TABS', prefix: '/settings',
-  }).filter((p) => p.startsWith('/settings/')).map((p) => p.slice('/settings/'.length));
+  // Header tab ids that live under /settings/<id> (cross-links already filtered
+  // by the generated section list). Require the trailing slash so a hypothetical
+  // bare `/settings` index entry cannot surface as a cryptic empty tab id.
+  const headerTabIds = () => getSectionNavTabs('Settings')
+    .map((tab) => tab.to)
+    .filter((p) => p.startsWith('/settings/'))
+    .map((p) => p.slice('/settings/'.length));
 
   const switchCaseIds = () => extractSwitchCases(
     fs.readFileSync(path.join(REPO_ROOT, SETTINGS_PAGE), 'utf8'), 'activeTab',


### PR DESCRIPTION
## Summary
- Move Providers and Usage child navigation into the Models section after their manifest section move.
- Generate Models and Settings child tabs from the navigation manifest and resolve the active parent from the current route.
- Add manifest and page-level tests covering legacy-path siblings, nested model routes, and moved destinations.

## Test plan
- `cd server && npm test -- lib/navManifest.test.js` (89 passed)
- `cd client && npm test -- src/pages/Models.test.jsx src/pages/AIProviders.test.jsx src/pages/Settings.tabs.test.jsx src/pages/UsagePage.test.jsx src/pages/LocalLlmPlayground.test.jsx` (123 passed)
- `cd client && npm run lint`
- `cd client && npm run build`
- Full server suite: 39,638 passed; 24 unrelated Windows external-tool fixture failures (`python3`, `cat`, `ffmpeg`, and similar commands unavailable in this environment).