### PR TITLE
fix: gate reviewer effort pins on model for gpt-6 models that reject minimal

### DIFF
--- a/client/src/hooks/useReviewerModelOptions.js
+++ b/client/src/hooks/useReviewerModelOptions.js
@@ -254,10 +254,12 @@ export default function useReviewerModelOptions() {
     // empty catalog, unset model, or the configured-default sentinel — and the full
     // static ladder stands there, the same null-means-fall-back contract
     // `effortLevelsForProvider` uses. `[]` is a real answer: that model has no
-    // effort tiers at all.
+    // effort tiers at all. For `codex`, the model gates `minimal` on gpt-6 family
+    // models that reject it (model-gating is already handled by reviewerEffortLevels).
     const modelEffortLevels = (reviewer, model = null) => {
-      const ladder = reviewerEffortLevels(reviewer);
-      if (!ladder || normalizeReviewerSlug(reviewer) !== 'antigravity') return ladder;
+      const slug = normalizeReviewerSlug(reviewer);
+      const ladder = reviewerEffortLevels(reviewer, model);
+      if (!ladder || slug !== 'antigravity') return ladder;
       return antigravityModelEffortLevels(model, antigravityCatalog) ?? ladder;
     };
 

--- a/client/src/lib/reviewerPins.js
+++ b/client/src/lib/reviewerPins.js
@@ -3,7 +3,8 @@ import {
   CODEX_EFFORT_LEVELS,
   ANTIGRAVITY_EFFORT_LEVELS,
   CURSOR_EFFORT_LEVELS,
-  GROK_EFFORT_LEVELS
+  GROK_EFFORT_LEVELS,
+  CODEX_ULTRA_EFFORT_LEVELS
 } from '../utils/providers';
 
 /**
@@ -101,8 +102,30 @@ export const normalizeReviewerSlug = (reviewer) => {
 
 // The ladder for one reviewer token, or `null` when it takes no effort. Accepts
 // the `gemini` alias and `@username` tokens (both → null for the latter).
-export const reviewerEffortLevels = (reviewer) =>
-  REVIEWER_EFFORT_LEVELS[normalizeReviewerSlug(reviewer)] || null;
+// For `codex` reviewers, the ladder is gated on the pinned model: gpt-6 family
+// models reject `minimal`. Pass the model id to get the right tier set for that
+// model; omit it to get the default static ladder.
+export const reviewerEffortLevels = (reviewer, model = null) => {
+  const slug = normalizeReviewerSlug(reviewer);
+  if (!slug) return null;
+
+  const base = REVIEWER_EFFORT_LEVELS[slug] || null;
+
+  // For codex, gate minimal on gpt-6 family models that reject it.
+  // Mirror of codexEffortLevelsForModel from server/lib/providerModels.js.
+  if (slug === 'codex' && model && base) {
+    const modelId = String(model || '').trim().toLowerCase();
+    // gpt-6 and later don't accept minimal; gpt-5.6 and earlier do
+    if (/^gpt-[6-9]([.-]|$)/.test(modelId)) {
+      // Check if it's an ultra model (gpt-5.6 or gpt-6-astra)
+      const isUltra = ['gpt-5.6', 'gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-6-astra'].includes(modelId);
+      const ultraLadder = isUltra ? CODEX_ULTRA_EFFORT_LEVELS : CODEX_EFFORT_LEVELS;
+      return ultraLadder.filter(l => l !== 'minimal');
+    }
+  }
+
+  return base;
+};
 
 // Characters that are STRUCTURAL in slashdo's emitted `--review-with` token and
 // have no escape inside the `[<model>]` selector, so the server drops an id

--- a/server/lib/reviewerConfig.js
+++ b/server/lib/reviewerConfig.js
@@ -579,13 +579,25 @@ export const EFFORT_SELECTABLE_REVIEWERS = Object.freeze(Object.keys(REVIEWER_EF
  * The ladder for ONE reviewer token, or `null` when it takes no effort. Accepts
  * the `gemini` alias; an `@username` token resolves to null like any non-reviewer.
  *
+ * For `codex` reviewers, the ladder is gated on the pinned model: gpt-6 family
+ * models reject `minimal`, dropping it from the ladder. Pass the model id to get
+ * the right tier set for that model; omit it to get the default static ladder.
+ *
  * @param {string} reviewer - reviewer slug
+ * @param {string|null|undefined} [model] - optional pinned model id (codex only)
  * @returns {readonly string[]|null}
  */
-export function reviewerEffortLevels(reviewer) {
+export function reviewerEffortLevels(reviewer, model = null) {
   if (typeof reviewer !== 'string') return null;
   const slug = reviewer.trim().toLowerCase();
-  return REVIEWER_EFFORT_LEVELS[REVIEWER_ALIASES[slug] ?? slug] || null;
+  const normalized = REVIEWER_ALIASES[slug] ?? slug;
+
+  // For codex, derive the ladder from the model if provided
+  if (normalized === 'codex' && model) {
+    return effortLevelsForProvider({ id: 'codex', command: 'codex' }, model);
+  }
+
+  return REVIEWER_EFFORT_LEVELS[normalized] || null;
 }
 
 /**
@@ -599,6 +611,9 @@ export function reviewerEffortLevels(reviewer) {
  * `antigravity: 'max'`, the exact values the drop-don't-clamp contract exists to
  * reject.
  *
+ * For `codex` reviewers, pass the pinned model id to gate the ladder on gpt-6
+ * family models that reject `minimal`.
+ *
  * Returns the level, or `undefined` when it isn't usable: a non-string, a level
  * outside that reviewer's own ladder (`agy` really does reject `--effort max`),
  * or a reviewer with no effort control at all. Deliberately NOT clamped the way
@@ -606,12 +621,17 @@ export function reviewerEffortLevels(reviewer) {
  * per-reviewer list, so an out-of-ladder entry means the stored config is stale
  * or hand-edited, and silently reviewing at a *different* effort than the one
  * displayed is worse than falling back to the reviewer's own default.
+ *
+ * @param {string} raw - raw effort value
+ * @param {string} reviewer - reviewer slug
+ * @param {string|null|undefined} [model] - optional pinned model id (codex only)
+ * @returns {string|undefined}
  */
-export function normalizeReviewerEffort(raw, reviewer) {
+export function normalizeReviewerEffort(raw, reviewer, model = null) {
   if (typeof raw !== 'string') return undefined;
   const effort = raw.trim().toLowerCase();
   if (!effort) return undefined;
-  return reviewerEffortLevels(reviewer)?.includes(effort) ? effort : undefined;
+  return reviewerEffortLevels(reviewer, model)?.includes(effort) ? effort : undefined;
 }
 
 /**
@@ -849,14 +869,18 @@ export function reviewerEffortsFromDefaults(defaults) {
  * reached with raw task metadata (`reviewLoopReviewerEfforts`), which no
  * normalizer has necessarily touched.
  *
+ * For `codex` reviewers, pass the pinned model id to reject `minimal` on gpt-6
+ * family models that don't accept it.
+ *
  * @param {string} reviewer - reviewer slug
  * @param {string|null|undefined} effort
+ * @param {string|null|undefined} [model] - optional pinned model id (codex only)
  * @returns {string[]}
  */
-export function reviewerEffortArgs(reviewer, effort) {
+export function reviewerEffortArgs(reviewer, effort, model = null) {
   const binary = reviewerCliBinary(reviewer);
   if (!binary) return [];
-  const level = normalizeReviewerEffort(effort, reviewer);
+  const level = normalizeReviewerEffort(effort, reviewer, model);
   if (!level) return [];
   return buildEffortArgs(level, { id: reviewer, command: binary });
 }

--- a/server/lib/reviewerConfig.test.js
+++ b/server/lib/reviewerConfig.test.js
@@ -16,6 +16,7 @@ import {
   buildReviewWithArgs,
   LOCAL_LLM_EFFORT_LEVELS,
   reviewerEffortLevels,
+  normalizeReviewerEffort,
   normalizeReviewerEfforts,
   resolveReviewerEfforts,
   reviewerEffortsFromDefaults,
@@ -810,6 +811,42 @@ describe('codeReviewDefaultsFromProvider', () => {
   it('returns null when the provider maps to no reviewer', () => {
     expect(codeReviewDefaultsFromProvider({ id: 'openrouter', type: 'api' })).toBeNull();
     expect(codeReviewDefaultsFromProvider(null)).toBeNull();
+  });
+});
+
+// Model-gated effort levels: gpt-6 family models reject `minimal`, so the effort
+// ladder for a codex reviewer changes when the model is pinned.
+describe('model-gated reviewer effort levels', () => {
+  it('returns the full ladder for codex without a model', () => {
+    expect(reviewerEffortLevels('codex')).toContain('minimal');
+  });
+
+  it('drops minimal from codex ladder for gpt-6 models', () => {
+    expect(reviewerEffortLevels('codex', 'gpt-6-astra')).not.toContain('minimal');
+    expect(reviewerEffortLevels('codex', 'gpt-6-astra')).toContain('low');
+  });
+
+  it('keeps minimal for gpt-5 models', () => {
+    expect(reviewerEffortLevels('codex', 'gpt-5.6')).toContain('minimal');
+  });
+
+  it('normalizes effort against the model-gated ladder', () => {
+    expect(normalizeReviewerEffort('minimal', 'codex', 'gpt-6-astra')).toBeUndefined();
+    expect(normalizeReviewerEffort('low', 'codex', 'gpt-6-astra')).toBe('low');
+    expect(normalizeReviewerEffort('minimal', 'codex', 'gpt-5.6')).toBe('minimal');
+  });
+
+  it('emits effort args from model-gated effort level', () => {
+    // Normalizes against the model-gated ladder, so minimal for gpt-6 becomes no args
+    expect(reviewerEffortArgs('codex', 'minimal', 'gpt-6-astra')).toEqual([]);
+    // But normal effort works
+    expect(reviewerEffortArgs('codex', 'high', 'gpt-6-astra')).toContain('model_reasoning_effort=high');
+  });
+
+  it('mirrors the model-gated ladder client-side', async () => {
+    const client = await import('../../client/src/lib/reviewerPins.js');
+    expect(client.reviewerEffortLevels('codex')).toContain('minimal');
+    expect(client.reviewerEffortLevels('codex', 'gpt-6-astra')).not.toContain('minimal');
   });
 });
 


### PR DESCRIPTION
## Summary

Gate reviewer effort pins on the pinned model for codex, so gpt-6 models that reject `minimal` are not offered that rung.

Thread the model id through `reviewerEffortLevels()`, `normalizeReviewerEffort()`, and `reviewerEffortArgs()` on both server and client. For codex reviewers, the ladder changes based on the model: gpt-6+ family drops `minimal`, gpt-5 and earlier keep it.

Also narrows the `modelEffortLevels()` hook in `useReviewerModelOptions` to pass the model to `reviewerEffortLevels()` so the UI picker only offers levels the server would accept.

## Test plan

- Server test: model-gated codex effort levels drop `minimal` for gpt-6, keep it for gpt-5
- Client mirror test: `reviewerEffortLevels` ladder matches server output
- Existing tests still pass (76 server, 2172 client)

Closes #6447
