### PR TITLE
fix: preserve local work when normalizing Windows line endings

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -86,14 +86,22 @@ details.
 
 ### Line Endings on Windows
 
-`.gitattributes` pins `eol=lf` for text files across all platforms. If you have an existing repository clone on Windows from before this setting landed, run:
+`.gitattributes` pins `eol=lf` for text files across all platforms. To normalize
+tracked files in an older Windows clone, first commit or stash unrelated work
+(including staged changes). Then run from the repository root:
 
 ```bash
-git rm --cached -r .
-git reset --hard
+git add --renormalize .
+git diff --cached --stat
+git diff --cached
 ```
 
-to re-index files with LF line endings.
+This reapplies the current attributes to tracked files in the index without
+overwriting working files. It also stages any other tracked edits or deletions,
+which is why unrelated work must be saved first. Commit only if the reviewed
+diff contains the intended normalization changes; an empty diff needs no commit.
+Do not use `git reset --hard` for this repair: it discards uncommitted tracked
+changes.
 
 ### Commit Messages
 


### PR DESCRIPTION
## Summary
The Windows line-ending repair in `docs/CONTRIBUTING.md:88` told contributors to remove the index and run `git reset --hard`, silently discarding uncommitted tracked changes. The actual normalization policy is `.gitattributes:2-3`; Git can reapply it with `git add --renormalize .` without overwriting working files.

Replace the destructive recipe with renormalization and staged-diff review. Explain that unrelated tracked changes must be saved first because renormalization also stages those edits. Scope is limited to this recovery instruction.

## Test plan
- Temporary Git repository using the real `.gitattributes`: verified CRLF becomes LF in the index, working files and an unrelated edit survive, the edit is staged as documented, and a binary fixture remains unchanged.
- `npm test --prefix server -- ../scripts/catalog-merge-union.test.js`: 6 tests passed.
- `git diff --check`: passed.
