### PR TITLE
fix: clarify automatic execution for perpetual on-demand tasks

### DIFF
--- a/client/src/components/cos/tabs/schedule/AppTaskCard.test.jsx
+++ b/client/src/components/cos/tabs/schedule/AppTaskCard.test.jsx
@@ -84,6 +84,13 @@ describe('AppTaskCard', () => {
     expect(screen.getByText('Manual trigger only')).toBeTruthy();
   });
 
+  it('labels on-demand perpetual tasks as automatic drains', () => {
+    renderCard({ type: 'on-demand', perpetual: true });
+    expect(screen.getByText('Automatic drain')).toHaveAttribute('title', expect.stringContaining('Turn Perpetual off'));
+    expect(screen.queryByText('On Demand')).toBeNull();
+    expect(screen.queryByText('Manual trigger only')).toBeNull();
+  });
+
   it('renders BOTH badges for a scheduled task that also drains perpetually', () => {
     renderCard({ type: 'cron', cronExpression: '0 6 * * 1-5', perpetual: true });
     expect(screen.getByText('Scheduled')).toBeTruthy();

--- a/client/src/components/cos/tabs/schedule/GlobalConfigControls.jsx
+++ b/client/src/components/cos/tabs/schedule/GlobalConfigControls.jsx
@@ -19,7 +19,7 @@ import PromptEditor from './PromptEditor';
 import TaskDependencyPicker from './TaskDependencyPicker';
 import RunTaskButton from './RunTaskButton';
 import TaskDataInputs from '../../TaskDataInputs';
-import { INTERVAL_DESCRIPTIONS, PERPETUAL_DESCRIPTION, toggleMetadataField, pipelineStages, IMPROVEMENT_DISABLED_TITLE, SAVING_TITLE, fileIssuesEffective, managedAgentOptionsFor, toggleFileIssuesMetadata } from './scheduleConstants';
+import { INTERVAL_DESCRIPTIONS, PERPETUAL_DESCRIPTION, ON_DEMAND_PERPETUAL_LABEL, ON_DEMAND_PERPETUAL_DESCRIPTION, toggleMetadataField, pipelineStages, IMPROVEMENT_DISABLED_TITLE, SAVING_TITLE, fileIssuesEffective, managedAgentOptionsFor, toggleFileIssuesMetadata } from './scheduleConstants';
 
 // Shown for the unpinned ('' → inherit) choice: the task type is global, so the
 // policy is whatever each target app configured, and PortOS's own self-improvement
@@ -293,7 +293,7 @@ export default function GlobalConfigControls({ taskType, config, onUpdate, onTri
           disabled={updating}
           className="w-full bg-port-card border border-port-border rounded px-3 py-2 text-white text-sm"
         >
-          <option value="on-demand">On Demand (manual trigger only)</option>
+          <option value="on-demand">{config.perpetual ? ON_DEMAND_PERPETUAL_LABEL : 'On Demand (manual trigger only)'}</option>
           <option value="cron">Scheduled (cron)</option>
         </select>
         {(selectedType === 'cron' && (cronEditing || config.type === 'cron')) ? (
@@ -304,7 +304,7 @@ export default function GlobalConfigControls({ taskType, config, onUpdate, onTri
             className="mt-2"
           />
         ) : (
-          <p className="text-xs text-gray-500 mt-1">{INTERVAL_DESCRIPTIONS[selectedType]}</p>
+          <p className="text-xs text-gray-500 mt-1">{selectedType === 'on-demand' && config.perpetual ? ON_DEMAND_PERPETUAL_DESCRIPTION : INTERVAL_DESCRIPTIONS[selectedType]}</p>
         )}
       </FormField>
 

--- a/client/src/components/cos/tabs/schedule/GlobalConfigControls.test.jsx
+++ b/client/src/components/cos/tabs/schedule/GlobalConfigControls.test.jsx
@@ -296,9 +296,18 @@ describe('GlobalConfigControls — cadence + perpetual', () => {
     expect(onUpdate).toHaveBeenCalledWith('feature-ideas', { perpetual: true });
   });
 
-  it('shows a recheck-cadence control only for an ON-DEMAND perpetual task', () => {
+  it('explains automatic rechecks without claiming manual-only execution', () => {
     renderControls({ config: { type: 'on-demand', cronExpression: null, perpetual: true } });
     expect(screen.getByText('Recheck Cadence')).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Automatic drain' }).selected).toBe(true);
+    expect(screen.getByText(/Turn Perpetual off for manual-only runs/)).toBeInTheDocument();
+    expect(screen.queryByText('Only runs when manually triggered')).not.toBeInTheDocument();
+
+    cleanup();
+    renderControls({ config: { type: 'on-demand', cronExpression: null, perpetual: false, recheckCron: '0 9 * * *' } });
+    expect(screen.getByRole('option', { name: 'On Demand (manual trigger only)' }).selected).toBe(true);
+    expect(screen.queryByText('Recheck Cadence')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Save schedule' })).not.toBeInTheDocument();
 
     cleanup();
     // A cron+perpetual task rechecks on its OWN expression, so it needs none.

--- a/client/src/components/cos/tabs/schedule/IntervalBadge.jsx
+++ b/client/src/components/cos/tabs/schedule/IntervalBadge.jsx
@@ -1,16 +1,17 @@
 import { describeCron } from '../../../../utils/cronHelpers';
-import { badge, INTERVAL_LABELS, INTERVAL_BADGE_VARIANT, PERPETUAL_BADGE_VARIANT, PERPETUAL_LABEL, PERPETUAL_DESCRIPTION } from './scheduleConstants';
+import { badge, INTERVAL_LABELS, INTERVAL_BADGE_VARIANT, PERPETUAL_BADGE_VARIANT, PERPETUAL_LABEL, PERPETUAL_DESCRIPTION, ON_DEMAND_PERPETUAL_LABEL, ON_DEMAND_PERPETUAL_DESCRIPTION } from './scheduleConstants';
 
 /**
  * The cadence chip, plus a separate Perpetual chip when the task carries the
  * drain flag — the two are orthogonal, so a Scheduled + Perpetual task shows both.
  */
 export default function IntervalBadge({ type, cronExpression, perpetual }) {
-  const label = INTERVAL_LABELS[type] || type;
+  const automaticDrain = type === 'on-demand' && perpetual;
+  const label = automaticDrain ? ON_DEMAND_PERPETUAL_LABEL : INTERVAL_LABELS[type] || type;
   const cronDesc = type === 'cron' && cronExpression ? describeCron(cronExpression) : null;
   const title = type === 'cron' && cronExpression
     ? (cronDesc ? `${cronDesc} (${cronExpression})` : cronExpression)
-    : undefined;
+    : automaticDrain ? ON_DEMAND_PERPETUAL_DESCRIPTION : undefined;
 
   return (
     <>

--- a/client/src/components/cos/tabs/schedule/scheduleConstants.js
+++ b/client/src/components/cos/tabs/schedule/scheduleConstants.js
@@ -18,6 +18,10 @@ export const INTERVAL_DESCRIPTIONS = {
   cron: 'Runs on a cron schedule'
 };
 
+export const ON_DEMAND_PERPETUAL_LABEL = 'Automatic drain';
+export const ON_DEMAND_PERPETUAL_DESCRIPTION =
+  'Perpetual runs this task automatically while work remains, then resumes on the recheck cadence. Turn Perpetual off for manual-only runs.';
+
 export const PERPETUAL_LABEL = 'Perpetual';
 export const PERPETUAL_DESCRIPTION =
   'Drains actionable work back-to-back until none remains, then rechecks on a cadence';

--- a/client/src/components/cos/tabs/workflow/ScheduleEditor.jsx
+++ b/client/src/components/cos/tabs/workflow/ScheduleEditor.jsx
@@ -4,7 +4,7 @@ import toast from '../../../ui/Toast';
 import * as api from '../../../../services/api';
 import { DEFAULT_CRON, buildCronFromRecurrence, parseCronToRecurrence } from '../../../../utils/cronHelpers';
 import CronSchedulePicker from '../../../CronSchedulePicker';
-import { PERPETUAL_DESCRIPTION } from '../schedule/scheduleConstants';
+import { PERPETUAL_DESCRIPTION, ON_DEMAND_PERPETUAL_LABEL, ON_DEMAND_PERPETUAL_DESCRIPTION } from '../schedule/scheduleConstants';
 
 const TASK_MODES = [
   ['on-demand', 'On Demand'],
@@ -162,7 +162,7 @@ export default function ScheduleEditor({ node, allNodes, timezone, onClose, onSa
           <label htmlFor="workflow-task-cadence" className="block text-xs text-gray-400">
             Scheduling behavior
             <select id="workflow-task-cadence" value={form.mode} onChange={event => setMode(event.target.value)} className="mt-1.5 w-full rounded border border-port-border bg-port-bg px-3 py-2 text-sm text-white">
-              {TASK_MODES.map(([value, label]) => <option key={value} value={value}>{label}</option>)}
+              {TASK_MODES.map(([value, label]) => <option key={value} value={value}>{value === 'on-demand' && form.perpetual ? ON_DEMAND_PERPETUAL_LABEL : label}</option>)}
             </select>
           </label>
         ) : (
@@ -176,6 +176,10 @@ export default function ScheduleEditor({ node, allNodes, timezone, onClose, onSa
               ))}
             </div>
           </div>
+        )}
+
+        {node.kind === 'task' && form.mode === 'on-demand' && form.perpetual && (
+          <p className="text-xs text-gray-400">{ON_DEMAND_PERPETUAL_DESCRIPTION}</p>
         )}
 
         {form.mode === 'cron' && (

--- a/client/src/components/cos/tabs/workflow/ScheduleEditor.test.jsx
+++ b/client/src/components/cos/tabs/workflow/ScheduleEditor.test.jsx
@@ -70,6 +70,8 @@ describe('ScheduleEditor task cadence', () => {
     renderEditor(taskNode({ perpetual: true, recheckCron: '0 11 * * *' }));
 
     fireEvent.change(screen.getByLabelText('Scheduling behavior'), { target: { value: 'on-demand' } });
+    expect(screen.getByRole('option', { name: 'Automatic drain' }).selected).toBe(true);
+    expect(screen.getByText(/Turn Perpetual off for manual-only runs/)).toBeInTheDocument();
     await act(async () => fireEvent.click(screen.getByRole('button', { name: 'Save schedule' })));
 
     expect(api.updateCosTaskInterval).toHaveBeenCalledWith('review', expect.objectContaining({


### PR DESCRIPTION
## Summary
On-demand tasks with Perpetual enabled automatically drain work and resume on their recheck cadence, but the form called them manual-only. Label this combination "Automatic drain" in the schedule form, task badge, and workflow editor, with visible guidance to turn Perpetual off for manual-only runs.

The scheduling engine and saved cadence contract retain their existing behavior.

## Test plan
- 62 tests passed across GlobalConfigControls, AppTaskCard, ScheduleEditor, and TaskHeader.
- Regression coverage distinguishes perpetual rechecks from manual-only tasks and verifies the workflow save payload retains the chosen cadence and perpetual flag.
- Biome lint passed for all seven changed files; git diff --check passed.
