### PR TITLE
Refuse a generative upscale on a host that cannot run the LTX-2.5 pack (#6537)

### DIFF
--- a/client/src/components/media/VideoUpscaleDrawer.jsx
+++ b/client/src/components/media/VideoUpscaleDrawer.jsx
@@ -17,6 +17,7 @@ import { Loader2 } from 'lucide-react';
 import Drawer from '../Drawer';
 import toast from '../ui/Toast';
 import { formatBytes } from '../../utils/formatters';
+import { isHardwareAvailable, hardwareUnavailableReason } from '../../utils/systemCapabilities';
 import { useSseProgress } from '../../hooks/useSseProgress';
 import { upscaleVideo, getUpscalePlan, upscaleAdapterDownloadUrl } from '../../services/apiImageVideo';
 
@@ -67,17 +68,28 @@ export default function VideoUpscaleDrawer({ item, onClose, onUpscaled }) {
   // (and silently downloading) one itself. Without this the button would read
   // ready for a job the dispatch refuses.
   const baseModelReady = plan?.baseModel?.cached === true;
-  const generativeReady = runtimeReady && adapterReady && baseModelReady;
-  const adapterMissing = !!plan && runtimeReady && !adapterReady;
+  // The host itself is a FOURTH axis (#6537): the machine can have the venv,
+  // the adapter and the whole 68 GB pack and still sit below what the pack needs
+  // of it (the CUDA pack asks for 64 GB of system memory). The dispatch refuses
+  // that host, so offering the button would promise a job that fails. Read
+  // through the shared helper, which already treats an absent annotation — a
+  // plan from an older server — as compatible rather than newly disabling it.
+  // Ordered ahead of the two "not downloaded" reasons because it outranks them:
+  // downloading 72 GB onto a machine that cannot run it helps nobody.
+  const hostReady = isHardwareAvailable(plan?.baseModel);
+  const generativeReady = runtimeReady && hostReady && adapterReady && baseModelReady;
+  const adapterMissing = !!plan && runtimeReady && hostReady && !adapterReady;
   const generativeDisabledReason = !plan
     ? null
     : !runtimeReady
       ? plan.runtime.reason
-      : !adapterReady
-        ? `The ${plan.adapter?.label || 'generative upscale'} adapter is not downloaded yet.`
-        : !baseModelReady
-          ? plan.baseModel?.reason || 'The LTX-2.5 model pack for this backend is not downloaded yet.'
-          : null;
+      : !hostReady
+        ? hardwareUnavailableReason(plan.baseModel?.name || 'The LTX-2.5 pack', plan.baseModel?.hardwareCompatibility)
+        : !adapterReady
+          ? `The ${plan.adapter?.label || 'generative upscale'} adapter is not downloaded yet.`
+          : !baseModelReady
+            ? plan.baseModel?.reason || 'The LTX-2.5 model pack for this backend is not downloaded yet.'
+            : null;
 
   // Inline adapter download (#6510 item 4) — the same provisioning surface
   // every IC-LoRA weight rides (#3100), just triggered from here instead of a

--- a/client/src/components/media/VideoUpscaleDrawer.test.jsx
+++ b/client/src/components/media/VideoUpscaleDrawer.test.jsx
@@ -39,6 +39,7 @@ const READY_PLAN = {
   baseModel: {
     id: 'ltx25_mlx_q8', name: 'LTX-2.5 MLX Q8', repo: 'Example/ltx25-mlx-q8', revision: 'abc1234',
     path: '/cache/ltx25-mlx-q8', cached: true, reason: null,
+    hardwareCompatibility: { state: 'available', reasons: [], requirements: {} },
   },
 };
 
@@ -150,5 +151,46 @@ describe('VideoUpscaleDrawer', () => {
 
     expect(screen.getByLabelText(/LTX-2\.5 generative/i).disabled).toBe(true);
     expect(screen.getByText(/is not downloaded/i)).toBeTruthy();
+  });
+
+  // #6537: the host is a fourth axis. Every download can be present on a machine
+  // that still cannot run the pack — the CUDA pack asks for 64 GB of system
+  // memory, and on a 32 GB host the render dies inside the runtime's own loader
+  // seconds in. The dispatch refuses that host, so the button must not offer it.
+  it('disables the generative method when the host cannot run the pack, even with everything downloaded', async () => {
+    getUpscalePlan.mockResolvedValue({
+      plan: {
+        ...READY_PLAN,
+        baseModel: {
+          ...READY_PLAN.baseModel,
+          name: 'LTX-2.5 CUDA Distilled',
+          hardwareCompatibility: {
+            state: 'unavailable',
+            reasons: ['Requires at least 64 GB of system memory'],
+            requirements: { minMemoryGb: 64 },
+          },
+        },
+      },
+    });
+    render(<VideoUpscaleDrawer item={ITEM} onClose={vi.fn()} onUpscaled={vi.fn()} />);
+    await waitFor(() => expect(getUpscalePlan).toHaveBeenCalled());
+
+    expect(screen.getByLabelText(/LTX-2\.5 generative/i).disabled).toBe(true);
+    expect(screen.getByText(/unavailable on this machine/i)).toBeTruthy();
+    // The adapter IS cached here, so the inline download button would be a
+    // pointless offer — a 327 MB pull that changes nothing about the refusal.
+    expect(screen.queryByText(/Download adapter/i)).toBeNull();
+  });
+
+  // Forward-compat: a plan from an older server carries no annotation. Absent must
+  // not read as incompatible, or updating the client alone would disable a
+  // button that install has always been able to press.
+  it('stays enabled when an older plan carries no host annotation', async () => {
+    const { hardwareCompatibility, ...baseModel } = READY_PLAN.baseModel;
+    getUpscalePlan.mockResolvedValue({ plan: { ...READY_PLAN, baseModel } });
+    render(<VideoUpscaleDrawer item={ITEM} onClose={vi.fn()} onUpscaled={vi.fn()} />);
+    await waitFor(() => expect(getUpscalePlan).toHaveBeenCalled());
+
+    expect(screen.getByLabelText(/LTX-2\.5 generative/i).disabled).toBe(false);
   });
 });

--- a/client/src/utils/systemCapabilities.js
+++ b/client/src/utils/systemCapabilities.js
@@ -8,6 +8,14 @@ export const isHardwareCompatible = (compatibility) => compatibility?.state !== 
 
 export const isHardwareAvailable = (item) => isHardwareCompatible(item?.hardwareCompatibility);
 
+// Mirrors `hardwareUnavailableReason` in `server/lib/systemCapabilities.js` so a
+// refusal reads identically whether the server rendered it or the browser did.
+// The reason list is what the server annotated; the browser never re-probes.
+export const hardwareUnavailableReason = (subject, compatibility) => (
+  `${subject} is unavailable on this machine: ${
+    (compatibility?.reasons || []).join(' · ') || 'this host does not meet its hardware requirements'}`
+);
+
 export const filterHardwareCompatibleModels = (models, { includeUnavailable = false } = {}) => {
   const list = Array.isArray(models) ? models : [];
   return includeUnavailable ? list : list.filter(isHardwareAvailable);

--- a/docs/features/video-upscale.md
+++ b/docs/features/video-upscale.md
@@ -50,7 +50,7 @@ is an immediate 4xx/501 rather than a job that dies minutes later:
 | Code | Status | Meaning |
 | --- | --- | --- |
 | `ALREADY_UPSCALED` | 400 | the source is itself an upscale output |
-| `UNSUPPORTED_RUNTIME` | 501 | no generative backend on this host, or its venv is not installed |
+| `UNSUPPORTED_RUNTIME` | 501 | this host cannot carry the generative method: no backend for the platform, its venv is not installed, or the machine is below what the backend's pack declares it needs |
 | `IC_LORA_WEIGHT_UNRESOLVED` | 400 | the upscaler adapter is not downloaded |
 | `UPSCALE_BASE_MODEL_UNRESOLVED` | 400 | the backend's LTX-2.5 pack is not downloaded |
 | `UPSCALE_SOURCE_UNALIGNABLE` | 400 | the source cannot be measured, or aligning it would lose duration |
@@ -89,6 +89,11 @@ decided by platform, not by the user:
 | macOS (Apple Silicon) | `ltx25` | `INSTALL_LTX25=1 ./scripts/setup-image-video.sh` | `ltx25_mlx_q8` |
 | Windows / Linux + NVIDIA | `ltx25_cuda` | `INSTALL_LTX25_CUDA=1 ./scripts/setup-image-video.sh` | `ltx25_cuda_distilled` |
 | Anything else | — | — | no generative backend; the plan says so rather than failing at render time |
+
+Platform is necessary but not sufficient: each pack also declares what it needs
+of the machine, and the CUDA pack asks for **64 GB of system memory** on top of
+the NVIDIA card. A host below that is refused up front — see
+[Readiness](#readiness).
 
 The base checkpoint is **not** part of the request. The adapter was trained
 against one LTX-2.5 checkpoint, so letting a user pick another would condition
@@ -188,16 +193,87 @@ explicitly adding the kind to one of them. See the privacy rules in
 
 ## Readiness
 
-The generative method is offered only on a host that already has the runtime,
-the adapter and the base pack; everywhere else the drawer shows it disabled
-with the reason. That gate is per host and permanent — it is how a machine
-without a GPU runtime learns it has no generative backend — and it is distinct
-from whether a backend has been **verified**:
+The generative method is offered only on a host that has the runtime, the
+adapter, the base pack, **and the hardware that pack declares it needs**;
+everywhere else the drawer shows it disabled with the reason. That gate is per
+host and permanent — it is how a machine without a GPU runtime learns it has no
+generative backend — and it is distinct from whether a backend has been
+**verified**:
 
 | Backend | Status |
 | --- | --- |
 | macOS MLX (`ltx25`) | **Verified** end to end on real renders (2026-09-07, [#6514](https://github.com/atomantic/PortOS/issues/6514)); supported. |
-| Windows / Linux CUDA (`ltx25_cuda`) | Code complete with the same recipe and contract ([#6513](https://github.com/atomantic/PortOS/issues/6513)); **awaiting a render on an NVIDIA host**, tracked in [#6537](https://github.com/atomantic/PortOS/issues/6537). Treat it as unverified until that evidence is recorded. |
+| Windows / Linux CUDA (`ltx25_cuda`) | Code complete with the same recipe and contract ([#6513](https://github.com/atomantic/PortOS/issues/6513)); **still unverified**. A first attempt on a real NVIDIA host (2026-09-07, [#6537](https://github.com/atomantic/PortOS/issues/6537)) did not produce a render — see below. Verification needs a host that meets the pack's declared 64 GB system-memory floor. |
+
+### The four readiness axes
+
+The runtime venv, the 327 MB adapter and the ~68 GB pack are three independent
+downloads. The **host itself** is the fourth, and it is the one a download
+cannot fix: `ltx25_cuda_distilled` declares `minMemoryGb: 64`, so a machine with
+less cannot run it however complete its cache is. `generateVideo.js` has always
+refused a plain render on such a host; the upscale path now refuses there too,
+with the same helper on the same verdict so the two gates cannot drift. An
+upscale renders at **twice** the source's linear dimensions, strictly above a
+plain render's peak — so anything a plain render is refused for, an upscale must
+be refused for as well.
+
+The plan reports the server's `baseModel.hardwareCompatibility` annotation — the
+same object every other model payload carries — rather than a flattened boolean,
+so the dispatch and the drawer share one predicate (`isHardwareCompatible`)
+instead of each re-deriving the rule. It stays independent of `cached`: a pack
+can be fully downloaded onto a host that cannot run it, and calling that "not
+downloaded" would send someone to re-fetch 72 GB that is already on disk. Where
+both apply, consumers state the host problem first — advising a 72 GB download
+onto a machine that cannot use it is worse than saying nothing. A requirement
+the host cannot *measure* stays allowed: only an explicit `unavailable` verdict
+refuses, so an unreadable probe never becomes a refusal invented from a missing
+number, and a plan from an older server (no annotation at all) queues exactly
+what it queues today.
+
+The refusal is `UNSUPPORTED_RUNTIME` (501) rather than the
+`MODEL_HARDWARE_UNAVAILABLE` (400) the plain-render sites raise, and the
+difference is deliberate: there the user *chose* an incompatible model, so the
+request is at fault. The upscale's checkpoint is pinned and not part of the
+request, so nothing the caller sent is wrong — the host simply cannot carry the
+method, which is what `UNSUPPORTED_RUNTIME` already means here.
+
+### What the NVIDIA attempt established (2026-09-07)
+
+The run that produced this section was made on a Windows RTX 3090 host with
+**32 GB of system memory** — half the pack's declared floor. Everything short of
+the render worked, and is recorded here because it is real evidence about the
+CUDA path:
+
+- The gated adapter downloaded through the model surface at exactly its pinned
+  `sizeBytes` (327,322,640), and its `reference_downscale_factor` read back as
+  **2, measured off the file** rather than taken from the registry.
+- The pre-submit plan was correct for all three source shapes: a conforming
+  320×576/25f source reported no padding; a 23-frame source reported
+  `padFrames: 2`; a 312×568 source reported `padWidth`/`padHeight` of 8 with the
+  padded source at 320×576. Audio presence was reported correctly in each case.
+- The runner's own guards passed on real weights: the pack resolved cache-only,
+  and `assert_adapter_fuses` verified the adapter fuses into **480** transformer
+  weights — so the adapter and the pinned checkpoint genuinely match, and the
+  "fuses into nothing" failure #6513 guards against does not occur here.
+- The render itself did **not** run. Both `upscale_ltx25_cuda.py` and
+  `generate_ltx25_cuda.py` fail identically ~18 s in, inside `ltx_core`'s own
+  loader (`sft_loader.py`), while loading the 26 GB Gemma text encoder:
+  `RuntimeError: Attempted to access the data pointer on an invalid python
+  storage`. It reduces to a six-line repro with no PortOS code involved — hold
+  one `safetensors.safe_open` handle on a pack file and open a second one on the
+  same file with `device="cuda"`; files up to ~1.5 GB are fine, the 26 GB text
+  encoder and the 42 GB transformer are not. `ltx_core`'s disk-streaming path
+  does exactly that (`DiskTensorReader` holds a CPU handle while
+  `_load_non_block_weights` opens a CUDA one), and a subsequent read of the same
+  file segfaults the process.
+
+So the failure is **not** upscale-specific and not a defect in the shared
+contract: it is the whole `ltx25_cuda` runtime on a host below the pack's memory
+floor. What the attempt did surface is the missing fourth axis above — PortOS
+offered the upscale as ready and queued a GPU job that died seconds later, on a
+host where it already refused the equivalent plain render. Recording a verified
+CUDA render still requires a licensed NVIDIA machine with ≥64 GB of system
+memory.
 
 Lanczos is unaffected by any of this.
 

--- a/server/lib/systemCapabilities.js
+++ b/server/lib/systemCapabilities.js
@@ -328,6 +328,20 @@ export function evaluateHardwareRequirements(requirements, capabilities = captur
 
 export const isHardwareCompatible = (compatibility) => compatibility?.state !== 'unavailable';
 
+/**
+ * The one sentence explaining WHY a host was refused, so callers stop
+ * hand-rolling it. This module already owns the verdict; owning its wording —
+ * and the fallback for an `unavailable` state that carries no reasons — is what
+ * keeps every refusal reading the same. `subject` is what the message is about
+ * (a model id, a pack name).
+ *
+ * Mirrored in `client/src/utils/systemCapabilities.js`, like `isHardwareCompatible`.
+ */
+export const hardwareUnavailableReason = (subject, compatibility) => (
+  `${subject} is unavailable on this machine: ${
+    (compatibility?.reasons || []).join(' · ') || 'this host does not meet its hardware requirements'}`
+);
+
 /** Resolve the derived requirements for an image or video registry entry. */
 export function hardwareRequirementsForMediaModel(model, { kind = 'image', bucket } = {}) {
   const runtimeRequirements = {};

--- a/server/lib/testHelper.js
+++ b/server/lib/testHelper.js
@@ -295,6 +295,18 @@ export function readClientSource(rel) {
  */
 export const posixPath = (value) => String(value).split('\\').join('/');
 
+// Save the own descriptor, define the pinned value, and hand back a restore
+// that reinstates exactly what was there. Shared by the two pins below so the
+// descriptor dance has one definition.
+const pinProcessProperty = (name) => (value) => {
+  const original = Object.getOwnPropertyDescriptor(process, name);
+  Object.defineProperty(process, name, { value, configurable: true });
+  return () => {
+    if (original) Object.defineProperty(process, name, original);
+    else delete process[name];
+  };
+};
+
 /**
  * Pin `process.platform` for a test, and return the restore.
  *
@@ -321,14 +333,17 @@ export const posixPath = (value) => String(value).split('\\').join('/');
  * @param {string} value - the platform to report, e.g. `'darwin'` / `'win32'`
  * @returns {() => void} restore — idempotent, safe to call from `afterEach`
  */
-export function pinPlatform(value) {
-  const original = Object.getOwnPropertyDescriptor(process, 'platform');
-  Object.defineProperty(process, 'platform', { value, configurable: true });
-  return () => {
-    if (original) Object.defineProperty(process, 'platform', original);
-    else delete process.platform;
-  };
-}
+export const pinPlatform = pinProcessProperty('platform');
+
+/**
+ * `pinPlatform`'s companion for `process.arch`.
+ *
+ * Pinning the platform alone is not enough to stand in for an Apple Silicon
+ * host: `isAppleSilicon()` reads BOTH, so a darwin pin on an x64 runner still
+ * evaluates as Intel and every `requiresAppleSilicon` model reads unavailable.
+ * A test that means "on an Apple Silicon Mac" has to pin the pair.
+ */
+export const pinArch = pinProcessProperty('arch');
 
 /**
  * Budget for a vitest test that shells out to a real Python interpreter.

--- a/server/lib/testHelper.test.js
+++ b/server/lib/testHelper.test.js
@@ -123,8 +123,15 @@ describe('platform-pin guard', () => {
   it('the helper still owns the only pin, and still documents the hazard', () => {
     // Both halves of the consolidation: the mechanism lives here, and the
     // warning that motivated centralizing it stays attached to it.
+    //
+    // Matched with `OWNS_A_PIN`, not `HAND_ROLLED_PIN`: the helper now shares one
+    // descriptor-swap body between `pinPlatform` and `pinArch`, so the property
+    // name is a parameter rather than a literal. `HAND_ROLLED_PIN` stays keyed to
+    // the literal spelling because that is what it must catch in OTHER files —
+    // this assertion only has to prove the mechanism still lives here.
+    const OWNS_A_PIN = /defineProperty\s*\(\s*process\s*,/;
     const source = readFileSync(join(REPO_ROOT, HELPER), 'utf8');
-    expect(HAND_ROLLED_PIN.test(source)).toBe(true);
+    expect(OWNS_A_PIN.test(source)).toBe(true);
     expect(source).toMatch(/native addon/);
   });
 });

--- a/server/services/videoGen/upscaleJob.js
+++ b/server/services/videoGen/upscaleJob.js
@@ -35,6 +35,7 @@ import { safeChildProcessEnv } from '../../lib/processEnv.js';
 import { PYTHON_NOISE_RE } from '../../lib/sseUtils.js';
 import { omitRenderTiming, renderTimingFields } from '../../lib/renderTiming.js';
 import { resolveIcLoraWeightByKey } from '../../lib/icLoraWeights.js';
+import { isHardwareCompatible, hardwareUnavailableReason } from '../../lib/systemCapabilities.js';
 import { hfChildEnv } from '../hfToken.js';
 import { enqueueJob } from '../mediaJobQueue/index.js';
 import { videoGenEvents } from './events.js';
@@ -86,6 +87,28 @@ export async function enqueueLtxUpscale(historyId) {
   if (!plan.runtime.supported || !plan.runtime.installed) {
     throw new ServerError(
       `Generative upscale is not available on this install: ${plan.runtime.reason}`,
+      { status: 501, code: 'UNSUPPORTED_RUNTIME' },
+    );
+  }
+  // The host gate (#6537), BEFORE the cache checks below: a machine that cannot
+  // run the pack must not be told to download 72 GB of it. `generateVideo.js`
+  // already refuses a plain render here; an upscale renders ABOVE a plain
+  // render's peak, so anything it refuses this must refuse too — same helper on
+  // the same annotation, so the two gates cannot drift. `isHardwareCompatible`
+  // refuses only an explicit `unavailable` verdict, so a requirement this host
+  // could not MEASURE stays allowed rather than becoming a refusal invented from
+  // a missing number, and a plan from an older server (no annotation at all)
+  // queues exactly what it queues today.
+  //
+  // Deliberately NOT the `MODEL_HARDWARE_UNAVAILABLE`/400 those render sites
+  // raise: there, the user CHOSE an incompatible model, so the request is at
+  // fault. The upscale's checkpoint is pinned and not part of the request
+  // (#6511), so nothing the caller sent is wrong — the host simply cannot carry
+  // the method, which is what `UNSUPPORTED_RUNTIME`/501 already means here.
+  if (!isHardwareCompatible(plan.baseModel?.hardwareCompatibility)) {
+    throw new ServerError(
+      `Generative upscale is not available on this install: ${
+        hardwareUnavailableReason(plan.baseModel?.name || 'The LTX-2.5 pack', plan.baseModel?.hardwareCompatibility)}`,
       { status: 501, code: 'UNSUPPORTED_RUNTIME' },
     );
   }

--- a/server/services/videoGen/upscaleJob.test.js
+++ b/server/services/videoGen/upscaleJob.test.js
@@ -113,7 +113,17 @@ const conformingPlan = () => ({
     id: 'ltx25_mlx_q8', name: 'LTX-2.5 MLX Q8', repo: 'MrMofer/ltx-2.5-mlx-q8',
     revision: 'f1b56e7dc89f71a9af2cddac787b89ed22a8b7fc',
     path: '/cache/ltx25-mlx-q8', cached: true, reason: null,
+    hardwareCompatibility: { state: 'available', reasons: [], requirements: {} },
   },
+});
+
+// The shape the plan reports for a host below the pack's declared floor — the
+// server's own annotation, not a pre-rendered string, so these tests exercise
+// the same predicate production reads.
+const INCOMPATIBLE_HOST = Object.freeze({
+  state: 'unavailable',
+  reasons: ['Requires at least 64 GB of system memory'],
+  requirements: { minMemoryGb: 64 },
 });
 
 const sourceRow = (extra = {}) => ({
@@ -266,11 +276,55 @@ describe('enqueueLtxUpscale', () => {
     state.plan.baseModel = {
       id: 'ltx25_mlx_q8', name: 'LTX-2.5 MLX Q8', repo: 'MrMofer/ltx-2.5-mlx-q8',
       revision: 'f1b56e7dc89f71a9af2cddac787b89ed22a8b7fc',
-      path: null, cached: false, reason: 'LTX-2.5 MLX Q8 is not downloaded — download or repair it in Video Gen.',
+      path: null, cached: false,
+      hardwareCompatibility: { state: 'available', reasons: [], requirements: {} },
+      reason: 'LTX-2.5 MLX Q8 is not downloaded — download or repair it in Video Gen.',
     };
     await expect(enqueueLtxUpscale(SOURCE_ID))
       .rejects.toMatchObject({ status: 400, code: 'UPSCALE_BASE_MODEL_UNRESOLVED' });
     expect(enqueueJob).not.toHaveBeenCalled();
+  });
+
+  // #6537: the FOURTH readiness axis. A host can hold the venv, the adapter and
+  // the whole pack and still sit below what the pack declares it needs — the
+  // CUDA pack asks for 64 GB of system memory, and on a 32 GB host both LTX-2.5
+  // CUDA runners die inside the runtime's own loader seconds into the render.
+  // `generateVideo.js` already refuses a plain render on such a host; an upscale
+  // renders at twice the source's linear dimensions, strictly above a plain
+  // render's peak, so it must refuse wherever that one does.
+  it('refuses when the host does not meet the base pack\'s declared hardware requirements', async () => {
+    state.plan.baseModel.hardwareCompatibility = INCOMPATIBLE_HOST;
+    // The message must carry the host's real reason. Asserting only the code
+    // would still pass if the gate were re-pointed at a field nothing sets.
+    await expect(enqueueLtxUpscale(SOURCE_ID)).rejects.toMatchObject({
+      status: 501,
+      code: 'UNSUPPORTED_RUNTIME',
+      message: expect.stringContaining('Requires at least 64 GB of system memory'),
+    });
+    expect(enqueueJob).not.toHaveBeenCalled();
+  });
+
+  // Ordering is load-bearing: an incompatible host that is ALSO missing the pack
+  // must be told it cannot run the model, not told to download 72 GB of it.
+  it('reports the host refusal ahead of the download advice when both apply', async () => {
+    Object.assign(state.plan.baseModel, {
+      cached: false, path: null, hardwareCompatibility: INCOMPATIBLE_HOST,
+    });
+    await expect(enqueueLtxUpscale(SOURCE_ID)).rejects.toMatchObject({
+      status: 501,
+      code: 'UNSUPPORTED_RUNTIME',
+      message: expect.not.stringContaining('not downloaded'),
+    });
+    expect(enqueueJob).not.toHaveBeenCalled();
+  });
+
+  // Forward-compat: a plan produced by an older server carries no annotation at
+  // all. Absent is not "incompatible" — that install keeps queueing exactly what
+  // it queues today rather than being newly refused by a field it never sends.
+  it('still queues when the plan carries no hardware annotation at all', async () => {
+    delete state.plan.baseModel.hardwareCompatibility;
+    await expect(enqueueLtxUpscale(SOURCE_ID)).resolves.toMatchObject({ status: 'queued' });
+    expect(enqueueJob).toHaveBeenCalled();
   });
 
   it('keeps the already-upscaled guard, matching the inline path', async () => {

--- a/server/services/videoGen/upscaleVideo.js
+++ b/server/services/videoGen/upscaleVideo.js
@@ -115,12 +115,37 @@ const describeLtxAdapter = async () => {
 // without this the drawer would show a ready button for a job that dies minutes
 // later. Cache-only by construction — `inspectModelCache` reads the local HF
 // cache and never fetches, which is what keeps the plan endpoint read-only.
+//
+// The HOST is a fourth axis (#6537), and the only one no download can satisfy:
+// the registry declares what a pack needs of the machine (`ltx25_cuda_distilled`
+// asks for 64 GB of system memory), and a host below that floor cannot run it
+// for an upscale either — an upscale renders at twice the source's linear
+// dimensions, so it sits strictly ABOVE a plain render's peak. Without it the
+// plain render is refused up front with a stated reason while the upscale queues
+// a GPU job that dies seconds later inside the runtime's own loader, which is
+// exactly the "ready button for a job that dies minutes later" this axis exists
+// to prevent. Found on a 32 GB / RTX 3090 Windows host, where the pack's 26 GB
+// text encoder cannot be mapped a second time and both LTX-2.5 CUDA runners die
+// identically in `ltx_core`'s safetensors loader.
+//
+// The plan reports the server's `hardwareCompatibility` ANNOTATION rather than a
+// flattened boolean, exactly as every other model payload does, so the consumers
+// (`enqueueLtxUpscale`, the drawer) share one predicate — `isHardwareCompatible`
+// — instead of each re-deriving the tri-state rule. It stays independent of
+// `cached`: a pack can be fully downloaded onto a host that cannot run it, and
+// reporting that as "not downloaded" would send someone to re-fetch 72 GB that
+// is already on disk.
 const describeLtxBaseModel = async (runtimeId) => {
   const id = ltxUpscaleBaseModelId(runtimeId);
   const model = id ? getVideoModels().find((m) => m.id === id) || null : null;
   if (!model) {
+    // A registry gap is a configuration problem, not a statement about the host,
+    // so it carries NO hardware verdict — an absent annotation stays compatible
+    // and the existing `cached: false` refusal (UPSCALE_BASE_MODEL_UNRESOLVED)
+    // remains the accurate one.
     return {
       id, name: null, repo: null, revision: null, path: null, cached: false,
+      hardwareCompatibility: null,
       reason: `No base LTX-2.5 checkpoint is registered for the ${runtimeId || 'unknown'} backend.`,
     };
   }
@@ -136,6 +161,7 @@ const describeLtxBaseModel = async (runtimeId) => {
     // path that happens to be missing on disk.
     path: cached ? cache.snapshotPath : null,
     cached,
+    hardwareCompatibility: model.hardwareCompatibility ?? null,
     reason: cached ? null : `${model.name} is not downloaded — download or repair it in Video Gen.`,
   };
 };

--- a/server/services/videoGen/upscaleVideo.test.js
+++ b/server/services/videoGen/upscaleVideo.test.js
@@ -1,8 +1,9 @@
 import { describe, it, expect, beforeEach, afterAll, vi } from 'vitest';
 import { mkdirSync, writeFileSync } from 'fs';
+import os from 'os';
 import { join } from 'path';
 import { makePathsProxy, lazyTempDataRoot, cleanupTempDataRoots } from '../../lib/mockPathsDataRoot.js';
-import { pinPlatform } from '../../lib/testHelper.js';
+import { pinPlatform, pinArch } from '../../lib/testHelper.js';
 
 // The Lanczos path really copies a file, so PATHS.data must point at a temp
 // tree — the install's data/ is the developer's live gallery.
@@ -267,6 +268,65 @@ describe('planUpscaleHistoryItem', () => {
     expect(plan.adapter.cached).toBe(true);
     expect(plan.baseModel).toMatchObject({ cached: false, path: null });
     expect(plan.baseModel.reason).toMatch(/not downloaded/i);
+  });
+
+  // #6537: readiness has a FOURTH axis — the host itself. Driven through the
+  // REAL registry (only `os.totalmem` is pinned) so it proves the pack's own
+  // declared `minMemoryGb: 64` is what decides, not a verdict the test invented.
+  // A 32 GB Windows host is where this was found: every download is present and
+  // both LTX-2.5 CUDA runners still die inside the runtime's loader.
+  describe('host hardware readiness (#6537)', () => {
+    // Only the host's memory and platform are pinned — the registry entry, its
+    // declared `minMemoryGb`, and the compatibility evaluation are all real, so
+    // this proves the PACK's own floor is what decides rather than a verdict the
+    // test handed in.
+    const withHost = async ({ memoryGb, platform = 'win32', arch }) => {
+      const restorePlatform = pinPlatform(platform);
+      const restoreArch = arch ? pinArch(arch) : null;
+      const totalmem = vi.spyOn(os, 'totalmem').mockReturnValue(memoryGb * 1024 ** 3);
+      try {
+        return await planUpscaleHistoryItem(SOURCE_ID, { method: 'ltx' });
+      } finally {
+        totalmem.mockRestore();
+        restoreArch?.();
+        restorePlatform();
+      }
+    };
+
+    it('refuses the pack on a host below its declared memory floor, with the cache untouched', async () => {
+      const plan = await withHost({ memoryGb: 32 });
+      expect(plan.baseModel.id).toBe('ltx25_cuda_distilled');
+      expect(plan.baseModel.hardwareCompatibility.state).toBe('unavailable');
+      expect(plan.baseModel.hardwareCompatibility.reasons.join(' ')).toMatch(/64 GB/);
+      // `cached` and `reason` stay the honest CACHE answer. The axes are
+      // independent: a pack can be fully downloaded onto a host that cannot run
+      // it, and reporting that as "not downloaded" would send the user to
+      // re-download 72 GB that is already on disk.
+      expect(plan.baseModel.cached).toBe(true);
+      expect(plan.baseModel.reason).toBeNull();
+    });
+
+    it('reports a compatible verdict on a host that meets the floor', async () => {
+      const plan = await withHost({ memoryGb: 128 });
+      expect(plan.baseModel.hardwareCompatibility.state).not.toBe('unavailable');
+    });
+
+    it('keeps the two axes separate when the host is short AND the pack is missing', async () => {
+      state.baseModelCached = false;
+      const plan = await withHost({ memoryGb: 32 });
+      expect(plan.baseModel.hardwareCompatibility.state).toBe('unavailable');
+      expect(plan.baseModel.cached).toBe(false);
+      expect(plan.baseModel.reason).toMatch(/not downloaded/i);
+    });
+
+    // The MLX pack declares no memory floor, so this axis must not invent one
+    // for it — the backend verified on real renders (#6514) stays exactly as
+    // ready on the Apple Silicon host it is verified on.
+    it('leaves the MLX backend, which declares no memory floor, compatible', async () => {
+      const plan = await withHost({ memoryGb: 32, platform: 'darwin', arch: 'arm64' });
+      expect(plan.baseModel.id).toBe('ltx25_mlx_q8');
+      expect(plan.baseModel.hardwareCompatibility.state).not.toBe('unavailable');
+    });
   });
 
   // The registry holds `null` for this gated weight on purpose. An install that


### PR DESCRIPTION
## Summary

Dispatched to run the first real NVIDIA render of the LTX-2.5 generative video upscale (#6537). The render did not complete on this host, and chasing why surfaced a genuine gap in the upscale's readiness check — which this PR fixes.

**The gap.** A generative upscale is offered when the runtime venv, the gated adapter and the ~68 GB pack are all present. Nothing checked whether the machine meets what the pack *declares it needs*. `ltx25_cuda_distilled` declares `minMemoryGb: 64`; the plain-render path (`generateVideo.js`) has always refused a host below that, but the upscale path did not — it showed a ready button, queued a GPU job, and let it die seconds later inside the runtime's own loader. That is exactly the "ready button for a job that dies minutes later" the base-pack readiness axis was added to prevent.

An upscale renders at twice the source's linear dimensions, strictly above a plain render's peak, so anything a plain render is refused for an upscale must be refused for too.

**The fix.** The plan now reports the base pack's `hardwareCompatibility` annotation — the same object every other model payload carries — and both the dispatch and the drawer read it through the existing shared `isHardwareCompatible` / `isHardwareAvailable` predicate instead of each re-deriving the rule. An absent annotation still counts as compatible, so a plan from an older server queues exactly what it queues today.

The refusal is `UNSUPPORTED_RUNTIME` (501), deliberately not the plain-render sites' `MODEL_HARDWARE_UNAVAILABLE` (400): there the user *chose* an incompatible model, so the request is at fault; the upscale's checkpoint is pinned and not part of the request, so nothing the caller sent is wrong — the host simply cannot carry the method.

The reason sentence moves into `systemCapabilities` (server, mirrored client-side) rather than being hand-rolled a sixth time. Migrating the five pre-existing copies is #6540.

## What the NVIDIA attempt established

Recorded in `docs/features/video-upscale.md`. Everything short of the render worked on real weights:

- The gated adapter downloaded through the model surface at exactly its pinned `sizeBytes` (327,322,640), and its `reference_downscale_factor` read back as **2, measured off the file**.
- Pre-submit plans were correct for all three source shapes — conforming (no padding), 23-frame (`padFrames: 2`), and 312×568 (`padWidth`/`padHeight` 8 → padded 320×576) — with audio presence right in each.
- `assert_adapter_fuses` verified the adapter fuses into **480** transformer weights, so the adapter and the pinned checkpoint genuinely match.
- The failed job left the source clips byte-identical, wrote no history row, and left no partial output.

The render itself did not run. Both `upscale_ltx25_cuda.py` **and** `generate_ltx25_cuda.py` fail identically ~18 s in, inside `ltx_core`'s own loader, on the 26 GB text encoder: `RuntimeError: Attempted to access the data pointer on an invalid python storage`. It reduces to a six-line repro with no PortOS code involved — hold one `safetensors.safe_open` handle on a pack file and open a second with `device="cuda"`; files up to ~1.5 GB are fine, the 26 GB text encoder and 42 GB transformer are not. `ltx_core`'s disk-streaming path does exactly that.

So the failure is **not** upscale-specific and not a defect in the shared runner contract — it is the whole `ltx25_cuda` runtime on a host below the pack's memory floor. The CUDA backend therefore stays documented as **unverified**.

## Test plan

- `server/services/videoGen/upscaleVideo.test.js` — four new cases drive the axis through the **real** registry (only `os.totalmem`/platform pinned), so the pack's own declared `minMemoryGb: 64` is what decides: refused at 32 GB with the cache verdict untouched, compatible at 128 GB, both axes kept separate when the host is short *and* the pack is missing, and the MLX backend (which declares no memory floor) left compatible.
- `server/services/videoGen/upscaleJob.test.js` — refuses with `UNSUPPORTED_RUNTIME` and a message carrying the host's real reason; states the host problem ahead of the download advice; still queues when the plan carries no annotation (older server).
- `client/.../VideoUpscaleDrawer.test.jsx` — button disabled with the host reason and no pointless "Download adapter" offer; stays enabled on an annotation-less plan.
- Full affected server surface green: 1438 passed across the 30 suites touching `pinPlatform`/`systemCapabilities`/`videoGen`. Client: 643 passed. The one red suite in `services/videoGen` (`ref2vaWrapper`, `spawn EFTYPE`) fails identically on unmodified `main` — pre-existing and Windows-specific.
- Verified end to end against a real server: the plan reports `state: "unavailable"` with the 64 GB reason, and `POST /api/video-gen/upscale/:id` returns 501 instead of queueing.

Refs #6537

## Remaining

#6537 stays open. Its acceptance — a real generative upscale rendered on an NVIDIA card with the numbers posted, and the readiness table flipped to verified — is **not** met: no render completed, so there is nothing to verify. That needs a licensed NVIDIA machine with **≥64 GB of system memory**; this host has 32 GB. Acceptance item 2 (confirming the existing LTX-2.5 text-to-video and image-conditioned paths still render) is likewise unmet here — they fail in the same loader, so this host has no working baseline to compare against.