### PR TITLE
fix: let a CoS job save as an AI-agent type without 400ing on null command

### DIFF
--- a/server/lib/cosValidation.js
+++ b/server/lib/cosValidation.js
@@ -435,8 +435,12 @@ export const createCosJobSchema = z.object({
   // An empty array actively clears every selection on update; absent preserves
   // the stored selection.
   dataInputs: taskDataInputsSchema.optional(),
-  command: z.string().optional(),
-  triggerAction: z.preprocess(v => v === '' ? undefined : v, z.string().optional()),
+  // Null actively clears the field: the jobs UI emits `command: null` /
+  // `triggerAction: null` whenever a job is saved as an AI-agent type (the two
+  // keys only apply to shell/script jobs), so rejecting null 400'd every edit of
+  // an agent job. Empty string keeps its historical meaning per field.
+  command: z.string().nullable().optional(),
+  triggerAction: z.preprocess(v => (v === '' ? undefined : v), z.string().nullable().optional()),
   // Optional AI provider + model override for agent jobs. Empty string from the
   // UI picker → null so a PUT can actively clear the override back to the active
   // provider/default model (updateJob only skips `undefined`). Forwarded into the

--- a/server/lib/cosValidation.test.js
+++ b/server/lib/cosValidation.test.js
@@ -306,3 +306,27 @@ describe('cosValidation job cadence (#6375)', () => {
     expect(updateCosJobSchema.safeParse({ enabled: false }).success).toBe(true);
   });
 });
+
+describe('cosValidation job shell-only fields cleared on an agent job', () => {
+  // The jobs UI emits `command: null` / `triggerAction: null` for any job saved
+  // as an AI-agent type, so a nullable-hostile schema 400'd every edit with
+  // "expected string, received null" on both keys.
+  it('accepts null command and triggerAction on create and update', () => {
+    const created = createCosJobSchema.parse({ name: 'j', type: 'agent', command: null, triggerAction: null });
+    expect(created.command).toBeNull();
+    expect(created.triggerAction).toBeNull();
+
+    const updated = updateCosJobSchema.parse({ command: null, triggerAction: null });
+    expect(updated.command).toBeNull();
+    expect(updated.triggerAction).toBeNull();
+  });
+
+  it('still drops an empty triggerAction so a PUT preserves the stored action', () => {
+    expect(updateCosJobSchema.parse({ triggerAction: '' }).triggerAction).toBeUndefined();
+  });
+
+  it('still rejects a non-string command', () => {
+    expect(updateCosJobSchema.safeParse({ command: 42 }).success).toBe(false);
+    expect(updateCosJobSchema.safeParse({ triggerAction: 42 }).success).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Editing a CoS scheduled task that is an AI-agent job (changing its model or schedule) failed with `Validation failed: command: Invalid input: expected string, received null, triggerAction: Invalid input: expected string, received null`.
- The jobs UI clears the shell-only `command` / `triggerAction` keys by sending `null` for any job saved as an agent type, but `createCosJobSchema` typed both as non-nullable strings, so every such save was rejected at the Zod layer.
- Both fields already accept `null` end-to-end (`createJob`/`updateJob` in `server/services/autonomousJobs/crud.js` normalize it); only the schema rejected it. `triggerAction` keeps its `'' → undefined` preprocess, so a PUT still preserves the stored action.

## Test plan

- `server/lib/cosValidation.test.js` — new cases: null accepted on create and update for both fields; `''` still drops `triggerAction` to `undefined`; non-string values still rejected.
- `cd server && npx vitest run lib/cosValidation.test.js routes/cosJobRoutes services/autonomousJobs` — 259 passing.