### PR TITLE
keep the call opening line pending until TTS actually delivers it

### DIFF
--- a/server/services/voice/callSession.js
+++ b/server/services/voice/callSession.js
@@ -166,14 +166,33 @@ export const isCallActive = () => publicState().active;
 export const getCallContext = () => (publicState().active ? session.context : null);
 
 /**
+ * Read the pending opening line without consuming it.
+ *
+ * Non-destructive on purpose: the delivery it feeds can fail (the TTS provider
+ * is down, rate-limited, or times out), and clearing before the line has
+ * actually been spoken loses it for good — the call then connects to silence
+ * permanently, which is the exact failure the opening line exists to prevent.
+ * The caller clears it with `clearCallOpeningLine` once delivery succeeded.
+ */
+export function peekCallOpeningLine() {
+  if (!publicState().active) return '';
+  return session.openingLine;
+}
+
+/** Retire the opening line once it has actually been delivered. */
+export function clearCallOpeningLine() {
+  session.openingLine = '';
+}
+
+/**
  * Take the pending opening line, clearing it. Consume-once on purpose: the
  * host speaks it on the first `connected` observation, and `voice:call:state`
  * is broadcast more than once per call.
  */
 export function takeCallOpeningLine() {
   if (!publicState().active) return '';
-  const line = session.openingLine;
-  session.openingLine = '';
+  const line = peekCallOpeningLine();
+  clearCallOpeningLine();
   return line;
 }
 

--- a/server/sockets/voice.js
+++ b/server/sockets/voice.js
@@ -30,6 +30,7 @@ import { transcribe } from '../services/voice/stt.js';
 import { CALL_AUDIO_SAMPLE_RATE, createCallEndpointer, pcmToFloat } from '../services/voice/callEndpointing.js';
 import {
   attachHost,
+  clearCallOpeningLine,
   detachHost,
   endCall,
   getCallContext,
@@ -39,9 +40,9 @@ import {
   markListening,
   markSpeaking,
   noteCallerSpeech,
+  peekCallOpeningLine,
   recordTurn,
   setCallStateListener,
-  takeCallOpeningLine,
 } from '../services/voice/callSession.js';
 import { synthesize } from '../services/voice/tts.js';
 import {
@@ -54,6 +55,12 @@ import {
   setCaptureStateListener,
   startCapture,
 } from '../services/voice/captureSession.js';
+
+// Attempts allowed at the same call opening line before it is given up on.
+// The retry rides the recurring `voice:call:state` broadcast rather than a
+// timer, so this is what keeps a dead TTS provider from being hammered for the
+// whole call.
+const OPENING_LINE_MAX_ATTEMPTS = 3;
 
 // Cap by messages (each user utterance + assistant reply is ~2). 24 → ~12 turns.
 const HISTORY_MESSAGES = 24;
@@ -398,7 +405,7 @@ export const registerVoiceHandlers = (socket) => {
   // `runTurn` utterances the microphone produces, and the destination of the
   // reply, which is played into the call rather than out of the speakers.
   // ---------------------------------------------------------------------------
-  const call = { endpointer: null, busy: false, ctrl: null };
+  const call = { endpointer: null, busy: false, ctrl: null, openingLine: '', openingLineFailures: 0 };
 
   // Speak the line the caller was rung to hear, once, as soon as the far end
   // picks up. Without this a mind-placed call connects to silence and the user
@@ -408,14 +415,32 @@ export const registerVoiceHandlers = (socket) => {
     // flight would drop it for good. Leaving it pending means the next state
     // emit (that turn's own markListening) retries it.
     if (call.busy) return;
-    const line = takeCallOpeningLine();
+    const line = peekCallOpeningLine();
     if (!line) return;
+    // A different line means a different call — restart the failure budget.
+    if (call.openingLine !== line) {
+      call.openingLine = line;
+      call.openingLineFailures = 0;
+    }
+    // Retrying on every later state emit is free while the provider is merely
+    // slow, but a provider that is down would retry for the life of the call;
+    // stop after a bounded number of attempts at the same line.
+    if (call.openingLineFailures >= OPENING_LINE_MAX_ATTEMPTS) return;
     call.busy = true;
     markSpeaking();
     try {
       const { wav, latencyMs } = await synthesize(line);
       socket.emit('voice:call:tts', { sentence: line, wav, latencyMs });
+      // Consume only now that the line has actually been delivered. Clearing
+      // it before synthesize resolved is what turned one TTS failure into a
+      // call that connects to silence for good.
+      clearCallOpeningLine();
       recordTurn('assistant', line);
+    } catch (error) {
+      // Deliberately does NOT clear: the line stays pending so the
+      // markListening() below re-broadcasts and this retries it.
+      call.openingLineFailures += 1;
+      console.error(`❌ voice call: opening line attempt ${call.openingLineFailures}/${OPENING_LINE_MAX_ATTEMPTS} failed: ${error.message}`);
     } finally {
       call.busy = false;
       markListening();
@@ -425,8 +450,9 @@ export const registerVoiceHandlers = (socket) => {
   const emitCallState = (snapshot) => {
     socket.emit('voice:call:state', snapshot);
     // 'listening' is the first state the poll reaches once the helper reports a
-    // connected call. `takeCallOpeningLine` is consume-once, so the repeated
-    // state emits this broadcast produces cannot repeat the line.
+    // connected call. The line is consumed only on a delivery that succeeded,
+    // so the repeated state emits this broadcast produces retry a failed line
+    // and cannot repeat a delivered one.
     if (snapshot?.state === 'listening') {
       deliverOpeningLine().catch((err) => console.error(`❌ voice call: opening line failed: ${err.message}`));
     }

--- a/server/sockets/voice.test.js
+++ b/server/sockets/voice.test.js
@@ -42,6 +42,7 @@ const {
   __resetVoiceOutput,
 } = await import('../services/voice/voiceOutput.js');
 const { transcribe } = await import('../services/voice/stt.js');
+const { synthesize } = await import('../services/voice/tts.js');
 const { runTurn } = await import('../services/voice/pipeline.js');
 const {
   attachHost: attachCallHost,
@@ -325,6 +326,10 @@ describe('call host opening line', () => {
   const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
 
   beforeEach(() => {
+    // The failure cases below install rejecting implementations; restore the
+    // shared stub so ordering between cases cannot matter.
+    synthesize.mockReset();
+    synthesize.mockImplementation(async (text) => ({ wav: Buffer.from(`wav:${text}`), latencyMs: 1 }));
     __resetCallSession();
     __setCallSessionDeps({
       probe: vi.fn(async () => ({ state: 'connected' })),
@@ -354,6 +359,49 @@ describe('call host opening line', () => {
     await pollCall();
     await flush();
     expect(host.emitted.filter((e) => e.event === 'voice:call:tts')).toHaveLength(1);
+  });
+
+  it('retries the line on the next state broadcast when synthesis fails, and speaks it exactly once', async () => {
+    // A call bridge fails TTS routinely (provider down, rate-limited, timed
+    // out). Consuming the line before synthesize resolved left the call
+    // connected to permanent silence, because every later state emit found
+    // nothing pending to say.
+    const host = makeFakeSocket();
+    registerVoiceHandlers(host);
+    await host.fire('voice:call:attach');
+
+    synthesize.mockRejectedValueOnce(new Error('tts provider unavailable'));
+
+    await startCall({ openingLine: 'This is PortOS about your backups.', origin: 'mind' });
+    await pollCall();
+    await flush();
+    await pollCall();
+    await flush();
+
+    const spoken = host.emitted.filter((e) => e.event === 'voice:call:tts');
+    expect(spoken).toHaveLength(1);
+    expect(spoken[0].payload.sentence).toBe('This is PortOS about your backups.');
+    // recordTurn ran only for the attempt that actually emitted the audio —
+    // the failed attempt must not leave a spoken turn in the transcript.
+    expect(getCallState().turns).toBe(1);
+  });
+
+  it('gives up on the line after three failed attempts rather than hammering a dead provider', async () => {
+    const host = makeFakeSocket();
+    registerVoiceHandlers(host);
+    await host.fire('voice:call:attach');
+
+    synthesize.mockRejectedValue(new Error('tts provider unavailable'));
+
+    await startCall({ openingLine: 'This is PortOS about your backups.', origin: 'mind' });
+    await pollCall();
+    await flush();
+    await pollCall();
+    await flush();
+
+    expect(synthesize).toHaveBeenCalledTimes(3);
+    expect(host.emitted.filter((e) => e.event === 'voice:call:tts')).toHaveLength(0);
+    expect(getCallState().turns).toBe(0);
   });
 
   it('says nothing extra on a call the user placed themselves', async () => {


### PR DESCRIPTION
## Summary

- `deliverOpeningLine` consumed the opening line *before* `synthesize` could fail, and the session clears it consume-once — so one ordinary TTS failure (provider down, rate-limited, timed out) left a mind-placed call connected to **silence for the rest of the call**, with `recordTurn` never firing so the post-call journal was wrong too.
- `callSession.js` now exposes a non-destructive `peekCallOpeningLine()` plus a separate `clearCallOpeningLine()`; `takeCallOpeningLine()` stays as a thin wrapper so its consume-once contract is unchanged.
- `voice.js` peeks, synthesizes, emits `voice:call:tts`, and only then clears + records the turn. A new `catch` logs without clearing, so the `finally`'s `markListening()` re-broadcast retries the line on the next state emit.
- Attempts are counted per line on the `call` object and capped at 3, so a dead provider is not hammered for the life of the call. No new timer or retry policy — the state broadcast already recurs and the `call.busy` guard already keeps it off a real turn.

## Test plan

- Two new cases in `server/sockets/voice.test.js`: one makes `synthesize` reject once and asserts the line is spoken exactly once on the retry (and that `recordTurn` fired only for the attempt that emitted audio); the other rejects always and asserts `synthesize` stops after 3 attempts with no turn recorded. Both fail against the pre-fix code (`expected [] to have a length of 1`, `called 3 times, but got 1`).
- `cd server && npm test` — 41,590 passed, 1 file skipped.

Closes #6639