### PR TITLE
fix: keep Codex TUI default selectable

### DIFF
--- a/client/src/components/providers/ProviderCard.jsx
+++ b/client/src/components/providers/ProviderCard.jsx
@@ -141,7 +141,13 @@ export default function ProviderCard({
   const optional = cardState.state === PROVIDER_CARD_STATE.DISABLED;
   const codexSubscription = isCodexSubscriptionProvider(provider);
   const subscriptionAccountReady = !codexSubscription || codexAccount?.status === 'ready';
-  const subscriptionReady = !codexSubscription || (subscriptionAccountReady && provider.textTransportEnabled === true);
+  // ChatGPT account readiness applies to both Codex modes, but the explicit
+  // text-transport consent only applies to the CLI's app-server path. The TUI
+  // is an interactive PTY launch and must remain selectable before generic
+  // text calls have been opted in.
+  const codexModeReady = (mode) => !isCodexSubscriptionProvider(mode)
+    || (subscriptionAccountReady && (isTuiProvider(mode) || mode.textTransportEnabled === true));
+  const subscriptionReady = codexModeReady(provider);
   return (
     <div
       className={`@container bg-port-card border border-l-4 rounded-xl p-4 ${style.border} ${style.dim || ''} ${
@@ -311,7 +317,7 @@ export default function ProviderCard({
               {provider.enabled && (
                 <button
                   onClick={() => onSetActive(mode.id)}
-                  disabled={mode.id === activeProviderId || (isCodexSubscriptionProvider(mode) && (!subscriptionAccountReady || mode.textTransportEnabled !== true))}
+                  disabled={mode.id === activeProviderId || !codexModeReady(mode)}
                   className="px-3 py-1.5 text-sm bg-port-accent/20 text-port-accent rounded disabled:opacity-50"
                 >
                   {mode.id === activeProviderId ? `${mode.type.toUpperCase()} default` : `Set ${mode.type.toUpperCase()} default`}

--- a/client/src/pages/AIProviders.test.jsx
+++ b/client/src/pages/AIProviders.test.jsx
@@ -145,7 +145,7 @@ describe('AIProviders page load error handling', () => {
     await waitFor(() => expect(api.setActiveProvider).toHaveBeenLastCalledWith('example'));
   });
 
-  it('gates each unified Codex default on that mode’s own transport consent', async () => {
+  it('gates the CLI default on transport consent but leaves the TUI default selectable', async () => {
     const executionModes = [{ id: 'codex', type: 'cli' }, { id: 'codex-tui', type: 'tui' }];
     api.getCodexAccount.mockResolvedValue({ readiness: { status: 'ready' } });
     api.getCodexModels.mockResolvedValue({ models: null });
@@ -155,7 +155,9 @@ describe('AIProviders page load error handling', () => {
     ] });
     renderPage();
     await waitFor(() => expect(screen.getByRole('button', { name: 'Set CLI default' })).toBeEnabled());
-    expect(screen.getByRole('button', { name: 'Set TUI default' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Set TUI default' })).toBeEnabled();
+    fireEvent.click(screen.getByRole('button', { name: 'Set TUI default' }));
+    await waitFor(() => expect(api.setActiveProvider).toHaveBeenCalledWith('codex-tui'));
   });
 
   it('offers an install button on the card of a provider whose CLI is missing', async () => {


### PR DESCRIPTION
## Summary

- Keep the Codex TUI default action available when the interactive mode is configured.
- Continue requiring ChatGPT account readiness and CLI text-transport consent only for their respective paths.

## Test plan
- `npm test -- --run src/pages/AIProviders.test.jsx src/components/providers/ProviderCard.test.jsx`
- `npm run build`