### PR TITLE
fix: avoid cloning task prompts for auto-fix telemetry

### DIFF
--- a/server/services/autoFixMetrics.js
+++ b/server/services/autoFixMetrics.js
@@ -16,7 +16,7 @@
  * recovery".
  */
 
-import { getAllTasks } from './cosTaskStore.js';
+import { getTaskDiagnostics } from './cosTaskStore.js';
 import { fixTierMeta } from './autoFixer.js';
 
 // A diagnostics-bearing task is "resolved" once its task reaches the terminal
@@ -168,11 +168,10 @@ export function aggregateAutoFixDiagnostics(tasks, { now = Date.now() } = {}) {
 }
 
 /**
- * Load all persisted tasks (user + internal) and aggregate their auto-fix
- * diagnostics. Thin I/O shim over the pure reducer above.
+ * Aggregate persisted auto-fix diagnostics from user and internal tasks.
+ * Thin I/O shim over the pure reducer above.
  */
 export async function getAutoFixMetrics({ now = Date.now() } = {}) {
-  const { user, cos } = await getAllTasks();
-  const tasks = [...(user?.tasks || []), ...(cos?.tasks || [])];
+  const tasks = await getTaskDiagnostics();
   return aggregateAutoFixDiagnostics(tasks, { now });
 }

--- a/server/services/cosTaskStore.js
+++ b/server/services/cosTaskStore.js
@@ -241,6 +241,29 @@ export async function getPendingTaskIds() {
 }
 
 /**
+ * Telemetry reads only diagnostics-bearing records, never full prompts or
+ * grouped history. Derive per snapshot and reuse the task cache's internal-write
+ * and external-edit invalidation; clone the projection to keep it private.
+ */
+export async function getTaskDiagnostics() {
+  const { config } = await loadState();
+  const sources = await Promise.all([config.userTasksFile, config.cosTasksFile].map(async (file) => {
+    const filePath = join(ROOT_DIR, file);
+    if (!existsSync(filePath)) return [];
+    const snapshot = await readTaskSnapshot(filePath);
+    snapshot.diagnosticTasks ??= snapshot.tasks.filter(task => {
+      const diagnostics = task.metadata?.diagnostics;
+      return diagnostics && typeof diagnostics === 'object' && !Array.isArray(diagnostics);
+    }).map(task => ({
+      status: task.status,
+      metadata: { diagnostics: task.metadata.diagnostics, updatedAt: task.metadata.updatedAt }
+    }));
+    return snapshot.diagnosticTasks;
+  }));
+  return structuredClone(sources.flat());
+}
+
+/**
  * Alias for backward compatibility
  */
 export const getTasks = getUserTasks;

--- a/server/services/cosTaskStore.test.js
+++ b/server/services/cosTaskStore.test.js
@@ -73,6 +73,8 @@ vi.mock('./cosState.js', () => ({
   ROOT_DIR: '/root'
 }));
 
+vi.mock('./cos.js', () => ({ isRunning: vi.fn(() => false) }));
+
 vi.mock('./cosEvents.js', () => ({
   cosEvents: { emit: (name, payload) => mock.events.push({ name, payload }) }
 }));
@@ -97,6 +99,7 @@ import {
   getCosTasks,
   getAllTasks,
   getPendingTaskIds,
+  getTaskDiagnostics,
   getTasks,
   getTaskById,
   addTask,
@@ -116,7 +119,8 @@ import {
   DEFAULT_FAILURE_TASK_MAX_AGE_MS,
   __resetTaskCache
 } from './cosTaskStore.js';
-import { PRIORITY_VALUES } from '../lib/taskParser.js';
+import { aggregateAutoFixDiagnostics, getAutoFixMetrics } from './autoFixMetrics.js';
+import { PRIORITY_VALUES, generateTasksMarkdown } from '../lib/taskParser.js';
 import { AGENT_PAUSED_CATEGORY, PAUSE_METADATA_KEYS, registerPauseReleaseAdapter, __resetPauseReleaseAdapter } from '../lib/taskPauseHold.js';
 import { MAX_TOTAL_SPAWNS } from '../lib/cosValidation.js';
 
@@ -189,6 +193,44 @@ describe('cosTaskStore.getUserTasks / getCosTasks', () => {
 // that every invalidation signal fires, and that a cached read can never leak a
 // caller's in-place mutations into the next reader.
 describe('cosTaskStore parsed-task cache (#3497)', () => {
+  it('reads telemetry without cloning prompts and keeps metrics fresh after task writes and external edits', async () => {
+    const now = Date.parse('2026-07-09T12:00:00Z');
+    expect(await getTaskDiagnostics()).toEqual([]);
+    const tasks = Array.from({ length: 300 }, (_, index) => ({
+      id: `task-${index}`, description: `Example task ${index}`, status: 'pending', priority: 'MEDIUM',
+      metadata: {
+        prompt: 'Example prompt. '.repeat(512),
+        updatedAt: '2026-07-09T11:00:00Z',
+        ...(index % 30 === 0 ? { diagnostics: { tier: 1, category: 'config', observedAt: '2026-07-09T10:00:00Z' } } : {})
+      }
+    }));
+    mock.files.set(USER_FILE, generateTasksMarkdown(tasks.slice(0, 150)));
+    mock.files.set(COS_FILE, generateTasksMarkdown(tasks.slice(150)));
+    const { user, cos } = await getAllTasks();
+    const expected = aggregateAutoFixDiagnostics([...user.tasks, ...cos.tasks], { now });
+    const clone = vi.spyOn(globalThis, 'structuredClone');
+    expect(await getAutoFixMetrics({ now })).toEqual(expected);
+    const projectedBytes = JSON.stringify(clone.mock.calls[0][0]).length;
+    expect(projectedBytes).toBeLessThan(JSON.stringify([...user.tasks, ...cos.tasks]).length / 100);
+    expect(clone.mock.calls[0][0]).toHaveLength(10);
+    const parses = mock.parseCalls;
+    const projection = await getTaskDiagnostics();
+    projection[0].metadata.diagnostics.tier = 99;
+    expect(await getAutoFixMetrics({ now })).toEqual(expected);
+    expect(mock.parseCalls).toBe(parses);
+    clone.mockRestore();
+
+    await updateTask('task-0', { status: 'completed' }, 'user');
+    expect((await getAutoFixMetrics({ now })).overall.resolved).toBe(1);
+    mock.files.set(COS_FILE, mock.files.get(COS_FILE).replace('- [ ]', '- [x]'));
+    mock.mtimes.set(COS_FILE, 5000);
+    expect((await getAutoFixMetrics({ now })).overall.resolved).toBe(2);
+    mock.files.delete(USER_FILE);
+    expect((await getAutoFixMetrics({ now })).total).toBe(5);
+    mock.files.set(COS_FILE, '');
+    expect((await getAutoFixMetrics({ now })).total).toBe(0);
+  });
+
   it('projects pending IDs without cloning task payloads and refreshes after writes and external edits', async () => {
     expect(await getPendingTaskIds()).toEqual([]);
     const user = await addTask({ description: 'Example user task' }, 'user');


### PR DESCRIPTION
## Summary
The dashboard Auto-Fix Telemetry widget polls every 60 seconds (`client/src/components/dashboard/builtins/AutoFixMetricsWidget.jsx:82`). `server/services/autoFixMetrics.js:174` previously loaded and grouped all user and internal tasks, cloning every prompt, before discarding records without diagnostics.

Use a diagnostics-only projection in the existing task snapshot cache (`server/services/cosTaskStore.js:248`). Warm reads now copy diagnostic payloads rather than all task payloads: O(B + N) task preparation becomes O(Bd), where B is all task bytes, N is all tasks, and Bd is diagnostic record bytes. The existing aggregation cost is unchanged. Changed snapshots still parse the task files and rebuild the projection; internal writes and external edits use the existing invalidation rules. No response or persistence format changes.

## Test plan
- Passed 233 tests across `cosTaskStore.test.js`, `autoFixMetrics.test.js`, and `taskParser.test.js` using the server workspace Vitest binary.
- Added a service workflow regression proving identical metrics, caller mutation isolation, warm cache reuse, and refresh after internal writes, external edits, deletion, and empty files.
- Synthetic measurement: 300 tasks with 8 KiB prompts, ten carrying diagnostics. Serialized clone-input size fell from 2,527,791 bytes to 1,501 bytes (99.94% reduction). Over 200 warm calls, the old task-read/aggregation path took 89.0 ms versus 4.0 ms with the projection. This uses the real parser, store, and reducer with mocked file I/O; it is not an HTTP latency measurement. Timing instrumentation was removed; the payload reduction assertion remains.
- `git diff --check` passed.
