### PR TITLE
fix: read embedding models from public status (#6703)

### DIFF
--- a/client/src/components/settings/EmbeddingsTab.jsx
+++ b/client/src/components/settings/EmbeddingsTab.jsx
@@ -39,8 +39,8 @@ export default function EmbeddingsTab() {
     setModelsLoading(true);
     const status = await getLocalLlmStatus({ silent: true }).catch(() => null);
     setModels({
-      ollama: (status?.ollama?.installedModels || []).map((m) => m.id || m.name),
-      lmstudio: (status?.lmstudio?.installedModels || []).map((m) => m.id || m.name),
+      ollama: (status?.ollama?.models || []).map((m) => m.id || m.name),
+      lmstudio: (status?.lmstudio?.models || []).map((m) => m.id || m.name),
     });
     setModelsLoading(false);
   };

--- a/client/src/components/settings/EmbeddingsTab.test.jsx
+++ b/client/src/components/settings/EmbeddingsTab.test.jsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
 
 vi.mock('../../services/apiSystem', () => ({
@@ -7,10 +7,9 @@ vi.mock('../../services/apiSystem', () => ({
   updateSettings: vi.fn(),
 }));
 vi.mock('../../services/apiLocalLlm', () => ({
-  getLocalLlmStatus: vi.fn().mockResolvedValue({
-    ollama: { models: [{ id: 'nomic-embed-text' }] },
-    lmstudio: { models: [] },
-  }),
+  getLocalLlmStatus: vi.fn()
+    .mockResolvedValueOnce({ ollama: { models: [{ id: 'custom-embed:latest' }] }, lmstudio: { models: [] } })
+    .mockResolvedValueOnce({ ollama: { models: [] }, lmstudio: { models: [{ id: 'example/custom-embedding' }] } }),
 }));
 vi.mock('../ui/Toast', () => ({
   default: Object.assign(vi.fn(), { success: vi.fn(), error: vi.fn() }),
@@ -19,9 +18,14 @@ vi.mock('../ui/Toast', () => ({
 import EmbeddingsTab from './EmbeddingsTab.jsx';
 
 describe('EmbeddingsTab', () => {
-  it('reads installed embedding choices from the public models field', async () => {
+  it('reads installed embedding choices from the public models field for both backends', async () => {
     render(<MemoryRouter><EmbeddingsTab /></MemoryRouter>);
 
-    await waitFor(() => expect(screen.getByRole('option', { name: 'nomic-embed-text' })).toBeInTheDocument());
+    const datalist = () => document.getElementById('embeddings-model-options');
+    await waitFor(() => expect(datalist().querySelector('option[value="custom-embed:latest"]')).toBeTruthy());
+
+    fireEvent.change(screen.getByLabelText('Provider'), { target: { value: 'lmstudio' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh' }));
+    await waitFor(() => expect(datalist().querySelector('option[value="example/custom-embedding"]')).toBeTruthy());
   });
 });

--- a/client/src/components/settings/EmbeddingsTab.test.jsx
+++ b/client/src/components/settings/EmbeddingsTab.test.jsx
@@ -9,6 +9,7 @@ vi.mock('../../services/apiSystem', () => ({
 vi.mock('../../services/apiLocalLlm', () => ({
   getLocalLlmStatus: vi.fn()
     .mockResolvedValueOnce({ ollama: { models: [{ id: 'custom-embed:latest' }] }, lmstudio: { models: [] } })
+    .mockResolvedValueOnce({ ollama: { models: [] }, lmstudio: { models: [] } })
     .mockResolvedValueOnce({ ollama: { models: [] }, lmstudio: { models: [{ id: 'example/custom-embedding' }] } }),
 }));
 vi.mock('../ui/Toast', () => ({
@@ -23,6 +24,12 @@ describe('EmbeddingsTab', () => {
 
     const datalist = () => document.getElementById('embeddings-model-options');
     await waitFor(() => expect(datalist().querySelector('option[value="custom-embed:latest"]')).toBeTruthy());
+
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh' }));
+    await waitFor(() => expect(datalist().querySelector('option[value="custom-embed:latest"]')).toBeFalsy());
+    expect(datalist().querySelector('option[value="nomic-embed-text"]')).toBeTruthy();
+    fireEvent.change(screen.getByLabelText('Model'), { target: { value: 'manual-embedding-model' } });
+    expect(screen.getByLabelText('Model')).toHaveValue('manual-embedding-model');
 
     fireEvent.change(screen.getByLabelText('Provider'), { target: { value: 'lmstudio' } });
     fireEvent.click(screen.getByRole('button', { name: 'Refresh' }));

--- a/client/src/components/settings/EmbeddingsTab.test.jsx
+++ b/client/src/components/settings/EmbeddingsTab.test.jsx
@@ -1,0 +1,27 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+
+vi.mock('../../services/apiSystem', () => ({
+  getSettings: vi.fn().mockResolvedValue({ embeddings: { provider: 'ollama', model: '' } }),
+  updateSettings: vi.fn(),
+}));
+vi.mock('../../services/apiLocalLlm', () => ({
+  getLocalLlmStatus: vi.fn().mockResolvedValue({
+    ollama: { models: [{ id: 'nomic-embed-text' }] },
+    lmstudio: { models: [] },
+  }),
+}));
+vi.mock('../ui/Toast', () => ({
+  default: Object.assign(vi.fn(), { success: vi.fn(), error: vi.fn() }),
+}));
+
+import EmbeddingsTab from './EmbeddingsTab.jsx';
+
+describe('EmbeddingsTab', () => {
+  it('reads installed embedding choices from the public models field', async () => {
+    render(<MemoryRouter><EmbeddingsTab /></MemoryRouter>);
+
+    await waitFor(() => expect(screen.getByRole('option', { name: 'nomic-embed-text' })).toBeInTheDocument());
+  });
+});


### PR DESCRIPTION
Use the public local LLM status `models` arrays when populating embedding choices, and add rendered regression coverage for both backends, refresh behavior, empty results, known suggestions, and manual model entry.

Tests: `npm test -- --run src/components/settings/EmbeddingsTab.test.jsx` (passed); `npx biome lint --error-on-warnings src/components/settings/EmbeddingsTab.jsx src/components/settings/EmbeddingsTab.test.jsx` (passed). The regression test fails against the former `installedModels` reads (exit 1) and passes with the `models` fix.

Closes #6703