### PR TITLE
stop offering codex effort 'minimal' for gpt-6 models, which reject it

### DIFF
--- a/client/src/components/media/MediaJobsQueue.jsx
+++ b/client/src/components/media/MediaJobsQueue.jsx
@@ -8,7 +8,7 @@ import AutoSizeTextarea from '../ui/AutoSizeTextarea';
 import { listMediaJobs, cancelMediaJob, cancelQueuedMediaJobs, deleteMediaJob, retryMediaJob, runMediaJobNow, listMediaVideoHolds, resumeMediaVideoHold } from '../../services/apiMediaJobs.js';
 import { listLoraTrainingCheckpoints } from '../../services/apiLoraTraining.js';
 import { isCloudCliMode, IMAGE_GEN_MODE, CODEX_IMAGEGEN_DEFAULT_EFFORT, supportsCloudModelOverride, modeLabel, mediaJobLane, isCloudVideoMode } from '../../lib/imageGenBackends';
-import { ANTIGRAVITY_CONFIGURED_DEFAULT, CODEX_EFFORT_LEVELS, isConfiguredDefaultModel } from '../../utils/providers';
+import { ANTIGRAVITY_CONFIGURED_DEFAULT, effortLevelsForProvider, isConfiguredDefaultModel } from '../../utils/providers';
 import { lossSparklineGeometry } from '../../lib/lossSparkline';
 import {
   DEFAULT_I2V_REFERENCE_MODE, isDefaultI2vReferenceMode, normalizeI2vReferenceMode,
@@ -662,11 +662,16 @@ function EditRetryForm({ job, onSubmit, onCancel }) {
   const [width, setWidth] = useState(p.width ?? '');
   const [height, setHeight] = useState(p.height ?? '');
   const [steps, setSteps] = useState(p.steps ?? '');
-  // The job's stored effort (a CODEX_EFFORT_LEVELS value) or the "default" option
+  // The job's stored effort (a codex effort level) or the "default" option
   // when it carried none. On submit we only send `effort` when this differs from
   // the original — the sentinel resets to default, a level pins that level.
   const originalEffort = codexEffortOf(p.effort) || EFFORT_DEFAULT_OPTION;
   const [effort, setEffort] = useState(originalEffort);
+  // Codex's ladder is MODEL-gated, so the options track the model field above:
+  // the gpt-6 family has no `minimal` rung and rejects it with an HTTP 400,
+  // failing the retry. An empty override means the shipped default model, whose
+  // ladder is the unrestricted one.
+  const codexEffortLevels = effortLevelsForProvider({ id: 'codex', command: 'codex' }, model.trim());
 
   const submit = (e) => {
     e.preventDefault();
@@ -755,7 +760,7 @@ function EditRetryForm({ job, onSubmit, onCancel }) {
             className="w-full px-2 py-1 bg-port-bg border border-port-border rounded text-white text-xs"
           >
             <option value={EFFORT_DEFAULT_OPTION}>Default ({CODEX_IMAGEGEN_DEFAULT_EFFORT})</option>
-            {CODEX_EFFORT_LEVELS.map((lvl) => (
+            {codexEffortLevels.map((lvl) => (
               <option key={lvl} value={lvl}>{lvl}</option>
             ))}
           </select>

--- a/client/src/components/settings/ImageGenTab.jsx
+++ b/client/src/components/settings/ImageGenTab.jsx
@@ -29,7 +29,7 @@ import { resolveCleanersFromConfig } from '../../lib/imageCleaners';
 import { useMediaJobSse } from '../../hooks/useMediaJobSse';
 import { useAgyModels } from '../../hooks/useAgyModels';
 import { useHfTokenStatus } from '../../hooks/useHfTokenStatus';
-import { CODEX_EFFORT_LEVELS } from '../../utils/providers';
+import { effortLevelsForProvider } from '../../utils/providers';
 
 const SDAPI_TOOL_ID = 'sdapi';
 const CODEX_TOOL_ID = 'codex-imagegen';
@@ -129,6 +129,13 @@ export function ImageGenTab() {
   const [codexModel, setCodexModel] = useState('');
   // Empty = use the shipped default effort (CODEX_IMAGEGEN_DEFAULT_EFFORT).
   const [codexEffort, setCodexEffort] = useState('');
+  // Codex's effort ladder is MODEL-gated, so the options track the model field
+  // above rather than a fixed constant: the gpt-6 family has no `minimal` rung
+  // and rejects it with an HTTP 400, failing the render.
+  const codexEffortLevels = effortLevelsForProvider(
+    { id: 'codex', command: 'codex' },
+    codexModel.trim() || CODEX_IMAGEGEN_DEFAULT_MODEL,
+  );
   const [codexParallelLimit, setCodexParallelLimit] = useState(1);
   // Grok Build CLI provider config — gated by `grokEnabled` the same way as
   // Codex (renders spend the user's Grok quota). No model/effort fields:
@@ -1007,11 +1014,11 @@ export function ImageGenTab() {
                 className="w-full bg-port-bg border border-port-border rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-port-accent"
               >
                 <option value="">Default ({CODEX_IMAGEGEN_DEFAULT_EFFORT})</option>
-                {CODEX_EFFORT_LEVELS.map((lvl) => (
+                {codexEffortLevels.map((lvl) => (
                   <option key={lvl} value={lvl}>{lvl}</option>
                 ))}
               </select>
-              <p className="text-xs text-gray-500 mt-1">Passed as <code>codex exec -c model_reasoning_effort=&lt;level&gt;</code>. Lower effort is cheaper; leave on the shipped default (<code>{CODEX_IMAGEGEN_DEFAULT_EFFORT}</code>) or drop to <code>minimal</code> for the cheapest possible renders.</p>
+              <p className="text-xs text-gray-500 mt-1">Passed as <code>codex exec -c model_reasoning_effort=&lt;level&gt;</code>. Lower effort is cheaper; leave on the shipped default (<code>{CODEX_IMAGEGEN_DEFAULT_EFFORT}</code>) or drop to <code>{codexEffortLevels[0]}</code> for the cheapest possible renders. The levels offered depend on the model above.</p>
             </FormField>
             <FormField label="Parallel render limit" labelClassName="block text-xs font-medium text-gray-400 mb-1">
               <input

--- a/client/src/utils/providerModels.js
+++ b/client/src/utils/providerModels.js
@@ -109,9 +109,24 @@ export const GROK_EFFORT_LEVELS = Object.freeze(['low', 'medium', 'high', 'xhigh
 
 const CODEX_ULTRA_MODELS = new Set(['gpt-5.6', 'gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-6-astra']);
 
-const codexEffortLevelsForModel = (model) => CODEX_ULTRA_MODELS.has(String(model || '').trim().toLowerCase())
-  ? CODEX_ULTRA_EFFORT_LEVELS
-  : CODEX_EFFORT_LEVELS;
+// MIRROR of `CODEX_NO_MINIMAL_MODEL_RE` in server/lib/providerModels.js. The
+// gpt-6 family dropped the `minimal` rung and answers HTTP 400
+// `unsupported_value` when it is sent, so the picker must not offer it. Matched
+// as a family prefix so a new gpt-6/7 model doesn't reintroduce the 400.
+const CODEX_NO_MINIMAL_MODEL_RE = /^gpt-[6-9]([.-]|$)/;
+
+const withoutMinimal = (levels) => Object.freeze(levels.filter((l) => l !== 'minimal'));
+const CODEX_EFFORT_LEVELS_NO_MINIMAL = withoutMinimal(CODEX_EFFORT_LEVELS);
+const CODEX_ULTRA_EFFORT_LEVELS_NO_MINIMAL = withoutMinimal(CODEX_ULTRA_EFFORT_LEVELS);
+
+const codexEffortLevelsForModel = (model) => {
+  const id = String(model || '').trim().toLowerCase();
+  const ultra = CODEX_ULTRA_MODELS.has(id);
+  if (CODEX_NO_MINIMAL_MODEL_RE.test(id)) {
+    return ultra ? CODEX_ULTRA_EFFORT_LEVELS_NO_MINIMAL : CODEX_EFFORT_LEVELS_NO_MINIMAL;
+  }
+  return ultra ? CODEX_ULTRA_EFFORT_LEVELS : CODEX_EFFORT_LEVELS;
+};
 
 /**
  * Antigravity base-model ↔ effort-suffix split — MIRROR of

--- a/client/src/utils/providers.test.js
+++ b/client/src/utils/providers.test.js
@@ -187,6 +187,21 @@ describe('effortLevelsForProvider (server mirror)', () => {
     expect(effortLevelsForProvider(provider)).toEqual(expected);
     expect(serverEffortLevelsForProvider(provider)).toEqual(expected);
   });
+
+  // Codex's ladder is model-gated in BOTH directions: the gpt-6 family adds
+  // `ultra` and drops `minimal` (sending it fails the run with HTTP 400
+  // `unsupported_value`). A client that still offers the rung shows the user a
+  // level whose only outcome is a dead run, so pin the gate on both sides.
+  it.each([
+    ['gpt-6-astra', ['low', 'medium', 'high', 'xhigh', 'max', 'ultra']],
+    ['gpt-6.1-nova', ['low', 'medium', 'high', 'xhigh', 'max']],
+    ['gpt-5.6-sol', ['minimal', 'low', 'medium', 'high', 'xhigh', 'max', 'ultra']],
+    ['gpt-5.3-codex-spark', CODEX_EFFORT_LEVELS],
+  ])('codex ladder for %s', (model, expected) => {
+    const codex = { id: 'codex', command: 'codex' };
+    expect(effortLevelsForProvider(codex, model)).toEqual(expected);
+    expect(serverEffortLevelsForProvider(codex, model)).toEqual(expected);
+  });
 });
 
 // Which providers the Generation Defaults block is offered for. The rule has to

--- a/server/lib/providerModels.js
+++ b/server/lib/providerModels.js
@@ -85,6 +85,9 @@ export const resolveCliModel = (model) => isConfiguredDefaultModel(model) ? null
 // Codex Ultra adds automatic task delegation on the models that advertise it.
 // Keep it model-gated: older Codex models and Luna top out at `max`.
 //
+// `minimal` is model-gated the other way — it is a gpt-5-era rung that the
+// gpt-6 family dropped. See CODEX_NO_MINIMAL_MODEL_RE below.
+//
 // `none` is a real codex variant but is deliberately NOT offered: it means "do
 // not reason at all", which no PortOS effort control should be able to select.
 // ---------------------------------------------------------------------------
@@ -123,9 +126,30 @@ export const EFFORT_LEVELS = Object.freeze([...new Set([
 
 const CODEX_ULTRA_MODELS = new Set(['gpt-5.6', 'gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-6-astra']);
 
-const codexEffortLevelsForModel = (model) => CODEX_ULTRA_MODELS.has(String(model || '').trim().toLowerCase())
-  ? CODEX_ULTRA_EFFORT_LEVELS
-  : CODEX_EFFORT_LEVELS;
+// Models that REJECT `minimal`. The gpt-6 family dropped the rung: codex
+// against `gpt-6-astra` answers HTTP 400 `unsupported_value` — "'minimal' is
+// not supported with the 'gpt-6-astra' model. Supported values are: 'low',
+// 'medium', 'high', 'xhigh', and 'max'." — so a picker that offers it hands the
+// user a level whose only outcome is a failed run.
+//
+// Matched as a FAMILY prefix rather than an id list, deliberately: the two
+// failure directions are not symmetric. Missing a new gpt-6/7 model ships that
+// 400 again, while over-matching a model that does still accept `minimal` costs
+// it only its weakest rung (a stored `minimal` clamps up to `low`).
+const CODEX_NO_MINIMAL_MODEL_RE = /^gpt-[6-9]([.-]|$)/;
+
+const withoutMinimal = (levels) => Object.freeze(levels.filter((l) => l !== 'minimal'));
+const CODEX_EFFORT_LEVELS_NO_MINIMAL = withoutMinimal(CODEX_EFFORT_LEVELS);
+const CODEX_ULTRA_EFFORT_LEVELS_NO_MINIMAL = withoutMinimal(CODEX_ULTRA_EFFORT_LEVELS);
+
+const codexEffortLevelsForModel = (model) => {
+  const id = String(model || '').trim().toLowerCase();
+  const ultra = CODEX_ULTRA_MODELS.has(id);
+  if (CODEX_NO_MINIMAL_MODEL_RE.test(id)) {
+    return ultra ? CODEX_ULTRA_EFFORT_LEVELS_NO_MINIMAL : CODEX_EFFORT_LEVELS_NO_MINIMAL;
+  }
+  return ultra ? CODEX_ULTRA_EFFORT_LEVELS : CODEX_EFFORT_LEVELS;
+};
 
 // ---------------------------------------------------------------------------
 // Antigravity base-model ↔ effort-suffix split.

--- a/server/lib/providerModels.mirror.test.js
+++ b/server/lib/providerModels.mirror.test.js
@@ -42,6 +42,10 @@ const MIRRORED_NAMES = [
   // as load-bearing as the ladders themselves: a new Ultra model added
   // server-side only tops the client picker out at `max`.
   'CODEX_ULTRA_MODELS',
+  // The other model gate: which Codex models REJECT `minimal`. Divergence here
+  // is worse than a missing rung — a client that still offers `minimal` for a
+  // gpt-6 model lets the user pick a level whose run dies on an HTTP 400.
+  'CODEX_NO_MINIMAL_MODEL_RE',
   // The clamp order. Divergence here is silent — every value stays "known", it
   // just resolves to a different rung than the run will actually use.
   'EFFORT_RANK',

--- a/server/lib/providerModels.test.js
+++ b/server/lib/providerModels.test.js
@@ -298,6 +298,23 @@ describe('providerModels', () => {
         .toBe(ANTIGRAVITY_EFFORT_LEVELS);
     });
 
+    it('drops `minimal` from the picker for the gpt-6 family, which rejects it', () => {
+      const codex = { id: 'codex', command: 'codex' };
+      // Real rejection: "'minimal' is not supported with the 'gpt-6-astra'
+      // model. Supported values are: 'low', 'medium', 'high', 'xhigh', 'max'."
+      expect(effortLevelsForProvider(codex, 'gpt-6-astra')).not.toContain('minimal');
+      expect(effortLevelsForProvider(codex, 'gpt-6-astra')).toContain('ultra');
+      expect(effortLevelsForProvider(codex, ' GPT-6-Astra ')).not.toContain('minimal');
+      // A future gpt-6/gpt-7 id is covered by the family prefix, so the 400
+      // can't come back the next time OpenAI ships one.
+      expect(effortLevelsForProvider(codex, 'gpt-6.1-nova')).toEqual(['low', 'medium', 'high', 'xhigh', 'max']);
+      // gpt-5-era models keep the rung.
+      expect(effortLevelsForProvider(codex, 'gpt-5.6-sol')).toContain('minimal');
+      expect(effortLevelsForProvider(codex, 'gpt-5.3-codex-spark')).toContain('minimal');
+      // Not a family match: only the version segment gates the rung.
+      expect(effortLevelsForProvider(codex, 'gpt-56-experimental')).toContain('minimal');
+    });
+
     it('ignores `model` for non-antigravity providers', () => {
       expect(effortLevelsForProvider({ id: 'codex', command: 'codex' }, 'gpt-5-high')).toBe(CODEX_EFFORT_LEVELS);
       expect(effortLevelsForProvider({ id: 'claude-code', command: 'claude' }, 'claude-opus-5-high'))
@@ -421,6 +438,20 @@ describe('providerModels', () => {
         .toEqual(['-c', 'model_reasoning_effort=ultra']);
       expect(buildEffortArgs('ultra', codex, [], 'gpt-5.6-luna'))
         .toEqual(['-c', 'model_reasoning_effort=max']);
+    });
+
+    it('clamps `minimal` UP to low on gpt-6 models, which reject it', () => {
+      // Sending `model_reasoning_effort=minimal` to gpt-6-astra fails the run
+      // with HTTP 400 `unsupported_value`, so an effort stored against a gpt-5
+      // model must resolve to the weakest rung gpt-6 actually offers.
+      const codex = { id: 'codex', command: 'codex' };
+      expect(buildEffortArgs('minimal', codex, [], 'gpt-6-astra'))
+        .toEqual(['-c', 'model_reasoning_effort=low']);
+      expect(buildEffortArgs('minimal', codex, [], 'gpt-5.6-sol'))
+        .toEqual(['-c', 'model_reasoning_effort=minimal']);
+      // The gpt-6 gate does not cost Astra its Ultra rung.
+      expect(buildEffortArgs('ultra', codex, [], 'gpt-6-astra'))
+        .toEqual(['-c', 'model_reasoning_effort=ultra']);
     });
 
     it('returns [] when unset, unsupported, or already baked into existing args', () => {

--- a/server/services/imageGen/codex.js
+++ b/server/services/imageGen/codex.js
@@ -197,9 +197,13 @@ export async function generateImage({
   // `resolveCliEffort` (rather than a bare `CODEX_EFFORT_LEVELS.includes`) so a
   // legacy `ultra` value resolves to Codex's strongest supported level instead
   // of collapsing to the cheap default and silently rendering at a fraction of
-  // the requested effort.
+  // the requested effort. `effectiveModel` is threaded through because Codex's
+  // ladder is MODEL-gated in both directions: it decides whether `ultra` is a
+  // real level here, and whether `minimal` is — a gpt-6 model rejects `minimal`
+  // outright (HTTP 400), so an unclamped legacy value would fail the render.
   const requestedEffort = (typeof effort === 'string' && effort.trim()) ? effort.trim() : CODEX_IMAGEGEN_DEFAULT_EFFORT;
-  const effectiveEffort = resolveCliEffort(requestedEffort, { command: 'codex' }) || CODEX_IMAGEGEN_DEFAULT_EFFORT;
+  const effectiveEffort = resolveCliEffort(requestedEffort, { command: 'codex' }, effectiveModel)
+    || CODEX_IMAGEGEN_DEFAULT_EFFORT;
 
   // Re-anchors every path to the approved image roots and caps the list at what
   // codex's image_gen accepts — see inputImages.js.
@@ -252,7 +256,7 @@ export async function generateImage({
     // Reasoning-effort override (`-c model_reasoning_effort=<level>`), defaulting
     // to `low` — also before the variadic `-i`. A user who baked an effort pin
     // into their config is respected via hasEffortFlag inside buildEffortArgs.
-    ...buildEffortArgs(effectiveEffort, { command: 'codex' }),
+    ...buildEffortArgs(effectiveEffort, { command: 'codex' }, [], effectiveModel),
     // `-i` is variadic, so every input image rides one flag.
     ...(inputImages.paths.length ? ['-i', ...inputImages.paths] : []),
     '-m', effectiveModel,


### PR DESCRIPTION
## Summary

Codex effort pickers offered `minimal` for `gpt-6-astra`, but that model rejects the rung: the API answers HTTP 400 `unsupported_value` — *"'minimal' is not supported with the 'gpt-6-astra' model. Supported values are: 'low', 'medium', 'high', 'xhigh', and 'max'."* — so picking it could only end in a dead run.

- **`minimal` is now gated off the gpt-6 family** inside `codexEffortLevelsForModel`, the same chokepoint that already model-gates the `ultra` rung. Pickers and the emitted `-c model_reasoning_effort=` argv now agree, and a stored `minimal` clamps up to `low` instead of being sent.
- Matched as a **family prefix** rather than an id list on purpose: missing a future gpt-6/7 model ships the 400 again, while over-matching one that does accept `minimal` costs it only its weakest rung.
- Two call sites built a codex effort **without the model that would run it**, so the clamp would not have reached them:
  - `server/services/imageGen/codex.js` resolved the effort with no model even though `effectiveModel` was already computed and passed as `-m` on the same invocation.
  - The Image Gen settings tab and the media-queue retry editor rendered the fixed `CODEX_EFFORT_LEVELS` constant in a `<select>` sitting beside a free-text model field, making `gpt-6-astra` + `minimal` reachable from the UI.
- `CODEX_NO_MINIMAL_MODEL_RE` is added to the mirror test's pinned declarations, so the server and client copies cannot drift.

Reviewer effort pins have the same gap on a slug-keyed ladder that would need the model threaded through its whole contract — filed as #6447 rather than ridden in here.

## Test plan

- `server`: 40,519 passed / 35 skipped — new coverage in `providerModels.test.js` for the picker ladder (`effortLevelsForProvider`) and the emitted argv (`buildEffortArgs`), including the family-prefix boundary (`gpt-6.1-nova` gated, `gpt-56-experimental` not) and that Astra keeps its `ultra` rung.
- `client`: 10,672 passed / 8 skipped — `providers.test.js` pins the same per-model ladders against **both** the client mirror and the server implementation.
- `client` lint (biome) clean.
- Ran `/simplify` (4 review angles); its findings produced the `imageGen/codex.js` and two-picker fixes above.
