### PR TITLE
Rename Death Clock widget to Meatspace Time Remaining

### DIFF
--- a/client/src/components/DeathClockWidget.jsx
+++ b/client/src/components/DeathClockWidget.jsx
@@ -27,7 +27,7 @@ export default function DeathClockWidget() {
     >
       <div className="flex items-center gap-2 mb-3">
         <Skull size={16} className="text-gray-500" />
-        <h3 className="text-sm font-semibold text-white">Death Clock</h3>
+        <h3 className="text-sm font-semibold text-white">Meatspace Time Remaining</h3>
       </div>
       <DeathClockCountdown deathDate={deathData.deathDate} size="sm" />
       <div className="mt-2 flex justify-between text-xs">

--- a/client/src/components/dashboard/LayoutEditor.test.jsx
+++ b/client/src/components/dashboard/LayoutEditor.test.jsx
@@ -101,7 +101,7 @@ describe('LayoutEditor reorder signal', () => {
   it('does not flag a widget toggle as a reorder', async () => {
     const { onSave } = await renderEditor();
     fireEvent.click(within(widgetRows()[1]).getByLabelText('Remove widget'));
-    clickButton('Death Clock');
+    clickButton('Meatspace Time Remaining');
     await save();
     expect(onSave).toHaveBeenCalledWith(expect.objectContaining({
       widgets: ['quick-task', 'backup', 'death-clock'],
@@ -113,7 +113,7 @@ describe('LayoutEditor reorder signal', () => {
   // would otherwise auto-place it at the bottom, ignoring where it was put.
   it('flags a widget that was added and then moved up', async () => {
     const { onSave } = await renderEditor();
-    clickButton('Death Clock');
+    clickButton('Meatspace Time Remaining');
     moveUp(3);
     await save();
     expect(onSave).toHaveBeenCalledWith(expect.objectContaining({
@@ -124,7 +124,7 @@ describe('LayoutEditor reorder signal', () => {
 
   it('flags a swap between two widgets added in the same session', async () => {
     const { onSave } = await renderEditor();
-    clickButton('Death Clock');
+    clickButton('Meatspace Time Remaining');
     clickButton('Review Hub');
     moveUp(4);
     await save();
@@ -138,7 +138,7 @@ describe('LayoutEditor reorder signal', () => {
   // baseline has to come from the order the widgets were added in.
   it('flags a reorder in a layout that started empty', async () => {
     const { onSave } = await renderEditor({ id: 'blank', name: 'Blank', widgets: [], grid: [] });
-    clickButton('Death Clock');
+    clickButton('Meatspace Time Remaining');
     clickButton('Review Hub');
     moveUp(1);
     await save();

--- a/client/src/components/dashboard/widgetRegistry.jsx
+++ b/client/src/components/dashboard/widgetRegistry.jsx
@@ -65,7 +65,7 @@ export const WIDGETS = [
   { id: 'system-health',     label: 'System Health',         Component: SystemHealthWidget,     width: 'quarter', defaultH: 8 },
   { id: 'network-exposure',  label: 'Network Exposure',      Component: NetworkExposureWidget,  width: 'quarter', defaultH: 5 },
   { id: 'backup',            label: 'Backup',                Component: BackupWidget,           width: 'quarter', defaultH: 5 },
-  { id: 'death-clock',       label: 'Death Clock',           Component: DeathClockWidget,       width: 'quarter', defaultH: 4 },
+  { id: 'death-clock',       label: 'Meatspace Time Remaining', Component: DeathClockWidget,    width: 'quarter', defaultH: 4 },
   { id: 'daily-post',        label: 'Daily POST',            Component: DailyPostWidget,        width: 'quarter', defaultH: 3, gate: postFeatureEnabled },
   { id: 'tribe-care',        label: 'Tribe Care',            Component: TribeCareWidget,        width: 'quarter', defaultH: 4, gate: (s) => !!s.tribeCare?.hasPeople },
   { id: 'quick-stats',       label: 'Quick Stats',           Component: QuickStatsWidget,       width: 'quarter', defaultH: 3, gate: (s) => s.apps.length > 0 },

--- a/client/src/pages/Ambient.jsx
+++ b/client/src/pages/Ambient.jsx
@@ -142,7 +142,7 @@ export default function Ambient() {
             />
             {deathData.percentComplete != null && (
               <div className="text-xs text-gray-700 mt-1">
-                {deathData.percentComplete}% of life elapsed
+                {deathData.percentComplete}% of est. meatspace time elapsed
               </div>
             )}
           </div>


### PR DESCRIPTION
## Summary
- Renames the "Death Clock" dashboard widget title and layout-picker label to "Meatspace Time Remaining"
- Updates the Ambient dashboard's percentage-elapsed caption to "% of est. meatspace time elapsed"

## Test plan
- [x] `client` full vitest suite: 871 files / 10598 tests passed
- [x] Updated `LayoutEditor.test.jsx` button-label assertions to match the new widget label