### PR TITLE
Verify the generative video upscale end to end on macOS, fix the finalize mux trimming frames to the audio track, and mark the MLX backend verified

### DIFF
--- a/docs/features/video-upscale.md
+++ b/docs/features/video-upscale.md
@@ -203,11 +203,9 @@ Lanczos is unaffected by any of this.
 
 ### What the verification matrix covers
 
-The matrix drives the real route, queue, runner and gallery row of a
-worktree server on a spare port (`NODE_ENV=test`, so the worktree's own `data/`
-is the data root and no Postgres write can reach the install), against the
-pinned MLX q8 pack and the gated adapter, with short clips so each render is
-minutes. Recorded for macOS on an Apple Silicon host:
+The matrix drives the real route, queue, runner and gallery row (a spare-port
+worktree server, short clips so each render is minutes) against the pinned MLX
+q8 pack and the gated adapter. Recorded for macOS on an Apple Silicon host:
 
 | Case | Source | Result |
 | --- | --- | --- |
@@ -215,19 +213,12 @@ minutes. Recorded for macOS on an Apple Silicon host:
 | needs frame padding, with audio | 576×1024, 23 f (padded to 25 for the render) | 1152×2048, **23 f** back, 0.96 s; audio intact; 345 s |
 | needs spatial padding, no audio | 560×1000, 25 f (padded to 576×1024) | **1120×2000**, 25 f, silent — padding cropped back off; 342 s |
 | cancellation mid-render | conforming source | job `canceled`; no history row, no partial file, no scratch left in the temp dir; source file and row byte-identical |
-| legacy Lanczos, no method / explicit `lanczos` | any | inline `{ video }` response, `upscaleMethod: 'lanczos'`, `upscaleRuntime: 'ffmpeg'`, unchanged before and after the generative runs |
-| invalid id · unknown id · missing asset · already-upscaled source | — | `400 VALIDATION_ERROR` · `404 NOT_FOUND` · `404 NOT_FOUND` · `400 ALREADY_UPSCALED` (both methods), and the plan endpoint refuses the missing asset the same way |
-| provenance | every render | row `width`/`height`/`fps`/`numFrames`/`duration` equal the file's; `seed`, `upscaleRuntime`, `upscaleAdapter`, `upscaleReferenceDownscale: 2`, the runtime fingerprint, and `renderMs` present |
 
-A source that "needs a trim" cannot be produced: the plan pads and never trims
-(see the model grid above), so that row of the matrix is a refusal by
-construction rather than a case to render.
-
-The matrix found and fixed one defect before this table was recorded: the
-finalize mux passed `-shortest` to ffmpeg, so a source whose AAC track ran a
-few milliseconds short of its video (25 frames / 1.024 s of audio) came back
-with 23 frames. The video is bounded to the source's frame count and nothing
-else now.
+Legacy Lanczos calls (no method, and explicit `lanczos`), the error codes in
+the API table, the provenance fields, and the pre-submit plan's padding
+disclosure all behaved exactly as the sections above describe, before and after
+the generative runs. A source that "needs a trim" is a refusal by construction
+(the plan never trims), not a case to render.
 
 ## Where the code lives
 

--- a/docs/features/video-upscale.md
+++ b/docs/features/video-upscale.md
@@ -188,14 +188,46 @@ explicitly adding the kind to one of them. See the privacy rules in
 
 ## Readiness
 
-The generative method is a **capability-gated preview**. It is offered only on a
-host that already has the runtime, the adapter and the base pack; everywhere
-else the drawer shows it disabled with the reason.
+The generative method is offered only on a host that already has the runtime,
+the adapter and the base pack; everywhere else the drawer shows it disabled
+with the reason. That gate is per host and permanent — it is how a machine
+without a GPU runtime learns it has no generative backend — and it is distinct
+from whether a backend has been **verified**:
 
-It stays a preview until the end-to-end verification matrix has been run with
-recorded render evidence on **both** supported backends — see
-[#6514](https://github.com/atomantic/PortOS/issues/6514), which tracks that
-matrix and the readiness flip. Lanczos is unaffected and is not a preview.
+| Backend | Status |
+| --- | --- |
+| macOS MLX (`ltx25`) | **Verified** end to end on real renders (2026-09-07, [#6514](https://github.com/atomantic/PortOS/issues/6514)); supported. |
+| Windows / Linux CUDA (`ltx25_cuda`) | Code complete with the same recipe and contract; **awaiting a render on an NVIDIA host** ([#6513](https://github.com/atomantic/PortOS/issues/6513)). Treat it as unverified until that evidence is recorded. |
+
+Lanczos is unaffected by any of this.
+
+### What the verification matrix covers
+
+The matrix drives the real route, queue, runner and gallery row of a
+worktree server on a spare port (`NODE_ENV=test`, so the worktree's own `data/`
+is the data root and no Postgres write can reach the install), against the
+pinned MLX q8 pack and the gated adapter, with short clips so each render is
+minutes. Recorded for macOS on an Apple Silicon host:
+
+| Case | Source | Result |
+| --- | --- | --- |
+| conforming source, with audio | 576×1024, 25 f, 24 fps, 1.04 s | 1152×2048, 25 f, 1.04 s; source AAC track re-muxed intact; 258 s |
+| needs frame padding, with audio | 576×1024, 23 f (padded to 25 for the render) | 1152×2048, **23 f** back, 0.96 s; audio intact; 345 s |
+| needs spatial padding, no audio | 560×1000, 25 f (padded to 576×1024) | **1120×2000**, 25 f, silent — padding cropped back off; 342 s |
+| cancellation mid-render | conforming source | job `canceled`; no history row, no partial file, no scratch left in the temp dir; source file and row byte-identical |
+| legacy Lanczos, no method / explicit `lanczos` | any | inline `{ video }` response, `upscaleMethod: 'lanczos'`, `upscaleRuntime: 'ffmpeg'`, unchanged before and after the generative runs |
+| invalid id · unknown id · missing asset · already-upscaled source | — | `400 VALIDATION_ERROR` · `404 NOT_FOUND` · `404 NOT_FOUND` · `400 ALREADY_UPSCALED` (both methods), and the plan endpoint refuses the missing asset the same way |
+| provenance | every render | row `width`/`height`/`fps`/`numFrames`/`duration` equal the file's; `seed`, `upscaleRuntime`, `upscaleAdapter`, `upscaleReferenceDownscale: 2`, the runtime fingerprint, and `renderMs` present |
+
+A source that "needs a trim" cannot be produced: the plan pads and never trims
+(see the model grid above), so that row of the matrix is a refusal by
+construction rather than a case to render.
+
+The matrix found and fixed one defect before this table was recorded: the
+finalize mux passed `-shortest` to ffmpeg, so a source whose AAC track ran a
+few milliseconds short of its video (25 frames / 1.024 s of audio) came back
+with 23 frames. The video is bounded to the source's frame count and nothing
+else now.
 
 ## Where the code lives
 

--- a/server/services/videoGen/runtimes.js
+++ b/server/services/videoGen/runtimes.js
@@ -46,8 +46,11 @@ export const LTX25_ENCODER_SHIM_DIR = join(homedir(), '.portos', 'ltx25-encoder-
 // entry point from a text/image render — so it gets its own helper script per
 // runtime rather than another mode flag on the generation script. Both runners
 // have landed (#6512 MLX / #6513 CUDA) and share one argv contract
-// (`scripts/_upscale_contract.py`); an install with neither runtime's venv
-// present still has no generative upscale, which is what gates the feature off.
+// (`scripts/_upscale_contract.py`). The MLX runner is verified end to end on
+// real renders (#6514, `docs/features/video-upscale.md` "Readiness"); the
+// CUDA runner carries the same recipe but awaits NVIDIA render evidence
+// (#6513). An install with neither runtime's venv present still has no
+// generative upscale, which is what gates the feature off per host.
 export const LTX25_UPSCALE_HELPER_SCRIPT = join(PATHS.root, 'scripts', 'upscale_ltx25.py');
 
 // Wan 2.2 MLX runtime — pinned MLX-Gen checkout provisioned on demand.

--- a/server/services/videoGen/runtimes.js
+++ b/server/services/videoGen/runtimes.js
@@ -46,11 +46,10 @@ export const LTX25_ENCODER_SHIM_DIR = join(homedir(), '.portos', 'ltx25-encoder-
 // entry point from a text/image render — so it gets its own helper script per
 // runtime rather than another mode flag on the generation script. Both runners
 // have landed (#6512 MLX / #6513 CUDA) and share one argv contract
-// (`scripts/_upscale_contract.py`). The MLX runner is verified end to end on
-// real renders (#6514, `docs/features/video-upscale.md` "Readiness"); the
-// CUDA runner carries the same recipe but awaits NVIDIA render evidence
-// (#6513). An install with neither runtime's venv present still has no
-// generative upscale, which is what gates the feature off per host.
+// (`scripts/_upscale_contract.py`); per-backend verification status lives in
+// `docs/features/video-upscale.md` "Readiness". An install with neither
+// runtime's venv present still has no generative upscale, which is what gates
+// the feature off per host.
 export const LTX25_UPSCALE_HELPER_SCRIPT = join(PATHS.root, 'scripts', 'upscale_ltx25.py');
 
 // Wan 2.2 MLX runtime — pinned MLX-Gen checkout provisioned on demand.

--- a/server/services/videoGen/upscaleFfmpeg.js
+++ b/server/services/videoGen/upscaleFfmpeg.js
@@ -101,8 +101,14 @@ export const finalizeUpscaleOutput = async (renderedPath, outPath, {
       ...H264_ENCODE_ARGS,
       ...BT709_CONTAINER_ARGS,
       '-c:a', 'copy',
+      // The video is bounded to the SOURCE's frame count here, and nothing
+      // else. `-shortest` must not be added: an AAC track routinely runs a few
+      // milliseconds short of its video (priming/padding), and `-shortest`
+      // then cuts the video to the audio's length — the #6514 matrix measured
+      // a 25-frame source come back with 23 frames, and a 23-frame one with
+      // 19. The source's own container already pairs this video length with
+      // this audio length, so the deliverable simply keeps both.
       '-frames:v', String(Math.round(frameCount)),
-      '-shortest',
       '-movflags', '+faststart',
       '-y', outPath,
     ],

--- a/server/services/videoGen/upscaleFfmpeg.js
+++ b/server/services/videoGen/upscaleFfmpeg.js
@@ -101,13 +101,10 @@ export const finalizeUpscaleOutput = async (renderedPath, outPath, {
       ...H264_ENCODE_ARGS,
       ...BT709_CONTAINER_ARGS,
       '-c:a', 'copy',
-      // The video is bounded to the SOURCE's frame count here, and nothing
-      // else. `-shortest` must not be added: an AAC track routinely runs a few
-      // milliseconds short of its video (priming/padding), and `-shortest`
-      // then cuts the video to the audio's length — the #6514 matrix measured
-      // a 25-frame source come back with 23 frames, and a 23-frame one with
-      // 19. The source's own container already pairs this video length with
-      // this audio length, so the deliverable simply keeps both.
+      // The ONLY length bound. Never add `-shortest` (or `-t`): an AAC track
+      // routinely runs a few ms short of its video, and either would trim the
+      // video to match (#6514). The source's own container pairs these two
+      // lengths already, so the deliverable keeps both.
       '-frames:v', String(Math.round(frameCount)),
       '-movflags', '+faststart',
       '-y', outPath,

--- a/server/services/videoGen/upscaleFfmpeg.test.js
+++ b/server/services/videoGen/upscaleFfmpeg.test.js
@@ -60,13 +60,11 @@ describe('finalizeUpscaleOutput', () => {
     expect(argFor('-frames:v')).toBe('121');
   });
 
-  // The #6514 matrix measured a 25-frame source come back with 23 frames: an
-  // AAC track runs a few ms short of its video, and `-shortest` cut the video
-  // to the audio's length. The frame bound above is the only trim; the
-  // deliverable keeps the source's own video/audio lengths.
+  // #6514: an AAC track a few ms short of its video must not trim it — the
+  // frame bound is the only output-length bound (see the source comment).
   it('never lets the audio track shorten the video', async () => {
     await finalize();
-    expect(ffmpeg.runs.at(-1).args).not.toContain('-shortest');
+    expect(ffmpeg.runs.at(-1).args.filter((a) => a === '-shortest' || a === '-t')).toEqual([]);
   });
 
   it('maps the source audio OPTIONALLY, so a silent source is a silent output rather than a failure', async () => {

--- a/server/services/videoGen/upscaleFfmpeg.test.js
+++ b/server/services/videoGen/upscaleFfmpeg.test.js
@@ -60,6 +60,15 @@ describe('finalizeUpscaleOutput', () => {
     expect(argFor('-frames:v')).toBe('121');
   });
 
+  // The #6514 matrix measured a 25-frame source come back with 23 frames: an
+  // AAC track runs a few ms short of its video, and `-shortest` cut the video
+  // to the audio's length. The frame bound above is the only trim; the
+  // deliverable keeps the source's own video/audio lengths.
+  it('never lets the audio track shorten the video', async () => {
+    await finalize();
+    expect(ffmpeg.runs.at(-1).args).not.toContain('-shortest');
+  });
+
   it('maps the source audio OPTIONALLY, so a silent source is a silent output rather than a failure', async () => {
     await finalize();
     const args = ffmpeg.runs.at(-1).args;


### PR DESCRIPTION
## Summary

Runs #6514's verification matrix on macOS against a worktree server on a spare port with the real MLX runner (route → media-job queue → `upscale_ltx25.py` → gallery row), fixes the one defect it found, and flips the docs' readiness language for the backend that now has evidence.

- **Defect found by the matrix.** The finalize mux passed `-shortest` to ffmpeg. An AAC track routinely runs a few milliseconds short of its video, so a 25-frame source came back with 23 frames and a 23-frame one with 19 — silent duration loss, exactly what #6502 forbids. The video is already bounded to the source's frame count by `-frames:v`, and the audio is the source's own track copied verbatim, so the deliverable's lengths are the source's own pairing; the flag is dropped and a test rejects both `-shortest` and `-t`.
- **Evidence (macOS MLX, Apple Silicon)**, from the re-run on the fix — all rows in `docs/features/video-upscale.md` "Readiness":

  | Case | Source | Result |
  | --- | --- | --- |
  | conforming, with audio | 576×1024, 25 f, 24 fps | 1152×2048, 25 f, audio intact; 258 s |
  | needs frame padding, with audio | 576×1024, 23 f | 1152×2048, 23 f back, audio intact; 345 s |
  | needs spatial padding, no audio | 560×1000, 25 f | 1120×2000 (padding cropped back), 25 f, silent; 342 s |
  | cancellation mid-render | — | job `canceled`; no row, no partial file, no scratch; source file and row byte-identical |

  Legacy Lanczos (no method / explicit), the error codes (`VALIDATION_ERROR`, `NOT_FOUND` ×2, `ALREADY_UPSCALED`), the plan's padding disclosure, and every provenance field (measured dims/fps/frames/duration, seed, runtime, adapter, factor 2, fingerprint, `renderMs`) behaved as documented. Full table on the issue.
- **Readiness.** The docs no longer call the method a preview: the MLX backend is verified and supported; the CUDA backend is stated as code-complete but unverified until an NVIDIA host records a render. The per-host capability gate is unchanged (it is how a machine without a GPU runtime learns it has no generative backend, not a readiness flag).

## Test plan

- `upscaleFfmpeg.test.js`: the finalize argv carries no `-shortest`/`-t`; existing crop/frame-bound/optional-audio cases unchanged.
- `services/videoGen`, `routes/videoGen`, and both runner suites: 1,092 passed.
- The matrix above, run twice (once on the base to find the defect, once on the fix).

## Remaining

- The Windows CUDA half of the matrix: no NVIDIA host is reachable from this run. #6513 carries that (same recipe and contract, awaiting a render), and #6514 stays open for its evidence per the issue's own note.

Refs #6514
Part of #6502
