### PR TITLE
fix: prevent managed app updates hanging on parallel PM2 restarts

### DIFF
--- a/server/services/pm2.js
+++ b/server/services/pm2.js
@@ -7,6 +7,7 @@ import { createRequire } from 'module';
 import { homedir } from 'os';
 import { atomicWrite, extractJSONArray, safeJSONParse, tryReadFile } from '../lib/fileUtils.js';
 import { parseCommandArgs } from '../lib/commandSecurity.js';
+import { bufferedSpawnOrThrow } from '../lib/bufferedSpawn.js';
 
 const IS_WIN = process.platform === 'win32';
 
@@ -266,19 +267,15 @@ export async function stopApp(name, pm2Home = null) {
  * @param {string} pm2Home Optional custom PM2_HOME path
  */
 export async function restartApp(name, pm2Home = null) {
-  // Use CLI for custom PM2_HOME
-  if (pm2Home) {
-    return spawnPm2Cli('restart', name, pm2Home);
-  }
-
-  return connectAndRun((pm2) => {
-    return new Promise((resolve, reject) => {
-      pm2.restart(name, (err) => {
-        if (err) return reject(err);
-        resolve({ success: true });
-      });
-    });
+  // Each restart owns its CLI connection. Parallel managed-app restarts must
+  // not disconnect the shared PM2 client while another RPC is still pending.
+  await bufferedSpawnOrThrow(process.execPath, [PM2_BIN, 'restart', name], {
+    env: withoutInheritedPm2Config(buildEnv(pm2Home)),
+    timeoutMs: 60_000,
+    timeoutLabel: `pm2 restart ${name}`,
   });
+  clearJlistCache(pm2Home);
+  return { success: true };
 }
 
 /**

--- a/server/services/pm2.restart.test.js
+++ b/server/services/pm2.restart.test.js
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { EventEmitter } from 'events';
+
+const mocks = vi.hoisted(() => ({ spawn: vi.fn(), connect: vi.fn(), disconnect: vi.fn() }));
+vi.mock('pm2', () => ({ default: mocks }));
+vi.mock('../lib/childProcess.js', async (importOriginal) => ({
+  ...(await importOriginal()),
+  spawn: mocks.spawn,
+}));
+import { restartApp } from './pm2.js';
+
+function child() {
+  return Object.assign(new EventEmitter(), {
+    stdout: new EventEmitter(), stderr: new EventEmitter(), kill: vi.fn(),
+  });
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.useRealTimers();
+  vi.unstubAllEnvs();
+});
+
+describe('PM2 restart lifecycle', () => {
+  it('completes overlapping restarts independently without disconnecting the shared client', async () => {
+    const first = child();
+    const second = child();
+    mocks.spawn.mockReturnValueOnce(first).mockReturnValueOnce(second);
+    vi.stubEnv('max_memory_restart', '4294967296');
+    vi.stubEnv('PORT', '5555');
+    const pending = [restartApp('api'), restartApp('worker', '/custom-pm2')];
+    second.emit('close', 0);
+    expect(await pending[1]).toEqual({ success: true });
+    first.emit('close', 0);
+    expect(await pending[0]).toEqual({ success: true });
+    expect(mocks.connect).not.toHaveBeenCalled();
+    expect(mocks.disconnect).not.toHaveBeenCalled();
+    expect(mocks.spawn.mock.calls.map(([, args]) => args.slice(-2))).toEqual([
+      ['restart', 'api'], ['restart', 'worker'],
+    ]);
+    expect(mocks.spawn.mock.calls[1][2].env.PM2_HOME).toBe('/custom-pm2');
+    for (const [, , options] of mocks.spawn.mock.calls) {
+      expect(options.env).not.toHaveProperty('max_memory_restart');
+      expect(options.env).not.toHaveProperty('PORT');
+    }
+  });
+
+  it('rejects a stalled restart within a minute even when the child never closes', async () => {
+    vi.useFakeTimers();
+    const stalled = child();
+    mocks.spawn.mockReturnValue(stalled);
+    const result = expect(restartApp('worker')).rejects.toThrow('pm2 restart worker timed out after 60s');
+    await vi.advanceTimersByTimeAsync(60_000);
+    await result;
+    expect(stalled.kill).toHaveBeenCalled();
+  });
+
+  it('preserves daemon error details on a failed restart', async () => {
+    const failed = child();
+    mocks.spawn.mockReturnValue(failed);
+    const result = expect(restartApp('missing')).rejects.toThrow('Process missing not found');
+    failed.stderr.emit('data', 'Process missing not found');
+    failed.emit('close', 1);
+    await result;
+  });
+});


### PR DESCRIPTION
## Summary
Managed updates restart an app's PM2 processes in parallel. Each default-home restart previously used and disconnected the shared PM2 client, potentially leaving other pending restarts unresolved and the Git page stuck on “Restarting app…”.

Use an isolated local PM2 CLI for every restart, with the existing buffered-spawn timeout and cleanup machinery. Restarts now settle within 60 seconds, preserve custom homes and environment filtering, and invalidate cached process status on success.

## Test plan
- Passed 31 tests across PM2 restart lifecycle, PM2 launch, and managed-app update suites.
- Regression coverage: overlapping restarts, a child that never closes, and daemon error propagation.
- Optional OpenCode review inconclusive: installed CLI help exposes no verifiable empty-tool and MCP/hooks isolation controls.
