### PR TITLE
fix: correct native database setup migration advice

### DIFF
--- a/docs/STORAGE.md
+++ b/docs/STORAGE.md
@@ -181,6 +181,25 @@ The escape hatch is **guarded from bitrot by the test suite** (tests boot with `
 
 `PGPASSWORD`/`PGUSER`/`PGDATABASE`/`PGPORT` are resolved from `process.env` first, then `.env`, then the backward-compatible defaults (`portos`/`portos`/`portos`/`5432`). The default `portos` password is an **intentional** local-development fallback (see the Distribution model note in [`AGENTS.md`](../AGENTS.md)); production deployments override it via `PGPASSWORD`.
 
+### Moving between Docker and native
+
+`scripts/db.sh migrate` exports the mode selected in the repository-root `.env`
+and imports into the other mode. The dump uses `--clean`: it **replaces the
+destination's database objects and records**, rather than merging records.
+Back up both databases and stop PortOS processes before an intentional move.
+
+`scripts/db.sh setup-native` selects **native** mode after provisioning; it does
+not copy Docker data. Running `scripts/db.sh migrate` immediately afterward
+therefore copies **native → Docker**, potentially overwriting your existing
+Docker records with a fresh database. For **Docker → native**, first select the
+Docker source with `scripts/db.sh use-docker`, ensure that source is running,
+then run `scripts/db.sh migrate`. Check `scripts/db.sh status` before migrating.
+The migration switches to the destination mode after a successful import.
+
+The migration command assumes the standard native `:5432` and Docker `:5561`
+destination ports. For custom ports, use an explicitly targeted dump/restore
+instead. See [Backup & Restore](./BACKUP.md) for backup and restore semantics.
+
 ### Boot schema upgrades & lock windows
 
 `ensureSchema()` in `server/lib/db.js` applies **idempotent** schema upgrades on every boot (`CREATE TABLE IF NOT EXISTS`, `ADD COLUMN IF NOT EXISTS`, `CREATE INDEX IF NOT EXISTS`). Every index it creates — including the HNSW vector index and the GIN full-text index on `catalog_scraps` — is a plain, **non-`CONCURRENT`** build.

--- a/scripts/db.sh
+++ b/scripts/db.sh
@@ -511,7 +511,9 @@ cmd_setup_native() {
   log "Native PostgreSQL is ready!"
   info "Using system PostgreSQL on port $PGPORT"
   info "Database: $PGDATABASE (user: $PGUSER)"
-  info "To migrate data from Docker: scripts/db.sh migrate"
+  info "Setup selected native mode; Docker data has not been migrated."
+  warn "Running 'scripts/db.sh migrate' now would copy native data OVER Docker data."
+  info "Before moving Docker data to native, see docs/STORAGE.md#moving-between-docker-and-native."
 }
 
 # Run psql command, using Docker exec in Docker mode if host psql is unavailable

--- a/scripts/setup-db.test.js
+++ b/scripts/setup-db.test.js
@@ -11,6 +11,17 @@ import {
 const here = dirname(fileURLToPath(import.meta.url));
 const setupDbSrc = readFileSync(join(here, 'setup-db.js'), 'utf8');
 
+describe('native setup migration guidance', () => {
+  it('warns that migrating immediately after native setup overwrites Docker data', () => {
+    const dbScript = readFileSync(join(here, 'db.sh'), 'utf8');
+    const nativeSetup = dbScript.split('cmd_setup_native() {')[1].split('\n}\n')[0];
+    expect(nativeSetup).toContain('set_mode native');
+    expect(nativeSetup).not.toContain('To migrate data from Docker: scripts/db.sh migrate');
+    expect(nativeSetup).toContain('copy native data OVER Docker data');
+    expect(nativeSetup).toContain('docs/STORAGE.md#moving-between-docker-and-native');
+  });
+});
+
 describe('setup-db menu choice resolver (Phase 1: Postgres mandatory)', () => {
   it('maps "2" to native', () => {
     expect(resolveStorageMenuChoice('2')).toBe('native');


### PR DESCRIPTION
## Summary
Native database setup recommended `scripts/db.sh migrate` to copy Docker data even though setup had just selected native mode. Following that instruction could overwrite Docker records with the fresh native database.

- Replace the misleading setup tip at `scripts/db.sh:514` with a direction warning and a link to storage guidance.
- Document source selection, destination replacement, backups, and the standard-port limitation in `docs/STORAGE.md:184`.
- Evidence: native mode is selected at `scripts/db.sh:508`; migration chooses the opposite destination at `scripts/db.sh:615`; export uses `--clean` at `scripts/db.sh:565`.

## Test plan
- Passed: server workspace Vitest, `../scripts/setup-db.test.js` (9 tests), including the unsafe-guidance regression guard.
- Passed: `bash -n scripts/db.sh` and `git diff --check`.
- No live database migration or setup was run.
