### PR TITLE
fix: reject invalid production plan dependency graphs

### DIFF
--- a/server/lib/creativeDirectorValidation.js
+++ b/server/lib/creativeDirectorValidation.js
@@ -374,7 +374,43 @@ export const creativeDirectorPlanStepSchema = z.object({
 
 export const creativeDirectorPlanSchema = z.object({
   steps: z.array(creativeDirectorPlanStepSchema).min(1).max(60),
-}).strict();
+}).strict().superRefine(({ steps }, ctx) => {
+  // Validate the whole graph before any adapter persists it or the route
+  // nudges dispatch. IDs are also result-reference keys, so duplicate IDs
+  // cannot be resolved by choosing the first/last occurrence.
+  const byId = new Map();
+  let invalid = false;
+  const report = (index, field, message) => {
+    invalid = true;
+    ctx.addIssue({ code: 'custom', path: ['steps', index, field], message });
+  };
+  steps.forEach((step, index) => {
+    if (byId.has(step.stepId)) report(index, 'stepId', `Duplicate step ID: ${step.stepId}`);
+    byId.set(step.stepId, step);
+  });
+  steps.forEach((step, index) => {
+    for (const dependency of step.dependsOn) {
+      if (!byId.has(dependency)) report(index, 'dependsOn', `Unknown dependency: ${dependency}`);
+    }
+  });
+  if (invalid) return;
+
+  // Plans are bounded to 60 steps. Walking ancestors permits forward edges
+  // and shared dependencies while rejecting self-links and longer cycles.
+  const visiting = new Set();
+  const visited = new Set();
+  const hasCycle = (id) => {
+    if (visiting.has(id)) return true;
+    if (visited.has(id)) return false;
+    visiting.add(id);
+    if (byId.get(id).dependsOn.some(hasCycle)) return true;
+    visiting.delete(id);
+    visited.add(id);
+    return false;
+  };
+  const cycleIndex = steps.findIndex((step) => hasCycle(step.stepId));
+  if (cycleIndex !== -1) report(cycleIndex, 'dependsOn', 'Dependency cycle: remove the circular dependency chain');
+});
 
 // Blocked-step triage actions (CDO Phase 4, #2186). The studio UI's Plan tab
 // dispatches one of these against a single plan step:

--- a/server/routes/creativeDirector.test.js
+++ b/server/routes/creativeDirector.test.js
@@ -748,6 +748,41 @@ describe('creativeDirector routes', () => {
   describe('PATCH /:id/plan — stepId grammar (#2773)', () => {
     const validStep = { stepId: 'create-series', toolName: 'pipeline_createSeries', args: { name: 'Nova' }, dependsOn: [] };
 
+    // Each case catches a different graph defect that otherwise reaches the
+    // executor as ambiguous identity or a permanently unrunnable consumer.
+    it.each([
+      ['duplicate identity', [{ stepId: 'a' }, { stepId: 'a' }], 'Duplicate step ID'],
+      ['missing producer', [{ stepId: 'a', dependsOn: ['missing'] }], 'Unknown dependency'],
+      ['self dependency', [{ stepId: 'a', dependsOn: ['a'] }], 'Dependency cycle'],
+      ['cycle behind a runnable root', [
+        { stepId: 'root' }, { stepId: 'a', dependsOn: ['root', 'b'] }, { stepId: 'b', dependsOn: ['a'] },
+      ], 'Dependency cycle'],
+    ])('rejects %s before saving or dispatching', async (_name, steps, message) => {
+      const planAdvance = await import('../services/creativeDirector/planAdvance.js');
+      const r = await request(app).patch('/api/creative-director/cd-1/plan')
+        .send({ steps: steps.map(step => ({ ...validStep, ...step })) });
+      expect(r.status).toBe(400);
+      expect(JSON.stringify(r.body)).toContain(message);
+      expect(cdService.setPlan).not.toHaveBeenCalled();
+      expect(planAdvance.advanceAfterPlanStepSettled).not.toHaveBeenCalled();
+    });
+
+    it('accepts forward and shared dependencies without reordering the authored plan', async () => {
+      const planAdvance = await import('../services/creativeDirector/planAdvance.js');
+      const steps = [
+        { ...validStep, stepId: 'cut', dependsOn: ['left', 'right'] },
+        { ...validStep, stepId: 'left', dependsOn: ['source'] },
+        { ...validStep, stepId: 'right', dependsOn: ['source'] },
+        { ...validStep, stepId: 'source' },
+      ];
+      cdService.getProject.mockResolvedValue({ id: 'cd-1' });
+      cdService.setPlan.mockResolvedValue({ id: 'cd-1', plan: { steps } });
+      const r = await request(app).patch('/api/creative-director/cd-1/plan').send({ steps });
+      expect(r.status).toBe(200);
+      expect(cdService.setPlan).toHaveBeenCalledWith('cd-1', { steps });
+      expect(planAdvance.advanceAfterPlanStepSettled).toHaveBeenCalledWith('cd-1');
+    });
+
     it('accepts a word/hyphen stepId', async () => {
       cdService.getProject.mockResolvedValue({ id: 'cd-1', directive: { goal: 'x', constraints: {} } });
       cdService.setPlan.mockResolvedValue({ id: 'cd-1', plan: { steps: [validStep] } });

--- a/server/services/creativeDirector/projectsFile.test.js
+++ b/server/services/creativeDirector/projectsFile.test.js
@@ -67,6 +67,22 @@ const project = (id, extra = {}) => ({
 const journalEntries = () => cj.conflictJournalStore().loadAll();
 
 describe('projectsFile federation merge', () => {
+  it('keeps the saved plan and completed results when a replan removes a required producer', async () => {
+    const p = await file.createProject({ name: 'Example production', modelId: 'example', aspectRatio: '16:9', quality: 'draft', targetDurationSeconds: 60 });
+    const producer = { stepId: 'source', toolName: 'pipeline_createSeries' };
+    const consumer = { stepId: 'consumer', toolName: 'pipeline_generateStage', dependsOn: ['source'] };
+    await file.setPlan(p.id, { steps: [producer, consumer] });
+    await file.updatePlanStep(p.id, 'source', { status: 'done', result: { id: 'example-series' } });
+    const saved = await file.getProject(p.id);
+    const writesBefore = writeCounter.project;
+    await expect(file.setPlan(p.id, { steps: [consumer] })).rejects.toThrow('Unknown dependency: source');
+    expect(writeCounter.project).toBe(writesBefore);
+    expect(await file.getProject(p.id)).toEqual(saved);
+    const revised = await file.setPlan(p.id, { steps: [consumer, producer] });
+    expect(revised.plan.replanRounds).toBe(1);
+    expect(revised.plan.steps[1]).toMatchObject({ status: 'done', result: { id: 'example-series' } });
+  });
+
   it('persists Video draft preferences and prevents removing the workspace barrier', async () => {
     const p = await file.createProject({
       name: 'Example short', workspace: 'video', modelId: '', aspectRatio: '16:9',


### PR DESCRIPTION
## Summary

Reject duplicate step IDs, missing dependency targets, and cyclic dependencies before a Creative Director production plan is saved or dispatched. Forward references and shared producers remain valid; a rejected replan preserves the saved plan and completed results.

This is a standalone prerequisite slice of #6547.

## Test plan

- 200 tests passed across Creative Director routes, file-store persistence, record transforms, and plan execution.
- Pinned optional Ollama review: No findings.
- `git diff --check` passed.

## Remaining

Revisioned scripts and stable scene/shot/reference artifacts; exact target selection and backend-bounded shot compilation; creative-source context/revision preservation and deleted-source repair; planner prompt integration and artifact presentation. These remain tracked in #6547.

Refs #6547
