### PR TITLE
fix: normalize Qwen3 voice IDs across audio pipeline

### DIFF
--- a/client/src/components/voice/VoicePicker.jsx
+++ b/client/src/components/voice/VoicePicker.jsx
@@ -39,6 +39,11 @@ let voiceListCache = null;
 let voiceListCacheAt = 0;
 let voiceListPromise = null;
 
+const normalizeCatalogVoiceId = (voiceId) =>
+  typeof voiceId === 'string' && voiceId.startsWith('qwen3:')
+    ? `qwen3-tts:${voiceId.slice('qwen3:'.length)}`
+    : voiceId;
+
 const cacheIsFresh = () =>
   voiceListCache !== null && (Date.now() - voiceListCacheAt) < VOICE_LIST_CACHE_TTL_MS;
 
@@ -125,6 +130,7 @@ export default function VoicePicker({
     return acc;
   }, {}), [voices]);
   const engineKeys = useMemo(() => Object.keys(byEngine).sort(), [byEngine]);
+  const catalogValue = normalizeCatalogVoiceId(value);
 
   const handleAudition = async () => {
     if (!value || previewingRef.current) return;
@@ -145,7 +151,7 @@ export default function VoicePicker({
     <div className="flex items-center gap-1.5 min-w-0">
       <select
         id={id}
-        value={value || ''}
+        value={catalogValue || ''}
         onChange={(e) => onChange?.(e.target.value || null)}
         disabled={disabled || loading}
         className="flex-1 min-w-0 px-1.5 py-0.5 text-xs bg-port-bg border border-port-border rounded text-white disabled:opacity-50"
@@ -155,7 +161,7 @@ export default function VoicePicker({
             catalog (engine uninstalled, voice renamed) so the user can see
             what they had bound before — losing it silently to a dropdown
             reset would mask the underlying drift. */}
-        {value && !voices.some((v) => v.id === value) ? (
+        {value && !voices.some((v) => v.id === catalogValue) ? (
           <option value={value}>{value} (unavailable)</option>
         ) : null}
         {engineKeys.map((engine) => (

--- a/client/src/components/voice/VoicePicker.jsx
+++ b/client/src/components/voice/VoicePicker.jsx
@@ -162,7 +162,7 @@ export default function VoicePicker({
             what they had bound before — losing it silently to a dropdown
             reset would mask the underlying drift. */}
         {value && !voices.some((v) => v.id === catalogValue) ? (
-          <option value={value}>{value} (unavailable)</option>
+          <option value={catalogValue}>{value} (unavailable)</option>
         ) : null}
         {engineKeys.map((engine) => (
           <optgroup key={engine} label={engine.charAt(0).toUpperCase() + engine.slice(1)}>

--- a/client/src/components/voice/VoicePicker.test.jsx
+++ b/client/src/components/voice/VoicePicker.test.jsx
@@ -106,6 +106,17 @@ describe('VoicePicker', () => {
       .not.toBeInTheDocument();
   });
 
+  it('preserves an unavailable legacy Qwen3 voiceId after normalizing the select value', async () => {
+    listPipelineTtsVoices.mockResolvedValue({ voices: SAMPLE_VOICES });
+    render(<VoicePicker value="qwen3:retired-voice" onChange={() => {}} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('combobox')).toHaveValue('qwen3-tts:retired-voice');
+    });
+    expect(screen.getByRole('option', { name: 'qwen3:retired-voice (unavailable)' }))
+      .toBeInTheDocument();
+  });
+
   it('audition button posts to preview and pipes the wav through playWav', async () => {
     listPipelineTtsVoices.mockResolvedValue({ voices: SAMPLE_VOICES });
     const buf = new ArrayBuffer(8);

--- a/client/src/components/voice/VoicePicker.test.jsx
+++ b/client/src/components/voice/VoicePicker.test.jsx
@@ -21,6 +21,7 @@ const SAMPLE_VOICES = [
   { id: 'kokoro:af_bella', engine: 'kokoro', voice: 'af_bella', name: 'af_bella', gender: 'female', language: 'en-US', grade: 'A' },
   { id: 'kokoro:am_michael', engine: 'kokoro', voice: 'am_michael', name: 'am_michael', gender: 'male', language: 'en-US', grade: 'B' },
   { id: 'piper:lessac-medium', engine: 'piper', voice: 'lessac-medium', name: 'lessac-medium', gender: 'female', accent: 'American', downloaded: true },
+  { id: 'qwen3-tts:warm-narrator', engine: 'qwen3-tts', voice: 'warm-narrator', name: 'Warm Narrator (1.7B Design)', label: 'Warm Narrator (1.7B Design)' },
 ];
 
 beforeEach(() => {
@@ -92,6 +93,17 @@ describe('VoicePicker', () => {
       expect(document.querySelector('option[value="kokoro:af_bella"]')).toBeInTheDocument();
     });
     expect(screen.getByRole('option', { name: /retired-voice \(unavailable\)/i })).toBeInTheDocument();
+  });
+
+  it('matches a legacy Qwen3 voiceId to its canonical catalog option', async () => {
+    listPipelineTtsVoices.mockResolvedValue({ voices: SAMPLE_VOICES });
+    render(<VoicePicker value="qwen3:warm-narrator" onChange={() => {}} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('combobox')).toHaveValue('qwen3-tts:warm-narrator');
+    });
+    expect(screen.queryByRole('option', { name: /qwen3:warm-narrator \(unavailable\)/i }))
+      .not.toBeInTheDocument();
   });
 
   it('audition button posts to preview and pipes the wav through playWav', async () => {

--- a/server/routes/pipeline.test.js
+++ b/server/routes/pipeline.test.js
@@ -267,7 +267,8 @@ vi.mock('../services/pipeline/episodeVideo.js', () => ({
 
 // Audio service mocks — avoid touching the real TTS pipeline + filesystem
 // while still exercising the route's voice-resolution + persist flow.
-vi.mock('../services/pipeline/audio.js', () => ({
+vi.mock('../services/pipeline/audio.js', async () => ({
+  ...await vi.importActual('../services/pipeline/audio.js'),
   listAllVoices: vi.fn(async () => [{ id: 'kokoro:af_heart', engine: 'kokoro', voice: 'af_heart', label: 'Heart' }]),
   synthesizeToFile: vi.fn(async ({ voiceId }) => ({
     filename: `vo-mock-${++uuidCounter}.wav`,
@@ -275,11 +276,6 @@ vi.mock('../services/pipeline/audio.js', () => ({
     engine: 'kokoro',
     voiceId: voiceId || null,
   })),
-  parseVoiceId: vi.fn((v) => {
-    if (!v) return { engine: null, voice: null };
-    const m = v.match(/^([a-z]+):(.+)$/);
-    return m ? { engine: m[1], voice: m[2] } : { engine: null, voice: v };
-  }),
   extractDialogueLines: vi.fn((issue) => {
     const scenes = issue?.stages?.storyboards?.scenes || [];
     const out = [];
@@ -314,7 +310,8 @@ vi.mock('../services/pipeline/audio.js', () => ({
 vi.mock('../services/voice/tts.js', () => ({
   synthesize: vi.fn(async () => ({ wav: Buffer.from('w'), latencyMs: 1, engine: 'kokoro' })),
   listVoices: vi.fn(async () => ({ engine: 'kokoro', voices: [] })),
-  VALID_ENGINES: new Set(['kokoro', 'piper']),
+  normalizeVoiceEngine: (engine) => engine === 'qwen3' ? 'qwen3-tts' : engine,
+  VALID_ENGINES: new Set(['kokoro', 'piper', 'qwen3-tts']),
 }));
 vi.mock('../services/voice/profiles.js', () => ({
   clearVoiceProfileRender: vi.fn(),
@@ -2690,6 +2687,25 @@ describe('pipeline routes', () => {
       });
       return iss.body;
     }
+
+    it('POST /tts/preview forwards a canonical Qwen3 preset to synthesis', async () => {
+      const voiceTts = await import('../services/voice/tts.js');
+      vi.mocked(voiceTts.synthesize).mockResolvedValueOnce({
+        wav: Buffer.from('qwen3-wav'), latencyMs: 12, engine: 'qwen3-tts',
+      });
+      const app = makeApp();
+
+      const r = await request(app)
+        .post('/api/pipeline/tts/preview')
+        .send({ voiceId: 'qwen3-tts:warm-narrator' });
+
+      expect(r.status).toBe(200);
+      expect(r.headers['x-tts-engine']).toBe('qwen3-tts');
+      expect(voiceTts.synthesize).toHaveBeenCalledWith(expect.any(String), {
+        engine: 'qwen3-tts',
+        voice: 'warm-narrator',
+      });
+    });
 
     it('POST /audio/extract-lines populates lines[] from storyboards dialogue', async () => {
       const app = makeApp();

--- a/server/services/pipeline/audio.js
+++ b/server/services/pipeline/audio.js
@@ -10,14 +10,20 @@
  * dispatch; the pipeline doesn't care which one rendered the bytes.
  *
  * Voice ID namespace: `engine:voiceName` — `kokoro:af_heart`,
- * `piper:en_GB-northern_english_male`. A bare voice name without the
- * `engine:` prefix is interpreted as the active engine's voice.
+ * `piper:en_GB-northern_english_male`, `qwen3-tts:warm-narrator`. A bare
+ * voice name without the `engine:` prefix is interpreted as the active
+ * engine's voice; legacy `qwen3:` ids normalize to `qwen3-tts:` on read.
  */
 
 import { join } from 'path';
 import { randomUUID } from 'crypto';
 import { PATHS, ensureDir, atomicWrite } from '../../lib/fileUtils.js';
-import { synthesize, listVoices, VALID_ENGINES } from '../voice/tts.js';
+import {
+  synthesize,
+  listVoices,
+  normalizeVoiceEngine,
+  VALID_ENGINES,
+} from '../voice/tts.js';
 import { ServerError } from '../../lib/errorHandler.js';
 
 const VOICE_ID_RE = /^([a-z][a-z0-9-]*):(.+)$/i;
@@ -32,7 +38,7 @@ export function parseVoiceId(voiceId) {
   const trimmed = voiceId.trim();
   const m = trimmed.match(VOICE_ID_RE);
   if (!m) return { engine: null, voice: trimmed };
-  const engine = m[1].toLowerCase();
+  const engine = normalizeVoiceEngine(m[1].toLowerCase());
   if (!VALID_ENGINES.has(engine)) return { engine: null, voice: trimmed };
   return { engine, voice: m[2] };
 }
@@ -49,16 +55,21 @@ export async function listAllVoices() {
   const results = await Promise.all(engines.map(async (engine) => {
     try {
       const { voices } = await listVoices(engine);
-      return voices.map((v) => ({
-        id: `${engine}:${v.name}`,
-        engine,
-        voice: v.name,
-        label: v.label || v.name,
-        // Carry through any metadata the engine surfaces (gender, language,
-        // accent, etc.) without locking the shape — the UI renders what's
-        // present.
-        ...v,
-      }));
+      return voices.map((v) => {
+        const voice = v.voice || v.name;
+        return {
+          // Carry through any metadata the engine surfaces (gender, language,
+          // accent, etc.) without locking the shape — the UI renders what's
+          // present.
+          ...v,
+          // Namespace fields are authoritative. Engine adapters may expose a
+          // legacy id, but it must not override the catalog contract.
+          id: `${engine}:${voice}`,
+          engine,
+          voice,
+          label: v.label ?? v.name,
+        };
+      });
     } catch (err) {
       console.warn(`⚠️ listAllVoices: ${engine} unavailable — ${err?.message || err}`);
       return [];

--- a/server/services/pipeline/audio.test.js
+++ b/server/services/pipeline/audio.test.js
@@ -18,10 +18,11 @@ vi.mock('../../lib/fileUtils.js', async () => {
 const synthesizeMock = vi.fn();
 const listVoicesMock = vi.fn();
 vi.mock('../voice/tts.js', () => ({
-tryReadFile: vi.fn().mockResolvedValue(null),
+  tryReadFile: vi.fn().mockResolvedValue(null),
   synthesize: (...a) => synthesizeMock(...a),
   listVoices: (...a) => listVoicesMock(...a),
-  VALID_ENGINES: new Set(['kokoro', 'piper']),
+  normalizeVoiceEngine: (engine) => engine === 'qwen3' ? 'qwen3-tts' : engine,
+  VALID_ENGINES: new Set(['kokoro', 'piper', 'qwen3-tts']),
 }));
 
 const { parseVoiceId, listAllVoices, synthesizeToFile, extractDialogueLines, resolveVoiceForLine, wavDurationMs } = await import('./audio.js');
@@ -67,6 +68,15 @@ describe('parseVoiceId', () => {
     });
   });
 
+  it('normalizes legacy and canonical Qwen3 prefixes to the registered engine', () => {
+    expect(parseVoiceId('qwen3:warm-narrator')).toEqual({
+      engine: 'qwen3-tts', voice: 'warm-narrator',
+    });
+    expect(parseVoiceId('qwen3-tts:warm-narrator')).toEqual({
+      engine: 'qwen3-tts', voice: 'warm-narrator',
+    });
+  });
+
   it('ignores unknown engine prefixes and treats the whole id as a bare voice name', () => {
     expect(parseVoiceId('elevenlabs:Rachel')).toEqual({ engine: null, voice: 'elevenlabs:Rachel' });
   });
@@ -97,6 +107,26 @@ describe('listAllVoices', () => {
     }));
     expect(voices).toContainEqual(expect.objectContaining({
       id: 'piper:en_GB-northern_english_male', engine: 'piper',
+    }));
+  });
+
+  it('keeps canonical namespace fields when an engine returns a legacy id', async () => {
+    listVoicesMock.mockImplementation(async (engine) => ({
+      engine,
+      voices: engine === 'qwen3-tts' ? [{
+        id: 'qwen3:warm-narrator',
+        name: 'Warm Narrator (1.7B Design)',
+        label: 'Warm Narrator (1.7B Design)',
+        voice: 'warm-narrator',
+        engine: 'qwen3',
+      }] : [],
+    }));
+
+    expect(await listAllVoices()).toContainEqual(expect.objectContaining({
+      id: 'qwen3-tts:warm-narrator',
+      engine: 'qwen3-tts',
+      voice: 'warm-narrator',
+      label: 'Warm Narrator (1.7B Design)',
     }));
   });
 

--- a/server/services/voice/tts-qwen3.js
+++ b/server/services/voice/tts-qwen3.js
@@ -20,9 +20,9 @@ import {
 } from './qwen3TtsRuntime.js';
 
 export const QWEN3_DEFAULT_PRESETS = Object.freeze([
-  { id: 'qwen3:warm-narrator', name: 'Warm Narrator (1.7B Design)', gender: 'neutral', language: 'en' },
-  { id: 'qwen3:expressive-alto', name: 'Expressive Alto (1.7B Design)', gender: 'female', language: 'en' },
-  { id: 'qwen3:clear-baritone', name: 'Clear Baritone (1.7B Design)', gender: 'male', language: 'en' },
+  { id: 'qwen3-tts:warm-narrator', voice: 'warm-narrator', name: 'Warm Narrator (1.7B Design)', label: 'Warm Narrator (1.7B Design)', gender: 'neutral', language: 'en' },
+  { id: 'qwen3-tts:expressive-alto', voice: 'expressive-alto', name: 'Expressive Alto (1.7B Design)', label: 'Expressive Alto (1.7B Design)', gender: 'female', language: 'en' },
+  { id: 'qwen3-tts:clear-baritone', voice: 'clear-baritone', name: 'Clear Baritone (1.7B Design)', label: 'Clear Baritone (1.7B Design)', gender: 'male', language: 'en' },
 ]);
 
 /**

--- a/server/services/voice/tts-qwen3.test.js
+++ b/server/services/voice/tts-qwen3.test.js
@@ -11,14 +11,19 @@ const testPython = resolveTestPython();
 describe('tts-qwen3', () => {
   it('enumerates default Qwen3 voices', async () => {
     const voices = await listQwen3Voices();
-    expect(Array.isArray(voices)).toBe(true);
-    expect(voices.length).toBeGreaterThan(0);
-    expect(voices[0]).toHaveProperty('id');
+    expect(voices).toContainEqual(expect.objectContaining({
+      id: 'qwen3-tts:warm-narrator',
+      voice: 'warm-narrator',
+      name: 'Warm Narrator (1.7B Design)',
+      label: 'Warm Narrator (1.7B Design)',
+    }));
+    expect(voices.every((preset) => preset.id === `qwen3-tts:${preset.voice}`)).toBe(true);
   });
 
   it.skipIf(!testPython)('synthesizes speech with voice design and rate controls', async () => {
     const result = await synthesizeQwen3('This is a test of voice design synthesis.', {
       mode: 'design',
+      voice: 'warm-narrator',
       instructions: 'warm low alto',
       seed: 42,
       rate: 1.1,

--- a/server/services/voice/tts.js
+++ b/server/services/voice/tts.js
@@ -14,6 +14,11 @@ import { ServerError } from '../../lib/errorHandler.js';
 // Single source of truth for the supported TTS engine names.
 export const VALID_ENGINES = new Set(['kokoro', 'piper', 'qwen3-tts']);
 
+// Qwen3 preset ids shipped with the shorter prefix before the engine registry
+// standardized on `qwen3-tts`. Keep those persisted ids readable while every
+// new catalog entry uses the canonical engine name.
+export const normalizeVoiceEngine = (engine) => engine === 'qwen3' ? 'qwen3-tts' : engine;
+
 let voiceTransformProbe = null;
 
 const probeVoiceTransforms = () => {
@@ -67,7 +72,7 @@ export const listVoiceEngines = async () => {
 // Normalize `engine` against the allowlist so an invalid value can't silently
 // produce Kokoro audio while the response reports `engine: 'elevenlabs'`.
 const resolveEngine = (engine) => {
-  const norm = engine === 'qwen3' ? 'qwen3-tts' : engine;
+  const norm = normalizeVoiceEngine(engine);
   return VALID_ENGINES.has(norm) ? norm : 'kokoro';
 };
 

--- a/server/services/voice/tts.test.js
+++ b/server/services/voice/tts.test.js
@@ -6,6 +6,7 @@ vi.mock('./config.js', () => ({
 }));
 vi.mock('./tts-kokoro.js', () => ({ synthesizeKokoro: vi.fn(), listKokoroVoices: vi.fn() }));
 vi.mock('./tts-piper.js', () => ({ synthesizePiper: vi.fn(), listPiperVoices: vi.fn() }));
+vi.mock('./tts-qwen3.js', () => ({ synthesizeQwen3: vi.fn(), listQwen3Voices: vi.fn() }));
 vi.mock('./piper-voices.js', () => ({ findPiperVoice: vi.fn() }));
 vi.mock('./kokoro-voices.js', () => ({ isKokoroVoice: vi.fn(() => true) }));
 vi.mock('./profiles.js', () => ({ getProfileForSynthesis: vi.fn() }));
@@ -13,8 +14,9 @@ vi.mock('./bootstrap.js', () => ({ which: vi.fn() }));
 
 import { getVoiceConfig } from './config.js';
 import { synthesizeKokoro } from './tts-kokoro.js';
+import { synthesizeQwen3 } from './tts-qwen3.js';
 import { getProfileForSynthesis } from './profiles.js';
-import { synthesize } from './tts.js';
+import { normalizeVoiceEngine, synthesize } from './tts.js';
 
 const CONFIG = {
   tts: {
@@ -25,11 +27,38 @@ const CONFIG = {
   },
 };
 
+describe('voice engine normalization', () => {
+  it('keeps canonical engines and upgrades the legacy Qwen3 alias', () => {
+    expect(normalizeVoiceEngine('kokoro')).toBe('kokoro');
+    expect(normalizeVoiceEngine('piper')).toBe('piper');
+    expect(normalizeVoiceEngine('qwen3-tts')).toBe('qwen3-tts');
+    expect(normalizeVoiceEngine('qwen3')).toBe('qwen3-tts');
+  });
+});
+
 describe('profile-aware TTS', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     getVoiceConfig.mockResolvedValue(CONFIG);
     synthesizeKokoro.mockResolvedValue({ wav: Buffer.from('wav'), latencyMs: 12 });
+  });
+
+  it('dispatches the legacy Qwen3 engine alias and preset key to the Qwen3 adapter', async () => {
+    getProfileForSynthesis.mockResolvedValue(null);
+    synthesizeQwen3.mockResolvedValue({
+      wav: Buffer.from('qwen3-wav'), latencyMs: 8, modelRevision: 'qwen3-model',
+    });
+
+    const result = await synthesize('A stable character line.', {
+      engine: 'qwen3', voice: 'warm-narrator',
+    });
+
+    expect(synthesizeQwen3).toHaveBeenCalledWith(
+      'A stable character line.',
+      expect.objectContaining({ voice: 'warm-narrator', rate: 1.7 }),
+      undefined,
+    );
+    expect(result.engine).toBe('qwen3-tts');
   });
 
   it('uses the approved profile voice and promoted delivery rate instead of later project defaults', async () => {


### PR DESCRIPTION
Qwen3 preset voices now use the canonical `qwen3-tts:` namespace throughout the audio catalog while legacy `qwen3:` bindings remain readable and selected in the UI. The shared TTS normalization helper handles the legacy engine alias, catalog assembly protects canonical identity fields, and presets keep stable display names alongside internal voice keys.

Tests cover legacy and canonical parsing, canonical catalog entries, Qwen3 facade dispatch, the preview HTTP boundary, and legacy VoicePicker selection.

## Test plan

- `cd server && node_modules/.bin/vitest run services/pipeline/audio.test.js services/voice/tts.test.js services/voice/tts-qwen3.test.js routes/pipeline.test.js`
- `cd client && node_modules/.bin/vitest run src/components/voice/VoicePicker.test.jsx`

Closes #6746
