### PR TITLE
Move Quota Burn page into Models nav section

### DIFF
--- a/server/lib/navManifest.js
+++ b/server/lib/navManifest.js
@@ -196,7 +196,7 @@ const RAW_NAV_COMMANDS = [
   { id: 'nav.devtools.image-clean', path: '/devtools/image-clean', label: 'Image Cleaner', section: 'Dev Tools', aliases: ['image-clean', 'image-cleaner'], keywords: ['metadata', 'c2pa', 'content-credentials', 'sharp', 'denoise'] },
   { id: 'nav.devtools.jira', path: '/devtools/jira', label: 'JIRA', section: 'Dev Tools', feature: 'jira', previousPaths: ['/jira'], aliases: ['jira', 'devtools-jira'] },
   { id: 'nav.devtools.jira-reports', path: '/devtools/jira/reports', label: 'JIRA Reports', section: 'Dev Tools', feature: 'jira', aliases: ['jira-reports'] },
-  { id: 'nav.devtools.quota-burn', path: '/devtools/quota-burn', label: 'Quota Burn', section: 'Dev Tools', aliases: ['quota-burn', 'burn-quota', 'quota'], keywords: ['subscription', 'usage', 'reset window', 'spend quota', 'claude', 'codex', 'grok', 'agy', 'burn'] },
+  { id: 'nav.devtools.quota-burn', path: '/devtools/quota-burn', label: 'Quota Burn', section: 'Models', aliases: ['quota-burn', 'burn-quota', 'quota'], keywords: ['subscription', 'usage', 'reset window', 'spend quota', 'claude', 'codex', 'grok', 'agy', 'burn'] },
   { id: 'nav.shell', path: '/shell', label: 'Shell', section: 'Dev Tools', aliases: ['shell', 'terminal'] },
   { id: 'nav.devtools.usage', path: '/devtools/usage', label: 'Usage', section: 'Models', tabId: 'usage', aliases: ['devtools-usage'] },
   { id: 'nav.devtools.video-download', path: '/devtools/video-download', label: 'Video Downloader', section: 'Dev Tools', aliases: ['video-download', 'video-downloader', 'download-video'], keywords: ['youtube', 'x.com', 'twitter', 'yt-dlp', 'download', 'clip'] },


### PR DESCRIPTION
## Summary
- Reclassifies the Quota Burn page's nav section from "Dev Tools" to "Models" in `server/lib/navManifest.js`, so it appears under the Models group in the sidebar and ⌘K palette, matching the precedent set by the Usage page (`nav.devtools.usage`), which already lives under "Models" while keeping its `/devtools/usage` path.

## Test plan
- `server/node_modules/.bin/vitest run server/lib/navManifest.test.js` — passed
- Full server suite (`npm test` in `server/`) — 2122 files / 42380 tests passed
- Full client suite (`npm test` in `client/`) — 917 files / 11271 tests passed