### PR TITLE
fix: handle Eidoverse connection readiness rejections

### DIFF
--- a/server/services/eidoverseWorld.js
+++ b/server/services/eidoverseWorld.js
@@ -689,6 +689,11 @@ function createWorldConnection({ world, id, avatar, agent = true, guest = false,
     resolveSnapshot = resolve;
     rejectSnapshot = reject;
   });
+  // Opening can fail before a caller reaches the snapshot await, or after
+  // cancellation detaches it. Own both rejections for the connection lifetime;
+  // callers still await the original promises and receive the same errors.
+  openPromise.catch(() => {});
+  snapshotPromise.catch(() => {});
 
   const settleOpen = (error = null) => {
     if (openSettled) return;

--- a/server/services/eidoverseWorld.runtime.test.js
+++ b/server/services/eidoverseWorld.runtime.test.js
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => ({
   worlds: new Map(),
   socketUrls: [],
   sockets: [],
+  connectionError: null,
   nextSeq: 0,
   sent: [],
   deferredVerbAcks: [],
@@ -86,6 +87,11 @@ vi.mock('ws', () => {
       mocks.socketUrls.push(String(url));
       mocks.sockets.push(this);
       queueMicrotask(() => {
+        if (mocks.connectionError) {
+          this.emit('error', mocks.connectionError);
+          this.close();
+          return;
+        }
         this.readyState = FakeWebSocket.OPEN;
         this.emit('open');
       });
@@ -191,6 +197,7 @@ beforeEach(async () => {
   mocks.worlds.clear();
   mocks.socketUrls.length = 0;
   mocks.sockets.length = 0;
+  mocks.connectionError = null;
   mocks.nextSeq = 0;
   mocks.sent.length = 0;
   mocks.deferredVerbAcks.length = 0;
@@ -230,6 +237,20 @@ beforeEach(async () => {
 });
 
 describe('Eidoverse private-world lifecycle', () => {
+  it('reports connection refusal without an unhandled rejection and allows a subsequent retry', async () => {
+    mocks.connectionError = new Error('connect ECONNREFUSED');
+    await expect(world.ensureEidoverseWorldPresence()).rejects.toMatchObject({
+      status: 503,
+      code: 'EIDOVERSE_WORLD_UNAVAILABLE',
+      message: expect.stringContaining('ECONNREFUSED'),
+    });
+    // Let Node report unhandled rejections: Vitest must fail if readiness leaked one.
+    await new Promise((resolve) => setImmediate(resolve));
+    expect((await world.getEidoverseWorldStatus()).presence.connected).toBe(false);
+    mocks.connectionError = null;
+    await expect(world.ensureEidoverseWorldPresence()).resolves.toMatchObject({ connected: true, role: 'owner' });
+  });
+
   it('keeps status read-only when config has not been persisted yet', async () => {
     const status = await world.getEidoverseWorldStatus();
     const compact = await world.getEidoverseWorldStatus({ compact: true });


### PR DESCRIPTION
## Summary
A transient Eidoverse restart rejects both WebSocket readiness promises. Waiting for opening fails first, leaving the snapshot rejection unobserved and escalating an ordinary 503 into a critical unhandled rejection.

Observe both promises for the connection lifetime while preserving their original errors for callers. The runtime was confirmed healthy again; server logs and browser console correlated the refusal with its restart.

## Test plan
- Reproduced the original unhandled rejection with a new public presence-workflow test before applying the fix.
- All 43 Eidoverse runtime tests pass, including refusal, disconnected status, and a successful subsequent retry.
- Confirmed the live runtime listens on its configured port and responds to its version endpoint.
- git diff --check passes.
