### PR TITLE
fix: avoid duplicate clipboard notifications

### DIFF
--- a/client/src/components/fableloom/LoomHostedSessionModal.jsx
+++ b/client/src/components/fableloom/LoomHostedSessionModal.jsx
@@ -114,11 +114,7 @@ export default function LoomHostedSessionModal({
     }
   };
 
-  const handleCopyLink = async () => {
-    if (!currentJoinUrl) return;
-    const ok = await copyToClipboard(currentJoinUrl);
-    if (ok) toast.success('Join link copied to clipboard!');
-  };
+  const handleCopyLink = () => copyToClipboard(currentJoinUrl, 'Join link copied to clipboard!');
 
   return (
     <Modal

--- a/client/src/pages/AIProviders.jsx
+++ b/client/src/pages/AIProviders.jsx
@@ -425,10 +425,7 @@ export default function AIProviders() {
     toast.success('ChatGPT subscription signed out');
   };
 
-  const handleCopyCodexDeviceCode = async (code) => {
-    if (await copyToClipboard(code)) toast.success('Device code copied');
-    else toast.error('Could not copy the device code');
-  };
+  const handleCopyCodexDeviceCode = (code) => copyToClipboard(code, 'Device code copied');
 
   // llama.cpp (and similar local daemons) answer as a single model id — the
   // server's `--alias`, not the preset name on this card. Matching the


### PR DESCRIPTION
## Summary
Copying a hosted-play join link or Codex device code currently shows duplicate clipboard notifications. Let the shared clipboard helper display the existing custom success message and handle failures once.

## Test plan
- Rebased onto main; the previously shipped timeline fade extraction was dropped.
- Full client suite: 917 files passed, 11,269 tests passed (1 file and 8 tests skipped).
- Client lint passed; git diff --check passed.
- Self-reviewed both handlers against the shared clipboard helper's success, failure, and empty-input behavior.
