### PR TITLE
fix: make shutdown error completion explicit

### DIFF
--- a/server/services/bootstrap.js
+++ b/server/services/bootstrap.js
@@ -890,19 +890,21 @@ export const runBootSequence = ({ io, httpServer, localHttpServer, httpsEnabled,
 // Run an async close but resolve anyway after `ms` — so a close that never
 // settles (e.g. a WebSocket-upgraded socket the server no longer tracks, or a
 // leaked DB client) can't hang shutdown; process.exit() reclaims the resources at
-// the OS level. `run(finish)` receives a settle-once callback: finish() /
-// finish(successMsg) / finish(errMsg, true). The backstop is .unref()'d so it
-// never keeps the event loop alive on its own.
+// the OS level. Both callbacks passed to run resolve the same settle-once
+// promise: finish logs success, finishWithError logs an error and continues.
+// The backstop is .unref()'d so it never keeps the event loop alive on its own.
 const withGrace = (label, ms, run) => new Promise((resolve) => {
   let settled = false;
-  const finish = (msg, isErr) => {
+  const complete = (msg, log) => {
     if (settled) return;
     settled = true;
-    if (msg) (isErr ? console.error : console.log)(msg);
+    if (msg) log(msg);
     resolve();
   };
-  run(finish);
-  setTimeout(() => finish(`⚠️ ${label} close exceeded ${ms}ms — proceeding`, true), ms).unref?.();
+  const finish = (msg) => complete(msg, console.log);
+  const finishWithError = (msg) => complete(msg, console.error);
+  run({ finish, finishWithError });
+  setTimeout(() => finishWithError(`⚠️ ${label} close exceeded ${ms}ms — proceeding`), ms).unref?.();
 });
 
 // graceMs is deliberately short: closeAllConnections() force-drops every
@@ -912,10 +914,10 @@ const withGrace = (label, ms, run) => new Promise((resolve) => {
 // the TCP remnant on process.exit). So don't tax every restart waiting on it.
 // ERR_SERVER_NOT_RUNNING means it was already closed (io.close() closes whichever
 // server is its current this.httpServer) — success for us, not a failure.
-const closeServer = (server, label, graceMs = 250) => withGrace(label, graceMs, (finish) => {
+const closeServer = (server, label, graceMs = 250) => withGrace(label, graceMs, ({ finish, finishWithError }) => {
   if (!server) return finish();
   server.close((err) => {
-    if (err && err.code !== 'ERR_SERVER_NOT_RUNNING') finish(`⚠️ Error closing ${label}: ${err.message}`, true);
+    if (err && err.code !== 'ERR_SERVER_NOT_RUNNING') finishWithError(`⚠️ Error closing ${label}: ${err.message}`);
     else finish(`✅ ${label} closed`);
   });
   // Order matters: close() above stops accepting NEW connections; NOW force-drop
@@ -997,18 +999,18 @@ export const registerShutdownHandlers = ({ io, httpServer, localHttpServer }) =>
     // both outcomes and never rejects (hence `finish()` with no message), the
     // `.catch` is the belt-and-suspenders for an out-of-lifecycle rejection, and a
     // marker we fail to write only degrades recovery to the pre-existing orphan path.
-    const markerWritten = withGrace('Host-shutdown marker', 1500, (finish) =>
+    const markerWritten = withGrace('Host-shutdown marker', 1500, ({ finish, finishWithError }) =>
       writeHostShutdownMarker({ agentIds: [...activeAgents.keys()], signal })
-        .then(() => finish(), (err) => finish(`⚠️ Host-shutdown marker failed: ${err.message}`, true)));
+        .then(() => finish(), (err) => finishWithError(`⚠️ Host-shutdown marker failed: ${err.message}`)));
 
     // Terminate the Codex app-server child before the socket teardown below.
     // pm2's TreeKill would reap it anyway, but a direct SIGTERM keeps a manual
     // `kill` of the server from orphaning a Codex process holding the user's
     // sign-in, and it is a no-op when nothing was ever spawned.
-    await withGrace('Codex app-server', 2000, (finish) =>
+    await withGrace('Codex app-server', 2000, ({ finish, finishWithError }) =>
       stopCodexAppServer().then(
         () => finish(),
-        (err) => finish(`⚠️ Codex app-server stop failed: ${err.message}`, true),
+        (err) => finishWithError(`⚠️ Codex app-server stop failed: ${err.message}`),
       ));
 
     // Drop existing long-lived sockets (SSE + keep-alive) up front so the closes
@@ -1023,8 +1025,11 @@ export const registerShutdownHandlers = ({ io, httpServer, localHttpServer }) =>
     // time on that already-closed server: Node registers the callback as a one-time
     // 'close' listener for an event that already fired, so it never runs and shutdown
     // hangs forever — the real cause of the reconcile "stopping apps" hang.
-    await withGrace('Socket.IO', 3000, (finish) =>
-      io.close((err) => finish(err ? `⚠️ Error closing Socket.IO: ${err.message}` : '✅ Socket.IO closed', !!err)));
+    await withGrace('Socket.IO', 3000, ({ finish, finishWithError }) =>
+      io.close((err) => {
+        if (err) finishWithError(`⚠️ Error closing Socket.IO: ${err.message}`);
+        else finish('✅ Socket.IO closed');
+      }));
     await import('./tailcatIngress.js').then(({ stopTailcatIngress }) => stopTailcatIngress())
       .catch(() => console.error('❌ Tailcat ingress shutdown failed'));
     // Close BOTH servers explicitly. Whichever one io.close() already closed resolves
@@ -1041,8 +1046,8 @@ export const registerShutdownHandlers = ({ io, httpServer, localHttpServer }) =>
       // Bound the DB pool close: pool.end() waits for every checked-out client to
       // be released, so one hung/leaked connection (e.g. a LISTEN channel) would
       // otherwise stall shutdown until the force-exit timer.
-      await withGrace('DB pool', 3000, (finish) =>
-        close().then(() => finish('✅ DB pool closed'), (err) => finish(`⚠️ DB pool close failed: ${err.message}`, true)));
+      await withGrace('DB pool', 3000, ({ finish, finishWithError }) =>
+        close().then(() => finish('✅ DB pool closed'), (err) => finishWithError(`⚠️ DB pool close failed: ${err.message}`)));
     } else {
       console.warn('ℹ️ DB pool close not available; skipping DB shutdown');
     }

--- a/server/services/bootstrap.shutdown.test.js
+++ b/server/services/bootstrap.shutdown.test.js
@@ -15,7 +15,8 @@
  *      survive the restart untouched, and must never be named as interrupted.
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { runInNewContext } from 'node:vm';
 import { readFileSync } from 'fs';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
@@ -68,5 +69,57 @@ describe('shutdown handler — host-restart bookkeeping (#3202)', () => {
     expect(startAt).toBeLessThan(code.indexOf('closeAllConnections'));
     expect(awaitAt).toBeGreaterThan(startAt);
     expect(awaitAt).toBeLessThan(exitAt);
+  });
+});
+
+// Execute only the close boundary; importing bootstrap loads the live service
+// graph. Fake time pins the shutdown deadline without production sleeps.
+describe('bounded server shutdown', () => {
+  afterEach(() => vi.useRealTimers());
+
+  const loadCloseServer = () => {
+    vi.useFakeTimers();
+    const log = vi.fn();
+    const error = vi.fn();
+    const closeServer = runInNewContext(`
+      ${extractDeclaration(SRC, 'withGrace')}
+      ${extractDeclaration(SRC, 'closeServer')}
+      closeServer;
+    `, { console: { log, error }, setTimeout });
+    return { closeServer, log, error };
+  };
+
+  it('resolves successful, already-closed and failed closes with their respective logs', async () => {
+    const { closeServer, log, error } = loadCloseServer();
+    for (const outcome of [undefined, { code: 'ERR_SERVER_NOT_RUNNING' }, new Error('close failed')]) {
+      const order = [];
+      await expect(closeServer({
+        close: (done) => { order.push('stop accepting'); done(outcome); },
+        closeAllConnections: () => order.push('drop connections'),
+      }, 'HTTP server')).resolves.toBeUndefined();
+      expect(order).toEqual(['stop accepting', 'drop connections']);
+    }
+    await expect(closeServer(null, 'Local HTTP mirror')).resolves.toBeUndefined();
+    expect(log.mock.calls).toEqual([['✅ HTTP server closed'], ['✅ HTTP server closed']]);
+    expect(error.mock.calls).toEqual([['⚠️ Error closing HTTP server: close failed']]);
+    await vi.runAllTimersAsync();
+    expect(error).toHaveBeenCalledTimes(1);
+  });
+
+  it('continues at the grace deadline and ignores late close callbacks', async () => {
+    const { closeServer, log, error } = loadCloseServer();
+    let onClose;
+    const settled = vi.fn();
+    const closing = closeServer({ close: (done) => { onClose = done; } }, 'HTTP server').then(settled);
+    await vi.advanceTimersByTimeAsync(249);
+    expect(settled).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1);
+    await closing;
+    expect(settled).toHaveBeenCalledTimes(1);
+    expect(error.mock.calls).toEqual([['⚠️ HTTP server close exceeded 250ms — proceeding']]);
+    onClose();
+    onClose(new Error('late failure'));
+    expect(log).not.toHaveBeenCalled();
+    expect(error).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary
The server shutdown path used `finish(message, true)` (`server/services/bootstrap.js:918` before this change). To edit a close callback safely, a reader had to look up what `true` selected, remember that an error still resolves the shutdown promise, and keep the shared settle-once guard in mind. Socket.IO additionally encoded the same error condition twice, in a message ternary and `!!err`.

Replace that flag with named `finish` and `finishWithError` callbacks sharing one completion guard. Each failure site now states that it finishes with an error; both callbacks continue shutdown. Preserve log text, close order, timeout durations, unref behavior, and late-callback suppression. No public exports change.

## Test plan
- 55 tests passed across `bootstrap.shutdown.test.js`, `bootstrap.hostedSessionSweep.test.js`, and `bootstrapSequence.test.js` (server Vitest).
- Added executable close-boundary coverage for successful/already-closed/failed/absent servers and a fake-time deadline test with late success/error callbacks.
- `git diff --check` passed.
