### PR TITLE
hide CoS Learning stat tile on mobile

### DIFF
--- a/client/src/components/cos/StatCard.jsx
+++ b/client/src/components/cos/StatCard.jsx
@@ -41,7 +41,7 @@ const SIZES = {
   },
 };
 
-export default function StatCard({ label, value, icon, active, activeLabel, compact, mini, tone, onClick, title }) {
+export default function StatCard({ label, value, icon, active, activeLabel, compact, mini, tone, onClick, title, className }) {
   const ariaLabel = `${label}: ${value}${active && activeLabel ? `, ${activeLabel}` : ''}`;
   // Only tint the icon when a tone was asked for — tone-less callers pass a
   // pre-colored icon element of their own.
@@ -65,7 +65,7 @@ export default function StatCard({ label, value, icon, active, activeLabel, comp
   const interactiveClass = onClick
     ? `text-left hover:bg-port-card/60${hasNeutralBorder ? ' hover:border-port-accent-2/50' : ''}`
     : '';
-  const shellClass = `${size.bg} border transition-all ${size.root} ${borderClass} ${interactiveClass}`;
+  const shellClass = `${size.bg} border transition-all ${size.root} ${borderClass} ${interactiveClass}${className ? ` ${className}` : ''}`;
 
   if (compact) {
     return (

--- a/client/src/pages/ChiefOfStaff.jsx
+++ b/client/src/pages/ChiefOfStaff.jsx
@@ -809,6 +809,7 @@ export default function ChiefOfStaff() {
         value={learningRate ?? 'No data'}
         icon={<Brain className="w-4 h-4" />}
         compact
+        className="hidden lg:flex"
       />
       {status?.running ? (
         <>


### PR DESCRIPTION
## Summary
- The compact CoS status grid rendered the Learning stat tile on both mobile and desktop, taking up an extra row on phones and pushing the Queue/Agent controls below the fold.
- `StatCard` now accepts an optional `className` passthrough; the Learning tile in the CoS sidebar grid is hidden under `lg:` breakpoint so it only shows on desktop where there's room.

## Test plan
- `cd client && npx vitest run src/components/cos/StatCard.test.jsx src/pages/ChiefOfStaff.test.jsx` — all passing.