### PR TITLE
fix: stop badging claim and read-only agent runs as coding on main

### DIFF
--- a/client/src/components/cos/tabs/AgentCard.jsx
+++ b/client/src/components/cos/tabs/AgentCard.jsx
@@ -25,6 +25,7 @@ import {
   Sparkles,
   RefreshCw,
   Copy,
+  Eye,
   Target
 } from 'lucide-react';
 import * as api from '../../../services/api';
@@ -46,6 +47,19 @@ import { useConfirmDelete } from '../../../hooks/useConfirmDelete';
 const RE_NUMBERED_LIST = /([.!?:]) (\d+)\. /g;
 const RE_DASH_LIST = /([.!?:]) - /g;
 const RE_SECTION_LABELS = / (Expected output|Steps|Success criteria|Actionable focus|Focus|Suggestions?|Notes?|Context|Requirements?|Constraints?|Result|Output|Summary|Details)([: ])/gi;
+// Every posture the agent-configuration badge row can render. Kept beside the row
+// so adding a badge and widening its visibility guard is one edit, not two — a
+// badge left out of this list silently never renders.
+const CONFIG_BADGE_KEYS = [
+  'configClaimFlow',
+  'configUseWorktree',
+  'configReadOnly',
+  'configCodingOnMain',
+  'configOpenPR',
+  'configSimplify',
+  'configReviewLoop',
+];
+
 const FINISH_SENTINEL_MESSAGE = 'Finish work and write sentinel.';
 
 // Normalize raw task description text into markdown for readable rendering.
@@ -811,8 +825,19 @@ export default function AgentCard({ agent, onPause, onKill, onDelete, onResume, 
         )}
 
         {/* Agent configuration badges */}
-        {(agent.metadata?.configUseWorktree || agent.metadata?.configOpenPR || agent.metadata?.configSimplify || agent.metadata?.configReviewLoop || agent.metadata?.configCodingOnMain) && (
+        {CONFIG_BADGE_KEYS.some(key => agent.metadata?.[key]) && (
           <div className="flex items-center gap-1.5 flex-wrap mb-2">
+            {/* A claim run self-manages its `claim/<item>` worktree and its own forge
+                handoff, so CoS keeps configUseWorktree/configOpenPR off to avoid
+                nesting a second worktree. Badge what it actually does rather than
+                leaving the row bare — the CoS-managed badges cannot speak for it. */}
+            {agent.metadata.configClaimFlow && !agent.metadata.configUseWorktree && (
+              <span className="flex items-center gap-1 px-1.5 py-0.5 text-[11px] rounded bg-teal-500/15 text-teal-400"
+                    title="Claim flow — the agent cuts its own claim worktree and owns its forge handoff (PR or filed issue)">
+                <GitBranch size={10} aria-hidden="true" />
+                Claim WT
+              </span>
+            )}
             {agent.metadata.configUseWorktree && (
               <span className={`flex items-center gap-1 px-1.5 py-0.5 text-[11px] rounded ${
                 agent.metadata.configWorktreeAutoDetected ? 'bg-orange-500/15 text-orange-400' : 'bg-teal-500/15 text-teal-400'
@@ -821,7 +846,19 @@ export default function AgentCard({ agent, onPause, onKill, onDelete, onResume, 
                 {agent.metadata.configWorktreeAutoDetected ? 'Auto-WT' : 'Worktree'}
               </span>
             )}
-            {agent.metadata.configCodingOnMain && !agent.metadata.configUseWorktree && (
+            {agent.metadata.configReadOnly && (
+              <span className="flex items-center gap-1 px-1.5 py-0.5 text-[11px] rounded bg-sky-500/15 text-sky-400"
+                    title="Read-only run — inspects the checkout and commits nothing">
+                <Eye size={10} aria-hidden="true" />
+                Read-only
+              </span>
+            )}
+            {/* Re-checked against the sibling postures on READ, not just at spawn:
+                agents registered before those postures joined the projection have a
+                stale configCodingOnMain frozen in their metadata, and an archived
+                card must not warn "coding on main" over its own worktree badge. */}
+            {agent.metadata.configCodingOnMain && !agent.metadata.configUseWorktree
+              && !agent.metadata.configClaimFlow && !agent.metadata.configReadOnly && (
               <span className="flex items-center gap-1 px-1.5 py-0.5 text-[11px] rounded bg-yellow-500/15 text-yellow-500"
                     title="Agent is coding directly on main branch">
                 <GitBranch size={10} aria-hidden="true" />

--- a/client/src/components/cos/tabs/AgentCard.test.jsx
+++ b/client/src/components/cos/tabs/AgentCard.test.jsx
@@ -553,3 +553,45 @@ describe('AgentCard goal fidelity', () => {
   });
 });
 
+// A claim run works in a `claim/<item>` worktree that the claim command creates
+// itself; CoS keeps useWorktree/openPR off only so it does not nest a second
+// worktree around it. Reading that false/false as "coding on main" made every
+// issue claim from the app Issues page badge itself `main` while it was in fact
+// on an isolated branch.
+describe('AgentCard branch posture badges', () => {
+  const renderWithMetadata = (metadata) => render(
+    <MemoryRouter>
+      <AgentCard agent={{ ...agent, metadata: { ...agent.metadata, ...metadata } }} completed />
+    </MemoryRouter>
+  );
+
+  // The load-bearing case for already-archived runs: every claim agent spawned
+  // before the server projection was corrected has BOTH flags frozen true in its
+  // metadata, so the card has to settle the contradiction on read or those cards
+  // wear two conflicting branch badges at once.
+  it('suppresses the main badge on a claim run whose stored metadata still says it', () => {
+    renderWithMetadata({ configClaimFlow: true, configUseWorktree: false, configCodingOnMain: true });
+
+    expect(screen.getByText('Claim WT')).toBeInTheDocument();
+    expect(screen.queryByText('main')).not.toBeInTheDocument();
+  });
+
+  // Same stale-record problem, other non-committing posture: a read-only run is
+  // denied a worktree on purpose and commits nothing, so the warning is false.
+  it('badges a read-only run as read-only rather than as coding on main', () => {
+    renderWithMetadata({ configReadOnly: true, configUseWorktree: false, configCodingOnMain: true });
+
+    expect(screen.getByText('Read-only')).toBeInTheDocument();
+    expect(screen.queryByText('main')).not.toBeInTheDocument();
+  });
+
+  // The control. Without it every assertion above is satisfied by deleting the
+  // main badge outright.
+  it('still badges a genuine commit-to-main run as main', () => {
+    renderWithMetadata({ configClaimFlow: false, configUseWorktree: false, configCodingOnMain: true });
+
+    expect(screen.getByText('main')).toBeInTheDocument();
+    expect(screen.queryByText('Claim WT')).not.toBeInTheDocument();
+    expect(screen.queryByText('Read-only')).not.toBeInTheDocument();
+  });
+});

--- a/server/services/agentLifecycle.js
+++ b/server/services/agentLifecycle.js
@@ -752,6 +752,11 @@ async function runAgentSpawn(task) {
       worktreeInfo,
       isTruthyMetaFn: isTruthyMeta,
     }) !== null;
+    // Evaluated once: `configClaimFlow` and `configCodingOnMain` below are two
+    // faces of the same fact, and two separate calls could drift on the
+    // `isTruthyMetaFn` argument — which is exactly the split that made a claim
+    // run badge itself "main".
+    const claimFlowTask = isClaimFlowTask(task, isTruthyMeta);
     await registerAgent(agentId, task.id, {
       instanceId,
       workspacePath,
@@ -893,13 +898,24 @@ async function runAgentSpawn(task) {
       // to avoid provisioning a nested worktree. Preserve that distinction in
       // the run record so completion diagnostics cannot mistake the claim path
       // for the generic commit-only handoff.
-      configClaimFlow: isClaimFlowTask(task, isTruthyMeta),
+      configClaimFlow: claimFlowTask,
       configSimplify: isTruthyMeta(task.metadata?.simplify),
       configReviewLoop: isTruthyMeta(task.metadata?.reviewLoop),
       configReviewers: normalizeReviewers(task.metadata),
       configUseWorktree: !!worktreeInfo,
       configWorktreeAutoDetected: !!worktreeInfo && !explicitWorktree,
-      configCodingOnMain: !worktreeInfo && !jiraBranchName,
+      // A read-only run is given no worktree on purpose (agentWorkspacePrep) and
+      // commits nothing, so it is not "coding on main" either. Projected as its own
+      // key because the card has no other way to tell it from a commit-only handoff.
+      configReadOnly: isTruthyMeta(task.metadata?.readOnly),
+      // Coding on the default branch is the LEFTOVER posture: no CoS worktree, no
+      // JIRA feature branch, no claim worktree of its own, and not read-only. Each
+      // new branch-owning or non-committing flow has to be excluded here, or its
+      // card wears a warning badge that is simply false — which is how every issue
+      // claimed from the Issues page came to be badged "main" while the claim
+      // command was working in its own `claim/<item>` worktree.
+      configCodingOnMain: !worktreeInfo && !jiraBranchName && !claimFlowTask
+        && !isTruthyMeta(task.metadata?.readOnly),
       // Feature-agent provenance must survive the in-memory runner handoff and
       // server restarts so featureAgents can clear currentAgentId and record the
       // run when the shared CoS lifecycle emits agent:completed.

--- a/server/services/agentLifecycle.postureGate.test.js
+++ b/server/services/agentLifecycle.postureGate.test.js
@@ -29,7 +29,7 @@
  * prep the gate cases deliberately stop at.
  */
 
-import { afterAll, describe, it, expect, vi, beforeEach } from 'vitest';
+import { afterAll, afterEach, describe, it, expect, vi, beforeEach } from 'vitest';
 import { rmSync } from 'fs';
 import { join } from 'path';
 import { makePathsProxy } from '../lib/mockPathsDataRoot.js';
@@ -150,7 +150,8 @@ import { prepareAgentWorkspace } from './agentWorkspacePrep.js';
 import { materializePublicReviewInput, materializePublicReviewPatches, readPublicReviewInputSnapshot } from './modelAbuseGuard.js';
 import { removeWorktree } from './worktreeManager.js';
 import { resolveAgentProviderAndModel } from './agentProviderResolution.js';
-import { buildAgentPrompt } from './agentPromptBuilder.js';
+import { buildAgentPrompt, isClaimFlowTask } from './agentPromptBuilder.js';
+import { registerAgent } from './cosAgentLifecycle.js';
 import { createAgentRun } from './agentRunTracking.js';
 import { buildCliSpawnConfig, isTuiProvider, spawnDirectly } from './agentCliSpawning.js';
 import { spawnAgentViaRunner } from './cosRunnerClient.js';
@@ -493,5 +494,69 @@ describe('public-review dispatch — direct-only, never the CoS runner (#6105)',
     expect(spawnDirectly).not.toHaveBeenCalled();
     // spawnViaRunner arms a 3s "still initializing" timer on the live agent.
     for (const agent of runnerAgents.values()) clearTimeout(agent.initializationTimeout);
+  });
+});
+
+/**
+ * The branch posture the agent card badges.
+ *
+ * A claim run works inside the `claim/<item>` worktree the claim command cuts
+ * for itself; CoS deliberately leaves `useWorktree`/`openPR` off so it does not
+ * provision a second worktree around that one. `configCodingOnMain` read that
+ * false/false as "commits straight to the default branch", so every issue
+ * claimed from the app Issues page wore a `main` badge while it was in fact on
+ * an isolated branch.
+ *
+ * Behavioral, through the real orchestrator, because the projection is a single
+ * expression the sibling source-scrape guards cannot evaluate.
+ */
+describe('registerAgent branch posture for a claim run', () => {
+  const registeredMetadata = () => vi.mocked(registerAgent).mock.calls.at(-1)?.[2];
+
+  // `vi.clearAllMocks()` in the file-wide beforeEach clears call records but KEEPS
+  // implementations, so a `mockReturnValue` here would leak into every case added
+  // after this block. Restore the factory default explicitly.
+  afterEach(() => vi.mocked(isClaimFlowTask).mockReturnValue(false));
+
+  it('does not report a claim run as coding on the default branch', async () => {
+    vi.mocked(isClaimFlowTask).mockReturnValue(true);
+    reachDispatch();
+
+    await spawnAgentForTask({ id: 'task-claim', metadata: { claimFlow: true } });
+
+    expect(registeredMetadata()).toMatchObject({
+      configClaimFlow: true,
+      configUseWorktree: false,
+      configCodingOnMain: false,
+    });
+  });
+
+  // A read-only run is denied a worktree by agentWorkspacePrep on purpose and
+  // commits nothing, so the same warning badge was equally false for it —
+  // pr-reviewer and jira-status-report both ship `readOnly: true`.
+  it('does not report a read-only run as coding on the default branch', async () => {
+    reachDispatch();
+
+    await spawnAgentForTask({ id: 'task-read-only', metadata: { readOnly: true } });
+
+    expect(registeredMetadata()).toMatchObject({
+      configReadOnly: true,
+      configUseWorktree: false,
+      configCodingOnMain: false,
+    });
+  });
+  // The control: a task that really does commit to the default branch must keep
+  // its warning badge, so the fix above cannot be satisfied by always reporting
+  // false.
+  it('still reports an ordinary worktree-less run as coding on the default branch', async () => {
+    vi.mocked(isClaimFlowTask).mockReturnValue(false);
+    reachDispatch();
+
+    await spawnAgentForTask({ id: 'task-on-main', metadata: {} });
+
+    expect(registeredMetadata()).toMatchObject({
+      configClaimFlow: false,
+      configCodingOnMain: true,
+    });
   });
 });

--- a/server/services/agentLifecycle.test.js
+++ b/server/services/agentLifecycle.test.js
@@ -750,7 +750,12 @@ describe('runAgentSpawn source — instance provenance + claim ordering (#1563)'
     // makes an unrelated comment above them read as a missing key.
     const metaSlice = AGENT_LIFECYCLE_SRC.slice(registerIdx, AGENT_LIFECYCLE_SRC.indexOf('\n  });', registerIdx));
     expect(metaSlice).toContain('configOpenPR: isTruthyMeta(task.metadata?.openPR)');
-    expect(metaSlice).toContain('configClaimFlow: isClaimFlowTask(task, isTruthyMeta)');
+    // Derived from \`isClaimFlowTask\`, not re-implemented inline: the predicate also
+    // recognises a claim run by its \`analysisType\`, which an inline
+    // \`isTruthyMeta(task.metadata?.claimFlow)\` would silently drop. Hoisted to one
+    // const because \`configCodingOnMain\` reads the same fact.
+    expect(AGENT_LIFECYCLE_SRC).toContain('const claimFlowTask = isClaimFlowTask(task, isTruthyMeta);');
+    expect(metaSlice).toContain('configClaimFlow: claimFlowTask');
     expect(metaSlice.indexOf('configClaimFlow')).toBeGreaterThan(metaSlice.indexOf('configOpenPR'));
   });
 


### PR DESCRIPTION
## Summary

Claiming an issue from the app Issues page queues a CoS agent that works in the `claim/<item>` worktree the claim command cuts for itself. CoS keeps `useWorktree`/`openPR` off on that task on purpose — so it doesn't provision a second worktree around the first — but `configCodingOnMain` read that `false`/`false` as "commits straight to the default branch", so the agent card warned **main** over a run that was on an isolated branch the whole time.

Read-only runs hit the same false warning for the same reason: `agentWorkspacePrep` denies them a worktree deliberately and they commit nothing, yet `pr-reviewer`, `jira-status-report` and `issue-watcher` all wore the badge.

- Derive `configCodingOnMain` as the **leftover** posture: no CoS worktree, no JIRA branch, no claim worktree, not read-only. `isClaimFlowTask` is hoisted to one const so that flag and `configClaimFlow` can't drift apart.
- Project `configReadOnly`, so the card can tell a non-committing run from a commit-only handoff, and badge it.
- Badge a claim run for what it actually does instead of leaving its row bare.
- **Re-check the posture on read, not only at spawn** — agents registered before this have a stale `configCodingOnMain: true` frozen in their metadata, so archived cards would otherwise show two contradictory branch badges at once.
- Collect the badge keys in one list, since the bug that hides a new badge is forgetting to widen the row's visibility guard.

Evidence the runs were never on main: the two agents in the report produced `origin/claim/issue-6605` and `origin/claim/issue-6608`, each carrying its own commit.

## Test plan

- `server/services/agentLifecycle.postureGate.test.js` — three behavioral cases through the real spawn orchestrator: a claim run and a read-only run must not report `configCodingOnMain`, plus a control that an ordinary worktree-less run still does. Verified failing against the pre-fix revision.
- `client/src/components/cos/tabs/AgentCard.test.jsx` — the stale-record cases (both flags true, as already-archived agents have them) must suppress the `main` badge, plus a control that a genuine commit-to-main run keeps it. Verified failing against the pre-fix component.
- `server/services/agentLifecycle.test.js` — existing source-shape guard updated for the hoisted const, still pinning that `configClaimFlow` derives from `isClaimFlowTask` rather than an inline check that would drop `analysisType` coverage.
- `cd server && npx vitest run services/agentLifecycle services/cosForgeSpawnGate services/agentPromptBuilder routes/cosTaskRoutes services/cosAgentLifecycle` → 454 passed.
- `cd client && npx vitest run src/components/cos` → 636 passed. Biome lint clean.

Follow-up filed as #6613 for the duplicated `CLAIM_FLOW_TASK_TYPES` list (the claim writer and reader keep separate copies).
