### PR TITLE
refactor: move description fold ownership to cosTaskStore (#6838)

### DIFF
--- a/server/services/cos.test.js
+++ b/server/services/cos.test.js
@@ -1658,24 +1658,6 @@ describe('cos.js source — priority + capacity invariants', () => {
       'queue path must NOT use getTaskDescription (one-line stub bypasses prompt enrichment)'
     ).not.toMatch(/getTaskDescription\s*\(/);
 
-    // The generator returns a multi-line `description` (the full Phase 1–7
-    // prompt template). COS-TASKS.md serialization interpolates the whole
-    // description onto a single `- [ ]` line and the parser only matches the
-    // first line, so persisting a multi-line description corrupts the file
-    // AND truncates the prompt on the next `dequeueNextTask` re-read. The
-    // queue path must move the body to `metadata.prompt` (which IS
-    // newline-escaped) so the agent prompt builder reconstitutes it on
-    // dispatch. `prompt`, not `context` — the two were split in #4153 so a
-    // multi-thousand-character agent payload is distinguishable from the
-    // one-line human note. Pin both halves of the split.
-    expect(
-      fnBody,
-      'queue path must move multi-line description body to metadata.prompt (survives markdown round-trip)'
-    ).toMatch(/metadata\.prompt\s*=\s*\w+\.description/);
-    expect(
-      fnBody,
-      'queue path must collapse description to a single line via firstLine()'
-    ).toMatch(/\.description\s*=\s*firstLine\(/);
 
     // appActivity helpers must come from the file-level static import (line ~23),
     // NOT a dynamic `await import('./appActivity.js')` *inside* the per-app

--- a/server/services/cosTaskGenerator.js
+++ b/server/services/cosTaskGenerator.js
@@ -40,7 +40,7 @@ import { remainingActionBudget } from '../lib/domainBudgets.js';
 import { getDomainBudgetStatus } from './domainUsage.js';
 import { pendingCosActionReservations } from './cosAdmissionReservations.js';
 import { cosEvents, emitLog } from './cosEvents.js';
-import { addTask, updateTask, getAllTasks, getCosTasks, firstLine } from './cosTaskStore.js';
+import { addTask, updateTask, getAllTasks, getCosTasks } from './cosTaskStore.js';
 import { PRIORITY_VALUES } from '../lib/taskParser.js';
 import { recordDecision, DECISION_TYPES } from './decisionLog.js';
 import { isAppOnCooldown, markAppReviewCooldown, bindAppReviewAgent, markIdleReviewStarted, getNextAppForReview, loadAppActivity, isAppActivityOnCooldown } from './appActivity.js';
@@ -1373,17 +1373,6 @@ export function buildImprovementDedupSets(existingTasks, { ignoreTaskId = null }
   return { existingTaskTypes, appsWithPendingImprovement, blockedTaskTypes, appsWithBlockedImprovement };
 }
 
-function prepareQueuedImprovementTask(task) {
-  // Queued tasks round-trip through COS-TASKS.md, whose task description field
-  // is single-line. Preserve the full prompt in metadata so the agent receives
-  // it after the task is re-read from disk.
-  if (typeof task.description === 'string' && task.description.includes('\n')) {
-    task.metadata = task.metadata || {};
-    task.metadata.prompt = task.description;
-    task.description = firstLine(task.description);
-  }
-  return task;
-}
 
 export async function queueDueInstallWideImprovementTasks({
   dueTasks,
@@ -1421,7 +1410,6 @@ export async function queueDueInstallWideImprovementTasks({
     task.priority = 'LOW';
     task.priorityValue = PRIORITY_VALUES.LOW;
     task.id = `sys-install-${taskType}-${Date.now().toString(36)}`;
-    prepareQueuedImprovementTask(task);
 
     const newTask = await persistTask(task, 'internal', { raw: true, ignoreTaskId, suppressDequeue: true });
     if (newTask?.duplicate) continue;
@@ -1560,38 +1548,10 @@ export async function queueEligibleImprovementTasks(state, cosTaskData, { ignore
     task.priorityValue = PRIORITY_VALUES.LOW;
     task.id = `sys-${app.id.slice(0, 8)}-${nextType}-${Date.now().toString(36)}`;
 
-    // Move the generator's multi-line prompt into `metadata.prompt` so it
-    // survives the COS-TASKS.md round-trip. The on-demand path dispatches the
-    // in-memory task immediately (cosEvents.emit('task:ready', task) with the
-    // unparsed object), so it never round-trips through the markdown — but
-    // the queue path persists first and re-reads from disk on the next
-    // `dequeueNextTask` tick. `generateTasksMarkdown` interpolates the full
-    // `task.description` onto a single line (taskParser.js:268) and
-    // `parseTasksMarkdown` only matches the first line of a `- [ ]` block —
-    // so any newline in `description` corrupts the file (stray `## Phase`
-    // lines become section headers, `- ` lines become new tasks) AND silently
-    // strips the Phase 1–7 instructions on the re-read. Task metadata is
-    // newline-escaped via `escapeNewlines`/`unescapeNewlines` (JSON-sentinel
-    // encoding) so it round-trips losslessly. The agent prompt builder
-    // (`cos-agent-briefing.md` + the built-in fallback in
-    // `agentPromptBuilder.js`) renders both `task.description` AND the task's
-    // context block into the agent's prompt, so the agent still sees the full
-    // Phase 1–7 body.
-    //
-    // The payload lands in `metadata.prompt`, NOT `metadata.context` (#4153):
-    // `context` is the one-line human note, and overloading it made a
-    // multi-thousand-character agent prompt indistinguishable from one. Readers
-    // go through `getTaskPrompt` (server/lib/cosTaskPrompt.js), which falls back
-    // to `metadata.context` for tasks written before the split.
-    // Keep the queue-path normalization visible here as well as in the
-    // install-wide helper: COS-TASKS.md is a single-line format, and the
-    // queue contract is source-checked by the scheduler tests.
-    if (typeof task.description === 'string' && task.description.includes('\n')) {
-      task.metadata = task.metadata || {};
-      task.metadata.prompt = task.description;
-      task.description = firstLine(task.description);
-    }
-
+    // Queue path: addTask's raw branch persists the task through COS-TASKS.md,
+    // which folds multi-line descriptions to first line + full body in
+    // metadata.prompt (#4153). On-demand path: emits unpersisted task on
+    // task:ready, renders full description via getTaskPrompt.
     const newTask = await addTask(task, 'internal', { raw: true, ignoreTaskId, suppressDequeue: true });
     if (newTask?.duplicate) continue;
     await recordDeferredPerpetualDispatch(task, taskSchedule);

--- a/server/services/cosTaskGenerator.test.js
+++ b/server/services/cosTaskGenerator.test.js
@@ -1391,10 +1391,12 @@ describe('buildImprovementDedupSets (#2614 — failure-blocked tasks occupy thei
     expect(queued).toBe(1);
     expect(generateTask).toHaveBeenCalledTimes(1);
     expect(persistTask).toHaveBeenCalledTimes(1);
+    // Generator passes the full multi-line description to the store; the store
+    // folds it into description: firstLine + metadata.prompt: full body (#6838).
     expect(persistTask.mock.calls[0][0]).toMatchObject({
       id: expect.stringMatching(/^sys-install-user-action-review-/),
-      description: 'Global task',
-      metadata: { prompt: 'Global task\nwith full prompt' }
+      description: 'Global task\nwith full prompt',
+      metadata: {}
     });
     expect(recordExecution).toHaveBeenCalledTimes(1);
     expect(recordExecution).toHaveBeenCalledWith('task:user-action-review');

--- a/server/services/cosTaskStore.test.js
+++ b/server/services/cosTaskStore.test.js
@@ -562,6 +562,29 @@ describe('cosTaskStore.addTask', () => {
       expect(created.metadata).toHaveProperty('prompt', '');
     });
 
+    it('preserves a producer-written prompt over the description when both are present', async () => {
+      // When a task carries both a multi-line description AND an explicit
+      // metadata.prompt, the producer's prompt wins — the description is still
+      // collapsed to first line for COS-TASKS.md serialization, but the prompt
+      // field is not overwritten.
+      const producerPrompt = 'Custom agent instructions for Example App';
+      const fullDescription = 'Audit task\n\nThis is the task body\nthat should be ignored.';
+      const created = await addTask({
+        id: 'task-producer-prompt-wins',
+        status: 'pending',
+        priority: 'MEDIUM',
+        priorityValue: 2,
+        description: fullDescription,
+        metadata: { prompt: producerPrompt },
+        section: 'pending',
+      }, 'internal', { raw: true });
+      expect(created.description).toBe('Audit task');
+      expect(created.metadata.prompt).toBe(producerPrompt);
+      const reloaded = await getTaskById('task-producer-prompt-wins');
+      expect(reloaded.description).toBe('Audit task');
+      expect(reloaded.metadata.prompt).toBe(producerPrompt);
+    });
+
     it('leaves a one-line human note on metadata.context', async () => {
       const created = await addTask({ description: 'job', id: 'task-note', context: 'Manually triggered job: nightly' }, 'user');
       expect(created.metadata.context).toBe('Manually triggered job: nightly');


### PR DESCRIPTION
## Summary

- Remove two duplicate implementations of the multi-line description fold from `cosTaskGenerator.js` — the store owns this rule (#4153)
- Replace vacuous source-text grep assertions in `cos.test.js` with a behavioral boundary test at the store
- Update generator test to expect unfolded description (fold now happens in store, not generator)

## Test plan

- `cosTaskStore.test.js`: 170 tests pass (added 1 new boundary test for producer-prompt-wins rule)
- `cosTaskGenerator.test.js`: 154 tests pass (updated expectations to match new fold ownership)
- `cos.test.js`: 151 tests pass (removed source grep, kept getTaskDescription assertion)
- Full server suite: 2133 test files passed, 42721 tests passed
- Mutation check: new test fails when fold disabled in cosTaskStore.js:376, passes when restored
- OpenCode review: clean, no findings, 65227ms

## Remaining scope

None.

Closes #6838
