### PR TITLE
fix: add Writers Room creation calls to action (#6807)

### DIFF
--- a/client/src/components/writers-room/LibraryPane.jsx
+++ b/client/src/components/writers-room/LibraryPane.jsx
@@ -15,11 +15,13 @@ import { KIND_LABELS } from './labels';
 
 const UNFILED_DROP_ID = 'wr-unfiled';
 
-export default function LibraryPane({ folders, works, activeWorkId, onSelectWork, onRefresh, onCollapse }) {
+export default function LibraryPane({
+  folders, works, activeWorkId, onSelectWork, onRefresh, onCollapse,
+  creatingWork, onCreatingWorkChange,
+}) {
   const [openFolders, setOpenFolders] = useState({});
   const [creatingFolder, setCreatingFolder] = useState(false);
   const [folderName, setFolderName] = useState('');
-  const [creatingWork, setCreatingWork] = useState(null); // folderId or 'unfiled'
   const [workTitle, setWorkTitle] = useState('');
   const [workKind, setWorkKind] = useState('short-story');
   // Inline delete confirm (no two-click-arm, no toast re-arm) — one row armed at
@@ -67,7 +69,7 @@ export default function LibraryPane({ folders, works, activeWorkId, onSelectWork
     if (!work) return;
     setWorkTitle('');
     setWorkKind('short-story');
-    setCreatingWork(null);
+    onCreatingWorkChange(null);
     onRefresh?.();
     onSelectWork?.(work.id);
   };
@@ -135,7 +137,7 @@ export default function LibraryPane({ folders, works, activeWorkId, onSelectWork
             it grows to 44px rather than clawing it back with a negative margin. */}
         <div className="flex items-center gap-1">
           <button
-            onClick={() => { setCreatingFolder(true); setCreatingWork(null); }}
+            onClick={() => { setCreatingFolder(true); onCreatingWorkChange(null); }}
             className="flex items-center justify-center min-w-[44px] min-h-[44px] text-gray-400 hover:text-port-accent"
             title="New folder"
             aria-label="New folder"
@@ -143,7 +145,7 @@ export default function LibraryPane({ folders, works, activeWorkId, onSelectWork
             <FolderPlus size={14} />
           </button>
           <button
-            onClick={() => { setCreatingWork('unfiled'); setCreatingFolder(false); }}
+            onClick={() => { onCreatingWorkChange('unfiled'); setCreatingFolder(false); }}
             className="flex items-center justify-center min-w-[44px] min-h-[44px] text-gray-400 hover:text-port-accent"
             title="New work"
             aria-label="New work"
@@ -201,7 +203,7 @@ export default function LibraryPane({ folders, works, activeWorkId, onSelectWork
           </select>
           <div className="flex items-center gap-1">
             <button type="submit" className="text-xs px-2 py-1 bg-port-accent text-white rounded flex-1 min-h-[44px]">Create</button>
-            <button type="button" onClick={() => setCreatingWork(null)} className="text-xs px-2 py-1 text-gray-400 min-w-[44px] min-h-[44px]">Cancel</button>
+            <button type="button" onClick={() => onCreatingWorkChange(null)} className="text-xs px-2 py-1 text-gray-400 min-w-[44px] min-h-[44px]">Cancel</button>
           </div>
         </form>
       )}
@@ -209,8 +211,16 @@ export default function LibraryPane({ folders, works, activeWorkId, onSelectWork
       <DndContext sensors={sensors} onDragStart={handleDragStart} onDragEnd={handleDragEnd}>
         <ul className="space-y-1">
           {folders.length === 0 && grouped.get(null).length === 0 && !creatingFolder && !creatingWork && (
-            <li className="text-xs text-gray-500 px-2 py-3 text-center">
-              No works yet. Click <FilePlus size={12} className="inline" /> to start.
+            <li className="px-2 py-3 text-center">
+              <p className="text-xs text-gray-500 mb-2">No works yet.</p>
+              <button
+                type="button"
+                onClick={() => { onCreatingWorkChange('unfiled'); setCreatingFolder(false); }}
+                className="inline-flex min-h-[44px] items-center gap-1.5 rounded px-3 py-2 text-xs font-medium text-port-accent hover:bg-port-accent/10"
+              >
+                <FilePlus size={14} aria-hidden="true" />
+                New work
+              </button>
             </li>
           )}
 
@@ -230,7 +240,7 @@ export default function LibraryPane({ folders, works, activeWorkId, onSelectWork
               isDragging={!!draggingWork}
               confirming={isConfirming(`folder:${folder.id}`)}
               onToggle={() => toggleFolder(folder.id)}
-              onCreateWork={() => { setCreatingWork(folder.id); setCreatingFolder(false); }}
+              onCreateWork={() => { onCreatingWorkChange(folder.id); setCreatingFolder(false); }}
               onRequestDelete={() => requestDelete(`folder:${folder.id}`)}
               onConfirmDelete={() => handleDeleteFolder(folder.id)}
               onCancelDelete={cancelDelete}

--- a/client/src/components/writers-room/LibraryPane.jsx
+++ b/client/src/components/writers-room/LibraryPane.jsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Folder, FolderPlus, FilePlus, FileText, ChevronDown, ChevronRight, Trash2, GripVertical, PanelLeftClose } from 'lucide-react';
 import { DndContext, DragOverlay, PointerSensor, useDraggable, useDroppable, useSensor, useSensors } from '@dnd-kit/core';
 import toast from '../ui/Toast';
@@ -24,6 +24,12 @@ export default function LibraryPane({
   const [folderName, setFolderName] = useState('');
   const [workTitle, setWorkTitle] = useState('');
   const [workKind, setWorkKind] = useState('short-story');
+
+  // The page-level empty state can start work creation too. Keep the two
+  // inline creation forms mutually exclusive regardless of which CTA fired.
+  useEffect(() => {
+    if (creatingWork) setCreatingFolder(false);
+  }, [creatingWork]);
   // Inline delete confirm (no two-click-arm, no toast re-arm) — one row armed at
   // a time, keyed by `work:<id>` / `folder:<id>`.
   const { isConfirming, requestDelete, cancelDelete, confirmDelete } = useConfirmDelete();

--- a/client/src/components/writers-room/LibraryPane.test.jsx
+++ b/client/src/components/writers-room/LibraryPane.test.jsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 
@@ -17,17 +18,24 @@ vi.mock('../../services/apiWritersRoom', () => ({
 
 import LibraryPane from './LibraryPane';
 
-const renderPane = (props = {}) => render(
-  <LibraryPane
-    folders={[]}
-    works={[]}
-    activeWorkId={null}
-    onSelectWork={() => {}}
-    onRefresh={() => {}}
-    onCollapse={() => {}}
-    {...props}
-  />,
-);
+function LibraryPaneHarness(props) {
+  const [creatingWork, setCreatingWork] = useState(null);
+  return (
+    <LibraryPane
+      folders={[]}
+      works={[]}
+      activeWorkId={null}
+      onSelectWork={() => {}}
+      onRefresh={() => {}}
+      onCollapse={() => {}}
+      creatingWork={creatingWork}
+      onCreatingWorkChange={setCreatingWork}
+      {...props}
+    />
+  );
+}
+
+const renderPane = (props = {}) => render(<LibraryPaneHarness {...props} />);
 
 // Tailwind arbitrary-value floors are what the rest of the app uses (see
 // Drawer.jsx's close button), so assert on the classes rather than on computed
@@ -40,9 +48,9 @@ const expectTouchTarget = (el) => {
 describe('LibraryPane header actions (#3569)', () => {
   it('meets the 44px touch floor on New folder, New work and Hide library', () => {
     renderPane();
-    for (const name of ['New folder', 'New work', 'Hide library']) {
-      expectTouchTarget(screen.getByRole('button', { name }));
-    }
+    expectTouchTarget(screen.getByRole('button', { name: 'New folder' }));
+    expectTouchTarget(screen.getAllByRole('button', { name: 'New work' })[0]);
+    expectTouchTarget(screen.getByRole('button', { name: 'Hide library' }));
   });
 
   it('keeps the Hide library button desktop-only without losing its flex centering', () => {
@@ -70,10 +78,17 @@ describe('LibraryPane header actions (#3569)', () => {
 
   it('gives the new-work form tappable controls', () => {
     renderPane();
-    fireEvent.click(screen.getByRole('button', { name: 'New work' }));
+    fireEvent.click(screen.getAllByRole('button', { name: 'New work' })[0]);
     expect(screen.getByPlaceholderText('Title').className).toContain('min-h-[44px]');
     expect(screen.getByRole('combobox').className).toContain('min-h-[44px]');
     expect(screen.getByRole('button', { name: 'Create' }).className).toContain('min-h-[44px]');
     expectTouchTarget(screen.getByRole('button', { name: 'Cancel' }));
+  });
+
+  it('offers a direct New work action when the library is empty', () => {
+    renderPane();
+    fireEvent.click(screen.getAllByRole('button', { name: 'New work' })[1]);
+    expect(screen.getByRole('textbox', { name: 'Work title' })).toBeInTheDocument();
+    expect(screen.queryByText(/Click .* to start/)).toBeNull();
   });
 });

--- a/client/src/pages/WritersRoom.jsx
+++ b/client/src/pages/WritersRoom.jsx
@@ -5,6 +5,7 @@ import LibraryPane from '../components/writers-room/LibraryPane';
 import WorkEditor from '../components/writers-room/WorkEditor';
 import ExercisePanel from '../components/writers-room/ExercisePanel';
 import CatalogCastPanel from '../components/CatalogCastPanel';
+import EmptyState from '../components/EmptyState';
 import {
   listWritersRoomFolders,
   listWritersRoomWorks,
@@ -21,6 +22,7 @@ export default function WritersRoom() {
   const [folders, setFolders] = useState([]);
   const [works, setWorks] = useState([]);
   const [activeWork, setActiveWork] = useState(null);
+  const [creatingWork, setCreatingWork] = useState(null);
   const [loadingWork, setLoadingWork] = useState(false);
   const [showExercise, setShowExercise] = useState(false);
   const [editorDirty, setEditorDirty] = useState(false);
@@ -179,6 +181,8 @@ export default function WritersRoom() {
               onSelectWork={selectWork}
               onRefresh={refreshLibrary}
               onCollapse={toggleLibrary}
+              creatingWork={creatingWork}
+              onCreatingWorkChange={setCreatingWork}
             />
           </aside>
         )}
@@ -186,12 +190,14 @@ export default function WritersRoom() {
         <main className="min-h-0 flex flex-col flex-1">
           {loadingWork && <div className="p-6 text-sm text-gray-500">Loading work…</div>}
           {!loadingWork && !activeWork && (
-            <div className="flex-1 flex items-center justify-center text-center p-8">
-              <div className="max-w-md space-y-2 text-gray-400">
-                <NotebookPen className="w-10 h-10 mx-auto text-gray-600" />
-                <h2 className="text-lg text-white">No work selected</h2>
-                <p className="text-sm">Pick a work from the library to start editing, or create a new one. Use the Write for 10 panel for timed sprints.</p>
-              </div>
+            <div className="flex-1 flex items-center justify-center p-8">
+              <EmptyState
+                icon={NotebookPen}
+                title="No work selected"
+                message="Create a work or pick one from the library to start writing."
+                actionLabel="New work"
+                onAction={() => setCreatingWork('unfiled')}
+              />
             </div>
           )}
           {!loadingWork && activeWork && (

--- a/client/src/pages/WritersRoom.jsx
+++ b/client/src/pages/WritersRoom.jsx
@@ -196,7 +196,10 @@ export default function WritersRoom() {
                 title="No work selected"
                 message="Create a work or pick one from the library to start writing."
                 actionLabel="New work"
-                onAction={() => setCreatingWork('unfiled')}
+                onAction={() => {
+                  setLibraryCollapsed(false);
+                  setCreatingWork('unfiled');
+                }}
               />
             </div>
           )}

--- a/client/src/pages/WritersRoom.test.jsx
+++ b/client/src/pages/WritersRoom.test.jsx
@@ -27,9 +27,13 @@ describe('WritersRoom empty state', () => {
     expect(within(main).getByText('Create a work or pick one from the library to start writing.')).toBeInTheDocument();
     expect(within(main).queryByText(/Write for 10/)).toBeNull();
 
+    fireEvent.click(screen.getByRole('button', { name: 'New folder' }));
+    expect(screen.getByRole('textbox', { name: 'Folder name' })).toBeInTheDocument();
     fireEvent.click(within(main).getByRole('button', { name: 'New work' }));
 
     expect(await screen.findByRole('textbox', { name: 'Work title' })).toBeInTheDocument();
+    expect(screen.getByRole('textbox', { name: 'Work title' })).toHaveFocus();
+    expect(screen.queryByRole('textbox', { name: 'Folder name' })).toBeNull();
     expect(screen.getByRole('combobox', { name: 'Work kind' })).toBeInTheDocument();
     fireEvent.change(screen.getByRole('textbox', { name: 'Work title' }), { target: { value: 'A new draft' } });
     fireEvent.click(screen.getByRole('button', { name: 'Create' }));

--- a/client/src/pages/WritersRoom.test.jsx
+++ b/client/src/pages/WritersRoom.test.jsx
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router';
+
+vi.mock('../services/apiWritersRoom', async (importOriginal) => ({
+  ...await importOriginal(),
+  listWritersRoomFolders: vi.fn(async () => []),
+  listWritersRoomWorks: vi.fn(async () => []),
+  getWritersRoomWork: vi.fn(),
+  createWritersRoomWork: vi.fn(async () => ({ id: 'work-new' })),
+}));
+
+import WritersRoom from './WritersRoom';
+
+describe('WritersRoom empty state', () => {
+  it('opens the existing New work form from the unselected work pane', async () => {
+    render(
+      <MemoryRouter initialEntries={['/writers-room']}>
+        <Routes>
+          <Route path="/writers-room" element={<WritersRoom />} />
+          <Route path="/writers-room/works/:workId" element={<div>New work opened</div>} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    const main = screen.getByRole('main');
+    expect(within(main).getByText('Create a work or pick one from the library to start writing.')).toBeInTheDocument();
+    expect(within(main).queryByText(/Write for 10/)).toBeNull();
+
+    fireEvent.click(within(main).getByRole('button', { name: 'New work' }));
+
+    expect(await screen.findByRole('textbox', { name: 'Work title' })).toBeInTheDocument();
+    expect(screen.getByRole('combobox', { name: 'Work kind' })).toBeInTheDocument();
+    fireEvent.change(screen.getByRole('textbox', { name: 'Work title' }), { target: { value: 'A new draft' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Create' }));
+    expect(await screen.findByText('New work opened')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

- replace the inert unselected Writers Room pane with the shared actionable empty state
- open the existing inline work creation form from the main pane and from the empty library
- remove the unavailable Write for 10 guidance and cover creation through navigation

## Test plan

- `cd client && ./node_modules/.bin/vitest related --run src/pages/WritersRoom.jsx src/components/writers-room/LibraryPane.jsx`
- `cd client && ./node_modules/.bin/biome lint --error-on-warnings src/pages/WritersRoom.jsx src/pages/WritersRoom.test.jsx src/components/writers-room/LibraryPane.jsx src/components/writers-room/LibraryPane.test.jsx`
- `cd client && npm run build`

Closes #6807
