### PR TITLE
fix: preserve JSON escaping when expanding app checkout paths

### DIFF
--- a/scripts/lib/rewriteAppsPortosRoot.js
+++ b/scripts/lib/rewriteAppsPortosRoot.js
@@ -21,6 +21,10 @@ export function rewriteAppsPortosRoot(dataDir, rootDir) {
   if (!existsSync(appsFile)) return { rewritten: false, appsFile };
   const content = readFileSync(appsFile, 'utf8');
   if (!containsPortosRootToken(content)) return { rewritten: false, appsFile };
-  writeFileSync(appsFile, expandPortosRootToken(content, rootDir));
+  // Expand string values after parsing, then let JSON.stringify escape paths
+  // (Windows backslashes and legal quote characters) at the storage boundary.
+  // Parsing before writing also leaves a malformed registry untouched.
+  const apps = JSON.parse(content, (_key, value) => expandPortosRootToken(value, rootDir));
+  writeFileSync(appsFile, `${JSON.stringify(apps, null, 2)}\n`);
   return { rewritten: true, appsFile, token: PORTOS_ROOT_TOKEN, rootDir };
 }

--- a/scripts/lib/rewriteAppsPortosRoot.test.js
+++ b/scripts/lib/rewriteAppsPortosRoot.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from 'fs';
+import { mkdtempSync, writeFileSync, readFileSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { rewriteAppsPortosRoot } from './rewriteAppsPortosRoot.js';
@@ -43,6 +43,51 @@ describe('rewriteAppsPortosRoot', () => {
     const result = rewriteAppsPortosRoot(dataDir, '/opt/PortOS');
     expect(result.rewritten).toBe(false);
     expect(readFileSync(join(dataDir, 'apps.json'), 'utf8')).toBe(body);
+  });
+
+  it.each([
+    String.raw`C:\apps\PortOS`,
+    String.raw`\\example-server\apps\PortOS`,
+    '/opt/Example "quoted" checkout',
+  ])('round-trips JSON-sensitive checkout paths: %s', (rootDir) => {
+    const registry = {
+      apps: {
+        example: {
+          repoPath: '__PORTOS_ROOT__',
+          appIconPath: '__PORTOS_ROOT__/client/public/portos-logo.png',
+          nested: { command: '__PORTOS_ROOT__/scripts/run' },
+          args: ['__PORTOS_ROOT__', '--example'],
+        },
+        custom: { repoPath: '/opt/custom-checkout', enabled: false },
+      },
+      version: 1,
+    };
+    const appsFile = join(dataDir, 'apps.json');
+    writeFileSync(appsFile, JSON.stringify(registry));
+
+    rewriteAppsPortosRoot(dataDir, rootDir);
+
+    expect(JSON.parse(readFileSync(appsFile, 'utf8'))).toEqual({
+      ...registry,
+      apps: {
+        ...registry.apps,
+        example: {
+          repoPath: rootDir,
+          appIconPath: `${rootDir}/client/public/portos-logo.png`,
+          nested: { command: `${rootDir}/scripts/run` },
+          args: [rootDir, '--example'],
+        },
+      },
+    });
+    expect(rewriteAppsPortosRoot(dataDir, rootDir).rewritten).toBe(false);
+  });
+
+  it('leaves malformed input untouched', () => {
+    const appsFile = join(dataDir, 'apps.json');
+    const body = '{"apps":{"example":{"repoPath":"__PORTOS_ROOT__"}';
+    writeFileSync(appsFile, body);
+    expect(() => rewriteAppsPortosRoot(dataDir, '/opt/PortOS')).toThrow(SyntaxError);
+    expect(readFileSync(appsFile, 'utf8')).toBe(body);
   });
 
   it('is a no-op when apps.json is missing', () => {


### PR DESCRIPTION
Expanding an install path directly inside JSON corrupted the apps registry on Windows or when the checkout path contained quotes. Parse the registry, expand its string values, and serialize it with JSON escaping; malformed input remains untouched.

Validation: 49 focused tests passed across the rewrite workflow, placeholder helpers, and apps service. New cases cover Windows drive paths, UNC paths, quoted paths, nested values, preservation of concrete overrides, idempotence, and malformed input.
