### PR TITLE
fix: recover share-bucket export cache writes (#6777)

### DIFF
--- a/server/services/sharing/exporter.js
+++ b/server/services/sharing/exporter.js
@@ -19,6 +19,7 @@ import { join, basename } from 'path';
 import { readFile, stat } from 'fs/promises';
 import { existsSync } from 'fs';
 import { PATHS, ensureDir, atomicWrite, readJSONFile, sha256File, copyFileGuarded } from '../../lib/fileUtils.js';
+import { createKeyCachedQueue } from '../../lib/createKeyCachedQueue.js';
 import { getOrComputeImageSha256 } from '../../lib/assetHash.js';
 import { isPlainObject } from '../../lib/objects.js';
 import { getBucket, ensureBucketLayout, bucketBlobsDir, bucketBlobPath, bucketBlobSidecarPath, bucketBlobIndexPath, bucketRecordsDir, bucketRecordPath, imageSidecarName, isHexHash } from './buckets.js';
@@ -96,24 +97,22 @@ async function loadAssetHashCache(bucketPath) {
   return isPlainObject(raw) ? raw : {};
 }
 
-// Per-bucket cache-write tail — serializes the re-load → merge → atomicWrite
+// Per-bucket cache-write queue — serializes the re-load → merge → atomicWrite
 // step so two concurrent exporters (e.g. `exportByKind` fanning out parallel
-// `exportSeries`) accumulate entries instead of clobbering. Mirrors the
-// `issueWriteTail` pattern in `pipeline/issues.js`.
-const cacheWriteTails = new Map();
+// `exportSeries`) accumulate entries instead of clobbering. The shared queue
+// also recovers after a rejected write so one transient bucket failure does not
+// poison every later export for the process lifetime.
+const cacheWriteQueue = createKeyCachedQueue();
 
 async function withAssetHashCache(bucketPath, fn) {
   const cache = await loadAssetHashCache(bucketPath);
   const initialKeys = Object.keys(cache).length;
   const result = await fn(cache);
   if (Object.keys(cache).length !== initialKeys) {
-    const prevTail = cacheWriteTails.get(bucketPath) || Promise.resolve();
-    const tail = prevTail.then(async () => {
+    await cacheWriteQueue(bucketPath, async () => {
       const onDisk = await loadAssetHashCache(bucketPath);
       await atomicWrite(bucketBlobIndexPath(bucketPath), { ...onDisk, ...cache });
     });
-    cacheWriteTails.set(bucketPath, tail);
-    await tail;
   }
   return result;
 }

--- a/server/services/sharing/integration.test.js
+++ b/server/services/sharing/integration.test.js
@@ -15,6 +15,8 @@ import { join } from 'path';
 import { createHash } from 'crypto';
 import { makePathsProxy, mockNoPeerSync, mockNoPeers } from '../../lib/mockPathsDataRoot.js';
 
+const fileUtilsMock = vi.hoisted(() => ({ atomicWrite: vi.fn(), realAtomicWrite: null }));
+
 function sha256Hex(buf) {
   return createHash('sha256').update(buf).digest('hex');
 }
@@ -32,7 +34,14 @@ let tempBucket;
 // The shared helper re-roots EVERY member that lives under `data/`, so a member
 // added tomorrow is covered without touching this file.
 vi.mock('../../lib/fileUtils.js', async () =>
-  makePathsProxy(await vi.importActual('../../lib/fileUtils.js'), { dataRoot: tempData }));
+  makePathsProxy(await vi.importActual('../../lib/fileUtils.js'), {
+    dataRoot: tempData,
+    overrides: { atomicWrite: fileUtilsMock.atomicWrite },
+  }));
+
+const fileUtilsActual = await vi.importActual('../../lib/fileUtils.js');
+fileUtilsMock.realAtomicWrite = fileUtilsActual.atomicWrite;
+fileUtilsMock.atomicWrite.mockImplementation((...args) => fileUtilsMock.realAtomicWrite(...args));
 
 // Stub instances.getInstanceId so the exporter doesn't try to read the
 // real identity.json. Returns a fixed id for assertions.
@@ -85,6 +94,8 @@ function simulateRemoteSender(bucketPath, filename, peerId = 'remote-peer-id') {
 
 describe('sharing round-trip', () => {
   beforeEach(() => {
+    fileUtilsMock.atomicWrite.mockClear();
+    fileUtilsMock.atomicWrite.mockImplementation((...args) => fileUtilsMock.realAtomicWrite(...args));
     // Wipe and re-seed the temp data dir + a fake asset for each test.
     rmSync(tempData, { recursive: true, force: true });
     mkdirSync(tempData, { recursive: true });
@@ -2311,6 +2322,34 @@ describe('sharing round-trip', () => {
     const keyB = `${join(tempData, 'images', 'parallelB.png')}:${statB.mtimeMs}:${statB.size}`;
     expect(idx[keyA]).toBe(sha256Hex('PARALLEL_A'));
     expect(idx[keyB]).toBe(sha256Hex('PARALLEL_B'));
+  });
+
+  it('retries a blob-index write after a transient failure instead of poisoning later exports', async () => {
+    const bucket = await buckets.createBucket({ name: 'RetryBucket', path: tempBucket, mode: 'auto-merge' });
+    const sourceA = join(tempData, 'images', 'retryA.png');
+    const sourceB = join(tempData, 'images', 'retryB.png');
+    writeFileSync(sourceA, 'RETRY_A');
+    writeFileSync(sourceB, 'RETRY_B');
+    const indexPath = join(tempBucket, 'assets', 'blobs', '.index.json');
+    let rejectFirstIndexWrite = true;
+    fileUtilsMock.atomicWrite.mockImplementation(async (...args) => {
+      if (String(args[0]) === indexPath && rejectFirstIndexWrite) {
+        rejectFirstIndexWrite = false;
+        throw new Error('transient blob-index failure');
+      }
+      return fileUtilsMock.realAtomicWrite(...args);
+    });
+
+    await expect(exporter.exportMedia([{ kind: 'image', ref: 'retryA.png' }], bucket.id))
+      .rejects.toThrow('transient blob-index failure');
+    await expect(exporter.exportMedia([{ kind: 'image', ref: 'retryB.png' }], bucket.id))
+      .resolves.toMatchObject({ assetCount: 1 });
+
+    const index = JSON.parse(readFileSync(indexPath, 'utf-8'));
+    const statB = statSync(sourceB);
+    const keyB = `${sourceB}:${statB.mtimeMs}:${statB.size}`;
+    expect(index[keyB]).toBe(sha256Hex('RETRY_B'));
+    expect(fileUtilsMock.atomicWrite.mock.calls.filter(([path]) => String(path) === indexPath)).toHaveLength(2);
   });
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Replace the exporter blob-index tail map with the shared self-pruning keyed queue.
- Preserve per-bucket reload-and-merge behavior for concurrent exports.
- Add a transient index-write failure regression test proving the next export succeeds.

## Tests
- `server/node_modules/.bin/vitest run lib/createKeyCachedQueue.test.js services/sharing/integration.test.js` (66 passed)
- `git diff --check`

Closes #6777