### PR TITLE
fix: preserve safe Reactor session rejection diagnostics

### DIFF
--- a/scripts/reactor-render.py
+++ b/scripts/reactor-render.py
@@ -206,7 +206,11 @@ async def render(params):
         shutil.rmtree(scratch_path)
         emit("complete", clipId=clip["clip_id"], seconds=expected / 24, frames=state["frames"])
     except Exception as error:
+        # Only the numeric HTTP status crosses stdio. SDK messages, codes and
+        # operation details may contain response bodies or credentials.
+        status = getattr(error, "status", None)
         emit("error", phase=phase, errorType=type(error).__name__,
+             **({"httpStatus": status} if type(status) is int and 400 <= status <= 599 else {}),
              **({"code": "INVALID_FRAME_BUFFER"} if state["error"] == "Invalid Reactor video frame buffer" else {}))
         raise
     finally:

--- a/scripts/reactor_render_test.py
+++ b/scripts/reactor_render_test.py
@@ -154,6 +154,27 @@ class CaptureLifecycleTest(unittest.IsolatedAsyncioTestCase):
                 self.assertFalse(Path(str(self.output) + ".capture").exists())
                 spawn.assert_not_awaited()
 
+    async def test_connection_rejection_reports_only_safe_http_status_without_submitting(self):
+        for status in (400, 402, 503, None, "private-status", True, 200, 600):
+            with self.subTest(status=status):
+                reactor = FakeReactor()
+                error = type("BadRequestError", (Exception,), {})("private response body")
+                error.status = status
+                reactor.connect = AsyncMock(side_effect=error)
+                log = io.StringIO()
+                with patch.object(self.runner, "Reactor", return_value=reactor), redirect_stdout(log):
+                    with self.assertRaises(type(error)):
+                        await self.runner.render(self.params)
+                events = [json.loads(line) for line in log.getvalue().splitlines()]
+                expected = {"type": "error", "phase": "connecting", "errorType": "BadRequestError"}
+                if type(status) is int and 400 <= status <= 599:
+                    expected["httpStatus"] = status
+                self.assertEqual(events[-1], expected)
+                self.assertNotIn("private", log.getvalue())
+                self.assertEqual(reactor.commands, [])
+                self.assertTrue(reactor.disconnected)
+                self.assertFalse(Path(str(self.output) + ".capture").exists())
+
     async def test_canvas_opens_on_the_requested_aspect_and_rejects_one_fast_h3_cannot_render(self):
         reactor = FakeReactor()
 

--- a/server/services/videoGen/reactor.js
+++ b/server/services/videoGen/reactor.js
@@ -175,6 +175,11 @@ function captureClip(entry, input, pythonPath, job, jobId) {
           if (message.type === 'error' && message.phase === 'connecting' && message.errorType === 'TimeoutError') {
             failure = new Error('Reactor connection timed out before any clip was submitted; check provider availability and network access, then retry');
           }
+          if (!failure && message.type === 'error' && message.phase === 'connecting' && /^[A-Za-z]+$/.test(message.errorType)) {
+            const status = Number.isInteger(message.httpStatus) && message.httpStatus >= 400 && message.httpStatus <= 599
+              ? `; HTTP ${message.httpStatus}` : '';
+            failure = new Error(`Reactor session connection failed (${message.errorType}${status}) before any clip was submitted; check the provider account and model availability before retrying`);
+          }
           if (!failure && message.type === 'error' && /^[a-z]+$/.test(message.phase) && /^[A-Za-z]+$/.test(message.errorType)) failure = new Error(`Reactor ${message.phase} failed (${message.errorType})`);
           if (message.type === 'status') {
             if (typeof message.message === 'string' && /^Captured [0-9.]+ of [0-9.]+ frames; audio=(True|False)$/.test(message.message)) console.log(`🎬 ${message.message}`);

--- a/server/services/videoGen/reactor.test.js
+++ b/server/services/videoGen/reactor.test.js
@@ -85,6 +85,22 @@ describe('Reactor SDK adapter', () => {
     expect(reactor.getActiveJob()).toBeNull();
   });
 
+  it.each([400, 402, undefined, 'private-status', 600])('reports session rejection with safe status %s before clip submission', async (httpStatus) => {
+    await started();
+    const failed = once(videoGenEvents, 'failed');
+    child.stdout.emit('data', Buffer.from(JSON.stringify({ type: 'error', phase: 'connecting', errorType: 'BadRequestError', httpStatus, message: 'private response body' }) + '\n'));
+    child.emit('close', 1);
+    const [event] = await failed;
+    expect(event.error).toContain('before any clip was submitted');
+    expect(event.error).toContain('check the provider account and model availability');
+    if (httpStatus === 400 || httpStatus === 402) expect(event.error).toContain(`HTTP ${httpStatus}`);
+    else expect(event.error).not.toContain('HTTP');
+    expect(event.error).not.toContain('private');
+    expect(mocks.spawn).toHaveBeenCalledOnce();
+    expect(mocks.finalize).not.toHaveBeenCalled();
+    expect(reactor.getActiveJob()).toBeNull();
+  });
+
   it('rejects all blank samples before history publication and removes the output', async () => {
     const sharp = (await import('sharp')).default;
     await sharp({ create: { width: 32, height: 32, channels: 3, background: '#000000' } }).png().toFile(join(root, 'blank.png'));


### PR DESCRIPTION
## Summary
Reactor connection rejections currently lose the SDK HTTP status and appear as `Reactor connecting failed (BadRequestError)`. Preserve only a validated numeric error status across the Python capture boundary and report that session connection failed before any clip was submitted, with guidance to check provider account and model availability. Raw SDK response bodies remain private.

The investigated render's duration, prompt length, and canvas meet the documented FastH3 constraints. Connection precedes canvas selection, image upload, and enqueue, so changing those valid parameters cannot fix this rejection. The original HTTP status was discarded; this change repairs that diagnostic gap but does not claim to resolve the historical provider-side rejection. No paid render was retried.

## Test plan
- Passed 68 tests across Reactor adapter, clip constraints, backend parameter mapping, Creative Director scene backend, and Python capture wrapper suites.
- Passed all 11 offline Python capture lifecycle tests directly.
- Regression coverage verifies safe HTTP status propagation, legacy/malformed status fallback, disconnect without command submission, and no private response text in emitted errors.
- Reviewed the diff for reuse, scope, privacy, and compatibility; `git diff --check` passes.
