### PR TITLE
fix: install tailcat via Homebrew so adding a tailcat peer works on macOS

### DIFF
--- a/client/src/pages/Instances.jsx
+++ b/client/src/pages/Instances.jsx
@@ -361,7 +361,7 @@ export function AddPeerForm({ onAdd, addressRef }) {
             Forwards <span className="font-mono text-gray-400">127.0.0.1:{DEFAULT_TAILCAT_LOCAL_PORT}</span>
             {' '}→ remote <span className="font-mono text-gray-400">:5555</span> via tailcat
             (next free port if {DEFAULT_TAILCAT_LOCAL_PORT} is busy). No Tailscale account required.
-            Tailcat is installed with Go if needed.
+            Tailcat is installed with Homebrew (or Go) if needed.
           </p>
         </>
       )}

--- a/docs/features/tailcat-peers.md
+++ b/docs/features/tailcat-peers.md
@@ -23,11 +23,34 @@ No `tailcat serve all`, no exit-node mode, and no Tailscale daemon are used.
 
 1. Open **Instances → Add Peer → Tailcat address**.
 2. Paste the peer's `tc…` address (received out of band).
-3. PortOS ensures `tailcat` is installed (PATH, else `go install
-   github.com/tailscale/tailcat/cmd/tailcat@latest`), starts the forward, and
-   calls the normal peer registration against `127.0.0.1:<localPort>`.
-   Select **Remote PortOS uses HTTPS** if the remote install has enabled TLS.
+3. PortOS ensures `tailcat` is installed, starts the forward, and calls the
+   normal peer registration against `127.0.0.1:<localPort>`. Select **Remote
+   PortOS uses HTTPS** if the remote install has enabled TLS.
 4. Classic **Host / port** add remains unchanged (still rejects loopback).
+
+### How `tailcat` gets installed
+
+`ensureTailcatInstalled` first looks for a runnable binary — PATH, then
+`$GOBIN`/`$GOPATH/bin`, then the Homebrew prefix, since a long-running server
+does not necessarily have a package manager's bin directory on its inherited
+PATH. When none is found it runs the package managers the operator already has,
+in order, and stops at the first that produces a working binary:
+
+| Order | Command | Available when |
+| --- | --- | --- |
+| 1 | `brew install tailcat` (with `HOMEBREW_NO_AUTO_UPDATE=1`) | `brew` on PATH |
+| 2 | `go install github.com/tailscale/tailcat/cmd/tailcat@latest` | `go` on PATH |
+
+Homebrew is tried first for two reasons. **Tailcat publishes release binaries
+for Linux and Windows only**, so on macOS `brew` is the only prebuilt route and
+the releases page is a dead end. And `go install` needs to reach the Go module
+proxy through Go's own dialer, which a local network filter can break in a way
+that surfaces only as `dial tcp …:443: connect: bad file descriptor` — Homebrew
+downloads over plain HTTPS and is unaffected.
+
+If every strategy fails, the error names each command and the first line of what
+it said, followed by platform-appropriate manual guidance (`brew install
+tailcat` on macOS, the releases page elsewhere).
 
 HTTP is the default; HTTPS runs through the same loopback tunnel. Remote
 announcements cannot replace the managed local host or forwarding port.
@@ -57,9 +80,9 @@ operator a tailcat address so the home install can federate in.
 
 ```bash
 # Install tailcat (pick one)
-go install github.com/tailscale/tailcat/cmd/tailcat@latest
-# or: brew install tailcat
-# or: download a release from https://github.com/tailscale/tailcat/releases
+brew install tailcat
+# or: go install github.com/tailscale/tailcat/cmd/tailcat@latest
+# or (Linux/Windows only): a release from https://github.com/tailscale/tailcat/releases
 
 # PortOS already listening on :5555 in the sandbox, then:
 tailcat serve --key=new 5555

--- a/server/services/tailcatPeer.js
+++ b/server/services/tailcatPeer.js
@@ -13,10 +13,11 @@
 
 import { createServer } from 'node:net';
 import { homedir } from 'node:os';
-import { join } from 'node:path';
+import { delimiter, join } from 'node:path';
 import { spawn } from '../lib/childProcess.js';
 import { createLineReader } from '../lib/streamLines.js';
 import { commandExists } from '../lib/commandExists.js';
+import { bufferedSpawn, spawnFailureDetail } from '../lib/bufferedSpawn.js';
 import { dataPath, readJSONFile, ensureDir, PATHS, atomicWrite } from '../lib/fileUtils.js';
 import { createMutex } from '../lib/asyncMutex.js';
 import { findCommandOnPath, safeChildProcessEnv, safeChildProcessOptions } from '../lib/processEnv.js';
@@ -29,6 +30,8 @@ import { addPeer, getPeers, removePeer as removeInstancePeer } from './instances
 
 const FORWARDS_FILE = dataPath('tailcat-forwards.json');
 const GO_INSTALL_PKG = 'github.com/tailscale/tailcat/cmd/tailcat@latest';
+const BREW_FORMULA = 'tailcat';
+const RELEASES_URL = 'https://github.com/tailscale/tailcat/releases';
 const INSTALL_TIMEOUT_MS = 180_000;
 const FORWARD_READY_MS = 8_000;
 const PORT_SCAN_LIMIT = 32;
@@ -77,14 +80,22 @@ async function saveForwards(data) {
   await atomicWrite(FORWARDS_FILE, data);
 }
 
-export function listCandidateTailcatBins() {
-  const home = homedir();
+/**
+ * Where a freshly installed `tailcat` can land. PATH is checked first, then the
+ * install directories a package manager uses but a long-running server process
+ * may never have inherited: GOBIN / GOPATH/bin for `go install`, and the
+ * Homebrew prefix for `brew install`.
+ */
+export function listCandidateTailcatBins({ env = process.env, home = homedir() } = {}) {
+  // GOPATH may be a delimiter-separated list; `go install` writes into the first entry's bin.
+  const goPath = String(env.GOPATH || '').split(delimiter).find(Boolean) || join(home, 'go');
+  const goBinDir = env.GOBIN || join(goPath, 'bin');
+  const brewPrefixes = [env.HOMEBREW_PREFIX, '/opt/homebrew', '/usr/local'].filter(Boolean);
   const candidates = [
     findCommandOnPath('tailcat'),
-    join(home, 'go', 'bin', 'tailcat'),
-    join(home, 'go', 'bin', 'tailcat.exe'),
-    '/usr/local/bin/tailcat',
-    '/opt/homebrew/bin/tailcat',
+    join(goBinDir, 'tailcat'),
+    join(goBinDir, 'tailcat.exe'),
+    ...brewPrefixes.map((prefix) => join(prefix, 'bin', 'tailcat')),
   ].filter(Boolean);
   return [...new Set(candidates)];
 }
@@ -104,79 +115,109 @@ export async function detectTailcat({
 }
 
 /**
- * Install via `go install` when Go is available. Clear, actionable errors when
- * neither binary nor toolchain is present — PortOS never downloads arbitrary
- * URLs without the operator knowing.
+ * Manual-install guidance for this host. Tailcat publishes release binaries for
+ * Linux and Windows ONLY — pointing a macOS operator at the releases page is a
+ * dead end, so darwin gets the Homebrew formula instead.
+ */
+export function manualInstallHint(platform = process.platform) {
+  if (platform === 'darwin') {
+    return `Install it with \`brew install ${BREW_FORMULA}\` (Tailcat ships no macOS release binary), then retry.`;
+  }
+  return `Install a release binary from ${RELEASES_URL}, then retry.`;
+}
+
+/**
+ * Ordered install strategies available on this host.
+ *
+ * Homebrew comes first: it is the only prebuilt route on macOS, and it fetches
+ * over plain HTTPS, so it still works where `go install` cannot reach the Go
+ * module proxy (a local network filter breaking Go's dialer shows up as an
+ * opaque `connect: bad file descriptor`). `go install` stays as the fallback
+ * for hosts with a toolchain but no brew.
+ */
+export function listTailcatInstallers({
+  brewBin = findCommandOnPath('brew'),
+  goBin = findCommandOnPath('go'),
+  runInstall = runInstallCommand,
+} = {}) {
+  const installers = [];
+  if (brewBin) {
+    installers.push({
+      label: `brew install ${BREW_FORMULA}`,
+      // Auto-update pulls the whole formula index before installing a ~10MB
+      // bottle; the operator asked to add a peer, not to refresh Homebrew.
+      run: () => runInstall(brewBin, ['install', BREW_FORMULA], {
+        HOMEBREW_NO_AUTO_UPDATE: '1',
+        HOMEBREW_NO_INSTALL_CLEANUP: '1',
+      }),
+    });
+  }
+  if (goBin) {
+    installers.push({
+      label: 'go install',
+      run: () => runInstall(goBin, ['install', GO_INSTALL_PKG]),
+    });
+  }
+  return installers;
+}
+
+/**
+ * Resolve a runnable `tailcat`, installing it through the first strategy that
+ * works. Every strategy is a named package manager the operator already has —
+ * PortOS never downloads an arbitrary URL on their behalf — and a total failure
+ * reports what each one actually said so the operator can act on it.
  */
 export async function ensureTailcatInstalled({
   detect = detectTailcat,
-  goBin = findCommandOnPath('go') || 'go',
-  runGoInstall = defaultGoInstall,
-  probeGo = (bin) => commandExists(bin, ['version'], { timeoutMs: 10_000 }),
+  installers = listTailcatInstallers(),
+  platform = process.platform,
 } = {}) {
   const existing = await detect();
   if (existing) return { bin: existing, installed: false };
 
-  const goOk = await probeGo(goBin);
-  if (!goOk) {
+  if (installers.length === 0) {
     throw new ServerError(
-      'tailcat is not installed and Go was not found on PATH. '
-      + 'Install from https://github.com/tailscale/tailcat/releases '
-      + 'or `brew install tailcat`, then retry.',
+      `tailcat is not installed, and neither Homebrew nor Go was found on PATH. ${manualInstallHint(platform)}`,
       { status: 503, code: 'TAILCAT_MISSING' }
     );
   }
 
-  try {
-    await runGoInstall(goBin);
-  } catch (err) {
-    throw new ServerError(
-      'Failed to install tailcat via go install. '
-      + 'Install a release binary from https://github.com/tailscale/tailcat/releases and retry.',
-      { status: 503, code: 'TAILCAT_INSTALL_FAILED' }
-    );
+  const failures = [];
+  for (const installer of installers) {
+    const error = await installer.run().then(() => null, (err) => err);
+    if (error) {
+      failures.push(`${installer.label} failed: ${summarizeInstallError(error)}`);
+      continue;
+    }
+    const bin = await detect();
+    if (bin) return { bin, installed: true };
+    failures.push(`${installer.label} finished but no tailcat binary was found`);
   }
 
-  const bin = await detect();
-  if (!bin) {
-    throw new ServerError(
-      'go install finished but `tailcat` is still not on PATH '
-      + '(check ~/go/bin). Add that directory to PATH and retry.',
-      { status: 503, code: 'TAILCAT_INSTALL_PATH' }
-    );
-  }
-  return { bin, installed: true };
+  throw new ServerError(
+    `Could not install tailcat — ${failures.join('; ')}. ${manualInstallHint(platform)}`,
+    { status: 503, code: 'TAILCAT_INSTALL_FAILED' }
+  );
 }
 
-function defaultGoInstall(goBin) {
-  return new Promise((resolve, reject) => {
-    const child = spawn(
-      goBin,
-      ['install', GO_INSTALL_PKG],
-      safeChildProcessOptions({
-        env: safeChildProcessEnv(),
-        stdio: ['ignore', 'pipe', 'pipe'],
-      })
-    );
-    let stderr = '';
-    child.stderr?.on('data', (chunk) => {
-      stderr += String(chunk);
-      if (stderr.length > 8_000) stderr = stderr.slice(-8_000);
-    });
-    const timer = setTimeout(() => {
-      child.kill('SIGTERM');
-      reject(new Error(`timed out after ${INSTALL_TIMEOUT_MS}ms`));
-    }, INSTALL_TIMEOUT_MS);
-    child.on('error', (err) => {
-      clearTimeout(timer);
-      reject(err);
-    });
-    child.on('close', (code) => {
-      clearTimeout(timer);
-      if (code === 0) resolve();
-      else reject(new Error(stderr.trim() || `exit ${code}`));
-    });
+/** One line of an installer's diagnostics, bounded so a toast stays readable. */
+function summarizeInstallError(error) {
+  const first = String(error?.message || 'unknown error').split('\n').map((line) => line.trim()).find(Boolean);
+  const text = first || 'unknown error';
+  return text.length > 240 ? `${text.slice(0, 240)}…` : text;
+}
+
+async function runInstallCommand(bin, args, extraEnv = {}) {
+  const result = await bufferedSpawn(bin, args, {
+    env: safeChildProcessEnv(extraEnv),
+    timeoutMs: INSTALL_TIMEOUT_MS,
   });
+  if (result.success) return;
+  throw new Error(result.timedOut
+    ? `timed out after ${INSTALL_TIMEOUT_MS / 1000}s`
+    // Homebrew opens with tap/deprecation warnings, so its FIRST stderr line is
+    // rarely the failure — spawnFailureDetail takes the last one it printed.
+    : spawnFailureDetail(result, `exit ${result.code}`));
 }
 
 /** True when nothing is listening on 127.0.0.1:port (or bind fails for other reasons → busy). */

--- a/server/services/tailcatPeer.js
+++ b/server/services/tailcatPeer.js
@@ -92,7 +92,7 @@ export function listCandidateTailcatBins({ env = process.env, home = homedir() }
   const goBinDir = env.GOBIN || join(goPath, 'bin');
   const brewPrefixes = [env.HOMEBREW_PREFIX, '/opt/homebrew', '/usr/local'].filter(Boolean);
   const candidates = [
-    findCommandOnPath('tailcat'),
+    findCommandOnPath('tailcat', { env }),
     join(goBinDir, 'tailcat'),
     join(goBinDir, 'tailcat.exe'),
     ...brewPrefixes.map((prefix) => join(prefix, 'bin', 'tailcat')),

--- a/server/services/tailcatPeer.js
+++ b/server/services/tailcatPeer.js
@@ -184,7 +184,10 @@ export async function ensureTailcatInstalled({
 
   const failures = [];
   for (const installer of installers) {
-    const error = await installer.run().then(() => null, (err) => err);
+    // Promise.resolve().then defers the call, so an installer that throws
+    // SYNCHRONOUSLY still falls through to the next one instead of escaping
+    // past the ServerError wrapper as an unhandled 500.
+    const error = await Promise.resolve().then(() => installer.run()).then(() => null, (err) => err);
     if (error) {
       failures.push(`${installer.label} failed: ${summarizeInstallError(error)}`);
       continue;

--- a/server/services/tailcatPeer.test.js
+++ b/server/services/tailcatPeer.test.js
@@ -27,6 +27,13 @@ vi.mock('../lib/fileUtils.js', async (original) => ({
 }));
 import { readJSONFile, atomicWrite } from '../lib/fileUtils.js';
 
+// Only the install path spawns through this; forwards use spawn() directly.
+vi.mock('../lib/bufferedSpawn.js', async (original) => ({
+  ...(await original()),
+  bufferedSpawn: vi.fn(),
+}));
+import { bufferedSpawn } from '../lib/bufferedSpawn.js';
+
 const EXAMPLE_TC = 'tcEXAMPLE' + 'A'.repeat(40);
 
 function fakeChild() {
@@ -110,18 +117,36 @@ describe('tailcatPeer helpers', () => {
   });
 
   it('reports what every installer said when they all fail', async () => {
-    await expect(ensureTailcatInstalled({
+    const error = await ensureTailcatInstalled({
       detect: async () => null,
       platform: 'linux',
       installers: [
         { label: 'brew install tailcat', run: async () => { throw new Error('brew boom'); } },
         { label: 'go install', run: async () => { throw new Error('dial tcp: connect: bad file descriptor\nignored'); } },
       ],
-    })).rejects.toMatchObject({
-      code: 'TAILCAT_INSTALL_FAILED',
-      status: 503,
-      message: expect.stringContaining('brew install tailcat failed: brew boom'),
+    }).catch((err) => err);
+    expect(error).toMatchObject({ code: 'TAILCAT_INSTALL_FAILED', status: 503 });
+    // Every strategy is named, not just the first one that failed.
+    expect(error.message).toContain('brew install tailcat failed: brew boom');
+    expect(error.message).toContain('go install failed: dial tcp: connect: bad file descriptor');
+    // Only the first line of a multi-line diagnostic reaches the toast.
+    expect(error.message).not.toContain('ignored');
+    expect(error.message).toContain('https://github.com/tailscale/tailcat/releases');
+  });
+
+  it('falls through to the next installer even when one throws synchronously', async () => {
+    let calls = 0;
+    const result = await ensureTailcatInstalled({
+      detect: async () => {
+        calls += 1;
+        return calls <= 1 ? null : '/example/go/bin/tailcat';
+      },
+      installers: [
+        { label: 'brew install tailcat', run: () => { throw new Error('sync boom'); } },
+        { label: 'go install', run: async () => {} },
+      ],
     });
+    expect(result).toEqual({ bin: '/example/go/bin/tailcat', installed: true });
   });
 
   it('treats an installer that leaves no binary as a failure, not a success', async () => {
@@ -164,9 +189,27 @@ describe('tailcatPeer helpers', () => {
       expect.objectContaining({ HOMEBREW_NO_AUTO_UPDATE: '1' }));
   });
 
-  it('surfaces a real install command failure as a readable error', async () => {
-    const [installer] = listTailcatInstallers({ brewBin: null, goBin: '/example/missing/go' });
-    await expect(installer.run()).rejects.toThrow(/ENOENT|spawn/);
+  // The default runner maps a bufferedSpawn result onto the message the operator
+  // reads in the toast; each terminal condition has to say something different.
+  it.each([
+    ['a non-zero exit', { success: false, code: 1, stdout: '', stderr: 'Warning: tap not trusted\nError: No available formula\n', timedOut: false },
+      'Error: No available formula'],
+    ['a spawn failure', { success: false, code: -1, stdout: '', stderr: '', timedOut: false, error: new Error('spawn /example/missing/go ENOENT') },
+      'spawn /example/missing/go ENOENT'],
+    ['a silent non-zero exit', { success: false, code: 7, stdout: '', stderr: '', timedOut: false }, 'exit 7'],
+    ['a timeout', { success: false, code: -1, stdout: '', stderr: '', timedOut: true }, 'timed out after 180s'],
+  ])('surfaces %s as a readable install error', async (_label, result, expected) => {
+    bufferedSpawn.mockResolvedValueOnce(result);
+    const [installer] = listTailcatInstallers({ brewBin: null, goBin: '/example/go' });
+    await expect(installer.run()).rejects.toThrow(expected);
+  });
+
+  it('treats a clean install-command exit as success', async () => {
+    bufferedSpawn.mockResolvedValueOnce({ success: true, code: 0, stdout: '', stderr: '', timedOut: false });
+    const [installer] = listTailcatInstallers({ brewBin: '/example/brew', goBin: null });
+    await expect(installer.run()).resolves.toBeUndefined();
+    expect(bufferedSpawn).toHaveBeenCalledWith('/example/brew', ['install', 'tailcat'],
+      expect.objectContaining({ env: expect.objectContaining({ HOMEBREW_NO_AUTO_UPDATE: '1' }) }));
   });
 
   it('looks for tailcat in the GOBIN and Homebrew prefixes a server may not have on PATH', () => {

--- a/server/services/tailcatPeer.test.js
+++ b/server/services/tailcatPeer.test.js
@@ -4,6 +4,9 @@ import {
   redactTcAddress,
   isValidTcAddress,
   ensureTailcatInstalled,
+  listTailcatInstallers,
+  listCandidateTailcatBins,
+  manualInstallHint,
   allocateLocalPort,
   startForwardProcess,
   addPeerViaTailcat,
@@ -66,38 +69,115 @@ describe('tailcatPeer helpers', () => {
   });
 
   it('ensureTailcatInstalled returns existing binary without installing', async () => {
-    const runGoInstall = vi.fn();
+    const run = vi.fn();
     const result = await ensureTailcatInstalled({
       detect: async () => '/usr/bin/tailcat',
-      runGoInstall,
-      probeGo: async () => true,
+      installers: [{ label: 'brew install tailcat', run }],
     });
     expect(result).toEqual({ bin: '/usr/bin/tailcat', installed: false });
-    expect(runGoInstall).not.toHaveBeenCalled();
+    expect(run).not.toHaveBeenCalled();
   });
 
-  it('ensureTailcatInstalled runs go install when missing, then re-detects', async () => {
+  it('ensureTailcatInstalled installs when missing, then re-detects', async () => {
     let calls = 0;
-    const runGoInstall = vi.fn(async () => {});
+    const run = vi.fn(async () => {});
     const result = await ensureTailcatInstalled({
       detect: async () => {
         calls += 1;
         return calls === 1 ? null : '/example/go/bin/tailcat';
       },
-      goBin: 'go',
-      runGoInstall,
-      probeGo: async () => true,
+      installers: [{ label: 'go install', run }],
     });
-    expect(runGoInstall).toHaveBeenCalledOnce();
+    expect(run).toHaveBeenCalledOnce();
     expect(result).toEqual({ bin: '/example/go/bin/tailcat', installed: true });
   });
 
-  it('ensureTailcatInstalled fails clearly when Go is absent', async () => {
+  it('falls back to the next installer when the first one fails', async () => {
+    let calls = 0;
+    const brew = vi.fn(async () => { throw new Error('Error: No available formula\nsecond line'); });
+    const go = vi.fn(async () => {});
+    const result = await ensureTailcatInstalled({
+      detect: async () => {
+        calls += 1;
+        return calls <= 1 ? null : '/example/go/bin/tailcat';
+      },
+      installers: [{ label: 'brew install tailcat', run: brew }, { label: 'go install', run: go }],
+    });
+    expect(brew).toHaveBeenCalledOnce();
+    expect(go).toHaveBeenCalledOnce();
+    expect(result).toEqual({ bin: '/example/go/bin/tailcat', installed: true });
+  });
+
+  it('reports what every installer said when they all fail', async () => {
     await expect(ensureTailcatInstalled({
       detect: async () => null,
-      probeGo: async () => false,
-      runGoInstall: vi.fn(),
+      platform: 'linux',
+      installers: [
+        { label: 'brew install tailcat', run: async () => { throw new Error('brew boom'); } },
+        { label: 'go install', run: async () => { throw new Error('dial tcp: connect: bad file descriptor\nignored'); } },
+      ],
+    })).rejects.toMatchObject({
+      code: 'TAILCAT_INSTALL_FAILED',
+      status: 503,
+      message: expect.stringContaining('brew install tailcat failed: brew boom'),
+    });
+  });
+
+  it('treats an installer that leaves no binary as a failure, not a success', async () => {
+    await expect(ensureTailcatInstalled({
+      detect: async () => null,
+      installers: [{ label: 'go install', run: async () => {} }],
+    })).rejects.toMatchObject({
+      code: 'TAILCAT_INSTALL_FAILED',
+      message: expect.stringContaining('go install finished but no tailcat binary was found'),
+    });
+  });
+
+  it('ensureTailcatInstalled fails clearly when no package manager is present', async () => {
+    await expect(ensureTailcatInstalled({
+      detect: async () => null,
+      installers: [],
     })).rejects.toMatchObject({ code: 'TAILCAT_MISSING', status: 503 });
+  });
+
+  it('points macOS at Homebrew, since tailcat ships no darwin release binary', () => {
+    expect(manualInstallHint('darwin')).toContain('brew install tailcat');
+    expect(manualInstallHint('darwin')).not.toContain('/releases');
+    expect(manualInstallHint('linux')).toContain('https://github.com/tailscale/tailcat/releases');
+  });
+
+  it('lists brew before go, and only for package managers that exist', () => {
+    const runInstall = vi.fn(async () => {});
+    expect(listTailcatInstallers({ brewBin: '/opt/homebrew/bin/brew', goBin: '/usr/bin/go', runInstall })
+      .map((i) => i.label)).toEqual(['brew install tailcat', 'go install']);
+    expect(listTailcatInstallers({ brewBin: null, goBin: '/usr/bin/go', runInstall })
+      .map((i) => i.label)).toEqual(['go install']);
+    expect(listTailcatInstallers({ brewBin: null, goBin: null, runInstall })).toEqual([]);
+  });
+
+  it('skips Homebrew auto-update so adding a peer does not refresh the formula index', async () => {
+    const runInstall = vi.fn(async () => {});
+    const [brew] = listTailcatInstallers({ brewBin: '/opt/homebrew/bin/brew', goBin: null, runInstall });
+    await brew.run();
+    expect(runInstall).toHaveBeenCalledWith('/opt/homebrew/bin/brew', ['install', 'tailcat'],
+      expect.objectContaining({ HOMEBREW_NO_AUTO_UPDATE: '1' }));
+  });
+
+  it('surfaces a real install command failure as a readable error', async () => {
+    const [installer] = listTailcatInstallers({ brewBin: null, goBin: '/example/missing/go' });
+    await expect(installer.run()).rejects.toThrow(/ENOENT|spawn/);
+  });
+
+  it('looks for tailcat in the GOBIN and Homebrew prefixes a server may not have on PATH', () => {
+    const bins = listCandidateTailcatBins({
+      env: { PATH: '', GOBIN: '/example/gobin', HOMEBREW_PREFIX: '/example/brew' },
+      home: '/example/home',
+    });
+    expect(bins).toContain('/example/gobin/tailcat');
+    expect(bins).toContain('/example/brew/bin/tailcat');
+    expect(bins).toContain('/opt/homebrew/bin/tailcat');
+    expect(listCandidateTailcatBins({ env: { PATH: '', GOPATH: '/example/gopath' }, home: '/example/home' }))
+      .toContain('/example/gopath/bin/tailcat');
   });
 
   it('allocateLocalPort prefers 15555 then walks upward when busy', async () => {

--- a/server/services/tailcatPeer.test.js
+++ b/server/services/tailcatPeer.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { EventEmitter } from 'node:events';
+import { delimiter, join } from 'node:path';
 import {
   redactTcAddress,
   isValidTcAddress,
@@ -169,15 +170,25 @@ describe('tailcatPeer helpers', () => {
   });
 
   it('looks for tailcat in the GOBIN and Homebrew prefixes a server may not have on PATH', () => {
+    // Empty PATH so the injected env is the only source — the real PATH must not leak in.
     const bins = listCandidateTailcatBins({
-      env: { PATH: '', GOBIN: '/example/gobin', HOMEBREW_PREFIX: '/example/brew' },
-      home: '/example/home',
+      env: { PATH: '', GOBIN: join('/example', 'gobin'), HOMEBREW_PREFIX: join('/example', 'brew') },
+      home: join('/example', 'home'),
     });
-    expect(bins).toContain('/example/gobin/tailcat');
-    expect(bins).toContain('/example/brew/bin/tailcat');
-    expect(bins).toContain('/opt/homebrew/bin/tailcat');
-    expect(listCandidateTailcatBins({ env: { PATH: '', GOPATH: '/example/gopath' }, home: '/example/home' }))
-      .toContain('/example/gopath/bin/tailcat');
+    expect(bins).toEqual([
+      join('/example', 'gobin', 'tailcat'),
+      join('/example', 'gobin', 'tailcat.exe'),
+      join('/example', 'brew', 'bin', 'tailcat'),
+      join('/opt', 'homebrew', 'bin', 'tailcat'),
+      join('/usr', 'local', 'bin', 'tailcat'),
+    ]);
+    // No GOBIN → the first GOPATH entry's bin; no GOPATH at all → ~/go/bin.
+    expect(listCandidateTailcatBins({
+      env: { PATH: '', GOPATH: [join('/example', 'gopath'), join('/example', 'other')].join(delimiter) },
+      home: join('/example', 'home'),
+    })).toContain(join('/example', 'gopath', 'bin', 'tailcat'));
+    expect(listCandidateTailcatBins({ env: { PATH: '' }, home: join('/example', 'home') }))
+      .toContain(join('/example', 'home', 'go', 'bin', 'tailcat'));
   });
 
   it('allocateLocalPort prefers 15555 then walks upward when busy', async () => {


### PR DESCRIPTION
## Summary

Adding a federated peer by tailcat address failed with:

> ❌ Failed to install tailcat via go install: … `dial tcp 142.250.73.81:443: connect: bad file descriptor`. Install a release binary from https://github.com/tailscale/tailcat/releases and retry.

Two things were wrong. PortOS only knew how to install the `tailcat` CLI with `go install`, which on this host cannot reach the Go module proxy through Go's own dialer. And the fallback advice is a dead end on macOS — **Tailcat publishes release binaries for Linux and Windows only**; the documented macOS route is `brew install tailcat` (homebrew/core).

`ensureTailcatInstalled` now runs the package managers the operator already has, in order, stopping at the first that yields a working binary:

| Order | Command | Available when |
| --- | --- | --- |
| 1 | `brew install tailcat` (with `HOMEBREW_NO_AUTO_UPDATE=1`) | `brew` on PATH |
| 2 | `go install github.com/tailscale/tailcat/cmd/tailcat@latest` | `go` on PATH |

Homebrew goes first because it is the only prebuilt route on macOS and it fetches over plain HTTPS, so it works where Go's dialer is broken. If every strategy fails, the error names each command and the first line of what it actually said, followed by platform-appropriate guidance (Homebrew on macOS, the releases page elsewhere) instead of a generic dead end.

Detection also looks in `$GOBIN` / the first `$GOPATH` entry's `bin` and the Homebrew prefix — directories a long-running PM2 server may never have inherited on its PATH.

The install spawn now reuses `bufferedSpawn` + `spawnFailureDetail` from `server/lib/bufferedSpawn.js` instead of hand-rolling a spawn/buffer/timeout promise, picking up process-tree kill with SIGKILL escalation and output caps.

## Test plan

- `server/services/tailcatPeer.test.js` — 31 passing. New coverage: installer ordering and availability gating, fallback to the next strategy on failure (async **and** sync throw), the aggregate error naming every strategy, "installer finished but no binary" treated as failure, the platform-specific hint, `HOMEBREW_NO_AUTO_UPDATE`, the candidate-path list under an injected env, and a table over every `bufferedSpawn` terminal condition (stderr tail / spawn error / silent exit code / timeout) plus the success path. Each new assertion was verified to fail against the pre-fix code.
- Full server suite: **2030 files / 40460 tests passing**.
- `client/src/pages/Instances.test.jsx`: 6 passing.
- Verified end to end on a macOS host: `brew install tailcat` succeeds, `ensureTailcatInstalled()` resolves `/opt/homebrew/bin/tailcat`, and the go-only path now produces the full diagnostic plus the Homebrew hint. Confirmed the installed CLI's `forward` argv and its `forwarding %s -> remote localhost:%d` ready line still match what `startForwardProcess` sends and waits for.