### PR TITLE
feat: configure registered TTS engines in Voice settings (#6749)

### DIFF
--- a/client/src/components/settings/VoiceTab.jsx
+++ b/client/src/components/settings/VoiceTab.jsx
@@ -4,7 +4,7 @@ import { Save, Mic, Play, Zap, RefreshCw, Globe } from 'lucide-react';
 import toast from '../ui/Toast';
 import BrailleSpinner from '../BrailleSpinner';
 import {
-  getVoiceStatus, getVoiceConfig, updateVoiceConfig, listVoices, testTts, fetchPiperVoice, getFaceTimeStatus, controlFaceTime,
+  getVoiceStatus, getVoiceConfig, updateVoiceConfig, listVoices, listVoiceEngines, testTts, fetchPiperVoice, getFaceTimeStatus, controlFaceTime,
 } from '../../services/apiVoice';
 import { getProviders, refreshProviderModels } from '../../services/apiProviders';
 import { playWav, webSpeechSupported } from '../../services/voiceClient';
@@ -25,11 +25,6 @@ const SERVICE_LABELS = {
 const STT_ENGINES = [
   { value: 'whisper', label: 'Whisper (local, accurate, works offline)' },
   { value: 'web-speech', label: 'Web Speech API (browser-native, zero latency)' },
-];
-
-const TTS_ENGINES = [
-  { value: 'kokoro', label: 'Kokoro (in-process, high quality)' },
-  { value: 'piper', label: 'Piper (CLI binary, lightweight)' },
 ];
 
 const KOKORO_DTYPES = [
@@ -81,6 +76,8 @@ export function VoiceTab() {
   const [cfg, setCfg] = useState(null);
   const [status, setStatus] = useState(null);
   const [voiceList, setVoiceList] = useState({ engine: null, voices: [] });
+  const [ttsEngines, setTtsEngines] = useState([]);
+  const [ttsEngineError, setTtsEngineError] = useState(null);
   const [testing, setTesting] = useState(false);
   const [previewingVoice, setPreviewingVoice] = useState(null);
   const [downloadingVoice, setDownloadingVoice] = useState(null);
@@ -102,6 +99,15 @@ export function VoiceTab() {
   };
 
   const currentEngine = cfg?.tts?.engine;
+
+  useEffect(() => {
+    if (!currentEngine || ttsEngines.length === 0) return;
+    const registered = ttsEngines.find((item) => (
+      item.id === currentEngine || item.aliases?.includes(currentEngine)
+    ));
+    if (!registered || registered.id === currentEngine) return;
+    setCfg((current) => ({ ...current, tts: { ...current.tts, engine: registered.id } }));
+  }, [currentEngine, ttsEngines]);
 
   const refreshStatus = useCallback(() => {
     return Promise.all([
@@ -129,6 +135,16 @@ export function VoiceTab() {
         setCodeProviders(all.filter((p) => p.type === 'cli' || p.type === 'tui'));
       })
       .catch(() => { setApiProviders([]); setCodeProviders([]); });
+    listVoiceEngines({ silent: true })
+      .then((data) => {
+        const engines = Array.isArray(data?.engines) ? data.engines : [];
+        setTtsEngines(engines);
+        setTtsEngineError(engines.length > 0 ? null : 'No TTS engines were returned by this server.');
+      })
+      .catch(() => {
+        setTtsEngines([]);
+        setTtsEngineError('Could not load the TTS engine registry. The saved engine remains selected.');
+      });
   }, []);
 
   // Refetch the voice catalog whenever the user flips TTS engine so the picker
@@ -266,10 +282,18 @@ export function VoiceTab() {
   const facetime = cfg.facetime || {};
   const faceTimeDirty = !facetime.targetHandle?.trim() || !facetime.targetName?.trim();
 
-  const engine = cfg.tts.engine || 'kokoro';
+  const configuredEngine = cfg.tts.engine || 'kokoro';
   const sttEngine = cfg.stt.engine || 'whisper';
-  const activeVoice = engine === 'kokoro' ? cfg.tts.kokoro?.voice : cfg.tts.piper?.voice;
+  const engineMeta = ttsEngines.find((item) => (
+    item.id === configuredEngine || item.aliases?.includes(configuredEngine)
+  ));
+  const engine = engineMeta?.id || configuredEngine;
   const voices = voiceList.voices || [];
+  const engineConfigKey = typeof engineMeta?.configKey === 'string' ? engineMeta.configKey : null;
+  const fallbackConfigKey = [configuredEngine, configuredEngine.replace(/-tts$/, '')]
+    .find((key) => cfg.tts[key] && typeof cfg.tts[key] === 'object');
+  const activeVoice = cfg.tts[engineConfigKey || fallbackConfigKey]?.voice;
+  const selectedEngineMetadataMissing = Boolean(engineMeta && !engineConfigKey);
 
   // LLM provider/model pickers. The saved provider/model are always shown even
   // when missing from the registry (e.g. provider deleted, or a model not in
@@ -308,7 +332,7 @@ export function VoiceTab() {
         <h2 className="text-lg font-semibold">Local Voice Chief-of-Staff</h2>
       </div>
       <p className="text-xs text-gray-500 -mt-4">
-        Hands-free or push-to-talk voice. Whisper (STT) + Kokoro/Piper (TTS) + your chosen LLM
+        Hands-free or push-to-talk voice. Whisper (STT) + local TTS + your chosen LLM
         provider with tool calling for real actions (brain capture, goal updates, PM2 control, feed
         digests, time, and more). Pick a local provider (LM Studio, Ollama) to keep everything on
         this machine, or any OpenAI-compatible API.
@@ -435,32 +459,40 @@ export function VoiceTab() {
           />
         </FormField>
 
-        <FormField label="TTS engine" hint="Kokoro is higher quality and runs in-process. Piper is a small CLI binary.">
+        <FormField label="TTS engine" hint={ttsEngineError
+          || (selectedEngineMetadataMissing
+            ? 'This server returned legacy engine metadata. Voice selection stays read-only until the server is updated.'
+            : engineMeta?.description || 'Choose a locally available speech engine.')}>
           <select
             value={engine}
             onChange={(e) => patch('tts.engine', e.target.value)}
             className={inputCls}
           >
-            {TTS_ENGINES.map((opt) => (
-              <option key={opt.value} value={opt.value}>{opt.label}</option>
+            {!ttsEngines.some((item) => item.id === engine) && (
+              <option value={engine}>{engine} (current)</option>
+            )}
+            {ttsEngines.map((opt) => (
+              <option key={opt.id} value={opt.id}>
+                {opt.label || opt.id}{opt.description ? ` (${opt.description})` : ''}
+              </option>
             ))}
           </select>
         </FormField>
 
-        <FormField label={`${engine === 'kokoro' ? 'Kokoro' : 'Piper'} voice`} hint={
-          engine === 'kokoro'
-            ? 'Grade letter = Kokoro author\'s quality rating. ❤️ 🔥 🎧 mark the best-sounding voices. Click ▶ to preview without saving.'
-            : 'Curated Piper catalog — selecting a ⬇ voice fetches it immediately so you can preview. Click ▶ to audition.'
-        }>
+        <FormField label={`${engineMeta?.label || engine} voice`} hint={engineConfigKey
+          ? engineMeta?.voiceHint
+          : 'Voice selection is read-only until engine configuration metadata is available.'}>
           <div className="flex items-center gap-2">
             <select
               value={activeVoice || ''}
               aria-label="Voice"
+              disabled={!engineConfigKey}
               onChange={(e) => {
                 const val = e.target.value;
-                if (engine === 'kokoro') { patch('tts.kokoro.voice', val); return; }
+                if (!engineConfigKey) return;
+                patch(`tts.${engineConfigKey}.voice`, val);
+                if (engine !== 'piper') return;
                 const v = voices.find((x) => x.name === val);
-                patch('tts.piper.voice', val);
                 if (v?.path) patch('tts.piper.voicePath', v.path);
                 patch('tts.piper.speakerId', null);
                 // Fetch voice on select so ▶ preview works without a save.

--- a/client/src/components/settings/VoiceTab.test.jsx
+++ b/client/src/components/settings/VoiceTab.test.jsx
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import VoiceTab from './VoiceTab';
+
+const voiceApi = vi.hoisted(() => ({
+  getVoiceStatus: vi.fn(),
+  getVoiceConfig: vi.fn(),
+  updateVoiceConfig: vi.fn(),
+  listVoices: vi.fn(),
+  listVoiceEngines: vi.fn(),
+  testTts: vi.fn(),
+  fetchPiperVoice: vi.fn(),
+  getFaceTimeStatus: vi.fn(),
+  controlFaceTime: vi.fn(),
+}));
+
+vi.mock('../../services/apiVoice', () => voiceApi);
+vi.mock('../../services/apiProviders', () => ({
+  getProviders: vi.fn().mockResolvedValue({ providers: [] }),
+  refreshProviderModels: vi.fn(),
+}));
+vi.mock('../../services/voiceClient', () => ({ playWav: vi.fn(), webSpeechSupported: true }));
+vi.mock('../../services/browserLlm', () => ({ nanoAvailability: vi.fn().mockResolvedValue('available') }));
+vi.mock('../../services/voiceVisibility', () => ({
+  readVoiceHidden: vi.fn(() => false),
+  writeVoiceHidden: vi.fn(),
+}));
+vi.mock('../../hooks/useInstanceFeatures', () => ({
+  useInstanceFeatures: () => ({ isFeatureEnabled: () => false }),
+}));
+
+const config = {
+  enabled: false,
+  hotkey: 'Space',
+  facetime: {},
+  stt: {
+    engine: 'web-speech', endpoint: 'http://127.0.0.1:5562', model: 'base.en', coreml: false,
+  },
+  tts: {
+    engine: 'qwen3-tts',
+    rate: 1,
+    kokoro: { voice: 'af_heart', dtype: 'q8' },
+    piper: { voice: 'en_GB-jenny_dioco-medium' },
+    qwen3: { voice: 'warm-narrator' },
+  },
+  llm: {
+    provider: 'lmstudio',
+    model: 'auto',
+    visionModel: 'auto',
+    systemPrompt: '',
+    usePersonality: false,
+    personality: {},
+    tools: { enabled: false },
+    codeAgent: { enabled: false },
+    proactive: { enabled: false },
+    fastPath: { enabled: false },
+  },
+};
+
+describe('VoiceTab TTS engine registry', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    voiceApi.getVoiceConfig.mockResolvedValue(structuredClone(config));
+    voiceApi.getVoiceStatus.mockResolvedValue({ services: {} });
+    voiceApi.listVoiceEngines.mockResolvedValue({
+      engines: [
+        { id: 'kokoro', configKey: 'kokoro', label: 'Kokoro', description: 'In-process, high quality' },
+        { id: 'piper', configKey: 'piper', label: 'Piper', description: 'CLI binary, lightweight' },
+        { id: 'qwen3-tts', configKey: 'qwen3', label: 'Qwen3-TTS', description: 'Voice design, cloning, and streaming', aliases: ['qwen3'] },
+      ],
+    });
+    voiceApi.listVoices.mockResolvedValue({
+      engine: 'qwen3-tts',
+      voices: [
+        { name: 'warm-narrator', label: 'Warm Narrator', language: 'en', gender: 'neutral' },
+        { name: 'expressive-alto', label: 'Expressive Alto', language: 'en', gender: 'female' },
+      ],
+    });
+    voiceApi.updateVoiceConfig.mockImplementation(async (nextConfig) => ({
+      config: nextConfig,
+      reconciliation: { skipped: true },
+    }));
+  });
+
+  it('loads engine options and patches the registry configuration key for Qwen3 voices', async () => {
+    render(<MemoryRouter><VoiceTab /></MemoryRouter>);
+
+    const engineSelect = await screen.findByRole('combobox', { name: 'TTS engine' });
+    expect(voiceApi.listVoiceEngines).toHaveBeenCalledWith({ silent: true });
+    expect(engineSelect).toHaveValue('qwen3-tts');
+    expect(screen.getByRole('option', { name: 'Qwen3-TTS (Voice design, cloning, and streaming)' })).toBeTruthy();
+
+    fireEvent.change(await screen.findByRole('combobox', { name: 'Voice' }), {
+      target: { value: 'expressive-alto' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Save & Reconcile' }));
+
+    await waitFor(() => expect(voiceApi.updateVoiceConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tts: expect.objectContaining({
+          qwen3: expect.objectContaining({ voice: 'expressive-alto' }),
+          piper: expect.objectContaining({ voice: 'en_GB-jenny_dioco-medium' }),
+        }),
+      }),
+      { silent: true },
+    ));
+  });
+
+  it('preserves the saved engine and disables voice edits when registry metadata is unavailable', async () => {
+    voiceApi.listVoiceEngines.mockRejectedValueOnce(new Error('offline'));
+
+    render(<MemoryRouter><VoiceTab /></MemoryRouter>);
+
+    const engineSelect = await screen.findByRole('combobox', { name: 'TTS engine' });
+    expect(engineSelect).toHaveValue('qwen3-tts');
+    expect(screen.getByRole('option', { name: 'qwen3-tts (current)' })).toBeTruthy();
+    expect(await screen.findByText(/Could not load the TTS engine registry/)).toBeTruthy();
+
+    const voiceSelect = await screen.findByRole('combobox', { name: 'Voice' });
+    expect(voiceSelect).toHaveValue('warm-narrator');
+    expect(voiceSelect.disabled).toBe(true);
+  });
+
+  it('normalizes a legacy Qwen engine alias from registry metadata', async () => {
+    voiceApi.getVoiceConfig.mockResolvedValue({
+      ...structuredClone(config),
+      tts: { ...structuredClone(config.tts), engine: 'qwen3' },
+    });
+
+    render(<MemoryRouter><VoiceTab /></MemoryRouter>);
+
+    expect(await screen.findByRole('combobox', { name: 'TTS engine' })).toHaveValue('qwen3-tts');
+    expect(screen.getByRole('combobox', { name: 'Voice' }).disabled).toBe(false);
+  });
+});

--- a/client/src/lib/voiceLabel.js
+++ b/client/src/lib/voiceLabel.js
@@ -5,6 +5,7 @@
 // to every consumer without per-component edits.
 
 const LANGUAGE_LABELS = Object.freeze({
+  en: 'English',
   'en-US': 'American',
   'en-GB': 'British',
 });
@@ -25,6 +26,12 @@ const ENGINE_FORMATTERS = Object.freeze({
     const note = v.note ? ` · ${v.note}` : '';
     const dl = v.downloaded === false ? ' ⬇' : '';
     return meta ? `${id} — ${meta}${note}${dl}` : `${id}${note}${dl}`;
+  },
+  'qwen3-tts': (v) => {
+    const display = v.label || v.name || v.voice || v.id || '';
+    const language = LANGUAGE_LABELS[v.language] || v.language;
+    const meta = [language, v.gender].filter(Boolean).join(' — ');
+    return meta ? `${display} — ${meta}` : display;
   },
 });
 

--- a/client/src/lib/voiceLabel.test.js
+++ b/client/src/lib/voiceLabel.test.js
@@ -45,6 +45,12 @@ describe('formatVoiceLabel', () => {
       .toBe('lessac-medium — American');
   });
 
+  it('formats Qwen3 voices with their display label, language, and gender', () => {
+    expect(formatVoiceLabel({
+      engine: 'qwen3-tts', label: 'Warm Narrator (1.7B Design)', language: 'en', gender: 'neutral',
+    })).toBe('Warm Narrator (1.7B Design) — English — neutral');
+  });
+
   it('falls back to label / voice / id when engine is unrecognised', () => {
     expect(formatVoiceLabel({ engine: 'elevenlabs', label: 'Rachel' })).toBe('Rachel');
     expect(formatVoiceLabel({ engine: 'elevenlabs', voice: 'rachel' })).toBe('rachel');

--- a/server/lib/README.md
+++ b/server/lib/README.md
@@ -628,4 +628,4 @@ pm` default, `NPM_CONFIG_PREFIX`, nvm/Volta) installed `codex` successfully and 
 | `providerTypes.js` | Pure shared `isCliProvider`, `isTuiProvider`, `isApiProvider`, `isProcessProvider`, and type-gated `isClaudeHarnessProvider` predicates. |
 
 | `videoTimelineFades.js` | Browser-safe `fitFades()` proportionally fits a fade pair to its visible duration. Shared by timeline normalization/export and the editor preview/trim controls; legacy import paths re-export it. |
-| `voiceEngines.js` | Shared TTS engine IDs, supported-engine set, and persisted configuration keys. |
+| `voiceEngines.js` | Shared TTS engine IDs, display metadata, supported-engine set, and persisted configuration keys. |

--- a/server/lib/voiceEngines.js
+++ b/server/lib/voiceEngines.js
@@ -1,9 +1,45 @@
-// Supported TTS engine IDs and their persisted configuration keys.
-export const TTS_ENGINE_CONFIG_KEYS = Object.freeze({
-  kokoro: 'kokoro',
-  piper: 'piper',
-  'qwen3-tts': 'qwen3',
+// Shared TTS engine metadata. The registry is returned by /api/voice/engines so
+// clients can render and update engines without copying IDs or config keys.
+export const TTS_ENGINE_REGISTRY = Object.freeze({
+  kokoro: Object.freeze({
+    configKey: 'kokoro',
+    label: 'Kokoro',
+    description: 'In-process, high quality',
+    voiceHint: 'Grade letter = Kokoro author\'s quality rating. ❤️ 🔥 🎧 mark the best-sounding voices. Click ▶ to preview without saving.',
+    capabilities: {
+      preset: true, voiceDesign: false, instantClone: false, fineTune: false,
+      streaming: false, instructionControl: false, emotionControl: false,
+      seed: false, wordTimings: false, rate: true, pitch: false, formant: false,
+    },
+  }),
+  piper: Object.freeze({
+    configKey: 'piper',
+    label: 'Piper',
+    description: 'CLI binary, lightweight',
+    voiceHint: 'Curated Piper catalog — selecting a ⬇ voice fetches it immediately so you can preview. Click ▶ to audition.',
+    capabilities: {
+      preset: true, voiceDesign: false, instantClone: false, fineTune: false,
+      streaming: false, instructionControl: false, emotionControl: false,
+      seed: false, wordTimings: false, rate: true, pitch: false, formant: false,
+    },
+  }),
+  'qwen3-tts': Object.freeze({
+    configKey: 'qwen3',
+    label: 'Qwen3-TTS',
+    description: 'Voice design, cloning, and streaming',
+    voiceHint: 'Designed Qwen3 voice presets with language and gender metadata. Click ▶ to preview without saving.',
+    aliases: Object.freeze(['qwen3']),
+    capabilities: {
+      preset: true, voiceDesign: true, instantClone: true, fineTune: true,
+      streaming: true, instructionControl: true, emotionControl: true,
+      seed: true, wordTimings: true, rate: true, pitch: false, formant: false,
+    },
+  }),
 });
 
-export const TTS_ENGINE_IDS = Object.freeze(Object.keys(TTS_ENGINE_CONFIG_KEYS));
+export const TTS_ENGINE_CONFIG_KEYS = Object.freeze(Object.fromEntries(
+  Object.entries(TTS_ENGINE_REGISTRY).map(([id, engine]) => [id, engine.configKey]),
+));
+
+export const TTS_ENGINE_IDS = Object.freeze(Object.keys(TTS_ENGINE_REGISTRY));
 export const VALID_ENGINES = new Set(TTS_ENGINE_IDS);

--- a/server/routes/voice.test.js
+++ b/server/routes/voice.test.js
@@ -323,6 +323,22 @@ describe('Voice Routes', () => {
       expect(config.updateVoiceConfig).toHaveBeenCalledWith(patch);
     });
 
+    it('accepts Qwen3-TTS engine and voice configuration', async () => {
+      config.updateVoiceConfig.mockResolvedValue({ ...DEFAULT_CFG });
+      bootstrap.reconcile.mockResolvedValue({ skipped: true });
+      const patch = {
+        tts: {
+          engine: 'qwen3-tts',
+          qwen3: { modelId: 'Qwen/Qwen3-TTS-12Hz-1.7B-VoiceDesign', voice: 'warm-narrator' },
+        },
+      };
+
+      const res = await request(buildApp()).put('/api/voice/config').send(patch);
+
+      expect(res.status).toBe(200);
+      expect(config.updateVoiceConfig).toHaveBeenCalledWith(patch);
+    });
+
     it('accepts a facetime.autoAnswer patch', async () => {
       config.updateVoiceConfig.mockResolvedValue({ ...DEFAULT_CFG });
       bootstrap.reconcile.mockResolvedValue({ skipped: true });

--- a/server/services/voice/config.js
+++ b/server/services/voice/config.js
@@ -62,7 +62,7 @@ export const VOICE_DEFAULTS = Object.freeze({
   },
 
   tts: {
-    engine: 'kokoro', // 'kokoro' | 'piper'
+    engine: 'kokoro', // 'kokoro' | 'piper' | 'qwen3-tts'
     rate: 1.0,
     kokoro: {
       modelId: 'onnx-community/Kokoro-82M-v1.0-ONNX',
@@ -75,6 +75,10 @@ export const VOICE_DEFAULTS = Object.freeze({
       // Null = use the catalog default (set per-voice in piper-voices.js).
       // Override here when experimenting with other VCTK speaker indices.
       speakerId: null,
+    },
+    qwen3: {
+      modelId: 'Qwen/Qwen3-TTS-12Hz-1.7B-VoiceDesign',
+      voice: 'warm-narrator',
     },
   },
 

--- a/server/services/voice/config.test.js
+++ b/server/services/voice/config.test.js
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest';
+import { VOICE_DEFAULTS } from './config.js';
+
+describe('voice configuration defaults', () => {
+  it('provides a usable Qwen3-TTS voice and model when the engine is selected', () => {
+    expect(VOICE_DEFAULTS.tts.qwen3).toEqual({
+      modelId: 'Qwen/Qwen3-TTS-12Hz-1.7B-VoiceDesign',
+      voice: 'warm-narrator',
+    });
+  });
+});

--- a/server/services/voice/tts.js
+++ b/server/services/voice/tts.js
@@ -11,7 +11,7 @@ import { getProfileForSynthesis, profileArtifactDirectory } from './profiles.js'
 import { whichFirst } from '../../lib/processEnv.js';
 import { ServerError } from '../../lib/errorHandler.js';
 
-import { VALID_ENGINES } from '../../lib/voiceEngines.js';
+import { TTS_ENGINE_IDS, TTS_ENGINE_REGISTRY, VALID_ENGINES } from '../../lib/voiceEngines.js';
 export { VALID_ENGINES } from '../../lib/voiceEngines.js';
 
 // Qwen3 preset ids shipped with the shorter prefix before the engine registry
@@ -35,38 +35,12 @@ export const listVoiceEngines = async () => {
   const unavailableControls = transforms.rubberband
     ? 'Rubber Band is installed, but PortOS has no approved formant-preserving adapter yet. Pitch and formant controls remain disabled until that adapter is enabled.'
     : 'Install Rubber Band to enable a future formant-preserving transform. Pitch and formant controls remain disabled rather than approximated by sample-rate changes.';
-  return [
-    {
-      id: 'kokoro',
-      capabilities: {
-        preset: true, voiceDesign: false, instantClone: false, fineTune: false,
-        streaming: false, instructionControl: false, emotionControl: false,
-        seed: false, wordTimings: false, rate: true, pitch: false, formant: false,
-      },
-      unavailableControls,
-      transformProbe: transforms,
-    },
-    {
-      id: 'piper',
-      capabilities: {
-        preset: true, voiceDesign: false, instantClone: false, fineTune: false,
-        streaming: false, instructionControl: false, emotionControl: false,
-        seed: false, wordTimings: false, rate: true, pitch: false, formant: false,
-      },
-      unavailableControls,
-      transformProbe: transforms,
-    },
-    {
-      id: 'qwen3-tts',
-      capabilities: {
-        preset: true, voiceDesign: true, instantClone: true, fineTune: true,
-        streaming: true, instructionControl: true, emotionControl: true,
-        seed: true, wordTimings: true, rate: true, pitch: false, formant: false,
-      },
-      unavailableControls,
-      transformProbe: transforms,
-    },
-  ];
+  return TTS_ENGINE_IDS.map((id) => ({
+    id,
+    ...TTS_ENGINE_REGISTRY[id],
+    unavailableControls,
+    transformProbe: transforms,
+  }));
 };
 
 // Normalize `engine` against the allowlist so an invalid value can't silently

--- a/server/services/voice/tts.test.js
+++ b/server/services/voice/tts.test.js
@@ -11,12 +11,13 @@ vi.mock('./piper-voices.js', () => ({ findPiperVoice: vi.fn() }));
 vi.mock('./kokoro-voices.js', () => ({ isKokoroVoice: vi.fn(() => true) }));
 vi.mock('./profiles.js', () => ({ getProfileForSynthesis: vi.fn() }));
 vi.mock('./bootstrap.js', () => ({ which: vi.fn() }));
+vi.mock('../../lib/processEnv.js', () => ({ whichFirst: vi.fn().mockResolvedValue(null) }));
 
 import { getVoiceConfig } from './config.js';
 import { synthesizeKokoro } from './tts-kokoro.js';
 import { synthesizeQwen3 } from './tts-qwen3.js';
 import { getProfileForSynthesis } from './profiles.js';
-import { normalizeVoiceEngine, synthesize } from './tts.js';
+import { listVoiceEngines, normalizeVoiceEngine, synthesize } from './tts.js';
 
 const CONFIG = {
   tts: {
@@ -33,6 +34,16 @@ describe('voice engine normalization', () => {
     expect(normalizeVoiceEngine('piper')).toBe('piper');
     expect(normalizeVoiceEngine('qwen3-tts')).toBe('qwen3-tts');
     expect(normalizeVoiceEngine('qwen3')).toBe('qwen3-tts');
+  });
+
+  it('publishes registry display and configuration metadata for every engine', async () => {
+    const engines = await listVoiceEngines();
+
+    expect(engines).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: 'kokoro', configKey: 'kokoro', label: 'Kokoro' }),
+      expect.objectContaining({ id: 'piper', configKey: 'piper', label: 'Piper' }),
+      expect.objectContaining({ id: 'qwen3-tts', configKey: 'qwen3', label: 'Qwen3-TTS' }),
+    ]));
   });
 });
 


### PR DESCRIPTION
## Summary

- make the server voice-engine registry the source of settings metadata, config keys, aliases, and capabilities
- load registered TTS engines in Voice settings while preserving saved values during request failures or legacy responses
- configure and format Qwen3-TTS voices through the `tts.qwen3` settings block

## Validation

- `cd client && npx vitest run src/components/settings/VoiceTab.test.jsx src/lib/voiceLabel.test.js`
- `cd client && npx biome check src/components/settings/VoiceTab.jsx src/components/settings/VoiceTab.test.jsx src/lib/voiceLabel.js src/lib/voiceLabel.test.js`
- `cd client && npm run build`
- `cd server && npx vitest run services/voice/config.test.js services/voice/tts.test.js routes/voice.test.js routes/voice.openapi.test.js lib/index.test.js`
- `git diff --check HEAD^ HEAD`

Closes #6749
