### PR TITLE
fix: give Video compilation a shared owner outside project storage

### DIFF
--- a/server/lib/README.md
+++ b/server/lib/README.md
@@ -607,3 +607,4 @@ pm` default, `NPM_CONFIG_PREFIX`, nvm/Volta) installed `codex` successfully and 
 | `cosFederationPolicy.js` | `isMachineLocalCosTask` excludes private assessments and explicitly machine-local tasks and agent archives from federation. |
 
 | `creativeDirectorVideoReview.js` | `retainVideoCuts` preserves rendered cut references on invalidation. Video checkpoint fingerprints, owner-only review actions, feedback, and targeted revision invalidation. |
+| `creativeDirectorVideoCompiler.js` | `compileVideoArtifact` and `validateVideoShot` — pure timed-shot/source-reference compilation and pinned-backend compatibility shared by Creative Director project mutations and Video execution preflight. Storage, history and approval remain with their existing owners. |

--- a/server/lib/creativeDirectorVideoCompiler.js
+++ b/server/lib/creativeDirectorVideoCompiler.js
@@ -1,0 +1,83 @@
+/**
+ * Pure Video treatment compilation and pinned-backend shot compatibility.
+ * Shared by project mutations and execution preflight; no storage, dispatch,
+ * approval, or revision-history mutation belongs here. Inputs have already
+ * passed the treatment/plan schemas; this checks their cross-field contracts.
+ */
+
+import { ServerError } from './errorHandler.js';
+import { GROK_VIDEO_DURATIONS } from './grokVideoClip.js';
+import { REACTOR_MIN_CLIP_SECONDS, REACTOR_MAX_CLIP_SECONDS, REACTOR_MAX_PROMPT_LENGTH, REACTOR_ASPECTS } from './reactorVideoClip.js';
+
+export function validateVideoShot(project, scene, isFirst) {
+  const backend = project.renderBackend?.video?.mode;
+  const unsupported = [];
+  if (isFirst && scene.useContinuationFromPrior) unsupported.push('continuation without a prior shot');
+  if (backend === 'grok' && !GROK_VIDEO_DURATIONS.includes(scene.durationSeconds)) {
+    unsupported.push(`duration (choose ${GROK_VIDEO_DURATIONS.join(' or ')} seconds)`);
+  }
+  if (backend === 'reactor') {
+    if (scene.durationSeconds < REACTOR_MIN_CLIP_SECONDS || scene.durationSeconds > REACTOR_MAX_CLIP_SECONDS) {
+      unsupported.push(`duration (choose ${REACTOR_MIN_CLIP_SECONDS}–${REACTOR_MAX_CLIP_SECONDS} seconds)`);
+    }
+    if (scene.prompt.length > REACTOR_MAX_PROMPT_LENGTH) unsupported.push(`prompt (maximum ${REACTOR_MAX_PROMPT_LENGTH} characters)`);
+    if (!REACTOR_ASPECTS.includes(project.aspectRatio)) unsupported.push('aspect ratio');
+  }
+  if (unsupported.length) {
+    throw new ServerError(`Video shot ${scene.sceneId} has incompatible ${unsupported.join(', ')}. Revise the shot or choose a compatible backend.`, {
+      status: 400, code: 'VIDEO_BACKEND_INPUT_UNSUPPORTED',
+    });
+  }
+}
+
+/** Compile the existing treatment into a persisted Video artifact, without dispatch. */
+export function compileVideoArtifact(project, treatment, sourceRevisions) {
+  if (!treatment.script) {
+    throw new ServerError('Video treatments require a production script. Add script text and resubmit the treatment.', {
+      status: 400, code: 'VALIDATION_ERROR',
+    });
+  }
+  const scenes = [...treatment.scenes].sort((a, b) => a.order - b.order);
+  const ids = new Set();
+  const orders = new Set();
+  let elapsed = 0;
+  const shots = scenes.map((scene) => {
+    validateVideoShot(project, scene, elapsed === 0);
+    if (ids.has(scene.sceneId) || orders.has(scene.order)) {
+      throw new ServerError('Video scenes must have unique sceneId and order values', { status: 400, code: 'VALIDATION_ERROR' });
+    }
+    ids.add(scene.sceneId);
+    orders.add(scene.order);
+    const startSeconds = elapsed;
+    elapsed = Math.round((elapsed + scene.durationSeconds) * 1000000) / 1000000;
+    return {
+      shotId: `shot-${scene.sceneId}`,
+      sceneId: scene.sceneId,
+      startSeconds,
+      endSeconds: elapsed,
+      durationSeconds: scene.durationSeconds,
+    };
+  });
+  if (Math.abs(elapsed - project.targetDurationSeconds) > 0.000001) {
+    throw new ServerError(`Video shots total ${elapsed}s; they must total the exact target of ${project.targetDurationSeconds}s`, { status: 400, code: 'VALIDATION_ERROR' });
+  }
+  const references = (project.videoPlanningContext?.references || project.videoDraft?.sources || []).map((source) => ({
+    ...source, referenceId: `${source.kind}:${source.id}`,
+    ...(sourceRevisions ? { sourceRevision: sourceRevisions[`${source.kind}:${source.id}`] ?? source.sourceRevision ?? null } : {}),
+  }));
+  if (new Set(references.map((ref) => ref.referenceId)).size !== references.length) {
+    throw new ServerError('Video source references must have unique kind and id values', { status: 400, code: 'VALIDATION_ERROR' });
+  }
+  return {
+    scriptId: project.treatment?.artifact?.scriptId || `script-${project.id}`,
+    revision: (project.treatment?.artifact?.revision || 0) + 1,
+    targetDurationSeconds: project.targetDurationSeconds,
+    aspectRatio: project.aspectRatio,
+    ...(project.videoPlanningContext ? { sourceContextRevision: project.videoPlanningContext.revision } : {}),
+    // Keep the selected IDs/revisions, never copy or mutate creative-suite records.
+    references,
+    shots,
+    stale: false,
+  };
+}
+

--- a/server/lib/importScoping.test.js
+++ b/server/lib/importScoping.test.js
@@ -351,3 +351,13 @@ describe('server suite import budget (#6156)', () => {
     ).toBeLessThanOrEqual(MAX_STATIC_INSTANTIATIONS);
   }, 60_000);
 });
+
+// The shared compiler must remain usable without loading project mutations.
+it('keeps Video compilation independent of project storage and execution', () => {
+  const closure = staticImportClosure(abs('lib/creativeDirectorVideoCompiler.js')).files;
+  expect(closure.has(abs('lib/grokVideoClip.js'))).toBe(true);
+  expect(closure.has(abs('lib/reactorVideoClip.js'))).toBe(true);
+  expect(closure.has(abs('services/creativeDirector/projectsLogic.js'))).toBe(false);
+  expect(closure.has(abs('services/creativeDirector/videoExecution.js'))).toBe(false);
+  expect(closure.has(abs('lib/validation.js'))).toBe(false);
+});

--- a/server/lib/index.js
+++ b/server/lib/index.js
@@ -587,3 +587,4 @@ export * from './privateSecuritySandbox.js';
 export * from './requestOrigin.js';
 export * from './cosFederationPolicy.js';
 export * from './creativeDirectorVideoReview.js';
+export * from './creativeDirectorVideoCompiler.js';

--- a/server/services/creativeDirector/projectsLogic.js
+++ b/server/services/creativeDirector/projectsLogic.js
@@ -11,6 +11,8 @@
  */
 
 import { videoSceneInputs, retainVideoCuts } from '../../lib/creativeDirectorVideoReview.js';
+import { compileVideoArtifact, validateVideoShot } from '../../lib/creativeDirectorVideoCompiler.js';
+
 import { randomUUID } from 'crypto';
 import { EFFORT_LEVELS } from '../../lib/providerModels.js';
 import { ServerError } from '../../lib/errorHandler.js';
@@ -21,8 +23,9 @@ import { compareNewerWins } from '../../lib/lwwTimestamp.js';
 import { pickLlmRoutePinLayer } from '../../lib/llmRoutePin.js';
 import { localImageFilename } from '../../lib/localImageFilename.js';
 import { sanitizeProjectForSync } from '../../lib/projectStoreKit.js';
-import { GROK_VIDEO_DURATIONS } from '../../lib/grokVideoClip.js';
-import { REACTOR_MIN_CLIP_SECONDS, REACTOR_MAX_CLIP_SECONDS, REACTOR_MAX_PROMPT_LENGTH, REACTOR_ASPECTS } from '../../lib/reactorVideoClip.js';
+
+// Preserve the existing validation export for callers on the project-store surface.
+export { validateVideoShot } from '../../lib/creativeDirectorVideoCompiler.js';
 
 export { sanitizeProjectForSync } from '../../lib/projectStoreKit.js';
 
@@ -376,77 +379,6 @@ export function applyProjectPatch(project, patch) {
   return next;
 }
 
-export function validateVideoShot(project, scene, isFirst) {
-  const backend = project.renderBackend?.video?.mode;
-  const unsupported = [];
-  if (isFirst && scene.useContinuationFromPrior) unsupported.push('continuation without a prior shot');
-  if (backend === 'grok' && !GROK_VIDEO_DURATIONS.includes(scene.durationSeconds)) {
-    unsupported.push(`duration (choose ${GROK_VIDEO_DURATIONS.join(' or ')} seconds)`);
-  }
-  if (backend === 'reactor') {
-    if (scene.durationSeconds < REACTOR_MIN_CLIP_SECONDS || scene.durationSeconds > REACTOR_MAX_CLIP_SECONDS) {
-      unsupported.push(`duration (choose ${REACTOR_MIN_CLIP_SECONDS}–${REACTOR_MAX_CLIP_SECONDS} seconds)`);
-    }
-    if (scene.prompt.length > REACTOR_MAX_PROMPT_LENGTH) unsupported.push(`prompt (maximum ${REACTOR_MAX_PROMPT_LENGTH} characters)`);
-    if (!REACTOR_ASPECTS.includes(project.aspectRatio)) unsupported.push('aspect ratio');
-  }
-  if (unsupported.length) {
-    throw new ServerError(`Video shot ${scene.sceneId} has incompatible ${unsupported.join(', ')}. Revise the shot or choose a compatible backend.`, {
-      status: 400, code: 'VIDEO_BACKEND_INPUT_UNSUPPORTED',
-    });
-  }
-}
-
-/** Compile the existing treatment into a persisted Video artifact, without dispatch. */
-function compileVideoArtifact(project, treatment, sourceRevisions) {
-  if (!treatment.script) {
-    throw new ServerError('Video treatments require a production script. Add script text and resubmit the treatment.', {
-      status: 400, code: 'VALIDATION_ERROR',
-    });
-  }
-  const scenes = [...treatment.scenes].sort((a, b) => a.order - b.order);
-  const ids = new Set();
-  const orders = new Set();
-  let elapsed = 0;
-  const shots = scenes.map((scene) => {
-    validateVideoShot(project, scene, elapsed === 0);
-    if (ids.has(scene.sceneId) || orders.has(scene.order)) {
-      throw new ServerError('Video scenes must have unique sceneId and order values', { status: 400, code: 'VALIDATION_ERROR' });
-    }
-    ids.add(scene.sceneId);
-    orders.add(scene.order);
-    const startSeconds = elapsed;
-    elapsed = Math.round((elapsed + scene.durationSeconds) * 1000000) / 1000000;
-    return {
-      shotId: `shot-${scene.sceneId}`,
-      sceneId: scene.sceneId,
-      startSeconds,
-      endSeconds: elapsed,
-      durationSeconds: scene.durationSeconds,
-    };
-  });
-  if (Math.abs(elapsed - project.targetDurationSeconds) > 0.000001) {
-    throw new ServerError(`Video shots total ${elapsed}s; they must total the exact target of ${project.targetDurationSeconds}s`, { status: 400, code: 'VALIDATION_ERROR' });
-  }
-  const references = (project.videoPlanningContext?.references || project.videoDraft?.sources || []).map((source) => ({
-    ...source, referenceId: `${source.kind}:${source.id}`,
-    ...(sourceRevisions ? { sourceRevision: sourceRevisions[`${source.kind}:${source.id}`] ?? source.sourceRevision ?? null } : {}),
-  }));
-  if (new Set(references.map((ref) => ref.referenceId)).size !== references.length) {
-    throw new ServerError('Video source references must have unique kind and id values', { status: 400, code: 'VALIDATION_ERROR' });
-  }
-  return {
-    scriptId: project.treatment?.artifact?.scriptId || `script-${project.id}`,
-    revision: (project.treatment?.artifact?.revision || 0) + 1,
-    targetDurationSeconds: project.targetDurationSeconds,
-    aspectRatio: project.aspectRatio,
-    ...(project.videoPlanningContext ? { sourceContextRevision: project.videoPlanningContext.revision } : {}),
-    // Keep the selected IDs/revisions, never copy or mutate creative-suite records.
-    references,
-    shots,
-    stale: false,
-  };
-}
 
 function priorVideoTreatments(project) {
   if (!project.treatment?.artifact) return [];

--- a/server/services/creativeDirector/videoExecution.js
+++ b/server/services/creativeDirector/videoExecution.js
@@ -267,7 +267,7 @@ export async function enqueueVideoProductionJob(project, { kind = 'video', param
   if (!Number.isFinite(seconds) || seconds < 1 || seconds > 10.1 || Number(params.chunks || 1) !== 1 || Number(params.batchSize || 1) !== 1) {
     throw new ServerError('A Video submission must contain one clip of at most 10 seconds.', { status: 409, code: 'VIDEO_PLAN_CLIP_BOUNDS' });
   }
-  const { validateVideoShot } = await import('./projectsLogic.js');
+  const { validateVideoShot } = await import('../../lib/creativeDirectorVideoCompiler.js');
   validateVideoShot(project, { sceneId: sceneId || stepId, prompt: String(params.prompt || ''), durationSeconds: seconds }, false);
   const { hasConfiguredMediaRoute, enqueueUnattendedMediaJob } = await import('../federatedMedia/defaultRouting.js');
   if (await hasConfiguredMediaRoute(kind)) throw new ServerError('A standing peer route would change the reviewed video backend. Change Settings before Resume.', { status: 409, code: 'VIDEO_ROUTE_CHANGED' });

--- a/server/services/creativeDirector/videoExecution.test.js
+++ b/server/services/creativeDirector/videoExecution.test.js
@@ -136,6 +136,10 @@ it('checks the duration the backend actually consumes and rejects batch expansio
     params: { mode: 'fal', durationSeconds: 5, duration: 60, prompt: 'Example' } })).rejects.toMatchObject({ code: 'VIDEO_PLAN_CLIP_BOUNDS' });
   await expect(enqueueVideoProductionJob(state.project, { sceneId: 'opening', workRevision: 0,
     params: { mode: 'text', durationSeconds: 5, numFrames: 1440, fps: 24, prompt: 'Example' } })).rejects.toMatchObject({ code: 'VIDEO_PLAN_CLIP_BOUNDS' });
+  // A clip within the queue bounds must still satisfy its pinned backend.
+  await expect(enqueueVideoProductionJob({ ...state.project, renderBackend: { video: { mode: 'grok' } } }, {
+    sceneId: 'opening', workRevision: 0, params: { mode: 'grok', duration: 5, prompt: 'Example' },
+  })).rejects.toMatchObject({ code: 'VIDEO_BACKEND_INPUT_UNSUPPORTED' });
   expect(state.project.videoExecution.attempts).toHaveLength(0);
   expect(enqueueUnattendedMediaJob).not.toHaveBeenCalled();
 });


### PR DESCRIPTION
## Summary

Video execution preflight reached into the Creative Director project-store mutation module solely to validate a shot (`videoExecution.js:270` before this change). The same store module owned timed-artifact compilation (`projectsLogic.js:379–450`), alongside generic record, sync, run and plan mutations. Backend validation changes therefore required editing the persistence transform owner even when used at dispatch.

Move `validateVideoShot` and `compileVideoArtifact` unchanged into `server/lib/creativeDirectorVideoCompiler.js`. Treatment saves and execution preflight now share this explicit owner. Project mutations retain schema parsing, status transitions, revision history and persistence semantics; the historical `validateVideoShot` export remains compatible. No data format, backend limit, authorization, or rendering behavior changes.

The lib catalog and barrel expose the compiler to contributors, with existing mechanical parity checks. A dependency guard keeps it independent of storage, execution and the broad validation module.

Audit evidence: a repository-wide tracked-source size and 80-commit churn inventory ranked `projectsLogic.js` first (702 lines, 13 changes). Importer searches identified both storage adapters plus the execution validator consumer. Catalog, exports and semantic searches for compilation, shots and validation found Grok/Reactor clip contracts (reused), schema validation, and Video review ownership, but no existing compiler. Prior work #6576, #6578, #6583 and #6588 established validation, timing, history and execution contracts; closed issue #5700 already addressed shared store scaffolding. No duplicate issue is filed. Large declarative schemas/barrels, already-shipped image capability work #6591, a broad store split, and unrelated stage-pin extraction were deliberately excluded.

## Test plan

- 131 tests passed across project transforms, file persistence, Video execution/review/source revisions, import scoping and lib catalog parity. Database-backed suites remain excluded by the normal runner; no live DB or rendering calls.
- Existing persistence tests cover exact timing, duplicate shot/reference rejection, backend compatibility, and legacy treatment behavior.
- Extended execution boundary coverage: a five-second Grok clip fails before attempt reservation or queue submission despite fitting generic queue bounds.
- Verified moved compiler/validator bodies are identical; `git diff --check` passed.
- Configured optional Ollama reviewer attempted with its pinned model; endpoint returned HTTP 401, recorded as unavailable/inconclusive under the task's optional-review policy.
