### PR TITLE
perf: skip unused CoS status during live activity polls

### DIFF
--- a/server/services/activeProcessing.js
+++ b/server/services/activeProcessing.js
@@ -8,17 +8,17 @@ import * as cos from './cos.js';
 const LIVE_STATUSES = new Set(['queued', 'running']);
 
 export async function getActiveProcessing() {
-  const [capability, jobs, models, loadedModels, taskData, cosStatus, agents] = await Promise.all([
+  const [capability, jobs, models, loadedModels, taskData, agents] = await Promise.all([
     getCudaCapability(),
     Promise.resolve(listJobs()).then((items) => items.filter((job) => LIVE_STATUSES.has(job.status))),
     listModels().catch(() => []),
     getLoadedModels().catch(() => []),
     cos.getAllTasks().catch(() => ({ user: {}, cos: {} })),
-    cos.getStatus().catch(() => null),
     // `null` = the read FAILED, distinct from `[]` = read fine, no agents. The
     // counts below degrade differently for the two, so they must stay separable.
     cos.getAgents().catch(() => null),
   ]);
+  const cosStatus = agents === null ? await cos.getStatus().catch(() => null) : null;
   const utilization = capability.status === 'available' ? await getCudaUtilization() : { status: capability.status, gpus: [] };
   // A task stays 'pending' until spawnAgentForTask flips it to 'in_progress',
   // which happens AFTER its agent is registered as running — so a snapshot taken

--- a/server/services/activeProcessing.test.js
+++ b/server/services/activeProcessing.test.js
@@ -37,6 +37,7 @@ describe('active processing snapshot', () => {
     expect(snapshot.extras.imageTo3d).toEqual([{ id: 'mesh-1', name: 'Fake mesh' }]);
     expect(snapshot.extras.ollama).toEqual([{ id: 'model-1', name: 'Fake model' }]);
     expect(snapshot.agents).toEqual({ active: 2, queued: 1 });
+    expect(deps.status).not.toHaveBeenCalled();
   });
 
   it('preserves an absent GPU as a real negative state without probing utilization', async () => {
@@ -95,14 +96,25 @@ describe('queued agent count', () => {
     deps.agents.mockRejectedValue(new Error('state unreadable'));
     const snapshot = await getActiveProcessing();
     expect(snapshot.agents).toEqual({ active: 3, queued: 1 });
+    expect(deps.status).toHaveBeenCalledTimes(1);
   });
 
   // ...and a successful read of an EMPTY list still means zero, not the fallback.
-  it('reports zero active from a successfully empty agent list', async () => {
-    deps.status.mockResolvedValue({ activeAgents: 7 });
+  it('reports zero active from an empty agent list without waiting for status', async () => {
+    deps.status.mockImplementation(() => new Promise(() => {}));
     deps.tasks.mockResolvedValue({ user: { tasks: [{ id: 'task-1', status: 'pending' }] }, cos: { tasks: [] } });
     deps.agents.mockResolvedValue([]);
     const snapshot = await getActiveProcessing();
     expect(snapshot.agents).toEqual({ active: 0, queued: 1 });
+    expect(deps.status).not.toHaveBeenCalled();
+  });
+
+  it('preserves pending tasks when both agent and fallback status reads fail', async () => {
+    deps.tasks.mockResolvedValue({ user: { tasks: [{ id: 'task-1', status: 'pending' }] }, cos: { tasks: [] } });
+    deps.agents.mockRejectedValue(new Error('state unreadable'));
+    deps.status.mockRejectedValue(new Error('status unavailable'));
+    const snapshot = await getActiveProcessing();
+    expect(snapshot.agents).toEqual({ active: 0, queued: 1 });
+    expect(deps.status).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
Live activity snapshots now skip the CoS status aggregation when the agent read succeeds, including an empty list. Failed reads retain the existing status fallback, and active/queued counts still use the same successful agent snapshot.

Validation: `cd server && npm test -- services/activeProcessing.test.js` — 7 tests passed. Coverage includes an unresolved status provider on a successful read and failure of both recovery sources. Claude reviewed the committed diff at medium effort with tools disabled; no correctness blockers remained after checking the status aggregation.

Closes #6689
