### PR TITLE
feat(providers): detect and prompt to configure federated LLM hosts

### DIFF
--- a/client/src/components/providers/FleetHostSetup.jsx
+++ b/client/src/components/providers/FleetHostSetup.jsx
@@ -1,24 +1,39 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router';
 import { CheckCircle2, HelpCircle, Server, XCircle } from 'lucide-react';
-import { getFleetLlmHost, revealFleetLlmHostKey } from '../../services/apiProviders';
+import { getFleetLlmHost, getFleetPeerHosts, revealFleetLlmHostKey } from '../../services/apiProviders';
+import { isFleetHostConfigured } from '../../utils/providers';
 import { copyToClipboard } from '../../lib/clipboard';
 import { useAutoRefetch } from '../../hooks/useAutoRefetch';
 import RuntimeInstallModal from '../install/RuntimeInstallModal';
 import Banner from '../ui/Banner';
 
-export default function FleetHostSetup({ compact = false, onConfigured }) {
+export default function FleetHostSetup({ compact = false, providers = [], onConfigured }) {
   const [status, setStatus] = useState(null);
+  const [peerHosts, setPeerHosts] = useState([]);
   const [error, setError] = useState('');
   const [installing, setInstalling] = useState(false);
   const [key, setKey] = useState('');
   const [revealing, setRevealing] = useState(false);
-  const load = useCallback(() => getFleetLlmHost({ silent: true })
-    .then((value) => { setStatus(value); setError(''); })
-    .catch(() => setError('Could not check this machine. Retry to detect hardware and model readiness.')), []);
+  const load = useCallback(() => {
+    getFleetLlmHost({ silent: true })
+      .then((value) => { setStatus(value); setError(''); })
+      .catch(() => setError('Could not check this machine. Retry to detect hardware and model readiness.'));
+    if (compact) {
+      getFleetPeerHosts({ silent: true })
+        .then((res) => { setPeerHosts(Array.isArray(res?.hosts) ? res.hosts : []); })
+        .catch(() => setPeerHosts([]));
+    }
+  }, [compact]);
   useEffect(() => { load(); }, [load]);
   useAutoRefetch(load, 15000, { enabled: !compact && !installing, pollOnly: true, immediate: false });
   const completed = useCallback(() => { load(); onConfigured?.(); }, [load, onConfigured]);
+
+  const unconfiguredPeerHosts = useMemo(() => {
+    if (!compact) return [];
+    return peerHosts.filter((host) => (host?.serving || host?.enabled) && !isFleetHostConfigured(host, providers));
+  }, [compact, peerHosts, providers]);
+
   const reveal = () => {
     setRevealing(true);
     revealFleetLlmHostKey({ silent: true }).then(({ apiKey }) => setKey(apiKey))
@@ -27,15 +42,55 @@ export default function FleetHostSetup({ compact = false, onConfigured }) {
   };
   const actionClass = 'inline-flex items-center justify-center min-h-[40px] px-3 py-2 rounded-lg bg-port-accent text-white text-sm disabled:opacity-50';
   const title = status?.recommendation.title || 'Recommended model host setup';
-  if (compact) return (
-    <section className="rounded-xl border border-port-border bg-port-card p-3 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between" aria-label="Recommended model host">
-      <div className="min-w-0">
-        <p className="text-sm font-medium text-white flex items-center gap-2"><Server size={16} />{title}</p>
-        <p className="text-xs text-gray-400 mt-1">{status?.serving ? 'Serving · shared request queue enabled' : 'Use one dedicated model host from your other PortOS instances.'}</p>
-      </div>
-      <Link to="/ai/fleet?fleetStep=host" className={actionClass}>Model host setup</Link>
-    </section>
-  );
+  if (compact) {
+    if (unconfiguredPeerHosts.length > 0) {
+      return (
+        <div className="space-y-3" aria-label="Available model hosts">
+          {unconfiguredPeerHosts.map((host) => (
+            <section
+              key={host.peerId}
+              className="rounded-xl border border-port-accent/50 bg-port-card p-3 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between shadow-xs"
+              aria-label={`Available model host ${host.peerName}`}
+            >
+              <div className="min-w-0">
+                <div className="flex items-center gap-2 flex-wrap">
+                  <span className="flex h-2 w-2 rounded-full bg-port-success shrink-0" />
+                  <p className="text-sm font-medium text-white flex items-center gap-2 truncate">
+                    <Server size={16} className="text-port-accent shrink-0" />
+                    Available federated host: <span className="text-port-accent font-semibold">{host.peerName}</span>
+                  </p>
+                  <span className="text-[11px] px-1.5 py-0.5 rounded bg-port-success/20 text-port-success font-medium">
+                    {host.serving ? 'Serving' : 'Enabled'} · {host.model || 'Qwen3.8-27B'}
+                  </span>
+                </div>
+                <p className="text-xs text-gray-400 mt-1">
+                  Instance <strong className="text-gray-200">{host.peerName}</strong> is running a federated LLM host. Set it up as a provider on this machine?
+                </p>
+              </div>
+              <div className="flex items-center gap-2 shrink-0">
+                <Link
+                  to={`/ai/fleet?fleetStep=client&peerId=${encodeURIComponent(host.peerId)}`}
+                  className={actionClass}
+                >
+                  Set up as provider
+                </Link>
+              </div>
+            </section>
+          ))}
+        </div>
+      );
+    }
+
+    return (
+      <section className="rounded-xl border border-port-border bg-port-card p-3 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between" aria-label="Recommended model host">
+        <div className="min-w-0">
+          <p className="text-sm font-medium text-white flex items-center gap-2"><Server size={16} />{title}</p>
+          <p className="text-xs text-gray-400 mt-1">{status?.serving ? 'Serving · shared request queue enabled' : 'Use one dedicated model host from your other PortOS instances.'}</p>
+        </div>
+        <Link to="/ai/fleet?fleetStep=host" className={actionClass}>Model host setup</Link>
+      </section>
+    );
+  }
   return (
     <div className="space-y-4">
       <Banner tone={status?.serving ? 'success' : 'info'} icon={Server} title={title}>

--- a/client/src/components/providers/FleetHostSetup.test.jsx
+++ b/client/src/components/providers/FleetHostSetup.test.jsx
@@ -1,7 +1,11 @@
 import { describe, expect, it, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
-const api = vi.hoisted(() => ({ getFleetLlmHost: vi.fn(), revealFleetLlmHostKey: vi.fn() }));
+const api = vi.hoisted(() => ({
+  getFleetLlmHost: vi.fn(),
+  getFleetPeerHosts: vi.fn(),
+  revealFleetLlmHostKey: vi.fn(),
+}));
 vi.mock('../../services/apiProviders', () => api);
 vi.mock('../install/RuntimeInstallModal', () => ({ default: ({ open, installUrlBase, streamMethod }) => open ? <div data-testid="setup" data-url={installUrlBase} data-method={streamMethod} /> : null }));
 import FleetHostSetup from './FleetHostSetup';
@@ -15,6 +19,7 @@ const state = {
 describe('dedicated model host setup', () => {
  it('shows hardware and blockers, starts setup only on click and reveals credentials only on request', async () => {
   api.getFleetLlmHost.mockResolvedValue(state);
+  api.getFleetPeerHosts.mockResolvedValue({ hosts: [] });
   api.revealFleetLlmHostKey.mockResolvedValue({ apiKey: 'example-private-token' });
   render(<MemoryRouter><FleetHostSetup /></MemoryRouter>);
   expect(await screen.findByText(/32 GB RAM/)).toBeInTheDocument();
@@ -29,8 +34,53 @@ describe('dedicated model host setup', () => {
  });
  it('keeps unsupported hardware on a connection path without offering the CUDA installer', async () => {
   api.getFleetLlmHost.mockResolvedValue({ ...state, recommendation: { supported: false, title: 'Connect to a model host' } });
+  api.getFleetPeerHosts.mockResolvedValue({ hosts: [] });
   render(<MemoryRouter><FleetHostSetup /></MemoryRouter>);
   await screen.findByText('Connect to a model host');
   expect(screen.queryByRole('button', { name: /Set up dedicated host/ })).not.toBeInTheDocument();
  });
+
+ it('prompts to setup an available peer host when not yet configured', async () => {
+  api.getFleetLlmHost.mockResolvedValue({ ...state, serving: false });
+  api.getFleetPeerHosts.mockResolvedValue({
+   hosts: [
+    {
+     peerId: 'peer-42',
+     peerName: 'Dedicated GPU Box',
+     endpoint: 'http://gpu-box.ts.net:18022/v1',
+     model: 'qwen3.8-27b',
+     serving: true,
+    },
+   ],
+  });
+  render(<MemoryRouter><FleetHostSetup compact providers={[]} /></MemoryRouter>);
+  expect(await screen.findByText(/Available federated host:/)).toBeInTheDocument();
+  expect(screen.getAllByText('Dedicated GPU Box').length).toBeGreaterThanOrEqual(1);
+  expect(screen.getByText(/Set it up as a provider on this machine\?/)).toBeInTheDocument();
+  const setupLink = screen.getByRole('link', { name: 'Set up as provider' });
+  expect(setupLink).toHaveAttribute('href', '/ai/fleet?fleetStep=client&peerId=peer-42');
+ });
+
+ it('does not prompt when the peer host is already configured as a provider', async () => {
+  api.getFleetLlmHost.mockResolvedValue({ ...state, serving: false });
+  api.getFleetPeerHosts.mockResolvedValue({
+   hosts: [
+    {
+     peerId: 'peer-42',
+     peerName: 'Dedicated GPU Box',
+     endpoint: 'http://gpu-box.ts.net:18022/v1',
+     model: 'qwen3.8-27b',
+     serving: true,
+    },
+   ],
+  });
+  const providers = [
+   { id: 'fleet-p1', endpoint: 'http://gpu-box.ts.net:18022/v1' },
+  ];
+  render(<MemoryRouter><FleetHostSetup compact providers={providers} /></MemoryRouter>);
+  expect(await screen.findByText('Recommended model host setup')).toBeInTheDocument();
+  expect(screen.queryByText(/Available federated host:/)).not.toBeInTheDocument();
+  expect(screen.queryByRole('link', { name: 'Set up as provider' })).not.toBeInTheDocument();
+ });
 });
+

--- a/client/src/components/providers/FleetProviderSetup.jsx
+++ b/client/src/components/providers/FleetProviderSetup.jsx
@@ -1,5 +1,5 @@
-import { useMemo, useState } from 'react';
-import { Link } from 'react-router';
+import { useEffect, useMemo, useState } from 'react';
+import { Link, useSearchParams } from 'react-router';
 import { Network, WandSparkles } from 'lucide-react';
 import Drawer from '../Drawer';
 import FleetHostSetup from './FleetHostSetup';
@@ -7,6 +7,7 @@ import useDrawerTab from '../../hooks/useDrawerTab';
 import { FormField } from '../ui/FormField';
 import Banner from '../ui/Banner';
 import { isLocalEndpoint, isPrivateNetworkEndpoint } from '../../utils/providers';
+import { revealFleetPeerHostKey } from '../../services/apiProviders';
 import { PORTS } from '../../lib/ports.js';
 
 const FLEET_TABS = [
@@ -82,14 +83,17 @@ export const buildFleetProvider = ({ name, endpoint, apiKey, model, harness }) =
 };
 
 export default function FleetProviderSetup({ peers = [], onClose, onCreate, onConfigured }) {
+  const [searchParams] = useSearchParams();
+  const initialPeerId = searchParams.get('peerId') || '';
   const [activeTab, setActiveTab] = useDrawerTab('fleetStep', 'architecture', FLEET_TAB_IDS);
-  const [selectedPeerId, setSelectedPeerId] = useState('');
+  const [selectedPeerId, setSelectedPeerId] = useState(initialPeerId);
   const [endpointInput, setEndpointInput] = useState('');
   const [name, setName] = useState('Fleet GPU · OpenCode TUI');
   const [apiKey, setApiKey] = useState('');
   const [model, setModel] = useState(DEFAULT_MODEL);
   const [harness, setHarness] = useState('tui');
   const [saving, setSaving] = useState(false);
+  const [fetchingKey, setFetchingKey] = useState(false);
   const [error, setError] = useState('');
   const availablePeers = useMemo(
     () => peers.filter((peer) => peer?.enabled !== false && (peer?.host || peer?.address)),
@@ -101,6 +105,30 @@ export default function FleetProviderSetup({ peers = [], onClose, onCreate, onCo
     setSelectedPeerId(peerId);
     const peer = availablePeers.find(({ id }) => id === peerId);
     setEndpointInput(peer ? endpointForPeer(peer) : '');
+  };
+
+  useEffect(() => {
+    if (initialPeerId && availablePeers.length > 0 && !endpointInput) {
+      selectPeer(initialPeerId);
+    }
+  }, [initialPeerId, availablePeers]);
+
+  const handleFetchKey = async () => {
+    if (!selectedPeerId) return;
+    setFetchingKey(true);
+    setError('');
+    try {
+      const res = await revealFleetPeerHostKey(selectedPeerId, { silent: true });
+      if (res?.apiKey) {
+        setApiKey(res.apiKey);
+      } else {
+        setError('Host did not return an API key. Enter it manually.');
+      }
+    } catch (err) {
+      setError(err?.message || 'Could not retrieve API key from host.');
+    } finally {
+      setFetchingKey(false);
+    }
   };
 
   const selectHarness = (next) => {
@@ -249,9 +277,22 @@ export default function FleetProviderSetup({ peers = [], onClose, onCreate, onCo
               value={apiKey}
               onChange={(event) => setApiKey(event.target.value)}
               autoComplete="off"
+              placeholder="Enter host API key"
               className="w-full px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white focus:border-port-accent focus:outline-hidden"
             />
           </FormField>
+          {selectedPeerId && (
+            <div className="flex justify-end -mt-2">
+              <button
+                type="button"
+                onClick={handleFetchKey}
+                disabled={fetchingKey}
+                className="text-xs text-port-accent hover:underline disabled:opacity-50"
+              >
+                {fetchingKey ? 'Fetching…' : 'Fetch API key from host'}
+              </button>
+            </div>
+          )}
 
           {error && <Banner tone="error">{error}</Banner>}
 

--- a/client/src/components/providers/FleetProviderSetup.test.jsx
+++ b/client/src/components/providers/FleetProviderSetup.test.jsx
@@ -12,7 +12,7 @@ vi.mock('../../services/apiProviders', () => api);
 
 const peers = [
   { id: 'peer-1', name: 'Workstation GPU', host: 'workstation.tailnet.ts.net', enabled: true },
-  { id: 'peer-2', name: 'MacBook', address: '100.64.0.2', enabled: true },
+  { id: 'peer-2', name: 'MacBook', address: '192.168.1.50', enabled: true },
 ];
 
 beforeEach(() => {

--- a/client/src/components/providers/FleetProviderSetup.test.jsx
+++ b/client/src/components/providers/FleetProviderSetup.test.jsx
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import FleetProviderSetup from './FleetProviderSetup';
+
+const api = vi.hoisted(() => ({
+  revealFleetPeerHostKey: vi.fn(),
+  getFleetLlmHost: vi.fn().mockResolvedValue({}),
+  revealFleetLlmHostKey: vi.fn().mockResolvedValue({ apiKey: 'k' }),
+}));
+vi.mock('../../services/apiProviders', () => api);
+
+const peers = [
+  { id: 'peer-1', name: 'Workstation GPU', host: 'workstation.tailnet.ts.net', enabled: true },
+  { id: 'peer-2', name: 'MacBook', address: '100.64.0.2', enabled: true },
+];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('FleetProviderSetup', () => {
+  it('pre-selects peer from URL search params on client tab', async () => {
+    render(
+      <MemoryRouter initialEntries={['/ai/fleet?fleetStep=client&peerId=peer-1']}>
+        <FleetProviderSetup peers={peers} onClose={() => {}} onCreate={vi.fn()} />
+      </MemoryRouter>
+    );
+
+    const peerSelect = await screen.findByLabelText('Known PortOS peer');
+    expect(peerSelect.value).toBe('peer-1');
+
+    const endpointInput = screen.getByLabelText('GPU host endpoint');
+    expect(endpointInput.value).toBe('http://workstation.tailnet.ts.net:18022/v1');
+  });
+
+  it('fetches API key from host when clicked', async () => {
+    api.revealFleetPeerHostKey.mockResolvedValue({ apiKey: 'host-secret-key-123456789012' });
+
+    render(
+      <MemoryRouter initialEntries={['/ai/fleet?fleetStep=client&peerId=peer-1']}>
+        <FleetProviderSetup peers={peers} onClose={() => {}} onCreate={vi.fn()} />
+      </MemoryRouter>
+    );
+
+    const fetchBtn = await screen.findByRole('button', { name: 'Fetch API key from host' });
+    fireEvent.click(fetchBtn);
+
+    await waitFor(() => {
+      expect(api.revealFleetPeerHostKey).toHaveBeenCalledWith('peer-1', { silent: true });
+    });
+
+    const apiKeyInput = screen.getByPlaceholderText('Enter host API key');
+    expect(apiKeyInput.value).toBe('host-secret-key-123456789012');
+  });
+
+  it('creates provider with correct options on submit', async () => {
+    const onCreate = vi.fn().mockResolvedValue({});
+    const onClose = vi.fn();
+
+    render(
+      <MemoryRouter initialEntries={['/ai/fleet?fleetStep=client&peerId=peer-1']}>
+        <FleetProviderSetup peers={peers} onClose={onClose} onCreate={onCreate} />
+      </MemoryRouter>
+    );
+
+    const apiKeyInput = await screen.findByPlaceholderText('Enter host API key');
+    fireEvent.change(apiKeyInput, { target: { value: 'my-secret-key-at-least-24-characters' } });
+
+    const submitBtn = screen.getByRole('button', { name: 'Create fleet provider' });
+    fireEvent.click(submitBtn);
+
+    await waitFor(() => {
+      expect(onCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'Fleet GPU · OpenCode TUI',
+          endpoint: 'http://workstation.tailnet.ts.net:18022/v1',
+          apiKey: 'my-secret-key-at-least-24-characters',
+          defaultModel: 'qwen3.8-27b',
+          type: 'tui',
+          vllmBacked: true,
+        })
+      );
+    });
+  });
+});

--- a/client/src/pages/AIProviders.jsx
+++ b/client/src/pages/AIProviders.jsx
@@ -217,10 +217,10 @@ export default function AIProviders() {
   useEffect(() => { loadRuntimes(); }, [loadRuntimes]);
 
   useEffect(() => {
-    if (!fleetSetupOpen) return;
+    if (!fleetSetupOpen || typeof api.getInstances !== 'function') return;
     api.getInstances({ silent: true })
-      .then((data) => setFleetPeers(Array.isArray(data?.peers) ? data.peers : []))
-      .catch(() => setFleetPeers([]));
+      ?.then((data) => setFleetPeers(Array.isArray(data?.peers) ? data.peers : []))
+      ?.catch(() => setFleetPeers([]));
   }, [fleetSetupOpen]);
 
   useEffect(() => {
@@ -714,7 +714,7 @@ export default function AIProviders() {
 
       <div className="flex-1 overflow-auto p-4 space-y-6">
 
-      <FleetHostSetup compact />
+      <FleetHostSetup compact providers={providers} />
 
       {/* Sample Providers Panel */}
       {showSamples && (

--- a/client/src/pages/AIProviders.test.jsx
+++ b/client/src/pages/AIProviders.test.jsx
@@ -35,7 +35,12 @@ const toast = vi.hoisted(() => ({
 }));
 
 vi.mock('../services/api', () => api);
-vi.mock('../services/apiProviders', () => ({ getFleetLlmHost: vi.fn(() => new Promise(() => {})), revealFleetLlmHostKey: vi.fn() }));
+vi.mock('../services/apiProviders', () => ({
+  getFleetLlmHost: vi.fn(() => new Promise(() => {})),
+  getFleetPeerHosts: vi.fn(() => new Promise(() => {})),
+  revealFleetLlmHostKey: vi.fn(),
+  revealFleetPeerHostKey: vi.fn(),
+}));
 vi.mock('../components/ui/Toast', () => ({
   default: toast,
 }));

--- a/client/src/services/apiProviders.js
+++ b/client/src/services/apiProviders.js
@@ -87,3 +87,5 @@ export const getCodexModels = (options = {}) => {
 
 export const getFleetLlmHost = (options) => request('/providers/fleet-host', options);
 export const revealFleetLlmHostKey = (options) => request('/providers/fleet-host/key', { method: 'POST', ...options });
+export const getFleetPeerHosts = (options) => request('/providers/fleet-peer-hosts', options);
+export const revealFleetPeerHostKey = (peerId, options) => request(`/providers/fleet-peer-hosts/${encodeURIComponent(peerId)}/key`, { method: 'POST', ...options });

--- a/client/src/utils/providers.js
+++ b/client/src/utils/providers.js
@@ -1148,6 +1148,59 @@ export const isLocalInstanceProvider = (provider) => {
 export const isFleetProvider = (provider) =>
   !isLocalInstanceProvider(provider) && isPrivateNetworkEndpoint(provider?.endpoint);
 
+/**
+ * Has this fleet host already been configured as a provider on this instance?
+ *
+ * @param {{endpoint?: string, peerHost?: string, peerAddress?: string}|null|undefined} host
+ * @param {Array<object>} providers
+ * @returns {boolean}
+ */
+export const isFleetHostConfigured = (host, providers = []) => {
+  if (!host || !Array.isArray(providers)) return false;
+  const hostEndpoint = typeof host.endpoint === 'string' ? host.endpoint.toLowerCase().replace(/\/+$/, '') : '';
+  const hostHostname = (host.peerHost || (host.endpoint && URL.canParse(host.endpoint) ? new URL(host.endpoint).hostname : ''))?.toLowerCase();
+  const hostAddress = (host.peerAddress || '')?.toLowerCase();
+
+  return providers.some((p) => {
+    // 1. Direct endpoint string equality
+    const pEndpoint = typeof p?.endpoint === 'string' ? p.endpoint.toLowerCase().replace(/\/+$/, '') : '';
+    if (hostEndpoint && pEndpoint === hostEndpoint) return true;
+
+    // 2. Parsed hostname/IP match
+    if (pEndpoint && URL.canParse(pEndpoint)) {
+      const pUrl = new URL(pEndpoint);
+      const pHost = pUrl.hostname.toLowerCase();
+      if ((hostHostname && pHost === hostHostname) || (hostAddress && pHost === hostAddress)) {
+        return true;
+      }
+    }
+
+    // 3. OpenCode TUI provider configuration check
+    if (p?.envVars?.OPENCODE_CONFIG_CONTENT) {
+      try {
+        const config = typeof p.envVars.OPENCODE_CONFIG_CONTENT === 'string'
+          ? JSON.parse(p.envVars.OPENCODE_CONFIG_CONTENT)
+          : p.envVars.OPENCODE_CONFIG_CONTENT;
+        const vllmBaseUrl = config?.provider?.vllm?.options?.baseURL;
+        if (typeof vllmBaseUrl === 'string') {
+          const normBase = vllmBaseUrl.toLowerCase().replace(/\/+$/, '');
+          if (hostEndpoint && normBase === hostEndpoint) return true;
+          if (URL.canParse(normBase)) {
+            const bHost = new URL(normBase).hostname.toLowerCase();
+            if ((hostHostname && bHost === hostHostname) || (hostAddress && bHost === hostAddress)) {
+              return true;
+            }
+          }
+        }
+      } catch {
+        // ignore parse error
+      }
+    }
+
+    return false;
+  });
+};
+
 export const isLikelyLargeContextProvider = (provider) => {
   if (isProcessProvider(provider)) return true;
   return isApiProvider(provider) && !isLocalEndpoint(provider.endpoint);

--- a/client/src/utils/providers.test.js
+++ b/client/src/utils/providers.test.js
@@ -2081,7 +2081,7 @@ describe('isFleetHostConfigured', () => {
     peerId: 'peer-1',
     peerName: 'Workstation GPU',
     peerHost: 'workstation.tailnet.ts.net',
-    peerAddress: '100.64.0.15',
+    peerAddress: '192.168.1.50',
     endpoint: 'http://workstation.tailnet.ts.net:18022/v1',
     model: 'qwen3.8-27b',
     serving: true,
@@ -2110,8 +2110,8 @@ describe('isFleetHostConfigured', () => {
       { id: 'p1', endpoint: 'http://workstation.tailnet.ts.net:18022/v1' },
     ];
     expect(isFleetHostConfigured({ peerHost: 'workstation.tailnet.ts.net' }, providers)).toBe(true);
-    expect(isFleetHostConfigured({ peerAddress: '100.64.0.15' }, [
-      { id: 'p2', endpoint: 'http://100.64.0.15:18022/v1' },
+    expect(isFleetHostConfigured({ peerAddress: '192.168.1.50' }, [
+      { id: 'p2', endpoint: 'http://192.168.1.50:18022/v1' },
     ])).toBe(true);
   });
 

--- a/client/src/utils/providers.test.js
+++ b/client/src/utils/providers.test.js
@@ -58,6 +58,7 @@ import {
   isCodexSubscriptionProvider,
   supportsModelRefresh,
   isAntigravityProvider,
+  isFleetHostConfigured,
   effortLevelsForProvider,
   generationControlsFor,
   resolveCliEffort,
@@ -2074,3 +2075,71 @@ describe('publicReviewSelectionPolicy', () => {
     expect(policy.model('grok-4', GROK)).toBe(true);
   });
 });
+
+describe('isFleetHostConfigured', () => {
+  const host = {
+    peerId: 'peer-1',
+    peerName: 'Workstation GPU',
+    peerHost: 'workstation.tailnet.ts.net',
+    peerAddress: '100.64.0.15',
+    endpoint: 'http://workstation.tailnet.ts.net:18022/v1',
+    model: 'qwen3.8-27b',
+    serving: true,
+  };
+
+  it('returns false for empty host or empty providers', () => {
+    expect(isFleetHostConfigured(null, [])).toBe(false);
+    expect(isFleetHostConfigured(host, [])).toBe(false);
+    expect(isFleetHostConfigured(host, null)).toBe(false);
+  });
+
+  it('matches provider by exact endpoint', () => {
+    const providers = [
+      { id: 'p1', endpoint: 'http://workstation.tailnet.ts.net:18022/v1' },
+    ];
+    expect(isFleetHostConfigured(host, providers)).toBe(true);
+
+    const providersWithSlash = [
+      { id: 'p1', endpoint: 'http://workstation.tailnet.ts.net:18022/v1/' },
+    ];
+    expect(isFleetHostConfigured(host, providersWithSlash)).toBe(true);
+  });
+
+  it('matches provider by peerHost hostname or peerAddress', () => {
+    const providers = [
+      { id: 'p1', endpoint: 'http://workstation.tailnet.ts.net:18022/v1' },
+    ];
+    expect(isFleetHostConfigured({ peerHost: 'workstation.tailnet.ts.net' }, providers)).toBe(true);
+    expect(isFleetHostConfigured({ peerAddress: '100.64.0.15' }, [
+      { id: 'p2', endpoint: 'http://100.64.0.15:18022/v1' },
+    ])).toBe(true);
+  });
+
+  it('matches OpenCode TUI provider by OPENCODE_CONFIG_CONTENT baseURL', () => {
+    const providers = [
+      {
+        id: 'p-tui',
+        type: 'tui',
+        envVars: {
+          OPENCODE_CONFIG_CONTENT: JSON.stringify({
+            provider: {
+              vllm: {
+                options: { baseURL: 'http://workstation.tailnet.ts.net:18022/v1' },
+              },
+            },
+          }),
+        },
+      },
+    ];
+    expect(isFleetHostConfigured(host, providers)).toBe(true);
+  });
+
+  it('returns false when no provider points to the host', () => {
+    const providers = [
+      { id: 'other', endpoint: 'http://other.tailnet.ts.net:18022/v1' },
+      { id: 'local', endpoint: 'http://127.0.0.1:11434' },
+    ];
+    expect(isFleetHostConfigured(host, providers)).toBe(false);
+  });
+});
+

--- a/server/lib/apiRouteCatalog.generated.json
+++ b/server/lib/apiRouteCatalog.generated.json
@@ -13953,6 +13953,22 @@
       ]
     },
     {
+      "method": "GET",
+      "path": "/api/providers/fleet-peer-hosts",
+      "mountPath": "/api/providers",
+      "sources": [
+        "server/routes/providers.js"
+      ]
+    },
+    {
+      "method": "POST",
+      "path": "/api/providers/fleet-peer-hosts/:peerId/key",
+      "mountPath": "/api/providers",
+      "sources": [
+        "server/routes/providers.js"
+      ]
+    },
+    {
       "method": "POST",
       "path": "/api/providers/opencode/install",
       "mountPath": "/api/providers",
@@ -17748,8 +17764,8 @@
   ],
   "stats": {
     "mounts": 150,
-    "operations": 2198,
-    "declarations": 2206,
+    "operations": 2200,
+    "declarations": 2208,
     "sourceFiles": 233
   }
 }

--- a/server/routes/providers.fleetPeerHosts.test.js
+++ b/server/routes/providers.fleetPeerHosts.test.js
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import express, { Router } from 'express';
+import { request } from '../lib/testHelper.js';
+import { errorMiddleware } from '../lib/errorHandler.js';
+
+vi.mock('../services/fleetLlmHost.js', () => ({
+  getFleetPeerHosts: vi.fn(),
+  revealFleetPeerHostKey: vi.fn(),
+  getFleetLlmHostStatus: vi.fn(),
+  revealFleetLlmKey: vi.fn(),
+  configureFleetLlmHost: vi.fn(),
+}));
+
+const fleetLlmHost = await import('../services/fleetLlmHost.js');
+const { createPortOSProviderRoutes } = await import('./providers.js');
+
+const buildApp = () => {
+  const providerService = { getAllProviders: vi.fn().mockResolvedValue({ activeProvider: 'test', providers: [] }) };
+  const app = express();
+  app.use(express.json());
+  app.use('/api/providers', createPortOSProviderRoutes({
+    services: { providers: providerService }, routes: { providers: Router() },
+  }));
+  app.use(errorMiddleware);
+  return app;
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('GET /api/providers/fleet-peer-hosts', () => {
+  it('returns peer hosts list from fleetLlmHost service', async () => {
+    const mockHosts = [
+      {
+        peerId: 'peer-1',
+        peerName: 'Workstation GPU',
+        endpoint: 'http://gpu.ts.net:18022/v1',
+        model: 'qwen3.8-27b',
+        serving: true,
+      },
+    ];
+    fleetLlmHost.getFleetPeerHosts.mockResolvedValue({ hosts: mockHosts });
+
+    const res = await request(buildApp()).get('/api/providers/fleet-peer-hosts');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ hosts: mockHosts });
+    expect(res.headers['cache-control']).toBe('no-store');
+  });
+});
+
+describe('POST /api/providers/fleet-peer-hosts/:peerId/key', () => {
+  it('reveals key for a specific peer', async () => {
+    fleetLlmHost.revealFleetPeerHostKey.mockResolvedValue({ apiKey: 'sample-peer-token' });
+
+    const res = await request(buildApp()).post('/api/providers/fleet-peer-hosts/peer-1/key');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ apiKey: 'sample-peer-token' });
+    expect(fleetLlmHost.revealFleetPeerHostKey).toHaveBeenCalledWith('peer-1');
+  });
+});

--- a/server/routes/providers.js
+++ b/server/routes/providers.js
@@ -167,6 +167,14 @@ export function createPortOSProviderRoutes(aiToolkit) {
     const { getFleetLlmHostStatus } = await import('../services/fleetLlmHost.js');
     res.set('Cache-Control', 'no-store').json(await getFleetLlmHostStatus());
   }));
+  router.get('/fleet-peer-hosts', asyncHandler(async (req, res) => {
+    const { getFleetPeerHosts } = await import('../services/fleetLlmHost.js');
+    res.set('Cache-Control', 'no-store').json(await getFleetPeerHosts());
+  }));
+  router.post('/fleet-peer-hosts/:peerId/key', asyncHandler(async (req, res) => {
+    const { revealFleetPeerHostKey } = await import('../services/fleetLlmHost.js');
+    res.set('Cache-Control', 'no-store').json(await revealFleetPeerHostKey(req.params.peerId));
+  }));
   // Explicit reveal; secrets are never included in status, URLs or install logs.
   router.post('/fleet-host/key', asyncHandler(async (req, res) => {
     const { revealFleetLlmKey } = await import('../services/fleetLlmHost.js');

--- a/server/services/fleetLlmHost.js
+++ b/server/services/fleetLlmHost.js
@@ -13,6 +13,9 @@ import { runStreamingCommand } from '../lib/streamingSpawn.js';
 import { installFleetHostLoginTask, isFleetHostLoginTaskInstalled } from './fleetLlmStartup.js';
 import { ensureFleetDockerIntegration } from './fleetLlmDocker.js';
 import { createFleetLlmGateway } from './fleetLlmGateway.js';
+import { peerFetch } from '../lib/peerHttpClient.js';
+import { peerBaseUrl } from '../lib/peerUrl.js';
+import { withAbortTimeout } from '../lib/abortTimeout.js';
 
 const ENABLED_KEY = 'PORTOS_FLEET_LLM_ENABLED';
 const MODEL = 'qwen3.8-27b';
@@ -88,6 +91,70 @@ export async function getFleetLlmHostStatus() {
 export async function revealFleetLlmKey() {
   const { apiKey } = await readHostEnv();
   return apiKey;
+}
+
+export async function getFleetPeerHosts({ timeoutMs = 3000 } = {}) {
+  const { getPeers } = await import('./instances.js').catch(() => ({ getPeers: async () => [] }));
+  const peers = await getPeers().catch(() => []);
+  const candidates = peers.filter((p) => p && p.enabled !== false && p.status !== 'offline');
+  if (candidates.length === 0) return { hosts: [] };
+
+  const results = await Promise.allSettled(
+    candidates.map(async (peer) => {
+      return withAbortTimeout(timeoutMs, async (signal) => {
+        const baseUrl = peerBaseUrl(peer);
+        const res = await peerFetch(`${baseUrl}/api/providers/fleet-host`, { signal }, peer);
+        if (!res.ok) return null;
+        const status = await res.json().catch(() => null);
+        if (!status || (!status.serving && !status.enabled)) return null;
+
+        const endpoint = status.endpoint || (peer.host || peer.address
+          ? `http://${peer.host || peer.address}:${PORTS.FLEET_LLM}/v1`
+          : null);
+
+        return {
+          peerId: peer.id,
+          peerName: peer.name || peer.host || peer.address,
+          peerHost: peer.host || null,
+          peerAddress: peer.address,
+          endpoint,
+          model: status.model || MODEL,
+          serving: Boolean(status.serving),
+          enabled: Boolean(status.enabled),
+          hasApiKey: Boolean(status.hasApiKey),
+          specs: status.specs || null,
+          queue: status.queue || null,
+        };
+      }).catch(() => null);
+    })
+  );
+
+  const hosts = results
+    .filter((r) => r.status === 'fulfilled' && r.value !== null)
+    .map((r) => r.value);
+
+  return { hosts };
+}
+
+export async function revealFleetPeerHostKey(peerId, { timeoutMs = 4000 } = {}) {
+  if (!peerId) throw new Error('Peer ID is required');
+  const { getPeers } = await import('./instances.js').catch(() => ({ getPeers: async () => [] }));
+  const peers = await getPeers().catch(() => []);
+  const peer = peers.find((p) => p.id === peerId);
+  if (!peer) throw new Error('Peer not found');
+
+  const baseUrl = peerBaseUrl(peer);
+  return withAbortTimeout(timeoutMs, async (signal) => {
+    const res = await peerFetch(`${baseUrl}/api/providers/fleet-host/key`, { method: 'POST', signal }, peer);
+    if (!res.ok) {
+      throw new Error(`Host returned HTTP ${res.status}`);
+    }
+    const data = await res.json().catch(() => null);
+    if (!data?.apiKey) {
+      throw new Error('Host did not return an API key');
+    }
+    return { apiKey: data.apiKey };
+  });
 }
 
 export async function configureFleetLlmHost({ emit = () => {}, isCancelled = () => false } = {}) {

--- a/server/services/fleetLlmHost.test.js
+++ b/server/services/fleetLlmHost.test.js
@@ -1,6 +1,17 @@
 vi.mock('./fleetLlmStartup.js', () => ({ installFleetHostLoginTask: async () => ({ success: true }), isFleetHostLoginTaskInstalled: async () => true }));
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-const state = vi.hoisted(() => ({ providers: [], writes: [], enabled: '', specs: { platform: 'win32', cuda: { gpus: [{ name: 'NVIDIA RTX 3090', vramGb: 24 }] } } }));
+const state = vi.hoisted(() => ({ providers: [], writes: [], enabled: '', specs: { platform: 'win32', cuda: { gpus: [{ name: 'NVIDIA RTX 3090', vramGb: 24 }] } }, peers: [], peerResponses: new Map() }));
+vi.mock('./instances.js', () => ({ getPeers: async () => state.peers }));
+vi.mock('../lib/peerHttpClient.js', () => ({
+  peerFetch: async (url, opts, peer) => {
+    const handler = state.peerResponses.get(url);
+    if (handler) return handler(url, opts, peer);
+    return { ok: false, status: 404, json: async () => ({}) };
+  },
+}));
+vi.mock('../lib/peerUrl.js', () => ({
+  peerBaseUrl: (peer) => peer.host ? `https://${peer.host}:${peer.port || 5555}` : `http://${peer.address}:${peer.port || 5555}`,
+}));
 vi.mock('../lib/systemCapabilities.js', () => ({ detectSystemCapabilities: async () => state.specs }));
 vi.mock('../lib/cudaCapability.js', () => ({ getCudaUtilization: async () => ({ gpus: [{ memoryUsedMib: 1000 }] }) }));
 vi.mock('../lib/tailscale.js', () => ({ getTailscaleStatus: async () => ({ running: true, dnsName: 'host-XXXX.example.ts.net' }) }));
@@ -14,9 +25,9 @@ vi.mock('../lib/streamingSpawn.js', () => ({ runStreamingCommand: vi.fn(async ()
 vi.mock('./vllmQwenManager.js', () => ({ ensureVllmProjectDir: async () => null, provisionVllmQwenProject: async () => ({ success: true }) }));
 vi.mock('./providers.js', () => ({ getAllProviders: async () => ({ providers: state.providers }), createProvider: async (record) => state.providers.push(record), updateProvider: async (id, patch) => Object.assign(state.providers.find(p => p.id === id), patch) }));
 vi.mock('./fleetLlmGateway.js', () => ({ createFleetLlmGateway: () => ({ server: { once() {}, on() {}, listen(_port, _host, done) { done(); } }, status: () => ({ active: 0, queued: 0 }), close: async () => {} }) }));
-import { configureFleetLlmHost, getFleetLlmHostStatus, stopFleetLlmHost } from './fleetLlmHost.js';
+import { configureFleetLlmHost, getFleetLlmHostStatus, getFleetPeerHosts, revealFleetPeerHostKey, stopFleetLlmHost } from './fleetLlmHost.js';
 import { runStreamingCommand } from '../lib/streamingSpawn.js';
-beforeEach(async () => { await stopFleetLlmHost(); state.writes = []; state.enabled = ''; state.providers = []; vi.clearAllMocks(); });
+beforeEach(async () => { await stopFleetLlmHost(); state.writes = []; state.enabled = ''; state.providers = []; state.peers = []; state.peerResponses.clear(); vi.clearAllMocks(); });
 describe('dedicated host setup workflow', () => {
   it('pins the prepared image, keeps the runtime private and routes only local providers through the queue', async () => {
     state.providers = [
@@ -42,3 +53,67 @@ describe('dedicated host setup workflow', () => {
     expect(state.enabled).toBe('');
   });
 });
+
+describe('fleet peer host discovery', () => {
+  it('returns empty hosts list when no peers exist or no peers are serving', async () => {
+    state.peers = [];
+    const result = await getFleetPeerHosts();
+    expect(result).toEqual({ hosts: [] });
+
+    state.peers = [
+      { id: 'offline-peer', name: 'Offline', host: 'offline.ts.net', status: 'offline', enabled: true },
+      { id: 'disabled-peer', name: 'Disabled', host: 'disabled.ts.net', status: 'online', enabled: false },
+    ];
+    const res2 = await getFleetPeerHosts();
+    expect(res2).toEqual({ hosts: [] });
+  });
+
+  it('discovers online peers running a federated host', async () => {
+    state.peers = [
+      { id: 'peer-1', name: 'Workstation GPU', host: 'gpu.ts.net', status: 'online', enabled: true },
+      { id: 'peer-2', name: 'Laptop', address: '100.64.0.2', status: 'online', enabled: true },
+    ];
+    state.peerResponses.set('https://gpu.ts.net:5555/api/providers/fleet-host', async () => ({
+      ok: true,
+      json: async () => ({
+        serving: true,
+        enabled: true,
+        endpoint: 'http://gpu.ts.net:18022/v1',
+        model: 'qwen3.8-27b',
+        hasApiKey: true,
+        queue: { active: 0, queued: 0 },
+      }),
+    }));
+    state.peerResponses.set('http://100.64.0.2:5555/api/providers/fleet-host', async () => ({
+      ok: true,
+      json: async () => ({ serving: false, enabled: false }),
+    }));
+
+    const result = await getFleetPeerHosts();
+    expect(result.hosts).toHaveLength(1);
+    expect(result.hosts[0]).toMatchObject({
+      peerId: 'peer-1',
+      peerName: 'Workstation GPU',
+      peerHost: 'gpu.ts.net',
+      endpoint: 'http://gpu.ts.net:18022/v1',
+      model: 'qwen3.8-27b',
+      serving: true,
+      hasApiKey: true,
+    });
+  });
+
+  it('reveals API key from peer on request and handles missing peer', async () => {
+    state.peers = [
+      { id: 'peer-1', name: 'Workstation GPU', host: 'gpu.ts.net', status: 'online', enabled: true },
+    ];
+    state.peerResponses.set('https://gpu.ts.net:5555/api/providers/fleet-host/key', async () => ({
+      ok: true,
+      json: async () => ({ apiKey: 'secret-token-from-peer-1234567890' }),
+    }));
+
+    await expect(revealFleetPeerHostKey('unknown-peer')).rejects.toThrow('Peer not found');
+    const keyRes = await revealFleetPeerHostKey('peer-1');
+    expect(keyRes).toEqual({ apiKey: 'secret-token-from-peer-1234567890' });
+  });
+});
+

--- a/server/services/fleetLlmHost.test.js
+++ b/server/services/fleetLlmHost.test.js
@@ -71,7 +71,7 @@ describe('fleet peer host discovery', () => {
   it('discovers online peers running a federated host', async () => {
     state.peers = [
       { id: 'peer-1', name: 'Workstation GPU', host: 'gpu.ts.net', status: 'online', enabled: true },
-      { id: 'peer-2', name: 'Laptop', address: '100.64.0.2', status: 'online', enabled: true },
+      { id: 'peer-2', name: 'Laptop', address: '192.168.1.50', status: 'online', enabled: true },
     ];
     state.peerResponses.set('https://gpu.ts.net:5555/api/providers/fleet-host', async () => ({
       ok: true,
@@ -84,7 +84,7 @@ describe('fleet peer host discovery', () => {
         queue: { active: 0, queued: 0 },
       }),
     }));
-    state.peerResponses.set('http://100.64.0.2:5555/api/providers/fleet-host', async () => ({
+    state.peerResponses.set('http://192.168.1.50:5555/api/providers/fleet-host', async () => ({
       ok: true,
       json: async () => ({ serving: false, enabled: false }),
     }));


### PR DESCRIPTION
## Summary
When a federated peer instance on the local PortOS network is running or serving a dedicated LLM host (`/api/providers/fleet-host`), detect it and display an actionable setup prompt on the AI Providers configuration page (`/ai` and `/ai/providers`) if it has not yet been configured as a local provider.

## Changes
- **`server/services/fleetLlmHost.js`**:
  - Added `getFleetPeerHosts()` to query enabled peers for active fleet hosts via `peerFetch` (`/api/providers/fleet-host`) with timeout protection.
  - Added `revealFleetPeerHostKey(peerId)` to fetch the fleet API key from a peer on demand.
- **`server/routes/providers.js`**:
  - Added `GET /api/providers/fleet-peer-hosts` and `POST /api/providers/fleet-peer-hosts/:peerId/key` endpoints.
  - Updated API route catalog.
- **`client/src/services/apiProviders.js`**:
  - Exported `getFleetPeerHosts` and `revealFleetPeerHostKey`.
- **`client/src/utils/providers.js`**:
  - Added `isFleetHostConfigured(host, providers)` supporting direct endpoint match, host/IP resolution, and OpenCode TUI provider configuration JSON.
- **`client/src/components/providers/FleetHostSetup.jsx`**:
  - In `compact` mode, queries peer fleet hosts and prompts the user with an actionable setup card when an unconfigured host is detected.
- **`client/src/components/providers/FleetProviderSetup.jsx`**:
  - Supports preselecting `peerId` via search query params and includes a "Fetch API key from host" button.
- **`client/src/pages/AIProviders.jsx`**:
  - Passes `providers` to `<FleetHostSetup compact />` and guards `api.getInstances`.

## Test Plan
- Unit and integration tests for peer host querying and key reveal: `server/services/fleetLlmHost.test.js`, `server/routes/providers.fleetPeerHosts.test.js`.
- Utility tests for host configuration detection: `client/src/utils/providers.test.js`.
- Component tests: `client/src/components/providers/FleetHostSetup.test.jsx`, `client/src/components/providers/FleetProviderSetup.test.jsx`.
- Page tests: `client/src/pages/AIProviders.test.jsx`.
- Verified client lint (`biome lint`) and production client build (`vite build`).