### PR TITLE
fix: hide generation target picker for external video backends

### DIFF
--- a/client/src/pages/VideoGen.federatedTarget.test.jsx
+++ b/client/src/pages/VideoGen.federatedTarget.test.jsx
@@ -126,4 +126,29 @@ describe('VideoGen federated render target', () => {
     expect(screen.getByText(/cannot take/i)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /^Generate$/ })).toBeDisabled();
   });
+
+  it.each([
+    ['Grok', { settings: { imageGen: { grok: { enabled: true } } }, status: {} }],
+    ['fal.ai', { status: { falEnabled: true } }],
+    ['Reactor.inc', { status: { reactorEnabled: true } }],
+  ])('hides generation target picker when %s external service is selected', async (label, config) => {
+    if (config.settings) state.settings = config.settings;
+    if (config.status) {
+      state.getVideoGenStatus.mockResolvedValue(videoGenStatus([MODEL], config.status));
+    }
+    await startRender();
+
+    // Target picker is visible initially on the Local backend
+    expect(screen.getByRole('combobox', { name: /generation target/i })).toBeInTheDocument();
+
+    // Switch to the external backend
+    fireEvent.click(screen.getByRole('button', { name: new RegExp(`^${label}$`, 'i') }));
+
+    // Target picker should now be hidden
+    expect(screen.queryByRole('combobox', { name: /generation target/i })).not.toBeInTheDocument();
+
+    // Switch back to Local backend — target picker reappears
+    fireEvent.click(screen.getByRole('button', { name: /^Local$/ }));
+    expect(screen.getByRole('combobox', { name: /generation target/i })).toBeInTheDocument();
+  });
 });

--- a/client/src/pages/VideoGen.jsx
+++ b/client/src/pages/VideoGen.jsx
@@ -1444,11 +1444,13 @@ export default function VideoGen() {
             />
           )}
 
-          <RemoteMediaTargetPicker
-            target={remoteTarget}
-            kind="video"
-            localBlockedReason={remoteUnsupportedInputs}
-          />
+          {!isGrok && !isFal && !isReactor && (
+            <RemoteMediaTargetPicker
+              target={remoteTarget}
+              kind="video"
+              localBlockedReason={remoteUnsupportedInputs}
+            />
+          )}
 
           {isGrok ? (
             <div className="grid grid-cols-2 gap-3">

--- a/client/src/test/videoGenPageMocks.jsx
+++ b/client/src/test/videoGenPageMocks.jsx
@@ -97,6 +97,7 @@ const SPIES = ['getVideoGenStatus', 'getVideoGenModelContext', 'generateVideo', 
 /** Restore every documented default, including fresh spies. Call it first in `beforeEach`. */
 export function resetVideoGenMockState() {
   state.peers = [];
+  state.settings = null;
   state.activeJob = null;
   state.modelStatuses = {};
   state.modelDownloadExtra = {};
@@ -186,7 +187,7 @@ vi.mock('../services/api', () => ({
   listImageGallery: vi.fn(async () => []),
   patchSettingsSlice: vi.fn(async () => ({})),
   getActiveVideoJob: vi.fn(async () => ({ activeJob: state.activeJob })),
-  getSettings: vi.fn(async () => ({ imageGen: { grok: { enabled: false } } })),
+  getSettings: vi.fn(async () => state.settings ?? ({ imageGen: { grok: { enabled: false } } })),
   getVideoGenRuntimeStatus: vi.fn(async () => ({ installed: true, ready: true, current: true })),
   listLorasFull: (...args) => state.listLorasFull(...args),
   // The prompt-enhancement controls mount useProviderModels, which fetches the


### PR DESCRIPTION
## Summary
Hides the federated "Generation target" instance picker in VideoGen when an external cloud backend (Grok, fal.ai, or Reactor.inc) is selected, ensuring the target picker only appears when generating locally.

## Test plan
- Added unit tests in `client/src/pages/VideoGen.federatedTarget.test.jsx` verifying that selecting Grok, fal.ai, or Reactor.inc hides the generation target combobox, and switching back to Local makes it reappear.
- Ran all VideoGen page test suites: `npm test -- src/pages/VideoGen` (all 38 tests passed).
- Ran full client test suite: `npm test` (all 10530 tests passed).