### PR TITLE
fix: preserve complete filenames in restore previews

### DIFF
--- a/server/services/backup.js
+++ b/server/services/backup.js
@@ -14,6 +14,7 @@ import { hostname } from 'os';
 import { join, resolve, relative, isAbsolute } from 'path';
 import { PATHS, ensureDir, readJSONFile, atomicWrite, sha256File } from '../lib/fileUtils.js';
 import { createFileWriteQueue } from '../lib/fileWriteQueue.js';
+import { createLineReader } from '../lib/streamLines.js';
 import { getEvent } from './eventScheduler.js';
 import { checkHealth, getServerMajorVersion } from '../lib/db.js';
 import { resolvePgDumpBinary } from '../lib/pgTools.js';
@@ -212,14 +213,12 @@ function runRsync(srcDir, destDir, flags = []) {
     const changed = [];
     let stderr = '';
 
-    proc.stdout.on('data', (chunk) => {
-      const lines = chunk.toString().split('\n').filter(Boolean);
-      for (const line of lines) {
-        if (line.startsWith('>') || line.startsWith('<')) {
-          changed.push(line);
-        }
+    const stdoutReader = createLineReader((line) => {
+      if (line.startsWith('>') || line.startsWith('<')) {
+        changed.push(line);
       }
     });
+    proc.stdout.on('data', stdoutReader.push);
 
     proc.stderr.on('data', (chunk) => {
       stderr += chunk.toString();
@@ -228,6 +227,7 @@ function runRsync(srcDir, destDir, flags = []) {
     proc.on('close', (code) => {
       // Exit code 24 = some files vanished mid-transfer (normal for active system)
       if (code === 0 || code === 24) {
+        stdoutReader.flush();
         resolve(changed);
       } else {
         reject(new Error(`rsync exited with code ${code}: ${stderr.trim()}`));

--- a/server/services/backup.test.js
+++ b/server/services/backup.test.js
@@ -1024,6 +1024,25 @@ describe('restoreSnapshot subdirFilter guard', () => {
     expect(spawn).not.toHaveBeenCalled();
   });
 
+  it('preserves complete restore preview paths across stdout byte boundaries', async () => {
+    const proc = fakeProc();
+    spawn.mockReturnValue(proc);
+    const restore = restoreSnapshot('/dest', 'snap-1');
+    await flush();
+
+    proc.stdout.emit('data', Buffer.from('>f+++++++++ example'));
+    const tail = Buffer.from('-settings.json\ncd+++++++++ ignored/\n<f.st...... café.json');
+    const split = tail.indexOf(Buffer.from('é')) + 1;
+    proc.stdout.emit('data', tail.subarray(0, split));
+    proc.stdout.emit('data', tail.subarray(split));
+    proc.emit('close', 0);
+
+    await expect(restore).resolves.toMatchObject({
+      dryRun: true,
+      changedFiles: ['>f+++++++++ example-settings.json', '<f.st...... café.json'],
+    });
+  });
+
   it('uses PORTOS_RSYNC when configured and keeps shell execution disabled', async () => {
     const previous = process.env.PORTOS_RSYNC;
     process.env.PORTOS_RSYNC = '/custom/bin/rsync';


### PR DESCRIPTION
## Summary
Restore previews now preserve complete filenames when rsync splits stdout across chunks, including UTF-8 characters and a final line without a newline. The existing shared line reader replaces the chunk-local splitter while retaining itemized-line filtering and exit-code handling.

## Test plan
- New restoreSnapshot regression failed on the original implementation and passes with the fix.
- Backup service, backup routes, and stream reader suites: 148 tests passed.
- Optional Claude local review at medium effort: CLEAN.

Closes #6708
