### PR TITLE
fix: disable selecting a disabled provider in AI model pickers

### DIFF
--- a/client/src/components/creative-director/CreativeDirectorModelsDrawer.jsx
+++ b/client/src/components/creative-director/CreativeDirectorModelsDrawer.jsx
@@ -307,7 +307,7 @@ export default function CreativeDirectorModelsDrawer({ open, onClose, project, o
                       className="bg-port-card border border-port-border rounded px-2 py-2 text-sm text-white"
                     >
                       <option value="">{isGlobal ? 'System default' : 'Inherit default'}</option>
-                      {providerOptions.map((p) => <option key={p.id} value={p.id}>{p.name}</option>)}
+                      {providerOptions.map((p) => <option key={p.id} value={p.id} disabled={p.enabled === false}>{p.name}</option>)}
                     </select>
                   </div>
 

--- a/client/src/components/settings/AiAssignmentsTab.jsx
+++ b/client/src/components/settings/AiAssignmentsTab.jsx
@@ -440,7 +440,7 @@ export default function AiAssignmentsTab() {
                           className="w-full bg-port-card border border-port-border rounded px-2 py-2 text-sm text-white disabled:opacity-50"
                         >
                           <option value="">Default / unset</option>
-                          {providerOptions.map((p) => <option key={p.id} value={p.id}>{p.name}</option>)}
+                          {providerOptions.map((p) => <option key={p.id} value={p.id} disabled={p.enabled === false}>{p.name}</option>)}
                         </select>
                       </FormField>
                     )}

--- a/client/src/utils/providerAssignments.js
+++ b/client/src/utils/providerAssignments.js
@@ -86,10 +86,15 @@ export const providerDisplayName = (providers, id, fallback = '') =>
   providers.find((p) => p.id === id)?.name || id || fallback;
 
 /**
- * Provider `{ id, name }` options eligible for an assignment entry — the entry's
- * pre-baked `providerOptions` when present, else every provider whose `type` is
- * in the entry's `providerTypes` (all providers when unfiltered), tagged with a
- * "(disabled)" suffix on disabled providers.
+ * Provider `{ id, name, enabled }` options eligible for an assignment entry —
+ * the entry's pre-baked `providerOptions` when present, else every provider
+ * whose `type` is in the entry's `providerTypes` (all providers when
+ * unfiltered), tagged with a "(disabled)" suffix on disabled providers.
+ *
+ * `enabled` rides along so a caller can mark the rendered `<option>` itself
+ * `disabled` — the suffix alone still lets a `<select>` submit a provider that
+ * can't actually run. Pre-baked `providerOptions` carry no `enabled` field, so
+ * they're left selectable (undefined, not false).
  */
 export const assignmentProviderOptions = (entry, providers) => {
   if (Array.isArray(entry?.providerOptions)) return entry.providerOptions;
@@ -98,7 +103,7 @@ export const assignmentProviderOptions = (entry, providers) => {
     : null;
   return providers
     .filter((p) => !types || types.has(p.type))
-    .map((p) => ({ id: p.id, name: `${p.name}${p.enabled ? '' : ' (disabled)'}` }));
+    .map((p) => ({ id: p.id, name: `${p.name}${p.enabled ? '' : ' (disabled)'}`, enabled: !!p.enabled }));
 };
 
 /**

--- a/client/src/utils/providers.test.js
+++ b/client/src/utils/providers.test.js
@@ -1489,9 +1489,9 @@ describe('AI Assignments option helpers', () => {
   it('assignmentProviderOptions filters by providerTypes and flags disabled', () => {
     expect(assignmentProviderOptions({ providerTypes: ['api'] }, providers))
       .toEqual([
-        { id: 'vlm-x', name: 'VLM X (disabled)' },
-        { id: 'ollama', name: 'Ollama' },
-        { id: 'openai', name: 'OpenAI' },
+        { id: 'vlm-x', name: 'VLM X (disabled)', enabled: false },
+        { id: 'ollama', name: 'Ollama', enabled: true },
+        { id: 'openai', name: 'OpenAI', enabled: true },
       ]);
     // No providerTypes → all providers.
     expect(assignmentProviderOptions({}, providers).map((p) => p.id))


### PR DESCRIPTION
## Summary
- The Creative Director model editor (the video-production stage picker) and the global AI Assignments table both labeled disabled providers "(disabled)" in the option text, but never marked the `<option>` itself disabled — so a disabled provider was still selectable, letting a user save a pin to a provider that can't actually run.
- `assignmentProviderOptions` now carries the provider's `enabled` flag through to callers; both drawers set `disabled={p.enabled === false}` on the rendered option.

## Test plan
- `npx vitest run` in `client/` — full suite green (10799 passed / 8 skipped).
- Updated `providers.test.js` assertions to cover the new `enabled` field on the option shape.