### PR TITLE
fix: isolate perpetual refill queue defaults (#6766)

### DIFF
--- a/server/services/cos.js
+++ b/server/services/cos.js
@@ -1512,14 +1512,12 @@ async function refillPerpetualForCompletedAgent(agent) {
       emitLog('debug', `Perpetual refill for ${plan.taskType} skipped: parked until its recheck cadence`, { appId: plan.appId });
       return;
     }
-    // `origin: 'refill'` — this re-issue borrows the on-demand LANE but is not a
-    // human pressing Run, so the drain engines must leave the park, the
-    // convergence signature, and the dispatch counter intact. Without it the
-    // refill wipes its own convergence state on every hop and the drain never
-    // parks while one actionable item remains.
-    await taskScheduleMod.triggerOnDemandTask(plan.taskType, plan.appId, {
-      emit: false, origin: taskScheduleMod.ON_DEMAND_ORIGINS.REFILL
-    });
+    // `queuePerpetualRefill` stamps the automated `origin: 'refill'` pair — this
+    // re-issue borrows the on-demand LANE but is not a human pressing Run, so
+    // the drain engines must leave the park, convergence signature, and dispatch
+    // counter intact. Without that pair the refill wipes its own convergence
+    // state on every hop and the drain never parks while one actionable item remains.
+    await taskScheduleMod.queuePerpetualRefill(plan.taskType, plan.appId);
     return;
   }
 

--- a/server/services/cos.test.js
+++ b/server/services/cos.test.js
@@ -2320,7 +2320,7 @@ describe('cos.js source — agent:completed triggers perpetual refill', () => {
     ).toBe(true);
   });
 
-  it('a MANUAL (on-demand) drain continues via triggerOnDemandTask under isImprovementEnabled, returning before the auto-run queue lane', () => {
+  it('a MANUAL (on-demand) drain continues via queuePerpetualRefill under isImprovementEnabled, returning before the auto-run queue lane', () => {
     // The bug fixed here: a "Run Now" perpetual drain is allowed to START in a
     // posture where canQueueImprovementTasks is false (auto-run off/dry-run or
     // idle-review off), but the scheduled queue lane refuses to continue it —
@@ -2339,14 +2339,14 @@ describe('cos.js source — agent:completed triggers perpetual refill', () => {
     expect(/plan\.lane === 'onDemand'/.test(fnSlice), 'refill must branch on the on-demand lane').toBe(true);
 
     const improveGateIdx = fnSlice.indexOf('if (!isImprovementEnabled(state)) return;');
-    // `emit: false` avoids a redundant second dequeue; `origin: REFILL` marks the
-    // re-issue as automated so the on-demand engines do NOT clear the drain's park /
-    // convergence signature / dispatch counter on its behalf.
-    const triggerMatch = /triggerOnDemandTask\(plan\.taskType, plan\.appId, \{\s*emit: false, origin: taskScheduleMod\.ON_DEMAND_ORIGINS\.REFILL\s*\}\)/.exec(fnSlice);
+    // queuePerpetualRefill owns the non-emitting REFILL pair so the on-demand
+    // engines do NOT clear the drain's park / convergence signature / dispatch
+    // counter on its behalf.
+    const triggerMatch = /queuePerpetualRefill\(plan\.taskType, plan\.appId\)/.exec(fnSlice);
     const triggerIdx = triggerMatch ? triggerMatch.index : -1;
     const queueIdx = fnSlice.indexOf('queueEligibleImprovementTasks(state, cosTaskData');
     expect(improveGateIdx, 'manual lane must gate on isImprovementEnabled').toBeGreaterThan(-1);
-    expect(triggerIdx, 'manual lane must re-issue via triggerOnDemandTask(plan.taskType, plan.appId, { emit: false, origin: ON_DEMAND_ORIGINS.REFILL })').toBeGreaterThan(-1);
+    expect(triggerIdx, 'manual lane must re-issue via queuePerpetualRefill(plan.taskType, plan.appId)').toBeGreaterThan(-1);
     expect(queueIdx, 'scheduled queue lane must still exist').toBeGreaterThan(-1);
     // Improve gate precedes the re-issue; the manual lane returns before the queue lane.
     expect(improveGateIdx).toBeLessThan(triggerIdx);
@@ -2381,7 +2381,7 @@ describe('cos.js source — agent:completed triggers perpetual refill', () => {
     const fnIdx = COS_SRC.indexOf('async function refillPerpetualForCompletedAgent');
     const fnSlice = COS_SRC.slice(fnIdx, fnIdx + 4600);
     const parkIdx = fnSlice.indexOf('isPerpetualParkActive(plan.taskType, plan.appId)');
-    const triggerIdx = fnSlice.indexOf('triggerOnDemandTask(plan.taskType, plan.appId');
+    const triggerIdx = fnSlice.indexOf('queuePerpetualRefill(plan.taskType, plan.appId');
     expect(parkIdx, 'refill must consult the type+app park before re-issuing').toBeGreaterThan(-1);
     expect(parkIdx).toBeLessThan(triggerIdx);
     const returnAfterPark = fnSlice.indexOf('return;', parkIdx);

--- a/server/services/cosTaskGenerator.test.js
+++ b/server/services/cosTaskGenerator.test.js
@@ -1725,7 +1725,7 @@ describe('pr-reviewer security preflight wiring', () => {
  */
 describe('automated drain refills do not clear their own convergence brakes', () => {
   it('the refill stamps origin: refill', () => {
-    expect(COS_SRC).toMatch(/triggerOnDemandTask\(plan\.taskType, plan\.appId, \{\s*emit: false, origin: taskScheduleMod\.ON_DEMAND_ORIGINS\.REFILL\s*\}\)/);
+    expect(COS_SRC).toMatch(/queuePerpetualRefill\(plan\.taskType, plan\.appId\)/);
   });
 
   // A drain path calling the reset primitives directly is the exact regression,

--- a/server/services/taskSchedule.js
+++ b/server/services/taskSchedule.js
@@ -1190,6 +1190,19 @@ export async function triggerOnDemandTask(taskType, appId = null, {
   return request;
 }
 
+/**
+ * Queue the next item in a perpetual drain without treating it as a human
+ * pressing Run. The two options are an inseparable policy pair: the refill's
+ * completion handler owns dequeue, and the automated origin must preserve the
+ * drain's park, convergence signature, and dispatch counter.
+ */
+export async function queuePerpetualRefill(taskType, appId) {
+  return triggerOnDemandTask(taskType, appId, {
+    emit: false,
+    origin: ON_DEMAND_ORIGINS.REFILL,
+  });
+}
+
 export async function getOnDemandRequests() {
   const schedule = await loadSchedule();
   const featureEnabled = createFeatureGate();

--- a/server/services/taskSchedule.test.js
+++ b/server/services/taskSchedule.test.js
@@ -140,6 +140,7 @@ import {
   getPerpetualDrainState,
   recordPerpetualDispatch,
   applyOnDemandRunResets,
+  queuePerpetualRefill,
   isRefillRequest,
   ON_DEMAND_ORIGINS,
   recordTaskTypeFailure,
@@ -2125,6 +2126,20 @@ describe('taskSchedule', () => {
       mockSchedule({ tasks: { 'branch-reconcile': { type: 'on-demand', perpetual: true, enabled: true } } })
       const refill = await triggerOnDemandTask('branch-reconcile', 'app-1', { emit: false, origin: ON_DEMAND_ORIGINS.REFILL })
       expect(refill.origin).toBe(ON_DEMAND_ORIGINS.REFILL)
+    })
+
+    it('queues a perpetual refill with its non-emitting automated origin', async () => {
+      mockSchedule({ tasks: { 'branch-reconcile': { type: 'on-demand', perpetual: true, enabled: true } } })
+
+      const refill = await queuePerpetualRefill('branch-reconcile', 'app-1')
+
+      expect(refill).toMatchObject({
+        taskType: 'branch-reconcile',
+        appId: 'app-1',
+        origin: ON_DEMAND_ORIGINS.REFILL,
+      })
+      expect(cosEvents.emit).not.toHaveBeenCalled()
+      expect(recordUserAction).not.toHaveBeenCalled()
     })
 
     // Operator-action ledger (#5594). Only a human pressing Run Now is an


### PR DESCRIPTION
## Summary

- Add `queuePerpetualRefill` so the perpetual drain always uses the non-emitting `REFILL` origin pair.
- Route the CoS completion refill through that dedicated entry point.
- Preserve direct user and quota-burn trigger semantics, with behavioral coverage for the refill contract.

## Tests

- `./node_modules/.bin/vitest run services/taskSchedule.test.js services/cos.test.js services/cosTaskGenerator.test.js services/taskScheduleModules.test.js services/onDemandEligibilityAgreement.test.js services/onDemandDrain.test.js services/quotaBurnInvoke.test.js`
- 7 test files passed, 658 tests passed

Closes #6766