### PR TITLE
Let the user choose the video upscale method, with disclosure before submit

### DIFF
--- a/client/src/components/media/MediaCard.jsx
+++ b/client/src/components/media/MediaCard.jsx
@@ -233,7 +233,7 @@ function MediaCard({
                 type="button"
                 onClick={() => onUpscale(item)}
                 className="shrink-0 px-1.5 py-1 bg-port-border hover:bg-port-border/70 text-white text-[10px] rounded flex items-center justify-center"
-                title="Upscale 2× (Lanczos, ~10s)" aria-label="Upscale 2× (Lanczos, ~10s)"
+                title="Upscale 2×" aria-label="Upscale 2×"
               >
                 <Maximize2 className="w-3 h-3" />
               </button>

--- a/client/src/components/media/VideoUpscaleDrawer.jsx
+++ b/client/src/components/media/VideoUpscaleDrawer.jsx
@@ -1,0 +1,233 @@
+/**
+ * Video upscale method picker (issue #6510) — the disclosure step between the
+ * gallery's Upscale button and the actual submit.
+ *
+ * Two methods, both 2×: `lanczos` (the historical ffmpeg pass, always
+ * available) and `ltx` (the LTX-2.5 generative adapter, gated on a supported
+ * BYOV runtime plus a cached adapter — #6509's plan endpoint). Opening the
+ * drawer fetches ONLY the read-only plan (`GET .../plan?method=ltx`); nothing
+ * is queued and no weight is pulled until the user presses Upscale.
+ *
+ * Shared by VideoGen.jsx and MediaHistory.jsx — both pages own the item that
+ * opens the drawer and get the finished entry back via `onUpscaled` for their
+ * existing reactive local-state update (no refetch).
+ */
+import { useState, useEffect, useCallback } from 'react';
+import { Loader2 } from 'lucide-react';
+import Drawer from '../Drawer';
+import toast from '../ui/Toast';
+import { formatBytes } from '../../utils/formatters';
+import { useSseProgress } from '../../hooks/useSseProgress';
+import { upscaleVideo, getUpscalePlan, upscaleAdapterDownloadUrl } from '../../services/apiImageVideo';
+
+export default function VideoUpscaleDrawer({ item, onClose, onUpscaled }) {
+  const open = !!item;
+  const itemId = item?.id ?? null;
+
+  const [method, setMethod] = useState('lanczos');
+  const [plan, setPlan] = useState(null);
+  const [planLoading, setPlanLoading] = useState(false);
+  const [planError, setPlanError] = useState(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [downloading, setDownloading] = useState(false);
+
+  // Fresh state per open (and per item, in case a second card is picked
+  // before the drawer fully unmounts) so a stale method/plan never carries
+  // over onto a different clip.
+  useEffect(() => {
+    if (!open) return;
+    setMethod('lanczos');
+    setPlan(null);
+    setPlanError(null);
+    setDownloading(false);
+  }, [open, itemId]);
+
+  // The generative plan drives the radio's disabled state AND its disclosure
+  // once picked, so fetch it as soon as the drawer opens rather than waiting
+  // for the user to select "generative" first — otherwise there's no way to
+  // show it disabled up front. Read-only: never queues a job, never pulls a
+  // weight (#6509).
+  useEffect(() => {
+    if (!open || !itemId) return undefined;
+    let cancelled = false;
+    setPlanLoading(true);
+    setPlanError(null);
+    getUpscalePlan(itemId, 'ltx')
+      .then((res) => { if (!cancelled) setPlan(res?.plan || null); })
+      .catch((err) => { if (!cancelled) setPlanError(err.message || 'Could not check generative upscale readiness'); })
+      .finally(() => { if (!cancelled) setPlanLoading(false); });
+    return () => { cancelled = true; };
+  }, [open, itemId]);
+
+  const runtimeReady = plan?.runtime?.installed === true;
+  const adapterReady = plan?.adapter?.cached === true;
+  const generativeReady = runtimeReady && adapterReady;
+  const adapterMissing = !!plan && runtimeReady && !adapterReady;
+  const generativeDisabledReason = !plan
+    ? null
+    : !runtimeReady
+      ? plan.runtime.reason
+      : !adapterReady
+        ? `The ${plan.adapter?.label || 'generative upscale'} adapter is not downloaded yet.`
+        : null;
+
+  // Inline adapter download (#6510 item 4) — the same provisioning surface
+  // every IC-LoRA weight rides (#3100), just triggered from here instead of a
+  // separate models page, since no such page manages this non-remix weight.
+  const adapterKey = plan?.adapter?.key || null;
+  const downloadUrl = downloading ? upscaleAdapterDownloadUrl(adapterKey) : null;
+  const dl = useSseProgress(downloadUrl, { enabled: !!downloadUrl });
+
+  useEffect(() => {
+    if (!downloading || !dl.latest) return;
+    if (dl.latest.type === 'complete') {
+      setDownloading(false);
+      // Re-probe so `adapter.cached` flips and the option re-enables.
+      getUpscalePlan(itemId, 'ltx').then((res) => setPlan(res?.plan || null)).catch(() => {});
+    } else if (dl.latest.type === 'error') {
+      setDownloading(false);
+      toast.error(dl.latest.message || 'Adapter download failed');
+    }
+  }, [dl.latest, downloading, itemId]);
+
+  const handleSubmit = useCallback(async () => {
+    if (!itemId || submitting) return;
+    if (method === 'ltx' && !generativeReady) return;
+    setSubmitting(true);
+    toast.loading(method === 'ltx' ? 'Upscaling 2× (generative)…' : 'Upscaling 2× — typically 10-30s…');
+    const result = await upscaleVideo(itemId, { method, silent: true }).catch((err) => {
+      toast.error(err.message || 'Upscale failed');
+      return null;
+    });
+    setSubmitting(false);
+    if (result?.video) {
+      onUpscaled(result.video);
+      toast.success('Upscaled 2×');
+      onClose();
+    }
+  }, [itemId, method, submitting, generativeReady, onUpscaled, onClose]);
+
+  const dlFrame = dl.latest;
+  const dlPct = typeof dlFrame?.progress === 'number' ? Math.round(dlFrame.progress * 100) : null;
+
+  return (
+    <Drawer open={open} onClose={onClose} title="Upscale video" size="sm">
+      <div className="space-y-4">
+        <fieldset className="space-y-2">
+          <legend className="text-xs font-medium text-gray-400 mb-1">Method</legend>
+
+          <label
+            htmlFor="upscale-method-lanczos"
+            className="flex items-start gap-2 p-2 border border-port-border rounded cursor-pointer hover:border-port-accent/60"
+          >
+            <input
+              type="radio"
+              id="upscale-method-lanczos"
+              name="upscale-method"
+              value="lanczos"
+              checked={method === 'lanczos'}
+              onChange={() => setMethod('lanczos')}
+              className="mt-0.5"
+            />
+            <span>
+              <span className="block text-sm text-white">Lanczos (fast, pixel-faithful)</span>
+              <span className="block text-[11px] text-gray-500">2× resize, ~10-30s, no model download.</span>
+            </span>
+          </label>
+
+          <label
+            htmlFor="upscale-method-ltx"
+            className={`flex items-start gap-2 p-2 border rounded ${
+              generativeReady ? 'border-port-border hover:border-port-accent/60 cursor-pointer' : 'border-port-border/50 opacity-80'
+            }`}
+          >
+            <input
+              type="radio"
+              id="upscale-method-ltx"
+              name="upscale-method"
+              value="ltx"
+              checked={method === 'ltx'}
+              disabled={!generativeReady}
+              onChange={() => setMethod('ltx')}
+              className="mt-0.5"
+              aria-describedby={generativeDisabledReason ? 'upscale-method-ltx-reason' : undefined}
+            />
+            <span className="flex-1 min-w-0">
+              <span className="block text-sm text-white">LTX-2.5 generative (synthesizes detail)</span>
+              <span className="block text-[11px] text-gray-500">2× via a GPU model — adds detail rather than resizing pixels.</span>
+              {planLoading && <span className="block text-[11px] text-gray-500 mt-1">Checking readiness…</span>}
+              {planError && <span className="block text-[11px] text-port-error mt-1">{planError}</span>}
+              {generativeDisabledReason && (
+                <span id="upscale-method-ltx-reason" className="block text-[11px] text-port-warning mt-1">
+                  {generativeDisabledReason}
+                  {adapterMissing && (
+                    <>
+                      {' '}
+                      {downloading ? (
+                        <span className="text-gray-400">
+                          {dlFrame?.type === 'verify' ? 'Verifying…' : 'Downloading…'}
+                          {dlPct != null ? ` ${dlPct}%` : ''}
+                        </span>
+                      ) : (
+                        <button
+                          type="button"
+                          onClick={() => setDownloading(true)}
+                          className="text-port-accent hover:text-white underline"
+                        >
+                          Download adapter{plan.adapter?.sizeBytes ? ` (${formatBytes(plan.adapter.sizeBytes)})` : ''}
+                        </button>
+                      )}
+                    </>
+                  )}
+                </span>
+              )}
+            </span>
+          </label>
+        </fieldset>
+
+        {method === 'ltx' && plan && (
+          <div className="p-2 border border-port-border rounded space-y-1 text-[11px] text-gray-400">
+            <p className="text-xs font-medium text-white">Before you submit</p>
+            <p>Model: <span className="text-white">{plan.adapter?.label || 'LTX-2.5 Pixel Spatial Upscaler'}</span></p>
+            <p>
+              Target size:{' '}
+              <span className="text-white">
+                {plan.target?.width ?? '?'}×{plan.target?.height ?? '?'}
+              </span>
+              {plan.target?.frameCount ? `, ${plan.target.frameCount} frames` : ''}
+            </p>
+            {plan.alignment && plan.alignment.conforming === false && (
+              <p>
+                Padding: source pads to {plan.alignment.paddedSource?.width}×{plan.alignment.paddedSource?.height}
+                {plan.alignment.padFrames ? `, +${plan.alignment.padFrames} frame(s)` : ''} to fit the model grid
+                (cropped back off the output — nothing is trimmed).
+              </p>
+            )}
+            <p className="text-port-warning">
+              Details are synthesized, not pixel-faithfully refined — the result will not exactly match the source.
+            </p>
+          </div>
+        )}
+
+        <div className="flex justify-end gap-2 pt-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-3 py-1.5 text-xs rounded border border-port-border text-gray-300 hover:text-white"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={handleSubmit}
+            disabled={submitting || (method === 'ltx' && !generativeReady)}
+            className="px-3 py-1.5 text-xs rounded bg-port-accent text-white hover:bg-port-accent/80 disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-1.5"
+          >
+            {submitting && <Loader2 className="w-3.5 h-3.5 animate-spin" />}
+            Upscale 2×
+          </button>
+        </div>
+      </div>
+    </Drawer>
+  );
+}

--- a/client/src/components/media/VideoUpscaleDrawer.test.jsx
+++ b/client/src/components/media/VideoUpscaleDrawer.test.jsx
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import VideoUpscaleDrawer from './VideoUpscaleDrawer';
+import { upscaleVideo, getUpscalePlan } from '../../services/apiImageVideo';
+
+vi.mock('../../services/apiImageVideo', () => ({
+  upscaleVideo: vi.fn(),
+  getUpscalePlan: vi.fn(),
+  upscaleAdapterDownloadUrl: vi.fn(() => null),
+}));
+
+vi.mock('../ui/Toast', () => ({
+  default: { loading: vi.fn(), success: vi.fn(), error: vi.fn() },
+}));
+
+const ITEM = { id: 'video-1' };
+
+const READY_PLAN = {
+  id: 'video-1',
+  method: 'ltx',
+  scale: 2,
+  alreadyUpscaled: false,
+  source: { width: 848, height: 480, fps: 24, frameCount: 121, durationSeconds: 5, hasAudio: false },
+  target: { width: 1728, height: 960, frameCount: 129 },
+  alignment: {
+    spatialMultiple: 64,
+    padWidth: 32,
+    padHeight: 16,
+    padFrames: 8,
+    trimFrames: 0,
+    paddedSource: { width: 864, height: 480, frameCount: 129 },
+    conforming: false,
+  },
+  runtime: { id: 'ltx25', label: 'LTX-2.5 MLX', supported: true, installed: true, reason: null },
+  adapter: {
+    key: 'pixel-upscale', label: 'Pixel Spatial Upscaler', repo: 'Lightricks/example', filename: 'weight.safetensors',
+    sizeBytes: 327_322_640, gated: true, cached: true,
+  },
+};
+
+const missingAdapterPlan = () => ({
+  ...READY_PLAN,
+  adapter: { ...READY_PLAN.adapter, cached: false },
+});
+
+const unsupportedRuntimePlan = () => ({
+  ...READY_PLAN,
+  runtime: { id: null, label: null, supported: false, installed: false, reason: 'No generative upscale backend exists for this platform.' },
+  adapter: { ...READY_PLAN.adapter, cached: false },
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getUpscalePlan.mockResolvedValue({ plan: READY_PLAN });
+  upscaleVideo.mockResolvedValue({ ok: true, video: { id: 'video-2', upscaledFrom: 'video-1' } });
+});
+
+describe('VideoUpscaleDrawer', () => {
+  it('opening the drawer fetches the plan but queues no mutation', async () => {
+    render(<VideoUpscaleDrawer item={ITEM} onClose={vi.fn()} onUpscaled={vi.fn()} />);
+
+    await waitFor(() => expect(getUpscalePlan).toHaveBeenCalledWith('video-1', 'ltx'));
+    expect(upscaleVideo).not.toHaveBeenCalled();
+  });
+
+  it('choosing Lanczos (the default) submits method: "lanczos"', async () => {
+    const onUpscaled = vi.fn();
+    render(<VideoUpscaleDrawer item={ITEM} onClose={vi.fn()} onUpscaled={onUpscaled} />);
+    await waitFor(() => expect(getUpscalePlan).toHaveBeenCalled());
+
+    fireEvent.click(screen.getByRole('button', { name: /upscale 2×/i }));
+
+    await waitFor(() => expect(upscaleVideo).toHaveBeenCalledWith('video-1', { method: 'lanczos', silent: true }));
+    await waitFor(() => expect(onUpscaled).toHaveBeenCalledWith({ id: 'video-2', upscaledFrom: 'video-1' }));
+  });
+
+  it('choosing the generative method submits method: "ltx"', async () => {
+    render(<VideoUpscaleDrawer item={ITEM} onClose={vi.fn()} onUpscaled={vi.fn()} />);
+    await waitFor(() => expect(getUpscalePlan).toHaveBeenCalled());
+
+    fireEvent.click(screen.getByLabelText(/LTX-2\.5 generative/i));
+    fireEvent.click(screen.getByRole('button', { name: /upscale 2×/i }));
+
+    await waitFor(() => expect(upscaleVideo).toHaveBeenCalledWith('video-1', { method: 'ltx', silent: true }));
+  });
+
+  it('renders target dimensions and the synthesized-detail warning once generative is picked', async () => {
+    render(<VideoUpscaleDrawer item={ITEM} onClose={vi.fn()} onUpscaled={vi.fn()} />);
+    await waitFor(() => expect(getUpscalePlan).toHaveBeenCalled());
+
+    fireEvent.click(screen.getByLabelText(/LTX-2\.5 generative/i));
+
+    expect(screen.getByText(/1728×960/)).toBeTruthy();
+    expect(screen.getByText(/synthesized, not pixel-faithfully refined/i)).toBeTruthy();
+  });
+
+  it('disables the generative option with a reason when the adapter is not cached', async () => {
+    getUpscalePlan.mockResolvedValue({ plan: missingAdapterPlan() });
+    render(<VideoUpscaleDrawer item={ITEM} onClose={vi.fn()} onUpscaled={vi.fn()} />);
+
+    const radio = await screen.findByLabelText(/LTX-2\.5 generative/i);
+    await waitFor(() => expect(radio).toBeDisabled());
+    expect(screen.getByText(/adapter is not downloaded yet/i)).toBeTruthy();
+  });
+
+  it('disables the generative option with a reason when the runtime is unready', async () => {
+    getUpscalePlan.mockResolvedValue({ plan: unsupportedRuntimePlan() });
+    render(<VideoUpscaleDrawer item={ITEM} onClose={vi.fn()} onUpscaled={vi.fn()} />);
+
+    const radio = await screen.findByLabelText(/LTX-2\.5 generative/i);
+    await waitFor(() => expect(radio).toBeDisabled());
+    expect(screen.getByText(/no generative upscale backend exists/i)).toBeTruthy();
+  });
+
+  it('renders nothing when no item is open', () => {
+    render(<VideoUpscaleDrawer item={null} onClose={vi.fn()} onUpscaled={vi.fn()} />);
+    expect(getUpscalePlan).not.toHaveBeenCalled();
+    expect(screen.queryByRole('dialog')).toBeFalsy();
+  });
+});

--- a/client/src/pages/MediaHistory.jsx
+++ b/client/src/pages/MediaHistory.jsx
@@ -5,13 +5,14 @@
  * into Video Gen.
  */
 
-import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import { Link, useNavigate } from 'react-router';
 import { Combine, Image as ImageIcon, Film, Search, X } from 'lucide-react';
 import PageSkeleton from '../components/ui/PageSkeleton';
 import toast from '../components/ui/Toast';
 import MediaCard from '../components/media/MediaCard';
 import MediaPreview from '../components/media/MediaPreview';
+import VideoUpscaleDrawer from '../components/media/VideoUpscaleDrawer';
 import FavoritesFilterChip from '../components/media/FavoritesFilterChip';
 import { normalizeImage, normalizeVideo } from '../components/media/normalize';
 import { useMediaCompletionRefresh } from '../hooks/useMediaCompletionRefresh';
@@ -21,7 +22,6 @@ import usePreviewRoute from '../hooks/usePreviewRoute';
 import { buildMediaHaystack, tokenizeQuery, matchHaystack } from '../lib/mediaSearch';
 import {
   listVideoHistory, deleteVideoHistoryItem, stitchVideos,
-  upscaleVideo,
   listImageGallery, deleteImage,
 } from '../services/api';
 
@@ -165,20 +165,14 @@ export default function MediaHistory() {
     onCleanComplete: handleCleanComplete,
   });
 
-  const upscalingRef = useRef(false);
-  const handleUpscale = useCallback(async (item) => {
-    if (upscalingRef.current) return;
-    upscalingRef.current = true;
-    toast.loading('Upscaling 2× — typically 10-30s…');
-    const result = await upscaleVideo(item.id, { silent: true }).catch((err) => {
-      toast.error(err.message || 'Upscale failed');
-      return null;
-    });
-    upscalingRef.current = false;
-    if (result?.video) {
-      setItems((all) => [normalizeVideo(result.video), ...all]);
-      toast.success('Upscaled 2×');
-    }
+  // The card button opens a method-picker drawer (#6510) instead of upscaling
+  // directly — the drawer owns the plan fetch, disclosure, and submit.
+  const [upscaleItem, setUpscaleItem] = useState(null);
+  const handleUpscale = useCallback((item) => {
+    setUpscaleItem(item);
+  }, []);
+  const handleUpscaled = useCallback((video) => {
+    setItems((all) => [normalizeVideo(video), ...all]);
   }, []);
   const handleAnnotate = useCallback((item) => {
     navigate(`/media/annotate/${encodeURIComponent(item.key)}`);
@@ -327,6 +321,12 @@ export default function MediaHistory() {
         onContinue={handleContinue}
         onClean={(item) => handleClean(item?.raw)}
         onRemoveWatermark={(item) => handleRemoveWatermark(item?.raw)}
+      />
+
+      <VideoUpscaleDrawer
+        item={upscaleItem}
+        onClose={() => setUpscaleItem(null)}
+        onUpscaled={handleUpscaled}
       />
     </div>
   );

--- a/client/src/pages/VideoGen.jsx
+++ b/client/src/pages/VideoGen.jsx
@@ -57,6 +57,7 @@ import VideoGenGallery from '../components/videoGen/VideoGenGallery';
 import EpisodeComposer from '../components/videoGen/EpisodeComposer';
 import GalleryImagePicker from '../components/imageGen/GalleryImagePicker';
 import MediaPreview from '../components/media/MediaPreview';
+import VideoUpscaleDrawer from '../components/media/VideoUpscaleDrawer';
 import StylePresetPicker from '../components/media/StylePresetPicker';
 import UniverseStylePicker from '../components/media/UniverseStylePicker';
 import PromptEnhancer from '../components/media/PromptEnhancer';
@@ -85,7 +86,6 @@ import RemoteMediaTargetPicker from '../components/federatedMedia/RemoteMediaTar
 import {
   getVideoGenStatus, getVideoGenModelContext, generateVideo, cancelVideoGen,
   listVideoHistory, deleteVideoHistoryItem, setVideoHidden,
-  upscaleVideo,
   patchSettingsSlice,
   getActiveVideoJob,
   getSettings,
@@ -432,23 +432,16 @@ export default function VideoGen() {
     });
     if (result) toast.success(nextHidden ? 'Video hidden' : 'Video unhidden');
   }, []);
-  // Keep the single-flight guard outside render state so the handler remains
-  // stable for memoized cards while ffmpeg processes one upscale at a time.
-  const upscalingRef = useRef(false);
-  const handleUpscaleHistory = useCallback(async (item) => {
-    const raw = item?.raw || item;
-    if (upscalingRef.current) return;
-    upscalingRef.current = true;
-    toast.loading('Upscaling 2× — typically 10-30s…');
-    const result = await upscaleVideo(raw.id, { silent: true }).catch((err) => {
-      toast.error(err.message || 'Upscale failed');
-      return null;
-    });
-    upscalingRef.current = false;
-    if (result?.video) {
-      setHistory((h) => [result.video, ...h]);
-      toast.success('Upscaled 2×');
-    }
+  // The button opens a method-picker drawer (#6510) instead of upscaling
+  // directly — the drawer owns the plan fetch, the disclosure, and the actual
+  // submit; this page just supplies which item is open and how to fold the
+  // finished entry into local state.
+  const [upscaleItem, setUpscaleItem] = useState(null);
+  const handleUpscaleHistory = useCallback((item) => {
+    setUpscaleItem(item?.raw || item);
+  }, []);
+  const handleUpscaled = useCallback((video) => {
+    setHistory((h) => [video, ...h]);
   }, []);
 
   // Remix a prior render: hand all its params back into the form (the hook
@@ -1949,6 +1942,12 @@ export default function VideoGen() {
         open={!!galleryPicker}
         onClose={() => setGalleryPicker(null)}
         onSelect={handleGalleryPick}
+      />
+
+      <VideoUpscaleDrawer
+        item={upscaleItem}
+        onClose={() => setUpscaleItem(null)}
+        onUpscaled={handleUpscaled}
       />
 
       <Drawer open={settingsOpen} onClose={closeSettings} title="Media Generation Settings" size="lg">

--- a/client/src/services/apiImageVideo.js
+++ b/client/src/services/apiImageVideo.js
@@ -254,7 +254,31 @@ export const updateVideoPrompt = (id, prompt, options = {}) => request(`/video-g
   method: 'PATCH', body: JSON.stringify({ prompt }), ...options,
 });
 export const extractLastFrame = (id, options = {}) => request(`/video-gen/last-frame/${encodeURIComponent(id)}`, { method: 'POST', ...options });
-export const upscaleVideo = (id, options = {}) => request(`/video-gen/upscale/${encodeURIComponent(id)}`, { method: 'POST', ...options });
+// `method` selects the upscale pass (#6509/#6510): 'lanczos' (the historical
+// ffmpeg-only default, and what every pre-#6510 caller gets by omitting it) or
+// 'ltx' for the generative adapter. Destructured out of `options` before the
+// spread so it can never collide with the HTTP `method: 'POST'` fetch config
+// below — an omitted `method` sends exactly the bare-POST request this
+// endpoint has always received, so existing mocks/tests keep matching.
+export const upscaleVideo = (id, { method, ...options } = {}) => request(`/video-gen/upscale/${encodeURIComponent(id)}`, {
+  method: 'POST',
+  ...(method != null ? { body: JSON.stringify({ method }) } : {}),
+  ...options,
+});
+// Read-only pre-submit disclosure (#6509): source geometry, target dimensions,
+// required padding, and runtime/adapter readiness for `method`. Never queues a
+// job or triggers a download. `silent` by default — the picker owns its own
+// inline error state rather than a toast.
+export const getUpscalePlan = (id, method, options = {}) => request(
+  `/video-gen/upscale/${encodeURIComponent(id)}/plan?method=${encodeURIComponent(method)}`,
+  { silent: true, ...options },
+);
+// Live-progress URL for the generative upscale adapter's HF pull, for a small
+// inline "Download adapter" control in the upscale picker. `key` is
+// `plan.adapter.key` from getUpscalePlan — the same key the server's generic
+// `/ic-loras/:key/download` route (issue #3100) already resolves for every
+// registered IC-LoRA weight, remix mode or not.
+export const upscaleAdapterDownloadUrl = (key) => (key ? `${API_BASE}/video-gen/ic-loras/${encodeURIComponent(key)}/download` : null);
 export const stitchVideos = (videoIds, options = {}) => request('/video-gen/stitch', {
   method: 'POST',
   body: JSON.stringify({ videoIds }),

--- a/client/src/services/apiImageVideo.test.js
+++ b/client/src/services/apiImageVideo.test.js
@@ -16,11 +16,14 @@ vi.mock('./apiCore.js', async (importOriginal) => ({
 
 let request;
 let previewLoraInstall;
+let upscaleVideo;
+let getUpscalePlan;
+let upscaleAdapterDownloadUrl;
 
 beforeEach(async () => {
   vi.resetModules();
   ({ request } = await import('./apiCore.js'));
-  ({ previewLoraInstall } = await import('./apiImageVideo.js'));
+  ({ previewLoraInstall, upscaleVideo, getUpscalePlan, upscaleAdapterDownloadUrl } = await import('./apiImageVideo.js'));
   request.mockReset();
 });
 
@@ -46,5 +49,54 @@ describe('previewLoraInstall', () => {
       family: 'ltx-video',
       file: 'weights.safetensors',
     });
+  });
+});
+
+describe('upscaleVideo', () => {
+  it('sends a bare POST with no body when method is omitted (#6510 back-compat)', async () => {
+    request.mockResolvedValue({ ok: true, video: {} });
+    await upscaleVideo('abc', { silent: true });
+
+    expect(request).toHaveBeenCalledWith('/video-gen/upscale/abc', { method: 'POST', silent: true });
+    expect(request.mock.calls[0][1]).not.toHaveProperty('body');
+  });
+
+  it('sends { method: "lanczos" } in the body when explicitly chosen', async () => {
+    request.mockResolvedValue({ ok: true, video: {} });
+    await upscaleVideo('abc', { method: 'lanczos', silent: true });
+
+    const [url, opts] = request.mock.calls[0];
+    expect(url).toBe('/video-gen/upscale/abc');
+    expect(opts.method).toBe('POST');
+    expect(JSON.parse(opts.body)).toEqual({ method: 'lanczos' });
+    expect(opts.silent).toBe(true);
+  });
+
+  it('sends { method: "ltx" } in the body for the generative method', async () => {
+    request.mockResolvedValue({ ok: true, video: {} });
+    await upscaleVideo('abc', { method: 'ltx', silent: true });
+
+    const opts = request.mock.calls[0][1];
+    expect(opts.method).toBe('POST');
+    expect(JSON.parse(opts.body)).toEqual({ method: 'ltx' });
+  });
+});
+
+describe('getUpscalePlan', () => {
+  it('is a silent GET against the read-only plan endpoint', async () => {
+    request.mockResolvedValue({ ok: true, plan: {} });
+    await getUpscalePlan('abc', 'ltx');
+
+    expect(request).toHaveBeenCalledWith('/video-gen/upscale/abc/plan?method=ltx', { silent: true });
+  });
+});
+
+describe('upscaleAdapterDownloadUrl', () => {
+  it('builds the shared IC-LoRA download URL for a given key', () => {
+    expect(upscaleAdapterDownloadUrl('pixel-upscale')).toBe('/api/video-gen/ic-loras/pixel-upscale/download');
+  });
+
+  it('returns null with no key rather than a malformed URL', () => {
+    expect(upscaleAdapterDownloadUrl(null)).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

- Adds a method-picker drawer (`VideoUpscaleDrawer`) between the gallery's Upscale button and the actual submit, on both VideoGen and Media History — choosing between Lanczos (fast, pixel-faithful) and the LTX-2.5 generative adapter.
- Opening the drawer fetches only #6509's read-only plan endpoint (`GET /video-gen/upscale/:id/plan?method=ltx`) so the generative option's readiness — runtime installed, adapter downloaded — is known before the user ever touches it; nothing is queued until Upscale is pressed.
- The generative option disables with an actionable reason (missing runtime, or an un-downloaded adapter with an inline "Download adapter" trigger against the shared IC-LoRA provisioning endpoint) instead of letting the submit fail with a 501.
- Picking generative shows target dimensions, any grid padding the source needs, and an explicit "synthesized, not pixel-faithfully refined" warning before submit.
- `upscaleVideo(id, options)` gains an `options.method` that maps to the request body #6509 defined, extracted before the fetch-options spread so it can never collide with the HTTP `method: 'POST'`; an omitted method keeps sending exactly what every existing caller sends today.
- Both pages keep their reactive local-state update (new item prepended, no refetch) via an `onUpscaled` callback the drawer calls after a successful submit.

## Test plan

- `client/src/services/apiImageVideo.test.js` — new cases: no-body request is unchanged; explicit `lanczos`/`ltx` methods serialize into the body; the plan-endpoint wrapper is a silent GET; the adapter-download URL builder.
- `client/src/components/media/VideoUpscaleDrawer.test.jsx` — new: opening issues no mutation (plan fetch only); choosing Lanczos submits `method: "lanczos"`; choosing generative submits `method: "ltx"`; the generative option disables with a reason for a missing adapter and for an unready runtime; the disclosure renders target dimensions and the synthesized-detail warning; no item renders nothing.
- Ran the full client suite (`cd client && npx vitest run`): 883 files / 10748 tests passed, including the existing VideoGen/MediaCard/MediaHistory-adjacent suites with no regressions.
- `npx biome lint` clean on all touched files.

Closes #6510
