### PR TITLE
fix: gate database restore on valid preview (#6671)

### DIFF
--- a/client/src/components/settings/BackupTab.jsx
+++ b/client/src/components/settings/BackupTab.jsx
@@ -195,11 +195,18 @@ export function BackupTab() {
 
   const handleRestoreDb = async (snapshotId) => {
     setRestorePreview(null);
+    setRestoreTarget(null);
     // Dry-run first to show what would restore, then open the confirm modal.
     const preview = await restoreDatabase({ snapshotId, dryRun: true }, { silent: true })
       .catch(() => null);
     if (!preview || preview.status === 'skipped') {
       toast.error(preview?.reason === 'no_dump' ? 'No DB dump in this snapshot' : 'DB restore unavailable');
+      return;
+    }
+    if (preview.status !== 'ok') {
+      toast.error(preview.reason === 'manifest_mismatch'
+        ? 'Snapshot dump failed integrity verification'
+        : `DB restore unavailable: ${preview.reason || 'unknown'}`);
       return;
     }
     setRestorePreview(preview);

--- a/client/src/components/settings/BackupTab.test.jsx
+++ b/client/src/components/settings/BackupTab.test.jsx
@@ -183,6 +183,21 @@ describe('BackupTab', () => {
       expect(toast.error).toHaveBeenCalledWith('No DB dump in this snapshot');
       expect(screen.queryByText(/Restore database\?/i)).toBeNull();
     });
+
+    it('aborts and reports an integrity failure before confirmation', async () => {
+      withSnapshot();
+      restoreDatabase.mockResolvedValue({ status: 'failed', reason: 'manifest_mismatch' });
+      await renderTab();
+
+      await act(async () => {
+        fireEvent.click(await screen.findByRole('button', { name: /Restore DB/i }));
+      });
+
+      expect(restoreDatabase).toHaveBeenCalledTimes(1);
+      expect(restoreDatabase).toHaveBeenCalledWith({ snapshotId: 'snap-2026-06-09', dryRun: true }, { silent: true });
+      expect(toast.error).toHaveBeenCalledWith('Snapshot dump failed integrity verification');
+      expect(screen.queryByText(/Restore database\?/i)).toBeNull();
+    });
   });
 
   describe('Run Now gating (saved state)', () => {


### PR DESCRIPTION
## Summary

Gate database restore confirmation on a successful dry-run preview and surface manifest integrity failures before any destructive action.

## Tests

- `npm test -- --run src/components/settings/BackupTab.test.jsx` (30 tests passed)
- `git diff --check`

Closes #6671
