### PR TITLE
feat: choose the Eidoverse Worlds clone branch

### DIFF
--- a/client/src/components/settings/InstanceFeaturesTab.jsx
+++ b/client/src/components/settings/InstanceFeaturesTab.jsx
@@ -65,6 +65,7 @@ export function InstanceFeaturesTab() {
   const { features, groups, error, reload } = useInstanceFeatures();
   const [savingId, setSavingId] = useState(null);
   const [eidoverseRepoUrl, setEidoverseRepoUrl] = useState(null);
+  const [eidoverseBranch, setEidoverseBranch] = useState(null);
   const [updatingEidoverseSource, setUpdatingEidoverseSource] = useState(false);
   const [recheckingEidoverse, setRecheckingEidoverse] = useState(false);
 
@@ -126,7 +127,7 @@ export function InstanceFeaturesTab() {
     const worldsRepoUrl = eidoverseRepoUrl ?? feature?.setup?.worldsRepoUrl;
     if (!worldsRepoUrl) return;
     setSavingId(feature.id);
-    const result = await installEidoverseFeature(worldsRepoUrl, { silent: true }).catch((err) => {
+    const result = await installEidoverseFeature(worldsRepoUrl, { silent: true }, eidoverseBranch ?? feature?.setup?.worldsBranch ?? '').catch((err) => {
       toast.error(err.message || 'Could not install Eidoverse Worlds');
       return null;
     });
@@ -304,6 +305,23 @@ export function InstanceFeaturesTab() {
                   placeholder="https://github.com/example-owner/eidoverse-worlds"
                 />
               </div>
+              {needsInstall && (
+                <div className="pt-2">
+                  <label className="block text-gray-300 mb-1" htmlFor="eidoverse-worlds-branch">Worlds clone branch</label>
+                  <input
+                    id="eidoverse-worlds-branch"
+                    type="text"
+                    value={eidoverseBranch ?? setup?.worldsBranch ?? ''}
+                    onChange={(event) => setEidoverseBranch(event.target.value)}
+                    disabled={savingId !== null}
+                    maxLength={255}
+                    placeholder="Repository default branch"
+                    aria-describedby="eidoverse-worlds-branch-help"
+                    className="w-full px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white focus:border-port-accent focus:outline-hidden disabled:opacity-50"
+                  />
+                  <p id="eidoverse-worlds-branch-help" className="mt-1">Leave blank to use the repository’s default branch. Applies to new clones; existing checkouts keep their current branch.</p>
+                </div>
+              )}
               {!repoIsValid && (
                 <p id="eidoverse-worlds-repo-error" role="alert" className="text-port-error">
                   {selectedRepoUrl === ''

--- a/client/src/components/settings/InstanceFeaturesTab.test.jsx
+++ b/client/src/components/settings/InstanceFeaturesTab.test.jsx
@@ -159,6 +159,7 @@ describe('InstanceFeaturesTab', () => {
     await waitFor(() => expect(mock.installEidoverseFeature).toHaveBeenCalledWith(
       'https://github.com/anima-research/eidoverse-worlds',
       { silent: true },
+      '',
     ));
     expect(await screen.findByRole('link', { name: 'Manage app' })).toHaveAttribute('href', '/apps/app-eidoverse');
     expect(screen.getByText(/start it from the managed app/i)).toBeInTheDocument();
@@ -170,11 +171,13 @@ describe('InstanceFeaturesTab', () => {
 
     const repoInput = await screen.findByRole('textbox', { name: 'Worlds GitHub repository' });
     fireEvent.change(repoInput, { target: { value: 'https://github.com/example-owner/eidoverse-worlds' } });
+    fireEvent.change(screen.getByRole('textbox', { name: 'Worlds clone branch' }), { target: { value: 'feature/worlds' } });
     fireEvent.click(screen.getByRole('button', { name: 'Install & enable' }));
 
     await waitFor(() => expect(mock.installEidoverseFeature).toHaveBeenCalledWith(
       'https://github.com/example-owner/eidoverse-worlds',
       { silent: true },
+      'feature/worlds',
     ));
   });
 
@@ -196,6 +199,7 @@ describe('InstanceFeaturesTab', () => {
     await waitFor(() => expect(mock.installEidoverseFeature).toHaveBeenCalledWith(
       'git@github.com:example-owner/eidoverse-worlds.git',
       { silent: true },
+      '',
     ));
   });
 

--- a/client/src/services/apiSystem.js
+++ b/client/src/services/apiSystem.js
@@ -81,9 +81,9 @@ export const updateInstanceFeatureGroup = (groupId, enabled, options = {}) => re
   body: JSON.stringify({ enabled }),
   ...options,
 });
-export const installEidoverseFeature = (worldsRepoUrl, options = {}) => request('/settings/features/eidoverse/install', {
+export const installEidoverseFeature = (worldsRepoUrl, options = {}, worldsBranch = '') => request('/settings/features/eidoverse/install', {
   method: 'POST',
-  body: JSON.stringify({ worldsRepoUrl }),
+  body: JSON.stringify({ worldsRepoUrl, worldsBranch }),
   ...options,
 });
 export const updateEidoverseWorldsSource = (worldsRepoUrl, options = {}) => request('/settings/features/eidoverse/source', {

--- a/server/routes/settings.js
+++ b/server/routes/settings.js
@@ -235,9 +235,12 @@ router.put('/credentials/:id', asyncHandler(async (req, res) => {
 // Explicit consent boundary: no Eidoverse checkout or dependency install occurs
 // until the user presses Install in Settings > Features.
 router.post('/features/eidoverse/install', asyncHandler(async (req, res) => {
-  const { worldsRepoUrl } = validateRequest(eidoverseRepoSchema, req.body || {});
-  const normalizedRepoUrl = await updateEidoverseWorldsRepo(worldsRepoUrl);
-  await installEidoverse({ worldsRepoUrl: normalizedRepoUrl });
+  const { worldsRepoUrl, worldsBranch } = validateRequest(eidoverseRepoSchema.extend({
+    // biome-ignore lint/suspicious/noControlCharactersInRegex: reject control characters in Git branch input
+    worldsBranch: z.string().trim().max(255).regex(/^[^\u0000-\u001f\u007f]*$/).optional(),
+  }), req.body || {});
+  const normalizedRepoUrl = await updateEidoverseWorldsRepo(worldsRepoUrl, worldsBranch);
+  await installEidoverse({ worldsRepoUrl: normalizedRepoUrl, ...(worldsBranch !== undefined ? { worldsBranch } : {}) });
   res.status(201).json(await updateInstanceFeature('eidoverse', true));
 }));
 

--- a/server/routes/settings.test.js
+++ b/server/routes/settings.test.js
@@ -297,6 +297,18 @@ describe('Settings routes — instance feature participation', () => {
     expect(res.body.features).toContainEqual(expect.objectContaining({ id: 'eidoverse', enabled: true }));
   });
 
+  it.each(['feature/worlds', ''])('persists and forwards clone branch %j', async (worldsBranch) => {
+    const worldsRepoUrl = 'https://github.com/example-owner/eidoverse-worlds';
+    const res = await request(buildApp())
+      .post('/api/settings/features/eidoverse/install')
+      .send({ worldsRepoUrl, worldsBranch });
+
+    expect(res.status).toBe(201);
+    expect(installEidoverse).toHaveBeenCalledWith({ worldsRepoUrl, worldsBranch });
+    expect(store.instanceFeatures.eidoverse.worldsBranch).toBe(worldsBranch);
+    expect(res.body.features.find(feature => feature.id === 'eidoverse').setup.worldsBranch).toBe(worldsBranch);
+  });
+
   it('updates the installed Eidoverse source without changing feature participation', async () => {
     const worldsRepoUrl = 'git@github.com:example-owner/eidoverse-worlds.git';
     store = { instanceFeatures: { eidoverse: { enabled: true } } };

--- a/server/services/eidoverse.js
+++ b/server/services/eidoverse.js
@@ -193,13 +193,13 @@ async function installDependencies(directory, bun) {
 
 let installInFlight = null;
 
-async function performInstall(worldsRepoUrl) {
+async function performInstall(worldsRepoUrl, worldsBranch) {
   const bun = await ensureBunRuntime();
 
   const configuredPaths = getEidoversePaths(worldsRepoUrl);
   const paths = await resolveEidoverseInstallPaths(worldsRepoUrl);
   await Promise.all([
-    paths.worlds === configuredPaths.worlds ? cloneRepo(worldsRepoUrl) : Promise.resolve(),
+    paths.worlds === configuredPaths.worlds ? cloneRepo(worldsRepoUrl, { branch: worldsBranch }) : Promise.resolve(),
     cloneRepo(EIDOVERSE_VIDEO_REPO),
   ]);
   await updateOriginAtPath(paths.worlds, worldsRepoUrl);
@@ -223,10 +223,10 @@ async function performInstall(worldsRepoUrl) {
  * a managed-app record. A process-local promise collapses double-clicks into
  * one clone/install operation.
  */
-export async function installEidoverse({ worldsRepoUrl = DEFAULT_EIDOVERSE_WORLDS_REPO } = {}) {
+export async function installEidoverse({ worldsRepoUrl = DEFAULT_EIDOVERSE_WORLDS_REPO, worldsBranch = '' } = {}) {
   const normalizedRepoUrl = normalizeEidoverseWorldsRepo(worldsRepoUrl);
   if (installInFlight) return installInFlight;
-  installInFlight = performInstall(normalizedRepoUrl).finally(() => {
+  installInFlight = performInstall(normalizedRepoUrl, worldsBranch.trim()).finally(() => {
     installInFlight = null;
   });
   return installInFlight;

--- a/server/services/eidoverse.test.js
+++ b/server/services/eidoverse.test.js
@@ -115,10 +115,16 @@ describe('Eidoverse managed-app installer', () => {
     });
   });
 
+  it('passes the selected branch only to the Worlds clone', async () => {
+    await installEidoverse({ worldsRepoUrl: SELECTED_WORLDS_REPO, worldsBranch: ' feature/worlds ' });
+    expect(mock.cloneRepo).toHaveBeenCalledWith(SELECTED_WORLDS_REPO, { branch: 'feature/worlds' });
+    expect(mock.cloneRepo).toHaveBeenCalledWith(EIDOVERSE_VIDEO_REPO);
+  });
+
   it('clones separate licensed repos, installs Bun dependencies, and registers Worlds', async () => {
     const status = await installEidoverse({ worldsRepoUrl: SELECTED_WORLDS_REPO });
 
-    expect(mock.cloneRepo).toHaveBeenCalledWith(SELECTED_WORLDS_REPO);
+    expect(mock.cloneRepo).toHaveBeenCalledWith(SELECTED_WORLDS_REPO, { branch: '' });
     expect(mock.cloneRepo).toHaveBeenCalledWith(EIDOVERSE_VIDEO_REPO);
     expect(mock.execGit).toHaveBeenCalledWith(
       ['remote', 'set-url', 'origin', SELECTED_WORLDS_REPO],
@@ -158,7 +164,7 @@ describe('Eidoverse managed-app installer', () => {
 
     const status = await installEidoverse({ worldsRepoUrl: SELECTED_WORLDS_REPO });
 
-    expect(mock.cloneRepo).not.toHaveBeenCalledWith(SELECTED_WORLDS_REPO);
+    expect(mock.cloneRepo).not.toHaveBeenCalledWith(SELECTED_WORLDS_REPO, { branch: '' });
     expect(mock.spawn).toHaveBeenCalledWith('bun', ['install', '--frozen-lockfile'], expect.objectContaining({ cwd: existingPaths.worlds }));
     expect(mock.atomicWrite).toHaveBeenCalledWith(
       existingPaths.envFile,
@@ -170,7 +176,7 @@ describe('Eidoverse managed-app installer', () => {
   it('configures a fresh checkout with the selected SSH origin', async () => {
     const status = await installEidoverse({ worldsRepoUrl: SELECTED_WORLDS_REPO_SSH });
 
-    expect(mock.cloneRepo).toHaveBeenCalledWith(SELECTED_WORLDS_REPO_SSH);
+    expect(mock.cloneRepo).toHaveBeenCalledWith(SELECTED_WORLDS_REPO_SSH, { branch: '' });
     expect(mock.execGit).toHaveBeenCalledWith(
       ['remote', 'set-url', 'origin', SELECTED_WORLDS_REPO_SSH],
       selectedPaths.worlds,

--- a/server/services/instanceFeatures.js
+++ b/server/services/instanceFeatures.js
@@ -203,7 +203,7 @@ const attachSetupStatus = async (features, settings) => {
     upstream,
   };
   return features.map((feature) => (
-    feature.id === 'eidoverse' ? { ...feature, setup: { ...eidoverse, sourceOwners } } : feature
+    feature.id === 'eidoverse' ? { ...feature, setup: { ...eidoverse, worldsBranch: settings?.instanceFeatures?.eidoverse?.worldsBranch ?? '', sourceOwners } } : feature
   ));
 };
 
@@ -222,7 +222,7 @@ export async function getInstanceFeatures() {
   return { features, groups };
 }
 
-export async function updateEidoverseWorldsRepo(worldsRepoUrl) {
+export async function updateEidoverseWorldsRepo(worldsRepoUrl, worldsBranch) {
   const normalizedRepoUrl = normalizeEidoverseWorldsRepo(worldsRepoUrl);
   await updateSettingsWith((current) => {
     const instanceFeatures = isPlainObject(current.instanceFeatures) ? current.instanceFeatures : {};
@@ -231,7 +231,7 @@ export async function updateEidoverseWorldsRepo(worldsRepoUrl) {
       ...current,
       instanceFeatures: {
         ...instanceFeatures,
-        eidoverse: { ...eidoverse, worldsRepoUrl: normalizedRepoUrl },
+        eidoverse: { ...eidoverse, worldsRepoUrl: normalizedRepoUrl, ...(worldsBranch !== undefined ? { worldsBranch } : {}) },
       },
     };
   });

--- a/server/services/repoCloner.js
+++ b/server/services/repoCloner.js
@@ -104,6 +104,7 @@ export async function cloneRepo(url, options = {}) {
     'clone',
     '--depth', '1',
     '--single-branch',
+    ...(options.branch ? ['--branch', options.branch] : []),
     httpsUrl,
     stagingPath
   ];

--- a/server/services/repoCloner.test.js
+++ b/server/services/repoCloner.test.js
@@ -74,6 +74,23 @@ describe('cloneRepo', () => {
     );
   });
 
+  it('clones a requested branch as a literal argument and surfaces a missing branch failure', async () => {
+    const child = createChild();
+    spawn.mockReturnValue(child);
+    const pending = cloneRepo('https://github.com/acme/widgets', { branch: 'feature/worlds' });
+    const rejected = expect(pending).rejects.toThrow('Remote branch feature/worlds not found');
+    await vi.waitFor(() => expect(spawn).toHaveBeenCalled());
+    expect(spawn).toHaveBeenCalledWith('git', [
+      'clone', '--depth', '1', '--single-branch', '--branch', 'feature/worlds',
+      'https://github.com/acme/widgets.git', STAGING_PATH
+    ], expect.objectContaining({ shell: false }));
+    child.stderr.emit('data', Buffer.from('Remote branch feature/worlds not found'));
+    child.emit('close', 128);
+    await rejected;
+    expect(rename).not.toHaveBeenCalled();
+    expect(rm).toHaveBeenCalledWith(STAGING_ROOT, { recursive: true, force: true });
+  });
+
   it('removes a legacy partial destination only for a recovered attempt', async () => {
     const child = createChild();
     spawn.mockReturnValue(child);


### PR DESCRIPTION
## Summary
Add a Worlds clone branch field to Settings > Features when setting up Eidoverse Worlds. The choice is saved for installation retries and passed to Git; leaving it blank uses the repository's default branch. Existing checkouts retain their current branch, and the companion video runtime continues using its default.

## Test plan
- 156 server tests passed across settings routes, instance features, Eidoverse installation, and the shared repository cloner.
- 21 settings UI tests passed, including custom and default branch submission.
- Changed client files pass lint; server lint has no errors (existing style warnings remain).
- Reviewed the diff for compatibility, reuse, and preservation of existing checkouts.
