### PR TITLE
feat: configure a separate claim handler for manual maintenance

### DIFF
--- a/client/src/components/cos/tabs/schedule/MaintenanceRunForm.jsx
+++ b/client/src/components/cos/tabs/schedule/MaintenanceRunForm.jsx
@@ -19,6 +19,7 @@ export default function MaintenanceRunForm({ schedule, apps = [], providers = []
   const [providerId, setProviderId] = useState('');
   const [model, setModel] = useState('');
   const [effort, setEffort] = useState('');
+  const [claimHandler, setClaimHandler] = useState({ providerId: '', model: '', effort: '' });
   const [mode, setMode] = useState('file-issues');
   const [claimBetweenAudits, setClaimBetweenAudits] = useState(true);
   const [consent, setConsent] = useState(false);
@@ -34,6 +35,9 @@ export default function MaintenanceRunForm({ schedule, apps = [], providers = []
   const groups = buildQuotaBurnTaskCatalog({ schedule, apps });
   const prerequisites = maintenancePrerequisites(groups, appId, { mode, claimBetweenAudits });
   const plannedSteps = buildMaintenanceSteps({ appId, idPrefix: 'preview', mode, claimBetweenAudits });
+  const hasClaims = plannedSteps.some(step => step.drain);
+  const claimProvider = availableProviders.find(entry => entry.id === claimHandler.providerId);
+  const claimReady = !hasClaims || !claimHandler.providerId || Boolean(claimProvider && claimHandler.model);
   const ready = Boolean(appId) && prerequisites.length === 0;
   const blocked = improvementDisabled || daemonRunning === false;
 
@@ -105,10 +109,10 @@ export default function MaintenanceRunForm({ schedule, apps = [], providers = []
     : `Maintenance run saved; holding: ${result?.reason || 'nothing dispatched'}. It retries on its own.`);
 
   const run = async () => {
-    if (busy || blocked || !ready || !provider || !model || !consent) return;
+    if (busy || blocked || !ready || !claimReady || !provider || !model || !consent) return;
     setBusy(true);
     setMessage('Starting maintenance…');
-    const response = await api.startMaintenanceRun({ appId, providerId, model, effort: effort || null, mode, claimBetweenAudits }, { silent: true }).catch(error => {
+    const response = await api.startMaintenanceRun({ appId, providerId, model, effort: effort || null, mode, claimBetweenAudits, ...(hasClaims && claimHandler.providerId ? { claimHandler: { ...claimHandler, effort: claimHandler.effort || null } } : {}) }, { silent: true }).catch(error => {
       setMessage(`Could not start maintenance: ${error.message}`);
       return null;
     });
@@ -165,6 +169,7 @@ export default function MaintenanceRunForm({ schedule, apps = [], providers = []
         <p className="font-medium">Planned steps · {plannedSteps.length}</p>
         <MaintenanceStepChecklist steps={plannedSteps} label="Planned maintenance steps" />
       </div>
+      <p className="font-medium">Audit and documentation handler</p>
       <ProviderModelSelector
         providers={availableProviders}
         selectedProviderId={providerId}
@@ -180,6 +185,24 @@ export default function MaintenanceRunForm({ schedule, apps = [], providers = []
         loading={!providersLoaded}
         disabled={busy}
       />
+      {hasClaims && <fieldset className="space-y-2">
+        <legend className="font-medium">Claim-issue handler</legend>
+        <ProviderModelSelector
+          providers={availableProviders}
+          label="Claim provider"
+          selectedProviderId={claimHandler.providerId}
+          selectedModel={claimHandler.model}
+          availableModels={claimProvider ? effortAwareModelOptions(claimProvider, claimHandler.model) : []}
+          onProviderChange={next => { setClaimHandler({ providerId: next, model: '', effort: '' }); setConsent(false); }}
+          onModelChange={next => { setClaimHandler(current => ({ ...current, model: next })); setConsent(false); }}
+          effort={claimHandler.effort}
+          onEffortChange={next => { setClaimHandler(current => ({ ...current, effort: next })); setConsent(false); }}
+          emptyProviderOption="Same as audit handler"
+          emptyModelOption="Select a model"
+          loading={!providersLoaded}
+          disabled={busy}
+        />
+      </fieldset>}
       {appId && !ready && <div className="space-y-2">
         <p role="status">Run now needs these saved task settings:</p>
         <ul className="list-disc pl-5 space-y-1">
@@ -198,10 +221,10 @@ export default function MaintenanceRunForm({ schedule, apps = [], providers = []
       <p className="text-xs">Runs sequentially, without Quota Burn gates. Blank effort uses each task’s saved setting.</p>
       <label className="flex items-start gap-2" htmlFor="maintenance-run-consent">
         <input id="maintenance-run-consent" type="checkbox" checked={consent} disabled={busy} onChange={event => setConsent(event.target.checked)} />
-        <span>Run these steps now using the selected provider’s quota.</span>
+        <span>Run these steps now using the selected providers’ quota.</span>
       </label>
       <div className="flex items-center gap-3 flex-wrap">
-        <button type="button" onClick={run} disabled={busy || blocked || !ready || !provider || !model || !consent || !providersLoaded} className="px-3 py-1.5 bg-port-accent text-white rounded disabled:opacity-50">
+        <button type="button" onClick={run} disabled={busy || blocked || !ready || !claimReady || !provider || !model || !consent || !providersLoaded} className="px-3 py-1.5 bg-port-accent text-white rounded disabled:opacity-50">
           {busy && !preparing ? 'Starting…' : 'Run now'}
         </button>
         <Link className="underline" to="/devtools/quota-burn">Schedule this sequence in Quota Burn instead</Link>

--- a/client/src/components/cos/tabs/schedule/MaintenanceRunForm.jsx
+++ b/client/src/components/cos/tabs/schedule/MaintenanceRunForm.jsx
@@ -175,10 +175,10 @@ export default function MaintenanceRunForm({ schedule, apps = [], providers = []
         selectedProviderId={providerId}
         selectedModel={model}
         availableModels={provider ? effortAwareModelOptions(provider, model) : []}
-        onProviderChange={next => { setProviderId(next); setModel(''); setEffort(''); }}
-        onModelChange={setModel}
+        onProviderChange={next => { setProviderId(next); setModel(''); setEffort(''); setConsent(false); }}
+        onModelChange={next => { setModel(next); setConsent(false); }}
         effort={effort}
-        onEffortChange={setEffort}
+        onEffortChange={next => { setEffort(next); setConsent(false); }}
         emptyProviderOption="Select a subscription provider"
         emptyModelOption="Select a model"
         alwaysShowModel
@@ -199,6 +199,7 @@ export default function MaintenanceRunForm({ schedule, apps = [], providers = []
           onEffortChange={next => { setClaimHandler(current => ({ ...current, effort: next })); setConsent(false); }}
           emptyProviderOption="Same as audit handler"
           emptyModelOption="Select a model"
+          alwaysShowModel={Boolean(claimHandler.providerId)}
           loading={!providersLoaded}
           disabled={busy}
         />

--- a/client/src/components/cos/tabs/schedule/MaintenanceRunForm.test.jsx
+++ b/client/src/components/cos/tabs/schedule/MaintenanceRunForm.test.jsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { act, render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router';
 import { MAINTENANCE_TASK_ORDER } from '../../../../lib/quotaBurnTasks';
@@ -207,4 +207,25 @@ it('previews and starts issue filing without requiring claim jobs', async () => 
   await user.click(screen.getByRole('checkbox'));
   await user.click(screen.getByRole('button', { name: 'Run now' }));
   expect(api.startMaintenanceRun).toHaveBeenCalledWith(expect.objectContaining({ mode: 'file-issues', claimBetweenAudits: false }), { silent: true });
+});
+
+it('selects an independent claim handler and omits it in file-only mode', async () => {
+  const user = userEvent.setup();
+  show();
+  await select(user);
+  const claim = within(screen.getByRole('group', { name: 'Claim-issue handler' }));
+  await user.selectOptions(claim.getByRole('combobox', { name: 'Claim provider' }), 'claude');
+  expect(screen.getByRole('button', { name: 'Run now' })).toBeDisabled();
+  await user.selectOptions(claim.getByRole('combobox', { name: 'Model' }), 'sonnet');
+  await user.selectOptions(claim.getByRole('combobox', { name: /effort/i }), 'low');
+  await user.click(screen.getByRole('checkbox'));
+  await user.click(screen.getByRole('button', { name: 'Run now' }));
+  expect(api.startMaintenanceRun).toHaveBeenLastCalledWith(expect.objectContaining({ effort: 'high', claimHandler: { providerId: 'claude', model: 'sonnet', effort: 'low' } }), { silent: true });
+  await user.selectOptions(screen.getByLabelText('Issue handling'), 'false');
+  expect(screen.queryByRole('group', { name: 'Claim-issue handler' })).not.toBeInTheDocument();
+  await user.click(screen.getByRole('checkbox'));
+  await user.click(screen.getByRole('button', { name: 'Run now' }));
+  expect(api.startMaintenanceRun.mock.calls.at(-1)[0]).not.toHaveProperty('claimHandler');
+  await user.selectOptions(screen.getByLabelText('Audit mode'), 'fix');
+  expect(screen.getByRole('group', { name: 'Claim-issue handler' })).toBeInTheDocument();
 });

--- a/client/src/services/apiAgents.js
+++ b/client/src/services/apiAgents.js
@@ -308,9 +308,9 @@ export const updateCosTaskInterval = (taskType, settings, options = {}) => reque
 // Manual maintenance runs — the Schedule tab's "Run maintenance now" (server:
 // services/maintenanceRun.js).
 export const getMaintenanceRuns = (options) => request('/cos/schedule/maintenance-runs', options);
-export const startMaintenanceRun = ({ appId, providerId, model, effort = null, mode = 'file-issues', claimBetweenAudits = true }, options = {}) => request('/cos/schedule/maintenance-runs', {
+export const startMaintenanceRun = ({ appId, providerId, model, effort = null, mode = 'file-issues', claimBetweenAudits = true, claimHandler }, options = {}) => request('/cos/schedule/maintenance-runs', {
   method: 'POST',
-  body: JSON.stringify({ appId, providerId, model, effort, mode, claimBetweenAudits }),
+  body: JSON.stringify({ appId, providerId, model, effort, mode, claimBetweenAudits, claimHandler }),
   ...options
 });
 export const stopMaintenanceRun = (id, options = {}) => request(`/cos/schedule/maintenance-runs/${id}/stop`, { method: 'POST', ...options });

--- a/client/src/services/apiAgents.test.js
+++ b/client/src/services/apiAgents.test.js
@@ -5,7 +5,7 @@ import { startMaintenanceRun } from './apiAgents';
 // in the form test cannot catch a selected mode being dropped before POST.
 afterEach(() => vi.unstubAllGlobals());
 it.each([
-  { mode: 'fix', claimBetweenAudits: true },
+  { mode: 'fix', claimBetweenAudits: true, claimHandler: { providerId: 'claude', model: 'sonnet', effort: 'low' } },
   { mode: 'file-issues', claimBetweenAudits: false },
 ])('sends maintenance choices to the server: %j', async choices => {
   const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 201, json: async () => ({ run: { id: 'example' } }) });

--- a/server/lib/maintenanceSequence.js
+++ b/server/lib/maintenanceSequence.js
@@ -51,9 +51,10 @@ export const maintenanceStepParams = (taskType, mode = 'file-issues') => (taskTy
  * Build the ladder as run-once steps targeting `appId`, every one pinned to the
  * provider/model/effort the user chose. `effort: null` inherits each scheduled
  * task's saved effort. Ids are `${idPrefix}-${index}`, so a fresh prefix per
- * invocation yields fresh step identities.
+ * invocation yields fresh step identities. An optional claimHandler replaces
+ * the provider/model/effort bundle for drains only; omitted keeps legacy pins.
  */
-export function buildMaintenanceSteps({ appId, idPrefix, providerId = null, model = null, effort = null, mode = 'file-issues', claimBetweenAudits = true }) {
+export function buildMaintenanceSteps({ appId, idPrefix, providerId = null, model = null, effort = null, mode = 'file-issues', claimBetweenAudits = true, claimHandler = null }) {
   const types = mode === 'fix' ? [...MAINTENANCE_TASK_ORDER, MAINTENANCE_DRAIN_TASK] : claimBetweenAudits ? MAINTENANCE_SEQUENCE_TYPES : MAINTENANCE_TASK_ORDER;
   return types.map((taskType, index) => ({
     id: `${idPrefix}-${index}`,
@@ -63,6 +64,6 @@ export function buildMaintenanceSteps({ appId, idPrefix, providerId = null, mode
     jobType: null,
     runOnce: true,
     drain: taskType === MAINTENANCE_DRAIN_TASK,
-    overrides: { providerId, model, effort, params: maintenanceStepParams(taskType, mode) },
+    overrides: { ...(taskType === MAINTENANCE_DRAIN_TASK && claimHandler ? claimHandler : { providerId, model, effort }), params: maintenanceStepParams(taskType, mode) },
   }));
 }

--- a/server/routes/cosScheduleRoutes.js
+++ b/server/routes/cosScheduleRoutes.js
@@ -37,6 +37,11 @@ const suggestedAfterSchema = z.array(z.string()).max(SUGGESTED_AFTER_MAX);
 const maintenanceRunStartSchema = z.object({
   mode: z.enum(['file-issues', 'fix']).optional(),
   claimBetweenAudits: z.boolean().optional(),
+  claimHandler: z.object({
+    providerId: z.string().trim().min(1),
+    model: z.string().trim().min(1),
+    effort: z.enum(EFFORT_LEVELS).nullable().optional(),
+  }).nullable().optional(),
   appId: z.string().trim().min(1),
   providerId: z.string().trim().min(1),
   model: z.string().trim().min(1),

--- a/server/routes/cosScheduleRoutes.test.js
+++ b/server/routes/cosScheduleRoutes.test.js
@@ -77,9 +77,10 @@ describe('CoS Schedule Routes', () => {
   describe('manual maintenance runs', () => {
     it('accepts fix mode and rejects unknown modes', async () => {
       maintenance.startMaintenanceRun.mockResolvedValue({ run: { id: 'maint-1' } });
-      const body = { appId: 'app-1', providerId: 'codex', model: 'gpt-5', mode: 'fix', claimBetweenAudits: false };
+      const body = { appId: 'app-1', providerId: 'codex', model: 'gpt-5', mode: 'fix', claimBetweenAudits: false, claimHandler: { providerId: 'claude', model: 'sonnet', effort: 'low' } };
       expect((await request(app).post('/api/cos/schedule/maintenance-runs').send(body)).status).toBe(201);
       expect(maintenance.startMaintenanceRun).toHaveBeenCalledWith(body);
+      expect((await request(app).post('/api/cos/schedule/maintenance-runs').send({ ...body, claimHandler: { providerId: 'claude' } })).status).toBe(400);
       expect((await request(app).post('/api/cos/schedule/maintenance-runs').send({ ...body, mode: 'unknown' })).status).toBe(400);
       expect((await request(app).post('/api/cos/schedule/maintenance-runs').send({ ...body, claimBetweenAudits: 'false' })).status).toBe(400);
     });

--- a/server/services/maintenanceRun.js
+++ b/server/services/maintenanceRun.js
@@ -20,7 +20,7 @@
  * What it shares with a burn is the INVOCATION: every step is dispatched through
  * `quotaBurnInvoke.invokeQuotaBurnStep`, so the schedule's own gate ladder (task
  * enabled, per-app switch, master Improve, target scope, duplicate requests)
- * still applies, the provider is pinned to the family the user named, and the
+ * still applies, each handler is pinned to the family the user named, and the
  * task carries the family provenance that makes it cooldown-exempt and lets an
  * observed refusal be credited to the right window. The `maintenanceRunId`
  * provenance field is what tells the quota-burn loop to leave these agents
@@ -138,7 +138,7 @@ async function assertNoRunningRun(appId) {
  * The first evaluation runs before this returns, so the caller learns whether
  * step one actually went out (or why it is holding) in the same response.
  */
-export async function startMaintenanceRun({ appId, providerId, model = null, effort = null, mode = 'file-issues', claimBetweenAudits = true }) {
+export async function startMaintenanceRun({ appId, providerId, model = null, effort = null, mode = 'file-issues', claimBetweenAudits = true, claimHandler = null }) {
   const [{ getAppById }, { getProviderById }, { resolveBurnProvider }] = await Promise.all([
     import('./apps.js'), import('./providers.js'), import('./scheduledHandlers/providerPick.js'),
   ]);
@@ -147,15 +147,23 @@ export async function startMaintenanceRun({ appId, providerId, model = null, eff
   const familyId = familyForProvider(provider);
   const pinned = familyId ? await resolveBurnProvider({ job: { providerId }, family: { id: familyId } }) : null;
   if (!pinned) throw new ServerError(`provider "${providerId}" is not an enabled subscription CLI/TUI provider`, { status: 400, code: 'MAINTENANCE_RUN_PROVIDER_UNAVAILABLE' });
+  // File-only runs never validate or retain a hidden claim selection.
+  const effectiveClaimHandler = mode === 'fix' || claimBetweenAudits ? claimHandler : null;
+  let claimFamilyId = familyId;
+  if (effectiveClaimHandler) {
+    claimFamilyId = familyForProvider(await getProviderById(effectiveClaimHandler.providerId));
+    const claimProvider = claimFamilyId ? await resolveBurnProvider({ job: effectiveClaimHandler, family: { id: claimFamilyId } }) : null;
+    if (!claimProvider) throw new ServerError(`provider "${effectiveClaimHandler.providerId}" is not an enabled subscription CLI/TUI provider`, { status: 400, code: 'MAINTENANCE_RUN_PROVIDER_UNAVAILABLE' });
+  }
   await assertNoRunningRun(appId);
 
   const id = `maint-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`;
   const now = new Date().toISOString();
   const pins = { providerId, model: model || null, effort: effort || null };
   const run = await insertRun({
-    id, appId, familyId, ...pins,
+    id, appId, familyId, claimFamilyId, ...pins,
     status: MAINTENANCE_RUN_STATUS.RUNNING,
-    steps: buildMaintenanceSteps({ appId, idPrefix: id, ...pins, mode, claimBetweenAudits }),
+    steps: buildMaintenanceSteps({ appId, idPrefix: id, ...pins, mode, claimBetweenAudits, claimHandler: effectiveClaimHandler }),
     completed: {},
     active: null,
     reason: null,
@@ -258,7 +266,7 @@ async function evaluate(id, { ignoreTaskId }) {
       }
       if (!probe.job) return hold(probe.reason);
     }
-    const result = await invokeQuotaBurnStep({ step, family: { id: run.familyId }, catalog, maintenanceRunId: id });
+    const result = await invokeQuotaBurnStep({ step, family: { id: step.drain ? (run.claimFamilyId || run.familyId) : run.familyId }, catalog, maintenanceRunId: id });
     if (!result.dispatched) return hold(result.reason, { completed });
     const taskType = step.taskRef.taskType;
     await patchRun(id, {

--- a/server/services/maintenanceRun.test.js
+++ b/server/services/maintenanceRun.test.js
@@ -201,7 +201,7 @@ it('runs fixes consecutively and drains remaining issues only after documentatio
 });
 
 it('files findings consecutively and finishes without claiming when claims are disabled', async () => {
-  const { run } = await startMaintenanceRun({ appId: 'app-1', providerId: 'codex', model: 'gpt-5', mode: 'file-issues', claimBetweenAudits: false });
+  const { run } = await startMaintenanceRun({ appId: 'app-1', providerId: 'codex', model: 'gpt-5', mode: 'file-issues', claimBetweenAudits: false, claimHandler: { providerId: 'unavailable', model: 'example' } });
   expect(run.steps.map(step => step.taskRef.taskType)).toEqual(MAINTENANCE_TASK_ORDER);
   for (let index = 0; index < run.steps.length; index++) {
     expect(state.invoked.at(-1).step.overrides.params.fileIssues).toBe(index < run.steps.length - 1);

--- a/server/services/maintenanceRun.test.js
+++ b/server/services/maintenanceRun.test.js
@@ -211,3 +211,29 @@ it('files findings consecutively and finishes without claiming when claims are d
   expect(await getMaintenanceRun(run.id)).toMatchObject({ status: 'completed' });
   expect((await listMaintenanceRuns())[0].steps).toHaveLength(7);
 });
+
+// A different subscription family must survive storage and dispatch, including
+// repeated claim passes, without changing the audit pins.
+it('dispatches claims with their own provider family, model and effort', async () => {
+  const { getProviderById } = await import('./providers.js');
+  const { resolveBurnProvider } = await import('./scheduledHandlers/providerPick.js');
+  getProviderById.mockImplementationOnce(async id => ({ id, type: 'cli', command: id, enabled: true }));
+  getProviderById.mockImplementationOnce(async id => ({ id, type: 'cli', command: id, enabled: true }));
+  resolveBurnProvider.mockResolvedValueOnce({ id: 'codex' });
+  resolveBurnProvider.mockImplementationOnce(async ({ job, family }) => job.providerId === family.id ? { id: job.providerId } : null);
+  const claimHandler = { providerId: 'claude', model: 'sonnet', effort: 'low' };
+  const { run } = await startMaintenanceRun({ appId: 'app-1', providerId: 'codex', model: 'gpt-5', effort: 'high', claimHandler });
+  expect((await getMaintenanceRun(run.id)).steps[1].overrides).toEqual({ ...claimHandler, params: {} });
+  await evaluateMaintenanceRun(run.id, { completeStepId: run.steps[0].id });
+  await evaluateMaintenanceRun(run.id);
+  expect(state.invoked.slice(1)).toHaveLength(2);
+  for (const call of state.invoked.slice(1)) expect(call).toMatchObject({ family: { id: 'claude' }, step: { overrides: claimHandler } });
+  state.probe = { drained: true };
+  await evaluateMaintenanceRun(run.id);
+  expect(state.invoked.at(-1)).toMatchObject({ family: { id: 'codex' }, step: { overrides: { providerId: 'codex', model: 'gpt-5', effort: 'high' } } });
+});
+
+it('rejects an unavailable claim provider before starting any work', async () => {
+  await expect(startMaintenanceRun({ appId: 'app-1', providerId: 'codex', claimHandler: { providerId: 'unavailable', model: 'example' } })).rejects.toMatchObject({ code: 'MAINTENANCE_RUN_PROVIDER_UNAVAILABLE' });
+  expect(state.invoked).toEqual([]);
+});


### PR DESCRIPTION
## Summary
- Add a separate provider, model, and effort selector for claim-issue runs in manual maintenance, defaulting to the audit handler.
- Hide and omit claim settings when leaving issues open for review; support the final claim pass in audit-and-fix mode.
- Validate the claim provider before starting and preserve its family and settings across repeated claim dispatches, while retaining compatibility with existing runs.

## Test plan
- Server maintenance workflow and schedule route suites: 58 tests passed.
- Client maintenance form and API serialization suites: 13 tests passed.
- Focused client lint and production build passed.
