### PR TITLE
fix: synchronize public voice synthesis engines

### DIFF
--- a/server/lib/README.md
+++ b/server/lib/README.md
@@ -628,3 +628,4 @@ pm` default, `NPM_CONFIG_PREFIX`, nvm/Volta) installed `codex` successfully and 
 | `providerTypes.js` | Pure shared `isCliProvider`, `isTuiProvider`, `isApiProvider`, `isProcessProvider`, and type-gated `isClaudeHarnessProvider` predicates. |
 
 | `videoTimelineFades.js` | Browser-safe `fitFades()` proportionally fits a fade pair to its visible duration. Shared by timeline normalization/export and the editor preview/trim controls; legacy import paths re-export it. |
+| `voiceEngines.js` | Shared TTS engine IDs, supported-engine set, and persisted configuration keys. |

--- a/server/lib/apiContractSchemas.js
+++ b/server/lib/apiContractSchemas.js
@@ -6,12 +6,13 @@
  */
 
 import { z } from 'zod';
+import { TTS_ENGINE_IDS } from './voiceEngines.js';
 
 export const VOICE_TEXT_MAX_CHARS = 4000;
 
 export const voiceSynthesizeBodySchema = z.object({
   text: z.string().trim().min(1).max(VOICE_TEXT_MAX_CHARS),
-  engine: z.enum(['kokoro', 'piper']).optional(),
+  engine: z.enum(TTS_ENGINE_IDS).optional(),
   voice: z.string().max(128).optional(),
   rate: z.number().min(0.25).max(4).optional()
     .describe('Speech rate. Validated 0.25-4 (Piper). Kokoro clamps to 0.5-2.0.'),

--- a/server/lib/apiOperationContracts.js
+++ b/server/lib/apiOperationContracts.js
@@ -5,6 +5,7 @@ import {
   voiceSynthesizeBodySchema,
   zodToOpenApiSchema,
 } from './apiContractSchemas.js';
+import { TTS_ENGINE_IDS } from './voiceEngines.js';
 import { cosToolCallSchema } from './cosToolContracts.js';
 import { agentContextMcpInboundSchema } from './agentContextValidation.js';
 
@@ -62,7 +63,7 @@ export const API_OPERATION_CONTRACTS = Object.freeze({
     get: {
       summary: 'List voices',
       description: 'Enumerate available voices for an engine. Defaults to the active engine.',
-      parameters: [{ name: 'engine', in: 'query', required: false, schema: { type: 'string', enum: ['kokoro', 'piper'] } }],
+      parameters: [{ name: 'engine', in: 'query', required: false, schema: { type: 'string', enum: [...TTS_ENGINE_IDS] } }],
       responses: { 200: { description: 'Voice list', content: { 'application/json': { schema: { type: 'object' } } } } },
       'x-portos-tool': { name: 'voice.list-voices', version: 1, policy: { privacy: 'internal', sideEffect: 'read', async: false } },
     },

--- a/server/lib/apiToolResource.test.js
+++ b/server/lib/apiToolResource.test.js
@@ -52,7 +52,7 @@ describe('buildToolResource', () => {
   it('flattens an object request body into the argument schema and keeps property descriptions', () => {
     const input = byName('voice.synthesize').input_schema;
     expect(input.required).toEqual(['text']);
-    expect(input.properties.engine.enum).toEqual(['kokoro', 'piper']);
+    expect(input.properties.engine.enum).toEqual(['kokoro', 'piper', 'qwen3-tts']);
     // The description is what lets a model pick a valid rate — minimization must not strip it.
     expect(input.properties.rate.description).toMatch(/Speech rate/);
     expect(input.additionalProperties).toBe(false);
@@ -60,7 +60,7 @@ describe('buildToolResource', () => {
 
   it('turns query parameters into input properties', () => {
     const input = byName('voice.list-voices').input_schema;
-    expect(input.properties.engine).toEqual({ type: 'string', enum: ['kokoro', 'piper'] });
+    expect(input.properties.engine).toEqual({ type: 'string', enum: ['kokoro', 'piper', 'qwen3-tts'] });
     expect(input.required).toBeUndefined(); // the engine param is optional
   });
 

--- a/server/lib/index.js
+++ b/server/lib/index.js
@@ -608,3 +608,4 @@ export * from './creativeDirectorVideoCompiler.js';
 export * from './providerTypes.js';
 export * from './notificationTypes.js';
 export * from './videoTimelineFades.js';
+export * from './voiceEngines.js';

--- a/server/lib/openapiSpec.test.js
+++ b/server/lib/openapiSpec.test.js
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { z } from 'zod';
 import { buildInternalOpenApiSpec, buildOpenApiSpec } from './openapiSpec.js';
 import { synthesizeBodySchema as routeSchema } from '../routes/voicePublic.js';
+import { VALID_ENGINES } from './voiceEngines.js';
 import { voiceSynthesizeBodySchema } from './apiContractSchemas.js';
 
 const exposed = (apiAccess) => ({ apiAccess });
@@ -36,7 +37,7 @@ describe('buildOpenApiSpec', () => {
     expect(body.type).toBe('object');
     expect(body.properties.text).toBeDefined();
     expect(body.required).toContain('text');
-    expect(body.properties.engine.enum).toEqual(['kokoro', 'piper']);
+    expect(body.properties.engine.enum).toEqual([...VALID_ENGINES]);
     // OpenAPI path schemas must not carry the JSON-Schema dialect marker.
     expect(body.$schema).toBeUndefined();
   });

--- a/server/lib/openapiSpec.test.js
+++ b/server/lib/openapiSpec.test.js
@@ -38,6 +38,7 @@ describe('buildOpenApiSpec', () => {
     expect(body.properties.text).toBeDefined();
     expect(body.required).toContain('text');
     expect(body.properties.engine.enum).toEqual([...VALID_ENGINES]);
+    expect(body.properties.engine.enum).toContain('qwen3-tts');
     // OpenAPI path schemas must not carry the JSON-Schema dialect marker.
     expect(body.$schema).toBeUndefined();
   });

--- a/server/lib/voiceEngines.js
+++ b/server/lib/voiceEngines.js
@@ -1,0 +1,9 @@
+// Supported TTS engine IDs and their persisted configuration keys.
+export const TTS_ENGINE_CONFIG_KEYS = Object.freeze({
+  kokoro: 'kokoro',
+  piper: 'piper',
+  'qwen3-tts': 'qwen3',
+});
+
+export const TTS_ENGINE_IDS = Object.freeze(Object.keys(TTS_ENGINE_CONFIG_KEYS));
+export const VALID_ENGINES = new Set(TTS_ENGINE_IDS);

--- a/server/routes/voice.js
+++ b/server/routes/voice.js
@@ -6,6 +6,7 @@
  */
 
 import { Router } from 'express';
+import { TTS_ENGINE_IDS } from '../lib/voiceEngines.js';
 import { z } from 'zod';
 import { asyncHandler, ServerError } from '../lib/errorHandler.js';
 import { validateRequest } from '../lib/validation.js';
@@ -67,7 +68,7 @@ const voiceConfigPatchSchema = z.object({
     vocabularyPrompt: z.string().max(4000).optional(),
   }).partial().optional(),
   tts: z.object({
-    engine: z.enum(['kokoro', 'piper', 'qwen3-tts']).optional(),
+    engine: z.enum(TTS_ENGINE_IDS).optional(),
     rate: z.number().min(0.25).max(4).optional(),
     kokoro: z.object({
       modelId: z.string().max(128).optional(),

--- a/server/routes/voicePublic.js
+++ b/server/routes/voicePublic.js
@@ -16,6 +16,7 @@
  */
 
 import { Router } from 'express';
+import { TTS_ENGINE_CONFIG_KEYS } from '../lib/voiceEngines.js';
 import { voiceSynthesizeBodySchema } from '../lib/apiContractSchemas.js';
 import { asyncHandler, ServerError } from '../lib/errorHandler.js';
 import { synthesize, listVoices, VALID_ENGINES } from '../services/voice/tts.js';
@@ -70,10 +71,9 @@ router.get('/engines', asyncHandler(async (_req, res) => {
   res.json({
     engines: [...VALID_ENGINES],
     active: cfg.tts?.engine,
-    defaults: {
-      kokoro: cfg.tts?.kokoro?.voice,
-      piper: cfg.tts?.piper?.voice,
-    },
+    defaults: Object.fromEntries([...VALID_ENGINES].map((engine) => [
+      engine, cfg.tts?.[TTS_ENGINE_CONFIG_KEYS[engine]]?.voice ?? null,
+    ])),
   });
 }));
 

--- a/server/routes/voicePublic.test.js
+++ b/server/routes/voicePublic.test.js
@@ -2,10 +2,10 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import express from 'express';
 import { request } from '../lib/testHelper.js';
 
-vi.mock('../services/voice/tts.js', () => ({
+vi.mock('../services/voice/tts.js', async () => ({
   synthesize: vi.fn(),
   listVoices: vi.fn(),
-  VALID_ENGINES: new Set(['kokoro', 'piper']),
+  VALID_ENGINES: (await import('../lib/voiceEngines.js')).VALID_ENGINES,
 }));
 vi.mock('../services/voice/config.js', () => ({
   getVoiceConfig: vi.fn(),
@@ -44,11 +44,12 @@ describe('Public Voice API (/api/voice/public)', () => {
       expect(tts.synthesize).toHaveBeenCalledWith('hello', expect.objectContaining({ engine: undefined }));
     });
 
-    it('passes engine/voice/rate overrides through', async () => {
+    it.each([...tts.VALID_ENGINES])('passes %s engine/voice/rate overrides through', async (engine) => {
       tts.synthesize.mockResolvedValue({ wav: Buffer.from('x'), latencyMs: 1, engine: 'piper' });
-      await request(buildApp()).post('/api/voice/public/synthesize')
-        .send({ text: 'hi', engine: 'piper', voice: 'en_US-amy-medium', rate: 1.5 });
-      expect(tts.synthesize).toHaveBeenCalledWith('hi', { engine: 'piper', voice: 'en_US-amy-medium', rate: 1.5 });
+      const res = await request(buildApp()).post('/api/voice/public/synthesize')
+        .send({ text: 'hi', engine, voice: 'en_US-amy-medium', rate: 1.5 });
+      expect(res.status).toBe(200);
+      expect(tts.synthesize).toHaveBeenCalledWith('hi', { engine, voice: 'en_US-amy-medium', rate: 1.5 });
     });
 
     it('400s on empty text', async () => {
@@ -96,10 +97,17 @@ describe('Public Voice API (/api/voice/public)', () => {
   });
 
   describe('GET /engines', () => {
+    it('reads Qwen3 defaults from its persisted configuration key', async () => {
+      config.getVoiceConfig.mockResolvedValue({ tts: { engine: 'qwen3-tts', qwen3: { voice: 'warm-narrator' } } });
+      const res = await request(buildApp()).get('/api/voice/public/engines');
+      expect(res.body.defaults['qwen3-tts']).toBe('warm-narrator');
+    });
     it('returns engines + active + per-engine default voice', async () => {
       const res = await request(buildApp()).get('/api/voice/public/engines');
       expect(res.status).toBe(200);
-      expect(res.body.engines).toEqual(expect.arrayContaining(['kokoro', 'piper']));
+      expect(res.body.engines).toEqual([...tts.VALID_ENGINES]);
+      expect(Object.keys(res.body.defaults)).toEqual([...tts.VALID_ENGINES]);
+      expect(res.body.defaults['qwen3-tts']).toBeNull();
       expect(res.body.active).toBe('kokoro');
       expect(res.body.defaults.kokoro).toBe('af_heart');
       expect(res.body.defaults.piper).toBe('en_GB-jenny_dioco-medium');

--- a/server/services/voice/tts.js
+++ b/server/services/voice/tts.js
@@ -11,8 +11,8 @@ import { getProfileForSynthesis, profileArtifactDirectory } from './profiles.js'
 import { whichFirst } from '../../lib/processEnv.js';
 import { ServerError } from '../../lib/errorHandler.js';
 
-// Single source of truth for the supported TTS engine names.
-export const VALID_ENGINES = new Set(['kokoro', 'piper', 'qwen3-tts']);
+import { VALID_ENGINES } from '../../lib/voiceEngines.js';
+export { VALID_ENGINES } from '../../lib/voiceEngines.js';
 
 // Qwen3 preset ids shipped with the shorter prefix before the engine registry
 // standardized on `qwen3-tts`. Keep those persisted ids readable while every


### PR DESCRIPTION
Public voice synthesis now accepts Qwen3-TTS, matching engine discovery. Shared engine IDs keep public validation, configuration validation, and OpenAPI aligned; discovery includes each engine’s configured voice or null when unset.

Validation: 152 tests passed across public/private voice routes, synthesis, OpenAPI, module exports, API tool discovery, and import scoping.

Closes #6747
