### PR TITLE
fix: retain and browse Video treatment revision history

### DIFF
--- a/client/src/components/creative-director/VideoArtifactsTab.jsx
+++ b/client/src/components/creative-director/VideoArtifactsTab.jsx
@@ -1,11 +1,17 @@
-import { Link } from 'react-router';
+import { Link, useSearchParams } from 'react-router';
 import { useEffect, useState } from 'react';
 import { getCreativeDirectorSources } from '../../services/apiCreativeDirector.js';
 import { formatTimecode } from '../../utils/formatters.js';
 import { PLAN_STEP_STATUS_META, stepResultLink } from '../../lib/creativeDirectorPlan.js';
 
 export default function VideoArtifactsTab({ project, basePath }) {
-  const treatment = project.treatment;
+  const [searchParams, setSearchParams] = useSearchParams();
+  const selectedRevision = searchParams.get('revision');
+  const revisions = [...(project.treatment?.history || []), ...(project.treatment ? [project.treatment] : [])];
+  const treatment = selectedRevision
+    ? revisions.find(value => String(value.artifact?.revision) === selectedRevision)
+    : project.treatment;
+  const historical = Boolean(treatment && treatment !== project.treatment);
   const artifact = treatment?.artifact;
   const projectPath = `${basePath}/${encodeURIComponent(project.id)}`;
   const scenes = new Map((treatment?.scenes || []).map(scene => [scene.sceneId, scene]));
@@ -27,6 +33,20 @@ export default function VideoArtifactsTab({ project, basePath }) {
     <div className="max-w-4xl space-y-4">
       <h2 className="text-lg font-medium">Production artifacts</h2>
       <p className="text-sm text-port-text-muted">Saved planning artifacts. Production remains blocked until revision approvals and dispatch controls are available.</p>
+      {project.treatment?.artifact && <div className="space-y-2">
+        <label htmlFor="video-artifact-revision" className="block text-sm">View revision</label>
+        <select id="video-artifact-revision" value={selectedRevision || ''} onChange={event => {
+          const next = new URLSearchParams(searchParams);
+          if (event.target.value) next.set('revision', event.target.value);
+          else next.delete('revision');
+          setSearchParams(next);
+        }} className="bg-port-card border border-port-border rounded p-2">
+          <option value="">Current revision</option>
+          {revisions.map(value => <option key={value.artifact.revision} value={value.artifact.revision}>Revision {value.artifact.revision}</option>)}
+        </select>
+        {historical && <p role="status" className="text-sm text-port-text-muted">Viewing a saved previous revision. Shot descriptions and source references are preserved as they were saved.</p>}
+        {selectedRevision && !treatment && <p role="alert">Revision not found. Select the current revision to continue.</p>}
+      </div>}
       <section aria-label="Source availability" className="bg-port-card border border-port-border rounded p-4 space-y-2 text-sm">
         <h3 className="font-medium">Source availability</h3>
         {sourceError ? <p role="alert">Unable to check sources. Availability is unknown; no references were changed.</p>
@@ -68,7 +88,7 @@ export default function VideoArtifactsTab({ project, basePath }) {
                 const scene = scenes.get(shot.sceneId);
                 return <li key={shot.shotId} className="bg-port-card border border-port-border rounded p-3 space-y-1 text-sm">
                   <div className="flex flex-wrap justify-between gap-2">
-                    {scene ? <Link className="text-port-accent hover:underline break-words" to={`${projectPath}/segments/${encodeURIComponent(shot.sceneId)}`}>{shot.shotId}</Link>
+                    {scene && !historical ? <Link className="text-port-accent hover:underline break-words" to={`${projectPath}/segments/${encodeURIComponent(shot.sceneId)}`}>{shot.shotId}</Link>
                       : <span className="break-words">{shot.shotId}</span>}
                     <span>{formatTimecode(shot.startSeconds)}–{formatTimecode(shot.endSeconds)} · {shot.durationSeconds}s</span>
                   </div>
@@ -85,7 +105,7 @@ export default function VideoArtifactsTab({ project, basePath }) {
             {!artifact.references.length && <p className="text-sm">No attached sources in this revision.</p>}
             <ul className="space-y-2">
               {artifact.references.map(reference => {
-                const available = sourceState?.artifact.find(source => source.referenceId === reference.referenceId)?.available;
+                const available = historical ? undefined : sourceState?.artifact.find(source => source.referenceId === reference.referenceId)?.available;
                 const sourcePath = reference.kind === 'universe' ? `/universes/${encodeURIComponent(reference.id)}`
                   : reference.kind === 'series' ? `/pipeline/series/${encodeURIComponent(reference.id)}` : null;
                 return <li key={reference.referenceId} className="bg-port-card border border-port-border rounded p-3 text-sm space-y-1 break-words">

--- a/client/src/pages/CreativeDirectorDetail.test.jsx
+++ b/client/src/pages/CreativeDirectorDetail.test.jsx
@@ -118,6 +118,21 @@ describe('Video saved artifacts', () => {
     vi.clearAllMocks();
     cdApi.getCreativeDirectorProject.mockResolvedValue(videoProject);
   });
+  it('restores a historical script from its URL without exposing current shot actions', async () => {
+    const user = userEvent.setup();
+    const previous = { ...videoProject.treatment, script: 'The original script.', artifact: { ...videoProject.treatment.artifact, revision: 1 } };
+    cdApi.getCreativeDirectorProject.mockResolvedValue({ ...videoProject, treatment: { ...videoProject.treatment, history: [previous] } });
+    const page = renderVideo('artifacts?revision=1');
+    expect(await screen.findByText('The original script.')).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'shot-arrival' })).not.toBeInTheDocument();
+    await user.selectOptions(screen.getByLabelText('View revision'), '');
+    expect(screen.getByText(/Example script/)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'shot-arrival' })).toBeInTheDocument();
+    page.unmount();
+    renderVideo('artifacts?revision=999');
+    expect(await screen.findByRole('alert')).toHaveTextContent('Revision not found');
+    expect(cdApi.startCreativeDirectorProject).not.toHaveBeenCalled();
+  });
   it('opens artifacts from Video navigation and restores the saved revision on a fresh deep link', async () => {
     const user = userEvent.setup();
     const page = renderVideo('overview');
@@ -151,7 +166,7 @@ describe('Video saved artifacts', () => {
     });
     renderVideo();
     await screen.findByText(/This artifact is out of date/);
-    expect(screen.getByRole('status')).toHaveTextContent('This artifact is out of date');
+    expect(screen.getByText(/This artifact is out of date/)).toHaveAttribute('role', 'status');
     expect(screen.getByText('Revision 2 · 120 seconds · 16:9')).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Review the current draft' })).toHaveAttribute('href', '/video/cd-example/overview');
     expect(screen.getAllByText(/Scene missing/)).toHaveLength(20);

--- a/docs/STORAGE.md
+++ b/docs/STORAGE.md
@@ -288,8 +288,16 @@ projects in their current state and do not dispatch production. Creative shot
 edits increment the artifact revision; runtime status updates do not. Changes to
 brief, source selection or production settings mark the artifact stale until it
 is compiled again. Source snapshots remain references, not copied source records.
+Replacing a Video treatment or changing a creative shot retains the previous
+script, scenes and artifact metadata in `treatment.history`. Each entry is one
+snapshot without nested history; runtime-only updates do not create revisions.
+The Artifacts revision selector uses the `revision` query parameter for reloadable
+read-only history. Missing history on older records means no retained snapshots;
+previously overwritten content cannot be reconstructed. History shares the same
+JSONB storage and backup coverage as its project.
+Sync v6 prevents older writers from discarding retained history.
 This is additive optional metadata: legacy treatments are unchanged and existing
-records are not backfilled. Sync advances to `creativeDirectorProjects` v5 because
+records are not backfilled. `creativeDirectorProjects` v5 originally shipped because
 a v4 peer can edit a shot without incrementing its artifact revision, or discard
 the artifact on treatment replacement. The Video dispatch barrier remains in
 force; this artifact does not certify backend compatibility or grant approval.

--- a/server/lib/schemaVersions.js
+++ b/server/lib/schemaVersions.js
@@ -451,7 +451,8 @@ export const PORTOS_SCHEMA_VERSIONS = Object.freeze({
   // v5: Video artifact revisions and stale-context tracking. A v4 peer can
   // edit a shot while preserving the old artifact revision, or replace the
   // treatment and drop its artifact. Gate that loss until both peers upgrade.
-  creativeDirectorProjects: 5,
+  // v6: Preserve Video treatment history; older writers discard prior snapshots.
+  creativeDirectorProjects: 6,
   // v1 = Mood boards (PostgreSQL `mood_boards`) federated via the per-record
   // peer-sync push pipeline (record kind `moodBoard`, sync category `moodBoards`,
   // #1564). Same posture as `creativeDirectorProjects` above: a brand-NEW synced

--- a/server/services/creativeDirector/projectsFile.test.js
+++ b/server/services/creativeDirector/projectsFile.test.js
@@ -128,6 +128,17 @@ describe('Video treatment artifacts', () => {
     const revised = (await file.getProject(p.id)).treatment;
     expect(revised.artifact).toEqual({ ...saved.treatment.artifact, revision: 2 });
     expect(revised.script).toBe('The visitor takes a different path.');
+    const { history: ignoredHistory, ...original } = saved.treatment;
+    expect(revised.history).toEqual([original]);
+    await file.updateScene(p.id, 'scene-0', { prompt: 'A different path through a moonlit garden' });
+    const edited = (await file.getProject(p.id)).treatment;
+    expect(edited.artifact.revision).toBe(3);
+    expect(edited.history.map(value => value.artifact.revision)).toEqual([1, 2]);
+    expect(edited.history[1].script).toBe(revised.script);
+    expect(edited.history[1].scenes).toEqual(revised.scenes);
+    expect(edited.history.every(value => !('history' in value))).toBe(true);
+    await file.updateScene(p.id, 'scene-0', { status: 'accepted' });
+    expect((await file.getProject(p.id)).treatment.history).toEqual(edited.history);
   });
 
   it('rejects ambiguous scene identities, ordering and a mismatched duration without replacing the saved artifact', async () => {

--- a/server/services/creativeDirector/projectsLogic.js
+++ b/server/services/creativeDirector/projectsLogic.js
@@ -434,6 +434,13 @@ function compileVideoArtifact(project, treatment) {
   };
 }
 
+function priorVideoTreatments(project) {
+  if (!project.treatment?.artifact) return [];
+  // Snapshots contain one revision only; nesting prior history grows exponentially.
+  const { history = [], ...snapshot } = project.treatment;
+  return [...history, structuredClone(snapshot)];
+}
+
 /**
  * Validate + apply a treatment to a project. Returns the next record. Initializes
  * each scene's runtime fields if the agent didn't supply them, and preserves
@@ -455,7 +462,10 @@ export function applyTreatment(project, treatmentInput) {
     evaluation: s.evaluation ?? null,
   }));
   const treatment = { ...parsed.data, scenes };
-  if (project.workspace === 'video') treatment.artifact = compileVideoArtifact(project, treatment);
+  if (project.workspace === 'video') {
+    treatment.artifact = compileVideoArtifact(project, treatment);
+    treatment.history = priorVideoTreatments(project);
+  }
   const nextStatus = (project.workspace === 'video' || project.status === 'paused' || project.status === 'failed')
     ? project.status
     : 'rendering';
@@ -566,6 +576,7 @@ export function applySceneUpdate(project, sceneId, patch) {
     validateVideoShot(project, updated, sceneId === [...scenes].sort((a, b) => a.order - b.order)[0].sceneId);
     // A shot edit changes the reviewed content, but cannot refresh stale source context.
     treatment.artifact = { ...treatment.artifact, revision: treatment.artifact.revision + 1 };
+    treatment.history = priorVideoTreatments(project);
   }
   const next = {
     ...project,


### PR DESCRIPTION
Video treatment replacement and creative shot edits incremented revision numbers while discarding the prior script and shot content. Retain flat snapshots in the existing project record and expose a reloadable revision selector in Artifacts, with historical shots kept read-only. Version-gate older peer writers to prevent history loss.

Validation: 110 focused server persistence/logic/schema tests; 7 rendered detail tests; client production build. No provider calls or paid renders.

Continues #6547 and #6542; source-context compilation, review dispatch, bounded execution, and final assembly remain open.