### PR TITLE
collapse the four hand-rolled MTPLX predicates into localRuntimeKind

### DIFF
--- a/server/lib/cliChildEnv.test.js
+++ b/server/lib/cliChildEnv.test.js
@@ -417,6 +417,17 @@ describe('composeProviderEnv — delta for sites that do not spawn directly', ()
     }).CLAUDE_CODE_MAX_OUTPUT_TOKENS).toBeUndefined();
   });
 
+  // #6466 named the shipped `mtplx` API record for `localRuntimeKind`, but this
+  // module's Claude-local tuning gates on `isClaudeCommand`, not
+  // `localRuntimeKind` directly — a plain `type: 'api'` record with no
+  // `command` was never a Claude harness and must not become one now.
+  it('leaves the bare mtplx API record untouched — no command, so no Claude tuning', () => {
+    const mtplxApiProvider = { id: 'mtplx', type: 'api', endpoint: 'http://127.0.0.1:8000/v1', envVars: {} };
+    const env = composeProviderEnv({ provider: mtplxApiProvider });
+    expect(env.CLAUDE_CODE_MAX_OUTPUT_TOKENS).toBeUndefined();
+    expect(env.API_TIMEOUT_MS).toBeUndefined();
+  });
+
   // A local daemon sends nothing until prefill completes, and Claude Code has
   // four independent ceilings on that silence — the binding one being the Bun
   // fetch timeout (~360s) that only `API_FORCE_IDLE_TIMEOUT=0` disables. With

--- a/server/lib/localProviderRuntime.js
+++ b/server/lib/localProviderRuntime.js
@@ -300,6 +300,18 @@ export function localRuntimeKind(provider) {
   if (namespace) return namespace;
   if (provider?.id === 'slotstream' || /slotstream/i.test(provider?.name || '')) return 'slotstream';
   if (Number(localEndpointPort(provider?.endpoint)) === PORTS.SLOTSTREAM) return 'slotstream';
+  // The shipped `mtplx` record is a plain OpenAI-compatible API provider with no
+  // marker of its own — `mtplxBacked` only ever rides the OpenCode/Claude CLI
+  // wrappers, never this record (#6466). `id` is the one signal it carries.
+  // Deliberately NO port arm here, unlike slotstream two lines up: slotstream's
+  // port is a PortOS-dedicated constant, while MTPLX's is user-configurable and
+  // its default (`:8000`) is a generic port — keying on it would claim an
+  // unrelated local API as MTPLX. `isMtplxProvider` in `mtplxServerManager.js`
+  // layers a narrower port check on top of this for an unmarked/unnamed
+  // provider aimed at wherever the managed daemon is actually listening right
+  // now; that check needs live process state this side-effect-free module
+  // cannot import without a cycle.
+  if (provider?.id === 'mtplx') return 'mtplx';
   return localBackendForProvider(provider);
 }
 
@@ -318,6 +330,13 @@ export function localRuntimeKind(provider) {
  *     a model that is installed and serving — that is how a pr-reviewer stage
  *     pinned to a freshly pulled Ollama model got "not offered by provider" on
  *     every dispatch.
+ *
+ * The shipped `mtplx` API record falls into the second bucket now that
+ * `localRuntimeKind` names it (#6466): it lists one static id, but `mtplx serve`
+ * names its process after whatever checkpoint is actually loaded, so the
+ * record's `models` array is exactly the same kind of stale snapshot Ollama's
+ * is — pass-through is correct here for the same reason, not a side effect of
+ * the collapse.
  *
  * Anything else enumerates its own catalog, and a pin outside it reaches the
  * CLI as a model it cannot serve.

--- a/server/lib/localProviderRuntime.test.js
+++ b/server/lib/localProviderRuntime.test.js
@@ -5,6 +5,7 @@ import {
   localBackendForProvider,
   localRuntimeForProvider,
   localRuntimeKind,
+  modelPinIsOffered,
   normalizeOpenAiBaseUrl,
 } from './localProviderRuntime.js';
 import { opencodeLocalBaseUrl } from './opencodeConfig.js';
@@ -100,6 +101,18 @@ describe('localRuntimeKind', () => {
     expect(localRuntimeKind({ name: 'Slotstream (local)' })).toBe('slotstream');
     expect(localRuntimeKind({ endpoint: `http://127.0.0.1:${PORTS.SLOTSTREAM}/v1` })).toBe('slotstream');
     expect(localRuntimeKind({ endpoint: 'http://127.0.0.1:11434/v1' })).toBe('ollama');
+  });
+
+  // #6466 — the shipped `mtplx` API record (`type: 'api'`, no `mtplxBacked`
+  // marker) is the one shape none of the earlier fallbacks reach, so it needs
+  // its own id-based arm rather than a generic port check.
+  it('recognizes the shipped mtplx API record by id, with no port arm', () => {
+    expect(localRuntimeKind({ id: 'mtplx', type: 'api', endpoint: 'http://127.0.0.1:8000/v1' })).toBe('mtplx');
+    // :8000 is a generic port a user's own local API could equally be bound
+    // to — MTPLX's is user-configurable, so an unrelated `id` on that same
+    // port must never resolve as MTPLX the way slotstream's DEDICATED port
+    // resolves above.
+    expect(localRuntimeKind({ id: 'some-local-api', type: 'api', endpoint: 'http://127.0.0.1:8000/v1' })).toBeNull();
   });
 });
 
@@ -218,6 +231,68 @@ describe('localRuntimeForProvider', () => {
       envVars: { OPENCODE_CONFIG_CONTENT: opencodeConfig('ollama', 'http://localhost:11600/v1') },
     });
     expect(runtime.endpoint).toBe('http://localhost:11600/v1');
+  });
+
+  // #6466 — before the id-based fallback, `localRuntimeKind` had no answer for
+  // the bare API record, so this returned null and the shipped provider got no
+  // readiness checklist at all.
+  it('resolves the shipped mtplx API record — no command, no marker', () => {
+    const runtime = localRuntimeForProvider({ id: 'mtplx', type: 'api', endpoint: 'http://127.0.0.1:8000/v1' });
+    expect(runtime.kind).toBe('mtplx');
+    expect(runtime.label).toBe('MTPLX');
+    expect(runtime.endpoint).toBe('http://127.0.0.1:8000/v1');
+  });
+});
+
+describe('modelPinIsOffered', () => {
+  it('passes through when the provider lists no models of its own', () => {
+    expect(modelPinIsOffered({ id: 'custom-api', models: [] }, 'anything')).toBe(true);
+    expect(modelPinIsOffered({ id: 'custom-api' }, 'anything')).toBe(true);
+  });
+
+  it('validates a pin against the listed catalog for a non-local provider', () => {
+    const provider = { id: 'openai', models: ['gpt-x', 'gpt-y'] };
+    expect(modelPinIsOffered(provider, 'gpt-x')).toBe(true);
+    expect(modelPinIsOffered(provider, 'gpt-z')).toBe(false);
+  });
+
+  it('passes through for a local-daemon provider, whatever the pin', () => {
+    // Ollama/LM Studio's `models` array is a cached snapshot; the daemon on
+    // this machine is the authority, so a pin outside the stale list must
+    // still be considered offered.
+    const provider = { command: 'opencode', ollamaBacked: true, models: ['stale-model'] };
+    expect(modelPinIsOffered(provider, 'freshly-pulled-model')).toBe(true);
+  });
+
+  // #6466 — decision: the shipped mtplx API record is a pass-through too, once
+  // `localRuntimeKind` names it. `mtplx serve` names its process after whatever
+  // checkpoint is actually loaded, so the record's static `models` entry is the
+  // same kind of stale snapshot Ollama's is — judging a pin against it would
+  // reject a checkpoint that is installed and serving.
+  it('passes through for the shipped mtplx API record, whatever the pin', () => {
+    const provider = {
+      id: 'mtplx',
+      type: 'api',
+      endpoint: 'http://127.0.0.1:8000/v1',
+      models: ['mtplx-qwen38-27b-optimized-speed'],
+    };
+    expect(modelPinIsOffered(provider, 'a-different-checkpoint-the-daemon-now-serves')).toBe(true);
+  });
+
+  it('is id-based, not locality-gated, matching the existing ollama/slotstream id checks', () => {
+    // `localRuntimeKind`'s id-based arms (ollama, slotstream, and now mtplx)
+    // do not themselves check the endpoint's locality — the callers that need
+    // that distinction (`isMtplxProvider`, `localRuntimeForProvider`) apply it
+    // on top. `modelPinIsOffered` calls `localRuntimeKind` raw, so an `id:
+    // 'mtplx'` record pointed at another machine passes through here exactly
+    // as an `id: 'ollama'` one already does — not a new gap this issue opens.
+    const provider = {
+      id: 'mtplx',
+      type: 'api',
+      endpoint: 'http://192.0.2.10:8000/v1',
+      models: ['mtplx-qwen38-27b-optimized-speed'],
+    };
+    expect(modelPinIsOffered(provider, 'a-different-checkpoint')).toBe(true);
   });
 });
 

--- a/server/lib/systemCapabilities.js
+++ b/server/lib/systemCapabilities.js
@@ -10,6 +10,7 @@
 
 import os from 'os';
 import { isLocalInstanceEndpoint } from './localEndpoint.js';
+import { localRuntimeKind } from './localProviderRuntime.js';
 import { isAppleSilicon } from './platform.js';
 import { getCudaCapability, getCudaComputeCapability } from './cudaCapability.js';
 
@@ -104,13 +105,18 @@ const providerRuntimeRequirements = Object.freeze({
   }),
 });
 
+// The trailing `id === 'mtplx'` shortcut used to duplicate a check
+// `localRuntimeKind` could not make on its own — the shipped `mtplx` record is
+// a plain API endpoint with no `mtplxBacked` marker to read. #6466 gave
+// `localRuntimeKind` an id-based fallback for exactly that record, so the
+// shortcut here is now a call to it instead of a hand-rolled copy.
 const localProvider = (provider) => provider?.ollamaBacked
   || provider?.lmstudioBacked
   || provider?.llamaBacked
   || provider?.mtplxBacked
   || provider?.vllmBacked
   || provider?.sglangBacked
-  || provider?.id === 'mtplx';
+  || localRuntimeKind(provider) === 'mtplx';
 
 const localModelHardwareRequirements = (model) => {
   if (typeof model !== 'string' || !model.trim()) return {};
@@ -354,7 +360,7 @@ export function hardwareRequirementsForLocalLlm(entry) {
 
 /** Resolve inferred and user-configured provider requirements. */
 export function hardwareRequirementsForProvider(provider) {
-  const runtime = provider?.mtplxBacked || provider?.id === 'mtplx'
+  const runtime = localRuntimeKind(provider) === 'mtplx'
     ? 'mtplx'
     : provider?.vllmBacked
       ? 'vllm'

--- a/server/lib/systemCapabilities.test.js
+++ b/server/lib/systemCapabilities.test.js
@@ -161,6 +161,30 @@ describe('systemCapabilities', () => {
     expect(hardwareRequirementsForProviderModel({ endpoint: 'https://api.example.com/v1' }, 'gemma4-31b')).toEqual({});
   });
 
+  // #6466 — the shipped `mtplx` record is a plain API provider (`type: 'api'`)
+  // with no `mtplxBacked` marker; only `localRuntimeKind`'s id-based fallback
+  // names it, so this pins that the Apple-Silicon requirement and the local
+  // hardware gate both still apply to it once collapsed onto that one call.
+  it('resolves the mtplx requirement via localRuntimeKind for the marked wrapper and the bare API record alike', () => {
+    const expected = { platforms: ['darwin'], requiresAppleSilicon: true };
+    expect(hardwareRequirementsForProvider({ id: 'opencode-mtplx', mtplxBacked: true })).toMatchObject(expected);
+    expect(hardwareRequirementsForProvider({ id: 'mtplx', type: 'api', endpoint: 'http://127.0.0.1:8000/v1' })).toMatchObject(expected);
+    // An unrelated local API on the same generic port must not inherit it.
+    expect(hardwareRequirementsForProvider({ id: 'some-local-api', type: 'api', endpoint: 'http://127.0.0.1:8000/v1' })).toEqual({});
+  });
+
+  // `localProvider` (internal) gates the per-model local hardware floors —
+  // this exercises it through the bare mtplx API record via the same public
+  // entry point the marker-backed case above uses.
+  it('gates per-model local hardware floors for the bare mtplx API record too', () => {
+    const provider = { id: 'mtplx', type: 'api', endpoint: 'http://127.0.0.1:8000/v1' };
+    expect(hardwareRequirementsForProviderModel(provider, 'qwen3.8-27b-mlx')).toMatchObject({
+      platforms: ['darwin'],
+      requiresAppleSilicon: true,
+      minMemoryGb: 32,
+    });
+  });
+
   it('decorates provider and model compatibility in one response projection', () => {
     const provider = withProviderHardwareCompatibility({
       id: 'vllm',

--- a/server/services/localCachedModels.js
+++ b/server/services/localCachedModels.js
@@ -63,17 +63,17 @@ const CACHED_MODEL_PROBES = {
  * a provider aimed there must never be answered with THIS host's cache. It also
  * keeps the ~one refresh per non-local provider from loading either manager.
  *
- * `provider.id` backs up `localRuntimeKind` because the shipped `mtplx` record
- * is a plain OpenAI-compatible endpoint carrying no vendor marker for
- * `localRuntimeKind` to read. Each probe re-checks identity itself, so a key
- * match is routing, not a verdict.
+ * `localRuntimeKind` resolves the shipped `mtplx` record by id (#6466) same as
+ * it resolves a marker-backed wrapper, so one lookup routes both. Each probe
+ * re-checks identity itself regardless, so a key match here is routing, not a
+ * verdict.
  *
  * @param {{id?: string, type?: string, endpoint?: string}|null|undefined} provider
  * @returns {Promise<string[]|null>}
  */
 export async function localCachedModelIds(provider) {
   if (!isLocalInstanceEndpoint(provider?.endpoint)) return null;
-  const load = CACHED_MODEL_PROBES[localRuntimeKind(provider) || provider?.id];
+  const load = CACHED_MODEL_PROBES[localRuntimeKind(provider)];
   if (!load) return null;
   const probe = await load();
   return probe(provider);

--- a/server/services/localModelHealing.test.js
+++ b/server/services/localModelHealing.test.js
@@ -80,6 +80,14 @@ describe('localBackendForProvider', () => {
     expect(localBackendForProvider({ endpoint: 'http://localhost:9999' })).toBeNull();
     expect(localBackendForProvider(null)).toBeNull();
   });
+
+  // #6466 gave `localRuntimeKind` an id-based fallback for the shipped `mtplx`
+  // API record, but healing stays scoped to Ollama/LM Studio via this narrower
+  // helper — MTPLX has no PortOS-side installed-model list to heal a stale pin
+  // against, so it must keep returning null here regardless of that change.
+  it('still returns null for the shipped mtplx record — healing is Ollama/LM Studio only', () => {
+    expect(localBackendForProvider({ id: 'mtplx', type: 'api', endpoint: 'http://127.0.0.1:8000/v1' })).toBeNull();
+  });
 });
 
 describe('isModelNotFoundError', () => {

--- a/server/services/mtplxServerManager.js
+++ b/server/services/mtplxServerManager.js
@@ -994,13 +994,19 @@ export function isMtplxProvider(provider) {
   if (!isLocalInstanceEndpoint(provider.endpoint)) return false;
   // `localRuntimeKind`, not `localBackendForProvider` — the latter only ever
   // answers 'ollama'/'lmstudio' (it maps those two catalog ports), so it reports
-  // every MTPLX provider as having no local backend at all. The authoritative
-  // signal is the `mtplxBacked` marker the spawner itself keys on.
+  // every MTPLX provider as having no local backend at all. This one call now
+  // covers both marker-backed wrappers (`mtplxBacked`) and the shipped bare API
+  // record (`id === 'mtplx'`) — #6466 collapsed the two hand-rolled checks that
+  // used to live here into `localRuntimeKind` itself.
   if (localRuntimeKind(provider) === 'mtplx') return true;
   // ...and an endpoint-only provider aimed at the port THIS daemon is serving.
   // Deliberately compared against the live launch config rather than treating
   // :8000 as "must be MTPLX" — 8000 is a generic port, and claiming any local
-  // server on it would lazily start MTPLX for someone else's API.
+  // server on it would lazily start MTPLX for someone else's API. This arm
+  // stays here rather than moving into `localRuntimeKind`: it needs the
+  // MANAGED daemon's live port, which only this module tracks, and reading it
+  // from `localProviderRuntime.js` (a side-effect-free module every readiness
+  // check imports) would be a circular import back to this one.
   const managedPort = currentConfig?.port;
   return Boolean(managedPort) && localEndpointPort(provider.endpoint) === managedPort;
 }
@@ -1039,15 +1045,13 @@ export async function mtplxCachedModelIds(provider) {
   // carries every signal below while its checkpoints are on the OTHER machine.
   // Answering there would offer this host's cache as that provider's catalog.
   if (!isLocalInstanceEndpoint(provider?.endpoint)) return null;
-  // Two signals, because the shipped records carry two (#6466 collapses these
-  // into `localRuntimeKind`): `localRuntimeKind` reads
-  // the `mtplxBacked` marker on the OpenCode CLI/TUI wrappers, and `id` names the
-  // API record — a plain OpenAI-compatible endpoint with no marker to read, the
-  // same shortcut `hardwareRequirementsForProvider` takes for it. A bare `:8000`
-  // is deliberately NOT a third: that port is generic, and this must not offer
-  // MTPLX's checkpoints as the catalog of someone else's local API.
-  const ours = localRuntimeKind(provider) === 'mtplx' || provider?.id === 'mtplx';
-  if (!ours) return null;
+  // `localRuntimeKind` now reads both signals the shipped records carry: the
+  // `mtplxBacked` marker on the OpenCode CLI/TUI wrappers, and the bare `id` on
+  // the API record — a plain OpenAI-compatible endpoint with no marker of its
+  // own (#6466). A bare `:8000` is deliberately NOT a third signal here: that
+  // port is generic, and this must not offer MTPLX's checkpoints as the
+  // catalog of someone else's local API.
+  if (localRuntimeKind(provider) !== 'mtplx') return null;
   const binaryPath = resolveMtplxBinary();
   if (!binaryPath) return null;
   if (!(await describeMtplxRuntime(binaryPath)).ready) return null;

--- a/server/services/providerReadiness.test.js
+++ b/server/services/providerReadiness.test.js
@@ -320,6 +320,22 @@ describe('getProviderReadiness', () => {
     expect(checkById(readiness, 'server').fixHint).toMatch(/Install & start MTPLX/);
   });
 
+  // #6466 — before `localRuntimeKind` learned the bare API record's id, this
+  // returned null (no card at all) for the shipped `mtplx` provider: only the
+  // `mtplxBacked` OpenCode/Claude wrapper got a readiness checklist. That was
+  // an accidental gap, not a decision — MTPLX's direct-API provider needs the
+  // exact same install/start/model checklist a wrapper pointed at it gets.
+  it('offers the same MTPLX checklist for the bare API record, not only the marked wrapper', async () => {
+    const restore = pinPlatform('darwin');
+    const readiness = await getProviderReadiness(
+      { id: 'mtplx', type: 'api', endpoint: 'http://127.0.0.1:8000/v1', defaultModel: 'mtplx-qwen38-27b-optimized-speed' },
+      { findCommand: () => null, probe: unreachable() },
+    );
+    restore();
+    expect(readiness).not.toBeNull();
+    expect(readiness.setup).toMatchObject({ runtime: 'mtplx', action: 'install-start', blockedReason: null });
+  });
+
   it('names the empty model cache on the checklist, and offers the download instead of a start', async () => {
     // The catch-22 as reported: "MTPLX installed ✓ / server not responding —
     // use Start MTPLX, PortOS does this for you", and Start answered "no model


### PR DESCRIPTION
## Summary

- Give `localRuntimeKind()` (`server/lib/localProviderRuntime.js`) an id-based fallback for the shipped `mtplx` API record — a plain OpenAI-compatible endpoint with no `mtplxBacked` marker of its own. Deliberately no port arm: MTPLX's port is user-configurable and `:8000` is generic, so an unrelated local API on that port must not resolve as MTPLX.
- Collapse the hand-rolled `id === 'mtplx'` shortcuts in `server/lib/systemCapabilities.js` (`localProvider`, `hardwareRequirementsForProvider`) and `server/services/mtplxServerManager.js` (`isMtplxProvider`, `mtplxCachedModelIds`) to call `localRuntimeKind()` instead — plus the same shortcut in `server/services/localCachedModels.js`'s probe-routing lookup, same root cause.
- `isMtplxProvider` keeps its own separate port-based fallback for an unmarked/unnamed provider pointed at wherever the managed daemon is actually listening — that needs live process state `localProviderRuntime.js` can't import without a circular dependency back to `mtplxServerManager.js`.

Re-checked the four load-bearing subsystems the issue called out, since naming this record changes real behavior for two of them:

- **`providerReadiness`** — now returns a full install/start/model checklist for the bare `mtplx` API provider instead of `null` (previously only the `mtplxBacked` OpenCode/Claude wrapper got one).
- **`modelPinIsOffered`** — now passes through any model pin for that record, same reasoning already applied to Ollama/LM Studio: `mtplx serve` names its process after whichever checkpoint is actually loaded, so the record's static `models` list is a stale snapshot, not the authority.
- **`localModelHealing`** — confirmed unaffected; healing stays scoped to Ollama/LM Studio via `localBackendForProvider`, a narrower helper this change doesn't touch.
- **`cliChildEnv`** — confirmed unaffected; its Claude-local tuning gates on `isClaudeCommand`, not `localRuntimeKind`, so a bare `type: 'api'` record with no `command` still gets no Claude-specific env.

## Test plan

- `cd server && npx vitest run lib/localProviderRuntime.test.js lib/systemCapabilities.test.js services/mtplxServerManager.test.js services/localCachedModels.test.js services/providerReadiness.test.js services/localModelHealing.test.js lib/cliChildEnv.test.js` — all pass, including new cases pinning: the mtplx id fallback, the `:8000` non-match for an unrelated local API, the readiness-checklist behavior change, the model-pin pass-through decision, and the two unaffected-subsystem regressions.
- Full `cd server && npx vitest run` — 2047 files / 40785 tests pass.

Closes #6466
