### PR TITLE
Track the outstanding NVIDIA render for the generative video upscale in its own issue

### DIFF
--- a/docs/features/video-upscale.md
+++ b/docs/features/video-upscale.md
@@ -197,7 +197,7 @@ from whether a backend has been **verified**:
 | Backend | Status |
 | --- | --- |
 | macOS MLX (`ltx25`) | **Verified** end to end on real renders (2026-09-07, [#6514](https://github.com/atomantic/PortOS/issues/6514)); supported. |
-| Windows / Linux CUDA (`ltx25_cuda`) | Code complete with the same recipe and contract; **awaiting a render on an NVIDIA host** ([#6513](https://github.com/atomantic/PortOS/issues/6513)). Treat it as unverified until that evidence is recorded. |
+| Windows / Linux CUDA (`ltx25_cuda`) | Code complete with the same recipe and contract ([#6513](https://github.com/atomantic/PortOS/issues/6513)); **awaiting a render on an NVIDIA host**, tracked in [#6537](https://github.com/atomantic/PortOS/issues/6537). Treat it as unverified until that evidence is recorded. |
 
 Lanczos is unaffected by any of this.
 


### PR DESCRIPTION
## Summary
- Every child of the LTX generative upscale epic (#6502) has shipped: the CUDA runner is code complete (#6513, via #6520 and #6534) and the MLX backend is verified end to end (#6514, via #6536).
- The one remaining acceptance item, a real render on an NVIDIA host, cannot be produced by any autonomous run on this install, so it is consolidated into #6537 and the readiness table in `docs/features/video-upscale.md` now points there. The CUDA backend stays documented as unverified and capability-gated until that evidence lands.
- Docs only; no runtime change.

Refs #6502

## Test plan
- Docs-only one-row change; the file is already indexed from `docs/README.md`.
- CI on this PR.