### PR TITLE
fix(creative-director): honor video audio contract

### DIFF
--- a/client/src/components/creative-director/VideoDraftDrawer.jsx
+++ b/client/src/components/creative-director/VideoDraftDrawer.jsx
@@ -35,7 +35,7 @@ export default function VideoDraftDrawer({ open, onClose, project, onSaved, cata
       videoMode: project?.renderBackend?.video?.mode || 'local', backendModelId: project?.renderBackend?.video?.modelId || '',
       aspectRatio: project?.aspectRatio || '16:9', quality: project?.quality || 'standard', modelId: (project?.renderBackend?.video?.mode === 'local' ? project.renderBackend.video.modelId : '') || project?.modelId || '',
       min: draft?.durationRange?.min || 30, max: draft?.durationRange?.max || 60,
-      reviewPolicy: draft?.reviewPolicy || 'review', transition: draft?.transition || 'cut', audioMode: draft?.audio?.mode || (project ? 'native' : 'silent'), trackId: draft?.audio?.trackId || '', audioPrompt: draft?.audio?.prompt || '', audioProvider: draft?.audio?.providerId || '', audioModel: draft?.audio?.model || '',
+      reviewPolicy: draft?.reviewPolicy || 'review', transition: draft?.transition || 'cut', audioMode: draft?.audio?.mode || 'native', trackId: draft?.audio?.trackId || '', audioPrompt: draft?.audio?.prompt || '', audioProvider: draft?.audio?.providerId || '', audioModel: draft?.audio?.model || '',
       sources: draft?.sources || catalogIngredientIds.map(id => ({ kind: 'catalog', id })) });
     listTracks({ silent: true }).then(data => setTracks(Array.isArray(data) ? data : data?.tracks || [])).catch(() => {});
     listMusicEngines({ silent: true }).then(data => setEngines(data?.engines || [])).catch(() => {});

--- a/client/src/components/creative-director/VideoDraftDrawer.test.jsx
+++ b/client/src/components/creative-director/VideoDraftDrawer.test.jsx
@@ -38,3 +38,8 @@ it('restores and saves a Reactor pin even when the local model list is unavailab
   await user.click(screen.getByRole('button', { name: 'Save draft' }));
   await waitFor(() => expect(updateCreativeDirectorProject).toHaveBeenCalledWith('reactor-draft', expect.objectContaining({ renderBackend: project.renderBackend }), { silent: true }));
 });
+
+it('defaults a new Video draft to native clip audio', async () => {
+  render(<MemoryRouter initialEntries={['/?videoDraftTab=production']}><VideoDraftDrawer open onClose={vi.fn()} onSaved={vi.fn()} /></MemoryRouter>);
+  expect(await screen.findByLabelText('Audio contract')).toHaveValue('native');
+});

--- a/client/src/components/creative-director/VideoExecutionPanel.jsx
+++ b/client/src/components/creative-director/VideoExecutionPanel.jsx
@@ -66,7 +66,7 @@ export default function VideoExecutionPanel({ project, onChange, basePath }) {
       <p className="text-xs text-port-text-muted">{preview.costNotice}</p>
       {preview.blockers.map(blocker => <p key={blocker} role="alert" className="text-port-warning">{blocker}</p>)}
       {preview.execution?.blocker && <p role="status" className="text-port-warning">{preview.execution.blocker}</p>}
-      <div className="flex flex-wrap gap-3 text-sm"><Link className="underline" to="/settings">Settings</Link><Link className="underline" to={`${basePath}/${project.id}/overview?models=1`}>Change models</Link><Link className="underline" to="/system-resources/queues">Inspect render queue</Link><Link className="underline" to={`${basePath}/${project.id}/review`}>Review artifacts</Link></div>
+      <div className="flex flex-wrap gap-3 text-sm"><Link className="underline" to="/video/generate?settings=1">Media settings</Link><Link className="underline" to={`${basePath}/${project.id}/overview?models=1`}>Change models</Link><Link className="underline" to="/system-resources/queues">Inspect render queue</Link><Link className="underline" to={`${basePath}/${project.id}/review`}>Review artifacts</Link></div>
       {limits && <div className="grid gap-3 sm:grid-cols-2">
         {LIMITS.map(([key, label, min, max]) => <div key={key}>
           <label className="block text-sm" htmlFor={`video-limit-${key}`}>{label}</label>

--- a/client/src/components/creative-director/VideoExecutionPanel.test.jsx
+++ b/client/src/components/creative-director/VideoExecutionPanel.test.jsx
@@ -16,6 +16,7 @@ it('shows reviewed choices and submits explicit limits with the displayed config
   const user = userEvent.setup();
   show('draft');
   expect(await screen.findByText('reactor · fast-h3')).toBeInTheDocument();
+  expect(screen.getByRole('link', { name: 'Media settings' })).toHaveAttribute('href', '/video/generate?settings=1');
   expect(startCreativeDirectorVideoExecution).not.toHaveBeenCalled();
   await user.clear(screen.getByLabelText('Maximum clip submissions'));
   expect(screen.getByRole('button', { name: 'Start production' })).toBeDisabled();

--- a/server/lib/creativeDirectorValidation.js
+++ b/server/lib/creativeDirectorValidation.js
@@ -156,7 +156,7 @@ export const creativeDirectorVideoDraftSchema = z.object({
     prompt: z.string().trim().max(1000).optional(),
     providerId: z.string().max(120).optional(),
     model: z.string().max(200).optional(),
-  }).strict().default({}),
+  }).strict().default({ mode: 'native' }),
   reviewPolicy: z.enum(['review', 'autonomous']).default('review'),
   checkpoints: z.array(z.enum(VIDEO_REVIEW_CHECKPOINTS))
     .max(VIDEO_REVIEW_CHECKPOINTS.length).default([...VIDEO_REVIEW_CHECKPOINTS]),
@@ -181,9 +181,10 @@ export const creativeDirectorProjectCreateSchema = z.object({
   // Server-derived from catalogIngredientIds; also accepted directly for off-UI
   // callers and sync. Schema-parity with buildProjectRecord's `cast` field.
   cast: z.array(creativeDirectorCastMemberSchema).max(50).optional(),
-  // Audio defaults OFF for CD projects — current model audio output is
+  // Legacy CD projects default audio OFF — current model audio output is
   // inconsistent across renders and the user can re-enable per-project.
-  // (videoGen one-offs still default to enabled.)
+  // Video workspace projects use videoDraft.audio instead; buildProjectRecord
+  // normalizes this legacy field off for those records.
   disableAudio: z.boolean().optional().default(true),
   autoAcceptScenes: z.boolean().optional().default(false),
   // Optional back-pointer to the pipeline issue that spawned this project,

--- a/server/services/creativeDirector/projectsLogic.js
+++ b/server/services/creativeDirector/projectsLogic.js
@@ -219,7 +219,11 @@ export function buildProjectRecord(input, { id, now, collectionId }) {
     // ingredients are also linked durably in catalog_ingredient_refs. Empty for
     // a bare project. Each member: { ingredientId, name, type, role, summary? }.
     cast: Array.isArray(cast) ? cast : [],
-    disableAudio,
+    // Video drafts use videoDraft.audio; keep the legacy top-level flag off on
+    // new Video records so old consumers cannot mistake a native draft for a
+    // request to strip clip audio. Legacy CD records retain their historical
+    // default and UI contract.
+    disableAudio: input.workspace === 'video' ? false : disableAudio,
     autoAcceptScenes,
     // Server-managed intent flag (#1867) — set on the project by the
     // auto-cast route when a user opts into both `compose` and

--- a/server/services/creativeDirector/projectsLogic.test.js
+++ b/server/services/creativeDirector/projectsLogic.test.js
@@ -161,6 +161,14 @@ describe('buildProjectRecord', () => {
     );
     expect(pinned.renderBackend).toEqual({ image: { mode: 'grok' }, video: { mode: 'local', modelId: 'example-model' } });
   });
+
+  it('keeps the legacy audio-off field disabled on new Video drafts', () => {
+    const p = buildProjectRecord({
+      workspace: 'video', name: 'Video draft', aspectRatio: '16:9', quality: 'standard', modelId: '', targetDurationSeconds: 30,
+    }, { id: 'video-1', now: 'now', collectionId: 'c-1' });
+    expect(p.videoDraft.audio.mode).toBe('native');
+    expect(p.disableAudio).toBe(false);
+  });
 });
 
 describe('normalizeRenderBackend (#3135)', () => {

--- a/server/services/creativeDirector/sceneRunner.backend.test.js
+++ b/server/services/creativeDirector/sceneRunner.backend.test.js
@@ -14,6 +14,8 @@
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
+const reviewState = vi.hoisted(() => ({ allowsDispatch: false }));
+
 vi.mock('../mediaJobQueue/index.js', () => ({
   enqueueJob: vi.fn(() => ({ jobId: 'job-1' })),
   getJob: vi.fn(() => null),
@@ -38,6 +40,7 @@ vi.mock('./local.js', () => ({
   getProject: vi.fn(async () => null),
 }));
 vi.mock('./sceneEvaluator.js', () => ({ dispatchSceneEvaluation: vi.fn(async () => {}) }));
+vi.mock('./videoReview.js', () => ({ videoReviewAllowsDispatch: vi.fn(async () => reviewState.allowsDispatch) }));
 vi.mock('../videoGen/local.js', () => ({
   extractLastFrame: vi.fn(async () => null),
   sampleEvaluationFrames: vi.fn(async () => []),
@@ -77,6 +80,7 @@ const enqueuedParams = () => enqueueJob.mock.calls[0][0].params;
 
 beforeEach(() => {
   vi.clearAllMocks();
+  reviewState.allowsDispatch = false;
   getProject.mockResolvedValue(null);
   resolveGalleryImage.mockReturnValue(null);
 });
@@ -241,6 +245,24 @@ describe('runSceneRender — Reactor and fal pins', () => {
     }));
     expect(updateScene.mock.calls.filter(([, , patch]) => patch.status === 'rendering')).toHaveLength(1);
   });
+
+  it('uses the Video audio contract instead of the legacy disableAudio flag', async () => {
+    reviewState.allowsDispatch = true;
+    const shot = scene({ status: 'pending', workRevision: 0 });
+    const video = project({ workspace: 'video', status: 'rendering', videoOwnerInstanceId: 'example-owner', disableAudio: true,
+      videoDraft: { sources: [], audio: { mode: 'native' } },
+      videoExecution: { id: 'example-execution', authorized: true,
+        limits: { maxClips: 3, maxRetries: 1, maxAgentCalls: 10, maxReplans: 1, spendCapUsd: null },
+        choices: { video: { mode: 'reactor' }, audio: { mode: 'native' }, evaluation: { type: 'agent' } },
+        attempts: [] },
+      treatment: { artifact: { revision: 1 }, script: 'Example script', scenes: [shot] } });
+    video.videoExecution.inputRevision = videoConfigurationRevision(video);
+    getProject.mockResolvedValue(video);
+    getSettings.mockResolvedValue({ videoGen: { reactor: { apiKey: 'example-test-key' } } });
+
+    expect(await runSceneRender(video, shot)).toBe('job-1');
+    expect(enqueuedParams()).not.toHaveProperty('disableAudio');
+  });
 });
 
 
@@ -257,6 +279,7 @@ describe('Video production review boundary', () => {
     expect(enqueueJob).not.toHaveBeenCalled();
     const checkpoint = videoReviewStages(video)[0];
     video.videoReview = { decisions: { [checkpoint.stage]: { action: 'approve', revision: checkpoint.revision } } };
+    reviewState.allowsDispatch = true;
     getProject.mockResolvedValue(video);
     expect(await runSceneRender(video, shot)).toBe('job-1');
     const completed = mediaJobEvents.on.mock.calls.find(([event]) => event === 'completed')[1];

--- a/server/services/creativeDirector/sceneRunner.js
+++ b/server/services/creativeDirector/sceneRunner.js
@@ -41,6 +41,7 @@ import { enqueueUnattendedMediaJob, hasConfiguredMediaRoute } from '../federated
 import { getSettings } from '../settings.js';
 import { updateScene, updateProject, getProject } from './local.js';
 import { dispatchSceneEvaluation } from './sceneEvaluator.js';
+import { videoAudioIsDisabled } from './videoAudio.js';
 
 // Max render+eval attempts per scene (shared with the evaluator so render-retry
 // and eval-retry caps can't silently diverge — both bump the same scene.retryCount).
@@ -222,7 +223,14 @@ export async function runSceneRender(project, scene) {
   const sceneParams = {
     ...shared,
     creativeDirector: { projectId: project.id, sceneId: scene.sceneId },
-    disableAudio: project.disableAudio === true,
+    // Video projects have their own frozen audio contract. The top-level flag
+    // predates the Video workspace and defaults to true on legacy records, so
+    // reading it here made a native Video choice look like audio-disabled
+    // output to cloud backends such as Reactor. Preserve that flag for legacy
+    // Creative Director projects, where it remains the public contract.
+    disableAudio: project.workspace === 'video'
+      ? videoAudioIsDisabled(project)
+      : project.disableAudio === true,
     ...(useLocal ? {
       pythonPath,
       modelId: project.modelId,

--- a/server/services/creativeDirector/videoAudio.js
+++ b/server/services/creativeDirector/videoAudio.js
@@ -5,9 +5,28 @@ import { sleep } from '../../lib/fileUtils.js';
 
 const blocked = message => new ServerError(message, { status: 409, code: 'VIDEO_AUDIO_BLOCKED' });
 
+/**
+ * Resolve the Video workspace's audio contract. The execution choice is the
+ * frozen value once production has started; drafts use the saved production
+ * choice before Start. Legacy Creative Director projects do not have a Video
+ * draft and keep using their top-level `disableAudio` flag elsewhere.
+ */
+export function resolveVideoAudioMode(project, { includeExecution = true } = {}) {
+  const executionMode = includeExecution ? project?.videoExecution?.choices?.audio?.mode : null;
+  return executionMode || project?.videoDraft?.audio?.mode || 'native';
+}
+
+export function videoAudioIsDisabled(project, options) {
+  return resolveVideoAudioMode(project, options) === 'silent';
+}
+
+export function isAudioDisabledBackendBlocker(blocker) {
+  return typeof blocker === 'string' && blocker.includes('audio-disabled output');
+}
+
 export async function resolveVideoAudioChoice(project) {
   const audio = project.videoDraft?.audio || {};
-  const mode = audio.mode || 'native';
+  const mode = resolveVideoAudioMode(project, { includeExecution: false });
   if (mode === 'silent' || mode === 'native') return { mode };
   if (mode === 'imported') {
     const { getTrack } = await import('../tracks/index.js');

--- a/server/services/creativeDirector/videoExecution.js
+++ b/server/services/creativeDirector/videoExecution.js
@@ -13,6 +13,9 @@ const now = () => new Date().toISOString();
 export function videoConfigurationRevision(project) {
   return canonicalSnapshotChecksum(Object.fromEntries(['userStory', 'styleSpec', 'cast', 'targetDurationSeconds',
     'aspectRatio', 'quality', 'modelId', 'renderBackend', 'modelOverrides', 'videoDraft', 'startingImageFile',
+    // Keep the legacy field in this persisted hash for compatibility with
+    // executions authorized by older releases; Video rendering itself reads
+    // videoDraft.audio / the frozen execution choice instead.
     'disableAudio', 'autoAcceptScenes', 'directive'].map(key => [key, project[key] ?? null])));
 }
 
@@ -90,11 +93,23 @@ export async function getVideoExecutionPreview(projectId) {
   const choices = canStart ? await resolveChoices(project).catch(error => { blockers.push(error.message); return null; }) : null;
   const { assertVideoSourcesAvailable } = await import('./videoSources.js');
   if (canStart) await assertVideoSourcesAvailable(project).catch(error => blockers.push(error.message));
+  let execution = project.videoExecution || null;
+  if (execution?.blocker) {
+    const { isAudioDisabledBackendBlocker, videoAudioIsDisabled } = await import('./videoAudio.js');
+    // A failed render can leave its blocker persisted after the operator edits
+    // the draft back to native audio. Do not keep showing an error that the
+    // current Video contract cannot produce; a new Start/Resume clears it.
+    if (project.workspace === 'video'
+      && isAudioDisabledBackendBlocker(execution.blocker)
+      && !videoAudioIsDisabled(project, { includeExecution: false })) {
+      execution = { ...execution, blocker: null };
+    }
+  }
   return { canStart: canStart && blockers.length === 0, blockers, choices,
     inputRevision: videoConfigurationRevision(project),
     configurationRevision: canonicalSnapshotChecksum({ input: videoConfigurationRevision(project), choices }),
     limits: creativeDirectorVideoLimitsSchema.parse(project.videoExecution?.limits || {}),
-    execution: project.videoExecution || null,
+    execution,
     costNotice: 'Provider prices and balances are unknown. Clip and agent-call limits are enforced; a dollar cap blocks calls whose price cannot be bounded.' };
 }
 

--- a/server/services/creativeDirector/videoExecution.test.js
+++ b/server/services/creativeDirector/videoExecution.test.js
@@ -64,6 +64,15 @@ it('previews cloud choices without local hardware or paid calls and makes Start 
   expect(state.project.videoExecution).toMatchObject({ authorized: true, limits: { maxClips: 2, maxRetries: 0 }, inputRevision: videoConfigurationRevision(state.project) });
 });
 
+it('does not expose a stale legacy audio blocker for a native Video draft', async () => {
+  const blocker = 'The reactor video backend cannot honor audio-disabled output.';
+  state.project.videoExecution = { blocker };
+  expect((await getVideoExecutionPreview('example-video')).execution.blocker).toBeNull();
+
+  state.project.videoDraft.audio = { mode: 'silent' };
+  expect((await getVideoExecutionPreview('example-video')).execution.blocker).toBe(blocker);
+});
+
 it('refuses stale choices, unavailable pinned credentials and unenforceable dollar caps', async () => {
   const input = await startInput();
   state.project.userStory = 'A changed brief.';


### PR DESCRIPTION
## Summary

- Make the Video workspace audio contract authoritative for scene submissions, so a native-audio choice no longer inherits the legacy Creative Director `disableAudio` default and trips Reactor.
- Default new Video drafts to native clip audio while preserving the legacy audio-off behavior for non-Video Creative Director projects.
- Hide a persisted audio-disabled backend blocker once the current Video draft is native, and link the panel to the media-generation settings drawer.

## Validation

- Server focused Creative Director tests: 89 passed.
- Server full suite: 2,116 files / 42,293 tests passed, 1 skipped.
- Client affected suites: 2 files / 6 tests passed.
- Client full suite: 912 files passed, 1 skipped; one unrelated existing `Catalog.test.jsx` act-warning failure remains.