### PR TITLE
fix: contain scheduled handler loading and execution failures

### DIFF
--- a/server/services/scheduledHandlers/index.js
+++ b/server/services/scheduledHandlers/index.js
@@ -68,9 +68,12 @@ const load = async (taskType) =>
  * broken handler can't wedge a burn family's whole plan or blank a status page.
  */
 export async function countScheduledHandlerPending({ taskType, params, job, family } = {}) {
-  const mod = await load(taskType);
-  if (!mod) return { count: 0, detail: `unknown scheduled handler: ${taskType}` };
-  return mod.countPending({ params, job, family })
+  // Include lazy module initialization and synchronous handler throws in the
+  // same failure boundary as rejected handler promises.
+  return load(taskType)
+    .then((mod) => mod
+      ? mod.countPending({ params, job, family })
+      : { count: 0, detail: `unknown scheduled handler: ${taskType}` })
     .catch((err) => ({ count: 0, detail: `probe failed: ${err.message}` }));
 }
 
@@ -80,8 +83,9 @@ export async function countScheduledHandlerPending({ taskType, params, job, fami
  * to start must not charge a quota window's cap.
  */
 export async function runScheduledHandler({ taskType, params, job, family, context, force = false } = {}) {
-  const mod = await load(taskType);
-  if (!mod) return { dispatched: false, reason: `unknown scheduled handler: ${taskType}` };
-  return mod.run({ params, job, family, context, force })
+  return load(taskType)
+    .then((mod) => mod
+      ? mod.run({ params, job, family, context, force })
+      : { dispatched: false, reason: `unknown scheduled handler: ${taskType}` })
     .catch((err) => ({ dispatched: false, reason: `handler failed: ${err.message}` }));
 }

--- a/server/services/scheduledHandlers/index.test.js
+++ b/server/services/scheduledHandlers/index.test.js
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  SCHEDULED_HANDLER_MODULES,
+  countScheduledHandlerPending,
+  runScheduledHandler,
+} from './index.js';
+
+afterEach(() => vi.restoreAllMocks());
+
+// This boundary owns failures from both lazy module initialization and handler
+// execution; callers rely on a result to continue draining the remaining work.
+describe.each([
+  ['probe', countScheduledHandlerPending, 'countPending', { count: 0, detail: 'probe failed: unavailable' }],
+  ['run', runScheduledHandler, 'run', { dispatched: false, reason: 'handler failed: unavailable' }],
+])('scheduled handler %s', (_label, invoke, method, failure) => {
+  const taskType = 'universe-bible-describe';
+
+  it.each(['module load', 'synchronous execution', 'asynchronous execution'])('contains failure during %s', async (phase) => {
+    const error = new Error('unavailable');
+    const loader = vi.spyOn(SCHEDULED_HANDLER_MODULES, taskType);
+    if (phase === 'module load') loader.mockRejectedValue(error);
+    else loader.mockResolvedValue({
+      [method]: phase === 'synchronous execution'
+        ? () => { throw error; }
+        : () => Promise.reject(error),
+    });
+
+    await expect(invoke({ taskType })).resolves.toEqual(failure);
+  });
+
+  it('preserves the handler result and invocation options', async () => {
+    const result = method === 'run' ? { dispatched: true, summary: 'Started' } : { count: 2, context: { ids: ['entry-1'] } };
+    const handler = vi.fn().mockResolvedValue(result);
+    vi.spyOn(SCHEDULED_HANDLER_MODULES, taskType).mockResolvedValue({ [method]: handler });
+    const options = { params: { maxEntries: 2 }, job: { model: 'example-model' }, family: { id: 'example-family' } };
+    if (method === 'run') Object.assign(options, { context: { ids: ['entry-1'] }, force: true });
+
+    await expect(invoke({ taskType, ...options })).resolves.toBe(result);
+    expect(handler).toHaveBeenCalledWith(options);
+  });
+
+  it('declines inherited registry keys without loading a handler', async () => {
+    const loader = vi.spyOn(SCHEDULED_HANDLER_MODULES, taskType);
+    const message = 'unknown scheduled handler: constructor';
+    await expect(invoke({ taskType: 'constructor' })).resolves.toEqual(
+      method === 'run' ? { dispatched: false, reason: message } : { count: 0, detail: message },
+    );
+    expect(loader).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
Scheduled handler probes and runs promised to return a failure result, but lazy import failures and synchronous handler throws escaped that boundary. A manual request could already be consumed before the error aborted its drain and prevented its completion notification.

Extend the existing promise catch over loading and invocation, preserving lazy imports, invocation options, success results, and unknown-handler refusal. The inventory found existing derivation and import-scoping safeguards worth retaining; this PR is limited to the concrete handler failure boundary.

## Test plan
- Reproduced four failures before the fix: module loading and synchronous execution for both probe and run.
- Passed 140 tests across eight suites covering scheduled handlers, registration contracts, quota invocation, manual request draining, and import scoping.
- Reviewed the diff for reuse, scope, compatibility, and sensitive data; `git diff --check` passed.
