### PR TITLE
fail a tailcat peer add when the tunnel cannot carry a request

### DIFF
--- a/docs/features/tailcat-peers.md
+++ b/docs/features/tailcat-peers.md
@@ -117,6 +117,16 @@ $ curl http://127.0.0.1:15555/api/system/health/details
 curl: (56) Recv failure: Connection reset by peer      # after ~10s, every time
 ```
 
+So the add does not stop at "the listener is up". Once the forward is bound,
+PortOS sends one request through it (`/api/system/health` on the loopback port,
+which is in the always-public set, so a password-gated remote still answers).
+**Any** HTTP response counts — this probes the transport, not the API, so a 401
+from a gating proxy or a 404 from an older remote is still proof that bytes
+crossed. When nothing answers, the add fails with `TAILCAT_TUNNEL_UNREACHABLE`
+and tailcat's own explanation, the child is killed, and no peer is registered —
+the saved address keeps the forward retryable. Registering the peer anyway would
+hand the operator a federation peer that looks added and can never answer.
+
 The only place tailcat says why is its post-startup stderr
 (`dial remote port 5555: context deadline exceeded`), which PortOS used to
 drain and discard. It now **reads** that stream for the lifetime of the child:
@@ -134,7 +144,8 @@ failed request, so a forward that is still broken keeps refreshing it, while one
 that started working again goes quiet — a latched "no route" would be the same
 lie as a permanently green "running", pointing the other way.
 
-**When you see `no route`,** the tunnel — not PortOS — is what to look at. The
+**When an add reports the tunnel could not reach the remote, or a live forward
+shows `no route`,** the tunnel — not PortOS — is what to look at. The
 usual cause on macOS is a local network filter (Little Snitch and friends)
 denying the `tailcat` binary itself: `tailcat forward --verbose` then logs a
 relay connect that dies the instant it is established, while `curl` to the same

--- a/server/services/tailcatPeer.js
+++ b/server/services/tailcatPeer.js
@@ -3,8 +3,9 @@
  * [tailcat](https://github.com/tailscale/tailcat) without a Tailscale account.
  *
  * Flow: ensure the `tailcat` CLI is installed → pre-warm the DERP map cache →
- * start `tailcat forward <tcADDR> LOCAL:5555` (preferred LOCAL=15555) → register
- * a normal peer at `127.0.0.1:LOCAL` over HTTP or explicitly selected HTTPS.
+ * start `tailcat forward <tcADDR> LOCAL:5555` (preferred LOCAL=15555) → prove the
+ * tunnel actually carries a request → register a normal peer at
+ * `127.0.0.1:LOCAL` over HTTP or explicitly selected HTTPS.
  *
  * The tc address is a bearer capability. Persist it only in the machine-local
  * forwards file for restart and retry; never log the full value, never put it on
@@ -23,6 +24,8 @@ import { bufferedSpawn, spawnFailureDetail } from '../lib/bufferedSpawn.js';
 import { dataPath, readJSONFile, ensureDir, PATHS, atomicWrite } from '../lib/fileUtils.js';
 import { createMutex } from '../lib/asyncMutex.js';
 import { isPortReachable } from '../lib/connectivity.js';
+import { peerFetch } from '../lib/peerHttpClient.js';
+import { peerBaseUrl } from '../lib/peerUrl.js';
 import { isTestRunner } from '../lib/runtimeEnv.js';
 import { findCommandOnPath, safeChildProcessEnv, safeChildProcessOptions } from '../lib/processEnv.js';
 import {
@@ -50,6 +53,9 @@ const DERP_MAP_FETCH_TIMEOUT_MS = 15_000;
 const DIAGNOSTIC_TAIL_CHARS = 4096;
 const DIAGNOSTIC_MAX_CHARS = 320;
 const PORT_SCAN_LIMIT = 32;
+// Long enough to outlast tailcat's own per-connection dial deadline, so a
+// blocked tunnel fails with tailcat's explanation rather than ours.
+const TUNNEL_VERIFY_TIMEOUT_MS = 20_000;
 // How long a delivery failure keeps describing the tunnel. tailcat re-emits the
 // line on every failed request, so a still-broken forward keeps refreshing it,
 // while one that started working again simply goes quiet and ages out. Without
@@ -619,6 +625,33 @@ export async function startForwardProcess({
   return child;
 }
 
+/**
+ * Prove the tunnel can carry a request, resolving to null when it did or to a
+ * short failure detail when it did not. See "A bound listener is not a working
+ * tunnel" in docs/features/tailcat-peers.md for why an add cannot stop at the
+ * listener, and why ANY HTTP response counts as proof.
+ *
+ * Deliberately not `probePeer`: that one needs a registered peer record, writes
+ * probe status into the store, and budgets a tailnet hop rather than tailcat's
+ * own dial deadline. The URL is still built through `peerBaseUrl`, so the probe
+ * cannot address the forward differently from the peer it gates.
+ *
+ * `fetchFn` defaults to null under the test runner so a suite can never reach
+ * the network by forgetting to inject it.
+ */
+export async function verifyTunnelReachable({
+  localPort,
+  protocol = 'http',
+  auth = null,
+  fetchFn = isTestRunner() ? null : peerFetch,
+  timeoutMs = TUNNEL_VERIFY_TIMEOUT_MS,
+} = {}) {
+  if (!fetchFn) return null;
+  const base = peerBaseUrl({ transport: 'tailcat', protocol, address: '127.0.0.1', port: localPort });
+  return fetchFn(`${base}/api/system/health`, { signal: AbortSignal.timeout(timeoutMs) }, auth ? { auth } : null)
+    .then(() => null, (err) => String(err?.message || 'no response'));
+}
+
 export function stopForwardForPeer(peerId) {
   return withLifecycle(async () => {
     const entries = await readForwards();
@@ -688,6 +721,7 @@ async function addTailcatPeer({
   persistForwardEntry = upsertForward,
   patchForwardEntry = patchForward,
   removePeerFn = removeInstancePeer,
+  verifyTunnel,
 } = {}) {
   const trimmed = String(tcAddress || '').trim();
   if (!isValidTcAddress(trimmed)) {
@@ -724,7 +758,7 @@ async function addTailcatPeer({
 
   const peer = await startAndRegister({
     entry, ensureInstalled, primeDerpMap, allocatePort, startForward, addPeerFn,
-    patchForwardEntry, removePeerFn,
+    patchForwardEntry, removePeerFn, verifyTunnel,
   }).catch(async (err) => {
     await markForwardFailed(entry.id, err, patchForwardEntry);
     throw err;
@@ -747,6 +781,7 @@ async function startAndRegister({
   patchForwardEntry,
   removePeerFn,
   setPeerPortFn = setTailcatPeerPort,
+  verifyTunnel = verifyTunnelReachable,
 }) {
   const { bin } = await ensureInstalled();
   // Best-effort, and deliberately before the spawn: on a host whose filter
@@ -769,6 +804,24 @@ async function startAndRegister({
   }
 
   ownedChildren.add(child);
+
+  // The listener being bound is not the tunnel being usable — see
+  // verifyTunnelReachable. Fail the add here, while the operator is watching,
+  // instead of registering a peer that can never answer.
+  const unreachable = await verifyTunnel({ localPort, protocol: entry.protocol, auth: entry.auth });
+  if (unreachable) {
+    try { child.kill('SIGTERM'); } catch { /* best-effort */ }
+    ownedChildren.delete(child);
+    // tailcat's own line names the cause; ours only says the request failed.
+    const detail = child.tailcatRuntimeError?.message || unreachable;
+    throw new ServerError(
+      `tailcat is forwarding 127.0.0.1:${localPort} but the tunnel could not reach the remote — ${detail}. `
+      + 'Check that the remote is still serving its tailcat address, and that a local firewall is not '
+      + 'blocking the `tailcat` binary itself.',
+      { status: 502, code: 'TAILCAT_TUNNEL_UNREACHABLE' }
+    );
+  }
+
   let peer = existingPeer;
   try {
     if (shuttingDown) throw new Error('PortOS is shutting down');

--- a/server/services/tailcatPeer.test.js
+++ b/server/services/tailcatPeer.test.js
@@ -11,6 +11,7 @@ import {
   allocateLocalPort,
   startForwardProcess,
   classifyTailcatRuntimeError,
+  verifyTunnelReachable,
   addPeerViaTailcat,
   listTailcatForwards,
   retryTailcatForward,
@@ -473,6 +474,37 @@ describe('tailcat lifecycle failure contracts', () => {
     expect(child.killed).toBe(true);
   });
 
+  it('refuses to register a peer the tunnel cannot actually reach', async () => {
+    const child = fakeChild();
+    child.tailcatRuntimeError = { message: 'dial remote port 5555: context deadline exceeded', at: 'now' };
+    const addPeerFn = vi.fn();
+    const saved = [];
+    // tailcat's own line is the cause; ours would only say the request failed.
+    await expect(addPeerViaTailcat(addOptions(child, {
+      addPeerFn,
+      patchForwardEntry: async (_id, patch) => { saved.push(patch); return {}; },
+      verifyTunnel: async () => 'fetch failed',
+    }))).rejects.toMatchObject({
+      code: 'TAILCAT_TUNNEL_UNREACHABLE',
+      status: 502,
+      message: expect.stringContaining('dial remote port 5555: context deadline exceeded'),
+    });
+    // A forward whose tunnel is dead must not leave a peer behind that will
+    // never answer — and the entry stays retryable without re-pasting the tc address.
+    expect(addPeerFn).not.toHaveBeenCalled();
+    expect(child.killed).toBe(true);
+    expect(_liveForwardCountForTests()).toBe(0);
+    expect(saved.at(-1)).toMatchObject({ status: 'failed' });
+  });
+
+  it('passes the verification through when the tunnel answers', async () => {
+    const child = fakeChild();
+    const verifyTunnel = vi.fn(async () => null);
+    const peer = await addPeerViaTailcat(addOptions(child, { verifyTunnel, protocol: 'https' }));
+    expect(peer.id).toBe('peer-example');
+    expect(verifyTunnel).toHaveBeenCalledWith({ localPort: 15555, protocol: 'https', auth: null });
+  });
+
   it('stops children on shutdown while preserving their restart metadata', async () => {
     const child = fakeChild();
     await addPeerViaTailcat(addOptions(child));
@@ -811,5 +843,30 @@ describe('tailcat startup diagnostics and DERP map priming', () => {
   it('never reaches the network from a suite that forgot to inject a fetch', async () => {
     await expect(primeDerpMapCache({ cachePath: '/example/cache/derpmap.json', statFn: async () => { throw new Error('ENOENT'); } }))
       .resolves.toEqual({ primed: false, reason: 'no-fetch' });
+  });
+});
+
+describe('verifyTunnelReachable', () => {
+  const url = 'http://127.0.0.1:15555/api/system/health';
+
+  it('treats any HTTP response as proof the tunnel carried the request', async () => {
+    // 401 from an auth-gating proxy still means bytes crossed — this probes the
+    // transport, not the API.
+    const fetchFn = vi.fn(async () => ({ status: 401 }));
+    await expect(verifyTunnelReachable({ localPort: 15555, fetchFn })).resolves.toBeNull();
+    expect(fetchFn.mock.calls[0][0]).toBe(url);
+  });
+
+  it('returns the failure detail when nothing answers, and honors https + auth', async () => {
+    const fetchFn = vi.fn(async () => { throw new Error('fetch failed'); });
+    const auth = { username: 'u', password: 'p' };
+    await expect(verifyTunnelReachable({ localPort: 15556, protocol: 'https', auth, fetchFn }))
+      .resolves.toBe('fetch failed');
+    expect(fetchFn.mock.calls[0][0]).toBe('https://127.0.0.1:15556/api/system/health');
+    expect(fetchFn.mock.calls[0][2]).toEqual({ auth });
+  });
+
+  it('skips verification rather than reaching the network when no fetch is available', async () => {
+    await expect(verifyTunnelReachable({ localPort: 15555, fetchFn: null })).resolves.toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

Adding a federated peer via tailcat could report success and register a peer that was never able to answer.

`tailcat forward` binds its loopback listener **eagerly** and only brings the WireGuard/DERP tunnel up when a connection arrives. On a host whose local network filter blocks the tailcat binary's own relay connection, the forward still bound, the add still went green, and the explanation stayed buried in tailcat's stderr until some later request happened to trigger a dial.

- **Add and retry now verify the tunnel before registering the peer** — one request through the forward to `/api/system/health` (always-public, so a password-gated remote still answers). Any HTTP response counts; this probes the transport, not the API.
- **On failure**: the child is killed, no peer is registered, and the add fails with `TAILCAT_TUNNEL_UNREACHABLE` carrying tailcat's own redacted diagnostic (`dial remote port 5555: context deadline exceeded`) plus a pointer at the firewall. The saved tc address keeps the forward retryable, so allowing tailcat through and pressing Retry is the whole recovery.
- **Boot-time restore is deliberately untouched** — it is best-effort and unwatched, and a 20s probe per forward does not belong on that path.

The probe builds its URL through `peerBaseUrl`, so it cannot address the forward differently from the peer it gates. It is intentionally not `probePeer`, which needs a registered peer record, writes probe status into the store, and budgets a tailnet hop rather than tailcat's dial deadline.

## Test plan

- `server/services/tailcatPeer.test.js` — new coverage: an unreachable tunnel refuses to register a peer, kills the child, leaves zero live forwards, marks the entry `failed` (retryable), and surfaces tailcat's own line; a reachable tunnel passes through with the right `protocol`/`auth`; `verifyTunnelReachable` treats any HTTP response as success, returns the failure detail otherwise, honors https + auth, and skips rather than reaching the network with no fetch available.
- Full server suite green (40,852 passed).
- Verified against a live tailcat 0.5.0: `verifyTunnelReachable` returns `null` against the local HTTPS server (self-signed cert handled via `peerFetch`) and the failure detail against a dead port.