### PR TITLE
fix: install zstd before Linux Ollama installs and upgrades

### DIFF
--- a/scripts/install-ollama.sh
+++ b/scripts/install-ollama.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Shared by setup:llm and the server's Linux install/upgrade actions.
+set -euo pipefail
+
+if ! command -v zstd >/dev/null 2>&1; then
+  if command -v apt-get >/dev/null 2>&1; then
+    install=(apt-get install -y zstd)
+  elif command -v dnf >/dev/null 2>&1; then
+    install=(dnf install -y zstd)
+  elif command -v yum >/dev/null 2>&1; then
+    install=(yum install -y zstd)
+  elif command -v pacman >/dev/null 2>&1; then
+    install=(pacman -S --noconfirm zstd)
+  else
+    echo 'Ollama requires zstd. Install zstd with your package manager, then retry.' >&2
+    exit 1
+  fi
+
+  echo 'Installing zstd, required to extract Ollama…'
+  # Server installs have no terminal for a password prompt. Fail with a usable
+  # command before the upstream installer can remove the existing version.
+  install_command=("${install[@]}")
+  if [ "$(id -u)" != 0 ]; then
+    install_command=(sudo -n "${install[@]}")
+  fi
+  if ! "${install_command[@]}"; then
+    echo "Could not install zstd automatically. Run: sudo ${install[*]}, then retry Ollama." >&2
+    exit 1
+  fi
+  if ! command -v zstd >/dev/null 2>&1; then
+    echo 'zstd is still missing from PATH after installation. Make zstd available, then retry Ollama.' >&2
+    exit 1
+  fi
+fi
+
+# pipefail also reports download failures instead of treating an empty sh as success.
+curl -fsSL https://ollama.com/install.sh | sh

--- a/scripts/install-ollama.test.js
+++ b/scripts/install-ollama.test.js
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, writeFileSync, rmSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const script = fileURLToPath(new URL('./install-ollama.sh', import.meta.url));
+
+// Execute the real shell flow with an isolated PATH: no network, sudo, or real
+// package manager can run. The fake package manager makes zstd discoverable.
+function run({ installed = false, manager = 'apt-get', uid = '0', fail = false, curlFails = false, missingAfter = false } = {}) {
+  const dir = mkdtempSync(join(tmpdir(), 'ollama-install-'));
+  const log = join(dir, 'calls');
+  const bin = (name, body) => writeFileSync(join(dir, name), `#!/bin/bash\n${body}\n`, { mode: 0o755 });
+  bin('id', `echo ${uid}`);
+  bin('curl', `echo curl >> '${log}'\n${curlFails ? 'exit 22' : "echo 'echo upstream'"}`);
+  bin('sh', `/bin/sh "$@"`);
+  bin('sudo', `echo "sudo $*" >> '${log}'\nshift\n"$@"`);
+  if (installed) bin('zstd', 'exit 0');
+  if (manager) bin(manager, `echo "${manager} $*" >> '${log}'\n${fail ? 'exit 1' : missingAfter ? ':' : `echo '#!/bin/bash' > '${dir}/zstd'\n/bin/chmod +x '${dir}/zstd'`}`);
+  const result = spawnSync('/bin/bash', [script], { env: { PATH: dir }, encoding: 'utf8' });
+  const calls = readFileSync(log, { encoding: 'utf8', flag: 'a+' });
+  rmSync(dir, { recursive: true, force: true });
+  return { ...result, calls };
+}
+
+describe.skipIf(process.platform === 'win32')('Linux Ollama installation', () => {
+  it('runs upstream directly when zstd is already installed', () => {
+    const result = run({ installed: true });
+    expect(result.status).toBe(0);
+    expect(result.calls).toBe('curl\n');
+    expect(result.stdout).toContain('upstream');
+  });
+
+  it.each([
+    ['apt-get', 'install -y zstd'], ['dnf', 'install -y zstd'],
+    ['yum', 'install -y zstd'], ['pacman', '-S --noconfirm zstd'],
+  ])('installs the prerequisite with %s before upstream runs', (manager, args) => {
+    const result = run({ manager });
+    expect(result.status).toBe(0);
+    expect(result.calls).toBe(`${manager} ${args}\ncurl\n`);
+  });
+
+  it('uses non-interactive sudo for non-root installs', () => {
+    const result = run({ uid: '1000' });
+    expect(result.status).toBe(0);
+    expect(result.calls).toContain('sudo -n apt-get install -y zstd');
+  });
+
+  it.each([
+    [{ fail: true }, 'Run: sudo apt-get install -y zstd'],
+    [{ manager: null }, 'Install zstd with your package manager'],
+    [{ missingAfter: true }, 'zstd is still missing from PATH'],
+  ])('stops before upstream cleanup when prerequisites fail: %j', (options, message) => {
+    const result = run(options);
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain(message);
+    expect(result.calls).not.toContain('curl');
+  });
+
+  it('does not report success when the upstream download fails', () => {
+    expect(run({ installed: true, curlFails: true }).status).toBe(22);
+  });
+});

--- a/scripts/setup-llm.js
+++ b/scripts/setup-llm.js
@@ -50,7 +50,7 @@ function installOllama() {
     }
     if (platform === 'linux') {
       console.log('⬇️  Installing Ollama via official script...');
-      execFileSync('bash', ['-c', 'curl -fsSL https://ollama.com/install.sh | sh'], { stdio: 'inherit' });
+      execFileSync('bash', [join(__dirname, 'install-ollama.sh')], { stdio: 'inherit' });
       return true;
     }
   } catch (err) {

--- a/server/services/localLlm.js
+++ b/server/services/localLlm.js
@@ -31,6 +31,7 @@ import { createWriteStream } from 'fs'
 import { rm } from 'fs/promises'
 import { join } from 'path'
 import { tmpdir } from 'os'
+import { fileURLToPath } from 'url'
 import { pipeline } from 'stream/promises'
 import { Readable } from 'stream'
 import { ensureDir, pathExists, sleep } from '../lib/fileUtils.js'
@@ -228,7 +229,7 @@ export async function installBackend(backend, onProgress = () => {}) {
   // Linux Ollama: official install script.
   if (process.platform === 'linux') {
     emit('Installing Ollama via the official install script…')
-    const r = await runStreaming('bash', ['-c', 'curl -fsSL https://ollama.com/install.sh | sh'], emit, BACKEND_INSTALL_TIMEOUT_MS)
+    const r = await runStreaming('bash', [fileURLToPath(new URL('../../scripts/install-ollama.sh', import.meta.url))], emit, BACKEND_INSTALL_TIMEOUT_MS)
     if (!r.success) return { success: false, error: `Ollama install failed: ${r.error}. ${downloadHint}` }
     console.log('⬇️ Installed Ollama (linux script)')
     return { success: true, backend }
@@ -478,7 +479,7 @@ export async function upgradeBackend(backend, onProgress = () => {}) {
   // Linux Ollama: the official install script is also the upgrade path.
   if (process.platform === 'linux' && backend === 'ollama') {
     emit('Upgrading Ollama via the official install script…')
-    const r = await runStreaming('bash', ['-c', 'curl -fsSL https://ollama.com/install.sh | sh'], emit, BACKEND_INSTALL_TIMEOUT_MS)
+    const r = await runStreaming('bash', [fileURLToPath(new URL('../../scripts/install-ollama.sh', import.meta.url))], emit, BACKEND_INSTALL_TIMEOUT_MS)
     if (!r.success) {
       console.error(`⚠️ Ollama upgrade (linux script) failed: ${r.error}`)
       return { success: false, error: `Ollama upgrade failed: ${r.error}. ${downloadHint}` }

--- a/server/services/localLlm.test.js
+++ b/server/services/localLlm.test.js
@@ -649,6 +649,18 @@ describe('localLlm', () => {
   });
 
   describe('installBackend', () => {
+    it.each(['installBackend', 'upgradeBackend'])('%s uses the shared Linux prerequisite installer', async (action) => {
+      const restorePlatform = pinPlatform('linux');
+      cp.spawn = vi.fn(() => fakeChild());
+      try {
+        expect(await svc[action]('ollama')).toMatchObject({ success: true, backend: 'ollama' });
+        expect(cp.spawn.mock.calls[0][0]).toBe('bash');
+        expect(cp.spawn.mock.calls[0][1]).toEqual([expect.stringMatching(/scripts\/install-ollama\.sh$/)]);
+      } finally {
+        restorePlatform();
+      }
+    });
+
     it('rejects an unknown backend', async () => {
       expect((await svc.installBackend('nope')).success).toBe(false);
     });

--- a/server/services/localLlm.test.js
+++ b/server/services/localLlm.test.js
@@ -655,7 +655,7 @@ describe('localLlm', () => {
       try {
         expect(await svc[action]('ollama')).toMatchObject({ success: true, backend: 'ollama' });
         expect(cp.spawn.mock.calls[0][0]).toBe('bash');
-        expect(cp.spawn.mock.calls[0][1]).toEqual([expect.stringMatching(/scripts\/install-ollama\.sh$/)]);
+        expect(cp.spawn.mock.calls[0][1]).toEqual([expect.stringContaining(path.join('scripts', 'install-ollama.sh'))]);
       } finally {
         restorePlatform();
       }


### PR DESCRIPTION
## Summary
Linux Ollama installs and upgrades could fail after upstream cleanup because zstd was missing. Run a shared prerequisite installer for setup and both backend actions, installing zstd via apt-get, dnf, yum, or pacman before invoking upstream.

Use non-interactive sudo when needed and return an actionable manual command if installation fails. Verify zstd is available before proceeding, and propagate upstream download failures.

## Test plan
- 87 focused tests passed across the shell installer and local LLM service.
- Shell workflow tests use an isolated PATH and fake executables; no packages or downloads run.
- Covered existing zstd, supported package managers, root and sudo paths, failed/missing prerequisites, and download failure.
- bash -n scripts/install-ollama.sh and git diff --check passed.
