### PR TITLE
cap guest mic frames and re-read the live session in the FableLoom hosted namespace

### DIFF
--- a/server/sockets/fableLoomHosted.js
+++ b/server/sockets/fableLoomHosted.js
@@ -18,6 +18,15 @@ import {
   verifyHostedToken,
 } from '../services/fableLoom/hostedSession.js';
 
+// Guest mic payload caps. This socket is authenticated by a single-use QR token
+// from a guest device, not by the install's one trusted user, so the root trust
+// model does not cover it and the numbers mirror the trusted call path in
+// `voice.js` (`MAX_CALL_FRAME_BYTES` / `MAX_AUDIO_BYTES`): one 64 KB frame is
+// two seconds of headroom over the ~20 ms bursts the audience page ships, and
+// 8 MB is ~4 minutes of 16 kHz mono audio for a single turn.
+const MAX_MIC_FRAME_BYTES = 64 * 1024;
+const MAX_UTTERANCE_BYTES = 8 * 1024 * 1024;
+
 let hostedNsInstance = null;
 
 export function getHostedNamespace() {
@@ -100,8 +109,25 @@ export function registerFableLoomHostedNamespace(io) {
       role,
     });
 
-    // Inbound frame buffer for streaming mic chunks
+    // Inbound frame buffer for streaming mic chunks. `micBytes` is a running
+    // counter rather than a re-sum of the array, and `micOverflow` latches the
+    // refusal so an over-cap turn is reported once and never processed as if it
+    // were a complete utterance.
     let micChunks = [];
+    let micBytes = 0;
+    let micOverflow = false;
+
+    const resetMicBuffer = () => {
+      micChunks = [];
+      micBytes = 0;
+      micOverflow = false;
+    };
+
+    // The record captured at connect goes stale: TTL expiry marks a session
+    // `ended` without touching `turnPhase`, so a closure gated on that snapshot
+    // reads `listening` forever. `_getInternalSession` re-evaluates the TTL and
+    // returns null for a dead session.
+    const liveSession = () => _getInternalSession(sessionId);
 
     // --- Host actions ---
     socket.on('hosted:playback:update', (data) => {
@@ -140,7 +166,7 @@ export function registerFableLoomHostedNamespace(io) {
     // --- Audience actions ---
     socket.on('hosted:mic:start', async () => {
       if (socket.hostedRole !== 'audience') return;
-      micChunks = [];
+      resetMicBuffer();
       try {
         await startHostedListening(sessionId, { io });
       } catch (err) {
@@ -150,22 +176,56 @@ export function registerFableLoomHostedNamespace(io) {
 
     socket.on('hosted:mic:frame', (chunk) => {
       if (socket.hostedRole !== 'audience') return;
-      if (!session || session.turnPhase !== 'listening') return;
-      if (chunk) {
-        micChunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+      const live = liveSession();
+      if (!live || live.turnPhase !== 'listening') return;
+      // Already refused this turn — keep dropping until the next mic:start.
+      if (micOverflow || !chunk) return;
+
+      const frame = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      if (frame.length > MAX_MIC_FRAME_BYTES) return;
+
+      if (micBytes + frame.length > MAX_UTTERANCE_BYTES) {
+        micOverflow = true;
+        micChunks = [];
+        micBytes = 0;
+        socket.emit('hosted:error', {
+          code: 'UTTERANCE_TOO_LARGE',
+          message: `audio too large (over ${MAX_UTTERANCE_BYTES} bytes)`,
+        });
+        return;
       }
+
+      micChunks.push(frame);
+      micBytes += frame.length;
     });
 
     socket.on('hosted:mic:stop', async (completeBuffer) => {
       if (socket.hostedRole !== 'audience') return;
-      if (!session || session.turnPhase !== 'listening') return;
+      const live = liveSession();
+      if (!live || live.turnPhase !== 'listening') return;
+
+      const overflowed = micOverflow;
       let finalAudio = null;
-      if (completeBuffer && (Buffer.isBuffer(completeBuffer) || ArrayBuffer.isView(completeBuffer))) {
-        finalAudio = Buffer.isBuffer(completeBuffer) ? completeBuffer : Buffer.from(completeBuffer);
-      } else if (micChunks.length > 0) {
+      if (!overflowed && completeBuffer
+        && (Buffer.isBuffer(completeBuffer) || ArrayBuffer.isView(completeBuffer))) {
+        const complete = Buffer.isBuffer(completeBuffer) ? completeBuffer : Buffer.from(completeBuffer);
+        if (complete.length > MAX_UTTERANCE_BYTES) {
+          resetMicBuffer();
+          socket.emit('hosted:error', {
+            code: 'UTTERANCE_TOO_LARGE',
+            message: `audio too large (${complete.length} > ${MAX_UTTERANCE_BYTES} bytes)`,
+          });
+          return;
+        }
+        finalAudio = complete;
+      } else if (!overflowed && micChunks.length > 0) {
         finalAudio = Buffer.concat(micChunks);
       }
-      micChunks = [];
+      resetMicBuffer();
+
+      // A truncated buffer would hand the LLM half a sentence with no signal,
+      // so an overflowed turn is refused outright; the error already went out.
+      if (overflowed) return;
 
       try {
         await processHostedUtterance(sessionId, { audioBuffer: finalAudio, io });
@@ -176,7 +236,8 @@ export function registerFableLoomHostedNamespace(io) {
 
     socket.on('hosted:turn:text', async (data) => {
       if (socket.hostedRole !== 'audience') return;
-      if (!session || session.turnPhase !== 'listening') return;
+      const live = liveSession();
+      if (!live || live.turnPhase !== 'listening') return;
       try {
         await processHostedUtterance(sessionId, { textMessage: data?.text, io });
       } catch (err) {
@@ -186,8 +247,9 @@ export function registerFableLoomHostedNamespace(io) {
 
     socket.on('hosted:speech:done', (_data) => {
       // Speech finished playback on output target
-      if (session && session.turnPhase === 'speaking') {
-        session.turnPhase = 'listening';
+      const live = liveSession();
+      if (live && live.turnPhase === 'speaking') {
+        live.turnPhase = 'listening';
         ns.to(room).emit('hosted:turn:phase', { phase: 'listening' });
       }
     });
@@ -214,3 +276,5 @@ export function registerFableLoomHostedNamespace(io) {
 
   return ns;
 }
+
+export { MAX_MIC_FRAME_BYTES, MAX_UTTERANCE_BYTES };

--- a/server/sockets/fableLoomHosted.test.js
+++ b/server/sockets/fableLoomHosted.test.js
@@ -2,6 +2,8 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import {
   registerFableLoomHostedNamespace,
   getHostedNamespace,
+  MAX_MIC_FRAME_BYTES,
+  MAX_UTTERANCE_BYTES,
 } from './fableLoomHosted.js';
 import {
   _getInternalSession,
@@ -306,6 +308,66 @@ describe('fableLoomHosted Socket.IO namespace', () => {
       await audience.listeners['hosted:mic:stop']();
 
       expect(stt.transcribe).toHaveBeenCalledWith(Buffer.from('aabb'), expect.anything());
+    });
+
+    it('stops buffering mic frames once the session expires mid-listen', async () => {
+      await audience.listeners['hosted:mic:start']();
+
+      // TTL expiry marks the record `ended` but never touches `turnPhase`, so a
+      // handler gated on the connect-time snapshot would still read `listening`
+      // and keep appending for the whole life of the socket.
+      const record = _getInternalSession(session.id);
+      record.expiresAt = new Date(Date.now() - 1000).toISOString();
+
+      audience.listeners['hosted:mic:frame'](Buffer.from('aa'));
+      audience.listeners['hosted:mic:frame'](Buffer.from('bb'));
+
+      // Revive the record so mic:stop reaches the buffer it would have filled.
+      record.expiresAt = new Date(Date.now() + 60_000).toISOString();
+      record.status = 'active';
+      await audience.listeners['hosted:mic:stop']();
+
+      expect(stt.transcribe).not.toHaveBeenCalled();
+    });
+
+    it('drops a single mic frame larger than the per-frame cap', async () => {
+      await audience.listeners['hosted:mic:start']();
+      audience.listeners['hosted:mic:frame'](Buffer.alloc(MAX_MIC_FRAME_BYTES + 1, 0x7a));
+      audience.listeners['hosted:mic:frame'](Buffer.from('aa'));
+      await audience.listeners['hosted:mic:stop']();
+
+      expect(stt.transcribe).toHaveBeenCalledWith(Buffer.from('aa'), expect.anything());
+    });
+
+    it('refuses the turn once buffered mic frames exceed the utterance cap', async () => {
+      await audience.listeners['hosted:mic:start']();
+
+      const frame = Buffer.alloc(MAX_MIC_FRAME_BYTES, 0x61);
+      const framesToCap = MAX_UTTERANCE_BYTES / MAX_MIC_FRAME_BYTES;
+      for (let i = 0; i < framesToCap; i += 1) {
+        audience.listeners['hosted:mic:frame'](frame);
+      }
+      expect(audience.emitted.filter((e) => e.event === 'hosted:error')).toHaveLength(0);
+
+      // These two both overflow; the refusal is reported exactly once per turn.
+      audience.listeners['hosted:mic:frame'](frame);
+      audience.listeners['hosted:mic:frame'](frame);
+
+      const errors = audience.emitted.filter((e) => e.event === 'hosted:error');
+      expect(errors).toHaveLength(1);
+      expect(errors[0].data).toMatchObject({ code: 'UTTERANCE_TOO_LARGE' });
+
+      await audience.listeners['hosted:mic:stop']();
+      expect(stt.transcribe).not.toHaveBeenCalled();
+    });
+
+    it('refuses a hosted:mic:stop complete buffer larger than the utterance cap', async () => {
+      await audience.listeners['hosted:mic:start']();
+      await audience.listeners['hosted:mic:stop'](Buffer.alloc(MAX_UTTERANCE_BYTES + 1, 0x61));
+
+      expect(stt.transcribe).not.toHaveBeenCalled();
+      expect(audience.emitted.find((e) => e.event === 'hosted:error')?.data)
+        .toMatchObject({ code: 'UTTERANCE_TOO_LARGE' });
     });
 
     it('ignores hosted:mic:stop when the session is not listening', async () => {


### PR DESCRIPTION
## Summary

A guest device streaming `hosted:mic:frame` on `/fableloom-hosted` could grow server RSS without bound until the process was OOM-killed. Two defects combined:

- **No cap** on per-frame or per-utterance bytes, unlike the trusted call path in `server/sockets/voice.js`.
- **The `listening` gate read the session record captured at connect.** TTL expiry sets `status = 'ended'` but leaves `turnPhase` alone, so once a listening turn expired the snapshot read `listening` for the life of the socket and every arriving frame was still buffered. `hosted:mic:stop` could not rescue it — `Buffer.concat` of a multi-gigabyte array is itself the failing allocation.

This socket authenticates with a single-use QR token from a guest device, not the install's one trusted user, so the single-user trust model does not cover it.

Changes in `server/sockets/fableLoomHosted.js`:

- `MAX_MIC_FRAME_BYTES` (64 KB) and `MAX_UTTERANCE_BYTES` (8 MB), mirroring `voice.js`'s `MAX_CALL_FRAME_BYTES` / `MAX_AUDIO_BYTES`. Oversized single frames are dropped; the running total is tracked in a counter, not re-summed.
- Overflow **refuses the turn** rather than truncating it — half a sentence with no signal is worse for the LLM than a reported failure. It emits `hosted:error` / `UTTERANCE_TOO_LARGE` exactly once per turn and latches, so the following `hosted:mic:stop` does not process the partial audio. `hosted:mic:stop`'s `completeBuffer` argument is capped the same way.
- `hosted:mic:frame`, `hosted:mic:stop`, `hosted:turn:text` and `hosted:speech:done` now gate on `_getInternalSession(sessionId)`, which re-evaluates the TTL, instead of the connect-time closure.

## Test plan

Four new tests in `server/sockets/fableLoomHosted.test.js`, each verified to **fail against the pre-fix code** and pass after:

- frames stop buffering once the session expires mid-listen (the TTL hole)
- a single frame over 64 KB is dropped without disturbing the rest of the turn
- crossing the 8 MB total emits `UTTERANCE_TOO_LARGE` exactly once and the subsequent `mic:stop` does not transcribe
- an oversized `mic:stop` complete buffer is refused

`cd server && npm test` — 41,591 passed. The one unrelated failure (`scripts/generate-prompt-stage-call-sites.test.js`) is a local 10s-timeout flake that reproduces identically on `origin/main` content.

Closes #6636