### PR TITLE
fix: support effort pins for configured provider reviewers

### DIFF
--- a/client/src/components/cos/ReviewerPicker.jsx
+++ b/client/src/components/cos/ReviewerPicker.jsx
@@ -16,7 +16,7 @@ import {
   sanitizeReviewerModelInput
 } from './constants';
 import ProviderModelSelector from '../ProviderModelSelector';
-import { selectableModelsForProvider } from '../../utils/providers';
+import { selectableModelsForProvider, effortLevelsForProvider, effectiveModelFor } from '../../utils/providers';
 import { isProviderReviewer, normalizeReviewerSlug } from '../../lib/reviewerPins';
 
 const normalizeReviewerValue = (value) => normalizeReviewerSlug(value);
@@ -149,6 +149,7 @@ export default function ReviewerPicker({
   const id = useId();
   const [addProviderId, setAddProviderId] = useState('');
   const [addProviderModel, setAddProviderModel] = useState('');
+  const [addProviderEffort, setAddProviderEffort] = useState('');
   const providerRecords = modelOptions?.providers || [];
   const addProvider = providerRecords.find(provider => provider.id === addProviderId);
   const labelFor = (token) => isProviderReviewer(token)
@@ -426,9 +427,8 @@ export default function ReviewerPicker({
     </select>
   );
 
-  // The Effort cell. Only EFFORT_SELECTABLE_REVIEWERS get one, and each offers
-  // only its own CLI's ladder — copilot has no CLI, grok's takes no effort flag,
-  // and a `@username` reviewer is a person.
+  // The Effort cell uses the configured provider catalog for provider identities
+  // and the built-in reviewer ladder for legacy CLI tokens.
   //
   // The ladder is narrowed by the row's PINNED MODEL where the CLI validates the
   // pair: `agy` rejects `gemini-3.1-pro --effort medium`, so offering `medium`
@@ -439,9 +439,10 @@ export default function ReviewerPicker({
   const renderEffortCell = (token) => {
     const subject = labelFor(token);
     const stored = efforts.get(token) ?? '';
-    const ladder = reviewerEffortLevels(token);
-    if (!ladder?.length) return renderNoPinCell(`${subject} has no reasoning-effort control`);
-    const levels = modelOptions?.modelEffortLevels?.(token, models.get(token)) ?? ladder;
+    const provider = providerRecords.find(record => `provider:${record.id}` === token);
+    const levels = isProviderReviewer(token)
+      ? effortLevelsForProvider(provider, effectiveModelFor(provider, models.get(token))) || []
+      : modelOptions?.modelEffortLevels?.(token, models.get(token)) ?? reviewerEffortLevels(token, models.get(token)) ?? [];
     // A pinned model whose catalog lists NO tiers still renders the select when
     // something is stored, so a pin made before the model changed (or on another
     // machine) stays visible and clearable rather than vanishing behind the dash.
@@ -685,8 +686,10 @@ export default function ReviewerPicker({
             selectedProviderId={addProviderId}
             selectedModel={addProviderModel}
             availableModels={addProvider ? selectableModelsForProvider(addProvider, addProvider.models || []) : []}
-            onProviderChange={value => { setAddProviderId(value); setAddProviderModel(''); }}
+            onProviderChange={value => { setAddProviderId(value); setAddProviderModel(''); setAddProviderEffort(''); }}
             onModelChange={setAddProviderModel}
+            effort={addProviderEffort}
+            onEffortChange={setAddProviderEffort}
             emptyProviderOption="Choose a reviewer provider"
             emptyModelOption="Provider default"
             alwaysShowModel
@@ -696,8 +699,8 @@ export default function ReviewerPicker({
             className="text-sm text-port-accent disabled:opacity-50 self-start"
             onClick={() => {
               const token = `provider:${addProviderId}`;
-              emit({ reviewers: [...selected, token], reviewerModels: { ...modelsMap, ...(addProviderModel ? { [token]: addProviderModel } : {}) } });
-              setAddProviderId(''); setAddProviderModel('');
+              emit({ reviewers: [...selected, token], reviewerModels: { ...modelsMap, ...(addProviderModel ? { [token]: addProviderModel } : {}) }, reviewerEfforts: { ...effortsMap, ...(addProviderEffort ? { [token]: addProviderEffort } : {}) } });
+              setAddProviderId(''); setAddProviderModel(''); setAddProviderEffort('');
             }}>Add provider reviewer</button>
           <p className="text-xs text-gray-500">Choose from your enabled AI providers. Providers need an API text transport or an enforced tool-free harness to run reviews.</p>
         </div>

--- a/client/src/components/cos/ReviewerPicker.test.jsx
+++ b/client/src/components/cos/ReviewerPicker.test.jsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -5,6 +6,26 @@ import ReviewerPicker from './ReviewerPicker';
 import { typeSettled } from '../../test/settledInput';
 
 describe('ReviewerPicker', () => {
+  it('adds, edits, and clears effort for a configured provider reviewer', () => {
+    const onChange = vi.fn();
+    const providers = [{ id: 'codex-tui', name: 'Codex TUI', command: 'codex', enabled: true, defaultModel: 'gpt-6-astra', models: ['gpt-6-astra'] }];
+    function Form() {
+      const [config, setConfig] = useState({ reviewers: [] });
+      return <ReviewerPicker {...config} modelOptions={{ providers }} onChange={value => { onChange(value); setConfig(value); }} />;
+    }
+    render(<Form />);
+    fireEvent.change(screen.getByLabelText('Provider'), { target: { value: 'codex-tui' } });
+    fireEvent.change(screen.getByLabelText('Thinking effort'), { target: { value: 'ultra' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Add provider reviewer' }));
+    const effort = screen.getByLabelText('Reasoning effort for Codex TUI');
+    expect(effort).toHaveValue('ultra');
+    expect([...effort.options].map(option => option.value)).not.toContain('minimal');
+    fireEvent.change(effort, { target: { value: 'high' } });
+    expect(onChange.mock.lastCall[0].reviewerEfforts).toEqual({ 'provider:codex-tui': 'high' });
+    fireEvent.change(effort, { target: { value: '' } });
+    expect(onChange.mock.lastCall[0].reviewerEfforts).toEqual({});
+  });
+
   it('renders the selected reviewers in order with numbered badges', () => {
     render(<ReviewerPicker reviewers={['codex', 'antigravity', 'copilot']} onChange={() => {}} />);
     expect(screen.getByText('1.')).toBeInTheDocument();

--- a/server/lib/reviewerConfig.js
+++ b/server/lib/reviewerConfig.js
@@ -636,7 +636,10 @@ export function normalizeReviewerEffort(raw, reviewer, model = null) {
   if (typeof raw !== 'string') return undefined;
   const effort = raw.trim().toLowerCase();
   if (!effort) return undefined;
-  return reviewerEffortLevels(reviewer, model)?.includes(effort) ? effort : undefined;
+  // Provider identities are dynamic; their model-specific ladder is resolved from
+  // the provider catalog at selection/execution, while storage accepts known tiers.
+  const levels = isProviderReviewer(reviewer) ? EFFORT_LEVELS : reviewerEffortLevels(reviewer, model);
+  return levels?.includes(effort) ? effort : undefined;
 }
 
 /**

--- a/server/lib/reviewerConfig.test.js
+++ b/server/lib/reviewerConfig.test.js
@@ -203,6 +203,7 @@ describe('per-reviewer reasoning effort (reviewerEfforts)', () => {
   it('DROPS rather than clamps a level the reviewer rejects — a displayed effort must be the one it runs', () => {
     // `agy` really does reject `--effort max`; clamping it to `high` would review
     // at a different effort than the picker shows.
+    expect(normalizeReviewerEfforts({ 'provider:codex-tui': 'ultra', 'provider:custom': 'invalid' })).toEqual({ 'provider:codex-tui': 'ultra' });
     expect(normalizeReviewerEfforts({ antigravity: 'max' })).toEqual({});
     // grok rejects `max` the way agy rejects it — dropped, not clamped.
     expect(normalizeReviewerEfforts({ grok: 'max' })).toEqual({});

--- a/server/services/codeReview.js
+++ b/server/services/codeReview.js
@@ -12,6 +12,7 @@
  * has to fit inside the agent's `curl` step.
  */
 
+import { effortLevelsForProvider } from '../lib/providerModels.js'
 import { fetchWithTimeout } from '../lib/fetchWithTimeout.js'
 import { readResponseJson } from '../lib/readResponseJson.js'
 import { commandExists } from '../lib/commandExists.js'
@@ -434,13 +435,13 @@ async function resolveServedModel(backend, baseUrl) {
 
 // Resolve the exact record the user selected. Never fall back to the active
 // provider, another account, or a replacement model for a pinned reviewer.
-async function runConfiguredProviderCompletion({ backend, model: pinnedModel, messages, timeoutMs }) {
+async function runConfiguredProviderCompletion({ backend, model: pinnedModel, messages, effort, timeoutMs }) {
   const { getProviderById } = await import('./providers.js')
   const { getAIToolkitInstance } = await import('../lib/aiToolkitState.js')
   const providerId = backend.slice('provider:'.length)
   // The auth-independent claim bridge has no server bootstrap. Use the same
   // provider-store reader there without starting a server or creating runners.
-  const provider = getAIToolkitInstance()
+  let provider = getAIToolkitInstance()
     ? await getProviderById(providerId)
     : await import('../lib/aiToolkit/providers.js').then(async ({ createProviderService }) => {
       const { PATHS } = await import('../lib/paths.js')
@@ -448,6 +449,10 @@ async function runConfiguredProviderCompletion({ backend, model: pinnedModel, me
     })
   if (!provider || provider.enabled === false) return { ok: false, error: 'Reviewer provider is missing or disabled.' }
   const model = pinnedModel || provider.defaultModel
+  if (effort && !effortLevelsForProvider(provider, model)?.includes(effort)) {
+    return { ok: false, error: 'The selected reviewer model does not support this reasoning effort.' }
+  }
+  if (effort) provider = { ...provider, effort }
   const prompt = messages.map(message => message.content).join('\n\n')
   const { isCodexTextTransportEnabled } = await import('../lib/codexTurn.js')
   let result
@@ -480,11 +485,11 @@ async function runConfiguredProviderCompletion({ backend, model: pinnedModel, me
     }
   }
   if (result.error || !result.text?.trim()) return { ok: false, error: result.error || 'Reviewer returned no content.' }
-  return { ok: true, backend, model, effort: null, content: result.text.trim() }
+  return { ok: true, backend, model, effort: effort || provider.effort || null, content: result.text.trim() }
 }
 
 async function runToolFreeLocalCompletion({ backend, model: pinnedModel, messages, effort, timeoutMs, baseUrl: requestedBaseUrl = null }) {
-  if (isProviderReviewer(backend)) return runConfiguredProviderCompletion({ backend, model: pinnedModel, messages, timeoutMs })
+  if (isProviderReviewer(backend)) return runConfiguredProviderCompletion({ backend, model: pinnedModel, messages, effort, timeoutMs })
   if (!isLocalLlmReviewer(backend)) {
     return { ok: false, error: `Unsupported reviewer backend: ${backend}` }
   }

--- a/server/services/codeReview.providers.test.js
+++ b/server/services/codeReview.providers.test.js
@@ -74,10 +74,12 @@ describe('configured provider reviewers', () => {
     const cli = { ...provider, type: 'tui', command: 'claude' };
     getProviderById.mockResolvedValue(cli);
     runCliProviderPrompt.mockResolvedValue({ text: '{"type":"result","result":"NO FINDINGS"}', partial: false, streamFormat: 'stream-json' });
-    const result = await runLocalCodeReview({ backend, model: 'pinned-coder', diff: 'example diff' });
-    expect(result).toMatchObject({ ok: true, findings: 'NO FINDINGS' });
+    const task = sanitizeTaskMetadata({ reviewers: [backend], reviewerEfforts: { [backend]: 'high' } });
+    expect(task.reviewerEfforts).toEqual({ [backend]: 'high' });
+    const result = await runLocalCodeReview({ backend, model: 'pinned-coder', effort: task.reviewerEfforts[backend], diff: 'example diff' });
+    expect(result).toMatchObject({ ok: true, findings: 'NO FINDINGS', effort: 'high' });
     const args = runCliProviderPrompt.mock.calls[0][0];
-    expect(args).toMatchObject({ provider: cli, model: 'pinned-coder', safetyProfile: 'public-review-gate' });
+    expect(args).toMatchObject({ provider: { ...cli, effort: 'high' }, model: 'pinned-coder', safetyProfile: 'public-review-gate' });
     await expect(access(args.cwd)).rejects.toThrow();
     expect(callProviderAISimple).not.toHaveBeenCalled();
 
@@ -85,6 +87,13 @@ describe('configured provider reviewers', () => {
     expect(await runLocalCodeReview({ backend, diff: 'example diff' })).toMatchObject({ ok: false });
     runCliProviderPrompt.mockResolvedValue({ text: 'NO FINDINGS', partial: true });
     expect(await runLocalCodeReview({ backend, diff: 'example diff' })).toMatchObject({ ok: false });
+  });
+
+  it('refuses an unsupported effort before invoking the provider', async () => {
+    getProviderById.mockResolvedValue({ ...provider, type: 'tui', command: 'codex', defaultModel: 'gpt-6-astra' });
+    expect(await runLocalCodeReview({ backend, effort: 'minimal', diff: 'example diff' })).toMatchObject({ ok: false, error: expect.stringContaining('reasoning effort') });
+    expect(callProviderAISimple).not.toHaveBeenCalled();
+    expect(runCliProviderPrompt).not.toHaveBeenCalled();
   });
 
   it('refuses an unsupported harness instead of spawning it with ordinary agent permissions', async () => {


### PR DESCRIPTION
## Summary
Configured provider reviewers now offer reasoning effort both when adding a reviewer and in its existing row, using the shared provider/model catalog. Task effort pins survive normalization and reach the configured reviewer transport; unsupported model/effort pairs fail explicitly.

## Test plan
- Client ReviewerPicker: 85 tests passed, including adding, editing, and clearing a Codex TUI / Astra effort pin.
- Server reviewer configuration, configured-provider execution, code review service, and route suites: 157 tests passed.
- Reviewed changes for shared-helper reuse, compatibility, and private data; `git diff --check` passed.
