### PR TITLE
feat: launch maintenance sequence from scheduled tasks

### DIFF
--- a/client/src/components/cos/tabs/ScheduleTab.jsx
+++ b/client/src/components/cos/tabs/ScheduleTab.jsx
@@ -10,6 +10,7 @@ import { CodeReviewDefaultsProvider } from '../../../hooks/useCodeReviewDefaults
 import { useAppOverrideActions } from '../../../hooks/useAppOverrideActions';
 import AppTaskTypeSection from './schedule/AppTaskTypeSection';
 import TaskConfigDrawer from './schedule/TaskConfigDrawer';
+import MaintenanceRunForm from './schedule/MaintenanceRunForm';
 import { TASK_FILTERS, DEFAULT_FILTER_ID, TASK_SORTS, DEFAULT_SORT_ID, suggestedOrderSteps } from './schedule/scheduleConstants';
 
 export function mergeUpdatedTaskInterval(schedule, taskType, interval) {
@@ -189,6 +190,10 @@ export default function ScheduleTab({ apps, providers, providersLoaded, activePr
       <Banner size="md" title="Recommended maintenance order">
         <p className="text-sm break-words">{MAINTENANCE_ORDER_GUIDANCE}</p>
         <p className="text-xs mt-1">Resolve findings between audits, then document the resulting code. Quota Burn offers this sequence with perpetual claim-issue drains between steps.</p>
+        <details className="mt-2">
+          <summary className="cursor-pointer text-sm font-medium">Run maintenance now</summary>
+          <MaintenanceRunForm schedule={schedule} apps={apps} providers={providers} providersLoaded={providersLoaded} improvementDisabled={improvementDisabled} daemonRunning={daemonRunning} />
+        </details>
       </Banner>
 
       {improvementDisabled && (

--- a/client/src/components/cos/tabs/ScheduleTab.jsx
+++ b/client/src/components/cos/tabs/ScheduleTab.jsx
@@ -192,7 +192,7 @@ export default function ScheduleTab({ apps, providers, providersLoaded, activePr
         <p className="text-xs mt-1">Resolve findings between audits, then document the resulting code. Quota Burn offers this sequence with perpetual claim-issue drains between steps.</p>
         <details className="mt-2">
           <summary className="cursor-pointer text-sm font-medium">Run maintenance now</summary>
-          <MaintenanceRunForm schedule={schedule} apps={apps} providers={providers} providersLoaded={providersLoaded} improvementDisabled={improvementDisabled} daemonRunning={daemonRunning} />
+          <MaintenanceRunForm schedule={{ ...schedule, tasks }} apps={apps} providers={providers} providersLoaded={providersLoaded} improvementDisabled={improvementDisabled} daemonRunning={daemonRunning} />
         </details>
       </Banner>
 

--- a/client/src/components/cos/tabs/schedule/MaintenanceRunForm.jsx
+++ b/client/src/components/cos/tabs/schedule/MaintenanceRunForm.jsx
@@ -25,6 +25,16 @@ export default function MaintenanceRunForm({ schedule, apps = [], providers = []
   const run = async () => {
     if (busy || blocked || !jobs || !provider || !model || !consent) return;
     setBusy(true);
+    setMessage('Checking existing plan…');
+    const current = await api.getQuotaBurn(false, { silent: true }).catch(error => {
+      setMessage(`Could not check existing plan: ${error.message}`);
+      return null;
+    });
+    if (!current?.config || current.config.families?.[familyId]?.jobs?.length) {
+      if (current?.config) setMessage('This family already has a plan. Manage or clear it in Quota Burn before starting another sequence.');
+      setBusy(false);
+      return;
+    }
     setMessage('Saving maintenance sequence…');
     // Each invocation gets fresh completion keys. Pins apply to the audits AND
     // their claim drains; the scheduled tasks' saved settings remain intact.
@@ -81,10 +91,10 @@ export default function MaintenanceRunForm({ schedule, apps = [], providers = []
       />
       {appId && !jobs && <p role="status">Enable every maintenance task and claim-issue for this app, and set claim-issue to perpetual, before running the sequence.</p>}
       {blocked && <p role="status">Enable Improvement and start the CoS daemon before running maintenance.</p>}
-      <p className="text-xs">Runs the first step now; later steps continue in order through Quota Burn, subject to its quota gates. Supports subscription CLI/TUI providers.</p>
+      <p className="text-xs">Runs the first step now, bypassing its reset window, reserve, and dispatch cap; later steps continue in order through Quota Burn, subject to its quota gates. Supports subscription CLI/TUI providers. Blank effort inherits each scheduled task’s saved effort.</p>
       <label className="flex items-start gap-2" htmlFor="maintenance-run-consent">
         <input id="maintenance-run-consent" type="checkbox" checked={consent} disabled={busy} onChange={event => setConsent(event.target.checked)} />
-        <span>Enable Quota Burn and replace this provider family’s plan with this maintenance sequence. Other enabled family plans may also resume.</span>
+        <span>Enable Quota Burn and add this maintenance sequence to an empty provider family plan. Other enabled family plans may also resume.</span>
       </label>
       <div className="flex items-center gap-3 flex-wrap">
         <button type="button" onClick={run} disabled={busy || blocked || !jobs || !provider || !model || !consent || !providersLoaded} className="px-3 py-1.5 bg-port-accent text-white rounded disabled:opacity-50">

--- a/client/src/components/cos/tabs/schedule/MaintenanceRunForm.jsx
+++ b/client/src/components/cos/tabs/schedule/MaintenanceRunForm.jsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { uuidv4 } from '../../../../lib/uuid';
 import { Link } from 'react-router';
 import ProviderModelSelector from '../../../ProviderModelSelector';
 import * as api from '../../../../services/api';
@@ -27,7 +28,7 @@ export default function MaintenanceRunForm({ schedule, apps = [], providers = []
     setMessage('Saving maintenance sequence…');
     // Each invocation gets fresh completion keys. Pins apply to the audits AND
     // their claim drains; the scheduled tasks' saved settings remain intact.
-    const steps = maintenanceSequence(groups, appId, `maintenance-${crypto.randomUUID()}`).map(job => ({
+    const steps = maintenanceSequence(groups, appId, `maintenance-${uuidv4()}`).map(job => ({
       ...job,
       overrides: { ...job.overrides, providerId, model, effort: effort || null },
     }));

--- a/client/src/components/cos/tabs/schedule/MaintenanceRunForm.jsx
+++ b/client/src/components/cos/tabs/schedule/MaintenanceRunForm.jsx
@@ -1,0 +1,97 @@
+import { useState } from 'react';
+import { Link } from 'react-router';
+import ProviderModelSelector from '../../../ProviderModelSelector';
+import * as api from '../../../../services/api';
+import { buildQuotaBurnTaskCatalog, maintenanceSequence } from '../../../../lib/quotaBurnTasks';
+import { effortAwareModelOptions, isProcessProvider } from '../../../../utils/providers';
+import { familyForProvider } from '../../../../../../server/lib/providerFamilies';
+
+export default function MaintenanceRunForm({ schedule, apps = [], providers = [], providersLoaded, improvementDisabled, daemonRunning }) {
+  const [appId, setAppId] = useState('');
+  const [providerId, setProviderId] = useState('');
+  const [model, setModel] = useState('');
+  const [effort, setEffort] = useState('');
+  const [consent, setConsent] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [message, setMessage] = useState('');
+  const availableProviders = providers.filter(provider => provider.enabled && isProcessProvider(provider) && familyForProvider(provider));
+  const provider = availableProviders.find(entry => entry.id === providerId);
+  const familyId = familyForProvider(provider);
+  const groups = buildQuotaBurnTaskCatalog({ schedule, apps });
+  const jobs = maintenanceSequence(groups, appId, 'preview');
+  const blocked = improvementDisabled || daemonRunning === false;
+
+  const run = async () => {
+    if (busy || blocked || !jobs || !provider || !model || !consent) return;
+    setBusy(true);
+    setMessage('Saving maintenance sequence…');
+    // Each invocation gets fresh completion keys. Pins apply to the audits AND
+    // their claim drains; the scheduled tasks' saved settings remain intact.
+    const steps = maintenanceSequence(groups, appId, `maintenance-${crypto.randomUUID()}`).map(job => ({
+      ...job,
+      overrides: { ...job.overrides, providerId, model, effort: effort || null },
+    }));
+    const saved = await api.saveQuotaBurn({
+      enabled: true,
+      families: { [familyId]: { enabled: true, sequence: true, jobs: steps } },
+    }, { silent: true }).catch(error => {
+      setMessage(`Could not save maintenance sequence: ${error.message}`);
+      return null;
+    });
+    if (saved) {
+      const response = await api.runQuotaBurn({ familyId, force: true }, { silent: true }).catch(error => {
+        setMessage(`Sequence saved, but could not start: ${error.message}. Manage it in Quota Burn.`);
+        return null;
+      });
+      if (response) {
+        const result = response.result;
+        setMessage(result?.dispatched
+          ? 'Maintenance started. Follow progress in Tasks and Quota Burn.'
+          : `Sequence saved; waiting: ${result?.reason || 'no task dispatched'}. See Quota Burn for details.`);
+      }
+      setConsent(false);
+    }
+    setBusy(false);
+  };
+
+  return (
+    <div className="mt-3 space-y-3 text-sm">
+      <label htmlFor="maintenance-run-app" className="block">
+        App
+        <select id="maintenance-run-app" value={appId} disabled={busy} onChange={event => setAppId(event.target.value)} className="mt-1 w-full bg-port-bg border border-port-border rounded p-2 text-white">
+          <option value="">Select an app</option>
+          {apps.filter(app => app.archived !== true).map(app => <option key={app.id} value={app.id}>{app.name}</option>)}
+        </select>
+      </label>
+      <ProviderModelSelector
+        providers={availableProviders}
+        selectedProviderId={providerId}
+        selectedModel={model}
+        availableModels={provider ? effortAwareModelOptions(provider, model) : []}
+        onProviderChange={next => { setProviderId(next); setModel(''); setEffort(''); }}
+        onModelChange={setModel}
+        effort={effort}
+        onEffortChange={setEffort}
+        emptyProviderOption="Select a subscription provider"
+        emptyModelOption="Select a model"
+        alwaysShowModel
+        loading={!providersLoaded}
+        disabled={busy}
+      />
+      {appId && !jobs && <p role="status">Enable every maintenance task and claim-issue for this app, and set claim-issue to perpetual, before running the sequence.</p>}
+      {blocked && <p role="status">Enable Improvement and start the CoS daemon before running maintenance.</p>}
+      <p className="text-xs">Runs the first step now; later steps continue in order through Quota Burn, subject to its quota gates. Supports subscription CLI/TUI providers.</p>
+      <label className="flex items-start gap-2" htmlFor="maintenance-run-consent">
+        <input id="maintenance-run-consent" type="checkbox" checked={consent} disabled={busy} onChange={event => setConsent(event.target.checked)} />
+        <span>Enable Quota Burn and replace this provider family’s plan with this maintenance sequence. Other enabled family plans may also resume.</span>
+      </label>
+      <div className="flex items-center gap-3 flex-wrap">
+        <button type="button" onClick={run} disabled={busy || blocked || !jobs || !provider || !model || !consent || !providersLoaded} className="px-3 py-1.5 bg-port-accent text-white rounded disabled:opacity-50">
+          {busy ? 'Starting…' : 'Run now'}
+        </button>
+        <Link className="underline" to={familyId ? `/devtools/quota-burn/${familyId}` : '/devtools/quota-burn'}>Manage sequence in Quota Burn</Link>
+      </div>
+      {message && <p role="status">{message}</p>}
+    </div>
+  );
+}

--- a/client/src/components/cos/tabs/schedule/MaintenanceRunForm.test.jsx
+++ b/client/src/components/cos/tabs/schedule/MaintenanceRunForm.test.jsx
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router';
+import { MAINTENANCE_TASK_ORDER } from '../../../../lib/quotaBurnTasks';
+import MaintenanceRunForm from './MaintenanceRunForm';
+
+const api = vi.hoisted(() => ({ saveQuotaBurn: vi.fn(), runQuotaBurn: vi.fn() }));
+vi.mock('../../../../services/api', () => api);
+const tasks = Object.fromEntries([...MAINTENANCE_TASK_ORDER, 'claim-issue'].map(taskType => [taskType, {
+  enabled: true, perpetual: taskType === 'claim-issue', appOverrides: { example: { enabled: true } },
+}]));
+const props = {
+  schedule: { tasks }, apps: [{ id: 'example', name: 'Example App' }],
+  providers: [{ id: 'claude', name: 'Claude', type: 'cli', command: 'claude', enabled: true, models: ['sonnet'] }],
+  providersLoaded: true, daemonRunning: true,
+};
+const show = (overrides = {}) => render(<MemoryRouter><MaintenanceRunForm {...props} {...overrides} /></MemoryRouter>);
+const select = async user => {
+  await user.selectOptions(screen.getByLabelText('App'), 'example');
+  await user.selectOptions(screen.getByRole('combobox', { name: 'Provider' }), 'claude');
+  await user.selectOptions(screen.getByRole('combobox', { name: 'Model' }), 'sonnet');
+  await user.selectOptions(screen.getByRole('combobox', { name: /effort/i }), 'high');
+  await user.click(screen.getByRole('checkbox'));
+};
+beforeEach(() => {
+  vi.clearAllMocks();
+  api.saveQuotaBurn.mockResolvedValue({ config: {} });
+  api.runQuotaBurn.mockResolvedValue({ result: { dispatched: true } });
+});
+describe('maintenance launch', () => {
+  it('saves ordered steps with app and pins before dispatch and gates duplicate launches', async () => {
+    const user = userEvent.setup();
+    let finishSave;
+    api.saveQuotaBurn.mockReturnValue(new Promise(resolve => { finishSave = resolve; }));
+    show();
+    expect(api.saveQuotaBurn).not.toHaveBeenCalled();
+    await select(user);
+    await user.click(screen.getByRole('button', { name: 'Run now' }));
+    expect(api.runQuotaBurn).not.toHaveBeenCalled();
+    expect(screen.getByRole('button', { name: 'Starting…' })).toBeDisabled();
+    const patch = api.saveQuotaBurn.mock.calls[0][0];
+    expect(patch.enabled).toBe(true);
+    const family = patch.families.claude;
+    expect(family.sequence).toBe(true);
+    expect(family.jobs.map(job => job.taskRef.taskType)).toEqual(MAINTENANCE_TASK_ORDER.flatMap((type, index) => index ? ['claim-issue', type] : [type]));
+    for (const job of family.jobs) {
+      expect(job.taskRef.appId).toBe('example');
+      expect(job.overrides).toMatchObject({ providerId: 'claude', model: 'sonnet', effort: 'high' });
+      expect(job.runOnce).toBe(true);
+    }
+    finishSave({ config: patch });
+    await waitFor(() => expect(api.runQuotaBurn).toHaveBeenCalledWith({ familyId: 'claude', force: true }, { silent: true }));
+    expect(await screen.findByText(/Maintenance started/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Run now' })).toBeDisabled();
+  });
+  it('does not dispatch after a failed save and reports a saved but blocked run honestly', async () => {
+    const user = userEvent.setup();
+    api.saveQuotaBurn.mockRejectedValueOnce(new Error('save unavailable'));
+    show();
+    await select(user);
+    await user.click(screen.getByRole('button', { name: 'Run now' }));
+    expect(await screen.findByText(/Could not save maintenance sequence: save unavailable/)).toBeInTheDocument();
+    expect(api.runQuotaBurn).not.toHaveBeenCalled();
+    api.runQuotaBurn.mockResolvedValueOnce({ result: { dispatched: false, reason: 'provider unavailable' } });
+    await user.click(screen.getByRole('button', { name: 'Run now' }));
+    expect(await screen.findByText(/Sequence saved; waiting: provider unavailable/)).toBeInTheDocument();
+  });
+  it('blocks missing task eligibility and a stopped daemon', async () => {
+    const user = userEvent.setup();
+    show({ schedule: { tasks: {} }, daemonRunning: false });
+    await select(user);
+    expect(screen.getByRole('button', { name: 'Run now' })).toBeDisabled();
+    expect(screen.getByText(/Enable every maintenance task/)).toBeInTheDocument();
+    expect(screen.getByText(/start the CoS daemon/)).toBeInTheDocument();
+    expect(api.saveQuotaBurn).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/components/cos/tabs/schedule/MaintenanceRunForm.test.jsx
+++ b/client/src/components/cos/tabs/schedule/MaintenanceRunForm.test.jsx
@@ -5,7 +5,7 @@ import { MemoryRouter } from 'react-router';
 import { MAINTENANCE_TASK_ORDER } from '../../../../lib/quotaBurnTasks';
 import MaintenanceRunForm from './MaintenanceRunForm';
 
-const api = vi.hoisted(() => ({ saveQuotaBurn: vi.fn(), runQuotaBurn: vi.fn() }));
+const api = vi.hoisted(() => ({ getQuotaBurn: vi.fn(), saveQuotaBurn: vi.fn(), runQuotaBurn: vi.fn() }));
 vi.mock('../../../../services/api', () => api);
 const tasks = Object.fromEntries([...MAINTENANCE_TASK_ORDER, 'claim-issue'].map(taskType => [taskType, {
   enabled: true, perpetual: taskType === 'claim-issue', appOverrides: { example: { enabled: true } },
@@ -25,6 +25,7 @@ const select = async user => {
 };
 beforeEach(() => {
   vi.clearAllMocks();
+  api.getQuotaBurn.mockResolvedValue({ config: { families: {} } });
   api.saveQuotaBurn.mockResolvedValue({ config: {} });
   api.runQuotaBurn.mockResolvedValue({ result: { dispatched: true } });
 });
@@ -65,6 +66,29 @@ describe('maintenance launch', () => {
     api.runQuotaBurn.mockResolvedValueOnce({ result: { dispatched: false, reason: 'provider unavailable' } });
     await user.click(screen.getByRole('button', { name: 'Run now' }));
     expect(await screen.findByText(/Sequence saved; waiting: provider unavailable/)).toBeInTheDocument();
+  });
+  it('preserves existing family plans and refuses to save when the plan cannot be read', async () => {
+    const user = userEvent.setup();
+    show();
+    await select(user);
+    api.getQuotaBurn.mockResolvedValueOnce({ config: { families: { claude: { jobs: [{ id: 'existing' }] } } } });
+    await user.click(screen.getByRole('button', { name: 'Run now' }));
+    expect(await screen.findByText(/This family already has a plan/)).toBeInTheDocument();
+    expect(api.saveQuotaBurn).not.toHaveBeenCalled();
+    api.getQuotaBurn.mockRejectedValueOnce(new Error('offline'));
+    await user.click(screen.getByRole('button', { name: 'Run now' }));
+    expect(await screen.findByText(/Could not check existing plan: offline/)).toBeInTheDocument();
+    expect(api.saveQuotaBurn).not.toHaveBeenCalled();
+    expect(api.runQuotaBurn).not.toHaveBeenCalled();
+  });
+  it('links to the saved plan after dispatch transport failure', async () => {
+    const user = userEvent.setup();
+    show();
+    await select(user);
+    api.runQuotaBurn.mockRejectedValueOnce(new Error('runner offline'));
+    await user.click(screen.getByRole('button', { name: 'Run now' }));
+    expect(await screen.findByText(/Sequence saved, but could not start: runner offline/)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Manage sequence/ })).toHaveAttribute('href', '/devtools/quota-burn/claude');
   });
   it('blocks missing task eligibility and a stopped daemon', async () => {
     const user = userEvent.setup();

--- a/server/lib/importScoping.test.js
+++ b/server/lib/importScoping.test.js
@@ -39,6 +39,8 @@ const reaches = (entry, target) => staticImportClosure(abs(entry)).files.has(abs
 // Each row: the entry that was narrowed, the module it must no longer
 // statically reach, and why the entry only ever needed a slice of it.
 const NARROWED = [
+  ['lib/providerFamilies.js', 'lib/grok.js',
+    'shares browser-safe family identity without Grok filesystem helpers'],
   ['services/promptSections/instructions.js', 'services/taskScheduleRegistry.js',
     'needs task names, which scheduledTaskTypes.js declares'],
   ['services/agentAppWorkspace.js', 'services/promptRunner.js',

--- a/server/lib/providerFamilies.js
+++ b/server/lib/providerFamilies.js
@@ -1,6 +1,5 @@
 import { isClaudeHarnessProvider } from './providerTypes.js';
 import { commandBasename } from './providerModels.js';
-import { isGrokCommand } from './grok.js';
 
 /**
  * Subscription-quota FAMILY identity: which provider configs belong to the same
@@ -45,7 +44,7 @@ export const PROVIDER_FAMILIES = [
     id: 'grok',
     label: 'Grok',
     idPattern: /grok/i,
-    matches: (p) => isGrokCommand(p.command) || /grok/i.test(p.id || '')
+    matches: (p) => commandBasename(p.command) === 'grok' || /grok/i.test(p.id || '')
   }
 ];
 


### PR DESCRIPTION
## Summary
Adds “Run maintenance now” beneath the recommended maintenance order on Scheduled Tasks. Users select an app and a subscription CLI/TUI provider, model, and effort. The launcher reuses the existing ordered Quota Burn sequence, including perpetual issue drains, and applies the selected pins to every step.

The form explains and requires consent to enabling Quota Burn and creating a plan in an empty family; existing plans are preserved. It waits for the save before dispatch, blocks ineligible task/app selections and stopped CoS, and displays dispatch failures or waiting reasons. Subsequent steps retain Quota Burn’s quota gates.

## Test plan
- Client: 28 focused tests across the launch form, ScheduleTab, and shared sequence catalog passed.
- Client production build passed.
- Biome lint passed for the changed files.
- Server: 56 tests covering import scoping and Grok helpers passed.
- Read-only Claude review completed its configured one-round budget; material findings fixed and verified.
