### PR TITLE
fix: allow /workspace in default Git path allowlist

### DIFF
--- a/server/lib/workspaceRoots.js
+++ b/server/lib/workspaceRoots.js
@@ -15,10 +15,11 @@ import { homedir, tmpdir } from 'os';
 //
 // Repos legitimately live on secondary volumes, so the defaults cover home plus
 // the places each platform mounts them: /Volumes (macOS), /mnt + /media (Linux),
-// and — because Windows has no such directory — any lettered non-system drive,
-// via the rule below. Windows also drops the POSIX literals entirely: there is
-// no /tmp or /opt there, and `resolve('/tmp')` means "\tmp on whatever drive the
-// process happens to be on", which is both meaningless and non-deterministic.
+// /workspace (Docker/devcontainer/agent layouts), and — because Windows has no
+// such directory — any lettered non-system drive, via the rule below. Windows
+// also drops the POSIX literals entirely: there is no /tmp or /opt there, and
+// `resolve('/tmp')` means "\tmp on whatever drive the process happens to be
+// on", which is both meaningless and non-deterministic.
 //
 // Operators extend either platform with PORTOS_WORKSPACE_ROOTS, split on the
 // platform path delimiter (`;` on Windows, where `:` would cut `D:\repos` at
@@ -30,7 +31,7 @@ const IS_WINDOWS = process.platform === 'win32';
 
 export const DEFAULT_WORKSPACE_ROOTS = IS_WINDOWS
   ? [homedir(), tmpdir()]
-  : [homedir(), '/tmp', '/Users', '/Volumes', '/mnt', '/media', '/opt'];
+  : [homedir(), '/tmp', '/Users', '/Volumes', '/mnt', '/media', '/opt', '/workspace'];
 
 // The drive Windows itself is installed on, e.g. `C:`. Everything on it stays
 // confined to the roots above, so C:\Windows and C:\Program Files are out.

--- a/server/lib/workspaceRoots.test.js
+++ b/server/lib/workspaceRoots.test.js
@@ -42,6 +42,10 @@ describe('isWithinAllowedRoots', () => {
     expect(isWithinAllowedRoots(join(homedir(), 'projects', 'foo'))).toBe(true);
   });
 
+  it.runIf(!IS_WINDOWS)('accepts a path under /workspace (Docker/devcontainer/agent layouts)', () => {
+    expect(isWithinAllowedRoots('/workspace/PortOS')).toBe(true);
+  });
+
   it('rejects a path outside every allowed root', () => {
     // /etc is not in DEFAULT_WORKSPACE_ROOTS and (in tests) PORTOS_WORKSPACE_ROOTS is unset.
     expect(isWithinAllowedRoots('/etc/shadow')).toBe(false);
@@ -108,8 +112,9 @@ describe('outsideAllowedRootsMessage', () => {
 });
 
 // Windows repos routinely live off the system drive (D:\code, E:\projects), and
-// the POSIX defaults (/tmp, /Users, /Volumes, /opt) resolve to nothing useful
-// there — so a non-system lettered drive is allowed, the way /Volumes is on macOS.
+// the POSIX defaults (/tmp, /Users, /Volumes, /opt, /workspace) resolve to nothing
+// useful there — so a non-system lettered drive is allowed, the way /Volumes is on
+// macOS.
 describe('Windows non-system drives', () => {
   const otherDrive = SYSTEM_DRIVE === 'Z:' ? 'Y:\\' : 'Z:\\';
 
@@ -128,6 +133,7 @@ describe('Windows non-system drives', () => {
   it.runIf(!IS_WINDOWS)('mounted-volume roots cover the Linux mount points', () => {
     expect(isWithinAllowedRoots('/mnt/data/code')).toBe(true);
     expect(isWithinAllowedRoots('/media/usb/repo')).toBe(true);
+    expect(isWithinAllowedRoots('/workspace/PortOS')).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary
- Apps Git tab calls path-based `/api/git/*` (e.g. `POST /api/git/info`) which enforce `DEFAULT_WORKSPACE_ROOTS` via `server/lib/workspaceRoots.js`. Checkouts under `/workspace` (common for Docker, devcontainers, and agent layouts) were rejected with `path is outside allowed directories` / 403.
- Managed Update still worked because it goes through app-id `repository-sources`, not the path allowlist — which is why `GET /api/git/portos-default` and Update looked fine while the Git tab did not.
- Add `/workspace` to the non-Windows `DEFAULT_WORKSPACE_ROOTS`. `PORTOS_WORKSPACE_ROOTS` is unchanged for operators who need extra roots.

## Test plan
- [x] `vitest run lib/workspaceRoots.test.js` — 20 passed, 3 skipped
- [x] `vitest run routes/git.test.js` — 34 passed
- [ ] Repro: `POST /api/git/info` with `{"path":"/workspace/PortOS"}` should succeed after deploy (was 403)