### PR TITLE
Send the cast's psychology profile and rated sliders to the author-side review

### DIFF
--- a/client/src/components/universe/CharacterDetailEditor.jsx
+++ b/client/src/components/universe/CharacterDetailEditor.jsx
@@ -24,8 +24,15 @@ import {
   CHARACTER_ARC_TYPES,
   CHARACTER_FRAMEWORK_EDITOR_FIELDS,
   CHARACTER_MOTIVATIONS_FIELD,
+  CHARACTER_PSYCHOLOGY_DRIVE_HINTS,
+  CHARACTER_PSYCHOLOGY_DRIVE_LEAVES,
+  CHARACTER_PSYCHOLOGY_EDITOR_FIELDS,
+  CHARACTER_PSYCHOLOGY_NOTE_FIELD,
   CHARACTER_SECRETS_FIELD,
   CHARACTER_SLIDER_AXES,
+  PSYCHOLOGY_ASSESSMENTS,
+  PSYCHOLOGY_DRIVE_AXES,
+  RELATIONSHIP_LINK_TYPES,
 } from '../../lib/characterFramework';
 import useFieldDraft from '../../hooks/useFieldDraft';
 import useRowDraft from '../../hooks/useRowDraft';
@@ -86,13 +93,9 @@ const SECTIONS = Object.freeze([
   },
 ]);
 
-// Mirrors `RELATIONSHIP_LINK_TYPES` / `RELATIONSHIP_OPPOSITION_AXES` in
-// server/lib/storyBible.js (#1287). The server sanitizer coerces an
-// unrecognized value to 'custom', so adding a token here without the server
-// side just means the UI offers a value the server folds back to custom.
-const RELATIONSHIP_LINK_TYPES = Object.freeze([
-  'ally', 'antagonist', 'rival', 'mentor', 'love-interest', 'family', 'custom',
-]);
+// Opposing-force axes (#1287) stay local: tagging a link as an opposing force
+// is Universe-editor-only, so the Writers Room row editor has no use for them.
+// The link TYPES are shared — see the `characterFramework` import above.
 const RELATIONSHIP_OPPOSITION_AXES = Object.freeze([
   'winner/loser', 'smart/dumb', 'hunter/prey', 'predator/prey', 'custom',
 ]);
@@ -1169,56 +1172,6 @@ function VoiceProfileSection({ universeId, entry, disabled }) {
   );
 }
 
-// Mirrors `PSYCHOLOGY_DRIVE_AXES` / `PSYCHOLOGY_ASSESSMENTS` in
-// server/lib/storyBible.js (#6414). `status` is PERCEIVED VALUE TO A GROUP —
-// not wealth, not dominance — which is why the axis carries its own hint below
-// rather than relying on the label alone.
-const PSYCHOLOGY_DRIVE_AXES = Object.freeze(['survival', 'connection', 'status']);
-const PSYCHOLOGY_ASSESSMENTS = Object.freeze(['assessed', 'unknown', 'not-applicable']);
-const DRIVE_HINTS = Object.freeze({
-  survival: 'staying safe, fed, intact — physical or existential continuity',
-  connection: 'being known, kept, belonged to',
-  status: 'perceived value to a group — respect, standing, being counted; NOT wealth or dominance',
-});
-const PSYCHOLOGY_PROSE_FIELDS = Object.freeze([
-  {
-    name: 'theoryOfControl',
-    label: 'Theory of control (one sentence)',
-    placeholder: 'the rule they operate by — "if I stay useful, nobody leaves"',
-    max: L.THEORY_OF_CONTROL_MAX,
-  },
-  {
-    name: 'strategy',
-    label: 'Strategy it motivates',
-    placeholder: 'the behavior the theory produces — "takes on everyone else\'s work, never asks for anything"',
-    max: L.PSYCHOLOGY_STRATEGY_MAX,
-  },
-  {
-    name: 'protectiveBenefit',
-    label: 'What it protects',
-    placeholder: 'the real thing it keeps them from feeling or losing',
-    max: L.PSYCHOLOGY_PROTECTION_MAX,
-  },
-  {
-    name: 'presentCost',
-    label: 'What it costs now',
-    placeholder: 'the price the strategy charges in the present',
-    max: L.PSYCHOLOGY_COST_MAX,
-  },
-  {
-    name: 'testingPressure',
-    label: 'Anticipated testing pressure',
-    placeholder: 'what would put the theory under load — anticipated, not yet dramatized',
-    max: L.PSYCHOLOGY_PRESSURE_MAX,
-  },
-  {
-    name: 'candidateChange',
-    label: 'Candidate change',
-    placeholder: 'the revision the theory might undergo if the pressure lands',
-    max: L.PSYCHOLOGY_CHANGE_MAX,
-  },
-]);
-
 // One draft-buffered textarea inside the psychology profile. A sub-component
 // because `useFieldDraft` is a hook and cannot be called inside a `.map`.
 function PsychologyField({ id, label, hint, placeholder, max, value, onCommit, disabled, rows = 2 }) {
@@ -1255,7 +1208,7 @@ function PsychologySection({ entry, onPatch, disabled }) {
   const commitDrive = (axis, patch) => commit({
     drives: { ...drives, [axis]: { ...(drives[axis] || {}), ...patch } },
   });
-  const filled = PSYCHOLOGY_PROSE_FIELDS.filter((f) => String(psychology[f.name] || '').trim()).length
+  const filled = CHARACTER_PSYCHOLOGY_EDITOR_FIELDS.filter((f) => String(psychology[f.name] || '').trim()).length
     + PSYCHOLOGY_DRIVE_AXES.filter((axis) => String(drives[axis]?.desire || '').trim() || String(drives[axis]?.fear || '').trim()).length;
   // "unassessed" is keyed on the PERSISTED object, not on the filled count: an
   // author who ruled the profile out wrote a real assessment even though every
@@ -1265,7 +1218,7 @@ function PsychologySection({ entry, onPatch, disabled }) {
     ? 'unassessed'
     : psychology.assessment && psychology.assessment !== 'assessed'
       ? psychology.assessment
-      : `${filled}/${PSYCHOLOGY_PROSE_FIELDS.length + PSYCHOLOGY_DRIVE_AXES.length} filled`;
+      : `${filled}/${CHARACTER_PSYCHOLOGY_EDITOR_FIELDS.length + PSYCHOLOGY_DRIVE_AXES.length} filled`;
   const assessmentId = `chr-psych-assessment-${entry.id}`;
   return (
     <BoxedSection icon={Compass} label="Psychology (theory of control & drives)" summary={summary}>
@@ -1299,16 +1252,16 @@ function PsychologySection({ entry, onPatch, disabled }) {
       {psychology.assessment === 'unknown' || psychology.assessment === 'not-applicable' ? (
         <PsychologyField
           id={`chr-psych-note-${entry.id}`}
-          label="Why"
-          hint="Required for unknown / not-applicable. A hive, a weather front, or an intelligence with no interior is a legitimate answer — say so here rather than inventing a human interior."
-          placeholder="why this character has no legible theory of control, or how to read one for a nonhuman"
-          max={L.PSYCHOLOGY_NOTE_MAX}
+          label={CHARACTER_PSYCHOLOGY_NOTE_FIELD.label}
+          hint={CHARACTER_PSYCHOLOGY_NOTE_FIELD.hint}
+          placeholder={CHARACTER_PSYCHOLOGY_NOTE_FIELD.placeholder}
+          max={CHARACTER_PSYCHOLOGY_NOTE_FIELD.max}
           value={psychology.assessmentNote}
           onCommit={(v) => commit({ assessmentNote: v })}
           disabled={disabled}
         />
       ) : null}
-      {PSYCHOLOGY_PROSE_FIELDS.map((field) => (
+      {CHARACTER_PSYCHOLOGY_EDITOR_FIELDS.map((field) => (
         <PsychologyField
           key={field.name}
           id={`chr-psych-${entry.id}-${field.name}`}
@@ -1329,27 +1282,20 @@ function PsychologySection({ entry, onPatch, disabled }) {
         {PSYCHOLOGY_DRIVE_AXES.map((axis) => (
           <div key={axis} className="space-y-1 border border-port-border/40 rounded p-1.5">
             <p className="text-[10px] uppercase tracking-wider text-gray-400 capitalize">{axis}</p>
-            <p className="text-[10px] leading-snug text-gray-500">{DRIVE_HINTS[axis]}</p>
-            <PsychologyField
-              id={`chr-psych-${entry.id}-${axis}-desire`}
-              label={`${axis} desire`}
-              placeholder="what they reach for on this axis"
-              max={L.PSYCHOLOGY_DRIVE_FIELD_MAX}
-              value={drives[axis]?.desire}
-              onCommit={(v) => commitDrive(axis, { desire: v })}
-              disabled={disabled}
-              rows={1}
-            />
-            <PsychologyField
-              id={`chr-psych-${entry.id}-${axis}-fear`}
-              label={`${axis} fear`}
-              placeholder="what they are bracing against on this axis"
-              max={L.PSYCHOLOGY_DRIVE_FIELD_MAX}
-              value={drives[axis]?.fear}
-              onCommit={(v) => commitDrive(axis, { fear: v })}
-              disabled={disabled}
-              rows={1}
-            />
+            <p className="text-[10px] leading-snug text-gray-500">{CHARACTER_PSYCHOLOGY_DRIVE_HINTS[axis]}</p>
+            {CHARACTER_PSYCHOLOGY_DRIVE_LEAVES.map((leaf) => (
+              <PsychologyField
+                key={leaf.name}
+                id={`chr-psych-${entry.id}-${axis}-${leaf.name}`}
+                label={`${axis} ${leaf.name}`}
+                placeholder={leaf.placeholder}
+                max={leaf.max}
+                value={drives[axis]?.[leaf.name]}
+                onCommit={(v) => commitDrive(axis, { [leaf.name]: v })}
+                disabled={disabled}
+                rows={1}
+              />
+            ))}
           </div>
         ))}
       </div>

--- a/client/src/components/writers-room/CharacterFrameworkEditors.jsx
+++ b/client/src/components/writers-room/CharacterFrameworkEditors.jsx
@@ -21,8 +21,8 @@
 import { Plus, Trash2 } from 'lucide-react';
 import {
   CHARACTER_PSYCHOLOGY_DRIVE_HINTS,
+  CHARACTER_PSYCHOLOGY_DRIVE_LEAVES,
   CHARACTER_PSYCHOLOGY_EDITOR_FIELDS,
-  CHARACTER_PSYCHOLOGY_LIMITS,
   CHARACTER_PSYCHOLOGY_NOTE_FIELD,
   CHARACTER_SLIDER_AXES,
   CHARACTER_SLIDER_MAX,
@@ -118,15 +118,15 @@ export function PsychologyFields({ value, onChange, idPrefix, inputCls }) {
         <div key={axis} className="space-y-1 border border-port-border/40 rounded p-1.5">
           <p className="text-[10px] uppercase tracking-wider text-gray-400 capitalize">{axis}</p>
           <p className={hintCls}>{CHARACTER_PSYCHOLOGY_DRIVE_HINTS[axis]}</p>
-          {['desire', 'fear'].map((leaf) => (
-            <div key={leaf}>
-              <label htmlFor={`${idPrefix}-${axis}-${leaf}`} className={subLabelCls}>{`${axis} ${leaf}`}</label>
+          {CHARACTER_PSYCHOLOGY_DRIVE_LEAVES.map((leaf) => (
+            <div key={leaf.name}>
+              <label htmlFor={`${idPrefix}-${axis}-${leaf.name}`} className={subLabelCls}>{`${axis} ${leaf.name}`}</label>
               <input
-                id={`${idPrefix}-${axis}-${leaf}`}
-                value={asObject(drives[axis])[leaf] || ''}
-                onChange={(e) => commitDrive(axis, { [leaf]: e.target.value })}
-                placeholder={leaf === 'desire' ? 'what they reach for on this axis' : 'what they are bracing against on this axis'}
-                maxLength={CHARACTER_PSYCHOLOGY_LIMITS.drive}
+                id={`${idPrefix}-${axis}-${leaf.name}`}
+                value={asObject(drives[axis])[leaf.name] || ''}
+                onChange={(e) => commitDrive(axis, { [leaf.name]: e.target.value })}
+                placeholder={leaf.placeholder}
+                maxLength={leaf.max}
                 className={inputCls}
               />
             </div>

--- a/client/src/lib/characterFramework.js
+++ b/client/src/lib/characterFramework.js
@@ -91,6 +91,9 @@ export const CHARACTER_PSYCHOLOGY_EDITOR_FIELDS = Object.freeze([
 export const CHARACTER_PSYCHOLOGY_NOTE_FIELD = Object.freeze({
   name: 'assessmentNote',
   label: 'Why',
+  // The Universe editor has room to spell the escape hatch out; the compact
+  // Writers Room row editor renders label + placeholder only.
+  hint: 'Required for unknown / not-applicable. A hive, a weather front, or an intelligence with no interior is a legitimate answer — say so here rather than inventing a human interior.',
   placeholder: 'why this character has no legible theory of control, or how to read one for a nonhuman',
   max: CHARACTER_PSYCHOLOGY_LIMITS.assessmentNote,
 });
@@ -100,3 +103,10 @@ export const CHARACTER_PSYCHOLOGY_DRIVE_HINTS = Object.freeze({
   connection: 'being known, kept, belonged to',
   status: 'perceived value to a group — respect, standing, being counted; NOT wealth or dominance',
 });
+
+// The two leaves every drive axis carries. Labelled per axis by the editors
+// (`survival desire`), so only the placeholder copy lives here.
+export const CHARACTER_PSYCHOLOGY_DRIVE_LEAVES = Object.freeze([
+  { name: 'desire', placeholder: 'what they reach for on this axis', max: CHARACTER_PSYCHOLOGY_LIMITS.drive },
+  { name: 'fear', placeholder: 'what they are bracing against on this axis', max: CHARACTER_PSYCHOLOGY_LIMITS.drive },
+]);

--- a/server/lib/characterFramework.js
+++ b/server/lib/characterFramework.js
@@ -60,7 +60,9 @@ export const CHARACTER_FRAMEWORK_FIELDS = Object.freeze([
 // to judge delivery against, without shipping the render-oriented half of the
 // profile (physical description, image refs, wardrobes, voice). Entries with
 // nothing authored are dropped so an unfilled cast contributes no prompt text
-// at all rather than a page of empty keys.
+// at all rather than a page of empty keys. Carries the whole framework the
+// store persists — the prose chain, the arc, the secrets and links, plus the
+// psychology profile (#6414) and the rated Three Sliders (#2175).
 export function pickCharacterFramework(entry) {
   if (!entry || typeof entry !== 'object') return null;
   const out = { name: typeof entry.name === 'string' ? entry.name : '' };
@@ -80,9 +82,62 @@ export function pickCharacterFramework(entry) {
       description: l?.description || '',
     }));
   }
+  const psychology = pickCharacterPsychology(entry.psychology);
+  if (psychology) out.psychology = psychology;
+  const sliders = pickCharacterSliders(entry.sliders);
+  if (sliders) out.sliders = sliders;
   // `name` alone means the writer has authored no framework for this
   // character — the caller drops it rather than prompting against a husk.
   return Object.keys(out).length > 1 ? out : null;
+}
+
+/**
+ * Authored half of the psychology profile (#6414), for the projection above.
+ * Returns null when nothing was authored, so an unassessed character adds no
+ * `psychology` key at all rather than a page of empty leaves.
+ *
+ * A NON-`assessed` verdict is authorship, not a gap: an author who marked a
+ * character `unknown` / `not-applicable` and said why in `assessmentNote` made
+ * a real decision, and it carries even when every prose leaf is blank — a
+ * review that read it as unfilled would flag that decision as a defect.
+ */
+function pickCharacterPsychology(raw) {
+  if (!raw || typeof raw !== 'object') return null;
+  const out = {};
+  for (const field of CHARACTER_PSYCHOLOGY_TEXT_FIELDS) {
+    const value = typeof raw[field] === 'string' ? raw[field].trim() : '';
+    if (value) out[field] = value;
+  }
+  if (PSYCHOLOGY_ASSESSMENTS.includes(raw.assessment)) out.assessment = raw.assessment;
+  const note = typeof raw.assessmentNote === 'string' ? raw.assessmentNote.trim() : '';
+  if (note) out.assessmentNote = note;
+  const rawDrives = raw.drives && typeof raw.drives === 'object' ? raw.drives : {};
+  const drives = {};
+  for (const axis of PSYCHOLOGY_DRIVE_AXES) {
+    const row = rawDrives[axis] && typeof rawDrives[axis] === 'object' ? rawDrives[axis] : {};
+    const desire = typeof row.desire === 'string' ? row.desire.trim() : '';
+    const fear = typeof row.fear === 'string' ? row.fear.trim() : '';
+    // The sanitizer materializes all three axes even when only one is filled,
+    // so an axis with neither leaf authored is dropped here rather than
+    // shipped as `{ desire: '', fear: '' }`.
+    if (desire || fear) drives[axis] = { ...(desire ? { desire } : {}), ...(fear ? { fear } : {}) };
+  }
+  if (Object.keys(drives).length) out.drives = drives;
+  return Object.keys(out).length ? out : null;
+}
+
+/**
+ * Rated Three-Sliders axes (#2175), for the projection above. `null` on an
+ * axis means UNRATED — never a low rating — so an unrated axis is omitted and
+ * an entirely unrated cast contributes no `sliders` key.
+ */
+function pickCharacterSliders(raw) {
+  if (!raw || typeof raw !== 'object') return null;
+  const out = {};
+  for (const axis of CHARACTER_SLIDER_AXES) {
+    if (Number.isInteger(raw[axis])) out[axis] = raw[axis];
+  }
+  return Object.keys(out).length ? out : null;
 }
 
 // Framework projection for a whole cast, empty entries removed. Returns `[]`

--- a/server/lib/characterFramework.test.js
+++ b/server/lib/characterFramework.test.js
@@ -1,0 +1,113 @@
+/**
+ * The author-side review projection (#6417). These are the cases an
+ * integration test through `evaluator.js` cannot pin cheaply, because they all
+ * turn on the difference between ABSENT and INTENTIONALLY EMPTY:
+ *
+ *   - an unrated slider axis is `null`, never a low rating;
+ *   - an unassessed psychology profile is absent, and a RULED-OUT one is a
+ *     real authored decision that must survive with no prose behind it;
+ *   - the sanitizer materializes all three drive axes even when one leaf is
+ *     filled, so blank axes must not ride into the prompt as empty husks.
+ *
+ * A projection that got any of those backwards would hand the editorial pass
+ * either a page of empty keys or a deliberate decision dressed as a gap.
+ */
+import { describe, it, expect } from 'vitest';
+import { pickCharacterFramework, pickCastFramework } from './characterFramework.js';
+
+const ASSESSED = Object.freeze({
+  theoryOfControl: 'If I stay useful, nobody leaves.',
+  strategy: 'Takes every shift nobody else wants.',
+  protectiveBenefit: '',
+  presentCost: '',
+  testingPressure: '',
+  candidateChange: '',
+  assessment: 'assessed',
+  assessmentNote: '',
+  drives: {
+    survival: { desire: '', fear: '' },
+    connection: { desire: 'to be kept', fear: '' },
+    status: { desire: '', fear: '' },
+  },
+});
+
+describe('pickCharacterFramework — psychology', () => {
+  it('carries the authored leaves and drops the blank ones', () => {
+    const out = pickCharacterFramework({ name: 'Wren Calloway', psychology: ASSESSED });
+    expect(out.psychology).toEqual({
+      theoryOfControl: 'If I stay useful, nobody leaves.',
+      strategy: 'Takes every shift nobody else wants.',
+      assessment: 'assessed',
+      drives: { connection: { desire: 'to be kept' } },
+    });
+  });
+
+  it('carries a ruled-out assessment and its note as a real assessment', () => {
+    const out = pickCharacterFramework({
+      name: 'The Tidewall',
+      psychology: {
+        assessment: 'not-applicable',
+        assessmentNote: 'A weather front. It has no interior to read.',
+        theoryOfControl: '',
+        drives: { survival: { desire: '', fear: '' } },
+      },
+    });
+    expect(out.psychology).toEqual({
+      assessment: 'not-applicable',
+      assessmentNote: 'A weather front. It has no interior to read.',
+    });
+  });
+
+  it('omits an unassessed or all-blank profile entirely', () => {
+    const blank = {
+      theoryOfControl: '', strategy: '', assessment: null, assessmentNote: '',
+      drives: { survival: { desire: '', fear: '' } },
+    };
+    expect(pickCharacterFramework({ name: 'Wren', lie: 'I only matter while useful.', psychology: blank }).psychology)
+      .toBeUndefined();
+    expect(pickCharacterFramework({ name: 'Wren', lie: 'I only matter while useful.' }).psychology)
+      .toBeUndefined();
+  });
+
+  it('ignores an assessment value the editor never offers', () => {
+    const out = pickCharacterFramework({
+      name: 'Wren',
+      psychology: { assessment: 'pending', strategy: 'Deflects.' },
+    });
+    expect(out.psychology).toEqual({ strategy: 'Deflects.' });
+  });
+});
+
+describe('pickCharacterFramework — sliders', () => {
+  it('carries rated axes and drops unrated ones', () => {
+    const out = pickCharacterFramework({
+      name: 'Wren',
+      sliders: { proactivity: 8, likability: null, competence: 7 },
+    });
+    expect(out.sliders).toEqual({ proactivity: 8, competence: 7 });
+  });
+
+  it('omits the block when no axis is rated', () => {
+    const out = pickCharacterFramework({
+      name: 'Wren',
+      lie: 'I only matter while useful.',
+      sliders: { proactivity: null, likability: null, competence: null },
+    });
+    expect(out.sliders).toBeUndefined();
+  });
+
+  it('keeps a deliberate low rating', () => {
+    expect(pickCharacterFramework({ name: 'Wren', sliders: { likability: 1 } }).sliders)
+      .toEqual({ likability: 1 });
+  });
+});
+
+describe('pickCastFramework', () => {
+  it('drops a character whose only framework content is an empty profile', () => {
+    const cast = pickCastFramework([
+      { name: 'Wren', psychology: { drives: { survival: { desire: '', fear: '' } } }, sliders: { proactivity: null } },
+      { name: 'Nils', sliders: { competence: 9 } },
+    ]);
+    expect(cast).toEqual([{ name: 'Nils', sliders: { competence: 9 } }]);
+  });
+});

--- a/server/services/writersRoom/evaluator.reviewContext.test.js
+++ b/server/services/writersRoom/evaluator.reviewContext.test.js
@@ -80,6 +80,31 @@ describe('writers room evaluate — review variables', () => {
     expect(cast[0].imageRefs).toBeUndefined();
   });
 
+  it('carries the psychology profile and the rated sliders through the store', async () => {
+    const workId = await seedWork();
+    await createCharacter(workId, {
+      name: 'Wren Calloway',
+      psychology: {
+        theoryOfControl: 'If I stay useful, nobody leaves.',
+        assessment: 'assessed',
+        drives: { connection: { fear: 'being set down' } },
+      },
+      sliders: { proactivity: 8, likability: null, competence: 7 },
+    });
+
+    await runAnalysis(workId, { kind: 'evaluate' });
+
+    const [, variables] = vi.mocked(runStagedLLM).mock.calls[0];
+    const [entry] = JSON.parse(variables.castFrameworkJson);
+    expect(entry.psychology).toEqual({
+      theoryOfControl: 'If I stay useful, nobody leaves.',
+      assessment: 'assessed',
+      drives: { connection: { fear: 'being set down' } },
+    });
+    // An unrated axis is dropped rather than sent as a low or null rating.
+    expect(entry.sliders).toEqual({ proactivity: 8, competence: 7 });
+  });
+
   it('omits the variable entirely when no character has an authored framework', async () => {
     const workId = await seedWork();
     await createCharacter(workId, { name: 'Wren Calloway', physicalDescription: 'tall, freckles' });


### PR DESCRIPTION
Refs #6417

Picks up the two remainders from #6435 that were not blocked on #6415.

## Summary

- **The author-side review now sees the psychology profile and the rated sliders.** `pickCharacterFramework` already handed the editorial `evaluate` pass the Ghost → Wound → Lie → Need → Want chain, the arc type, the secrets and the relationship links; the `psychology` profile (#6414) and the Three Sliders (#2175) stopped at the store, so the pass judged delivery against half the plan.
- **Absent stays distinct from intentionally empty**, on the same terms as the rest of the projection: an unrated slider axis is dropped rather than sent as `null` or as a low rating, a drive axis with neither leaf authored is dropped rather than shipped as `{ desire: '', fear: '' }`, and a character nobody assessed adds no `psychology` key at all. A **non-`assessed` verdict carries on its own** — note and all, with every prose leaf blank — because an author who ruled a character `unknown` / `not-applicable` made a real decision, and a review reading that as unfilled would flag it as a defect.
- **The Universe cast editor now reads the shared descriptors** instead of its own copies of `PSYCHOLOGY_DRIVE_AXES`, `PSYCHOLOGY_ASSESSMENTS`, the drive hints, the six psychology prose fields and `RELATIONSHIP_LINK_TYPES`. Behavior-preserving: same options, labels, placeholders, caps and order. The one descriptor left local is the opposing-force axis list, which only this editor authors.
- Both cast editors now take the drive `desire` / `fear` placeholders from one `CHARACTER_PSYCHOLOGY_DRIVE_LEAVES` descriptor, and the `assessmentNote` escape-hatch hint moved onto the shared note descriptor.

The framework leaf stays pure and browser-safe — no new imports. No migration, no `schemaVersions` gate and no prompt-template change: the sanitizer already persists both fields and `castFrameworkJson` is self-describing JSON.

## Decisions

- **The sliders ride along with the psychology bullet.** The issue named only `psychology`, but `CHARACTER_FRAMEWORK_FIELDS` lists `sliders` too and the function documents itself as projecting "the framework" — shipping one without the other would leave the identical one-line gap open for a third follow-up.
- **The `writers-room-evaluate` template is not edited.** It enumerates the framework fields in prose above the JSON block, so naming psychology there would read better, but a sibling branch owns `data.reference/prompts/stages/**` this cycle and the payload needs no template change to be usable. Copy-only follow-up.

## Test plan

- `server/lib/characterFramework.test.js` (new) — the absent-vs-empty cases an integration test cannot pin cheaply: authored leaves kept and blank ones dropped, a ruled-out assessment carried with no prose behind it, an all-blank profile omitted, an assessment value the editor never offers ignored, rated vs unrated slider axes, and a deliberate low rating preserved.
- `server/services/writersRoom/evaluator.reviewContext.test.js` — extended with the profile and sliders arriving through the real store, alongside the existing "nothing authored sends nothing" and "opening a work starts no AI work" guards.
- Full `server` suite: 2033 files / 40500 tests passing.
- Full `client` suite: 876 files / 10668 tests passing, no `act()` warnings.

## Remaining

- ▢ Shared cast-integrity review + selective augmentation wiring — still blocked on #6415's Writers Room adapter. This PR touches none of `characterIntegrity.js`, `writersRoom/syncedReview.js` or `fableLoom/**`.
