### PR TITLE
fix: recognize Cursor workspace trust accelerator

### DIFF
--- a/server/lib/tuiHandshake.js
+++ b/server/lib/tuiHandshake.js
@@ -295,7 +295,7 @@ export const TUI_TRUST_PROMPT_PATTERN =
 // wait until the choices themselves have painted, then move off a highlighted
 // decline choice instead of assuming a bare Enter always accepts the folder.
 // These patterns run against createInputReadyTracker's whitespace-free tail.
-const TUI_TRUST_ACCEPT_OPTION_PATTERN = /(?:yes,?itrustthisfolder|yes,?continue)/i;
+const TUI_TRUST_ACCEPT_OPTION_PATTERN = /(?:yes,?itrustthisfolder|yes,?continue|\[a\]trustthisworkspace)/i;
 const TUI_TRUST_DECLINE_OPTION_PATTERN = /no,?(?:exit|quit)/i;
 const TUI_HIGHLIGHT_PATTERN_PREFIX = String.raw`(?:❯|›|>)\d*\.?`;
 const TUI_TRUST_HIGHLIGHTED_ACCEPT_PATTERN = new RegExp(
@@ -466,7 +466,11 @@ export function createInputReadyTracker({ readyTextPattern = null, directLaunch 
           const declineMatch = TUI_TRUST_DECLINE_OPTION_PATTERN.exec(tail);
           if (acceptMatch) {
             trustChoiceReady = true;
-            if (TUI_TRUST_HIGHLIGHTED_DECLINE_PATTERN.test(tail)) {
+            if (acceptMatch[0].toLowerCase() === '[a]trustthisworkspace') {
+              // Cursor exposes a direct accelerator, independent of highlight
+              // position (including Linux terminals using the ▶ cursor glyph).
+              trustSelectionKey = 'a';
+            } else if (TUI_TRUST_HIGHLIGHTED_DECLINE_PATTERN.test(tail)) {
               trustSelectionKey = declineMatch && declineMatch.index < acceptMatch.index ? '\x1b[B' : '\x1b[A';
             } else if (TUI_TRUST_HIGHLIGHTED_ACCEPT_PATTERN.test(tail)) {
               trustSelectionKey = '';

--- a/server/lib/tuiHandshake.test.js
+++ b/server/lib/tuiHandshake.test.js
@@ -1069,6 +1069,22 @@ describe('createInputReadyTracker', () => {
     expect(codex.trustSelectionKey).toBe('');
   });
 
+  it('waits for Cursor workspace trust to paint across chunks and uses its accelerator', () => {
+    const tracker = createInputReadyTracker();
+    tracker.observe(PASTE_OFF, 'Do you trust the contents of this directory?\n/workspace/example\n');
+    tracker.observe(PASTE_ON, '▶ [a] Trust this work');
+    expect(tracker.needsTrust).toBe(true);
+    expect(tracker.trustChoiceReady).toBe(false);
+    expect(tracker.ready).toBe(false);
+    tracker.observe('', 'space\n[q] Quit\nUse arrow keys to navigate, Enter to select, or press the key shown');
+    expect(tracker.trustChoiceReady).toBe(true);
+    expect(tracker.trustSelectionKey).toBe('a');
+    expect(tracker.ready).toBe(false);
+    tracker.ackTrustChoice();
+    tracker.observe(PASTE_ON, '');
+    expect(tracker.ready).toBe(true);
+  });
+
   it('detects when Claude highlights the decline choice before trust acceptance', () => {
     const tracker = createInputReadyTracker({ directLaunch: true });
     tracker.observe('', 'Quick safety check: Is this a project you created or one you trust?\n'

--- a/server/services/agentTuiSpawning.test.js
+++ b/server/services/agentTuiSpawning.test.js
@@ -1290,6 +1290,22 @@ describe('spawnTuiAgent runtime', () => {
     expect(pasteCount()).toBe(1);
   });
 
+  it('Cursor workspace trust: selects the keyed choice before delivering the task', async () => {
+    runSpawn({ tuiConfig: { command: 'cursor-agent', args: ['--force'], commandLine: 'cursor-agent --force', promptDelayMs: 100 } });
+    await flushMicrotasks();
+    await capturedOnData(Buffer.from(`${PASTE_OFF}Do you trust the contents of this directory?\n/workspace/example\n▶ [a] Trust this workspace\n[q] Quit\n`));
+    await flushMicrotasks();
+    await vi.advanceTimersByTimeAsync(700);
+    await flushMicrotasks();
+    expect(vi.mocked(shellService.writeToSession).mock.calls.map(([, data]) => data)).toContain('a\r');
+    expect(pasteCount()).toBe(0);
+    await capturedOnData(Buffer.from(PASTE_ON));
+    await flushMicrotasks();
+    await vi.advanceTimersByTimeAsync(2000);
+    await flushMicrotasks();
+    expect(pasteCount()).toBe(1);
+  });
+
   it('claude trust gate: moves from a highlighted No choice before confirming', async () => {
     runSpawn({ tuiConfig: claudeTuiConfig, useDurableRunner: true });
     await flushMicrotasks();


### PR DESCRIPTION
## Summary
Cursor Agent can still display a workspace-trust selector on fresh Linux installs. PortOS recognized the question but not `[a] Trust this workspace`, so startup failed before sending the task.

Recognize that explicit affirmative choice and select its accelerator through the shared TUI handshake. Existing vendor navigation and blocking for unidentified choices remain intact.

## Test plan
- Passed 438 tests across tuiHandshake, agentTuiSpawning, and tuiPromptRunner.
- Added fragmented selector parsing and a simulated Cursor startup verifying trust selection precedes task delivery.
- Reviewed the diff and passed git diff --check.
