### PR TITLE
fix: honor provider timeout for scene vision evaluation

### DIFF
--- a/server/services/creativeDirector/sceneEvaluator.js
+++ b/server/services/creativeDirector/sceneEvaluator.js
@@ -43,11 +43,12 @@ import { enqueueEvaluateTask } from './agentBridge.js';
 // body, so a large batch balloons the prompt and a local VLM's context window.
 // 5 samples across the timeline is plenty to judge a short clip.
 const MAX_EVAL_FRAMES = 5;
-// Local VLMs on modest hardware can be slow to first token; give them room.
+// Local VLMs on modest hardware can be slow to first token; honor the
+// configured provider timeout and use this default only when it is absent.
 // This timeout is the only bound on generation length — the toolkit's api
 // runner does not send `max_tokens`, so a verbose model is capped by time, not
 // tokens (the structured-JSON prompt keeps a compliant model's reply short).
-const VISION_EVAL_TIMEOUT_MS = 180000;
+const DEFAULT_VISION_EVAL_TIMEOUT_MS = 180000;
 
 // Local backends served by an aiToolkit `api`-type provider. Auto-resolution
 // only picks from these — the whole point is a LOCAL vision model. An explicit
@@ -191,7 +192,7 @@ export async function evaluateSceneWithVision(project, scene) {
     return { ok: false, fallbackToAgent: true, reason: 'no evaluation frames on disk' };
   }
 
-  // Record a RUNNING evaluate run BEFORE the (up-to-180s) vision call so a
+  // Record a RUNNING evaluate run BEFORE the bounded vision call so a
   // concurrent advanceAfterSceneSettled (user clicks Start/Resume, or a stale
   // completion fires) sees a live run via completionHook's `noLiveEvaluateRun`
   // check and won't dispatch a second evaluation of the same render. This
@@ -216,7 +217,7 @@ export async function evaluateSceneWithVision(project, scene) {
       prompt,
       source: 'cd-scene-evaluate',
       screenshots: frames,
-      timeout: VISION_EVAL_TIMEOUT_MS,
+      timeout: target.provider.timeout ?? DEFAULT_VISION_EVAL_TIMEOUT_MS,
       ...(project.workspace === 'video' ? { allowFallback: false } : {}),
     });
 

--- a/server/services/creativeDirector/sceneEvaluator.test.js
+++ b/server/services/creativeDirector/sceneEvaluator.test.js
@@ -214,6 +214,20 @@ describe('evaluateSceneWithVision', () => {
       resolvePath('/data/video-thumbnails/job-1-f2.jpg'),
     ]);
     expect(call.source).toBe('cd-scene-evaluate');
+    expect(call.timeout).toBe(180000);
+  });
+
+  it.each([600000, 60000])('honors a configured provider timeout of %ims', async (timeout) => {
+    const provider = { ...OLLAMA, timeout };
+    mocks.getProviderById.mockResolvedValue(provider);
+    mocks.runPromptThroughProvider.mockResolvedValue({
+      text: '{"accepted": true}', model: 'qwen2.5-vl', provider,
+    });
+
+    const result = await evaluateSceneWithVision(project, scene);
+
+    expect(result.verdict.accepted).toBe(true);
+    expect(mocks.runPromptThroughProvider.mock.calls[0][0].timeout).toBe(timeout);
   });
 
   it('falls back to the agent when no vision provider is configured', async () => {


### PR DESCRIPTION
## Summary
Scene vision evaluation imposed a fixed 180-second deadline even when its API provider was configured to allow longer. A local vision response could be cut off mid-verdict and fail evaluation despite the configured budget.

Honor the selected provider's timeout, retaining the existing 180-second default when no timeout is configured. This preserves both longer local-model budgets and deliberately shorter provider limits. The reported stale-build commit did not address this path.

## Test plan
- Passed all 33 tests in `server/services/creativeDirector/sceneEvaluator.test.js`, including configured longer/shorter deadlines and the default.
- `git diff --check` passed.
- Verified the local provider's model listing and confirmed the failed run contained partial generated output; no generation retry or production data mutation was needed.
