### PR TITLE
surface per-app provider pins that silently override the task schedule

### DIFF
--- a/client/src/components/apps/tabs/AutomationTab.jsx
+++ b/client/src/components/apps/tabs/AutomationTab.jsx
@@ -1,13 +1,13 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useNavigate } from 'react-router';
-import { RefreshCw, Play, PauseCircle, Settings, ChevronDown, ChevronRight, Sparkles } from 'lucide-react';
+import { RefreshCw, Play, PauseCircle, Settings, ChevronDown, ChevronRight, Sparkles, AlertTriangle } from 'lucide-react';
 import toast from '../../ui/Toast';
 import BrailleSpinner from '../../BrailleSpinner';
 import CronInput from '../../CronInput';
 import ToggleSwitch from '../../ToggleSwitch';
 import AppProviderPin from '../../cos/AppProviderPin';
 import * as api from '../../../services/api';
-import { AGENT_OPTIONS, hasProviderPin, toggleAppMetadataOverride, agentOptionButtonClass } from '../../cos/constants';
+import { AGENT_OPTIONS, hasProviderPin, providerPinDivergesFromSchedule, toggleAppMetadataOverride, agentOptionButtonClass } from '../../cos/constants';
 import { isCronExpression, describeCron } from '../../../utils/cronHelpers';
 import { PROVIDER_TYPES, providerDisplayName } from '../../../utils/providers';
 import CustomTasksSection from './CustomTasksSection';
@@ -251,6 +251,12 @@ export default function AutomationTab({ appId, appName }) {
             const effectiveProviderName = override.providerId
               ? providerDisplayName(providers, override.providerId)
               : taskProviderName;
+            // Surfaced collapsed (not just inside Configure): an app-level pin
+            // silently wins over the Schedule pin at spawn (#4783), so a task
+            // schedule showing one provider while this app's override names a
+            // DIFFERENT one is exactly the "why did it run somewhere else"
+            // confusion a user hits with only the Schedule page open.
+            const providerDivergesFromSchedule = providerPinDivergesFromSchedule(override, globalConfig);
 
             return (
               <div key={taskType} className="bg-port-card border border-port-border rounded-lg p-3 space-y-2">
@@ -276,6 +282,15 @@ export default function AutomationTab({ appId, appName }) {
                   </span>
                   <div className="flex-1 min-w-0">
                     <span className="text-white font-mono text-xs">{taskType}</span>
+                    {providerDivergesFromSchedule && (
+                      <span
+                        className="inline-flex items-center gap-1 ml-2 text-port-warning"
+                        title={`Runs on ${effectiveProviderName} — the schedule's default is ${taskProviderName}, but this app's provider override wins`}
+                      >
+                        <AlertTriangle size={11} />
+                        <span className="text-[10px] uppercase tracking-wide">Provider override</span>
+                      </span>
+                    )}
                     <div className="text-xs text-gray-500">{effectiveLabel}{intervalSuffix}</div>
                   </div>
                   <button

--- a/client/src/components/apps/tabs/AutomationTab.test.jsx
+++ b/client/src/components/apps/tabs/AutomationTab.test.jsx
@@ -89,6 +89,27 @@ describe('AutomationTab per-app options', () => {
     expect(within(row).getByLabelText('Provider override')).toBeInTheDocument();
   });
 
+  it('flags a provider override that diverges from the schedule pin, collapsed', async () => {
+    // Schedule pins layered-intelligence to 'global-claude'; the app overrides
+    // it to a DIFFERENT provider — the exact silent-shadowing scenario #4783
+    // documents. Must be visible without expanding Configure.
+    await renderTab({ 'layered-intelligence': { providerId: 'claude-cli' } });
+    const row = rowFor('layered-intelligence');
+    expect(within(row).getByText('Provider override')).toBeInTheDocument();
+  });
+
+  it('does not flag an override that matches the schedule pin', async () => {
+    await renderTab({ 'layered-intelligence': { providerId: 'global-claude' } });
+    const row = rowFor('layered-intelligence');
+    expect(within(row).queryByText('Provider override')).toBeNull();
+  });
+
+  it('does not flag a task type with no app override', async () => {
+    await renderTab();
+    const row = rowFor('layered-intelligence');
+    expect(within(row).queryByText('Provider override')).toBeNull();
+  });
+
   it('changing the provider PATCHes updateAppTaskTypeOverride with providerId + cleared model', async () => {
     await renderTab();
     const row = rowFor('layered-intelligence');

--- a/client/src/components/cos/constants.js
+++ b/client/src/components/cos/constants.js
@@ -433,6 +433,18 @@ export function hasProviderPin(override) {
   return !!(override?.providerId || override?.model);
 }
 
+// Whether an app's per-task provider pin NAMES A DIFFERENT PROVIDER than the
+// task's own Schedule pin. The app pin always wins at spawn (#4783), so this is
+// the "silently overrides what the Schedule page shows" case worth flagging —
+// not merely "an override exists" (hasProviderPin above): an app pin that
+// happens to match the schedule, or a schedule with no pin of its own, isn't a
+// surprise. Both sides must actually name a provider; an unset schedule pin
+// (any override "diverges" from nothing) or an unset app pin (nothing to
+// diverge) are not divergence.
+export function providerPinDivergesFromSchedule(override, globalConfig) {
+  return !!(override?.providerId && globalConfig?.providerId && override.providerId !== globalConfig.providerId);
+}
+
 // Compute new taskMetadata after toggling a field in a per-app override.
 // Returns null when all overrides are cleared (inherit everything).
 // Enforces invariant: openPR implies useWorktree (turning on openPR forces

--- a/client/src/components/cos/constants.test.js
+++ b/client/src/components/cos/constants.test.js
@@ -20,7 +20,8 @@ import {
   healthIssueTone,
   fresherHealth,
   providerPinPatch,
-  hasProviderPin
+  hasProviderPin,
+  providerPinDivergesFromSchedule
 } from './constants';
 
 // These mirror the server's domainBudgets/domainAutonomy helpers so the UI's
@@ -330,6 +331,28 @@ describe('hasProviderPin', () => {
     expect(hasProviderPin({ model: 'opus' })).toBe(true);
     expect(hasProviderPin({ providerId: '', model: null })).toBe(false);
     expect(hasProviderPin(undefined)).toBe(false);
+  });
+});
+
+describe('providerPinDivergesFromSchedule', () => {
+  it('is true only when both sides name a provider AND they differ', () => {
+    expect(providerPinDivergesFromSchedule(
+      { providerId: 'claude-ollama-tui' }, { providerId: 'fleet-gpu---opencode-tui' }
+    )).toBe(true);
+  });
+
+  it('is false when the app pin matches the schedule pin', () => {
+    expect(providerPinDivergesFromSchedule({ providerId: 'claude-cli' }, { providerId: 'claude-cli' })).toBe(false);
+  });
+
+  it('is false when the app has no pin of its own', () => {
+    expect(providerPinDivergesFromSchedule({}, { providerId: 'claude-cli' })).toBe(false);
+    expect(providerPinDivergesFromSchedule(undefined, { providerId: 'claude-cli' })).toBe(false);
+  });
+
+  it('is false when the schedule has no pin to diverge from', () => {
+    expect(providerPinDivergesFromSchedule({ providerId: 'claude-cli' }, {})).toBe(false);
+    expect(providerPinDivergesFromSchedule({ providerId: 'claude-cli' }, undefined)).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary
- An app's per-task provider/model pin always wins over the global Task Schedule's pin at spawn time (#4783), but nothing showed a pin was even set unless you expanded that row's Configure panel.
- **layered-intelligence** is the concrete case: its global schedule pin points at the fleet GPU OpenCode provider, but a stale per-app pin (carried over from the old global-job migration) silently kept routing every run to the local Ollama provider instead, with no visible sign of the mismatch anywhere in the UI.
- Add a "Provider override" badge to the collapsed row in the app's Automation tab whenever the app's pin names a different provider than the schedule's own pin, so the divergence is visible at a glance.
- Extracted the check into a `providerPinDivergesFromSchedule` helper alongside the existing `hasProviderPin`/`providerPinPatch` pair so other surfaces can reuse it.

## Test plan
- `client/node_modules/.bin/vitest run src/components/apps/tabs/AutomationTab.test.jsx src/components/cos/constants.test.js` — 61/61 pass, including 4 new cases covering diverges/matches/no-override.
- `client/node_modules/.bin/biome lint --error-on-warnings` on all 4 changed files — clean.