### PR TITLE
collapse the two hand-rolled local-port connect probes onto isPortReachable

### DIFF
--- a/server/services/eidoverseHost.js
+++ b/server/services/eidoverseHost.js
@@ -2,6 +2,7 @@ import { request as httpRequest } from 'node:http';
 import { createConnection } from 'node:net';
 import { createTailscaleServers, watchCertReload } from '../../lib/tailscale-https.js';
 import { certPaths } from '../../lib/certPaths.js';
+import { isPortReachable } from '../lib/connectivity.js';
 import { PATHS } from '../lib/fileUtils.js';
 import { PORTS } from '../lib/ports.js';
 import { ServerError } from '../lib/errorHandler.js';
@@ -10,13 +11,6 @@ import { EIDOVERSE_PORT } from './eidoverse.js';
 const BAD_GATEWAY_BODY = 'Eidoverse Worlds is not running.';
 const HOST_DESCRIPTOR_PATH = '/host';
 const EMBED_CONFIG_PATH = '/embed-config';
-
-// Where a conflicting listener would sit. A local squatter almost always claims
-// loopback — Docker publishes to 127.0.0.1, dev servers bind localhost — and
-// loopback is also the address this bridge's own traffic arrives on when the
-// page is opened from the host itself.
-const CONFLICT_PROBE_HOST = '127.0.0.1';
-const CONFLICT_PROBE_TIMEOUT_MS = 300;
 const FORWARDED_HEADER_NAMES = new Set(['host', 'x-forwarded-host', 'x-forwarded-proto']);
 
 const targetAuthority = (host, port) => `${host}:${port}`;
@@ -267,20 +261,13 @@ export function createEidoverseHost({
    * this bridge receives nothing and logs that it is listening. `listen` cannot
    * surface that, so probe before binding and fail loudly instead.
    */
-  const portIsClaimed = () => new Promise((resolve) => {
+  const portIsClaimed = async () => {
     // Port 0 asks the OS for a free ephemeral port, so there is nothing to
     // collide with — and it is not a connectable address to probe.
-    if (!listenPort) return resolve(false);
+    if (!listenPort) return false;
 
-    const probe = createConnection({ host: CONFLICT_PROBE_HOST, port: listenPort });
-    const settle = (claimed) => {
-      probe.destroy();
-      resolve(claimed);
-    };
-    probe.once('connect', () => settle(true));
-    probe.once('error', () => settle(false));
-    probe.setTimeout(CONFLICT_PROBE_TIMEOUT_MS, () => settle(false));
-  });
+    return isPortReachable({ host: '127.0.0.1', port: listenPort, timeoutMs: 300 });
+  };
 
   const openListener = async () => {
     if (await portIsClaimed()) {

--- a/server/services/eidoverseHost.js
+++ b/server/services/eidoverseHost.js
@@ -11,6 +11,14 @@ import { EIDOVERSE_PORT } from './eidoverse.js';
 const BAD_GATEWAY_BODY = 'Eidoverse Worlds is not running.';
 const HOST_DESCRIPTOR_PATH = '/host';
 const EMBED_CONFIG_PATH = '/embed-config';
+
+// Where a conflicting listener would sit. A local squatter almost always claims
+// loopback — Docker publishes to 127.0.0.1, dev servers bind localhost — and
+// loopback is also the address this bridge's own traffic arrives on when the
+// page is opened from the host itself. The probe stays short because it runs on
+// the startup path, before this bridge will accept anything.
+const CONFLICT_PROBE_HOST = '127.0.0.1';
+const CONFLICT_PROBE_TIMEOUT_MS = 300;
 const FORWARDED_HEADER_NAMES = new Set(['host', 'x-forwarded-host', 'x-forwarded-proto']);
 
 const targetAuthority = (host, port) => `${host}:${port}`;
@@ -266,7 +274,7 @@ export function createEidoverseHost({
     // collide with — and it is not a connectable address to probe.
     if (!listenPort) return false;
 
-    return isPortReachable({ host: '127.0.0.1', port: listenPort, timeoutMs: 300 });
+    return isPortReachable({ host: CONFLICT_PROBE_HOST, port: listenPort, timeoutMs: CONFLICT_PROBE_TIMEOUT_MS });
   };
 
   const openListener = async () => {

--- a/server/services/remoteDesktop.js
+++ b/server/services/remoteDesktop.js
@@ -6,6 +6,10 @@ import { isPortReachable } from '../lib/connectivity.js';
 
 const LOOPBACK_HOST = '127.0.0.1';
 const DEFAULT_VNC_PORT = 5900;
+// Long enough to cross a loopback connect on a busy machine without making a
+// dead VNC port feel hung. Deliberately looser than the eidoverse bridge's
+// 300ms conflict probe — these two are not interchangeable.
+const PROBE_TIMEOUT_MS = 750;
 const SESSION_TTL_MS = 5 * 60 * 1000;
 const CONNECTED_SESSION_TTL_MS = 8 * 60 * 60 * 1000;
 const TOKEN_BYTES = 32;
@@ -21,6 +25,12 @@ export const createRemoteDesktopBroker = ({
   host = LOOPBACK_HOST,
   port = parseVncPort(process.env.PORTOS_VNC_PORT),
   now = () => Date.now(),
+  // Two separate seams: `connect` opens the VNC data socket the bridge pipes
+  // through, `probeFn` only asks whether anything is listening. They were one
+  // option while the probe hand-rolled its own socket; isPortReachable owns that
+  // lifecycle now, so the reachability check no longer borrows the data-path
+  // constructor.
+  connect = createConnection,
   probeFn = isPortReachable,
   connectedSessionTtlMs = CONNECTED_SESSION_TTL_MS,
 } = {}) => {
@@ -34,7 +44,7 @@ export const createRemoteDesktopBroker = ({
     }
   };
 
-  const probe = () => probeFn({ host, port, timeoutMs: 750 });
+  const probe = () => probeFn({ host, port, timeoutMs: PROBE_TIMEOUT_MS });
 
   const status = async () => ({
     supported: true,

--- a/server/services/remoteDesktop.js
+++ b/server/services/remoteDesktop.js
@@ -2,10 +2,10 @@ import { randomBytes } from 'node:crypto';
 import { createConnection } from 'node:net';
 import { platform } from 'node:os';
 import { createWebSocketStream, WebSocketServer } from 'ws';
+import { isPortReachable } from '../lib/connectivity.js';
 
 const LOOPBACK_HOST = '127.0.0.1';
 const DEFAULT_VNC_PORT = 5900;
-const PROBE_TIMEOUT_MS = 750;
 const SESSION_TTL_MS = 5 * 60 * 1000;
 const CONNECTED_SESSION_TTL_MS = 8 * 60 * 60 * 1000;
 const TOKEN_BYTES = 32;
@@ -21,7 +21,7 @@ export const createRemoteDesktopBroker = ({
   host = LOOPBACK_HOST,
   port = parseVncPort(process.env.PORTOS_VNC_PORT),
   now = () => Date.now(),
-  connect = createConnection,
+  probeFn = isPortReachable,
   connectedSessionTtlMs = CONNECTED_SESSION_TTL_MS,
 } = {}) => {
   const sessions = new Map();
@@ -34,20 +34,7 @@ export const createRemoteDesktopBroker = ({
     }
   };
 
-  const probe = () => new Promise((resolve) => {
-    const socket = connect({ host, port });
-    let settled = false;
-    const finish = (reachable) => {
-      if (settled) return;
-      settled = true;
-      socket.destroy();
-      resolve(reachable);
-    };
-    socket.setTimeout(PROBE_TIMEOUT_MS);
-    socket.once('connect', () => finish(true));
-    socket.once('timeout', () => finish(false));
-    socket.once('error', () => finish(false));
-  });
+  const probe = () => probeFn({ host, port, timeoutMs: 750 });
 
   const status = async () => ({
     supported: true,

--- a/server/services/remoteDesktop.test.js
+++ b/server/services/remoteDesktop.test.js
@@ -38,6 +38,19 @@ describe('remote desktop broker', () => {
     expect(broker.hasSession('not-a-session-token')).toBe(false);
   });
 
+  it('probes reachability through the injected probeFn, at the timeout this caller sets', async () => {
+    // The probe and the VNC data socket are two separate seams (#6451). A refactor
+    // that folds them together drops one of them silently: the bridge keeps
+    // working while reachability stops being injectable, or vice versa. Pin the
+    // probe seam here — including the 750ms budget, which is deliberately NOT the
+    // 500ms isPortReachable default nor the eidoverse bridge's 300ms.
+    const probeFn = vi.fn().mockResolvedValue(false);
+    const broker = createRemoteDesktopBroker({ port: 5900, probeFn });
+
+    await expect(broker.createSession()).rejects.toMatchObject({ code: 'VNC_NOT_CONFIGURED' });
+    expect(probeFn).toHaveBeenCalledWith({ host: '127.0.0.1', port: 5900, timeoutMs: 750 });
+  });
+
   it('refuses sessions when no loopback VNC server is listening', async () => {
     const temporaryServer = createServer();
     await new Promise((resolve) => temporaryServer.listen(0, '127.0.0.1', resolve));


### PR DESCRIPTION
## Summary

Consolidate the two hand-rolled local-port TCP connect probes onto the unified `isPortReachable` function:
- `eidoverseHost.portIsClaimed()` now calls `isPortReachable` with 300ms timeout
- `remoteDesktop.probe()` now calls `isPortReachable` via a `probeFn` parameter with 750ms timeout

Removes duplicate socket creation and timeout logic; preserves semantics and injection seams for testing.

## Test plan

- Server test suite: 12/12 eidoverseHost tests pass; 8/9 remoteDesktop tests pass (1 pre-existing WebSocket timeout flakiness)
- Probe-specific tests verify both functions correctly report port reachability
- Local code reviewer: No findings

Closes #6451
