### PR TITLE
fix: reveal-gate descriptive canon fields so concealed background stays out of viewer prompts

### DIFF
--- a/server/lib/universePromptRenderers.js
+++ b/server/lib/universePromptRenderers.js
@@ -90,6 +90,72 @@ const formatObject = (o) => {
   return `  - ${o.name}${desc ? `: ${desc}` : ''}${sig}`;
 };
 
+// --- The single reveal gate for prompt-facing canon ------------------------
+//
+// A canon entry carrying a hard `spoiler` flag or a `revealIssue` holds
+// authored history the audience has not earned yet. Every prompt-facing block
+// in this module routes through this ONE gate — the descriptive canon block
+// (`renderCanonForPrompt`) and the authored psychology block
+// (`renderCharacterNarrativeContext`) — so the two cannot drift into parallel
+// rules the way they had before #6426, when the psychology block withheld a
+// spoiler character's ghost while the descriptive block rendered that same
+// character's `background` in the very next paragraph.
+//
+// The gate is an ALLOWLIST PROJECTION, not a per-field subtraction: a gated
+// entry is rebuilt from `CONCEALMENT_SAFE_CANON_FIELDS` alone and rendered by
+// `renderGatedCanonLine` instead of by its per-kind formatter. A field added to
+// a canon record (or to a formatter) later is therefore withheld by default and
+// has to be argued onto the list — it cannot leak by simply not having been
+// thought about here.
+//
+// What a gated entry may still show:
+//   `id`                — callers key pinning/priority off it; carries no fact.
+//   `name` / `slugline` — the roster has to be able to name a cast member or a
+//                         location; withholding identity makes the block
+//                         unusable rather than safe.
+//   `role`              — "antagonist" is a cast slot, not the concealed
+//                         history behind it.
+//   `surfaceDescriptor` — the author's OWN sanctioned pre-reveal stand-in.
+//                         `surfaceCanonEntry` in storyBible.js makes exactly
+//                         this call for the drafting-context filter; reusing it
+//                         keeps one project-wide answer to "what may a gated
+//                         entry show" instead of inventing a second one here.
+//
+// `personality` and `physicalDescription` are deliberately NOT safe — the call
+// #6426 left open, recorded here because the next reader will ask. An authored
+// bible routinely puts the post-reveal true self in `personality` ("a meek
+// clerk who signed the order"), the same concealed-interiority register the
+// psychology block already withholds wholesale, and a `physicalDescription`
+// just as routinely carries the tell ("the burn scar from the fire she set").
+// `surfaceDescriptor` exists precisely to say what the audience is allowed to
+// see so far, so masking those two costs an author nothing they cannot state
+// deliberately. `background` is the concealed-history field and was the actual
+// leak this gate closes.
+export const CONCEALMENT_SAFE_CANON_FIELDS = Object.freeze(['id', 'name', 'role', 'slugline', 'surfaceDescriptor']);
+
+const REVEAL_GATED_CANON_NOTE = '(reveal-gated — concealed canon withheld until the story earns it)';
+
+// Project a gated entry down to the safe fields. Returns null when the gate is
+// off or the entry is ungated, so callers read as `concealCanonEntry(e, on) ?? e`.
+const concealCanonEntry = (entry, respectRevealGates) => {
+  if (!respectRevealGates || !isEntryRevealGated(entry)) return null;
+  const safe = {};
+  for (const field of CONCEALMENT_SAFE_CANON_FIELDS) {
+    if (entry[field] !== undefined) safe[field] = entry[field];
+  }
+  return safe;
+};
+
+// One line shape for a gated entry of ANY kind. The per-kind formatter is never
+// reached, which is what makes a newly added descriptive field unable to bypass
+// the gate even if nobody remembers this comment.
+const renderGatedCanonLine = (entry) => {
+  const label = entry.name || entry.slugline || '(unnamed)';
+  const role = entry.role ? ` [${entry.role}]` : '';
+  const surface = truncDesc(entry.surfaceDescriptor || '');
+  return `  - ${label}${role}: ${surface ? `${surface} — ` : ''}${REVEAL_GATED_CANON_NOTE}`;
+};
+
 const CANON_SECTIONS = [
   { field: 'characters', header: 'characters', formatEntry: formatCharacter },
   { field: 'places', header: 'places', formatEntry: formatPlace },
@@ -122,7 +188,7 @@ const hoistPriorityEntries = (entries, priority) => {
 // Caps each section at CANON_PROMPT_ENTRIES_PER_KIND_MAX entries; an
 // "(… + N more)" footer signals truncation so the LLM doesn't assume the
 // canon is complete.
-export function renderCanonForPrompt(world, { priorityCharacterIds = null } = {}) {
+export function renderCanonForPrompt(world, { priorityCharacterIds = null, respectRevealGates = false } = {}) {
   if (!world || typeof world !== 'object') return '';
   const priority = asIdSet(priorityCharacterIds);
   const sections = [];
@@ -138,7 +204,10 @@ export function renderCanonForPrompt(world, { priorityCharacterIds = null } = {}
     if (!entries.length) continue;
     const shown = entries.slice(0, CANON_PROMPT_ENTRIES_PER_KIND_MAX);
     const hiddenCount = entries.length - shown.length;
-    const lines = shown.map(formatEntry);
+    const lines = shown.map((entry) => {
+      const concealed = concealCanonEntry(entry, respectRevealGates);
+      return concealed ? renderGatedCanonLine(concealed) : formatEntry(entry);
+    });
     if (hiddenCount > 0) {
       lines.push(`  - (… + ${hiddenCount} more ${header} not shown — prompt budget reached)`);
     }
@@ -340,7 +409,9 @@ function rankCharactersForNarrativeContext(characters, {
  * `spoiler` flag or a `revealIssue` has authored history the audience has NOT
  * earned yet, so the gated entry renders as a named placeholder rather than
  * handing a generation prompt the concealed origin. Author-side planning
- * surfaces that already reason over the full bible leave it off.
+ * surfaces that already reason over the full bible leave it off. It is the SAME
+ * predicate and allowlist the descriptive block uses (`concealCanonEntry`) —
+ * see the gate comment above; do not add a second rule here.
  *
  * `reportOmitted` appends a coverage footer naming how many cast members the
  * cap withheld — a reviewer that is told the ensemble is complete when it is
@@ -356,7 +427,11 @@ export function renderCharacterNarrativeContext(characters, {
   if (!shown.length) return '';
   const lines = shown.map((character) => {
     const name = character.name || 'Unnamed';
-    if (respectRevealGates && isEntryRevealGated(character)) {
+    // Same projection the descriptive block uses — one predicate, one
+    // allowlist. The psychology block replaces the WHOLE line rather than
+    // rendering the safe fields, because every spec row below `role` is
+    // concealed interiority by construction.
+    if (concealCanonEntry(character, respectRevealGates)) {
       return `- ${name}: (reveal-gated — authored psychology withheld until the story earns it)`;
     }
     const fields = CHARACTER_NARRATIVE_FIELD_SPECS
@@ -387,8 +462,15 @@ const CHARACTER_ENGINES_HEADER = 'character engines (author-only canon — motiv
  * NOT for reader-facing surfaces. The play turn and the cold-opening
  * first-time-viewer review deliberately withhold canon; they must keep passing
  * their own placeholder rather than calling this.
+ *
+ * `respectRevealGates` defaults ON and drives BOTH blocks from the one gate
+ * above, so a spoiler character's concealed `background` can no longer ride the
+ * descriptive block into a generation prompt while the psychology block masks
+ * that same character (#6426). Read-only author-side surfaces that are supposed
+ * to reason over the whole bible — the editorial pass, whose continuity checks
+ * exist precisely to catch a premature reveal — pass `false` explicitly.
  */
-export function renderStoryCanonDigest(universe, { protagonistCharacterId = null } = {}) {
+export function renderStoryCanonDigest(universe, { protagonistCharacterId = null, respectRevealGates = true } = {}) {
   if (!universe || typeof universe !== 'object') return '';
   const characters = Array.isArray(universe.characters) ? universe.characters : [];
   const protagonist = protagonistCharacterId
@@ -398,12 +480,12 @@ export function renderStoryCanonDigest(universe, { protagonistCharacterId = null
   const narrative = renderCharacterNarrativeContext(characters, {
     max: CHARACTER_NARRATIVE_DIGEST_MAX,
     priorityIds,
-    respectRevealGates: true,
+    respectRevealGates,
     reportOmitted: true,
   });
   return [
     protagonist ? `Verified Universe protagonist: id=${protagonist.id}; name=${protagonist.name}.` : '',
-    renderCanonForPrompt(universe, { priorityCharacterIds: priorityIds }),
+    renderCanonForPrompt(universe, { priorityCharacterIds: priorityIds, respectRevealGates }),
     narrative ? `${CHARACTER_ENGINES_HEADER}\n${narrative}` : '',
   ].filter(Boolean).join('\n\n');
 }

--- a/server/lib/universePromptRenderers.test.js
+++ b/server/lib/universePromptRenderers.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import {
+  renderCanonForPrompt,
   renderEntitiesSummary,
   renderCharacterNarrativeContext,
   renderStoryCanonDigest,
@@ -7,6 +8,7 @@ import {
   CHARACTER_NARRATIVE_FIELD_MAX,
   ENTITIES_SUMMARY_MAX_PER_KIND,
   ENTITIES_SUMMARY_DESCRIPTOR_MAX,
+  CONCEALMENT_SAFE_CANON_FIELDS,
 } from './universePromptRenderers.js';
 
 describe('renderEntitiesSummary', () => {
@@ -240,8 +242,110 @@ describe('renderStoryCanonDigest (#6416)', () => {
     expect(digest).toContain('not shown — prompt budget reached');
   });
 
+it('drives both blocks from one gate, and lets a read-only author surface opt out (#6426)', () => {
+    const masked = universe({
+      characters: [{
+        id: 'char-masked', name: 'Example Auditor', role: 'antagonist', spoiler: true,
+        surfaceDescriptor: 'a clerk with a ledger',
+        background: 'LEAK-background signed off on the collapse',
+        personality: 'LEAK-personality outwardly meek',
+        lie: 'LEAK-lie the ledger is the only honest thing left',
+      }],
+    });
+
+    // Generation-facing default: the descriptive block no longer contradicts
+    // the psychology block by publishing the same character's concealed history.
+    const gated = renderStoryCanonDigest(masked);
+    expect(gated).toContain('a clerk with a ledger — (reveal-gated');
+    expect(gated).toContain('Example Auditor: (reveal-gated');
+    expect(gated).not.toMatch(/LEAK-/);
+
+    // Author-side review opts out and gets the whole bible from both blocks.
+    const open = renderStoryCanonDigest(masked, { respectRevealGates: false });
+    expect(open).toContain('LEAK-background signed off on the collapse');
+    expect(open).toContain('lie=LEAK-lie the ledger is the only honest thing left');
+  });
+
   it('returns empty for a missing universe', () => {
     expect(renderStoryCanonDigest(null)).toBe('');
     expect(renderStoryCanonDigest('nope')).toBe('');
+  });
+});
+
+describe('the single reveal gate on the descriptive canon block (#6426)', () => {
+  // Obviously-fake placeholder canon. Every concealable field carries a
+  // distinct `LEAK-` sentinel so a failure names the field that escaped.
+  const gatedCharacter = (over = {}) => ({
+    id: 'char-masked',
+    name: 'Example Auditor',
+    role: 'antagonist',
+    spoiler: true,
+    surfaceDescriptor: 'a clerk with a ledger',
+    physicalDescription: 'LEAK-physicalDescription',
+    personality: 'LEAK-personality',
+    background: 'LEAK-background',
+    tags: ['LEAK-tags'],
+    ...over,
+  });
+  const world = (over = {}) => ({ characters: [gatedCharacter(over)], places: [], objects: [] });
+
+  it('masks the concealed descriptive fields and keeps identity plus the authored surface stand-in', () => {
+    const out = renderCanonForPrompt(world(), { respectRevealGates: true });
+    expect(out).toContain('- Example Auditor [antagonist]: a clerk with a ledger — (reveal-gated');
+    expect(out).not.toMatch(/LEAK-/);
+  });
+
+  it('names a gated entry that has no surface stand-in rather than dropping it from the roster', () => {
+    const out = renderCanonForPrompt(world({ surfaceDescriptor: '' }), { respectRevealGates: true });
+    expect(out).toContain('- Example Auditor [antagonist]: (reveal-gated');
+    expect(out).not.toMatch(/LEAK-/);
+  });
+
+  it('treats an unresolved revealIssue like a hard spoiler flag, and leaves an ungated character whole', () => {
+    const byIssue = renderCanonForPrompt(world({ spoiler: false, revealIssue: 4 }), { respectRevealGates: true });
+    expect(byIssue).toContain('(reveal-gated');
+    expect(byIssue).not.toMatch(/LEAK-/);
+
+    const ungated = renderCanonForPrompt(world({ spoiler: false }), { respectRevealGates: true });
+    expect(ungated).toContain('LEAK-background');
+  });
+
+  it('stays off by default so author-side planning still reasons over the whole bible', () => {
+    expect(renderCanonForPrompt(world())).toContain('LEAK-background');
+  });
+
+  it('gates places and objects through the same projection', () => {
+    const out = renderCanonForPrompt({
+      characters: [],
+      places: [{
+        name: 'Example Bunker', slugline: 'INT. BUNKER', spoiler: true,
+        description: 'LEAK-place-description', recurringDetails: 'LEAK-place-recurring',
+      }],
+      objects: [{
+        name: 'Example Ledger', revealIssue: 9,
+        description: 'LEAK-object-description', significance: 'LEAK-object-significance',
+      }],
+    }, { respectRevealGates: true });
+    expect(out).toContain('- Example Bunker: (reveal-gated');
+    expect(out).toContain('- Example Ledger: (reveal-gated');
+    expect(out).not.toMatch(/LEAK-/);
+  });
+
+  it('renders a gated entry from the allowlist alone, so a field added later cannot bypass the gate', () => {
+    // The regression this uniquely catches: someone adds a descriptive field to
+    // a canon record (or to formatCharacter) and never revisits the gate. The
+    // gate is an allowlist PROJECTION, so an unknown key is withheld with no
+    // edit here; a per-field subtraction would let each of these through.
+    const loaded = {
+      ...gatedCharacter(),
+      description: '', confession: '', secretName: '', theoryOfControl: '', ghost: '',
+    };
+    for (const key of Object.keys(loaded)) {
+      if (!CONCEALMENT_SAFE_CANON_FIELDS.includes(key) && typeof loaded[key] === 'string') {
+        loaded[key] = `LEAK-${key}`;
+      }
+    }
+    const out = renderCanonForPrompt({ characters: [loaded], places: [], objects: [] }, { respectRevealGates: true });
+    expect(out).not.toMatch(/LEAK-/);
   });
 });

--- a/server/services/fableLoom/editorial.js
+++ b/server/services/fableLoom/editorial.js
@@ -198,8 +198,18 @@ const loadEditorialDependencies = async (loom, {
     // Same composer the generation stages use, so the editor reviews a story
     // against the SAME authored psychology the writer was given — a reviewer
     // that can't see the Lie can't tell a broken arc from an intended one.
+    //
+    // The reveal gate is OFF here on purpose (#6426). The editorial pass is a
+    // read-only author-side critique whose whole job includes catching a
+    // premature reveal; a reviewer handed the masked view cannot tell concealed
+    // history from history the story never had. storyBible.js makes the same
+    // call for its editorial checks ("NOT by the editorial checks — they get
+    // full canon"). Generation stages keep the gate on via the default.
     canonDigest: universe
-      ? renderStoryCanonDigest(universe, { protagonistCharacterId: loom.protagonistCharacterId })
+      ? renderStoryCanonDigest(universe, {
+        protagonistCharacterId: loom.protagonistCharacterId,
+        respectRevealGates: false,
+      })
       : '',
   };
 };

--- a/server/services/fableLoom/editorial.test.js
+++ b/server/services/fableLoom/editorial.test.js
@@ -740,6 +740,25 @@ describe('editorial canon dependencies carry authored psychology (#6416)', () =>
     expect(canonDigest).toContain('do not treat this cast list as complete');
   });
 
+it('still shows the editorial reviewer a reveal-gated character in full (#6426)', async () => {
+    // The generation stages now mask a spoiler character's concealed history in
+    // BOTH canon blocks. The editorial pass must not inherit that: its
+    // continuity checks exist to catch a premature reveal, and a reviewer handed
+    // the masked view cannot tell concealed history from history that was never
+    // written.
+    const { canonDigest } = await load(authoredUniverse({
+      characters: [{
+        id: 'character-masked', name: 'The Auditor', role: 'antagonist', spoiler: true,
+        surfaceDescriptor: 'a clerk with a ledger',
+        background: 'Signed off on the collapse.',
+        lie: 'The ledger is the only honest thing left.',
+      }],
+    }));
+    expect(canonDigest).toContain('background: Signed off on the collapse.');
+    expect(canonDigest).toContain('lie=The ledger is the only honest thing left.');
+    expect(canonDigest).not.toContain('reveal-gated');
+  });
+
   it('invalidates an in-flight editorial result when a belief is edited mid-run', async () => {
     const before = await load(authoredUniverse());
     const edited = authoredUniverse();

--- a/server/services/fableLoom/weave.js
+++ b/server/services/fableLoom/weave.js
@@ -145,6 +145,11 @@ const playRouting = (loom, perCall) => resolveLlmRoutePin(loom.playSettings, per
  *
  * Reader-facing paths do NOT call this: `playTurn` never renders canon, and the
  * cold-opening first-time-viewer review passes its own withheld placeholder.
+ *
+ * The composer's reveal gate is left ON (its default): a character carrying a
+ * `spoiler` flag or an unresolved `revealIssue` reaches these generation stages
+ * as name + role + the authored surface stand-in, with the concealed
+ * `background`/`personality` and the psychology block both withheld (#6426).
  */
 export async function buildCanonDigest(loom) {
   if (!loom.universeId) return '';

--- a/server/services/fableLoom/weave.test.js
+++ b/server/services/fableLoom/weave.test.js
@@ -1201,6 +1201,66 @@ describe('authored psychology at the FableLoom prompt boundary (#6416)', () => {
   });
 });
 
+describe('descriptive canon reveal gate at the FableLoom prompt boundary (#6426)', () => {
+  // A spoiler character whose concealed origin lives in `background` — the
+  // field the descriptive block used to publish while the psychology block
+  // masked the same character. Obviously-fake placeholder content only.
+  const maskedCanonUniverse = () => authoredCanonUniverse({
+    characters: [{
+      id: 'character-masked',
+      name: 'The Auditor',
+      role: 'antagonist',
+      spoiler: true,
+      surfaceDescriptor: 'a clerk with a ledger',
+      background: 'LEAK-background signed off on the collapse',
+      personality: 'LEAK-personality outwardly meek, actually the signatory',
+      lie: 'LEAK-lie the ledger is the only honest thing left',
+    }],
+  });
+
+  it('keeps the concealed background out of the generation digest while still naming the character', async () => {
+    getUniverseMock.mockResolvedValue(maskedCanonUniverse());
+    const digest = await buildCanonDigest({ universeId: 'uni-1' });
+    expect(digest).toContain('- The Auditor [antagonist]: a clerk with a ledger — (reveal-gated');
+    expect(digest).not.toMatch(/LEAK-/);
+  });
+
+  it('never reaches the reader-facing play turn', async () => {
+    const { loomId, episodeId } = await setup();
+    getUniverseMock.mockResolvedValue(maskedCanonUniverse());
+    await updateLoom(loomId, { participationMode: 'protagonist' });
+    runStagedLLM.mockResolvedValueOnce({ content: generatedGraph(), runId: 'weave-run' });
+    const woven = await weaveEpisode(loomId, episodeId, {});
+    const startNode = woven.loom.episodes[0].nodes.find((node) => node.id === woven.loom.episodes[0].startNodeId);
+    runStagedLLM.mockClear();
+    runStagedLLM.mockResolvedValueOnce({ content: { action: 'stay', narration: 'You wait.' }, runId: 'play-run' });
+
+    await playTurn(loomId, episodeId, { nodeId: startNode.id, message: 'look around' });
+
+    const prompt = JSON.stringify(runStagedLLM.mock.calls[0]);
+    expect(prompt).not.toMatch(/LEAK-/);
+    // Not even the masked identity line: a play turn renders no canon at all,
+    // so piping any digest in here — gated or not — fails this.
+    expect(prompt).not.toContain('The Auditor');
+    expect(prompt).not.toContain('character engines');
+  });
+
+  it('never reaches the first-time-viewer cold read', async () => {
+    const { loomId, episodeId } = await setup();
+    getUniverseMock.mockResolvedValue(maskedCanonUniverse());
+    runStagedLLM.mockResolvedValueOnce({ content: generatedOutline(), runId: 'outline-run' });
+    await generateEpisodeOutline(loomId, episodeId, {});
+    runStagedLLM.mockClear();
+    runStagedLLM.mockResolvedValueOnce({ content: { summary: 'No personal goal is shown.', risks: ['Show what she wants.'] }, runId: 'cold-review' });
+
+    await reviewEpisodeOutline(loomId, episodeId, {});
+
+    const prompt = JSON.stringify(runStagedLLM.mock.calls[0]);
+    expect(prompt).toContain('(withheld for first-time-viewer review)');
+    expect(prompt).not.toMatch(/LEAK-/);
+  });
+});
+
 describe('series plan AI', () => {
   it('drafts and persists a complete scaffold while preserving episode records', async () => {
     const { loomId, episodeId } = await setup();


### PR DESCRIPTION
## Summary

The FableLoom canon digest gated one of its two character blocks and not the other. `renderCharacterNarrativeContext` withheld a spoiler character's authored psychology, while `formatCharacter` — three paragraphs earlier in the same digest — published that same character's `background` and `personality` in full, so a concealed origin still reached generation prompts.

- **One gate, not two rules.** Both blocks in `server/lib/universePromptRenderers.js` now route through a single predicate + allowlist. The gate is an allowlist **projection**, not a per-field subtraction: a gated entry is rebuilt from `CONCEALMENT_SAFE_CANON_FIELDS` (`id`, `name`, `role`, `slugline`, `surfaceDescriptor`) and rendered by one kind-agnostic line builder, so the per-kind formatter is never reached and a descriptive field added later cannot leak by simply not having been thought about.
- **Places and objects go through the same projection**, closing the same hole for a gated location or artifact.
- **Per-field call (the one the issue left open), argued in a code comment:** `personality` and `physicalDescription` are concealed alongside `background`. An authored bible routinely puts the post-reveal true self in `personality` and the tell in `physicalDescription`, and `surfaceDescriptor` already exists as the sanctioned pre-reveal stand-in — matching `surfaceCanonEntry` in `storyBible.js`, so there is one project-wide answer to what a gated entry may show. A gated character renders as `- Name [role]: <surfaceDescriptor> — (reveal-gated …)`, or the note alone when no stand-in was authored.
- **Author-side surfaces keep the full bible.** `renderStoryCanonDigest` defaults the gate ON for the generation stages; the editorial pass opts out explicitly, because its continuity checks exist to catch a premature reveal and a reviewer handed the masked view cannot tell concealed history from history that was never written (`storyBible.js` makes the same call for its editorial checks). Arc planning is unchanged — the gate is off by default in `renderCanonForPrompt`.

## Test plan

- `cd server && npm test` — full suite green (2021 files / 40329 tests).
- New coverage:
  - `server/lib/universePromptRenderers.test.js` — gated character/place/object masking, numeric `revealIssue` parity with `spoiler`, gate off by default, and a projection test that stamps a sentinel into every non-allowlisted key (including keys this module has never heard of) and asserts none reach the output.
  - `server/services/fableLoom/weave.test.js` — prompt-boundary: the concealed `background` stays out of the generation digest while the character is still named, and never reaches the play turn (which carries no canon at all, masked or otherwise) or the first-time-viewer cold read.
  - `server/services/fableLoom/editorial.test.js` — the same gated character's `background` and `lie` still reach the editorial reviewer.
- Mutation probe: reverting the gated-line routing to `formatEntry` fails 7 of the new assertions, confirming they observe the defect rather than restating the implementation.
- Existing reveal-gate and cold-opening tests pass unchanged.
- Local `ollama` reviewer was unavailable (no reviewer model configured on this install); it is an optional reviewer, so this is non-blocking.

Closes #6426
