### PR TITLE
fix: build the DERP map cache path for the requested platform, not the host

### DIFF
--- a/server/services/tailcatPeer.js
+++ b/server/services/tailcatPeer.js
@@ -16,7 +16,7 @@ import { randomUUID } from 'node:crypto';
 import { createServer } from 'node:net';
 import { stat } from 'node:fs/promises';
 import { homedir } from 'node:os';
-import { delimiter, join } from 'node:path';
+import { delimiter, join, posix, win32 } from 'node:path';
 import { spawn } from '../lib/childProcess.js';
 import { commandExists } from '../lib/commandExists.js';
 import { bufferedSpawn, spawnFailureDetail } from '../lib/bufferedSpawn.js';
@@ -376,10 +376,13 @@ export function derpMapCachePath({
   home = homedir(),
   platform = process.platform,
 } = {}) {
-  const base = platform === 'darwin' ? join(home, 'Library', 'Caches')
-    : platform === 'win32' ? (env.LOCALAPPDATA || join(home, 'AppData', 'Local'))
-      : (env.XDG_CACHE_HOME || join(home, '.cache'));
-  return join(base, 'tailcat', `derpmap-${goQueryEscape(url)}.json`);
+  // Join for the REQUESTED platform, not the host: the caller names the platform,
+  // so a `darwin` path asked for from a Windows runner must still be POSIX.
+  const { join: joinFor } = platform === 'win32' ? win32 : posix;
+  const base = platform === 'darwin' ? joinFor(home, 'Library', 'Caches')
+    : platform === 'win32' ? (env.LOCALAPPDATA || joinFor(home, 'AppData', 'Local'))
+      : (env.XDG_CACHE_HOME || joinFor(home, '.cache'));
+  return joinFor(base, 'tailcat', `derpmap-${goQueryEscape(url)}.json`);
 }
 
 /**

--- a/server/services/tailcatPeer.test.js
+++ b/server/services/tailcatPeer.test.js
@@ -685,6 +685,10 @@ describe('tailcat startup diagnostics and DERP map priming', () => {
       url: 'https://example.com/derpmap.json', platform: 'linux', home: '/example/home',
       env: { XDG_CACHE_HOME: '/example/cache' },
     })).toBe('/example/cache/tailcat/derpmap-https%3A%2F%2Fexample.com%2Fderpmap.json.json');
+    expect(derpMapCachePath({
+      url: 'https://example.com/derpmap.json', platform: 'win32', home: 'C:\\example\\home',
+      env: { LOCALAPPDATA: 'C:\\example\\cache' },
+    })).toBe('C:\\example\\cache\\tailcat\\derpmap-https%3A%2F%2Fexample.com%2Fderpmap.json.json');
   });
 
   it('primes the DERP map with PortOS own fetch, but never caches a non-map body', async () => {


### PR DESCRIPTION
## Summary

- **Windows CI has been red on `main` since a60b295f** (merged in #6453), and CI tests a PR merged *into* `main`, so every PR opened since inherited the failure. This unblocks them.
- `derpMapCachePath` accepts a `platform` argument but built the path with `node:path`'s host-bound `join`. On a Windows runner the `darwin` and `linux` cases came back with backslashes and the pinned assertions failed. The mirror bug was already there on POSIX hosts — a `win32` request returned forward slashes — it just had no assertion covering it.
- The fix selects `posix` / `win32` join from the **requested** platform. Behavior under the default argument is unchanged on every host, because the selected join now matches the host that `process.platform` names.
- The failing run is easy to misread: the Windows shard runs `Cancel sibling CI jobs after failure`, so the other jobs report `cancelled` and the run concludes `cancelled` rather than `failure`. Only *Windows server unit tests (1/3)* carries a genuinely failing step.

## Test plan

- `server/services/tailcatPeer.test.js` — 48 passed. Added the missing `win32` case to the existing per-platform assertion.
- Mutation-probed it: restoring the host-bound `join` turns that new assertion red **on macOS** (`'C:\example\cache/tailcat/…'` vs `'C:\example\cache\tailcat\…'`), so it catches the defect on any host rather than only on the runner where it happened to surface.

Closes #6457
