### PR TITLE
fix: preserve quality reports in scheduled audit completion

### DIFF
--- a/client/src/components/apps/AppQuality.jsx
+++ b/client/src/components/apps/AppQuality.jsx
@@ -5,8 +5,10 @@ import { formatDateShort } from '../../utils/formatters';
 export default function AppQuality({ app, detail = false }) {
   const quality = app.quality;
   const score = quality?.score;
+  const hasAssessments = quality?.categories?.some(category => category.assessedAt);
+  const unscoredLabel = hasAssessments ? 'Quality: no qualifying score' : 'Quality: not assessed';
   const label = quality?.unavailable ? 'Quality unavailable'
-    : score == null ? 'Quality: not assessed' : `Quality: ${score}/100`;
+    : score == null ? unscoredLabel : `Quality: ${score}/100`;
   if (!detail) return (
     <Link to={`/apps/${app.id}/overview`} className="text-xs text-port-accent hover:underline" title="View audit scores and coverage">
       {label}{score != null && ` · ${quality.ratedCategories}/${quality.totalCategories} categories`}
@@ -19,6 +21,13 @@ export default function AppQuality({ app, detail = false }) {
         Assessments describe the code before fixes. The overall score is the equal-weight mean of broad, medium/high-confidence assessments from the last 30 days.
         {' '}{quality?.ratedCategories ?? 0}/{quality?.totalCategories ?? 0} categories contribute. Missing, partial, low-confidence and stale assessments are excluded, not counted as perfect.
       </p>
+      {score == null && !quality?.unavailable && (
+        <p className="text-sm text-gray-400">
+          {hasAssessments
+            ? 'Saved assessments do not currently qualify for an overall score. Check the category breakdown for coverage, confidence and age.'
+            : 'No audit assessment has been saved. Completed maintenance tasks only supply a score when they return a valid quality report. Earlier runs are not scored retroactively; run a scheduled audit to collect an assessment.'}
+        </p>
+      )}
       <Link to={`/apps/${app.id}/tasks`} className="inline-block text-sm text-port-accent hover:underline">Configure or run scheduled audits</Link>
       <AppQualityHistory appId={app.id} categories={quality?.categories} />
       {!!quality?.categories?.length && (

--- a/client/src/components/apps/AppQuality.test.jsx
+++ b/client/src/components/apps/AppQuality.test.jsx
@@ -21,3 +21,22 @@ it('links an unassessed tile to its app overview without inventing a score', () 
   render(<MemoryRouter><AppQuality app={{ id: 'other' }} /></MemoryRouter>);
   expect(screen.getByRole('link', { name: 'Quality: not assessed' })).toHaveAttribute('href', '/apps/other/overview');
 });
+
+it('explains why completed maintenance can still have no saved assessment', async () => {
+  render(<MemoryRouter><AppQuality app={{ id: 'example', quality: { score: null, categories: [] } }} detail /></MemoryRouter>);
+  await screen.findByText(/No scored assessments/);
+  expect(screen.getByText(/Earlier runs are not scored retroactively/)).toBeInTheDocument();
+  expect(screen.getByRole('link', { name: /Configure or run scheduled audits/ })).toHaveAttribute('href', '/apps/example/tasks');
+});
+
+it('distinguishes saved but excluded evidence from an app that was never assessed', async () => {
+  const app = { id: 'example', quality: { score: null, ratedCategories: 0, totalCategories: 25, categories: [
+    { id: 'security', label: 'Security', score: 60, coverage: 'partial', confidence: 'high', assessedAt: '2026-09-10T00:00:00Z' },
+  ] } };
+  const { rerender } = render(<MemoryRouter><AppQuality app={app} /></MemoryRouter>);
+  expect(screen.getByRole('link', { name: 'Quality: no qualifying score' })).toBeInTheDocument();
+  rerender(<MemoryRouter><AppQuality app={app} detail /></MemoryRouter>);
+  await screen.findByText(/No scored assessments/);
+  expect(screen.getByText(/Saved assessments do not currently qualify/)).toBeInTheDocument();
+  expect(screen.getByText('60/100')).toBeInTheDocument();
+});

--- a/server/services/agentPromptBuilder.js
+++ b/server/services/agentPromptBuilder.js
@@ -36,6 +36,7 @@ import { COMPLETION_MODES, resolveCompletionMode } from '../lib/agentCompletionM
 import {
   DISCARD_WORKTREE_NOTE,
   buildActionOutputCompletionSection,
+  buildAuditOutputCompletionSection,
   buildClaimFlowCompletionSection,
   buildCliCompletionSection,
   buildCompletionGuidelineBullet,
@@ -592,7 +593,7 @@ ${buildResumeSection(task, worktreeInfo)}` : '';
   // nothing HERE because the full path carries its contract elsewhere: the
   // review-loop follow-up has its own procedure section below, read-only and
   // the commit/push modes are covered by the Guidelines bullet and Git Hygiene.
-  const tuiCompletionSection = ({
+  const completionSection = ({
     [COMPLETION_MODES.TOOL_FREE]: () => buildToolFreeReasoningCompletionSection(),
     [COMPLETION_MODES.SENTINEL_PAYLOAD]: () => buildProgrammaticOutputCompletionSection(sentinelPath),
     [COMPLETION_MODES.ACTION_OUTPUT]: () => buildActionOutputCompletionSection({ isTui, sentinelPath }),
@@ -603,6 +604,8 @@ ${buildResumeSection(task, worktreeInfo)}` : '';
     [COMPLETION_MODES.TUI_SLASHDO_FREE]: buildFullPathTuiCompletion,
     [COMPLETION_MODES.TUI]: buildFullPathTuiCompletion,
   }[completionMode] || (() => ''))();
+  const tuiCompletionSection = [completionSection, buildAuditOutputCompletionSection(task, sentinelPath)]
+    .filter(Boolean).join('\n\n');
 
   const {
     reviewLoopSection, reviewLoopFollowUpSection, jiraSection, skillSection,
@@ -1188,6 +1191,9 @@ function buildLightContextSections(task, workspaceDir, worktreeInfo, isTruthyMet
       workflowStep: localReviewSection ? 5 : 4,
     }));
   }
+
+  const auditCompletion = buildAuditOutputCompletionSection(task, lightSentinelPath());
+  if (auditCompletion) contractSections.push(auditCompletion);
 
   return { taskSections, contractSections };
 }

--- a/server/services/cosTaskGenerator.auditMode.test.js
+++ b/server/services/cosTaskGenerator.auditMode.test.js
@@ -183,6 +183,10 @@ describe('issues-only audit dispatch never acquires code-shipping instructions (
     expect(prompt).toContain('Repository-wide discovery, worst offender first');
     expect(prompt).toContain(`"category":"${taskType}"`);
     expect(prompt).toContain('## Completion (No Code Output)');
+    const handoff = prompt.slice(prompt.indexOf('## Required audit assessment handoff'));
+    expect(handoff).toContain(`category "${taskType}"`);
+    expect(handoff).toContain('summary AND exactly one single-line QUALITY_AUDIT_JSON:');
+    expect(prompt).not.toContain('write a one-line summary');
     expect(prompt).not.toContain('{modeInstructions}');
     expect(prompt).not.toContain('{trackerInstructions}');
   });
@@ -214,7 +218,16 @@ describe('issues-only audit dispatch never acquires code-shipping instructions (
     expect(prompt).toContain('Repository-wide discovery, worst offender first');
     expect(prompt).toContain(`"category":"${taskType}"`);
     expect(prompt).toMatch(/^## Completion Workflow$/m);
+    expect(prompt).toContain('## Required audit assessment handoff');
     expect(prompt).toMatch(/^\s*\d+\.\s+`\/do:push/m);
+  });
+
+  it('requires a persisted report for CLI audits that normally finish by exiting', async () => {
+    const task = await generate('better-complexity');
+    const prompt = buildLightContextPrompt(task, WORKSPACE, null, isTruthyMeta, { isTui: false });
+    expect(prompt).toContain('## Required audit assessment handoff');
+    expect(prompt).toContain('including agents that normally finish by exiting');
+    expect(prompt).toContain('.agent-done');
   });
 
   it('substitutes the banner into a template that still carries {modeInstructions}', async () => {

--- a/server/services/promptSections/completion.js
+++ b/server/services/promptSections/completion.js
@@ -3,6 +3,8 @@
  */
 
 import { DEFAULT_REVIEWER, DEFAULT_REVIEWERS, DEFAULT_REVIEW_STOP_MODE, normalizeReviewUsernames, resolveClaimReviewerConfig, buildReviewerPinNote, buildReviewerEffortNote, buildReviewWithArgs } from '../../lib/reviewerConfig.js';
+import { isAuditTaskType } from '../../lib/auditCatalog.js';
+import { resolveTaskHookType } from '../taskTypeHooks.js';
 import { PROGRAMMATIC_OUTPUT_COMPLETION_HEADING } from '../../lib/agentSentinel.js';
 import { canTypeSlashCommands, agentOwnsPrWorkflow } from '../../lib/slashdoInvocation.js';
 import { shellQuote } from '../../lib/shellQuote.js';
@@ -369,8 +371,19 @@ export function buildActionOutputCompletionSection({ isTui = false, sentinelPath
   return [
     notice,
     '',
-    `Your task is complete once that request succeeds. Then write a one-line summary to \`${sentinelPath}\` and stop — PortOS watches this sentinel and finalizes the run shortly after it appears. Do NOT run \`/quit\` and do NOT wait for anything after writing the sentinel.`
+    `Your task is complete once that request succeeds. Then write a short summary, including any structured report required by your task, to \`${sentinelPath}\` and stop — PortOS watches this sentinel and finalizes the run shortly after it appears. Do NOT run \`/quit\` and do NOT wait for anything after writing the sentinel.`
   ].join('\n');
+}
+
+/** Audit reports are a deliverable even when the run only files issues. */
+export function buildAuditOutputCompletionSection(task, sentinelPath) {
+  const category = resolveTaskHookType(task);
+  if (!isAuditTaskType(category)) return '';
+  return `## Required audit assessment handoff
+Before writing the completion sentinel, prepare the validated QUALITY_AUDIT_JSON report described in the audit instructions for category "${category}".
+Write your human summary AND exactly one single-line QUALITY_AUDIT_JSON: {...} report together to \`${sentinelPath}\`, then stop. This applies to every provider, including agents that normally finish by exiting.
+The report is required even when no issues are filed or no code changes are needed. A successful issue or PR does not supply a quality assessment. A final response alone is not enough: PortOS reads the sentinel file to save the dashboard score.
+Preserve the report when following the summary template above; the template's length guidance does not replace this required output. If assessment is unavailable, use score:null and explain the missing evidence rather than inventing a score.`;
 }
 
 /**


### PR DESCRIPTION
## Summary
Scheduled audits could finish without saving dashboard quality: the issue-only completion workflow asked for a one-line summary despite the audit mission requiring a structured report. Preserve required reports in that workflow and add an explicit, category-specific sentinel handoff for both TUI and CLI audit agents.

Explain why completed maintenance may have no saved assessment, and distinguish saved but excluded evidence from an app that has never been assessed. Existing scoring thresholds remain unchanged; historical runs without reports cannot supply a score.

## Test plan
- 419 server tests passed across scheduled audit prompt generation, agent prompt building, quality persistence/aggregation, and import boundaries.
- 4 AppQuality component tests passed, including missing reports and excluded assessments.
- Focused client lint and git diff whitespace checks passed.
- Reviewed changed code for reuse, quality, efficiency, and private-data exposure.
