### PR TITLE
fix: simplify agent prompt developer context loading

### DIFF
--- a/server/services/agentPromptBuilder.js
+++ b/server/services/agentPromptBuilder.js
@@ -414,21 +414,9 @@ export async function buildAgentPrompt(task, config, workspaceDir, worktreeInfo 
   // Architect doctrine for an orchestrated run (#5992). '' for every direct-mode
   // task, which is the default, so this is inert unless a profile is configured.
   const orchestrationSection = buildOrchestrationDoctrineSection(task);
-  // Fetch independent context sections in parallel
-  const [memorySection, agentInstructionsSection, digitalTwinSection] = await Promise.all([
-    skipDevContext
-      ? Promise.resolve(null)
-      : getMemorySection(task, { maxTokens: config.memory?.maxContextTokens || 2000 })
-          .catch(err => { console.log(`⚠️ Memory retrieval failed: ${err.message}`); return null; }),
-    skipDevContext
-      ? Promise.resolve(null)
-      : getAgentInstructionsContext(workspaceDir)
-          .catch(err => { console.log(`⚠️ Agent instructions retrieval failed: ${err.message}`); return null; }),
-    skipDevContext
-      ? Promise.resolve(null)
-      : getDigitalTwinForPrompt({ maxTokens: config.digitalTwin?.maxContextTokens || config.soul?.maxContextTokens || 2000, personaId: 'active' })
-          .catch(err => { console.log(`⚠️ Digital twin context retrieval failed: ${err.message}`); return null; })
-  ]);
+  const { memorySection, agentInstructionsSection, digitalTwinSection } = await loadDeveloperContext(
+    task, config, workspaceDir, skipDevContext,
+  );
 
   // Build context compaction section if task is retrying after a context-limit failure
   const compactionSection = task.metadata?.compaction?.needed ? buildCompactionSection(task) : '';
@@ -685,6 +673,22 @@ ${buildResumeSection(task, worktreeInfo)}` : '';
     toolsSection, planningContextSection, uiAuditRuntimeSection,
     completionBullet, completionInstructions, noChangeSuccess,
   });
+}
+
+/** Load independent developer context concurrently, unless this is a content-only task. */
+async function loadDeveloperContext(task, config, workspaceDir, skipDevContext) {
+  if (skipDevContext) {
+    return { memorySection: null, agentInstructionsSection: null, digitalTwinSection: null };
+  }
+  const [memorySection, agentInstructionsSection, digitalTwinSection] = await Promise.all([
+    getMemorySection(task, { maxTokens: config.memory?.maxContextTokens || 2000 })
+      .catch(err => { console.log(`⚠️ Memory retrieval failed: ${err.message}`); return null; }),
+    getAgentInstructionsContext(workspaceDir)
+      .catch(err => { console.log(`⚠️ Agent instructions retrieval failed: ${err.message}`); return null; }),
+    getDigitalTwinForPrompt({ maxTokens: config.digitalTwin?.maxContextTokens || config.soul?.maxContextTokens || 2000, personaId: 'active' })
+      .catch(err => { console.log(`⚠️ Digital twin context retrieval failed: ${err.message}`); return null; })
+  ]);
+  return { memorySection, agentInstructionsSection, digitalTwinSection };
 }
 
 /**

--- a/server/services/agentPromptBuilder.test.js
+++ b/server/services/agentPromptBuilder.test.js
@@ -3029,6 +3029,31 @@ describe('discardWorktree (reasoning-only) completion contract', () => {
       vi.mocked(getToolsSummaryForPrompt).mockResolvedValue('');
     });
 
+    it('keeps API briefing instructions when optional context retrieval fails, preserving budget fallbacks', async () => {
+      vi.mocked(getMemorySection).mockRejectedValueOnce(new Error('memory unavailable'));
+      vi.mocked(getDigitalTwinForPrompt).mockRejectedValueOnce(new Error('twin unavailable'));
+      const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+      try {
+        await buildAgentPrompt(makeTask(), {
+          memory: { maxContextTokens: 0 },
+          digitalTwin: { maxContextTokens: 0 },
+          soul: { maxContextTokens: 1200 },
+        }, '/r', null, isTruthyMeta, { providerType: 'api' });
+        const [, context] = vi.mocked(buildPrompt).mock.calls.at(-1);
+        expect(context.memorySection).toBeNull();
+        expect(context.digitalTwinSection).toBeNull();
+        expect(context.agentInstructionsSection).toContain('Example Global Instructions');
+        expect(context.claudeMdSection).toBe(context.agentInstructionsSection);
+        expect(context.soulSection).toBeNull();
+        expect(getMemorySection).toHaveBeenLastCalledWith(expect.anything(), { maxTokens: 2000 });
+        expect(getDigitalTwinForPrompt).toHaveBeenLastCalledWith({ maxTokens: 1200, personaId: 'active' });
+        expect(log).toHaveBeenCalledWith('⚠️ Memory retrieval failed: memory unavailable');
+        expect(log).toHaveBeenCalledWith('⚠️ Digital twin context retrieval failed: twin unavailable');
+      } finally {
+        log.mockRestore();
+      }
+    });
+
     it('a non-CD api task still loads memory, digital-twin, and onboard-tools sections', async () => {
       vi.mocked(getMemorySection).mockClear().mockResolvedValue('## Memory Context\nNONCD_MEMORY_SENTINEL');
       vi.mocked(getDigitalTwinForPrompt).mockClear().mockResolvedValue('## Digital Twin\nNONCD_TWIN_SENTINEL');


### PR DESCRIPTION
## Summary

API agent prompts repeated the same content-only skip decision for memory, repository instructions, and digital-twin context. Extract the cohesive `loadDeveloperContext` step and collapse those three branches into one early return. Retrieval remains concurrent; failures still log and yield null independently, and token budgets and legacy template aliases are unchanged.

Measured with an AST walk: base 1 plus each if, non-default case, loop, catch clause, logical operator (`&&`, `||`, `??`), and ternary; nested functions are counted separately. Optional chaining is not counted. Churn is file-touch count from `git log --since='90 days ago' --name-only --format=''`.

| Candidate and evidence | Before → after | 90-day file touches | Caller evidence and selection |
| --- | --- | --- | --- |
| `server/services/agentPromptBuilder.js:322`, `buildAgentPrompt` | 46 → 40 | 131 | One production call at `server/services/agentLifecycle.js:547`, shared by ordinary agent spawns. Selected: repeated context exclusion branches have one coherent rule. |
| `server/services/agentLifecycle.js:143`, `runAgentSpawn` | 70 → 70 | 119 | Called by `spawnAgentForTask` at line 125, reached from `server/services/subAgentSpawner.js:227`. Not selected: existing named eligibility guards and spawn lifecycle ownership make it less suitable for this bounded change. |
| `server/services/cosTaskGenerator.js:2541`, `generateManagedAppImprovementTaskForType` | 40 → 40 | 175 | Three production calls: same file lines 1524/1996 and `server/services/onDemandDrain.js:146`. Not selected: much branching is already a flat sequence of named precondition gates. |

The selected function's count is 1 + 4 if + 4 `&&` + 12 `||` + 24 ternaries + 1 `??` = 46; afterward the `||` count is 9 and ternaries 21, yielding 40. New private helper `server/services/agentPromptBuilder.js:679` is 5 (1 + 1 if + 3 `||`); its three rejection callbacks each remain 1. This removes two decision points overall, rather than only moving branches.

## Test plan

- Added a public `buildAgentPrompt` boundary regression at `server/services/agentPromptBuilder.test.js:3032` before modifying production code: optional retrieval failures retain instructions and template aliases, log independently, and preserve zero-value/legacy token-budget fallback. All 275 prompt tests passed on the original implementation.
- Existing boundary cases at test lines 3002 and 3057 pin Creative Director no-fetch/null behavior and ordinary context inclusion.
- After refactor: `cd server && node_modules/.bin/vitest related --run services/agentPromptBuilder.js --silent=passed-only` — 16 files, 751 tests passed.
- `git diff --check` passed; reviewed diff for behavior preservation and private data.
