### PR TITLE
fix: tighten Eidoverse header for mobile, hide empty federation bar

### DIFF
--- a/client/src/components/eidoverse/EidoverseTravel.jsx
+++ b/client/src/components/eidoverse/EidoverseTravel.jsx
@@ -53,15 +53,16 @@ export default function EidoverseTravel({ travelRef, enabled, objects = [], onDe
     travelRef.current = depart;
     return () => { travelRef.current = null; };
   }, [depart, travelRef]);
-  if (!enabled) return null;
+  if (!enabled || (!destinations.length && !error)) return null;
   return <div className="flex flex-wrap items-center gap-2 border-b border-port-border px-4 py-2 text-sm">
-    <span className="text-gray-400">Federation Terminal · Use a pod in-world or choose a destination</span>
+    {Boolean(destinations.length) && (
+      <span className="text-gray-400">Federation Terminal · Use a pod in-world or choose a destination</span>
+    )}
     {destinations.map((destination) => <button key={destination.peerId} type="button" disabled={Boolean(pending)}
       onClick={() => depart(destination.peerId)} className="min-h-10 rounded-lg border border-port-border px-3 hover:border-port-accent disabled:opacity-50">
       {pending === destination.peerId ? 'Opening guest visit…' : destination.label}
       <span className="ml-2 text-xs text-gray-400">{objects.find((object) => object.travelPeerId === destination.peerId)?.name}</span>
     </button>)}
-    {!destinations.length && <span className="text-gray-500">No connected guest worlds available</span>}
     {error && <p role="alert" className="text-red-400">{error}</p>}
   </div>;
 }

--- a/client/src/pages/Eidoverse.jsx
+++ b/client/src/pages/Eidoverse.jsx
@@ -502,9 +502,10 @@ export default function Eidoverse() {
             aria-pressed={frame.labelVisibility !== 'off'}
             onClick={() => frame.changeLabelVisibility(frame.labelVisibility === 'off' ? 'nearby' : 'off')}
             title="Toggle object labels for this visit"
-            className="inline-flex min-h-[40px] items-center gap-1.5 rounded-lg border border-port-border px-3 text-sm text-gray-200 hover:border-port-accent hover:text-white aria-pressed:border-port-accent aria-pressed:text-port-accent"
+            className="inline-flex min-h-[40px] min-w-[40px] items-center justify-center gap-1.5 rounded-lg border border-port-border px-2 sm:px-3 text-sm text-gray-200 hover:border-port-accent hover:text-white aria-pressed:border-port-accent aria-pressed:text-port-accent"
           >
-            <Tags size={16} aria-hidden="true" />Labels
+            <Tags size={16} aria-hidden="true" />
+            <span className="hidden sm:inline">Labels</span>
           </button>
           <button
             type="button"
@@ -520,7 +521,7 @@ export default function Eidoverse() {
             type="button"
             aria-label="World controls"
             onClick={() => setSettingsOpen(true)}
-            className="inline-flex min-h-[40px] items-center gap-1.5 rounded-lg bg-port-accent px-3 py-1.5 text-sm font-semibold text-black transition-opacity hover:opacity-90"
+            className="inline-flex min-h-[40px] items-center gap-1.5 rounded-lg bg-port-accent px-2 sm:px-3 py-1.5 text-sm font-semibold text-black transition-opacity hover:opacity-90"
           >
             <SlidersHorizontal size={15} aria-hidden="true" />
             <span aria-hidden="true" className="sm:hidden">Controls</span>
@@ -533,11 +534,11 @@ export default function Eidoverse() {
           to="/eidoverse/solo"
           aria-label="Open Eidoverse without PortOS controls"
           title="Open Eidoverse fullscreen inside PortOS (same iframe path as this page)"
-          className="inline-flex min-h-[40px] items-center gap-1.5 rounded-lg border border-port-border px-3 py-1.5 text-sm text-gray-200 transition-colors hover:border-port-accent hover:text-white"
+          className="inline-flex min-h-[40px] min-w-[40px] items-center justify-center gap-1.5 rounded-lg border border-port-border px-2 sm:px-3 py-1.5 text-sm text-gray-200 transition-colors hover:border-port-accent hover:text-white"
         >
           <Maximize2 size={15} aria-hidden="true" />
           <span className="hidden md:inline">Open Eidoverse alone</span>
-          <span className="md:hidden">World only</span>
+          <span className="hidden sm:inline md:hidden">World only</span>
         </Link>
       )}
       {appId && (


### PR DESCRIPTION
## Summary
- Hide the Federation Terminal bar on the Eidoverse page when there are no connected guest worlds to travel to, instead of rendering an empty "No connected guest worlds available" row that ate mobile screen space above the page header.
- Collapse the Labels / World controls / World-only action buttons to icon-only below the `sm` breakpoint so they fit on one row next to the page title instead of wrapping onto their own cramped, multi-line row.

## Test plan
- `npx vitest run src/components/eidoverse/EidoverseTravel.test.jsx src/pages/Eidoverse.test.jsx` — 32 passed