### PR TITLE
feat: sync Artificial Analysis without a key prompt and auto-close the dialog

### DIFF
--- a/client/src/components/models/ModelComparison.jsx
+++ b/client/src/components/models/ModelComparison.jsx
@@ -305,6 +305,16 @@ export default function ModelComparison() {
       });
   };
 
+  // Dismissing the prompt discards the typed key. Without this it survives in
+  // state, and the next click of a button that no longer opens the dialog would
+  // silently sync — and re-save — the key the user just backed out of.
+  const closeSyncModal = () => {
+    setSyncModalOpen(false);
+    setSyncKey('');
+    setSyncError('');
+    setSyncStatus('');
+  };
+
   // A configured key makes the dialog a pure speed bump — sync straight away and
   // only prompt when there is nothing stored to sync with.
   const startSyncAA = () => {
@@ -659,7 +669,7 @@ export default function ModelComparison() {
           are the caller's. Without them the dialog renders transparent. */}
       <Modal
         open={syncModalOpen}
-        onClose={() => setSyncModalOpen(false)}
+        onClose={closeSyncModal}
         size="sm"
         ariaLabelledBy="aa-sync-title"
       >
@@ -695,7 +705,7 @@ export default function ModelComparison() {
             <button
               type="button"
               className="px-3 py-1.5 text-sm border border-port-border rounded-lg hover:bg-port-bg"
-              onClick={() => setSyncModalOpen(false)}
+              onClick={closeSyncModal}
               disabled={syncing}
             >
               Cancel

--- a/client/src/components/models/ModelComparison.jsx
+++ b/client/src/components/models/ModelComparison.jsx
@@ -31,6 +31,7 @@ import {
   syncArtificialAnalysis,
 } from '../../services/apiModelComparison';
 import Modal from '../ui/Modal';
+import toast from '../ui/Toast';
 import ComparisonResearch from './ComparisonResearch';
 import { EFFORT_LADDER, withEstimatedCosts } from '../../lib/effortCostEstimate';
 import { safeReadStorage, safeWriteStorage } from '../../lib/safeStorage';
@@ -284,17 +285,36 @@ export default function ModelComparison() {
     setSyncStatus('Connecting to Artificial Analysis and syncing models…');
     syncArtificialAnalysis({ ...(syncKey.trim() ? { apiKey: syncKey.trim() } : {}) }, { silent: true })
       .then(res => {
+        // The sync is done and the catalog is reloading behind it — the dialog
+        // has nothing left to ask for, so it closes itself and the result is
+        // reported as a toast instead of stranding the user on a dead modal.
         setSyncKey('');
-        setSyncStatus(`Sync successful! Updated ${res.observations} models (${res.total} total).`);
+        setSyncStatus('');
+        setSyncModalOpen(false);
+        toast.success(`Sync successful! Updated ${res.observations} models (${res.total} total).`);
         refreshView();
       })
       .catch(err => {
+        // A failed sync keeps the dialog open: a rejected key is re-entered here.
+        setSyncModalOpen(true);
         setSyncError(err.message || 'Sync failed.');
         setSyncStatus('');
       })
       .finally(() => {
         setSyncing(false);
       });
+  };
+
+  // A configured key makes the dialog a pure speed bump — sync straight away and
+  // only prompt when there is nothing stored to sync with.
+  const startSyncAA = () => {
+    if (catalog?.artificialAnalysisKeyConfigured) {
+      handleSyncAA();
+      return;
+    }
+    setSyncError('');
+    setSyncStatus('');
+    setSyncModalOpen(true);
   };
 
   if (!catalog) {
@@ -603,11 +623,12 @@ export default function ModelComparison() {
         <div className="flex flex-wrap gap-2">
           <button
             type="button"
-            className="inline-flex items-center gap-2 px-3 py-1.5 text-xs bg-port-card border border-port-border rounded-lg hover:border-port-accent transition-colors"
-            onClick={() => setSyncModalOpen(true)}
+            className="inline-flex items-center gap-2 px-3 py-1.5 text-xs bg-port-card border border-port-border rounded-lg hover:border-port-accent disabled:opacity-50 transition-colors"
+            onClick={startSyncAA}
+            disabled={syncing}
           >
-            <CloudDownload size={14} aria-hidden="true" className="text-port-accent-text" />
-            Sync from Artificial Analysis
+            <CloudDownload size={14} aria-hidden="true" className={`text-port-accent-text ${syncing ? 'animate-pulse' : ''}`} />
+            {syncing ? 'Syncing…' : 'Sync from Artificial Analysis'}
           </button>
           <button
             type="button"
@@ -648,7 +669,10 @@ export default function ModelComparison() {
           </h3>
           <p className="text-xs text-port-text-muted leading-relaxed">
             Fetch the latest benchmark evaluations, pricing, response times, and reasoning effort measurements from the
-            Artificial Analysis Free API. A key entered here is saved privately after authentication succeeds. Leave blank to reuse a configured key, or manage it in Settings → Credentials.
+            Artificial Analysis Free API. {catalog.artificialAnalysisKeyConfigured
+              ? 'The saved key did not work — enter a replacement below.'
+              : 'This install has no key yet, so enter one below.'} A key entered here is saved privately after
+            authentication succeeds, and later syncs run without asking. Manage it in Settings → Credentials.
           </p>
           <div className="space-y-1.5">
             <label htmlFor="aa-api-key" className="text-xs font-medium text-port-text-muted">
@@ -657,7 +681,7 @@ export default function ModelComparison() {
             <input
               id="aa-api-key"
               type="password"
-              placeholder="Leave blank to use your saved key"
+              placeholder="aa-…"
               aria-label="Artificial Analysis API Key"
               className="w-full bg-port-bg text-port-text border border-port-border rounded-lg p-2.5 text-sm font-mono"
               value={syncKey}
@@ -680,7 +704,7 @@ export default function ModelComparison() {
               type="button"
               className="px-4 py-1.5 text-sm bg-port-accent text-port-on-accent rounded-lg font-medium hover:opacity-90 disabled:opacity-50"
               onClick={handleSyncAA}
-              disabled={syncing}
+              disabled={syncing || (!syncKey.trim() && !catalog.artificialAnalysisKeyConfigured)}
             >
               {syncing ? 'Syncing…' : 'Start Sync'}
             </button>

--- a/client/src/components/models/ModelComparison.test.jsx
+++ b/client/src/components/models/ModelComparison.test.jsx
@@ -120,7 +120,7 @@ it('connects reasoning effort points with line and allows toggling line style an
   expect(screen.getByRole('button', { name: 'Toggle gpt-5.6-sol' })).toHaveAttribute('aria-pressed', 'true');
 });
 
-it('opens the Artificial Analysis sync modal and syncs observations', async () => {
+it('prompts for a key when none is stored and closes the modal once the sync lands', async () => {
   api.syncArtificialAnalysis.mockResolvedValue({ success: true, observations: 636, total: 636 });
 
   render(<MemoryRouter><ModelComparison /></MemoryRouter>);
@@ -128,12 +128,39 @@ it('opens the Artificial Analysis sync modal and syncs observations', async () =
 
   fireEvent.click(screen.getByRole('button', { name: /Sync from Artificial Analysis/i }));
   expect(screen.getByLabelText(/Artificial Analysis API Key/i)).toBeTruthy();
+  expect(screen.getByRole('button', { name: 'Start Sync' })).toBeDisabled();
 
   fireEvent.change(screen.getByLabelText(/Artificial Analysis API Key/i), { target: { value: 'test-key-123' } });
   fireEvent.click(screen.getByRole('button', { name: 'Start Sync' }));
 
-  await screen.findByText(/Sync successful! Updated 636 models/);
-  expect(api.syncArtificialAnalysis).toHaveBeenCalledWith({ apiKey: 'test-key-123' }, { silent: true });
+  await waitFor(() => expect(api.syncArtificialAnalysis).toHaveBeenCalledWith({ apiKey: 'test-key-123' }, { silent: true }));
+  await waitFor(() => expect(screen.queryByLabelText(/Artificial Analysis API Key/i)).toBeNull());
+});
+
+it('syncs straight away without a key prompt when one is already configured', async () => {
+  api.getModelComparison.mockResolvedValue({ schemaVersion: 1, observations: [observation], inventory: [], artificialAnalysisKeyConfigured: true });
+  api.syncArtificialAnalysis.mockResolvedValue({ success: true, observations: 636, total: 636 });
+
+  render(<MemoryRouter><ModelComparison /></MemoryRouter>);
+  await act(async () => {});
+
+  fireEvent.click(screen.getByRole('button', { name: /Sync from Artificial Analysis/i }));
+
+  await waitFor(() => expect(api.syncArtificialAnalysis).toHaveBeenCalledWith({}, { silent: true }));
+  expect(screen.queryByLabelText(/Artificial Analysis API Key/i)).toBeNull();
+});
+
+it('falls back to the key prompt when a sync with the stored key is rejected', async () => {
+  api.getModelComparison.mockResolvedValue({ schemaVersion: 1, observations: [observation], inventory: [], artificialAnalysisKeyConfigured: true });
+  api.syncArtificialAnalysis.mockRejectedValue(new Error('Artificial Analysis API failed (401): Unauthorized'));
+
+  render(<MemoryRouter><ModelComparison /></MemoryRouter>);
+  await act(async () => {});
+
+  fireEvent.click(screen.getByRole('button', { name: /Sync from Artificial Analysis/i }));
+
+  await screen.findByText(/Artificial Analysis API failed \(401\)/);
+  expect(screen.getByLabelText(/Artificial Analysis API Key/i)).toBeTruthy();
 });
 
 it('opens on a log cost axis and scopes the chart to the providers models', async () => {
@@ -349,13 +376,4 @@ it('keeps exact Zen IDs in available coverage and plots free prices without inve
   fireEvent.change(screen.getByLabelText('Y axis'), { target: { value: 'quality' } });
   expect(screen.queryByTestId('scatter-example-free')).toBeNull();
   expect(screen.getAllByText('Unknown').length).toBeGreaterThan(0);
-});
-
-it('syncs with the saved server key when the key input is blank', async () => {
-  api.syncArtificialAnalysis.mockResolvedValue({ success: true, observations: 1, total: 1 });
-  render(<MemoryRouter><ModelComparison /></MemoryRouter>);
-  fireEvent.click(await screen.findByRole('button', { name: /Sync from Artificial Analysis/i }));
-  fireEvent.click(screen.getByRole('button', { name: 'Start Sync' }));
-  await screen.findByText(/Sync successful!/);
-  expect(api.syncArtificialAnalysis).toHaveBeenCalledWith({}, { silent: true });
 });

--- a/client/src/components/models/ModelComparison.test.jsx
+++ b/client/src/components/models/ModelComparison.test.jsx
@@ -150,6 +150,19 @@ it('syncs straight away without a key prompt when one is already configured', as
   expect(screen.queryByLabelText(/Artificial Analysis API Key/i)).toBeNull();
 });
 
+it('discards a typed key when the prompt is cancelled', async () => {
+  render(<MemoryRouter><ModelComparison /></MemoryRouter>);
+  await act(async () => {});
+
+  fireEvent.click(screen.getByRole('button', { name: /Sync from Artificial Analysis/i }));
+  fireEvent.change(screen.getByLabelText(/Artificial Analysis API Key/i), { target: { value: 'abandoned-key' } });
+  fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+  fireEvent.click(screen.getByRole('button', { name: /Sync from Artificial Analysis/i }));
+  expect(screen.getByLabelText(/Artificial Analysis API Key/i)).toHaveValue('');
+  expect(api.syncArtificialAnalysis).not.toHaveBeenCalled();
+});
+
 it('falls back to the key prompt when a sync with the stored key is rejected', async () => {
   api.getModelComparison.mockResolvedValue({ schemaVersion: 1, observations: [observation], inventory: [], artificialAnalysisKeyConfigured: true });
   api.syncArtificialAnalysis.mockRejectedValue(new Error('Artificial Analysis API failed (401): Unauthorized'));

--- a/server/routes/modelComparison.js
+++ b/server/routes/modelComparison.js
@@ -2,7 +2,7 @@ import { Router } from 'express';
 import { asyncHandler, ServerError } from '../lib/errorHandler.js';
 import { validateRequest, modelComparisonImportSchema, modelComparisonDiscoverySchema, modelComparisonSyncSchema } from '../lib/validation.js';
 import { getModelComparison, importModelComparison } from '../services/modelComparison.js';
-import { syncArtificialAnalysisCatalog } from '../services/artificialAnalysis.js';
+import { hasArtificialAnalysisKey, syncArtificialAnalysisCatalog } from '../services/artificialAnalysis.js';
 import { canRefreshModels } from '../lib/aiToolkit/internal/modelFetchers.js';
 import { effortLevelsForProvider, filterSelectableModels } from '../lib/providerModels.js';
 import { providerCatalogSlugs } from '../lib/comparisonModelScope.js';
@@ -10,7 +10,9 @@ import { providerCatalogSlugs } from '../lib/comparisonModelScope.js';
 export function createModelComparisonRoutes(providerService) {
   const router = Router();
   router.get('/', asyncHandler(async (req, res) => {
-    const [catalog, { providers }] = await Promise.all([getModelComparison(), providerService.getAllProviders()]);
+    const [catalog, { providers }, artificialAnalysisKeyConfigured] = await Promise.all([
+      getModelComparison(), providerService.getAllProviders(), hasArtificialAnalysisKey(),
+    ]);
     const inventory = providers.filter(p => p.enabled !== false).map(p => ({
       id: p.id, name: p.name, type: p.type, canDiscover: canRefreshModels(p),
       models: filterSelectableModels(p.models).filter(m => typeof m === 'string' && m).map(model => ({
@@ -19,7 +21,11 @@ export function createModelComparisonRoutes(providerService) {
     }));
     // Benchmark rows the user can act on: the chart defaults to the models their
     // own providers can dispatch, with the rest of the index one click away.
-    res.json({ ...catalog, inventory, availableModels: [...providerCatalogSlugs(inventory)].sort() });
+    res.json({
+      ...catalog, inventory, availableModels: [...providerCatalogSlugs(inventory)].sort(),
+      // Presence only, never the key — the page skips its key prompt when set.
+      artificialAnalysisKeyConfigured,
+    });
   }));
   // Explicit read-only catalog discovery: no model inference or provider writes.
   router.post('/discover', asyncHandler(async (req, res) => {

--- a/server/routes/modelComparison.test.js
+++ b/server/routes/modelComparison.test.js
@@ -90,6 +90,19 @@ it('imports an observation when reasoning pricing is its only known metric', asy
   expect(stored).toEqual(row);
 });
 
+// The comparison page skips its key prompt on this flag, so presence has to be
+// reported — and the key itself must never ride along with it.
+it('reports Artificial Analysis key presence without exposing the key', async () => {
+  const { getSettings } = await import('../services/settings.js');
+  delete process.env.ARTIFICIAL_ANALYSIS_API_KEY;
+  expect((await request(app).get('/comparison')).body.artificialAnalysisKeyConfigured).toBe(false);
+
+  getSettings.mockResolvedValueOnce({ secrets: { artificialAnalysis: { apiKey: 'mock-stored-key' } } });
+  const configured = (await request(app).get('/comparison')).body;
+  expect(configured.artificialAnalysisKeyConfigured).toBe(true);
+  expect(JSON.stringify(configured)).not.toContain('mock-stored-key');
+});
+
 it('rejects sync-aa when no API key is provided and syncs successfully when mocked', async () => {
   delete process.env.ARTIFICIAL_ANALYSIS_API_KEY;
   const noKey = await request(app).post('/comparison/sync-aa').send({});

--- a/server/services/artificialAnalysis.js
+++ b/server/services/artificialAnalysis.js
@@ -201,9 +201,19 @@ export async function fetchAllArtificialAnalysisModels(apiKey) {
   return allModels;
 }
 
-export async function syncArtificialAnalysisCatalog({ apiKey } = {}) {
+// Presence only — never the value. The comparison page reads this to decide
+// whether the Sync button prompts for a key or just syncs with the stored one.
+export async function hasArtificialAnalysisKey() {
+  return Boolean(await resolveArtificialAnalysisKey());
+}
+
+async function resolveArtificialAnalysisKey(apiKey) {
   const settings = await getSettings();
-  const key = apiKey?.trim() || settings.secrets?.artificialAnalysis?.apiKey || process.env.ARTIFICIAL_ANALYSIS_API_KEY;
+  return apiKey?.trim() || settings.secrets?.artificialAnalysis?.apiKey || process.env.ARTIFICIAL_ANALYSIS_API_KEY || '';
+}
+
+export async function syncArtificialAnalysisCatalog({ apiKey } = {}) {
+  const key = await resolveArtificialAnalysisKey(apiKey);
   if (!key) {
     throw new ServerError('No Artificial Analysis API key provided or configured in ARTIFICIAL_ANALYSIS_API_KEY', { status: 400 });
   }


### PR DESCRIPTION
## Summary

Two friction points on **Models → Intelligence vs. cost per task**, both in the Artificial Analysis sync flow:

1. **The key dialog opened on every sync**, even on an install that already had a key saved — the field just said "leave blank to reuse your saved key," so the dialog was a pure speed bump.
2. **A successful sync left the dialog open**, with the result buried inside it, so the user had to dismiss a dead modal to get back to the chart.

Now the comparison catalog response carries `artificialAnalysisKeyConfigured` — presence only, never the key itself, matching the credential-registry convention of reporting source and presence and nothing else. The Sync button reads it and:

- **key stored** → syncs immediately, button shows `Syncing…`, result lands as a toast;
- **no key** → opens the prompt, whose copy now says so, with `Start Sync` disabled until something is typed;
- **stored key rejected** → reopens the prompt asking for a replacement, so a 401 is still recoverable without a trip to Settings.

Key resolution used to be an inline fallback chain inside `syncArtificialAnalysisCatalog`; it is now `resolveArtificialAnalysisKey()`, shared with the new presence check, so the flag can never report a key the sync wouldn't actually use.

A follow-on fix from the self-review: cancelling the prompt now discards the typed key. Without that it survived in component state, and on an install with a stored key — where the button no longer opens the dialog at all — the next click would have silently synced and re-saved the key the user had just backed out of.

## Test plan

Server (`server/routes/modelComparison.test.js`):
- `GET /comparison` reports `artificialAnalysisKeyConfigured: false` with no key, `true` with one in settings, and the key value never appears in the serialized response.

Client (`client/src/components/models/ModelComparison.test.jsx`):
- no stored key → prompt opens, `Start Sync` disabled until a key is typed, dialog closes once the sync resolves;
- stored key → syncs with `{}` and no prompt is rendered;
- stored key rejected → the prompt comes back carrying the error;
- cancelling the prompt discards the typed key and starts no sync.

The obsolete "blank field reuses the saved key" test was removed along with the behavior it pinned.

Full suites green: server 2006 files / 39,981 tests, client 872 files / 10,596 tests.