### PR TITLE
fix: describe backup exclusion rules without promising file inclusion

### DIFF
--- a/client/src/components/settings/BackupTab.jsx
+++ b/client/src/components/settings/BackupTab.jsx
@@ -320,10 +320,10 @@ export function BackupTab() {
                         <ShieldOff size={14} />
                       </span>
                     )}
-                    <code className={`px-1.5 py-0.5 bg-port-bg border rounded shrink-0 ${d.defaultActive ? 'text-gray-300 border-port-border' : 'text-port-success border-port-success/30'}`}>{d.path}</code>
+                    <code className="px-1.5 py-0.5 bg-port-bg border rounded shrink-0 text-gray-300 border-port-border">{d.path}</code>
                     <span className="text-gray-500">
                       {d.reason}
-                      {!d.defaultActive && <span className="text-port-success/80 ml-1">(Default exclusion disabled)</span>}
+                      {!d.defaultActive && <span className="text-gray-400 ml-1">(Default exclusion disabled)</span>}
                     </span>
                   </li>
                 ))}

--- a/client/src/components/settings/BackupTab.jsx
+++ b/client/src/components/settings/BackupTab.jsx
@@ -20,23 +20,6 @@ const sameSet = (a, b) => a.length === b.length && a.every(x => b.includes(x));
 // downstream `.some` / `.includes` / `.filter` calls crash the Backup tab.
 const asArray = (v) => Array.isArray(v) ? v : [];
 
-// Whether a user-supplied custom rsync exclude pattern covers (shadows) a default
-// exclude path — broader than a bare `===` check so the UI doesn't mark a default
-// as "included" while a custom entry like `loras/`, `loras/**`, or `/cos/` is
-// still effectively excluding it via rsync. Strips leading `/`, trailing `/`, and
-// a trailing `**`/`*` glob from both sides, then compares directory prefixes:
-// the custom path shadows the default when the default's normalized form equals
-// the custom's OR lives inside the custom's subtree.
-const normalizePattern = (p) =>
-  String(p ?? '').replace(/^\/+/, '').replace(/\/+\*+$/, '').replace(/\*+$/, '').replace(/\/+$/, '');
-const shadowsDefault = (customPath, defaultPath) => {
-  if (customPath === defaultPath) return true;
-  const c = normalizePattern(customPath);
-  const d = normalizePattern(defaultPath);
-  if (!c || !d) return false;
-  return d === c || d.startsWith(c + '/');
-};
-
 export function BackupTab() {
   const destPathId = useId();
   const additionalExcludeId = useId();
@@ -132,18 +115,9 @@ export function BackupTab() {
   };
 
   const toggleDefaultExclude = (path) => {
-    const currentlyDisabled = disabledDefaultExcludes.includes(path);
-    if (currentlyDisabled) {
-      // Re-enabling the default exclude — path goes back to being excluded.
-      setDisabledDefaultExcludes(prev => prev.filter(p => p !== path));
-    } else {
-      // Disabling the default — the user is opting this path back IN to backups.
-      // Strip every shadowing custom entry (exact match AND broader patterns
-      // like `loras/`, `loras/**`); otherwise rsync would still exclude it and
-      // the toggle would lie about the actual behavior.
-      setDisabledDefaultExcludes(prev => [...prev, path]);
-      setExcludePaths(prev => prev.filter(p => !shadowsDefault(p, path)));
-    }
+    setDisabledDefaultExcludes(prev => prev.includes(path)
+      ? prev.filter(p => p !== path)
+      : [...prev, path]);
   };
 
   const [handleRunNow, running] = useAsyncAction(async () => {
@@ -171,14 +145,6 @@ export function BackupTab() {
   const addExclude = () => {
     const trimmed = newExclude.trim();
     if (!trimmed || excludePaths.includes(trimmed)) return;
-    // A custom exclude that shadows a default would lie about toggle state
-    // (toggle "included" but rsync still excludes via the custom entry).
-    // Catches exact matches AND broader patterns like `loras/` or `loras/**`.
-    const shadowed = defaultExcludes.find(d => shadowsDefault(trimmed, d.path));
-    if (shadowed) {
-      toast.error(`"${trimmed}" shadows the default exclusion "${shadowed.path}" — use the toggle above instead`);
-      return;
-    }
     setExcludePaths([...excludePaths, trimmed]);
     setNewExclude('');
   };
@@ -220,31 +186,12 @@ export function BackupTab() {
   const runTitle = runDisabledReason || 'Run a backup snapshot now using saved settings';
   const formStatus = saving ? 'Saving…' : dirty ? 'Unsaved changes' : '';
 
-  // Per-default row state, derived once so the collapsed summary count and the
-  // expanded rows can never disagree about what is actually being excluded.
-  // Custom excludes can shadow a default via exact match (`loras/...`) OR a
-  // broader pattern (`loras/`, `loras/**`, `/cos/`). The broader check is
-  // necessary because rsync still applies the custom pattern even when the
-  // default toggle says "included".
-  // `defaultActive` (is this default still switched on?) is what the row's
-  // ToggleSwitch binds to, NOT the effective `isExcluded` — a shadowing custom
-  // exclude keeps the path out of the backup while the user's override is on,
-  // and binding the switch to the effective state made such a row look
-  // untoggled and silently dropped the override on the next click. The
-  // "(still excluded via …)" note carries the effective state instead.
-  const defaultExcludeRows = defaultExcludes.map((d) => {
-    const shadowingCustom = excludePaths.find(p => shadowsDefault(p, d.path));
-    const defaultActive = !(d.overridable && disabledDefaultExcludes.includes(d.path));
-    return {
-      ...d,
-      shadowingCustom,
-      defaultActive,
-      isExcluded: defaultActive || !!shadowingCustom,
-      shadowedByCustom: !defaultActive && !!shadowingCustom,
-    };
-  });
-  const skippedCount = defaultExcludeRows.filter(r => r.isExcluded).length;
-  const includedCount = defaultExcludeRows.length - skippedCount;
+  const defaultExcludeRows = defaultExcludes.map(d => ({
+    ...d,
+    defaultActive: !(d.overridable && disabledDefaultExcludes.includes(d.path)),
+  }));
+  const enabledDefaultCount = defaultExcludeRows.filter(d => d.defaultActive).length;
+  const disabledDefaultCount = defaultExcludeRows.length - enabledDefaultCount;
 
   const renderPgStatus = () => {
     if (!pgBackup) return <span className="text-gray-500">No backup run yet</span>;
@@ -352,12 +299,11 @@ export function BackupTab() {
           >
             {showDefaultExcludes ? <ChevronDown size={14} className="shrink-0" /> : <ChevronRight size={14} className="shrink-0" />}
             <ShieldOff size={14} className="text-gray-500 shrink-0" />
-            <span>Default exclusions — {skippedCount} path{skippedCount === 1 ? '' : 's'} skipped</span>
-            {includedCount > 0 && <span className="text-xs text-port-success/80">({includedCount} re-included)</span>}
+            <span>Default exclusions — {enabledDefaultCount} enabled, {disabledDefaultCount} disabled</span>
           </button>
           {showDefaultExcludes && (
             <div id={defaultExcludesPanelId} className="space-y-2">
-              <p className="text-xs text-gray-500">Built-in paths skipped by default to keep snapshots small. Overridable entries (large re-downloadable assets) can be re-enabled below; fixed entries hold ephemeral data and stay off.</p>
+              <p className="text-xs text-gray-500">Built-in exclusion rules keep snapshots small. Switch on to disable an overridable default rule; fixed rules remain enabled.</p>
               <ul className="space-y-1.5 mt-1">
                 {defaultExcludeRows.map((d, i) => (
                   <li key={i} className="flex items-start gap-2 text-xs">
@@ -366,19 +312,18 @@ export function BackupTab() {
                         enabled={!d.defaultActive}
                         onChange={() => toggleDefaultExclude(d.path)}
                         size="sm"
-                        ariaLabel={`Include ${d.path} in backups`}
+                        ariaLabel={`Disable default exclusion ${d.path}`}
                         className="mt-0.5"
                       />
                     ) : (
-                      <span className="inline-flex items-center justify-center w-12 h-7 shrink-0 text-gray-600" title="Always excluded — cannot be backed up">
+                      <span className="inline-flex items-center justify-center w-12 h-7 shrink-0 text-gray-600" title="Fixed default exclusion — always enabled">
                         <ShieldOff size={14} />
                       </span>
                     )}
-                    <code className={`px-1.5 py-0.5 bg-port-bg border rounded shrink-0 ${d.isExcluded ? 'text-gray-300 border-port-border' : 'text-port-success border-port-success/30'}`}>{d.path}</code>
+                    <code className={`px-1.5 py-0.5 bg-port-bg border rounded shrink-0 ${d.defaultActive ? 'text-gray-300 border-port-border' : 'text-port-success border-port-success/30'}`}>{d.path}</code>
                     <span className="text-gray-500">
                       {d.reason}
-                      {!d.isExcluded && <span className="text-port-success/80 ml-1">(included)</span>}
-                      {d.shadowedByCustom && <span className="text-port-warning ml-1">(still excluded via Additional Exclude Paths — remove <code>{d.shadowingCustom}</code> below)</span>}
+                      {!d.defaultActive && <span className="text-port-success/80 ml-1">(Default exclusion disabled)</span>}
                     </span>
                   </li>
                 ))}
@@ -390,7 +335,7 @@ export function BackupTab() {
 
       <div className="space-y-2">
         <label htmlFor={additionalExcludeId} className="block text-sm text-gray-400">Additional Exclude Paths</label>
-        <p className="text-xs text-gray-500">Custom directories/patterns to skip during backup (relative to data/)</p>
+        <p className="text-xs text-gray-500">Custom directories/patterns to skip during backup (relative to data/). Additional rules still apply when a default exclusion is disabled. Disabling a default does not guarantee matching files will be backed up.</p>
         <div className="flex gap-2">
           <input
             id={additionalExcludeId}

--- a/client/src/components/settings/BackupTab.test.jsx
+++ b/client/src/components/settings/BackupTab.test.jsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { render, cleanup, screen, fireEvent, waitFor, act } from '@testing-library/react';
 
 vi.mock('../../services/api', () => ({
   getSettings: vi.fn(),
@@ -349,41 +349,57 @@ describe('BackupTab', () => {
 
       const disclosure = screen.getByRole('button', { name: /Default exclusions/i });
       expect(disclosure.getAttribute('aria-expanded')).toBe('false');
-      expect(disclosure.textContent).toMatch(/2 paths skipped/);
+      expect(disclosure.textContent).toMatch(/2 enabled, 0 disabled/);
       // Collapsed: the per-path rows (and their toggles) are not in the DOM, so
       // the tab's actionable content isn't pushed below the fold.
-      expect(screen.queryByRole('switch', { name: /Include \/models in backups/i })).toBeNull();
+      expect(screen.queryByRole('switch', { name: /Disable default exclusion \/models/i })).toBeNull();
 
       fireEvent.click(disclosure);
       expect(disclosure.getAttribute('aria-expanded')).toBe('true');
-      expect(screen.getByRole('switch', { name: /Include \/models in backups/i })).toBeTruthy();
+      expect(screen.getByRole('switch', { name: /Disable default exclusion \/models/i })).toBeTruthy();
     });
 
-    it('counts a re-included default as no longer skipped in the collapsed summary', async () => {
-      getSettings.mockResolvedValue({ backup: { destPath: '/backups', enabled: false, cronExpression: '0 2 * * *', excludePaths: [], disabledDefaultExcludes: ['/models'] } });
-      getBackupStatus.mockResolvedValue({ status: 'never', defaultExcludes: EXCLUDES, pgBackup: null });
+    // Regression: wildcard rules must survive edits and reload without the UI
+    // promising that disabling a default includes the matching files.
+    it('preserves independent custom rules through default toggles, save, and reload', async () => {
+      const loraPath = '/loras/*.safetensors';
+      const custom = ['*.safetensors', '/lo*/', 'loras/'];
+      const backup = { destPath: '/backups', enabled: false, cronExpression: '0 2 * * *', excludePaths: custom, disabledDefaultExcludes: [loraPath, '/cache'] };
+      getSettings.mockResolvedValue({ backup });
+      getBackupStatus.mockResolvedValue({ defaultExcludes: [EXCLUDES[0], { path: loraPath, reason: 'LoRA weights', overridable: true }] });
+      updateSettings.mockImplementation(async payload => { getSettings.mockResolvedValue(payload); return {}; });
       await renderTab();
 
-      const disclosure = screen.getByRole('button', { name: /Default exclusions/i });
-      expect(disclosure.textContent).toMatch(/1 path skipped/);
-      expect(disclosure.textContent).toMatch(/1 re-included/);
-    });
-
-    // The switch reports the user's own override, not the effective rsync
-    // outcome: a custom exclude that shadows a re-included default still keeps
-    // the path out of the backup, but the toggle must stay ON so clicking it
-    // doesn't silently drop the override while appearing to do nothing.
-    it('keeps a re-included default toggled on even when a custom exclude shadows it', async () => {
-      getSettings.mockResolvedValue({ backup: { destPath: '/backups', enabled: false, cronExpression: '0 2 * * *', excludePaths: ['models/'], disabledDefaultExcludes: ['/models'] } });
-      getBackupStatus.mockResolvedValue({ status: 'never', defaultExcludes: EXCLUDES, pgBackup: null });
-      await renderTab();
-
-      fireEvent.click(screen.getByRole('button', { name: /Default exclusions/i }));
-
-      const toggle = screen.getByRole('switch', { name: /Include \/models in backups/i });
+      expect(screen.getByText(/Additional rules still apply/)).toBeTruthy();
+      expect(screen.getByRole('button', { name: /Default exclusions/ }).textContent).toMatch(/1 enabled, 1 disabled/);
+      fireEvent.click(screen.getByRole('button', { name: /Default exclusions/ }));
+      const toggle = screen.getByRole('switch', { name: `Disable default exclusion ${loraPath}` });
       expect(toggle.getAttribute('aria-checked')).toBe('true');
-      // The effective state is surfaced in prose instead.
-      expect(screen.getByText(/still excluded via Additional Exclude Paths/i)).toBeTruthy();
+      expect(screen.getByText('(Default exclusion disabled)')).toBeTruthy();
+      expect(screen.queryByText(/re-included|\(included\)|paths? skipped/)).toBeNull();
+      expect(screen.queryByRole('switch', { name: /default exclusion \/cache/ })).toBeNull();
+      expect(screen.getByTitle('Fixed default exclusion — always enabled')).toBeTruthy();
+
+      fireEvent.click(toggle);
+      expect(toggle.getAttribute('aria-checked')).toBe('false');
+      fireEvent.click(toggle);
+      expect(toggle.getAttribute('aria-checked')).toBe('true');
+      for (const pattern of custom) expect(screen.getByText(pattern)).toBeTruthy();
+
+      // Broader patterns used to be rejected by the prefix approximation.
+      fireEvent.change(screen.getByLabelText('Additional Exclude Paths'), { target: { value: 'loras/**' } });
+      fireEvent.click(screen.getByLabelText('Add exclude path'));
+      await act(async () => { fireEvent.click(screen.getByRole('button', { name: /^Save$/ })); });
+      expect(updateSettings).toHaveBeenLastCalledWith({ backup: { ...backup, disabledDefaultExcludes: expect.arrayContaining([loraPath, '/cache']), excludePaths: [...custom, 'loras/**'] } }, { silent: true });
+      expect(toast.error).not.toHaveBeenCalled();
+
+      cleanup();
+      await renderTab();
+      for (const pattern of [...custom, 'loras/**']) expect(screen.getByText(pattern)).toBeTruthy();
+      fireEvent.click(screen.getByRole('button', { name: /Default exclusions/ }));
+      expect(screen.getByRole('switch', { name: `Disable default exclusion ${loraPath}` }).getAttribute('aria-checked')).toBe('true');
+      expect(screen.getByText('(Default exclusion disabled)')).toBeTruthy();
+      expect(screen.getByText(/Disabling a default does not guarantee/)).toBeTruthy();
     });
   });
 

--- a/client/src/components/settings/BackupTab.test.jsx
+++ b/client/src/components/settings/BackupTab.test.jsx
@@ -390,7 +390,7 @@ describe('BackupTab', () => {
       fireEvent.change(screen.getByLabelText('Additional Exclude Paths'), { target: { value: 'loras/**' } });
       fireEvent.click(screen.getByLabelText('Add exclude path'));
       await act(async () => { fireEvent.click(screen.getByRole('button', { name: /^Save$/ })); });
-      expect(updateSettings).toHaveBeenLastCalledWith({ backup: { ...backup, disabledDefaultExcludes: expect.arrayContaining([loraPath, '/cache']), excludePaths: [...custom, 'loras/**'] } }, { silent: true });
+      expect(updateSettings).toHaveBeenLastCalledWith({ backup: { ...backup, disabledDefaultExcludes: ['/cache', loraPath], excludePaths: [...custom, 'loras/**'] } }, { silent: true });
       expect(toast.error).not.toHaveBeenCalled();
 
       cleanup();

--- a/docs/BACKUP.md
+++ b/docs/BACKUP.md
@@ -28,15 +28,17 @@ A backup run (`runBackup` in `server/services/backup.js`) writes to:
 `DEFAULT_EXCLUDES` (in `backup.js`) skips ephemeral/cache data and large re-downloadable assets — all anchored with a leading `/` (rsync filter syntax). Two tiers:
 
 - **Non-overridable** (`overridable: false`): browser CDP profile, agent worktrees — caches with no irreplaceable user data; never backed up.
-- **Overridable** (`overridable: true`): LoRA weight files, cloned repos, reference repos, browser downloads — re-downloadable; the user can opt back in from the Backup settings UI via `disabledDefaultExcludes`.
+- **Overridable** (`overridable: true`): LoRA weight files, cloned repos, reference repos, browser downloads — re-downloadable; the user can disable these built-in exclusion rules from the Backup settings UI via `disabledDefaultExcludes`.
 
 The effective exclude list is computed by the pure `computeEffectiveExcludes()` helper (unit-tested in `backup.test.js`). The scheduled cron handler in `backupScheduler.js` re-reads settings on every run, so `destPath`, `excludePaths`, `disabledDefaultExcludes`, and `enabled` all take effect on the next run without a restart. See [Scheduling & status](#scheduling--status) for how the cron registration itself tracks settings.
 
-#### Why every exclude must be anchored with a leading `/`
+#### Why every default exclude must be anchored with a leading `/`
 
 `DEFAULT_EXCLUDES` is **rsync filter syntax** — the leading `/` means "relative to the transfer root". Without the anchor, `loras/*.safetensors` also matches any `loras/` directory nested anywhere under `data/`, silently dropping unrelated user data (e.g. `brain/.../loras/`). An unanchored pattern is a data-loss bug, not a style nit.
 
-The two `overridable` tiers are enforced, not advisory. A hand-edited `settings.json` that lists a non-overridable path in `disabledDefaultExcludes` is silently dropped server-side; `computeEffectiveExcludes()` enforces both the overridable allow-list and `Array.isArray` guards for hand-edited settings. The Backup tab's toggle UI uses a `shadowsDefault()` helper that also catches broader custom patterns (`loras/`, `loras/**`, `/cos/`) so the "included" state never lies about rsync's actual behavior.
+The two `overridable` tiers are enforced, not advisory. A hand-edited `settings.json` that lists a non-overridable path in `disabledDefaultExcludes` is silently dropped server-side; `computeEffectiveExcludes()` enforces both the overridable allow-list and `Array.isArray` guards for hand-edited settings. The Backup tab switches describe default rule state: switching on disables that default exclusion, and switching off re-enables it. The summary counts enabled and disabled default rules, not included files.
+
+Additional Exclude Paths is independent: toggling a default never removes custom patterns, and custom rsync patterns remain accepted even when they overlap defaults. Additional rules still apply when a default is disabled, so disabling `/loras/*.safetensors` does not guarantee weights will be backed up: `*.safetensors` or `/lo*/` can still exclude them. `computeEffectiveExcludes()` produces the filter list; rsync alone decides which paths match. The UI does not predict snapshot contents.
 
 ## The Postgres dump is mandatory, not optional
 


### PR DESCRIPTION
## Summary

Backup settings now describe whether each built-in exclusion rule is enabled or disabled, without claiming matching files are included. Disabling a default preserves all custom exclusions, and overlapping rsync patterns remain accepted. A persistent explanation and the backup guide clarify that additional rules still apply.

## Test plan

- All 27 rendered Backup tab tests pass, including wildcard preservation through toggle, save, and reload, plus fixed-default behavior.
- Targeted Biome lint passes.
- Client production build passes.

Closes #6652
