### PR TITLE
register the gated LTX-2.5 Pixel Spatial Upscaler IC-LoRA and keep it out of the 2.3 remix pipeline

### DIFF
--- a/client/src/lib/videoGenParams.js
+++ b/client/src/lib/videoGenParams.js
@@ -421,9 +421,12 @@ export const icLoraSpecForMode = (mode) => IC_LORA_MODES.find((m) => m.mode === 
 // when the output dimensions aren't divisible by the weight's reference-downscale
 // factor, else null. One implementation so the panel's warning and the submit
 // gate can never disagree.
+// A null/absent factor means UNKNOWN (a gated weight whose metadata hasn't been
+// read yet), not 1. Both assert no rule, but the non-number guard keeps the two
+// implementations byte-for-byte equivalent rather than agreeing by accident.
 export const icResolutionIssue = (spec, width, height) => {
-  const scale = spec?.referenceDownscaleFactor ?? 1;
-  if (scale <= 1) return null;
+  const scale = spec?.referenceDownscaleFactor;
+  if (typeof scale !== 'number' || !Number.isFinite(scale) || scale <= 1) return null;
   if (Number(width) % scale === 0 && Number(height) % scale === 0) return null;
   return `${spec.label} mode needs a resolution divisible by ${scale} (its reference encoder downscales by ${scale}); got ${width}×${height}.`;
 };

--- a/server/lib/icLoraWeights.js
+++ b/server/lib/icLoraWeights.js
@@ -30,10 +30,27 @@
 
 import { findCachedRepoFile } from './hfCache.js';
 
-// One entry per shipped remix mode. `minReferences`/`maxReferences` are the
-// weight's contract: the Python helper receives them as flags (never a second
-// hardcoded table) so this registry stays the single source of truth across
-// both languages.
+// The base model the MLX `ICLoraPipeline` remix path is pinned to. A weight
+// whose `baseModel` is anything else is registered here for PROVISIONING only —
+// it rides the same download/verify/repair surface, but it must never reach the
+// render-mode enum, because fusing a 2.5 adapter into the 2.3 pipeline loads
+// without erroring and produces garbage rather than a clean failure.
+export const IC_LORA_REMIX_BASE_MODEL = 'ltx-2.3';
+
+// One entry per registered IC-LoRA weight. `minReferences`/`maxReferences` are
+// the weight's contract: the Python helper receives them as flags (never a
+// second hardcoded table) so this registry stays the single source of truth
+// across both languages.
+//
+// `baseModel` is which LTX release the adapter was trained against, and
+// `mode` is the PortOS remix mode it is offered as — `null` for a weight that
+// is not a remix mode at all (the Pixel Spatial Upscaler is an upscale
+// adapter, reached from the upscale flow rather than the render form). The two
+// fields are INDEPENDENT gates: `listIcLoraRemixModes` requires both.
+//
+// `revision` pins the HF commit the weight is fetched and cache-resolved at.
+// `null` means unpinned — the historical behavior for the 2.3 weights, which
+// resolve out of whatever snapshot the install happens to hold.
 //
 // `referenceDownscaleFactor` is informational (the pipeline reads the real
 // value from the weight's safetensors metadata): the IC encoder divides the
@@ -46,11 +63,15 @@ import { findCachedRepoFile } from './hfCache.js';
 // The MIRRORED fields (label/description/referenceKind/uploadLabel/the counts/
 // the factor) are duplicated in client/src/lib/videoGenParams.js so the form can
 // validate pre-submit; icLoraWeights.parity.test.js diffs the two so a change
-// here can't silently leave the client accepting what the server rejects.
+// here can't silently leave the client accepting what the server rejects. That
+// mirror covers REMIX MODES only — a non-remix weight has no form surface, so
+// mirroring it would ship a field the client never reads.
 export const IC_LORA_MODES = Object.freeze({
   control: Object.freeze({
     id: 'control',
     mode: 'ic-control',
+    baseModel: 'ltx-2.3',
+    revision: null,
     label: 'Control',
     description: 'Structure + motion from a control clip',
     // Drives the panel's upload copy + `accept` filter, so a new mode needs no
@@ -69,6 +90,8 @@ export const IC_LORA_MODES = Object.freeze({
   colorize: Object.freeze({
     id: 'colorize',
     mode: 'ic-colorize',
+    baseModel: 'ltx-2.3',
+    revision: null,
     label: 'Colorize',
     description: 'Color restored onto a black-and-white clip',
     uploadLabel: 'Upload a B&W clip to restore',
@@ -90,6 +113,8 @@ export const IC_LORA_MODES = Object.freeze({
   ingredients: Object.freeze({
     id: 'ingredients',
     mode: 'ic-ingredients',
+    baseModel: 'ltx-2.3',
+    revision: null,
     label: 'Ingredients',
     description: 'A scene recomposed from 2-8 reference stills (characters, props, settings)',
     uploadLabel: 'Upload a reference still (character / prop / setting)',
@@ -125,28 +150,111 @@ export const IC_LORA_MODES = Object.freeze({
     // user must pre-download the weight through PortOS' single-file path first.
     requiresPreDownload: true,
   }),
+  // NOT a remix mode (`mode: null`) and NOT on the remix base model — the
+  // Pixel Spatial Upscaler is a 2x reference-conditioned upscale adapter for
+  // LTX-2.5, reached from the video upscale flow (#6502) rather than the render
+  // form. It is registered here so it rides the one provisioning surface every
+  // other IC weight uses.
+  'pixel-upscale': Object.freeze({
+    id: 'pixel-upscale',
+    mode: null,
+    baseModel: 'ltx-2.5',
+    label: 'Pixel Spatial Upscaler',
+    description: '2x reference-conditioned upscale that synthesizes detail (LTX-2.5)',
+    uploadLabel: 'Upscale an existing clip',
+    repo: 'Lightricks/LTX-2.5-22b-IC-LoRA-Pixel-Spatial-Upscaler',
+    filename: 'ltx-2.5-22b-ic-lora-pixel-spatial-upscaler-x2-1.0.safetensors',
+    // Pinned so an install can't silently resolve a different commit's weight
+    // out of an older snapshot. Read from the HF repo metadata on 2026-09-07.
+    revision: '5863fdef3eaa8b2d69fa22e259a1d75fede215dd',
+    // Exact, from the repo's blob listing — not an estimate. Do not round it.
+    sizeBytes: 327_322_640,
+    // UNKNOWN, deliberately. Every other entry's factor was read from the
+    // weight's safetensors `__metadata__`, and this weight's file is gated —
+    // so there is nothing to read yet. `null` means "no constraint asserted",
+    // which icResolutionIssue treats as "impose no rule" rather than guessing
+    // a factor and either rejecting valid resolutions or green-lighting bad
+    // ones. Fill it in from the real metadata once an install with accepted
+    // terms can read the header (#6512).
+    referenceDownscaleFactor: null,
+    // The clip being upscaled is the single reference.
+    minReferences: 1,
+    maxReferences: 1,
+    referenceKind: 'video',
+    // Gated: the model card 401s anonymously and the weight needs an accepted
+    // license plus an HF token. There is deliberately NO mirror — #6502 rules
+    // out adopting a third-party release mirror or side-stepping the terms.
+    gated: true,
+    // Suppresses resolveIcLoraWeight's bare-repo-id fallback: handing a gated
+    // repo id to a pipeline's own resolver produces a 401 deep inside a render
+    // instead of an actionable "download the weight first" error.
+    requiresPreDownload: true,
+  }),
 });
 
-// Every registered spec, in declaration order. Consumers use this instead of
-// reaching into IC_LORA_MODES directly so the container shape stays private.
+// Every registered spec, in declaration order — the PROVISIONING surface
+// (download / verify / repair / cache probe), which covers weights that are not
+// remix modes. Consumers use this instead of reaching into IC_LORA_MODES
+// directly so the container shape stays private.
 export const listIcLoraWeights = () => Object.values(IC_LORA_MODES);
+
+// A weight is offered as a render remix mode only if it both carries a `mode`
+// value and targets the base model the remix pipeline is pinned to. A weight
+// failing either test is still provisioned, just never rendered with.
+const isRemixSpec = (spec) => !!spec?.mode && spec.baseModel === IC_LORA_REMIX_BASE_MODEL;
+
+export const listIcLoraRemixModes = () => listIcLoraWeights().filter(isRemixSpec);
 
 // PortOS `mode` values that route to the IC-LoRA pipeline. Every entry is
 // `ic-<id>` so a single prefix test identifies the family, and the route enum
 // stays a closed list derived from the registry (never hand-maintained).
 export const IC_LORA_MODE_VALUES = Object.freeze(
-  Object.values(IC_LORA_MODES).map((m) => m.mode),
+  listIcLoraRemixModes().map((m) => m.mode),
 );
 
 export const isIcLoraMode = (mode) => typeof mode === 'string' && IC_LORA_MODE_VALUES.includes(mode);
 
 // `ic-control` → the registry entry, or null for anything else. Accepts the
 // bare id (`control`) too so callers that already stripped the prefix work.
+//
+// REMIX MODES ONLY. Every caller is on the render path, where resolving a
+// non-remix weight would let an upscale adapter be fused into the 2.3 remix
+// pipeline. Provisioning callers, which legitimately need the whole registry,
+// use `icLoraSpecByKey` instead.
 export const icLoraSpecForMode = (mode) => {
   if (typeof mode !== 'string' || !mode) return null;
   const id = mode.startsWith('ic-') ? mode.slice(3) : mode;
+  const spec = IC_LORA_MODES[id] || null;
+  return isRemixSpec(spec) ? spec : null;
+};
+
+// The stable identifier a weight is addressed by outside the render path — the
+// remix mode when it has one, else its registry id. This is what the models
+// status payload reports and what the download/repair routes take as a param,
+// so an existing client URL (`/ic-loras/ic-control/download`) is unchanged.
+export const icLoraWeightKey = (spec) => (spec ? (spec.mode || spec.id) : null);
+
+// Resolve ANY registered weight by its `icLoraWeightKey`, for the provisioning
+// endpoints. Also accepts a bare registry id so a caller that already stripped
+// the `ic-` prefix works, matching icLoraSpecForMode's tolerance.
+export const icLoraSpecByKey = (key) => {
+  if (typeof key !== 'string' || !key) return null;
+  const direct = listIcLoraWeights().find((spec) => icLoraWeightKey(spec) === key);
+  if (direct) return direct;
+  const id = key.startsWith('ic-') ? key.slice(3) : key;
   return IC_LORA_MODES[id] || null;
 };
+
+// Every addressable weight key, for the "expected one of …" error the
+// provisioning routes raise on an unknown param.
+export const IC_LORA_WEIGHT_KEYS = Object.freeze(listIcLoraWeights().map(icLoraWeightKey));
+
+// Whether this weight must be located by its EXACT (repo, filename, revision)
+// rather than by a repo-wide cache verdict. True for a mirrored spec (the
+// aggregate mirror reports `cached` off any unrelated resident weight) and for
+// a revision-pinned spec (a repo-wide check would happily accept a different
+// commit's snapshot). Both cases also make an unscoped integrity walk wrong.
+export const icLoraProbesExactFile = (spec) => !!(spec && (spec.mirrorRepo || spec.revision));
 
 // Every IC-LoRA HF repo, for the integrity-scan / status surface. The mirror
 // repos are deliberately EXCLUDED: an unscoped integrity scan walks each repo's
@@ -161,11 +269,17 @@ export const icLoraRepos = () => listIcLoraWeights().map((m) => m.repo);
 // exactly one answer.
 export const icLoraWeightCandidates = (spec) => {
   if (!spec) return [];
-  const candidates = [{ repo: spec.repo, filename: spec.filename, mirror: false }];
+  const candidates = [{
+    repo: spec.repo, filename: spec.filename, revision: spec.revision || null, mirror: false,
+  }];
   if (spec.mirrorRepo) {
     candidates.push({
       repo: spec.mirrorRepo,
       filename: spec.mirrorFilename || spec.filename,
+      // The pinned revision belongs to the OFFICIAL repo's history; a mirror is
+      // a different repository whose commits have nothing to do with it, so
+      // pinning it there would resolve nothing. Mirrors stay unpinned.
+      revision: null,
       mirror: true,
     });
   }
@@ -196,9 +310,14 @@ export const assertIcReferenceCount = (spec, count, fail) => {
 // requires the OUTPUT dimensions to divide evenly by it. Returns a human message
 // when they don't, else null. Mirrored client-side (icResolutionIssue in
 // client/src/lib/videoGenParams.js) so the form can warn before submit.
+// A `null`/absent factor is UNKNOWN, not 1 — the weight's metadata hasn't been
+// read yet (a gated file nobody with accepted terms has opened). Both resolve
+// to "assert no rule", but they must stay distinguishable: guessing a factor
+// here would either reject valid resolutions or green-light ones the pipeline
+// will refuse deep inside a render.
 export const icResolutionIssue = (spec, width, height) => {
-  const scale = spec?.referenceDownscaleFactor ?? 1;
-  if (scale <= 1) return null;
+  const scale = spec?.referenceDownscaleFactor;
+  if (typeof scale !== 'number' || !Number.isFinite(scale) || scale <= 1) return null;
   if (Number(width) % scale === 0 && Number(height) % scale === 0) return null;
   return `${spec.label} mode needs a resolution divisible by ${scale} (its reference encoder downscales by ${scale}); got ${width}×${height}.`;
 };
@@ -213,8 +332,11 @@ export const findCachedIcLoraWeight = async (spec) => {
   for (const candidate of icLoraWeightCandidates(spec)) {
     // findCachedRepoFile, NOT inspectModelCache: the latter recursively walks and
     // stats every weight in the snapshot, which for the aggregate mirror means
-    // hundreds of GB of unrelated files. This resolves the one filename directly.
-    const path = await findCachedRepoFile(candidate.repo, candidate.filename);
+    // hundreds of GB of unrelated files. This resolves the one filename directly,
+    // inside the PINNED revision's snapshot when the spec pins one.
+    const path = await findCachedRepoFile(candidate.repo, candidate.filename, {
+      revision: candidate.revision,
+    });
     if (path) return { ...candidate, path };
   }
   return null;
@@ -234,11 +356,17 @@ export const findCachedIcLoraWeight = async (spec) => {
 // Returns `{ path, cached, spec, repo? }`: `cached` is true only when a real local
 // file was found, so callers can warn the user that an un-cached weight means a
 // silent multi-hundred-MB pull at render time.
-export const resolveIcLoraWeight = async (mode) => {
-  const spec = icLoraSpecForMode(mode);
+export const resolveIcLoraWeightSpec = async (spec) => {
   if (!spec) return null;
   const cached = await findCachedIcLoraWeight(spec);
   if (cached) return { path: cached.path, cached: true, spec, repo: cached.repo };
   if (spec.requiresPreDownload) return { path: null, cached: false, spec };
   return { path: spec.repo, cached: false, spec };
 };
+
+export const resolveIcLoraWeight = async (mode) => resolveIcLoraWeightSpec(icLoraSpecForMode(mode));
+
+// The provisioning/upscale-flow counterpart: resolves ANY registered weight by
+// its `icLoraWeightKey`, including weights that are not remix modes. Same return
+// shape, so a caller outside the render path reads one contract.
+export const resolveIcLoraWeightByKey = async (key) => resolveIcLoraWeightSpec(icLoraSpecByKey(key));

--- a/server/lib/icLoraWeights.parity.test.js
+++ b/server/lib/icLoraWeights.parity.test.js
@@ -17,7 +17,10 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { listIcLoraWeights, icResolutionIssue as serverIcResolutionIssue } from './icLoraWeights.js';
+import {
+  listIcLoraWeights, listIcLoraRemixModes,
+  icResolutionIssue as serverIcResolutionIssue,
+} from './icLoraWeights.js';
 import {
   IC_LORA_MODES as CLIENT_MODES,
   IC_LORA_MODE_VALUES as CLIENT_MODE_VALUES,
@@ -34,7 +37,12 @@ const MIRRORED_FIELDS = [
   'minReferences', 'maxReferences',
 ];
 
-const SERVER_MODES = listIcLoraWeights();
+// REMIX MODES, not every registered weight. The client mirror exists so the
+// render form can validate before submit, and a weight that is not a remix mode
+// has no form surface — mirroring it would ship the client a row it never
+// renders. The guard below is what keeps that scoping honest: it fails if a
+// non-remix weight ever leaks into the mirror.
+const SERVER_MODES = listIcLoraRemixModes();
 
 describe('IC-LoRA registry — server↔client parity', () => {
   it('exposes the same mode ids in the same order', () => {
@@ -52,6 +60,20 @@ describe('IC-LoRA registry — server↔client parity', () => {
     }
   });
 
+  it('keeps weights that are not remix modes out of the client mirror', () => {
+    // The registry's provisioning list is a superset of the remix modes. A
+    // non-remix weight (the LTX-2.5 upscale adapter) rides the download/verify
+    // surface but must never reach the form — so it must be absent from the
+    // mirror AND from the mode-value enum the route builds its z.enum from.
+    const nonRemix = listIcLoraWeights().filter((s) => !SERVER_MODES.includes(s));
+    expect(nonRemix.length, 'expected at least one non-remix weight to guard').toBeGreaterThan(0);
+    for (const spec of nonRemix) {
+      expect(CLIENT_MODES.some((m) => m.mode === spec.mode)).toBe(false);
+      expect(CLIENT_MODES.some((m) => m.label === spec.label)).toBe(false);
+      expect(CLIENT_MODE_VALUES).not.toContain(spec.mode);
+    }
+  });
+
   it('icResolutionIssue agrees across server and client', () => {
     // Covers divisible, both-odd, one-odd, and the factor-1 (no-rule) case for
     // every registered mode — the client's warning text is also the server's
@@ -66,5 +88,10 @@ describe('IC-LoRA registry — server↔client parity', () => {
     }
     expect(clientIcResolutionIssue({ referenceDownscaleFactor: 1 }, 705, 449)).toBeNull();
     expect(serverIcResolutionIssue({ referenceDownscaleFactor: 1 }, 705, 449)).toBeNull();
+    // An UNKNOWN factor (the gated upscaler, whose metadata nobody with accepted
+    // terms has read yet) asserts no rule on either side rather than defaulting
+    // to a guessed divisor.
+    expect(clientIcResolutionIssue({ referenceDownscaleFactor: null }, 705, 449)).toBeNull();
+    expect(serverIcResolutionIssue({ referenceDownscaleFactor: null }, 705, 449)).toBeNull();
   });
 });

--- a/server/lib/icLoraWeights.test.js
+++ b/server/lib/icLoraWeights.test.js
@@ -9,9 +9,10 @@ const { mockFindCachedRepoFile } = vi.hoisted(() => ({ mockFindCachedRepoFile: v
 vi.mock('./hfCache.js', () => ({ findCachedRepoFile: mockFindCachedRepoFile }));
 
 const {
-  IC_LORA_MODES, IC_LORA_MODE_VALUES, isIcLoraMode, icLoraSpecForMode,
-  icLoraRepos, listIcLoraWeights, icLoraWeightCandidates, findCachedIcLoraWeight,
-  resolveIcLoraWeight, icResolutionIssue,
+  IC_LORA_MODES, IC_LORA_MODE_VALUES, IC_LORA_WEIGHT_KEYS, IC_LORA_REMIX_BASE_MODEL,
+  isIcLoraMode, icLoraSpecForMode, icLoraSpecByKey, icLoraWeightKey, icLoraProbesExactFile,
+  icLoraRepos, listIcLoraWeights, listIcLoraRemixModes, icLoraWeightCandidates,
+  findCachedIcLoraWeight, resolveIcLoraWeight, resolveIcLoraWeightByKey, icResolutionIssue,
 } = await import('./icLoraWeights.js');
 
 beforeEach(() => {
@@ -49,6 +50,7 @@ describe('IC-LoRA registry', () => {
       'Lightricks/LTX-2.3-22b-IC-LoRA-Union-Control',
       'DoctorDiffusion/LTX-2.3-IC-LoRA-Colorizer',
       'Lightricks/LTX-2.3-22b-IC-LoRA-Ingredients',
+      'Lightricks/LTX-2.5-22b-IC-LoRA-Pixel-Spatial-Upscaler',
     ]);
   });
 
@@ -63,14 +65,36 @@ describe('IC-LoRA registry', () => {
 
   it('keeps every entry internally consistent', () => {
     for (const spec of Object.values(IC_LORA_MODES)) {
-      expect(spec.mode).toBe(`ic-${spec.id}`);
       expect(spec.filename.endsWith('.safetensors')).toBe(true);
       expect(spec.repo).toMatch(/^[^/]+\/[^/]+$/);
       expect(spec.sizeBytes).toBeGreaterThan(0);
       expect(spec.uploadLabel).toBeTruthy();
+      expect(spec.baseModel).toMatch(/^ltx-\d+\.\d+$/);
       expect(spec.minReferences).toBeGreaterThanOrEqual(1);
       expect(spec.maxReferences).toBeGreaterThanOrEqual(spec.minReferences);
-      expect(spec.referenceDownscaleFactor).toBeGreaterThanOrEqual(1);
+      // Either a real factor read from the weight's metadata, or an explicit
+      // null meaning "not read yet" — never 0, a string, or a guess.
+      expect(
+        spec.referenceDownscaleFactor === null || spec.referenceDownscaleFactor >= 1,
+      ).toBe(true);
+    }
+  });
+
+  it('keys every registry entry by its own id', () => {
+    // icLoraSpecForMode and icLoraSpecByKey both fall back to a bare-id lookup
+    // straight into this map, so a key that drifts from its entry's `id` makes
+    // that lookup silently miss for one weight and work for the rest.
+    for (const [key, spec] of Object.entries(IC_LORA_MODES)) expect(key).toBe(spec.id);
+  });
+
+  it('names every remix mode ic-<id>, and gives a non-remix weight no mode at all', () => {
+    // The `ic-` prefix is load-bearing for the remix modes; a weight that is not
+    // a remix mode must carry `mode: null` rather than an unreachable `ic-` value
+    // that would read as a render mode the enum silently drops.
+    for (const spec of listIcLoraRemixModes()) expect(spec.mode).toBe(`ic-${spec.id}`);
+    for (const spec of listIcLoraWeights()) {
+      if (listIcLoraRemixModes().includes(spec)) continue;
+      expect(spec.mode).toBeNull();
     }
   });
 
@@ -89,6 +113,17 @@ describe('IC-LoRA registry', () => {
     expect(icResolutionIssue(IC_LORA_MODES.colorize, 705, 449)).toBeNull();
     expect(icResolutionIssue(IC_LORA_MODES.control, 705, 449)).toMatch(/divisible by 2/);
     expect(icResolutionIssue(IC_LORA_MODES.control, 704, 448)).toBeNull();
+  });
+
+  it('asserts no resolution rule for a weight whose factor has not been read', () => {
+    // The upscaler's file is gated, so its `reference_downscale_factor` is
+    // unknown rather than known-to-be-1. Guessing either way is the bug: a
+    // guessed 2 rejects valid resolutions, and treating a non-number as a
+    // divisor produces a nonsense message. Both must yield "no rule".
+    expect(IC_LORA_MODES['pixel-upscale'].referenceDownscaleFactor).toBeNull();
+    expect(icResolutionIssue(IC_LORA_MODES['pixel-upscale'], 705, 449)).toBeNull();
+    expect(icResolutionIssue({ referenceDownscaleFactor: undefined }, 705, 449)).toBeNull();
+    expect(icResolutionIssue({ referenceDownscaleFactor: '2' }, 705, 449)).toBeNull();
   });
 });
 
@@ -121,7 +156,7 @@ describe('resolveIcLoraWeight', () => {
     expect(resolved.path).toBe(join('/hf/snap', IC_LORA_MODES.colorize.filename));
     expect(resolved.spec).toBe(IC_LORA_MODES.colorize);
     expect(mockFindCachedRepoFile).toHaveBeenCalledWith(
-      IC_LORA_MODES.colorize.repo, IC_LORA_MODES.colorize.filename,
+      IC_LORA_MODES.colorize.repo, IC_LORA_MODES.colorize.filename, { revision: null },
     );
   });
 
@@ -203,15 +238,42 @@ describe('icLoraWeightCandidates', () => {
     // Order IS the policy: a user WITH an HF token gets the first-party weight; a
     // user without one falls through to the un-gated mirror.
     expect(icLoraWeightCandidates(IC_LORA_MODES.ingredients)).toEqual([
-      { repo: IC_LORA_MODES.ingredients.repo, filename: IC_LORA_MODES.ingredients.filename, mirror: false },
-      { repo: IC_LORA_MODES.ingredients.mirrorRepo, filename: IC_LORA_MODES.ingredients.mirrorFilename, mirror: true },
+      {
+        repo: IC_LORA_MODES.ingredients.repo,
+        filename: IC_LORA_MODES.ingredients.filename,
+        revision: null,
+        mirror: false,
+      },
+      {
+        repo: IC_LORA_MODES.ingredients.mirrorRepo,
+        filename: IC_LORA_MODES.ingredients.mirrorFilename,
+        revision: null,
+        mirror: true,
+      },
     ]);
   });
 
   it('yields a single candidate for a mirror-less spec', () => {
     expect(icLoraWeightCandidates(IC_LORA_MODES.control)).toEqual([
-      { repo: IC_LORA_MODES.control.repo, filename: IC_LORA_MODES.control.filename, mirror: false },
+      {
+        repo: IC_LORA_MODES.control.repo,
+        filename: IC_LORA_MODES.control.filename,
+        revision: null,
+        mirror: false,
+      },
     ]);
+  });
+
+  it('carries a pinned revision on the official candidate only', () => {
+    // The pin belongs to the official repo's history. A mirror is a different
+    // repository whose commits have nothing to do with it, so pinning one there
+    // would resolve nothing — the mirror stays unpinned by construction.
+    const [official] = icLoraWeightCandidates(IC_LORA_MODES['pixel-upscale']);
+    expect(official.revision).toBe(IC_LORA_MODES['pixel-upscale'].revision);
+    expect(official.revision).toMatch(/^[0-9a-f]{40}$/);
+    for (const c of icLoraWeightCandidates(IC_LORA_MODES.ingredients)) {
+      if (c.mirror) expect(c.revision).toBeNull();
+    }
   });
 
   it('returns nothing for a null spec', () => {
@@ -230,6 +292,116 @@ describe('findCachedIcLoraWeight', () => {
 
   it('returns nothing for a null spec without probing the cache', async () => {
     expect(await findCachedIcLoraWeight(null)).toBeNull();
+    expect(mockFindCachedRepoFile).not.toHaveBeenCalled();
+  });
+
+  it('probes a pinned weight inside its pinned revision, not the newest snapshot', async () => {
+    // Without the revision, findCachedRepoFile resolves the NEWEST snapshot —
+    // so an install holding an older commit of the repo would report the weight
+    // cached and hand a different commit's tensors to the pipeline.
+    mockFindCachedRepoFile.mockResolvedValue('/cache/pinned.safetensors');
+    const found = await findCachedIcLoraWeight(IC_LORA_MODES['pixel-upscale']);
+    expect(found.path).toBe('/cache/pinned.safetensors');
+    expect(mockFindCachedRepoFile).toHaveBeenCalledWith(
+      IC_LORA_MODES['pixel-upscale'].repo,
+      IC_LORA_MODES['pixel-upscale'].filename,
+      { revision: IC_LORA_MODES['pixel-upscale'].revision },
+    );
+  });
+
+  it('probes an unpinned weight with no revision, preserving the existing behavior', async () => {
+    mockFindCachedRepoFile.mockResolvedValue('/cache/control.safetensors');
+    await findCachedIcLoraWeight(IC_LORA_MODES.control);
+    expect(mockFindCachedRepoFile).toHaveBeenCalledWith(
+      IC_LORA_MODES.control.repo,
+      IC_LORA_MODES.control.filename,
+      { revision: null },
+    );
+  });
+});
+
+describe('the LTX-2.5 Pixel Spatial Upscaler weight (#6502)', () => {
+  const spec = () => IC_LORA_MODES['pixel-upscale'];
+
+  it('is registered for provisioning but is NOT a remix mode', () => {
+    // The whole point of the base-model split: this adapter rides the same
+    // download/verify/repair surface, but fusing it into the LTX-2.3 remix
+    // pipeline would load without erroring and render garbage.
+    expect(listIcLoraWeights()).toContain(spec());
+    expect(listIcLoraRemixModes()).not.toContain(spec());
+    expect(spec().baseModel).not.toBe(IC_LORA_REMIX_BASE_MODEL);
+  });
+
+  it('is absent from the render-mode enum the route builds its z.enum from', () => {
+    expect(IC_LORA_MODE_VALUES).toEqual(['ic-control', 'ic-colorize', 'ic-ingredients']);
+    expect(IC_LORA_MODE_VALUES).not.toContain('ic-pixel-upscale');
+    expect(isIcLoraMode('ic-pixel-upscale')).toBe(false);
+    expect(isIcLoraMode('pixel-upscale')).toBe(false);
+  });
+
+  it('is unreachable through the render-path spec lookup', () => {
+    // icLoraSpecForMode feeds the render path. It must not resolve a non-remix
+    // weight by ANY spelling, including the bare registry id that the same
+    // helper accepts for the remix modes.
+    expect(icLoraSpecForMode('pixel-upscale')).toBeNull();
+    expect(icLoraSpecForMode('ic-pixel-upscale')).toBeNull();
+    expect(icLoraSpecForMode(spec().id)).toBeNull();
+  });
+
+  it('IS reachable through the provisioning lookup, by its weight key', () => {
+    expect(icLoraWeightKey(spec())).toBe('pixel-upscale');
+    expect(icLoraSpecByKey('pixel-upscale')).toBe(spec());
+    // Remix modes keep their existing URL identity through the same lookup, so
+    // `/ic-loras/ic-control/download` is unchanged.
+    expect(icLoraWeightKey(IC_LORA_MODES.control)).toBe('ic-control');
+    expect(icLoraSpecByKey('ic-control')).toBe(IC_LORA_MODES.control);
+    expect(IC_LORA_WEIGHT_KEYS).toEqual(['ic-control', 'ic-colorize', 'ic-ingredients', 'pixel-upscale']);
+  });
+
+  it('pins the exact repo, filename, revision and byte size from the HF listing', () => {
+    // Read from the repo's public blob listing. The size is exact, not an
+    // estimate — the download badge shows it before the pull.
+    expect(spec().repo).toBe('Lightricks/LTX-2.5-22b-IC-LoRA-Pixel-Spatial-Upscaler');
+    expect(spec().filename).toBe('ltx-2.5-22b-ic-lora-pixel-spatial-upscaler-x2-1.0.safetensors');
+    expect(spec().revision).toBe('5863fdef3eaa8b2d69fa22e259a1d75fede215dd');
+    expect(spec().sizeBytes).toBe(327_322_640);
+  });
+
+  it('is gated with NO mirror, so a gated failure is not swallowed by a fallback', () => {
+    // #6502 rules out adopting a third-party release mirror or side-stepping the
+    // license. A single candidate also means the download stream reports the
+    // gated failure itself instead of downgrading it on the way to a fallback.
+    expect(spec().gated).toBe(true);
+    expect(spec().mirrorRepo).toBeUndefined();
+    expect(icLoraWeightCandidates(spec())).toHaveLength(1);
+  });
+
+  it('is probed by its exact file, never by a repo-wide cache verdict', () => {
+    expect(icLoraProbesExactFile(spec())).toBe(true);
+    // Un-pinned, un-mirrored weights keep the cheaper repo-wide path.
+    expect(icLoraProbesExactFile(IC_LORA_MODES.control)).toBe(false);
+    expect(icLoraProbesExactFile(IC_LORA_MODES.ingredients)).toBe(true);
+  });
+
+  it('never emits a bare repo id for the pipeline to snapshot_download', async () => {
+    // Handing a gated repo id to a pipeline's own resolver produces a 401 deep
+    // inside a render. `path: null` is what makes the caller fail fast with an
+    // actionable "download the weight first" instead.
+    mockFindCachedRepoFile.mockResolvedValue(null);
+    const resolved = await resolveIcLoraWeightByKey('pixel-upscale');
+    expect(resolved).toEqual({ path: null, cached: false, spec: spec() });
+    expect(spec().requiresPreDownload).toBe(true);
+  });
+
+  it('resolves the cached file once it is downloaded', async () => {
+    mockFindCachedRepoFile.mockResolvedValue('/cache/upscaler.safetensors');
+    const resolved = await resolveIcLoraWeightByKey('pixel-upscale');
+    expect(resolved).toMatchObject({ path: '/cache/upscaler.safetensors', cached: true, repo: spec().repo });
+  });
+
+  it('stays unresolvable through the render-path resolver', async () => {
+    expect(await resolveIcLoraWeight('ic-pixel-upscale')).toBeNull();
+    expect(await resolveIcLoraWeight('pixel-upscale')).toBeNull();
     expect(mockFindCachedRepoFile).not.toHaveBeenCalled();
   });
 });

--- a/server/routes/videoGen.integrity.test.js
+++ b/server/routes/videoGen.integrity.test.js
@@ -19,6 +19,10 @@ vi.mock('../lib/mediaModels.js', () => ({
 vi.mock('../lib/hfCache.js', async (importOriginal) => ({
   ...(await importOriginal()),
   inspectModelCache: vi.fn(async () => ({ cached: true, sizeBytes: 100, snapshotPath: '/snap' })),
+  // IO-bound like its siblings: the IC-weight status probe resolves one exact
+  // file out of the HF cache, and leaving it real made this suite walk the
+  // developer's actual ~/.cache through a partially-mocked `fs`.
+  findCachedRepoFile: vi.fn(async () => null),
   verifyModelCache: vi.fn(async (repoId, opts) => ({
     repoId, status: 'bad', cached: false, sizeBytes: 0, snapshotPath: '/snap',
     checkedDeep: !!opts?.deep,

--- a/server/routes/videoGen.js
+++ b/server/routes/videoGen.js
@@ -54,8 +54,8 @@ import { VIDEO_GEN_LOCAL_ONLY_FIELDS } from '../services/videoGen/requestFields.
 import { attachSseClient, cancelJob, listJobs } from '../services/mediaJobQueue/index.js';
 import { getTextEncoderRepo, isHfRepoId } from '../lib/mediaModels.js';
 import {
-  IC_LORA_MODE_VALUES, icLoraSpecForMode, listIcLoraWeights,
-  icLoraWeightCandidates, findCachedIcLoraWeight,
+  IC_LORA_MODE_VALUES, icLoraSpecForMode, listIcLoraWeights, listIcLoraRemixModes,
+  icLoraWeightCandidates, findCachedIcLoraWeight, icLoraWeightKey, icLoraProbesExactFile,
 } from '../lib/icLoraWeights.js';
 import { publicTextEncoderOption } from '../lib/videoTextEncoders.js';
 import { DRAFT_DECODE_IDS } from '../lib/videoDraftDecoders.js';
@@ -188,7 +188,7 @@ const optionalInt = (min, max, label) => z.preprocess(
 // weight raising its own maxReferences doesn't get rejected by a stale literal in
 // the schema before the per-mode assertion below can speak. Per-weight bounds are
 // still enforced against the mode's own spec (assertIcReferenceCount).
-const MAX_IC_REFERENCES = Math.max(...listIcLoraWeights().map((s) => s.maxReferences));
+const MAX_IC_REFERENCES = Math.max(...listIcLoraRemixModes().map((s) => s.maxReferences));
 
 // Chain ceiling — 8 × ~5min ≈ 40min on an M3 Max keeps the worst-case wall time
 // bounded. Shared by `chunks` and the per-chunk prompt list so the two can never
@@ -667,22 +667,27 @@ router.get('/models/status', asyncHandler(async (_req, res) => {
         integrity: cached ? summarizeVerify(verify) : null,
       };
     })),
-    // IC-LoRA remix weights (issue #3100). Each is a separate several-hundred-MB
-    // pull the IC render path needs, so they get the same cached/size/integrity
-    // shape as the models — that's what lets the mode panel render a Download
-    // badge and a Repair banner with the existing components.
+    // IC-LoRA weights (issue #3100). Each is a separate several-hundred-MB pull,
+    // so they get the same cached/size/integrity shape as the models — that's
+    // what lets the mode panel render a Download badge and a Repair banner with
+    // the existing components. This is the PROVISIONING list, so it spans weights
+    // that are not remix modes (the LTX-2.5 upscale adapter, #6502) and reports
+    // each by its `icLoraWeightKey` rather than assuming a `mode` value exists.
     Promise.all(listIcLoraWeights().map(async (spec) => {
-      // A mirrored spec (Ingredients) can't use the repo-wide verdict: its
-      // official repo is gated and its mirror is a 708 GB aggregate that reports
-      // `cached` off any unrelated weight. Probe the ONE file across both
-      // candidates instead, and skip the integrity walk (which would stat/hash
-      // every sibling weight in that mirror).
-      if (spec.mirrorRepo) {
+      // A spec that must be located by its exact file can't use the repo-wide
+      // verdict. Two reasons, both fatal to it: a mirrored spec (Ingredients)
+      // has a 708 GB aggregate mirror that reports `cached` off any unrelated
+      // weight, and a revision-pinned spec would accept a DIFFERENT commit's
+      // snapshot. Probe the ONE file across the candidates instead, and skip the
+      // integrity walk (which would stat/hash every sibling weight in a mirror).
+      if (icLoraProbesExactFile(spec)) {
         const found = await findCachedIcLoraWeight(spec);
         return {
-          id: spec.mode, repo: spec.repo, label: spec.label,
+          id: icLoraWeightKey(spec), repo: spec.repo, label: spec.label,
+          baseModel: spec.baseModel, revision: spec.revision || null,
+          requiresPreDownload: !!spec.requiresPreDownload,
           estimatedBytes: spec.sizeBytes,
-          gated: !!spec.gated, mirrorRepo: spec.mirrorRepo,
+          gated: !!spec.gated, mirrorRepo: spec.mirrorRepo || null,
           cached: !!found,
           resolvedRepo: found?.repo || null,
           // The badge falls back to `estimatedBytes` when sizeBytes is 0, and the
@@ -693,7 +698,9 @@ router.get('/models/status', asyncHandler(async (_req, res) => {
         };
       }
       return {
-        id: spec.mode, repo: spec.repo, label: spec.label,
+        id: icLoraWeightKey(spec), repo: spec.repo, label: spec.label,
+        baseModel: spec.baseModel, revision: spec.revision || null,
+        requiresPreDownload: !!spec.requiresPreDownload,
         estimatedBytes: spec.sizeBytes,
         gated: !!spec.gated,
         ...await repoCacheStatus(spec.repo),
@@ -761,25 +768,31 @@ router.get('/models/:modelId/download', asyncHandler(async (req, res) => {
 // but are NOT listVideoModels() entries, so the model-id-keyed routes above
 // can't reach them. Keyed by the PortOS remix mode ('ic-control', …) so the
 // client uses the same identifier it puts in the render payload.
-// Download one IC weight. A spec with a `mirrorRepo` is fetched SINGLE-FILE and
-// only ever single-file: the official Ingredients repo is gated (an anonymous
-// pull 401s) and its un-gated mirror is the ~708 GB `DeepBeepMeep/LTX-2`
-// aggregate, so a snapshot of either would either fail or fill the user's disk.
-// Candidates are tried in order (official → mirror) so a user WITH an HF token
-// gets the first-party weight and a user without one still succeeds via the
-// mirror — no token, no extra button. The exact filename is pinned so the mirror
-// can't hand back a sibling weight.
+// Download one IC weight. An exact-file spec is fetched SINGLE-FILE and only ever
+// single-file. For Ingredients that is because the official repo is gated (an
+// anonymous pull 401s) and its un-gated mirror is the ~708 GB `DeepBeepMeep/LTX-2`
+// aggregate, so a snapshot of either would either fail or fill the user's disk;
+// for a revision-pinned spec it is because the pinned commit and filename are the
+// whole point of the pin. Candidates are tried in order (official → mirror) so a
+// user WITH an HF token gets the first-party weight and a user without one still
+// succeeds via the mirror — no token, no extra button. The exact filename is
+// pinned so a mirror can't hand back a sibling weight.
+//
+// A spec with NO mirror (the LTX-2.5 upscaler) therefore has exactly one
+// candidate: a gated failure surfaces with its actionable "accept the license"
+// message rather than being downgraded on the way to a fallback that isn't there.
 router.get('/ic-loras/:mode/download', asyncHandler(async (req, res) => {
   const spec = icLoraSpecFromParam(req.params.mode);
   const force = req.query.force === '1';
-  if (!spec.mirrorRepo) {
+  if (!icLoraProbesExactFile(spec)) {
     await startHfDownloadStream({ req, res, repo: spec.repo, force });
     return;
   }
   await startHfDownloadStream({
     req,
     res,
-    fallbacks: icLoraWeightCandidates(spec).map((c) => ({ repo: c.repo, only: [c.filename] })),
+    fallbacks: icLoraWeightCandidates(spec)
+      .map((c) => ({ repo: c.repo, only: [c.filename], revision: c.revision })),
     // The repo-wide `cached` verdict is meaningless for the aggregate mirror (it
     // reports cached as soon as ANY unrelated weight is resident), so gate the
     // already-have short-circuit on this exact weight instead.
@@ -797,7 +810,7 @@ router.post('/ic-loras/:mode/repair', asyncHandler(async (req, res) => {
   // the WHOLE snapshot — against the 708 GB aggregate mirror that would stat (and
   // under `deep`, hash) every unrelated LTX weight the user has. Delete just this
   // weight and let the single-file download re-fetch it.
-  if (spec.mirrorRepo) {
+  if (icLoraProbesExactFile(spec)) {
     const found = await findCachedIcLoraWeight(spec);
     if (!found) return res.json({ deep, deleted: [], repos: [spec.repo] });
     await repairCachedFile(found.path);

--- a/server/routes/videoGen.test.js
+++ b/server/routes/videoGen.test.js
@@ -288,7 +288,9 @@ import { prepareRemoteMediaJob } from '../services/federatedMedia/remoteSubmissi
 import { getProject as getMusicVideoProject } from '../services/musicVideo/projects.js';
 import { getTrack } from '../services/tracks/index.js';
 import { resolveGalleryImage } from '../lib/fileUtils.js';
-import { listIcLoraWeights } from '../lib/icLoraWeights.js';
+import {
+  listIcLoraWeights, listIcLoraRemixModes, IC_LORA_MODES, icLoraWeightKey,
+} from '../lib/icLoraWeights.js';
 import videoGenRoutes, { isAudioMime, LOCAL_ONLY_VIDEO_PARAMS } from './videoGen.js';
 
 // isAudioMime is the gating function inside the fileFilter callback. The
@@ -3024,6 +3026,53 @@ describe('videoGen routes', () => {
         expect(rejected.status).toBe(400);
       }
       expect(mediaJobQueue.enqueueJob).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // The IC-LoRA provisioning endpoints span the whole weight registry, not just
+  // the remix modes — the LTX-2.5 upscale adapter (#6502) is downloadable and
+  // repairable without ever being a render mode. These pin that split.
+  describe('IC-LoRA provisioning endpoints', () => {
+    const upscaler = IC_LORA_MODES['pixel-upscale'];
+
+    it('downloads a pinned weight single-file, at its pinned revision', async () => {
+      const res = await request(app).get(`/api/video-gen/ic-loras/${icLoraWeightKey(upscaler)}/download`);
+      expect(res.status).toBe(200);
+      const [{ fallbacks, repo }] = sseDownload.start.mock.calls[0];
+      // Never a whole-repo snapshot: the pin names one commit and one file, and
+      // a bare `repo` argument would ignore both.
+      expect(repo).toBeUndefined();
+      expect(fallbacks).toEqual([{
+        repo: upscaler.repo,
+        only: [upscaler.filename],
+        revision: upscaler.revision,
+      }]);
+    });
+
+    it('keeps an unpinned, un-mirrored weight on the cheap whole-repo path', async () => {
+      const res = await request(app).get('/api/video-gen/ic-loras/ic-control/download');
+      expect(res.status).toBe(200);
+      const [args] = sseDownload.start.mock.calls[0];
+      expect(args.repo).toBe(IC_LORA_MODES.control.repo);
+      expect(args.fallbacks).toBeUndefined();
+    });
+
+    it('404s an unknown weight key and names the real ones', async () => {
+      const res = await request(app).get('/api/video-gen/ic-loras/not-a-weight/download');
+      expect(res.status).toBe(404);
+      expect(res.body.error).toMatch(/pixel-upscale/);
+      expect(res.body.error).toMatch(/ic-control/);
+    });
+
+    it('rejects the upscale adapter as a render mode', async () => {
+      // The registry entry exists, so the only thing keeping it out of a render
+      // is the mode enum. Every spelling must 400 rather than reaching the
+      // LTX-2.3 remix pipeline it cannot be fused into.
+      expect(listIcLoraRemixModes()).not.toContain(upscaler);
+      for (const mode of ['pixel-upscale', 'ic-pixel-upscale']) {
+        const res = await request(app).post('/api/video-gen/').send({ prompt: 'Example shot', mode });
+        expect(res.status).toBe(400);
+      }
     });
   });
 

--- a/server/services/hfDownloadStream.js
+++ b/server/services/hfDownloadStream.js
@@ -91,6 +91,13 @@ export async function startHfDownloadStream({ req, res, repo, revision = null, r
   // and the per-attempt failures to report if none did.
   let succeededRepo = null;
   const attemptErrors = [];
+  // The typed error kinds the failed attempts reported. When every attempt
+  // failed the SAME way — always true for a single-candidate spec — that kind is
+  // still the honest verdict, so it survives into the final frame instead of
+  // being flattened to a generic `all_sources_failed` the UI can't act on. The
+  // one that matters is `gated_repo`: the client keys its "accept the license
+  // and save an HF token" affordance off it.
+  const attemptKinds = [];
   for (let i = 0; i < targets.length; i += 1) {
     const { repo: r, only: onlyFiles, ignore: ignorePatterns, revision } = targets[i];
     const isLastTarget = i === targets.length - 1;
@@ -218,14 +225,18 @@ export async function startHfDownloadStream({ req, res, repo, revision = null, r
     // A user cancel must not silently roll onto the next candidate.
     if (result?.errorKind === 'cancelled') return safeEnd();
     attemptErrors.push(`${r}: ${result?.errorMessage || 'unknown error'}`);
+    attemptKinds.push(result?.errorKind || 'download_failed');
   }
 
   if (!aborted) {
     if (firstSuccessWins) {
       if (!succeededRepo) {
+        const sharedKind = attemptKinds.length > 0 && attemptKinds.every((k) => k === attemptKinds[0])
+          ? attemptKinds[0]
+          : 'all_sources_failed';
         send({
           type: 'error',
-          kind: 'all_sources_failed',
+          kind: sharedKind,
           message: `Every source failed — ${attemptErrors.join('; ')}`,
         });
         return safeEnd();

--- a/server/services/hfDownloadStream.test.js
+++ b/server/services/hfDownloadStream.test.js
@@ -315,9 +315,57 @@ describe('startHfDownloadStream single-file + fallbacks (#3112)', () => {
     const terminal = events.filter((event) => event.type === 'error');
     expect(terminal).toHaveLength(1);
     const last = terminal[0];
-    expect(last).toMatchObject({ type: 'error', kind: 'all_sources_failed' });
+    // Every attempt failed the SAME way, so that kind is still the honest
+    // verdict and survives into the terminal frame — flattening it would strip
+    // the signal the UI keys its "accept the license" affordance off.
+    expect(last).toMatchObject({ type: 'error', kind: 'x' });
     expect(last.message).toContain('org/official broke');
     expect(last.message).toContain('org/mirror-708gb broke');
+  });
+
+  it('falls back to all_sources_failed when the attempts disagree on why', async () => {
+    // Two different causes have no single honest kind, so the generic one is
+    // correct here — the per-attempt reasons are still in the message.
+    downloadHfRepo.mockImplementation(({ repo, onEvent }) => {
+      const kind = repo === 'org/official' ? 'gated_repo' : 'network';
+      onEvent({ type: 'error', kind, message: `${repo} broke` });
+      return {
+        promise: Promise.resolve({ ok: false, errorKind: kind, errorMessage: `${repo} broke` }),
+        kill: vi.fn(),
+      };
+    });
+
+    const { req, res, frames } = makeReqRes();
+    await startHfDownloadStream({ req, res, fallbacks: CANDIDATES, cachedFile: async () => false });
+    const terminal = parseFrames(frames).filter((event) => event.type === 'error');
+    expect(terminal).toHaveLength(1);
+    expect(terminal[0]).toMatchObject({ type: 'error', kind: 'all_sources_failed' });
+  });
+
+  it('keeps a gated failure actionable for a single-candidate weight', async () => {
+    // The LTX-2.5 upscaler has NO mirror, so its one candidate is the whole
+    // chain. Before, its 401 was flattened to `all_sources_failed` and the
+    // client lost the cue to prompt for license acceptance + an HF token.
+    downloadHfRepo.mockImplementation(({ repo, onEvent }) => {
+      const message = `Access to ${repo} is gated. Accept the license and save your Hugging Face token.`;
+      onEvent({ type: 'error', kind: 'gated_repo', message });
+      return {
+        promise: Promise.resolve({ ok: false, errorKind: 'gated_repo', errorMessage: message }),
+        kill: vi.fn(),
+      };
+    });
+
+    const { req, res, frames } = makeReqRes();
+    await startHfDownloadStream({
+      req,
+      res,
+      fallbacks: [{ repo: 'org/gated-only', only: ['weight.safetensors'], revision: 'a'.repeat(40) }],
+      cachedFile: async () => false,
+    });
+    const terminal = parseFrames(frames).filter((event) => event.type === 'error');
+    expect(terminal).toHaveLength(1);
+    expect(terminal[0].kind).toBe('gated_repo');
+    expect(terminal[0].message).toMatch(/Accept the license/);
   });
 
   it('does not roll onto the next source after a user cancel', async () => {

--- a/server/services/videoGen/modelCache.js
+++ b/server/services/videoGen/modelCache.js
@@ -13,7 +13,7 @@
 
 import { ServerError } from '../../lib/errorHandler.js';
 import { repoForModel, getTextEncoderRepo, isHfRepoId } from '../../lib/mediaModels.js';
-import { IC_LORA_MODE_VALUES, icLoraSpecForMode, icLoraRepos } from '../../lib/icLoraWeights.js';
+import { IC_LORA_WEIGHT_KEYS, icLoraSpecByKey, icLoraRepos } from '../../lib/icLoraWeights.js';
 import { downloadableVideoTextEncoders, downloadableVideoTextEncoder } from '../../lib/videoTextEncoders.js';
 import { downloadableVideoDraftDecoders } from '../../lib/videoDraftDecoders.js';
 import {
@@ -159,13 +159,17 @@ export const modelCacheStatus = async (model, cache = null) => {
   };
 };
 
-// Mode → IC-LoRA spec, keyed by the PortOS remix mode ('ic-control', …) the
-// client also puts in the render payload.
-export const icLoraSpecFromParam = (mode) => {
-  const spec = icLoraSpecForMode(mode);
+// Weight key → IC-LoRA spec, for the download/verify/repair endpoints. Keyed by
+// `icLoraWeightKey`: the PortOS remix mode ('ic-control', …) the client also puts
+// in the render payload, or the registry id for a weight that is provisioned but
+// is not a remix mode (the LTX-2.5 upscale adapter). This is the PROVISIONING
+// lookup, so it deliberately spans the whole registry — the render path uses
+// icLoraSpecForMode, which resolves remix modes only.
+export const icLoraSpecFromParam = (key) => {
+  const spec = icLoraSpecByKey(key);
   if (!spec) {
     throw new ServerError(
-      `Unknown IC-LoRA remix mode: ${mode} (expected one of ${IC_LORA_MODE_VALUES.join(', ')})`,
+      `Unknown IC-LoRA weight: ${key} (expected one of ${IC_LORA_WEIGHT_KEYS.join(', ')})`,
       { status: 404, code: 'IC_LORA_UNKNOWN_MODE' },
     );
   }

--- a/server/services/videoGen/modelCache.test.js
+++ b/server/services/videoGen/modelCache.test.js
@@ -21,8 +21,8 @@ vi.mock('../../lib/videoDraftDecoders.js', () => ({
 }));
 
 vi.mock('../../lib/icLoraWeights.js', () => ({
-  IC_LORA_MODE_VALUES: ['ic-control'],
-  icLoraSpecForMode: vi.fn(() => null),
+  IC_LORA_WEIGHT_KEYS: ['ic-control'],
+  icLoraSpecByKey: vi.fn(() => null),
   icLoraRepos: vi.fn(() => []),
 }));
 


### PR DESCRIPTION
## Summary

Registers the gated LTX-2.5 Pixel Spatial Upscaler IC-LoRA so it can be downloaded, cache-resolved and verified — without letting it reach the LTX-2.3 remix pipeline it cannot be fused into. No upscale behavior changes here; this is the provisioning groundwork for #6502.

- **The registry now splits provisioning from rendering.** A spec declares the `baseModel` its adapter targets, and carries `mode: null` when it is not a remix mode at all. `listIcLoraWeights()` stays the provisioning surface and spans both kinds; `listIcLoraRemixModes()` is the render subset that `IC_LORA_MODE_VALUES` and `icLoraSpecForMode` resolve against. Dropping a 2.5 adapter into the old flat map would have offered it as an `ic-*` render mode — and fusing it into the 2.3 pipeline loads *without erroring* and renders garbage rather than failing cleanly.
- **Weights are addressable by revision.** `findCachedIcLoraWeight` probes inside the pinned snapshot rather than the newest one, and the download endpoint pulls the pinned commit's single file. Without this, an install holding an older snapshot of the repo reports the weight cached and hands a different commit's tensors to the pipeline. The three existing weights stay unpinned (`revision: null`), so their behavior is unchanged.
- **A gated failure stays actionable.** The adapter has deliberately no mirror, which surfaced a related gap: a fallback chain flattened every failure to `all_sources_failed`, so a single-candidate gated repo lost the `gated_repo` kind the client keys its license-acceptance prompt off. The terminal frame now keeps the typed kind when every attempt failed the same way, and falls back to the generic one when they disagree.
- **`referenceDownscaleFactor` is left `null`, not guessed.** The weight's file is gated, so its safetensors metadata has not been read — unlike every other entry, whose factor was measured. Both `icResolutionIssue` implementations now treat a non-number factor as "assert no rule" instead of coercing it to 1. #6512 fills in the real value once an install with accepted terms can read the header.

Facts pinned from the repo's public HF metadata (the listing is public; the model card 401s): revision `5863fdef3eaa8b2d69fa22e259a1d75fede215dd`, file `ltx-2.5-22b-ic-lora-pixel-spatial-upscaler-x2-1.0.safetensors`, exactly 327,322,640 bytes.

### Two judgment calls worth flagging

- **The client mirror stays remix-only.** The issue suggested mirroring the new entry into `client/src/lib/videoGenParams.js`. That mirror exists so the render form can validate before submit, and a non-remix weight has no form surface — so mirroring it would ship a row the client never reads. Instead the parity test is scoped to remix modes and gained an explicit guard that fails if a non-remix weight ever leaks into the mirror or into the mode-value enum.
- **`icLoraSpecForMode` is now remix-only**, preserving every existing caller's meaning exactly (all four are on the render path). Provisioning callers use the new `icLoraSpecByKey`, which spans the whole registry. Existing client URLs are unchanged: `icLoraWeightKey` returns the remix mode when there is one, so `/ic-loras/ic-control/download` still resolves.

## Test plan

- `cd server && npm test` — 2056 files, 40,992 tests pass.
- `cd client && npm test` — 882 files, 10,735 tests pass.
- New coverage: the upscaler is registered for provisioning but absent from `IC_LORA_MODE_VALUES` and unreachable through `icLoraSpecForMode` by any spelling; `resolveIcLoraWeightByKey` returns `path: null` rather than a bare repo id; the pinned revision is what `findCachedRepoFile` is called with (and `null` for an unpinned weight); an unknown factor asserts no resolution rule; the download route sends one pinned single-file candidate while an unpinned weight keeps the cheap whole-repo path; a POST render with `mode: pixel-upscale` / `ic-pixel-upscale` 400s; a single-candidate gated failure keeps `kind: gated_repo`, and mixed causes still report `all_sources_failed`.
- A registry-key-equals-id invariant test was added after the self-review caught the new entry keyed `pixelUpscale` while its id was `pixel-upscale` — the bare-id lookup would have missed for that one weight and worked for the other three.

Reviewed locally by the configured ollama reviewer. Its two findings both described code that is not there (it claimed the `ic-` prefix is stripped twice, when the double-strip path is unreachable behind an early return, and that the function returns `undefined`, when it already returns `null`); the second also cited a garbled filename. Verified against the source and the suite, no changes applied.

Part of #6502.

Closes #6508
