### PR TITLE
fix: make code review defaults opt-in

### DIFF
--- a/client/src/components/cos/ReviewerPicker.jsx
+++ b/client/src/components/cos/ReviewerPicker.jsx
@@ -164,10 +164,9 @@ export default function ReviewerPicker({
   // Render the parent's list (de-duped, order-preserving) so display === stored
   // state for valid input while staying robust to malformed/legacy duplicates —
   // dupes would otherwise collide on the `key={value}` below and corrupt
-  // reorder/remove. An empty list shows the "follows your default AI provider"
-  // hint and lets the user clear the chain entirely; the server resolves [] to
-  // the active provider's own reviewer (falling back to copilot when that
-  // provider maps to none) — see `codeReviewDefaultsFromProvider`.
+  // reorder/remove. An empty list shows the opt-in hint and lets the user clear
+  // the chain entirely; no reviewer is silently inferred from the active AI
+  // provider.
   const selected = Array.isArray(reviewers) ? [...new Set(reviewers.map(normalizeReviewerValue))] : [];
   const addable = REVIEWER_OPTIONS.filter(o => !selected.includes(o.value));
   const hasNonCopilot = selected.some(r => r !== 'copilot');
@@ -738,7 +737,7 @@ export default function ReviewerPicker({
           </>
         )}
         {selected.length === 0 && (
-          <span className="text-xs text-gray-600 italic">none — follows your default AI provider</span>
+          <span className="text-xs text-gray-600 italic">none — code review is disabled by default</span>
         )}
       </div>
 

--- a/client/src/components/cos/ReviewerPicker.test.jsx
+++ b/client/src/components/cos/ReviewerPicker.test.jsx
@@ -97,7 +97,7 @@ describe('ReviewerPicker', () => {
 
   it('shows the empty-state hint when no reviewers are selected', () => {
     render(<ReviewerPicker reviewers={[]} onChange={() => {}} />);
-    expect(screen.getByText(/none — follows your default AI provider/)).toBeInTheDocument();
+    expect(screen.getByText(/none — code review is disabled by default/)).toBeInTheDocument();
   });
 
   it('de-dupes a malformed list with duplicates (order-preserving)', () => {

--- a/client/src/components/settings/CodeReviewersTab.jsx
+++ b/client/src/components/settings/CodeReviewersTab.jsx
@@ -124,7 +124,7 @@ export default function CodeReviewersTab() {
         <h2 className="text-base font-semibold text-white">Code Review Defaults</h2>
       </div>
       <p className="text-xs text-gray-500">
-        Default Review Loop reviewer chain — used by ad-hoc CoS tasks and task-type schedules that haven't pinned their own. Leave it empty and reviews follow your default AI provider, at its own model and reasoning effort. Local-LLM reviewers route the diff through PortOS's local code-review endpoint; the {CLI_REVIEWER_LIST} reviewers invoke their CLI directly. Each runs the model picked on its row — choose <span className="font-mono">Custom…</span> to type an id its catalog doesn't list, such as an installed Ollama model for an Ollama-backed Claude.
+        Default Review Loop reviewer chain — used by ad-hoc CoS tasks and task-type schedules that haven't pinned their own. Leave it empty to keep code review disabled by default. Local-LLM reviewers route the diff through PortOS's local code-review endpoint; the {CLI_REVIEWER_LIST} reviewers invoke their CLI directly. Each runs the model picked on its row — choose <span className="font-mono">Custom…</span> to type an id its catalog doesn't list, such as an installed Ollama model for an Ollama-backed Claude.
       </p>
 
       {loadError && (
@@ -196,4 +196,3 @@ export default function CodeReviewersTab() {
     </div>
   );
 }
-

--- a/client/src/hooks/useCodeReviewDefaults.jsx
+++ b/client/src/hooks/useCodeReviewDefaults.jsx
@@ -13,7 +13,7 @@ const pinScalars = (source) => Object.fromEntries([
 
 // Resolved "Code Review Defaults" (Models → Code Reviewers) — used by TaskAddForm
 // and ScheduleTab's per-task-type config to seed the picker's fallback state
-// instead of the hardcoded `['copilot']`. Returned shape mirrors the server's
+// instead of a hardcoded reviewer. Returned shape mirrors the server's
 // `getCodeReviewDefaults()` so a consumer can rely on the same field names
 // regardless of whether it reads context or calls the API directly.
 // Mirrors the server's `pickCodeReviewDefaults` shape, including every

--- a/client/src/lib/reviewerPins.js
+++ b/client/src/lib/reviewerPins.js
@@ -158,10 +158,10 @@ export const sanitizeReviewerModelInput = (raw) =>
 // review-loop reviewer that never runs; the reverse hides one their install has.
 export const REVIEWER_VALUES = ['copilot', 'claude', 'antigravity', 'codex', 'grok', 'cursor', 'pi', 'opencode', 'kimi', 'lmstudio', 'ollama', 'mtplx'];
 
-// The reviewer a task falls back to when none is configured. Mirror of
-// DEFAULT_REVIEWER / DEFAULT_REVIEWERS.
+// The reviewer identity used for Copilot-specific handling. An empty default
+// reviewer list keeps code review opt-in on a fresh install.
 export const DEFAULT_REVIEWER = 'copilot';
-export const DEFAULT_REVIEWERS = [DEFAULT_REVIEWER];
+export const DEFAULT_REVIEWERS = [];
 
 // Arbitrary GitHub reviewer usernames (e.g. `@CodeReviewbot`) requested as PR
 // reviewers to gate merging, appended to slashdo's `--review-with` after the

--- a/server/lib/reviewerConfig.js
+++ b/server/lib/reviewerConfig.js
@@ -11,7 +11,7 @@
  * This module must stay Zod-free — it is pure reviewer domain vocabulary.
  */
 import { isPlainObject } from './objects.js';
-import { EFFORT_LEVELS, effortLevelsForProvider, buildEffortArgs, foldCursorEffortIntoModel, splitAntigravityModel, commandBasename, isConfiguredDefaultModel } from './providerModels.js';
+import { EFFORT_LEVELS, effortLevelsForProvider, buildEffortArgs, foldCursorEffortIntoModel, splitAntigravityModel } from './providerModels.js';
 import { ANTIGRAVITY_COMMAND } from './antigravity.js';
 import { CURSOR_COMMAND } from './cursor.js';
 
@@ -33,7 +33,7 @@ import { CURSOR_COMMAND } from './cursor.js';
 export const REVIEWER_VALUES = ['copilot', 'claude', 'antigravity', 'codex', 'grok', 'cursor', 'pi', 'opencode', 'kimi', 'lmstudio', 'ollama', 'mtplx'];
 export const REVIEWER_ALIASES = { gemini: 'antigravity', 'cursor-agent': 'cursor' };
 export const DEFAULT_REVIEWER = 'copilot';
-export const DEFAULT_REVIEWERS = ['copilot'];
+export const DEFAULT_REVIEWERS = [];
 // Reviewers that resolve to a local-LLM backend (rather than a CLI or GitHub
 // bot). Used by the code-review endpoint, settings panel, and prompt builder
 // to gate model-id resolution.
@@ -1133,11 +1133,10 @@ function markSuffixes(token, optSet, maxLookup, modelLookup, effortLookup) {
 /**
  * Resolve task metadata to an ordered, deduped reviewer list. Prefers the new
  * `reviewers` array; falls back to the legacy single `reviewer` string. When
- * the metadata yields nothing, returns `fallback` (default `['copilot']`) —
- * pass the settings-resolved defaults here so a Review Loop run picks up the
- * user's Code Review Defaults instead of the hardcoded copilot when the task
- * itself didn't pin reviewers. Filters to known reviewers and preserves
- * first-occurrence order.
+ * the metadata yields nothing, returns `fallback` (empty by default) — pass the
+ * settings-resolved defaults here so a Review Loop run picks up the user's Code
+ * Review Defaults when the task itself didn't pin reviewers. Filters to known
+ * reviewers and preserves first-occurrence order.
  */
 export function normalizeReviewers(meta, fallback = DEFAULT_REVIEWERS) {
   const raw = meta && typeof meta === 'object' && !Array.isArray(meta) ? meta : {};
@@ -1167,8 +1166,8 @@ export function normalizeReviewers(meta, fallback = DEFAULT_REVIEWERS) {
  * Resolve the keyed (enum) reviewer list, honoring the "username-only" case: an
  * EXPLICITLY empty keyed list with username reviewers present (e.g. copilot was
  * stripped on a non-GitHub forge) stays empty rather than falling back to the
- * copilot default normalizeReviewers would apply. Absent/legacy input still
- * normalizes to the default. Single source for the guard shared by
+ * install default normalizeReviewers would apply. Absent/legacy input still
+ * normalizes to the configured default. Single source for the guard shared by
  * `buildReviewWithArgs` and the review-loop follow-up prompt builder.
  */
 export function resolveKeyedReviewers(reviewers, hasUsernames) {
@@ -1179,7 +1178,7 @@ export function resolveKeyedReviewers(reviewers, hasUsernames) {
 /**
  * Build the comma-separated reviewer token list used to fill the `{reviewers}`
  * placeholder in claim/plan prompts: keyed reviewers (falling back to the
- * default when empty) followed by `@user` tokens for the reviewer usernames.
+ * configured default when empty) followed by `@user` tokens for the reviewer usernames.
  * Reviewers in `optionalReviewers` get slashdo's `~opt` non-blocking suffix, and
  * reviewers carrying a `reviewerMaxRounds` cap get `~max=<n>` after it. A
  * reviewer with a `reviewerModels` pin gets slashdo's `[<model>]` selector
@@ -1281,68 +1280,4 @@ export function buildReviewWithArgs(reviewers, {
   }
   if (reviewerApplies && hasNonCopilot) parts.push('--reviewer-applies');
   return parts.join(' ');
-}
-
-/**
- * The reviewer slug an AI provider config would review as, or `null` when the
- * provider is nothing the Review Loop can run (a hosted API provider with no
- * spawnable CLI, an unrecognized binary).
- *
- * Two ways in, matching how the two reviewer kinds are actually identified:
- * a local-LLM reviewer is named by PROVIDER ID (`ollama`/`lmstudio`/`mtplx` —
- * it has no binary; `POST /api/code-review/local` talks to the daemon), and a
- * CLI reviewer is named by the BINARY its provider spawns, looked up through
- * `REVIEWER_CLI_BINARIES` so the slug↔executable mapping stays in one table
- * (`antigravity` is the stored slug, `agy` the command — see that constant).
- *
- * An Ollama/SGLang-backed `claude` or `opencode` wrapper resolves to the
- * `claude` / `opencode` reviewer on purpose: the reviewer runs the same binary
- * against the same environment, and its model pin is free text precisely so a
- * locally-served id can be named.
- *
- * @param {{id?:string, command?:string}|null|undefined} provider
- * @returns {string|null}
- */
-export function reviewerForProvider(provider) {
-  if (!isPlainObject(provider)) return null;
-  const id = typeof provider.id === 'string' ? provider.id.trim().toLowerCase() : '';
-  if (LOCAL_LLM_REVIEWERS.includes(id)) return id;
-  const command = commandBasename(provider.command);
-  if (!command) return null;
-  return Object.entries(REVIEWER_CLI_BINARIES).find(([, binary]) => binary === command)?.[0] || null;
-}
-
-/**
- * Code Review Defaults derived from the install's DEFAULT AI provider — the
- * reviewer chain an install gets before anyone opens Settings › Code Reviewers.
- *
- * The historical fallback was a hardcoded `['copilot']`, which is wrong on two
- * counts: an install with no GitHub Copilot subscription gets a review that
- * never arrives, and an install that has already told PortOS which agent it
- * wants to run gets a different one for review with no way to have known. So
- * the fallback follows the active provider instead — same vendor, same model,
- * same reasoning effort — and only falls back to `DEFAULT_REVIEWERS` when the
- * provider maps to no reviewer at all (a hosted API provider, or none set).
- *
- * The model is dropped when it is a `*-configured-default` sentinel: that
- * string is a marker meaning "whatever the CLI is configured for", not an id
- * the reviewer's `--model` could take. The effort is dropped when it falls
- * outside that reviewer's own ladder, the same drop-don't-clamp rule
- * `normalizeReviewerEffort` applies everywhere else.
- *
- * Returns `null` (not a partial object) when there is nothing to derive, so the
- * caller can tell "no provider-derived default" from "derived, with no pins".
- *
- * @param {{id?:string, command?:string, defaultModel?:string, effort?:string}|null|undefined} provider
- * @returns {{reviewer: string, model: string|null, effort: string|null}|null}
- */
-export function codeReviewDefaultsFromProvider(provider) {
-  const reviewer = reviewerForProvider(provider);
-  if (!reviewer) return null;
-  const rawModel = provider.defaultModel;
-  return {
-    reviewer,
-    model: isConfiguredDefaultModel(rawModel) ? null : (normalizeReviewerModel(rawModel, reviewer) ?? null),
-    effort: normalizeReviewerEffort(provider.effort, reviewer) ?? null,
-  };
 }

--- a/server/lib/reviewerConfig.test.js
+++ b/server/lib/reviewerConfig.test.js
@@ -42,8 +42,6 @@ import {
   MAX_REVIEW_USERNAMES,
   MAX_REVIEWER_MAX_ROUNDS,
   normalizeReviewUsernames,
-  reviewerForProvider,
-  codeReviewDefaultsFromProvider,
 } from './reviewerConfig.js';
 // The Zod half of the old cosValidation.js — these cases assert that a reviewer
 // pin survives the schema that persists it, so they need both modules.
@@ -750,67 +748,6 @@ describe('claim reviewer round-trip (prompt CSV ↔ persisted metadata)', () => 
     // three claim generators rather than degrade.
     expect(reviewerConfigMetadata(null)).toEqual({});
     expect(reviewerConfigMetadata({ reviewers: ['bogus'] })).toEqual({});
-  });
-});
-
-describe('reviewerForProvider', () => {
-  it('names a CLI reviewer by the binary its provider spawns', () => {
-    expect(reviewerForProvider({ id: 'claude-code-tui', command: 'claude' })).toBe('claude');
-    expect(reviewerForProvider({ id: 'codex', command: '/opt/homebrew/bin/codex' })).toBe('codex');
-    // The stored slug is `antigravity`; the executable is `agy`.
-    expect(reviewerForProvider({ id: 'antigravity-cli', command: 'agy' })).toBe('antigravity');
-    expect(reviewerForProvider({ id: 'cursor-cli', command: 'cursor-agent' })).toBe('cursor');
-  });
-
-  it('names a local-LLM reviewer by provider id (it has no binary at all)', () => {
-    expect(reviewerForProvider({ id: 'ollama', type: 'api' })).toBe('ollama');
-    expect(reviewerForProvider({ id: 'lmstudio', type: 'api' })).toBe('lmstudio');
-    expect(reviewerForProvider({ id: 'mtplx', type: 'api' })).toBe('mtplx');
-  });
-
-  it('follows the wrapper binary for a locally-served CLI provider', () => {
-    // A locally-served `claude` reviews as `claude`: same binary, same env, and
-    // its model pin is free text precisely so a local id can be named.
-    expect(reviewerForProvider({ id: 'claude-ollama', command: 'claude', ollamaBacked: true })).toBe('claude');
-    expect(reviewerForProvider({ id: 'opencode-vllm', command: 'opencode' })).toBe('opencode');
-  });
-
-  it('returns null for a provider the Review Loop cannot run', () => {
-    // A hosted API provider spawns nothing and is not a local backend.
-    expect(reviewerForProvider({ id: 'openrouter', type: 'api' })).toBeNull();
-    expect(reviewerForProvider({ id: 'mystery', command: 'some-unknown-agent' })).toBeNull();
-    expect(reviewerForProvider(null)).toBeNull();
-    expect(reviewerForProvider('claude')).toBeNull();
-  });
-});
-
-describe('codeReviewDefaultsFromProvider', () => {
-  it('carries the provider model and effort onto its reviewer', () => {
-    expect(codeReviewDefaultsFromProvider({
-      id: 'claude-code', command: 'claude', defaultModel: 'claude-opus-5', effort: 'high',
-    })).toEqual({ reviewer: 'claude', model: 'claude-opus-5', effort: 'high' });
-  });
-
-  it('drops a configured-default sentinel — it is a marker, not a model id', () => {
-    const out = codeReviewDefaultsFromProvider({ id: 'grok-cli', command: 'grok', defaultModel: 'grok-configured-default' });
-    expect(out).toEqual({ reviewer: 'grok', model: null, effort: null });
-  });
-
-  it('drops an effort the reviewer\'s own ladder rejects', () => {
-    // agy really does reject `--effort max`; reviewing at a silently different
-    // level than the one configured is worse than using its own default.
-    expect(codeReviewDefaultsFromProvider({
-      id: 'antigravity-cli', command: 'agy', defaultModel: 'gemini-3.6-flash', effort: 'max',
-    }).effort).toBeNull();
-    // A provider with no effort set at all leaves the reviewer at its own default.
-    expect(codeReviewDefaultsFromProvider({ id: 'codex', command: 'codex' }).effort).toBeNull();
-    // ...as does a value that is not an effort level in the first place.
-    expect(codeReviewDefaultsFromProvider({ id: 'codex', command: 'codex', effort: 'turbo' }).effort).toBeNull();
-  });
-
-  it('returns null when the provider maps to no reviewer', () => {
-    expect(codeReviewDefaultsFromProvider({ id: 'openrouter', type: 'api' })).toBeNull();
-    expect(codeReviewDefaultsFromProvider(null)).toBeNull();
   });
 });
 

--- a/server/lib/validation.test.js
+++ b/server/lib/validation.test.js
@@ -1155,11 +1155,11 @@ describe('validation.js', () => {
   });
 
   describe('normalizeReviewers', () => {
-    it('defaults to [copilot] when absent/empty', () => {
-      expect(normalizeReviewers(undefined)).toEqual(['copilot']);
-      expect(normalizeReviewers({})).toEqual(['copilot']);
-      expect(normalizeReviewers({ reviewers: [] })).toEqual(['copilot']);
-      expect(normalizeReviewers({ reviewers: ['bogus'] })).toEqual(['copilot']);
+    it('defaults to no reviewers when absent/empty', () => {
+      expect(normalizeReviewers(undefined)).toEqual([]);
+      expect(normalizeReviewers({})).toEqual([]);
+      expect(normalizeReviewers({ reviewers: [] })).toEqual([]);
+      expect(normalizeReviewers({ reviewers: ['bogus'] })).toEqual([]);
     });
 
     it('prefers reviewers, falls back to legacy reviewer, preserves order + dedupes', () => {
@@ -1175,12 +1175,12 @@ describe('validation.js', () => {
       expect(normalizeReviewers({ reviewer: 'lmstudio' })).toEqual(['lmstudio']);
     });
 
-    it('uses the fallback when metadata is empty and falls back to copilot when the fallback is invalid', () => {
+    it('uses the fallback when metadata is empty and drops an invalid fallback', () => {
       // Settings-derived defaults flow through when the task didn't pin reviewers.
       expect(normalizeReviewers({}, ['antigravity', 'codex'])).toEqual(['antigravity', 'codex']);
       expect(normalizeReviewers({}, ['gemini', 'codex'])).toEqual(['antigravity', 'codex']);
-      // An all-bogus fallback collapses to the hardcoded copilot, never an empty list.
-      expect(normalizeReviewers({}, ['bogus', null])).toEqual(['copilot']);
+      // An all-bogus fallback collapses to the empty install default.
+      expect(normalizeReviewers({}, ['bogus', null])).toEqual([]);
       // Explicit task metadata still wins over the fallback.
       expect(normalizeReviewers({ reviewers: ['claude'] }, ['antigravity'])).toEqual(['claude']);
     });
@@ -1218,13 +1218,13 @@ describe('validation.js', () => {
   describe('resolveKeyedReviewers', () => {
     it('keeps an explicitly empty list empty only when usernames carry the review', () => {
       expect(resolveKeyedReviewers([], true)).toEqual([]);
-      // No usernames → falls back to the copilot default (can never be empty).
-      expect(resolveKeyedReviewers([], false)).toEqual(['copilot']);
+      // No usernames → follows the empty install default.
+      expect(resolveKeyedReviewers([], false)).toEqual([]);
     });
 
-    it('normalizes a populated list and defaults absent/legacy input to copilot', () => {
+    it('normalizes a populated list and defaults absent/legacy input to the install default', () => {
       expect(resolveKeyedReviewers(['codex', 'gemini'], true)).toEqual(['codex', 'antigravity']);
-      expect(resolveKeyedReviewers(undefined, true)).toEqual(['copilot']);
+      expect(resolveKeyedReviewers(undefined, true)).toEqual([]);
     });
   });
 
@@ -1245,9 +1245,9 @@ describe('validation.js', () => {
       expect(buildReviewersCsv(['copilot', 'codex'], ['@Bot'])).toBe('copilot,codex,@Bot');
     });
 
-    it('falls back to the copilot default when the keyed list is empty', () => {
-      expect(buildReviewersCsv([], [])).toBe('copilot');
-      expect(buildReviewersCsv([], ['Bot'])).toBe('copilot,@Bot');
+    it('keeps the keyed list empty when no reviewers are configured', () => {
+      expect(buildReviewersCsv([], [])).toBe('');
+      expect(buildReviewersCsv([], ['Bot'])).toBe('@Bot');
     });
 
     it('normalizes/strips bogus usernames', () => {

--- a/server/routes/codeReview.js
+++ b/server/routes/codeReview.js
@@ -40,7 +40,7 @@ const localReviewRequestSchema = z.object({
 })
 
 // GET /api/code-review/defaults — resolved global defaults (settings.codeReview
-// + hardcoded fallback). The Code Reviewers settings page reads this to render the
+// + an empty opt-in fallback). The Code Reviewers settings page reads this to render the
 // initial state; TaskAddForm + ScheduleTab read it to seed new reviewer lists.
 // `installed` (per-CLI-reviewer boolean, TTL-probed) rides alongside so a
 // picker can flag a configured reviewer whose binary isn't on this machine

--- a/server/services/agentPromptBuilder.js
+++ b/server/services/agentPromptBuilder.js
@@ -299,11 +299,9 @@ export async function buildAgentPrompt(task, config, workspaceDir, worktreeInfo 
   // `settings.codeReview.reviewers`). Threaded as the `normalizeReviewers`
   // fallback so a task that pins no `reviewers` (e.g. every app-improve /
   // self-improvement scheduled task) resolves to the configured default
-  // instead of the hardcoded `copilot` — which stalls the review loop on
-  // installs without GitHub Copilot review enabled (issue #2507). Unset →
-  // `['copilot']` (getCodeReviewDefaults returns the copilot fallback), so
-  // behavior is unchanged when nothing is configured. A settings read error
-  // degrades to the hardcoded default inside normalizeReviewers.
+  // instead of a hardcoded reviewer. Unset → [] (getCodeReviewDefaults keeps
+  // code review opt-in), so a fresh install does not silently start a review
+  // loop. A settings read error likewise leaves the reviewer list empty.
   //
   // Resolved BEFORE the slashdo section below, which prunes the reviewer
   // variants a run can't reach out of the command body (#3110).
@@ -335,7 +333,8 @@ export async function buildAgentPrompt(task, config, workspaceDir, worktreeInfo 
   // leave-open, JIRA, or a merge gate with no reviewer to invoke — doesn't pay
   // for the read and the staging write. The reviewer-list term matters too: the
   // section only inlines the recipe when a SPAWNABLE CLI reviewer resolves, so a
-  // copilot-only or username-only list (the default install) would otherwise
+  // copilot-only or username-only list (including an unconfigured install)
+  // would otherwise
   // read + `atomicWrite` 56KB and then render nothing from it.
   const isInlineNeedingRecipes = inlinePrLifecycleSection(task, {
     providerType, providerId, providerCommand, leanMode, worktreeInfo, isTruthyMetaFn,
@@ -493,7 +492,7 @@ After completing your work and before committing, ${simplifyInstruction}. Fix an
 ` : '';
 
   // Resolve the user's ordered reviewer list + flags (task metadata wins; else the
-  // install's configured Code Review Defaults; else `[copilot]`). Declared up here
+  // install's configured Code Review Defaults; else `[]`). Declared up here
   // so the TUI completion block can thread `--review-with …` into `/do:pr`.
   // Thread the install's Code Review Defaults as the fallback for ALL five
   // reviewer fields (not just `reviewers`) with task-over-default precedence —
@@ -872,7 +871,7 @@ function buildLightContextSections(task, workspaceDir, worktreeInfo, isTruthyMet
   const isWorktreeOnExistingBranch = isPrBranchWorktree(task, worktreeInfo);
   // Ordered reviewer list + flags for the Review Loop (task metadata wins; else
   // the install's configured Code Review Defaults threaded from buildAgentPrompt;
-  // else `[copilot]`). Flows as `/do:pr --review-with a,b,c [--review-stop-on-*]
+  // else `[]`). Flows as `/do:pr --review-with a,b,c [--review-stop-on-*]
   // [--reviewer-applies]`. All five fields fall back to the defaults with
   // task-over-default precedence (see the matching block in buildAgentPrompt and
   // resolveReviewLoopOptions) — not just the reviewer list.

--- a/server/services/agentPromptBuilder.test.js
+++ b/server/services/agentPromptBuilder.test.js
@@ -105,7 +105,8 @@ tryReadFile: vi.fn().mockResolvedValue(null),
 }));
 // Code Review Defaults resolver — mocked so tests can control the install-wide
 // default reviewer list threaded into buildAgentPrompt without touching disk.
-// Default matches pickCodeReviewDefaults's unset shape (`['copilot']`).
+// Most prompt-builder cases need an explicit reviewer to exercise their
+// completion text; opt-in/empty-default cases override this fixture locally.
 vi.mock('./codeReview.js', () => ({
   getCodeReviewDefaults: vi.fn().mockResolvedValue({ reviewers: ['copilot'] }),
 }));
@@ -1290,11 +1291,11 @@ describe('buildLightContextPrompt', () => {
       // gate only recognized OpenCode + lean mode, so codex fell through to the
       // slashdo path.
       const prompt = buildLightContextPrompt(
-        makeTask({ metadata: { openPR: true, reviewLoop: true } }),
+        makeTask({ metadata: { openPR: true, reviewLoop: true, reviewers: ['copilot'] } }),
         '/r',
         { branchName: 'claim/x', worktreePath: '/tmp/wt', baseBranch: 'main' },
         isTruthyMeta,
-        { isTui: true, providerId: 'codex-tui', providerCommand: 'codex' });
+        { isTui: true, providerId: 'codex-tui', providerCommand: 'codex', defaultReviewers: ['copilot'] });
       expect(prompt).toMatch(/## Completion Workflow/);
       expect(prompt).toMatch(/does NOT have slashdo/);
       expect(prompt).not.toMatch(/`\/do:pr`/);
@@ -1697,6 +1698,7 @@ describe('buildLightContextPrompt', () => {
       const prompt = buildLightContextPrompt(
         makeTask({ metadata: {
           reviewLoopFollowUp: true,
+          reviewLoopReviewers: ['copilot'],
           reviewLoopPRUrl: 'https://github.com/o/r/pull/9',
           reviewLoopPRBranch: 'b',
           reviewLoopPRNumber: 9,
@@ -1706,7 +1708,7 @@ describe('buildLightContextPrompt', () => {
         }}),
         '/r',
         { branchName: 'b', worktreePath: '/tmp/wt' },
-        isTruthyMeta);
+        isTruthyMeta, { defaultReviewers: ['copilot'] });
       expect(prompt).toMatch(/## Review-Loop Follow-up/);
       expect(prompt).toMatch(/task-src-1/);
       expect(prompt).toMatch(/gh pr merge "https:\/\/github\.com\/o\/r\/pull\/9" --merge --delete-branch/);
@@ -1903,8 +1905,8 @@ describe('buildLightContextPrompt', () => {
     });
 
     it('does not leak default usernames/stop-mode/reviewer-applies when no Code Review Defaults are set', () => {
-      // Same task, no `codeReviewDefaults` option → the lone-copilot default,
-      // which suppresses `--review-with` entirely and emits none of the flags.
+      // Same task, no `codeReviewDefaults` option → the empty install default,
+      // which emits none of the reviewer flags.
       const prompt = buildLightContextPrompt(
         makeTask({ metadata: { openPR: true, reviewLoop: true } }),
         '/r',
@@ -3014,7 +3016,7 @@ describe('discardWorktree (reasoning-only) completion contract', () => {
 
 // #2507 — CoS app-improve/self-improvement tasks pin no `reviewers`, so the
 // review loop must resolve them from the install's Code Review Defaults
-// (settings.codeReview.reviewers) rather than the hardcoded copilot default,
+// (settings.codeReview.reviewers) rather than a hardcoded reviewer,
 // which stalls on installs without GitHub Copilot review enabled.
 describe('buildAgentPrompt — reviewer resolution honors Code Review Defaults (#2507)', () => {
   const reviewLoopTask = () => makeTask({ metadata: { openPR: true, reviewLoop: true, simplify: false } });
@@ -3030,11 +3032,11 @@ describe('buildAgentPrompt — reviewer resolution honors Code Review Defaults (
     expect(prompt).not.toMatch(/--review-with copilot/);
   });
 
-  it('falls back to copilot (unchanged behavior) when no default is configured', async () => {
-    vi.mocked(getCodeReviewDefaults).mockResolvedValueOnce({ reviewers: ['copilot'] });
+  it('keeps review opt-in when no default is configured', async () => {
+    vi.mocked(getCodeReviewDefaults).mockResolvedValueOnce({ reviewers: [] });
     const prompt = await buildAgentPrompt(reviewLoopTask(), {}, '/r', { branchName: 'b', worktreePath: '/tmp/wt' }, isTruthyMeta, claudeCliOpts);
-    // Lone-copilot default is suppressed from --review-with (buildReviewWithArgs
-    // isDefaultOnly), so /do:pr runs without an explicit reviewer flag.
+    // An empty default is suppressed from --review-with, so /do:pr runs without
+    // an explicit reviewer flag.
     expect(prompt).toMatch(/`\/do:pr`/);
     expect(prompt).not.toMatch(/--review-with claude/);
   });
@@ -3047,7 +3049,7 @@ describe('buildAgentPrompt — reviewer resolution honors Code Review Defaults (
     expect(prompt).not.toMatch(/--review-with claude/);
   });
 
-  it('degrades to the hardcoded copilot default when the settings read fails', async () => {
+  it('keeps review opt-in when the settings read fails', async () => {
     vi.mocked(getCodeReviewDefaults).mockRejectedValueOnce(new Error('settings unavailable'));
     const prompt = await buildAgentPrompt(reviewLoopTask(), {}, '/r', { branchName: 'b', worktreePath: '/tmp/wt' }, isTruthyMeta, claudeCliOpts);
     expect(prompt).toMatch(/`\/do:pr`/);
@@ -3549,11 +3551,10 @@ describe('buildAgentPrompt — slashdo prompt-size controls', () => {
       expect(skipArg()).not.toContain('ollama-review-loop');
     });
 
-    it('prunes NOTHING on an unconfigured install (a lone copilot default is the unset shape)', async () => {
-      // pickCodeReviewDefaults collapses "nothing configured" to ['copilot'], so a
-      // lone copilot can't authorize pruning — and pinning --review-with copilot on
-      // an install without Copilot review is the #2507 stall.
-      vi.mocked(getCodeReviewDefaults).mockResolvedValue({ reviewers: ['copilot'] });
+    it('prunes NOTHING on an unconfigured install', async () => {
+      // An empty default cannot authorize pruning or pin a reviewer on an
+      // install that has not opted into code review.
+      vi.mocked(getCodeReviewDefaults).mockResolvedValue({ reviewers: [] });
       const prompt = await buildAgentPrompt(
         slashdoTask(), {}, '/r', null, isTruthyMeta,
         { providerType: 'cli', providerId: 'codex' });

--- a/server/services/agentWorktreeCleanup.js
+++ b/server/services/agentWorktreeCleanup.js
@@ -132,7 +132,7 @@ async function auditRepoState(agentId, success, originalTask, warnings) {
   });
 }
 
-async function runCleanupAgentWorktree(agentId, success, { prCreation = PR_CREATION.NEVER, prCompletion = null, requestCopilotReview: legacyRequestCopilotReview = false, reviewers = DEFAULT_REVIEWERS, usernames = [], optionalReviewers = [], reviewerMaxRounds = {}, reviewStopMode = DEFAULT_REVIEW_STOP_MODE, reviewerApplies = false, reviewerModels = null, reviewerEfforts = null, skipMerge = false, description = null, agentOutput = null, originalTask = null } = {}) {
+async function runCleanupAgentWorktree(agentId, success, { prCreation = PR_CREATION.NEVER, prCompletion = null, requestCopilotReview: legacyRequestCopilotReview = false, reviewers, usernames = [], optionalReviewers = [], reviewerMaxRounds = {}, reviewStopMode = DEFAULT_REVIEW_STOP_MODE, reviewerApplies = false, reviewerModels = null, reviewerEfforts = null, skipMerge = false, description = null, agentOutput = null, originalTask = null } = {}) {
   const { getAgent: getAgentState } = await import('./cos.js');
   const agentState = await getAgentState(agentId).catch(() => null);
   if (!agentState?.metadata?.isWorktree) return [];
@@ -289,7 +289,13 @@ async function runCleanupAgentWorktree(agentId, success, { prCreation = PR_CREAT
         ? prCompletion
         : (legacyRequestCopilotReview ? PR_COMPLETIONS.REVIEW_THEN_MERGE : PR_COMPLETIONS.MERGE_ON_GREEN);
       const runsReviewLoop = resolvedPrCompletion === PR_COMPLETIONS.REVIEW_THEN_MERGE;
-      const reviewerList = normalizeReviewers({ reviewers });
+      // Keep the pre-reviewer-chain API contract for direct callers: the legacy
+      // flag explicitly requested Copilot, whereas an explicitly supplied empty
+      // list means the caller opted into no reviewers. Production callers pass
+      // the resolved list, so a fresh install remains reviewer-free by default.
+      const reviewerList = reviewers === undefined
+        ? (legacyRequestCopilotReview ? [DEFAULT_REVIEWER] : [...DEFAULT_REVIEWERS])
+        : normalizeReviewers({ reviewers });
       const copilotIsFirst = reviewerList[0] === DEFAULT_REVIEWER;
       const nonCopilotReviewers = reviewerList.filter(r => r !== DEFAULT_REVIEWER);
       // Pre-request the native Copilot review ONLY when copilot LEADS the order — it

--- a/server/services/codeReview.js
+++ b/server/services/codeReview.js
@@ -34,7 +34,6 @@ import {
   normalizeReviewerMaxRounds,
   resolveReviewerMaxRounds,
   reviewerEffortsFromDefaults,
-  codeReviewDefaultsFromProvider,
   resolveReviewerPins,
   normalizeReviewerEffort,
   prioritizeToolFreeReviewers,
@@ -47,7 +46,6 @@ import {
   resolveGoalFidelityConfig,
 } from '../lib/goalFidelity.js'
 import { getSettings, settingsEvents } from './settings.js'
-import { getActiveProvider } from './providers.js'
 import { getBaseUrl as getLmStudioBaseUrl } from './lmStudioManager.js'
 import {
   getBaseUrl as getOllamaBaseUrl,
@@ -82,12 +80,10 @@ export function isLocalLlmReviewer(backend) {
  * The reviewer chain the user actually configured, with aliases mapped and
  * unknown enum values dropped — empty when they have configured none.
  *
- * Its own function because "did the user choose a chain?" is asked twice and the
- * two answers must agree exactly: `pickCodeReviewDefaults` uses it to decide
- * whether to derive defaults from the active AI provider, and
- * `getCodeReviewDefaults` uses it to decide whether it may memoize the result.
- * A settings.json holding only junk (`reviewers: ['bogus']`) has configured
- * nothing, and both callers have to see that the same way.
+ * Its own function because the settings-backed chain must be normalized in one
+ * place before the defaults are returned. A settings.json holding only junk
+ * (`reviewers: ['bogus']`) has configured nothing, so it receives the empty
+ * install default just like an absent reviewer list.
  */
 function configuredReviewers(settings) {
   const raw = settings && typeof settings === 'object' ? settings.codeReview : null
@@ -102,31 +98,19 @@ function configuredReviewers(settings) {
  * in bogus reviewer names. Returns a value-only shape (no I/O) so the spawner
  * and `GET /api/code-review/defaults` can share.
  *
- * `activeProvider` is the install's DEFAULT AI provider (the caller's, because
- * this function does no I/O). With no configured reviewer chain the defaults
- * follow that provider — its reviewer slug, its default model, its reasoning
- * effort — rather than the hardcoded `copilot`, which reviews through a GitHub
- * subscription the install may not have and ignores the agent the user already
- * chose. `DEFAULT_REVIEWERS` remains the last resort, for a provider that maps
- * to no reviewer (a hosted API provider) or none being set at all.
- *
- * A provider-derived model/effort is only a DEFAULT: a stored `<reviewer>Model`
- * / `<reviewer>Effort` scalar still wins, so pinning one reviewer's model does
- * not silently un-derive the rest.
+ * An unconfigured install has no reviewer chain. Reviewers are opt-in through
+ * this settings slice or a task-local override; the active AI provider does not
+ * silently turn itself into a code reviewer.
  */
-export function pickCodeReviewDefaults(settings, { activeProvider = null } = {}) {
+export function pickCodeReviewDefaults(settings) {
   const raw = settings && typeof settings === 'object' ? settings.codeReview : null
   const effortDefaults = reviewerEffortsFromDefaults(raw)
   const reviewers = configuredReviewers(settings)
-  // Only consulted when the user has configured no chain of their own — a saved
-  // chain is an explicit choice and must not be re-derived from the provider.
-  const derived = reviewers.length ? null : codeReviewDefaultsFromProvider(activeProvider)
   return {
-    reviewers: reviewers.length ? reviewers : (derived ? [derived.reviewer] : [...DEFAULT_REVIEWERS]),
+    reviewers: reviewers.length ? reviewers : [...DEFAULT_REVIEWERS],
     // Arbitrary GitHub reviewer usernames appended to `--review-with` to gate the
     // merge. Normalized so a hand-edited settings.json can't smuggle in unsafe
-    // tokens. Empty array = none configured (distinct from the copilot fallback
-    // reviewers get).
+    // tokens. Empty array = none configured.
     usernames: normalizeReviewUsernames(raw?.usernames),
     // Reviewer identities marked non-blocking (`~opt`). Normalized so a
     // hand-edited settings.json can't smuggle in junk. Empty = none optional.
@@ -164,7 +148,7 @@ export function pickCodeReviewDefaults(settings, { activeProvider = null } = {})
       MODEL_SELECTABLE_REVIEWERS.map((reviewer) => {
         const stored = raw?.[`${reviewer}Model`]
         if (typeof stored === 'string' && stored) return [`${reviewer}Model`, stored]
-        return [`${reviewer}Model`, derived?.reviewer === reviewer ? derived.model : null]
+        return [`${reviewer}Model`, null]
       })
     ),
     // Per-reviewer reasoning-effort defaults. Unlike the model scalars above these
@@ -180,7 +164,7 @@ export function pickCodeReviewDefaults(settings, { activeProvider = null } = {})
     ...Object.fromEntries(
       EFFORT_SELECTABLE_REVIEWERS.map((reviewer) => [
         `${reviewer}Effort`,
-        effortDefaults[reviewer] ?? (derived?.reviewer === reviewer ? derived.effort : null),
+        effortDefaults[reviewer] ?? null,
       ])
     ),
   }
@@ -206,19 +190,8 @@ export function __resetCodeReviewDefaultsCache() { cachedSettings = null; cached
 export async function getCodeReviewDefaults() {
   if (cachedDefaults) return cachedDefaults
   if (!cachedSettings) cachedSettings = await getSettings()
-  const configured = configuredReviewers(cachedSettings).length > 0
-  // `getActiveProvider` needs an initialized AI toolkit, which an early-boot
-  // caller (or a unit-test process) may not have — a failed read just means no
-  // provider-derived default, never a failed resolve. It reads the toolkit's own
-  // in-memory provider cache, so an unconfigured install pays no disk I/O for it.
-  const activeProvider = configured ? null : await getActiveProvider().catch(() => null)
-  const defaults = pickCodeReviewDefaults(cachedSettings, { activeProvider })
-  // Only a settings-derived answer is memoized: `settings:updated` invalidates it
-  // completely. A provider-derived one has no such event — the active provider
-  // lives in its own store — so it is re-resolved per call rather than pinned to
-  // whichever vendor happened to be active when the cache was first filled.
-  if (configured) cachedDefaults = defaults
-  return defaults
+  cachedDefaults = pickCodeReviewDefaults(cachedSettings)
+  return cachedDefaults
 }
 
 /**

--- a/server/services/codeReview.test.js
+++ b/server/services/codeReview.test.js
@@ -13,13 +13,6 @@ vi.mock('./settings.js', () => ({
 // Same one-liner stub for the two backend managers — `getCodeReviewDefaults`
 // + `pickCodeReviewDefaults` don't touch them, only `runLocalCodeReview`
 // does, and those tests stub `global.fetch` directly.
-// The install's default AI provider, which the unconfigured reviewer fallback
-// now follows. Mutable holder so each test picks the vendor it is asserting on;
-// `null` reproduces an install with no provider (or an uninitialized toolkit).
-const mockedActiveProvider = { current: null }
-vi.mock('./providers.js', () => ({
-  getActiveProvider: () => Promise.resolve(mockedActiveProvider.current),
-}))
 vi.mock('./lmStudioManager.js', () => ({ getBaseUrl: () => 'http://localhost:1234' }))
 // MTPLX's endpoint is resolved through a DYNAMIC import in the SUT (its manager
 // drags in the managed-daemon/PM2 graph), and it reports the OpenAI `/v1` root
@@ -67,7 +60,6 @@ const testDeps = {
 describe('codeReview helpers', () => {
   afterEach(() => {
     mockedSettings.current = {}
-    mockedActiveProvider.current = null
     __resetCodeReviewDefaultsCache()
     __resetReviewerCliInstalledCache()
     __resetThinkingUnsupportedCache()
@@ -105,9 +97,9 @@ describe('codeReview helpers', () => {
     // than more `<reviewer>*` scalars: it is a different review with a different
     // question, and the user can run it on a different model.
     const NO_GOAL_FIDELITY = { goalFidelity: { enabled: true, backend: null, model: null, effort: null } }
-    it('returns the hardcoded fallback when settings has no codeReview slice', () => {
+    it('returns no reviewers when settings has no codeReview slice', () => {
       expect(pickCodeReviewDefaults(null)).toEqual({
-        reviewers: ['copilot'],
+        reviewers: [],
         usernames: [],
         optionalReviewers: [],
         reviewerMaxRounds: {},
@@ -118,7 +110,7 @@ describe('codeReview helpers', () => {
         ...NO_GOAL_FIDELITY,
       })
       expect(pickCodeReviewDefaults({})).toEqual({
-        reviewers: ['copilot'],
+        reviewers: [],
         usernames: [],
         optionalReviewers: [],
         reviewerMaxRounds: {},
@@ -220,63 +212,6 @@ describe('codeReview helpers', () => {
       expect(pickCodeReviewDefaults({ codeReview: { reviewers: ['copilot'] } }).usernames).toEqual([])
     })
 
-    describe('unconfigured fallback follows the default AI provider', () => {
-      const claudeProvider = { id: 'claude-code-tui', command: 'claude', defaultModel: 'claude-opus-5', effort: 'high' }
-
-      it('reviews with the active provider, its model, and its effort', () => {
-        const out = pickCodeReviewDefaults(null, { activeProvider: claudeProvider })
-        expect(out.reviewers).toEqual(['claude'])
-        expect(out.claudeModel).toBe('claude-opus-5')
-        expect(out.claudeEffort).toBe('high')
-        // Only the derived reviewer gets pins — the rest stay at "its own default".
-        expect(out.codexModel).toBeNull()
-        expect(out.codexEffort).toBeNull()
-      })
-
-      it('leaves a configured chain alone', () => {
-        const out = pickCodeReviewDefaults(
-          { codeReview: { reviewers: ['copilot'] } },
-          { activeProvider: claudeProvider }
-        )
-        expect(out.reviewers).toEqual(['copilot'])
-        expect(out.claudeModel).toBeNull()
-      })
-
-      it('lets a stored pin win over the provider-derived one', () => {
-        const out = pickCodeReviewDefaults(
-          { codeReview: { claudeModel: 'claude-sonnet-5', claudeEffort: 'low' } },
-          { activeProvider: claudeProvider }
-        )
-        expect(out.reviewers).toEqual(['claude'])
-        expect(out.claudeModel).toBe('claude-sonnet-5')
-        expect(out.claudeEffort).toBe('low')
-      })
-
-      it('keeps copilot for a provider that maps to no reviewer', () => {
-        // A hosted API provider spawns no binary and is not a local backend.
-        const out = pickCodeReviewDefaults(null, { activeProvider: { id: 'openrouter', type: 'api', defaultModel: 'stealth/ox-alpha' } })
-        expect(out.reviewers).toEqual(['copilot'])
-      })
-
-      it('drops a configured-default sentinel rather than pinning it as a model', () => {
-        const out = pickCodeReviewDefaults(null, {
-          activeProvider: { id: 'antigravity-cli', command: 'agy', defaultModel: 'antigravity-configured-default' },
-        })
-        expect(out.reviewers).toEqual(['antigravity'])
-        // The sentinel means "whatever agy is configured for" — `agy --model
-        // antigravity-configured-default` is not a runnable invocation.
-        expect(out.antigravityModel).toBeNull()
-      })
-
-      it('drops an effort outside the derived reviewer\'s own ladder', () => {
-        // agy rejects `--effort max`, so a provider pinned there must not
-        // silently review at a level its CLI refuses.
-        const out = pickCodeReviewDefaults(null, {
-          activeProvider: { id: 'antigravity-cli', command: 'agy', defaultModel: 'gemini-3.6-flash', effort: 'max' },
-        })
-        expect(out.antigravityEffort).toBeNull()
-      })
-    })
   })
 
   describe('getCodeReviewDefaults', () => {
@@ -290,12 +225,11 @@ describe('codeReview helpers', () => {
       expect(out.stopMode).toBe('all')
     })
 
-    it('falls back to the active provider when nothing is configured', async () => {
+    it('keeps the reviewer chain empty when nothing is configured', async () => {
       mockedSettings.current = {}
-      mockedActiveProvider.current = { id: 'codex', command: 'codex', defaultModel: 'gpt-5.6-terra' }
       const out = await getCodeReviewDefaults()
-      expect(out.reviewers).toEqual(['codex'])
-      expect(out.codexModel).toBe('gpt-5.6-terra')
+      expect(out.reviewers).toEqual([])
+      expect(out.codexModel).toBeNull()
     })
   })
 

--- a/server/services/cosTaskPreStepBlocks.js
+++ b/server/services/cosTaskPreStepBlocks.js
@@ -781,11 +781,11 @@ export async function resolvePrWatcherBlock(app, taskType, metadata, taskSchedul
 export async function buildImprovementTaskDescription({ promptTemplate, app, promptTaskType, metadata, blocks }) {
   // Resolve the `{reviewers}` the agent is told to run. When the task itself
   // didn't pin reviewers, fall back to the user's PortOS Code Review Defaults
-  // (Settings → Code Reviewers) rather than the hardcoded `copilot` —
+  // (Settings → Code Reviewers) rather than a hardcoded reviewer —
   // otherwise scheduled tasks like claim-issue, whose prompt drives the review
-  // loop directly, would always tell the agent to use Copilot regardless of the
-  // user's configured reviewers. Settings I/O failures degrade to the hardcoded
-  // default inside normalizeReviewers, so a read error never blocks dispatch.
+  // loop directly, would otherwise ignore the user's configured reviewers.
+  // Settings I/O failures leave the reviewer list empty, so a read error never
+  // silently enables a review.
   //
   // One resolver for the whole bundle (list + usernames + `~opt` set + the three
   // keyed pins). Local-LLM reviewers stay in the operative list; their service


### PR DESCRIPTION
## Summary
- Make fresh-install code review defaults empty instead of implicitly selecting Copilot or the active AI provider.
- Preserve explicit task/settings reviewer chains, pins, usernames, and legacy requestCopilotReview behavior.
- Update picker messaging and prompt/default resolution tests for the opt-in contract.

## Test plan
- `cd server && npx vitest run --reporter=dot`
- `cd client && npx vitest run --reporter=dot`
- `cd server && npx vitest run services/cleanupAgentWorktree.test.js`