### PR TITLE
feat: make onboarding networking optional with Tailcat choice

### DIFF
--- a/client/src/pages/CapabilityMap.jsx
+++ b/client/src/pages/CapabilityMap.jsx
@@ -1,3 +1,5 @@
+import { useState } from 'react';
+import toast from '../components/ui/Toast';
 import { Link } from 'react-router';
 import {
   CheckCircle, AlertTriangle, XCircle, Circle, ChevronRight, ListChecks,
@@ -46,6 +48,8 @@ function CapabilityRow({ cap }) {
 }
 
 export default function CapabilityMap() {
+  const [savedPreference, setSavedPreference] = useState(null);
+  const [saving, setSaving] = useState(false);
   const { data, loading } = useAutoRefetch(
     () => api.getCapabilities({ silent: true }),
     20_000,
@@ -67,12 +71,21 @@ export default function CapabilityMap() {
     return <div className="p-6 text-gray-400">Capability map unavailable.</div>;
   }
 
+  const preference = savedPreference ?? data.networkSetupPreference ?? '';
+  const savePreference = (value) => {
+    setSaving(true);
+    api.updateSettings({ networkSetupPreference: value }, { silent: true })
+      .then(() => setSavedPreference(value))
+      .catch((error) => toast.error(error.message || 'Could not save networking preference'))
+      .finally(() => setSaving(false));
+  };
+
   const caps = Array.isArray(data.capabilities) ? data.capabilities : [];
   const summary = data.summary || { ok: 0, warn: 0, error: 0, unconfigured: 0, overall: 'unconfigured' };
   const optionalSummary = data.optionalSummary || summary;
   const setup = data.setup || { total: 0, ready: 0, remaining: 0, complete: false };
   const providerCapability = caps.find((cap) => cap.id === 'providers');
-  const optionalCapabilities = caps.filter((cap) => cap.setupRequired !== true);
+  const optionalCapabilities = caps.filter((cap) => cap.setupRequired !== true && cap.id !== 'network');
   const overallStyle = STATUS_STYLE[optionalSummary.overall] || STATUS_STYLE.unconfigured;
   const OverallIcon = overallStyle.icon;
 
@@ -92,22 +105,37 @@ export default function CapabilityMap() {
       </div>
 
       <p className="text-sm text-gray-500">
-        Finish secure remote access and enable at least one runnable AI provider. Optional integrations stay below as a health overview.
+        Enable at least one runnable AI provider. Networking and other integrations are optional; you can configure them whenever they are useful.
       </p>
 
       <section className="space-y-3 rounded-xl border border-port-border bg-port-card p-4 sm:p-5">
         <div>
-          <h3 className="font-semibold text-white">1. Tailscale, MagicDNS &amp; HTTPS</h3>
+          <h3 className="font-semibold text-white">Optional networking</h3>
           <p className="mt-1 text-xs text-gray-500">
-            PortOS automates certificate provisioning once Tailscale is connected and HTTPS Certificates are enabled in the tailnet.
+            Choose Tailscale for private device access, Tailcat to bridge instances, or mark networking as not desired. This preference does not start or stop connections.
           </p>
         </div>
-        <NetworkSetupGuide networkExposure={data.network} />
+        <label htmlFor="network-setup-preference" className="block text-sm text-gray-300">Networking preference</label>
+        <select id="network-setup-preference" value={preference} disabled={saving}
+          onChange={(event) => savePreference(event.target.value)}
+          className="w-full rounded-lg border border-port-border bg-port-bg p-2 text-sm text-white">
+          <option value="" disabled>Choose an option (optional)</option>
+          <option value="tailscale">Tailscale — private device access</option>
+          <option value="tailcat">Tailcat — bridge instances</option>
+          <option value="none">Not desired</option>
+        </select>
+        {saving && <p role="status" className="text-xs text-gray-400">Saving preference…</p>}
+        {preference === 'tailscale' && <NetworkSetupGuide networkExposure={data.network} />}
+        {preference === 'tailcat' && <p className="text-sm text-gray-400">
+          Open Instances, choose Tailcat when adding a peer, and dial its address or let it dial yours. Tailscale and its HTTPS certificates are not required.
+          {' '}<Link to="/instances" className="text-port-accent underline">Configure Tailcat bridge</Link>
+        </p>}
+        {preference === 'none' && <p className="text-sm text-gray-400">Networking marked as not desired. You can change this preference at any time.</p>}
       </section>
 
       <section className="space-y-3 rounded-xl border border-port-border bg-port-card p-4 sm:p-5">
         <div>
-          <h3 className="font-semibold text-white">2. AI provider</h3>
+          <h3 className="font-semibold text-white">AI provider</h3>
           <p className="mt-1 text-xs text-gray-500">
             Enable one option you intend to use: an authenticated subscription CLI, a paid API key, or a local runtime with a downloaded model. PortOS never enables a paid provider or starts model work without your action.
           </p>

--- a/client/src/pages/CapabilityMap.test.jsx
+++ b/client/src/pages/CapabilityMap.test.jsx
@@ -1,12 +1,13 @@
 import { describe, expect, it, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
 
 vi.mock('../hooks/useAutoRefetch', () => ({
   useAutoRefetch: () => ({
     loading: false,
     data: {
-      setup: { total: 2, ready: 0, remaining: 2, complete: false },
+      networkSetupPreference: 'tailscale',
+      setup: { total: 1, ready: 0, remaining: 1, complete: false },
       summary: { ok: 0, warn: 2, error: 0, unconfigured: 1, total: 3, overall: 'warn' },
       optionalSummary: { ok: 0, warn: 0, error: 0, unconfigured: 1, total: 1, overall: 'unconfigured' },
       network: {
@@ -39,6 +40,9 @@ vi.mock('../hooks/useAutoRefetch', () => ({
   }),
 }));
 
+vi.mock('../services/api', () => ({ updateSettings: vi.fn() }));
+import * as api from '../services/api';
+
 import CapabilityMap from './CapabilityMap';
 
 describe('CapabilityMap setup walkthrough', () => {
@@ -46,17 +50,33 @@ describe('CapabilityMap setup walkthrough', () => {
     render(<MemoryRouter><CapabilityMap /></MemoryRouter>);
 
     expect(screen.getByRole('heading', { name: 'Setup & Capabilities' })).toBeInTheDocument();
-    expect(screen.getByText('2 essential steps remaining')).toBeInTheDocument();
-    expect(screen.getByRole('heading', { name: '1. Tailscale, MagicDNS & HTTPS' })).toBeInTheDocument();
+    expect(screen.getByText('1 essential step remaining')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Optional networking' })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Open Tailscale DNS admin' })).toHaveAttribute(
       'href',
       'https://login.tailscale.com/admin/dns',
     );
-    expect(screen.getByRole('heading', { name: '2. AI provider' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'AI provider' })).toBeInTheDocument();
     expect(screen.getByText('Subscription CLI')).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'Optional capabilities' })).toBeInTheDocument();
     expect(screen.getByText('Calendar')).toBeInTheDocument();
     expect(screen.getByText('1 not set up')).toBeInTheDocument();
     expect(screen.queryByText('2 degraded')).not.toBeInTheDocument();
   });
+});
+
+it('saves Tailcat and not-desired choices and retains the saved choice on failure', async () => {
+  api.updateSettings.mockResolvedValue({});
+  render(<MemoryRouter><CapabilityMap /></MemoryRouter>);
+  const select = screen.getByLabelText('Networking preference');
+  fireEvent.change(select, { target: { value: 'tailcat' } });
+  await waitFor(() => expect(screen.getByRole('link', { name: 'Configure Tailcat bridge' })).toHaveAttribute('href', '/instances'));
+  expect(screen.queryByText('Enable MagicDNS')).not.toBeInTheDocument();
+  fireEvent.change(select, { target: { value: 'none' } });
+  await waitFor(() => expect(select).toHaveValue('none'));
+  expect(api.updateSettings).toHaveBeenLastCalledWith({ networkSetupPreference: 'none' }, { silent: true });
+  api.updateSettings.mockRejectedValueOnce(new Error('Save failed'));
+  fireEvent.change(select, { target: { value: 'tailscale' } });
+  await waitFor(() => expect(select).not.toBeDisabled());
+  expect(select).toHaveValue('none');
 });

--- a/scripts/setup-guide.js
+++ b/scripts/setup-guide.js
@@ -40,6 +40,10 @@ export function formatSetupGuide(guide, { localUrl, setupUrl } = {}) {
     '',
   ];
 
+  lines.push('Networking is optional: choose Tailscale, Tailcat, or Not desired on the Setup page.');
+  lines.push('For a Tailcat bridge, open Instances and choose Tailcat when adding a peer.');
+  lines.push('', 'Optional Tailscale / MagicDNS / HTTPS guide:');
+
   for (const step of guide.steps || []) {
     lines.push(`[${MARK[step.status] || '·'}] ${step.title}`);
     lines.push(`    ${step.detail}`);
@@ -70,7 +74,7 @@ export function formatSetupGuide(guide, { localUrl, setupUrl } = {}) {
 export function formatSetupSummary(guide) {
   if (guide.complete) return `Trusted Tailscale HTTPS ready at ${guide.trustedUrl}`;
   const next = guide.nextStep;
-  return next ? `${next.title} — ${next.detail}` : 'Tailscale HTTPS setup needs attention';
+  return next ? `Optional Tailscale setup: ${next.title} — ${next.detail}` : 'Optional Tailscale HTTPS setup is available';
 }
 
 async function probeHealthScheme(port) {

--- a/scripts/setup-guide.test.js
+++ b/scripts/setup-guide.test.js
@@ -101,7 +101,7 @@ describe('setup walkthrough formatting', () => {
 
   it('summarizes the next action without claiming setup is complete', () => {
     expect(formatSetupSummary(incompleteGuide)).toBe(
-      'Provision a trusted HTTPS certificate — Enable HTTPS Certificates, then let PortOS fetch the certificate.',
+      'Optional Tailscale setup: Provision a trusted HTTPS certificate — Enable HTTPS Certificates, then let PortOS fetch the certificate.',
     );
   });
 

--- a/server/lib/capabilityMap.js
+++ b/server/lib/capabilityMap.js
@@ -225,7 +225,7 @@ export function networkRow(net = {}) {
         tailscaleHost: net.setup.dnsName || net?.cert?.tailscaleHost || null,
         nextStepId: net.setup.nextStep?.id || null,
       },
-      setupRequired: true,
+      setupRequired: false,
       setupComplete: complete,
     });
   }
@@ -237,7 +237,7 @@ export function networkRow(net = {}) {
       status: UNCONFIGURED,
       configured: false,
       summary: 'HTTP only · Tailscale not detected',
-      setupRequired: true,
+      setupRequired: false,
       setupComplete: false,
     });
   }
@@ -249,7 +249,7 @@ export function networkRow(net = {}) {
       tailscale ? `Tailscale: ${tailscaleHost}` : 'Tailscale not detected',
     ].join(' · '),
     detail: { https, tailscaleHost },
-    setupRequired: true,
+    setupRequired: false,
     setupComplete: https && tailscale,
   });
 }

--- a/server/lib/capabilityMap.test.js
+++ b/server/lib/capabilityMap.test.js
@@ -229,7 +229,7 @@ describe('networkRow', () => {
       },
       cert: {},
     });
-    expect(r).toMatchObject({ status: WARN, setupRequired: true, setupComplete: false });
+    expect(r).toMatchObject({ status: WARN, setupRequired: false, setupComplete: false });
     expect(r.detail.nextStepId).toBe('magic-dns');
   });
 });

--- a/server/lib/validation.js
+++ b/server/lib/validation.js
@@ -1744,6 +1744,8 @@ export const locationSettingsSchema = z.object({
 // Durable "don't show this again" for the dashboard first-run card (#5640).
 // Top-level general-settings boolean — same record as timezone/location, never
 // localStorage. Absent means show; only an explicit true suppresses.
+export const networkSetupPreferenceSchema = z.enum(['tailscale', 'tailcat', 'none']);
+
 export const hideFirstRunCardSchema = z.boolean();
 
 // Grok Imagegen settings slice (`imageGen.grok`) — the Grok Build CLI backend

--- a/server/routes/capabilities.js
+++ b/server/routes/capabilities.js
@@ -81,6 +81,7 @@ router.get('/', asyncHandler(async (req, res) => {
     telegramStatus,
     appSummary,
     network,
+    settings,
   ] = await Promise.all([
     providersPromise,
     providerPrerequisiteReadinessPromise,
@@ -95,6 +96,7 @@ router.get('/', asyncHandler(async (req, res) => {
     resolveTelegram().catch(() => ({})),
     apps.getAppStatusSummary().catch(() => ({ total: 0 })),
     getNetworkExposureSetupStatus().catch(() => ({})),
+    getSettings(),
   ]);
 
   const rows = buildCapabilityRows({
@@ -116,10 +118,11 @@ router.get('/', asyncHandler(async (req, res) => {
   res.json({
     timestamp: new Date().toISOString(),
     summary: summarizeCapabilities(rows),
-    optionalSummary: summarizeCapabilities(rows.filter((row) => row.setupRequired !== true)),
+    optionalSummary: summarizeCapabilities(rows.filter((row) => row.setupRequired !== true && row.id !== 'network')),
     setup: summarizeSetupCapabilities(rows),
     capabilities: rows,
     network,
+    networkSetupPreference: settings.networkSetupPreference || null,
   });
 }));
 

--- a/server/routes/capabilities.test.js
+++ b/server/routes/capabilities.test.js
@@ -91,7 +91,7 @@ describe('GET /api/capabilities', () => {
     expect(res.body.capabilities).toHaveLength(9);
     expect(res.body.summary).toMatchObject({ overall: expect.any(String), total: 9 });
     expect(res.body.optionalSummary).toMatchObject({ overall: expect.any(String), total: 7 });
-    expect(res.body.setup).toEqual({ total: 2, ready: 2, remaining: 0, complete: true });
+    expect(res.body.setup).toEqual({ total: 1, ready: 1, remaining: 0, complete: true });
     expect(res.body.network.setup.complete).toBe(true);
     // every row is fully formed + deep-links to settings
     for (const c of res.body.capabilities) {
@@ -206,4 +206,15 @@ describe('GET /api/capabilities', () => {
       detail: { available: 1, blocked: 0, standby: 2, setupReady: 1 },
     });
   });
+});
+
+it('does not require networking on an install without Tailscale', async () => {
+  const { getNetworkExposureSetupStatus } = await import('../lib/networkExposure.js');
+  const { getSettings } = await import('../services/settings.js');
+  getNetworkExposureSetupStatus.mockResolvedValueOnce({ setup: { complete: false }, tailscale: { available: false } });
+  getSettings.mockResolvedValue({ networkSetupPreference: 'tailcat' });
+  const res = await request(makeApp()).get('/api/capabilities');
+  expect(res.body.setup).toEqual({ total: 1, ready: 1, remaining: 0, complete: true });
+  expect(byId(res.body, 'network').setupRequired).toBe(false);
+  expect(res.body.networkSetupPreference).toBe('tailcat');
 });

--- a/server/routes/settings.js
+++ b/server/routes/settings.js
@@ -22,7 +22,7 @@ import { isPlainObject } from '../lib/objects.js';
 import { DEFAULT_UNTRUSTED_CONTENT_POLICY, untrustedContentSettingsSchema } from '../lib/untrustedContent.js';
 import { agentContextSettingsSchema } from '../lib/agentContextValidation.js';
 import { EFFORT_LEVELS } from '../lib/providerModels.js';
-import { privateCredentialParamsSchema, privateCredentialInputSchema, backupConfigSchema, sharingSettingsPatchSchema, featureProviderConfigSchema, autofixerSettingsSchema, codeReviewSettingsSchema, locationSettingsSchema, hideFirstRunCardSchema, settingsEmbeddingsSchema, localLlmSettingsSchema, imessageConfigSchema, signalConfigSchema, spotifyConfigSchema, youtubeConfigSchema, apiAccessSettingsSchema, instanceFeatureSettingsSchema, instanceFeatureIdSchema, instanceFeatureUpdateSchema, loraTrainingConfigSchema, pipelineEditorialChecksSettingsSchema, creativeDirectorSettingsSchema, musicSettingsSchema, federationSettingsSchema, privacySettingsSchema, seriesAutopilotSettingsSchema, layeredIntelligenceSettingsSchema, imageGenGrokSettingsSchema, imageGenAgySettingsSchema, renderDefaultsSettingsSchema, videoGenSettingsSchema, subscriptionCostsMapSchema, usageApiBilledInstanceIdsSchema, namedOrchestrationProfileSchema, orchestrationProfilesSettingsSchema, validateRequest } from '../lib/validation.js';
+import { privateCredentialParamsSchema, privateCredentialInputSchema, backupConfigSchema, sharingSettingsPatchSchema, featureProviderConfigSchema, autofixerSettingsSchema, codeReviewSettingsSchema, locationSettingsSchema, hideFirstRunCardSchema, networkSetupPreferenceSchema, settingsEmbeddingsSchema, localLlmSettingsSchema, imessageConfigSchema, signalConfigSchema, spotifyConfigSchema, youtubeConfigSchema, apiAccessSettingsSchema, instanceFeatureSettingsSchema, instanceFeatureIdSchema, instanceFeatureUpdateSchema, loraTrainingConfigSchema, pipelineEditorialChecksSettingsSchema, creativeDirectorSettingsSchema, musicSettingsSchema, federationSettingsSchema, privacySettingsSchema, seriesAutopilotSettingsSchema, layeredIntelligenceSettingsSchema, imageGenGrokSettingsSchema, imageGenAgySettingsSchema, renderDefaultsSettingsSchema, videoGenSettingsSchema, subscriptionCostsMapSchema, usageApiBilledInstanceIdsSchema, namedOrchestrationProfileSchema, orchestrationProfilesSettingsSchema, validateRequest } from '../lib/validation.js';
 
 const router = Router();
 
@@ -321,6 +321,9 @@ router.put('/', asyncHandler(async (req, res) => {
   // whole slice rather than .partial()ing away that pairing rule.
   if (req.body?.location !== undefined) {
     validateRequest(locationSettingsSchema, req.body.location);
+  }
+  if (req.body?.networkSetupPreference !== undefined) {
+    validateRequest(networkSetupPreferenceSchema, req.body.networkSetupPreference);
   }
   if (req.body?.hideFirstRunCard !== undefined) {
     validateRequest(hideFirstRunCardSchema, req.body.hideFirstRunCard);

--- a/server/routes/settings.test.js
+++ b/server/routes/settings.test.js
@@ -804,3 +804,18 @@ it('accepts only registered private keys and never returns the submitted secret'
   await request(app).put('/api/settings/credentials/artificial-analysis').send({ value: '' });
   expect(store.secrets.artificialAnalysis.apiKey).toBe('');
 });
+
+describe('Settings routes — optional networking preference', () => {
+  beforeEach(() => { store = {}; vi.clearAllMocks(); });
+  it('persists all supported choices and rejects invalid preferences without replacing the saved choice', async () => {
+    for (const networkSetupPreference of ['tailscale', 'tailcat', 'none']) {
+      const saved = await request(buildApp()).put('/api/settings').send({ networkSetupPreference });
+      expect(saved.status).toBe(200);
+      const loaded = await request(buildApp()).get('/api/settings');
+      expect(loaded.body.networkSetupPreference).toBe(networkSetupPreference);
+    }
+    const invalid = await request(buildApp()).put('/api/settings').send({ networkSetupPreference: 'invalid' });
+    expect(invalid.status).toBe(400);
+    expect(store.networkSetupPreference).toBe('none');
+  });
+});


### PR DESCRIPTION
## Summary
Networking no longer blocks essential onboarding. The Setup page saves an optional Tailscale, Tailcat, or Not desired preference per install, showing the Tailscale walkthrough or linking to existing Tailcat bridge controls as appropriate. Changing the preference does not start or stop connections.

The command-line walkthrough also identifies networking as optional. Existing network diagnostics and provider readiness checks remain available.

## Test plan
- Passed 120 targeted client/server tests covering rendered choices, save failure, settings persistence and validation, capability readiness, and CLI walkthrough formatting.
- Client production build passed.
- Optional pinned Ollama review attempted; endpoint returned HTTP 401 (unavailable).
