### PR TITLE
fix: preserve exact Git paths in CI test selection

### DIFF
--- a/scripts/ci-test-plan.js
+++ b/scripts/ci-test-plan.js
@@ -714,15 +714,16 @@ function fullPlan(changedFiles, reason, options) {
   }, options);
 }
 
-const gitLines = (args) => execFileSync('git', args, { encoding: 'utf8' })
-  .split('\n')
-  .map((line) => line.trim())
+// Git's display output quotes non-ASCII/control characters; trimming also
+// changes valid paths. Read raw NUL-delimited paths so selectors stay exact.
+const gitPaths = (args) => execFileSync('git', args, { encoding: 'utf8' })
+  .split('\0')
   .filter(Boolean);
 
 /** Tracked test files whose text matches `pattern`; `git grep` exit 1 is "none". */
 const gitGrepFiles = (pattern, pathspecs) => {
   try {
-    return gitLines(['grep', '-l', '-E', pattern, '--', ...pathspecs]);
+    return gitPaths(['grep', '-z', '-l', '-E', pattern, '--', ...pathspecs]);
   } catch (err) {
     if (err.status === 1) return [];
     throw err;
@@ -788,8 +789,8 @@ function main() {
   }
   const changedFiles = forceFull
     ? []
-    : gitLines(['diff', '--name-only', '--diff-filter=ACMRD', `${base}...HEAD`]);
-  const trackedFiles = gitLines(['ls-files']);
+    : gitPaths(['diff', '-z', '--name-only', '--diff-filter=ACMRD', `${base}...HEAD`]);
+  const trackedFiles = gitPaths(['ls-files', '-z']);
   const appDiff = forceFull || !changedFiles.includes('client/src/App.jsx')
     ? null
     : execFileSync('git', ['diff', '--unified=0', `${base}...HEAD`, '--', 'client/src/App.jsx'], { encoding: 'utf8' });

--- a/scripts/ci-test-plan.test.js
+++ b/scripts/ci-test-plan.test.js
@@ -1,4 +1,9 @@
 import { describe, expect, it } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import {
   ALWAYS_RUN_TESTS,
@@ -57,6 +62,54 @@ const TRACKED = [
   'scripts/migrations/210-example.test.js',
   'scripts/fix-windows-console.js',
 ];
+
+it('preserves Git-quoted source and contract paths through the planner CLI', () => {
+  const root = mkdtempSync(join(tmpdir(), 'portos-ci-paths-'));
+  const planner = fileURLToPath(new URL('./ci-test-plan.js', import.meta.url));
+  const git = (...args) => execFileSync('git', args, { cwd: root, encoding: 'utf8' }).trim();
+  const source = 'server/lib/example.js';
+  const unicodeSource = 'server/lib/café.js';
+  const contract = 'server/lib/café.test.js';
+  const write = (path, body) => {
+    mkdirSync(dirname(join(root, path)), { recursive: true });
+    writeFileSync(join(root, path), body);
+  };
+  const commit = () => {
+    git('add', '--all');
+    git('-c', 'user.name=Example Contributor', '-c', 'user.email=contributor@example.com',
+      '-c', 'commit.gpgsign=false', 'commit', '-qm', 'fixture');
+  };
+  const plan = (base) => JSON.parse(execFileSync(process.execPath, [planner], {
+    cwd: root,
+    encoding: 'utf8',
+    env: { ...process.env, CI_BASE_SHA: base, CI_BASE_REF: 'main', CI_FORCE_FULL: 'false', GITHUB_OUTPUT: '' },
+  }));
+  try {
+    git('init', '-q');
+    git('config', 'core.hooksPath', join(root, 'empty-hooks'));
+    git('config', 'core.quotePath', 'true');
+    write(source, 'export const value = 1;\n');
+    write(unicodeSource, 'export const value = 1;\n');
+    write(contract, '// Reads example.js as text rather than importing it.\n');
+    commit();
+    const base = git('rev-parse', 'HEAD');
+    write(source, 'export const value = 2;\n');
+    commit();
+    const sourcePlan = plan(base);
+    expect(sourcePlan.full).toBe(false);
+    expect(JSON.parse(sourcePlan.server_files)).toContain(contract);
+
+    write(unicodeSource, 'export const value = 2;\n');
+    commit();
+    const unicodePlan = plan(base);
+    expect(unicodePlan.full).toBe(false);
+    expect(unicodePlan.changed_files).toEqual([unicodeSource, source]);
+    expect(JSON.parse(unicodePlan.server_sources)).toContain(unicodeSource);
+    expect(JSON.parse(unicodePlan.server_files)).toContain(contract);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
 
 describe('CI test impact planner', () => {
   it('skips all expensive jobs for documentation-only changes, keeping the always-run guards', () => {


### PR DESCRIPTION
## Summary

The CI planner parsed Git's display-formatted filename output as trimmed lines (`scripts/ci-test-plan.js:719`). With Git's default quoting, changing an ASCII source silently omitted a text-reading contract named `café.test.js`; non-ASCII source changes also lost their exact selectors.

Read NUL-delimited paths from diff, ls-files, and grep so the existing impact rules receive exact filenames. This fixes the Git-output boundary behind the text-reading contract selection introduced in #6363 without changing the selection policy.

## Test plan

- Reproduced the omitted contract with a real temporary Git repository and the planner CLI; the new regression failed before the fix.
- Verified contract selection and non-ASCII changed-source selectors after the fix.
- Passed 91 tests across ci-test-plan, run-ci-tests, run-ci-lint, ci-base-sha, pre-install-entrypoints, and githubOutput.
- Reviewed the scoped diff for reuse, edge cases, and private data; git diff --check passed.
