### PR TITLE
fix: resolve pinned nav rows from the bundled manifest instead of refetching it

### DIFF
--- a/client/src/components/Layout.jsx
+++ b/client/src/components/Layout.jsx
@@ -160,7 +160,6 @@ function ThemeModeToggle({ className = '' }) {
     </button>
   );
 }
-import * as api from '../services/api';
 
 // `NAV_COMMANDS` owns every structural field shared with the sidebar. This map
 // intentionally contains presentation only: giving a manifest path an icon is
@@ -758,25 +757,20 @@ export default function Layout() {
   const pipelineSeries = useSidebarSeries();
   const universes = useSidebarUniverses();
 
-  // Fetch the palette nav manifest once on mount so manifest-only paths
-  // (e.g. /wiki/log, /goals/tree) can be resolved in the Pinned/Recent sections
-  // even though they are not sidebar leaves.
-  const [manifestNav, setManifestNav] = useState([]);
-  useEffect(() => {
-    api.getPaletteManifest({ silent: true })
-      .then((data) => setManifestNav(Array.isArray(data?.nav) ? data.nav : []))
-      .catch((err) => console.warn(`⚠️ Layout: palette manifest fetch failed: ${err?.message || err}`));
-  }, []);
-
-  // Manifest-only paths still honour the feature gate, so a row pinned before the
-  // user disabled its feature stops resolving into Pinned/Recent too.
+  // Manifest-only paths (e.g. /wiki/log, /goals/tree) have no sidebar leaf, so
+  // they resolve out of the statically imported manifest that already backs
+  // `commandByPath`. Reading the bundle instead of re-fetching `/palette/manifest`
+  // is what lets a Pinned/Recent row for one of those paths render on the FIRST
+  // paint rather than popping in once a request lands (and keeps it rendering on
+  // an install where that request fails). They still honour the feature gate, so
+  // a row pinned before the user disabled its feature stops resolving too.
   const manifestEntryByPath = useMemo(() => {
     const map = new Map();
-    filterNavByFeatures(manifestNav, isFeatureEnabled).forEach((c) => {
-      if (c?.path && !map.has(c.path)) map.set(c.path, { path: c.path, label: c.label, icon: Navigation });
+    filterNavByFeatures([...commandByPath.values()], isFeatureEnabled).forEach((c) => {
+      map.set(c.path, { path: c.path, label: c.label, icon: Navigation });
     });
     return map;
-  }, [manifestNav, isFeatureEnabled]);
+  }, [isFeatureEnabled]);
 
   useEffect(() => {
     safeWriteStorage(SIDEBAR_KEY, String(collapsed));
@@ -881,11 +875,11 @@ export default function Layout() {
     (path) => {
       const direct = navEntryByPath.get(path) || manifestEntryByPath.get(path);
       if (direct) return direct;
-      const current = migrateLegacyNavPath(path, manifestNav);
+      const current = migrateLegacyNavPath(path, NAV_COMMANDS);
       if (current === path) return null;
       return navEntryByPath.get(current) || manifestEntryByPath.get(current) || null;
     },
-    [navEntryByPath, manifestEntryByPath, manifestNav],
+    [navEntryByPath, manifestEntryByPath],
   );
 
   const { pinned, recent, pin, unpin, isPinned } = useNavWorkingSet(resolveNavEntry);

--- a/client/src/components/Layout.test.jsx
+++ b/client/src/components/Layout.test.jsx
@@ -72,14 +72,6 @@ vi.mock('../services/api', () => ({
   getApps: vi.fn(() => Promise.resolve([])),
   listPipelineSeries: vi.fn(() => Promise.resolve([])),
   listUniverses: vi.fn(() => Promise.resolve([])),
-  getPaletteManifest: vi.fn(() => Promise.resolve({
-    nav: [{
-      path: '/eidoverse',
-      label: 'Eidoverse Worlds',
-      feature: 'eidoverse',
-      previousPaths: ['/openworld', '/city'],
-    }],
-  })),
   getDailyActions: vi.fn(() => Promise.resolve({ actions: [] })),
   getInstanceFeatures: vi.fn(() => Promise.resolve({ features: featureMock.features })),
 }));
@@ -208,6 +200,25 @@ describe('Layout — pinned single nav rows', () => {
   it('omits the Pinned section entirely when nothing is pinned', async () => {
     await renderLayout();
     expect(pinnedSection()).toBeNull();
+  });
+
+  it('renders a pinned manifest-only path on the first paint, with no network mock', async () => {
+    // `/wiki/log` has a NAV_COMMANDS entry but no sidebar presentation, so it
+    // resolves only through `manifestEntryByPath`. That map is derived from the
+    // statically imported manifest, so the row must be in the DOM on the very
+    // first render — assert BEFORE the act() flush renderLayout does, which is
+    // what a fetch-backed manifest would have needed to land.
+    localStorage.setItem(PINNED_KEY, JSON.stringify(['/wiki/log']));
+    render(
+      <MemoryRouter initialEntries={['/brain/inbox']}>
+        <Layout />
+      </MemoryRouter>,
+    );
+
+    const pinned = pinnedSection();
+    expect(pinned).toBeTruthy();
+    expect(within(pinned).getByRole('link', { name: /Log/i })).toHaveAttribute('href', '/wiki/log');
+    await act(async () => {});
   });
 
   it('filters out an unknown pinned path while keeping the known one', async () => {


### PR DESCRIPTION
## Summary

`Layout.jsx` has imported `NAV_COMMANDS` statically since #5053, but it still fetched `GET /api/palette/manifest` on every mount to resolve the Pinned/Recent rows whose paths have no sidebar presentation (`/wiki/log`, `/goals/tree`, …) and every stored path that needs `previousPaths` migration.

Those rows rendered nothing until the request landed and then popped in — and stayed missing for the whole session whenever the request failed (network, or an expired session on a password-gated install), with only a `console.warn`.

Changes:

- `manifestEntryByPath` is now derived from the manifest the bundle already carries, reusing the module-level `commandByPath` map that `navRowForPath` already builds from `NAV_COMMANDS`. The memo now depends only on `isFeatureEnabled`, so the feature gate is unchanged.
- `resolveNavEntry` passes `NAV_COMMANDS` to `migrateLegacyNavPath` instead of the fetched copy.
- Dropped the `import * as api` in `Layout.jsx`, whose only consumer was that fetch.

The endpoint itself is untouched — `CmdKSearch.jsx` and `VoiceWidget.jsx` still need its `actions` half, which only the server can hydrate from the voice tool registry, and `docs/COMPANION_APP_API.md` documents it for companion apps.

## Test plan

- `Layout.test.jsx` no longer mocks `getPaletteManifest`, so its nav assertions (including the existing eidoverse `previousPaths` case) now run against the real manifest rather than a hand-written one-entry fake.
- New case pins `/wiki/log` — a manifest-only path with no sidebar leaf — and asserts the Pinned row is in the DOM on the *first* render, before any `act()` flush. Verified this fails against the pre-fix component even when the mock is widened to return the complete real manifest, so it pins the timing, not just the data.
- `cd client && npm test -- Layout` → 115 passed.
- Full client suite → 876 files, 10656 passed.
- `server/lib/navManifest.test.js` + `server/routes/palette.test.js` unchanged → 75 passed.
- `cd client && npm run lint` clean.

Closes #6362