### PR TITLE
fix: show 1-based current step on recommended-workflow maintenance status

### DIFF
--- a/client/src/components/cos/tabs/schedule/MaintenanceRunForm.test.jsx
+++ b/client/src/components/cos/tabs/schedule/MaintenanceRunForm.test.jsx
@@ -56,9 +56,21 @@ describe('maintenance launch', () => {
     expect(await screen.findByText(/Maintenance started with better-structural-drift/)).toBeInTheDocument();
     const row = screen.getByRole('list', { name: 'Maintenance runs' });
     expect(row).toHaveTextContent('Example App');
-    expect(row).toHaveTextContent('running · 1/13 steps · claim-issue');
+    expect(row).toHaveTextContent('running · 2/13 steps · claim-issue');
     expect(screen.getByRole('button', { name: 'Run now' })).toBeDisabled();
     expect(screen.getByRole('link', { name: /Quota Burn/ })).toHaveAttribute('href', '/devtools/quota-burn');
+  });
+  it('names the live 1-based step while a recommended-workflow audit is running', async () => {
+    const auditSteps = MAINTENANCE_TASK_ORDER.map((taskType, index) => ({ id: `maint-1-${index}`, taskRef: { taskType } }));
+    api.getMaintenanceRuns.mockResolvedValue({ runs: [runRecord({
+      steps: auditSteps,
+      completed: { 'maint-1-0': 'done', 'maint-1-1': 'done' },
+      active: { stepId: 'maint-1-2', taskType: 'module-hygiene' },
+    })] });
+    show();
+    const row = await screen.findByRole('list', { name: 'Maintenance runs' });
+    expect(row).toHaveTextContent('running · 3/7 steps · module-hygiene');
+    expect(screen.getByRole('progressbar')).toHaveAttribute('value', '2');
   });
   it('reports a saved-but-holding run and a failed start honestly', async () => {
     const user = userEvent.setup();

--- a/client/src/components/cos/tabs/schedule/MaintenanceRunStatus.jsx
+++ b/client/src/components/cos/tabs/schedule/MaintenanceRunStatus.jsx
@@ -1,12 +1,31 @@
 import MaintenanceStepChecklist from './MaintenanceStepChecklist';
 
+/**
+ * Live status is 1-based ("running · 3/7 steps · module-hygiene") so it matches
+ * the checklist numbering. The progress bar still uses completed-count.
+ */
+export function maintenanceRunProgress(run = {}) {
+  const steps = Array.isArray(run.steps) ? run.steps : [];
+  const completed = run.completed || {};
+  const total = steps.length;
+  const done = Object.keys(completed).length;
+  const activeId = run.active?.stepId;
+  const activeType = run.active?.taskType;
+  const activeIndex = steps.findIndex((entry) => (activeId
+    ? entry.id === activeId
+    : Boolean(activeType) && entry.taskRef?.taskType === activeType && !Object.hasOwn(completed, entry.id)));
+  const current = activeIndex >= 0
+    ? activeIndex + 1
+    : (run.status === 'running' && total > 0 && done < total ? done + 1 : done);
+  const step = activeType || steps.find((entry) => !Object.hasOwn(completed, entry.id))?.taskRef?.taskType;
+  return { current, done, total, step };
+}
+
 /** Shared live progress content for the schedule card and corner notification. */
 export default function MaintenanceRunStatus({ run, showSteps = false }) {
-  const done = Object.keys(run.completed || {}).length;
-  const total = run.steps?.length || 0;
-  const step = run.active?.taskType || run.steps?.find(entry => !run.completed?.[entry.id])?.taskRef?.taskType;
+  const { current, done, total, step } = maintenanceRunProgress(run);
   return <div className={`space-y-1 text-xs min-w-0 ${showSteps ? 'w-full' : ''}`} role="status">
-    <p>{run.status} · {done}/{total} steps{run.status === 'running' && step ? ` · ${step}` : ''}</p>
+    <p>{run.status} · {current}/{total} steps{run.status === 'running' && step ? ` · ${step}` : ''}</p>
     <progress aria-label="Maintenance steps completed" value={done} max={total || 1} className="w-full h-1 accent-port-accent" />
     {run.active && <p className="flex items-center gap-2">
       {run.active.status === 'running' && <span aria-hidden="true" className="w-2 h-2 rounded-full bg-port-accent motion-safe:animate-pulse" />}

--- a/client/src/components/cos/tabs/schedule/MaintenanceRunStatus.jsx
+++ b/client/src/components/cos/tabs/schedule/MaintenanceRunStatus.jsx
@@ -14,9 +14,10 @@ export function maintenanceRunProgress(run = {}) {
   const activeIndex = steps.findIndex((entry) => (activeId
     ? entry.id === activeId
     : Boolean(activeType) && entry.taskRef?.taskType === activeType && !Object.hasOwn(completed, entry.id)));
-  const current = activeIndex >= 0
+  const running = run.status === 'running';
+  const current = running && activeIndex >= 0
     ? activeIndex + 1
-    : (run.status === 'running' && total > 0 && done < total ? done + 1 : done);
+    : (running && total > 0 && done < total ? done + 1 : done);
   const step = activeType || steps.find((entry) => !Object.hasOwn(completed, entry.id))?.taskRef?.taskType;
   return { current, done, total, step };
 }

--- a/client/src/hooks/useOnDemandTaskToast.js
+++ b/client/src/hooks/useOnDemandTaskToast.js
@@ -1,5 +1,5 @@
 import { createElement, useEffect } from 'react';
-import MaintenanceRunStatus from '../components/cos/tabs/schedule/MaintenanceRunStatus';
+import MaintenanceRunStatus, { maintenanceRunProgress } from '../components/cos/tabs/schedule/MaintenanceRunStatus';
 import toast from '../components/ui/Toast';
 import socket from '../services/socket';
 import { timeUntil } from '../utils/formatters';
@@ -51,7 +51,8 @@ export function useOnDemandTaskToast() {
     socket.on('connect', subscribe);
     const maintenanceStates = new Map();
     const handleMaintenance = run => {
-      const label = `Maintenance · ${Object.keys(run.completed || {}).length}/${run.steps?.length || 0} · ${run.status}`;
+      const { current, total } = maintenanceRunProgress(run);
+      const label = `Maintenance · ${current}/${total} · ${run.status}`;
       const signature = JSON.stringify([run.status, run.completed, run.active, run.reason]);
       if (maintenanceStates.get(run.id) === signature) return;
       maintenanceStates.set(run.id, signature);

--- a/client/src/hooks/useOnDemandTaskToast.test.jsx
+++ b/client/src/hooks/useOnDemandTaskToast.test.jsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { renderHook, cleanup } from '@testing-library/react';
+import { render, renderHook, cleanup, screen } from '@testing-library/react';
 
 // Capture the socket handler the hook registers so tests can drive the
 // `cos:schedule:on-demand-empty` event, and record toast calls.
@@ -240,4 +240,23 @@ it('updates one maintenance notification with an agent link and expires terminal
   expect(toastSpy.mock.calls[1][1]).toMatchObject({ duration: 8000, label: 'Maintenance · 1/1 · completed' });
   unmount();
   expect(handlers.has('cos:maintenance:updated')).toBe(false);
+});
+
+it('keeps a stopped run on completed-count even when the stale active step is retained', () => {
+  toastSpy.mockClear();
+  const { unmount } = renderHook(() => useOnDemandTaskToast());
+  const update = handlers.get('cos:maintenance:updated');
+  const steps = ['better-structural-drift', 'simplify', 'module-hygiene', 'better-complexity', 'performance', 'better-cognitive-load', 'documentation']
+    .map((taskType, index) => ({ id: `maint-1-${index}`, taskRef: { taskType } }));
+  update({
+    id: 'maint-stopped', status: 'stopped', steps,
+    completed: { 'maint-1-0': 'done', 'maint-1-1': 'done' },
+    active: { stepId: 'maint-1-2', taskType: 'module-hygiene' },
+    updatedAt: 'stopped',
+  });
+  expect(toastSpy.mock.calls[0][1]).toMatchObject({ label: 'Maintenance · 2/7 · stopped' });
+  render(toastSpy.mock.calls[0][0]());
+  expect(screen.getByRole('status')).toHaveTextContent('stopped · 2/7 steps');
+  expect(screen.getByRole('progressbar')).toHaveAttribute('value', '2');
+  unmount();
 });


### PR DESCRIPTION
## Summary
The Schedule tab's recommended-workflow (maintenance) live status used completed-count, so an in-progress audit appeared as `running · 2/7 steps · module-hygiene` instead of `running · 3/7 steps · module-hygiene`. Number the active step from 1 to match the checklist; keep the progress bar on completed-count. Stopped runs still report completed-count because they retain a stale `active` step.

## Test plan
- Client: `cd client && npx vitest run src/components/cos/tabs/schedule/MaintenanceRunForm.test.jsx src/hooks/useOnDemandTaskToast.test.jsx`
- Confirm a 7-audit file-issues run on `module-hygiene` (third audit, two completed) renders `running · 3/7 steps · module-hygiene` with progress value 2.
- Confirm a stopped run that still carries that active step renders `stopped · 2/7 steps` (toast and progress bar agree).