### PR TITLE
fix: ship OpenClaw and GSD features disabled by default

### DIFF
--- a/server/lib/instanceFeatureRegistry.js
+++ b/server/lib/instanceFeatureRegistry.js
@@ -46,15 +46,13 @@ export const INSTANCE_FEATURES = Object.freeze([
     id: 'gsd',
     label: 'GSD',
     description: 'Get Stuff Done project planning and progress tracking for managed apps.',
-    defaultEnabled: true,
+    defaultEnabled: false,
   }),
   Object.freeze({
     id: 'openclaw',
     label: 'OpenClaw',
     description: 'Operator chat with a configured OpenClaw runtime.',
-    // Preserve the existing behavior for installs that already configured
-    // OpenClaw; an explicit Settings > Features toggle remains authoritative.
-    defaultEnabled: true,
+    defaultEnabled: false,
   }),
   Object.freeze({
     id: 'health',

--- a/server/routes/settings.test.js
+++ b/server/routes/settings.test.js
@@ -184,10 +184,9 @@ describe('Settings routes — instance feature participation', () => {
       enabled: false,
       setup: expect.objectContaining({ installed: false }),
     }));
-    // GSD remains enabled by default so existing app planning tabs stay
-    // available unless the install explicitly opts out.
-    expect(res.body.features).toContainEqual(expect.objectContaining({ id: 'gsd', enabled: true }));
-    expect(res.body.features).toContainEqual(expect.objectContaining({ id: 'openclaw', enabled: true }));
+    // GSD and OpenClaw ship disabled by default; the install opts in.
+    expect(res.body.features).toContainEqual(expect.objectContaining({ id: 'gsd', enabled: false }));
+    expect(res.body.features).toContainEqual(expect.objectContaining({ id: 'openclaw', enabled: false }));
     expect(res.body.features).toContainEqual(expect.objectContaining({ id: 'health', enabled: true }));
   });
 

--- a/server/services/instanceFeatures.test.js
+++ b/server/services/instanceFeatures.test.js
@@ -305,7 +305,7 @@ describe('instance features', () => {
 
     const { features } = await getInstanceFeatures();
     expect(Object.fromEntries(features.map((f) => [f.id, f.enabled])))
-      .toEqual({ post: true, datadog: true, jira: false, eidoverse: false, gsd: true, openclaw: true, health: true, rigging: false, facetime: false });
+      .toEqual({ post: true, datadog: true, jira: false, eidoverse: false, gsd: false, openclaw: false, health: true, rigging: false, facetime: false });
   });
 
   it('rejects an unknown feature id', async () => {


### PR DESCRIPTION
## Summary
- OpenClaw and GSD previously defaulted to `enabled: true` in the instance feature registry, exposing operator chat and project planning tabs on every fresh install without an explicit opt-in.
- Flip `defaultEnabled` to `false` for both so a fresh install stays quiet until the user turns them on in Settings > Features.
- Installs with a stored per-feature override are unaffected — this only changes the fallback used when no override exists.

## Test plan
- `NODE_ENV=test vitest run lib/instanceFeatureRegistry.test.js services/instanceFeatures.test.js routes/settings.test.js` — 87 passed
- Full server suite: 41158 passed, 1 unrelated pre-existing timeout flake (`buildMediaLibraryManifest`, filesystem hashing test unrelated to this change)