### PR TITLE
Parse sources instead of regex-tokenizing them in the prompt-stage call-site generator

### DIFF
--- a/docs/DEPS.md
+++ b/docs/DEPS.md
@@ -44,6 +44,7 @@ Before removing a Tier 3 candidate, run a transitive-dep check (`npm ls <pkg>`).
 | `ws` | 1 | KEEP | remote desktop + browser WebSockets | Foundational WebSocket transport; also used transitively by Socket.IO |
 | `zod` | 1 | KEEP | input validation | Widely-audited |
 | **Server devDeps** | | | | |
+| `@babel/parser` | 1 | KEEP | `scripts/generate-prompt-stage-call-sites.js` — parses `server/` sources to index prompt-stage call sites | Already present transitively (via vitest); promoted to an explicit devDep in #6624 so the generator can't break on a hoist change. Declared on `server` rather than root because CI never installs root `node_modules` |
 | `vitest` | 1 | KEEP | test runner | |
 | `@vitest/coverage-v8` | 1 | KEEP | coverage | Paired with vitest |
 | **Client deps** | | | | |

--- a/scripts/generate-prompt-stage-call-sites.js
+++ b/scripts/generate-prompt-stage-call-sites.js
@@ -18,6 +18,18 @@
  * regenerates and fails on drift, so a new literal-key call site can't land
  * without the manifest catching up.
  *
+ * Why a real parse rather than a regex tokenizer (#6624): the previous scanner
+ * walked comments and quoted spans with one alternation, which could LOSE
+ * PHASE — a backtick inside a regex literal opened a phantom template that ran
+ * to the next backtick, several lines and one `//` comment later, swallowing
+ * every call site in between. That failure is stable rather than flaky, so the
+ * drift test reports it as "the manifest is stale" and the documented fix
+ * ("run the generator and commit the result") ACCEPTS the wrong manifest,
+ * quietly unprotecting a shipped stage. It cost `cos-agent-briefing` its only
+ * reference during a refactor that changed no call site at all. A parser
+ * cannot lose phase, and comments simply aren't in the AST, so the scanner's
+ * comment-skipping special case disappears with it.
+ *
  * Usage:  node scripts/generate-prompt-stage-call-sites.js
  *
  * Output shape: `{ "<stage-key>": ["server/services/foo.js", …] }`, keys and
@@ -26,6 +38,7 @@
 
 import { execFileSync } from 'node:child_process';
 import { readFileSync, writeFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { isDirectlyInvoked } from './lib/directInvocation.js';
@@ -34,6 +47,16 @@ const HERE = dirname(fileURLToPath(import.meta.url));
 
 /** Repo root, resolved from this script's own location. */
 export const REPO_ROOT = resolve(HERE, '..');
+
+/**
+ * `@babel/parser` is a devDependency of the `server` workspace, not of the
+ * repo root — CI installs `server/`, `client/`, and `autofixer/` and never the
+ * root, so a bare `import '@babel/parser'` from `scripts/` would resolve
+ * against the (pm2-only) root tree and fail. Anchoring the resolver at
+ * `server/package.json` finds it under both plain Node and Vitest.
+ */
+const requireFromServerWorkspace = createRequire(join(REPO_ROOT, 'server', 'package.json'));
+const { parse } = requireFromServerWorkspace('@babel/parser');
 
 /** Manifest location, repo-relative (posix) so it reads the same on Windows. */
 export const MANIFEST_RELATIVE_PATH = 'server/lib/promptStageCallSites.generated.json';
@@ -49,29 +72,22 @@ export const REGENERATE_COMMAND = 'node scripts/generate-prompt-stage-call-sites
  * key reaches the resolver (direct call, a `{ idea: 'pipeline-idea-expansion' }`
  * lookup table, a `const STAGE = '…'` module constant, …).
  */
-const LITERAL_CALL_RE =
-  /\b(?:getStage|getStageTemplate|buildPrompt|runStage|runStagedLLM|runStageScopedInlineLLM|previewPrompt|resolveStageContext|resolveJudgeForStage)\(\s*(['"])([^'"\n]+)\1/g;
+const STAGE_CALL_NAMES = new Set([
+  'getStage',
+  'getStageTemplate',
+  'buildPrompt',
+  'runStage',
+  'runStagedLLM',
+  'runStageScopedInlineLLM',
+  'previewPrompt',
+  'resolveStageContext',
+  'resolveJudgeForStage',
+]);
 
 /**
- * One pass over a JS source, in precedence order: block comment, line comment,
- * single-quoted, double-quoted, template literal.
- *
- * Comments are in the alternation only so they can be SKIPPED — a stage key
- * named in a `//` note or a JSDoc block is prose, not a call site, and listing
- * that file under "Referenced in" in the delete dialog would be a lie.
- * Matching them here rather than pre-stripping is what keeps a `'http://…'`
- * literal from being mistaken for the start of a comment.
- *
- * A regex literal containing a quote could still desync the scan. That would
- * be stable, not flaky (the drift test compares two runs of the same scanner),
- * and no `server/` source does it today.
- */
-const TOKEN_RE = /\/\*[\s\S]*?\*\/|\/\/[^\n]*|'(?:[^'\\\n]|\\.)*'|"(?:[^"\\\n]|\\.)*"|`(?:[^`\\]|\\[\s\S])*`/g;
-
-/**
- * A static hyphenated prefix inside a template literal, followed by an
- * interpolation — `` `pipeline-panel-${personaId}` ``. Stages reached this way
- * (the reader-panel personas) have NO literal key anywhere in source, so a
+ * A static hyphenated prefix immediately before an interpolation —
+ * `` `pipeline-panel-${personaId}` ``. Stages reached this way (the
+ * reader-panel personas) have NO literal key anywhere in source, so a
  * literal-only scan would leave them unprotected. Every known key under the
  * prefix counts as referenced by that file.
  *
@@ -115,6 +131,49 @@ export function collectServerSources(repoRoot = REPO_ROOT) {
   return tracked.map((path) => ({ path, source: readFileSync(join(repoRoot, path), 'utf8') }));
 }
 
+/** Keys babel hangs off a node that are never child AST nodes worth walking. */
+const NON_AST_KEYS = new Set(['loc', 'leadingComments', 'trailingComments', 'innerComments', 'extra']);
+
+/** Every node in a parsed program, depth-first. Avoids a `@babel/traverse` dependency. */
+function* walkNodes(node) {
+  if (!node || typeof node !== 'object') return;
+  if (Array.isArray(node)) {
+    for (const child of node) yield* walkNodes(child);
+    return;
+  }
+  if (typeof node.type !== 'string') return;
+  yield node;
+  for (const key of Object.keys(node)) {
+    if (NON_AST_KEYS.has(key)) continue;
+    yield* walkNodes(node[key]);
+  }
+}
+
+/**
+ * Parse one source into its node list.
+ *
+ * A source that will not parse throws, naming the file: contributing nothing
+ * would silently drop every call site in it, which is the exact failure this
+ * rewrite exists to end.
+ */
+function parseNodes(path, source) {
+  // Outside any request lifecycle, and babel's message names a line/column but
+  // not the file — which of 500 sources broke is the only useful half.
+  try {
+    const ast = parse(source, { sourceType: 'module', plugins: ['jsx'] });
+    return [...walkNodes(ast.program)];
+  } catch (err) {
+    throw new Error(`${path}: ${err.message}`, { cause: err });
+  }
+}
+
+/** The callee name of a call expression, for both `fn(…)` and `obj.fn(…)`. */
+function calleeName(callee) {
+  if (callee?.type === 'Identifier') return callee.name;
+  if (callee?.type === 'MemberExpression' && !callee.computed) return callee.property?.name ?? null;
+  return null;
+}
+
 /**
  * Build the `stageKey -> [source paths]` index.
  *
@@ -125,11 +184,18 @@ export function collectServerSources(repoRoot = REPO_ROOT) {
  *   references omitted
  */
 export function buildStageCallSites({ shippedStageKeys, sources }) {
+  const parsed = sources.map(({ path, source }) => ({ path, nodes: parseNodes(path, source) }));
+
   // A call site may name a stage whose config entry was never shipped; those
   // keys still deserve protection if the user (or a migration) creates them.
   const keys = new Set(shippedStageKeys);
-  for (const { source } of sources) {
-    for (const [, , key] of source.matchAll(LITERAL_CALL_RE)) keys.add(key);
+  for (const { nodes } of parsed) {
+    for (const node of nodes) {
+      if (node.type !== 'CallExpression') continue;
+      if (!STAGE_CALL_NAMES.has(calleeName(node.callee))) continue;
+      const [first] = node.arguments;
+      if (first?.type === 'StringLiteral') keys.add(first.value);
+    }
   }
 
   const index = new Map();
@@ -138,20 +204,30 @@ export function buildStageCallSites({ shippedStageKeys, sources }) {
     index.get(key).add(path);
   };
 
-  for (const { path, source } of sources) {
-    for (const [token] of source.matchAll(TOKEN_RE)) {
-      if (token.startsWith('/')) continue; // comment — prose, not a call site
-      if (token.startsWith('`')) {
-        for (const [, prefix] of token.matchAll(TEMPLATE_PREFIX_RE)) {
-          for (const key of keys) {
-            if (key.length > prefix.length && key.startsWith(prefix)) record(key, path);
-          }
+  for (const { path, nodes } of parsed) {
+    for (const node of nodes) {
+      if (node.type === 'StringLiteral') {
+        if (keys.has(node.value)) record(node.value, path);
+        continue;
+      }
+      if (node.type !== 'TemplateLiteral') continue;
+
+      // A template with no interpolation is just a string spelled differently.
+      if (node.expressions.length === 0) {
+        const only = node.quasis[0]?.value?.cooked;
+        if (only != null && keys.has(only)) record(only, path);
+        continue;
+      }
+
+      // Rebuild the template's SHAPE — static chunks with a placeholder where
+      // each interpolation sat — so a prefix is still recognized as sitting
+      // immediately before a `${`, wherever in the template it appears.
+      const shape = node.quasis.map((quasi) => quasi.value.raw).join('${}');
+      for (const [, prefix] of shape.matchAll(TEMPLATE_PREFIX_RE)) {
+        for (const key of keys) {
+          if (key.length > prefix.length && key.startsWith(prefix)) record(key, path);
         }
       }
-      // An interpolated or escaped literal is never a bare stage key, so the
-      // same unwrap covers all three quote styles.
-      const literal = token.slice(1, -1);
-      if (keys.has(literal)) record(literal, path);
     }
   }
 

--- a/scripts/generate-prompt-stage-call-sites.test.js
+++ b/scripts/generate-prompt-stage-call-sites.test.js
@@ -112,6 +112,37 @@ describe('prompt stage call-site scanner', () => {
     expect(index['demo-panel-one']).toBeUndefined();
   });
 
+  // #6624. The regex tokenizer this scanner replaced walked comments and
+  // quoted spans in one alternation, so a backtick it could not attribute
+  // opened a phantom template that ran to the NEXT backtick — here, one inside
+  // a `//` comment two lines later — swallowing every call site in between.
+  // The failure was stable rather than flaky, so the drift test reported it as
+  // "the manifest is stale" and its advice ("regenerate and commit") would
+  // have ACCEPTED a manifest missing a shipped stage's only reference.
+  it('finds a call site after a backtick the old tokenizer could not attribute', () => {
+    const desyncing = [
+      'const stripTicks = (s) => s.replace(/`/g, "");',
+      "export const build = (ctx) => buildPrompt('demo-alpha', ctx);",
+      '// The helper above removes every ` from the rendered prompt.',
+    ].join('\n');
+
+    const index = buildStageCallSites({
+      shippedStageKeys,
+      sources: [src('server/services/desync.js', desyncing)],
+    });
+
+    expect(index['demo-alpha']).toEqual(['server/services/desync.js']);
+  });
+
+  it('throws naming the file when a source will not parse', () => {
+    expect(() =>
+      buildStageCallSites({
+        shippedStageKeys,
+        sources: [src('server/services/broken.js', 'export const = ;')],
+      }),
+    ).toThrow(/server\/services\/broken\.js/);
+  });
+
   it('does not match a longer key that merely starts with a shorter one', () => {
     const index = buildStageCallSites({
       shippedStageKeys: ['demo-alpha', 'demo-alpha-extended'],

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -28,6 +28,7 @@
         "zod": "4.5.4"
       },
       "devDependencies": {
+        "@babel/parser": "7.29.8",
         "@vitest/coverage-v8": "5.0.0",
         "vitest": "5.0.0"
       },

--- a/server/package.json
+++ b/server/package.json
@@ -41,6 +41,7 @@
     "zod": "4.5.4"
   },
   "devDependencies": {
+    "@babel/parser": "7.29.8",
     "@vitest/coverage-v8": "5.0.0",
     "vitest": "5.0.0"
   },

--- a/server/services/agentPromptBuilder.js
+++ b/server/services/agentPromptBuilder.js
@@ -83,12 +83,7 @@ const AGENTS_DIR = PATHS.cosAgents;
 // These scheduled audits inspect a running web UI. Keep their runtime contract
 // in the builder rather than only in the default prompt bodies so customized
 // prompts and tasks queued before a prompt revision get the same guidance.
-// The configurable briefing template the full (`api`) path renders. Named here,
-// above this file's first template literal, because the prompt-stage call-site
-// generator indexes stage keys by scanning string tokens — and its scanner can
-// lose phase on a file with this many nested backticks, which silently dropped
-// agentPromptBuilder.js from this stage's "Referenced in" list. A key declared
-// before the first multi-line template is found regardless of that phase.
+// The configurable briefing template the full (`api`) path renders.
 const BRIEFING_STAGE_KEY = 'cos-agent-briefing';
 
 export const UI_AUDIT_TASK_TYPES = Object.freeze([


### PR DESCRIPTION
## Summary

The prompt-stage call-site scanner walked comments and quoted spans with one regex alternation, so a backtick it could not attribute — one inside a regex literal, say — opened a phantom template that ran to the next backtick several lines later, **swallowing every stage-key call site in between**. Whether a literal was seen then depended on backtick parity, so an unrelated refactor could flip it: during #6616 a change that only moved code and adjusted comments dropped `"cos-agent-briefing": ["server/services/agentPromptBuilder.js"]` while the `buildPrompt` call was still right there.

The failure is stable rather than flaky, so the drift test reported it as "the manifest is stale" and its advice — regenerate and commit — would have **accepted a manifest missing the only reference protecting a shipped stage from deletion**. A missing row means the delete-confirm dialog stops warning, the stage is deleted, and a feature breaks with no diagnostic.

- Parses each source with `@babel/parser` and walks `StringLiteral` / `TemplateLiteral` nodes. `TOKEN_RE` and its "could still desync" caveat are gone, and the comment-skipping special case goes with them — comments simply aren't in the AST.
- Key discovery moves from `LITERAL_CALL_RE` to a `CallExpression` walk over the same callee names.
- Template prefixes keep today's deliberate over-matching for `` `pipeline-panel-${personaId}` ``.
- A source that will not parse now throws naming the file rather than silently contributing nothing.
- Retires the #6616 workaround comment in `agentPromptBuilder.js` — the named constant no longer has to sit above the file's first template literal.
- `@babel/parser` was already present transitively via vitest; promoted to an explicit **server** devDependency so a hoist change can't break the generator, and declared on that workspace rather than the root because CI never installs root `node_modules`.

## Test plan

- `server/lib/promptStageCallSites.generated.json` is **byte-identical** on a clean checkout — verified by regenerating before and after, including after the `agentPromptBuilder.js` comment removal shifted the constant's position.
- New regression test: a fixture whose phantom template closes on a backtick inside a `//` comment, swallowing a `buildPrompt('demo-alpha', …)` call. Verified against the pre-change scanner — it returns `{}` (key missing) — and passes after.
- New test: an unparseable source throws with the file path in the message. Verified the old scanner did not throw.
- `scripts/generate-prompt-stage-call-sites.test.js`, `scripts/lib/positionInvariance.js` invariance guard, and `server/lib/generatedManifests.test.js` all pass unchanged.
- `cd server && npm test` — 2087 files, 41531 tests passed.
- `docs/DEPS.md` row added for the new explicit devDependency (`docs/deps-doc.test.js` parity guard).

Closes #6624