### PR TITLE
feat: add code review overrides to app issue claims

### DIFF
--- a/client/src/components/apps/tabs/IssuesTab.jsx
+++ b/client/src/components/apps/tabs/IssuesTab.jsx
@@ -14,10 +14,28 @@ import { useCosTaskUpdates } from '../../../hooks/useCosTaskUpdates';
 import useProviderModels from '../../../hooks/useProviderModels';
 import useClaimReviewers from '../../../hooks/useClaimReviewers';
 import ClaimReviewerSource from '../ClaimReviewerSource';
+import ReviewerPicker from '../../cos/ReviewerPicker';
+import useReviewerModelOptions from '../../../hooks/useReviewerModelOptions';
 import { chipColors } from '../../../lib/chipContrast';
 import { enabledProcessProviderFilter } from '../../../utils/providers';
 import * as api from '../../../services/api';
 import { timeAgo } from '../../../utils/formatters';
+
+function ClaimReviewOverride({ defaults, overrides, onChange }) {
+  const modelOptions = useReviewerModelOptions();
+  return (
+    <ReviewerPicker
+      {...defaults}
+      {...overrides}
+      defaults={defaults}
+      modelOptions={modelOptions}
+      showRunFlags={false}
+      onChange={({ reviewers, usernames, optionalReviewers, reviewerMaxRounds, reviewerModels, reviewerEfforts }) =>
+        onChange(Object.fromEntries(Object.entries({ reviewers, usernames, optionalReviewers, reviewerMaxRounds, reviewerModels, reviewerEfforts })
+          .filter(([, value]) => value !== undefined)))}
+    />
+  );
+}
 
 const FORGE_LABEL = { github: 'GitHub', gitlab: 'GitLab' };
 
@@ -252,9 +270,14 @@ export default function IssuesTab({ appId, appName }) {
   const [overrideContext, setOverrideContext] = useState('');
   // The reviewers a Claim launched from this tab will actually run — NOT the
   // Models → Code Reviewers list, whenever a claim-work override is in play (see
-  // `GET /apps/:id/claim-reviewers`). This tab has no reviewer picker, so it
-  // names them read-only beside the provider pin.
+  // `GET /apps/:id/claim-reviewers`). Untouched fields remain inherited.
   const claimReviewers = useClaimReviewers(appId);
+  const [reviewOverrides, setReviewOverrides] = useState({});
+  const [showReviewOverride, setShowReviewOverride] = useState(false);
+  useEffect(() => {
+    setReviewOverrides({});
+    setShowReviewOverride(false);
+  }, [appId]);
 
   // Keep the event-driven path based on the latest runs without putting a
   // mutable state snapshot in its effect dependencies. Socket callbacks can
@@ -424,6 +447,7 @@ export default function IssuesTab({ appId, appName }) {
       provider: selectedProviderId || undefined,
       model: selectedModel || undefined,
       effort: effort || undefined,
+      ...(action === 'claim' ? reviewOverrides : {}),
       ...(trimmedOverrideContext ? { overrideContext: trimmedOverrideContext } : {}),
     }, { silent: true })
       .catch(err => {
@@ -578,18 +602,36 @@ export default function IssuesTab({ appId, appName }) {
             />
           </div>
         </div>
-        {claimReviewers && (
+        {claimReviewers && !Object.keys(reviewOverrides).length && (
           <div className="flex flex-col sm:flex-row sm:items-center gap-2">
             <span className="flex items-center gap-1.5 text-xs text-gray-500 uppercase tracking-wide shrink-0">
               <ClipboardCheck size={14} /> Reviewed by
             </span>
-            {/* No empty-list branch: the route resolves through
-                `claimSafeReviewers`, which falls back to a non-empty list rather
-                than ever handing a claim agent nothing to run. */}
             <p className="flex-1 text-xs text-gray-400">
               <code className="text-gray-300">{claimReviewers.csv}</code>
               <ClaimReviewerSource source={claimReviewers.source} />
             </p>
+          </div>
+        )}
+        {claimReviewers && (
+          <div className="space-y-2">
+            <button
+              type="button"
+              aria-expanded={showReviewOverride}
+              onClick={() => setShowReviewOverride(value => !value)}
+              className="text-sm text-port-accent hover:underline"
+            >
+              Code-review override{Object.keys(reviewOverrides).length > 0 ? ' (active)' : ''}
+            </button>
+            {showReviewOverride && (
+              <>
+                <ClaimReviewOverride defaults={claimReviewers} overrides={reviewOverrides} onChange={setReviewOverrides} />
+                <p className="text-xs text-gray-500">Applies to Claims launched below. Replan only reviews the issue plan.</p>
+                <button type="button" onClick={() => setReviewOverrides({})} className="text-xs text-port-accent hover:underline">
+                  Use configured reviewers
+                </button>
+              </>
+            )}
           </div>
         )}
         <div className="space-y-1">

--- a/client/src/components/apps/tabs/IssuesTab.jsx
+++ b/client/src/components/apps/tabs/IssuesTab.jsx
@@ -21,8 +21,7 @@ import { enabledProcessProviderFilter } from '../../../utils/providers';
 import * as api from '../../../services/api';
 import { timeAgo } from '../../../utils/formatters';
 
-function ClaimReviewOverride({ defaults, overrides, onChange }) {
-  const modelOptions = useReviewerModelOptions();
+function ClaimReviewOverride({ defaults, overrides, onChange, modelOptions }) {
   return (
     <ReviewerPicker
       {...defaults}
@@ -273,6 +272,9 @@ export default function IssuesTab({ appId, appName }) {
   // `GET /apps/:id/claim-reviewers`). Untouched fields remain inherited.
   const claimReviewers = useClaimReviewers(appId);
   const [reviewOverrides, setReviewOverrides] = useState({});
+  const reviewerModelOptions = useReviewerModelOptions();
+  const invalidReviewOverride = Array.isArray(reviewOverrides.reviewers)
+    && !reviewOverrides.reviewers.some(reviewer => reviewer !== 'copilot');
   const [showReviewOverride, setShowReviewOverride] = useState(false);
   useEffect(() => {
     setReviewOverrides({});
@@ -433,6 +435,7 @@ export default function IssuesTab({ appId, appName }) {
   // content reach a replan exactly as they reach a claim.
   const handleRun = async (issue, action) => {
     const spec = ISSUE_ACTIONS[action];
+    if (action === 'claim' && invalidReviewOverride) return;
     const key = runKey(action, issue.number);
     replaceRuns(prev => ({ ...prev, [key]: { status: 'queuing', taskId: null } }));
     const trimmedOverrideContext = overrideContext.trim();
@@ -602,14 +605,26 @@ export default function IssuesTab({ appId, appName }) {
             />
           </div>
         </div>
-        {claimReviewers && !Object.keys(reviewOverrides).length && (
+        {claimReviewers && !invalidReviewOverride && (
           <div className="flex flex-col sm:flex-row sm:items-center gap-2">
             <span className="flex items-center gap-1.5 text-xs text-gray-500 uppercase tracking-wide shrink-0">
               <ClipboardCheck size={14} /> Reviewed by
             </span>
             <p className="flex-1 text-xs text-gray-400">
-              <code className="text-gray-300">{claimReviewers.csv}</code>
-              <ClaimReviewerSource source={claimReviewers.source} />
+              {Object.keys(reviewOverrides).length ? (
+                <>
+                  <code className="text-gray-300">{[
+                    ...(reviewOverrides.reviewers ?? claimReviewers.reviewers),
+                    ...(reviewOverrides.usernames ?? claimReviewers.usernames ?? []).map(username => `@${username}`),
+                  ].join(', ')}</code>
+                  {' — run override; expand below for model, effort, and round limits.'}
+                </>
+              ) : (
+                <>
+                  <code className="text-gray-300">{claimReviewers.csv}</code>
+                  <ClaimReviewerSource source={claimReviewers.source} />
+                </>
+              )}
             </p>
           </div>
         )}
@@ -623,9 +638,12 @@ export default function IssuesTab({ appId, appName }) {
             >
               Code-review override{Object.keys(reviewOverrides).length > 0 ? ' (active)' : ''}
             </button>
+            {invalidReviewOverride && (
+              <p className="text-xs text-port-warning" role="alert">Claims require at least one non-Copilot reviewer. Add one or use configured reviewers.</p>
+            )}
             {showReviewOverride && (
               <>
-                <ClaimReviewOverride defaults={claimReviewers} overrides={reviewOverrides} onChange={setReviewOverrides} />
+                <ClaimReviewOverride defaults={claimReviewers} overrides={reviewOverrides} onChange={setReviewOverrides} modelOptions={reviewerModelOptions} />
                 <p className="text-xs text-gray-500">Applies to Claims launched below. Replan only reviews the issue plan.</p>
                 <button type="button" onClick={() => setReviewOverrides({})} className="text-xs text-port-accent hover:underline">
                   Use configured reviewers
@@ -775,7 +793,7 @@ export default function IssuesTab({ appId, appName }) {
                         <button
                           key={action}
                           onClick={() => handleRun(issue, action)}
-                          disabled={state === 'queuing'}
+                          disabled={state === 'queuing' || (action === 'claim' && invalidReviewOverride)}
                           title={spec.title(issue.number, appName)}
                           className={`px-3 py-1.5 ${spec.tone} border border-port-border rounded-lg text-xs flex items-center gap-1.5 disabled:opacity-50 transition-colors`}
                         >

--- a/client/src/components/apps/tabs/IssuesTab.test.jsx
+++ b/client/src/components/apps/tabs/IssuesTab.test.jsx
@@ -357,21 +357,31 @@ describe('IssuesTab', () => {
     expect(payload).not.toHaveProperty('stopMode');
   });
 
-  it('overrides claim reviewers, leaves replans alone, and restores inheritance', async () => {
+  it('blocks an empty claim review chain, leaves replans alone, and restores inheritance', async () => {
     await renderTab();
     fireEvent.click(await screen.findByRole('button', { name: 'Code-review override' }));
     fireEvent.click(await screen.findByRole('button', { name: /Remove Antigravity/i }));
-    fireEvent.click(screen.getByRole('button', { name: /Claim/ }));
-    await waitFor(() => expect(api.createSlashdoTask).toHaveBeenCalledWith(
-      'next', 'app-1', expect.objectContaining({ reviewers: [] }), { silent: true }
-    ));
-    api.createSlashdoTask.mockClear();
+    expect(screen.getByRole('button', { name: /Claim/ })).toBeDisabled();
+    expect(screen.getByRole('alert')).toHaveTextContent('Claims require at least one non-Copilot reviewer');
     fireEvent.click(screen.getByRole('button', { name: /Replan/ }));
     await waitFor(() => expect(api.createSlashdoTask).toHaveBeenCalled());
     expect(api.createSlashdoTask.mock.calls[0][2]).not.toHaveProperty('reviewers');
     fireEvent.click(screen.getByRole('button', { name: 'Use configured reviewers' }));
     expect(screen.getByText('Reviewed by')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Remove Antigravity/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Claim/ })).toBeEnabled();
+  });
+
+  it('clears review overrides when switching apps', async () => {
+    const view = await renderTab();
+    fireEvent.click(await screen.findByRole('button', { name: 'Code-review override' }));
+    fireEvent.change(await screen.findByLabelText('Reasoning effort for Antigravity'), { target: { value: 'high' } });
+    view.rerender(<MemoryRouter><IssuesTab appId="app-2" appName="Other" /></MemoryRouter>);
+    await screen.findByRole('button', { name: 'Code-review override' });
+    fireEvent.click(screen.getByRole('button', { name: /Claim/ }));
+    await waitFor(() => expect(api.createSlashdoTask).toHaveBeenCalled());
+    expect(api.createSlashdoTask.mock.calls[0][1]).toBe('app-2');
+    expect(api.createSlashdoTask.mock.calls[0][2]).not.toHaveProperty('reviewerEfforts');
   });
 
   it('sends optional override context with the selected claim', async () => {

--- a/client/src/components/apps/tabs/IssuesTab.test.jsx
+++ b/client/src/components/apps/tabs/IssuesTab.test.jsx
@@ -29,6 +29,7 @@ vi.mock('../../../services/api', () => ({
   getAppIssues: vi.fn(),
   createSlashdoTask: vi.fn(),
   getProviders: vi.fn(),
+  getLocalLlmStatus: vi.fn().mockResolvedValue(null),
   // The tab reads the reviewers a claim will actually run so it can name them
   // (and say whether a claim-work override supplied them).
   getAppClaimReviewers: vi.fn(),
@@ -341,6 +342,36 @@ describe('IssuesTab', () => {
       },
       { silent: true }
     ));
+  });
+
+  it('sends a reviewer effort override without pinning untouched defaults', async () => {
+    await renderTab();
+    fireEvent.click(await screen.findByRole('button', { name: 'Code-review override' }));
+    fireEvent.change(await screen.findByLabelText('Reasoning effort for Antigravity'), { target: { value: 'high' } });
+    fireEvent.click(screen.getByRole('button', { name: /Claim/ }));
+    await waitFor(() => expect(api.createSlashdoTask).toHaveBeenCalled());
+    const payload = api.createSlashdoTask.mock.calls[0][2];
+    expect(payload.reviewerEfforts).toEqual({ antigravity: 'high' });
+    expect(payload).not.toHaveProperty('reviewers');
+    expect(payload).not.toHaveProperty('reviewerModels');
+    expect(payload).not.toHaveProperty('stopMode');
+  });
+
+  it('overrides claim reviewers, leaves replans alone, and restores inheritance', async () => {
+    await renderTab();
+    fireEvent.click(await screen.findByRole('button', { name: 'Code-review override' }));
+    fireEvent.click(await screen.findByRole('button', { name: /Remove Antigravity/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Claim/ }));
+    await waitFor(() => expect(api.createSlashdoTask).toHaveBeenCalledWith(
+      'next', 'app-1', expect.objectContaining({ reviewers: [] }), { silent: true }
+    ));
+    api.createSlashdoTask.mockClear();
+    fireEvent.click(screen.getByRole('button', { name: /Replan/ }));
+    await waitFor(() => expect(api.createSlashdoTask).toHaveBeenCalled());
+    expect(api.createSlashdoTask.mock.calls[0][2]).not.toHaveProperty('reviewers');
+    fireEvent.click(screen.getByRole('button', { name: 'Use configured reviewers' }));
+    expect(screen.getByText('Reviewed by')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Remove Antigravity/i })).toBeInTheDocument();
   });
 
   it('sends optional override context with the selected claim', async () => {


### PR DESCRIPTION
## Summary
Add a code-review override beside the provider/model/effort controls on an app's Issues tab. Claims can choose reviewers and their model, effort, optional status, and round limits using the shared reviewer picker. Untouched fields inherit the app's resolved configuration; a reset restores inheritance. Replan runs remain unaffected.

## Test plan
- IssuesTab: 40 tests passed, including invalid empty-chain blocking, effort-only overrides, reset, app switching, and Replan isolation.
- Server claim generator and CoS routes: 296 tests passed.
- Changed client files pass Biome lint.
- Read-only Claude review completed; findings addressed within the configured one-round cap.
