### PR TITLE
fix: skip goal fidelity checks for swarm coordinators

### DIFF
--- a/server/services/agentFinalization.goalFidelity.test.js
+++ b/server/services/agentFinalization.goalFidelity.test.js
@@ -175,7 +175,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   getTaskOutputHook.mockResolvedValue(null);
   isProgrammaticIoTaskType.mockReturnValue(false);
-  resolveTaskHookType.mockReturnValue(null);
+  resolveTaskHookType.mockImplementation(task => task?.metadata?.analysisType || task?.metadata?.taskAnalysisType || task?.taskType || null);
   resolveFailedTaskUpdate.mockImplementation(async (_task, analysis) => ({
     status: 'pending',
     metadata: { lastErrorCategory: analysis?.category || null },
@@ -193,6 +193,27 @@ describe('finalizeAgent — goal-fidelity gate', () => {
     expect(args.objective).not.toContain('done');
     expect(args.diff).toBe('diff --git a/a.js b/a.js');
     expect(args.backend).toBe('ollama');
+  });
+
+  it.each([
+    { swarmCount: 3, analysisType: 'claim-issue' },
+    { swarmCount: '3', analysisType: 'claim-issue-gitlab' },
+    { analysisType: 'branch-reconcile' },
+  ])('skips coordinator review before reading a diff or calling a model: %j', async metadata => {
+    runLocalGoalFidelityReviewMock.mockResolvedValue(verdict({ verdict: 'rethink' }));
+    await finalize({ task: { id: 'task-1', taskType: 'internal', description: 'Complete the batch', metadata } });
+    expect(completion()).toMatchObject({ success: true });
+    expect(completion().goalFidelity).toBeUndefined();
+    expect(runWindowDiffMock).not.toHaveBeenCalled();
+    expect(runLocalGoalFidelityReviewMock).not.toHaveBeenCalled();
+    expect(cosEvents.emit).not.toHaveBeenCalledWith(GOAL_FIDELITY_HOLD_EVENT, expect.anything());
+    expect(updateTaskMock).toHaveBeenCalledWith('task-1', expect.objectContaining({ status: 'completed' }), 'internal');
+  });
+
+  it.each([0, 1, undefined])('still judges single-issue claims with swarmCount %s', async swarmCount => {
+    await finalize({ task: { id: 'task-1', description: 'Fix the uploader', metadata: { analysisType: 'claim-issue', swarmCount } } });
+    expect(runLocalGoalFidelityReviewMock).toHaveBeenCalledOnce();
+    expect(completion().goalFidelity).toMatchObject({ verdict: 'ship' });
   });
 
   it('records a passing verdict without disturbing the run — absence is what means "never judged"', async () => {

--- a/server/services/agentFinalization.js
+++ b/server/services/agentFinalization.js
@@ -520,6 +520,12 @@ function prVerificationAnalysis(verdict) {
 async function evaluateGoalFidelity({ task, workspacePath, startedAt }) {
   const none = (error = null) => ({ verdict: null, review: null, error });
   if (!workspacePath || !task?.id) return none();
+  // A coordinator's run-window diff cannot represent work delegated across
+  // worker branches. Judge individual tasks, not the aggregate swarm objective.
+  // Stored Markdown metadata may carry numeric values as strings.
+  const workers = Number(task.metadata?.swarmCount);
+  if ((Number.isSafeInteger(workers) && workers > 1)
+      || resolveTaskHookType(task) === 'branch-reconcile') return none();
   const objective = taskObjective(task);
   if (!objective) return none();
   const config = await getGoalFidelityConfig().catch(() => null);


### PR DESCRIPTION
## Summary
Skip the post-task goal fidelity check for configured multi-worker swarms and branch-reconcile coordinators. Their run-window diff cannot represent the independent objectives and changes delegated across worker branches.

Single-agent tasks retain the existing fidelity check. Coordinator completion skips both the diff probe and model call and records no fidelity verdict.

## Test plan
- Passed 75 tests covering goal fidelity, success criteria, and agent import cycles.
- Verified numeric and persisted string swarm counts skip review, branch-reconcile skips review, and single-issue claims retain review.
- Optional Ollama review attempted; endpoint returned HTTP 401 (authentication required), so no review verdict was available.
