### PR TITLE
fix: exclude help wanted issues from scheduled task context

### DIFF
--- a/server/lib/taskDataInputCatalog.js
+++ b/server/lib/taskDataInputCatalog.js
@@ -9,7 +9,7 @@
 export const TASK_DATA_INPUT_DEFINITIONS = Object.freeze([
   Object.freeze({ id: 'product-requirements', label: 'Product requirements', description: 'Find and include PRD.md files from the target repository.', requiresApp: true }),
   Object.freeze({ id: 'project-goals', label: 'Project goals', description: 'Find and include GOALS.md files from the target repository.', requiresApp: true }),
-  Object.freeze({ id: 'open-issues', label: 'Open issues', description: 'Include the target repository\'s current open forge issues, with their labels.', requiresApp: true, carriesDispatchLabels: true }),
+  Object.freeze({ id: 'open-issues', label: 'Open issues', description: 'Include the target repository\'s current open forge issues, with their labels, excluding help wanted issues.', requiresApp: true, carriesDispatchLabels: true }),
   Object.freeze({ id: 'open-pull-requests', label: 'Open pull requests', description: 'Include the target repository\'s current open pull or merge requests.', requiresApp: true }),
   Object.freeze({ id: 'closed-unmerged-pull-requests', label: 'Closed unmerged pull requests', description: 'Include recently closed pull or merge requests that were not merged.', requiresApp: true }),
 ]);

--- a/server/services/taskDataInputs.js
+++ b/server/services/taskDataInputs.js
@@ -230,7 +230,13 @@ const INPUT_LOADERS = {
         }, forge.env)
       : await deps.listIssues({ cli: forge.cli, cwd: app.repoPath, env: forge.env });
     return result.ok
-      ? renderForgeItems(result.issues, { emptyMessage: configured ? 'No open issues match this task’s configured filters.' : 'No open issues.' })
+      ? renderForgeItems(
+          // Human-gated work is never a scheduled agent input. Keep the raw
+          // listing intact for callers that need it for duplicate detection.
+          result.issues.filter((issue) => !normalizeLabels(issue.labels)
+            .some((label) => label.trim().toLowerCase() === 'help wanted')),
+          { emptyMessage: 'No open issues match this task’s configured filters (help wanted is excluded).' }
+        )
         + (result.truncated ? TRUNCATION_NOTICE : '')
       : unavailableMessage('Open issues');
   },

--- a/server/services/taskDataInputs.test.js
+++ b/server/services/taskDataInputs.test.js
@@ -65,7 +65,7 @@ describe('taskDataInputs', () => {
 
     common.dependencies.listIssues.mockResolvedValue({ ok: true, issues: [] });
     const empty = await resolveTaskDataInputs(['open-issues'], common);
-    expect(empty[0].content).toBe('No open issues.');
+    expect(empty[0].content).toContain('No open issues match');
   });
 
   it('uses task policy for issue context and fails closed when policy resolution fails', async () => {
@@ -88,6 +88,32 @@ describe('taskDataInputs', () => {
     await resolveTaskDataInputs(['open-issues'], options);
     expect(listConfiguredIssues).toHaveBeenLastCalledWith('gh', APP, { issueAuthorFilter: 'self', issueExcludeLabels: [] }, expect.any(Object));
     expect(listIssues).not.toHaveBeenCalled();
+  });
+
+  it.each([false, true])('omits human-gated issues from scheduled context (configured: %s)', async (configured) => {
+    const issues = [
+      { number: 1, title: 'Human hardware validation', labels: [' Help Wanted '] },
+      { number: 2, title: 'Human perspectives', labels: [{ name: 'help wanted' }] },
+      { number: 3, title: 'Automatable work', labels: ['bug'] },
+    ];
+    const list = vi.fn().mockResolvedValue({ ok: true, issues });
+    const options = {
+      app: APP,
+      taskMetadata: configured ? { issueExcludeLabels: ['human-only'] } : {},
+      dependencies: {
+        resolveTracker: vi.fn().mockResolvedValue({ forge: 'gh', host: 'github.com' }),
+        resolveTokenEnv: vi.fn().mockResolvedValue({}),
+        listIssues: list, listConfiguredIssues: list,
+      },
+    };
+    const [section] = await resolveTaskDataInputs(['open-issues'], options);
+    expect(section.content).toContain('#3 Automatable work');
+    expect(section.content).not.toContain('Human hardware');
+    expect(section.content).not.toContain('Human perspectives');
+    expect(issues).toHaveLength(3);
+    list.mockResolvedValue({ ok: true, issues: issues.slice(0, 2) });
+    expect((await resolveTaskDataInputs(['open-issues'], options))[0].content)
+      .toContain('help wanted is excluded');
   });
 
   it('reports a discovered document that could not be read', async () => {


### PR DESCRIPTION
## Summary
Scheduled-task open-issue preloads now omit `help wanted` issues, including when a task has additional author or label filters. This keeps work reserved for human participation out of agent context. The data-input catalog describes the exclusion; raw tracker listings remain available for deduplication.

Chose the default exclusion instead of adding a second label configuration system; existing task metadata filters continue to apply.

## Test plan
- Server taskDataInputs suite: 17 tests passed.
- Regression coverage for configured and unconfigured tasks, string and object label formats, case normalization, and fully excluded lists.
- Reviewed diff for reuse and scope; git diff --check passed.
