### PR TITLE
feat: enable model refresh on OpenCode Zen provider cards

### DIFF
--- a/server/routes/providers.js
+++ b/server/routes/providers.js
@@ -41,6 +41,8 @@ import {
   getProviderRuntimeStatus,
   getProviderRuntimeStatuses,
 } from '../services/providerRuntimeInstaller.js';
+import { refreshHarnessModels, usesHarnessCatalog } from '../services/harnesses.js';
+import { providerRuntimeKey } from '../lib/providerPrerequisites.js';
 import { streamHarnessAction } from '../services/harnessActionStream.js';
 import { getProviderReadinessMap, resetProviderReadinessCache, servedModelId } from '../services/providerReadiness.js';
 import { getLlamaServerEndpoint, relaunchLlamaServerWithAlias } from '../services/llamaServerManager.js';
@@ -139,6 +141,11 @@ const withTuiLaunchCommand = (provider) => {
   return launch ? { ...provider, tuiCommandLine: launch.commandLine } : provider;
 };
 
+// Reuse the harness catalog only for wrappers the managed OpenCode refresh
+// can update; custom binaries and declared backends keep their own catalogs.
+const refreshesOpenCodeCatalog = (provider) =>
+  providerRuntimeKey(provider) === 'opencode' && usesHarnessCatalog(provider);
+
 /**
  * The shape a provider takes on its way OUT to the client: secrets stripped,
  * plus the derived `canRefreshModels` flag the AI Providers page reads to
@@ -173,6 +180,7 @@ const presentProvider = (provider, capabilities = captureSystemCapabilities()) =
   const publicReviewPostures = publicReviewPosturesForProvider(provider);
   return sanitizeProvider({
     ...decorated,
+    canRefreshModels: decorated.canRefreshModels || refreshesOpenCodeCatalog(provider),
     publicReviewPostures,
     publicReviewEnforcedPostures: enforcedPublicReviewPosturesForProvider(provider),
     publicReviewSupported: publicReviewPostures.includes(PUBLIC_REVIEW_NO_TOOL_POSTURE),
@@ -888,7 +896,18 @@ export function createPortOSProviderRoutes(aiToolkit) {
   // provider record receives the same secret redaction as every other provider
   // response. The toolkit returns its raw persisted record here.
   router.post('/:id/refresh-models', asyncHandler(async (req, res) => {
-    const provider = await providerService.refreshProviderModels(req.params.id);
+    const stored = await providerService.getProviderById(req.params.id);
+    if (!stored) throw new ServerError('Provider not found', { status: 404 });
+    let provider;
+    if (refreshesOpenCodeCatalog(stored)) {
+      const result = await refreshHarnessModels('opencode');
+      if (!result.ok || !result.updated.includes(stored.id)) {
+        throw new ServerError(result.reason || 'No models matched this provider’s namespace; its catalog was preserved.', { status: 502 });
+      }
+      provider = await providerService.getProviderById(stored.id);
+    } else {
+      provider = await providerService.refreshProviderModels(req.params.id);
+    }
     if (!provider) throw new ServerError('Provider not found', { status: 404 });
     res.json(presentProvider(provider, await detectSystemCapabilities()));
   }));

--- a/server/routes/providers.refreshModels.test.js
+++ b/server/routes/providers.refreshModels.test.js
@@ -5,6 +5,11 @@ import { request } from '../lib/testHelper.js';
 import { errorMiddleware } from '../lib/errorHandler.js';
 import { createPortOSProviderRoutes } from './providers.js';
 
+const refreshHarnessModels = vi.hoisted(() => vi.fn());
+vi.mock('../services/harnesses.js', async (importOriginal) => ({
+  ...await importOriginal(), refreshHarnessModels,
+}));
+
 const RAW_PROVIDER = {
   id: 'openai',
   name: 'OpenAI',
@@ -26,7 +31,7 @@ function appWith(providerService) {
 
 describe('POST /:id/refresh-models provider redaction', () => {
   it('returns refreshed models without the API key or secret env value', async () => {
-    const app = appWith({ refreshProviderModels: vi.fn().mockResolvedValue(RAW_PROVIDER) });
+    const app = appWith({ getProviderById: vi.fn().mockResolvedValue(RAW_PROVIDER), refreshProviderModels: vi.fn().mockResolvedValue(RAW_PROVIDER) });
 
     const res = await request(app).post('/api/providers/openai/refresh-models');
 
@@ -40,10 +45,51 @@ describe('POST /:id/refresh-models provider redaction', () => {
   });
 
   it('returns 404 when the provider does not exist', async () => {
-    const app = appWith({ refreshProviderModels: vi.fn().mockResolvedValue(null) });
+    const app = appWith({ getProviderById: vi.fn().mockResolvedValue(null) });
 
     const res = await request(app).post('/api/providers/missing/refresh-models');
 
     expect(res.status).toBe(404);
   });
+});
+
+describe('OpenCode Zen card refresh', () => {
+  const zen = { id: 'opencode-zen-cli', name: 'OpenCode Zen', type: 'cli', command: 'opencode', models: ['opencode/old'] };
+
+  it.each(['cli', 'tui'])('exposes refresh and returns the persisted scoped catalog through the harness workflow (%s)', async (type) => {
+    const provider = { ...zen, type };
+    const refreshed = { ...provider, models: ['opencode/new'], defaultModel: 'opencode/new' };
+    const service = {
+      getProviderById: vi.fn().mockResolvedValueOnce(provider).mockResolvedValueOnce(provider).mockResolvedValue(refreshed),
+      refreshProviderModels: vi.fn(),
+    };
+    refreshHarnessModels.mockResolvedValue({ ok: true, updated: [zen.id] });
+    const app = appWith(service);
+    expect((await request(app).get('/api/providers/' + zen.id)).body.canRefreshModels).toBe(true);
+    const res = await request(app).post('/api/providers/' + zen.id + '/refresh-models');
+    expect(res.status).toBe(200);
+    expect(res.body.models).toEqual(['opencode/new']);
+    expect(refreshHarnessModels).toHaveBeenCalledWith('opencode');
+    expect(service.refreshProviderModels).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { ok: false, reason: 'OpenCode is not installed.', updated: [] },
+    { ok: true, updated: [] },
+  ])('reports an unsuccessful refresh without claiming success', async (result) => {
+    refreshHarnessModels.mockResolvedValue(result);
+    const app = appWith({ getProviderById: vi.fn().mockResolvedValue(zen) });
+    const res = await request(app).post('/api/providers/' + zen.id + '/refresh-models');
+    expect(res.status).toBe(502);
+  });
+});
+
+it('does not offer harness refresh for a hand-declared OpenCode backend', async () => {
+  const provider = {
+    id: 'example-custom', type: 'tui', command: 'opencode',
+    envVars: { OPENCODE_CONFIG_CONTENT: JSON.stringify({ provider: { example: { models: {} } } }) },
+  };
+  const app = appWith({ getProviderById: vi.fn().mockResolvedValue(provider) });
+  const res = await request(app).get('/api/providers/example-custom');
+  expect(res.body.canRefreshModels).toBe(false);
 });


### PR DESCRIPTION
## Summary
OpenCode Zen CLI/TUI cards now offer Refresh Models in AI Providers. The action reuses the existing harness catalog refresh, preserving namespace filtering and custom backend boundaries while returning the updated, sanitized provider to the card.

Failures report an error instead of claiming the catalog was refreshed.

## Test plan
- Provider refresh and capability route suites passed, including CLI/TUI refresh, unavailable catalog, unmatched namespace, and custom backend coverage.
- Harness service suite passed.
- ProviderCard and AIProviders UI suites passed (87 tests).
- Reviewed the diff for reuse, scope, and sensitive data; git diff --check passed.
