### PR TITLE
fix: hide update banners while agents or renders are active

### DIFF
--- a/client/src/components/UpdateBanners.jsx
+++ b/client/src/components/UpdateBanners.jsx
@@ -1,6 +1,7 @@
 import { AlertTriangle, RefreshCw } from 'lucide-react';
 import { useNavigate } from 'react-router';
 import Banner from './ui/Banner';
+import { useAutoRefetch } from '../hooks/useAutoRefetch';
 import { useUpdateChecker } from '../hooks/useUpdateChecker';
 import * as api from '../services/api';
 
@@ -13,7 +14,16 @@ export default function UpdateBanners() {
     update, outOfSync, ignoreUpdate, dismissUpdate, clearOutOfSync, dismissOutOfSync
   } = useUpdateChecker();
 
-  if (!update && !outOfSync) return null;
+  const hasAdvisory = Boolean(update || outOfSync);
+  const { data: processing } = useAutoRefetch(() => api.getActiveProcessing({ silent: true }), 3000, {
+    enabled: hasAdvisory,
+  });
+  // Keep advisories pending until activity is known and jobs have drained.
+  // Hiding must not dismiss them: they become actionable again when idle.
+  const jobsActive = processing?.agents?.active > 0
+    || processing?.jobs?.length > 0
+    || processing?.extras?.imageTo3d?.length > 0;
+  if (!hasAdvisory || !processing || jobsActive) return null;
 
   const goToUpdate = () => navigate(`/apps/${api.PORTOS_APP_ID}/update`);
 

--- a/client/src/components/UpdateBanners.jsx
+++ b/client/src/components/UpdateBanners.jsx
@@ -15,15 +15,15 @@ export default function UpdateBanners() {
   } = useUpdateChecker();
 
   const hasAdvisory = Boolean(update || outOfSync);
-  const { data: processing } = useAutoRefetch(() => api.getActiveProcessing({ silent: true }), 3000, {
-    enabled: hasAdvisory,
-  });
+  const { data: jobsActive } = useAutoRefetch(async () => {
+    const processing = await api.getActiveProcessing({ silent: true });
+    return processing.agents?.active > 0
+      || processing.jobs?.length > 0
+      || processing.extras?.imageTo3d?.length > 0;
+  }, 15000, { enabled: hasAdvisory });
   // Keep advisories pending until activity is known and jobs have drained.
   // Hiding must not dismiss them: they become actionable again when idle.
-  const jobsActive = processing?.agents?.active > 0
-    || processing?.jobs?.length > 0
-    || processing?.extras?.imageTo3d?.length > 0;
-  if (!hasAdvisory || !processing || jobsActive) return null;
+  if (!hasAdvisory || jobsActive !== false) return null;
 
   const goToUpdate = () => navigate(`/apps/${api.PORTOS_APP_ID}/update`);
 

--- a/client/src/components/UpdateBanners.test.jsx
+++ b/client/src/components/UpdateBanners.test.jsx
@@ -80,12 +80,12 @@ describe('UpdateBanners', () => {
     expect(screen.queryByRole('status')).toBeNull();
 
     getActiveProcessing.mockResolvedValue({ agents: { active: 0 }, jobs: [] });
-    await act(async () => { await vi.advanceTimersByTimeAsync(3000); });
+    await act(async () => { await vi.advanceTimersByTimeAsync(15000); });
     expect(screen.getByRole('button', { name: 'Reconcile' })).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Update' })).toBeTruthy();
 
     getActiveProcessing.mockResolvedValue(busy);
-    await act(async () => { await vi.advanceTimersByTimeAsync(3000); });
+    await act(async () => { await vi.advanceTimersByTimeAsync(15000); });
     expect(screen.queryByRole('status')).toBeNull();
     expect(localStorage.getItem(__internal.OUT_OF_SYNC_DISMISS_KEY)).toBeNull();
     expect(ignoreUpdateVersion).not.toHaveBeenCalled();

--- a/client/src/components/UpdateBanners.test.jsx
+++ b/client/src/components/UpdateBanners.test.jsx
@@ -15,8 +15,10 @@ vi.mock('../services/socket', () => ({
 }));
 
 const getUpdateStatus = vi.fn();
+const getActiveProcessing = vi.fn();
 const ignoreUpdateVersion = vi.fn(() => Promise.resolve({}));
 vi.mock('../services/api', () => ({
+  getActiveProcessing: (...a) => getActiveProcessing(...a),
   PORTOS_APP_ID: 'portos-default',
   getUpdateStatus: (...a) => getUpdateStatus(...a),
   ignoreUpdateVersion: (...a) => ignoreUpdateVersion(...a),
@@ -44,12 +46,14 @@ beforeEach(() => {
   navigate.mockClear();
   toastFn.mockClear();
   ignoreUpdateVersion.mockClear();
+  getActiveProcessing.mockReset();
+  getActiveProcessing.mockResolvedValue({ agents: { active: 0 }, jobs: [], extras: { imageTo3d: [] } });
   getUpdateStatus.mockReset();
   getUpdateStatus.mockResolvedValue({});
   localStorage.clear();
 });
 
-afterEach(() => cleanup());
+afterEach(() => { cleanup(); vi.useRealTimers(); });
 
 describe('UpdateBanners', () => {
   it('renders nothing when the install is current', async () => {
@@ -57,6 +61,45 @@ describe('UpdateBanners', () => {
     await flush();
     expect(container).toBeEmptyDOMElement();
     expect(toastFn).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['agents', { agents: { active: 1 } }],
+    ['media renders', { jobs: [{ id: 'render', status: 'running' }] }],
+    ['queued media', { jobs: [{ id: 'render', status: 'queued' }] }],
+    ['3D renders', { extras: { imageTo3d: [{ id: 'model' }] } }],
+  ])('hides both advisories during %s and restores them when work drains', async (_label, busy) => {
+    vi.useFakeTimers();
+    getUpdateStatus.mockResolvedValue({
+      installState: { outOfSync: true, currentCommit: 'abc123' },
+      updateAvailable: true, currentVersion: '1.0.0', latestRelease: { version: '1.1.0' },
+    });
+    getActiveProcessing.mockResolvedValue(busy);
+    renderBanners();
+    await flush();
+    expect(screen.queryByRole('status')).toBeNull();
+
+    getActiveProcessing.mockResolvedValue({ agents: { active: 0 }, jobs: [] });
+    await act(async () => { await vi.advanceTimersByTimeAsync(3000); });
+    expect(screen.getByRole('button', { name: 'Reconcile' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Update' })).toBeTruthy();
+
+    getActiveProcessing.mockResolvedValue(busy);
+    await act(async () => { await vi.advanceTimersByTimeAsync(3000); });
+    expect(screen.queryByRole('status')).toBeNull();
+    expect(localStorage.getItem(__internal.OUT_OF_SYNC_DISMISS_KEY)).toBeNull();
+    expect(ignoreUpdateVersion).not.toHaveBeenCalled();
+  });
+
+  it('waits for the first activity snapshot before showing an advisory', async () => {
+    getUpdateStatus.mockResolvedValue({ installState: { outOfSync: true, currentCommit: 'abc123' } });
+    let resolveActivity;
+    getActiveProcessing.mockReturnValue(new Promise(resolve => { resolveActivity = resolve; }));
+    renderBanners();
+    await flush();
+    expect(screen.queryByRole('status')).toBeNull();
+    await act(async () => { resolveActivity({ agents: { active: 0 }, jobs: [] }); });
+    expect(screen.getByRole('button', { name: 'Reconcile' })).toBeTruthy();
   });
 
   it('renders the out-of-sync advisory inline (no toast)', async () => {


### PR DESCRIPTION
## Summary
Hide the top update and install-reconciliation banners while CoS agents, queued/running media jobs, or 3D renders are active. Pending advisories return after jobs drain, without being dismissed.

Reuse the existing activity endpoint and visibility-aware polling every 15 seconds. Wait for the first activity snapshot and preserve the last known state on request failures.

## Test plan
- 19 tests passed across UpdateBanners and polling conventions, including busy-to-idle-to-busy transitions and initial activity loading.
- Client production build passed.
- Completed the optional local review round; applied polling efficiency feedback.
