### PR TITLE
refactor: reuse media queue capacity in system resources

### DIFF
--- a/server/services/systemResources.js
+++ b/server/services/systemResources.js
@@ -420,7 +420,12 @@ export async function buildSystemResourceReport() {
     downloadedModels,
     npmCacheBytes,
   });
-  const mediaQueue = getQueueCapacity();
+  const capacity = getQueueCapacity();
+  const mediaQueue = {
+    queued: capacity.totals.queued,
+    running: capacity.totals.running,
+    byKind: capacity.byKind,
+  };
   const agentQueue = agentQueueSummary(cosTasks, cosStatus);
   const modelBytes = sumKnownBytes([hf?.totalBytes, loraStorage?.totalBytes, ollamaBytes, lmStudioBytes]);
   const storageAreas = [
@@ -517,8 +522,8 @@ export async function buildSystemResourceReport() {
       modelBytes,
       managedReclaimableBytes,
       loadedModels: loadedModels.length,
-      queuedJobs: agentQueue ? mediaQueue.totals.queued + queuedAgents : null,
-      runningJobs: agentQueue ? mediaQueue.totals.running + agentQueue.inProgress : null,
+      queuedJobs: agentQueue ? mediaQueue.queued + queuedAgents : null,
+      runningJobs: agentQueue ? mediaQueue.running + agentQueue.inProgress : null,
     },
     storageAreas,
     dataCategories: categories,

--- a/server/services/systemResources.js
+++ b/server/services/systemResources.js
@@ -21,7 +21,7 @@ import { getDataOverview } from './dataManager.js';
 import { listHfModelStorage, listLoraStorage } from './mediaModelStorage.js';
 import * as ollamaManager from './ollamaManager.js';
 import * as lmStudioManager from './lmStudioManager.js';
-import { listJobs } from './mediaJobQueue/index.js';
+import { getQueueCapacity } from './mediaJobQueue/index.js';
 import * as cos from './cos.js';
 import { getSettings } from './settings.js';
 
@@ -314,18 +314,14 @@ function loadedModelInventory({ ollamaLoaded, lmStudioLoaded }) {
   ];
 }
 
-function mediaQueueSummary(jobs) {
-  const live = jobs.filter((job) => job.status === 'queued' || job.status === 'running');
-  const byKind = Object.fromEntries(['image', 'video', 'training', 'audio'].map((kind) => {
-    const matching = live.filter((job) => job.kind === kind);
-    return [kind, {
-      queued: matching.filter((job) => job.status === 'queued').length,
-      running: matching.filter((job) => job.status === 'running').length,
-    }];
-  }));
+function mediaQueueSummary(capacity) {
+  const byKind = Object.fromEntries(['image', 'video', 'training', 'audio'].map((kind) => [
+    kind,
+    capacity?.byKind?.[kind] || { queued: 0, running: 0 },
+  ]));
   return {
-    queued: live.filter((job) => job.status === 'queued').length,
-    running: live.filter((job) => job.status === 'running').length,
+    queued: capacity?.totals?.queued || 0,
+    running: capacity?.totals?.running || 0,
     byKind,
   };
 }
@@ -436,7 +432,7 @@ export async function buildSystemResourceReport() {
     downloadedModels,
     npmCacheBytes,
   });
-  const mediaQueue = mediaQueueSummary(listJobs());
+  const mediaQueue = mediaQueueSummary(getQueueCapacity());
   const agentQueue = agentQueueSummary(cosTasks, cosStatus);
   const modelBytes = sumKnownBytes([hf?.totalBytes, loraStorage?.totalBytes, ollamaBytes, lmStudioBytes]);
   const storageAreas = [

--- a/server/services/systemResources.js
+++ b/server/services/systemResources.js
@@ -314,18 +314,6 @@ function loadedModelInventory({ ollamaLoaded, lmStudioLoaded }) {
   ];
 }
 
-function mediaQueueSummary(capacity) {
-  const byKind = Object.fromEntries(['image', 'video', 'training', 'audio'].map((kind) => [
-    kind,
-    capacity?.byKind?.[kind] || { queued: 0, running: 0 },
-  ]));
-  return {
-    queued: capacity?.totals?.queued || 0,
-    running: capacity?.totals?.running || 0,
-    byKind,
-  };
-}
-
 function agentQueueSummary(tasks, status) {
   if (!tasks) return null;
   return {
@@ -432,7 +420,7 @@ export async function buildSystemResourceReport() {
     downloadedModels,
     npmCacheBytes,
   });
-  const mediaQueue = mediaQueueSummary(getQueueCapacity());
+  const mediaQueue = getQueueCapacity();
   const agentQueue = agentQueueSummary(cosTasks, cosStatus);
   const modelBytes = sumKnownBytes([hf?.totalBytes, loraStorage?.totalBytes, ollamaBytes, lmStudioBytes]);
   const storageAreas = [
@@ -529,8 +517,8 @@ export async function buildSystemResourceReport() {
       modelBytes,
       managedReclaimableBytes,
       loadedModels: loadedModels.length,
-      queuedJobs: agentQueue ? mediaQueue.queued + queuedAgents : null,
-      runningJobs: agentQueue ? mediaQueue.running + agentQueue.inProgress : null,
+      queuedJobs: agentQueue ? mediaQueue.totals.queued + queuedAgents : null,
+      runningJobs: agentQueue ? mediaQueue.totals.running + agentQueue.inProgress : null,
     },
     storageAreas,
     dataCategories: categories,

--- a/server/services/systemResources.test.js
+++ b/server/services/systemResources.test.js
@@ -71,10 +71,13 @@ vi.mock('./lmStudioManager.js', () => ({
   getModelsDir: vi.fn(async () => '/example/lmstudio'),
 }));
 vi.mock('./mediaJobQueue/index.js', () => ({
-  listJobs: vi.fn(() => [
-    { id: 'image-1', kind: 'image', status: 'queued' },
-    { id: 'video-1', kind: 'video', status: 'running' },
-  ]),
+  getQueueCapacity: vi.fn(() => ({
+    totals: { queued: 1, running: 1 },
+    byKind: {
+      image: { queued: 1, running: 0 },
+      video: { queued: 0, running: 1 },
+    },
+  })),
 }));
 vi.mock('./cos.js', () => ({
   getAllTasks: vi.fn(async () => ({

--- a/server/services/systemResources.test.js
+++ b/server/services/systemResources.test.js
@@ -72,7 +72,7 @@ vi.mock('./lmStudioManager.js', () => ({
 }));
 vi.mock('./mediaJobQueue/index.js', () => ({
   getQueueCapacity: vi.fn(() => ({
-    totals: { queued: 1, running: 1 },
+    totals: { queued: 3, running: 1 },
     byKind: {
       image: { queued: 1, running: 0 },
       video: { queued: 0, running: 1 },
@@ -144,10 +144,11 @@ describe('system resource reporting', () => {
       freeBytes: 25000,
       usagePercent: 75,
     });
-    expect(report.summary).toMatchObject({ loadedModels: 1, queuedJobs: 3, runningJobs: 1 });
+    expect(report.summary).toMatchObject({ loadedModels: 1, queuedJobs: 5, runningJobs: 1 });
     expect(report.queues.media).toMatchObject({
+      queued: 3,
+      running: 1,
       byKind: expect.objectContaining({ 'video-upscale': { queued: 2, running: 0 } }),
-      totals: { queued: 1, running: 1 },
     });
     expect(report.queues.agents).toMatchObject({ pendingSystem: 1, awaitingApproval: 1 });
     expect(report.models.downloaded.map((model) => model.backend)).toEqual(

--- a/server/services/systemResources.test.js
+++ b/server/services/systemResources.test.js
@@ -76,6 +76,7 @@ vi.mock('./mediaJobQueue/index.js', () => ({
     byKind: {
       image: { queued: 1, running: 0 },
       video: { queued: 0, running: 1 },
+      'video-upscale': { queued: 2, running: 0 },
     },
   })),
 }));
@@ -144,6 +145,10 @@ describe('system resource reporting', () => {
       usagePercent: 75,
     });
     expect(report.summary).toMatchObject({ loadedModels: 1, queuedJobs: 3, runningJobs: 1 });
+    expect(report.queues.media).toMatchObject({
+      byKind: expect.objectContaining({ 'video-upscale': { queued: 2, running: 0 } }),
+      totals: { queued: 1, running: 1 },
+    });
     expect(report.queues.agents).toMatchObject({ pendingSystem: 1, awaitingApproval: 1 });
     expect(report.models.downloaded.map((model) => model.backend)).toEqual(
       expect.arrayContaining(['huggingface', 'lora', 'ollama', 'lmstudio']),


### PR DESCRIPTION
## Summary
Use the media job queue's canonical capacity report for system resource queue metrics, preserving the existing flat report shape while carrying every queue kind.

## Tests
- server/node_modules/.bin/vitest run server/services/systemResources.test.js

Closes #6755