### PR TITLE
fix: unify hardware-unavailable messages and fallback

### DIFF
--- a/client/src/components/providers/ProviderCard.jsx
+++ b/client/src/components/providers/ProviderCard.jsx
@@ -11,6 +11,7 @@
  * and which section the page filed the card under can never disagree.
  */
 
+import { hardwareUnavailableReason } from '../../utils/systemCapabilities';
 import { Link } from 'react-router';
 import { ExternalLink, Network, Terminal } from 'lucide-react';
 import {
@@ -242,7 +243,7 @@ export default function ProviderCard({
           {!isProviderHardwareCompatible(provider) && (
             <span
               className="text-xs px-2 py-0.5 rounded bg-port-warning/20 text-port-warning"
-              title={provider.hardwareCompatibility?.reasons?.join(' · ')}
+              title={hardwareUnavailableReason('This provider', provider.hardwareCompatibility)}
             >
               HARDWARE MISMATCH
             </span>
@@ -423,7 +424,7 @@ export default function ProviderCard({
 
         {!isProviderHardwareCompatible(provider) && (
           <div className="max-w-3xl text-xs rounded border border-port-warning/40 bg-port-warning/10 px-3 py-2 text-port-warning">
-            Hidden from provider/model pickers on this machine: {provider.hardwareCompatibility?.reasons?.join(' · ') || 'hardware requirements are not met'}.
+            {hardwareUnavailableReason('This provider', provider.hardwareCompatibility)}. Hidden from provider/model pickers on this machine.
           </div>
         )}
 

--- a/client/src/components/providers/ProviderForm.jsx
+++ b/client/src/components/providers/ProviderForm.jsx
@@ -1,3 +1,4 @@
+import { hardwareUnavailableReason } from '../../utils/systemCapabilities';
 import { useState } from 'react';
 import { AlertTriangle } from 'lucide-react';
 import toast from '../ui/Toast';
@@ -400,7 +401,7 @@ export default function ProviderForm({ provider, onClose, onSave, onEditProvider
           {provider?.hardwareCompatibility?.state === 'unavailable' && (
             <Banner tone="warning" icon={AlertTriangle}>
               <p>
-                This provider is unavailable on this machine: {provider.hardwareCompatibility.reasons?.join(' · ') || 'hardware requirements are not met'}.
+                {hardwareUnavailableReason('This provider', provider.hardwareCompatibility)}.
                 Its models are hidden from selection until the host matches those requirements.
               </p>
             </Banner>

--- a/server/services/imageGen/local.js
+++ b/server/services/imageGen/local.js
@@ -41,7 +41,7 @@ import { parseByteProgress, formatDownloadMessage } from '../videoGen/generateVi
 const IS_WIN = process.platform === 'win32';
 
 import { getImageModels, isFlux2, isErnie, isHiDream, isQwen } from '../../lib/mediaModels.js';
-import { isHardwareCompatible } from '../../lib/systemCapabilities.js';
+import { hardwareUnavailableReason, isHardwareCompatible } from '../../lib/systemCapabilities.js';
 import { usesDiffusersRunner, flux2Bf16BaseRepo } from '../../lib/runners.js';
 import { weaveLoraTriggers } from '../../lib/loraTriggers.js';
 import { provenanceForRender } from '../../lib/assetProvenance.js';
@@ -574,7 +574,7 @@ export async function generateImage({ pythonPath, prompt = '', negativePrompt = 
   if (!model) throw new ServerError(`Unknown or unsupported model: ${modelId}`, { status: 400, code: 'VALIDATION_ERROR' });
   if (!isHardwareCompatible(model.hardwareCompatibility)) {
     throw new ServerError(
-      `Image model "${modelId}" is unavailable on this machine: ${model.hardwareCompatibility.reasons.join(' · ')}`,
+      hardwareUnavailableReason(`Image model "${modelId}"`, model.hardwareCompatibility),
       { status: 400, code: 'MODEL_HARDWARE_UNAVAILABLE' },
     );
   }

--- a/server/services/imageGen/prepareParams.js
+++ b/server/services/imageGen/prepareParams.js
@@ -36,7 +36,7 @@ import { RENDER_TARGET, recordRenderPin } from '../../lib/renderTargets.js';
 import { getProject as getMusicVideoProject } from '../musicVideo/projects.js';
 import { getUniverseRenderPin } from '../universeBuilder/crud.js';
 import { getImageModels, isFlux2, isEditOnly } from '../../lib/mediaModels.js';
-import { isHardwareCompatible } from '../../lib/systemCapabilities.js';
+import { hardwareUnavailableReason, isHardwareCompatible } from '../../lib/systemCapabilities.js';
 import { usesDiffusersRunner } from '../../lib/runners.js';
 
 // The job tags that name the record owning a render, each mapped to the record
@@ -382,7 +382,7 @@ export function resolveLocalImageModel(settings, params) {
   const selectedModel = selectLocalImageModel(params.modelId, allModels);
   if (selectedModel && !isHardwareCompatible(selectedModel.hardwareCompatibility)) {
     throw new ServerError(
-      `Image model "${selectedModel.id}" is unavailable on this machine: ${selectedModel.hardwareCompatibility.reasons.join(' · ')}`,
+      hardwareUnavailableReason(`Image model "${selectedModel.id}"`, selectedModel.hardwareCompatibility),
       { status: 400, code: 'MODEL_HARDWARE_UNAVAILABLE' },
     );
   }

--- a/server/services/videoGen/generateVideo.js
+++ b/server/services/videoGen/generateVideo.js
@@ -26,7 +26,7 @@ import {
 import { videoGenEvents } from './events.js';
 import { broadcastSse, closeJobAfterDelay } from '../../lib/sseUtils.js';
 import { getVideoModels, getDefaultVideoModelId, getTextEncoderRepo } from '../../lib/mediaModels.js';
-import { isHardwareCompatible } from '../../lib/systemCapabilities.js';
+import { hardwareUnavailableReason, isHardwareCompatible } from '../../lib/systemCapabilities.js';
 import { resolveVideoModelSelection } from './modelSelection.js';
 import { findFfmpeg, findFfprobe } from '../../lib/ffmpeg.js';
 import { inspectModelCache, findCachedRepoFile, findCachedRepoFiles } from '../../lib/hfCache.js';
@@ -167,7 +167,7 @@ export async function generateVideo({ pythonPath, prompt, negativePrompt = '', m
   validateVideoBatch({ batchSize, seed }, model);
   if (!isHardwareCompatible(model.hardwareCompatibility)) {
     throw new ServerError(
-      `Video model "${modelId}" is unavailable on this machine: ${model.hardwareCompatibility.reasons.join(' · ')}`,
+      hardwareUnavailableReason(`Video model "${modelId}"`, model.hardwareCompatibility),
       { status: 400, code: 'MODEL_HARDWARE_UNAVAILABLE' },
     );
   }

--- a/server/services/videoGen/prepareParams.js
+++ b/server/services/videoGen/prepareParams.js
@@ -62,6 +62,7 @@ import {
 import {
   captureSystemCapabilities,
   detectSystemCapabilities,
+  hardwareUnavailableReason,
   isHardwareCompatible,
   withHardwareCompatibility,
 } from '../../lib/systemCapabilities.js';
@@ -95,7 +96,7 @@ export async function validateVideoRetryParams(params = {}) {
   }
   if (!isHardwareCompatible(model.hardwareCompatibility)) {
     throw new ServerError(
-      `Video model "${modelId}" is unavailable on this machine: ${model.hardwareCompatibility.reasons.join(' · ')}`,
+      hardwareUnavailableReason(`Video model "${modelId}"`, model.hardwareCompatibility),
       { status: 400, code: 'MODEL_HARDWARE_UNAVAILABLE' },
     );
   }
@@ -330,7 +331,7 @@ export async function prepareVideoGenParams({ body, uploads, localOnlyParamKeys 
   if (effectiveModel && !isHardwareCompatible(effectiveModel.hardwareCompatibility)) {
     await cleanupMultipartTemp(uploads);
     throw new ServerError(
-      `Video model "${effectiveModelId}" is unavailable on this machine: ${effectiveModel.hardwareCompatibility.reasons.join(' · ')}`,
+      hardwareUnavailableReason(`Video model "${effectiveModelId}"`, effectiveModel.hardwareCompatibility),
       { status: 400, code: 'MODEL_HARDWARE_UNAVAILABLE' },
     );
   }


### PR DESCRIPTION
The five image/video hardware refusals now use hardwareUnavailableReason, preserving their model-ID subjects and MODEL_HARDWARE_UNAVAILABLE/400 errors while handling absent or empty reasons. Provider card and editor warnings use the mirrored client helper and retain picker-visibility guidance.

Validation: 143 focused server tests and 18 client tests passed; client production build passed. The refusal template remains only in the two unchanged helper implementations. Pinned tool-free Ollama review: No findings.

Closes #6540
