### PR TITLE
fix: retain Creative Director effort pins through stage dispatch

### DIFF
--- a/client/src/components/creative-commission/CommissionConfigForm.jsx
+++ b/client/src/components/creative-commission/CommissionConfigForm.jsx
@@ -163,6 +163,7 @@ export default function CommissionConfigForm({ form, patchForm, saving, onSave, 
         <AssignmentPicker
           assignment={form.assignment}
           onChange={(next) => patchForm(['assignment'], next)}
+          onEffortChange={(effort) => patchForm(['assignment', 'effort'], effort)}
         />
       </section>
 
@@ -501,7 +502,7 @@ function RenderBackendSection({ ability, generation, patchForm }) {
 // so naming the registry's active provider here would misreport the processor on
 // installs that assign the CD stages separately. Label it neutrally; the section
 // helper text points the user at their Creative Director assignment.
-function AssignmentPicker({ assignment, onChange }) {
+function AssignmentPicker({ assignment, onChange, onEffortChange }) {
   const [providers, setProviders] = useState([]);
 
   useEffect(() => {
@@ -520,8 +521,10 @@ function AssignmentPicker({ assignment, onChange }) {
       providers={providers}
       selectedProviderId={assignment.providerId || ''}
       selectedModel={assignment.model || ''}
+      effort={assignment.effort || ''}
+      onEffortChange={onEffortChange}
       availableModels={availableModels}
-      onProviderChange={(id) => onChange({ providerId: id || '', model: '' })}
+      onProviderChange={(id) => onChange({ providerId: id || '', model: '', effort: '' })}
       onModelChange={(model) => onChange({ ...assignment, model: model || '' })}
       label="Provider"
       modelDisabled={availableModels.length === 0}

--- a/client/src/components/creative-commission/CommissionConfigForm.test.jsx
+++ b/client/src/components/creative-commission/CommissionConfigForm.test.jsx
@@ -9,21 +9,26 @@ const api = vi.hoisted(() => ({
   listImageModels: vi.fn(), listVideoModels: vi.fn(),
 }));
 vi.mock('../../services/api', () => api);
-vi.mock('../ProviderModelSelector', () => ({ default: () => <div data-testid="provider-model-selector" /> }));
+vi.mock('../../services/apiLocalLlm', () => ({ getToolUseModels: vi.fn(async () => ({ providers: [] })) }));
 
-function Harness() {
+
+function Harness({ assignment } = {}) {
   const [form, setForm] = useState(toForm({
+    assignment,
     targetAbility: 'music',
     brief: { intent: 'original ambient track', musicTaste: { source: 'digital-twin' } },
     generation: { lengthSeconds: 45 },
   }));
   return (
+    <>
+    <output data-testid="assignment">{JSON.stringify(form.assignment)}</output>
     <CommissionConfigForm
       form={form}
       patchForm={(path, value) => setForm((prev) => patchFormState(prev, path, value))}
       saving={false}
       onSave={() => {}}
     />
+    </>
   );
 }
 
@@ -124,4 +129,14 @@ describe('CommissionConfigForm video duration controls', () => {
     fireEvent.change(screen.getByLabelText('Video length'), { target: { value: 'manual' } });
     expect(screen.getByLabelText('Duration (sec)')).toHaveValue(10);
   });
+});
+
+
+it('keeps a newly selected model when that selection clears unsupported effort', async () => {
+  api.getProviders.mockResolvedValue({ providers: [{ id: 'agent', type: 'cli', enabled: true, name: 'Example agent', models: ['thinking', 'plain'], effortLevels: ['low', 'high'], effortLevelsByModel: { thinking: ['low', 'high'], plain: [] } }] });
+  render(<Harness assignment={{ providerId: 'agent', model: 'thinking', effort: 'high' }} />);
+  await waitFor(() => expect(screen.getByLabelText('Thinking effort')).toHaveValue('high'));
+  const modelSelect = screen.getAllByRole('combobox').find(select => [...select.options].some(option => option.value === 'plain'));
+  fireEvent.change(modelSelect, { target: { value: 'plain' } });
+  expect(JSON.parse(screen.getByTestId('assignment').textContent)).toEqual({ providerId: 'agent', model: 'plain', effort: '' });
 });

--- a/client/src/components/creative-commission/commissionForm.js
+++ b/client/src/components/creative-commission/commissionForm.js
@@ -253,6 +253,7 @@ export function toForm(c) {
     assignment: {
       providerId: c.assignment?.providerId || '',
       model: c.assignment?.model || '',
+      effort: c.assignment?.effort || '',
     },
     // How many recent reactions steer the next run (0 disables conditioning).
     feedbackWindow: Number.isInteger(c.feedbackWindow) ? c.feedbackWindow : 5,
@@ -301,6 +302,7 @@ export function toPayload(form) {
     assignment: {
       providerId: form.assignment.providerId || null,
       model: form.assignment.providerId ? (form.assignment.model || null) : null,
+      ...(form.assignment.providerId && form.assignment.effort ? { effort: form.assignment.effort } : {}),
     },
     feedbackWindow: Number(form.feedbackWindow),
   };

--- a/client/src/components/creative-commission/commissionForm.test.js
+++ b/client/src/components/creative-commission/commissionForm.test.js
@@ -21,7 +21,7 @@ describe('commissionForm helpers', () => {
         quality: 'standard', aspectRatio: '16:9', targetDurationSeconds: 10, durationMode: 'auto',
         videoMode: 'auto', videoModelId: null,
       });
-      expect(f.assignment).toEqual({ providerId: '', model: '' });
+      expect(f.assignment).toEqual({ providerId: '', model: '', effort: '' });
       expect(f.musicTaste).toEqual({
         enabled: false, source: 'digital-twin', window: 'month', anchorCount: 3,
         explorationPercent: 20, musicEngineId: '', musicModelId: '',
@@ -303,3 +303,12 @@ describe('commissionForm helpers', () => {
   });
 });
 // @vitest-environment node
+
+
+it('round-trips commission effort and drops it when the provider is cleared', () => {
+  const assignment = { providerId: 'example-agent', model: 'example-model', effort: 'high' };
+  const form = toForm({ assignment });
+  expect(toPayload(form).assignment).toEqual(assignment);
+  form.assignment.providerId = '';
+  expect(toPayload(form).assignment).toEqual({ providerId: null, model: null });
+});

--- a/client/src/components/creative-director/CreativeDirectorModelsDrawer.jsx
+++ b/client/src/components/creative-director/CreativeDirectorModelsDrawer.jsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router';
 import { Bot, Save } from 'lucide-react';
 import Drawer from '../Drawer.jsx';
+import EffortSelect from '../cos/EffortSelect.jsx';
 import toast from '../ui/Toast';
 import ToolUseWarning from '../ui/ToolUseWarning.jsx';
 import { getAiAssignments, updateAiAssignment } from '../../services/api';
@@ -10,6 +11,8 @@ import useVisionModelIds from '../../hooks/useVisionModelIds.js';
 import useToolUseModelIds from '../../hooks/useToolUseModelIds.js';
 import {
   providerDisplayName,
+  effortSurvivingModel,
+  effectiveModelFor,
   assignmentProviderOptions,
   assignmentModelOptions,
   assignmentDefaultModel,
@@ -57,7 +60,7 @@ const assignmentIdFor = (key) => `settings.creativeDirector.${key}`;
 // below sound.
 const draftsFrom = (pinFor) => Object.fromEntries(STAGES.map(({ key }) => {
   const pin = pinFor(key) || {};
-  return [key, { providerId: pin.providerId || '', model: pin.model || '' }];
+  return [key, { providerId: pin.providerId || '', model: pin.model || '', ...(key !== 'evaluation' ? { effort: pin.effort || '' } : {}) }];
 }));
 
 const blankDrafts = () => draftsFrom(() => null);
@@ -159,7 +162,7 @@ export default function CreativeDirectorModelsDrawer({ open, onClose, project, o
       if (JSON.stringify(d) === JSON.stringify(baseline[key])) continue;
       const next = await updateAiAssignment(
         assignmentIdFor(key),
-        { providerId: d.providerId || null, model: d.model || null },
+        { providerId: d.providerId || null, model: d.model || null, ...(key !== 'evaluation' ? { effort: d.effort || null } : {}) },
         { silent: true },
       ).catch((err) => {
         toast.error(`Failed to save ${label}: ${err.message}`);
@@ -177,7 +180,7 @@ export default function CreativeDirectorModelsDrawer({ open, onClose, project, o
     const modelOverrides = {};
     for (const { key } of STAGES) {
       const d = drafts[key];
-      if (d?.providerId) modelOverrides[key] = { providerId: d.providerId, ...(d.model ? { model: d.model } : {}) };
+      if (d?.providerId) modelOverrides[key] = { providerId: d.providerId, ...(d.model ? { model: d.model } : {}), ...(key !== 'evaluation' && d.effort ? { effort: d.effort } : {}) };
     }
     return updateCreativeDirectorProject(project.id, { modelOverrides }, { silent: true })
       .catch((err) => {
@@ -299,7 +302,7 @@ export default function CreativeDirectorModelsDrawer({ open, onClose, project, o
                           : '';
                         // Seed the provider's default model on switch; clearing the
                         // provider clears the model too.
-                        setStage(stage.key, { providerId, model: nextDefault });
+                        setStage(stage.key, { providerId, model: nextDefault, ...(stage.key !== 'evaluation' ? { effort: '' } : {}) });
                       }}
                       className="bg-port-card border border-port-border rounded px-2 py-2 text-sm text-white"
                     >
@@ -322,7 +325,7 @@ export default function CreativeDirectorModelsDrawer({ open, onClose, project, o
                       <select
                         value={draft.model}
                         aria-label={`${stage.label} model`}
-                        onChange={(e) => setStage(stage.key, { model: e.target.value })}
+                        onChange={(e) => setStage(stage.key, { model: e.target.value, ...(stage.key !== 'evaluation' ? { effort: effortSurvivingModel(selectedProvider, e.target.value, draft.effort) } : {}) })}
                         className="bg-port-card border border-port-border rounded px-2 py-2 text-sm text-white"
                       >
                         <option value="">Provider default / auto</option>
@@ -338,13 +341,25 @@ export default function CreativeDirectorModelsDrawer({ open, onClose, project, o
                       <input
                         value={draft.model}
                         aria-label={`${stage.label} model`}
-                        onChange={(e) => setStage(stage.key, { model: e.target.value })}
+                        onChange={(e) => setStage(stage.key, { model: e.target.value, ...(stage.key !== 'evaluation' ? { effort: effortSurvivingModel(selectedProvider, e.target.value, draft.effort) } : {}) })}
                         placeholder="Provider default / auto"
                         className="bg-port-card border border-port-border rounded px-2 py-2 text-sm text-white placeholder-gray-600"
                       />
                     )}
                   </div>
                 </div>
+
+                {stage.key !== 'evaluation' && pinned && (
+                  <EffortSelect
+                    provider={selectedProvider}
+                    model={effectiveModelFor(selectedProvider, draft.model)}
+                    value={draft.effort}
+                    onChange={(effort) => setStage(stage.key, { effort })}
+                    label={`${stage.label} effort`}
+                    className="bg-port-card border border-port-border rounded px-2 py-2 text-sm text-white"
+                    hint="Default effort uses this provider's default, without inheriting another assignment's effort."
+                  />
+                )}
 
                 {noVisionModels && (
                   <p className="text-xs text-port-warning">

--- a/client/src/components/creative-director/CreativeDirectorModelsDrawer.test.jsx
+++ b/client/src/components/creative-director/CreativeDirectorModelsDrawer.test.jsx
@@ -382,7 +382,7 @@ describe('CreativeDirectorModelsDrawer', () => {
 
       await waitFor(() => expect(updateAiAssignment).toHaveBeenCalledTimes(1));
       expect(updateAiAssignment.mock.calls[0][0]).toBe('settings.creativeDirector.treatment');
-      expect(updateAiAssignment.mock.calls[0][1]).toEqual({ providerId: 'agent-a', model: 'a-default' });
+      expect(updateAiAssignment.mock.calls[0][1]).toEqual({ providerId: 'agent-a', model: 'a-default', effort: null });
       // Untouched stages are not PUT.
       expect(updateAiAssignment.mock.calls.map((c) => c[0])).not.toContain('settings.creativeDirector.plan');
     });
@@ -425,4 +425,23 @@ describe('CreativeDirectorModelsDrawer', () => {
       expect(updateCreativeDirectorProject).not.toHaveBeenCalled();
     });
   });
+});
+
+
+it('loads, changes, clears and resets project effort without exposing vision effort', async () => {
+  getAiAssignments.mockResolvedValue({ ...ASSIGNMENTS, providers: ASSIGNMENTS.providers.map(p => p.id === 'agent-a' ? { ...p, effortLevels: ['low', 'high', 'max'] } : p) });
+  updateCreativeDirectorProject.mockImplementation(async (_id, patch) => patch);
+  renderDrawer({ id: 'cd-1', name: 'Example', modelOverrides: { plan: { providerId: 'agent-a', model: 'a-default', effort: 'high' } } });
+  await waitFor(() => expect(screen.getByLabelText('Production plan effort')).toHaveValue('high'));
+  expect(screen.queryByLabelText('Scene evaluation effort')).not.toBeInTheDocument();
+  fireEvent.change(screen.getByLabelText('Production plan effort'), { target: { value: 'max' } });
+  fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+  await waitFor(() => expect(updateCreativeDirectorProject).toHaveBeenLastCalledWith('cd-1', { modelOverrides: { plan: { providerId: 'agent-a', model: 'a-default', effort: 'max' } } }, { silent: true }));
+  fireEvent.change(screen.getByLabelText('Production plan effort'), { target: { value: '' } });
+  fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+  await waitFor(() => expect(updateCreativeDirectorProject).toHaveBeenLastCalledWith('cd-1', { modelOverrides: { plan: { providerId: 'agent-a', model: 'a-default' } } }, { silent: true }));
+  fireEvent.change(screen.getByLabelText('Production plan effort'), { target: { value: 'high' } });
+  fireEvent.change(screen.getByLabelText('Production plan provider'), { target: { value: '' } });
+  fireEvent.change(screen.getByLabelText('Production plan provider'), { target: { value: 'agent-a' } });
+  expect(screen.getByLabelText('Production plan effort')).toHaveValue('');
 });

--- a/server/lib/creativeCommissionValidation.js
+++ b/server/lib/creativeCommissionValidation.js
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { EFFORT_LEVELS } from './providerModels.js';
 import { QUEUEABLE_IMAGE_MODES, VIDEO_GEN_MODES } from './generationModes.js';
 import { RENDER_TARGET_BACKEND_AUTO } from './renderTargets.js';
 import { recurrenceRuleSchema } from './recurrenceValidation.js';
@@ -327,6 +328,7 @@ function refineGenerationForAbilityIfTargetPresent(data, ctx) {
 // API-type provider injected into an agent task trips the harness-boundary guard
 // (see agentBridge.js). Bounded to 120 chars like the CD project pin.
 export const creativeCommissionAssignmentSchema = z.object({
+  effort: z.preprocess(v => v === '' ? undefined : v, z.enum(EFFORT_LEVELS).nullable().optional()),
   providerId: z.string().trim().max(120).nullable().optional(),
   model: z.string().trim().max(120).nullable().optional(),
 });

--- a/server/lib/creativeDirectorValidation.js
+++ b/server/lib/creativeDirectorValidation.js
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { EFFORT_LEVELS } from './providerModels.js';
 import { ASPECT_RATIOS, QUALITIES, PROJECT_STATUSES, SCENE_STATUSES, PLAN_STEP_STATUSES } from './creativeDirectorPresets.js';
 import { ARC_SHAPE_IDS, ARC_ROLES } from './storyArc.js';
 import { BIBLE_LIMITS } from './storyBible.js';
@@ -90,6 +91,7 @@ export const creativeDirectorDirectiveSchema = z.object({
 export const creativeDirectorStagePinSchema = z.object({
   providerId: z.string().max(120).nullable().optional(),
   model: z.string().max(200).nullable().optional(),
+  effort: z.preprocess(emptyToUndefined, z.enum(EFFORT_LEVELS).nullable().optional()),
 }).strict();
 
 export const creativeDirectorModelOverridesSchema = z.object({

--- a/server/services/aiAssignments.js
+++ b/server/services/aiAssignments.js
@@ -156,6 +156,8 @@ const addSettingsEntries = async (entries) => {
     source: 'settings.creativeDirector.treatment',
     providerId: settings.creativeDirector?.treatment?.providerId || null,
     model: settings.creativeDirector?.treatment?.model || null,
+    effort: settings.creativeDirector?.treatment?.effort || null,
+    effortEditable: true,
     ...agentEntry,
     notes: 'Agent model that turns a project brief into a treatment and scene plan. Blank = system default provider and model. Each Creative Director project can override this from its Models drawer.',
     link: '/creative-director',
@@ -169,6 +171,8 @@ const addSettingsEntries = async (entries) => {
     source: 'settings.creativeDirector.plan',
     providerId: settings.creativeDirector?.plan?.providerId || null,
     model: settings.creativeDirector?.plan?.model || null,
+    effort: settings.creativeDirector?.plan?.effort || null,
+    effortEditable: true,
     ...agentEntry,
     notes: 'Agent model that converts a production directive into an executable plan. Blank = system default provider and model. Each Creative Director project can override this from its Models drawer.',
     link: '/creative-director',
@@ -539,7 +543,7 @@ export async function updateAiAssignment(id, payload = {}) {
     if (!['treatment', 'plan', 'evaluation'].includes(stage)) {
       throw new ServerError(`Unknown Creative Director assignment: ${id}`, { status: 400, code: 'VALIDATION_ERROR' });
     }
-    await patchSettingsPath(`creativeDirector.${stage}`, { providerId: nextProviderId, model: nextModel });
+    await patchSettingsPath(`creativeDirector.${stage}`, { providerId: nextProviderId, model: nextModel, ...(stage !== 'evaluation' ? effortPatch : {}) });
     return getAiAssignments();
   }
 

--- a/server/services/aiAssignments.test.js
+++ b/server/services/aiAssignments.test.js
@@ -225,8 +225,8 @@ describe('updateAiAssignment routing', () => {
   });
 
   it.each(['treatment', 'plan'])('settings.creativeDirector.%s writes that agent stage provider/model', async (stage) => {
-    await updateAiAssignment(`settings.creativeDirector.${stage}`, { providerId: 'claude', model: 'sonnet' });
-    expect(mocks.updateSettings).toHaveBeenCalledWith({ creativeDirector: { [stage]: { providerId: 'claude', model: 'sonnet' } } });
+    await updateAiAssignment(`settings.creativeDirector.${stage}`, { providerId: 'claude', model: 'sonnet', effort: 'high' });
+    expect(mocks.updateSettings).toHaveBeenCalledWith({ creativeDirector: { [stage]: { providerId: 'claude', model: 'sonnet', effort: 'high' } } });
   });
 
   it('settings.creativeDirector.<unknown> rejects with a 400 instead of writing a bogus stage', async () => {

--- a/server/services/creativeCommissions/projectControl.js
+++ b/server/services/creativeCommissions/projectControl.js
@@ -88,7 +88,7 @@ export async function commissionStagePin(commissionId) {
     console.warn(`⚠️ Creative commission ${commissionId} pins unusable provider '${providerId}' (${reason}) — falling back to the default CD assignment`);
     return null;
   }
-  return { providerId, ...(commission.assignment.model ? { model: commission.assignment.model } : {}) };
+  return { providerId, ...(commission.assignment.model ? { model: commission.assignment.model } : {}), ...(commission.assignment.effort ? { effort: commission.assignment.effort } : {}) };
 }
 
 /**

--- a/server/services/creativeCommissions/projectControl.test.js
+++ b/server/services/creativeCommissions/projectControl.test.js
@@ -62,7 +62,7 @@ const {
 const commission = (over = {}) => ({
   id: 'commission-1',
   enabled: true,
-  assignment: { providerId: 'lmstudio-tui', model: 'qwen3.6:35b' },
+  assignment: { providerId: 'lmstudio-tui', model: 'qwen3.6:35b', effort: 'high' },
   runs: [],
   ...over,
 });
@@ -109,7 +109,7 @@ describe('ledgerProjectIds', () => {
 describe('commissionStagePin', () => {
   it('resolves the commission LIVE, so a dispatch picks up an edited provider', async () => {
     readRawMock.mockResolvedValue(commission());
-    expect(await commissionStagePin('commission-1')).toEqual({ providerId: 'lmstudio-tui', model: 'qwen3.6:35b' });
+    expect(await commissionStagePin('commission-1')).toEqual({ providerId: 'lmstudio-tui', model: 'qwen3.6:35b', effort: 'high' });
   });
 
   it('inherits the default when nothing is pinned', async () => {

--- a/server/services/creativeCommissions/store.js
+++ b/server/services/creativeCommissions/store.js
@@ -51,6 +51,7 @@
  * scheduler graph.
  */
 
+import { EFFORT_LEVELS } from '../../lib/providerModels.js';
 import { join } from 'path';
 import { randomUUID } from 'crypto';
 import { EventEmitter } from 'events';
@@ -280,6 +281,7 @@ export function sanitizeCommission(raw) {
     assignment: {
       providerId: assignmentProviderId,
       model: assignmentModel,
+      ...(assignmentProviderId && EFFORT_LEVELS.includes(assignment.effort) ? { effort: assignment.effort } : {}),
     },
     // Phase 2: deep-sanitize each reaction (drop ratingless/malformed entries)
     // and cap history. Phase 1 records carry an empty array, so this is a no-op

--- a/server/services/creativeCommissions/store.test.js
+++ b/server/services/creativeCommissions/store.test.js
@@ -866,3 +866,9 @@ describe('submitCommissionFeedback', () => {
     ).rejects.toMatchObject({ code: ERR_NOT_FOUND });
   });
 });
+
+
+it('keeps effort on a valid commission assignment and clears orphaned effort', () => {
+  expect(sanitizeCommission({ id: 'example', assignment: { providerId: 'agent', effort: 'high' } }).assignment).toEqual({ providerId: 'agent', model: null, effort: 'high' });
+  expect(sanitizeCommission({ id: 'example', assignment: { effort: 'high' } }).assignment).toEqual({ providerId: null, model: null });
+});

--- a/server/services/creativeDirector/agentBridge.js
+++ b/server/services/creativeDirector/agentBridge.js
@@ -76,6 +76,7 @@ async function getStageAssignment(kind, project) {
   return {
     ...(assignment.providerId ? { provider: assignment.providerId, providerId: assignment.providerId } : {}),
     ...(assignment.model ? { model: assignment.model } : {}),
+    ...(assignment.effort ? { effort: assignment.effort } : {}),
   };
 }
 

--- a/server/services/creativeDirector/agentBridge.test.js
+++ b/server/services/creativeDirector/agentBridge.test.js
@@ -267,3 +267,23 @@ describe('deliverable baseline stamped on the run row (#4146)', () => {
     expect(mocks.recordRun.mock.calls[0][1]).not.toHaveProperty('deliverableMark');
   });
 });
+
+
+describe('cognitive effort dispatch', () => {
+  it('takes the entire project, live commission, or global pin, including effort', async () => {
+    mocks.getSettings.mockResolvedValue({ creativeDirector: { plan: { providerId: 'global', model: 'global-model', effort: 'low' } } });
+    mocks.commissionStagePin.mockResolvedValue({ providerId: 'commission', model: 'commission-model', effort: 'high' });
+    const owned = { ...project, commissionId: 'commission-1' };
+    const first = await enqueuePlanTask({ ...owned, modelOverrides: { plan: { providerId: 'project', model: 'project-model', effort: 'max' } } });
+    expect(first.metadata).toMatchObject({ providerId: 'project', model: 'project-model', effort: 'max' });
+    const providerOnly = await enqueuePlanTask({ ...owned, modelOverrides: { plan: { providerId: 'project' } } });
+    expect(providerOnly.metadata).not.toHaveProperty('effort');
+    expect(providerOnly.metadata).not.toHaveProperty('model');
+    expect((await enqueuePlanTask(owned)).metadata).toMatchObject({ providerId: 'commission', effort: 'high' });
+    mocks.commissionStagePin.mockResolvedValue(null);
+    expect((await enqueuePlanTask(owned)).metadata).toMatchObject({ providerId: 'global', effort: 'low' });
+    const evaluation = await enqueueEvaluateTask({ ...owned, modelOverrides: { evaluation: { providerId: 'vision', effort: 'high' } } }, { sceneId: 'scene-1', order: 0 });
+    expect(evaluation.metadata).not.toHaveProperty('effort');
+    expect(evaluation.metadata).not.toHaveProperty('providerId');
+  });
+});

--- a/server/services/creativeDirector/projectsDB.test.js
+++ b/server/services/creativeDirector/projectsDB.test.js
@@ -73,6 +73,17 @@ describe.skipIf(!runDb)('projectsDB round-trip', () => {
     await close();
   });
 
+  it('round-trips and clears cognitive effort through create and patch', async () => {
+    const pin = { providerId: 'example-agent', model: 'example-model', effort: 'high' };
+    const p = await db.createProject({ ...CREATE_INPUT, modelOverrides: { plan: pin } });
+    created.push(p.id);
+    expect((await db.getProject(p.id)).modelOverrides.plan).toEqual(pin);
+    await db.updateProject(p.id, { modelOverrides: { plan: { ...pin, effort: null } } });
+    expect((await db.getProject(p.id)).modelOverrides.plan).toEqual({ providerId: pin.providerId, model: pin.model });
+    await db.updateProject(p.id, { modelOverrides: {} });
+    expect((await db.getProject(p.id)).modelOverrides).toEqual({});
+  });
+
   it('creates, reads back, and lists a project (lossless shape)', async () => {
     const p = await db.createProject(CREATE_INPUT);
     created.push(p.id);

--- a/server/services/creativeDirector/projectsFile.test.js
+++ b/server/services/creativeDirector/projectsFile.test.js
@@ -67,6 +67,17 @@ const project = (id, extra = {}) => ({
 const journalEntries = () => cj.conflictJournalStore().loadAll();
 
 describe('projectsFile federation merge', () => {
+  it('round-trips and clears cognitive effort through create and patch', async () => {
+    const pin = { providerId: 'example-agent', model: 'example-model', effort: 'high' };
+    const p = await file.createProject({ name: 'Example', modelId: 'example', aspectRatio: '1:1', quality: 'draft', targetDurationSeconds: 9, modelOverrides: { plan: pin } });
+
+    expect((await file.getProject(p.id)).modelOverrides.plan).toEqual(pin);
+    await file.updateProject(p.id, { modelOverrides: { plan: { ...pin, effort: null } } });
+    expect((await file.getProject(p.id)).modelOverrides.plan).toEqual({ providerId: pin.providerId, model: pin.model });
+    await file.updateProject(p.id, { modelOverrides: {} });
+    expect((await file.getProject(p.id)).modelOverrides).toEqual({});
+  });
+
   it('inserts a remote project and seeds its base hash', async () => {
     const res = await file.mergeProjectsFromSync([project('cd-1')]);
     expect(res).toEqual({ applied: true, count: 1 });

--- a/server/services/creativeDirector/projectsLogic.js
+++ b/server/services/creativeDirector/projectsLogic.js
@@ -11,6 +11,7 @@
  */
 
 import { randomUUID } from 'crypto';
+import { EFFORT_LEVELS } from '../../lib/providerModels.js';
 import { ServerError } from '../../lib/errorHandler.js';
 import { creativeDirectorTreatmentSchema, creativeDirectorPlanSchema } from '../../lib/validation.js';
 import { PROJECT_STATUSES, PLAN_STEP_TERMINAL_SUCCESS } from '../../lib/creativeDirectorPresets.js';
@@ -25,7 +26,7 @@ const isStr = (v) => typeof v === 'string';
 
 // Per-project AI model override (per-project CD provider/model pins). Stored on
 // the project record as `modelOverrides.{treatment,plan,evaluation}` — each an
-// optional `{ providerId, model }`. Only stages that name a `providerId` are
+// optional `{ providerId, model, effort }`. Only stages that name a `providerId` are
 // kept, so the stored object never carries empty stubs (a blank stage means
 // "inherit the global AI Assignment"). Additive: the whole record round-trips
 // through the JSONB `data` column verbatim in sanitizeProjectForSync, so this
@@ -42,7 +43,8 @@ export function normalizeModelOverrides(raw) {
     const model = isStr(v.model) ? v.model.trim() : '';
     // A model without a provider can't be resolved (the runtime keys on the
     // provider first), so drop a model-only stage — it would inherit anyway.
-    if (providerId) out[stage] = { providerId, ...(model ? { model } : {}) };
+    const effort = stage !== 'evaluation' && EFFORT_LEVELS.includes(v.effort) ? v.effort : null;
+    if (providerId) out[stage] = { providerId, ...(model ? { model } : {}), ...(effort ? { effort } : {}) };
   }
   return out;
 }
@@ -84,10 +86,13 @@ export function normalizeRenderBackend(raw) {
  * for whatever provider the assignment names). See `lib/llmRoutePin.js` for why
  * that differs from the per-field `resolveLlmRoutePin`.
  *
- * Returns `{ providerId, model }` with STRING values ('' when unset), not the
+ * Returns `{ providerId, model, effort? }` with STRING values ('' when unset), not the
  * shared lib's `null`s: `getStageAssignment` and `resolveVisionEvalTarget` both
  * branch on plain falsiness and spread the result into task metadata, so keeping
- * the two dimensions as strings is this resolver's own contract.
+ * the route dimensions as strings is this resolver's own contract. Effort is
+ * additive and omitted when cleared, invalid, or evaluating through vision.
+ * Legacy provider-only records keep provider defaults; both storage adapters
+ * round-trip this optional JSON field without a migration.
  */
 export function resolveStagePin(stage, project, settings) {
   const chosen = pickLlmRoutePinLayer(
@@ -97,6 +102,7 @@ export function resolveStagePin(stage, project, settings) {
   return {
     providerId: isStr(chosen?.providerId) ? chosen.providerId : '',
     model: isStr(chosen?.model) ? chosen.model : '',
+    ...(stage !== 'evaluation' && EFFORT_LEVELS.includes(chosen?.effort) ? { effort: chosen.effort } : {}),
   };
 }
 

--- a/server/services/creativeDirector/projectsLogic.test.js
+++ b/server/services/creativeDirector/projectsLogic.test.js
@@ -534,3 +534,11 @@ describe('applyPlanStepUpdate', () => {
     expect(updated).toBeNull();
   });
 });
+
+
+it('validates optional effort without changing legacy provider-only pins', async () => {
+  const { creativeDirectorStagePinSchema } = await import('../../lib/creativeDirectorValidation.js');
+  expect(creativeDirectorStagePinSchema.parse({ providerId: 'agent', effort: 'high' })).toEqual({ providerId: 'agent', effort: 'high' });
+  expect(creativeDirectorStagePinSchema.safeParse({ providerId: 'agent', effort: 'unlimited' }).success).toBe(false);
+  expect(normalizeModelOverrides({ plan: creativeDirectorStagePinSchema.parse({ providerId: 'agent', effort: '' }) })).toEqual({ plan: { providerId: 'agent' } });
+});


### PR DESCRIPTION
Creative Director treatment and planning agents now receive the reasoning effort chosen for their project, live owning commission, or global assignment. The winning provider/model/effort pin stays together; clearing a pin restores defaults. Scene evaluation retains its separate vision path.

The project Models drawer and commission editor use the shared effort controls, and persisted JSON records round-trip the optional field without a migration. Legacy provider-only records keep their existing defaults.

Validation: 307 focused server tests (including route and import-scoping checks), 68 rendered/client helper tests, 10 PostgreSQL roundtrip tests against portos_test, and the client production build passed.

Closes #6544
