### PR TITLE
fix: give the manual PLAN claim prompt its own key instead of reading history

### DIFF
--- a/server/services/taskPromptDefaults.test.js
+++ b/server/services/taskPromptDefaults.test.js
@@ -87,9 +87,9 @@ describe('taskPromptDefaults integrity snapshot', () => {
     expect(gitlab).toContain('Never force-delete with `-D`');
   });
 
-  it('plan-task v18 scheduled default omits review while preserving CI and v17', () => {
+  it('plan-task v18 scheduled default omits review while plan-task-claim preserves it', () => {
     const current = DEFAULT_TASK_PROMPTS['plan-task'];
-    const previous = PREVIOUS_DEFAULT_PROMPTS['plan-task'].at(-1);
+    const claimFlow = DEFAULT_TASK_PROMPTS['plan-task-claim'];
 
     expect(PROMPT_VERSIONS['plan-task']).toBe(18);
     expect(current).not.toContain('## Phase 6 — Review locally');
@@ -97,9 +97,9 @@ describe('taskPromptDefaults integrity snapshot', () => {
     expect(current).not.toContain('LOCAL reviewers');
     expect(current).not.toContain('PR-SIDE reviewers');
     expect(current).toContain('gh pr checks <num> --required --watch --fail-fast');
-    expect(previous).toContain('## Phase 6 — Review locally');
-    expect(previous).toContain('{reviewers}');
-    expect(previous).not.toBe(current);
+    expect(claimFlow).toContain('## Phase 6 — Review locally');
+    expect(claimFlow).toContain('{reviewers}');
+    expect(claimFlow).not.toBe(current);
   });
 
   afterEach(() => {
@@ -340,6 +340,11 @@ describe('taskPromptDefaults integrity snapshot', () => {
     'code-reviewer-review',
     'code-reviewer-implement',
     'branch-cleanup',
+    // The manual /do:next PLAN claim's default body: taskPromptService reads it
+    // only as a claimFlow fallback when the STORED 'plan-task' prompt is a
+    // shipped default (see getTaskPrompt) — it is never itself persisted to a
+    // schedule, so it carries no PROMPT_VERSIONS entry of its own (issue #6479).
+    'plan-task-claim',
   ];
 
   it('every persisted default prompt is versioned, so none is silently exempt from auto-upgrade', () => {

--- a/server/services/taskPromptDefaults/integrity.snapshot.json
+++ b/server/services/taskPromptDefaults/integrity.snapshot.json
@@ -28,6 +28,7 @@
     "performance": "672bd3958b12afb0f382bcebb6dc3b33",
     "plan-feature": "87f71a894757f89354da4e2119e07118",
     "plan-task": "b85fe92999aa4ee4a8910320457c4242",
+    "plan-task-claim": "910802d67f3b5a785f068f4d90178543",
     "pr-reviewer": "de9c295018df7c403a722a9ac2e780af",
     "pr-reviewer-eligibility": "a5652f7bcb7e2e50b1cfb9a54a6fabe0",
     "pr-reviewer-review": "a4b35a1dc44e03b3d0ecf1a4e1bae6df",

--- a/server/services/taskPromptDefaults/prompts.js
+++ b/server/services/taskPromptDefaults/prompts.js
@@ -1172,6 +1172,181 @@ If \`git branch -d\` refuses, fetch the default branch and re-check remote \`MER
 
 _(Phase 3b is defined above, right after Phase 3 — see the "alternative exit from Phase 3" section.)_`,
 
+  // plan-task-claim: the manual /do:next PLAN claim owns the complete claim
+  // lifecycle (local review + verified merge), unlike the scheduled plan-task
+  // default above, which intentionally omits the review loop. Kept as its own
+  // key -- not read off the PREVIOUS_DEFAULT_PROMPTS['plan-task'] history tail --
+  // so it can be revised without editing a preserved historical body the
+  // integrity snapshot pins (issue #6479). Never persisted to a schedule; see
+  // UNPERSISTED_PROMPT_KEYS in taskPromptDefaults.test.js.
+  'plan-task-claim': `[Plan Task: {appName}] Claim and ship next PLAN.md item
+
+Pick the next available unclaimed PLAN.md item by its \`[<slug>]\` ID, **create your own worktree at \`claim/<slug>\`**, implement, ship a PR, and clean up. Mirrors the \`/claim\` slash command — same in-flight scan, same branch naming, same no-local-merge cleanup. **YOU pick the item in Phase 1 — the scheduler does not reserve one for you.** Picking at execution time and immediately creating the \`claim/<slug>\` branch **narrows** the window for two concurrent runs to collide on the same slug — it does NOT eliminate it: two runs can still complete Phase 1 before either creates a branch, then race at \`git worktree add\`. That race is handled in Phase 2 — the loser re-picks the next item. (A dispatch-time pre-pick is strictly worse: it commits both runs to the same slug long before any branch exists.) Do NOT modify files in the source repo directly; ALL editing happens inside the worktree you create.
+
+**How claiming works.** Every PLAN.md checkbox carries a \`[<slug>]\` ID. A slug is "in flight" when it appears as the slug-position segment in either a \`claim/<slug>\` ref (the human/TUI pattern) or a \`cos/<task>/<slug>/<agent>\` ref (the CoS sub-agent pattern) — across local branches, remote branches, or open PR head refs. The \`claim/<slug>\` branch you create IS the claim, visible to every other agent and to the human running \`/claim\` in a TUI.
+
+## Phase 1 — Pick the target slug
+
+Run steps 1–5 in order.
+
+1. Read PLAN.md from the repo root.
+2. **If any \`- [ ]\` line lacks an \`[<slug>]\` ID, stop and exit cleanly** — \`do-replan\` populates IDs in one pass; without IDs, this task has nothing to claim.
+3. Build the in-flight set. Collect every ref from these sources:
+   \`\`\`bash
+   git fetch --prune 2>/dev/null
+   git branch -a --no-color --format='%(refname:short)'
+   gh pr list --state open --json headRefName -q '.[].headRefName' 2>/dev/null
+   \`\`\`
+   For each ref, extract the slug **only when the ref matches one of these documented patterns** (after stripping any leading remote prefix like \`origin/\` or \`upstream/\`):
+   - \`claim/<slug>\` — the slug is everything after \`claim/\`.
+   - \`cos/<task>/<slug>/<agent>\` — the slug is the third \`/\`-separated segment.
+
+   A slug is "in flight" iff it appears in a ref matching one of those patterns AND is present in PLAN.md. **Do NOT** flag a slug just because the bare word appears as some other segment of a ref — that would falsely flag any slug literally named \`main\`, \`fix\`, \`feature\`, \`release\`, \`dev\`, etc. against virtually every branch in the repo.
+4. **Pick the target slug:** walk PLAN.md top-to-bottom and pick the FIRST \`- [ ]\` line where ALL of the following are true:
+   - The slug is NOT in the in-flight set.
+   - The immediately-preceding line does NOT start with \`> ⚠️ DRIFT:\`.
+   - The line does NOT carry the \`<!-- NEEDS_INPUT -->\` annotation.
+5. **If no eligible item exists**, exit cleanly — that's a healthy plan state, not a failure. Brainstorming is handled by the \`feature-ideas\` task; do NOT add new items here.
+
+Capture the exact text of the selected item (without the leading \`- [ ]\`) verbatim, **including its \`[<slug>]\` ID** — the changelog entry will reuse both.
+
+## Phase 2 — Claim (worktree)
+
+Create the worktree on a branch named \`claim/<slug>\`. This branch name is the claim — once created and pushed, no other agent or \`/claim\` session will pick the same slug. Do all editing inside the worktree, NEVER in the source repo's working tree (which may have the user's in-flight work).
+
+\`\`\`bash
+SLUG=<picked-slug>
+WORKTREE="{worktreesRoot}/claim-\${SLUG}"
+mkdir -p {worktreesRoot}
+git fetch origin main
+git worktree add --no-track -b "claim/\${SLUG}" "\${WORKTREE}" origin/main
+cd "\${WORKTREE}"
+\`\`\`
+
+**If the worktree-creation command fails because the claim/<slug> branch already exists** (a concurrent run won the branch-creation race, or a remote claim/<slug> is now visible), do NOT force or reuse it — that branch IS another run's claim. Treat the slug as in-flight, return to Phase 1, and pick the next eligible item; if nothing else is eligible, exit cleanly.
+
+Stash the worktree path; you'll need it for Phase 7 cleanup.
+
+## Phase 3 — Verify still valid
+
+Before writing any code, sanity-check that executing the item won't regress newer work. **If ANY of these are true, jump to Phase 3b** (clarification path, not implementation):
+
+- The picked line is preceded by a \`> ⚠️ DRIFT:\` blockquote (you should already have filtered it; double-check).
+- The item description references a function, file, or component that no longer exists. Run \`grep -rn\` for the named identifiers — if they're gone, the item is stale.
+- The item depends on a predecessor that hasn't shipped (e.g. "Phase B work" when Phase B isn't done).
+- The work would require touching files outside the inferred scope (>5 unrelated files), suggesting the item is bigger than originally estimated.
+
+Otherwise: **ambiguity is not a reason to jump to Phase 3b — decide.** If the item merely leaves a design choice unstated or is open to more than one reasonable reading, pick the most reasonable interpretation, note the approach you chose in the commit/PR, and proceed to Phase 4. Jump to Phase 3b ONLY when proceeding would be destructive/irreversible, or genuinely requires the human — specific hardware/credentials you don't have, or a judgment only they can make (the same narrow bar as a \`blocked\` item). The user would rather iterate on top of a shipped best-guess than have the item parked waiting on a decision they didn't ask to make.
+
+## Phase 3b — Request Clarification (alternative exit from Phase 3)
+
+Done from INSIDE the worktree (you've already created \`claim/<slug>\` in Phase 2):
+
+1. Create \`.plan-questions.md\` in the worktree:
+   \`\`\`
+   # Plan Question: <short title summarizing the PLAN.md item>
+
+   ## PLAN.md Item
+   <the exact text of the unchecked item, including its [<slug>]>
+
+   ## Questions
+   - <question 1>
+   - <question 2>
+   \`\`\`
+2. **Move the unchecked item to the bottom of PLAN.md and annotate it with \` <!-- NEEDS_INPUT -->\`** — remove from its current position and append at the end with the annotation, **preserving the \`[<slug>]\` ID**. This keeps the queue moving so the next \`plan-task\` run picks a different actionable item.
+3. Commit, push the branch (\`git push -u origin claim/<slug>\`), and open a PR with \`gh pr create\` so the user can see the questions. **Do NOT merge** — the user resolves \`.plan-questions.md\` first.
+4. Then run the **Phase 3b cleanup** (which differs from Phase 7 — the PR is intentionally unmerged here, so the local branch must NOT be deleted):
+   \`\`\`bash
+   cd {repoPath}
+   git worktree remove "\${WORKTREE}"
+   \`\`\`
+   Leave the local \`claim/<slug>\` branch alone — \`git branch -d\` will refuse (PR not merged) and \`-D\` would discard work that's still in flight. The branch lives on locally and remotely until the user resolves the questions and the PR merges; \`git branch -d "claim/<slug>"\` becomes safe only after that point.
+
+After Phase 3b runs, **exit** — do NOT proceed to Phase 4. The implementing path resumes only when the user reopens the slug post-clarification.
+
+## Phase 4 — Implement
+
+Write the code, tests, and any docs the item requires. Follow the repo conventions in AGENTS.md / CLAUDE.md (no try/catch in route handlers, functional programming, Zod validation, Tailwind tokens, reactive UI updates).
+
+Run the relevant test suite as you go.
+
+**Commit messages reference the slug** so the work is grep-able across the changelog, branches, and PR titles:
+
+\`\`\`
+<type>([<slug>]): <one-line description>
+
+<optional body>
+\`\`\`
+
+Use \`feat:\` / \`fix:\` / \`refactor:\` / \`chore:\` / etc. (The bracketed-scope form \`([<slug>])\` is intentional and matches the project's existing convention — grep \`git log --oneline\` for prior examples. The brackets carry the PLAN.md \`[<slug>]\` ID syntax through to commits, branches, and PRs so a single slug grep finds the whole trail.)
+
+## Phase 5 — Update PLAN.md and the changelog
+
+**Remove the item from PLAN.md outright.** The audit trail for shipped work lives in \`git log\` and the project's changelog (however that repo keeps it) — do NOT archive to a \`DONE.md\`, that file has been retired. Do NOT leave a checked \`- [x]\` behind in PLAN.md.
+
+1. Remove the picked \`- [ ]\` line from PLAN.md entirely. If removing it leaves a heading empty, leave the heading alone — section curation is \`do-replan\`'s job.
+2. Record the shipped item in the repo's changelog, **following the convention that repo documents** — read its \`AGENTS.md\` (or \`CLAUDE.md\`) and changelog README (e.g. \`.changelog/README.md\`) BEFORE writing anything. Some repos collect per-branch fragments in a directory (e.g. \`.changelog/next/\`) via a helper script rather than appending to one shared file, precisely so parallel agents don't conflict on every merge. When such a convention is documented, use it — run the documented command and remember the fragment file it created as \`CHANGELOG_FILE\`.
+
+   Only when no convention is documented, detect a changelog file (in this order — pick the first match) and append an entry there:
+   - \`.changelog/NEXT.md\` (staged-release file)
+   - \`CHANGELOG.md\` at repo root with an \`## Unreleased\` or \`## [Unreleased]\` heading
+   - any other \`changelog\`-shaped file the repo already maintains (look at recent \`git log\` for examples of where prior entries landed)
+
+   Either way, mirror the prose style of recent entries; lead with the slug in brackets so \`git log --grep='<slug>'\` and changelog greps line up:
+
+   \`\`\`markdown
+   - **[<slug>] <Title from the PLAN.md line>** — <1–3 sentences on what shipped, key files touched, any caveats>
+   \`\`\`
+
+   Remember the exact path you wrote to as \`CHANGELOG_FILE\` — you'll stage it in step 3. If the repo has no changelog at all, skip this step and leave \`CHANGELOG_FILE\` unset; the commit message + \`git log\` becomes the audit trail.
+
+3. Stage PLAN.md plus the changelog file you actually edited (if any) and commit. **Do NOT use a glob or a swallow-on-failure fallback** — staging the exact file you edited is what keeps the audit trail honest:
+
+   \`\`\`bash
+   git add PLAN.md
+   [ -n "$CHANGELOG_FILE" ] && git add "$CHANGELOG_FILE"
+   git commit -m "docs([<slug>]): remove from PLAN.md and log to changelog"
+   \`\`\`
+
+## Phase 6 — Review locally, then open the PR and ship
+
+The configured reviewers for this task, in order, are \`{reviewers}\`. Split them by where they can run, preserving order: **LOCAL reviewers** — every token that is NOT an \`@<login>\` (\`claude\` / \`codex\` / \`antigravity\` (CLI binary: \`agy\`) / \`grok\` / \`cursor\` invoke a local-CLI critique; \`lmstudio\` / \`ollama\` use the appended Local Reviewer Procedure) read the working tree and need no PR, so they run BEFORE the PR is opened. **PR-SIDE reviewers** — every \`@<login>\` token, plus any review bot the repo requests automatically on open — review cloud-side, so they can only run once the PR exists. Open the PR only when the branch is already review-clean and all that remains is CI plus those PR-side reviewers.
+
+1. **Self-review your diff for reuse, quality, and efficiency** (DRY, dead code, naming, simpler equivalents, missed edge cases) and fix findings in the same diff — BEFORE opening the PR, not retroactively. Claude Code runs this as the three-agent \`/simplify\` pass; on other CLIs, do the equivalent review by hand.
+2. **Run each LOCAL reviewer in order against the BRANCH diff, not a PR diff.** No PR exists yet, so use the CLI's own base-diff mode or \`git diff origin/main...HEAD\` (substitute the repo's default branch when it isn't \`main\`); local LLM reviewers go through the appended endpoint procedure. Apply the fixes, run the tests, and commit them — capped at 3 rounds per reviewer — then advance. A missing CLI, timeout, transport failure, malformed response, or empty response is UNSATISFIED, not clean. Do NOT substitute your own self-review, and never open the PR on the strength of it. If a local reviewer is still unsatisfied after 3 rounds, or its fixes leave the build/tests red, do NOT open a PR — leave the branch and worktree in place, report the reviewer and the failure, and stop.
+3. Push the branch: \`git push -u origin claim/<slug>\`, then confirm \`git log --oneline @{u}..HEAD\` is empty so every review fix from step 2 is in the PR's diff.
+4. Open the PR with \`gh pr create\` — title MUST encode the slug: \`<type>([<slug>]): <description>\`. Body should summarize what shipped + test plan.
+5. **Satisfy the PR-SIDE reviewers and CI before merging.** Request each \`@<login>\` (\`gh pr edit <num> --add-reviewer <login>\`, drop the \`@\`), poll every 5–15s, and address the findings — push fixes, capped at 3 rounds each; their approval gates the merge. Wait out any auto-requested review bot the same way, then let required CI finish (\`gh pr checks <num> --required --watch --fail-fast\` — REQUIRED checks only, so an optional job can't stall the merge). If a reviewer stays unsatisfied or a required check stays red, comment on the PR naming the failure, remove only the worktree, and leave the branch and PR for reconciliation.
+
+6. **Merge immediately via \`gh pr merge\`** — NEVER a local merge and NEVER \`--auto\`. Prefer a true merge commit so Git retains the branch tip, but fall back when the repository disallows that method:
+   \`\`\`bash
+   PR_URL=$(gh pr view --json url -q .url)   # no number: resolves the PR from the checked-out branch
+   gh pr merge "$PR_URL" --merge --delete-branch || {
+     [ "$(gh pr view "$PR_URL" --json state -q .state)" = "MERGED" ] ||        gh pr merge "$PR_URL" --squash --delete-branch ||        gh pr merge "$PR_URL" --rebase --delete-branch
+   }
+   STATE=$(gh pr view "$PR_URL" --json state -q .state)
+   [ "$STATE" = "MERGED" ] || { echo "Expected MERGED, got $STATE" >&2; exit 1; }
+   \`\`\`
+   The exact comparison must succeed. Investigate and retry on \`OPEN\`; \`CLOSED\` is not success. Do not enter Phase 7 until remote state is exactly \`MERGED\`.
+
+## Phase 7 — Clean up (post-merge ONLY)
+
+This phase runs only after the PR was merged via Phase 6. If you exited via Phase 3b instead, you already did the 3b-specific cleanup — do NOT also run Phase 7.
+
+From the **source repo** (cd back to {repoPath} first; you are currently inside the worktree):
+
+\`\`\`bash
+cd {repoPath}
+git worktree remove "\${WORKTREE}"
+git branch -d "claim/\${SLUG}"
+\`\`\`
+
+If \`git branch -d\` refuses, fetch the default branch and re-check remote \`MERGED\` state. Retry \`-d\` only when Git proves the branch integrated; otherwise leave it for reconciliation. Never force-delete with \`-D\`.
+
+**Do NOT \`git pull\` from inside this phase** (no \`--rebase\`, no \`--autostash\`, no plain \`pull\`). The agent's work is already integrated on GitHub via \`gh pr merge\`; pulling locally provides no functional benefit and risks rebasing the user's in-progress branch / shuffling their uncommitted changes through stash if the source repo HEAD happens to be on a tracking feature branch when the agent runs. Leave the user's working tree alone.
+
+_(Phase 3b is defined above, right after Phase 3 — see the "alternative exit from Phase 3" section.)_`,
+
   'claim-issue': `[Claim Issue: {appName}] Claim and ship the next open GitHub issue
 
 Pick the next available unclaimed open GitHub issue, **create your own worktree at \`claim/issue-<num>\`**, implement the fix, ship a PR that closes the issue, and clean up. This is the \`/claim --issues\` flow — same in-flight scan, same branch naming, same no-local-merge cleanup, but the work source is the repo's GitHub issue tracker instead of PLAN.md. **YOU pick the issue in Phase 1 — the scheduler does not reserve one for you.** Picking at execution time and immediately claiming (worktree + assignee + label) **narrows** the window for two concurrent runs to collide on the same issue — it does NOT eliminate it. Do NOT modify files in the source repo directly; ALL editing happens inside the worktree you create.

--- a/server/services/taskPromptService.js
+++ b/server/services/taskPromptService.js
@@ -49,10 +49,13 @@ export {
 
 // The scheduled plan-task default intentionally omits the review loop, but the
 // manual /do:next PLAN claim still owns the complete claim lifecycle. Keep that
-// path on the last shipped review-capable body rather than silently handing it
-// a partial prompt just because both paths resolve the same task type.
+// path on its own DEFAULT_TASK_PROMPTS['plan-task-claim'] key rather than
+// reading the tail of PREVIOUS_DEFAULT_PROMPTS['plan-task'] — that history is
+// frozen by the integrity snapshot, so the manual-claim body could never be
+// revised, and every future plan-task version bump would silently reposition
+// which retired body the manual claim resolved to (issue #6479).
 const CLAIM_FLOW_DEFAULT_PROMPTS = Object.freeze({
-  'plan-task': PREVIOUS_DEFAULT_PROMPTS['plan-task'].at(-1)
+  'plan-task': DEFAULT_TASK_PROMPTS['plan-task-claim']
 });
 
 // ============================================================

--- a/server/services/taskPromptService.test.js
+++ b/server/services/taskPromptService.test.js
@@ -25,7 +25,7 @@ vi.mock('../lib/slashdoLoader.js', () => ({
   loadSlashdoLib: vi.fn(async (name) => `# ${name} lens\n${BACKREFERENCE_BAIT}`),
 }));
 
-import { getTaskPrompt, getStagePrompt, DEFAULT_TASK_PROMPTS, PREVIOUS_DEFAULT_PROMPTS } from './taskPromptService.js';
+import { getTaskPrompt, getStagePrompt, DEFAULT_TASK_PROMPTS } from './taskPromptService.js';
 import { getTaskInterval } from './taskSchedule.js';
 import { loadSlashdoFile, loadSlashdoLib } from '../lib/slashdoLoader.js';
 import { PATHS } from '../lib/fileUtils.js';
@@ -116,7 +116,7 @@ describe('claim-flow prompt variants', () => {
 
     expect(scheduled).not.toContain('## Phase 6 — Review locally');
     expect(scheduled).toContain('gh pr checks <num> --required --watch --fail-fast');
-    const expectedManual = PREVIOUS_DEFAULT_PROMPTS['plan-task'].at(-1)
+    const expectedManual = DEFAULT_TASK_PROMPTS['plan-task-claim']
       .replace(/\{worktreesRoot\}/g, PATHS.worktrees);
     expect(manual).toBe(expectedManual);
     expect(manual).toContain('## Phase 6 — Review locally');


### PR DESCRIPTION
## Summary

- `taskPromptService.js` resolved the manual `/do:next` PLAN claim's prompt as `PREVIOUS_DEFAULT_PROMPTS['plan-task'].at(-1)` — the tail of the frozen retired-prompt history. That made the manual-claim body unrevisable (the integrity snapshot rejects edits to history) and coupled it to array position, so the next `plan-task` version bump would silently drop the manual claim's review phase.
- Added `DEFAULT_TASK_PROMPTS['plan-task-claim']` holding the current v17 bytes verbatim, and pointed `CLAIM_FLOW_DEFAULT_PROMPTS` at it instead of the history tail.
- Listed `plan-task-claim` in `UNPERSISTED_PROMPT_KEYS` (it's only read as a `claimFlow` fallback, never persisted to a schedule) and regenerated the integrity snapshot — only the one new key's hash was added, no historical bodies changed.
- Repointed the two tests that pinned `.at(-1)` at the new key.

Closes #6479

## Test plan

- `cd server && npx vitest run services/taskPromptDefaults.test.js services/taskPromptService.test.js` — 76 passed
- `cd server && npx vitest run` — full suite green (2051 files, 40864 tests)
- `grep -rn "PREVIOUS_DEFAULT_PROMPTS\[.*\]\.at(-1)" server scripts --include='*.js'` — no matches in `taskPromptService.js` or any test file for `plan-task`