### PR TITLE
fix: preserve and display exact Video draft durations

### DIFF
--- a/client/src/components/creative-director/VideoDraftDrawer.jsx
+++ b/client/src/components/creative-director/VideoDraftDrawer.jsx
@@ -43,13 +43,14 @@ export default function VideoDraftDrawer({ open, onClose, project, onSaved, cata
   const change = (key, value) => setForm(prev => ({ ...prev, [key]: value }));
   const input = (key, label, options = {}) => <label htmlFor={`video-draft-${key}`} className="block text-sm">{label}<input id={`video-draft-${key}`} className={fieldClass} value={form[key] ?? ''} onChange={e => change(key, e.target.value)} {...options} /></label>;
   const select = (key, label, choices) => <label htmlFor={`video-draft-${key}`} className="block text-sm">{label}<select id={`video-draft-${key}`} className={fieldClass} value={form[key] || ''} onChange={e => change(key, e.target.value)}>{choices.map(([value, text]) => <option key={value} value={value}>{text}</option>)}</select></label>;
+  const exactTarget = Math.min(Number(form.max), Math.max(Number(form.min), project?.targetDurationSeconds ?? Number(form.max)));
   const save = async () => {
     if (!form.name?.trim()) { setTab('brief'); toast.error('Name is required'); return; }
     const min = Number(form.min), max = Number(form.max);
     if (!Number.isInteger(min) || !Number.isInteger(max) || min < 5 || max > 600 || min > max) { setTab('brief'); toast.error('Choose a duration range between 5 and 600 seconds, minimum first'); return; }
     const sources = form.sources || [];
     const payload = { name: form.name.trim(), userStory: form.userStory, styleSpec: form.styleSpec,
-      aspectRatio: form.aspectRatio, quality: form.quality, modelId: form.modelId, targetDurationSeconds: max,
+      aspectRatio: form.aspectRatio, quality: form.quality, modelId: form.modelId, targetDurationSeconds: exactTarget,
       ...(!project ? { workspace: 'video', catalogIngredientIds: sources.filter(s => s.kind === 'catalog').map(s => s.id) } : {}),
       renderBackend: { ...project?.renderBackend, video: { ...project?.renderBackend?.video, mode: form.videoMode, modelId: form.videoMode === 'local' ? form.modelId : form.backendModelId || null } },
       videoDraft: { durationRange: { min, max }, sources, audio: { ...(form.audioProvider ? { providerId: form.audioProvider } : {}), ...(form.audioModel ? { model: form.audioModel } : {}) }, reviewPolicy: form.reviewPolicy, checkpoints: project?.videoDraft?.checkpoints || VIDEO_REVIEW_CHECKPOINTS } };
@@ -66,6 +67,7 @@ export default function VideoDraftDrawer({ open, onClose, project, onSaved, cata
         <label htmlFor="video-draft-userStory" className="block text-sm">Brief<textarea id="video-draft-userStory" value={form.userStory || ''} onChange={e => change('userStory', e.target.value)} className={fieldClass} rows={4} maxLength={10000} /></label>
         <label htmlFor="video-draft-styleSpec" className="block text-sm">Style<textarea id="video-draft-styleSpec" value={form.styleSpec || ''} onChange={e => change('styleSpec', e.target.value)} className={fieldClass} rows={3} maxLength={5000} /></label>
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">{input('min', 'Minimum duration (seconds)', { type: 'number', min: 5, max: 600 })}{input('max', 'Maximum duration (seconds)', { type: 'number', min: 5, max: 600 })}</div>
+        <p className="text-sm text-port-text-muted" aria-live="polite">Exact target: {Number.isFinite(exactTarget) && Number(form.min) <= Number(form.max) ? `${exactTarget} seconds` : 'Choose a valid range'}. Existing targets are preserved within the range; new drafts use the maximum.</p>
       </>}
       {tab === 'production' && <>
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">{select('aspectRatio', 'Aspect ratio', ['16:9', '9:16', '1:1'].map(x => [x, x]))}{select('quality', 'Quality', ['draft', 'standard', 'high'].map(x => [x, x]))}</div>

--- a/client/src/components/creative-director/VideoDraftDrawer.test.jsx
+++ b/client/src/components/creative-director/VideoDraftDrawer.test.jsx
@@ -13,15 +13,16 @@ import { createCreativeDirectorProject, updateCreativeDirectorProject } from '..
 import VideoDraftDrawer from './VideoDraftDrawer.jsx';
 it('edits the same draft without changing workspace or losing source revisions', async () => {
   const user = userEvent.setup();
-  const project = { id: 'draft-1', workspace: 'video', name: 'Example', videoDraft: { sources: [{ kind: 'catalog', id: 'example', revision: 'r1' }], durationRange: { min: 20, max: 40 }, reviewPolicy: 'review', checkpoints: ['rough-cut'] } };
+  const project = { id: 'draft-1', targetDurationSeconds: 30, workspace: 'video', name: 'Example', videoDraft: { sources: [{ kind: 'catalog', id: 'example', revision: 'r1' }], durationRange: { min: 20, max: 40 }, reviewPolicy: 'review', checkpoints: ['rough-cut'] } };
   updateCreativeDirectorProject.mockResolvedValue(project);
   const saved = vi.fn();
   render(<MemoryRouter><VideoDraftDrawer open project={project} onClose={vi.fn()} onSaved={saved} /></MemoryRouter>);
+  expect(screen.getByText(/Exact target: 30 seconds/)).toBeInTheDocument();
   await user.clear(screen.getByLabelText('Name'));
   await user.type(screen.getByLabelText('Name'), 'Revised');
   await user.click(screen.getByRole('button', { name: 'Save draft' }));
   await waitFor(() => expect(saved).toHaveBeenCalledWith(project));
-  expect(updateCreativeDirectorProject).toHaveBeenCalledWith('draft-1', expect.objectContaining({ name: 'Revised', videoDraft: expect.objectContaining({ sources: project.videoDraft.sources, checkpoints: ['rough-cut'] }) }), { silent: true });
+  expect(updateCreativeDirectorProject).toHaveBeenCalledWith('draft-1', expect.objectContaining({ name: 'Revised', targetDurationSeconds: 30, videoDraft: expect.objectContaining({ sources: project.videoDraft.sources, checkpoints: ['rough-cut'] }) }), { silent: true });
   expect(updateCreativeDirectorProject.mock.calls[0][1]).not.toHaveProperty('workspace');
   expect(createCreativeDirectorProject).not.toHaveBeenCalled();
 });

--- a/client/src/pages/CreativeDirectorDetail.jsx
+++ b/client/src/pages/CreativeDirectorDetail.jsx
@@ -328,7 +328,7 @@ export default function CreativeDirectorDetail({ basePath = '/creative-director'
           <h2 className="text-lg font-medium">Video draft</h2>
           <p className="text-port-text-muted">Stage: {project.status}. Production is blocked until revision approvals and dispatch controls are available. Next: refine your brief, source references, and model selections.</p>
           <p className="whitespace-pre-wrap">{project.userStory || 'Add a brief to describe this video.'}</p>
-          <p className="text-sm">Target: {project.videoDraft?.durationRange?.min}–{project.videoDraft?.durationRange?.max} seconds · {project.aspectRatio} · {project.quality}</p>
+          <p className="text-sm">Exact target: {project.targetDurationSeconds} seconds (requested: {project.videoDraft?.durationRange?.min}–{project.videoDraft?.durationRange?.max} seconds) · {project.aspectRatio} · {project.quality}</p>
           <p className="text-sm">Review: {project.videoDraft?.reviewPolicy || 'review'} · Checkpoints: {(project.videoDraft?.checkpoints || []).join(', ')}</p>
           <button onClick={() => setEditingDraft(true)} className="px-3 py-2 rounded bg-port-accent text-white">Edit draft</button>
           <VideoDraftDrawer open={editingDraft} onClose={() => setEditingDraft(false)} project={project} onSaved={saved => setProject(prev => ({ ...prev, ...saved }))} />

--- a/server/services/creativeDirector/projectsFile.test.js
+++ b/server/services/creativeDirector/projectsFile.test.js
@@ -67,6 +67,18 @@ const project = (id, extra = {}) => ({
 const journalEntries = () => cj.conflictJournalStore().loadAll();
 
 describe('projectsFile federation merge', () => {
+  it('bounds Video targets on create and range edits and preserves them across reload', async () => {
+    const p = await file.createProject({ name: 'Example short', workspace: 'video', modelId: '', aspectRatio: '16:9', quality: 'draft', targetDurationSeconds: 240, videoDraft: { durationRange: { min: 60, max: 180 } } });
+    expect(p.targetDurationSeconds).toBe(180);
+    await file.updateProject(p.id, { targetDurationSeconds: 120 });
+    await file.updateProject(p.id, { name: 'Revised short', videoDraft: { ...p.videoDraft, durationRange: { min: 60, max: 150 } } });
+    expect((await file.getProject(p.id)).targetDurationSeconds).toBe(120);
+    await file.updateProject(p.id, { videoDraft: { ...p.videoDraft, durationRange: { min: 130, max: 150 } } });
+    expect((await file.getProject(p.id)).targetDurationSeconds).toBe(130);
+    const legacy = await file.createProject({ name: 'Legacy project', modelId: '', aspectRatio: '16:9', quality: 'draft', targetDurationSeconds: 240 });
+    expect((await file.getProject(legacy.id)).targetDurationSeconds).toBe(240);
+  });
+
   it('keeps the saved plan and completed results when a replan removes a required producer', async () => {
     const p = await file.createProject({ name: 'Example production', modelId: 'example', aspectRatio: '16:9', quality: 'draft', targetDurationSeconds: 60 });
     const producer = { stepId: 'source', toolName: 'pipeline_createSeries' };

--- a/server/services/creativeDirector/projectsLogic.js
+++ b/server/services/creativeDirector/projectsLogic.js
@@ -182,14 +182,16 @@ export function buildProjectRecord(input, { id, now, collectionId }) {
     cast = [], generateFirstPass = false, directive = null,
     modelOverrides = {}, renderBackend = null,
   } = input;
+  const videoDraft = input.workspace === 'video'
+    ? creativeDirectorVideoDraftSchema.parse(input.videoDraft || {
+      durationRange: { min: targetDurationSeconds, max: targetDurationSeconds },
+    }) : null;
   return {
     id,
     name,
     ...(input.workspace === 'video' ? {
       workspace: 'video',
-      videoDraft: creativeDirectorVideoDraftSchema.parse(input.videoDraft || {
-        durationRange: { min: targetDurationSeconds, max: targetDurationSeconds },
-      }),
+      videoDraft,
     } : {}),
     status: 'draft',
     createdAt: now,
@@ -197,7 +199,9 @@ export function buildProjectRecord(input, { id, now, collectionId }) {
     aspectRatio,
     quality,
     modelId,
-    targetDurationSeconds,
+    targetDurationSeconds: videoDraft
+      ? Math.min(videoDraft.durationRange.max, Math.max(videoDraft.durationRange.min, targetDurationSeconds))
+      : targetDurationSeconds,
     styleSpec,
     startingImageFile,
     userStory,
@@ -343,6 +347,10 @@ export function applyProjectPatch(project, patch) {
   }
   const next = { ...project, ...patch, updatedAt: new Date().toISOString() };
   if ('videoDraft' in patch) next.videoDraft = creativeDirectorVideoDraftSchema.parse(patch.videoDraft);
+  if (next.workspace === 'video' && next.videoDraft && ('videoDraft' in patch || 'targetDurationSeconds' in patch)) {
+    const { min, max } = next.videoDraft.durationRange;
+    next.targetDurationSeconds = Math.min(max, Math.max(min, next.targetDurationSeconds));
+  }
   if ('renderBackend' in patch) next.renderBackend = normalizeRenderBackend(patch.renderBackend);
   // Normalize the whole override object on write so stored records never carry
   // empty/model-only stage stubs; the client sends the full object each save.


### PR DESCRIPTION
Video draft edits previously reset the exact duration to the range maximum, while API writes could persist a target outside that range. Preserve existing targets, constrain them on create/range/target updates in both storage backends, and display the exact duration in the editor and overview. New drafts retain the existing maximum-duration default.

Validation: 162 tests passed across project persistence, record transforms, routes, and rendered UI; client production build passed; pinned optional Ollama reviewer returned No findings; git diff --check passed.

## Remaining

This is a standalone duration-consistency slice. Revisioned script/scene/shot/reference artifacts, backend-bounded shot compilation, source context revisions and deleted-source repair, planner prompt integration, and artifact presentation remain in #6547. Dependency graph validation was delivered in #6561.

Refs #6547
