### PR TITLE
fix: show only active maintenance runs on schedule

### DIFF
--- a/client/src/components/cos/tabs/schedule/MaintenanceRunForm.jsx
+++ b/client/src/components/cos/tabs/schedule/MaintenanceRunForm.jsx
@@ -13,7 +13,6 @@ import { effortAwareModelOptions, isProcessProvider } from '../../../../utils/pr
 import { familyForProvider } from '../../../../../../server/lib/providerFamilies';
 
 const RUNS_POLL_MS = 15_000;
-const FINISHED_RUNS_SHOWN = 3;
 
 export default function MaintenanceRunForm({ schedule, apps = [], providers = [], providersLoaded, improvementDisabled, daemonRunning, onRefresh }) {
   const [appId, setAppId] = useState('');
@@ -122,11 +121,10 @@ export default function MaintenanceRunForm({ schedule, apps = [], providers = []
     setBusy(false);
   };
 
-  const applyRun = (updated, result) => {
+  const applyRun = updated => {
     if (!updated) return;
     revision.current += 1;
     setRuns(current => (current || []).map(entry => (entry.id === updated.id ? updated : entry)));
-    if (result) setMessage(describe(result));
   };
   const stop = async id => {
     const response = await api.stopMaintenanceRun(id, { silent: true }).catch(error => {
@@ -135,18 +133,7 @@ export default function MaintenanceRunForm({ schedule, apps = [], providers = []
     });
     applyRun(response?.run);
   };
-  const resume = async id => {
-    const response = await api.resumeMaintenanceRun(id, { silent: true }).catch(error => {
-      setMessage(`Could not resume the run: ${error.message}`);
-      return null;
-    });
-    applyRun(response?.run, response?.result);
-  };
-
-  const visibleRuns = [
-    ...(runs || []).filter(entry => entry.status === 'running'),
-    ...(runs || []).filter(entry => entry.status !== 'running').slice(0, FINISHED_RUNS_SHOWN),
-  ];
+  const visibleRuns = (runs || []).filter(entry => entry.status === 'running');
 
   return (
     <div className="mt-3 space-y-3 text-sm">
@@ -226,9 +213,7 @@ export default function MaintenanceRunForm({ schedule, apps = [], providers = []
             <span className="font-medium">{getAppName(entry.appId, apps, entry.appId)}</span>
             <span className="text-xs">{entry.providerId}{entry.model ? ` · ${entry.model}` : ''}</span>
             <MaintenanceRunStatus run={entry} showSteps />
-            {entry.status === 'running'
-              ? <button type="button" onClick={() => stop(entry.id)} className="px-2 py-1 text-xs bg-port-border rounded">Stop</button>
-              : entry.status === 'stopped' && <button type="button" onClick={() => resume(entry.id)} className="px-2 py-1 text-xs bg-port-border rounded">Resume</button>}
+            <button type="button" onClick={() => stop(entry.id)} className="px-2 py-1 text-xs bg-port-border rounded">Stop</button>
           </li>;
         })}
       </ul>}

--- a/client/src/components/cos/tabs/schedule/MaintenanceRunForm.test.jsx
+++ b/client/src/components/cos/tabs/schedule/MaintenanceRunForm.test.jsx
@@ -72,18 +72,22 @@ describe('maintenance launch', () => {
     await user.click(screen.getByRole('button', { name: 'Run now' }));
     expect(await screen.findByText(/Could not start maintenance: a maintenance run is already in progress/)).toBeInTheDocument();
   });
-  it('stops and resumes an existing run from the list', async () => {
+  it('shows only active runs and removes a run when stopped', async () => {
     const user = userEvent.setup();
-    api.getMaintenanceRuns.mockResolvedValue({ runs: [runRecord()] });
+    api.getMaintenanceRuns.mockResolvedValue({ runs: [
+      runRecord({ id: 'old-completed', status: 'completed', providerId: 'historical-completed' }),
+      runRecord(),
+      runRecord({ id: 'old-stopped', status: 'stopped', providerId: 'historical-stopped' }),
+    ] });
     api.stopMaintenanceRun.mockResolvedValue({ run: runRecord({ status: 'stopped', reason: 'stopped by the user' }) });
-    api.resumeMaintenanceRun.mockResolvedValue({ run: runRecord(), result: { dispatched: true, taskType: 'claim-issue' } });
     show();
-    await user.click(await screen.findByRole('button', { name: 'Stop' }));
-    expect(await screen.findByText(/stopped · 1\/13 steps/)).toBeInTheDocument();
+    await screen.findByRole('button', { name: 'Stop' });
+    expect(screen.queryByText(/historical-/)).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Resume' })).not.toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Stop' }));
     expect(api.stopMaintenanceRun).toHaveBeenCalledWith('maint-1', { silent: true });
-    await user.click(screen.getByRole('button', { name: 'Resume' }));
-    expect(await screen.findByText(/running · 1\/13 steps/)).toBeInTheDocument();
-    expect(screen.getByText(/Maintenance started with claim-issue/)).toBeInTheDocument();
+    expect(screen.queryByRole('list', { name: 'Maintenance runs' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Refresh runs' })).not.toBeInTheDocument();
   });
   it('blocks missing task eligibility and a stopped daemon', async () => {
     const user = userEvent.setup();
@@ -158,6 +162,8 @@ it('streams agent activity and completed steps, and removes listeners on unmount
   expect(screen.getByRole('link', { name: 'Open agent in new tab' })).toHaveAttribute('target', '_blank');
   act(() => update(runRecord()));
   expect(screen.getByRole('progressbar')).toHaveAttribute('value', '1');
+  act(() => update(runRecord({ status: 'completed', active: null })));
+  expect(screen.queryByRole('list', { name: 'Maintenance runs' })).not.toBeInTheDocument();
   view.unmount();
   expect(socket.off).toHaveBeenCalledWith('cos:maintenance:updated', update);
 });
@@ -172,7 +178,7 @@ it('keeps a newer live update when an older initial fetch resolves late, and ref
   expect(screen.getByRole('progressbar')).toHaveAttribute('value', '1');
   api.getMaintenanceRuns.mockResolvedValue({ runs: [runRecord({ status: 'completed', active: null })] });
   await act(async () => socket.on.mock.calls.find(([name]) => name === 'connect')[1]());
-  expect(screen.getByText(/completed · 1\/13 steps/)).toBeInTheDocument();
+  expect(screen.queryByRole('list', { name: 'Maintenance runs' })).not.toBeInTheDocument();
 });
 
 it('launches fix mode only after renewed consent', async () => {


### PR DESCRIPTION
## Summary
Show only running maintenance sequences in the Recommended maintenance order card. Completed and stopped runs disappear, including after live updates; active progress and Stop remain available.

Remove the now-unreachable Resume action from this card. Persisted run history and server APIs are unchanged.

## Test plan
- 15 tests passed across MaintenanceRunForm and ScheduleTab, including mixed historical/active records, stopping, live completion, and reconnect refresh.
- Client lint passed.
- Reviewed the diff for reuse, dead code, and lifecycle edge cases.
