### PR TITLE
report a tailcat forward that binds but cannot reach the remote

### DIFF
--- a/client/src/components/instances/TailcatForwardsPanel.jsx
+++ b/client/src/components/instances/TailcatForwardsPanel.jsx
@@ -9,6 +9,12 @@
  * makes that recoverable: it names which forward is down, what tailcat actually
  * said, and offers Retry without the address ever coming back to the browser.
  *
+ * It also separates "the listener is bound" from "the tunnel can carry a
+ * request". tailcat binds its loopback port eagerly and only dials the remote
+ * once traffic arrives, so a forward whose relay is blocked stays `active` and
+ * `running` while every request through it is reset — which reads as a working
+ * loopback that simply refuses to answer.
+ *
  * Rows carry only the redacted address. Nothing here can reveal the capability.
  */
 
@@ -74,13 +80,28 @@ export default function TailcatForwardsPanel({ onChange }) {
       </p>
       <ul className="space-y-2">
         {forwards.map(forward => {
-          const StatusIcon = STATUS_ICON[forward.status] || Clock;
+          // A bound listener is not a working tunnel: tailcat binds eagerly and
+          // only dials the remote when a request arrives, so a forward whose
+          // relay is blocked reports `active`/`running` while every request
+          // through it is reset. Show that as its own state instead of green.
+          const broken = forward.live && !!forward.tunnelError;
+          const StatusIcon = broken ? AlertCircle : (STATUS_ICON[forward.status] || Clock);
           const busy = busyId === forward.id;
+          const failure = broken
+            ? { message: forward.tunnelError, at: forward.tunnelErrorAt }
+            : (forward.status !== 'active' && forward.lastError
+              ? { message: forward.lastError, at: forward.lastErrorAt }
+              : null);
           return (
             <li key={forward.id} className="bg-port-bg border border-port-border rounded-lg p-3">
               <div className="flex flex-wrap items-center gap-2">
-                <Pill tone={STATUS_TONE[forward.status] || 'bare'} size="xs" bordered={false} icon={StatusIcon}>
-                  {forward.live ? 'running' : forward.status}
+                <Pill
+                  tone={broken ? 'warning' : (STATUS_TONE[forward.status] || 'bare')}
+                  size="xs"
+                  bordered={false}
+                  icon={StatusIcon}
+                >
+                  {broken ? 'no route' : (forward.live ? 'running' : forward.status)}
                 </Pill>
                 <span className="text-sm text-white truncate">
                   {forward.name || forward.tcAddress}
@@ -111,10 +132,10 @@ export default function TailcatForwardsPanel({ onChange }) {
                   </button>
                 </div>
               </div>
-              {forward.status !== 'active' && forward.lastError && (
+              {failure && (
                 <p className="text-[11px] text-port-error mt-2 leading-snug break-words">
-                  {forward.lastError}
-                  {forward.lastErrorAt && <span className="text-gray-500"> · {timeAgo(forward.lastErrorAt)}</span>}
+                  {failure.message}
+                  {failure.at && <span className="text-gray-500"> · {timeAgo(failure.at)}</span>}
                 </p>
               )}
             </li>

--- a/client/src/components/instances/TailcatForwardsPanel.test.jsx
+++ b/client/src/components/instances/TailcatForwardsPanel.test.jsx
@@ -53,6 +53,25 @@ describe('TailcatForwardsPanel', () => {
     expect(screen.getByText(/no port yet/)).toBeInTheDocument();
   });
 
+  it('does not report a forward as running when its tunnel cannot deliver', async () => {
+    // Exactly the shape of the operator symptom: the listener is bound and
+    // tracked, so status/live both read healthy, but every request is reset.
+    getTailcatForwards.mockResolvedValue({ forwards: [{
+      ...failedForward,
+      status: 'active',
+      localPort: 15555,
+      live: true,
+      lastError: null,
+      lastErrorAt: null,
+      tunnelError: 'dial remote port 5555: context deadline exceeded',
+      tunnelErrorAt: '2026-01-02T00:00:00.000Z',
+    }] });
+    render(<TailcatForwardsPanel />);
+    expect(await screen.findByText('no route')).toBeInTheDocument();
+    expect(screen.queryByText('running')).not.toBeInTheDocument();
+    expect(screen.getByText(/dial remote port 5555/)).toBeInTheDocument();
+  });
+
   it('retries from the stored address and re-reads the server-derived status', async () => {
     retryTailcatForward.mockResolvedValue({ id: 'peer-9', port: 15555 });
     getTailcatForwards.mockResolvedValueOnce({ forwards: [failedForward] })

--- a/docs/features/tailcat-peers.md
+++ b/docs/features/tailcat-peers.md
@@ -73,7 +73,7 @@ even retry.
 
 | Surface | What it does |
 | --- | --- |
-| `GET /api/instances/peers/tailcat/forwards` | Every saved forward: status (`pending`/`active`/`failed`), whether it is running, the local↔remote ports, and the last **redacted** startup error. `tcAddress` is the redacted form; the credential is reported as `hasAuth` only. |
+| `GET /api/instances/peers/tailcat/forwards` | Every saved forward: status (`pending`/`active`/`failed`), whether it is running, the local↔remote ports, the last **redacted** startup error, and `tunnelError`/`tunnelErrorAt` when a running forward cannot actually deliver. `tcAddress` is the redacted form; the credential is reported as `hasAuth` only. |
 | `POST …/forwards/:id/retry` | Restarts from the stored capability, registering the peer if the original add never got that far, and repointing an existing peer when a retry has to bind a different local port. |
 | `DELETE …/forwards/:id` | Stops the forward, deletes the stored capability, and removes its peer. |
 
@@ -103,6 +103,53 @@ tokens scrubbed, last few lines only. An opaque "startup timed out" with the rea
 reason discarded is what made this take three passes to diagnose.
 
 A failed metadata write rolls back the new peer.
+
+### A bound listener is not a working tunnel
+
+`tailcat forward` binds its loopback port **eagerly** and only brings the
+WireGuard/DERP tunnel up when a connection arrives. So on a host where the relay
+is unreachable, the forward still binds, still passes both readiness signals,
+and still reports `active` / `running` — while every request through it is reset
+once tailcat's dial deadline expires:
+
+```
+$ curl http://127.0.0.1:15555/api/system/health/details
+curl: (56) Recv failure: Connection reset by peer      # after ~10s, every time
+```
+
+The only place tailcat says why is its post-startup stderr
+(`dial remote port 5555: context deadline exceeded`), which PortOS used to
+drain and discard. It now **reads** that stream for the lifetime of the child:
+a delivery failure is redacted, logged once per distinct reason, and reported on
+the forward as `tunnelError` / `tunnelErrorAt`. The Instances row for such a
+forward reads **no route** with the reason beneath it, instead of a green
+`running` on a tunnel that cannot carry a byte.
+
+The classifier is deliberately narrow — relay reconnects, backoff lines, and
+netcheck chatter are normal on a healthy tunnel; a failed dial is not. The
+values are in-memory only: they describe the child running right now, and a
+per-connection failure repeating every few seconds would thrash the metadata
+file. They also age out after five minutes: tailcat re-emits the line on every
+failed request, so a forward that is still broken keeps refreshing it, while one
+that started working again goes quiet — a latched "no route" would be the same
+lie as a permanently green "running", pointing the other way.
+
+**When you see `no route`,** the tunnel — not PortOS — is what to look at. The
+usual cause on macOS is a local network filter (Little Snitch and friends)
+denying the `tailcat` binary itself: `tailcat forward --verbose` then logs a
+relay connect that dies the instant it is established, while `curl` to the same
+relay from the same machine succeeds.
+
+```
+netcheck: [v1] report: udp=false v4=false icmpv4=false v6=false derp=0
+magicsock: derp.Recv(derp-301): ... connect to region 301 (nyc):
+  read tcp4 <local>:<port>-><relay>:443: read: socket is not connected
+dial remote port 5555: context deadline exceeded
+```
+
+UDP blocked *and* the relay refused leaves no path at all, so nothing ever
+reaches the remote — which is also why the far side shows no activity. Allow
+the `tailcat` binary outbound in the filter, then Retry the forward.
 
 ### The DERP map has to be reachable — by Go
 

--- a/server/services/privateSecurityAssessment.test.js
+++ b/server/services/privateSecurityAssessment.test.js
@@ -9,6 +9,11 @@ let repo;
 beforeEach(async () => {
   repo = await mkdtemp(join(tmpdir(), 'portos-assessment-test-'));
   await execGit(['init'], repo);
+  // The fixture deliberately commits paths a developer's own global gitignore
+  // commonly lists (`data/`, `.env`), and `git add` honours core.excludesFile
+  // from ~/.gitconfig. Without this the omitted-coverage count silently drops
+  // on that machine only — same reason the commits below pin core.hooksPath.
+  await execGit(['config', 'core.excludesFile', '/dev/null'], repo);
 });
 afterEach(async () => { await rm(repo, { recursive: true, force: true }); });
 const commit = () => execGit(['-c', 'user.name=Example', '-c', 'user.email=example@example.com', '-c', 'core.hooksPath=/dev/null', 'commit', '-m', 'Synthetic fixture'], repo);

--- a/server/services/tailcatPeer.js
+++ b/server/services/tailcatPeer.js
@@ -50,6 +50,12 @@ const DERP_MAP_FETCH_TIMEOUT_MS = 15_000;
 const DIAGNOSTIC_TAIL_CHARS = 4096;
 const DIAGNOSTIC_MAX_CHARS = 320;
 const PORT_SCAN_LIMIT = 32;
+// How long a delivery failure keeps describing the tunnel. tailcat re-emits the
+// line on every failed request, so a still-broken forward keeps refreshing it,
+// while one that started working again simply goes quiet and ages out. Without
+// a window a single blip would latch "no route" forever — the same lie as a
+// permanently green "running", pointing the other way.
+const TUNNEL_ERROR_FRESH_MS = 5 * 60 * 1000;
 const DEFAULT_DATA = { version: 1, forwards: [] };
 
 const withLock = createMutex();
@@ -97,6 +103,27 @@ export function redactTailcatDiagnostics(text) {
     .filter(Boolean);
   const joined = lines.slice(-3).join(' | ');
   return joined.length > DIAGNOSTIC_MAX_CHARS ? `${joined.slice(0, DIAGNOSTIC_MAX_CHARS)}…` : joined;
+}
+
+/**
+ * tailcat's per-connection delivery failures. `tailcat forward` binds its local
+ * listener eagerly and only brings the WireGuard/DERP tunnel up when a
+ * connection arrives, so a forward whose relay is blocked still binds, still
+ * reports `active`, and still shows `running` — while every request through it
+ * is reset once the dial deadline expires. That line is the only place tailcat
+ * says so, which is why the post-startup stderr has to be read rather than
+ * drained: the operator's symptom is "the loopback says running but nothing
+ * answers", and this is the sentence that explains it.
+ *
+ * Deliberately narrow. Relay reconnects and netcheck chatter are normal even on
+ * a healthy tunnel; a failed dial is not.
+ */
+const RUNTIME_FAILURE_PATTERN = /^.*\bdial remote\b.*$/m;
+
+/** The redacted tailcat line explaining a failed delivery, or null. */
+export function classifyTailcatRuntimeError(text) {
+  const match = RUNTIME_FAILURE_PATTERN.exec(String(text || ''));
+  return match ? redactTailcatDiagnostics(match[0]) || null : null;
 }
 
 async function loadForwards() {
@@ -194,21 +221,33 @@ async function markForwardFailed(id, error, patchFn = patchForward) {
  */
 export async function listTailcatForwards() {
   const entries = await readForwards();
-  return entries.map((entry) => ({
-    id: entry.id,
-    peerId: entry.peerId,
-    tcAddress: redactTcAddress(entry.tcAddress),
-    localPort: entry.localPort,
-    remotePort: entry.remotePort,
-    name: entry.name,
-    protocol: entry.protocol,
-    hasAuth: !!entry.auth,
-    status: entry.status,
-    lastError: entry.lastError,
-    lastErrorAt: entry.lastErrorAt,
-    createdAt: entry.createdAt,
-    live: liveForwards.has(entry.id),
-  }));
+  return entries.map((entry) => {
+    // In-memory, never persisted: it describes the child running right now, and
+    // a per-connection failure repeating every few seconds would thrash the file.
+    const recorded = liveForwards.get(entry.id)?.child?.tailcatRuntimeError || null;
+    const runtimeError = recorded && Date.now() - Date.parse(recorded.at) < TUNNEL_ERROR_FRESH_MS
+      ? recorded
+      : null;
+    return {
+      id: entry.id,
+      peerId: entry.peerId,
+      tcAddress: redactTcAddress(entry.tcAddress),
+      localPort: entry.localPort,
+      remotePort: entry.remotePort,
+      name: entry.name,
+      protocol: entry.protocol,
+      hasAuth: !!entry.auth,
+      status: entry.status,
+      lastError: entry.lastError,
+      lastErrorAt: entry.lastErrorAt,
+      createdAt: entry.createdAt,
+      live: liveForwards.has(entry.id),
+      // "running" only ever meant the local listener is bound. This is the
+      // separate answer to "can it actually carry a request?".
+      tunnelError: runtimeError?.message || null,
+      tunnelErrorAt: runtimeError?.at || null,
+    };
+  });
 }
 
 /**
@@ -503,6 +542,28 @@ export async function startForwardProcess({
     safeChildProcessOptions({ env: safeChildProcessEnv(), stdio: ['ignore', 'pipe', 'pipe'] }));
   ownedChildren.add(child);
   child.stdout?.on('data', () => {});
+  // Liveness of the listener is not liveness of the tunnel — see
+  // RUNTIME_FAILURE_PATTERN. Null until tailcat reports it cannot deliver.
+  child.tailcatRuntimeError = null;
+
+  // Post-startup stderr is read, not merely drained. The rolling buffer holds
+  // at most one partial line, so a diagnostic split across chunk boundaries is
+  // still recognizable and no capability bytes are retained beyond a line.
+  let runtimeTail = '';
+  const observeRuntime = (text) => {
+    runtimeTail = (runtimeTail + text).slice(-DIAGNOSTIC_TAIL_CHARS);
+    const lastNewline = runtimeTail.lastIndexOf('\n');
+    if (lastNewline === -1) return;
+    const complete = runtimeTail.slice(0, lastNewline);
+    runtimeTail = runtimeTail.slice(lastNewline + 1);
+    const message = classifyTailcatRuntimeError(complete);
+    if (!message) return;
+    // Once per distinct reason: a blocked relay repeats this every request.
+    if (child.tailcatRuntimeError?.message !== message) {
+      console.error(`❌ tailcat forward 127.0.0.1:${localPort} cannot reach the remote — ${message}`);
+    }
+    child.tailcatRuntimeError = { message, at: new Date().toISOString() };
+  };
 
   // tailcat's own diagnostics can contain the bearer capability, so the raw tail
   // is bounded, redacted on the way into an error, and no longer accumulated once
@@ -531,10 +592,16 @@ export async function startForwardProcess({
     const poller = setInterval(() => {
       isListening(localPort).then((listening) => { if (listening) finish(); }, () => {});
     }, probeMs);
-    // Stays attached past startup so the pipe keeps draining, but stops
-    // accumulating: settled means the capability bytes are no longer kept.
+    // Stays attached past startup: the startup tail stops accumulating (settled
+    // means those capability bytes are no longer kept) and the same pipe becomes
+    // the runtime health signal.
     child.stderr?.on('data', (chunk) => {
-      if (settled) return;
+      if (settled) {
+        // Stream callback, outside any request lifecycle: an uncaught throw here
+        // would take the whole server down.
+        try { observeRuntime(String(chunk)); } catch { /* diagnostics only */ }
+        return;
+      }
       tail = (tail + String(chunk)).slice(-DIAGNOSTIC_TAIL_CHARS);
       if (readyPattern.test(tail)) finish();
     });

--- a/server/services/tailcatPeer.test.js
+++ b/server/services/tailcatPeer.test.js
@@ -10,6 +10,7 @@ import {
   manualInstallHint,
   allocateLocalPort,
   startForwardProcess,
+  classifyTailcatRuntimeError,
   addPeerViaTailcat,
   listTailcatForwards,
   retryTailcatForward,
@@ -318,6 +319,52 @@ describe('tailcatPeer helpers', () => {
     expect(failure.message).not.toContain('tcEXAMPLE');
   });
 
+  it('reports a post-startup delivery failure instead of a bound-but-dead "running"', async () => {
+    const child = fakeChild();
+    const errors = [];
+    const logSpy = vi.spyOn(console, 'error').mockImplementation((line) => errors.push(line));
+    const spawnFn = vi.fn(() => {
+      queueMicrotask(() => child.stderr.emit('data', 'forwarding 127.0.0.1:15555 -> remote localhost:5555\n'));
+      return child;
+    });
+    await startForwardProcess({
+      bin: 'tailcat', tcAddress: EXAMPLE_TC, localPort: 15555, remotePort: 5555,
+      spawnFn, readyMs: 200, probeMs: 5, isListening: async () => false,
+    });
+    // Healthy relay churn is not a verdict; only a failed delivery is.
+    child.stderr.emit('data', 'derp-301: [v1] backoff: 114 msec\n');
+    expect(child.tailcatRuntimeError).toBeNull();
+
+    // Split across chunks, exactly as a real pipe delivers it.
+    child.stderr.emit('data', 'dial remote port 5555: context');
+    child.stderr.emit('data', ' deadline exceeded\n');
+    expect(child.tailcatRuntimeError.message).toContain('dial remote port 5555');
+    expect(errors.join(' ')).toContain('cannot reach the remote');
+    logSpy.mockRestore();
+  });
+
+  it('never leaks the capability through a post-startup diagnostic', async () => {
+    const child = fakeChild();
+    const spawnFn = vi.fn(() => {
+      queueMicrotask(() => child.stderr.emit('data', 'forwarding 127.0.0.1:15555 -> remote localhost:5555\n'));
+      return child;
+    });
+    await startForwardProcess({
+      bin: 'tailcat', tcAddress: EXAMPLE_TC, localPort: 15555, remotePort: 5555,
+      spawnFn, readyMs: 200, probeMs: 5, isListening: async () => false,
+    });
+    child.stderr.emit('data', `dial remote target ${EXAMPLE_TC}: refused\n`);
+    expect(child.tailcatRuntimeError.message).not.toContain('tcEXAMPLE');
+  });
+
+  it('classifyTailcatRuntimeError ignores relay churn and picks the delivery failure', () => {
+    expect(classifyTailcatRuntimeError('netcheck: UDP is blocked, trying HTTPS')).toBeNull();
+    expect(classifyTailcatRuntimeError('derp-301: [v1] backoff: 5 msec')).toBeNull();
+    expect(classifyTailcatRuntimeError(
+      'derp-301: [v1] backoff: 5 msec\ndial remote port 5555: context deadline exceeded'
+    )).toContain('dial remote port 5555: context deadline exceeded');
+  });
+
   it('addPeerViaTailcat installs, forwards, and registers loopback peer', async () => {
     const child = fakeChild();
     const addPeerFn = vi.fn(async (data) => ({ id: 'peer-1', ...data }));
@@ -513,6 +560,44 @@ describe('saved tailcat forwards', () => {
     expect(JSON.stringify(row)).not.toContain(EXAMPLE_TC);
     // The stored Basic credential is a secret too — presence only, never a value.
     expect(JSON.stringify(row)).not.toContain('password');
+  });
+
+  it('separates a bound listener from a tunnel that cannot carry a request', async () => {
+    const child = fakeChild();
+    const saved = [];
+    await addPeerViaTailcat({
+      tcAddress: EXAMPLE_TC,
+      name: 'sandbox',
+      ensureInstalled: async () => ({ bin: '/example/bin/tailcat' }),
+      primeDerpMap: async () => null,
+      allocatePort: async () => 15555,
+      startForward: async () => child,
+      addPeerFn: async (data) => ({ id: 'peer-1', ...data }),
+      persistForwardEntry: async (entry) => { saved.push(entry); },
+      patchForwardEntry: async (id, patch) => ({ ...saved[0], ...patch, id }),
+    });
+    readJSONFile.mockResolvedValue({ version: 1, forwards: [{
+      ...saved[0], peerId: 'peer-1', localPort: 15555, status: 'active',
+    }] });
+
+    // Bound and tracked: the row reads exactly as the operator's did — green.
+    const [healthy] = await listTailcatForwards();
+    expect(healthy).toMatchObject({ live: true, status: 'active', tunnelError: null });
+
+    const at = new Date().toISOString();
+    child.tailcatRuntimeError = { message: 'dial remote port 5555: context deadline exceeded', at };
+    const [broken] = await listTailcatForwards();
+    expect(broken).toMatchObject({
+      live: true, status: 'active', tunnelErrorAt: at,
+      tunnelError: 'dial remote port 5555: context deadline exceeded',
+    });
+
+    // A forward that started working again goes quiet, so the failure ages out
+    // rather than latching "no route" on a tunnel that now delivers.
+    child.tailcatRuntimeError = { message: 'dial remote port 5555: context deadline exceeded',
+      at: new Date(Date.now() - 6 * 60 * 1000).toISOString() };
+    const [recovered] = await listTailcatForwards();
+    expect(recovered).toMatchObject({ live: true, tunnelError: null, tunnelErrorAt: null });
   });
 
   it('retries from the stored address without the operator supplying it again', async () => {


### PR DESCRIPTION
## Summary

A tailcat loopback reported `running` while every request through it was reset — and the far peer saw no activity at all. The status was the bug: `active`/`running` only ever meant *the local listener is bound*.

`tailcat forward` binds its loopback port eagerly and only brings the WireGuard/DERP tunnel up when a connection arrives. On a host whose relay is unreachable, the forward still binds, still passes both readiness signals, and still reports healthy, while tailcat resets each connection once its dial deadline expires:

```
$ curl http://127.0.0.1:15555/api/system/health/details
curl: (56) Recv failure: Connection reset by peer      # after ~10s, every time
```

The only place tailcat says why is its post-startup stderr (`dial remote port 5555: context deadline exceeded`) — which PortOS drained and discarded, so the reason never reached anyone.

## What changed

- **`startForwardProcess` now reads its child's stderr for the lifetime of the forward** instead of draining it. A delivery failure is redacted through the existing `redactTailcatDiagnostics` scrubber, logged once per distinct reason, and recorded on the child.
- **`listTailcatForwards` exposes `tunnelError` / `tunnelErrorAt`** — the separate answer to "can it actually carry a request?", alongside the existing `status`/`live`.
- **The Instances row reads `no route`** with the reason beneath it, instead of a green `running` on a tunnel that cannot carry a byte.
- The classifier is deliberately narrow: relay reconnects, backoff lines and netcheck chatter are normal on a healthy tunnel; a failed dial is not.
- The values are **in-memory** (they describe the child running right now; a per-connection failure repeating every few seconds would thrash the metadata file) and **age out after five minutes** — tailcat re-emits the line on every failed request, so a still-broken forward keeps refreshing it while a recovered one goes quiet. A latched `no route` would be the same lie as a permanent green `running`, pointing the other way.

Also unrelated-but-blocking: the private-security-assessment fixture deliberately commits `data/` and `.env` paths, and `git add` honours `core.excludesFile` from `~/.gitconfig` — so its omitted-coverage assertion silently failed on any machine whose global ignore lists them. The fixture now pins `core.excludesFile`, matching its existing `core.hooksPath` isolation.

## Test plan

- `server/services/tailcatPeer.test.js` — a post-startup delivery failure is recorded (including split across chunk boundaries) while relay churn is not; the capability never leaks into a runtime diagnostic; the listing separates a bound listener from a tunnel that cannot deliver; a stale failure ages out.
- `client/.../TailcatForwardsPanel.test.jsx` — a forward with `live: true, status: 'active'` and a `tunnelError` renders `no route` with the reason, not `running`. Verified this test **fails** against the pre-fix component.
- Full server suite: 2047 files / 40787 tests passing.
- Full client suite: 879 files / 10711 tests passing.
- Client build passes.

Docs: `docs/features/tailcat-peers.md` gains "A bound listener is not a working tunnel", including how to tell a blocked relay from a PortOS problem.