### PR TITLE
Connect Eidoverse name commands to World Design identity settings

### DIFF
--- a/client/src/components/eidoverse/EidoverseWorldDrawer.jsx
+++ b/client/src/components/eidoverse/EidoverseWorldDrawer.jsx
@@ -167,6 +167,9 @@ export default function EidoverseWorldDrawer({
           placeholder="Leave blank for a private generated name"
         />
       </label>
+      <p className="text-xs leading-5 text-gray-400">
+        In the embedded world, <code>/name &lt;new name&gt;</code> stages this field. Save and project leaves the current session and re-enters under the new name.
+      </p>
       <label className="block text-sm text-gray-300" htmlFor="eidoverse-cos-name">
         CoS / Persistent Mind name
         <input

--- a/client/src/hooks/useEidoverseFrame.js
+++ b/client/src/hooks/useEidoverseFrame.js
@@ -3,13 +3,16 @@ import { useNavigate } from 'react-router';
 import {
   EIDOVERSE_FRAME_VERSION,
   EIDOVERSE_LABEL_PREFERENCES,
+  eidoverseIdentityRenameName,
   eidoverseNavigationTarget,
   isEidoverseFrameMessage,
 } from '../lib/eidoverseFrame';
-export default function useEidoverseFrame(hostUrl, objects = [], onTravel = null) {
+export default function useEidoverseFrame(hostUrl, objects = [], onTravel = null, onIdentityRename = null) {
   const frameRef = useRef(null);
   const travelRef = useRef(onTravel);
   travelRef.current = onTravel;
+  const identityRenameRef = useRef(onIdentityRename);
+  identityRenameRef.current = onIdentityRename;
   const objectsRef = useRef(objects);
   objectsRef.current = objects;
   const sessionRef = useRef(null);
@@ -44,7 +47,7 @@ export default function useEidoverseFrame(hostUrl, objects = [], onTravel = null
       const data = event.data;
       if (data.type === 'eidoverse:ready') {
         clearTimeout(timer);
-        session.capabilities = Object.fromEntries(['objectLabels', 'portosNavigation', 'labelPreferences', 'worldDeparture', 'objectInteraction']
+        session.capabilities = Object.fromEntries(['objectLabels', 'portosNavigation', 'labelPreferences', 'worldDeparture', 'objectInteraction', 'identityRenameRequest']
           .map((key) => [key, data.capabilities?.[key] === 1]));
         setConnection({ status: 'ready', capabilities: session.capabilities });
         if (session.capabilities.labelPreferences) source.postMessage({
@@ -59,12 +62,19 @@ export default function useEidoverseFrame(hostUrl, objects = [], onTravel = null
         const object = objectsRef.current.find((entry) => entry.id === data.entityId);
         if (object?.travelPeerId && travelRef.current) travelRef.current(object.travelPeerId);
         else navigate(target);
+      } else if (data.type === 'eidoverse:identity-rename' && session.capabilities.identityRenameRequest) {
+        const name = eidoverseIdentityRenameName(data);
+        if (name !== null) identityRenameRef.current?.(name);
       }
     };
     window.addEventListener('message', receive);
     source.postMessage({
       type: 'portos:connect', version: EIDOVERSE_FRAME_VERSION, nonce,
-      capabilities: { portosNavigation: 1, labelPreferences: 1 },
+      capabilities: {
+        portosNavigation: 1,
+        labelPreferences: 1,
+        ...(identityRenameRef.current ? { identityRenameRequest: 1 } : {}),
+      },
       labelVisibility: preferenceRef.current,
     }, origin);
     return () => {

--- a/client/src/hooks/useEidoverseFrame.test.jsx
+++ b/client/src/hooks/useEidoverseFrame.test.jsx
@@ -6,8 +6,8 @@ import { safeRemoveStorage, safeWriteStorage } from '../lib/safeStorage';
 
 const hostUrl = 'https://world.example.com/';
 const objects = [{ id: 'portos-design-v2-signal-app-example', route: '/apps' }];
-function Harness({ projected = objects, onTravel, capture } = {}) {
-  const frame = useEidoverseFrame(hostUrl, projected, onTravel);
+function Harness({ projected = objects, onTravel, onIdentityRename, capture } = {}) {
+  const frame = useEidoverseFrame(hostUrl, projected, onTravel, onIdentityRename);
   capture?.(frame);
   const location = useLocation();
   return <>
@@ -83,6 +83,46 @@ describe('hosted Eidoverse frame navigation', () => {
     expect(onTravel).toHaveBeenCalledExactlyOnceWith('peer-example');
   });
 
+  it('accepts a bounded identity draft only from the negotiated current frame session', () => {
+    const onIdentityRename = vi.fn();
+    render(<MemoryRouter><Harness onIdentityRename={onIdentityRename} /></MemoryRouter>);
+    const iframe = screen.getByTitle('Test renderer');
+    const source = iframe.contentWindow;
+    const post = vi.spyOn(source, 'postMessage').mockImplementation(() => {});
+    fireEvent.load(iframe);
+    const [hello] = post.mock.calls.at(-1);
+    expect(hello.capabilities.identityRenameRequest).toBe(1);
+    const ready = { type: 'eidoverse:ready', version: 1, nonce: hello.nonce,
+      capabilities: { identityRenameRequest: 1 } };
+    const request = { type: 'eidoverse:identity-rename', version: 1, nonce: hello.nonce,
+      name: '  Example Visitor  ' };
+    send(source, request);
+    send(source, ready);
+    for (const [data, extra] of [
+      [request, { origin: 'https://attacker.example.com' }],
+      [request, { source: window }],
+      [{ ...request, nonce: 'stale' }, {}],
+      [{ ...request, name: 'x'.repeat(65) }, {}],
+      [{ ...request, name: 'line\nbreak' }, {}],
+    ]) send(source, data, extra);
+    expect(onIdentityRename).not.toHaveBeenCalled();
+    send(source, request);
+    expect(onIdentityRename).toHaveBeenCalledExactlyOnceWith('Example Visitor');
+  });
+
+  it('refuses identity drafts from a renderer without the negotiated capability', () => {
+    const onIdentityRename = vi.fn();
+    render(<MemoryRouter><Harness onIdentityRename={onIdentityRename} /></MemoryRouter>);
+    const iframe = screen.getByTitle('Test renderer');
+    const source = iframe.contentWindow;
+    const post = vi.spyOn(source, 'postMessage').mockImplementation(() => {});
+    fireEvent.load(iframe);
+    const [hello] = post.mock.calls.at(-1);
+    send(source, { type: 'eidoverse:ready', version: 1, nonce: hello.nonce, capabilities: {} });
+    send(source, { type: 'eidoverse:identity-rename', version: 1, nonce: hello.nonce, name: 'Example Visitor' });
+    expect(onIdentityRename).not.toHaveBeenCalled();
+  });
+
   it('requires the hosted window, exact origin, current handshake and projected section route', () => {
     mount();
     const frame = screen.getByTitle('Test renderer');
@@ -92,6 +132,7 @@ describe('hosted Eidoverse frame navigation', () => {
     const [hello, origin] = post.mock.calls.at(-1);
     expect(origin).toBe('https://world.example.com');
     expect(hello).toMatchObject({ type: 'portos:connect', version: 1, labelVisibility: 'off' });
+    expect(hello.capabilities.identityRenameRequest).toBeUndefined();
     expect(Object.keys(hello).sort()).toEqual(['capabilities', 'labelVisibility', 'nonce', 'type', 'version']);
     const navigation = { type: 'eidoverse:navigate', version: 1, nonce: hello.nonce, entityId: objects[0].id, route: '/apps' };
     send(source, navigation); // No handshake yet.

--- a/client/src/lib/eidoverseFrame.js
+++ b/client/src/lib/eidoverseFrame.js
@@ -18,6 +18,14 @@ export function isEidoverseFrameMessage(event, { source, origin, nonce }) {
     && data.version === EIDOVERSE_FRAME_VERSION && data.nonce === nonce);
 }
 
+export function eidoverseIdentityRenameName(data) {
+  if (data?.type !== 'eidoverse:identity-rename' || typeof data.name !== 'string') return null;
+  const name = data.name.trim();
+  const hasControlCharacter = [...name]
+    .some((character) => character.charCodeAt(0) <= 31 || character.charCodeAt(0) === 127);
+  return name.length > 0 && name.length <= 64 && !hasControlCharacter ? name : null;
+}
+
 export function eidoverseNavigationTarget(data, objects) {
   if (typeof data.entityId !== 'string' || !ROUTES.has(data.route)) return null;
   return objects.some((object) => object.id === data.entityId && object.route === data.route)

--- a/client/src/pages/Eidoverse.jsx
+++ b/client/src/pages/Eidoverse.jsx
@@ -9,7 +9,7 @@ import {
   SlidersHorizontal,
   Tags,
 } from 'lucide-react';
-import { Link, useLocation } from 'react-router';
+import { Link, useLocation, useNavigate } from 'react-router';
 import PageHeader from '../components/PageHeader';
 import BrailleSpinner from '../components/BrailleSpinner';
 import useEidoverseFrame from '../hooks/useEidoverseFrame';
@@ -170,7 +170,9 @@ function reconcileResetAliases(current, submitted, after, reset, sources) {
 }
 
 export default function Eidoverse() {
-  const { pathname } = useLocation();
+  const location = useLocation();
+  const navigate = useNavigate();
+  const { pathname } = location;
   const solo = pathname.replace(/\/+$/, '') === '/eidoverse/solo';
   const requestGeneration = useRef(0);
   const configDraftRevision = useRef(0);
@@ -197,8 +199,28 @@ export default function Eidoverse() {
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [iframeReady, setIframeReady] = useState(false);
 
+  const markConfigDirty = useCallback(() => {
+    configDraftRevision.current += 1;
+    setDraftDirty(true);
+    setConfigStatus((current) => current === 'saving' ? current : '');
+  }, []);
+
+  const stageIdentityRename = useCallback((name) => {
+    markConfigDirty();
+    setHumanName(name);
+    setSettingsOpen(true);
+    const search = new URLSearchParams(location.search);
+    search.set('eidoverseTab', 'experience');
+    navigate({ pathname: location.pathname, search: search.toString() }, { replace: true });
+  }, [location.pathname, location.search, markConfigDirty, navigate]);
+
   const travelRef = useRef(null);
-  const frame = useEidoverseFrame(hostUrl, worldState?.projection?.lastSummary?.objects, (peerId) => travelRef.current?.(peerId));
+  const frame = useEidoverseFrame(
+    hostUrl,
+    worldState?.projection?.lastSummary?.objects,
+    (peerId) => travelRef.current?.(peerId),
+    stageIdentityRename,
+  );
 
   const applyWorldResponse = useCallback((updated, { replaceDraft = true } = {}) => {
     setWorldState((current) => current
@@ -358,12 +380,6 @@ export default function Eidoverse() {
       clearTimeout(projectionPollTimer.current);
     };
   }, [prepare]);
-
-  const markConfigDirty = useCallback(() => {
-    configDraftRevision.current += 1;
-    setDraftDirty(true);
-    setConfigStatus((current) => current === 'saving' ? current : '');
-  }, []);
 
   const mutateRecipe = useCallback((mutator) => {
     markConfigDirty();
@@ -613,6 +629,39 @@ export default function Eidoverse() {
     </>
   );
 
+  const worldDrawer = (
+    <EidoverseWorldDrawer
+      open={settingsOpen}
+      onClose={() => setSettingsOpen(false)}
+      worldState={worldState}
+      worldName={worldName}
+      setWorldName={setWorldName}
+      humanName={humanName}
+      setHumanName={setHumanName}
+      cosId={cosId}
+      setCosId={setCosId}
+      suggestedCosId={worldState?.suggestedCosId || null}
+      recipeDraft={recipeDraft}
+      assetOverridesDraft={assetOverridesDraft}
+      labelAliasesDraft={labelAliasesDraft}
+      mutateLabelAlias={mutateLabelAlias}
+      frameConnection={frame.connection}
+      labelVisibility={frame.labelVisibility}
+      onLabelVisibilityChange={frame.changeLabelVisibility}
+      appId={appId}
+      mutateRecipe={mutateRecipe}
+      mutateAssetOverride={mutateAssetOverride}
+      markDirty={markConfigDirty}
+      configStatus={configStatus}
+      projectionStatus={projectionStatus}
+      dirty={draftDirty}
+      onSave={saveWorldConfig}
+      onProject={() => { if (!draftDirty) void runProjection().catch(() => {}); }}
+      onReset={(scope, districtId) => { void runConfigAction({ reset: { scope, ...(districtId ? { districtId } : {}) } }); }}
+      onRefreshAssets={() => { if (!draftDirty) void runConfigAction({ refreshAssets: true }); }}
+    />
+  );
+
   // Chromeless world-only surface: same hostUrl iframe as the embedded page,
   // without a top-level navigation to /eidoverse-host/ (Safari stuck-splash).
   if (solo) {
@@ -633,6 +682,7 @@ export default function Eidoverse() {
           </Link>
         </header>
         {frameStage}
+        {worldDrawer}
       </div>
     );
   }
@@ -659,36 +709,7 @@ export default function Eidoverse() {
 
       {frameStage}
 
-      <EidoverseWorldDrawer
-        open={settingsOpen}
-        onClose={() => setSettingsOpen(false)}
-        worldState={worldState}
-        worldName={worldName}
-        setWorldName={setWorldName}
-        humanName={humanName}
-        setHumanName={setHumanName}
-        cosId={cosId}
-        setCosId={setCosId}
-        suggestedCosId={worldState?.suggestedCosId || null}
-        recipeDraft={recipeDraft}
-        assetOverridesDraft={assetOverridesDraft}
-        labelAliasesDraft={labelAliasesDraft}
-        mutateLabelAlias={mutateLabelAlias}
-        frameConnection={frame.connection}
-        labelVisibility={frame.labelVisibility}
-        onLabelVisibilityChange={frame.changeLabelVisibility}
-        appId={appId}
-        mutateRecipe={mutateRecipe}
-        mutateAssetOverride={mutateAssetOverride}
-        markDirty={markConfigDirty}
-        configStatus={configStatus}
-        projectionStatus={projectionStatus}
-        dirty={draftDirty}
-        onSave={saveWorldConfig}
-        onProject={() => { if (!draftDirty) void runProjection().catch(() => {}); }}
-        onReset={(scope, districtId) => { void runConfigAction({ reset: { scope, ...(districtId ? { districtId } : {}) } }); }}
-        onRefreshAssets={() => { if (!draftDirty) void runConfigAction({ refreshAssets: true }); }}
-      />
+      {worldDrawer}
     </div>
   );
 }

--- a/client/src/pages/Eidoverse.test.jsx
+++ b/client/src/pages/Eidoverse.test.jsx
@@ -439,6 +439,23 @@ describe('Eidoverse hosted page', () => {
     expect(screen.queryByRole('link', { name: 'Open Eidoverse without PortOS controls' })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'World controls' })).not.toBeInTheDocument();
     expect(screen.queryByText('Your PortOS, made spatial')).not.toBeInTheDocument();
+
+    const source = frame.contentWindow;
+    const post = vi.spyOn(source, 'postMessage').mockImplementation(() => {});
+    fireEvent.load(frame);
+    const [hello] = post.mock.calls.at(-1);
+    act(() => window.dispatchEvent(new MessageEvent('message', {
+      source, origin: new URL(frame.src).origin,
+      data: { type: 'eidoverse:ready', version: 1, nonce: hello.nonce,
+        capabilities: { identityRenameRequest: 1 } },
+    })));
+    act(() => window.dispatchEvent(new MessageEvent('message', {
+      source, origin: new URL(frame.src).origin,
+      data: { type: 'eidoverse:identity-rename', version: 1, nonce: hello.nonce,
+        name: 'Example Solo Visitor' },
+    })));
+    expect(await screen.findByLabelText('My Eidoverse name')).toHaveValue('Example Solo Visitor');
+    expect(screen.getByRole('heading', { name: 'Eidoverse · world only' })).toBeInTheDocument();
   });
 
   it('keeps a successful local save visible when projection fails', async () => {
@@ -454,6 +471,61 @@ describe('Eidoverse hosted page', () => {
     expect(await screen.findByText('Saved locally and queued for projection.')).toBeInTheDocument();
     expect(await screen.findByText('Example projection failure')).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Check the Eidoverse runtime' })).toHaveAttribute('href', '/apps/app-eidoverse/overview');
+  });
+
+  it('stages a renderer name request in World Design and retains it when save fails', async () => {
+    const user = userEvent.setup();
+    renderPage();
+    const frame = await screen.findByTitle('Eidoverse Worlds');
+    await user.click(screen.getByRole('button', { name: 'World controls' }));
+    const worldInput = screen.getByLabelText('World name');
+    await user.type(worldInput, '-draft');
+    await user.click(screen.getByRole('tab', { name: 'Districts & Data' }));
+    await user.click(screen.getByRole('button', { name: 'Close' }));
+    const source = frame.contentWindow;
+    const post = vi.spyOn(source, 'postMessage').mockImplementation(() => {});
+    fireEvent.load(frame);
+    const [hello] = post.mock.calls.at(-1);
+    expect(hello.capabilities.identityRenameRequest).toBe(1);
+    act(() => window.dispatchEvent(new MessageEvent('message', {
+      source, origin: new URL(frame.src).origin,
+      data: { type: 'eidoverse:ready', version: 1, nonce: hello.nonce,
+        capabilities: { identityRenameRequest: 1 } },
+    })));
+    act(() => window.dispatchEvent(new MessageEvent('message', {
+      source, origin: new URL(frame.src).origin,
+      data: { type: 'eidoverse:identity-rename', version: 1, nonce: hello.nonce,
+        name: 'Example Visitor' },
+    })));
+
+    const nameInput = await screen.findByLabelText('My Eidoverse name');
+    expect(screen.getByRole('tab', { name: 'Experience' })).toHaveAttribute('aria-selected', 'true');
+    expect(nameInput).toHaveValue('Example Visitor');
+    expect(screen.getByLabelText('World name')).toHaveValue('portos-draft');
+    expect(screen.getByText(/Save and project leaves the current session and re-enters/)).toBeInTheDocument();
+
+    api.updateEidoverseWorldConfig.mockRejectedValueOnce(new Error('Example identity save failure'));
+    await user.click(screen.getByRole('button', { name: 'Save and project' }));
+    expect(await screen.findByText('Example identity save failure')).toBeInTheDocument();
+    expect(nameInput).toHaveValue('Example Visitor');
+    expect(screen.getByLabelText('World name')).toHaveValue('portos-draft');
+    expect(api.updateEidoverseWorldConfig).toHaveBeenLastCalledWith(
+      expect.objectContaining({ world: 'portos-draft', humanName: 'Example Visitor' }),
+      { silent: true },
+    );
+    expect(frame).toHaveAttribute('src', `${window.location.protocol}//${window.location.host}/eidoverse-host/?world=portos&name=example-portos-user`);
+
+    api.updateEidoverseWorldConfig.mockResolvedValueOnce({
+      ...worldResponse,
+      world: 'portos-draft',
+      identity: { name: 'Example Visitor' },
+      human: { name: 'Example Visitor' },
+    });
+    await user.click(screen.getByRole('button', { name: 'Save and project' }));
+    await waitFor(() => expect(frame).toHaveAttribute(
+      'src',
+      `${window.location.protocol}//${window.location.host}/eidoverse-host/?world=portos-draft&name=Example+Visitor`,
+    ));
   });
 
   it('keeps newer edits intact while an earlier save is in flight', async () => {

--- a/docs/features/eidoverse.md
+++ b/docs/features/eidoverse.md
@@ -464,7 +464,7 @@ pretend it supports the updated runtime.
 After each iframe load, PortOS posts to its **exact hosted origin**:
 
 ```json
-{"type":"portos:connect","version":1,"nonce":"fresh-opaque-session","capabilities":{"portosNavigation":1,"labelPreferences":1},"labelVisibility":"nearby"}
+{"type":"portos:connect","version":1,"nonce":"fresh-opaque-session","capabilities":{"portosNavigation":1,"labelPreferences":1,"identityRenameRequest":1},"labelVisibility":"nearby"}
 ```
 
 The renderer validates `event.source === parent` and the embedding PortOS origin,
@@ -496,6 +496,19 @@ and exact equality between the requested route and that object's known PortOS
 section route. Only the fixed source-section routes (plus `/eidoverse`) are
 allowed. URLs, query strings, encoded/relative paths, record payloads, and
 unknown entities cannot navigate. No URL proxy is exposed.
+
+When both sides advertise `identityRenameRequest: 1`, `/name <new name>` and
+`/rename <new name>` in the home-world renderer send
+`{type:'eidoverse:identity-rename', version:1, nonce, name}`. PortOS accepts the
+request only from the current iframe window, exact hosted origin, and current
+nonce, and only for a trimmed 1–64 character name without control characters.
+The request stages the existing World Design human-name field and opens its
+Experience tab; it cannot write configuration, change an actor id, or rename a
+live session. **Save and project** uses the normal validated configuration path,
+reconciles presence, and re-enters the world with the saved URL identity. Older
+renderers keep the manual World Design flow. Standalone, authenticated, and
+guest sessions retain their authoritative identity and receive guidance instead
+of sending a host configuration request.
 
 The Eidoverse framework leaves object labels off by default. PortOS explicitly enables
 them through its trusted frame session only after the user enables Labels. Each


### PR DESCRIPTION
Embedded Eidoverse `/name` and `/rename` commands had no supported path into PortOS's durable human identity flow. This adds a capability-negotiated, source/origin/nonce-checked frame request that stages the existing World Design name field, opens its Experience tab, and preserves every other pending design edit.

Saving still uses the existing validated configuration and projection flow. A failed save retains the draft and current iframe identity; a successful save recomputes the iframe URL and re-enters under the persisted name. The shared drawer now remains available on the chromeless `/eidoverse/solo` route, and user guidance explains the re-entry behavior.

Companion dependency: https://github.com/atomantic/eidoverse-worlds/pull/13. Merge the renderer PR first, then this PortOS PR. Capability negotiation keeps either intermediate version compatible, but both revisions are required for the command flow.

Validation:
- `npm test -- --run src/hooks/useEidoverseFrame.test.jsx src/pages/Eidoverse.test.jsx` (38 tests)
- `npm run lint`
- `npm run build`
- Synthetic browser integration with the actual PortOS client and companion renderer, isolated world storage, and mocked PortOS APIs: `/name` and `/rename`, unrelated-draft preservation, failed save retention, and successful iframe re-entry
- Pinned optional Ollama review completed; its sole lifecycle finding was checked against the existing effect cleanup and rejected as a false positive

Closes #6564
