### PR TITLE
fix: World only uses chromeless /eidoverse/solo (Safari iframe path)

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -254,6 +254,9 @@ export default function App() {
     <Suspense fallback={<PageLoader />}>
       <Routes>
         <Route path="/eidoverse/guest" element={<EidoverseGuest />} />
+        {/* Chromeless world-only surface: same iframe hostUrl as /eidoverse, without
+            a Safari top-level navigation to /eidoverse-host/ (stuck splash). */}
+        <Route path="/eidoverse/solo" element={<Eidoverse />} />
         <Route path="/login" element={<Login />} />
         <Route path="/ambient" element={<Ambient />} />
         {/* Hosted audience devices need the full dynamic viewport, without the

--- a/client/src/pages/Eidoverse.jsx
+++ b/client/src/pages/Eidoverse.jsx
@@ -1,14 +1,15 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   AlertTriangle,
-  ExternalLink,
+  ArrowLeft,
+  Maximize2,
   Orbit,
   RotateCcw,
   Settings,
   SlidersHorizontal,
   Tags,
 } from 'lucide-react';
-import { Link } from 'react-router';
+import { Link, useLocation } from 'react-router';
 import PageHeader from '../components/PageHeader';
 import BrailleSpinner from '../components/BrailleSpinner';
 import useEidoverseFrame from '../hooks/useEidoverseFrame';
@@ -169,6 +170,8 @@ function reconcileResetAliases(current, submitted, after, reset, sources) {
 }
 
 export default function Eidoverse() {
+  const { pathname } = useLocation();
+  const solo = pathname.replace(/\/+$/, '') === '/eidoverse/solo';
   const requestGeneration = useRef(0);
   const configDraftRevision = useRef(0);
   const savedDraftRevision = useRef(0);
@@ -506,19 +509,17 @@ export default function Eidoverse() {
           </button>
         </>
       )}
-      {hostUrl && (
-        <a
-          href={hostUrl}
-          target="_blank"
-          rel="noreferrer"
+      {hostUrl && !solo && (
+        <Link
+          to="/eidoverse/solo"
           aria-label="Open Eidoverse without PortOS controls"
-          title="Open Eidoverse in a separate tab without the PortOS page frame"
+          title="Open Eidoverse fullscreen inside PortOS (same iframe path as this page)"
           className="inline-flex min-h-[40px] items-center gap-1.5 rounded-lg border border-port-border px-3 py-1.5 text-sm text-gray-200 transition-colors hover:border-port-accent hover:text-white"
         >
-          <ExternalLink size={15} aria-hidden="true" />
+          <Maximize2 size={15} aria-hidden="true" />
           <span className="hidden md:inline">Open Eidoverse alone</span>
           <span className="md:hidden">World only</span>
-        </a>
+        </Link>
       )}
       {appId && (
         <Link
@@ -540,26 +541,8 @@ export default function Eidoverse() {
     && !FRESH_WORLD_VISIBLE_CHECKPOINTS.has(reconciliation.checkpoint);
   const showLoadingCurtain = !iframeReady || freshWorldLighting;
 
-  return (
-    <div className="flex h-full min-h-0 flex-col bg-port-bg">
-      <EidoverseTravel travelRef={travelRef} beforeDeparture={frame.leaveWorld} enabled={Boolean(hostUrl)} objects={worldState?.projection?.lastSummary?.objects || []}
-        onDestinationsChange={() => {
-          if (projectionStatus === 'running' || draftDirty) return false;
-          if (worldState?.recipe?.includes?.peers !== false) void runProjection().catch(() => {});
-          return true;
-        }} />
-      <PageHeader
-        icon={Orbit}
-        title="Eidoverse Worlds"
-        subtitle="PortOS rendered as a living systems garden"
-        actions={actions}
-        className="bg-port-bg"
-      />
-
-      {appId && phase !== 'setup' && (
-        <EidoverseUpdateBanner appId={appId} onUpdated={prepare} />
-      )}
-
+  const frameStage = (
+    <>
       {phase === 'ready' && (
         <main className="relative min-h-0 flex-1 overflow-hidden bg-port-bg">
           <iframe
@@ -579,7 +562,7 @@ export default function Eidoverse() {
           )}
 
           {projectionError && (
-            <div className="port-media-overlay-strong pointer-events-auto absolute inset-x-3 top-3 z-10 mx-auto flex max-w-2xl items-start gap-3 rounded-xl border border-port-error/50 p-3 text-sm text-port-error shadow-xl" role="status">
+            <div className={`port-media-overlay-strong pointer-events-auto absolute inset-x-3 z-10 mx-auto flex max-w-2xl items-start gap-3 rounded-xl border border-port-error/50 p-3 text-sm text-port-error shadow-xl ${solo ? 'bottom-3' : 'top-3'}`} role="status">
               <AlertTriangle className="mt-0.5 shrink-0" size={17} aria-hidden="true" />
               <div className="min-w-0 flex-1">
                 <p>{projectionError}</p>
@@ -587,7 +570,6 @@ export default function Eidoverse() {
               </div>
             </div>
           )}
-
         </main>
       )}
 
@@ -625,6 +607,54 @@ export default function Eidoverse() {
           </section>
         </div>
       )}
+    </>
+  );
+
+  // Chromeless world-only surface: same hostUrl iframe as the embedded page,
+  // without a top-level navigation to /eidoverse-host/ (Safari stuck-splash).
+  if (solo) {
+    return (
+      <div className="flex h-dvh flex-col bg-port-bg text-white">
+        <header className="flex flex-wrap items-center justify-between gap-3 border-b border-port-border px-4 py-3">
+          <div>
+            <h1 className="font-semibold">Eidoverse · world only</h1>
+            <p className="text-sm text-gray-400">Fullscreen inside PortOS · same renderer path as the Eidoverse page</p>
+          </div>
+          <Link
+            to="/eidoverse"
+            aria-label="Back to Eidoverse controls"
+            className="inline-flex min-h-10 items-center gap-1.5 rounded-lg border border-port-border px-3 text-sm text-gray-200 transition-colors hover:border-port-accent hover:text-white"
+          >
+            <ArrowLeft size={15} aria-hidden="true" />
+            Controls
+          </Link>
+        </header>
+        {frameStage}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full min-h-0 flex-col bg-port-bg">
+      <EidoverseTravel travelRef={travelRef} beforeDeparture={frame.leaveWorld} enabled={Boolean(hostUrl)} objects={worldState?.projection?.lastSummary?.objects || []}
+        onDestinationsChange={() => {
+          if (projectionStatus === 'running' || draftDirty) return false;
+          if (worldState?.recipe?.includes?.peers !== false) void runProjection().catch(() => {});
+          return true;
+        }} />
+      <PageHeader
+        icon={Orbit}
+        title="Eidoverse Worlds"
+        subtitle="PortOS rendered as a living systems garden"
+        actions={actions}
+        className="bg-port-bg"
+      />
+
+      {appId && phase !== 'setup' && (
+        <EidoverseUpdateBanner appId={appId} onUpdated={prepare} />
+      )}
+
+      {frameStage}
 
       <EidoverseWorldDrawer
         open={settingsOpen}

--- a/client/src/pages/Eidoverse.test.jsx
+++ b/client/src/pages/Eidoverse.test.jsx
@@ -163,7 +163,7 @@ describe('Eidoverse hosted page', () => {
     expect(screen.queryByRole('region', { name: 'PortOS district legend' })).not.toBeInTheDocument();
     expect(screen.queryByText('12/48 live signals')).not.toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Open Eidoverse without PortOS controls' }))
-      .toHaveAttribute('href', `${window.location.protocol}//${window.location.host}/eidoverse-host/?world=portos&name=example-portos-user`);
+      .toHaveAttribute('href', '/eidoverse/solo');
     await waitFor(() => expect(api.projectEidoverseWorld).toHaveBeenCalledWith({ silent: true }));
     expect(screen.getByRole('link', { name: 'Manage Eidoverse app' })).toHaveAttribute('href', '/apps/app-eidoverse/overview');
 
@@ -393,6 +393,21 @@ describe('Eidoverse hosted page', () => {
       setup,
       { protocol: 'http:', hostname: 'localhost', host: 'localhost:5553' },
     )).toBe(`http://localhost:${setup.uiPort}/`);
+  });
+
+  it('opens World only as an in-app chromeless route that reuses the same host iframe', async () => {
+    renderPage('/eidoverse/solo');
+
+    const frame = await screen.findByTitle('Eidoverse Worlds');
+    expect(frame).toHaveAttribute(
+      'src',
+      `${window.location.protocol}//${window.location.host}/eidoverse-host/?world=portos&name=example-portos-user`,
+    );
+    expect(screen.getByRole('heading', { name: 'Eidoverse · world only' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Back to Eidoverse controls' })).toHaveAttribute('href', '/eidoverse');
+    expect(screen.queryByRole('link', { name: 'Open Eidoverse without PortOS controls' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'World controls' })).not.toBeInTheDocument();
+    expect(screen.queryByText('Your PortOS, made spatial')).not.toBeInTheDocument();
   });
 
   it('keeps a successful local save visible when projection fails', async () => {

--- a/docs/features/eidoverse.md
+++ b/docs/features/eidoverse.md
@@ -378,6 +378,12 @@ in front of an HTTPS-only host certificate that does not cover the hostname
 (loopback `:5553` / some Vite setups), where the iframe falls back to a direct
 `:uiPort` load — scene renders, handshake stays dormant.
 
+**World only / Open Eidoverse alone** opens `/eidoverse/solo` — a chromeless
+PortOS route that mounts the **same** `/eidoverse-host/` iframe fullscreen
+(outside the app sidebar). A top-level Safari tab aimed at `/eidoverse-host/`
+can stick on the renderer splash; staying inside PortOS reuses the proven iframe
+path through a single-port tailcat forward.
+
 Projection protocol and asset preflight target the same runtime. The default
 HTTP library origin is derived from `EIDOVERSE_WS_URL` by mapping `ws`/`wss` to
 `http`/`https` on the same host and port. Deployments whose one Eidoverse runtime

--- a/server/lib/navManifest.js
+++ b/server/lib/navManifest.js
@@ -32,6 +32,7 @@ const RAW_NAV_COMMANDS = [
   { id: 'nav.dashboard', path: '/', label: 'Dashboard', section: 'Main', aliases: ['dashboard', 'home'], keywords: ['overview', 'start'] },
   { id: 'nav.review-hub', path: '/review', label: 'Review Hub', section: 'Main', aliases: ['review', 'review-hub'] },
   { id: 'nav.eidoverse.guest', path: '/eidoverse/guest', label: 'Eidoverse Guest', section: 'Main', feature: 'eidoverse', aliases: ['eidoverse-guest'], keywords: ['travel', 'teleport', 'visitor'] },
+  { id: 'nav.eidoverse.solo', path: '/eidoverse/solo', label: 'Eidoverse World Only', section: 'Main', feature: 'eidoverse', aliases: ['eidoverse-solo', 'world-only', 'eidoverse-alone'], keywords: ['fullscreen', 'solo', 'without controls', 'chromeless'] },
   { id: 'nav.eidoverse', path: '/eidoverse', label: 'Eidoverse', section: 'Main', feature: 'eidoverse', previousPaths: ['/openworld', '/city'], preservePreviousPathSuffix: false, aliases: ['eidoverse', 'eidoverse-worlds', 'worlds', 'openworld', 'open-world', 'city'], keywords: ['3d', 'world', 'agents', 'spatial', 'managed app', 'private environment'] },
   { id: 'nav.apps', path: '/apps', label: 'Apps', section: 'Main', aliases: ['apps'] },
   // Submodules are per-app (a tab on the app detail page), so this entry is


### PR DESCRIPTION
## Summary

- **Root cause:** On Safari (via single-port `tailcat` `localhost:15555` → box `:5555`), the Eidoverse **iframe** at `/eidoverse-host/…` wakes and renders WebGPU fine, but a **top-level** tab opened by World only / Open Eidoverse alone (`target=_blank` → same `hostUrl`) sticks on the renderer splash (“waking the engine…” → 20s timeout). So this is not a WebGPU/Safari capability gap — it is top-level host navigation failing where the embedded path works.
- **Fix (PortOS-side):** Change World only to an in-app chromeless route `/eidoverse/solo` (outside Layout, like Ambient/guest) that mounts the **same** `hostUrl` iframe fullscreen, with a Back to controls link. Avoids Safari top-level `/eidoverse-host/` navigation while keeping single-port forward behavior.
- Docs + ⌘K nav entry for the solo path; tests updated/added in `Eidoverse.test.jsx`.

## Test plan

- [x] `client`: `Eidoverse.test.jsx` (28 passed)
- [x] `server`: `navManifest.test.js` (61 passed)
- [ ] Manual: on Safari via `:15555` forward, open Eidoverse — iframe works; tap **World only** → `/eidoverse/solo` fullscreen iframe works; **Controls** returns to `/eidoverse`
- [ ] Manual: confirm World only no longer opens a bare `/eidoverse-host/` tab