### PR TITLE
fix: separate Codex answers from echoed Mind instructions

### DIFF
--- a/server/services/persistentMindAdapter.js
+++ b/server/services/persistentMindAdapter.js
@@ -308,6 +308,10 @@ async function runPinnedPrompt({ provider, model, effort, prompt, screenshots = 
       if (signal?.aborted) interrupt();
     },
   }).then((result) => {
+    if (!result.text?.trim() || result.text.trimStart().startsWith('OpenAI Codex v')
+      || result.text.includes('\n# Response contract\n')) {
+      throw new Error('Persistent Mind received an empty response or CLI transcript instead of an assistant response');
+    }
     if (screenshots.length > 0) assertVisionRunUsedImages(result, provider);
     return result;
   }).finally(async () => {
@@ -420,6 +424,10 @@ export function createPersistentMindTurnAdapter() {
           }),
         );
         parsed = persistentMindResponseSchema.parse(parseLLMJSON(result.text));
+        if (parsed.toolCalls.some((call) => call.name === 'catalog-name')
+          || parsed.message === 'The conversational reply. Required for a human message; optional for a self-directed wake.') {
+          throw new Error('Persistent Mind received response-contract placeholders instead of an assistant response');
+        }
         // Persist before semantic tools can erase the history these candidates
         // preserve. Keep one bounded, deduplicated set across provider rounds.
         for (const candidate of parsed.memoryCandidates) {

--- a/server/services/persistentMindAdapter.test.js
+++ b/server/services/persistentMindAdapter.test.js
@@ -79,6 +79,28 @@ beforeEach(() => {
 });
 
 describe('persistent mind adapter', () => {
+  it.each([
+    'OpenAI Codex v1\nuser\n{"message":"example"}',
+    JSON.stringify({ toolCalls: [{ name: 'catalog-name', arguments: {} }], memoryCandidates: [{ content: 'Example memory' }] }),
+  ])('rejects prompt echoes before any side effects', async (text) => {
+    mock.runPrompt.mockResolvedValue({ text });
+    await expect(createPersistentMindTurnAdapter().run({
+      turnId: 'echo-turn', wake: { kind: 'self' }, ...profile,
+      signal: new AbortController().signal, context: { text: '# Context' },
+    })).rejects.toThrow(/instead of an assistant response/);
+    expect(mock.executeToolCall).not.toHaveBeenCalled();
+    expect(mock.executeTaskRequests).not.toHaveBeenCalled();
+    expect(mock.executeCallRequest).not.toHaveBeenCalled();
+    expect(mock.createPersistentMindMemoryFromCandidate).not.toHaveBeenCalled();
+    expect(mock.runPrompt).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(['', 'OpenAI Codex v1\nuser\nSummarize prior events'])('rejects unusable summaries', async (text) => {
+    mock.runPrompt.mockResolvedValue({ text });
+    await expect(createPersistentMindTurnAdapter().summarize({ events: [], ...profile }))
+      .rejects.toThrow(/instead of an assistant response/);
+  });
+
   it('prepares editable prompt and curated memory context without inference', async () => {
     const prepared = await createPersistentMindTurnAdapter().prepare({ profile });
     expect(prepared).toMatchObject({

--- a/server/services/promptRunner.js
+++ b/server/services/promptRunner.js
@@ -1367,9 +1367,13 @@ async function executeProviderRunOnce({
         // the response file the model was directed to write, falling back
         // to cleanTuiResponse on the screen scrape). Trust `result.text`
         // — the accumulated `text` here is the raw chrome-laden stream.
+        // Codex CLI likewise supplies stdout as its authoritative final text;
+        // its diagnostic stream includes prompt examples that are not answers.
         const finalText = effectiveProvider.type === PROVIDER_TYPES.TUI
           ? (typeof result?.text === 'string' ? result.text : '')
-          : text;
+          : effectiveProvider.type === PROVIDER_TYPES.CLI && typeof result?.text === 'string'
+            ? result.text
+            : text;
         // Report the provider that ACTUALLY ran. `effectiveProvider` reflects
         // createRun's proactive swap (when the requested provider was already
         // benched) — distinct from the retry-fallback path, which the outer

--- a/server/services/promptRunner.test.js
+++ b/server/services/promptRunner.test.js
@@ -117,6 +117,16 @@ describe('promptRunner — happy paths', () => {
     expect(runner.executeApiRun).not.toHaveBeenCalled();
   });
 
+  it('uses the CLI final response even when diagnostics contain valid prompt JSON', async () => {
+    runner.executeCliRun.mockImplementation(async ({ onData, onComplete }) => {
+      onData('OpenAI Codex v1\nuser\n{"message":"example"}\n');
+      onData('{"message":"actual answer"}');
+      onComplete({ success: true, text: '{"message":"actual answer"}' });
+    });
+    const out = await runPromptThroughProvider({ provider: cliProvider(), prompt: 'p', source: 'test' });
+    expect(JSON.parse(out.text)).toEqual({ message: 'actual answer' });
+  });
+
   it('forwards images through the ordinary Codex CLI lifecycle and rejects unsupported CLIs', async () => {
     const codex = cliProvider({ command: 'codex' });
     runner.executeCliRun.mockImplementation(async ({ screenshots, onComplete }) => {

--- a/server/services/runner.js
+++ b/server/services/runner.js
@@ -7,7 +7,7 @@ import { readFile } from 'fs/promises';
 import { join } from 'path';
 import { atomicWrite, ensureDir, tryReadFile, writeFileGuarded, PATHS } from '../lib/fileUtils.js';
 import { resolveSpawnCwd } from '../lib/spawnCwd.js';
-import { hasModelFlag, extractBakedModel } from '../lib/providerModels.js';
+import { hasModelFlag, extractBakedModel, isCodexProvider } from '../lib/providerModels.js';
 import { buildCliArgs, prepareCliPrompt } from '../lib/cliProviderArgs.js';
 import { buildCliChildEnv } from '../lib/cliChildEnv.js';
 import { createImmediateFallbackSignalDetector, ERROR_CATEGORIES } from '../lib/aiToolkit/errorDetection.js';
@@ -328,6 +328,10 @@ export async function executeCliRun({ runId, provider, prompt, workspacePath, sc
 
   const startTime = Date.now();
   let output = '';
+  // Codex writes its final answer to stdout; stderr is a diagnostic transcript
+  // containing the input prompt. Keep both in logs, but never parse stderr.
+  let assistantOutput = '';
+  const stdoutIsResponse = isCodexProvider(provider);
   let immediateFallbackAnalysis = null;
   let childProcess = null;
   // Set by the wall-clock timeout below so the close handler can classify the
@@ -470,6 +474,7 @@ export async function executeCliRun({ runId, provider, prompt, workspacePath, sc
   childProcess.stdout?.on('data', (data) => {
     const text = data.toString();
     output += text;
+    if (stdoutIsResponse) assistantOutput += text;
     onData?.(text);
     abortForImmediateFallbackSignal(text);
   });
@@ -573,7 +578,7 @@ export async function executeCliRun({ runId, provider, prompt, workspacePath, sc
       } else if (!canceled) {
         safeSettle(() => runnerConfig.hooks?.onRunFailed?.(metadata, metadata.error, output), `Run ${runId} onRunFailed hook`);
       }
-      safeSettle(() => onComplete?.(metadata), `Run ${runId} onComplete`);
+      safeSettle(() => onComplete?.(stdoutIsResponse && metadata.success ? { ...metadata, text: assistantOutput } : metadata), `Run ${runId} onComplete`);
       return metadata;
     } catch (err) {
       const handler = spawnError ? 'error' : 'close';

--- a/server/services/runner.test.js
+++ b/server/services/runner.test.js
@@ -354,6 +354,29 @@ describe('patchRunMetadata — serialized merges', () => {
   });
 });
 
+describe('executeCliRun — Codex response channel', () => {
+  it('returns only stdout while retaining diagnostic chunks for observers', async () => {
+    const child = makeChild();
+    spawn.mockReturnValue(child);
+    setAIToolkit(fakeToolkit(), { dataDir: '/tmp/test-runner' });
+    const onComplete = vi.fn();
+    const onData = vi.fn();
+    await executeCliRun({
+      runId: 'run-response-channel',
+      provider: { id: 'codex', command: 'codex', args: [], timeout: 5000 },
+      prompt: 'Return JSON', workspacePath: TEST_WORKSPACE, onData, onComplete,
+    });
+    child.stderr.emit('data', Buffer.from('OpenAI Codex v1\nuser\n{"message":"example"}\n'));
+    child.stdout.emit('data', Buffer.from('{"message":'));
+    child.stderr.emit('data', Buffer.from('tokens used\n20\n'));
+    child.stdout.emit('data', Buffer.from('"answer"}'));
+    child.emit('close', 0);
+    await flushMicrotasks();
+    expect(onComplete).toHaveBeenCalledWith(expect.objectContaining({ success: true, text: '{"message":"answer"}' }));
+    expect(onData).toHaveBeenCalledTimes(4);
+  });
+});
+
 describe('executeCliRun — wall-clock timeout classification', () => {
   // The CLI runner kills its own child on timeout, so the close event carries
   // `exitCode: null` rather than the 124 finalizeRunRecord keys on. Without the


### PR DESCRIPTION
## Summary
Codex CLI diagnostics echo the input prompt. Combining stderr with stdout caused Persistent Mind to parse its response-contract example as an answer, repeatedly request nonexistent tools, save placeholder memories, and contaminate summaries.

Return Codex stdout as the authoritative completion while retaining both streams for diagnostics. The shared prompt runner honors that response, and Persistent Mind rejects empty output, echoed transcripts, and placeholder actions before saving memories or executing capabilities. Existing grants and provider choices remain intact.

## Test plan
- 213 passing tests across runner, promptRunner, and persistentMindAdapter.
- Regression coverage for interleaved stdout/stderr, authoritative completion selection, and rejection before tool, task, memory, or call effects.
- `git diff --check` passed.
