### PR TITLE
Run the LTX-2.5 generative video upscale as a single conditioned stage at the output size, verified on Apple Silicon

### DIFF
--- a/docs/features/video-upscale.md
+++ b/docs/features/video-upscale.md
@@ -102,11 +102,40 @@ the script path differ. What stays per-runner is what genuinely differs: the
 runtime it imports, the host it gates on, the pack layout it validates, and the
 rename maps its loader fuses through.
 
+## The recipe
+
+The generative method is Lightricks' standard IC-LoRA video-to-video pass, as
+their IC-LoRA guide and ComfyUI reference workflow run the Pixel Spatial
+Upscaler: the distilled model with the adapter fused at strength 1.0, a single
+denoising stage **at the output resolution**, and the low-resolution clip as
+the in-context reference at half of it (the adapter's
+`reference_downscale_factor` is 2). No text steering is added — the source clip
+is the whole conditioning signal — and the distilled 8-sigma schedule is used
+as-is.
+
+Both runtimes' `ICLoraPipeline` interpret the size they are handed as the dims
+of an optional latent-upsample second stage, rendering the conditioned stage
+at half of it. The runners therefore request **twice** the output and skip
+that second stage, so the conditioned stage renders at the output size with
+the source as a native-resolution reference. Requesting the output size itself
+would condition on the source downscaled by another 2× and hand the second
+doubling to the latent upsampler — a pixel-faithful refinement the adapter is
+not.
+
+On macOS the MLX q8 pack may hold the distilled model either pre-fused
+(`transformer-distilled.safetensors`) or as the dev transformer plus the
+450-step distilled LoRA; the runner takes the pre-fused file when present and
+otherwise fuses the distilled LoRA beside the adapter, which the pack documents
+as the equivalent layout. A dev transformer without that LoRA is refused, since
+the distilled schedule is only valid on the distilled model.
+
 ## The model grid, and why nothing is silently lost
 
-LTX-2.5 renders on a two-stage grid: output dimensions must divide by **64**,
-and the frame count must satisfy `frames % 8 == 1` with a floor of **9**. Since
-the scale is 2×, a *source* axis conforms exactly when it divides by 32.
+LTX-2.5 renders on a fixed grid: output dimensions must divide by **64**, and
+the frame count must satisfy `frames % 8 == 1` with a floor of **9**. Since the
+scale is 2×, a *source* axis conforms exactly when it divides by 32 — which is
+also what keeps the reference at the (padded) source's own size on the VAE's
+32-pixel grid rather than resampling it before it conditions anything.
 
 A source that does not conform is **padded, never trimmed** — extra pixels on
 the right/bottom and extra frames on the tail, cropped back off the output

--- a/docs/features/video-upscale.md
+++ b/docs/features/video-upscale.md
@@ -113,14 +113,10 @@ the in-context reference at half of it (the adapter's
 is the whole conditioning signal — and the distilled 8-sigma schedule is used
 as-is.
 
-Both runtimes' `ICLoraPipeline` interpret the size they are handed as the dims
-of an optional latent-upsample second stage, rendering the conditioned stage
-at half of it. The runners therefore request **twice** the output and skip
-that second stage, so the conditioned stage renders at the output size with
-the source as a native-resolution reference. Requesting the output size itself
-would condition on the source downscaled by another 2× and hand the second
-doubling to the latent upsampler — a pixel-faithful refinement the adapter is
-not.
+Both runtimes' `ICLoraPipeline` render their conditioned stage at half the size
+they are handed, so the runners request **twice** the output and skip the
+latent-upsample second stage (`PIPELINE_REQUEST_MULTIPLIER` in
+`scripts/_upscale_contract.py` records why).
 
 On macOS the MLX q8 pack may hold the distilled model either pre-fused
 (`transformer-distilled.safetensors`) or as the dev transformer plus the

--- a/scripts/_runner_common.py
+++ b/scripts/_runner_common.py
@@ -100,6 +100,15 @@ def heartbeat(stage: "str | Callable[[], str]", interval: float = 20.0):
         t.join(timeout=interval + 1)
 
 
+# The LTX-2.5 MLX q8 pack's dev-layout files. The distilled model ships either
+# pre-fused (`transformer-distilled.safetensors`) or as the dev transformer
+# plus this 450-step distilled LoRA; both the render bridge
+# (`generate_ltx2.py`) and the upscale runner (`upscale_ltx25.py`) resolve the
+# same pair, so a re-pin of the adapter is one edit rather than two.
+LTX25_DEV_TRANSFORMER_FILENAME = "transformer-dev.safetensors"
+LTX25_DISTILLED_LORA_FILENAME = "ltx-2.5-22b-distilled-lora-450.safetensors"
+
+
 def parse_user_loras(raw: "str | None") -> "list[tuple[str, float]]":
     """Parse a `--user-loras` JSON string into a list of (path, strength) tuples.
 

--- a/scripts/_upscale_contract.py
+++ b/scripts/_upscale_contract.py
@@ -33,15 +33,18 @@ from pathlib import Path
 # runners make (`conditioned_stage_request` below). Temporal compression is 8
 # and the reference encoder needs a (1 + 8k)-frame input, so `frames % 8 == 1`
 # with a floor of 9.
-SPATIAL_MULTIPLE = 64
-FRAME_MODULUS = 8
-FRAME_REMAINDER = 1
-MIN_FRAMES = 9
-
 # The VAE's spatial compression: the reference clip is resized onto this grid
 # before it is encoded, so a reference that is not a multiple of it gets
 # resampled — which for an upscaler means conditioning on a blurred source.
 VAE_SPATIAL_COMPRESSION = 32
+# The shipped adapter's declared `reference_downscale_factor` (measured, and
+# declared by `icLoraWeights.js`); `assert_reference_scale_fits` re-derives the
+# same rule from the factor read off the file actually fused.
+SHIPPED_REFERENCE_DOWNSCALE = 2
+SPATIAL_MULTIPLE = SHIPPED_REFERENCE_DOWNSCALE * VAE_SPATIAL_COMPRESSION
+FRAME_MODULUS = 8
+FRAME_REMAINDER = 1
+MIN_FRAMES = 9
 
 # How both `ICLoraPipeline`s interpret the `height`/`width` they are handed:
 # as the dims of the OPTIONAL latent-upsample stage 2, with the IC-conditioned
@@ -116,7 +119,7 @@ def validate_args(args: argparse.Namespace) -> None:
     """
     if args.width % SPATIAL_MULTIPLE or args.height % SPATIAL_MULTIPLE:
         raise SystemExit(
-            f"The two-stage LTX-2.5 pipeline requires width and height divisible by {SPATIAL_MULTIPLE}; "
+            f"The LTX-2.5 upscale requires width and height divisible by {SPATIAL_MULTIPLE}; "
             f"got {args.width}x{args.height}."
         )
     if args.num_frames < MIN_FRAMES or args.num_frames % FRAME_MODULUS != FRAME_REMAINDER:

--- a/scripts/_upscale_contract.py
+++ b/scripts/_upscale_contract.py
@@ -24,21 +24,38 @@ import json
 import struct
 from pathlib import Path
 
-# The LTX-2.5 two-stage grid, mirrored from `LTX_GRID` in
-# `server/services/videoGen/upscalePlan.js` and confirmed against both runtimes:
-# stage 1 renders at `height // 2` / `width // 2` and the video VAE compresses
-# spatially by 32, so the OUTPUT axis must be divisible by 64 (upstream's own
-# `assert_resolution(..., is_two_stage=True)` asserts exactly that). Temporal
-# compression is 8 and the reference encoder needs a (1 + 8k)-frame input, so
-# `frames % 8 == 1` with a floor of 9.
+# The LTX-2.5 grid, mirrored from `LTX_GRID` in
+# `server/services/videoGen/upscalePlan.js` and confirmed against both runtimes.
+# The video VAE compresses spatially by 32, and the upscaler's reference has to
+# land on that grid at HALF the output (see `assert_reference_scale_fits`), so
+# the OUTPUT axis must be divisible by 64 — which is also what upstream's own
+# `assert_resolution(..., is_two_stage=True)` demands of the request both
+# runners make (`conditioned_stage_request` below). Temporal compression is 8
+# and the reference encoder needs a (1 + 8k)-frame input, so `frames % 8 == 1`
+# with a floor of 9.
 SPATIAL_MULTIPLE = 64
 FRAME_MODULUS = 8
 FRAME_REMAINDER = 1
 MIN_FRAMES = 9
 
-# Stage 1 renders at half the requested output, and it is those halved dims the
-# IC encoder divides by `reference_downscale_factor`.
-STAGE1_DIVISOR = 2
+# The VAE's spatial compression: the reference clip is resized onto this grid
+# before it is encoded, so a reference that is not a multiple of it gets
+# resampled — which for an upscaler means conditioning on a blurred source.
+VAE_SPATIAL_COMPRESSION = 32
+
+# How both `ICLoraPipeline`s interpret the `height`/`width` they are handed:
+# as the dims of the OPTIONAL latent-upsample stage 2, with the IC-conditioned
+# stage 1 rendering at exactly half of that. The Pixel Spatial Upscaler is the
+# standard single-stage IC-LoRA video-to-video recipe (Lightricks' IC-LoRA
+# guide and their ComfyUI reference workflow run it "single-stage distilled at
+# your set resolution", reference at half), so a runner asks for TWICE the
+# output and skips stage 2: stage 1 then renders AT the output size with the
+# source as a native-resolution reference, and the decoded clip is the output.
+# Requesting the output itself would render stage 1 at half the output —
+# conditioning on the source downscaled by another 2x — and hand the second
+# doubling to the latent upsampler, which is exactly the pixel-faithful
+# refinement the adapter is not.
+PIPELINE_REQUEST_MULTIPLIER = 2
 
 # The upscale contract carries no prompt (#6511): the source clip is the whole
 # conditioning signal, and inventing text steering would push synthesized detail
@@ -183,20 +200,32 @@ def reference_downscale_factor(header: "dict | None") -> int:
     return scale if scale >= 1 else 1
 
 
+def conditioned_stage_request(width: int, height: int) -> "tuple[int, int]":
+    """The `(width, height)` a runner hands the pipeline so stage 1 renders at the output.
+
+    Paired with `skip_stage_2=True` on both runtimes — see
+    `PIPELINE_REQUEST_MULTIPLIER`. Kept as one helper so the two runners cannot
+    disagree about which stage the output comes from.
+    """
+    return width * PIPELINE_REQUEST_MULTIPLIER, height * PIPELINE_REQUEST_MULTIPLIER
+
+
 def assert_reference_scale_fits(scale: int, width: int, height: int) -> None:
-    """Enforce the adapter's own resolution rule on the STAGE-1 dimensions.
+    """Enforce the adapter's own resolution rule on the conditioned stage's dims.
 
     `append_ic_lora_reference_video_conditionings` divides the dims it is HANDED
-    by the factor, and both pipelines hand it `height // 2` / `width // 2`.
-    Stating the rule in OUTPUT terms is what makes the message actionable — the
-    user picked an output size, not a stage size.
+    by the factor and snaps the result onto the VAE grid. With
+    `conditioned_stage_request` those dims ARE the output, so the reference is
+    `output / scale` — and for the upscaler that must be the (padded) source's
+    own size, or the source is resampled before it conditions anything. Hence
+    the output must divide by `scale * 32`. Stating the rule in OUTPUT terms is
+    what makes the message actionable — the user picked an output size.
     """
     if scale <= 1:
         return
-    stage_h, stage_w = height // STAGE1_DIVISOR, width // STAGE1_DIVISOR
-    if stage_h % scale == 0 and stage_w % scale == 0:
+    required = scale * VAE_SPATIAL_COMPRESSION
+    if height % required == 0 and width % required == 0:
         return
-    required = scale * STAGE1_DIVISOR
     raise SystemExit(
         f"This adapter downscales its reference by {scale}, so the output dimensions must be "
         f"divisible by {required}; got {width}x{height}."

--- a/scripts/generate_ltx2.py
+++ b/scripts/generate_ltx2.py
@@ -67,7 +67,6 @@ import sys
 from pathlib import Path
 from typing import NoReturn
 
-DISTILLED_LORA_25 = "ltx-2.5-22b-distilled-lora-450.safetensors"
 DISTILLED_LORA_V11 = "ltx-2.3-22b-distilled-lora-384-1.1.safetensors"
 DISTILLED_LORA_LEGACY = "ltx-2.3-22b-distilled-lora-384.safetensors"
 
@@ -86,7 +85,16 @@ os.environ.setdefault("LTX2_GEMMA_EVAL_EVERY", "1")
 # for direct and imported execution. _runner_common is stdlib-only at import time, so
 # this is safe from the ltx-2-mlx venv (no torch pulled in).
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from _runner_common import emit_runtime_fingerprint, parse_user_loras, write_stepwise_preview  # noqa: E402
+from _runner_common import (  # noqa: E402
+    LTX25_DISTILLED_LORA_FILENAME,
+    emit_runtime_fingerprint,
+    parse_user_loras,
+    write_stepwise_preview,
+)
+
+# The 2.5 pack's distilled adapter, shared with the upscale runner so a re-pin
+# is one edit (see _runner_common).
+DISTILLED_LORA_25 = LTX25_DISTILLED_LORA_FILENAME
 
 
 def emit_status(msg: str) -> None:

--- a/scripts/upscale_ltx25.py
+++ b/scripts/upscale_ltx25.py
@@ -22,15 +22,10 @@ gated model card:
     it and otherwise falls back to the remote 2.3 Gemma 3 id — a wrong encoder
     AND an unannounced multi-GB download — so `validate_model_dir` refuses a
     pack that lacks it instead of letting that fallback happen.
-  - The recipe is the standard single-stage IC-LoRA video-to-video pass
-    (Lightricks' IC-LoRA guide and their ComfyUI reference workflow: distilled
-    schedule at the set resolution, the low-resolution clip as the reference at
-    half of it). `ICLoraPipeline.generate` renders its IC-conditioned stage 1
-    at HALF the dims it is handed and offers a latent-upsample stage 2 for the
-    other half, so this runner requests twice the output and skips stage 2 —
-    stage 1 then renders at the output size, conditioned on the source at its
-    native resolution, and its decode is the deliverable
-    (`_upscale_contract.conditioned_stage_request`).
+  - The recipe is the standard single-stage IC-LoRA video-to-video pass at the
+    output size with the source as the reference at half of it — see
+    `PIPELINE_REQUEST_MULTIPLIER` in `_upscale_contract.py` for why that means
+    requesting twice the output and skipping stage 2.
   - The schedule is the fixed distilled one: `DISTILLED_SIGMAS` is 8 steps.
     Passing no step count selects exactly that, which is why this runner
     exposes no steps flag.
@@ -57,7 +52,12 @@ import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from _runner_common import emit_runtime_fingerprint, heartbeat  # noqa: E402
+from _runner_common import (  # noqa: E402
+    LTX25_DEV_TRANSFORMER_FILENAME,
+    LTX25_DISTILLED_LORA_FILENAME,
+    emit_runtime_fingerprint,
+    heartbeat,
+)
 # The argv, grid and adapter contract this runner shares with the CUDA one
 # (#6513). Re-exported names stay module attributes, so a caller — or a test —
 # still reaches them as `upscale_ltx25.validate_args` / `.lora_target_keys`.
@@ -76,16 +76,6 @@ from _upscale_contract import (  # noqa: E402
 # than a fallback — see the module docstring.
 TEXT_ENCODER_DIRNAME = "text_encoder"
 
-# The two layouts the pinned q8 pack documents for the distilled model. The
-# pre-fused `transformer-distilled.safetensors` is what `ICLoraPipeline.load()`
-# resolves on its own; a pack that carries only the dev transformer holds the
-# SAME model as dev weights plus the 450-step distilled LoRA, which the pack
-# README names as the equivalent non-streaming arrangement and the runtime's
-# own two-stage pipelines fuse for their distilled stage. The distilled
-# schedule this runner drives is only valid on the distilled model, so dev
-# WITHOUT that LoRA is a refusal, never a fallback.
-DEV_TRANSFORMER_FILENAME = "transformer-dev.safetensors"
-DISTILLED_LORA_FILENAME = "ltx-2.5-22b-distilled-lora-450.safetensors"
 # Full strength turns the dev weights INTO the distilled model — the pack's
 # README states the pre-fused file is this LoRA at the default strength of 1.0.
 DISTILLED_LORA_STRENGTH = 1.0
@@ -161,23 +151,35 @@ def resolve_transformer_path(model_dir: Path) -> "Path | None":
     return fallback if fallback.is_file() else None
 
 
-def resolve_transformer_layout(model_dir: Path) -> "tuple[Path | None, Path | None]":
-    """`(transformer, distilled_lora)` for the pack — see the layout constants.
+def resolve_transformer_layout(model_dir: Path) -> "tuple[Path, list[tuple[str, float]]]":
+    """The DiT file to fuse into, plus any LoRA the pack needs to make it the distilled model.
 
-    The pre-fused distilled transformer wins whenever present (`distilled_lora`
-    is then None). Otherwise the dev transformer is returned WITH the distilled
-    LoRA that turns it into the distilled model, and `(None, None)` when the
-    pack has neither the distilled file nor a dev file. A dev file whose LoRA is
-    missing is reported as `(dev, None)` so the caller can refuse it by name.
+    The pinned q8 pack documents two layouts for the distilled model. The
+    pre-fused `transformer-distilled.safetensors` is what `ICLoraPipeline.load()`
+    resolves on its own and wins whenever present (no extra LoRA). A pack that
+    carries only the dev transformer holds the SAME model as dev weights plus
+    the 450-step distilled LoRA — the layout the pack README names as the
+    equivalent non-streaming arrangement and the runtime's own pipelines fuse
+    for their distilled stage — so that LoRA is returned beside it. The
+    distilled schedule this runner drives is only valid on the distilled model,
+    so dev WITHOUT that LoRA is a refusal, never a fallback.
     """
     distilled = resolve_transformer_path(model_dir)
     if distilled is not None:
-        return distilled, None
-    dev = model_dir / DEV_TRANSFORMER_FILENAME
+        return distilled, []
+    dev = model_dir / LTX25_DEV_TRANSFORMER_FILENAME
     if not dev.is_file():
-        return None, None
-    lora = model_dir / DISTILLED_LORA_FILENAME
-    return dev, (lora if lora.is_file() else None)
+        raise SystemExit(
+            f"The LTX-2.5 pack at {model_dir} has no transformer weight file. Repair the model in Video Gen."
+        )
+    lora = model_dir / LTX25_DISTILLED_LORA_FILENAME
+    if not lora.is_file():
+        raise SystemExit(
+            f"The LTX-2.5 pack at {model_dir} carries only {LTX25_DEV_TRANSFORMER_FILENAME} and not the "
+            f"{LTX25_DISTILLED_LORA_FILENAME} that makes it the distilled model the upscale schedule needs. "
+            "Repair the model in Video Gen."
+        )
+    return dev, [(str(lora), DISTILLED_LORA_STRENGTH)]
 
 
 def make_pipeline(pipeline_cls, model_dir: Path, transformer_path: Path, lora_paths):
@@ -191,14 +193,24 @@ def make_pipeline(pipeline_cls, model_dir: Path, transformer_path: Path, lora_pa
     the DiT resident through prompt encoding. `lora_paths` is every adapter
     `_fuse_loras` will add to the DiT in ONE pass — the IC adapter, and on a dev
     layout the distilled LoRA beside it.
+
+    `load()` also builds the latent upsampler for a stage 2 this runner never
+    runs (`skip_stage_2`), reading a ~1 GB weight into memory that then sits
+    beside the DiT for the whole render. Pre-seeding the slot makes `load()`
+    skip it; nothing under `skip_stage_2` dereferences the upsampler.
     """
     class PackLayoutPipeline(pipeline_cls):
         def load(self):
             if self.dit is None and not self._loaded:
                 self.dit = self._load_transformer_with_optional_streaming(transformer_path)
+            if self.upsampler is None:
+                self.upsampler = _UNUSED_UPSAMPLER
             super().load()
 
     return PackLayoutPipeline(model_dir=str(model_dir), lora_paths=list(lora_paths))
+
+
+_UNUSED_UPSAMPLER = object()
 
 
 def transformer_weight_keys(transformer_path: Path) -> "set[str]":
@@ -266,9 +278,8 @@ def main() -> None:
     header = read_safetensors_header(args.ic_lora_path)
     scale = reference_downscale_factor(header)
     assert_reference_scale_fits(scale, args.width, args.height)
-    # Recorded rather than guessed: `icLoraWeights.js` holds `null` for this
-    # gated weight precisely because nobody had opened it, and this line is the
-    # measurement (#6508's registry note points here).
+    # The per-install measurement the queue records beside the registry's
+    # declared value — a re-pinned weight is measured, not trusted.
     log(f"UPSCALE_REFERENCE_DOWNSCALE:{scale}")
 
     log("STAGE:verify-adapter")
@@ -282,18 +293,8 @@ def main() -> None:
     # move this behind a `pipe.load()`: `generate()` deliberately loads the text
     # encoder, encodes, frees it, and only THEN loads the transformer, so
     # pre-loading would hold a multi-GB DiT resident through prompt encoding.
-    transformer_path, distilled_lora = resolve_transformer_layout(model_dir)
-    if transformer_path is None:
-        raise SystemExit(
-            f"The LTX-2.5 pack at {model_dir} has no transformer weight file. Repair the model in Video Gen."
-        )
-    if transformer_path.name == DEV_TRANSFORMER_FILENAME and distilled_lora is None:
-        raise SystemExit(
-            f"The LTX-2.5 pack at {model_dir} carries only {DEV_TRANSFORMER_FILENAME} and not the "
-            f"{DISTILLED_LORA_FILENAME} that makes it the distilled model the upscale schedule needs. "
-            "Repair the model in Video Gen."
-        )
-    layout = transformer_path.name + (f" + {distilled_lora.name}" if distilled_lora else "")
+    transformer_path, pack_loras = resolve_transformer_layout(model_dir)
+    layout = " + ".join([transformer_path.name, *(Path(path).name for path, _ in pack_loras)])
     log(f"STATUS:Transformer layout: {layout}")
     fused = assert_adapter_fuses(
         args.ic_lora_path,
@@ -304,21 +305,17 @@ def main() -> None:
 
     log("STAGE:load-pipeline")
     log(f"STATUS:Loading LTX-2.5 MLX upscale pipeline ({args.width}x{args.height}, {args.num_frames} frames)")
-    lora_paths = [(args.ic_lora_path, 1.0)]
-    if distilled_lora is not None:
-        lora_paths.append((str(distilled_lora), DISTILLED_LORA_STRENGTH))
-    pipe = make_pipeline(ICLoraPipeline, model_dir, transformer_path, lora_paths)
+    pipe = make_pipeline(ICLoraPipeline, model_dir, transformer_path, [(args.ic_lora_path, 1.0), *pack_loras])
 
     output = Path(args.output)
     output.parent.mkdir(parents=True, exist_ok=True)
     request_width, request_height = conditioned_stage_request(args.width, args.height)
     log("STAGE:inference")
     with heartbeat("ltx25-upscale-inference"):
-        # Stage 1 renders at half the requested dims — i.e. AT the output — with
-        # the source as its native-resolution reference, and `skip_stage_2`
-        # makes that stage's decode the deliverable (see the module docstring).
-        # No stage-1 step count: `DISTILLED_SIGMAS` IS the distilled schedule
-        # (8 steps), and passing a count would truncate it.
+        # Twice the output + `skip_stage_2` = one conditioned stage AT the
+        # output (see `conditioned_stage_request`). No stage-1 step count:
+        # `DISTILLED_SIGMAS` IS the distilled schedule (8 steps), and passing a
+        # count would truncate it.
         pipe.generate_and_save(
             prompt=args.prompt,
             output_path=str(output),

--- a/scripts/upscale_ltx25.py
+++ b/scripts/upscale_ltx25.py
@@ -22,9 +22,18 @@ gated model card:
     it and otherwise falls back to the remote 2.3 Gemma 3 id — a wrong encoder
     AND an unannounced multi-GB download — so `validate_model_dir` refuses a
     pack that lacks it instead of letting that fallback happen.
-  - The schedule is the fixed distilled one: `DISTILLED_SIGMAS` is 8 steps and
-    `STAGE_2_SIGMAS` is 3. Passing no step counts selects exactly those, which
-    is why this runner exposes no steps flag.
+  - The recipe is the standard single-stage IC-LoRA video-to-video pass
+    (Lightricks' IC-LoRA guide and their ComfyUI reference workflow: distilled
+    schedule at the set resolution, the low-resolution clip as the reference at
+    half of it). `ICLoraPipeline.generate` renders its IC-conditioned stage 1
+    at HALF the dims it is handed and offers a latent-upsample stage 2 for the
+    other half, so this runner requests twice the output and skips stage 2 —
+    stage 1 then renders at the output size, conditioned on the source at its
+    native resolution, and its decode is the deliverable
+    (`_upscale_contract.conditioned_stage_request`).
+  - The schedule is the fixed distilled one: `DISTILLED_SIGMAS` is 8 steps.
+    Passing no step count selects exactly that, which is why this runner
+    exposes no steps flag.
   - Quantization-safe fusion is the runtime's own contract: `apply_loras()`
     dequantizes an int4/int8 weight, adds the delta, and re-quantizes. What it
     does NOT do is complain when an adapter addresses keys the transformer does
@@ -56,6 +65,7 @@ from _upscale_contract import (  # noqa: E402
     REFERENCE_STRENGTH,
     add_upscale_arguments,
     assert_reference_scale_fits,
+    conditioned_stage_request,
     lora_target_keys,
     read_safetensors_header,
     reference_downscale_factor,
@@ -65,6 +75,20 @@ from _upscale_contract import (  # noqa: E402
 # The 2.5 pack's own prompt conditioner. Its absence is a hard refusal rather
 # than a fallback — see the module docstring.
 TEXT_ENCODER_DIRNAME = "text_encoder"
+
+# The two layouts the pinned q8 pack documents for the distilled model. The
+# pre-fused `transformer-distilled.safetensors` is what `ICLoraPipeline.load()`
+# resolves on its own; a pack that carries only the dev transformer holds the
+# SAME model as dev weights plus the 450-step distilled LoRA, which the pack
+# README names as the equivalent non-streaming arrangement and the runtime's
+# own two-stage pipelines fuse for their distilled stage. The distilled
+# schedule this runner drives is only valid on the distilled model, so dev
+# WITHOUT that LoRA is a refusal, never a fallback.
+DEV_TRANSFORMER_FILENAME = "transformer-dev.safetensors"
+DISTILLED_LORA_FILENAME = "ltx-2.5-22b-distilled-lora-450.safetensors"
+# Full strength turns the dev weights INTO the distilled model — the pack's
+# README states the pre-fused file is this LoRA at the default strength of 1.0.
+DISTILLED_LORA_STRENGTH = 1.0
 
 FINGERPRINT_PACKAGES = ["ltx_pipelines_mlx", "ltx_core_mlx", "mlx", "mlx_metal"]
 
@@ -135,6 +159,46 @@ def resolve_transformer_path(model_dir: Path) -> "Path | None":
         return versioned[-1]
     fallback = model_dir / "transformer-distilled.safetensors"
     return fallback if fallback.is_file() else None
+
+
+def resolve_transformer_layout(model_dir: Path) -> "tuple[Path | None, Path | None]":
+    """`(transformer, distilled_lora)` for the pack — see the layout constants.
+
+    The pre-fused distilled transformer wins whenever present (`distilled_lora`
+    is then None). Otherwise the dev transformer is returned WITH the distilled
+    LoRA that turns it into the distilled model, and `(None, None)` when the
+    pack has neither the distilled file nor a dev file. A dev file whose LoRA is
+    missing is reported as `(dev, None)` so the caller can refuse it by name.
+    """
+    distilled = resolve_transformer_path(model_dir)
+    if distilled is not None:
+        return distilled, None
+    dev = model_dir / DEV_TRANSFORMER_FILENAME
+    if not dev.is_file():
+        return None, None
+    lora = model_dir / DISTILLED_LORA_FILENAME
+    return dev, (lora if lora.is_file() else None)
+
+
+def make_pipeline(pipeline_cls, model_dir: Path, transformer_path: Path, lora_paths):
+    """An `ICLoraPipeline` whose DiT is the resolved transformer, whichever layout.
+
+    `ICLoraPipeline.load()` resolves the transformer itself and knows only the
+    distilled-file layout, so a dev-layout pack has to be steered: the subclass
+    loads the resolved file first and lets `load()` skip its own resolution
+    (it only resolves when `dit` is still None). The load still happens inside
+    `generate()`, AFTER the text encoder has been freed, so nothing here holds
+    the DiT resident through prompt encoding. `lora_paths` is every adapter
+    `_fuse_loras` will add to the DiT in ONE pass — the IC adapter, and on a dev
+    layout the distilled LoRA beside it.
+    """
+    class PackLayoutPipeline(pipeline_cls):
+        def load(self):
+            if self.dit is None and not self._loaded:
+                self.dit = self._load_transformer_with_optional_streaming(transformer_path)
+            super().load()
+
+    return PackLayoutPipeline(model_dir=str(model_dir), lora_paths=list(lora_paths))
 
 
 def transformer_weight_keys(transformer_path: Path) -> "set[str]":
@@ -218,11 +282,19 @@ def main() -> None:
     # move this behind a `pipe.load()`: `generate()` deliberately loads the text
     # encoder, encodes, frees it, and only THEN loads the transformer, so
     # pre-loading would hold a multi-GB DiT resident through prompt encoding.
-    transformer_path = resolve_transformer_path(model_dir)
+    transformer_path, distilled_lora = resolve_transformer_layout(model_dir)
     if transformer_path is None:
         raise SystemExit(
             f"The LTX-2.5 pack at {model_dir} has no transformer weight file. Repair the model in Video Gen."
         )
+    if transformer_path.name == DEV_TRANSFORMER_FILENAME and distilled_lora is None:
+        raise SystemExit(
+            f"The LTX-2.5 pack at {model_dir} carries only {DEV_TRANSFORMER_FILENAME} and not the "
+            f"{DISTILLED_LORA_FILENAME} that makes it the distilled model the upscale schedule needs. "
+            "Repair the model in Video Gen."
+        )
+    layout = transformer_path.name + (f" + {distilled_lora.name}" if distilled_lora else "")
+    log(f"STATUS:Transformer layout: {layout}")
     fused = assert_adapter_fuses(
         args.ic_lora_path,
         transformer_weight_keys(transformer_path),
@@ -232,23 +304,31 @@ def main() -> None:
 
     log("STAGE:load-pipeline")
     log(f"STATUS:Loading LTX-2.5 MLX upscale pipeline ({args.width}x{args.height}, {args.num_frames} frames)")
-    pipe = ICLoraPipeline(model_dir=str(model_dir), lora_paths=[(args.ic_lora_path, 1.0)])
+    lora_paths = [(args.ic_lora_path, 1.0)]
+    if distilled_lora is not None:
+        lora_paths.append((str(distilled_lora), DISTILLED_LORA_STRENGTH))
+    pipe = make_pipeline(ICLoraPipeline, model_dir, transformer_path, lora_paths)
 
     output = Path(args.output)
     output.parent.mkdir(parents=True, exist_ok=True)
+    request_width, request_height = conditioned_stage_request(args.width, args.height)
     log("STAGE:inference")
     with heartbeat("ltx25-upscale-inference"):
-        # No stage step counts: `DISTILLED_SIGMAS` / `STAGE_2_SIGMAS` ARE the
-        # distilled schedule (8 + 3), and passing a count would truncate them.
+        # Stage 1 renders at half the requested dims — i.e. AT the output — with
+        # the source as its native-resolution reference, and `skip_stage_2`
+        # makes that stage's decode the deliverable (see the module docstring).
+        # No stage-1 step count: `DISTILLED_SIGMAS` IS the distilled schedule
+        # (8 steps), and passing a count would truncate it.
         pipe.generate_and_save(
             prompt=args.prompt,
             output_path=str(output),
             video_conditioning=[(reference, REFERENCE_STRENGTH) for reference in args.ic_reference],
-            height=args.height,
-            width=args.width,
+            height=request_height,
+            width=request_width,
             num_frames=args.num_frames,
             frame_rate=args.fps,
             seed=args.seed,
+            skip_stage_2=True,
         )
     if not output.is_file():
         raise SystemExit(f"The LTX-2.5 upscale completed but did not write {output}.")

--- a/scripts/upscale_ltx25.test.js
+++ b/scripts/upscale_ltx25.test.js
@@ -311,17 +311,17 @@ describe.skipIf(!pyBin)('upscale_ltx25.py — transformer header (#6512)', () =>
   // schedule on an un-distilled model is not a fallback, it is a wrong render.
   it('resolves the dev + distilled-LoRA layout, preferring a pre-fused distilled file', () => {
     const pack = mkdtempSync(join(tmpdir(), 'portos-ltx25-layout-'));
-    const layout = (dir) => call(`[p and p.name for p in runner.resolve_transformer_layout(__import__("pathlib").Path(${JSON.stringify(dir)}))]`);
-    expect(layout(pack)).toBe('[None, None]');
+    const layout = (dir) => call(`(lambda t, loras: [t.name, [(__import__("pathlib").Path(p).name, s) for p, s in loras]])(*runner.resolve_transformer_layout(__import__("pathlib").Path(${JSON.stringify(dir)})))`);
+    expect(layout(pack)).toMatch(/^REJECTED:.*no transformer weight file/);
 
     writeFileSync(join(pack, 'transformer-dev.safetensors'), '');
-    expect(layout(pack)).toBe("['transformer-dev.safetensors', None]");
+    expect(layout(pack)).toMatch(/^REJECTED:.*carries only transformer-dev\.safetensors/);
 
     writeFileSync(join(pack, 'ltx-2.5-22b-distilled-lora-450.safetensors'), '');
-    expect(layout(pack)).toBe("['transformer-dev.safetensors', 'ltx-2.5-22b-distilled-lora-450.safetensors']");
+    expect(layout(pack)).toBe("['transformer-dev.safetensors', [('ltx-2.5-22b-distilled-lora-450.safetensors', 1.0)]]");
 
     writeFileSync(join(pack, 'transformer-distilled.safetensors'), '');
-    expect(layout(pack)).toBe("['transformer-distilled.safetensors', None]");
+    expect(layout(pack)).toBe("['transformer-distilled.safetensors', []]");
   }, PY_TEST_TIMEOUT_MS);
 
   // `ICLoraPipeline.load()` resolves the transformer only while `dit` is None,
@@ -332,7 +332,7 @@ describe.skipIf(!pyBin)('upscale_ltx25.py — transformer header (#6512)', () =>
     const source = [
       'class FakeBase:',
       '    def __init__(self, model_dir, lora_paths=None):',
-      '        self.model_dir = model_dir; self.lora_paths = lora_paths; self.dit = None; self._loaded = False; self.calls = []',
+      '        self.model_dir = model_dir; self.lora_paths = lora_paths; self.dit = None; self.upsampler = None; self._loaded = False; self.calls = []',
       '    def _load_transformer_with_optional_streaming(self, path):',
       '        self.calls.append(path.name); return "dit"',
       '    def load(self):',
@@ -340,9 +340,11 @@ describe.skipIf(!pyBin)('upscale_ltx25.py — transformer header (#6512)', () =>
       'from pathlib import Path',
       'pipe = runner.make_pipeline(FakeBase, Path("/pack"), Path("/pack/transformer-dev.safetensors"), [("adapter", 1.0), ("distilled", 1.0)])',
       'pipe.load(); pipe.load()',
-      'print(pipe.calls, pipe.lora_paths, pipe.model_dir)',
+      // The latent upsampler slot is pre-seeded so the base load() skips the
+      // ~1 GB stage-2 weight a skip_stage_2 render never touches.
+      'print(pipe.calls, pipe.lora_paths, pipe.model_dir, pipe.upsampler is not None)',
     ].join('\n');
     expect(trimmed(runPython(`${importRunner}\n${source}`)))
-      .toBe("['transformer-dev.safetensors', 'base-load:dit', 'base-load:dit'] [('adapter', 1.0), ('distilled', 1.0)] /pack");
+      .toBe("['transformer-dev.safetensors', 'base-load:dit', 'base-load:dit'] [('adapter', 1.0), ('distilled', 1.0)] /pack True");
   }, PY_TEST_TIMEOUT_MS);
 });

--- a/scripts/upscale_ltx25.test.js
+++ b/scripts/upscale_ltx25.test.js
@@ -194,14 +194,27 @@ describe.skipIf(!pyBin)('upscale_ltx25.py — adapter metadata (#6512)', () => {
     expect(call(`repr(runner.read_safetensors_header(${JSON.stringify(join(scratch, 'nope.safetensors'))}))`)).toBe('None');
   }, PY_TEST_TIMEOUT_MS);
 
-  // The rule the pipeline enforces applies to the STAGE-1 dims, which are half
-  // the output — so a factor of 2 really demands an output divisible by 4. The
-  // message has to speak in output terms because that is what the user chose.
-  it('enforces the adapter factor against the half-resolution stage dims', () => {
+  // The conditioned stage renders AT the output, so the reference is
+  // `output / factor` — and it has to land on the VAE's 32-pixel grid at the
+  // source's own size, or the source is resampled before it conditions
+  // anything. A factor of 2 therefore demands an output divisible by 64, and a
+  // factor of 4 by 128. The message speaks in output terms because that is
+  // what the user chose.
+  it('enforces the adapter factor against the output the conditioned stage renders at', () => {
     expect(call('runner.assert_reference_scale_fits(2, 1728, 1024) or "OK"')).toBe('OK');
     expect(call('runner.assert_reference_scale_fits(1, 100, 100) or "OK"')).toBe('OK');
-    expect(call('runner.assert_reference_scale_fits(4, 1028, 1024) or "OK"'))
-      .toMatch(/^REJECTED:.*divisible by 8/);
+    expect(call('runner.assert_reference_scale_fits(2, 1056, 1024) or "OK"'))
+      .toMatch(/^REJECTED:.*divisible by 64/);
+    expect(call('runner.assert_reference_scale_fits(4, 1088, 1024) or "OK"'))
+      .toMatch(/^REJECTED:.*divisible by 128/);
+  }, PY_TEST_TIMEOUT_MS);
+
+  // Both pipelines render their IC-conditioned stage at HALF the dims they are
+  // handed. The recipe is single-stage at the output with the source at half,
+  // so the runner asks for twice the output and skips stage 2 — a runner that
+  // passed the output through would condition on a further-downscaled source.
+  it('requests twice the output so the conditioned stage renders at the output size', () => {
+    expect(call('runner.conditioned_stage_request(1024, 576)')).toBe('(2048, 1152)');
   }, PY_TEST_TIMEOUT_MS);
 
   // `apply_loras` pairs lora_A with lora_B per weight and skips a prefix missing
@@ -289,5 +302,47 @@ describe.skipIf(!pyBin)('upscale_ltx25.py — transformer header (#6512)', () =>
 
     writeFileSync(join(pack, 'transformer.safetensors'), '');
     expect(resolve(pack)).toBe("'transformer.safetensors'");
+  }, PY_TEST_TIMEOUT_MS);
+
+  // The pinned q8 pack documents two layouts for the distilled model: the
+  // pre-fused file, or the dev transformer plus the 450-step distilled LoRA.
+  // The pipeline's own loader knows only the first, so the runner resolves the
+  // layout itself — and refuses dev WITHOUT the LoRA, because the distilled
+  // schedule on an un-distilled model is not a fallback, it is a wrong render.
+  it('resolves the dev + distilled-LoRA layout, preferring a pre-fused distilled file', () => {
+    const pack = mkdtempSync(join(tmpdir(), 'portos-ltx25-layout-'));
+    const layout = (dir) => call(`[p and p.name for p in runner.resolve_transformer_layout(__import__("pathlib").Path(${JSON.stringify(dir)}))]`);
+    expect(layout(pack)).toBe('[None, None]');
+
+    writeFileSync(join(pack, 'transformer-dev.safetensors'), '');
+    expect(layout(pack)).toBe("['transformer-dev.safetensors', None]");
+
+    writeFileSync(join(pack, 'ltx-2.5-22b-distilled-lora-450.safetensors'), '');
+    expect(layout(pack)).toBe("['transformer-dev.safetensors', 'ltx-2.5-22b-distilled-lora-450.safetensors']");
+
+    writeFileSync(join(pack, 'transformer-distilled.safetensors'), '');
+    expect(layout(pack)).toBe("['transformer-distilled.safetensors', None]");
+  }, PY_TEST_TIMEOUT_MS);
+
+  // `ICLoraPipeline.load()` resolves the transformer only while `dit` is None,
+  // so steering a dev-layout pack means loading the resolved file first and
+  // letting the base `load()` skip its own resolution. Exercised against a
+  // stand-in base class so the contract is pinned without the MLX wheel.
+  it('loads the resolved transformer before the base pipeline resolves its own', () => {
+    const source = [
+      'class FakeBase:',
+      '    def __init__(self, model_dir, lora_paths=None):',
+      '        self.model_dir = model_dir; self.lora_paths = lora_paths; self.dit = None; self._loaded = False; self.calls = []',
+      '    def _load_transformer_with_optional_streaming(self, path):',
+      '        self.calls.append(path.name); return "dit"',
+      '    def load(self):',
+      '        self.calls.append("base-load:" + str(self.dit)); self._loaded = True',
+      'from pathlib import Path',
+      'pipe = runner.make_pipeline(FakeBase, Path("/pack"), Path("/pack/transformer-dev.safetensors"), [("adapter", 1.0), ("distilled", 1.0)])',
+      'pipe.load(); pipe.load()',
+      'print(pipe.calls, pipe.lora_paths, pipe.model_dir)',
+    ].join('\n');
+    expect(trimmed(runPython(`${importRunner}\n${source}`)))
+      .toBe("['transformer-dev.safetensors', 'base-load:dit', 'base-load:dit'] [('adapter', 1.0), ('distilled', 1.0)] /pack");
   }, PY_TEST_TIMEOUT_MS);
 });

--- a/scripts/upscale_ltx25.test.js
+++ b/scripts/upscale_ltx25.test.js
@@ -342,9 +342,11 @@ describe.skipIf(!pyBin)('upscale_ltx25.py — transformer header (#6512)', () =>
       'pipe.load(); pipe.load()',
       // The latent upsampler slot is pre-seeded so the base load() skips the
       // ~1 GB stage-2 weight a skip_stage_2 render never touches.
-      'print(pipe.calls, pipe.lora_paths, pipe.model_dir, pipe.upsampler is not None)',
+      // `model_dir` is compared by its last segment: it is passed through
+      // `str(Path)`, which renders the separator per platform.
+      'print(pipe.calls, pipe.lora_paths, Path(pipe.model_dir).name, pipe.upsampler is not None)',
     ].join('\n');
     expect(trimmed(runPython(`${importRunner}\n${source}`)))
-      .toBe("['transformer-dev.safetensors', 'base-load:dit', 'base-load:dit'] [('adapter', 1.0), ('distilled', 1.0)] /pack True");
+      .toBe("['transformer-dev.safetensors', 'base-load:dit', 'base-load:dit'] [('adapter', 1.0), ('distilled', 1.0)] pack True");
   }, PY_TEST_TIMEOUT_MS);
 });

--- a/scripts/upscale_ltx25_cuda.py
+++ b/scripts/upscale_ltx25_cuda.py
@@ -18,14 +18,11 @@ installs), not inferred from the gated model card:
     that `generate_ltx25_cuda.py` already drives `DistilledPipeline` with, so
     the FP8 cast policy and disk streaming that make a 22B model fit a consumer
     card carry over unchanged. It fuses the adapter into STAGE 1 only
-    (`stage_2` is built with `loras=()`), and stage 1 renders at HALF the
+    (`stage_2` is built with `loras=()`) and renders that stage at HALF the
     `height`/`width` it is handed — so, exactly like the MLX runner, this one
-    requests twice the output and passes `skip_stage_2=True`: the conditioned
-    stage renders at the output size with the source as a native-resolution
-    reference and its decode is the deliverable
-    (`_upscale_contract.conditioned_stage_request`). That is the standard
-    single-stage IC-LoRA video-to-video recipe Lightricks documents for the
-    upscaler; the latent-upsample stage 2 never runs.
+    requests twice the output and passes `skip_stage_2=True` (see
+    `PIPELINE_REQUEST_MULTIPLIER` in `_upscale_contract.py`); the
+    latent-upsample stage 2 never runs.
   - The LoRA is a `LoraPathStrengthAndSDOps(path, strength, sd_ops)` and the
     `sd_ops` is the runtime's own `LTXV_LORA_COMFY_RENAMING_MAP`. Both come
     from `ltx_core.loader`; naming the map here rather than reimplementing it
@@ -252,9 +249,8 @@ def main() -> None:
     header = read_safetensors_header(args.ic_lora_path)
     scale = reference_downscale_factor(header)
     assert_reference_scale_fits(scale, args.width, args.height)
-    # Recorded rather than guessed: `icLoraWeights.js` holds `null` for this
-    # gated weight precisely because nobody had opened it, and this line is the
-    # measurement (#6508's registry note points here).
+    # The per-install measurement the queue records beside the registry's
+    # declared value — a re-pinned weight is measured, not trusted.
     log(f"UPSCALE_REFERENCE_DOWNSCALE:{scale}")
 
     log("STAGE:verify-adapter")
@@ -320,8 +316,8 @@ def main() -> None:
     request_width, request_height = conditioned_stage_request(args.width, args.height)
     log("STAGE:inference")
     with heartbeat("ltx25-cuda-upscale-inference"):
-        # Stage 1 renders at half the requested dims — i.e. AT the output — and
-        # `skip_stage_2` makes its decode the deliverable (module docstring).
+        # Twice the output + `skip_stage_2` = one conditioned stage AT the
+        # output (see `conditioned_stage_request`).
         # No sigma override: `DISTILLED_SIGMAS` IS the distilled schedule (8)
         # and is this call's stage-1 default. `images=[]` because the
         # reference is the clip, not a still.

--- a/scripts/upscale_ltx25_cuda.py
+++ b/scripts/upscale_ltx25_cuda.py
@@ -18,8 +18,14 @@ installs), not inferred from the gated model card:
     that `generate_ltx25_cuda.py` already drives `DistilledPipeline` with, so
     the FP8 cast policy and disk streaming that make a 22B model fit a consumer
     card carry over unchanged. It fuses the adapter into STAGE 1 only
-    (`stage_2` is built with `loras=()`), which is correct here: stage 2 is the
-    latent-upsample refinement pass, not the conditioned one.
+    (`stage_2` is built with `loras=()`), and stage 1 renders at HALF the
+    `height`/`width` it is handed — so, exactly like the MLX runner, this one
+    requests twice the output and passes `skip_stage_2=True`: the conditioned
+    stage renders at the output size with the source as a native-resolution
+    reference and its decode is the deliverable
+    (`_upscale_contract.conditioned_stage_request`). That is the standard
+    single-stage IC-LoRA video-to-video recipe Lightricks documents for the
+    upscaler; the latent-upsample stage 2 never runs.
   - The LoRA is a `LoraPathStrengthAndSDOps(path, strength, sd_ops)` and the
     `sd_ops` is the runtime's own `LTXV_LORA_COMFY_RENAMING_MAP`. Both come
     from `ltx_core.loader`; naming the map here rather than reimplementing it
@@ -39,12 +45,12 @@ installs), not inferred from the gated model card:
     requires the raw `model.diffusion_model.` prefix and strips it; the LoRA
     map strips a bare `diffusion_model.`. The two meet on the same base names,
     which is exactly what the guard verifies rather than assumes.
-  - The schedule is the fixed distilled one — `DISTILLED_SIGMAS` (8) and
-    `STAGE_2_DISTILLED_SIGMAS` (3) are `__call__` defaults — which is why this
-    runner, like the MLX one, exposes no steps flag.
-  - `assert_resolution(..., is_two_stage=True)` enforces the same `% 64` rule
-    the shared contract does, so a source is refused before a GPU rather than
-    inside the pipeline.
+  - The schedule is the fixed distilled one — `DISTILLED_SIGMAS` (8) is the
+    `__call__` default for stage 1 — which is why this runner, like the MLX
+    one, exposes no steps flag.
+  - `assert_resolution(..., is_two_stage=True)` demands `% 64` of the REQUEST,
+    which the shared contract's `% 64` rule on the output satisfies twice over,
+    so a source is refused before a GPU rather than inside the pipeline.
 
 Audio is deliberately NOT taken from the model. `encode_video` is called with
 `audio=None` and `finalizeUpscaleOutput` (`upscaleFfmpeg.js`) re-muxes the
@@ -73,6 +79,7 @@ from _upscale_contract import (  # noqa: E402
     REFERENCE_STRENGTH,
     add_upscale_arguments,
     assert_reference_scale_fits,
+    conditioned_stage_request,
     entry_shape,
     lora_delta_shapes,
     read_safetensors_header,
@@ -310,21 +317,25 @@ def main() -> None:
             offload_mode=OffloadMode.DISK,
         )
 
+    request_width, request_height = conditioned_stage_request(args.width, args.height)
     log("STAGE:inference")
     with heartbeat("ltx25-cuda-upscale-inference"):
-        # No sigma overrides: `DISTILLED_SIGMAS` / `STAGE_2_DISTILLED_SIGMAS`
-        # ARE the distilled schedule (8 + 3) and are this call's defaults.
-        # `images=[]` because the reference is the clip, not a still.
+        # Stage 1 renders at half the requested dims — i.e. AT the output — and
+        # `skip_stage_2` makes its decode the deliverable (module docstring).
+        # No sigma override: `DISTILLED_SIGMAS` IS the distilled schedule (8)
+        # and is this call's stage-1 default. `images=[]` because the
+        # reference is the clip, not a still.
         video, _audio, tiling = pipe(
             prompt=args.prompt,
             seed=args.seed,
-            height=args.height,
-            width=args.width,
+            height=request_height,
+            width=request_width,
             num_frames=args.num_frames,
             frame_rate=args.fps,
             images=[],
             video_conditioning=[(reference, REFERENCE_STRENGTH) for reference in args.ic_reference],
             tiling_config=AUTO_TILING,
+            skip_stage_2=True,
         )
 
     output = Path(args.output)

--- a/scripts/upscale_ltx25_cuda.test.js
+++ b/scripts/upscale_ltx25_cuda.test.js
@@ -321,11 +321,18 @@ describe.skipIf(!pyBin)('upscale_ltx25_cuda.py — adapter fusion guard (#6513)'
 // the MLX runner, exercised here because this runner is the one that would
 // commit a CUDA render to it.
 describe.skipIf(!pyBin)('upscale_ltx25_cuda.py — reference downscale factor (#6513)', () => {
-  it('reads the factor off the weight and enforces it against the stage-1 dims', () => {
+  it('reads the factor off the weight and enforces it against the output the conditioned stage renders at', () => {
     expect(call(`runner.reference_downscale_factor(runner.read_safetensors_header(${JSON.stringify(ADAPTER)}))`))
       .toBe('2');
     expect(call('runner.assert_reference_scale_fits(2, 1728, 1024) or "OK"')).toBe('OK');
-    expect(call('runner.assert_reference_scale_fits(4, 1028, 1024) or "OK"'))
-      .toMatch(/^REJECTED:.*divisible by 8/);
+    expect(call('runner.assert_reference_scale_fits(4, 1088, 1024) or "OK"'))
+      .toMatch(/^REJECTED:.*divisible by 128/);
+  }, PY_TEST_TIMEOUT_MS);
+
+  // Same recipe as MLX: upstream's `ICLoraPipeline` renders stage 1 at half
+  // the dims it is handed, so the runner requests twice the output and skips
+  // stage 2. Shared through the contract module so the two cannot drift.
+  it('requests twice the output through the shared contract', () => {
+    expect(call('runner.conditioned_stage_request(1024, 576)')).toBe('(2048, 1152)');
   }, PY_TEST_TIMEOUT_MS);
 });

--- a/scripts/upscale_ltx25_cuda.test.js
+++ b/scripts/upscale_ltx25_cuda.test.js
@@ -134,7 +134,7 @@ describe.skipIf(!pyBin)('upscale_ltx25_cuda.py — one argv for both backends (#
     ]);
   }, PY_TEST_TIMEOUT_MS);
 
-  // The distilled schedule is fixed at 8 + 3 sigmas on both runtimes, so there
+  // The distilled schedule is fixed at 8 sigmas on both runtimes, so there
   // is nothing for a steps flag to select; and the pass carries no prompt,
   // because the source clip is the whole conditioning signal.
   it('exposes no steps flag and defaults the prompt to empty', () => {
@@ -316,10 +316,11 @@ describe.skipIf(!pyBin)('upscale_ltx25_cuda.py — adapter fusion guard (#6513)'
   }, PY_TEST_TIMEOUT_MS);
 });
 
-// The adapter's declared factor applies to the STAGE-1 dims, which are half the
-// output — so a factor of 2 really demands an output divisible by 4. Shared with
-// the MLX runner, exercised here because this runner is the one that would
-// commit a CUDA render to it.
+// The adapter's declared factor applies to the output the conditioned stage
+// renders at, and the reference must land on the VAE's 32-pixel grid at the
+// source's own size — so a factor of N demands an output divisible by N × 32.
+// Shared with the MLX runner, exercised here because this runner is the one
+// that would commit a CUDA render to it.
 describe.skipIf(!pyBin)('upscale_ltx25_cuda.py — reference downscale factor (#6513)', () => {
   it('reads the factor off the weight and enforces it against the output the conditioned stage renders at', () => {
     expect(call(`runner.reference_downscale_factor(runner.read_safetensors_header(${JSON.stringify(ADAPTER)}))`))

--- a/server/lib/icLoraWeights.js
+++ b/server/lib/icLoraWeights.js
@@ -313,11 +313,10 @@ export const assertIcReferenceCount = (spec, count, fail) => {
 // requires the OUTPUT dimensions to divide evenly by it. Returns a human message
 // when they don't, else null. Mirrored client-side (icResolutionIssue in
 // client/src/lib/videoGenParams.js) so the form can warn before submit.
-// A `null`/absent factor is UNKNOWN, not 1 — the weight's metadata hasn't been
-// read yet (a gated file nobody with accepted terms has opened). Both resolve
-// to "assert no rule", but they must stay distinguishable: guessing a factor
-// here would either reject valid resolutions or green-light ones the pipeline
-// will refuse deep inside a render.
+// A `null`/absent factor is UNKNOWN, not 1 — a weight whose metadata has not
+// been read. Both resolve to "assert no rule", but they must stay
+// distinguishable: guessing a factor here would either reject valid
+// resolutions or green-light ones the pipeline will refuse deep inside a render.
 export const icResolutionIssue = (spec, width, height) => {
   const scale = spec?.referenceDownscaleFactor;
   if (typeof scale !== 'number' || !Number.isFinite(scale) || scale <= 1) return null;
@@ -328,9 +327,9 @@ export const icResolutionIssue = (spec, width, height) => {
 /**
  * The reference downscale factor a spec's DOWNLOADED weight actually declares.
  *
- * `referenceDownscaleFactor` on the registry entry is what this repo could
- * verify when the entry was written; for a gated weight that is `null`. This
- * reads the truth off the file an install holds — the same
+ * `referenceDownscaleFactor` on the registry entry is what was verified when
+ * the entry was written (`null` for a weight nobody has opened). This reads
+ * the truth off the file an install holds — the same
  * `__metadata__.reference_downscale_factor` the MLX pipeline itself reads
  * (`iclora_utils.read_lora_reference_downscale_factor`) — so the resolution
  * rule can be stated before a render commits to it.

--- a/server/lib/icLoraWeights.js
+++ b/server/lib/icLoraWeights.js
@@ -170,20 +170,16 @@ export const IC_LORA_MODES = Object.freeze({
     revision: '5863fdef3eaa8b2d69fa22e259a1d75fede215dd',
     // Exact, from the repo's blob listing — not an estimate. Do not round it.
     sizeBytes: 327_322_640,
-    // UNKNOWN, deliberately, and it STAYS unknown here. Every other entry's
-    // factor was read from the weight's safetensors `__metadata__`; this
-    // weight's file is gated, so there is nothing for the repo to read. `null`
-    // means "no constraint asserted", which icResolutionIssue treats as "impose
-    // no rule" rather than guessing a factor and either rejecting valid
-    // resolutions or green-lighting bad ones.
-    //
-    // #6512 resolved this by MEASURING instead of transcribing: an install that
-    // has accepted the terms and downloaded the weight reads the real value out
-    // of the file it holds (`readIcLoraReferenceDownscaleFactor` below, and
-    // `reference_downscale_factor` in `scripts/upscale_ltx25.py`, which enforces
-    // it). Hardcoding a number here would put a value nobody in this repo can
-    // verify ahead of the one every user can — so leave it null.
-    referenceDownscaleFactor: null,
+    // Read from the weight's safetensors `__metadata__.reference_downscale_factor`
+    // — "2" — on 2026-09-07, off the file at the pinned revision above
+    // (sha256 984851b769ea2bcb4c9e0a239a7676239e42c6a6001ddc69943b41ff0b283c1d),
+    // on an install that had accepted the license (#6512). The model card
+    // states the same value. The entry was `null` until then precisely because
+    // the file is gated and nothing in this repo could open it; the value here
+    // is the DECLARED one, and `readIcLoraReferenceDownscaleFactor` below still
+    // reads the real file whenever an install holds it, so a re-pinned weight
+    // that changes its factor is measured rather than trusted.
+    referenceDownscaleFactor: 2,
     // The clip being upscaled is the single reference.
     minReferences: 1,
     maxReferences: 1,

--- a/server/lib/icLoraWeights.test.js
+++ b/server/lib/icLoraWeights.test.js
@@ -120,13 +120,15 @@ describe('IC-LoRA registry', () => {
     expect(icResolutionIssue(IC_LORA_MODES.control, 704, 448)).toBeNull();
   });
 
-  it('asserts no resolution rule for a weight whose factor has not been read', () => {
-    // The upscaler's file is gated, so its `reference_downscale_factor` is
-    // unknown rather than known-to-be-1. Guessing either way is the bug: a
-    // guessed 2 rejects valid resolutions, and treating a non-number as a
-    // divisor produces a nonsense message. Both must yield "no rule".
-    expect(IC_LORA_MODES['pixel-upscale'].referenceDownscaleFactor).toBeNull();
-    expect(icResolutionIssue(IC_LORA_MODES['pixel-upscale'], 705, 449)).toBeNull();
+  it('applies the upscaler factor now that it has been measured, and no rule for an unread one', () => {
+    // The upscaler's factor was read off the gated weight (#6512), so the
+    // plan can state its rule before a download. A weight whose factor is
+    // genuinely unknown must still yield "no rule": guessing rejects valid
+    // resolutions, and treating a non-number as a divisor produces a nonsense
+    // message.
+    expect(icResolutionIssue(IC_LORA_MODES['pixel-upscale'], 705, 449)).toMatch(/divisible by 2/);
+    expect(icResolutionIssue(IC_LORA_MODES['pixel-upscale'], 704, 448)).toBeNull();
+    expect(icResolutionIssue({ referenceDownscaleFactor: null }, 705, 449)).toBeNull();
     expect(icResolutionIssue({ referenceDownscaleFactor: undefined }, 705, 449)).toBeNull();
     expect(icResolutionIssue({ referenceDownscaleFactor: '2' }, 705, 449)).toBeNull();
   });
@@ -411,18 +413,22 @@ describe('the LTX-2.5 Pixel Spatial Upscaler weight (#6502)', () => {
   });
 });
 
-// #6512. The Pixel Spatial Upscaler entry holds `referenceDownscaleFactor: null`
-// because its file is gated and nobody in this repo can read it — so the value
-// is MEASURED off the weight an install downloaded rather than transcribed from
-// a card. `measured` is what keeps "the weight declares 1" apart from "nobody
-// has read it yet": both impose no rule, but only one is a fact.
+// #6512. The Pixel Spatial Upscaler's factor was MEASURED off the gated weight
+// once an install could open it, and the registry now declares that value — but
+// the file is still read whenever it is present, so `measured` keeps "the
+// registry says 2" apart from "this file says 2": a re-pinned weight that
+// changes its factor is measured rather than trusted.
 describe('readIcLoraReferenceDownscaleFactor', () => {
   const upscaler = () => icLoraSpecByKey('pixel-upscale');
+
+  it('declares the measured factor so the plan can state the rule before the weight is downloaded', () => {
+    expect(upscaler().referenceDownscaleFactor).toBe(2);
+  });
 
   it('falls back to the registry value when nothing is cached, without reading a file', async () => {
     mockFindCachedRepoFile.mockResolvedValue(null);
     expect(await readIcLoraReferenceDownscaleFactor(upscaler()))
-      .toEqual({ factor: null, measured: false });
+      .toEqual({ factor: 2, measured: false });
     expect(mockReadSafetensorsHeader).not.toHaveBeenCalled();
   });
 
@@ -444,12 +450,13 @@ describe('readIcLoraReferenceDownscaleFactor', () => {
   });
 
   // An UNREADABLE header is not a measurement of anything. Collapsing it into a
-  // measured 1 would assert a rule off a file we failed to open.
+  // measured 1 would assert a rule off a file we failed to open; the declared
+  // registry value stands, unmeasured.
   it('does not claim a measurement when the header cannot be read', async () => {
     mockFindCachedRepoFile.mockResolvedValue('/cache/truncated.safetensors');
     mockReadSafetensorsHeader.mockResolvedValue(null);
     expect(await readIcLoraReferenceDownscaleFactor(upscaler()))
-      .toEqual({ factor: null, measured: false });
+      .toEqual({ factor: 2, measured: false });
   });
 
   // A 2.3 weight already carries a verified number, so a cached read must agree

--- a/server/services/videoGen/generateVideoHelpers.js
+++ b/server/services/videoGen/generateVideoHelpers.js
@@ -145,17 +145,14 @@ export function makeVideoGenLineHandler({ job, jobId, pythonNoiseRe }) {
     // job so finalizeGeneratedVideo can persist it on the history record, and
     // log a single self-documenting line so a render that produced garbled
     // output can be tied to a specific ltx/mlx/torch + chip + OS stack.
-    if (line.startsWith('RUNTIME:')) {
-      try {
-        const fp = JSON.parse(line.slice('RUNTIME:'.length));
-        job.runtime = fp;
-        console.log(`🏷️ runtime [${jobId.slice(0, 8)}] ${formatRuntimeFingerprint(fp) || '?'}`);
-        return true;
-      } catch {
-        // Malformed fingerprint line — fall through to raw-logging so the
-        // broken payload is visible rather than silently swallowed.
-        return false;
-      }
+    if (line.startsWith(RUNTIME_LINE_PREFIX)) {
+      const fp = parseRuntimeFingerprintLine(line);
+      // Malformed fingerprint line — fall through to raw-logging so the
+      // broken payload is visible rather than silently swallowed.
+      if (!fp) return false;
+      job.runtime = fp;
+      console.log(`🏷️ runtime [${jobId.slice(0, 8)}] ${formatRuntimeFingerprint(fp) || '?'}`);
+      return true;
     }
     // What the runner ACTUALLY applied of a requested speed profile
     // (SPEEDPROFILE:<json> — see scripts/generate_ltx2.py). PortOS asks for a
@@ -355,6 +352,29 @@ export function describeRenderConditioning({
   if (audioFilePath) kinds.push('audio');
   if (Array.isArray(icReferencePaths) && icReferencePaths.length > 0) kinds.push('icReference');
   return kinds.sort();
+}
+
+// The one-line protocol every helper script announces its stack on at startup
+// (`scripts/_runner_common.py emit_runtime_fingerprint`). Parsed here for the
+// render path and the upscale job alike, so a payload-shape change has one
+// consumer to update.
+export const RUNTIME_LINE_PREFIX = 'RUNTIME:';
+
+/**
+ * The fingerprint object carried by a `RUNTIME:<json>` line, or null when the
+ * line is not one or its payload is malformed — the caller decides whether a
+ * broken payload is logged raw or dropped.
+ * @param {string} line - one trimmed child-output line
+ * @returns {object|null}
+ */
+export function parseRuntimeFingerprintLine(line) {
+  if (typeof line !== 'string' || !line.startsWith(RUNTIME_LINE_PREFIX)) return null;
+  try {
+    const fp = JSON.parse(line.slice(RUNTIME_LINE_PREFIX.length));
+    return fp && typeof fp === 'object' ? fp : null;
+  } catch {
+    return null;
+  }
 }
 
 /**

--- a/server/services/videoGen/upscaleJob.js
+++ b/server/services/videoGen/upscaleJob.js
@@ -50,6 +50,14 @@ import {
 
 const MAX_SEED = 2 ** 32 - 1;
 const STAGE_RE = /^STAGE:\s*(\S+)\s*(.*)$/;
+// Both runners emit these once, before the pipeline loads: the runtime
+// fingerprint (`scripts/_runner_common.py emit_runtime_fingerprint`) and the
+// adapter's `reference_downscale_factor` read off the weight. They are
+// provenance, so they are captured here and written onto the history row —
+// a render can then be tied to the exact ltx/mlx/torch + chip stack and the
+// factor it enforced, the way a plain render's row carries `runtime`.
+const RUNTIME_PREFIX = 'RUNTIME:';
+const REFERENCE_DOWNSCALE_RE = /^UPSCALE_REFERENCE_DOWNSCALE:\s*(\d+)\s*$/;
 const STDERR_TAIL_LINES = 20;
 
 // jobId → the in-flight run's cancel handles. Module-local rather than the
@@ -212,6 +220,7 @@ const runUpscaleChild = async ({ jobId, bin, args, runtime, entry }) => {
   // so signal it immediately instead of waiting for a render nobody wants.
   if (entry.canceled) cancel(jobId);
   const stderrTail = [];
+  const provenance = { runtime: null, referenceDownscale: null };
   const onLine = (line, isStderr) => {
     const text = String(line).trim();
     if (!text || PYTHON_NOISE_RE.test(text)) return;
@@ -220,6 +229,17 @@ const runUpscaleChild = async ({ jobId, bin, args, runtime, entry }) => {
       if (stderrTail.length > STDERR_TAIL_LINES) stderrTail.shift();
     }
     videoGenEvents.emit('activity', { generationId: jobId });
+    if (text.startsWith(RUNTIME_PREFIX)) {
+      // A malformed payload stays in the stderr tail rather than becoming a
+      // half-parsed fingerprint on the row.
+      try { provenance.runtime = JSON.parse(text.slice(RUNTIME_PREFIX.length)); } catch { /* keep null */ }
+      return;
+    }
+    const downscale = REFERENCE_DOWNSCALE_RE.exec(text);
+    if (downscale) {
+      provenance.referenceDownscale = Number(downscale[1]);
+      return;
+    }
     const stage = STAGE_RE.exec(text);
     if (stage) {
       videoGenEvents.emit('status', { generationId: jobId, phase: stage[1], message: stage[2] || stage[1] });
@@ -240,7 +260,7 @@ const runUpscaleChild = async ({ jobId, bin, args, runtime, entry }) => {
     };
     proc.on('error', (err) => settle({ ok: false, reason: `spawn failed: ${err.message}` }));
     proc.on('close', (code, signal) => {
-      if (code === 0) { settle({ ok: true }); return; }
+      if (code === 0) { settle({ ok: true, ...provenance }); return; }
       const tail = stderrTail.slice(-4).join(' | ');
       const how = signal ? `killed (${signal})` : `exit ${code}`;
       settle({ ok: false, reason: tail ? `upscale runner ${how}: ${tail}` : `upscale runner ${how}` });
@@ -394,6 +414,12 @@ export async function runVideoUpscale({
       upscaleMethod: 'ltx',
       upscaleRuntime: runtime,
       upscaleAdapter: adapterKey,
+      // Measured by the runner off the weight it fused, and the rule it
+      // enforced — null when the runner did not report one.
+      upscaleReferenceDownscale: rendered.referenceDownscale ?? null,
+      // Same shape a plain render's row carries: the exact ltx/mlx/torch +
+      // chip + OS stack this clip rendered on. Absent when not reported.
+      ...(rendered.runtime ? { runtime: rendered.runtime } : {}),
       // What the grid actually required of this source, kept beside the result
       // so a reader can tell a padded render from a conforming one.
       upscaleAlignment: {

--- a/server/services/videoGen/upscaleJob.js
+++ b/server/services/videoGen/upscaleJob.js
@@ -38,6 +38,7 @@ import { resolveIcLoraWeightByKey } from '../../lib/icLoraWeights.js';
 import { hfChildEnv } from '../hfToken.js';
 import { enqueueJob } from '../mediaJobQueue/index.js';
 import { videoGenEvents } from './events.js';
+import { RUNTIME_LINE_PREFIX, parseRuntimeFingerprintLine, formatRuntimeFingerprint } from './generateVideoHelpers.js';
 import { getHistoryItem, loadHistory, mutateVideoHistory } from './history.js';
 import { buildArgs } from './renderArgs.js';
 import { runtimeIsCacheOnly, runtimeNeedsProcessGroupKill } from './runtimes.js';
@@ -51,12 +52,11 @@ import {
 const MAX_SEED = 2 ** 32 - 1;
 const STAGE_RE = /^STAGE:\s*(\S+)\s*(.*)$/;
 // Both runners emit these once, before the pipeline loads: the runtime
-// fingerprint (`scripts/_runner_common.py emit_runtime_fingerprint`) and the
+// fingerprint (parsed by the same helper the render path uses) and the
 // adapter's `reference_downscale_factor` read off the weight. They are
 // provenance, so they are captured here and written onto the history row —
 // a render can then be tied to the exact ltx/mlx/torch + chip stack and the
 // factor it enforced, the way a plain render's row carries `runtime`.
-const RUNTIME_PREFIX = 'RUNTIME:';
 const REFERENCE_DOWNSCALE_RE = /^UPSCALE_REFERENCE_DOWNSCALE:\s*(\d+)\s*$/;
 const STDERR_TAIL_LINES = 20;
 
@@ -229,10 +229,13 @@ const runUpscaleChild = async ({ jobId, bin, args, runtime, entry }) => {
       if (stderrTail.length > STDERR_TAIL_LINES) stderrTail.shift();
     }
     videoGenEvents.emit('activity', { generationId: jobId });
-    if (text.startsWith(RUNTIME_PREFIX)) {
+    if (text.startsWith(RUNTIME_LINE_PREFIX)) {
       // A malformed payload stays in the stderr tail rather than becoming a
       // half-parsed fingerprint on the row.
-      try { provenance.runtime = JSON.parse(text.slice(RUNTIME_PREFIX.length)); } catch { /* keep null */ }
+      const fp = parseRuntimeFingerprintLine(text);
+      if (!fp) return;
+      provenance.runtime = fp;
+      console.log(`🏷️ runtime [${jobId.slice(0, 8)}] ${formatRuntimeFingerprint(fp) || '?'}`);
       return;
     }
     const downscale = REFERENCE_DOWNSCALE_RE.exec(text);
@@ -414,11 +417,11 @@ export async function runVideoUpscale({
       upscaleMethod: 'ltx',
       upscaleRuntime: runtime,
       upscaleAdapter: adapterKey,
-      // Measured by the runner off the weight it fused, and the rule it
-      // enforced — null when the runner did not report one.
-      upscaleReferenceDownscale: rendered.referenceDownscale ?? null,
-      // Same shape a plain render's row carries: the exact ltx/mlx/torch +
-      // chip + OS stack this clip rendered on. Absent when not reported.
+      // Measured by the runner off the weight it fused (the rule it enforced),
+      // and — in the same shape a plain render's row carries — the exact
+      // ltx/mlx/torch + chip + OS stack this clip rendered on. Both are absent
+      // sentinels when the runner did not report them, never a guessed value.
+      ...(rendered.referenceDownscale !== null ? { upscaleReferenceDownscale: rendered.referenceDownscale } : {}),
       ...(rendered.runtime ? { runtime: rendered.runtime } : {}),
       // What the grid actually required of this source, kept beside the result
       // so a reader can tell a padded render from a conforming one.

--- a/server/services/videoGen/upscaleJob.test.js
+++ b/server/services/videoGen/upscaleJob.test.js
@@ -299,6 +299,30 @@ describe('local-only (#6511 item 7)', () => {
 });
 
 describe('runVideoUpscale — success', () => {
+  // Both runners announce the fingerprint of the stack they run on and the
+  // factor they read off the adapter before the pipeline loads. Those are
+  // provenance: a clip must be traceable to the exact runtime and the rule it
+  // enforced, the way a plain render's row carries `runtime` (#6512).
+  it('records the runtime fingerprint and measured reference factor the runner reports', async () => {
+    const fingerprint = { runtime: 'ltx25', versions: { mlx: '0.32.0' }, chip: 'Apple Mx' };
+    const entry = await runWith(() => {
+      state.child.stderr.emit('data', 'UPSCALE_REFERENCE_DOWNSCALE:2\n');
+      state.child.stderr.emit('data', `RUNTIME:${JSON.stringify(fingerprint)}\n`);
+      state.child.stderr.emit('data', 'STAGE:inference\n');
+      finishChild(0);
+    });
+    expect(entry.upscaleReferenceDownscale).toBe(2);
+    expect(entry.runtime).toEqual(fingerprint);
+  });
+
+  it('keeps a malformed fingerprint line off the row instead of half-parsing it', async () => {
+    const entry = await runWith(() => {
+      state.child.stderr.emit('data', 'RUNTIME:{not json\n');
+      finishChild(0);
+    });
+    expect(entry.runtime).toBeUndefined();
+  });
+
   it('writes a new history row carrying the full provenance contract', async () => {
     const completed = [];
     videoGenEvents.on('completed', (e) => completed.push(e));
@@ -322,6 +346,10 @@ describe('runVideoUpscale — success', () => {
       hidden: false,
     });
     expect(entry.renderMs).toBeGreaterThanOrEqual(0);
+    // Nothing reported by the runner → explicit absent sentinels, never a
+    // guessed factor or a half-parsed fingerprint.
+    expect(entry.upscaleReferenceDownscale).toBeNull();
+    expect(entry.runtime).toBeUndefined();
     // The source render's timing must not ride along on a row that only paid
     // for the upscale.
     expect(entry.renderStartedAt).not.toBe('2026-01-01T00:00:00.000Z');

--- a/server/services/videoGen/upscaleJob.test.js
+++ b/server/services/videoGen/upscaleJob.test.js
@@ -348,7 +348,7 @@ describe('runVideoUpscale — success', () => {
     expect(entry.renderMs).toBeGreaterThanOrEqual(0);
     // Nothing reported by the runner → explicit absent sentinels, never a
     // guessed factor or a half-parsed fingerprint.
-    expect(entry.upscaleReferenceDownscale).toBeNull();
+    expect(entry.upscaleReferenceDownscale).toBeUndefined();
     expect(entry.runtime).toBeUndefined();
     // The source render's timing must not ride along on a row that only paid
     // for the upscale.

--- a/server/services/videoGen/upscalePlan.js
+++ b/server/services/videoGen/upscalePlan.js
@@ -53,18 +53,18 @@ export const ltxUpscaleBaseModelId = (runtime) => (
   LTX_UPSCALE_BASE_MODEL_BY_RUNTIME[runtime] || null
 );
 
-// The LTX-2.5 two-stage grid, mirrored from `validate_args` in
-// `scripts/generate_ltx25_cuda.py`: output dimensions must be divisible by 64
-// and the frame count must satisfy `frames % 8 == 1` with a floor of 9.
+// The LTX-2.5 grid, mirrored from `scripts/_upscale_contract.py`: output
+// dimensions must be divisible by 64 and the frame count must satisfy
+// `frames % 8 == 1` with a floor of 9.
 //
-// #6512 confirmed the MLX backend imposes the SAME rule, and read it off the
-// pinned runtime rather than the gated model card: `ICLoraPipeline.generate`
-// renders Stage 1 at `height // 2` / `width // 2`, and
-// `compute_video_latent_shape` compresses spatially by 32 — so the OUTPUT axis
-// must divide by 64. Temporal compression is 8 and the IC reference encoder
-// needs a (1 + 8k)-frame input, which is the frame rule. Both runners now read
-// the rule from here; `scripts/upscale_ltx25.py` mirrors the numbers with a
-// comment pointing back, the way the CUDA runner already does.
+// #6512 established the rule on both backends from the runtimes and Lightricks'
+// own IC-LoRA recipe rather than the gated card. The upscaler is the standard
+// single-stage IC-LoRA pass at the OUTPUT size with the source as a reference
+// at half of it; the video VAE compresses spatially by 32, so for the reference
+// to land on that grid at exactly the (padded) source's own size — rather than
+// being resampled before it conditions anything — the output must divide by
+// 2 × 32. Temporal compression is 8 and the IC reference encoder needs a
+// (1 + 8k)-frame input, which is the frame rule.
 export const LTX_GRID = Object.freeze({
   spatialMultiple: 64,
   frameModulus: 8,

--- a/server/services/videoGen/upscaleVideo.js
+++ b/server/services/videoGen/upscaleVideo.js
@@ -92,11 +92,9 @@ const describeLtxRuntime = () => {
 const describeLtxAdapter = async () => {
   const spec = icLoraSpecByKey(LTX_UPSCALE_WEIGHT_KEY);
   const resolved = await resolveIcLoraWeightByKey(LTX_UPSCALE_WEIGHT_KEY);
-  // Read off the downloaded file when there is one, so the registry's honest
-  // `null` for this gated weight resolves to the real number on the installs
-  // that actually hold it (#6512). `measured` keeps "the weight declares 1"
-  // apart from "nobody has read it yet" — both impose no rule, but only one is
-  // a fact.
+  // Read off the downloaded file when there is one (#6512), so a re-pinned
+  // weight is measured rather than trusted; `measured` keeps the registry's
+  // declared value apart from the one this install's file actually carries.
   const { factor, measured } = await readIcLoraReferenceDownscaleFactor(spec);
   return {
     key: icLoraWeightKey(spec),


### PR DESCRIPTION
## Summary

The first real Apple Silicon render of the generative upscale (the gated weight is now provisioned on an install that accepted the license) exposed two gaps in the runners #6512 / #6513 shipped blind, plus the measurement #6508 left open.

- **Recipe.** Both runtimes' `ICLoraPipeline` render their IC-conditioned stage 1 at *half* the size they are handed and offer a latent-upsample stage 2 for the rest. Handing them the output size conditioned on the source downscaled by another 2× and left the second doubling to the latent upsampler — a pixel-faithful refinement, not the adapter's recipe. Lightricks' IC-LoRA guide and ComfyUI reference workflow run the Pixel Spatial Upscaler as the standard single-stage distilled video-to-video pass at the set resolution with the reference at half of it, so both runners now request twice the output and skip stage 2 (`conditioned_stage_request` in the shared contract). The factor rule moves with it: the reference must land on the VAE's 32-pixel grid at the source's own size, so the output must divide by `factor × 32` (64 for this adapter — unchanged in practice).
- **Pack layout.** The pinned MLX q8 pack may hold the distilled model as `transformer-dev.safetensors` plus the 450-step distilled LoRA rather than the pre-fused file the pipeline's own loader resolves. The runner resolves the layout itself, preferring the pre-fused file and otherwise fusing the distilled LoRA beside the adapter (the pack README's documented equivalent); dev *without* that LoRA is refused. The unused latent upsampler is no longer loaded.
- **Measured factor.** `reference_downscale_factor` read off the weight at the pinned revision is **2**; the registry now declares it (the file is still read whenever present, so a re-pinned weight is measured rather than trusted). The job reader records the runtime fingerprint and that measured factor on the history row, through the same fingerprint parser the render path uses.

### Render evidence (Apple Silicon, MLX q8 pack, dev + distilled-LoRA layout)

| | source | output |
| --- | --- | --- |
| dimensions | 512×512 | 1024×1024 |
| frames / fps | 73 / 24 | 73 / 24 |
| duration | 3.04 s | 3.04 s |
| audio | none | none (queue re-muxes the source track; silent source → silent output) |

Wall-clock 461 s (8 distilled steps ≈ 50 s each, decode 32 s); adapter fused into 480 transformer weights; output downscaled to source size scores 33 dB PSNR against the source, and a second run on the final code is byte-identical. Composition and motion carry over with re-rendered detail — a reference-conditioned upscale, not an unconditioned render.

The CUDA runner receives the identical recipe change, but has no NVIDIA render evidence from this branch — that stays with #6513.

## Test plan

- `scripts/upscale_ltx25.test.js` (28) and `scripts/upscale_ltx25_cuda.test.js`: the 2× request contract, the `factor × 32` rule, the pack-layout resolver's refusals, and the `load()` steering — all on a bare interpreter.
- `upscaleJob` records the fingerprint and factor, and keeps a malformed fingerprint off the row; `icLoraWeights` declares the measured factor and still reads the file.
- Full server suite: 41,166 passed. Full client suite: 10,759 passed.
- Two real renders on Apple Silicon (above).

Closes #6512
Part of #6502
