### PR TITLE
fix: remove misleading playground copy confirmation

### DIFF
--- a/client/src/components/localLlm/PlaygroundOutput.jsx
+++ b/client/src/components/localLlm/PlaygroundOutput.jsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react';
-import { Check, Code2, Copy, Eye } from 'lucide-react';
+import { Code2, Copy, Eye } from 'lucide-react';
 import MarkdownOutput from '../cos/MarkdownOutput';
 import { copyToClipboard } from '../../lib/clipboard';
 
@@ -53,20 +53,6 @@ export function parseSegments(text) {
   return segments;
 }
 
-function CopyButton({ value, label = 'Copied' }) {
-  const [copied, setCopied] = useState(false);
-  return (
-    <button
-      onClick={() => { copyToClipboard(value, label); setCopied(true); setTimeout(() => setCopied(false), 1200); }}
-      className="flex items-center gap-1 text-[11px] text-gray-400 hover:text-white"
-      title="Copy code"
-    >
-      {copied ? <Check size={12} className="text-port-success" /> : <Copy size={12} />}
-      {copied ? 'Copied' : 'Copy'}
-    </button>
-  );
-}
-
 function CodeBlock({ lang, code, closed }) {
   const htmlPreviewable = useMemo(() => isHtmlLike(lang, code), [lang, code]);
   // 'code' | 'preview' — only meaningful when htmlPreviewable. Default to code so
@@ -97,7 +83,14 @@ function CodeBlock({ lang, code, closed }) {
               </button>
             </div>
           )}
-          <CopyButton value={code} label="Copied code" />
+          <button
+            type="button"
+            onClick={() => copyToClipboard(code, 'Copied code')}
+            className="flex items-center gap-1 text-[11px] text-gray-400 hover:text-white"
+            title="Copy code"
+          >
+            <Copy size={12} /> Copy
+          </button>
         </div>
       </div>
       {showPreview ? (

--- a/client/src/components/localLlm/PlaygroundOutput.test.jsx
+++ b/client/src/components/localLlm/PlaygroundOutput.test.jsx
@@ -1,6 +1,14 @@
-import { describe, it, expect } from 'vitest';
-import { render, fireEvent } from '@testing-library/react';
+import { afterEach, describe, it, expect, vi } from 'vitest';
+import { render, fireEvent, waitFor } from '@testing-library/react';
 import PlaygroundOutput, { parseSegments } from './PlaygroundOutput';
+
+const toast = vi.hoisted(() => ({ success: vi.fn(), error: vi.fn() }));
+vi.mock('../ui/Toast', () => ({ default: toast }));
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
 
 describe('parseSegments', () => {
   it('splits prose and fenced code into ordered segments with the language captured', () => {
@@ -55,5 +63,30 @@ describe('PlaygroundOutput rendering', () => {
   it('offers Preview for a bare fence whose body sniffs as HTML', () => {
     const { getByText } = render(<PlaygroundOutput text={'```\n<!doctype html><html></html>\n```'} />);
     expect(getByText('Preview')).toBeTruthy();
+  });
+});
+
+describe('code copying', () => {
+  it('reports success only after the code reaches the clipboard', async () => {
+    let finishWrite;
+    const writeText = vi.fn(() => new Promise(resolve => { finishWrite = resolve; }));
+    vi.stubGlobal('navigator', { clipboard: { writeText } });
+    const { getByTitle, queryByText } = render(<PlaygroundOutput text={'```js\nconst answer = 42;\n```'} />);
+    fireEvent.click(getByTitle('Copy code'));
+    expect(writeText).toHaveBeenCalledWith('const answer = 42;');
+    expect(queryByText('Copied')).toBeNull();
+    expect(toast.success).not.toHaveBeenCalled();
+    finishWrite();
+    await waitFor(() => expect(toast.success).toHaveBeenCalledWith('Copied code'));
+    expect(toast.success).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports a denied copy without a false Copied indicator', async () => {
+    vi.stubGlobal('navigator', { clipboard: { writeText: vi.fn().mockRejectedValue(new Error('denied')) } });
+    const { getByTitle, queryByText } = render(<PlaygroundOutput text={'```js\nconst answer = 42;\n```'} />);
+    fireEvent.click(getByTitle('Copy code'));
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith('Copy failed'));
+    expect(queryByText('Copied')).toBeNull();
+    expect(toast.success).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
The local LLM playground displayed “Copied” immediately, including when clipboard access was denied, and duplicated the shared helper's success notification. Remove the local copy-button state and timer and use `client/src/lib/clipboard.js` as the sole outcome notification.

The audit was bounded to client clipboard handling. `PlaygroundOutput.jsx` had drifted from the result-aware handling in `ModelThroughputReport.jsx`; no storage or compatibility paths change.

## Test plan
- Passed 27 tests across PlaygroundOutput and the shared clipboard helper, including rendered pending-write and denied-write regressions.
- Passed client Biome lint for both changed files.
- Passed `git diff --check`.
