### PR TITLE
fix: enforce scoped permissions in code review workflows

### DIFF
--- a/server/lib/slashdoLoader.test.js
+++ b/server/lib/slashdoLoader.test.js
@@ -46,6 +46,28 @@ describe.skipIf(!hasSubmodule)('slashdo rendering adapter', () => {
     expect(await loadSlashdoLib('example')).toContain('SUBPROCESS');
   });
 
+  it('renders the bundled scoped review without rejecting it or enabling public edits', async () => {
+    const { buildReviewLoopFollowUpSection } = await import('../services/promptSections/reviewLifecycle.js');
+    const recipe = readFileSync(new URL('../../lib/slashdo/lib/local-agent-review-loop.md', import.meta.url), 'utf8');
+    write(join(fixtureRoot, 'lib/scoped-review.md'), recipe);
+    const body = await loadSlashdoLib('scoped-review');
+    const prompt = buildReviewLoopFollowUpSection(
+      { reviewLoopReviewers: ['claude', 'antigravity', 'codex'], reviewLoopReviewerApplies: true },
+      { localOnly: true, baseBranch: 'main', localAgentLoopBody: body },
+    );
+
+    expect(prompt).not.toContain('entire recipe was rejected');
+    expect(prompt).toContain('--tools "Read,Glob,Grep" --allowedTools "Read,Glob,Grep"');
+    expect(prompt).toContain('--strict-mcp-config');
+    expect(prompt).toContain('disableAllHooks');
+    expect(prompt).toMatch(/Inlining a\s+diff alone is not tool isolation/);
+    expect(prompt).toContain('--sandbox read-only review --base');
+    expect(prompt).not.toContain('--sandbox workspace-write');
+    expect(prompt).not.toContain('--sandbox danger-full-access');
+    expect(prompt).not.toContain('agy --dangerously');
+    expect(prompt).toContain('Reviewer applies (off)');
+  });
+
   it('keeps inline reviewer recipes limited to explicit reads', async () => {
     write(join(fixtureRoot, 'lib/recipe.md'), 'Recipe\n!read lib/required.md\nSee `lib/unrelated.md`.');
     write(join(fixtureRoot, 'lib/required.md'), 'Required verification');

--- a/server/services/agentPromptBuilder.test.js
+++ b/server/services/agentPromptBuilder.test.js
@@ -1393,7 +1393,7 @@ describe('buildLightContextPrompt', () => {
         });
       expect(prompt).toMatch(/### CLI Reviewer Procedure \(codex\)/);
       expect(prompt).toMatch(/RECIPE: codex --sandbox read-only review/);
-      expect(prompt).toMatch(/do NOT probe the CLI/);
+      expect(prompt).toMatch(/verify isolation flags with the installed CLI/);
     });
 
     it('points an over-budget CLI-reviewer recipe at its staged file instead of pasting 40KB', () => {
@@ -3078,7 +3078,7 @@ describe('buildReviewLoopFollowUpSection — CLI reviewer procedure inlining', (
       expect(out).toContain('CLI Reviewer Procedure');
       expect(out).toContain(LOOP_SENTINEL);
       // The vague invocation step points the agent at the inlined procedure.
-      expect(out).toMatch(/do NOT probe the CLI/i);
+      expect(out).toMatch(/verify isolation flags with the installed CLI/i);
     });
   }
 

--- a/server/services/promptSections/reviewLifecycle.js
+++ b/server/services/promptSections/reviewLifecycle.js
@@ -51,6 +51,9 @@ const AGY_UNSANDBOXED_REVIEW = 'agy --dangerously-skip-permissions --model "$AGY
 const GROK_UNSANDBOXED_REVIEW = 'grok --permission-mode bypassPermissions ${MODEL_FLAG[@]+"${MODEL_FLAG[@]}"} ${EFFORT_FLAG[@]+"${EFFORT_FLAG[@]}"} -p "$LOCAL_PROMPT"';
 const CODEX_READ_ONLY_REVIEW = 'codex ${MODEL_FLAG[@]+"${MODEL_FLAG[@]}"} ${EFFORT_FLAG[@]+"${EFFORT_FLAG[@]}"} --sandbox read-only review --base "$BASE_BRANCH" --title "$REVIEW_TITLE"';
 const CODEX_APPLY_REVIEW = 'codex ${MODEL_FLAG[@]+"${MODEL_FLAG[@]}"} ${EFFORT_FLAG[@]+"${EFFORT_FLAG[@]}"} --sandbox danger-full-access -a never exec "$CODEX_APPLY_PROMPT"';
+// Current slashdo supports scoped edits on trusted input. Public review still
+// forbids reviewer-applies, including this narrower workspace-write recipe.
+const CODEX_SCOPED_APPLY_REVIEW = 'codex ${MODEL_FLAG[@]+"${MODEL_FLAG[@]}"} ${EFFORT_FLAG[@]+"${EFFORT_FLAG[@]}"} --sandbox workspace-write -c sandbox_workspace_write.network_access=false -c features.shell_tool=false -a never exec "$CODEX_APPLY_PROMPT"';
 const CURSOR_READ_ONLY_REVIEW = '"$REVIEW_BIN" -p --trust --mode=ask --output-format text ${MODEL_FLAG[@]+"${MODEL_FLAG[@]}"} "$LOCAL_PROMPT"';
 const CURSOR_APPLY_REVIEW = '"$REVIEW_BIN" -p --force --trust --output-format text --sandbox disabled ${MODEL_FLAG[@]+"${MODEL_FLAG[@]}"} "$LOCAL_PROMPT"';
 const READ_ONLY_REVIEW_UNAVAILABLE = '{ echo "Reviewer unavailable: public-content review requires an enforced read-only mode" >&2; false; }';
@@ -71,6 +74,7 @@ export function prepareSandboxedReviewLoopBody(body) {
     .replaceAll(AGY_UNSANDBOXED_REVIEW, READ_ONLY_REVIEW_UNAVAILABLE)
     .replaceAll(GROK_UNSANDBOXED_REVIEW, READ_ONLY_REVIEW_UNAVAILABLE)
     .replaceAll(CODEX_APPLY_REVIEW, CODEX_READ_ONLY_REVIEW)
+    .replaceAll(CODEX_SCOPED_APPLY_REVIEW, CODEX_READ_ONLY_REVIEW)
     .replaceAll(CURSOR_APPLY_REVIEW, CURSOR_READ_ONLY_REVIEW)
     // Explanatory sections in the maintained recipe repeat the unsafe flags
     // outside the invocation table. Make those fragments non-copyable too; the
@@ -598,7 +602,7 @@ Only a successfully extracted \`.findings\` value is the review text; treat it l
   const localOnlyProcedureNote = localOnly
     ? '**Pre-PR rule:** keep reviewer fixes committed locally. Do NOT push or open a PR/MR here; the outer workflow publishes after the local review phase completes.\n\n'
     : '';
-  const cliProcedureHeader = `\n### CLI Reviewer Procedure (${cliReviewerHeading})\n\n${localOnlyProcedureNote}Drive each spawnable CLI reviewer EXACTLY as the slashdo local-agent review loop specifies — use its per-CLI invocation and review-only prompt contract verbatim; do NOT probe the CLI's \`--help\`, test it with throwaway prompts, or hand-roll flags. Run the reviewer once per round, capture its findings, and (unless reviewer-applies is set) apply the fixes yourself.\n\n`;
+  const cliProcedureHeader = `\n### CLI Reviewer Procedure (${cliReviewerHeading})\n\n${localOnlyProcedureNote}Drive each spawnable CLI reviewer EXACTLY as the slashdo local-agent review loop specifies — use its per-CLI invocation and review-only prompt contract verbatim; verify isolation flags with the installed CLI's help before supplying review data. Do not use throwaway provider prompts or invent unsupported flags. Run the reviewer once per round, capture its findings, and (unless reviewer-applies is set) apply the fixes yourself.\n\n`;
   //
   // The path IS the decision — it is non-null only when the caller already
   // measured the body over budget and staged it. Re-testing the length here


### PR DESCRIPTION
## Summary

Code-review workflows no longer recover from denied headless tools by granting blanket permissions. Adopt the merged slashdo fix (atomantic/slashdo#247), covering both reviewer and enhancement recipes, and keep PortOS public reviews read-only when translating the new scoped Codex edit recipe.

The guide provides scoped read tools, disables network and shell access for the explicit Codex edit mode, and requires enforced tool-free fallback or an unavailable verdict for unsupported CLIs. Antigravity currently has no invocation-local settings selector; its profile is documented without inventing a flag or changing global settings. CLI help checks are now allowed so the orchestrator can verify isolation before providing public data.

Closes #6338.

## Test plan

- PortOS: 420 tests passed across prompt building, code review, and slashdo loader/invocation contracts.
- Upstream slashdo: 522 tests passed; Node 18/20/22 CI and shellcheck passed.
- Regression checks prohibit blanket grants and exercise the actual bundled recipe through PortOS's public-review renderer.
- Optional configured Antigravity review unavailable because no enforceable invocation-local isolation mechanism was verified; no external clean verdict is claimed.
