### PR TITLE
Fix first-run card persistence and mobile footprint

### DIFF
--- a/client/src/components/onboarding/FirstRunCard.jsx
+++ b/client/src/components/onboarding/FirstRunCard.jsx
@@ -67,6 +67,11 @@ export default function FirstRunCard() {
     setSessionDismissed(true);
   }, []);
 
+  const persistChoice = useCallback(() => (
+    api.updateSettings({ [FIRST_RUN_HIDE_SETTING]: true }, { silent: true })
+      .then(() => setHideSetting(true))
+  ), []);
+
   useEscapeKey(visible && !busy, hideForSession);
 
   const pickMission = (mission) => {
@@ -83,18 +88,32 @@ export default function FirstRunCard() {
       .catch((err) => {
         toast.error(err.message || 'Could not enable those features');
       })
+      .then(persistChoice)
+      .catch((err) => {
+        toast.error(err.message || 'Could not save that preference');
+      })
       .finally(() => {
         hideForSession();
         navigate(mission.to);
       });
   };
 
+  const exploreOnOwn = () => {
+    if (busy) return;
+    setBusy(true);
+    persistChoice()
+      .then(hideForSession)
+      .catch((err) => {
+        toast.error(err.message || 'Could not save that preference');
+      })
+      .finally(() => setBusy(false));
+  };
+
   const hideForever = () => {
     if (busy) return;
     setBusy(true);
-    api.updateSettings({ [FIRST_RUN_HIDE_SETTING]: true }, { silent: true })
+    persistChoice()
       .then(() => {
-        setHideSetting(true);
         hideForSession();
       })
       .catch((err) => {
@@ -108,7 +127,7 @@ export default function FirstRunCard() {
   return (
     <section
       aria-labelledby="first-run-heading"
-      className="bg-port-card border border-port-accent/40 rounded-xl p-4 sm:p-5"
+      className="bg-port-card border border-port-accent/40 rounded-xl p-3 sm:p-5"
     >
       <div className="flex items-start gap-2 sm:gap-3">
         <Sparkles size={18} className="text-port-accent shrink-0 mt-0.5" />
@@ -116,9 +135,10 @@ export default function FirstRunCard() {
           <h3 id="first-run-heading" className="text-base font-semibold text-white">
             Where do you want to start?
           </h3>
-          <p className="mt-1 text-sm text-gray-400">
+          <p className="hidden sm:block mt-1 text-sm text-gray-400">
             Pick a mission to turn on that slice of PortOS and jump in. Exploring
-            on your own, or pressing escape, just hides this for the session.
+            on your own or picking a mission hides this on future visits. Pressing
+            escape just hides it for this session.
           </p>
         </div>
         <button
@@ -133,7 +153,7 @@ export default function FirstRunCard() {
         </button>
       </div>
 
-      <div className="mt-4 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
+      <div className="mt-2 sm:mt-4 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-1.5 sm:gap-3">
         {FIRST_RUN_MISSIONS.map((mission) => {
           const Icon = MISSION_ICONS[mission.icon] || Sparkles;
           return (
@@ -142,12 +162,12 @@ export default function FirstRunCard() {
               type="button"
               onClick={() => pickMission(mission)}
               disabled={busy}
-              className="flex items-start gap-2 text-left p-3 rounded-lg border border-port-border hover:border-port-accent transition-colors disabled:opacity-50 min-h-[40px]"
+              className="flex items-center sm:items-start gap-2 text-left p-2 sm:p-3 rounded-lg border border-port-border hover:border-port-accent transition-colors disabled:opacity-50 min-h-[40px]"
             >
               <Icon size={16} className="text-port-accent shrink-0 mt-0.5" />
               <span className="min-w-0 flex-1">
                 <span className="block text-sm font-medium text-white">{mission.label}</span>
-                <span className="block text-xs text-gray-500 mt-0.5">{mission.description}</span>
+                <span className="hidden sm:block text-xs text-gray-500 mt-0.5">{mission.description}</span>
               </span>
               <ArrowRight size={14} className="text-port-accent shrink-0 mt-0.5" />
             </button>
@@ -155,10 +175,10 @@ export default function FirstRunCard() {
         })}
       </div>
 
-      <div className="mt-4 flex flex-wrap items-center gap-3 text-sm">
+      <div className="mt-2 sm:mt-4 flex flex-wrap items-center gap-3 text-sm">
         <button
           type="button"
-          onClick={hideForSession}
+          onClick={exploreOnOwn}
           disabled={busy}
           className="text-gray-400 hover:text-white disabled:opacity-50"
         >

--- a/client/src/components/onboarding/FirstRunCard.test.jsx
+++ b/client/src/components/onboarding/FirstRunCard.test.jsx
@@ -45,6 +45,7 @@ const renderCard = async (path = '/') => {
 };
 
 beforeEach(() => {
+  sessionStorage.clear();
   vi.clearAllMocks();
   __resetInstanceFeatureCache();
   mock.getSettings.mockResolvedValue({});
@@ -72,10 +73,26 @@ describe('FirstRunCard show/hide', () => {
     expect(screen.queryByRole('heading', { name: heading })).not.toBeInTheDocument();
   });
 
-  it('hides for the rest of the session after explore / escape / the X', async () => {
+  it('persists Explore on my own for future sessions', async () => {
     await renderCard('/');
     expect(await screen.findByRole('heading', { name: heading })).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: 'Explore on my own' }));
+    await waitFor(() => {
+      expect(mock.updateSettings).toHaveBeenCalledWith(
+        { [FIRST_RUN_HIDE_SETTING]: true },
+        { silent: true },
+      );
+    });
+    await waitFor(() => {
+      expect(screen.queryByRole('heading', { name: heading })).not.toBeInTheDocument();
+    });
+    expect(sessionStorage.getItem(FIRST_RUN_SESSION_KEY)).toBe('1');
+  });
+
+  it('keeps the X dismissal session-only', async () => {
+    await renderCard('/');
+    expect(await screen.findByRole('heading', { name: heading })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss for this session' }));
     expect(screen.queryByRole('heading', { name: heading })).not.toBeInTheDocument();
     expect(sessionStorage.getItem(FIRST_RUN_SESSION_KEY)).toBe('1');
     expect(mock.updateSettings).not.toHaveBeenCalled();
@@ -130,6 +147,10 @@ describe('FirstRunCard mission feature writes', () => {
     });
     expect(mock.updateInstanceFeature).toHaveBeenCalledTimes(1);
     expect(mock.updateInstanceFeature.mock.calls.every(([id]) => id === 'health')).toBe(true);
+    expect(mock.updateSettings).toHaveBeenCalledWith(
+      { [FIRST_RUN_HIDE_SETTING]: true },
+      { silent: true },
+    );
     await waitFor(() => {
       expect(router.state.location.pathname).toBe('/brain/inbox');
     });
@@ -143,5 +164,25 @@ describe('FirstRunCard mission feature writes', () => {
       expect(router.state.location.pathname).toBe('/start-story');
     });
     expect(mock.updateInstanceFeature).not.toHaveBeenCalled();
+    expect(mock.updateSettings).toHaveBeenCalledWith(
+      { [FIRST_RUN_HIDE_SETTING]: true },
+      { silent: true },
+    );
+  });
+
+  it('persists the mission choice even when its feature cannot be enabled', async () => {
+    mock.updateInstanceFeature.mockRejectedValue(new Error('feature unavailable'));
+    const router = await renderCard('/');
+    expect(await screen.findByRole('heading', { name: heading })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /Personal knowledge/ }));
+    await waitFor(() => {
+      expect(mock.updateSettings).toHaveBeenCalledWith(
+        { [FIRST_RUN_HIDE_SETTING]: true },
+        { silent: true },
+      );
+    });
+    await waitFor(() => {
+      expect(router.state.location.pathname).toBe('/brain/inbox');
+    });
   });
 });


### PR DESCRIPTION
## Summary

- persist the first-run preference after choosing a mission or exploring independently
- keep X and Escape as session-only dismissals
- compact the mobile mission card by hiding secondary copy and reducing spacing below `sm`

## Test plan

- `cd client && ./node_modules/.bin/vitest run src/components/onboarding/FirstRunCard.test.jsx src/lib/firstRunMissions.test.js`
- `cd client && ./node_modules/.bin/biome lint --error-on-warnings src/components/onboarding/FirstRunCard.jsx src/components/onboarding/FirstRunCard.test.jsx`
- `cd client && npm run build`

Closes #6803
