### PR TITLE
fix: stop the sidebar's glass-theme background from bleeding into the task drawer

### DIFF
--- a/client/src/components/Drawer.jsx
+++ b/client/src/components/Drawer.jsx
@@ -107,7 +107,7 @@ export default function Drawer({
         role="dialog"
         aria-modal="true"
         aria-label={title}
-        className={`fixed inset-y-0 right-0 z-50 w-full max-w-full ${resolvedWidth} bg-port-card border-l border-port-border shadow-2xl flex flex-col`}
+        className={`port-opaque-surface fixed inset-y-0 right-0 z-50 w-full max-w-full ${resolvedWidth} bg-port-card border-l border-port-border shadow-2xl flex flex-col`}
       >
         <header className="flex items-center justify-between px-4 py-3 border-b border-port-border">
           <div className="min-w-0 pr-2">

--- a/client/src/components/Layout.jsx
+++ b/client/src/components/Layout.jsx
@@ -1205,6 +1205,7 @@ export default function Layout() {
       {/* Sidebar */}
       <aside
         className={`
+          port-app-sidebar
           fixed inset-y-0 left-0 z-50 h-dvh-screen print:hidden
           flex flex-col bg-port-card border-r border-port-border
           transition-all duration-300 ease-in-out
@@ -1407,7 +1408,7 @@ export default function Layout() {
       {/* Main area — print drops the sidebar offset so printed pages aren't shifted right */}
       <div className={`flex-1 flex flex-col min-w-0 max-w-full transition-all duration-300 print:ml-0 ${collapsed ? 'lg:ml-16' : 'lg:ml-64'}`}>
         {/* Mobile header */}
-        <header className="lg:hidden flex items-center justify-between px-2 py-1.5 border-b border-port-border bg-port-card print:hidden">
+        <header className="port-app-topbar lg:hidden flex items-center justify-between px-2 py-1.5 border-b border-port-border bg-port-card print:hidden">
           <button
             onClick={() => setMobileOpen(true)}
             className="inline-flex items-center justify-center min-w-[44px] min-h-[44px] -ml-1 rounded-lg text-gray-400 hover:text-white"

--- a/client/src/components/cos/tabs/schedule/RunTaskButton.jsx
+++ b/client/src/components/cos/tabs/schedule/RunTaskButton.jsx
@@ -153,7 +153,7 @@ export default function RunTaskButton({ taskType, apps, onTrigger, installWide =
       {open && !disabled && createPortal(
         <div
           ref={popoverRef}
-          className="port-menu-surface fixed z-[100] max-h-64 overflow-y-auto border border-port-border rounded-lg shadow-lg"
+          className="port-opaque-surface fixed z-[100] max-h-64 overflow-y-auto border border-port-border rounded-lg shadow-lg"
           style={{
             left: menuStyle?.left ?? `${VIEWPORT_PADDING}px`,
             top: menuStyle?.top ?? `${VIEWPORT_PADDING}px`,

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -378,13 +378,15 @@ html[data-port-theme] .bg-port-card {
   background-color: rgb(var(--port-card) / var(--port-card-alpha)) !important;
 }
 
-/* Floating menus/popovers (e.g. the schedule "Run on App" picker) must stay
-   fully opaque even on translucent ("glass") card themes — otherwise the
-   content behind the free-floating menu bleeds through and the list becomes
-   unreadable. Unlike modals, these have no backdrop to sit on. Use the themed
-   card color with no alpha. */
-.port-menu-surface,
-html[data-port-theme] .port-menu-surface {
+/* Any surface with no dimmed backdrop behind it — a floating menu/popover
+   (e.g. the schedule "Run on App" picker) or a slide-over modal panel (the
+   shared `Drawer`) whose mobile width sits directly over the page it was
+   opened from — must stay fully opaque even on translucent ("glass") card
+   themes, or the arbitrary content behind it bleeds through and becomes
+   unreadable/illegible (WebKit especially). Use the themed card color with no
+   alpha. */
+.port-opaque-surface,
+html[data-port-theme] .port-opaque-surface {
   background-color: rgb(var(--port-card)) !important;
 }
 
@@ -923,8 +925,17 @@ html[data-port-theme] #root > .bg-port-bg {
   background: var(--port-app-backdrop) !important;
 }
 
-html[data-port-theme] aside.bg-port-card,
-html[data-port-theme] header.bg-port-card {
+/* Scoped to the app shell's OWN nav landmarks (`.port-app-sidebar` /
+   `.port-app-topbar` in Layout.jsx), not the bare `aside`/`header` tag — a
+   bare-tag selector here also matched every unrelated `<aside class="...
+   bg-port-card ...">` in the app, including the shared slide-over `Drawer`
+   panel (`components/Drawer.jsx`), silently swapping its opaque card fill for
+   the sidebar's translucent gradient + blur (tuned to sit against the
+   persistent app background, not to obscure a modal's arbitrary scrolled
+   content underneath). `Drawer.jsx`'s panel now carries `.port-opaque-surface`
+   (above) instead, the same fix as the analogous floating-menu case. */
+html[data-port-theme] .port-app-sidebar.bg-port-card,
+html[data-port-theme] .port-app-topbar.bg-port-card {
   background: var(--port-sidebar-bg) !important;
   backdrop-filter: var(--port-backdrop-filter);
 }
@@ -1342,7 +1353,7 @@ html[data-port-theme-mode="day"] .always-dark [class~="hover:text-slate-100"]:ho
 
 /* Solid variant for a small label sitting directly on photography, where even
    10% show-through takes its contrast from whatever pixels it lands on. Same
-   fill as `.port-menu-surface` (above) for the same reason — an opaque themed
+   fill as `.port-opaque-surface` (above) for the same reason — an opaque themed
    surface with arbitrary content behind it and no backdrop to sit on — but no
    `!important`, since these labels are not fighting a `bg-port-card/NN`. */
 .port-media-overlay-strong {


### PR DESCRIPTION
## Summary
- On mobile, the CoS Schedule tab's task config drawer showed a large blank/ghosted region between the tab selector and the visible fields — reported as "a long area of empty space that we have to scroll through to get to the settings."
- Root cause: a bare-tag CSS rule (`aside.bg-port-card, header.bg-port-card`) meant only for the app shell's own sidebar/mobile topbar also matched the shared `Drawer` panel (also an `<aside class="bg-port-card">`). On translucent "glass" themes that swapped the drawer's opaque fill for the sidebar's ~50-60%-alpha gradient, so on mobile WebKit the scrolled page behind the drawer ghosted through legibly.
- Scoped the sidebar rule to dedicated `.port-app-sidebar`/`.port-app-topbar` classes (`Layout.jsx`), and generalized the existing `.port-menu-surface` opaque-surface utility (previously only used by the schedule "Run on App" picker) to `.port-opaque-surface` so the `Drawer` panel reuses it instead of adding a one-off rule.

## Test plan
- `client && npx vitest run` (via `node_modules/.bin/vitest`) — 891 files / 10799 tests passed.
- Reproduced the bug and verified the fix with a real WebKit render (Playwright, iPhone viewport) of the actual `TaskConfigDrawer` component tree over a scrolled background page: before the fix, the drawer panel resolved to `rgba(0,0,0,0)` background with a gradient/blur, and the page behind it ghosted through; after the fix, the panel resolves to a fully opaque themed background with no ghosting.