### PR TITLE
Add delete buttons for downloaded speculative-decoding weights

### DIFF
--- a/client/src/components/settings/LocalLlmRuntimesView.jsx
+++ b/client/src/components/settings/LocalLlmRuntimesView.jsx
@@ -7,7 +7,7 @@ import BrailleSpinner from '../BrailleSpinner';
 import { formatBytes } from '../../utils/formatters';
 import useDownloadPreflightConfirm from '../../hooks/useDownloadPreflightConfirm';
 import useLocalLlmStatus from '../../hooks/useLocalLlmStatus';
-import { migrateLocalLlmBackend, controlOllamaService, patchSettingsSlice, getLlamaServerStatus, getLlamaServerUpdateStatus, startLlamaServer, stopLlamaServer, installLlamaServer, upgradeLlamaServer, downloadSpecDecodeModel, cancelSpecDecodeModelDownload, previewLocalLlmDownload, controlLmStudioService, getMtplxServerStatus, startMtplxServer, stopMtplxServer, installMtplx, searchMtplxModels, pullMtplxModel, removeMtplxModel, getSlotstreamServerStatus, startSlotstreamServer, stopSlotstreamServer, installSlotstream, downloadSlotstreamModel, cancelSlotstreamModelDownload, saveRuntimeStartupList } from '../../services/api';
+import { migrateLocalLlmBackend, controlOllamaService, patchSettingsSlice, getLlamaServerStatus, getLlamaServerUpdateStatus, startLlamaServer, stopLlamaServer, installLlamaServer, upgradeLlamaServer, downloadSpecDecodeModel, cancelSpecDecodeModelDownload, removeSpecDecodeModel, previewLocalLlmDownload, controlLmStudioService, getMtplxServerStatus, startMtplxServer, stopMtplxServer, installMtplx, searchMtplxModels, pullMtplxModel, removeMtplxModel, getSlotstreamServerStatus, startSlotstreamServer, stopSlotstreamServer, installSlotstream, downloadSlotstreamModel, cancelSlotstreamModelDownload, saveRuntimeStartupList } from '../../services/api';
 import socket from '../../services/socket';
 import SpecDecodeWeightRow from './SpecDecodeWeightRow.jsx';
 import RuntimeServersCard from './RuntimeServersCard.jsx';
@@ -548,6 +548,17 @@ export default function LocalLlmRuntimesView() {
     }
   };
 
+  const handleDeleteSpecModel = async (role) => {
+    try {
+      const res = await removeSpecDecodeModel(llamaPresetId, role, { silent: true });
+      toast.success(res?.path ? `Deleted ${res.path}` : 'Weight file deleted');
+    } catch (err) {
+      toast.error(err?.message || 'Could not delete the weight file');
+    } finally {
+      loadLlamaStatus();
+    }
+  };
+
   const handleStartLlama = async (e) => {
     e?.preventDefault?.();
     // Submitting with Enter bypasses the disabled button, so re-check here.
@@ -918,6 +929,7 @@ export default function LocalLlmRuntimesView() {
                     progress={llamaDownloads[downloadKey(llamaPresetId, entry.role)]}
                     onDownload={handleDownloadSpecModel}
                     onCancel={handleCancelSpecModelDownload}
+                    onDelete={handleDeleteSpecModel}
                     disabled={llamaLoading}
                   />
                 ))}

--- a/client/src/components/settings/LocalLlmRuntimesView.test.jsx
+++ b/client/src/components/settings/LocalLlmRuntimesView.test.jsx
@@ -47,6 +47,7 @@ vi.mock('../../services/api', () => ({
     verdict: 'ok',
   })),
   cancelSpecDecodeModelDownload: vi.fn(),
+  removeSpecDecodeModel: vi.fn(),
 }));
 vi.mock('../../services/socket', () => ({
   default: { on: vi.fn(), off: vi.fn() },
@@ -677,6 +678,39 @@ describe('LocalLlmRuntimesView llama-server management', () => {
     await waitFor(() => {
       expect(cancelSpecDecodeModelDownload).toHaveBeenCalledWith('qwen3.8-27b-dspark', 'model', { silent: true });
     });
+  });
+
+  // The "unload this method" cleanup path: a downloaded weight offers Delete,
+  // gated behind an inline confirm rather than firing on the first click.
+  it('deletes a downloaded preset GGUF after an inline confirm', async () => {
+    const { getLlamaServerStatus, removeSpecDecodeModel } = await import('../../services/api');
+    getLlamaServerStatus.mockResolvedValue(llamaReady());
+    removeSpecDecodeModel.mockResolvedValue({ success: true, deleted: true, path: 'models/Qwen3.8-27B-Instruct-Q4_K_M.gguf' });
+
+    await renderRuntimes();
+
+    expect(await screen.findByText(/Downloaded \(1\.1 GB\)/)).toBeInTheDocument();
+    fireEvent.click(screen.getAllByRole('button', { name: /^Delete$/ })[0]);
+    expect(removeSpecDecodeModel).not.toHaveBeenCalled();
+
+    fireEvent.click(await screen.findByRole('button', { name: /Yes, delete/ }));
+
+    await waitFor(() => {
+      expect(removeSpecDecodeModel).toHaveBeenCalledWith('qwen3.8-27b-dspark', 'model', { silent: true });
+    });
+  });
+
+  it('backs out of the delete confirm without calling the delete endpoint', async () => {
+    const { getLlamaServerStatus, removeSpecDecodeModel } = await import('../../services/api');
+    getLlamaServerStatus.mockResolvedValue(llamaReady());
+
+    await renderRuntimes();
+
+    fireEvent.click((await screen.findAllByRole('button', { name: /^Delete$/ }))[0]);
+    fireEvent.click(await screen.findByRole('button', { name: /^Cancel$/ }));
+
+    expect(screen.queryByRole('button', { name: /Yes, delete/ })).not.toBeInTheDocument();
+    expect(removeSpecDecodeModel).not.toHaveBeenCalled();
   });
 
   it('blocks Start while a preset GGUF is missing and names the fix', async () => {

--- a/client/src/components/settings/SpecDecodeWeightRow.jsx
+++ b/client/src/components/settings/SpecDecodeWeightRow.jsx
@@ -1,5 +1,7 @@
-import { Check, Download, ExternalLink, X } from 'lucide-react';
+import { Check, Download, ExternalLink, Trash2, X } from 'lucide-react';
 import BrailleSpinner from '../BrailleSpinner';
+import ConfirmButtonPair from '../ui/ConfirmButtonPair.jsx';
+import useConfirmDelete from '../../hooks/useConfirmDelete.js';
 import { formatBytes } from '../../utils/formatters';
 
 const ROLE_LABELS = { model: 'Target base model', draftModel: 'Drafter' };
@@ -13,7 +15,8 @@ const ROLE_LABELS = { model: 'Target base model', draftModel: 'Drafter' };
  * this row is what turns "The base model was not found at `models/…`" into a
  * thing the user can act on without leaving the page.
  */
-export default function SpecDecodeWeightRow({ entry, progress, onDownload, onCancel, disabled }) {
+export default function SpecDecodeWeightRow({ entry, progress, onDownload, onCancel, onDelete, disabled }) {
+  const { isConfirming, requestDelete, cancelDelete, confirmDelete } = useConfirmDelete();
   if (!entry?.path) return null;
   const label = ROLE_LABELS[entry.role] || entry.role;
   const downloading = Boolean(progress) || entry.downloading;
@@ -32,10 +35,35 @@ export default function SpecDecodeWeightRow({ entry, progress, onDownload, onCan
         </div>
         <div className="flex items-center gap-2 shrink-0">
           {entry.exists ? (
-            <span className="flex items-center gap-1 text-[11px] text-port-success">
-              <Check size={12} />
-              Downloaded{entry.sizeBytes ? ` (${formatBytes(entry.sizeBytes)})` : ''}
-            </span>
+            isConfirming(entry.role) ? (
+              <ConfirmButtonPair
+                prompt="Delete this file?"
+                confirmIcon={Trash2}
+                confirmText="Yes, delete"
+                busy={disabled}
+                onConfirm={() => confirmDelete(() => onDelete(entry.role))}
+                onCancel={cancelDelete}
+              />
+            ) : (
+              <>
+                <span className="flex items-center gap-1 text-[11px] text-port-success">
+                  <Check size={12} />
+                  Downloaded{entry.sizeBytes ? ` (${formatBytes(entry.sizeBytes)})` : ''}
+                </span>
+                {onDelete && (
+                  <button
+                    type="button"
+                    onClick={() => requestDelete(entry.role)}
+                    disabled={disabled}
+                    className="flex items-center gap-1 px-2 py-1 text-[11px] text-gray-500 hover:text-port-error hover:bg-port-error/10 rounded transition-colors disabled:opacity-50"
+                    title={`Delete ${label.toLowerCase()} from disk to free up space`}
+                  >
+                    <Trash2 size={11} />
+                    Delete
+                  </button>
+                )}
+              </>
+            )
           ) : downloading ? (
             <>
               <span className="flex items-center gap-1.5 text-[11px] text-gray-400">

--- a/client/src/services/apiLocalLlm.js
+++ b/client/src/services/apiLocalLlm.js
@@ -197,6 +197,16 @@ export const cancelSpecDecodeModelDownload = (presetId, role, options) =>
     ...options,
   });
 
+// Delete an already-downloaded preset GGUF to reclaim disk space for a method
+// the user no longer wants — the unload/cleanup counterpart to the download
+// above. Refused server-side while llama-server is running that exact file.
+export const removeSpecDecodeModel = (presetId, role, options) =>
+  request('/local-llm/llama-server/download-model/remove', {
+    method: 'POST',
+    body: JSON.stringify({ presetId, role }),
+    ...options,
+  });
+
 // Set the default backend (which one PortOS routes local runs to) — does not move models.
 export const switchLocalLlmBackend = (to) =>
   request('/local-llm/switch', { method: 'POST', body: JSON.stringify({ to }) });

--- a/server/lib/apiRouteCatalog.generated.json
+++ b/server/lib/apiRouteCatalog.generated.json
@@ -9027,6 +9027,14 @@
     },
     {
       "method": "POST",
+      "path": "/api/local-llm/llama-server/download-model/remove",
+      "mountPath": "/api/local-llm",
+      "sources": [
+        "server/routes/localLlm.js"
+      ]
+    },
+    {
+      "method": "POST",
       "path": "/api/local-llm/llama-server/install",
       "mountPath": "/api/local-llm",
       "sources": [
@@ -17924,8 +17932,8 @@
   ],
   "stats": {
     "mounts": 150,
-    "operations": 2220,
-    "declarations": 2228,
+    "operations": 2221,
+    "declarations": 2229,
     "sourceFiles": 233
   }
 }

--- a/server/routes/localLlm.js
+++ b/server/routes/localLlm.js
@@ -55,7 +55,7 @@ import { SLOTSTREAM_APP, getSlotstreamServerStatus, startSlotstreamServer, stopS
 import { cancelSlotstreamModelDownload, downloadSlotstreamModel, previewSlotstreamDownload } from '../services/slotstreamModelManager.js'
 import { searchMtplxCatalog, pullMtplxModel, previewMtplxPull, removeMtplxModel } from '../services/mtplxModelManager.js'
 import { saveProcessList } from '../services/pm2.js'
-import { getSpecDecodePresetStatus, downloadSpecDecodeModel, previewSpecDecodeDownload, cancelSpecDecodeModelDownload } from '../services/specDecodeModels.js'
+import { getSpecDecodePresetStatus, downloadSpecDecodeModel, previewSpecDecodeDownload, cancelSpecDecodeModelDownload, removeSpecDecodeModel } from '../services/specDecodeModels.js'
 import { SPEC_TYPE_SUGGESTIONS } from '../lib/specDecodePresets.js'
 import { resetProviderReadinessCache } from '../services/providerReadiness.js'
 import { MODEL_ABUSE_GUARD } from '../lib/modelAbuseGuard.js'
@@ -751,6 +751,17 @@ router.post('/llama-server/download-model/cancel', asyncHandler(async (req, res)
   const { presetId, role } = validateRequest(localLlmSpecModelDownloadSchema, req.body)
   const cancelled = cancelSpecDecodeModelDownload({ presetId, role })
   res.json({ success: true, cancelled })
+}))
+
+// POST /api/local-llm/llama-server/download-model/remove — delete an already
+// downloaded preset GGUF to free disk space for a method the user has decided
+// not to use. removeSpecDecodeModel refuses on its own while llama-server is
+// running that exact file, so unloading can't unlink weights out from under
+// an active launch.
+router.post('/llama-server/download-model/remove', asyncHandler(async (req, res) => {
+  const { presetId, role } = validateRequest(localLlmSpecModelDownloadSchema, req.body)
+  const result = await removeSpecDecodeModel({ presetId, role })
+  res.json(result)
 }))
 
 // Each of the three actions below changes exactly what the provider-readiness

--- a/server/routes/localLlm.test.js
+++ b/server/routes/localLlm.test.js
@@ -122,6 +122,7 @@ vi.mock('../services/specDecodeModels.js', () => ({
     kind: 'spec-decode', verdict: 'ok', destPath: 'models/base.gguf', expectedBytes: 6, freeBytes: 1e12, requiredBytes: 6, headroomBytes: 0, alreadyDownloaded: false,
   })),
   cancelSpecDecodeModelDownload: vi.fn(() => true),
+  removeSpecDecodeModel: vi.fn(async () => ({ success: true, deleted: true, path: 'models/base.gguf' })),
 }));
 
 // /loaded reads getSettings() to honor a user's intentionally-disabled backends,
@@ -834,6 +835,25 @@ describe('llama-server routes', () => {
     expect(res.status).toBe(200);
     expect(res.body).toEqual({ success: true, cancelled: true });
     expect(cancelSpecDecodeModelDownload).toHaveBeenCalledWith({ presetId: 'test-preset', role: 'model' });
+  });
+
+  it('POST /api/local-llm/llama-server/download-model/remove deletes one preset GGUF', async () => {
+    const { removeSpecDecodeModel } = await import('../services/specDecodeModels.js');
+    const res = await request(makeApp())
+      .post('/api/local-llm/llama-server/download-model/remove')
+      .send({ presetId: 'test-preset', role: 'model' });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ success: true, deleted: true, path: 'models/base.gguf' });
+    expect(removeSpecDecodeModel).toHaveBeenCalledWith({ presetId: 'test-preset', role: 'model' });
+  });
+
+  it('POST /api/local-llm/llama-server/download-model/remove rejects an unknown role', async () => {
+    const res = await request(makeApp())
+      .post('/api/local-llm/llama-server/download-model/remove')
+      .send({ presetId: 'test-preset', role: 'sneaky' });
+
+    expect(res.status).toBe(400);
   });
 
   it('POST /api/local-llm/llama-server/start launches server with valid payload', async () => {

--- a/server/services/specDecodeModels.js
+++ b/server/services/specDecodeModels.js
@@ -12,7 +12,7 @@
  * about which file a relative or `~`-prefixed path means.
  */
 
-import { stat } from 'fs/promises';
+import { stat, unlink } from 'fs/promises';
 import { resolve } from 'path';
 import { expandHome } from '../lib/fileUtils.js';
 import { isProjectorName, isShardedGguf } from '../lib/localLlmDisk.js';
@@ -335,6 +335,51 @@ export function cancelSpecDecodeModelDownload({ presetId, role }) {
   return downloadSlot.cancel(resolveSpecModelPath(source.path));
 }
 
+
+/**
+ * Delete one preset role's on-disk GGUF — the "unload this method" cleanup
+ * counterpart to `downloadSpecDecodeModel`. Refuses while that same file is
+ * mid-download (cancel it first) or while llama-server is running it (stop it
+ * first) — both guards belong here rather than at the route, so any other
+ * caller of this function inherits them too.
+ *
+ * `llamaServerManager.js` imports `resolveSpecModelPath` from this module at
+ * the top level, so a static import back would be circular; importing it
+ * lazily inside the function reaches the same module once both are loaded
+ * without introducing that cycle (server/AGENTS.md "Import scoping").
+ */
+export async function removeSpecDecodeModel({ presetId, role }) {
+  if (!SPEC_MODEL_ROLES.includes(role)) {
+    throw new ServerError(`Unknown model role "${role}"`, { status: 400 });
+  }
+  const entry = findSpecDecodePreset(presetId)?.[role];
+  if (!entry?.path) {
+    throw new ServerError('No weight is configured for that preset role', { status: 400 });
+  }
+  const destPath = resolveSpecModelPath(entry.path);
+  if (downloadSlot.get(destPath)) {
+    throw new ServerError(
+      `${entry.path} is still downloading — cancel the download before deleting it`,
+      { status: 409, code: 'SPEC_DOWNLOAD_ACTIVE' },
+    );
+  }
+  const { getLlamaServerStatus } = await import('./llamaServerManager.js');
+  const status = await getLlamaServerStatus();
+  const runningPath = status?.config?.[role];
+  if (status?.running && runningPath && resolveSpecModelPath(runningPath) === destPath) {
+    throw new ServerError(
+      'Stop llama-server before deleting the weights it is currently running',
+      { status: 409, code: 'SPEC_MODEL_IN_USE' },
+    );
+  }
+  const stats = await stat(destPath).catch(() => null);
+  if (!stats?.isFile()) {
+    return { success: true, deleted: false, path: entry.path };
+  }
+  await unlink(destPath);
+  console.log(`🗑️  Deleted speculative-decoding weights: ${entry.path}`);
+  return { success: true, deleted: true, path: entry.path };
+}
 
 /** Clears in-flight download bookkeeping (used by test suites). */
 export const _resetSpecDecodeDownloadsForTests = () => downloadSlot.reset();

--- a/server/services/specDecodeModels.test.js
+++ b/server/services/specDecodeModels.test.js
@@ -1,11 +1,12 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mkdtemp, readFile, rm, writeFile } from 'fs/promises';
 import { homedir, tmpdir } from 'os';
-import { isAbsolute, join } from 'path';
+import { isAbsolute, join, relative } from 'path';
 import { Readable } from 'stream';
 import {
   downloadSpecDecodeModel,
   cancelSpecDecodeModelDownload,
+  removeSpecDecodeModel,
   getSpecDecodePresetStatus,
   pickGgufSibling,
   resolveSpecModelPath,
@@ -14,6 +15,14 @@ import {
 import * as specDecodePresets from '../lib/specDecodePresets.js';
 import * as hfToken from './hfToken.js';
 import * as huggingfaceLora from '../lib/huggingfaceLora.js';
+
+// removeSpecDecodeModel reaches this lazily (a static import would cycle back
+// here — llamaServerManager.js imports resolveSpecModelPath from this module)
+// to refuse deleting a weight llama-server is actively running.
+vi.mock('./llamaServerManager.js', () => ({
+  getLlamaServerStatus: vi.fn(async () => ({ running: false, config: null })),
+}));
+import { getLlamaServerStatus } from './llamaServerManager.js';
 
 const siblings = (...names) => ({ siblings: names.map((rfilename) => ({ rfilename, size: 6 })) });
 
@@ -318,6 +327,121 @@ describe('downloadSpecDecodeModel', () => {
 
   it('rejects an unknown role outright', async () => {
     await expect(downloadSpecDecodeModel({ presetId: 'test-preset', role: 'sneaky' }))
+      .rejects.toThrow(/Unknown model role/);
+  });
+});
+
+describe('removeSpecDecodeModel', () => {
+  let dir;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'portos-spec-decode-remove-'));
+    _resetSpecDecodeDownloadsForTests();
+  });
+
+  afterEach(async () => {
+    _resetSpecDecodeDownloadsForTests();
+    vi.restoreAllMocks();
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  const stubEntry = (path) => {
+    vi.spyOn(specDecodePresets, 'findSpecDecodePreset').mockImplementation((id) => (
+      id === 'test-preset' ? { model: { path }, draftModel: { path } } : null
+    ));
+  };
+
+  it('deletes an on-disk weight file', async () => {
+    const path = join(dir, 'base.gguf');
+    await writeFile(path, 'weights');
+    stubEntry(path);
+
+    const result = await removeSpecDecodeModel({ presetId: 'test-preset', role: 'model' });
+
+    expect(result).toMatchObject({ success: true, deleted: true, path });
+    await expect(readFile(path)).rejects.toThrow();
+  });
+
+  it('is a no-op when nothing is on disk to delete', async () => {
+    const path = join(dir, 'missing.gguf');
+    stubEntry(path);
+
+    const result = await removeSpecDecodeModel({ presetId: 'test-preset', role: 'model' });
+
+    expect(result).toMatchObject({ success: true, deleted: false, path });
+  });
+
+  // Deleting the partial mid-transfer would pull the file out from under the
+  // stream write it's racing; Cancel is the correct action for that, not Delete.
+  it('refuses to delete a file that is still downloading', async () => {
+    stubEntry(join(dir, 'base.gguf'));
+    vi.spyOn(specDecodePresets, 'specDecodeSource').mockImplementation((id, role) => (
+      id === 'test-preset' && role === 'model'
+        ? { path: join(dir, 'base.gguf'), repo: 'acme/Example-GGUF', quant: 'Q4_K_M' }
+        : null
+    ));
+    vi.spyOn(hfToken, 'getHfToken').mockResolvedValue(null);
+    let releaseMetadata;
+    vi.spyOn(huggingfaceLora, 'fetchHuggingfaceModel').mockImplementation(
+      () => new Promise((resolve) => { releaseMetadata = () => resolve(siblings('Example-Q4_K_M.gguf')); }),
+    );
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: { get: () => '2' },
+      body: Readable.toWeb(Readable.from([Buffer.from('gg')])),
+    });
+
+    const download = downloadSpecDecodeModel({ presetId: 'test-preset', role: 'model' });
+    await vi.waitFor(() => expect(releaseMetadata).toBeTypeOf('function'));
+
+    await expect(removeSpecDecodeModel({ presetId: 'test-preset', role: 'model' }))
+      .rejects.toThrow(/still downloading/);
+
+    releaseMetadata();
+    await download;
+  });
+
+  // Deleting the weight out from under a running launch would leave
+  // llama-server serving a now-deleted (POSIX) or unwritable (Windows) file.
+  it('refuses to delete a weight llama-server is currently running', async () => {
+    const path = join(dir, 'base.gguf');
+    await writeFile(path, 'weights');
+    stubEntry(path);
+    getLlamaServerStatus.mockResolvedValueOnce({ running: true, config: { model: path } });
+
+    await expect(removeSpecDecodeModel({ presetId: 'test-preset', role: 'model' }))
+      .rejects.toThrow(/Stop llama-server/);
+    await expect(readFile(path, 'utf8')).resolves.toBe('weights');
+  });
+
+  // The comparison resolves both sides — the running config can carry a
+  // relative launch-line path while the preset's own path is absolute (or
+  // vice versa) and the two must still be recognized as the same file.
+  it('matches the running config against the resolved path, not the raw string', async () => {
+    const path = join(dir, 'base.gguf');
+    await writeFile(path, 'weights');
+    stubEntry(path);
+    getLlamaServerStatus.mockResolvedValueOnce({ running: true, config: { model: relative(process.cwd(), path) } });
+
+    await expect(removeSpecDecodeModel({ presetId: 'test-preset', role: 'model' }))
+      .rejects.toThrow(/Stop llama-server/);
+  });
+
+  it('allows deletion once llama-server is running a different weight', async () => {
+    const path = join(dir, 'base.gguf');
+    await writeFile(path, 'weights');
+    stubEntry(path);
+    getLlamaServerStatus.mockResolvedValueOnce({ running: true, config: { model: join(dir, 'other.gguf') } });
+
+    const result = await removeSpecDecodeModel({ presetId: 'test-preset', role: 'model' });
+
+    expect(result).toMatchObject({ success: true, deleted: true, path });
+  });
+
+  it('rejects an unknown role outright', async () => {
+    stubEntry(join(dir, 'base.gguf'));
+    await expect(removeSpecDecodeModel({ presetId: 'test-preset', role: 'sneaky' }))
       .rejects.toThrow(/Unknown model role/);
   });
 });


### PR DESCRIPTION
## Summary
- The Speculative Decoding & Custom Runtimes (DFlash 2 / llama.cpp) card showed downloaded state for each preset's GGUF but had no way to remove one — switching away from a method meant hunting down multi-gigabyte files on disk by hand.
- Adds a Delete action to each downloaded weight row, behind an inline confirm.
- The server refuses the delete while that file is mid-download (cancel it first) or while llama-server is actively running it (stop it first).

## Test plan
- `server/services/specDecodeModels.test.js` — delete success, no-op when nothing's on disk, refuses mid-download, refuses while llama-server is running that exact weight (including a relative-vs-absolute path match), unknown role.
- `server/routes/localLlm.test.js` — route wiring and validation.
- `client/src/components/settings/LocalLlmRuntimesView.test.jsx` — confirm → delete flow and cancel-out-of-confirm flow.
- Full server (`npm test` in `server/`) and client settings suites pass locally.