### PR TITLE
fix: decode misaligned PCM frames in voice:call:audio instead of dropping them

### DIFF
--- a/server/sockets/voice.js
+++ b/server/sockets/voice.js
@@ -107,6 +107,25 @@ const audioByteLength = (audio) => {
   return 0;
 };
 
+// Reinterpret an incoming audio payload as Int16 samples WITHOUT aliasing a
+// misaligned backing store. A websocket frame's payload is a subarray of the
+// receiver's read buffer, so its byteOffset is routinely ODD — `ws` advances
+// the offset by each frame's payload plus its 2–14 byte header — and
+// `new Int16Array(buffer, byteOffset, …)` THROWS a RangeError on an odd
+// offset rather than failing soft. The caller's catch would swallow that and
+// the frame's audio would simply vanish from the endpointer, so copy the
+// bytes on the misaligned path instead; a 640-byte copy per 20 ms frame is
+// negligible next to STT. A trailing odd byte is truncated either way.
+const toInt16Samples = (audio) => {
+  if (!Buffer.isBuffer(audio) && !ArrayBuffer.isView(audio)) {
+    if (!(audio instanceof ArrayBuffer)) return new Int16Array(0);
+    return new Int16Array(audio, 0, Math.floor(audio.byteLength / 2));
+  }
+  const samples = Math.floor(audio.byteLength / 2);
+  if (audio.byteOffset % 2 === 0) return new Int16Array(audio.buffer, audio.byteOffset, samples);
+  return new Int16Array(audio.buffer.slice(audio.byteOffset, audio.byteOffset + samples * 2));
+};
+
 export const registerVoiceHandlers = (socket) => {
   const state = {
     history: [],
@@ -535,9 +554,7 @@ export const registerVoiceHandlers = (socket) => {
       const { pcm } = payload || {};
       const bytes = audioByteLength(pcm);
       if (!bytes || bytes > MAX_CALL_FRAME_BYTES) return;
-      const view = Buffer.isBuffer(pcm) || ArrayBuffer.isView(pcm)
-        ? new Int16Array(pcm.buffer, pcm.byteOffset, Math.floor(pcm.byteLength / 2))
-        : new Int16Array(pcm);
+      const view = toInt16Samples(pcm);
 
       if (asCallHost) {
         const utterance = call.endpointer.push(view);

--- a/server/sockets/voice.test.js
+++ b/server/sockets/voice.test.js
@@ -35,7 +35,17 @@ vi.mock(import('../services/voice/callSession.js'), async (importOriginal) => {
   return { ...actual, detachHost: vi.fn(actual.detachHost) };
 });
 
+// Partial-mock the endpointer factory so the frame-alignment tests can observe
+// exactly which sample views voice:call:audio handed to endpointer.push().
+// The default implementation is still the real endpointer, so every other case
+// in this file exercises genuine endpointing.
+vi.mock(import('../services/voice/callEndpointing.js'), async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, createCallEndpointer: vi.fn(actual.createCallEndpointer) };
+});
+
 const { truncateOnWordBoundary, registerVoiceHandlers } = await import('./voice.js');
+const { createCallEndpointer } = await import('../services/voice/callEndpointing.js');
 const {
   getVoiceOutputSocket,
   emitVoiceOutput,
@@ -694,5 +704,103 @@ describe('voice:capture socket handlers (meeting capture)', () => {
 
     releaseFirstTurn({});
     await flushMicrotasks();
+  });
+});
+
+describe('voice:call:audio frame alignment', () => {
+  // ~20 ms of 16 kHz mono, matching the call-host page's frame size.
+  const FRAME_SAMPLES = 320;
+  const FRAME_BYTES = FRAME_SAMPLES * 2;
+
+  const sourceSamples = () => {
+    const frame = new Int16Array(FRAME_SAMPLES);
+    for (let i = 0; i < FRAME_SAMPLES; i += 1) frame[i] = Math.round(Math.sin(i / 8) * 20000);
+    return frame;
+  };
+
+  // How `ws` actually hands a frame over: a subarray of the receiver's read
+  // buffer. The offset advances by each frame's payload PLUS its 2–14 byte
+  // header, so an odd byteOffset is the common case, not a corner case.
+  const frameAt = (byteOffset, byteLength = FRAME_BYTES) => {
+    const backing = Buffer.alloc(byteOffset + byteLength + 8);
+    Buffer.from(sourceSamples().buffer).copy(backing, byteOffset);
+    return backing.subarray(byteOffset, byteOffset + byteLength);
+  };
+
+  // The real endpointer, wrapped so a test can see exactly which sample views
+  // the handler pushed. `speaking` is a getter on the real object, so forward
+  // it rather than spreading (a spread would snapshot it once).
+  const realCreateCallEndpointer = createCallEndpointer.getMockImplementation();
+  const attachRecordingHost = async (pushed) => {
+    createCallEndpointer.mockImplementationOnce((...args) => {
+      const endpointer = realCreateCallEndpointer(...args);
+      return {
+        get speaking() { return endpointer.speaking; },
+        push(chunk) { pushed.push(chunk); return endpointer.push(chunk); },
+        flush: () => endpointer.flush(),
+        reset: () => endpointer.reset(),
+      };
+    });
+    const socket = makeFakeSocket();
+    registerVoiceHandlers(socket);
+    await socket.fire('voice:call:attach');
+    return socket;
+  };
+
+  beforeEach(() => __resetCallSession());
+  afterEach(() => __resetCallSession());
+
+  it('decodes a frame that landed at an odd byteOffset instead of silently dropping its audio', async () => {
+    // Regression: the handler built its Int16Array view straight over the
+    // incoming Buffer's backing store, and `new Int16Array(buffer, byteOffset,
+    // …)` THROWS a RangeError on an odd offset. The handler's own catch
+    // swallowed it, so the frame's audio never reached the endpointer and a
+    // live call lost a large share of its samples with only console spam.
+    const pushed = [];
+    const socket = await attachRecordingHost(pushed);
+    const misaligned = frameAt(1);
+    expect(misaligned.byteOffset % 2).toBe(1);
+
+    socket.fire('voice:call:audio', { pcm: misaligned });
+
+    expect(pushed).toHaveLength(1);
+    // The copy must not shift or drop values: identical to the same bytes
+    // delivered at an aligned offset.
+    expect(Array.from(pushed[0])).toEqual(Array.from(sourceSamples()));
+  });
+
+  it('keeps an even-offset frame on the zero-copy path', async () => {
+    const pushed = [];
+    const socket = await attachRecordingHost(pushed);
+    const aligned = frameAt(2);
+
+    socket.fire('voice:call:audio', { pcm: aligned });
+
+    expect(pushed).toHaveLength(1);
+    expect(Array.from(pushed[0])).toEqual(Array.from(sourceSamples()));
+    // Same backing store — no copy was made for an already-aligned frame.
+    expect(pushed[0].buffer).toBe(aligned.buffer);
+    expect(pushed[0].byteOffset).toBe(aligned.byteOffset);
+  });
+
+  it('truncates a trailing odd byte at a misaligned offset rather than throwing', async () => {
+    const pushed = [];
+    const socket = await attachRecordingHost(pushed);
+
+    socket.fire('voice:call:audio', { pcm: frameAt(3, FRAME_BYTES + 1) });
+
+    expect(pushed).toHaveLength(1);
+    expect(pushed[0]).toHaveLength(FRAME_SAMPLES);
+    expect(Array.from(pushed[0])).toEqual(Array.from(sourceSamples()));
+  });
+
+  it('decodes a bare ArrayBuffer payload', async () => {
+    const pushed = [];
+    const socket = await attachRecordingHost(pushed);
+
+    socket.fire('voice:call:audio', { pcm: sourceSamples().buffer });
+
+    expect(pushed).toHaveLength(1);
+    expect(Array.from(pushed[0])).toEqual(Array.from(sourceSamples()));
   });
 });


### PR DESCRIPTION
## Summary

`voice:call:audio` built its `Int16Array` view directly over the incoming Buffer's backing store. `new Int16Array(buffer, byteOffset, …)` **throws a `RangeError` on an odd `byteOffset`**, and the handler's own `catch` swallowed it — so those frames never reached the endpointer.

Odd offsets are the common case, not a corner case: `ws` consumes each frame's payload as a subarray of the read buffer and advances the offset by the payload **plus its 2–14 byte header**. A live FaceTime call or a meeting capture could silently lose a large share of its audio while the client widget still showed a healthy `listening` state; the only evidence was console spam.

- New module-private `toInt16Samples()` in `server/sockets/voice.js` copies the bytes when the view is misaligned, and keeps the zero-copy path for an aligned one. A 640-byte copy per 20 ms frame is negligible next to STT, and the server cannot control websocket framing.
- A trailing odd byte is still truncated rather than throwing; a bare `ArrayBuffer` payload is handled without a misalignment assumption.

## Test plan

- Four new cases in `server/sockets/voice.test.js` drive `voice:call:audio` through an attached call host with a real endpointer wrapped to record every pushed sample view: odd `byteOffset`, even `byteOffset` (asserts the same backing store — no copy), a misaligned frame with a trailing odd byte, and a bare `ArrayBuffer`.
- Baseline probe: reverting only the production change makes the odd-offset and trailing-odd-byte cases fail (2 failed / 40 passed), so the tests observe the actual defect.
- `cd server && npm test` — 41594 passed, 35 skipped.

Closes #6635