### PR TITLE
fix: align Video treatment planning with timed script artifacts

### DIFF
--- a/data.reference/prompts/stages/cd-treatment.md
+++ b/data.reference/prompts/stages/cd-treatment.md
@@ -1,6 +1,7 @@
 # Creative Director — Treatment task
 
-You are the Creative Director for a long-form generated-video project. Your job in this task is to produce a TREATMENT — a complete scene-by-scene plan that the server will then render scene-by-scene (no further agent task is needed for rendering — the server orchestrates that). After each render lands, a separate short evaluation task will judge it.
+{{^standaloneVideo}}You are the Creative Director for a long-form generated-video project. Your job in this task is to produce a TREATMENT — a complete scene-by-scene plan that the server will then render scene-by-scene (no further agent task is needed for rendering — the server orchestrates that). After each render lands, a separate short evaluation task will judge it.{{/standaloneVideo}}
+{{#standaloneVideo}}You are the Creative Director for a standalone Video draft. Write its script and timed shot plan. Saving this treatment does not authorize or start rendering.{{/standaloneVideo}}
 
 ## Project: "{{project.name}}" (id: {{project.id}})
 
@@ -41,12 +42,25 @@ The user did not supply a story. Invent one that suits the style spec and target
 
 ## Task
 
+{{^standaloneVideo}}
 1. Design a story arc that fits ~{{project.targetDurationSeconds}}s of total runtime. Think in scenes that are 1–10 seconds each (most should be 4–6s; reserve short ones for cuts and long ones for held shots).
 2. Each scene should have a clear visual intent and a render prompt that incorporates the style spec.
 3. Decide for each scene whether it continues from the previous scene's last frame (`useContinuationFromPrior: true`) or starts from a new image (`useContinuationFromPrior: false`, optionally with a `sourceImageFile` basename if you want to seed from a specific gallery image). Scene 1 either uses the project starting image (if provided — copy its filename into `sourceImageFile`) or starts as text-to-video.
 4. Optionally set `imageStrength` (0.0–1.0) on i2v scenes (continuation OR seeded) to control how strongly the source image conditions the render. Higher values stick closer to the source (good for tight continuation); lower values give the model more freedom (good when the prompt deliberately diverges from the seed). Omit (or set null) to accept the default — continuation scenes default to 0.85, other scenes use the renderer's built-in default.
 5. Don't pad with filler; if the natural arc is shorter than the target, that's fine — produce fewer scenes.
+{{/standaloneVideo}}
 
+
+{{#standaloneVideo}}
+1. Write a complete production script in the top-level `script` string (1–50,000 characters), including action, dialogue or narration as appropriate. Return artifacts and ordinary summaries, never private reasoning.
+2. Resolve the story to exactly {{project.targetDurationSeconds}} seconds. The selected range is {{video.durationRangeJson}}; the exact target is already chosen. Every shot must be 1–10 seconds, and the sum must equal the exact target. A 180-second production is many shots, never one clip. Use at most 120 scenes.
+3. Respect the pinned video backend: {{video.backend}}. Its draft input limits are {{video.clipLimitsJson}}. These are intersected with the treatment schema, not a guarantee of renderer availability. If the exact target cannot be composed from supported durations, report the conflict and request a compatible target/backend; do not silently round or change settings.
+4. Give each shot a unique stable `sceneId` (at most 64 characters) and unique zero-based `order`. Preserve IDs for retained shots on revision. The server derives script/shot/reference IDs, contiguous start/end timing, and artifact revisions; do not author those fields or runtime status/results.
+5. Include clear visual intent (at most 1,000 characters) and a full prompt with the style spec (at most 8,000 characters, or the lower backend limit). The first shot cannot continue from a prior shot. Use only an explicitly provided image basename for `sourceImageFile`; source record IDs are not image filenames. Do not invent starting frames or claim continuation support from duration limits.
+6. Selected source references and revisions: {{video.sourcesJson}}. These are context pointers, not resolved source content. Do not fabricate canon or asset contents from IDs, mutate the sources, or assert that references were validated. Missing/unresolved source content must be reported before it is consumed.
+7. Current saved treatment (null on first draft): {{video.currentTreatmentJson}}. Use it to preserve script and scene identity while revising the requested content.
+
+{{/standaloneVideo}}
 ## Output contract
 
 Issue ONE HTTP request to update the project with the treatment, then exit:
@@ -58,6 +72,7 @@ Content-Type: application/json
 {
   "logline": "<one-sentence high-concept>",
   "synopsis": "<short paragraph synopsis>",
+{{#standaloneVideo}}  "script": "<complete production script>",{{/standaloneVideo}}
   "scenes": [
     {
       "sceneId": "scene-1",
@@ -65,7 +80,7 @@ Content-Type: application/json
       "intent": "<what this scene does narratively/visually>",
       "prompt": "<full render prompt with style spec inlined>",
       "negativePrompt": "<optional>",
-      "durationSeconds": 5,
+      "durationSeconds": {{#standaloneVideo}}6{{/standaloneVideo}}{{^standaloneVideo}}5{{/standaloneVideo}},
       "useContinuationFromPrior": false,
       "sourceImageFile": {{startingImageFileLiteral}},
       "imageStrength": null{{#hasCast}},
@@ -76,6 +91,6 @@ Content-Type: application/json
 }
 ```
 
-On a 200 response your task is complete. The server will automatically begin rendering scene 1 — do not create any additional tasks yourself.
+On a 200 response your task is complete. {{^standaloneVideo}}The server will automatically begin rendering scene 1 — do not create any additional tasks yourself.{{/standaloneVideo}}{{#standaloneVideo}}The treatment remains a draft for review. Do not start production, enqueue renders, or create additional tasks.{{/standaloneVideo}}
 
 If the PATCH returns 4xx, fix the validation issue (read the error body) and retry. Do not retry on 5xx more than twice.

--- a/scripts/migrations/155-heal-cd-treatment-cast-strand.js
+++ b/scripts/migrations/155-heal-cd-treatment-cast-strand.js
@@ -42,7 +42,7 @@ export const ACCEPTED_OLD_MD5 = {
 };
 
 export const NEW_SHIPPED_MD5 = {
-  'cd-treatment.md': 'd940eadfb406ce584f0e244032f33382', // #1808 shipped reference (cast list + per-scene cast field)
+  'cd-treatment.md': '1de973575a772db0544bbeda2ba5df77', // current shipped reference; migration 371 upgrades existing installs
 };
 
 const { applyMigration, up } = makePromptReplaceMigration({

--- a/scripts/migrations/371-video-treatment-contract.js
+++ b/scripts/migrations/371-video-treatment-contract.js
@@ -1,0 +1,20 @@
+/**
+ * Upgrade shipped treatment prompts to the standalone Video script/timing contract.
+ * Customized prompts are preserved; setup-data discovers this hash lineage.
+ */
+import { makePromptReplaceMigration } from './_lib.js';
+
+export const ACCEPTED_OLD_MD5 = {
+  'cd-treatment.md': ['d940eadfb406ce584f0e244032f33382'],
+};
+export const NEW_SHIPPED_MD5 = {
+  'cd-treatment.md': '1de973575a772db0544bbeda2ba5df77',
+};
+const { applyMigration, up } = makePromptReplaceMigration({
+  accepted: ACCEPTED_OLD_MD5,
+  current: NEW_SHIPPED_MD5,
+  label: 'standalone Video treatment contract',
+  customizedHint: (filename) => '   Merge the standalone Video sections from data.reference/prompts/stages/' + filename + ' into your customized prompt.',
+});
+export { applyMigration };
+export default { up };

--- a/scripts/migrations/371-video-treatment-contract.test.js
+++ b/scripts/migrations/371-video-treatment-contract.test.js
@@ -1,0 +1,10 @@
+import { describe } from 'vitest';
+import { runPromptMigrationTests } from './_testHelpers.js';
+import migration, { applyMigration, ACCEPTED_OLD_MD5, NEW_SHIPPED_MD5 } from './371-video-treatment-contract.js';
+
+describe('migration 371 — standalone Video treatment contract', () => {
+  runPromptMigrationTests({
+    migration, applyMigration, ACCEPTED_OLD_MD5, NEW_SHIPPED_MD5,
+    prefix: 'migration-371-',
+  });
+});

--- a/server/services/creativeDirector/projectsFile.test.js
+++ b/server/services/creativeDirector/projectsFile.test.js
@@ -141,6 +141,7 @@ describe('Video treatment artifacts', () => {
     const wrongDuration = videoTreatment();
     wrongDuration.scenes[0].durationSeconds = 9;
     const writesBefore = writeCounter.project;
+    await expect(file.setTreatment(p.id, { ...videoTreatment(), script: undefined })).rejects.toThrow('require a production script');
     await expect(file.setTreatment(p.id, duplicateId)).rejects.toThrow('unique sceneId');
     await expect(file.setTreatment(p.id, duplicateOrder)).rejects.toThrow('unique sceneId');
     await expect(file.setTreatment(p.id, wrongDuration)).rejects.toThrow('exact target of 120s');

--- a/server/services/creativeDirector/projectsLogic.js
+++ b/server/services/creativeDirector/projectsLogic.js
@@ -387,6 +387,11 @@ function validateVideoShot(project, scene, isFirst) {
 
 /** Compile the existing treatment into a persisted Video artifact, without dispatch. */
 function compileVideoArtifact(project, treatment) {
+  if (!treatment.script) {
+    throw new ServerError('Video treatments require a production script. Add script text and resubmit the treatment.', {
+      status: 400, code: 'VALIDATION_ERROR',
+    });
+  }
   const scenes = [...treatment.scenes].sort((a, b) => a.order - b.order);
   const ids = new Set();
   const orders = new Set();

--- a/server/services/creativeDirectorPrompts.js
+++ b/server/services/creativeDirectorPrompts.js
@@ -24,6 +24,8 @@ import {
   QUALITY_PRESETS,
   presetToRenderParams,
 } from '../lib/creativeDirectorPresets.js';
+import { GROK_VIDEO_DURATIONS } from '../lib/grokVideoClip.js';
+import { REACTOR_MIN_CLIP_SECONDS, REACTOR_MAX_CLIP_SECONDS, REACTOR_MAX_PROMPT_LENGTH, REACTOR_ASPECTS } from '../lib/reactorVideoClip.js';
 import { PORTOS_API_URL } from '../lib/portosUrls.js';
 import { buildPrompt } from './promptService.js';
 
@@ -71,6 +73,24 @@ function buildTreatmentView(project) {
     apiUrl: PORTOS_API_URL,
     startingImageFileLiteral,
     hasCast,
+    standaloneVideo: project.workspace === 'video',
+    video: {
+      durationRangeJson: JSON.stringify(project.videoDraft?.durationRange || {}),
+      backend: project.renderBackend?.video?.mode || 'inherited (not resolved)',
+      clipLimitsJson: JSON.stringify(project.renderBackend?.video?.mode === 'grok'
+        ? { durationSeconds: GROK_VIDEO_DURATIONS }
+        : project.renderBackend?.video?.mode === 'reactor'
+          ? { minSeconds: REACTOR_MIN_CLIP_SECONDS, maxSeconds: Math.min(10, REACTOR_MAX_CLIP_SECONDS), maxPromptCharacters: REACTOR_MAX_PROMPT_LENGTH, aspectRatios: REACTOR_ASPECTS }
+          : { minSeconds: 1, maxSeconds: 10, backendCompatibility: 'unresolved' }),
+      sourcesJson: JSON.stringify(project.videoDraft?.sources || []),
+      currentTreatmentJson: JSON.stringify(project.treatment ? {
+        script: project.treatment.script,
+        scenes: project.treatment.scenes?.map(({ sceneId, order, intent, prompt, negativePrompt, durationSeconds, sourceImageFile, useContinuationFromPrior, imageStrength, cast }) => ({
+          sceneId, order, intent, prompt, negativePrompt, durationSeconds, sourceImageFile, useContinuationFromPrior, imageStrength, cast,
+        })),
+        artifact: project.treatment.artifact,
+      } : null),
+    },
   };
 }
 

--- a/server/services/creativeDirectorPrompts.test.js
+++ b/server/services/creativeDirectorPrompts.test.js
@@ -250,3 +250,35 @@ describe('buildEvaluatePrompt — imageStrength surfacing', () => {
     expect(out).toContain('Image strength: default');
   });
 });
+
+describe('standalone Video treatment planning', () => {
+  it('requires an exact timed script and preserves revision context without authorizing renders', async () => {
+    const project = {
+      ...baseProject, workspace: 'video', targetDurationSeconds: 120,
+      renderBackend: { video: { mode: 'reactor' } },
+      videoDraft: { durationRange: { min: 60, max: 180 }, sources: [{ kind: 'universe', id: 'example-universe', revision: 'rev-2' }] },
+      treatment: { script: 'A visitor returns.', scenes: [{ sceneId: 'scene-retained', order: 0 }], artifact: { scriptId: 'script-example', revision: 2 } },
+    };
+    const out = await buildTreatmentPrompt(project);
+    expect(out).toContain('exactly 120 seconds');
+    expect(out).toContain('"script": "<complete production script>"');
+    expect(out).toContain('"minSeconds":5.167');
+    expect(out).toContain('"maxPromptCharacters":800');
+    expect(out).toContain('"sceneId":"scene-retained"');
+    expect(out).toContain('"scriptId":"script-example"');
+    expect(out).toContain('"revision":"rev-2"');
+    expect(out).toContain('Do not start production');
+    expect(out).not.toContain('produce fewer scenes');
+    expect(out).not.toContain('automatically begin rendering');
+    expect(out).not.toMatch(/{{[#/^]?[a-zA-Z]/);
+  });
+
+  it('distinguishes pinned Grok durations from unresolved inherited capabilities', async () => {
+    const project = { ...baseProject, workspace: 'video' };
+    const grok = await buildTreatmentPrompt({ ...project, renderBackend: { video: { mode: 'grok' } } });
+    expect(grok).toContain('"durationSeconds":[6,10]');
+    const inherited = await buildTreatmentPrompt(project);
+    expect(inherited).toContain('"backendCompatibility":"unresolved"');
+    expect(inherited).toContain('source record IDs are not image filenames');
+  });
+});


### PR DESCRIPTION
Standalone Video treatment planning now asks for a complete script and shots totaling the exact selected runtime, preserves saved scene/artifact identity during revision, and surfaces shared pinned Grok/Reactor input limits. It no longer promises automatic rendering or permits a shorter runtime. Treatment saves reject missing scripts without replacing the saved artifact; legacy treatments retain their behavior.

Migration 371 upgrades uncustomized shipped treatment prompts and preserves custom templates. The prompt-hash drift tables track the new version.

## Test plan

- 220 focused prompt, route, persistence, transform, import-scoping and migration tests passed.
- Prompt tests rerun after the final revision-context adjustment: 20 passed.
- Pinned optional Ollama reviewer: No findings.
- git diff --check passed. No paid rendering or real database tests.

## Remaining

This ships the treatment-planning contract slice. Source resolution/canon grounding and deleted-source repair, tool-plan artifact links and artifact UI, inherited/local/fal capability resolution, and full starting-frame/continuation compatibility remain within #6547. Draft production dispatch remains gated by the existing approval barrier.

Refs #6547
