### PR TITLE
fix task-schedule card top alignment and tighten the page header

### DIFF
--- a/client/src/components/cos/tabs/ScheduleTab.jsx
+++ b/client/src/components/cos/tabs/ScheduleTab.jsx
@@ -155,13 +155,11 @@ export default function ScheduleTab({ apps, providers, providersLoaded, activePr
 
   return (
     <CodeReviewDefaultsProvider>
-    <div className="space-y-6">
-      <div className="flex items-center justify-between">
-        <div>
+    <div className="space-y-4">
+      <div className="flex items-center justify-between gap-3 flex-wrap">
+        <div className="flex items-baseline gap-2 flex-wrap min-w-0">
           <h2 className="text-xl font-semibold text-white">Task Schedule</h2>
-          <p className="text-sm text-gray-400 mt-1">
-            Configure how often each task type runs.
-          </p>
+          <p className="text-sm text-gray-400">Configure how often each task type runs.</p>
         </div>
         <button
           onClick={fetchSchedule}

--- a/client/src/components/cos/tabs/schedule/AppTaskCard.jsx
+++ b/client/src/components/cos/tabs/schedule/AppTaskCard.jsx
@@ -27,10 +27,13 @@ export default function AppTaskCard({ taskType, config, apps, onTrigger, onConfi
 
   return (
     <div className="flex flex-col border border-port-border rounded-lg bg-port-card hover:border-port-border/60 transition-colors">
+      {/* `flex flex-col items-stretch` is load-bearing: a stretched <button> centers its
+          content box vertically, which floats a short card's body to the middle of the
+          card and breaks the top alignment across a row. */}
       <button
         type="button"
         onClick={() => onConfigure(taskType)}
-        className="flex-1 text-left p-4 space-y-3 rounded-t-lg hover:bg-port-card/60 transition-colors"
+        className="flex-1 flex flex-col items-stretch gap-3 text-left p-4 rounded-t-lg hover:bg-port-card/60 transition-colors"
       >
         <TaskHeader taskType={taskType} config={config} />
 

--- a/client/src/components/cos/tabs/schedule/AppTaskTypeSection.jsx
+++ b/client/src/components/cos/tabs/schedule/AppTaskTypeSection.jsx
@@ -26,8 +26,13 @@ export default function AppTaskTypeSection({ tasks, apps, providers, providersLo
 
   return (
     <div className="space-y-3">
-      <div className="flex items-center gap-2 flex-wrap">
-        <h3 className="text-lg font-semibold text-white">Improvement Tasks</h3>
+      <div className="flex items-start gap-2 flex-wrap">
+        <div className="min-w-0">
+          <h3 className="text-lg font-semibold text-white leading-tight">Improvement Tasks</h3>
+          <p className="text-xs text-gray-400 mt-0.5">
+            Tasks that analyze and improve PortOS and managed apps. Click a card to configure its schedule and to turn it on or off per app.
+          </p>
+        </div>
         <div className="flex items-center gap-1 ml-auto flex-wrap">
           {TASK_FILTERS.map(f => {
             const active = activeFilter.id === f.id;
@@ -48,11 +53,29 @@ export default function AppTaskTypeSection({ tasks, apps, providers, providersLo
           })}
         </div>
       </div>
-      <p className="text-sm text-gray-400">
-        Tasks that analyze and improve PortOS and managed apps. Click a card to configure its schedule and to turn it on or off per app.
-      </p>
-
+      {/* Label + search share one row so the card grid starts higher above the fold. */}
       <div className="flex flex-wrap items-center gap-2">
+        <div className="relative flex-1 min-w-[14rem] max-w-sm">
+          <Search size={14} className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-500 pointer-events-none" />
+          <input
+            type="text"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Search names, descriptions, labels…"
+            aria-label="Filter tasks by name"
+            className="w-full bg-port-card border border-port-border rounded-lg pl-9 pr-9 py-2 text-sm text-white placeholder-gray-500 focus:outline-none focus:border-port-accent/50"
+          />
+          {search && (
+            <button
+              type="button"
+              onClick={() => setSearch('')}
+              aria-label="Clear filter"
+              className="min-h-[44px] min-w-[44px] inline-flex items-center justify-center absolute right-2 top-1/2 -translate-y-1/2 p-1 text-gray-500 hover:text-white"
+            >
+              <X size={14} />
+            </button>
+          )}
+        </div>
         <label htmlFor="schedule-label-filter" className="text-sm text-gray-400">Label</label>
         <select id="schedule-label-filter" value={label} onChange={event => onLabelChange(event.target.value)}
           className="max-w-full bg-port-card border border-port-border rounded px-3 py-2 text-sm text-white">
@@ -61,27 +84,6 @@ export default function AppTaskTypeSection({ tasks, apps, providers, providersLo
           {labels.map(value => <option key={value} value={value}>{value} ({taskEntries.filter(([, config]) => taskLabels(config).includes(value)).length})</option>)}
         </select>
         {label && <button onClick={() => onLabelChange('')} className="text-sm text-port-accent">Clear label</button>}
-      </div>
-      <div className="relative max-w-sm">
-        <Search size={14} className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-500 pointer-events-none" />
-        <input
-          type="text"
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-          placeholder="Search names, descriptions, labels…"
-          aria-label="Filter tasks by name"
-          className="w-full bg-port-card border border-port-border rounded-lg pl-9 pr-9 py-2 text-sm text-white placeholder-gray-500 focus:outline-none focus:border-port-accent/50"
-        />
-        {search && (
-          <button
-            type="button"
-            onClick={() => setSearch('')}
-            aria-label="Clear filter"
-            className="min-h-[44px] min-w-[44px] inline-flex items-center justify-center absolute right-2 top-1/2 -translate-y-1/2 p-1 text-gray-500 hover:text-white"
-          >
-            <X size={14} />
-          </button>
-        )}
       </div>
 
       {visibleEntries.length === 0 ? (


### PR DESCRIPTION
## Summary

- **Cards in a row no longer float mid-card.** The clickable card body is a `<button>` stretched by `flex-1`; a stretched button centers its content box vertically, so any card whose content was shorter than its row sat visually centered while its neighbours sat at the top. It now gets an explicit `flex flex-col items-stretch`, which restores top alignment across every row.
- **~3 rows of header height reclaimed above the grid**, so more cards land above the fold:
  - Page title and its subtitle share one line.
  - The section description moves beside the "Improvement Tasks" heading instead of taking its own full-width row.
  - The label filter and the search box share a single row.

No logic, state, or props changed — presentational only.

## Test plan

- `cd client && npx vitest run src/components/cos/tabs/ScheduleTab.test.jsx src/components/cos/tabs/schedule/` — 154 tests, 10 files, all pass.
- `cd client && npm run lint` — clean.
- Visual: cards in each row now share a common top edge; the first card grid row starts higher on the CoS → Schedule page.