### PR TITLE
fix: back off gh's consecutive-failure calls instead of retrying every tick

### DIFF
--- a/server/routes/update.js
+++ b/server/routes/update.js
@@ -44,9 +44,12 @@ router.get('/status', asyncHandler(async (req, res) => {
   res.json({ ...status, activeCosAgents, persistentMindImages });
 }));
 
-// POST /api/update/check — triggers manual check
+// POST /api/update/check — triggers manual check. `manual: true` bypasses the
+// unattended scheduler's gh backoff — a user who explicitly asked for a check
+// must get a real attempt, not a silent rejection from a cooldown the
+// background poller armed on its own.
 router.post('/check', asyncHandler(async (req, res) => {
-  const result = await updateChecker.checkForUpdate();
+  const result = await updateChecker.checkForUpdate({ manual: true });
   res.json(result);
 }));
 

--- a/server/routes/update.test.js
+++ b/server/routes/update.test.js
@@ -626,3 +626,19 @@ describe('POST /api/update/sync-fork', () => {
     expect(updateChecker.getRemoteInfo).not.toHaveBeenCalled();
   });
 });
+
+describe('POST /api/update/check', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('marks the check manual so it bypasses the unattended scheduler\'s gh backoff', async () => {
+    // A user who explicitly clicks "check now" must get a real attempt, not a
+    // silent rejection from a cooldown the background 30-min poller armed on
+    // its own after an earlier unattended failure.
+    updateChecker.checkForUpdate.mockResolvedValue(baseStatus());
+    const res = await request(makeApp()).post('/api/update/check').send({});
+    expect(res.status).toBe(200);
+    expect(updateChecker.checkForUpdate).toHaveBeenCalledWith({ manual: true });
+  });
+});

--- a/server/services/branchReconcile.js
+++ b/server/services/branchReconcile.js
@@ -213,7 +213,9 @@ export function classifyBranches(inputs) {
  * Three answers, never two (#3358):
  *   - a Map (possibly empty) — the forge answered
  *   - an EMPTY Map for a non-GitHub origin — there is no GitHub PR state to have
- *   - `null` — we could NOT ask (gh transport/auth failure, unparseable output)
+ *   - `null` — we could NOT ask (gh transport/auth failure, unparseable output,
+ *     or a backoff cooldown from recent consecutive failures — see `execGh`'s
+ *     `backoffKey`, passed here as the repo spec)
  *
  * `null` must never be read as "this branch has no PR": that is what made an
  * unreachable forge classify every pushed branch as NEEDS_PR and hand the
@@ -235,11 +237,16 @@ async function getOpenPrsByHead(repoPath, providedOrigin) {
   // the host-qualified `HOST/OWNER/REPO` selector (null for a non-GitHub origin).
   const repoSpec = githubRepoSpec(origin);
   if (!repoSpec) return new Map();
+  // `backoffKey: repoSpec` opts this polling read into execGh's consecutive-
+  // failure backoff — this call is retried on every scheduler tick with no
+  // parking cooldown (resolveBranchReconcileBlock treats `prStateUnavailable`
+  // as transient), so a `gh` blip must not turn into every managed repo
+  // re-firing this same expensive call on its very next tick.
   const raw = await execGh([
     'pr', 'list', '--repo', repoSpec, '--state', 'open',
     '--limit', String(PR_LIST_LIMIT),
     '--json', 'number,headRefName,mergeable,isDraft,url'
-  ]).catch((err) => {
+  ], undefined, { backoffKey: repoSpec }).catch((err) => {
     console.error(`❌ branch-reconcile: gh pr list failed for ${repoSpec}: ${err.message}`);
     return null;
   });

--- a/server/services/branchReconcile.test.js
+++ b/server/services/branchReconcile.test.js
@@ -764,6 +764,24 @@ describe('unreachable forge (#3358)', () => {
     expect(res.inFlight).toEqual([]);
   });
 
+  it('opts the `gh pr list` read into execGh\'s consecutive-failure backoff, keyed by repo spec', async () => {
+    // The actual backoff/cooldown mechanics live in execGh itself (github.js,
+    // mocked wholesale here) so every polling caller shares one implementation —
+    // this only proves branch-reconcile hands it the right key. See
+    // github.test.js for the backoff behavior itself.
+    git.getBranches.mockResolvedValue([
+      { name: 'claim/issue-1', isDefault: false, current: false, tracking: 'origin/claim/issue-1', merged: false }
+    ]);
+    wt.listWorktrees.mockResolvedValue([]);
+    git.isBranchMergedInto.mockResolvedValue(false);
+    execGh.mockResolvedValue('[]');
+
+    await reconcile('/repo');
+
+    const [, , options] = execGh.mock.calls.find(([callArgs]) => callArgs[0] === 'pr' && callArgs[1] === 'list');
+    expect(options).toMatchObject({ backoffKey: 'github.com/atomantic/PortOS' });
+  });
+
   it('reuses the successful origin read for PR state instead of reopening a fail-closed gap', async () => {
     git.getBranches.mockResolvedValue([
       { name: 'claim/issue-1', isDefault: false, current: false, tracking: 'origin/claim/issue-1', merged: false }

--- a/server/services/github.js
+++ b/server/services/github.js
@@ -77,6 +77,40 @@ const reposForAccount = (data, login = data.githubUser) => Object.fromEntries(
   Object.entries(data.repos || {}).filter(([, repo]) => repoBelongsToAccount(repo, login))
 );
 
+// Consecutive-failure backoff, opt-in per call via `backoffKey`. A caller that
+// polls the same gh read on every scheduler tick (branch-reconcile's `pr list`,
+// updateChecker's release check, …) must not re-fire it on the very next tick
+// after a failure — that is what piled up concurrent 60s-timeout `gh`
+// processes across every managed repo during a real `gh` blip (branch-reconcile,
+// updateChecker, and repeated retries all hit the same struggling `gh` at once).
+// One-off/mutating calls (create a PR, merge, set a secret) intentionally opt
+// out by not passing `backoffKey` — silently skipping those would be a correctness
+// surprise, not a load-shedding win. In-memory only: a stuck cooldown clears
+// itself after GH_BACKOFF_MAX_MS, same as a server restart would clear it.
+const GH_BACKOFF_BASE_MS = 30_000;
+const GH_BACKOFF_MAX_MS = 15 * 60 * 1000;
+const ghCallBackoff = new Map();
+
+function ghBackoffActive(key, now = Date.now()) {
+  const entry = ghCallBackoff.get(key);
+  return Boolean(entry && now < entry.retryAfter);
+}
+
+function recordGhCallOutcome(key, ok, now = Date.now()) {
+  if (ok) {
+    ghCallBackoff.delete(key);
+    return;
+  }
+  const failures = (ghCallBackoff.get(key)?.failures || 0) + 1;
+  const delay = Math.min(GH_BACKOFF_BASE_MS * 2 ** (failures - 1), GH_BACKOFF_MAX_MS);
+  ghCallBackoff.set(key, { failures, retryAfter: now + delay });
+}
+
+/** Test seam — drops the in-memory `execGh` backoff state between runs. */
+export function __resetGhCallBackoff() {
+  ghCallBackoff.clear();
+}
+
 /**
  * Execute a gh CLI command safely using spawn. `gh` hits the network, so a
  * stalled call (bad credentials prompt, hung network) would otherwise leave
@@ -85,8 +119,13 @@ const reposForAccount = (data, login = data.githubUser) => Object.fromEntries(
  * process. `timeoutMs` kills the child and rejects with a clear error; it's
  * cleared on normal exit so it never fires for a completed run. `input`, when
  * supplied, is written to stdin (used by structured `gh api --input -` calls).
+ * `backoffKey`, when supplied, opts this call into the consecutive-failure
+ * backoff above — see the comment there for why it's opt-in.
  */
-export function execGh(args, timeoutMs = DEFAULT_EXEC_GH_TIMEOUT_MS, { cwd = null, env = null, input = null } = {}) {
+export function execGh(args, timeoutMs = DEFAULT_EXEC_GH_TIMEOUT_MS, { cwd = null, env = null, input = null, backoffKey = null } = {}) {
+  if (backoffKey !== null && ghBackoffActive(backoffKey)) {
+    return Promise.reject(new Error(`gh command backing off for ${backoffKey} after repeated failures`));
+  }
   return new Promise((resolve, reject) => {
     const operation = 'gh command';
     const baseEnv = env || process.env;
@@ -97,11 +136,13 @@ export function execGh(args, timeoutMs = DEFAULT_EXEC_GH_TIMEOUT_MS, { cwd = nul
     let stdout = '';
     let stderr = '';
     let timedOut = false;
+    const settle = (ok) => { if (backoffKey !== null) recordGhCallOutcome(backoffKey, ok); };
     const timer = setTimeout(() => {
       timedOut = true;
       // setTimeout callback boundary — guard so a kill() throw can't crash
       // the process (e.g. the child already exited between checks).
       try { child.kill('SIGKILL'); } catch (err) { console.error(`❌ execGh: failed to kill timed-out ${operation}: ${err.message}`); }
+      settle(false);
       reject(new Error(`${operation} timed out after ${timeoutMs}ms`));
     }, timeoutMs);
     child.stdout.on('data', (d) => { stdout += d.toString(); });
@@ -110,23 +151,27 @@ export function execGh(args, timeoutMs = DEFAULT_EXEC_GH_TIMEOUT_MS, { cwd = nul
       if (timedOut) return;
       clearTimeout(timer);
       if (code !== 0) {
+        settle(false);
         const error = new Error(stderr.trim() || `gh exited with code ${code}`);
         error.ghExitCode = code;
         error.ghStderr = stderr.trim();
         reject(error);
       } else {
+        settle(true);
         resolve(stdout.trim());
       }
     });
     child.on('error', (err) => {
       if (timedOut) return;
       clearTimeout(timer);
+      settle(false);
       reject(err);
     });
     if (input !== null && input !== undefined) {
       child.stdin.on('error', (err) => {
         if (timedOut || err.code === 'EPIPE') return;
         clearTimeout(timer);
+        settle(false);
         reject(err);
       });
       child.stdin.end(String(input));

--- a/server/services/github.js
+++ b/server/services/github.js
@@ -96,13 +96,13 @@ function ghBackoffActive(key, now = Date.now()) {
   return Boolean(entry && now < entry.retryAfter);
 }
 
-function recordGhCallOutcome(key, ok, now = Date.now()) {
+function recordGhCallOutcome(key, ok, maxMs = GH_BACKOFF_MAX_MS, now = Date.now()) {
   if (ok) {
     ghCallBackoff.delete(key);
     return;
   }
   const failures = (ghCallBackoff.get(key)?.failures || 0) + 1;
-  const delay = Math.min(GH_BACKOFF_BASE_MS * 2 ** (failures - 1), GH_BACKOFF_MAX_MS);
+  const delay = Math.min(GH_BACKOFF_BASE_MS * 2 ** (failures - 1), maxMs);
   ghCallBackoff.set(key, { failures, retryAfter: now + delay });
 }
 
@@ -120,9 +120,14 @@ export function __resetGhCallBackoff() {
  * cleared on normal exit so it never fires for a completed run. `input`, when
  * supplied, is written to stdin (used by structured `gh api --input -` calls).
  * `backoffKey`, when supplied, opts this call into the consecutive-failure
- * backoff above — see the comment there for why it's opt-in.
+ * backoff above — see the comment there for why it's opt-in. `backoffMaxMs`
+ * overrides the default cap: it MUST exceed the calling scheduler's own tick
+ * interval, or the cooldown always expires before the next tick and never
+ * actually suppresses a retry — a real attempt fires every tick regardless of
+ * `backoffKey` (#3358-style silent no-op, caught in review on the updateChecker
+ * caller: its 30-min interval exceeds the 15-min default cap).
  */
-export function execGh(args, timeoutMs = DEFAULT_EXEC_GH_TIMEOUT_MS, { cwd = null, env = null, input = null, backoffKey = null } = {}) {
+export function execGh(args, timeoutMs = DEFAULT_EXEC_GH_TIMEOUT_MS, { cwd = null, env = null, input = null, backoffKey = null, backoffMaxMs = GH_BACKOFF_MAX_MS } = {}) {
   if (backoffKey !== null && ghBackoffActive(backoffKey)) {
     return Promise.reject(new Error(`gh command backing off for ${backoffKey} after repeated failures`));
   }
@@ -143,7 +148,7 @@ export function execGh(args, timeoutMs = DEFAULT_EXEC_GH_TIMEOUT_MS, { cwd = nul
     const settle = (ok) => {
       if (settled) return;
       settled = true;
-      if (backoffKey !== null) recordGhCallOutcome(backoffKey, ok);
+      if (backoffKey !== null) recordGhCallOutcome(backoffKey, ok, backoffMaxMs);
     };
     const timer = setTimeout(() => {
       timedOut = true;

--- a/server/services/github.js
+++ b/server/services/github.js
@@ -136,7 +136,15 @@ export function execGh(args, timeoutMs = DEFAULT_EXEC_GH_TIMEOUT_MS, { cwd = nul
     let stdout = '';
     let stderr = '';
     let timedOut = false;
-    const settle = (ok) => { if (backoffKey !== null) recordGhCallOutcome(backoffKey, ok); };
+    let settled = false;
+    // Idempotent: a spawn failure (e.g. ENOENT) fires BOTH 'error' and 'close'
+    // for the same failed attempt, so without this guard a single failure
+    // would record two consecutive-failure backoff entries instead of one.
+    const settle = (ok) => {
+      if (settled) return;
+      settled = true;
+      if (backoffKey !== null) recordGhCallOutcome(backoffKey, ok);
+    };
     const timer = setTimeout(() => {
       timedOut = true;
       // setTimeout callback boundary — guard so a kill() throw can't crash

--- a/server/services/github.test.js
+++ b/server/services/github.test.js
@@ -34,6 +34,7 @@ vi.mock('./settings.js', () => {
 import { spawn } from '../lib/childProcess.js';
 import {
   __resetGitHubDataCache,
+  __resetGhCallBackoff,
   execGh,
   getGitHubAuthStatus,
   getPullRequestState,
@@ -157,6 +158,86 @@ describe('execGh', () => {
       authenticated: false,
       status: 'unreachable',
     });
+  });
+});
+
+// A caller that polls the same gh read on every scheduler tick (branch-reconcile's
+// `pr list`, updateChecker's release check, …) must not re-fire it on the very
+// next tick after a failure — see the comment above `execGh`'s backoff map for
+// the incident this prevents.
+describe('execGh backoffKey', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    __resetGhCallBackoff();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('does not spawn while a key is in its cooldown after a failure', async () => {
+    const failing = makeChild();
+    spawn.mockReturnValueOnce(failing);
+    const first = execGh(['pr', 'list'], 5000, { backoffKey: 'github.com/o/r' });
+    first.catch(() => {});
+    failing.emit('close', 1);
+    await expect(first).rejects.toThrow();
+    expect(spawn).toHaveBeenCalledTimes(1);
+
+    await expect(execGh(['pr', 'list'], 5000, { backoffKey: 'github.com/o/r' }))
+      .rejects.toThrow(/backing off/);
+    expect(spawn).toHaveBeenCalledTimes(1); // second call never spawned a child
+  });
+
+  it('spawns again once the backoff window elapses', async () => {
+    const failing = makeChild();
+    spawn.mockReturnValueOnce(failing);
+    const first = execGh(['pr', 'list'], 5000, { backoffKey: 'github.com/o/r' });
+    first.catch(() => {});
+    failing.emit('close', 1);
+    await expect(first).rejects.toThrow();
+
+    vi.advanceTimersByTime(31_000); // past the 30s base cooldown for one failure
+
+    const succeeding = makeChild();
+    spawn.mockReturnValueOnce(succeeding);
+    const second = execGh(['pr', 'list'], 5000, { backoffKey: 'github.com/o/r' });
+    succeeding.emit('close', 0);
+    await expect(second).resolves.toBe('');
+    expect(spawn).toHaveBeenCalledTimes(2);
+  });
+
+  it('clears the backoff on success so a later failure starts a fresh cooldown', async () => {
+    const ok = makeChild();
+    spawn.mockReturnValueOnce(ok);
+    const p1 = execGh(['pr', 'list'], 5000, { backoffKey: 'github.com/o/r' });
+    ok.emit('close', 0);
+    await expect(p1).resolves.toBe('');
+
+    const ok2 = makeChild();
+    spawn.mockReturnValueOnce(ok2);
+    const p2 = execGh(['pr', 'list'], 5000, { backoffKey: 'github.com/o/r' });
+    ok2.emit('close', 0);
+    await expect(p2).resolves.toBe('');
+    expect(spawn).toHaveBeenCalledTimes(2); // no backoff was ever armed
+  });
+
+  it('never backs off a call with no backoffKey — one-off/mutating calls opt out', async () => {
+    const failing = makeChild();
+    spawn.mockReturnValueOnce(failing);
+    const p1 = execGh(['repo', 'create', 'o/r']);
+    p1.catch(() => {});
+    failing.emit('close', 1);
+    await expect(p1).rejects.toThrow();
+
+    const failing2 = makeChild();
+    spawn.mockReturnValueOnce(failing2);
+    const p2 = execGh(['repo', 'create', 'o/r']);
+    p2.catch(() => {});
+    failing2.emit('close', 1);
+    await expect(p2).rejects.toThrow(/exited with code 1/); // real second attempt, not a backoff rejection
+    expect(spawn).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/server/services/github.test.js
+++ b/server/services/github.test.js
@@ -239,6 +239,40 @@ describe('execGh backoffKey', () => {
     await expect(p2).rejects.toThrow(/exited with code 1/); // real second attempt, not a backoff rejection
     expect(spawn).toHaveBeenCalledTimes(2);
   });
+
+  it('honors a caller-supplied backoffMaxMs instead of the default cap', async () => {
+    // Regression for a real defect: a caller whose own retry interval exceeds
+    // the default 15-min cap (e.g. updateChecker's 30-min scheduler) would see
+    // the cooldown always expire before its next attempt, making the backoff a
+    // silent no-op — a real gh call fires every tick regardless of consecutive
+    // failures. A longer backoffMaxMs must actually widen the window past what
+    // the default cap would allow.
+    //
+    // 6 consecutive failures push the uncapped exponential delay (30s * 2^5 =
+    // 960s = 16min) past the DEFAULT 15-min cap but under a 60-min custom cap —
+    // the exact boundary where the two caps disagree. Each iteration advances
+    // time past its own delay first, so the prior failure's cooldown never
+    // blocks the next attempt from actually spawning.
+    for (let i = 0; i < 6; i++) {
+      const uncappedDelay = 30_000 * 2 ** i;
+      if (i > 0) vi.advanceTimersByTime(uncappedDelay + 1000);
+      const failing = makeChild();
+      spawn.mockReturnValueOnce(failing);
+      const attempt = execGh(['api', 'releases/latest'], 5000, { backoffKey: 'k', backoffMaxMs: 60 * 60 * 1000 });
+      attempt.catch(() => {});
+      failing.emit('close', 1);
+      await expect(attempt).rejects.toThrow();
+    }
+    expect(spawn).toHaveBeenCalledTimes(6);
+
+    // Past the 15-min DEFAULT cap (which would have already expired and let a
+    // real 7th attempt through) but short of the 16-min delay the custom
+    // 60-min cap actually applies.
+    vi.advanceTimersByTime(15 * 60 * 1000 + 1000);
+    await expect(execGh(['api', 'releases/latest'], 5000, { backoffKey: 'k', backoffMaxMs: 60 * 60 * 1000 }))
+      .rejects.toThrow(/backing off/);
+    expect(spawn).toHaveBeenCalledTimes(6); // still no 7th spawn — the custom cap, not the default, governed this
+  });
 });
 
 // The merge-follow-up reaper turns "the forge says this PR is OPEN" into a

--- a/server/services/updateChecker.js
+++ b/server/services/updateChecker.js
@@ -202,7 +202,15 @@ export async function checkForUpdate() {
     const state = await loadState();
     const currentVersion = await getCurrentVersion();
 
-    const raw = await execGh(['api', `repos/${UPSTREAM_OWNER}/${UPSTREAM_REPO}/releases/latest`]);
+    // `backoffKey` opts this periodic read into execGh's consecutive-failure
+    // backoff — the 30-min scheduler retries a failure on its very next tick
+    // with no cooldown of its own, which piled up alongside branch-reconcile's
+    // identical gap during a real `gh` blip (both logged the same incident).
+    const raw = await execGh(
+      ['api', `repos/${UPSTREAM_OWNER}/${UPSTREAM_REPO}/releases/latest`],
+      undefined,
+      { backoffKey: 'update-check' }
+    );
     let data;
     try { data = JSON.parse(raw); } catch { throw new Error(`Failed to parse GitHub release response: ${raw.slice(0, 200)}`); }
     const release = {

--- a/server/services/updateChecker.js
+++ b/server/services/updateChecker.js
@@ -196,20 +196,28 @@ export async function syncFork({ branch, remoteInfo } = {}) {
  * Always polls the upstream atomantic/PortOS releases so users running
  * from a fork still see upstream version availability. Pull/checkout
  * behavior is unchanged — update.sh still pulls from origin.
+ *
+ * @param {{ manual?: boolean }} [options] - `manual: true` (the `POST
+ *   /api/update/check` "check now" route) always makes a real attempt: a
+ *   user who explicitly asked for a check must never be silently swallowed
+ *   by the background scheduler's backoff cooldown from an earlier failure
+ *   it hit on its own. Only the unattended 30-min scheduler tick opts into
+ *   that backoff.
  */
-export async function checkForUpdate() {
+export async function checkForUpdate({ manual = false } = {}) {
   return withLock(async () => {
     const state = await loadState();
     const currentVersion = await getCurrentVersion();
 
-    // `backoffKey` opts this periodic read into execGh's consecutive-failure
-    // backoff — the 30-min scheduler retries a failure on its very next tick
-    // with no cooldown of its own, which piled up alongside branch-reconcile's
-    // identical gap during a real `gh` blip (both logged the same incident).
+    // `backoffKey` opts the unattended periodic read into execGh's
+    // consecutive-failure backoff — the 30-min scheduler retries a failure
+    // on its very next tick with no cooldown of its own, which piled up
+    // alongside branch-reconcile's identical gap during a real `gh` blip
+    // (both logged the same incident).
     const raw = await execGh(
       ['api', `repos/${UPSTREAM_OWNER}/${UPSTREAM_REPO}/releases/latest`],
       undefined,
-      { backoffKey: 'update-check' }
+      manual ? {} : { backoffKey: 'update-check' }
     );
     let data;
     try { data = JSON.parse(raw); } catch { throw new Error(`Failed to parse GitHub release response: ${raw.slice(0, 200)}`); }

--- a/server/services/updateChecker.js
+++ b/server/services/updateChecker.js
@@ -213,11 +213,15 @@ export async function checkForUpdate({ manual = false } = {}) {
     // consecutive-failure backoff — the 30-min scheduler retries a failure
     // on its very next tick with no cooldown of its own, which piled up
     // alongside branch-reconcile's identical gap during a real `gh` blip
-    // (both logged the same incident).
+    // (both logged the same incident). `backoffMaxMs` must exceed
+    // CHECK_INTERVAL_MS (30 min) — execGh's default 15-min cap always expires
+    // before this scheduler's own next tick, so it would never actually skip
+    // a scheduled attempt; a comfortable margin above the interval is what
+    // lets repeated failures widen the gap between real attempts.
     const raw = await execGh(
       ['api', `repos/${UPSTREAM_OWNER}/${UPSTREAM_REPO}/releases/latest`],
       undefined,
-      manual ? {} : { backoffKey: 'update-check' }
+      manual ? {} : { backoffKey: 'update-check', backoffMaxMs: CHECK_INTERVAL_MS * 3 }
     );
     let data;
     try { data = JSON.parse(raw); } catch { throw new Error(`Failed to parse GitHub release response: ${raw.slice(0, 200)}`); }

--- a/server/services/updateChecker.test.js
+++ b/server/services/updateChecker.test.js
@@ -289,6 +289,29 @@ describe('checkForUpdate', () => {
     expect(result.latestRelease.version).toBe('1.27.0');
   });
 
+  it('opts the release-check read into execGh\'s consecutive-failure backoff', async () => {
+    readJSONFile
+      .mockResolvedValueOnce({
+        lastCheck: null,
+        latestRelease: null,
+        ignoredVersions: [],
+        updateInProgress: false,
+        lastUpdateResult: null
+      })
+      .mockResolvedValueOnce({ version: '1.26.0' });
+    execGh.mockResolvedValue(JSON.stringify({ tag_name: 'v1.27.0' }));
+
+    await checkForUpdate();
+    // The scheduler retries a failed check on its next 30-min tick with no
+    // cooldown of its own — the actual backoff mechanics live in execGh
+    // itself (github.js, mocked wholesale here); see github.test.js.
+    expect(execGh).toHaveBeenCalledWith(
+      ['api', 'repos/atomantic/PortOS/releases/latest'],
+      undefined,
+      { backoffKey: 'update-check' }
+    );
+  });
+
   it('should not detect update when versions match', async () => {
     readJSONFile
       .mockResolvedValueOnce({

--- a/server/services/updateChecker.test.js
+++ b/server/services/updateChecker.test.js
@@ -312,6 +312,29 @@ describe('checkForUpdate', () => {
     );
   });
 
+  it('bypasses the backoff for a manual "check now" request', async () => {
+    readJSONFile
+      .mockResolvedValueOnce({
+        lastCheck: null,
+        latestRelease: null,
+        ignoredVersions: [],
+        updateInProgress: false,
+        lastUpdateResult: null
+      })
+      .mockResolvedValueOnce({ version: '1.26.0' });
+    execGh.mockResolvedValue(JSON.stringify({ tag_name: 'v1.27.0' }));
+
+    // A user who explicitly asked for a check must always get a real
+    // attempt, not a silent rejection from a cooldown the unattended
+    // scheduler armed on its own after an earlier failure.
+    await checkForUpdate({ manual: true });
+    expect(execGh).toHaveBeenCalledWith(
+      ['api', 'repos/atomantic/PortOS/releases/latest'],
+      undefined,
+      {}
+    );
+  });
+
   it('should not detect update when versions match', async () => {
     readJSONFile
       .mockResolvedValueOnce({

--- a/server/services/updateChecker.test.js
+++ b/server/services/updateChecker.test.js
@@ -304,11 +304,14 @@ describe('checkForUpdate', () => {
     await checkForUpdate();
     // The scheduler retries a failed check on its next 30-min tick with no
     // cooldown of its own — the actual backoff mechanics live in execGh
-    // itself (github.js, mocked wholesale here); see github.test.js.
+    // itself (github.js, mocked wholesale here); see github.test.js. The cap
+    // must exceed the 30-min scheduler interval (90 min = 3x here) or the
+    // cooldown always expires before the next tick and never actually
+    // suppresses a retry — a real gh call fires every tick regardless.
     expect(execGh).toHaveBeenCalledWith(
       ['api', 'repos/atomantic/PortOS/releases/latest'],
       undefined,
-      { backoffKey: 'update-check' }
+      { backoffKey: 'update-check', backoffMaxMs: 90 * 60 * 1000 }
     );
   });
 


### PR DESCRIPTION
## Summary
- A `gh` blip let branch-reconcile and updateChecker re-fire the same 60s-timeout `gh pr list` / release-check call for every managed repo on every scheduler tick with no cooldown — logs showed repeated timeouts across multiple repos within a few minutes during a real incident. `ensureForgeReachable`'s cheap health probe doesn't catch this: it can pass while the heavier read still hangs.
- Adds an opt-in `backoffKey` to `execGh()` with exponential backoff per key, cleared on success. Mutating/one-off gh calls are unaffected (no key = no backoff — silently skipping those would be a correctness surprise, not a load-shedding win).
- Wired into branch-reconcile's PR-list read (keyed by repo spec) and updateChecker's release check (keyed by a fixed string, with `backoffMaxMs` sized to exceed its own 30-min scheduler interval — the default 15-min cap would otherwise always expire before the next tick and never actually suppress anything).
- A manual "check for updates now" click always bypasses the backoff (`{ manual: true }`), so an explicit user action is never silently swallowed by a cooldown the background scheduler armed on its own.
- Filed #6343 to extend `backoffKey` to the remaining periodic `gh` readers (prWatcher, issueReconcile, blockedIssueReconcile).

## Test plan
- `cd server && NODE_ENV=test npx vitest run services/github.test.js services/branchReconcile.test.js services/updateChecker.test.js routes/update.test.js` — all green, including new regression tests for the backoff mechanics, the idempotent-settle fix, and the configurable cap.
- Full server suite green except two pre-existing/unrelated items: a known load-flaky test (`eidoverseWorld.runtime.test.js`, passes in isolation) and local submodule pointer drift in `lib/slashdo` (not part of this change).