### PR TITLE
fix: normalize declared navigation aliases before matching

### DIFF
--- a/server/lib/navManifest.js
+++ b/server/lib/navManifest.js
@@ -483,7 +483,6 @@ for (const cmd of NAV_COMMANDS) {
     if (!aliasToPath[alias]) aliasToPath[alias] = cmd.path;
   }
 }
-const ALIAS_KEYS = Object.keys(aliasToPath);
 
 export const getNavAliasMap = () => ({ ...aliasToPath });
 
@@ -493,9 +492,19 @@ export const normalizeLabel = (s) => (s || '')
   .trim()
   .replace(/[.!?:;,"']+$/, '');
 
+// Derive lookup keys using the same normalization as spoken input. Keep the
+// original alias for getNavAliasMap(), matched, and command ownership lookup.
+const normalizeNavAlias = (alias) => normalizeLabel(alias).replace(/\s+/g, '-');
+const normalizedAliases = new Map();
+for (const alias of Object.keys(aliasToPath)) {
+  const key = normalizeNavAlias(alias);
+  if (!normalizedAliases.has(key)) normalizedAliases.set(key, alias);
+}
+const ALIAS_KEYS = [...normalizedAliases.keys()];
+
 export const resolveNavCommand = (input) => {
   if (!input || typeof input !== 'string') return null;
-  const norm = normalizeLabel(input).replace(/\s+/g, '-');
+  const norm = normalizeNavAlias(input);
   if (!norm) return null;
 
   const tail = norm.split('-').filter(Boolean).pop();
@@ -529,6 +538,7 @@ export const resolveNavCommand = (input) => {
   }
   if (!matched) return null;
 
+  matched = normalizedAliases.get(matched);
   const path = aliasToPath[matched];
   const command = NAV_COMMANDS.find((c) => c.path === path && (c.aliases || []).includes(matched))
     || NAV_COMMANDS.find((c) => c.path === path);

--- a/server/lib/navManifest.test.js
+++ b/server/lib/navManifest.test.js
@@ -248,6 +248,17 @@ describe('nav contract — instance-feature gating', () => {
 });
 
 describe('resolveNavCommand — fuzzy matching', () => {
+  it('resolves every declared alias to its owning command', () => {
+    for (const command of NAV_COMMANDS) {
+      for (const alias of command.aliases || []) {
+        const hit = resolveNavCommand(alias);
+        expect(hit?.path, alias).toBe(command.path);
+        expect(hit?.command?.id, alias).toBe(command.id);
+        expect(command.aliases, alias).toContain(hit?.matched);
+      }
+    }
+  });
+
   it('resolves exact alias', () => {
     expect(resolveNavCommand('dashboard')?.path).toBe('/');
     expect(resolveNavCommand('tasks')?.path).toBe('/cos/tasks');


### PR DESCRIPTION
## Summary

The manifest declares space-containing aliases that the server never normalized, although it normalizes spoken input to hyphens. `data brokers` opened `/data`, `opt out` failed, and four other aliases disagreed with browser voice navigation. Derive normalized lookup keys from the declaring aliases once at module load and use the same normalizer for input.

Producer: `server/lib/navManifest.js` (`NAV_COMMANDS`). Consumers: server `voice/tools/ui.js` through `resolveNavCommand`; the palette, sidebar and browser `voiceFastPath.js` consume manifest entries. The compatibility alias-map export and original `matched` spelling remain unchanged; browser high-precision and server fuzzy matching remain separate policies.

History: commit `33646086b` added `data brokers` and the other Brokers aliases without changing the input-only normalization introduced in `665da2778`. Present-day comparison reproduced six wrong/missing server destinations. A manifest-driven guard now verifies that every alias resolves to its owning command, so new aliases cannot silently become unreachable.

## Test plan

- New guard failed before the fix: `data brokers` resolved to `/data` instead of `/privacy/brokers`.
- Server: `vitest run lib/navManifest.test.js services/voice/tools.test.js` — 238 tests passed.
- Compared browser and server destinations for all 763 declared aliases: six discrepancies before, zero afterward.
- `git diff --check` passed.
