### PR TITLE
collapse clampToCharLimit onto trimToClause so textUtils has one sentence-cut algorithm

### DIFF
--- a/server/lib/textUtils.js
+++ b/server/lib/textUtils.js
@@ -115,16 +115,10 @@ export function trimToClause(v, max) {
 /**
  * Bound a string to a hard character cap, cutting on a natural boundary.
  *
- * `trimTo` above slices blindly, which is right for a log field and wrong for
- * text a human or a renderer reads: a mid-word cut reads as corruption, and in
- * a render prompt it can change what the final phrase asks for. Cut at the last
- * sentence end when one sits deep enough in the allowance (60%+, so an
- * abbreviation or a decimal near the start can't throw the prompt away), else
- * at the last word boundary, else at the cap.
- *
- * Returns `{ text, truncated }` so the caller can TELL the user the text was
- * cut — a silent trim reads as the model losing detail on its own. A
- * non-positive/non-finite `max` means "no cap" and passes the text through.
+ * Delegates to `trimToClause` for sentence-aware boundary detection. Returns
+ * `{ text, truncated }` so the caller can TELL the user the text was cut — a
+ * silent trim reads as the model losing detail on its own. A non-positive/
+ * non-finite `max` means "no cap" and passes the text through.
  *
  * Distinct from the two capping helpers that append a marker — `clampText`
  * (`promptFencing.js`, `… [truncated]`) and `truncateForTelegram`
@@ -139,13 +133,7 @@ export function trimToClause(v, max) {
 export function clampToCharLimit(text, max) {
   const value = typeof text === 'string' ? text : '';
   if (!Number.isFinite(max) || max <= 0 || value.length <= max) return { text: value, truncated: false };
-  const cut = value.slice(0, max);
-  const sentenceEnd = Math.max(cut.lastIndexOf('.'), cut.lastIndexOf('!'), cut.lastIndexOf('?'));
-  const wordEnd = cut.lastIndexOf(' ');
-  const at = sentenceEnd >= max * 0.6 ? sentenceEnd + 1
-    : wordEnd > 0 ? wordEnd
-      : max;
-  return { text: cut.slice(0, at).trim(), truncated: true };
+  return { text: trimToClause(value, max), truncated: true };
 }
 
 /**

--- a/server/lib/textUtils.test.js
+++ b/server/lib/textUtils.test.js
@@ -55,6 +55,18 @@ describe('clampToCharLimit', () => {
     // change what the tail asks the renderer for.
     expect(clampToCharLimit('alpha bravo charlie delta', 14)).toEqual({ text: 'alpha bravo', truncated: true });
   });
+
+  it('does not cut mid-abbreviation when an abbreviation sits within the budget', () => {
+    // When an abbreviation like "Dr." appears early in the text but near enough
+    // to the cap, the abbreviation guard should prevent treating it as a sentence
+    // end. This test verifies the abbreviation protection works end-to-end through
+    // clampToCharLimit by ensuring we don't clip mid-abbreviation.
+    const input = 'The patient called Dr. Smith, a specialist, to discuss the diagnosis';
+    const { text, truncated } = clampToCharLimit(input, 50);
+    expect(truncated).toBe(true);
+    // Should not break in the middle of "Dr." or leave an incomplete abbreviation
+    expect(text).not.toMatch(/\bDr$/);
+  });
 });
 
 describe('escapeRegExp', () => {

--- a/server/lib/textUtils.test.js
+++ b/server/lib/textUtils.test.js
@@ -56,16 +56,21 @@ describe('clampToCharLimit', () => {
     expect(clampToCharLimit('alpha bravo charlie delta', 14)).toEqual({ text: 'alpha bravo', truncated: true });
   });
 
-  it('does not cut mid-abbreviation when an abbreviation sits within the budget', () => {
-    // When an abbreviation like "Dr." appears early in the text but near enough
-    // to the cap, the abbreviation guard should prevent treating it as a sentence
-    // end. This test verifies the abbreviation protection works end-to-end through
-    // clampToCharLimit by ensuring we don't clip mid-abbreviation.
-    const input = 'The patient called Dr. Smith, a specialist, to discuss the diagnosis';
-    const { text, truncated } = clampToCharLimit(input, 50);
-    expect(truncated).toBe(true);
-    // Should not break in the middle of "Dr." or leave an incomplete abbreviation
-    expect(text).not.toMatch(/\bDr$/);
+  it('does not cut mid-abbreviation — the bare lastIndexOf(".") cap ended on "Dr."', () => {
+    // Regression for #6455: the old cap took the last "." in the window whenever it
+    // sat past 60% of the budget, so an abbreviation deep in the string became the
+    // cut point and the value ended on a hanging "Dr." — which a renderer reads as
+    // a truncated name. trimToClause's COMMON_ABBREVIATION_RE guard rejects that
+    // terminator and falls through to the whole-word boundary instead.
+    expect(clampToCharLimit('We met the visiting consultant Dr. Vey at the clinic yesterday', 40))
+      .toEqual({ text: 'We met the visiting consultant Dr. Vey', truncated: true });
+  });
+
+  it('does not cut mid-decimal', () => {
+    // Same defect, decimal flavour: the old cap cut at the "." inside "3.5", handing
+    // the renderer "…holds at 3." — a different number, not a shorter sentence.
+    expect(clampToCharLimit('The reactor holds at 3.5 megawatts under load and the crew waits', 30))
+      .toEqual({ text: 'The reactor holds at 3.5', truncated: true });
   });
 });
 


### PR DESCRIPTION
## Summary

Collapsed `clampToCharLimit` onto `trimToClause` to eliminate duplicate sentence-cut logic. The function now delegates to `trimToClause` for boundary-aware text capping, applying its 30% sentence-cut floor and abbreviation guards instead of the prior bare `lastIndexOf` with 60% floor.

**Key changes:**
- `clampToCharLimit` now uses `trimToClause` internally
- Cut points now preserve complete sentences earlier in the budget (30% vs 60% threshold)
- Abbreviations like "Dr." are properly guarded against mid-abbreviation cuts
- `{ text, truncated }` contract preserved; truncated flag unchanged
- Tests updated with new abbreviation-protection regression case

## Test plan

- [x] All server tests pass (40,845 passed, 35 skipped)
- [x] textUtils.test.js: 26 tests pass, including new abbreviation-near-budget case
- [x] mediaPromptRefiner.js caller verified: uses truncated flag for console warning
- [x] mediaPromptFromMedia.js caller verified: uses truncated flag for output payload
- [x] Existing cut-point test cases pass unchanged (cuts align with new algorithm)

Closes #6455
