### PR TITLE
fix: recognize Grok collapsed paste markers

### DIFF
--- a/server/lib/tuiHandshake.js
+++ b/server/lib/tuiHandshake.js
@@ -35,7 +35,8 @@ export const PASTE_DEADLINE_MS = 10000;
 export const TUI_INPUT_READY_DEADLINE_MS = 45000;
 
 // Claude Code emits `[Pasted text #N +M lines]`, Codex emits
-// `[Pasted Content N chars]`, and OpenCode emits `[Pasted ~N lines]` after
+// `[Pasted Content N chars]`, OpenCode emits `[Pasted ~N lines]`, and
+// Grok Build emits `[Pasted: 31 KB]` after
 // committing a paste. Watch for any of these markers (or fall back after
 // PASTE_TO_ENTER_FALLBACK_MS) before sending `\r` so Enter doesn't get
 // swallowed mid-paste-commit.
@@ -64,7 +65,7 @@ export const PASTE_RETRY_MAX_ATTEMPTS = 3;
 export const PASTE_RETRY_BASE_DELAY_MS = 800;
 // Minimum prefix length for verification (shorter prompts verify whole-text)
 const MIN_VERIFIABLE_PREFIX_LEN = 15;
-export const PASTE_MARKER_PATTERN = /\[Pasted\s*(?:text\s*#\d+[^\]]*|content\s*\d+\s*chars|~\s*\d+\s*lines?)\]/i;
+export const PASTE_MARKER_PATTERN = /\[Pasted\s*(?:text\s*#\d+[^\]]*|content\s*\d+\s*chars|~\s*\d+\s*lines?|:\s*\d+(?:\.\d+)?\s*(?:B|KB|MB))\]/i;
 export const PASTE_TO_ENTER_MIN_DELAY_MS = 200;
 export const PASTE_TO_ENTER_FALLBACK_MS = 3500;
 
@@ -126,7 +127,7 @@ export function verifyPasteRendered(strippedBuffer, prefix) {
 }
 
 /**
- * Count paste-commit markers from Claude Code, Codex, or OpenCode in
+ * Count paste-commit markers from Claude Code, Codex, OpenCode, or Grok in
  * `strippedText`.
  * Callers MUST pass ANSI-STRIPPED output (see PASTE_MARKER_PATTERN above for why
  * the raw stream never matches). Shared by both TUI consumers so the

--- a/server/services/agentTuiSpawning.test.js
+++ b/server/services/agentTuiSpawning.test.js
@@ -1920,6 +1920,32 @@ describe('spawnTuiAgent runtime', () => {
     expect(pasteWrites()).toHaveLength(1);
   });
 
+  it('Grok collapsed paste: submits its size chip once without retrying the hidden prompt', async () => {
+    // agent-5ffe35b5 rendered this chip, but its truncated preview could not
+    // satisfy prefix verification. Retrying expanded/duplicated the input.
+    runSpawn({
+      provider: { id: 'grok-tui', name: 'Grok TUI', type: 'tui', envVars: {} },
+      tuiConfig: { ...defaultTuiConfig, command: 'grok', commandLine: 'grok' },
+      prompt: 'A long UX audit prompt whose full prefix is hidden by the collapsed preview.',
+    });
+    await flushMicrotasks();
+    await capturedOnData(Buffer.from('Grok Build 1.0.25 [stable]'));
+    await vi.advanceTimersByTimeAsync(2000);
+    const writes = () => vi.mocked(shellService.writeToSession).mock.calls
+      .filter(([id]) => id === SESSION_ID);
+    expect(pasteCount()).toBe(1);
+    expect(writes().filter(([, data]) => data === '\r')).toHaveLength(0);
+
+    // ANSI styling and PTY chunk boundaries match the real size chip.
+    await capturedOnData(Buffer.from('\x1b[38;2;65;65;65m[\x1b[38;2;200;200;200mPasted: 31'));
+    await capturedOnData(Buffer.from(' KB\x1b[38;2;65;65;65m] Enter:send'));
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(writes().some(([, data]) => data === '\r')).toBe(true);
+    await vi.advanceTimersByTimeAsync(20000);
+    expect(pasteCount()).toBe(1);
+    expect(agentLifecycle.finalizeAgent).not.toHaveBeenCalled();
+  });
+
   // ── 1c2. The readiness probe's own echo must not seed the startup-idle clock ──
   // shell.js's waitForPromptReady round-trips a shell-level probe (posix printf /
   // PowerShell Write-Output) BEFORE injecting the real CLI command, and fires


### PR DESCRIPTION
## Summary
Grok Build collapses large prompts into a `[Pasted: 31 KB]` chip. PortOS did not recognize this marker, so successful pastes were retried and ultimately failed as `paste-not-rendered` without submitting the task. Recognize Grok's size marker through the shared paste handshake.

The failed agent's raw transcript confirmed a rendered paste chip and an active composer. The chrome-devtools install offer appeared after delivery; no startup-dialog dismissal was needed.

## Test plan
- Passed 445 tests in `tuiHandshake.test.js`, `agentTuiSpawning.test.js`, and `tuiPromptRunner.test.js`.
- Added a fake-time spawner regression covering an ANSI-styled Grok chip split across PTY chunks: sends Enter and does not repeat the paste or finalize a startup failure.
- `git diff --check` passed.
