### PR TITLE
fix: validate explicitly pinned Video shot drafts

### DIFF
--- a/server/services/creativeDirector/projectsFile.test.js
+++ b/server/services/creativeDirector/projectsFile.test.js
@@ -84,6 +84,30 @@ const createVideo = () => file.createProject({
 });
 
 describe('Video treatment artifacts', () => {
+  it('rejects backend-incompatible drafts and edits before replacing a saved artifact', async () => {
+    const p = await createVideo();
+    await file.updateProject(p.id, { renderBackend: { video: { mode: 'reactor' } } });
+    await file.setTreatment(p.id, videoTreatment());
+    const saved = await file.getProject(p.id);
+    const tooShort = videoTreatment();
+    tooShort.scenes[0].durationSeconds = 5;
+    const tooLong = videoTreatment();
+    tooLong.scenes[0].prompt = 'x'.repeat(801);
+    const missingPrior = videoTreatment();
+    missingPrior.scenes[0].useContinuationFromPrior = true;
+    await expect(file.setTreatment(p.id, tooShort)).rejects.toThrow('incompatible duration');
+    await expect(file.setTreatment(p.id, tooLong)).rejects.toThrow('maximum 800 characters');
+    await expect(file.setTreatment(p.id, missingPrior)).rejects.toThrow('without a prior shot');
+    await expect(file.updateScene(p.id, 'scene-0', { prompt: 'x'.repeat(801) })).rejects.toThrow('maximum 800 characters');
+    expect(await file.getProject(p.id)).toEqual(saved);
+    await file.updateProject(p.id, { renderBackend: { video: { mode: 'grok' } } });
+    const rounded = videoTreatment();
+    rounded.scenes = Array.from({ length: 15 }, (_, order) => ({ ...rounded.scenes[0], sceneId: `scene-${order}`, order, durationSeconds: 8 }));
+    await expect(file.setTreatment(p.id, rounded)).rejects.toThrow('choose 6 or 10 seconds');
+    await file.setTreatment(p.id, videoTreatment());
+    expect((await file.getProject(p.id)).treatment.artifact.targetDurationSeconds).toBe(120);
+  });
+
   it('persists a timed two-minute script and stable identities across revised drafts and reloads', async () => {
     const p = await createVideo();
     const treatment = videoTreatment();

--- a/server/services/creativeDirector/projectsLogic.js
+++ b/server/services/creativeDirector/projectsLogic.js
@@ -20,6 +20,8 @@ import { compareNewerWins } from '../../lib/lwwTimestamp.js';
 import { pickLlmRoutePinLayer } from '../../lib/llmRoutePin.js';
 import { localImageFilename } from '../../lib/localImageFilename.js';
 import { sanitizeProjectForSync } from '../../lib/projectStoreKit.js';
+import { GROK_VIDEO_DURATIONS } from '../../lib/grokVideoClip.js';
+import { REACTOR_MIN_CLIP_SECONDS, REACTOR_MAX_CLIP_SECONDS, REACTOR_MAX_PROMPT_LENGTH, REACTOR_ASPECTS } from '../../lib/reactorVideoClip.js';
 
 export { sanitizeProjectForSync } from '../../lib/projectStoreKit.js';
 
@@ -362,6 +364,27 @@ export function applyProjectPatch(project, patch) {
   return next;
 }
 
+function validateVideoShot(project, scene, isFirst) {
+  const backend = project.renderBackend?.video?.mode;
+  const unsupported = [];
+  if (isFirst && scene.useContinuationFromPrior) unsupported.push('continuation without a prior shot');
+  if (backend === 'grok' && !GROK_VIDEO_DURATIONS.includes(scene.durationSeconds)) {
+    unsupported.push(`duration (choose ${GROK_VIDEO_DURATIONS.join(' or ')} seconds)`);
+  }
+  if (backend === 'reactor') {
+    if (scene.durationSeconds < REACTOR_MIN_CLIP_SECONDS || scene.durationSeconds > REACTOR_MAX_CLIP_SECONDS) {
+      unsupported.push(`duration (choose ${REACTOR_MIN_CLIP_SECONDS}–${REACTOR_MAX_CLIP_SECONDS} seconds)`);
+    }
+    if (scene.prompt.length > REACTOR_MAX_PROMPT_LENGTH) unsupported.push(`prompt (maximum ${REACTOR_MAX_PROMPT_LENGTH} characters)`);
+    if (!REACTOR_ASPECTS.includes(project.aspectRatio)) unsupported.push('aspect ratio');
+  }
+  if (unsupported.length) {
+    throw new ServerError(`Video shot ${scene.sceneId} has incompatible ${unsupported.join(', ')}. Revise the shot or choose a compatible backend.`, {
+      status: 400, code: 'VIDEO_BACKEND_INPUT_UNSUPPORTED',
+    });
+  }
+}
+
 /** Compile the existing treatment into a persisted Video artifact, without dispatch. */
 function compileVideoArtifact(project, treatment) {
   const scenes = [...treatment.scenes].sort((a, b) => a.order - b.order);
@@ -369,6 +392,7 @@ function compileVideoArtifact(project, treatment) {
   const orders = new Set();
   let elapsed = 0;
   const shots = scenes.map((scene) => {
+    validateVideoShot(project, scene, elapsed === 0);
     if (ids.has(scene.sceneId) || orders.has(scene.order)) {
       throw new ServerError('Video scenes must have unique sceneId and order values', { status: 400, code: 'VALIDATION_ERROR' });
     }
@@ -532,6 +556,7 @@ export function applySceneUpdate(project, sceneId, patch) {
   const treatment = { ...project.treatment, scenes };
   if (project.workspace === 'video' && treatment.artifact
       && ['prompt', 'imageStrength'].some((key) => key in patch && patch[key] !== project.treatment.scenes[sceneIdx][key])) {
+    validateVideoShot(project, updated, sceneId === [...scenes].sort((a, b) => a.order - b.order)[0].sceneId);
     // A shot edit changes the reviewed content, but cannot refresh stale source context.
     treatment.artifact = { ...treatment.artifact, revision: treatment.artifact.revision + 1 };
   }


### PR DESCRIPTION
Video treatment saves now reject unsupported durations for explicitly pinned Grok/Reactor backends, oversized Reactor prompts, unsupported Reactor aspect ratios, and first-shot continuation. Validation uses the shared clip contracts and preserves the saved artifact when a draft or prompt edit fails. Legacy Creative Director treatments keep their existing behavior.

Validation: 111 persistence, transform and import-scoping tests passed; git diff --check passed. No paid rendering or real database tests.

## Remaining

This is a partial validation slice. Source resolution/canon grounding and deleted-source repair, planner prompt integration, tool-plan artifact links and artifact UI remain in #6547. Compilation against inherited/local/fal capabilities and full starting-frame compatibility also remain. Explicit pin checks do not establish renderer availability or authorize dispatch.

Refs #6547
