### PR TITLE
Fix confusing fleet-provider setup: self-host TUI path and repoint-in-place

### DIFF
--- a/client/src/components/providers/FleetHostSetup.jsx
+++ b/client/src/components/providers/FleetHostSetup.jsx
@@ -34,6 +34,18 @@ export default function FleetHostSetup({ compact = false, providers = [], onConf
     return peerHosts.filter((host) => (host?.serving || host?.enabled) && !isFleetHostConfigured(host, providers));
   }, [compact, peerHosts, providers]);
 
+  // Host setup only ever creates a Direct API provider on the host itself
+  // (fleetLlmHost.js `configure()`), never an OpenCode TUI one — and the
+  // peer-discovery cards above only ever surface OTHER instances, so a host
+  // machine that wants to also run OpenCode TUI against its own queue had no
+  // discoverable path to it. Reuse the same dedupe the peer cards use, keyed
+  // on this machine's own tailnet endpoint.
+  const selfNeedsProvider = useMemo(
+    () => compact && Boolean(status?.endpoint) && Boolean(status?.serving || status?.enabled)
+      && !isFleetHostConfigured({ endpoint: status.endpoint }, providers),
+    [compact, status, providers],
+  );
+
   const reveal = () => {
     setRevealing(true);
     revealFleetLlmHostKey({ silent: true }).then(({ apiKey }) => setKey(apiKey))
@@ -43,39 +55,29 @@ export default function FleetHostSetup({ compact = false, providers = [], onConf
   const actionClass = 'inline-flex items-center justify-center min-h-[40px] px-3 py-2 rounded-lg bg-port-accent text-white text-sm disabled:opacity-50';
   const title = status?.recommendation.title || 'Recommended model host setup';
   if (compact) {
-    if (unconfiguredPeerHosts.length > 0) {
+    if (selfNeedsProvider || unconfiguredPeerHosts.length > 0) {
       return (
         <div className="space-y-3" aria-label="Available model hosts">
+          {selfNeedsProvider && (
+            <HostCard
+              ariaLabel="This machine's model host"
+              headline="This machine is serving its own model host — add a provider for it?"
+              badge={`${status.serving ? 'Serving' : 'Enabled'} · ${status.model || 'Qwen3.8-27B'}`}
+              description="Host setup already created a Direct API provider. Add OpenCode TUI (or another one) on this same machine to use it for coding agents too."
+              href="/ai/fleet?fleetStep=client&selfHost=1"
+              actionClass={actionClass}
+            />
+          )}
           {unconfiguredPeerHosts.map((host) => (
-            <section
+            <HostCard
               key={host.peerId}
-              className="rounded-xl border border-port-accent/50 bg-port-card p-3 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between shadow-xs"
-              aria-label={`Available model host ${host.peerName}`}
-            >
-              <div className="min-w-0">
-                <div className="flex items-center gap-2 flex-wrap">
-                  <span className="flex h-2 w-2 rounded-full bg-port-success shrink-0" />
-                  <p className="text-sm font-medium text-white flex items-center gap-2 truncate">
-                    <Server size={16} className="text-port-accent shrink-0" />
-                    Available federated host: <span className="text-port-accent font-semibold">{host.peerName}</span>
-                  </p>
-                  <span className="text-[11px] px-1.5 py-0.5 rounded bg-port-success/20 text-port-success font-medium">
-                    {host.serving ? 'Serving' : 'Enabled'} · {host.model || 'Qwen3.8-27B'}
-                  </span>
-                </div>
-                <p className="text-xs text-gray-400 mt-1">
-                  Instance <strong className="text-gray-200">{host.peerName}</strong> is running a federated LLM host. Set it up as a provider on this machine?
-                </p>
-              </div>
-              <div className="flex items-center gap-2 shrink-0">
-                <Link
-                  to={`/ai/fleet?fleetStep=client&peerId=${encodeURIComponent(host.peerId)}`}
-                  className={actionClass}
-                >
-                  Set up as provider
-                </Link>
-              </div>
-            </section>
+              ariaLabel={`Available model host ${host.peerName}`}
+              headline={<>Available federated host: <span className="text-port-accent font-semibold">{host.peerName}</span></>}
+              badge={`${host.serving ? 'Serving' : 'Enabled'} · ${host.model || 'Qwen3.8-27B'}`}
+              description={<>Instance <strong className="text-gray-200">{host.peerName}</strong> is running a federated LLM host. Set it up as a provider on this machine?</>}
+              href={`/ai/fleet?fleetStep=client&peerId=${encodeURIComponent(host.peerId)}`}
+              actionClass={actionClass}
+            />
           ))}
         </div>
       );
@@ -112,7 +114,7 @@ export default function FleetHostSetup({ compact = false, providers = [], onConf
           </ul>
           {status.recommendation.supported && (
             <section className="rounded-lg border border-port-border p-3 space-y-3 text-sm">
-              <p>Reserve this GPU for Qwen. Setup reuses prepared weights, fills in missing runtime settings, keeps the container loaded, and creates a local API provider. A new install can download about 30 GB.</p>
+              <p>Reserve this GPU for Qwen. Setup reuses prepared weights, fills in missing runtime settings, keeps the container loaded, and creates a Direct API provider on this machine (not an OpenCode TUI one — add that separately below if you want coding agents on this same machine). A new install can download about 30 GB.</p>
               <p className="text-xs text-gray-400">One active generation across all clients; up to 16 requests wait for at most two minutes. Disconnecting cancels the request. Requests are held in memory and are not replayed after a restart. Other GPU models must be unloaded first. Setup disables competing local providers so they do not reload automatically.</p>
               <button type="button" disabled={installing || status.setupRunning} onClick={() => setInstalling(true)} className={actionClass}>
                 {status.serving ? 'Reapply recommended host setup' : 'Set up dedicated host · download if needed'}
@@ -125,6 +127,17 @@ export default function FleetHostSetup({ compact = false, providers = [], onConf
               {status.serving ? 'Ready for client connections.' : 'Configured; model is loading or unavailable. Refresh until all checks pass.'}
               <p className="mt-1 text-xs">{status.queue.active} generating · {status.queue.queued} queued · limit {status.queue.maxActive} active / {status.queue.maxQueued} waiting</p>
             </Banner>
+          )}
+          {status.hasApiKey && status.endpoint && (
+            <section className="space-y-2 text-sm">
+              <h3 className="font-medium">Use this host from this same machine</h3>
+              <p className="text-xs text-gray-400">
+                The Direct API provider above was created automatically. To also run OpenCode coding agents against this queue on this machine, add that provider explicitly — its endpoint and key are filled in for you.
+              </p>
+              <Link to="/ai/fleet?fleetStep=client&selfHost=1" className={actionClass}>
+                Set up OpenCode TUI on this machine
+              </Link>
+            </section>
           )}
           <section className="space-y-3 text-sm">
             <h3 className="font-medium">Connect another PortOS instance</h3>
@@ -152,5 +165,32 @@ export default function FleetHostSetup({ compact = false, providers = [], onConf
         description="Prepare missing weights (~30 GB on a fresh install), reserve the GPU and enable the shared API queue."
         doneText="Host configured. Check readiness while the model loads." />
     </div>
+  );
+}
+
+// Shared shape for the compact "here's an unconfigured host, add it as a
+// provider?" prompt — used for both this machine's own host and a discovered
+// peer's, which differ only in copy and link target.
+function HostCard({ ariaLabel, headline, badge, description, href, actionClass }) {
+  return (
+    <section
+      className="rounded-xl border border-port-accent/50 bg-port-card p-3 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between shadow-xs"
+      aria-label={ariaLabel}
+    >
+      <div className="min-w-0">
+        <div className="flex items-center gap-2 flex-wrap">
+          <span className="flex h-2 w-2 rounded-full bg-port-success shrink-0" />
+          <p className="text-sm font-medium text-white flex items-center gap-2 truncate">
+            <Server size={16} className="text-port-accent shrink-0" />
+            {headline}
+          </p>
+          <span className="text-[11px] px-1.5 py-0.5 rounded bg-port-success/20 text-port-success font-medium">{badge}</span>
+        </div>
+        <p className="text-xs text-gray-400 mt-1">{description}</p>
+      </div>
+      <div className="flex items-center gap-2 shrink-0">
+        <Link to={href} className={actionClass}>Set up as provider</Link>
+      </div>
+    </section>
   );
 }

--- a/client/src/components/providers/FleetHostSetup.jsx
+++ b/client/src/components/providers/FleetHostSetup.jsx
@@ -7,6 +7,15 @@ import { copyToClipboard } from '../../lib/clipboard';
 import { useAutoRefetch } from '../../hooks/useAutoRefetch';
 import RuntimeInstallModal from '../install/RuntimeInstallModal';
 import Banner from '../ui/Banner';
+import { PORTS } from '../../lib/ports.js';
+
+// A self-host provider (the auto-created Direct API one from `configure()` in
+// server/services/fleetLlmHost.js, and the OpenCode one from `?selfHost=1`)
+// is always wired to the loopback queue address, never `status.endpoint` (the
+// tailnet-facing address published for OTHER machines to connect to) — dedupe
+// against the address these providers actually use, or the "add a provider"
+// nudge below never clears even after the provider exists.
+const SELF_HOST_ENDPOINT = `http://127.0.0.1:${PORTS.FLEET_LLM}/v1`;
 
 export default function FleetHostSetup({ compact = false, providers = [], onConfigured }) {
   const [status, setStatus] = useState(null);
@@ -39,10 +48,10 @@ export default function FleetHostSetup({ compact = false, providers = [], onConf
   // peer-discovery cards above only ever surface OTHER instances, so a host
   // machine that wants to also run OpenCode TUI against its own queue had no
   // discoverable path to it. Reuse the same dedupe the peer cards use, keyed
-  // on this machine's own tailnet endpoint.
+  // on the loopback address self-host providers are actually wired to.
   const selfNeedsProvider = useMemo(
-    () => compact && Boolean(status?.endpoint) && Boolean(status?.serving || status?.enabled)
-      && !isFleetHostConfigured({ endpoint: status.endpoint }, providers),
+    () => compact && Boolean(status?.serving || status?.enabled)
+      && !isFleetHostConfigured({ endpoint: SELF_HOST_ENDPOINT }, providers),
     [compact, status, providers],
   );
 

--- a/client/src/components/providers/FleetHostSetup.test.jsx
+++ b/client/src/components/providers/FleetHostSetup.test.jsx
@@ -82,5 +82,31 @@ describe('dedicated model host setup', () => {
   expect(screen.queryByText(/Available federated host:/)).not.toBeInTheDocument();
   expect(screen.queryByRole('link', { name: 'Set up as provider' })).not.toBeInTheDocument();
  });
+
+ it('prompts to set up this machine itself when its own host is serving and unconfigured', async () => {
+  api.getFleetLlmHost.mockResolvedValue({ ...state, serving: true });
+  api.getFleetPeerHosts.mockResolvedValue({ hosts: [] });
+  render(<MemoryRouter><FleetHostSetup compact providers={[]} /></MemoryRouter>);
+  expect(await screen.findByText(/serving its own model host/)).toBeInTheDocument();
+  const setupLink = screen.getByRole('link', { name: 'Set up as provider' });
+  expect(setupLink).toHaveAttribute('href', '/ai/fleet?fleetStep=client&selfHost=1');
+ });
+
+ it('does not prompt for this machine when it already has a matching provider', async () => {
+  api.getFleetLlmHost.mockResolvedValue({ ...state, serving: true });
+  api.getFleetPeerHosts.mockResolvedValue({ hosts: [] });
+  const providers = [{ id: 'self-p1', endpoint: state.endpoint }];
+  render(<MemoryRouter><FleetHostSetup compact providers={providers} /></MemoryRouter>);
+  expect(await screen.findByText('Recommended model host setup')).toBeInTheDocument();
+  expect(screen.queryByText(/serving its own model host/)).not.toBeInTheDocument();
+ });
+
+ it('offers a one-click self-host OpenCode TUI setup on the full host panel', async () => {
+  api.getFleetLlmHost.mockResolvedValue(state);
+  api.getFleetPeerHosts.mockResolvedValue({ hosts: [] });
+  render(<MemoryRouter><FleetHostSetup /></MemoryRouter>);
+  const link = await screen.findByRole('link', { name: 'Set up OpenCode TUI on this machine' });
+  expect(link).toHaveAttribute('href', '/ai/fleet?fleetStep=client&selfHost=1');
+ });
 });
 

--- a/client/src/components/providers/FleetHostSetup.test.jsx
+++ b/client/src/components/providers/FleetHostSetup.test.jsx
@@ -95,7 +95,11 @@ describe('dedicated model host setup', () => {
  it('does not prompt for this machine when it already has a matching provider', async () => {
   api.getFleetLlmHost.mockResolvedValue({ ...state, serving: true });
   api.getFleetPeerHosts.mockResolvedValue({ hosts: [] });
-  const providers = [{ id: 'self-p1', endpoint: state.endpoint }];
+  // Self-host providers are wired to the loopback queue address (both the
+  // auto-created Direct API one and the `?selfHost=1` OpenCode one) — never
+  // to `state.endpoint`, which is the tailnet address published for OTHER
+  // machines to connect to.
+  const providers = [{ id: 'self-p1', endpoint: 'http://127.0.0.1:18022/v1' }];
   render(<MemoryRouter><FleetHostSetup compact providers={providers} /></MemoryRouter>);
   expect(await screen.findByText('Recommended model host setup')).toBeInTheDocument();
   expect(screen.queryByText(/serving its own model host/)).not.toBeInTheDocument();

--- a/client/src/components/providers/FleetProviderSetup.jsx
+++ b/client/src/components/providers/FleetProviderSetup.jsx
@@ -101,10 +101,33 @@ export default function FleetProviderSetup({ peers = [], onClose, onCreate, onCo
   );
   const endpoint = normalizeEndpoint(endpointInput);
 
+  const fetchKeyFor = async (peerId) => {
+    if (!peerId) return;
+    setFetchingKey(true);
+    setError('');
+    try {
+      const res = await revealFleetPeerHostKey(peerId, { silent: true });
+      if (res?.apiKey) {
+        setApiKey(res.apiKey);
+      } else {
+        setError('Host did not return an API key. Enter it manually.');
+      }
+    } catch (err) {
+      setError(err?.message || 'Could not retrieve API key from host. Enter it manually.');
+    } finally {
+      setFetchingKey(false);
+    }
+  };
+
+  // Selecting a known peer auto-fetches its key too — a user who only fills the
+  // pre-populated fields and clicks Create must not be stopped by a manual
+  // "Fetch API key" click they had no reason to expect: submit rejects a blank
+  // key, but nothing upstream of that prompts for it.
   const selectPeer = (peerId) => {
     setSelectedPeerId(peerId);
     const peer = availablePeers.find(({ id }) => id === peerId);
     setEndpointInput(peer ? endpointForPeer(peer) : '');
+    if (peerId) fetchKeyFor(peerId);
   };
 
   useEffect(() => {
@@ -113,23 +136,7 @@ export default function FleetProviderSetup({ peers = [], onClose, onCreate, onCo
     }
   }, [initialPeerId, availablePeers]);
 
-  const handleFetchKey = async () => {
-    if (!selectedPeerId) return;
-    setFetchingKey(true);
-    setError('');
-    try {
-      const res = await revealFleetPeerHostKey(selectedPeerId, { silent: true });
-      if (res?.apiKey) {
-        setApiKey(res.apiKey);
-      } else {
-        setError('Host did not return an API key. Enter it manually.');
-      }
-    } catch (err) {
-      setError(err?.message || 'Could not retrieve API key from host.');
-    } finally {
-      setFetchingKey(false);
-    }
-  };
+  const handleFetchKey = () => fetchKeyFor(selectedPeerId);
 
   const selectHarness = (next) => {
     setHarness(next);

--- a/client/src/components/providers/FleetProviderSetup.jsx
+++ b/client/src/components/providers/FleetProviderSetup.jsx
@@ -6,7 +6,7 @@ import FleetHostSetup from './FleetHostSetup';
 import useDrawerTab from '../../hooks/useDrawerTab';
 import { FormField } from '../ui/FormField';
 import Banner from '../ui/Banner';
-import { isApiProvider, isLocalEndpoint, isPrivateNetworkEndpoint, isTuiProvider, mergeProviderUpdate } from '../../utils/providers';
+import { commandBasename, isApiProvider, isLocalEndpoint, isPrivateNetworkEndpoint, isTuiProvider, mergeProviderUpdate } from '../../utils/providers';
 import { getFleetLlmHost, revealFleetLlmHostKey, revealFleetPeerHostKey } from '../../services/apiProviders';
 import { PORTS } from '../../lib/ports.js';
 
@@ -109,8 +109,15 @@ export default function FleetProviderSetup({ peers = [], providers = [], onClose
   // Repoint targets: providers a fleet endpoint can plausibly replace — an
   // existing OpenCode TUI or Direct API provider. Without this, the only way
   // to point an already-created provider at a fleet host was delete-and-recreate.
+  // A TUI provider must already be OpenCode (or have no command set yet) —
+  // `buildFleetProvider` always overwrites `command`/`args`/`envVars` with the
+  // OpenCode wiring, so repointing a Claude/Codex/Grok TUI provider here would
+  // silently convert it into an OpenCode one out from under the user.
   const repointCandidates = useMemo(
-    () => providers.filter((provider) => isTuiProvider(provider) || isApiProvider(provider)),
+    () => providers.filter((provider) => (
+      isApiProvider(provider)
+      || (isTuiProvider(provider) && (!provider.command || commandBasename(provider.command) === 'opencode'))
+    )),
     [providers],
   );
   const repointTarget = useMemo(
@@ -193,7 +200,15 @@ export default function FleetProviderSetup({ peers = [], providers = [], onClose
   const selectTarget = (id) => {
     setTargetProviderId(id);
     const target = providers.find((provider) => provider.id === id);
-    if (!target) return;
+    if (!target) {
+      // Back to "create a new provider" — undo whatever a previously
+      // selected target's type/name/model left behind, or the form keeps
+      // showing that provider's values with no visible reason why.
+      setHarness('tui');
+      setName('Fleet GPU · OpenCode TUI');
+      setModel(DEFAULT_MODEL);
+      return;
+    }
     setHarness(isTuiProvider(target) ? 'tui' : 'api');
     setName(target.name || name);
     if (target.defaultModel) setModel(target.defaultModel);

--- a/client/src/components/providers/FleetProviderSetup.jsx
+++ b/client/src/components/providers/FleetProviderSetup.jsx
@@ -6,8 +6,8 @@ import FleetHostSetup from './FleetHostSetup';
 import useDrawerTab from '../../hooks/useDrawerTab';
 import { FormField } from '../ui/FormField';
 import Banner from '../ui/Banner';
-import { isLocalEndpoint, isPrivateNetworkEndpoint } from '../../utils/providers';
-import { revealFleetPeerHostKey } from '../../services/apiProviders';
+import { isApiProvider, isLocalEndpoint, isPrivateNetworkEndpoint, isTuiProvider, mergeProviderUpdate } from '../../utils/providers';
+import { getFleetLlmHost, revealFleetLlmHostKey, revealFleetPeerHostKey } from '../../services/apiProviders';
 import { PORTS } from '../../lib/ports.js';
 
 const FLEET_TABS = [
@@ -82,11 +82,17 @@ export const buildFleetProvider = ({ name, endpoint, apiKey, model, harness }) =
   };
 };
 
-export default function FleetProviderSetup({ peers = [], onClose, onCreate, onConfigured }) {
+export default function FleetProviderSetup({ peers = [], providers = [], onClose, onCreate, onUpdate, onConfigured }) {
   const [searchParams] = useSearchParams();
   const initialPeerId = searchParams.get('peerId') || '';
+  // `?selfHost=1` is how the host's own status card (FleetHostSetup) links
+  // here: this machine already runs the queue, so skip peer discovery and
+  // prefill the loopback address host setup already wired the auto-created
+  // Direct API provider to, plus this machine's own key.
+  const selfHost = searchParams.get('selfHost') === '1';
   const [activeTab, setActiveTab] = useDrawerTab('fleetStep', 'architecture', FLEET_TAB_IDS);
   const [selectedPeerId, setSelectedPeerId] = useState(initialPeerId);
+  const [targetProviderId, setTargetProviderId] = useState('');
   const [endpointInput, setEndpointInput] = useState('');
   const [name, setName] = useState('Fleet GPU · OpenCode TUI');
   const [apiKey, setApiKey] = useState('');
@@ -94,10 +100,22 @@ export default function FleetProviderSetup({ peers = [], onClose, onCreate, onCo
   const [harness, setHarness] = useState('tui');
   const [saving, setSaving] = useState(false);
   const [fetchingKey, setFetchingKey] = useState(false);
+  const [selfHostLoading, setSelfHostLoading] = useState(false);
   const [error, setError] = useState('');
   const availablePeers = useMemo(
     () => peers.filter((peer) => peer?.enabled !== false && (peer?.host || peer?.address)),
     [peers],
+  );
+  // Repoint targets: providers a fleet endpoint can plausibly replace — an
+  // existing OpenCode TUI or Direct API provider. Without this, the only way
+  // to point an already-created provider at a fleet host was delete-and-recreate.
+  const repointCandidates = useMemo(
+    () => providers.filter((provider) => isTuiProvider(provider) || isApiProvider(provider)),
+    [providers],
+  );
+  const repointTarget = useMemo(
+    () => providers.find((provider) => provider.id === targetProviderId) || null,
+    [providers, targetProviderId],
   );
   const endpoint = normalizeEndpoint(endpointInput);
 
@@ -136,11 +154,49 @@ export default function FleetProviderSetup({ peers = [], onClose, onCreate, onCo
     }
   }, [initialPeerId, availablePeers]);
 
+  // Self-host: this machine already runs the queue on the loopback address
+  // host setup wired the auto-created Direct API provider to (see
+  // `configure()` in server/services/fleetLlmHost.js), so there is no peer to
+  // pick — fetch this machine's own key instead of asking for one by hand.
+  useEffect(() => {
+    if (!selfHost || endpointInput) return;
+    let cancelled = false;
+    setSelfHostLoading(true);
+    setError('');
+    Promise.all([
+      getFleetLlmHost({ silent: true }).catch(() => null),
+      revealFleetLlmHostKey({ silent: true }).catch(() => null),
+    ]).then(([status, keyRes]) => {
+      if (cancelled) return;
+      if (!status?.hasApiKey) {
+        setError('Complete Model host setup (the GPU host tab) on this machine first, then come back to connect it.');
+        return;
+      }
+      setEndpointInput(`http://127.0.0.1:${DEFAULT_PORT}/v1`);
+      if (status.model) setModel(status.model);
+      if (keyRes?.apiKey) setApiKey(keyRes.apiKey);
+      else setError('Could not read this host\'s API key. Enter it manually from the GPU host tab.');
+    }).finally(() => { if (!cancelled) setSelfHostLoading(false); });
+    return () => { cancelled = true; };
+  }, [selfHost, endpointInput]);
+
   const handleFetchKey = () => fetchKeyFor(selectedPeerId);
 
   const selectHarness = (next) => {
     setHarness(next);
-    setName(next === 'tui' ? 'Fleet GPU · OpenCode TUI' : 'Fleet GPU · API');
+    if (!targetProviderId) setName(next === 'tui' ? 'Fleet GPU · OpenCode TUI' : 'Fleet GPU · API');
+  };
+
+  // Repointing an existing provider locks the harness to its current type —
+  // an in-place update changes its endpoint/key/model, not what kind of
+  // provider it is.
+  const selectTarget = (id) => {
+    setTargetProviderId(id);
+    const target = providers.find((provider) => provider.id === id);
+    if (!target) return;
+    setHarness(isTuiProvider(target) ? 'tui' : 'api');
+    setName(target.name || name);
+    if (target.defaultModel) setModel(target.defaultModel);
   };
 
   const submit = (event) => {
@@ -148,16 +204,21 @@ export default function FleetProviderSetup({ peers = [], onClose, onCreate, onCo
     setError('');
     if (!name.trim()) return setError('Provider name is required.');
     if (!URL.canParse(endpoint)) return setError('Enter a full HTTP endpoint for the GPU host.');
-    if (isLocalEndpoint(endpoint) || !isPrivateNetworkEndpoint(endpoint)) {
+    if (!selfHost && (isLocalEndpoint(endpoint) || !isPrivateNetworkEndpoint(endpoint))) {
       return setError('Use a private LAN, MagicDNS, or Tailscale endpoint on another machine.');
     }
     if (!apiKey.trim()) return setError('The networked vLLM runtime must have an API key.');
     if (!model.trim()) return setError('Model id is required.');
 
     setSaving(true);
-    return onCreate(buildFleetProvider({ name, endpoint, apiKey, model, harness }))
+    // A partial update replaces whichever fields it names — merge rather than
+    // overwrite so an existing provider's unrelated env vars, models, and
+    // secret markers survive being repointed at a new fleet host.
+    const payload = mergeProviderUpdate(repointTarget, buildFleetProvider({ name, endpoint, apiKey, model, harness }));
+    const save = repointTarget ? onUpdate(repointTarget.id, payload) : onCreate(payload);
+    return save
       .then(onClose)
-      .catch((err) => setError(err?.message || 'Could not create the fleet provider.'))
+      .catch((err) => setError(err?.message || 'Could not save the fleet provider.'))
       .finally(() => setSaving(false));
   };
 
@@ -215,10 +276,31 @@ export default function FleetProviderSetup({ peers = [], onClose, onCreate, onCo
       {activeTab === 'client' && (
         <form onSubmit={submit} className="space-y-4">
           <Banner tone="info" icon={Network}>
-            Create this provider on each client PortOS instance. The saved endpoint and the spawned OpenCode harness will point at the same fleet host.
+            {selfHost
+              ? (selfHostLoading
+                ? 'Reading this machine\'s own model host endpoint and API key…'
+                : 'This machine already runs the queue — its endpoint and key are filled in below. Pick a provider to point at it, or create a new one.')
+              : 'Create this provider on each client PortOS instance. The saved endpoint and the spawned OpenCode harness will point at the same fleet host.'}
           </Banner>
 
-          {availablePeers.length > 0 && (
+          {repointCandidates.length > 0 && (
+            <FormField label="Provider" hint="Point an existing provider at this fleet host, or create a new one.">
+              <select
+                value={targetProviderId}
+                onChange={(event) => selectTarget(event.target.value)}
+                className="w-full px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white focus:border-port-accent focus:outline-hidden"
+              >
+                <option value="">Create a new provider</option>
+                {repointCandidates.map((provider) => (
+                  <option key={provider.id} value={provider.id}>
+                    {provider.name} ({isTuiProvider(provider) ? 'OpenCode TUI' : 'Direct API'})
+                  </option>
+                ))}
+              </select>
+            </FormField>
+          )}
+
+          {availablePeers.length > 0 && !selfHost && (
             <FormField label="Known PortOS peer">
               <select
                 value={selectedPeerId}
@@ -248,11 +330,15 @@ export default function FleetProviderSetup({ peers = [], onClose, onCreate, onCo
             />
           </FormField>
 
-          <FormField label="Harness">
+          <FormField
+            label="Harness"
+            hint={targetProviderId ? 'Locked to the selected provider\'s existing type.' : undefined}
+          >
             <select
               value={harness}
               onChange={(event) => selectHarness(event.target.value)}
-              className="w-full px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white focus:border-port-accent focus:outline-hidden"
+              disabled={Boolean(targetProviderId)}
+              className="w-full px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white focus:border-port-accent focus:outline-hidden disabled:opacity-50"
             >
               <option value="tui">OpenCode TUI — coding agents (recommended)</option>
               <option value="api">Direct API — text and thinking workflows</option>
@@ -307,10 +393,12 @@ export default function FleetProviderSetup({ peers = [], onClose, onCreate, onCo
             <Link to="/instances" className="text-sm text-port-accent hover:underline">Manage peers</Link>
             <button
               type="submit"
-              disabled={saving}
+              disabled={saving || selfHostLoading}
               className="px-4 py-2 rounded-lg bg-port-accent hover:bg-port-accent/80 text-white disabled:opacity-50"
             >
-              {saving ? 'Creating…' : 'Create fleet provider'}
+              {saving
+                ? (targetProviderId ? 'Updating…' : 'Creating…')
+                : (targetProviderId ? 'Update provider' : 'Create fleet provider')}
             </button>
           </div>
         </form>

--- a/client/src/components/providers/FleetProviderSetup.jsx
+++ b/client/src/components/providers/FleetProviderSetup.jsx
@@ -219,7 +219,11 @@ export default function FleetProviderSetup({ peers = [], providers = [], onClose
     setError('');
     if (!name.trim()) return setError('Provider name is required.');
     if (!URL.canParse(endpoint)) return setError('Enter a full HTTP endpoint for the GPU host.');
-    if (!selfHost && (isLocalEndpoint(endpoint) || !isPrivateNetworkEndpoint(endpoint))) {
+    // Self-host mode prefills the loopback address on purpose (it's this same
+    // machine) — but if the user then edits that field to something else, the
+    // normal "must be a private/remote endpoint" rule still applies rather
+    // than skipping validation for whatever they typed.
+    if (!(selfHost && isLocalEndpoint(endpoint)) && (isLocalEndpoint(endpoint) || !isPrivateNetworkEndpoint(endpoint))) {
       return setError('Use a private LAN, MagicDNS, or Tailscale endpoint on another machine.');
     }
     if (!apiKey.trim()) return setError('The networked vLLM runtime must have an API key.');

--- a/client/src/components/providers/FleetProviderSetup.test.jsx
+++ b/client/src/components/providers/FleetProviderSetup.test.jsx
@@ -10,6 +10,10 @@ const api = vi.hoisted(() => ({
 }));
 vi.mock('../../services/apiProviders', () => api);
 
+const existingProviders = [
+  { id: 'opencode-1', name: 'My OpenCode', type: 'tui', command: 'opencode', envVars: { OTHER_VAR: '1' }, models: ['old-model'] },
+];
+
 const peers = [
   { id: 'peer-1', name: 'Workstation GPU', host: 'workstation.tailnet.ts.net', enabled: true },
   { id: 'peer-2', name: 'MacBook', address: '192.168.1.50', enabled: true },
@@ -118,5 +122,66 @@ describe('FleetProviderSetup', () => {
         })
       );
     });
+  });
+
+  it('prefills this machine\'s own loopback endpoint and key in self-host mode', async () => {
+    api.getFleetLlmHost.mockResolvedValue({ hasApiKey: true, model: 'qwen3.8-27b' });
+    api.revealFleetLlmHostKey.mockResolvedValue({ apiKey: 'self-host-key-1234567890123456' });
+
+    render(
+      <MemoryRouter initialEntries={['/ai/fleet?fleetStep=client&selfHost=1']}>
+        <FleetProviderSetup onClose={() => {}} onCreate={vi.fn()} />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('GPU host endpoint').value).toBe('http://127.0.0.1:18022/v1');
+    });
+    expect(screen.getByPlaceholderText('Enter host API key').value).toBe('self-host-key-1234567890123456');
+  });
+
+  it('surfaces an error in self-host mode when the host has not been set up yet', async () => {
+    api.getFleetLlmHost.mockResolvedValue({ hasApiKey: false });
+
+    render(
+      <MemoryRouter initialEntries={['/ai/fleet?fleetStep=client&selfHost=1']}>
+        <FleetProviderSetup onClose={() => {}} onCreate={vi.fn()} />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/Complete Model host setup/)).toBeInTheDocument();
+  });
+
+  it('updates an existing provider in place instead of creating a new one when repointing', async () => {
+    const onUpdate = vi.fn().mockResolvedValue({});
+    const onCreate = vi.fn();
+    const onClose = vi.fn();
+
+    render(
+      <MemoryRouter initialEntries={['/ai/fleet?fleetStep=client&peerId=peer-1']}>
+        <FleetProviderSetup peers={peers} providers={existingProviders} onClose={onClose} onCreate={onCreate} onUpdate={onUpdate} />
+      </MemoryRouter>
+    );
+
+    fireEvent.change(await screen.findByLabelText('Provider'), { target: { value: 'opencode-1' } });
+    fireEvent.change(screen.getByPlaceholderText('Enter host API key'), { target: { value: 'repoint-key-at-least-24-characters' } });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Update provider' }));
+
+    await waitFor(() => {
+      expect(onUpdate).toHaveBeenCalledWith(
+        'opencode-1',
+        expect.objectContaining({
+          name: 'My OpenCode',
+          apiKey: 'repoint-key-at-least-24-characters',
+          type: 'tui',
+          // The provider's other env var and previously-served model survive
+          // the repoint instead of being clobbered by the fleet defaults.
+          envVars: expect.objectContaining({ OTHER_VAR: '1' }),
+          models: expect.arrayContaining(['old-model', 'qwen3.8-27b']),
+        })
+      );
+    });
+    expect(onCreate).not.toHaveBeenCalled();
   });
 });

--- a/client/src/components/providers/FleetProviderSetup.test.jsx
+++ b/client/src/components/providers/FleetProviderSetup.test.jsx
@@ -141,6 +141,29 @@ describe('FleetProviderSetup', () => {
     expect(screen.getByPlaceholderText('Enter host API key').value).toBe('self-host-key-1234567890123456');
   });
 
+  it('still validates the endpoint in self-host mode if the user edits it away from loopback', async () => {
+    api.getFleetLlmHost.mockResolvedValue({ hasApiKey: true, model: 'qwen3.8-27b' });
+    api.revealFleetLlmHostKey.mockResolvedValue({ apiKey: 'self-host-key-1234567890123456' });
+    const onCreate = vi.fn();
+
+    render(
+      <MemoryRouter initialEntries={['/ai/fleet?fleetStep=client&selfHost=1']}>
+        <FleetProviderSetup onClose={() => {}} onCreate={onCreate} />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('GPU host endpoint').value).toBe('http://127.0.0.1:18022/v1');
+    });
+    // The self-host bypass exists only for the prefilled loopback value — an
+    // edited-away public endpoint must still fail the private-network check.
+    fireEvent.change(screen.getByLabelText('GPU host endpoint'), { target: { value: 'http://example.com:18022/v1' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Create fleet provider' }));
+
+    expect(await screen.findByText(/private LAN, MagicDNS, or Tailscale endpoint/)).toBeInTheDocument();
+    expect(onCreate).not.toHaveBeenCalled();
+  });
+
   it('surfaces an error in self-host mode when the host has not been set up yet', async () => {
     api.getFleetLlmHost.mockResolvedValue({ hasApiKey: false });
 

--- a/client/src/components/providers/FleetProviderSetup.test.jsx
+++ b/client/src/components/providers/FleetProviderSetup.test.jsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
 import FleetProviderSetup from './FleetProviderSetup';
 
@@ -12,6 +12,7 @@ vi.mock('../../services/apiProviders', () => api);
 
 const existingProviders = [
   { id: 'opencode-1', name: 'My OpenCode', type: 'tui', command: 'opencode', envVars: { OTHER_VAR: '1' }, models: ['old-model'] },
+  { id: 'claude-tui-1', name: 'My Claude Code', type: 'tui', command: 'claude' },
 ];
 
 const peers = [
@@ -183,5 +184,36 @@ describe('FleetProviderSetup', () => {
       );
     });
     expect(onCreate).not.toHaveBeenCalled();
+  });
+
+  it('does not offer a non-OpenCode TUI provider as a repoint target', async () => {
+    render(
+      <MemoryRouter initialEntries={['/ai/fleet?fleetStep=client&peerId=peer-1']}>
+        <FleetProviderSetup peers={peers} providers={existingProviders} onClose={() => {}} onCreate={vi.fn()} onUpdate={vi.fn()} />
+      </MemoryRouter>
+    );
+
+    const providerSelect = await screen.findByLabelText('Provider');
+    // buildFleetProvider always overwrites command/args/envVars with the
+    // OpenCode wiring — repointing a Claude Code TUI provider here would
+    // silently convert it into an OpenCode one out from under the user.
+    expect(within(providerSelect).queryByText(/My Claude Code/)).not.toBeInTheDocument();
+    expect(within(providerSelect).getByText(/My OpenCode/)).toBeInTheDocument();
+  });
+
+  it('resets name/model/harness back to defaults when switching from a selected target back to "create a new provider"', async () => {
+    render(
+      <MemoryRouter initialEntries={['/ai/fleet?fleetStep=client&peerId=peer-1']}>
+        <FleetProviderSetup peers={peers} providers={existingProviders} onClose={() => {}} onCreate={vi.fn()} onUpdate={vi.fn()} />
+      </MemoryRouter>
+    );
+
+    const providerSelect = await screen.findByLabelText('Provider');
+    fireEvent.change(providerSelect, { target: { value: 'opencode-1' } });
+    expect(screen.getByDisplayValue('My OpenCode')).toBeInTheDocument();
+
+    fireEvent.change(providerSelect, { target: { value: '' } });
+    expect(screen.getByDisplayValue('Fleet GPU · OpenCode TUI')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('qwen3.8-27b')).toBeInTheDocument();
   });
 });

--- a/client/src/components/providers/FleetProviderSetup.test.jsx
+++ b/client/src/components/providers/FleetProviderSetup.test.jsx
@@ -34,6 +34,42 @@ describe('FleetProviderSetup', () => {
     expect(endpointInput.value).toBe('http://workstation.tailnet.ts.net:18022/v1');
   });
 
+  it('auto-fetches the API key as soon as a peer is selected from the URL, with no extra click', async () => {
+    api.revealFleetPeerHostKey.mockResolvedValue({ apiKey: 'auto-fetched-key-123456789012' });
+
+    render(
+      <MemoryRouter initialEntries={['/ai/fleet?fleetStep=client&peerId=peer-1']}>
+        <FleetProviderSetup peers={peers} onClose={() => {}} onCreate={vi.fn()} />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(api.revealFleetPeerHostKey).toHaveBeenCalledWith('peer-1', { silent: true });
+    });
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('Enter host API key').value).toBe('auto-fetched-key-123456789012');
+    });
+  });
+
+  it('auto-fetches the API key when a peer is chosen from the dropdown, not just from the URL', async () => {
+    api.revealFleetPeerHostKey.mockResolvedValue({ apiKey: 'dropdown-fetched-key-12345678' });
+
+    render(
+      <MemoryRouter initialEntries={['/ai/fleet?fleetStep=client']}>
+        <FleetProviderSetup peers={peers} onClose={() => {}} onCreate={vi.fn()} />
+      </MemoryRouter>
+    );
+
+    fireEvent.change(screen.getByLabelText('Known PortOS peer'), { target: { value: 'peer-2' } });
+
+    await waitFor(() => {
+      expect(api.revealFleetPeerHostKey).toHaveBeenCalledWith('peer-2', { silent: true });
+    });
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('Enter host API key').value).toBe('dropdown-fetched-key-12345678');
+    });
+  });
+
   it('fetches API key from host when clicked', async () => {
     api.revealFleetPeerHostKey.mockResolvedValue({ apiKey: 'host-secret-key-123456789012' });
 

--- a/client/src/pages/AIProviders.jsx
+++ b/client/src/pages/AIProviders.jsx
@@ -527,6 +527,15 @@ export default function AIProviders() {
     return created;
   };
 
+  // Repoints an existing provider at a fleet host in place, rather than
+  // leaving the user to create a duplicate and manually delete the old one.
+  const handleUpdateFleetProvider = async (id, patch) => {
+    const updated = await api.updateProvider(id, patch);
+    setProviders((current) => current.map((entry) => (entry.id === id ? updated : entry)));
+    toast.success(`${updated.name} is connected to the fleet GPU host`);
+    return updated;
+  };
+
   const handleAddAllSamples = async () => {
     if (addableSamples.length === 0) return;
 
@@ -1066,8 +1075,10 @@ export default function AIProviders() {
       {fleetSetupOpen && (
         <FleetProviderSetup
           peers={fleetPeers}
+          providers={providers}
           onClose={closeForm}
           onCreate={handleCreateFleetProvider}
+          onUpdate={handleUpdateFleetProvider}
           onConfigured={loadData}
         />
       )}

--- a/client/src/utils/providers.js
+++ b/client/src/utils/providers.js
@@ -1294,6 +1294,28 @@ export const mergeModelLists = (...lists) => {
 };
 
 /**
+ * Merge a partial-update payload onto an existing provider record in place, so
+ * repointing a provider at a new backend (e.g. a fleet host) doesn't clobber
+ * fields the payload didn't set out to change. A raw PATCH replaces whichever
+ * top-level keys it names wholesale — without this, pointing an OpenCode TUI
+ * provider at a new endpoint would silently drop its other env vars and reset
+ * its served-model history to just the one new model id.
+ *
+ * @param {object|null|undefined} target - the existing provider being updated
+ * @param {object} payload - field values about to be written; mutated in place
+ * @returns {object} payload
+ */
+export const mergeProviderUpdate = (target, payload) => {
+  if (!target) return payload;
+  if (payload.envVars) payload.envVars = { ...target.envVars, ...payload.envVars };
+  if (payload.secretEnvVars) {
+    payload.secretEnvVars = Array.from(new Set([...(target.secretEnvVars || []), ...payload.secretEnvVars]));
+  }
+  if (payload.models) payload.models = mergeModelLists(target.models, payload.models);
+  return payload;
+};
+
+/**
  * Display label for a model `<option>`: the id plus a "(32K ctx)" parenthetical
  * when the model's context window is known. The option's `value` stays the raw
  * id — only the label carries the annotation.

--- a/docs/features/fleet-llm-host.md
+++ b/docs/features/fleet-llm-host.md
@@ -55,7 +55,9 @@ Other existing PortOS paths remain useful, but solve different problems:
 
 Open **AI Providers → Model host setup → Host**. The banner is visible above the provider list and detects GPU/platform capabilities. On Windows/Linux with an RTX 3090 (24 GB), the recommended action prepares missing weights, preserves the prepared image by digest, selects DFlash 2 and prefix caching, and starts a persistent container. The recorded warm agent-prompt result was **105.3 tok/s**; this is a measured reference, not a speed guarantee for every prompt.
 
-Setup binds the underlying runtime to loopback `:18020` and exposes a bearer-authenticated queue on `:18022`. It creates a direct API provider and moves existing local vLLM providers (including OpenCode's baseURL) through the queue. Competing local LM Studio/Ollama/llama/SGLang/SlotStream providers are disabled; their configurations remain available. Unload other GPU models before starting. PortOS no longer enables the default local backend at boot while dedicated hosting is enabled.
+Setup binds the underlying runtime to loopback `:18020` and exposes a bearer-authenticated queue on `:18022`. It creates a **Direct API** provider — not an OpenCode TUI one — and moves existing local vLLM providers (including OpenCode's baseURL) through the queue. Competing local LM Studio/Ollama/llama/SGLang/SlotStream providers are disabled; their configurations remain available. Unload other GPU models before starting. PortOS no longer enables the default local backend at boot while dedicated hosting is enabled.
+
+Once the host is configured (`hasApiKey` and an endpoint are both present), the host panel itself offers **Set up OpenCode TUI on this machine** — the same "Connect client" walkthrough below, but pre-filled with this machine's own loopback endpoint and key, so running coding agents on the host machine doesn't require hand-copying its own credentials. The provider list on this page also surfaces this as an "add a provider" prompt when the host is serving and no matching provider exists yet.
 
 The status panel checks Docker, prepared weights/key, the loaded model, Tailscale and queue listener. Copy the endpoint and explicitly reveal/copy the key only when connecting a client. The key never appears in the status payload. Driver installation, Docker engine repair, Windows reboot and enabling Docker Desktop startup may still require host interaction. Setup enables the model distro in Docker Desktop, wakes it before retrying a failed WSL integration, and registers a Windows login task to restore PortOS and the prepared container. The login task waits for Docker, never downloads weights or generates tokens, and does nothing when the dedicated-host flag is disabled. Once Docker starts, the container's `unless-stopped` policy restores the model; PortOS restores the queue from its machine-local opt-in flag. Cold model initialization can take 5–7 minutes. Boot makes no generation requests.
 
@@ -77,8 +79,13 @@ On each client PortOS:
    `VLLM_API_KEY`, and keep the served model id in sync.
 4. Choose **OpenCode TUI** for CoS coding agents. Choose **Direct API** for
    PortOS text-generation calls that do not need a file/tool harness.
-5. Create the provider, refresh models, run the card test, then test one small
-   tool-using workspace before making it the default.
+5. Optionally point an existing provider at this host instead of creating a
+   new one: pick it from the **Provider** dropdown (candidates are existing
+   OpenCode TUI and Direct API providers). Its harness type is locked, but its
+   endpoint, key, and model are updated in place — its other env vars and
+   previously-served models are preserved rather than overwritten.
+6. Create (or update) the provider, refresh models, run the card test, then
+   test one small tool-using workspace before making it the default.
 
 OpenCode is the optimal coding harness for this vLLM server because it speaks
 the OpenAI-compatible protocol directly and preserves structured tool calls.


### PR DESCRIPTION
## Summary
- Host setup only ever created a Direct API provider on the host itself (never an OpenCode TUI one), and the peer-discovery cards on AI Providers only ever surfaced *other* PortOS instances — so a machine running its own fleet host had no discoverable way to add itself as a provider.
- The Connect Client wizard could only create brand-new providers, so pointing an existing OpenCode TUI or Direct API provider at a fleet host meant creating a duplicate and manually deleting the old one.
- Added a one-click "Set up as provider" / "Set up OpenCode TUI on this machine" path (`?selfHost=1`) that prefills this machine's own loopback endpoint and API key.
- The Connect Client tab can now repoint an existing OpenCode TUI or Direct API provider in place, merging (not clobbering) its other env vars, models, and secret markers. Repoint candidates are restricted to already-OpenCode TUI providers (or command-less ones) so a Claude/Codex/Grok TUI provider can't be silently converted.
- Fixed the "add a provider" self-host nudge comparing against the tailnet endpoint instead of the loopback address self-host providers actually use (it would never clear once configured).

## Test plan
- `npm test` (client workspace): 867 files / 10572 tests passing, including new coverage for the self-host prefill, repoint-in-place merge behavior, the OpenCode-only repoint filter, and the self-host dedupe fix.
- `npx biome lint` clean on all touched files.