### PR TITLE
fix: allow Reactor session setup beyond one minute

### DIFF
--- a/scripts/reactor-render.py
+++ b/scripts/reactor-render.py
@@ -21,6 +21,9 @@ from reactor_sdk import Reactor
 # frame into a landscape session and returned a clip with audio and no picture.
 CANVASES = {"16:9": (1344, 768), "4:3": (1024, 768), "1:1": (768, 768), "9:16": (768, 1344)}
 DEFAULT_ASPECT = "16:9"
+# connect() includes remote session creation and WebRTC establishment. Allow
+# slow setup beyond one minute, while retaining a bound inside the JS watchdog.
+CONNECT_TIMEOUT_SECONDS = 180
 
 
 def emit(kind, **fields):
@@ -74,7 +77,7 @@ async def render(params):
     phase = "connecting"
     try:
         emit("status", message="Connecting to Reactor")
-        await asyncio.wait_for(reactor.connect(), 60)
+        await asyncio.wait_for(reactor.connect(), CONNECT_TIMEOUT_SECONDS)
         scratch_path = Path(str(output) + ".capture")
         scratch_path.mkdir(parents=True, exist_ok=True)
         raw_video = scratch_path / "video.bgra"

--- a/scripts/reactor_render_test.py
+++ b/scripts/reactor_render_test.py
@@ -118,6 +118,42 @@ class CaptureLifecycleTest(unittest.IsolatedAsyncioTestCase):
         self.assertFalse(Path(str(self.output) + ".capture").exists())
         spawn.assert_awaited_once()
 
+    async def test_slow_session_setup_can_finish_before_enqueuing_once(self):
+        reactor = FakeReactor()
+        wait_for = asyncio.wait_for
+
+        async def simulated_wait(awaitable, timeout):
+            # Model a connection taking 90 seconds without production sleeps.
+            if not reactor.commands and not reactor.callbacks:
+                if timeout <= 90:
+                    awaitable.close()
+                    raise asyncio.TimeoutError()
+                self.assertLessEqual(timeout, 180)
+            return await wait_for(awaitable, timeout)
+
+        async def encode(*command, **kwargs):
+            self.output.write_bytes(b"example-mp4")
+            return SimpleNamespace(returncode=0, wait=AsyncMock(return_value=0))
+
+        with patch.object(self.runner.asyncio, "wait_for", simulated_wait):
+            await self.run_capture(reactor, AsyncMock(side_effect=encode))
+        self.assertEqual([name for name, _ in reactor.commands], ["set_canvas", "enqueue", "play"])
+        self.assertTrue(reactor.disconnected)
+
+    async def test_connection_timeout_or_cancellation_disconnects_without_submitting(self):
+        for failure in (asyncio.TimeoutError, asyncio.CancelledError):
+            with self.subTest(failure=failure.__name__):
+                reactor = FakeReactor()
+                reactor.connect = (AsyncMock(side_effect=asyncio.Event().wait)
+                                   if failure is asyncio.TimeoutError else AsyncMock(side_effect=failure))
+                spawn = AsyncMock()
+                with patch.object(self.runner, "CONNECT_TIMEOUT_SECONDS", 0.001), self.assertRaises(failure):
+                    await self.run_capture(reactor, spawn)
+                self.assertTrue(reactor.disconnected)
+                self.assertEqual(reactor.commands, [])
+                self.assertFalse(Path(str(self.output) + ".capture").exists())
+                spawn.assert_not_awaited()
+
     async def test_canvas_opens_on_the_requested_aspect_and_rejects_one_fast_h3_cannot_render(self):
         reactor = FakeReactor()
 

--- a/server/services/videoGen/reactor.js
+++ b/server/services/videoGen/reactor.js
@@ -172,6 +172,9 @@ function captureClip(entry, input, pythonPath, job, jobId) {
           const message = JSON.parse(line);
           if (message.type === 'complete' && typeof message.clipId === 'string' && Number.isFinite(message.seconds)) complete = message;
           if (message.type === 'error' && message.code === 'INVALID_FRAME_BUFFER') failure = new Error('Reactor supplied an invalid video frame buffer; expected width × height × 4 bytes');
+          if (message.type === 'error' && message.phase === 'connecting' && message.errorType === 'TimeoutError') {
+            failure = new Error('Reactor connection timed out before any clip was submitted; check provider availability and network access, then retry');
+          }
           if (!failure && message.type === 'error' && /^[a-z]+$/.test(message.phase) && /^[A-Za-z]+$/.test(message.errorType)) failure = new Error(`Reactor ${message.phase} failed (${message.errorType})`);
           if (message.type === 'status') {
             if (typeof message.message === 'string' && /^Captured [0-9.]+ of [0-9.]+ frames; audio=(True|False)$/.test(message.message)) console.log(`🎬 ${message.message}`);

--- a/server/services/videoGen/reactor.test.js
+++ b/server/services/videoGen/reactor.test.js
@@ -72,6 +72,19 @@ describe('Reactor SDK adapter', () => {
     await vi.waitFor(() => expect(mocks.finalize).toHaveBeenCalledWith(expect.objectContaining({ jobId: job.jobId, meta: expect.objectContaining({ clipId: 'clip-example', seconds: 6 }) })));
   });
 
+  it('identifies connection timeouts before submission without exposing SDK diagnostics', async () => {
+    await started();
+    const failed = once(videoGenEvents, 'failed');
+    child.stdout.emit('data', Buffer.from(JSON.stringify({ type: 'error', phase: 'connecting', errorType: 'TimeoutError', message: 'private SDK diagnostics' }) + '\n'));
+    child.emit('close', 1);
+    const [event] = await failed;
+    expect(event.error).toContain('connection timed out before any clip was submitted');
+    expect(event.error).toContain('check provider availability and network access, then retry');
+    expect(event.error).not.toContain('private SDK diagnostics');
+    expect(mocks.finalize).not.toHaveBeenCalled();
+    expect(reactor.getActiveJob()).toBeNull();
+  });
+
   it('rejects all blank samples before history publication and removes the output', async () => {
     const sharp = (await import('sharp')).default;
     await sharp({ create: { width: 32, height: 32, channels: 3, background: '#000000' } }).png().toFile(join(root, 'blank.png'));


### PR DESCRIPTION
## Summary

Reactor renders with valid inputs could be canceled by PortOS's 60-second deadline while the SDK was still creating the session and establishing WebRTC. The investigated job failed after roughly 62 seconds, before any canvas, upload, or enqueue command; its duration, aspect and prompt length were within the provider constraints.

Allow up to 180 seconds for this connection phase, retaining cancellation, disconnect cleanup and the outer render watchdog. Report connection timeouts as pre-submission failures with provider/network retry guidance. Render parameters and provider constraints remain unchanged. This removes the premature local deadline; it does not establish the cause of provider latency or guarantee recovery from an outage.

## Test plan

- Passed: `npm test --prefix server -- services/videoGen/reactor.test.js services/videoGen/backendPin.test.js services/creativeDirector/sceneRunner.backend.test.js ../scripts/reactor-render.test.js` (55 tests).
- Passed: `python3 scripts/reactor_render_test.py` (10 offline lifecycle tests).
- Added slow connection, timeout/cancellation cleanup, and sanitized failure-event coverage.
- Reviewed changed code and ran `git diff --check`.
- No live paid render was submitted.
