### PR TITLE
fix: back off repeated GitHub CLI reads

### DIFF
--- a/server/routes/update.js
+++ b/server/routes/update.js
@@ -44,9 +44,12 @@ router.get('/status', asyncHandler(async (req, res) => {
   res.json({ ...status, activeCosAgents, persistentMindImages });
 }));
 
-// POST /api/update/check — triggers manual check
+// POST /api/update/check — triggers manual check. `manual: true` bypasses the
+// unattended scheduler's gh backoff — a user who explicitly asked for a check
+// must get a real attempt, not a silent rejection from a cooldown the
+// background poller armed on its own.
 router.post('/check', asyncHandler(async (req, res) => {
-  const result = await updateChecker.checkForUpdate();
+  const result = await updateChecker.checkForUpdate({ manual: true });
   res.json(result);
 }));
 

--- a/server/routes/update.test.js
+++ b/server/routes/update.test.js
@@ -626,3 +626,19 @@ describe('POST /api/update/sync-fork', () => {
     expect(updateChecker.getRemoteInfo).not.toHaveBeenCalled();
   });
 });
+
+describe('POST /api/update/check', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('marks the check manual so it bypasses the unattended scheduler\'s gh backoff', async () => {
+    // A user who explicitly clicks "check now" must get a real attempt, not a
+    // silent rejection from a cooldown the background 30-min poller armed on
+    // its own after an earlier unattended failure.
+    updateChecker.checkForUpdate.mockResolvedValue(baseStatus());
+    const res = await request(makeApp()).post('/api/update/check').send({});
+    expect(res.status).toBe(200);
+    expect(updateChecker.checkForUpdate).toHaveBeenCalledWith({ manual: true });
+  });
+});

--- a/server/services/blockedIssueReconcile.js
+++ b/server/services/blockedIssueReconcile.js
@@ -78,7 +78,7 @@ async function getGithubBlockedState(repoSpec, apiHost, fullName) {
   const forge = await ensureForgeReachable('blocked-issue-reconcile', { hostname: apiHost });
   if (!forge.ok) return null;
 
-  const ghList = (args, what) => execGh(args).catch((err) => {
+  const ghList = (args, what) => execGh(args, undefined, { backoffKey: repoSpec }).catch((err) => {
     console.error(`❌ blocked-issue-reconcile: ${what} failed for ${repoSpec}: ${err.message}`);
     return null;
   });

--- a/server/services/blockedIssueReconcile.test.js
+++ b/server/services/blockedIssueReconcile.test.js
@@ -120,6 +120,10 @@ describe('gatherBlockedIssueState (GitHub)', () => {
     const result = await gatherBlockedIssueState('/repo');
     expect(result.forge).toBe('github');
     expect(result.ready).toEqual([]);
+    expect(execGhMock.mock.calls.slice(0, 2).map(([, , options]) => options)).toEqual([
+      { backoffKey: 'github.com/atomantic/PortOS' },
+      { backoffKey: 'github.com/atomantic/PortOS' },
+    ]);
   });
 
   it('resolves a blocked issue whose named blocker is now closed', async () => {

--- a/server/services/branchReconcile.js
+++ b/server/services/branchReconcile.js
@@ -213,7 +213,9 @@ export function classifyBranches(inputs) {
  * Three answers, never two (#3358):
  *   - a Map (possibly empty) — the forge answered
  *   - an EMPTY Map for a non-GitHub origin — there is no GitHub PR state to have
- *   - `null` — we could NOT ask (gh transport/auth failure, unparseable output)
+ *   - `null` — we could NOT ask (gh transport/auth failure, unparseable output,
+ *     or a backoff cooldown from recent consecutive failures — see `execGh`'s
+ *     `backoffKey`, passed here as the repo spec)
  *
  * `null` must never be read as "this branch has no PR": that is what made an
  * unreachable forge classify every pushed branch as NEEDS_PR and hand the
@@ -235,11 +237,16 @@ async function getOpenPrsByHead(repoPath, providedOrigin) {
   // the host-qualified `HOST/OWNER/REPO` selector (null for a non-GitHub origin).
   const repoSpec = githubRepoSpec(origin);
   if (!repoSpec) return new Map();
+  // `backoffKey: repoSpec` opts this polling read into execGh's consecutive-
+  // failure backoff — this call is retried on every scheduler tick with no
+  // parking cooldown (resolveBranchReconcileBlock treats `prStateUnavailable`
+  // as transient), so a `gh` blip must not turn into every managed repo
+  // re-firing this same expensive call on its very next tick.
   const raw = await execGh([
     'pr', 'list', '--repo', repoSpec, '--state', 'open',
     '--limit', String(PR_LIST_LIMIT),
     '--json', 'number,headRefName,mergeable,isDraft,url'
-  ]).catch((err) => {
+  ], undefined, { backoffKey: repoSpec }).catch((err) => {
     console.error(`❌ branch-reconcile: gh pr list failed for ${repoSpec}: ${err.message}`);
     return null;
   });

--- a/server/services/branchReconcile.test.js
+++ b/server/services/branchReconcile.test.js
@@ -764,6 +764,24 @@ describe('unreachable forge (#3358)', () => {
     expect(res.inFlight).toEqual([]);
   });
 
+  it('opts the `gh pr list` read into execGh\'s consecutive-failure backoff, keyed by repo spec', async () => {
+    // The actual backoff/cooldown mechanics live in execGh itself (github.js,
+    // mocked wholesale here) so every polling caller shares one implementation —
+    // this only proves branch-reconcile hands it the right key. See
+    // github.test.js for the backoff behavior itself.
+    git.getBranches.mockResolvedValue([
+      { name: 'claim/issue-1', isDefault: false, current: false, tracking: 'origin/claim/issue-1', merged: false }
+    ]);
+    wt.listWorktrees.mockResolvedValue([]);
+    git.isBranchMergedInto.mockResolvedValue(false);
+    execGh.mockResolvedValue('[]');
+
+    await reconcile('/repo');
+
+    const [, , options] = execGh.mock.calls.find(([callArgs]) => callArgs[0] === 'pr' && callArgs[1] === 'list');
+    expect(options).toMatchObject({ backoffKey: 'github.com/atomantic/PortOS' });
+  });
+
   it('reuses the successful origin read for PR state instead of reopening a fail-closed gap', async () => {
     git.getBranches.mockResolvedValue([
       { name: 'claim/issue-1', isDefault: false, current: false, tracking: 'origin/claim/issue-1', merged: false }

--- a/server/services/github.js
+++ b/server/services/github.js
@@ -77,6 +77,40 @@ const reposForAccount = (data, login = data.githubUser) => Object.fromEntries(
   Object.entries(data.repos || {}).filter(([, repo]) => repoBelongsToAccount(repo, login))
 );
 
+// Consecutive-failure backoff, opt-in per call via `backoffKey`. A caller that
+// polls the same gh read on every scheduler tick (branch-reconcile's `pr list`,
+// updateChecker's release check, …) must not re-fire it on the very next tick
+// after a failure — that is what piled up concurrent 60s-timeout `gh`
+// processes across every managed repo during a real `gh` blip (branch-reconcile,
+// updateChecker, and repeated retries all hit the same struggling `gh` at once).
+// One-off/mutating calls (create a PR, merge, set a secret) intentionally opt
+// out by not passing `backoffKey` — silently skipping those would be a correctness
+// surprise, not a load-shedding win. In-memory only: a stuck cooldown clears
+// itself after GH_BACKOFF_MAX_MS, same as a server restart would clear it.
+const GH_BACKOFF_BASE_MS = 30_000;
+const GH_BACKOFF_MAX_MS = 15 * 60 * 1000;
+const ghCallBackoff = new Map();
+
+function ghBackoffActive(key, now = Date.now()) {
+  const entry = ghCallBackoff.get(key);
+  return Boolean(entry && now < entry.retryAfter);
+}
+
+function recordGhCallOutcome(key, ok, now = Date.now()) {
+  if (ok) {
+    ghCallBackoff.delete(key);
+    return;
+  }
+  const failures = (ghCallBackoff.get(key)?.failures || 0) + 1;
+  const delay = Math.min(GH_BACKOFF_BASE_MS * 2 ** (failures - 1), GH_BACKOFF_MAX_MS);
+  ghCallBackoff.set(key, { failures, retryAfter: now + delay });
+}
+
+/** Test seam — drops the in-memory `execGh` backoff state between runs. */
+export function __resetGhCallBackoff() {
+  ghCallBackoff.clear();
+}
+
 /**
  * Execute a gh CLI command safely using spawn. `gh` hits the network, so a
  * stalled call (bad credentials prompt, hung network) would otherwise leave
@@ -85,8 +119,13 @@ const reposForAccount = (data, login = data.githubUser) => Object.fromEntries(
  * process. `timeoutMs` kills the child and rejects with a clear error; it's
  * cleared on normal exit so it never fires for a completed run. `input`, when
  * supplied, is written to stdin (used by structured `gh api --input -` calls).
+ * `backoffKey`, when supplied, opts this call into the consecutive-failure
+ * backoff above — see the comment there for why it's opt-in.
  */
-export function execGh(args, timeoutMs = DEFAULT_EXEC_GH_TIMEOUT_MS, { cwd = null, env = null, input = null } = {}) {
+export function execGh(args, timeoutMs = DEFAULT_EXEC_GH_TIMEOUT_MS, { cwd = null, env = null, input = null, backoffKey = null } = {}) {
+  if (backoffKey !== null && ghBackoffActive(backoffKey)) {
+    return Promise.reject(new Error(`gh command backing off for ${backoffKey} after repeated failures`));
+  }
   return new Promise((resolve, reject) => {
     const operation = 'gh command';
     const baseEnv = env || process.env;
@@ -97,11 +136,13 @@ export function execGh(args, timeoutMs = DEFAULT_EXEC_GH_TIMEOUT_MS, { cwd = nul
     let stdout = '';
     let stderr = '';
     let timedOut = false;
+    const settle = (ok) => { if (backoffKey !== null) recordGhCallOutcome(backoffKey, ok); };
     const timer = setTimeout(() => {
       timedOut = true;
       // setTimeout callback boundary — guard so a kill() throw can't crash
       // the process (e.g. the child already exited between checks).
       try { child.kill('SIGKILL'); } catch (err) { console.error(`❌ execGh: failed to kill timed-out ${operation}: ${err.message}`); }
+      settle(false);
       reject(new Error(`${operation} timed out after ${timeoutMs}ms`));
     }, timeoutMs);
     child.stdout.on('data', (d) => { stdout += d.toString(); });
@@ -110,23 +151,27 @@ export function execGh(args, timeoutMs = DEFAULT_EXEC_GH_TIMEOUT_MS, { cwd = nul
       if (timedOut) return;
       clearTimeout(timer);
       if (code !== 0) {
+        settle(false);
         const error = new Error(stderr.trim() || `gh exited with code ${code}`);
         error.ghExitCode = code;
         error.ghStderr = stderr.trim();
         reject(error);
       } else {
+        settle(true);
         resolve(stdout.trim());
       }
     });
     child.on('error', (err) => {
       if (timedOut) return;
       clearTimeout(timer);
+      settle(false);
       reject(err);
     });
     if (input !== null && input !== undefined) {
       child.stdin.on('error', (err) => {
         if (timedOut || err.code === 'EPIPE') return;
         clearTimeout(timer);
+        settle(false);
         reject(err);
       });
       child.stdin.end(String(input));

--- a/server/services/github.js
+++ b/server/services/github.js
@@ -136,7 +136,12 @@ export function execGh(args, timeoutMs = DEFAULT_EXEC_GH_TIMEOUT_MS, { cwd = nul
     let stdout = '';
     let stderr = '';
     let timedOut = false;
-    const settle = (ok) => { if (backoffKey !== null) recordGhCallOutcome(backoffKey, ok); };
+    let settled = false;
+    const settle = (ok) => {
+      if (settled) return;
+      settled = true;
+      if (backoffKey !== null) recordGhCallOutcome(backoffKey, ok);
+    };
     const timer = setTimeout(() => {
       timedOut = true;
       // setTimeout callback boundary — guard so a kill() throw can't crash

--- a/server/services/github.test.js
+++ b/server/services/github.test.js
@@ -34,6 +34,7 @@ vi.mock('./settings.js', () => {
 import { spawn } from '../lib/childProcess.js';
 import {
   __resetGitHubDataCache,
+  __resetGhCallBackoff,
   execGh,
   getGitHubAuthStatus,
   getPullRequestState,
@@ -157,6 +158,86 @@ describe('execGh', () => {
       authenticated: false,
       status: 'unreachable',
     });
+  });
+});
+
+// A caller that polls the same gh read on every scheduler tick (branch-reconcile's
+// `pr list`, updateChecker's release check, …) must not re-fire it on the very
+// next tick after a failure — see the comment above `execGh`'s backoff map for
+// the incident this prevents.
+describe('execGh backoffKey', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    __resetGhCallBackoff();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('does not spawn while a key is in its cooldown after a failure', async () => {
+    const failing = makeChild();
+    spawn.mockReturnValueOnce(failing);
+    const first = execGh(['pr', 'list'], 5000, { backoffKey: 'github.com/o/r' });
+    first.catch(() => {});
+    failing.emit('close', 1);
+    await expect(first).rejects.toThrow();
+    expect(spawn).toHaveBeenCalledTimes(1);
+
+    await expect(execGh(['pr', 'list'], 5000, { backoffKey: 'github.com/o/r' }))
+      .rejects.toThrow(/backing off/);
+    expect(spawn).toHaveBeenCalledTimes(1); // second call never spawned a child
+  });
+
+  it('spawns again once the backoff window elapses', async () => {
+    const failing = makeChild();
+    spawn.mockReturnValueOnce(failing);
+    const first = execGh(['pr', 'list'], 5000, { backoffKey: 'github.com/o/r' });
+    first.catch(() => {});
+    failing.emit('close', 1);
+    await expect(first).rejects.toThrow();
+
+    vi.advanceTimersByTime(31_000); // past the 30s base cooldown for one failure
+
+    const succeeding = makeChild();
+    spawn.mockReturnValueOnce(succeeding);
+    const second = execGh(['pr', 'list'], 5000, { backoffKey: 'github.com/o/r' });
+    succeeding.emit('close', 0);
+    await expect(second).resolves.toBe('');
+    expect(spawn).toHaveBeenCalledTimes(2);
+  });
+
+  it('clears the backoff on success so a later failure starts a fresh cooldown', async () => {
+    const ok = makeChild();
+    spawn.mockReturnValueOnce(ok);
+    const p1 = execGh(['pr', 'list'], 5000, { backoffKey: 'github.com/o/r' });
+    ok.emit('close', 0);
+    await expect(p1).resolves.toBe('');
+
+    const ok2 = makeChild();
+    spawn.mockReturnValueOnce(ok2);
+    const p2 = execGh(['pr', 'list'], 5000, { backoffKey: 'github.com/o/r' });
+    ok2.emit('close', 0);
+    await expect(p2).resolves.toBe('');
+    expect(spawn).toHaveBeenCalledTimes(2); // no backoff was ever armed
+  });
+
+  it('never backs off a call with no backoffKey — one-off/mutating calls opt out', async () => {
+    const failing = makeChild();
+    spawn.mockReturnValueOnce(failing);
+    const p1 = execGh(['repo', 'create', 'o/r']);
+    p1.catch(() => {});
+    failing.emit('close', 1);
+    await expect(p1).rejects.toThrow();
+
+    const failing2 = makeChild();
+    spawn.mockReturnValueOnce(failing2);
+    const p2 = execGh(['repo', 'create', 'o/r']);
+    p2.catch(() => {});
+    failing2.emit('close', 1);
+    await expect(p2).rejects.toThrow(/exited with code 1/); // real second attempt, not a backoff rejection
+    expect(spawn).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/server/services/github.test.js
+++ b/server/services/github.test.js
@@ -190,6 +190,20 @@ describe('execGh backoffKey', () => {
     expect(spawn).toHaveBeenCalledTimes(1); // second call never spawned a child
   });
 
+  it('records a child error only once when close follows it', async () => {
+    const failing = makeChild();
+    spawn.mockReturnValueOnce(failing);
+    const first = execGh(['pr', 'list'], 5000, { backoffKey: 'github.com/o/r' });
+    failing.emit('error', new Error('spawn gh ENOENT'));
+    await expect(first).rejects.toThrow(/ENOENT/);
+
+    // ChildProcess emits close after error; it must not settle this invocation again.
+    failing.emit('close', 0);
+    await expect(execGh(['pr', 'list'], 5000, { backoffKey: 'github.com/o/r' }))
+      .rejects.toThrow(/backing off/);
+    expect(spawn).toHaveBeenCalledTimes(1);
+  });
+
   it('spawns again once the backoff window elapses', async () => {
     const failing = makeChild();
     spawn.mockReturnValueOnce(failing);

--- a/server/services/issueReconcile.js
+++ b/server/services/issueReconcile.js
@@ -323,7 +323,7 @@ async function getGithubState(repoSpec, fullName, apiHost = null) {
   const forge = await ensureForgeReachable('issue-reconcile', { hostname: apiHost });
   if (!forge.ok) return null;
 
-  const ghList = (args, what) => execGh(args).catch((err) => {
+  const ghList = (args, what) => execGh(args, undefined, { backoffKey: repoSpec }).catch((err) => {
     console.error(`❌ issue-reconcile: ${what} failed for ${fullName}: ${err.message}`);
     return null;
   });

--- a/server/services/issueReconcile.test.js
+++ b/server/services/issueReconcile.test.js
@@ -367,6 +367,19 @@ describe('reconcile', () => {
       .toEqual(expect.arrayContaining(['--hostname', 'github.acme.example']));
   });
 
+  it('keys every periodic GitHub read by its repository selector', async () => {
+    mockGh({ issues: [], merged: [], open: [] });
+
+    const result = await gatherIssueState('/repo');
+
+    expect(result).not.toBeNull();
+    const periodicReads = execGh.mock.calls.filter(([argv]) => argv[0] === 'issue' || argv[0] === 'pr');
+    expect(periodicReads).toHaveLength(3);
+    for (const [, , options] of periodicReads) {
+      expect(options).toEqual({ backoffKey: 'github.com/atomantic/PortOS' });
+    }
+  });
+
   it('scans a custom-hostname self-hosted forge when the app pins workTracker (issue #3767)', async () => {
     // Neither `github.*` nor `gitlab.*` — no hostname heuristic can classify a
     // self-hosted forge, so the app's own pin is the only signal. Without the

--- a/server/services/prWatcher.js
+++ b/server/services/prWatcher.js
@@ -68,7 +68,11 @@ export async function getSelfLogin(host) {
   if (_selfLoginCache.has(host)) return _selfLoginCache.get(host);
   // `--hostname` is required: without it `gh api` targets github.com regardless
   // of cwd, resolving the wrong identity for an enterprise repo.
-  const login = await execGh(['api', 'user', '--hostname', host, '--jq', '.login']).catch((err) => {
+  const login = await execGh(
+    ['api', 'user', '--hostname', host, '--jq', '.login'],
+    undefined,
+    { backoffKey: host }
+  ).catch((err) => {
     // Log rather than swallow (#3358): without this a firewalled/unauthenticated
     // gh is indistinguishable from "this host has no login", and every self/others
     // gate silently stops firing with nothing in the log to explain it.
@@ -97,7 +101,11 @@ export function __resetSelfLoginCache() {
  * cwd-based auto-detection would resolve ambiguously. Returns null on failure.
  */
 async function getDefaultBranch(repoSpec) {
-  const name = await execGh(['repo', 'view', repoSpec, '--json', 'defaultBranchRef', '-q', '.defaultBranchRef.name'])
+  const name = await execGh(
+    ['repo', 'view', repoSpec, '--json', 'defaultBranchRef', '-q', '.defaultBranchRef.name'],
+    undefined,
+    { backoffKey: repoSpec }
+  )
     .catch((err) => {
       console.error(`❌ pr-watcher: could not resolve the default branch for ${repoSpec}: ${err.message}`);
       return null;
@@ -117,7 +125,7 @@ async function listOpenPullRequests(repoSpec, baseBranch) {
     '--base', baseBranch, '--state', 'open',
     '--limit', String(PR_LIST_LIMIT),
     '--json', 'number,title,author,url,createdAt,updatedAt,isDraft,headRefName,headRefOid,mergeStateStatus,statusCheckRollup'
-  ]).catch((err) => {
+  ], undefined, { backoffKey: repoSpec }).catch((err) => {
     console.error(`❌ pr-watcher: gh pr list failed for ${repoSpec}: ${err.message}`);
     return null;
   });
@@ -281,7 +289,7 @@ async function readPendingPullRequest(repoSpec, prNumber) {
   const raw = await execGh([
     'pr', 'view', String(prNumber), '--repo', repoSpec,
     '--json', 'state,mergeStateStatus,statusCheckRollup'
-  ]).catch(() => null);
+  ], undefined, { backoffKey: repoSpec }).catch(() => null);
   const parsed = raw === null ? null : safeJSONParse(raw, null);
   return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : null;
 }

--- a/server/services/prWatcher.test.js
+++ b/server/services/prWatcher.test.js
@@ -216,7 +216,7 @@ describe('merge-only PR watcher', () => {
     expect(execGhMock).toHaveBeenCalledWith([
       'pr', 'view', '88', '--repo', 'github.com/o/r',
       '--json', 'state,mergeStateStatus,statusCheckRollup'
-    ]);
+    ], undefined, { backoffKey: 'github.com/o/r' });
   });
 
   it.each([
@@ -369,7 +369,11 @@ describe('getSelfLogin', () => {
     expect(execGhMock).toHaveBeenCalledTimes(1);
     // --hostname is required: without it `gh api` hits github.com regardless of
     // cwd and would resolve the wrong identity on an enterprise repo.
-    expect(execGhMock).toHaveBeenCalledWith(['api', 'user', '--hostname', 'github.com', '--jq', '.login']);
+    expect(execGhMock).toHaveBeenCalledWith(
+      ['api', 'user', '--hostname', 'github.com', '--jq', '.login'],
+      undefined,
+      { backoffKey: 'github.com' }
+    );
   });
 
   it('caches each host independently — a different login per host', async () => {
@@ -451,6 +455,9 @@ describe('checkPullRequests trusted maintenance boundary', () => {
     expect((await checkPullRequests(app)).newPrs).toHaveLength(1);
     expect(execGhMock.mock.calls.filter(([a]) => a[0] === 'api').every(([a]) => a.includes('github.enterprise.example'))).toBe(true);
     expect(execGhMock.mock.calls.filter(([a]) => a.includes('--repo')).every(([a]) => a.includes('github.enterprise.example/example/project'))).toBe(true);
+    expect(execGhMock.mock.calls
+      .filter(([a]) => a[0] === 'repo' || (a[0] === 'pr' && a[1] === 'list'))
+      .every(([, , options]) => options?.backoffKey === 'github.enterprise.example/example/project')).toBe(true);
     forge([rawPr(10, 'collaborator')], { permission: 'read' });
     expect((await checkPullRequests(app)).newPrs).toEqual([]);
     execGhMock.mockImplementation(async args => args[0] === 'repo' ? 'main' : args[0] === 'pr' ? JSON.stringify([rawPr(10, 'collaborator')]) : Promise.reject(new Error('unavailable')));

--- a/server/services/updateChecker.js
+++ b/server/services/updateChecker.js
@@ -202,7 +202,15 @@ export async function checkForUpdate() {
     const state = await loadState();
     const currentVersion = await getCurrentVersion();
 
-    const raw = await execGh(['api', `repos/${UPSTREAM_OWNER}/${UPSTREAM_REPO}/releases/latest`]);
+    // `backoffKey` opts this periodic read into execGh's consecutive-failure
+    // backoff — the 30-min scheduler retries a failure on its very next tick
+    // with no cooldown of its own, which piled up alongside branch-reconcile's
+    // identical gap during a real `gh` blip (both logged the same incident).
+    const raw = await execGh(
+      ['api', `repos/${UPSTREAM_OWNER}/${UPSTREAM_REPO}/releases/latest`],
+      undefined,
+      { backoffKey: 'update-check' }
+    );
     let data;
     try { data = JSON.parse(raw); } catch { throw new Error(`Failed to parse GitHub release response: ${raw.slice(0, 200)}`); }
     const release = {

--- a/server/services/updateChecker.js
+++ b/server/services/updateChecker.js
@@ -196,20 +196,28 @@ export async function syncFork({ branch, remoteInfo } = {}) {
  * Always polls the upstream atomantic/PortOS releases so users running
  * from a fork still see upstream version availability. Pull/checkout
  * behavior is unchanged — update.sh still pulls from origin.
+ *
+ * @param {{ manual?: boolean }} [options] - `manual: true` (the `POST
+ *   /api/update/check` "check now" route) always makes a real attempt: a
+ *   user who explicitly asked for a check must never be silently swallowed
+ *   by the background scheduler's backoff cooldown from an earlier failure
+ *   it hit on its own. Only the unattended 30-min scheduler tick opts into
+ *   that backoff.
  */
-export async function checkForUpdate() {
+export async function checkForUpdate({ manual = false } = {}) {
   return withLock(async () => {
     const state = await loadState();
     const currentVersion = await getCurrentVersion();
 
-    // `backoffKey` opts this periodic read into execGh's consecutive-failure
-    // backoff — the 30-min scheduler retries a failure on its very next tick
-    // with no cooldown of its own, which piled up alongside branch-reconcile's
-    // identical gap during a real `gh` blip (both logged the same incident).
+    // `backoffKey` opts the unattended periodic read into execGh's
+    // consecutive-failure backoff — the 30-min scheduler retries a failure
+    // on its very next tick with no cooldown of its own, which piled up
+    // alongside branch-reconcile's identical gap during a real `gh` blip
+    // (both logged the same incident).
     const raw = await execGh(
       ['api', `repos/${UPSTREAM_OWNER}/${UPSTREAM_REPO}/releases/latest`],
       undefined,
-      { backoffKey: 'update-check' }
+      manual ? {} : { backoffKey: 'update-check' }
     );
     let data;
     try { data = JSON.parse(raw); } catch { throw new Error(`Failed to parse GitHub release response: ${raw.slice(0, 200)}`); }

--- a/server/services/updateChecker.test.js
+++ b/server/services/updateChecker.test.js
@@ -289,6 +289,29 @@ describe('checkForUpdate', () => {
     expect(result.latestRelease.version).toBe('1.27.0');
   });
 
+  it('opts the release-check read into execGh\'s consecutive-failure backoff', async () => {
+    readJSONFile
+      .mockResolvedValueOnce({
+        lastCheck: null,
+        latestRelease: null,
+        ignoredVersions: [],
+        updateInProgress: false,
+        lastUpdateResult: null
+      })
+      .mockResolvedValueOnce({ version: '1.26.0' });
+    execGh.mockResolvedValue(JSON.stringify({ tag_name: 'v1.27.0' }));
+
+    await checkForUpdate();
+    // The scheduler retries a failed check on its next 30-min tick with no
+    // cooldown of its own — the actual backoff mechanics live in execGh
+    // itself (github.js, mocked wholesale here); see github.test.js.
+    expect(execGh).toHaveBeenCalledWith(
+      ['api', 'repos/atomantic/PortOS/releases/latest'],
+      undefined,
+      { backoffKey: 'update-check' }
+    );
+  });
+
   it('should not detect update when versions match', async () => {
     readJSONFile
       .mockResolvedValueOnce({

--- a/server/services/updateChecker.test.js
+++ b/server/services/updateChecker.test.js
@@ -312,6 +312,29 @@ describe('checkForUpdate', () => {
     );
   });
 
+  it('bypasses the backoff for a manual "check now" request', async () => {
+    readJSONFile
+      .mockResolvedValueOnce({
+        lastCheck: null,
+        latestRelease: null,
+        ignoredVersions: [],
+        updateInProgress: false,
+        lastUpdateResult: null
+      })
+      .mockResolvedValueOnce({ version: '1.26.0' });
+    execGh.mockResolvedValue(JSON.stringify({ tag_name: 'v1.27.0' }));
+
+    // A user who explicitly asked for a check must always get a real
+    // attempt, not a silent rejection from a cooldown the unattended
+    // scheduler armed on its own after an earlier failure.
+    await checkForUpdate({ manual: true });
+    expect(execGh).toHaveBeenCalledWith(
+      ['api', 'repos/atomantic/PortOS/releases/latest'],
+      undefined,
+      {}
+    );
+  });
+
   it('should not detect update when versions match', async () => {
     readJSONFile
       .mockResolvedValueOnce({


### PR DESCRIPTION
## Summary
- apply consecutive-failure backoff to periodic GitHub read paths in PR, issue, blocked-issue, branch, and update reconciliation
- preserve explicit/manual update checks and mutating GitHub calls as immediate operations
- guard per-process backoff outcome settlement across child lifecycle events

Closes #6343

## Validation
- `npm test -- services/github.test.js services/branchReconcile.test.js services/updateChecker.test.js services/prWatcher.test.js services/issueReconcile.test.js services/blockedIssueReconcile.test.js services/taskDataInputs.test.js` — 418 passed
- `npm test` — 39,846 passed, 35 skipped

## Review gate
- Required local `agy --effort medium` reviewer found and the fix was applied for one low-severity child lifecycle finding.
- Follow-up invocation timed out after 5 minutes without a verdict; review status is `review-blocked`. Per delivery policy this PR is left open for cold pickup and is not being merged.