### PR TITLE
fix: share readiness gate labels across pipeline surfaces (#6771)

### DIFF
--- a/client/src/components/pipeline/AutopilotPanel.jsx
+++ b/client/src/components/pipeline/AutopilotPanel.jsx
@@ -28,6 +28,7 @@ import AutopilotMilestones from './AutopilotMilestones';
 import CanonReadinessPanel from './CanonReadinessPanel';
 import SeriesAutopilotSchedule from './SeriesAutopilotSchedule';
 import { severityColor } from './constants.js';
+import { READINESS_GATE_LABELS, READINESS_GATE_ORDER } from '../../lib/editorialHealth.js';
 
 // Convergence-round bounds — mirror the server (seriesAutopilot.js + the
 // pipelineEditorialChecks settings schema). 0 = skip that gate entirely.
@@ -103,11 +104,6 @@ const clampFoundationThreshold = (n, fallback) => {
 // Options select sends a chosen gate as a PER-RUN override only (it does NOT
 // persist, unlike the round inputs) so a one-off looser/stricter run never edits
 // the install's saved default; '' means "use the saved default" and sends nothing.
-const READINESS_GATE_LABELS = {
-  noOpenHigh: 'No open High findings',
-  noOpenHighOrMedium: 'No open High or Medium (strict)',
-  none: 'None — skip the health gate',
-};
 // Clamp a number-input value to [min, max] integers, with a blank/invalid field
 // falling back to `fallback` (NOT min — for round gates fallback is the default,
 // not 0, so a cleared input never silently disables a gate; an explicitly typed 0
@@ -1295,8 +1291,8 @@ export default function AutopilotPanel({ series, onSeriesUpdate, onIssuesUpdate 
               <option value="">
                 Use saved default{savedGate ? ` (${READINESS_GATE_LABELS[savedGate]})` : ''}
               </option>
-              {Object.entries(READINESS_GATE_LABELS).map(([value, label]) => (
-                <option key={value} value={value}>{label}</option>
+              {READINESS_GATE_ORDER.map((value) => (
+                <option key={value} value={value}>{READINESS_GATE_LABELS[value]}</option>
               ))}
             </select>
           </div>

--- a/client/src/components/pipeline/AutopilotPanel.test.jsx
+++ b/client/src/components/pipeline/AutopilotPanel.test.jsx
@@ -273,7 +273,7 @@ describe('AutopilotPanel', () => {
     fireEvent.click(screen.getByRole('button', { name: /options/i }));
     // The saved default is surfaced in the "use saved default" option label.
     await waitFor(() => expect(screen.getByLabelText('Readiness gate')).toHaveValue(''));
-    expect(screen.getByText(/Use saved default \(No open High or Medium/)).toBeInTheDocument();
+    expect(screen.getByText(/Use saved default \(No open high or medium findings/)).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: /run autopilot/i }));
     // Nothing chosen → no readinessGate sent; server resolves from the setting.
     await waitFor(() => expect(startPipelineAutopilot).toHaveBeenCalledWith(

--- a/client/src/lib/editorialHealth.test.js
+++ b/client/src/lib/editorialHealth.test.js
@@ -9,7 +9,16 @@ import {
   countSparklineGeometry,
   diffCountMaps,
   snapshotDiff,
+  READINESS_GATE_LABELS,
+  READINESS_GATE_ORDER,
 } from './editorialHealth.js';
+
+describe('readiness gate labels', () => {
+  it('keeps the label table aligned with the complete gate order', () => {
+    expect(Object.keys(READINESS_GATE_LABELS)).toEqual([...READINESS_GATE_ORDER]);
+    expect(READINESS_GATE_ORDER).toEqual(['noOpenHigh', 'noOpenHighOrMedium', 'none']);
+  });
+});
 
 describe('scoreBand', () => {
   it('bands scores into label + tone', () => {


### PR DESCRIPTION
Autopilot now consumes the shared editorial health readiness-gate labels and order, keeping its options aligned with the Editorial Health panel. The parity test pins the complete three-gate set, and the existing per-run gate ids remain unchanged.

Tests: `cd client && npm test -- --run src/lib/editorialHealth.test.js src/components/pipeline/AutopilotPanel.test.jsx`

Closes #6771
