### PR TITLE
feat: expose saved Video production artifacts

### DIFF
--- a/client/src/components/creative-director/VideoArtifactsTab.jsx
+++ b/client/src/components/creative-director/VideoArtifactsTab.jsx
@@ -1,0 +1,89 @@
+import { Link } from 'react-router';
+import { formatTimecode } from '../../utils/formatters.js';
+import { PLAN_STEP_STATUS_META, stepResultLink } from '../../lib/creativeDirectorPlan.js';
+
+export default function VideoArtifactsTab({ project, basePath }) {
+  const treatment = project.treatment;
+  const artifact = treatment?.artifact;
+  const projectPath = `${basePath}/${encodeURIComponent(project.id)}`;
+  const scenes = new Map((treatment?.scenes || []).map(scene => [scene.sceneId, scene]));
+
+  return (
+    <div className="max-w-4xl space-y-4">
+      <h2 className="text-lg font-medium">Production artifacts</h2>
+      <p className="text-sm text-port-text-muted">Saved planning artifacts. Production remains blocked until revision approvals and dispatch controls are available.</p>
+      {!artifact ? (
+        <p className="text-sm text-port-text-muted">
+          No compiled artifact yet. A saved Video treatment with a script and shots totaling the exact target will appear here.
+          {' '}<Link className="text-port-accent hover:underline" to={`${projectPath}/overview`}>Review the brief</Link>
+        </p>
+      ) : (
+        <>
+          <section aria-label="Artifact revision" className="bg-port-card border border-port-border rounded p-4 space-y-2">
+            <p className="font-medium">Revision {artifact.revision} · {artifact.targetDurationSeconds} seconds · {artifact.aspectRatio}</p>
+            <p className="text-xs text-port-text-muted break-words">Script ID: {artifact.scriptId}</p>
+            {artifact.stale && <p role="status" className="text-sm text-port-warning">
+              This artifact is out of date. The brief, sources, or production settings changed after it was compiled.
+              {' '}<Link className="underline" to={`${projectPath}/overview`}>Review the current draft</Link>
+              {' '}and save a revised treatment before production.
+            </p>}
+          </section>
+          <section aria-labelledby="video-artifact-script" className="space-y-2">
+            <h3 id="video-artifact-script" className="font-medium">Script</h3>
+            <p className="bg-port-card border border-port-border rounded p-4 text-sm whitespace-pre-wrap break-words">{treatment.script || 'No script text saved in this revision.'}</p>
+          </section>
+          <section aria-labelledby="video-artifact-shots" className="space-y-2">
+            <h3 id="video-artifact-shots" className="font-medium">Timed shots ({artifact.shots.length})</h3>
+            <ol className="space-y-2">
+              {artifact.shots.map(shot => {
+                const scene = scenes.get(shot.sceneId);
+                return <li key={shot.shotId} className="bg-port-card border border-port-border rounded p-3 space-y-1 text-sm">
+                  <div className="flex flex-wrap justify-between gap-2">
+                    {scene ? <Link className="text-port-accent hover:underline break-words" to={`${projectPath}/segments/${encodeURIComponent(shot.sceneId)}`}>{shot.shotId}</Link>
+                      : <span className="break-words">{shot.shotId}</span>}
+                    <span>{formatTimecode(shot.startSeconds)}–{formatTimecode(shot.endSeconds)} · {shot.durationSeconds}s</span>
+                  </div>
+                  <p className="text-xs text-port-text-muted break-words">Scene ID: {shot.sceneId}</p>
+                  {scene ? <p className="break-words">{scene.intent}</p>
+                    : <p className="text-port-warning">Scene missing. Save a revised treatment to repair this shot.</p>}
+                </li>;
+              })}
+            </ol>
+          </section>
+          <section aria-labelledby="video-artifact-references" className="space-y-2">
+            <h3 id="video-artifact-references" className="font-medium">Saved references ({artifact.references.length})</h3>
+            <p className="text-sm text-port-text-muted">References belong to this artifact revision. Source availability has not been checked.</p>
+            {!artifact.references.length && <p className="text-sm">No attached sources in this revision.</p>}
+            <ul className="space-y-2">
+              {artifact.references.map(reference => {
+                const sourcePath = reference.kind === 'universe' ? `/universes/${encodeURIComponent(reference.id)}`
+                  : reference.kind === 'series' ? `/pipeline/series/${encodeURIComponent(reference.id)}` : null;
+                return <li key={reference.referenceId} className="bg-port-card border border-port-border rounded p-3 text-sm space-y-1 break-words">
+                  <p>{reference.kind}: {reference.id}</p>
+                  <p className="text-xs text-port-text-muted">Reference ID: {reference.referenceId}</p>
+                  <p>Source revision: {reference.revision || 'Not recorded'}</p>
+                  {sourcePath && <Link className="text-port-accent hover:underline" to={sourcePath}>Open {reference.kind}</Link>}
+                </li>;
+              })}
+            </ul>
+          </section>
+        </>
+      )}
+      <section aria-labelledby="video-artifact-tools" className="space-y-2">
+        <h3 id="video-artifact-tools" className="font-medium">Tool summaries</h3>
+        {!project.plan?.steps?.length && <p className="text-sm text-port-text-muted">No tool plan saved.</p>}
+        <ul className="space-y-2">
+          {(project.plan?.steps || []).map(step => {
+            const resultLink = stepResultLink(step);
+            return <li key={step.stepId} className="bg-port-card border border-port-border rounded p-3 text-sm space-y-1 break-words">
+              <p>{step.toolName} · {PLAN_STEP_STATUS_META[step.status || 'pending']?.label || 'Unknown status'}</p>
+              <p className="text-xs text-port-text-muted">Step ID: {step.stepId}</p>
+              {step.dependsOn?.length > 0 && <p>Depends on: {step.dependsOn.join(', ')}</p>}
+              {resultLink && <Link className="text-port-accent hover:underline" to={resultLink.to}>{resultLink.label}</Link>}
+            </li>;
+          })}
+        </ul>
+      </section>
+    </div>
+  );
+}

--- a/client/src/pages/CreativeDirectorDetail.jsx
+++ b/client/src/pages/CreativeDirectorDetail.jsx
@@ -17,6 +17,7 @@ import {
 import VideoDraftDrawer from '../components/creative-director/VideoDraftDrawer.jsx';
 import OverviewTab from '../components/creative-director/OverviewTab.jsx';
 import TreatmentTab from '../components/creative-director/TreatmentTab.jsx';
+import VideoArtifactsTab from '../components/creative-director/VideoArtifactsTab.jsx';
 import SegmentsTab from '../components/creative-director/SegmentsTab.jsx';
 import PlanTab from '../components/creative-director/PlanTab.jsx';
 import RunsTab from '../components/creative-director/RunsTab.jsx';
@@ -29,7 +30,7 @@ import useMediaJobProgress from '../hooks/useMediaJobProgress';
 
 const TERMINAL_PROJECT_STATUSES = new Set(['complete', 'failed', 'paused', 'draft']);
 
-const VIDEO_DRAFT_TABS = [{ id: 'overview', label: 'Overview' }, { id: 'segments', label: 'Shots' }, { id: 'runs', label: 'Runs' }];
+const VIDEO_DRAFT_TABS = [{ id: 'overview', label: 'Overview' }, { id: 'artifacts', label: 'Artifacts' }, { id: 'segments', label: 'Shots' }, { id: 'runs', label: 'Runs' }];
 
 const TABS = [
   { id: 'overview', label: 'Overview' },
@@ -347,6 +348,7 @@ export default function CreativeDirectorDetail({ basePath = '/creative-director'
           />
         )}
         {project.workspace !== 'video' && activeTab === 'treatment' && <TreatmentTab project={project} />}
+        {project.workspace === 'video' && activeTab === 'artifacts' && <VideoArtifactsTab project={project} basePath={basePath} />}
         {activeTab === 'segments' && <SegmentsTab project={project} activeAgents={activeAgents} basePath={basePath} />}
         {activeTab === 'runs' && <RunsTab project={project} />}
       </div>

--- a/client/src/pages/CreativeDirectorDetail.test.jsx
+++ b/client/src/pages/CreativeDirectorDetail.test.jsx
@@ -80,3 +80,87 @@ describe('CreativeDirectorDetail project deletion', () => {
     expect(screen.getByTestId('location')).toHaveTextContent('/creative-director');
   });
 });
+
+describe('Video saved artifacts', () => {
+  const videoProject = {
+    ...PROJECT, workspace: 'video', targetDurationSeconds: 120,
+    plan: { steps: [{
+      stepId: 'attach-series', toolName: 'series.create', status: 'blocked', dependsOn: ['outline'],
+      args: { privateReasoning: 'Hidden tool arguments' },
+      result: { seriesId: 'example-series', privateReasoning: 'Hidden result field' },
+    }] },
+    treatment: {
+      script: 'Example script.\nA traveler arrives.',
+      scenes: Array.from({ length: 20 }, (_, order) => ({ sceneId: order === 0 ? 'arrival' : `scene-${order}`, intent: 'A traveler arrives', order, durationSeconds: 6 })),
+      artifact: {
+        scriptId: 'script-cd-example', revision: 2, targetDurationSeconds: 120, aspectRatio: '16:9', stale: false,
+        shots: Array.from({ length: 20 }, (_, order) => ({ shotId: order === 0 ? 'shot-arrival' : `shot-scene-${order}`, sceneId: order === 0 ? 'arrival' : `scene-${order}`, startSeconds: order * 6, endSeconds: (order + 1) * 6, durationSeconds: 6 })),
+        references: [
+          { referenceId: 'universe:example-universe', kind: 'universe', id: 'example-universe', revision: 'rev-4' },
+          { referenceId: 'voice:example-voice', kind: 'voice', id: 'example-voice' },
+        ],
+      },
+    },
+  };
+  function renderVideo(tab = 'artifacts') {
+    return render(
+      <MemoryRouter initialEntries={[`/video/cd-example/${tab}`]}>
+        <LocationProbe />
+        <Routes>
+          <Route path="/video/:id/:tab" element={<CreativeDirectorDetail basePath="/video" />} />
+          <Route path="/video/:id/:tab/:sceneId" element={<CreativeDirectorDetail basePath="/video" />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+  }
+  beforeEach(() => {
+    vi.clearAllMocks();
+    cdApi.getCreativeDirectorProject.mockResolvedValue(videoProject);
+  });
+  it('opens artifacts from Video navigation and restores the saved revision on a fresh deep link', async () => {
+    const user = userEvent.setup();
+    const page = renderVideo('overview');
+    await screen.findByRole('heading', { name: PROJECT.name });
+    await user.click(screen.getByRole('tab', { name: 'Artifacts', exact: true }));
+    expect(screen.getByTestId('location')).toHaveTextContent('/video/cd-example/artifacts');
+    expect(screen.getByText('Revision 2 · 120 seconds · 16:9')).toBeInTheDocument();
+    expect(screen.getByText(/Example script/)).toHaveTextContent('A traveler arrives.');
+    expect(screen.getByText('0:00.00–0:06.00 · 6s')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'shot-arrival' })).toHaveAttribute('href', '/video/cd-example/segments/arrival');
+    expect(screen.getByRole('link', { name: 'Open universe' })).toHaveAttribute('href', '/universes/example-universe');
+    expect(screen.getByText('Source revision: rev-4')).toBeInTheDocument();
+    expect(screen.getByText('Source revision: Not recorded')).toBeInTheDocument();
+    expect(screen.getByText('series.create · Blocked')).toBeInTheDocument();
+    expect(screen.getByText('Depends on: outline')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Open series' })).toHaveAttribute('href', '/pipeline/series/example-series');
+    expect(screen.queryByText(/Hidden tool arguments|Hidden result field/)).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Start|Resume|Approve|Render/ })).not.toBeInTheDocument();
+    page.unmount();
+    renderVideo();
+    expect(await screen.findByText('Revision 2 · 120 seconds · 16:9')).toBeInTheDocument();
+    await user.click(screen.getByRole('link', { name: 'shot-arrival' }));
+    expect(screen.getByTestId('location')).toHaveTextContent('/video/cd-example/segments/arrival');
+    expect(cdApi.startCreativeDirectorProject).not.toHaveBeenCalled();
+    expect(cdApi.resumeCreativeDirectorProject).not.toHaveBeenCalled();
+  });
+  it('shows stale and missing-scene repair guidance while retaining original artifact timing', async () => {
+    cdApi.getCreativeDirectorProject.mockResolvedValue({
+      ...videoProject, targetDurationSeconds: 180,
+      treatment: { ...videoProject.treatment, scenes: [], artifact: { ...videoProject.treatment.artifact, stale: true } },
+    });
+    renderVideo();
+    await screen.findByText(/This artifact is out of date/);
+    expect(screen.getByRole('status')).toHaveTextContent('This artifact is out of date');
+    expect(screen.getByText('Revision 2 · 120 seconds · 16:9')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Review the current draft' })).toHaveAttribute('href', '/video/cd-example/overview');
+    expect(screen.getAllByText(/Scene missing/)).toHaveLength(20);
+    expect(screen.queryByRole('link', { name: 'shot-arrival' })).not.toBeInTheDocument();
+  });
+  it('keeps drafts without compiled artifacts usable', async () => {
+    cdApi.getCreativeDirectorProject.mockResolvedValue({ ...videoProject, treatment: null, plan: null });
+    renderVideo();
+    expect(await screen.findByText(/No compiled artifact yet/)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Review the brief' })).toHaveAttribute('href', '/video/cd-example/overview');
+    expect(screen.getByText('No tool plan saved.')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Video projects persist compiled treatment artifacts, but their detail page hid the script, timing, and revision. A new Artifacts tab displays the saved script and exact runtime, timed shot links, source IDs and recorded revisions, plus stale and missing-scene guidance. Tool summaries show status, dependencies, and existing result links without exposing arbitrary arguments or result payloads.

## Validation

- 29 focused client tests passed across project detail, project list, plan board, and responsive layout contracts.
- Detail tests passed again after making the fixture a complete 120-second shot plan.
- Client production build passed.
- Pinned optional Ollama review: No findings.
- No paid rendering or database tests.

## Remaining

Source resolution/canon grounding and deleted-source repair, complete creative-suite tool artifact linkage, and inherited/local/fal capability resolution with full starting-frame/continuation validation remain within #6547. The artifact surface reports that source availability has not been checked. Production stays behind the existing approval/dispatch barrier.

Refs #6547
