### PR TITLE
fix: preserve Qwen3 preset model revision (#6748)

### DIFF
--- a/server/routes/voice.js
+++ b/server/routes/voice.js
@@ -17,13 +17,14 @@ import { reconcile, verifyBinaries, verifyModels, downloadPiperVoice, startWhisp
 import { synthesize, listVoices, listVoiceEngines, VALID_ENGINES } from '../services/voice/tts.js';
 import {
   listVoiceProfiles,
+  parsePresetVoiceId,
   promotePresetProfile,
   createVoiceDesignCandidate,
   createClonedVoiceCandidate,
   promoteVoiceProfile,
 } from '../services/voice/profiles.js';
 import { renderProfileBenchmark, benchmarkProfileInteractive } from '../services/voice/profileBenchmarks.js';
-import { getQwen3RuntimeStatus, downloadQwen3Model } from '../services/voice/qwen3TtsRuntime.js';
+import { getQwen3RuntimeStatus, downloadQwen3Model, DEFAULT_DESIGN_MODEL } from '../services/voice/qwen3TtsRuntime.js';
 import {
   startFineTuningJob,
   getFineTuningJobStatus,
@@ -280,11 +281,13 @@ router.get('/profiles', asyncHandler(async (req, res) => {
 router.post('/profiles/preset', asyncHandler(async (req, res) => {
   const body = validateRequest(promotePresetProfileSchema, req.body || {});
   const cfg = await getVoiceConfig();
+  const preset = parsePresetVoiceId(body.voiceId);
+  const modelRevision = preset?.engine === 'kokoro'
+    ? `${cfg.tts.kokoro?.modelId || 'configured'}:${cfg.tts.kokoro?.dtype || 'configured'}`
+    : (preset?.engine === 'qwen3-tts' ? DEFAULT_DESIGN_MODEL : `piper:${preset?.voice || ''}`);
   const profile = await promotePresetProfile({
     ...body,
-    modelRevision: /^kokoro:/i.test(body.voiceId)
-      ? `${cfg.tts.kokoro?.modelId || 'configured'}:${cfg.tts.kokoro?.dtype || 'configured'}`
-      : `piper:${body.voiceId.slice('piper:'.length)}`,
+    modelRevision,
     delivery: { rate: cfg.tts?.rate },
   });
   res.status(201).json({ profile });

--- a/server/routes/voice.test.js
+++ b/server/routes/voice.test.js
@@ -29,16 +29,9 @@ vi.mock('../services/voice/tts.js', () => ({
   listVoiceEngines: vi.fn(),
   VALID_ENGINES: new Set(['kokoro', 'piper', 'qwen3-tts']),
 }));
-vi.mock('../services/voice/profiles.js', () => ({
+vi.mock('../services/voice/profiles.js', async (importActual) => ({
+  ...(await importActual()),
   listVoiceProfiles: vi.fn(),
-  parsePresetVoiceId: (voiceId) => {
-    const match = /^([a-z][a-z0-9-]*):([^:\s]+)$/i.exec(voiceId);
-    if (!match) return null;
-    const engine = match[1].toLowerCase() === 'qwen3' ? 'qwen3-tts' : match[1].toLowerCase();
-    return ['kokoro', 'piper', 'qwen3-tts'].includes(engine)
-      ? { engine, voice: match[2], voiceId: `${engine}:${match[2]}` }
-      : null;
-  },
   promotePresetProfile: vi.fn(),
   createVoiceDesignCandidate: vi.fn(),
   createClonedVoiceCandidate: vi.fn(),

--- a/server/routes/voice.test.js
+++ b/server/routes/voice.test.js
@@ -31,6 +31,14 @@ vi.mock('../services/voice/tts.js', () => ({
 }));
 vi.mock('../services/voice/profiles.js', () => ({
   listVoiceProfiles: vi.fn(),
+  parsePresetVoiceId: (voiceId) => {
+    const match = /^([a-z][a-z0-9-]*):([^:\s]+)$/i.exec(voiceId);
+    if (!match) return null;
+    const engine = match[1].toLowerCase() === 'qwen3' ? 'qwen3-tts' : match[1].toLowerCase();
+    return ['kokoro', 'piper', 'qwen3-tts'].includes(engine)
+      ? { engine, voice: match[2], voiceId: `${engine}:${match[2]}` }
+      : null;
+  },
   promotePresetProfile: vi.fn(),
   createVoiceDesignCandidate: vi.fn(),
   createClonedVoiceCandidate: vi.fn(),
@@ -43,6 +51,7 @@ vi.mock('../services/voice/profileBenchmarks.js', () => ({
 vi.mock('../services/voice/qwen3TtsRuntime.js', () => ({
   getQwen3RuntimeStatus: vi.fn(),
   downloadQwen3Model: vi.fn(),
+  DEFAULT_DESIGN_MODEL: 'Qwen/Qwen3-TTS-12Hz-1.7B-VoiceDesign',
 }));
 vi.mock('../services/voice/fineTuning.js', () => ({
   startFineTuningJob: vi.fn(),
@@ -145,6 +154,21 @@ describe('Voice Routes', () => {
         modelRevision: 'kokoro-test:q8', delivery: { rate: 1 },
       }));
       expect(res.body).toEqual({ profile: { id: 'voice-profile-1' } });
+    });
+
+    it.each([
+      ['piper:en_GB-jenny_dioco-medium', 'piper:en_GB-jenny_dioco-medium'],
+      ['qwen3:warm-narrator', 'Qwen/Qwen3-TTS-12Hz-1.7B-VoiceDesign'],
+      ['qwen3-tts:warm-narrator', 'Qwen/Qwen3-TTS-12Hz-1.7B-VoiceDesign'],
+    ])('preserves the model revision for %s preset promotion', async (voiceId, modelRevision) => {
+      voiceProfiles.promotePresetProfile.mockResolvedValue({ id: 'voice-profile-1' });
+      const res = await request(buildApp()).post('/api/voice/profiles/preset').send({
+        universeId: 'uni-1', characterId: 'char-1', voiceId,
+      });
+      expect(res.status).toBe(201);
+      expect(voiceProfiles.promotePresetProfile).toHaveBeenCalledWith(expect.objectContaining({
+        modelRevision,
+      }));
     });
 
     it('creates a candidate voice design profile without altering approved binding', async () => {


### PR DESCRIPTION
## Summary
Preserve the correct model revision when promoting Kokoro, Piper, or Qwen3 voice presets.

## Changes
- Resolve preset engine and voice through the shared parser.
- Record Qwen3 promotions with the canonical design model revision and retain Piper provenance.
- Cover all supported preset engines at the route boundary.

## Tests
- `server/node_modules/.bin/vitest run routes/voice.test.js`

Closes #6748
