### PR TITLE
fix: respect scheduled task issue filters in prompt context

### DIFF
--- a/server/services/autonomousJobs/skillTemplates.js
+++ b/server/services/autonomousJobs/skillTemplates.js
@@ -150,7 +150,7 @@ async function generateTaskFromJob(job) {
     ? (job.appId ? await getAppById(job.appId) : { id: null, name: 'PortOS', repoPath: PATHS.root })
     : null
   const inputs = selectedInputs.length > 0
-    ? await resolveTaskDataInputs(selectedInputs, { app })
+    ? await resolveTaskDataInputs(selectedInputs, { app, taskMetadata: job.taskMetadata })
     : []
   const taskPrompt = appendTaskDataInputs(prompt, inputs)
   const description = taskPrompt.split('\n').map(line => line.trim()).find(Boolean) || job.name

--- a/server/services/cosTaskGenerator.js
+++ b/server/services/cosTaskGenerator.js
@@ -1917,7 +1917,9 @@ export async function generateSelfImprovementTaskForType(taskType, state) {
   }
 
   const taskDataInputs = await resolveTaskDataInputs(interval.dataInputs, {
-    app: { id: null, name: 'PortOS', repoPath: PATHS.root }
+    app: { id: null, name: 'PortOS', repoPath: PATHS.root },
+    taskMetadata: metadata,
+    taskType
   });
   description = appendTaskDataInputs(description, taskDataInputs);
 
@@ -3171,7 +3173,7 @@ export async function generateManagedAppImprovementTaskForType(taskType, app, st
       planConstraint: planConstraintBlock
     }
   });
-  const taskDataInputs = await resolveTaskDataInputs(interval.dataInputs, { app });
+  const taskDataInputs = await resolveTaskDataInputs(interval.dataInputs, { app, taskMetadata: metadata, taskType: promptTaskType });
   const description = scopeDescriptionToPullRequest(
     appendTaskDataInputs(baseDescription, taskDataInputs),
     metadata

--- a/server/services/perpetualWork.js
+++ b/server/services/perpetualWork.js
@@ -68,10 +68,10 @@ export const WORK_ITEM_LIMIT = 50;
  * Never rejects: a spawn error, non-zero exit, or timeout all resolve to a
  * result object the detectors classify themselves.
  */
-function runCli(cmd, args, cwd) {
+function runCli(cmd, args, cwd, env) {
   return new Promise((resolve) => {
     let stdout = '', stderr = '', settled = false;
-    const child = spawn(cmd, args, { cwd, shell: false });
+    const child = spawn(cmd, args, { cwd, shell: false, ...(env ? { env } : {}) });
     const done = (result) => { if (!settled) { settled = true; clearTimeout(timer); resolve(result); } };
     child.stdout.on('data', (d) => { stdout += d.toString(); });
     child.stderr.on('data', (d) => { stderr += d.toString(); });
@@ -266,9 +266,9 @@ const withGithubHost = async (args, repoPath) => [
   ...args.slice(1)
 ];
 
-async function resolveAuthenticatedLogin(cli, args, repoPath) {
+async function resolveAuthenticatedLogin(cli, args, repoPath, env) {
   const probeArgs = cli === 'gh' ? await withGithubHost(args, repoPath) : args;
-  const res = await runCli(cli, probeArgs, repoPath);
+  const res = await runCli(cli, probeArgs, repoPath, env);
   const login = (res.stdout || '').trim();
   return (res.code !== 0 || !login) ? { error: `${cli}-unavailable` } : { login };
 }
@@ -282,13 +282,13 @@ async function resolveAuthenticatedLogin(cli, args, repoPath) {
  * security boundary. Both are worse than retrying next tick, so the failure
  * carries a `remedy` the caller can surface instead.
  */
-async function resolveTrustedLogins(cfg, repoPath) {
-  const { login, error } = await resolveAuthenticatedLogin(cfg.cli, cfg.selfLoginArgs, repoPath);
+async function resolveTrustedLogins(cfg, repoPath, env) {
+  const { login, error } = await resolveAuthenticatedLogin(cfg.cli, cfg.selfLoginArgs, repoPath, env);
   if (error) return { error };
   const membersArgs = cfg.cli === 'gh'
     ? await withGithubHost(cfg.membersArgs, repoPath)
     : cfg.membersArgs;
-  const res = await runCli(cfg.cli, membersArgs, repoPath);
+  const res = await runCli(cfg.cli, membersArgs, repoPath, env);
   if (res.code !== 0) return { error: cfg.membersFail, remedy: cfg.membersRemedy };
   const logins = new Set([login.toLowerCase()]);
   for (const line of (res.stdout || '').split('\n')) {
@@ -367,8 +367,8 @@ const FORGE_ISSUE_CONFIG = {
     // gh; transient if gh is unauthenticated / not a GitHub remote. `isOrg` lets
     // detectForgeIssues short-circuit the owner-filter org trap — an org login is
     // never an issue author, so `--author <org>` is guaranteed to match nothing.
-    resolveOwner: async (repoPath) => {
-      const r = await runCli('gh', ['repo', 'view', '--json', 'owner,isInOrganization'], repoPath);
+    resolveOwner: async (repoPath, env) => {
+      const r = await runCli('gh', ['repo', 'view', '--json', 'owner,isInOrganization'], repoPath, env);
       if (r.code !== 0) return { error: 'gh-unavailable' };
       let parsed;
       try {
@@ -433,20 +433,20 @@ const FORGE_ISSUE_CONFIG = {
     // somehow does, skip the ambiguous probe and take the safe `--author <ns>`
     // path (isOrg:false). Nested subgroups are URL-encoded (`parent%2Fsub`) and so
     // are never all-numeric — they still probe normally.
-    resolveOwner: async (repoPath) => {
+    resolveOwner: async (repoPath, env) => {
       const namespace = await resolveGitlabNamespace(repoPath);
       if (!namespace) return { error: 'glab-owner-unresolved' };
       const probe = /^\d+$/.test(namespace)
         ? { code: 1 }
-        : await runCli('glab', ['api', `groups/${encodeURIComponent(namespace)}`], repoPath);
+        : await runCli('glab', ['api', `groups/${encodeURIComponent(namespace)}`], repoPath, env);
       return { owner: namespace, isOrg: probe.code === 0 };
     },
     // `--self` mode: glab's `--author` expects a username (no `@me` token), so
     // resolve the authenticated account via the API; the same lookup also powers
     // the self-assignee retry check. It is transient if glab is unauthenticated
     // or unreachable.
-    resolveSelf: async (repoPath) => {
-      const { login, error } = await resolveAuthenticatedLogin('glab', GLAB_SELF_LOGIN_ARGS, repoPath);
+    resolveSelf: async (repoPath, env) => {
+      const { login, error } = await resolveAuthenticatedLogin('glab', GLAB_SELF_LOGIN_ARGS, repoPath, env);
       return error ? { error } : { author: login };
     },
     // `collaborators` mode: you + every project member. `members/all` (not
@@ -472,8 +472,8 @@ const FORGE_ISSUE_CONFIG = {
  * phantom count. Reuses `cfg.listArgs`, which is the base list WITHOUT the
  * `--author` filter (the filter is appended separately in detectForgeIssues).
  */
-async function countOpenIssuesUnfiltered(cfg, repoPath) {
-  const res = await runCli(cfg.cli, [...cfg.listArgs], repoPath);
+async function countOpenIssuesUnfiltered(cfg, repoPath, env) {
+  const res = await runCli(cfg.cli, [...cfg.listArgs], repoPath, env);
   if (res.code !== 0) return 0;
   let raw;
   try {
@@ -493,7 +493,7 @@ async function countOpenIssuesUnfiltered(cfg, repoPath) {
  * issues; 'any' = every author). The in-flight scan runs only when the list is
  * non-empty, so an empty queue parks without a wasted branch/PR scan.
  */
-async function detectForgeIssues(forgeKey, app, { issueAuthorFilter = 'self', issueExcludeLabels = [] } = {}) {
+async function detectForgeIssues(forgeKey, app, { issueAuthorFilter = 'self', issueExcludeLabels = [] } = {}, contextOnly = false, env) {
   const cfg = FORGE_ISSUE_CONFIG[forgeKey];
   const repoPath = app?.repoPath;
   if (!repoPath) return { actionable: false, count: 0, reason: 'no-repo-path' };
@@ -537,12 +537,12 @@ async function detectForgeIssues(forgeKey, app, { issueAuthorFilter = 'self', is
   if (issueAuthorFilter === 'any') {
     // no --author filter
   } else if (issueAuthorFilter === 'collaborators') {
-    const { logins, error, remedy } = await resolveTrustedLogins(cfg, repoPath);
+    const { logins, error, remedy } = await resolveTrustedLogins(cfg, repoPath, env);
     if (error) return transient(error, remedy);
     trustedLogins = logins;
     authorApplied = true;
   } else if (issueAuthorFilter === 'owner') {
-    const { owner, isOrg, error } = await cfg.resolveOwner(repoPath);
+    const { owner, isOrg, error } = await cfg.resolveOwner(repoPath, env);
     if (error) return transient(error);
     if (isOrg) {
       // The owner filter resolved to a non-authoring owner (a GitHub ORG or a
@@ -551,13 +551,13 @@ async function detectForgeIssues(forgeKey, app, { issueAuthorFilter = 'self', is
       // count with the forge-flavored short-circuit reason (`owner-is-org` /
       // `owner-is-group`), so the toast steers the user to 'self'/'any' instead of
       // implying a personal-username mismatch (the failure that motivated this).
-      const openCount = await countOpenIssuesUnfiltered(cfg, repoPath);
+      const openCount = contextOnly ? 0 : await countOpenIssuesUnfiltered(cfg, repoPath, env);
       return parked(cfg.ownerIsOrgReason, openCount);
     }
     args.push('--author', owner);
     authorApplied = true;
   } else {
-    const { author, error } = await cfg.resolveSelf(repoPath);
+    const { author, error } = await cfg.resolveSelf(repoPath, env);
     if (error) return transient(error);
     args.push('--author', author);
     authorApplied = true;
@@ -566,8 +566,9 @@ async function detectForgeIssues(forgeKey, app, { issueAuthorFilter = 'self', is
   // One issue-list invocation: run it, parse it, and report the forge-flavored
   // transient reason on any failure. Shared by the single-query paths and by the
   // `collaborators` per-login fan-out below.
+  let listingTruncated = false;
   const listIssues = async (extraArgs = []) => {
-    const res = await runCli(cfg.cli, [...args, ...extraArgs], repoPath);
+    const res = await runCli(cfg.cli, [...args, ...extraArgs], repoPath, env);
     if (res.code !== 0) return { error: cfg.listFail };
     let parsed;
     try {
@@ -576,6 +577,7 @@ async function detectForgeIssues(forgeKey, app, { issueAuthorFilter = 'self', is
       return { error: cfg.parseFail };
     }
     if (!Array.isArray(parsed)) return { error: cfg.parseFail };
+    if (parsed.length >= (cfg.cli === 'gh' ? 500 : 100)) listingTruncated = true;
     return { issues: cfg.normalize(parsed) };
   };
 
@@ -612,6 +614,18 @@ async function detectForgeIssues(forgeKey, app, { issueAuthorFilter = 'self', is
   // boundary, so "can't tell who filed it" resolves to "not trusted".
   if (trustedLogins) issues = issues.filter((i) => trustedLogins.has(i.authorLogin));
 
+  // Prompt context observes author and configured label policy without hiding
+  // blocked/assigned work that a non-claim task may need to inspect.
+  if (contextOnly) {
+    const excluded = new Set((Array.isArray(issueExcludeLabels) ? issueExcludeLabels : []).map((label) => String(label).toLowerCase()));
+    return {
+      truncated: listingTruncated || (trustedLogins?.size || 0) > MAX_COLLABORATOR_AUTHOR_QUERIES,
+      issues: issues.filter((issue) => !(issue.labels || []).some((label) =>
+        excluded.has(String(typeof label === 'string' ? label : label?.name).toLowerCase())
+      ))
+    };
+  }
+
   if (issues.length === 0) {
     // An empty *filtered* list is ambiguous: the repo may truly have no open
     // issues, OR it has open issues that just don't match the author filter —
@@ -631,7 +645,7 @@ async function detectForgeIssues(forgeKey, app, { issueAuthorFilter = 'self', is
     // when the other-authored issues are all blocked/assigned/decomposed
     // epics. Counting claimable ones would cost the full skip-list scan here.
     if (authorApplied) {
-      const openCount = await countOpenIssuesUnfiltered(cfg, repoPath);
+      const openCount = await countOpenIssuesUnfiltered(cfg, repoPath, env);
       if (openCount > 0) return parked('no-authored-issues', openCount);
     }
     return parked('no-open-issues');
@@ -641,7 +655,7 @@ async function detectForgeIssues(forgeKey, app, { issueAuthorFilter = 'self', is
   const [inFlight, currentLoginResult] = await Promise.all([
     inFlightIssueNumbers(repoPath, cfg.inFlightForge),
     hasAssignedIssue
-      ? resolveAuthenticatedLogin(cfg.cli, cfg.selfLoginArgs, repoPath)
+      ? resolveAuthenticatedLogin(cfg.cli, cfg.selfLoginArgs, repoPath, env)
       : Promise.resolve({ login: null })
   ]);
   if (currentLoginResult.error) return transient(currentLoginResult.error);
@@ -672,6 +686,14 @@ async function detectForgeIssues(forgeKey, app, { issueAuthorFilter = 'self', is
     signature: JSON.stringify(canonicalizeIds(actionable.map((i) => i.number))),
     items: actionable.slice(0, WORK_ITEM_LIMIT).map((i) => ({ ref: String(i.number), title: i.title || '' }))
   };
+}
+
+/** List prompt inputs using the same author-resolution boundary as claiming. */
+export async function listConfiguredForgeIssues(cli, app, options, env) {
+  const result = await detectForgeIssues(
+    cli === 'glab' ? 'claim-issue-gitlab' : 'claim-issue', app, options, true, env
+  );
+  return { ok: !result.transient && result.reason !== 'no-repo-path', issues: result.issues || [], truncated: result.truncated === true };
 }
 
 // Forge-specific detector entry points (thin wrappers over the shared factory).

--- a/server/services/perpetualWork.test.js
+++ b/server/services/perpetualWork.test.js
@@ -18,6 +18,7 @@ import {
   issueNumberFromRef,
   detectActionableWork,
   detectGithubIssues,
+  listConfiguredForgeIssues,
   detectGitlabIssues,
   registerWorkDetector,
   getWorkDetector,
@@ -543,6 +544,35 @@ describe('perpetualWork', () => {
         expect(authorListCalls()).toEqual(['alice', 'bob', 'carol']);
         const memberCall = spawn.mock.calls.find(([cmd, args]) => cmd === 'gh' && args[0] === 'api' && args.includes('--paginate'));
         expect(memberCall[1]).toEqual(expect.arrayContaining(['--hostname', 'github.com']));
+      });
+
+      it('preloads only trusted authors and configured labels without applying claim-state skips', async () => {
+        routeCollaborators({ issuesByAuthor: {
+          alice: [
+            { number: 1, title: 'Blocked context', labels: ['blocked'], author: { login: 'alice' } },
+            { number: 2, title: 'Reserved', labels: [{ name: 'Human-Only' }], author: { login: 'alice' } },
+            { number: 3, title: 'External', labels: [], author: { login: 'outsider' } },
+            { number: 4, title: 'Unknown', labels: [] }
+          ],
+          bob: [{ number: 5, title: 'Teammate', labels: [], author: { login: 'Bob' } }],
+          carol: []
+        } });
+        const out = await listConfiguredForgeIssues('gh', app, {
+          issueAuthorFilter: 'collaborators', issueExcludeLabels: ['human-only']
+        }, { PATH: '/bin' });
+        expect(out.ok).toBe(true);
+        expect(out.issues.map(issue => issue.number)).toEqual([1, 5]);
+        expect(spawn.mock.calls.filter(([cmd]) => cmd === 'gh').every(([, , options]) =>
+          options.env?.PATH === '/bin'
+        )).toBe(true);
+        expect(authorListCalls()).toEqual(['alice', 'bob', 'carol']);
+      });
+
+      it('does not preload a partial trusted set when collaborator lookup fails', async () => {
+        routeCollaborators({ collabCode: 1 });
+        const out = await listConfiguredForgeIssues('gh', app, { issueAuthorFilter: 'collaborators' });
+        expect(out).toMatchObject({ ok: false, issues: [] });
+        expect(authorListCalls()).toEqual([]);
       });
 
       it('de-duplicates an issue returned by more than one author query', async () => {

--- a/server/services/taskDataInputs.js
+++ b/server/services/taskDataInputs.js
@@ -216,11 +216,22 @@ const INPUT_LOADERS = {
   'project-goals': async ({ app, deps }) => renderRepositoryDocuments(
     'GOALS.md', await deps.findFiles(app?.repoPath, 'GOALS.md')
   ),
-  'open-issues': async ({ app, deps, forge }) => {
+  'open-issues': async ({ app, deps, forge, taskMetadata, taskType }) => {
     if (!forge) return unavailableMessage('Open issues', 'repository forge is unavailable');
-    const result = await deps.listIssues({ cli: forge.cli, cwd: app.repoPath, env: forge.env });
+    const claimTask = ['claim-issue', 'claim-issue-gitlab', 'claim-work'].includes(taskType);
+    const configured = taskMetadata.issueAuthorFilter !== undefined
+      || taskMetadata.issueExcludeLabels?.length > 0
+      || claimTask;
+    const result = configured
+      ? await deps.listConfiguredIssues(forge.cli, app, {
+          issueAuthorFilter: taskMetadata.issueAuthorFilter
+            ?? (claimTask ? 'self' : 'any'),
+          issueExcludeLabels: taskMetadata.issueExcludeLabels || [],
+        }, forge.env)
+      : await deps.listIssues({ cli: forge.cli, cwd: app.repoPath, env: forge.env });
     return result.ok
-      ? renderForgeItems(result.issues, { emptyMessage: 'No open issues.' })
+      ? renderForgeItems(result.issues, { emptyMessage: configured ? 'No open issues match this task’s configured filters.' : 'No open issues.' })
+        + (result.truncated ? TRUNCATION_NOTICE : '')
       : unavailableMessage('Open issues');
   },
   'open-pull-requests': async ({ app, deps, forge }) => {
@@ -240,7 +251,7 @@ const INPUT_LOADERS = {
 };
 
 /** Resolve selected input ids into prompt-ready sections without throwing. */
-export async function resolveTaskDataInputs(inputIds, { app, dependencies = {} } = {}) {
+export async function resolveTaskDataInputs(inputIds, { app, taskMetadata = {}, taskType, dependencies = {} } = {}) {
   const selected = Array.isArray(inputIds) ? [...new Set(inputIds)] : [];
   if (!selected.length) return [];
   const definitions = new Map(TASK_DATA_INPUT_DEFINITIONS.map((definition) => [definition.id, definition]));
@@ -249,6 +260,10 @@ export async function resolveTaskDataInputs(inputIds, { app, dependencies = {} }
     resolveTracker: resolveAppWorkTracker,
     resolveTokenEnv: resolveForgeTokenEnv,
     listIssues: listForgeOpenIssues,
+    listConfiguredIssues: async (...args) => {
+      const { listConfiguredForgeIssues } = await import('./perpetualWork.js');
+      return listConfiguredForgeIssues(...args);
+    },
     listPullRequests: listForgePullRequests,
     environment: process.env,
     ...dependencies,
@@ -262,7 +277,7 @@ export async function resolveTaskDataInputs(inputIds, { app, dependencies = {} }
     const definition = definitions.get(id);
     const loader = INPUT_LOADERS[id];
     if (!definition || !loader) return null;
-    const content = await loader({ app, deps, forge }).catch(() => unavailableMessage(definition.label));
+    const content = await loader({ app, deps, forge, taskMetadata, taskType }).catch(() => unavailableMessage(definition.label));
     return { id, label: definition.label, content };
   }));
   return sections.filter(Boolean);

--- a/server/services/taskDataInputs.test.js
+++ b/server/services/taskDataInputs.test.js
@@ -68,6 +68,28 @@ describe('taskDataInputs', () => {
     expect(empty[0].content).toBe('No open issues.');
   });
 
+  it('uses task policy for issue context and fails closed when policy resolution fails', async () => {
+    const listConfiguredIssues = vi.fn().mockResolvedValue({ ok: true, issues: [{ number: 7, title: 'Eligible' }] });
+    const listIssues = vi.fn();
+    const options = {
+      app: APP, taskType: 'claim-issue',
+      taskMetadata: { issueAuthorFilter: 'collaborators', issueExcludeLabels: ['human-only'] },
+      dependencies: {
+        resolveTracker: vi.fn().mockResolvedValue({ forge: 'gh', host: 'github.com' }),
+        resolveTokenEnv: vi.fn().mockResolvedValue({}), listConfiguredIssues, listIssues,
+      },
+    };
+    const sections = await resolveTaskDataInputs(['open-issues'], options);
+    expect(sections[0].content).toContain('#7 Eligible');
+    expect(listConfiguredIssues).toHaveBeenCalledWith('gh', APP, options.taskMetadata, expect.any(Object));
+    listConfiguredIssues.mockResolvedValue({ ok: false, issues: [] });
+    expect((await resolveTaskDataInputs(['open-issues'], options))[0].content).toContain('could not be preloaded');
+    options.taskMetadata = {};
+    await resolveTaskDataInputs(['open-issues'], options);
+    expect(listConfiguredIssues).toHaveBeenLastCalledWith('gh', APP, { issueAuthorFilter: 'self', issueExcludeLabels: [] }, expect.any(Object));
+    expect(listIssues).not.toHaveBeenCalled();
+  });
+
   it('reports a discovered document that could not be read', async () => {
     const sections = await resolveTaskDataInputs(['project-goals'], {
       app: APP,


### PR DESCRIPTION
## Summary
Scheduled-task open-issue context now respects the effective author filter and excluded labels, including per-app overrides. Claim tasks retain the default self-only policy when older configuration omits it.

Reuse the existing GitHub/GitLab author-resolution path, preserve sanitized forge credentials, and report failed policy lookups as unavailable without falling back to all issues. General tasks without issue filters keep their existing open-issue context.

## Test plan
- Passed 329 tests across taskDataInputs, perpetualWork, cosTaskGenerator, and autonomousJobs.
- Regression coverage includes collaborator and unknown-author exclusion, case-insensitive label exclusions, credential environment forwarding, and failed collaborator lookup.
- Optional Ollama local review attempted; endpoint returned HTTP 401 without a verdict.
