### PR TITLE
fix: prioritize local runtime controls (#6806)

### DIFF
--- a/client/src/components/settings/HardwareLlmRecommendation.jsx
+++ b/client/src/components/settings/HardwareLlmRecommendation.jsx
@@ -104,40 +104,9 @@ export function hardwareLlmRecommendation(capabilities) {
   return APPLE_PROFILES.find((profile) => memory >= profile.minMemoryGb && (profile.maxMemoryGb == null || memory <= profile.maxMemoryGb)) || null;
 }
 
-export default function HardwareLlmRecommendation() {
-  const [capabilities, setCapabilities] = useState(null);
-  const [loaded, setLoaded] = useState(false);
-
-  useEffect(() => {
-    let cancelled = false;
-    getSystemCapabilities({ silent: true })
-      .then((result) => {
-        if (!cancelled) setCapabilities(result);
-      })
-      .catch(() => {})
-      .finally(() => { if (!cancelled) setLoaded(true); });
-    return () => { cancelled = true; };
-  }, []);
-
-  const profile = hardwareLlmRecommendation(capabilities);
-  if (!loaded) {
-    return <div className="bg-port-card border border-port-border rounded-xl p-4 text-xs text-gray-500">Checking this machine for a curated coding-agent setup…</div>;
-  }
-  if (!profile) return null;
-
+function RecommendationBody({ profile }) {
   return (
-    <section className="bg-port-accent/5 border border-port-accent/40 rounded-xl p-4 sm:p-5 space-y-3" aria-labelledby="hardware-llm-recommendation-title">
-      <div className="flex flex-col sm:flex-row sm:items-start justify-between gap-3">
-        <div className="min-w-0">
-          <div className="flex items-center gap-2 text-port-accent">
-            <Sparkles size={16} />
-            <h2 id="hardware-llm-recommendation-title" className="text-sm font-semibold">Recommended coding-agent setup</h2>
-          </div>
-          <p className="text-xs text-gray-400 mt-1">Curated for this machine: {profile.machine}</p>
-        </div>
-        <span className="text-[11px] px-2 py-1 rounded border border-port-accent/30 text-port-accent shrink-0">Qwen3.8-27B</span>
-      </div>
-
+    <>
       <div className="grid grid-cols-1 sm:grid-cols-3 gap-2 text-xs">
         <div className="bg-port-bg/70 rounded-lg p-2.5 min-w-0"><span className="text-gray-500">Runtime</span><p className="text-gray-200 mt-0.5 font-medium">{profile.runtime}</p></div>
         <div className="bg-port-bg/70 rounded-lg p-2.5 min-w-0"><span className="text-gray-500">Harness</span><p className="text-gray-200 mt-0.5 font-medium">{profile.harness}</p></div>
@@ -154,6 +123,64 @@ export default function HardwareLlmRecommendation() {
         <Link to="/ai" className="text-port-accent hover:underline">Configure the harness in AI Providers</Link>
         <Link to="/models/performance" className="inline-flex items-center gap-1 text-port-accent hover:underline"><Gauge size={12} /> Validate with a local task check</Link>
       </div>
-    </section>
+    </>
+  );
+}
+
+export default function HardwareLlmRecommendation() {
+  const [capabilities, setCapabilities] = useState(null);
+  const [loaded, setLoaded] = useState(false);
+  const [wideViewport, setWideViewport] = useState(() => window.matchMedia?.('(min-width: 640px)').matches ?? false);
+  const [mobileExpanded, setMobileExpanded] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    getSystemCapabilities({ silent: true })
+      .then((result) => {
+        if (!cancelled) setCapabilities(result);
+      })
+      .catch(() => {})
+      .finally(() => { if (!cancelled) setLoaded(true); });
+    return () => { cancelled = true; };
+  }, []);
+
+  useEffect(() => {
+    const media = window.matchMedia?.('(min-width: 640px)');
+    if (!media) return undefined;
+    const syncViewport = () => setWideViewport(media.matches);
+    syncViewport();
+    media.addEventListener('change', syncViewport);
+    return () => media.removeEventListener('change', syncViewport);
+  }, []);
+
+  const profile = hardwareLlmRecommendation(capabilities);
+  if (!loaded) {
+    return <div className="bg-port-card border border-port-border rounded-xl p-4 text-xs text-gray-500">Checking this machine for a curated coding-agent setup…</div>;
+  }
+  if (!profile) return null;
+
+  return (
+    <details
+      className="group bg-port-accent/5 border border-port-accent/40 rounded-xl p-4 sm:p-5"
+      open={wideViewport || mobileExpanded}
+      onToggle={(event) => { if (!wideViewport) setMobileExpanded(event.currentTarget.open); }}
+    >
+      <summary
+        className="flex cursor-pointer list-none flex-col sm:flex-row sm:cursor-default sm:items-start justify-between gap-3"
+        onClick={(event) => { if (wideViewport) event.preventDefault(); }}
+      >
+        <div className="min-w-0">
+          <div className="flex items-center gap-2 text-port-accent">
+            <Sparkles size={16} />
+            <h2 id="hardware-llm-recommendation-title" className="text-sm font-semibold">Recommended coding-agent setup</h2>
+          </div>
+          <p className="text-xs text-gray-400 mt-1">Curated for this machine: {profile.machine}</p>
+        </div>
+        <span className="text-[11px] px-2 py-1 rounded border border-port-accent/30 text-port-accent shrink-0">Qwen3.8-27B</span>
+      </summary>
+      <div className="mt-3 space-y-3 group-open:block sm:block">
+        <RecommendationBody profile={profile} />
+      </div>
+    </details>
   );
 }

--- a/client/src/components/settings/LocalLlmRuntimesView.jsx
+++ b/client/src/components/settings/LocalLlmRuntimesView.jsx
@@ -647,8 +647,6 @@ export default function LocalLlmRuntimesView() {
 
   return (
     <section id="llm-management-panel-runtimes" role="tabpanel" aria-labelledby="tab-runtimes" className="space-y-4">
-      <HardwareLlmRecommendation />
-      <LocalPersistentMindSetupCard />
       {/* One start/stop/install surface for every local server PortOS can run */}
       <RuntimeServersCard
         status={status}
@@ -678,6 +676,8 @@ export default function LocalLlmRuntimesView() {
         onSaveIdleWindow={saveIdleWindow}
         onToggleKeepLoaded={toggleKeepLoaded}
       />
+      <LocalPersistentMindSetupCard />
+      <HardwareLlmRecommendation />
 
       {/* Backends — model catalog, default marker, cross-backend import */}
       <div className="bg-port-card border border-port-border rounded-xl p-4 sm:p-6 space-y-4">

--- a/client/src/components/settings/LocalLlmRuntimesView.test.jsx
+++ b/client/src/components/settings/LocalLlmRuntimesView.test.jsx
@@ -95,6 +95,11 @@ const renderRuntimes = async () => {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  window.matchMedia = vi.fn(() => ({
+    matches: false,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  }));
   getLocalLlmStatus.mockResolvedValue({
     backend: 'ollama',
     ollama: {
@@ -132,8 +137,25 @@ describe('LocalLlmRuntimesView information architecture', () => {
     expect(screen.getByRole('heading', { name: 'Local Runtime Servers' })).toBeInTheDocument();
     expect(screen.queryByRole('heading', { name: 'Models' })).not.toBeInTheDocument();
     expect(getLocalLlmCatalog).not.toHaveBeenCalled();
-    expect(await screen.findByRole('heading', { name: 'Recommended coding-agent setup' })).toBeInTheDocument();
-    expect(screen.getByText('OpenCode MTPLX TUI')).toBeInTheDocument();
+    const recommendationHeading = await screen.findByRole('heading', { name: 'Recommended coding-agent setup' });
+    const runtimeHeading = screen.getByRole('heading', { name: 'Local Runtime Servers' });
+    expect(runtimeHeading.compareDocumentPosition(recommendationHeading) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    const recommendation = recommendationHeading.closest('details');
+    expect(recommendation).not.toHaveAttribute('open');
+    expect(within(recommendation).getByText('OpenCode MTPLX TUI')).toBeInTheDocument();
+    fireEvent.click(recommendationHeading.closest('summary'));
+    expect(recommendation).toHaveAttribute('open');
+  });
+
+  it('keeps the recommendation expanded on desktop', async () => {
+    window.matchMedia = vi.fn(() => ({
+      matches: true,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }));
+    await renderRuntimes();
+
+    expect((await screen.findByRole('heading', { name: 'Recommended coding-agent setup' })).closest('details')).toHaveAttribute('open');
   });
 
   // The two views never mount together, so whichever one is on screen must be the


### PR DESCRIPTION
## Summary

- put Local Runtime Servers first on the LLM runtimes page so Start and Install actions appear before setup guidance
- collapse the hardware recommendation into a native disclosure on mobile while keeping its content expanded from the `sm` breakpoint
- cover runtime/recommendation order and recommendation disclosure behavior

## Test plan

- `cd client && npm test -- src/components/settings/LocalLlmRuntimesView.test.jsx`
- `cd client && npm run build`

Closes #6806
