### PR TITLE
fix: require substantive review in issue-only audits

### DIFF
--- a/server/lib/auditCatalog.js
+++ b/server/lib/auditCatalog.js
@@ -37,15 +37,16 @@ Your deliverable is tracker items, not code. The run must end with the same \`gi
 ## How to run this audit
 
 1. **Pick a bounded slice and say so first.** Do NOT attempt the whole repository. Choose one coherent area (a feature directory, a route group, a handful of related screens) — prefer one that recent audit issues have not already covered — and open your report by naming the slice in one line.
-2. **Read the actual code.** Every finding must cite \`path/to/file.js:LINE\` and describe a concrete, reproducible impact: a reachable runtime/data failure, a CI or release failure, or recurring manual churn demonstrated by repository history. Delete subjective style preferences and any finding whose consequence you cannot prove.
-3. **De-duplicate before filing.** Follow the Inventory step under "Where to record findings" above. If it is already filed, skip it; comment on the existing item only when you have genuinely new evidence.
-4. **File each surviving finding as its own item.** One problem per item — never a bundle. Cap yourself at 5. Bodies must be decision-complete:
+2. **Complete a substantive review before filing.** Spend most of the available run budget investigating and validating candidates, reserving time for de-duplication, filing, and the final report. Within the bounded slice, inventory at least three distinct relevant paths or components (or all of them if fewer exist), then inspect their callers, consumers, tests, and relevant history. Finding or filing the first issue is NOT a stopping condition: continue through the remaining inventory, including when the first candidate is a duplicate or rejected. Stop when the inventory is reviewed, the configured run budget is nearly exhausted, or a concrete blocker prevents further review; do not idle to fill time or exceed the run budget.
+3. **Read the actual code.** Every finding must cite \`path/to/file.js:LINE\` and describe a concrete, reproducible impact: a reachable runtime/data failure, a CI or release failure, or recurring manual churn demonstrated by repository history. Delete subjective style preferences and any finding whose consequence you cannot prove.
+4. **De-duplicate before filing.** Follow the Inventory step under "Where to record findings" above. If it is already filed, skip it; comment on the existing item only when you have genuinely new evidence.
+5. **File the highest-value surviving findings as separate items after the review.** One root cause per item — never split one problem to inflate the count. Cap yourself at 5 (or a lower mission-specific cap); this is a filing ceiling, not a review limit or a quota. Zero or one issue is valid after a substantive review. Bodies must be decision-complete:
    - **Problem** — what is wrong, with file:line references.
    - **Impact** — the observable consequence (runtime, data, CI/release, or recurring maintenance), not a code-smell label.
    - **Fix** — the approach you have DECIDED on, with the files it touches. If the only obstacle was a design choice, make the call and state it. Do not file a question.
    - **Acceptance criteria** — checkboxes another agent can verify cold.
-5. **Redact before you publish.** An issue is world-readable the moment it is filed. Never paste a secret, credential, token, hostname, IP address, absolute path containing a username, or any personal record into a title or body.
-6. **Report at the end**: the slice you audited, each item you filed, and anything you deliberately did not file and why.
+6. **Redact before you publish.** An issue is world-readable the moment it is filed. Never paste a secret, credential, token, hostname, IP address, absolute path containing a username, or any personal record into a title or body.
+7. **Report at the end**: the slice and paths reviewed, each item you filed, candidates you deliberately did not file and why, any unreviewed inventory, and the reason you stopped.
 
 Read this repository's \`AGENTS.md\` (and any nested per-directory ones covering the slice) before you start, and honor its conventions and its explicitly declared non-issues.`;
 

--- a/server/lib/auditCatalog.test.js
+++ b/server/lib/auditCatalog.test.js
@@ -170,6 +170,7 @@ describe('mode contracts + wrapper', () => {
     expect(FILE_ISSUES_MODE_CONTRACT).toContain('filing ceiling, not a review limit or a quota');
     expect(FILE_ISSUES_MODE_CONTRACT).toContain('do not idle to fill time or exceed the run budget');
     expect(FILE_ISSUES_MODE_CONTRACT).toContain('any unreviewed inventory');
+    expect(FILE_ISSUES_MODE_CONTRACT).toContain('Zero or one issue is valid after a substantive review');
     expect(modeContractFor(true)).toBe(FILE_ISSUES_MODE_CONTRACT);
   });
 

--- a/server/lib/auditCatalog.test.js
+++ b/server/lib/auditCatalog.test.js
@@ -165,6 +165,11 @@ describe('mode contracts + wrapper', () => {
     expect(FILE_ISSUES_MODE_CONTRACT).toContain('same `git status`');
     expect(FILE_ISSUES_MODE_CONTRACT).toContain('CI or release failure');
     expect(FILE_ISSUES_MODE_CONTRACT).toContain('recurring manual churn');
+    expect(FILE_ISSUES_MODE_CONTRACT).toContain('first issue is NOT a stopping condition');
+    expect(FILE_ISSUES_MODE_CONTRACT).toContain('at least three distinct relevant paths');
+    expect(FILE_ISSUES_MODE_CONTRACT).toContain('filing ceiling, not a review limit or a quota');
+    expect(FILE_ISSUES_MODE_CONTRACT).toContain('do not idle to fill time or exceed the run budget');
+    expect(FILE_ISSUES_MODE_CONTRACT).toContain('any unreviewed inventory');
     expect(modeContractFor(true)).toBe(FILE_ISSUES_MODE_CONTRACT);
   });
 


### PR DESCRIPTION
## Summary
Issue-only scheduled audits, including the better-* lanes, now complete a bounded review across at least three relevant paths when available before filing the highest-value findings. The first finding no longer serves as a stopping condition; the shared dispatch contract directs most of the available budget toward investigation and requires reporting coverage and the stopping reason.

The five-issue ceiling remains a maximum, with zero or one issue valid after review. Implement mode is unchanged. Because the guidance is injected at dispatch, existing customized prompts receive it without a prompt migration.

## Test plan
- Passed 259 focused tests across auditCatalog, taskPromptDefaults, and cosTaskGenerator.
- Passed all 32 auditCatalog tests after adding the reviewer-suggested zero-or-one-issue assertion.
- Configured optional Claude review completed its one-round budget; applied its assertion suggestion. Its output included extra prose, so the strict verdict was recorded as optional inconclusive.
