### PR TITLE
fix: preserve actionable Reactor runtime setup failures

### DIFF
--- a/scripts/lib/reactorSetupErrors.js
+++ b/scripts/lib/reactorSetupErrors.js
@@ -1,0 +1,11 @@
+// Exit codes are the setup subprocess's public protocol. Never forward raw
+// installer output: it can contain credentials, proxy URLs and local paths.
+export const REACTOR_SETUP_ERRORS = Object.freeze({
+  20: 'Reactor runtime manager download failed; check access to GitHub releases and retry the render',
+  21: 'Reactor runtime download failed integrity verification; retry the render',
+  22: 'Reactor runtime archive extraction failed; check tar availability and disk space, then retry the render',
+  23: 'Reactor Python environment preparation failed; check uv access to Python downloads on GitHub releases, proxy settings and disk space, then retry the render',
+  24: 'Reactor SDK installation failed; check uv access to the configured Python package index and disk space, then retry the render',
+  25: 'Reactor SDK verification failed; retry the render to repair the installation',
+  26: 'Reactor runtime is not supported on this operating system/architecture',
+});

--- a/scripts/setup-reactor.js
+++ b/scripts/setup-reactor.js
@@ -5,6 +5,7 @@ import { createHash } from 'node:crypto';
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 import { join } from 'node:path';
+import { REACTOR_SETUP_ERRORS } from './lib/reactorSetupErrors.js';
 
 const root = fileURLToPath(new URL('..', import.meta.url));
 const data = process.env.PORTOS_REACTOR_DATA || join(root, 'data');
@@ -21,13 +22,16 @@ const targets = {
   'win32-x64': ['x86_64-pc-windows-msvc', 'f65744f94072152b1f86ba2aace4d01f1124d9a8ecb235805039e3718c36cac2'],
 };
 const env = { ...process.env, UV_PYTHON_INSTALL_DIR: join(data, 'venvs', 'reactor-python'), UV_NO_PROGRESS: '1' };
-function run(executable, args, timeout = 450_000) {
+function setupError(code) {
+  return Object.assign(new Error(REACTOR_SETUP_ERRORS[code]), { code });
+}
+function run(code, executable, args, timeout = 450_000) {
   const result = spawnSync(executable, args, { env, stdio: 'ignore', shell: false, windowsHide: true, timeout, killSignal: 'SIGKILL' });
-  if (result.error || result.status !== 0) throw new Error('Reactor runtime preparation failed; check network access and available disk space, then retry the render');
+  if (result.error || result.status !== 0) throw setupError(code);
 }
 async function setup() {
   const target = targets[`${process.platform}-${process.arch}`];
-  if (!target) throw new Error('Reactor runtime is not supported on this operating system/architecture');
+  if (!target) throw setupError(26);
   const [triple, digest] = target;
   const directory = join(data, 'venvs', `reactor-uv-${version}`);
   const archive = join(directory, windows ? 'uv.zip' : 'uv.tar.gz');
@@ -35,18 +39,22 @@ async function setup() {
   const cached = await readFile(archive).catch(() => null);
   let bytes = cached;
   if (!bytes || createHash('sha256').update(bytes).digest('hex') !== digest) {
-    const response = await fetch(`https://github.com/astral-sh/uv/releases/download/${version}/uv-${triple}.${windows ? 'zip' : 'tar.gz'}`, { signal: AbortSignal.timeout(120_000) });
-    if (!response.ok) throw new Error('Could not download the Reactor runtime manager; retry the render when network access is restored');
-    bytes = Buffer.from(await response.arrayBuffer());
-    if (createHash('sha256').update(bytes).digest('hex') !== digest) throw new Error('Reactor runtime download failed integrity verification');
+    const response = await fetch(`https://github.com/astral-sh/uv/releases/download/${version}/uv-${triple}.${windows ? 'zip' : 'tar.gz'}`, { signal: AbortSignal.timeout(120_000) }).catch(() => { throw setupError(20); });
+    if (!response.ok) throw setupError(20);
+    bytes = Buffer.from(await response.arrayBuffer().catch(() => { throw setupError(20); }));
+    if (createHash('sha256').update(bytes).digest('hex') !== digest) throw setupError(21);
     await writeFile(archive, bytes);
   }
-  run('tar', ['-xf', archive, '-C', directory], 30_000);
+  run(22, 'tar', ['-xf', archive, '-C', directory], 30_000);
   const uv = join(directory, ...(windows ? ['uv.exe'] : [`uv-${triple}`, 'uv']));
   // An interrupted installation is repaired in place; no system Python or pip changes.
-  run(uv, ['venv', '--python', '3.12', '--managed-python', '--allow-existing', venv]);
-  run(uv, ['pip', 'install', '--reinstall-package', 'reactor-sdk', '--python', python, '--only-binary', ':all:', '-r', join(root, 'scripts', 'requirements-reactor.txt')]);
-  run(python, ['-c', 'from reactor_sdk import Reactor; Reactor("reactor/fast-h3")'], 15_000);
+  run(23, uv, ['venv', '--python', '3.12', '--managed-python', '--allow-existing', venv]);
+  run(24, uv, ['pip', 'install', '--reinstall-package', 'reactor-sdk', '--python', python, '--only-binary', ':all:', '-r', join(root, 'scripts', 'requirements-reactor.txt')]);
+  run(25, python, ['-c', 'from reactor_sdk import Reactor; Reactor("reactor/fast-h3")'], 15_000);
   console.log('✅ Reactor runtime ready');
 }
-setup().catch((error) => { console.error(`❌ ${error.message}`); process.exitCode = 1; });
+setup().catch((error) => {
+  const code = Number.isInteger(error.code) && Object.hasOwn(REACTOR_SETUP_ERRORS, error.code) ? error.code : 1;
+  console.error(`❌ ${REACTOR_SETUP_ERRORS[code] || 'Reactor runtime preparation failed; check network access and disk space, then retry the render'}`);
+  process.exitCode = code;
+});

--- a/scripts/setup-reactor.test.js
+++ b/scripts/setup-reactor.test.js
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, expect, it, vi } from 'vitest';
+import { readFile, mkdir } from 'node:fs/promises';
+
+const mocks = vi.hoisted(() => ({ spawn: vi.fn(), fetch: vi.fn() }));
+vi.mock('node:child_process', () => ({ spawnSync: mocks.spawn }));
+vi.mock('node:fs/promises', () => ({ mkdir: vi.fn(), readFile: vi.fn(async () => Buffer.from('archive')), writeFile: vi.fn() }));
+vi.mock('node:crypto', () => ({ createHash: () => ({ update: () => ({ digest: () => '173d95a0c32d18c896c46ba6fafbf3cf9c14ab74b033f81b76c883ef492a976b' }) }) }));
+
+let previousExitCode;
+beforeEach(() => {
+  vi.resetModules();
+  vi.clearAllMocks();
+  previousExitCode = process.exitCode;
+  process.exitCode = undefined;
+  vi.spyOn(process, 'platform', 'get').mockReturnValue('linux');
+  vi.spyOn(process, 'arch', 'get').mockReturnValue('x64');
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+  vi.stubGlobal('fetch', mocks.fetch);
+  mocks.spawn.mockReturnValue({ status: 0 });
+});
+afterEach(() => {
+  process.exitCode = previousExitCode;
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+it.each([
+  [1, 22, 'archive extraction'],
+  [2, 23, 'Python environment preparation'],
+  [3, 24, 'SDK installation'],
+  [4, 25, 'SDK verification'],
+])('reports failing setup command %i without exposing subprocess diagnostics', async (step, code, message) => {
+  for (let i = 1; i < step; i++) mocks.spawn.mockReturnValueOnce({ status: 0 });
+  mocks.spawn.mockReturnValueOnce({ status: 2, stderr: 'private proxy credentials', error: new Error('private local path') });
+  await import('./setup-reactor.js');
+  await vi.waitFor(() => expect(process.exitCode).toBe(code));
+  expect(console.error).toHaveBeenCalledWith(expect.stringContaining(message));
+  expect(console.error.mock.calls.flat().join(' ')).not.toContain('private');
+  expect(mocks.spawn).toHaveBeenCalledTimes(step);
+  expect(mocks.fetch).not.toHaveBeenCalled();
+});
+
+it('finishes all setup steps when the runtime is installed successfully', async () => {
+  await import('./setup-reactor.js');
+  await vi.waitFor(() => expect(console.log).toHaveBeenCalledWith('✅ Reactor runtime ready'));
+  expect(mocks.spawn).toHaveBeenCalledTimes(4);
+  expect(process.exitCode).toBeUndefined();
+});
+
+it('reports a runtime-manager connection failure without its private URL', async () => {
+  readFile.mockResolvedValueOnce(null);
+  mocks.fetch.mockRejectedValueOnce(new Error('private proxy URL'));
+  await import('./setup-reactor.js');
+  await vi.waitFor(() => expect(process.exitCode).toBe(20));
+  expect(console.error).toHaveBeenCalledWith(expect.stringContaining('runtime manager download failed'));
+  expect(console.error.mock.calls.flat().join(' ')).not.toContain('private');
+  expect(mocks.spawn).not.toHaveBeenCalled();
+});
+
+it('redacts unexpected filesystem errors from command-line setup', async () => {
+  mkdir.mockRejectedValueOnce(Object.assign(new Error('private local path'), { code: 'EACCES' }));
+  await import('./setup-reactor.js');
+  await vi.waitFor(() => expect(process.exitCode).toBe(1));
+  expect(console.error.mock.calls.flat().join(' ')).not.toContain('private');
+  expect(mocks.spawn).not.toHaveBeenCalled();
+});

--- a/server/services/videoGen/reactorRuntime.js
+++ b/server/services/videoGen/reactorRuntime.js
@@ -4,6 +4,7 @@ import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { execFile } from '../../lib/childProcess.js';
 import { PATHS } from '../../lib/fileUtils.js';
+import { REACTOR_SETUP_ERRORS } from '../../../scripts/lib/reactorSetupErrors.js';
 
 const execute = promisify(execFile);
 let preparation;
@@ -30,7 +31,12 @@ async function prepareRuntime(python, expected) {
   if (await probe(python, expected)) return python;
   await execute(process.execPath, [join(PATHS.root, 'scripts', 'setup-reactor.js')], {
     env: { ...process.env, PORTOS_REACTOR_DATA: PATHS.data }, timeout: 1_200_000, maxBuffer: 8192,
-  }).catch(() => { throw new Error('Automatic Reactor runtime preparation failed; check network access and disk space, then retry the render'); });
+  }).catch((error) => {
+    const message = Number.isInteger(error.code) && Object.hasOwn(REACTOR_SETUP_ERRORS, error.code)
+      ? REACTOR_SETUP_ERRORS[error.code]
+      : 'Automatic Reactor runtime preparation failed; check network access and disk space, then retry the render';
+    throw new Error(message);
+  });
   if (!await probe(python, expected)) throw new Error('Reactor runtime verification failed; retry the render to repair the installation');
   return python;
 }

--- a/server/services/videoGen/reactorRuntime.test.js
+++ b/server/services/videoGen/reactorRuntime.test.js
@@ -51,4 +51,16 @@ describe('automatic Reactor runtime preparation', () => {
     await expect(ensureReactorRuntime()).rejects.toThrow('remove the custom override');
     expect(mocks.execFile).toHaveBeenCalledOnce();
   });
+
+  it('preserves the safe Python preparation failure through the subprocess boundary', async () => {
+    mocks.execFile.mockImplementationOnce(reply(new Error('missing SDK')))
+      .mockImplementationOnce(reply(Object.assign(new Error('private installer details'), { code: 23 })));
+    await expect(ensureReactorRuntime()).rejects.toThrow('Reactor Python environment preparation failed; check uv access to Python downloads on GitHub releases');
+  });
+
+  it.each([1, 'ENOENT', 'toString'])('keeps unknown setup code %s private', async (code) => {
+    mocks.execFile.mockImplementationOnce(reply(new Error('missing SDK')))
+      .mockImplementationOnce(reply(Object.assign(new Error('private installer details'), { code })));
+    await expect(ensureReactorRuntime()).rejects.toThrow('Automatic Reactor runtime preparation failed; check network access and disk space, then retry the render');
+  });
 });


### PR DESCRIPTION
## Summary
Reactor runtime provisioning discarded the failing installer stage and reported the same network/disk message for every failure. Carry a fixed, shared exit-code protocol from setup to the render worker so Python provisioning, SDK installation, verification, download, and extraction failures retain actionable guidance. Raw subprocess diagnostics and unexpected filesystem errors remain private.

Investigation confirmed valid Creative Director render parameters and reproduced a managed-Python download connection timeout in an isolated temporary runtime, before token minting. This fixes the obscured failure diagnosis; the affected environment still requires uv download connectivity before rendering can succeed. No paid render was started.

## Test plan
- Passed 68 focused server tests: `npm test --prefix server -- setup-reactor reactorRuntime reactor.test.js backendPin.test.js sceneRunner.backend creativeDirectorVideoCompiler`.
- Added setup workflow tests for successful installation, failed stages, connection failure, and diagnostic redaction; covered safe error propagation and unknown exit codes in the runtime adapter.
- Reviewed the diff for reuse, privacy, compatibility, and unchanged authorization/repair behavior; `git diff --check` passed.
