### PR TITLE
drive the peer-sync push envelope's strip/pending/withhold lifecycle off one extension table (#6844)

### DIFF
--- a/server/services/sharing/peerSync.test.js
+++ b/server/services/sharing/peerSync.test.js
@@ -250,6 +250,7 @@ import {
 } from './peerSync.js';
 
 import { buildPushPayload } from './peerSyncPush.js';
+import { ENVELOPE_EXTENSIONS } from './peerSyncShared.js';
 import { getPeers } from '../instances.js';
 import { getInstanceId } from '../instanceIdentity.js';
 import { getUniverse, mergeUniversesFromSync, listUniverses } from '../universeBuilder.js';
@@ -4624,6 +4625,269 @@ describe('peerSync', () => {
   // -------------------------------------------------------------------------
   // mediaCollection push + receiver
   // -------------------------------------------------------------------------
+  // -------------------------------------------------------------------------
+  // #6844 — the optional envelope keys share ONE strip / pending / withhold
+  // lifecycle, declared once in ENVELOPE_EXTENSIONS. Every case below is driven
+  // off that table so a row added later is exercised on both sides of the wire
+  // without a hand-written twin of each flag.
+  describe('envelope extensions (#6844)', () => {
+    const SIDECARS = ENVELOPE_EXTENSIONS.filter((e) => e.pendingKey);
+    const SELF_RECONCILING = ENVELOPE_EXTENSIONS.filter((e) => !e.pendingKey);
+    const PENDING_KEYS = SIDECARS.map((e) => e.pendingKey);
+
+    const legacyRejects = (key) => {
+      const rejection = { ok: false, status: 400, json: async () => ({
+        code: 'VALIDATION_ERROR',
+        message: 'Validation failed',
+        context: { details: [{ path: '', message: `Unrecognized key(s) in object: '${key}'` }] },
+      }) };
+      rejection.clone = () => rejection;
+      return rejection;
+    };
+    const accepts = (body = {}) => ({ ok: true, status: 200, json: async () => body });
+    // A peer whose strict schema predates `key`: rejects every push carrying
+    // it, accepts the stripped retry.
+    const mockPeerRejecting = (key) => {
+      vi.mocked(peerFetch).mockImplementation(async (_url, init) => (
+        key in JSON.parse(init.body) ? legacyRejects(key) : accepts()
+      ));
+    };
+    const armSeries = () => {
+      vi.mocked(getSeries).mockResolvedValue({ id: 's1', name: 'Series' });
+      vi.mocked(listIssuesForSeries).mockResolvedValue([{ id: 'i1', seriesId: 's1', number: 1 }]);
+    };
+    // How the sender comes to carry each key on the wire. Every table row MUST
+    // have a carrier (guarded below) — that is what makes this suite grow with
+    // the table instead of silently skipping a new extension.
+    const CARRIERS = {
+      portosMeta: {
+        recordKind: 'universe', recordId: 'u1',
+        arm: async () => { vi.mocked(getUniverse).mockResolvedValue({ id: 'u1', name: 'Foo' }); },
+      },
+      catalogBundle: {
+        recordKind: 'universe', recordId: 'u1',
+        arm: async () => {
+          vi.mocked(getBackendName).mockReturnValue('postgres');
+          vi.mocked(getUniverse).mockResolvedValue({ id: 'u1', name: 'Foo' });
+          vi.mocked(getCatalogBundleForRef).mockResolvedValue({
+            ingredients: [{ id: 'cat-chr-1', type: 'character', name: 'Hero', updatedAt: '2026-01-02T00:00:00Z' }],
+            refs: [{ ingredientId: 'cat-chr-1', refKind: 'universe', refId: 'u1', role: 'canon-character', createdAt: '2026-01-02T00:00:00Z' }],
+          });
+        },
+      },
+      manuscriptReview: {
+        recordKind: 'series', recordId: 's1',
+        arm: async () => {
+          armSeries();
+          vi.mocked(getReview).mockResolvedValue({
+            schemaVersion: 1,
+            comments: [{ id: 'mrc-1', problem: 'pacing', status: 'open', updatedAt: '2026-06-02T00:00:00Z' }],
+          });
+        },
+      },
+      reverseOutline: {
+        recordKind: 'series', recordId: 's1',
+        arm: async () => {
+          armSeries();
+          vi.mocked(getStoredOutline).mockResolvedValue({
+            seriesId: 's1', schemaVersion: 1, status: 'complete', generatedAt: '2026-06-02T00:00:00Z',
+            plotlines: [{ id: 'a', label: 'A', kind: 'main', color: '#3b82f6' }],
+            scenes: [{ id: 'scene-001', sequence: 0, summary: 'opening', plotlineId: 'a' }],
+          });
+        },
+      },
+      linkedTrack: {
+        recordKind: 'musicVideoProject', recordId: 'mv-1',
+        arm: async () => {
+          vi.mocked(getPeers).mockResolvedValue([{
+            instanceId: 'peer-a', name: 'Peer A', host: null, address: '10.0.0.2', port: 5555,
+            enabled: true, syncEnabled: true, directions: ['outbound', 'inbound'],
+            syncCategories: { musicVideoProjects: true },
+          }]);
+          await writeFile(join(PATHS.music, 'linked.mp3'), Buffer.from('linked track audio'));
+          vi.mocked(getTrack).mockResolvedValue({
+            id: 'track-1', title: 'Anthem', audioFilename: 'linked.mp3',
+            updatedAt: '2026-06-28T00:00:00Z', deleted: false, deletedAt: null,
+          });
+          vi.mocked(getMusicVideoProject).mockResolvedValue({
+            id: 'mv-1', name: 'Linked', mode: 'director', trackId: 'track-1',
+            uploadedAudioFilename: null, scenes: [],
+            updatedAt: '2026-06-28T00:00:00Z', deleted: false, deletedAt: null,
+          });
+        },
+      },
+    };
+    const claim = ({ recordKind, recordId }) => subscribePeer(
+      { peerId: 'peer-a', recordKind, recordId },
+      { adoptedFromReverse: true },
+    );
+    const refresh = ({ recordKind, recordId }) => findPeerSubscription('peer-a', recordKind, recordId);
+    const payloadOf = (call) => JSON.parse(call[1].body);
+
+    it('pins the wire vocabulary older peers depend on', () => {
+      // Older senders and receivers read exactly these names off the wire — a
+      // rename here is a cross-version break, not a refactor.
+      expect(ENVELOPE_EXTENSIONS.map(({ key, pendingKey }) => [key, pendingKey])).toEqual([
+        ['portosMeta', null],
+        ['catalogBundle', null],
+        ['manuscriptReview', 'reviewSyncPending'],
+        ['reverseOutline', 'outlineSyncPending'],
+        ['linkedTrack', 'trackSyncPending'],
+      ]);
+      expect(Object.isFrozen(ENVELOPE_EXTENSIONS)).toBe(true);
+    });
+
+    it('has a sender-side carrier for every table row (a new extension must be exercised here)', () => {
+      expect(Object.keys(CARRIERS).sort()).toEqual(ENVELOPE_EXTENSIONS.map((e) => e.key).sort());
+    });
+
+    describe.each(ENVELOPE_EXTENSIONS)('$key — strip', ({ key }) => {
+      it('is dropped — and only it — on the one retry a legacy peer\'s strict-schema 400 earns', async () => {
+        const carrier = CARRIERS[key];
+        await carrier.arm();
+        mockPeerRejecting(key);
+        const result = await pushRecordToPeer(await claim(carrier));
+        expect(result.pushed).toBe(true);
+        const calls = vi.mocked(peerFetch).mock.calls;
+        expect(calls).toHaveLength(2);
+        const first = payloadOf(calls[0]);
+        const retry = payloadOf(calls[1]);
+        expect(first[key]).toBeDefined();
+        expect(retry[key]).toBeUndefined();
+        // Surgical: every other extension the first push carried survives, so
+        // a peer that supports portosMeta but not this key keeps its handshake.
+        for (const other of ENVELOPE_EXTENSIONS) {
+          if (other.key !== key && other.key in first) expect(retry[other.key]).toEqual(first[other.key]);
+        }
+        expect(retry.record.id).toBe(carrier.recordId);
+      });
+    });
+
+    describe.each(SIDECARS)('$key — no independent cycle ($pendingKey)', ({ key, pendingKey }) => {
+      it('withholds lastPushedHash and water-marks lastPushedLegacyHash after a stripped push (#3928)', async () => {
+        const carrier = CARRIERS[key];
+        await carrier.arm();
+        mockPeerRejecting(key);
+        const result = await pushRecordToPeer(await claim(carrier));
+        expect(result.pushed).toBe(true);
+        const refreshed = await refresh(carrier);
+        expect(refreshed.lastPushedHash).toBeFalsy();
+        expect(refreshed.lastPushedLegacyHash).toBe(result.hash);
+        // An unchanged record settles instead of re-running the 400 + retry pair.
+        const second = await pushRecordToPeer(refreshed);
+        expect(second.reason).toBe('unchanged-legacy-stripped');
+        expect(vi.mocked(peerFetch).mock.calls).toHaveLength(2);
+      });
+
+      it('withholds the hash WITHOUT a legacy water-mark when the receiver reports it pending (transient merge failure)', async () => {
+        const carrier = CARRIERS[key];
+        await carrier.arm();
+        vi.mocked(peerFetch).mockResolvedValue(accepts({ [pendingKey]: true }));
+        const result = await pushRecordToPeer(await claim(carrier));
+        expect(result.pushed).toBe(true);
+        expect(vi.mocked(peerFetch).mock.calls).toHaveLength(1);
+        const refreshed = await refresh(carrier);
+        expect(refreshed.lastPushedHash).toBeFalsy();
+        expect(refreshed.lastPushedLegacyHash).toBeFalsy();
+        // The next cycle must genuinely re-push, not short-circuit.
+        vi.mocked(peerFetch).mockClear();
+        vi.mocked(peerFetch).mockResolvedValue(accepts());
+        const second = await pushRecordToPeer(refreshed);
+        expect(second.pushed).toBe(true);
+        expect(vi.mocked(peerFetch).mock.calls).toHaveLength(1);
+      });
+    });
+
+    describe.each(SELF_RECONCILING)('$key — own reconciliation cycle', ({ key }) => {
+      it('saves lastPushedHash normally after a stripped push (nothing is owed through this hash)', async () => {
+        const carrier = CARRIERS[key];
+        await carrier.arm();
+        mockPeerRejecting(key);
+        const result = await pushRecordToPeer(await claim(carrier));
+        expect(result.pushed).toBe(true);
+        const refreshed = await refresh(carrier);
+        expect(refreshed.lastPushedHash).toBe(result.hash);
+        expect(refreshed.lastPushedLegacyHash).toBeFalsy();
+        const second = await pushRecordToPeer(refreshed);
+        expect(second.reason).toBe('unchanged');
+      });
+    });
+
+    it('leaves the bundled-track GC floor unstamped when linkedTrack was stripped for a legacy peer (#1922)', async () => {
+      // The project landed (its own confirmed floor advances) but the peer
+      // never got the track, so the bundle-specific floor tombstoneGc's
+      // `track` cutoff reads off musicVideoProject rows must stay unset.
+      const carrier = CARRIERS.linkedTrack;
+      await carrier.arm();
+      mockPeerRejecting('linkedTrack');
+      const sub = await claim(carrier);
+      expect(sub.lastConfirmedTrackBundleAtMs).toBeNull();
+      const result = await pushRecordToPeer(sub);
+      expect(result.pushed).toBe(true);
+      const refreshed = await refresh(carrier);
+      expect(refreshed.lastConfirmedPushedAt).toBeTruthy();
+      expect(refreshed.lastConfirmedTrackBundleAtMs).toBeNull();
+    });
+
+    describe('receiver — applyIncomingPush', () => {
+      // How each sidecar reaches the receiver, and the merge that can throw.
+      const RECEIVE_CARRIERS = {
+        manuscriptReview: {
+          merge: mergeReviewFromSync,
+          payload: () => ({
+            kind: 'series',
+            record: { id: 's1', name: 'S', deleted: false, deletedAt: null },
+            issues: [],
+            manuscriptReview: { schemaVersion: 1, comments: [{ id: 'mrc-1', problem: 'x', status: 'open', updatedAt: '2026-06-02T00:00:00Z' }] },
+            assetManifest: [],
+            sourceInstanceId: 'peer-a',
+          }),
+        },
+        reverseOutline: {
+          merge: mergeOutlineFromSync,
+          payload: () => ({
+            kind: 'series',
+            record: { id: 's1', name: 'S', deleted: false, deletedAt: null },
+            issues: [],
+            reverseOutline: {
+              schemaVersion: 1, status: 'complete', generatedAt: '2026-06-02T00:00:00Z',
+              plotlines: [{ id: 'a', label: 'A', kind: 'main' }],
+              scenes: [{ id: 'scene-001', sequence: 0, summary: 'opening', plotlineId: 'a' }],
+            },
+            assetManifest: [],
+            sourceInstanceId: 'peer-a',
+          }),
+        },
+        linkedTrack: {
+          merge: mergeTracksFromSync,
+          payload: () => ({
+            kind: 'musicVideoProject',
+            record: { id: 'mv-9', trackId: 'track-9', deleted: false, deletedAt: null },
+            linkedTrack: { id: 'track-9', audioFilename: 'linked.mp3' },
+            assetManifest: [],
+            sourceInstanceId: 'peer-a',
+          }),
+        },
+      };
+
+      it('has a receiver-side carrier for every sidecar row', () => {
+        expect(Object.keys(RECEIVE_CARRIERS).sort()).toEqual(SIDECARS.map((e) => e.key).sort());
+      });
+
+      it.each(SIDECARS)('raises exactly $pendingKey when the bundled $key merge throws, and no flag when it succeeds', async ({ key, pendingKey }) => {
+        const { merge, payload } = RECEIVE_CARRIERS[key];
+        const clean = await applyIncomingPush(payload());
+        for (const flag of PENDING_KEYS) expect(clean).not.toHaveProperty(flag);
+        vi.mocked(merge).mockRejectedValueOnce(new Error('disk full'));
+        const failed = await applyIncomingPush(payload());
+        expect(failed[pendingKey]).toBe(true);
+        for (const flag of PENDING_KEYS) {
+          if (flag !== pendingKey) expect(failed).not.toHaveProperty(flag);
+        }
+      });
+    });
+  });
+
   describe('collectCollectionAssetReferences', () => {
     it('maps items to image/video refs with an empty directImageRefFilenames', () => {
       const refs = collectCollectionAssetReferences({ items: [

--- a/server/services/sharing/peerSync.test.js
+++ b/server/services/sharing/peerSync.test.js
@@ -250,7 +250,7 @@ import {
 } from './peerSync.js';
 
 import { buildPushPayload } from './peerSyncPush.js';
-import { ENVELOPE_EXTENSIONS } from './peerSyncShared.js';
+import { ENVELOPE_EXTENSIONS, ENVELOPE_PENDING_KEYS } from './peerSyncShared.js';
 import { getPeers } from '../instances.js';
 import { getInstanceId } from '../instanceIdentity.js';
 import { getUniverse, mergeUniversesFromSync, listUniverses } from '../universeBuilder.js';
@@ -440,6 +440,40 @@ afterEach(async () => {
     PATHS.videos = originalVideosPath;
     PATHS.music = originalMusicPath;
   }
+});
+
+// A receiver whose strict schema predates `key`: the 400 Zod emits for an
+// unrecognized envelope key.
+const legacyRejectsKey = (key) => {
+  const rejection = { ok: false, status: 400, json: async () => ({
+    code: 'VALIDATION_ERROR',
+    message: 'Validation failed',
+    context: { details: [{ path: '', message: `Unrecognized key(s) in object: '${key}'` }] },
+  }) };
+  rejection.clone = () => rejection;
+  return rejection;
+};
+const acceptsPush = (body = {}) => ({ ok: true, status: 200, json: async () => body });
+// A legacy peer for `key`: rejects every push carrying it, accepts the
+// stripped retry.
+const mockPeerRejecting = (key) => {
+  vi.mocked(peerFetch).mockImplementation(async (_url, init) => (
+    key in JSON.parse(init.body) ? legacyRejectsKey(key) : acceptsPush()
+  ));
+};
+// The default peer fixture carries no musicVideoProjects category; music-video
+// pushes need this opt-in or peerHasCategory short-circuits them.
+const enableMusicVideoPeer = () => {
+  vi.mocked(getPeers).mockResolvedValue([{
+    instanceId: 'peer-a', name: 'Peer A', host: null, address: '10.0.0.2', port: 5555,
+    enabled: true, syncEnabled: true, directions: ['outbound', 'inbound'],
+    syncCategories: { musicVideoProjects: true },
+  }]);
+};
+const sampleOutline = (generatedAt = '2026-06-02T00:00:00Z') => ({
+  schemaVersion: 1, status: 'complete', generatedAt,
+  plotlines: [{ id: 'a', label: 'A', kind: 'main' }],
+  scenes: [{ id: 'scene-001', sequence: 0, summary: 'opening', plotlineId: 'a' }],
 });
 
 describe('peerSync', () => {
@@ -2104,30 +2138,6 @@ describe('peerSync', () => {
       expect(peerFetch).toHaveBeenCalledTimes(1);
     });
 
-    it('withholds lastPushedHash when the receiver reports reviewSyncPending (so the next cycle re-sends)', async () => {
-      vi.mocked(getSeries).mockResolvedValue({ id: 's1', name: 'Series' });
-      vi.mocked(getReview).mockResolvedValue({
-        schemaVersion: 1,
-        comments: [{ id: 'mrc-1', problem: 'pacing', status: 'open', updatedAt: '2026-06-02T00:00:00Z' }],
-      });
-      // Receiver merged the record but its review merge threw → reviewSyncPending.
-      vi.mocked(peerFetch).mockResolvedValue({ ok: true, json: async () => ({ reviewSyncPending: true }) });
-      const sub = await subscribePeer(
-        { peerId: 'peer-a', recordKind: 'series', recordId: 's1' },
-        { adoptedFromReverse: true },
-      );
-      const r = await pushRecordToPeer(sub);
-      expect(r.pushed).toBe(true);
-      // Hash withheld → a subsequent push with identical content is NOT a no-op.
-      const refreshed = await findPeerSubscription('peer-a', 'series', 's1');
-      expect(refreshed.lastPushedHash).toBeFalsy();
-      vi.mocked(peerFetch).mockClear();
-      vi.mocked(peerFetch).mockResolvedValue({ ok: true, json: async () => ({}) });
-      const second = await pushRecordToPeer(refreshed);
-      expect(second.reason).not.toBe('unchanged');
-      expect(peerFetch).toHaveBeenCalledTimes(1);
-    });
-
     it('bundles the linked media collection with a universe push so collection-only edits propagate', async () => {
       // Regression: collection items[] adds emit recordEvents.updated('universe', id)
       // but the universe record content itself doesn't change, so the
@@ -2549,14 +2559,6 @@ describe('peerSync', () => {
     });
 
     // --- Music Video project media federation (#1772) ---
-    const enableMusicVideoPeer = () => {
-      vi.mocked(getPeers).mockResolvedValue([{
-        instanceId: 'peer-a', name: 'Peer A', host: null, address: '10.0.0.2', port: 5555,
-        enabled: true, syncEnabled: true, directions: ['outbound', 'inbound'],
-        syncCategories: { musicVideoProjects: true },
-      }]);
-    };
-
     it('bundles uploaded audio + rendered scene clips + reference-frame stills for a music video project push', async () => {
       // #1772: the project record federated but shipped an empty manifest, so a
       // selectively-subscribed peer never received the referenced media. Audio
@@ -3077,21 +3079,6 @@ describe('peerSync', () => {
       expect(mergeTracksFromSync).not.toHaveBeenCalled();
     });
 
-    it('signals trackSyncPending when the bundled linkedTrack merge fails (#1858)', async () => {
-      // The linked track has no independent reconciliation cycle for a
-      // musicVideoProjects-only subscriber, so a swallowed failure must surface
-      // a pending flag that makes the sender withhold its hash and re-send.
-      vi.mocked(mergeTracksFromSync).mockRejectedValueOnce(new Error('disk full'));
-      const res = await applyIncomingPush({
-        kind: 'musicVideoProject',
-        record: { id: 'mv-9', trackId: 'track-9', deleted: false, deletedAt: null },
-        linkedTrack: { id: 'track-9', audioFilename: 'linked.mp3' },
-        assetManifest: [],
-        sourceInstanceId: 'peer-a',
-      });
-      expect(res.trackSyncPending).toBe(true);
-    });
-
     it('routes a bundled manuscriptReview through mergeReviewFromSync on a series push', async () => {
       const manuscriptReview = {
         schemaVersion: 1,
@@ -3144,27 +3131,6 @@ describe('peerSync', () => {
       expect(mergeReviewFromSync).not.toHaveBeenCalled();
     });
 
-    it('returns reviewSyncPending when the bundled review merge throws (so the sender retries)', async () => {
-      vi.mocked(mergeReviewFromSync).mockRejectedValueOnce(new Error('disk full'));
-      const res = await applyIncomingPush({
-        kind: 'series',
-        record: { id: 's1', name: 'S', deleted: false, deletedAt: null },
-        issues: [],
-        manuscriptReview: { schemaVersion: 1, comments: [{ id: 'mrc-1', problem: 'x', status: 'open', updatedAt: '2026-06-02T00:00:00Z' }] },
-        assetManifest: [],
-        sourceInstanceId: 'peer-a',
-      });
-      // The series/issues merge still succeeded — the push isn't failed — but
-      // the sender is told to withhold its hash and retry the review.
-      expect(res.reviewSyncPending).toBe(true);
-    });
-
-    const sampleOutline = (generatedAt = '2026-06-02T00:00:00Z') => ({
-      schemaVersion: 1, status: 'complete', generatedAt,
-      plotlines: [{ id: 'a', label: 'A', kind: 'main' }],
-      scenes: [{ id: 'scene-001', sequence: 0, summary: 'opening', plotlineId: 'a' }],
-    });
-
     it('routes a bundled reverseOutline through mergeOutlineFromSync on a series push', async () => {
       const reverseOutline = sampleOutline();
       await applyIncomingPush({
@@ -3212,21 +3178,6 @@ describe('peerSync', () => {
         sourceInstanceId: 'peer-a',
       });
       expect(mergeOutlineFromSync).not.toHaveBeenCalled();
-    });
-
-    it('returns outlineSyncPending when the bundled outline merge throws (so the sender retries)', async () => {
-      vi.mocked(mergeOutlineFromSync).mockRejectedValueOnce(new Error('disk full'));
-      const res = await applyIncomingPush({
-        kind: 'series',
-        record: { id: 's1', name: 'S', deleted: false, deletedAt: null },
-        issues: [],
-        reverseOutline: sampleOutline(),
-        assetManifest: [],
-        sourceInstanceId: 'peer-a',
-      });
-      // Series/issues merge still succeeded — the outline has no independent
-      // reconciliation path, so the sender withholds its hash and retries.
-      expect(res.outlineSyncPending).toBe(true);
     });
 
     it('refuses to merge linkedCollection when the incoming record is a tombstone', async () => {
@@ -4220,225 +4171,13 @@ describe('peerSync', () => {
         expect(cleared.lastPushedHash).toBeTruthy(); // succeeded → hash recorded
       });
 
-      it('falls back without portosMeta when the peer is on a pre-version-gate PortOS (strict schema 400)', async () => {
-        // Pre-version-gate receiver: its `peerSyncPushSchema` is `.strict()`
-        // and has no `portosMeta` field, so it rejects our envelope as a
-        // generic VALIDATION_ERROR before any schema-gate logic. The sender
-        // must detect that specific shape, strip portosMeta, and retry —
-        // otherwise universe/series pushes to not-yet-upgraded peers fail
-        // hard and silently during a federation rollout.
-        vi.mocked(getUniverse).mockResolvedValue({ id: 'u1', name: 'Foo' });
-        const firstCallBody = { ok: false, status: 400, json: async () => ({
-          code: 'VALIDATION_ERROR',
-          message: 'Validation failed',
-          context: { details: [{ path: '', message: "Unrecognized key(s) in object: 'portosMeta'" }] },
-        }) };
-        firstCallBody.clone = () => firstCallBody;
-        const retryBody = { ok: true, status: 200, json: async () => ({}) };
-        vi.mocked(peerFetch)
-          .mockResolvedValueOnce(firstCallBody)
-          .mockResolvedValueOnce(retryBody);
-        const sub = await subscribePeer({
-          peerId: 'peer-a', recordKind: 'universe', recordId: 'u1',
-        }, { adoptedFromReverse: true });
-        const result = await pushRecordToPeer(sub);
-        expect(result.pushed).toBe(true);
-        // Two network calls: the failed validating one + the retry without portosMeta.
-        const calls = vi.mocked(peerFetch).mock.calls;
-        expect(calls.length).toBe(2);
-        const firstPayload = JSON.parse(calls[0][1].body);
-        const retryPayload = JSON.parse(calls[1][1].body);
-        expect(firstPayload.portosMeta).toBeDefined();
-        expect(retryPayload.portosMeta).toBeUndefined();
-        // Record content is preserved across the retry.
-        expect(retryPayload.record.id).toBe('u1');
-        expect(retryPayload.sourceInstanceId).toBe(firstPayload.sourceInstanceId);
-      });
-
-      it('falls back without catalogBundle when an older peer rejects the new key, keeping portosMeta', async () => {
-        // A peer that supports portosMeta but predates catalog federation
-        // rejects the new `catalogBundle` key with a strict VALIDATION_ERROR.
-        // The sender must strip ONLY catalogBundle (not portosMeta, which the
-        // peer supports) and retry, so the universe push still lands — the
-        // receiver re-derives the catalog enrichments from the embedded canon.
-        vi.mocked(getBackendName).mockReturnValue('postgres');
-        vi.mocked(getUniverse).mockResolvedValue({ id: 'u1', name: 'Foo' });
-        vi.mocked(getCatalogBundleForRef).mockResolvedValue({
-          ingredients: [{ id: 'cat-chr-1', type: 'character', name: 'Hero', updatedAt: '2026-01-02T00:00:00Z' }],
-          refs: [{ ingredientId: 'cat-chr-1', refKind: 'universe', refId: 'u1', role: 'canon-character', createdAt: '2026-01-02T00:00:00Z' }],
-        });
-        const firstCallBody = { ok: false, status: 400, json: async () => ({
-          code: 'VALIDATION_ERROR',
-          message: 'Validation failed',
-          context: { details: [{ path: '', message: "Unrecognized key(s) in object: 'catalogBundle'" }] },
-        }) };
-        firstCallBody.clone = () => firstCallBody;
-        const retryBody = { ok: true, status: 200, json: async () => ({}) };
-        vi.mocked(peerFetch).mockResolvedValueOnce(firstCallBody).mockResolvedValueOnce(retryBody);
-        const sub = await subscribePeer({
-          peerId: 'peer-a', recordKind: 'universe', recordId: 'u1',
-        }, { adoptedFromReverse: true });
-        const result = await pushRecordToPeer(sub);
-        expect(result.pushed).toBe(true);
-        const calls = vi.mocked(peerFetch).mock.calls;
-        expect(calls.length).toBe(2);
-        const firstPayload = JSON.parse(calls[0][1].body);
-        const retryPayload = JSON.parse(calls[1][1].body);
-        expect(firstPayload.catalogBundle).toBeDefined();
-        expect(retryPayload.catalogBundle).toBeUndefined();
-        // Surgical strip: portosMeta survives because the peer didn't reject it.
-        expect(retryPayload.portosMeta).toBeDefined();
-        expect(retryPayload.record.id).toBe('u1');
-      });
-
-      it('falls back without manuscriptReview when a pre-feature peer rejects the new key, keeping series + issues', async () => {
-        // A pre-manuscript-review-sync peer's seriesPushSchema is still
-        // `.strict()` without `manuscriptReview`, so it 400-rejects a review-
-        // bearing series push. The sender must strip ONLY manuscriptReview and
-        // retry so the series + issues still land (the review reaches the peer
-        // once it upgrades). This is what makes the review's "degrades
-        // gracefully on older peers" contract hold.
-        vi.mocked(getSeries).mockResolvedValue({ id: 's1', name: 'Series' });
-        vi.mocked(listIssuesForSeries).mockResolvedValue([{ id: 'i1', seriesId: 's1', number: 1 }]);
-        vi.mocked(getReview).mockResolvedValue({
-          schemaVersion: 1,
-          comments: [{ id: 'mrc-1', problem: 'pacing', status: 'open', updatedAt: '2026-06-02T00:00:00Z' }],
-        });
-        const firstCallBody = { ok: false, status: 400, json: async () => ({
-          code: 'VALIDATION_ERROR',
-          message: 'Validation failed',
-          context: { details: [{ path: '', message: "Unrecognized key(s) in object: 'manuscriptReview'" }] },
-        }) };
-        firstCallBody.clone = () => firstCallBody;
-        const retryBody = { ok: true, status: 200, json: async () => ({}) };
-        vi.mocked(peerFetch).mockResolvedValueOnce(firstCallBody).mockResolvedValueOnce(retryBody);
-        const sub = await subscribePeer({
-          peerId: 'peer-a', recordKind: 'series', recordId: 's1',
-        }, { adoptedFromReverse: true });
-        const result = await pushRecordToPeer(sub);
-        expect(result.pushed).toBe(true);
-        const calls = vi.mocked(peerFetch).mock.calls;
-        expect(calls.length).toBe(2);
-        const firstPayload = JSON.parse(calls[0][1].body);
-        const retryPayload = JSON.parse(calls[1][1].body);
-        expect(firstPayload.manuscriptReview).toBeDefined();
-        expect(retryPayload.manuscriptReview).toBeUndefined();
-        // Surgical strip: portosMeta survives, and the series + issues still land.
-        expect(retryPayload.portosMeta).toBeDefined();
-        expect(retryPayload.record.id).toBe('s1');
-        expect(retryPayload.issues).toHaveLength(1);
-        // Hash withheld so the review re-sends once the peer upgrades (the
-        // retry landed with the review stripped, so saving the full-payload
-        // hash would short-circuit the next push as 'unchanged').
-        const refreshed = await findPeerSubscription('peer-a', 'series', 's1');
-        expect(refreshed.lastPushedHash).toBeFalsy();
-      });
-
-      it('falls back without reverseOutline when a pre-#1348 peer rejects the new key, keeping series + issues', async () => {
-        // Same graceful-degradation contract as the manuscriptReview strip above:
-        // a pre-#1348 peer's `.strict()` series schema 400-rejects the
-        // reverseOutline key, so the sender strips ONLY it and retries, then
-        // withholds the hash so the outline re-sends once the peer upgrades.
-        vi.mocked(getSeries).mockResolvedValue({ id: 's1', name: 'Series' });
-        vi.mocked(listIssuesForSeries).mockResolvedValue([{ id: 'i1', seriesId: 's1', number: 1 }]);
-        vi.mocked(getStoredOutline).mockResolvedValue({
-          seriesId: 's1', schemaVersion: 1, status: 'complete', generatedAt: '2026-06-02T00:00:00Z',
-          plotlines: [{ id: 'a', label: 'A', kind: 'main', color: '#3b82f6' }],
-          scenes: [{ id: 'scene-001', sequence: 0, summary: 'opening', plotlineId: 'a' }],
-        });
-        const firstCallBody = { ok: false, status: 400, json: async () => ({
-          code: 'VALIDATION_ERROR',
-          message: 'Validation failed',
-          context: { details: [{ path: '', message: "Unrecognized key(s) in object: 'reverseOutline'" }] },
-        }) };
-        firstCallBody.clone = () => firstCallBody;
-        const retryBody = { ok: true, status: 200, json: async () => ({}) };
-        vi.mocked(peerFetch).mockResolvedValueOnce(firstCallBody).mockResolvedValueOnce(retryBody);
-        const sub = await subscribePeer({
-          peerId: 'peer-a', recordKind: 'series', recordId: 's1',
-        }, { adoptedFromReverse: true });
-        const result = await pushRecordToPeer(sub);
-        expect(result.pushed).toBe(true);
-        const calls = vi.mocked(peerFetch).mock.calls;
-        expect(calls.length).toBe(2);
-        const firstPayload = JSON.parse(calls[0][1].body);
-        const retryPayload = JSON.parse(calls[1][1].body);
-        expect(firstPayload.reverseOutline).toBeDefined();
-        expect(retryPayload.reverseOutline).toBeUndefined();
-        // Surgical strip: portosMeta + series + issues still land.
-        expect(retryPayload.portosMeta).toBeDefined();
-        expect(retryPayload.record.id).toBe('s1');
-        expect(retryPayload.issues).toHaveLength(1);
-        // Hash withheld so the outline re-sends once the peer upgrades.
-        const refreshed = await findPeerSubscription('peer-a', 'series', 's1');
-        expect(refreshed.lastPushedHash).toBeFalsy();
-      });
-
       // #3928 — the legacy-stripped water-mark. Withholding `lastPushedHash`
-      // (the two tests above) is what keeps the stripped key deliverable, but
-      // on its own it made EVERY subsequent cycle re-run the 400 +
-      // stripped-retry pair forever. `lastPushedLegacyHash` records the full
-      // payload hash we delivered in stripped form so an unchanged record
-      // settles.
-      const legacyRejectsKey = (key) => {
-        const rejection = { ok: false, status: 400, json: async () => ({
-          code: 'VALIDATION_ERROR',
-          message: 'Validation failed',
-          context: { details: [{ path: '', message: `Unrecognized key(s) in object: '${key}'` }] },
-        }) };
-        rejection.clone = () => rejection;
-        return rejection;
-      };
-      const mockLegacyReviewPeer = () => {
-        // A pre-feature peer: rejects `manuscriptReview` on every full push,
-        // accepts the stripped retry.
-        vi.mocked(peerFetch).mockImplementation(async (_url, init) => (
-          JSON.parse(init.body).manuscriptReview
-            ? legacyRejectsKey('manuscriptReview')
-            : { ok: true, status: 200, json: async () => ({}) }
-        ));
-      };
-
-      it('records lastPushedLegacyHash when a stripped retry lands on a legacy peer (#3928)', async () => {
-        vi.mocked(getSeries).mockResolvedValue({ id: 's1', name: 'Series' });
-        vi.mocked(listIssuesForSeries).mockResolvedValue([{ id: 'i1', seriesId: 's1', number: 1 }]);
-        vi.mocked(getReview).mockResolvedValue({
-          schemaVersion: 1,
-          comments: [{ id: 'mrc-1', problem: 'pacing', status: 'open', updatedAt: '2026-06-02T00:00:00Z' }],
-        });
-        mockLegacyReviewPeer();
-        const sub = await subscribePeer({
-          peerId: 'peer-a', recordKind: 'series', recordId: 's1',
-        }, { adoptedFromReverse: true });
-        const result = await pushRecordToPeer(sub);
-        expect(result.pushed).toBe(true);
-        const refreshed = await findPeerSubscription('peer-a', 'series', 's1');
-        // The review is still owed (hash withheld) but the delivered content
-        // is water-marked so the next cycle can settle.
-        expect(refreshed.lastPushedHash).toBeFalsy();
-        expect(refreshed.lastPushedLegacyHash).toBe(result.hash);
-      });
-
-      it('short-circuits the next cycle as unchanged instead of re-running the 400 + retry pair (#3928)', async () => {
-        vi.mocked(getSeries).mockResolvedValue({ id: 's1', name: 'Series' });
-        vi.mocked(listIssuesForSeries).mockResolvedValue([{ id: 'i1', seriesId: 's1', number: 1 }]);
-        vi.mocked(getReview).mockResolvedValue({
-          schemaVersion: 1,
-          comments: [{ id: 'mrc-1', problem: 'pacing', status: 'open', updatedAt: '2026-06-02T00:00:00Z' }],
-        });
-        mockLegacyReviewPeer();
-        const sub = await subscribePeer({
-          peerId: 'peer-a', recordKind: 'series', recordId: 's1',
-        }, { adoptedFromReverse: true });
-        await pushRecordToPeer(sub);
-        expect(vi.mocked(peerFetch).mock.calls.length).toBe(2); // 400 + stripped retry
-        // Next sync cycle, same content: zero HTTP.
-        const second = await pushRecordToPeer(await findPeerSubscription('peer-a', 'series', 's1'));
-        expect(second.pushed).toBe(false);
-        expect(second.reason).toBe('unchanged-legacy-stripped');
-        expect(vi.mocked(peerFetch).mock.calls.length).toBe(2);
-      });
-
+      // after a strip (pinned per row in 'envelope extensions (#6844)') is what
+      // keeps the stripped key deliverable, but on its own it made EVERY
+      // subsequent cycle re-run the 400 + stripped-retry pair forever.
+      // `lastPushedLegacyHash` records the full payload hash we delivered in
+      // stripped form so an unchanged record settles; these two cases cover
+      // what moves it again.
       it('re-pushes when the bundled review actually changes after a stripped push (#3928)', async () => {
         vi.mocked(getSeries).mockResolvedValue({ id: 's1', name: 'Series' });
         vi.mocked(listIssuesForSeries).mockResolvedValue([{ id: 'i1', seriesId: 's1', number: 1 }]);
@@ -4446,7 +4185,7 @@ describe('peerSync', () => {
           schemaVersion: 1,
           comments: [{ id: 'mrc-1', problem: 'pacing', status: 'open', updatedAt: '2026-06-02T00:00:00Z' }],
         });
-        mockLegacyReviewPeer();
+        mockPeerRejecting('manuscriptReview');
         const sub = await subscribePeer({
           peerId: 'peer-a', recordKind: 'series', recordId: 's1',
         }, { adoptedFromReverse: true });
@@ -4473,7 +4212,7 @@ describe('peerSync', () => {
           schemaVersion: 1,
           comments: [{ id: 'mrc-1', problem: 'pacing', status: 'open', updatedAt: '2026-06-02T00:00:00Z' }],
         });
-        mockLegacyReviewPeer();
+        mockPeerRejecting('manuscriptReview');
         const sub = await subscribePeer({
           peerId: 'peer-a', recordKind: 'series', recordId: 's1',
         }, { adoptedFromReverse: true });
@@ -4492,27 +4231,6 @@ describe('peerSync', () => {
         const refreshed = await findPeerSubscription('peer-a', 'series', 's1');
         expect(refreshed.lastPushedHash).toBe(upgraded.hash);
         expect(refreshed.lastPushedLegacyHash).toBeFalsy();
-      });
-
-      it('does NOT record a legacy hash when the RECEIVER reported the bundled merge failed (#3928)', async () => {
-        // `reviewSyncPending` from the receiver is a transient merge failure,
-        // not a version gap — the next cycle must genuinely re-push.
-        vi.mocked(getSeries).mockResolvedValue({ id: 's1', name: 'Series' });
-        vi.mocked(listIssuesForSeries).mockResolvedValue([{ id: 'i1', seriesId: 's1', number: 1 }]);
-        vi.mocked(getReview).mockResolvedValue({
-          schemaVersion: 1,
-          comments: [{ id: 'mrc-1', problem: 'pacing', status: 'open', updatedAt: '2026-06-02T00:00:00Z' }],
-        });
-        vi.mocked(peerFetch).mockResolvedValue({ ok: true, status: 200, json: async () => ({ reviewSyncPending: true }) });
-        const sub = await subscribePeer({
-          peerId: 'peer-a', recordKind: 'series', recordId: 's1',
-        }, { adoptedFromReverse: true });
-        await pushRecordToPeer(sub);
-        const refreshed = await findPeerSubscription('peer-a', 'series', 's1');
-        expect(refreshed.lastPushedHash).toBeFalsy();
-        expect(refreshed.lastPushedLegacyHash).toBeFalsy();
-        const second = await pushRecordToPeer(refreshed);
-        expect(second.pushed).toBe(true);
       });
 
       it('does NOT retry on a 400 whose validation error is unrelated to portosMeta', async () => {
@@ -4623,9 +4341,6 @@ describe('peerSync', () => {
   });
 
   // -------------------------------------------------------------------------
-  // mediaCollection push + receiver
-  // -------------------------------------------------------------------------
-  // -------------------------------------------------------------------------
   // #6844 — the optional envelope keys share ONE strip / pending / withhold
   // lifecycle, declared once in ENVELOPE_EXTENSIONS. Every case below is driven
   // off that table so a row added later is exercised on both sides of the wire
@@ -4633,25 +4348,8 @@ describe('peerSync', () => {
   describe('envelope extensions (#6844)', () => {
     const SIDECARS = ENVELOPE_EXTENSIONS.filter((e) => e.pendingKey);
     const SELF_RECONCILING = ENVELOPE_EXTENSIONS.filter((e) => !e.pendingKey);
-    const PENDING_KEYS = SIDECARS.map((e) => e.pendingKey);
+    const PENDING_KEYS = Object.values(ENVELOPE_PENDING_KEYS);
 
-    const legacyRejects = (key) => {
-      const rejection = { ok: false, status: 400, json: async () => ({
-        code: 'VALIDATION_ERROR',
-        message: 'Validation failed',
-        context: { details: [{ path: '', message: `Unrecognized key(s) in object: '${key}'` }] },
-      }) };
-      rejection.clone = () => rejection;
-      return rejection;
-    };
-    const accepts = (body = {}) => ({ ok: true, status: 200, json: async () => body });
-    // A peer whose strict schema predates `key`: rejects every push carrying
-    // it, accepts the stripped retry.
-    const mockPeerRejecting = (key) => {
-      vi.mocked(peerFetch).mockImplementation(async (_url, init) => (
-        key in JSON.parse(init.body) ? legacyRejects(key) : accepts()
-      ));
-    };
     const armSeries = () => {
       vi.mocked(getSeries).mockResolvedValue({ id: 's1', name: 'Series' });
       vi.mocked(listIssuesForSeries).mockResolvedValue([{ id: 'i1', seriesId: 's1', number: 1 }]);
@@ -4699,12 +4397,7 @@ describe('peerSync', () => {
       linkedTrack: {
         recordKind: 'musicVideoProject', recordId: 'mv-1',
         arm: async () => {
-          vi.mocked(getPeers).mockResolvedValue([{
-            instanceId: 'peer-a', name: 'Peer A', host: null, address: '10.0.0.2', port: 5555,
-            enabled: true, syncEnabled: true, directions: ['outbound', 'inbound'],
-            syncCategories: { musicVideoProjects: true },
-          }]);
-          await writeFile(join(PATHS.music, 'linked.mp3'), Buffer.from('linked track audio'));
+          enableMusicVideoPeer();
           vi.mocked(getTrack).mockResolvedValue({
             id: 'track-1', title: 'Anthem', audioFilename: 'linked.mp3',
             updatedAt: '2026-06-28T00:00:00Z', deleted: false, deletedAt: null,
@@ -4727,14 +4420,14 @@ describe('peerSync', () => {
     it('pins the wire vocabulary older peers depend on', () => {
       // Older senders and receivers read exactly these names off the wire — a
       // rename here is a cross-version break, not a refactor.
-      expect(ENVELOPE_EXTENSIONS.map(({ key, pendingKey }) => [key, pendingKey])).toEqual([
+      const byKey = (rows) => [...rows].sort((a, b) => a[0].localeCompare(b[0]));
+      expect(byKey(ENVELOPE_EXTENSIONS.map(({ key, pendingKey }) => [key, pendingKey]))).toEqual(byKey([
         ['portosMeta', null],
         ['catalogBundle', null],
         ['manuscriptReview', 'reviewSyncPending'],
         ['reverseOutline', 'outlineSyncPending'],
         ['linkedTrack', 'trackSyncPending'],
-      ]);
-      expect(Object.isFrozen(ENVELOPE_EXTENSIONS)).toBe(true);
+      ]));
     });
 
     it('has a sender-side carrier for every table row (a new extension must be exercised here)', () => {
@@ -4753,14 +4446,37 @@ describe('peerSync', () => {
         const first = payloadOf(calls[0]);
         const retry = payloadOf(calls[1]);
         expect(first[key]).toBeDefined();
-        expect(retry[key]).toBeUndefined();
-        // Surgical: every other extension the first push carried survives, so
-        // a peer that supports portosMeta but not this key keeps its handshake.
-        for (const other of ENVELOPE_EXTENSIONS) {
-          if (other.key !== key && other.key in first) expect(retry[other.key]).toEqual(first[other.key]);
-        }
-        expect(retry.record.id).toBe(carrier.recordId);
+        // Surgical: the retry is the first push minus exactly this key — the
+        // record, bundled issues, sourceInstanceId and every other extension
+        // survive, so a peer that supports portosMeta but not this key keeps
+        // its version-gate handshake.
+        const rest = { ...first };
+        delete rest[key];
+        expect(retry).toEqual(rest);
       });
+    });
+
+    it('drops every key a single 400 names in one retry (Zod lists all unrecognized keys in one issue)', async () => {
+      const carrier = CARRIERS.catalogBundle; // carries portosMeta AND catalogBundle
+      await carrier.arm();
+      const rejectsBoth = legacyRejectsKey('portosMeta');
+      rejectsBoth.json = async () => ({
+        code: 'VALIDATION_ERROR',
+        message: 'Validation failed',
+        context: { details: [{ path: '', message: "Unrecognized key(s) in object: 'portosMeta', 'catalogBundle'" }] },
+      });
+      vi.mocked(peerFetch).mockResolvedValueOnce(rejectsBoth).mockResolvedValueOnce(acceptsPush());
+      const result = await pushRecordToPeer(await claim(carrier));
+      expect(result.pushed).toBe(true);
+      const calls = vi.mocked(peerFetch).mock.calls;
+      expect(calls).toHaveLength(2);
+      const first = payloadOf(calls[0]);
+      const retry = payloadOf(calls[1]);
+      expect(first.portosMeta).toBeDefined();
+      expect(first.catalogBundle).toBeDefined();
+      expect(retry.portosMeta).toBeUndefined();
+      expect(retry.catalogBundle).toBeUndefined();
+      expect(retry.record.id).toBe(carrier.recordId);
     });
 
     describe.each(SIDECARS)('$key — no independent cycle ($pendingKey)', ({ key, pendingKey }) => {
@@ -4782,7 +4498,7 @@ describe('peerSync', () => {
       it('withholds the hash WITHOUT a legacy water-mark when the receiver reports it pending (transient merge failure)', async () => {
         const carrier = CARRIERS[key];
         await carrier.arm();
-        vi.mocked(peerFetch).mockResolvedValue(accepts({ [pendingKey]: true }));
+        vi.mocked(peerFetch).mockResolvedValue(acceptsPush({ [pendingKey]: true }));
         const result = await pushRecordToPeer(await claim(carrier));
         expect(result.pushed).toBe(true);
         expect(vi.mocked(peerFetch).mock.calls).toHaveLength(1);
@@ -4791,7 +4507,7 @@ describe('peerSync', () => {
         expect(refreshed.lastPushedLegacyHash).toBeFalsy();
         // The next cycle must genuinely re-push, not short-circuit.
         vi.mocked(peerFetch).mockClear();
-        vi.mocked(peerFetch).mockResolvedValue(accepts());
+        vi.mocked(peerFetch).mockResolvedValue(acceptsPush());
         const second = await pushRecordToPeer(refreshed);
         expect(second.pushed).toBe(true);
         expect(vi.mocked(peerFetch).mock.calls).toHaveLength(1);
@@ -4849,11 +4565,7 @@ describe('peerSync', () => {
             kind: 'series',
             record: { id: 's1', name: 'S', deleted: false, deletedAt: null },
             issues: [],
-            reverseOutline: {
-              schemaVersion: 1, status: 'complete', generatedAt: '2026-06-02T00:00:00Z',
-              plotlines: [{ id: 'a', label: 'A', kind: 'main' }],
-              scenes: [{ id: 'scene-001', sequence: 0, summary: 'opening', plotlineId: 'a' }],
-            },
+            reverseOutline: sampleOutline(),
             assetManifest: [],
             sourceInstanceId: 'peer-a',
           }),
@@ -4888,6 +4600,9 @@ describe('peerSync', () => {
     });
   });
 
+  // -------------------------------------------------------------------------
+  // mediaCollection push + receiver
+  // -------------------------------------------------------------------------
   describe('collectCollectionAssetReferences', () => {
     it('maps items to image/video refs with an empty directImageRefFilenames', () => {
       const refs = collectCollectionAssetReferences({ items: [

--- a/server/services/sharing/peerSyncPush.js
+++ b/server/services/sharing/peerSyncPush.js
@@ -44,6 +44,8 @@ import {
   PUSH_TIMEOUT_MS,
   ERR_SCHEMA_VERSION_AHEAD,
   PEER_SUBSCRIBABLE_KINDS,
+  ENVELOPE_EXTENSIONS,
+  ENVELOPE_PENDING_KEYS,
 } from './peerSyncShared.js';
 import { isStr, isNonBlankStr } from '../../lib/textUtils.js';
 
@@ -123,25 +125,8 @@ export async function pushRecordToPeer(sub, options = {}) {
   const payload = await buildPushPayload(sub, ourInstanceId);
   if (!payload) return { pushed: false, reason: 'record-not-found' };
 
-  // No-op short-circuit: don't re-push bytes we already pushed. Hash the
-  // FULL logical payload (record + bundled issues + linked collection +
-  // asset manifest) — not just the record — so an issue-only edit, an
-  // asset-only re-render, a collection-only item add, or a new image
-  // landing under the same series still propagates instead of collapsing
-  // to "unchanged" because the parent series didn't move.
-  // sourceInstanceId is intentionally excluded: it's an envelope field, not
-  // a content field, and hashing it would force a re-push every time we
-  // bumped instance metadata.
-  const hash = simplePayloadHash({
-    record: payload.record,
-    issues: payload.issues ?? null,
-    linkedCollection: payload.linkedCollection ?? null,
-    linkedTrack: payload.linkedTrack ?? null,
-    manuscriptReview: payload.manuscriptReview ?? null,
-    reverseOutline: payload.reverseOutline ?? null,
-    assetManifest: payload.assetManifest ?? [],
-    draftBodyManifest: payload.draftBodyManifest ?? [],
-  });
+  // No-op short-circuit: don't re-push bytes we already pushed.
+  const hash = pushPayloadHash(payload);
   if (sub.lastPushedHash && sub.lastPushedHash === hash) {
     return { pushed: false, reason: 'unchanged', hash };
   }
@@ -178,87 +163,39 @@ export async function pushRecordToPeer(sub, options = {}) {
     });
   };
   let res = await postPayload(payload);
-  // Set when the older-peer retry below strips `manuscriptReview`: the retry
-  // succeeds with the review removed, so saving the full-payload hash would
-  // make the next push short-circuit as `unchanged` and never deliver the
-  // review once that peer upgrades. Withhold the hash (like reviewSyncPending)
-  // so the next cycle re-sends.
-  let reviewStrippedForLegacyPeer = false;
-  // Same as reviewStrippedForLegacyPeer, for the bundled reverse-outline doc —
-  // a pre-#1348 peer's strict series schema rejects the `reverseOutline` key, so
-  // the retry strips it and we withhold the hash to re-send once it upgrades.
-  let outlineStrippedForLegacyPeer = false;
-  // Same as the two flags above, for the #1858 bundled linked-track record — a
-  // pre-feature peer's strict musicVideoProject push schema rejects the
-  // `linkedTrack` key, so the retry strips it and we withhold the hash to
-  // re-send once it upgrades (the track has no independent cycle for a
-  // musicVideoProjects-only subscriber).
-  let trackStrippedForLegacyPeer = false;
-  // MIXED-VERSION COMPAT: an older receiver's push schema is still `.strict()`
-  // without a `portosMeta` field, so it 400-rejects our envelope at Zod
-  // validation BEFORE its schema-version gate code (which doesn't exist on
-  // that version anyway) can run. Detect that specific rejection — Zod emits
-  // "Unrecognized key(s) in object: 'portosMeta'" — and retry once without
-  // the envelope so the push lands on the older peer. The older peer can't
-  // see schemaVersions, but until the user upgrades it that's the
-  // best-effort behavior we want (vs. permanently stranded pushes). Once
-  // they upgrade, the next push round naturally re-includes `portosMeta`.
-  // `catalogBundle` (catalog-federation push enrichment) is a second new
-  // top-level key an even-newer-than-version-gate-but-pre-catalog peer's strict
-  // schema also rejects. `manuscriptReview` (the bundled "Finish the draft"
-  // review doc) is a third — a pre-feature peer's series push schema is still
-  // `.strict()` without it, so it 400-rejects a review-bearing series push and
-  // would strand the series + issues. This retry is exactly what makes the
-  // review's "degrades gracefully on older peers" contract hold (see
-  // schemaVersions.js): strip the unknown key the older peer can't parse so the
-  // record/issues still land; the review reaches it once it upgrades. Strip
-  // whichever key(s) the receiver actually named — surgically, so a peer that
-  // supports `portosMeta` but not `catalogBundle`/`manuscriptReview` keeps its
-  // version-gate handshake. Zod `.strict()` lists all unrecognized keys in one
-  // issue, so a single retry covers all of them.
-  // A 400 from the receiver is Zod rejecting our envelope BEFORE its schema-version
-  // gate (the 409 path below) runs. Parse the body ONCE and route on which part it
-  // couldn't accept — two distinct mixed-version cases share this block:
+  // ENVELOPE_EXTENSIONS rows the receiver's `.strict()` schema rejected and
+  // this push retried without. Empty when the first POST was accepted; the
+  // sidecar rows among them are what `resolvePushWatermarks` counts as still
+  // owed to this peer.
+  let stripped = [];
+  // A 400 from the receiver is Zod rejecting our envelope BEFORE its schema-
+  // version gate (the 409 path below) runs. Parse the body ONCE and route on
+  // which part it couldn't accept — two distinct mixed-version cases share it:
   if (res && res.status === 400) {
-    const errBody = await res.clone().json().catch(() => null);
-    const isValidationError = errBody?.code === 'VALIDATION_ERROR';
-    const details = Array.isArray(errBody?.context?.details) ? errBody.context.details : [];
-    const mentions = (key) => details.some((d) => new RegExp(key).test(`${d?.path || ''} ${d?.message || ''}`));
-    if (
-      isValidationError
-      && (payload.portosMeta || payload.catalogBundle || payload.manuscriptReview || payload.reverseOutline || payload.linkedTrack)
-      && (mentions('portosMeta') || mentions('catalogBundle') || mentions('manuscriptReview') || mentions('reverseOutline') || mentions('linkedTrack'))
-    ) {
+    const rejection = await classifyEnvelopeRejection(res, payload);
+    if (rejection.stripped.length > 0) {
       // (1) UNKNOWN ENVELOPE KEY — the peer recognizes the record `kind` but its
       // `.strict()` schema predates a newer top-level key we sent. Strip whichever
       // key(s) it named and retry so the record/issues still land; the stripped
       // feature reaches it once it upgrades (the re-push re-includes the key).
+      stripped = rejection.stripped;
       const legacyPayload = { ...payload };
-      const stripped = [];
-      if (mentions('portosMeta') && 'portosMeta' in legacyPayload) { delete legacyPayload.portosMeta; stripped.push('portosMeta'); }
-      if (mentions('catalogBundle') && 'catalogBundle' in legacyPayload) { delete legacyPayload.catalogBundle; stripped.push('catalogBundle'); }
-      if (mentions('manuscriptReview') && 'manuscriptReview' in legacyPayload) { delete legacyPayload.manuscriptReview; stripped.push('manuscriptReview'); reviewStrippedForLegacyPeer = true; }
-      if (mentions('reverseOutline') && 'reverseOutline' in legacyPayload) { delete legacyPayload.reverseOutline; stripped.push('reverseOutline'); outlineStrippedForLegacyPeer = true; }
-      if (mentions('linkedTrack') && 'linkedTrack' in legacyPayload) { delete legacyPayload.linkedTrack; stripped.push('linkedTrack'); trackStrippedForLegacyPeer = true; }
+      for (const { key } of stripped) delete legacyPayload[key];
       console.log(
-        `ℹ️ peerSync: ${peer.name || peer.instanceId} rejected newer envelope key(s) ${stripped.join(', ')} — retrying push without them`,
+        `ℹ️ peerSync: ${peer.name || peer.instanceId} rejected newer envelope key(s) ${stripped.map((e) => e.key).join(', ')} — retrying push without them`,
       );
       res = await postPayload(legacyPayload);
-    } else if (isValidationError && details.some((d) => d?.path === 'kind' && /discriminator|enum/i.test(d?.message || ''))) {
+    } else if (rejection.unknownKind) {
       // (2) UNKNOWN RECORD KIND → schema-version block (NOT a bare http-400 retry).
-      // When we introduce a NEW federated record kind (authors did this;
-      // mediaCollection had the same gap when it landed), a peer on an older PortOS
-      // whose `peerSyncPushSchema` discriminated union has no arm for that `kind`
-      // rejects the push at the discriminator — so unlike case (1) there's no
-      // smuggled key to drop: the record KIND itself is what the peer can't parse,
-      // and retrying changes nothing. Treat it like the 409: persist an empty-gap
-      // `peer-pre-feature` block so the SchemaGapBadge surfaces "peer needs to update
-      // PortOS to sync <kind>" and the edit-push cooldown engages, instead of letting
-      // the sub churn as a bare `http-400` the UI never explains. The block clears on
-      // the next successful push once the peer upgrades (same recovery as the 409
-      // path). The signal is a `kind`-path discriminator/enum error — a value WE
-      // always send as a valid literal, so the only reason a receiver faults on
-      // `kind` is that its schema doesn't know this record kind yet.
+      // The receiver's `peerSyncPushSchema` discriminated union has no arm for
+      // this `kind` (authors did this; mediaCollection had the same gap when it
+      // landed), so unlike case (1) there is no smuggled key to drop and
+      // retrying changes nothing. Treat it like the 409: persist an empty-gap
+      // `peer-pre-feature` block so the SchemaGapBadge surfaces "peer needs to
+      // update PortOS to sync <kind>" and the edit-push cooldown engages,
+      // instead of letting the sub churn as a bare `http-400` the UI never
+      // explains. The block clears on the next successful push once the peer
+      // upgrades (same recovery as the 409 path).
       await persistSchemaVersionBlock(sub.id, { reason: 'peer-pre-feature' });
       console.warn(
         `⚠️ peerSync: ${peer.name || peer.instanceId} rejected push — its PortOS doesn't recognize the ` +
@@ -337,23 +274,11 @@ export async function pushRecordToPeer(sub, options = {}) {
   // next `unchanged` short-circuit and the prose body stranded).
   const missingCount = (Array.isArray(body?.missingAssets) ? body.missingAssets.length : 0)
     + (Array.isArray(body?.missingDraftBodies) ? body.missingDraftBodies.length : 0);
-  // REVIEW-STRANDED GUARD: the receiver merged the record/issues (returned 2xx)
-  // but its bundled manuscript-review merge threw. Withhold lastPushedHash like
-  // the missing-assets case so the next push cycle re-sends the review instead
-  // of short-circuiting on `unchanged` — the review has no independent
-  // reconciliation path, so a saved hash here would strand the update.
-  const reviewSyncPending = body?.reviewSyncPending === true || reviewStrippedForLegacyPeer;
-  // OUTLINE-STRANDED GUARD: same as the review above — the receiver merged the
-  // record/issues but its bundled reverse-outline merge threw (or we stripped
-  // the key for a pre-#1348 peer). The outline has no independent reconciliation
-  // path, so withhold lastPushedHash to re-send next cycle.
-  const outlineSyncPending = body?.outlineSyncPending === true || outlineStrippedForLegacyPeer;
-  // TRACK-STRANDED GUARD: same as the review/outline guards — the receiver merged
-  // the project (returned 2xx) but its bundled linked-track merge threw, OR we
-  // stripped the key for a pre-#1858 peer. The track has no independent
-  // reconciliation path for a musicVideoProjects-only subscriber, so withhold
-  // lastPushedHash to re-send next cycle.
-  const trackSyncPending = body?.trackSyncPending === true || trackStrippedForLegacyPeer;
+  // SIDECAR-STRANDED GUARD: `resolvePushWatermarks` folds the receiver's
+  // ENVELOPE_EXTENSIONS pending flags and this push's own legacy strips into
+  // the same decision — a bundled doc the receiver doesn't hold yet withholds
+  // lastPushedHash exactly like the missing-assets case above.
+  const { pushedHash, legacyStrippedHash, trackSyncPending } = resolvePushWatermarks({ hash, missingCount, stripped, body });
   // This push landed (receiver returned 2xx). Stamp the per-record confirmed-
   // delivery water-mark so tombstoneGc won't prune THIS record's tombstone
   // until its delete-push has been confirmed — even if a later push for a
@@ -387,21 +312,7 @@ export async function pushRecordToPeer(sub, options = {}) {
   const trackBundleConfirmed = sub.recordKind === 'musicVideoProject'
     && !trackSyncPending
     && (!trackOwed || Boolean(payload.linkedTrack));
-  // #3928: separate the two reasons a bundled doc is still pending. A
-  // RECEIVER-reported pending (its bundled merge threw) is transient — the
-  // next cycle must genuinely re-push, so it gets no water-mark. A
-  // SENDER-side strip for a legacy peer is stable — the peer will reject the
-  // key again until it upgrades, so record the full-payload hash in
-  // `lastPushedLegacyHash` and let an unchanged record short-circuit above
-  // instead of looping a 400 + retry pair every cycle. Missing assets/bodies
-  // also stay un-water-marked: the receiver is still pulling and needs a
-  // fresh manifest each cycle.
-  const receiverReportedPending = body?.reviewSyncPending === true
-    || body?.outlineSyncPending === true
-    || body?.trackSyncPending === true;
-  const strippedForLegacyPeer = reviewStrippedForLegacyPeer || outlineStrippedForLegacyPeer || trackStrippedForLegacyPeer;
-  const legacyStrippedHash = (strippedForLegacyPeer && missingCount === 0 && !receiverReportedPending) ? hash : null;
-  await persistPushSuccess(sub.id, (missingCount > 0 || reviewSyncPending || outlineSyncPending || trackSyncPending) ? null : hash, {
+  await persistPushSuccess(sub.id, pushedHash, {
     confirmedAtMs: Date.now(),
     trackBundleConfirmed,
     legacyStrippedHash,
@@ -452,6 +363,84 @@ export async function pushRecordToPeer(sub, options = {}) {
     hash,
     response: body || {},
     missingAssets: Array.isArray(body?.missingAssets) ? body.missingAssets : [],
+  };
+}
+
+/**
+ * Classify a receiver's 400 against the envelope we sent. A 400 is Zod
+ * rejecting the envelope BEFORE the receiver's schema-version gate can run
+ * (that gate answers 409), and two mixed-version cases share it:
+ *
+ *   `stripped`    — the ENVELOPE_EXTENSIONS rows the receiver named as
+ *                   unrecognized keys AND this payload carries. Its `.strict()`
+ *                   schema predates them (a pre-version-gate peer has no
+ *                   `portosMeta` field, a pre-catalog peer no `catalogBundle`,
+ *                   a pre-feature peer none of the sidecar docs), so the
+ *                   caller retries once without exactly those keys. Zod lists
+ *                   every unrecognized key in one issue, so a single retry
+ *                   covers them all — and stripping only the keys it NAMED
+ *                   keeps a peer that supports `portosMeta` but not
+ *                   `catalogBundle` on its version-gate handshake. Until the
+ *                   user upgrades that peer this best-effort landing beats a
+ *                   permanently stranded push; the next push round after the
+ *                   upgrade naturally re-includes the key.
+ *   `unknownKind` — the receiver faulted on the `kind` discriminator itself:
+ *                   its push schema has no arm for this record kind, so there
+ *                   is no key to drop and a retry changes nothing; the caller
+ *                   persists a `peer-pre-feature` block instead. `kind` is a
+ *                   value WE always send as a valid literal, so the only reason
+ *                   a receiver faults on it is that its schema doesn't know
+ *                   this kind yet.
+ *
+ * Anything else — not a VALIDATION_ERROR, or one naming fields we can't
+ * strip — is a plain http-400 for the caller to report.
+ */
+async function classifyEnvelopeRejection(res, payload) {
+  const errBody = await res.clone().json().catch(() => null);
+  if (errBody?.code !== 'VALIDATION_ERROR') return { stripped: [], unknownKind: false };
+  const details = Array.isArray(errBody.context?.details) ? errBody.context.details : [];
+  const mentions = (key) => details.some((d) => new RegExp(key).test(`${d?.path || ''} ${d?.message || ''}`));
+  const stripped = ENVELOPE_EXTENSIONS.filter((e) => e.key in payload && mentions(e.key));
+  const unknownKind = stripped.length === 0
+    && details.some((d) => d?.path === 'kind' && /discriminator|enum/i.test(d?.message || ''));
+  return { stripped, unknownKind };
+}
+
+/**
+ * The hash-withholding contract for a push that landed (receiver returned
+ * 2xx), stated once for every ENVELOPE_EXTENSIONS row (#6844).
+ *
+ * `pushedHash` becomes `lastPushedHash`, the `unchanged` short-circuit's
+ * water-mark, so it is saved ONLY when the receiver now holds everything this
+ * push carried: no asset or draft body still to pull (`missingCount`), no
+ * sidecar doc the receiver reported as failed (`body[pendingKey]`), and no
+ * sidecar doc this push stripped for a legacy peer. Saving it in any of those
+ * states would make the next cycle short-circuit and strand the piece that
+ * never arrived — the sidecar docs have no independent reconciliation path.
+ *
+ * #3928 separates the two reasons a sidecar is pending. A RECEIVER-reported
+ * failure is transient — the next cycle must genuinely re-push, so it gets no
+ * water-mark at all. A SENDER-side strip is stable — the peer rejects the key
+ * again until it upgrades — so `legacyStrippedHash` records the full-payload
+ * hash delivered in stripped form and an unchanged record short-circuits as
+ * `unchanged-legacy-stripped` instead of looping a 400 + retry pair every
+ * cycle. Missing assets/bodies stay un-water-marked either way: the receiver
+ * is still pulling and needs a fresh manifest each cycle.
+ *
+ * A stripped row with `pendingKey: null` (`portosMeta`, `catalogBundle`) is
+ * reconciled by its own cycle, so it never counts as pending here.
+ */
+function resolvePushWatermarks({ hash, missingCount, stripped, body }) {
+  const strippedPending = new Set(stripped.map((e) => e.pendingKey).filter(Boolean));
+  const receiverReportedPending = ENVELOPE_EXTENSIONS.some((e) => e.pendingKey && body?.[e.pendingKey] === true);
+  const anyPending = strippedPending.size > 0 || receiverReportedPending;
+  const trackPendingKey = ENVELOPE_PENDING_KEYS.linkedTrack;
+  return {
+    pushedHash: (missingCount > 0 || anyPending) ? null : hash,
+    legacyStrippedHash: (strippedPending.size > 0 && missingCount === 0 && !receiverReportedPending) ? hash : null,
+    // #1922's bundled-track GC floor still needs the linked track's OWN state
+    // (see `trackBundleConfirmed` at the call site).
+    trackSyncPending: strippedPending.has(trackPendingKey) || body?.[trackPendingKey] === true,
   };
 }
 
@@ -773,6 +762,28 @@ async function buildCatalogBundleForRef(refKind, refId) {
   const refs = Array.isArray(bundle.refs) ? bundle.refs : [];
   if (ingredients.length === 0 && refs.length === 0) return null;
   return { ingredients, refs };
+}
+
+/**
+ * Hash the FULL logical payload — record + bundled issues + linked collection
+ * + sidecar docs + asset/body manifests — not just the record, so an
+ * issue-only edit, an asset-only re-render, a collection-only item add, or a
+ * new image landing under the same series still propagates instead of
+ * collapsing to `unchanged` because the parent record didn't move.
+ * `sourceInstanceId` and `portosMeta` are envelope fields, not content, and
+ * hashing them would force a re-push every time we bumped instance metadata.
+ */
+function pushPayloadHash(payload) {
+  return simplePayloadHash({
+    record: payload.record,
+    issues: payload.issues ?? null,
+    linkedCollection: payload.linkedCollection ?? null,
+    linkedTrack: payload.linkedTrack ?? null,
+    manuscriptReview: payload.manuscriptReview ?? null,
+    reverseOutline: payload.reverseOutline ?? null,
+    assetManifest: payload.assetManifest ?? [],
+    draftBodyManifest: payload.draftBodyManifest ?? [],
+  });
 }
 
 // Tiny stable-string hash for the push short-circuit. NOT a cryptographic

--- a/server/services/sharing/peerSyncPush.js
+++ b/server/services/sharing/peerSyncPush.js
@@ -132,7 +132,7 @@ export async function pushRecordToPeer(sub, options = {}) {
   }
   // LEGACY-STRIPPED SHORT-CIRCUIT (#3928): the last push to this peer landed
   // only after we stripped a top-level key its older `.strict()` schema
-  // rejects (`manuscriptReview` / `reverseOutline` / `linkedTrack`), so
+  // rejects (a sidecar row of ENVELOPE_EXTENSIONS), so
   // `lastPushedHash` was deliberately withheld. Without a second water-mark
   // that withheld hash makes EVERY subsequent cycle re-run the same 400 +
   // stripped-retry pair forever — two HTTP round-trips per 60s sync for a
@@ -163,46 +163,33 @@ export async function pushRecordToPeer(sub, options = {}) {
     });
   };
   let res = await postPayload(payload);
-  // ENVELOPE_EXTENSIONS rows the receiver's `.strict()` schema rejected and
-  // this push retried without. Empty when the first POST was accepted; the
-  // sidecar rows among them are what `resolvePushWatermarks` counts as still
-  // owed to this peer.
-  let stripped = [];
-  // A 400 from the receiver is Zod rejecting our envelope BEFORE its schema-
-  // version gate (the 409 path below) runs. Parse the body ONCE and route on
-  // which part it couldn't accept — two distinct mixed-version cases share it:
-  if (res && res.status === 400) {
-    const rejection = await classifyEnvelopeRejection(res, payload);
-    if (rejection.stripped.length > 0) {
-      // (1) UNKNOWN ENVELOPE KEY — the peer recognizes the record `kind` but its
-      // `.strict()` schema predates a newer top-level key we sent. Strip whichever
-      // key(s) it named and retry so the record/issues still land; the stripped
-      // feature reaches it once it upgrades (the re-push re-includes the key).
-      stripped = rejection.stripped;
-      const legacyPayload = { ...payload };
-      for (const { key } of stripped) delete legacyPayload[key];
-      console.log(
-        `ℹ️ peerSync: ${peer.name || peer.instanceId} rejected newer envelope key(s) ${stripped.map((e) => e.key).join(', ')} — retrying push without them`,
-      );
-      res = await postPayload(legacyPayload);
-    } else if (rejection.unknownKind) {
-      // (2) UNKNOWN RECORD KIND → schema-version block (NOT a bare http-400 retry).
-      // The receiver's `peerSyncPushSchema` discriminated union has no arm for
-      // this `kind` (authors did this; mediaCollection had the same gap when it
-      // landed), so unlike case (1) there is no smuggled key to drop and
-      // retrying changes nothing. Treat it like the 409: persist an empty-gap
-      // `peer-pre-feature` block so the SchemaGapBadge surfaces "peer needs to
-      // update PortOS to sync <kind>" and the edit-push cooldown engages,
-      // instead of letting the sub churn as a bare `http-400` the UI never
-      // explains. The block clears on the next successful push once the peer
-      // upgrades (same recovery as the 409 path).
-      await persistSchemaVersionBlock(sub.id, { reason: 'peer-pre-feature' });
-      console.warn(
-        `⚠️ peerSync: ${peer.name || peer.instanceId} rejected push — its PortOS doesn't recognize the ` +
-        `'${sub.recordKind}' record kind yet. Re-tries pause until they upgrade.`,
-      );
-      return { pushed: false, reason: 'peer-schema-behind', blockedBySchema: true };
-    }
+  // A 400 is Zod rejecting the envelope before the receiver's version gate
+  // (the 409 path below) runs — `classifyEnvelopeRejection` separates the two
+  // mixed-version cases it can mean.
+  const { stripped, unknownKind } = await classifyEnvelopeRejection(res, payload);
+  if (stripped.length > 0) {
+    // (1) UNKNOWN ENVELOPE KEY — retry once without exactly the keys the
+    // receiver named, so the record/issues still land; the stripped feature
+    // reaches it once it upgrades, because the next push re-includes the key.
+    const legacyPayload = { ...payload };
+    for (const { key } of stripped) delete legacyPayload[key];
+    console.log(
+      `ℹ️ peerSync: ${peer.name || peer.instanceId} rejected newer envelope key(s) ${stripped.map((e) => e.key).join(', ')} — retrying push without them`,
+    );
+    res = await postPayload(legacyPayload);
+  } else if (unknownKind) {
+    // (2) UNKNOWN RECORD KIND → schema-version block, NOT a bare http-400:
+    // persist an empty-gap `peer-pre-feature` block so the SchemaGapBadge
+    // surfaces "peer needs to update PortOS to sync <kind>" and the edit-push
+    // cooldown engages, instead of the sub churning as an `http-400` the UI
+    // never explains. It clears on the next successful push once the peer
+    // upgrades (same recovery as the 409 path).
+    await persistSchemaVersionBlock(sub.id, { reason: 'peer-pre-feature' });
+    console.warn(
+      `⚠️ peerSync: ${peer.name || peer.instanceId} rejected push — its PortOS doesn't recognize the ` +
+      `'${sub.recordKind}' record kind yet. Re-tries pause until they upgrade.`,
+    );
+    return { pushed: false, reason: 'peer-schema-behind', blockedBySchema: true };
   }
   // 409 with `code: SCHEMA_VERSION_AHEAD` means the receiver is on an OLDER
   // PortOS and can't parse our newer storage layout. Persist the gap on the
@@ -274,11 +261,10 @@ export async function pushRecordToPeer(sub, options = {}) {
   // next `unchanged` short-circuit and the prose body stranded).
   const missingCount = (Array.isArray(body?.missingAssets) ? body.missingAssets.length : 0)
     + (Array.isArray(body?.missingDraftBodies) ? body.missingDraftBodies.length : 0);
-  // SIDECAR-STRANDED GUARD: `resolvePushWatermarks` folds the receiver's
-  // ENVELOPE_EXTENSIONS pending flags and this push's own legacy strips into
-  // the same decision — a bundled doc the receiver doesn't hold yet withholds
-  // lastPushedHash exactly like the missing-assets case above.
-  const { pushedHash, legacyStrippedHash, trackSyncPending } = resolvePushWatermarks({ hash, missingCount, stripped, body });
+  // SIDECAR-STRANDED GUARD: a bundled doc the receiver doesn't hold yet —
+  // reported pending by it, or stripped above for a legacy peer — withholds
+  // lastPushedHash exactly like the missing-assets case.
+  const { pushedHash, legacyStrippedHash, pending } = resolvePushWatermarks({ hash, missingCount, stripped, body });
   // This push landed (receiver returned 2xx). Stamp the per-record confirmed-
   // delivery water-mark so tombstoneGc won't prune THIS record's tombstone
   // until its delete-push has been confirmed — even if a later push for a
@@ -309,6 +295,7 @@ export async function pushRecordToPeer(sub, options = {}) {
   // track is owed at all (`trackId` absent), OR a `linkedTrack` was actually
   // included in this push.
   const trackOwed = isStr(payload.record?.trackId);
+  const trackSyncPending = pending.has(ENVELOPE_PENDING_KEYS.linkedTrack);
   const trackBundleConfirmed = sub.recordKind === 'musicVideoProject'
     && !trackSyncPending
     && (!trackOwed || Boolean(payload.linkedTrack));
@@ -366,38 +353,38 @@ export async function pushRecordToPeer(sub, options = {}) {
   };
 }
 
+const NO_REJECTION = Object.freeze({ stripped: Object.freeze([]), unknownKind: false });
+
 /**
- * Classify a receiver's 400 against the envelope we sent. A 400 is Zod
- * rejecting the envelope BEFORE the receiver's schema-version gate can run
- * (that gate answers 409), and two mixed-version cases share it:
+ * Classify the receiver's response to the envelope we sent. Only a 400 is
+ * interesting: it is Zod rejecting the envelope BEFORE the receiver's
+ * schema-version gate can run (that gate answers 409), and two mixed-version
+ * cases share it:
  *
  *   `stripped`    — the ENVELOPE_EXTENSIONS rows the receiver named as
  *                   unrecognized keys AND this payload carries. Its `.strict()`
- *                   schema predates them (a pre-version-gate peer has no
- *                   `portosMeta` field, a pre-catalog peer no `catalogBundle`,
- *                   a pre-feature peer none of the sidecar docs), so the
- *                   caller retries once without exactly those keys. Zod lists
- *                   every unrecognized key in one issue, so a single retry
- *                   covers them all — and stripping only the keys it NAMED
- *                   keeps a peer that supports `portosMeta` but not
- *                   `catalogBundle` on its version-gate handshake. Until the
- *                   user upgrades that peer this best-effort landing beats a
- *                   permanently stranded push; the next push round after the
- *                   upgrade naturally re-includes the key.
+ *                   schema predates them. Zod's message is
+ *                   `Unrecognized key(s) in object: '<key>'` — every
+ *                   unrecognized key in ONE issue, so a single retry covers
+ *                   them all — and `mentions` regex-matches each key against
+ *                   path + message. Stripping only the keys it NAMED keeps a
+ *                   peer that supports `portosMeta` but not `catalogBundle` on
+ *                   its version-gate handshake.
  *   `unknownKind` — the receiver faulted on the `kind` discriminator itself:
  *                   its push schema has no arm for this record kind, so there
- *                   is no key to drop and a retry changes nothing; the caller
- *                   persists a `peer-pre-feature` block instead. `kind` is a
+ *                   is no key to drop and a retry changes nothing. `kind` is a
  *                   value WE always send as a valid literal, so the only reason
  *                   a receiver faults on it is that its schema doesn't know
  *                   this kind yet.
  *
- * Anything else — not a VALIDATION_ERROR, or one naming fields we can't
- * strip — is a plain http-400 for the caller to report.
+ * Anything else — no response, a non-400, a 400 that is not a
+ * VALIDATION_ERROR, or one naming fields we can't strip — is NO_REJECTION and
+ * the caller reports the status as it stands.
  */
 async function classifyEnvelopeRejection(res, payload) {
+  if (res?.status !== 400) return NO_REJECTION;
   const errBody = await res.clone().json().catch(() => null);
-  if (errBody?.code !== 'VALIDATION_ERROR') return { stripped: [], unknownKind: false };
+  if (errBody?.code !== 'VALIDATION_ERROR') return NO_REJECTION;
   const details = Array.isArray(errBody.context?.details) ? errBody.context.details : [];
   const mentions = (key) => details.some((d) => new RegExp(key).test(`${d?.path || ''} ${d?.message || ''}`));
   const stripped = ENVELOPE_EXTENSIONS.filter((e) => e.key in payload && mentions(e.key));
@@ -407,40 +394,36 @@ async function classifyEnvelopeRejection(res, payload) {
 }
 
 /**
- * The hash-withholding contract for a push that landed (receiver returned
- * 2xx), stated once for every ENVELOPE_EXTENSIONS row (#6844).
+ * The two hash water-marks for a push that landed (receiver returned 2xx),
+ * decided once for every ENVELOPE_EXTENSIONS row.
  *
  * `pushedHash` becomes `lastPushedHash`, the `unchanged` short-circuit's
- * water-mark, so it is saved ONLY when the receiver now holds everything this
- * push carried: no asset or draft body still to pull (`missingCount`), no
- * sidecar doc the receiver reported as failed (`body[pendingKey]`), and no
- * sidecar doc this push stripped for a legacy peer. Saving it in any of those
- * states would make the next cycle short-circuit and strand the piece that
- * never arrived — the sidecar docs have no independent reconciliation path.
+ * water-mark, so it is saved only once the receiver holds everything this
+ * push carried: no asset or draft body still to pull (`missingCount`) and no
+ * sidecar doc still owed — reported pending by the receiver, or stripped here
+ * for a legacy peer. Saving it earlier would make the next cycle short-circuit
+ * and strand the piece that never arrived.
  *
- * #3928 separates the two reasons a sidecar is pending. A RECEIVER-reported
- * failure is transient — the next cycle must genuinely re-push, so it gets no
- * water-mark at all. A SENDER-side strip is stable — the peer rejects the key
- * again until it upgrades — so `legacyStrippedHash` records the full-payload
- * hash delivered in stripped form and an unchanged record short-circuits as
+ * #3928 separates the two reasons a sidecar is owed. A RECEIVER-reported
+ * failure is transient — the next cycle must genuinely re-push, so nothing is
+ * water-marked. A SENDER-side strip is stable — the peer rejects the key again
+ * until it upgrades — so `legacyStrippedHash` records the full-payload hash
+ * delivered in stripped form and an unchanged record short-circuits as
  * `unchanged-legacy-stripped` instead of looping a 400 + retry pair every
  * cycle. Missing assets/bodies stay un-water-marked either way: the receiver
  * is still pulling and needs a fresh manifest each cycle.
  *
- * A stripped row with `pendingKey: null` (`portosMeta`, `catalogBundle`) is
- * reconciled by its own cycle, so it never counts as pending here.
+ * `pending` is the set of receiver flags still owed, for the one consumer that
+ * asks about a specific row (#1922's bundled-track GC floor).
  */
 function resolvePushWatermarks({ hash, missingCount, stripped, body }) {
-  const strippedPending = new Set(stripped.map((e) => e.pendingKey).filter(Boolean));
-  const receiverReportedPending = ENVELOPE_EXTENSIONS.some((e) => e.pendingKey && body?.[e.pendingKey] === true);
-  const anyPending = strippedPending.size > 0 || receiverReportedPending;
-  const trackPendingKey = ENVELOPE_PENDING_KEYS.linkedTrack;
+  const strippedPending = stripped.map((e) => e.pendingKey).filter(Boolean);
+  const receiverPending = Object.values(ENVELOPE_PENDING_KEYS).filter((k) => body?.[k] === true);
+  const settled = missingCount === 0 && receiverPending.length === 0;
   return {
-    pushedHash: (missingCount > 0 || anyPending) ? null : hash,
-    legacyStrippedHash: (strippedPending.size > 0 && missingCount === 0 && !receiverReportedPending) ? hash : null,
-    // #1922's bundled-track GC floor still needs the linked track's OWN state
-    // (see `trackBundleConfirmed` at the call site).
-    trackSyncPending: strippedPending.has(trackPendingKey) || body?.[trackPendingKey] === true,
+    pushedHash: settled && strippedPending.length === 0 ? hash : null,
+    legacyStrippedHash: settled && strippedPending.length > 0 ? hash : null,
+    pending: new Set([...strippedPending, ...receiverPending]),
   };
 }
 
@@ -766,21 +749,27 @@ async function buildCatalogBundleForRef(refKind, refId) {
 
 /**
  * Hash the FULL logical payload — record + bundled issues + linked collection
- * + sidecar docs + asset/body manifests — not just the record, so an
+ * + every sidecar doc + asset/body manifests — not just the record, so an
  * issue-only edit, an asset-only re-render, a collection-only item add, or a
  * new image landing under the same series still propagates instead of
  * collapsing to `unchanged` because the parent record didn't move.
- * `sourceInstanceId` and `portosMeta` are envelope fields, not content, and
- * hashing them would force a re-push every time we bumped instance metadata.
+ *
+ * The sidecar keys come from ENVELOPE_EXTENSIONS: a doc with no reconciliation
+ * cycle of its own (`pendingKey` set) is delivered ONLY by this hash moving,
+ * so a row added there rides the hash without a second listing. The
+ * self-reconciling rows stay out — `portosMeta` is envelope metadata, and
+ * hashing it would force a re-push every time instance metadata moved;
+ * catalog sync reconciles `catalogBundle` — as does `sourceInstanceId`. The
+ * keys are sorted so the object's key order, which `JSON.stringify` feeds the
+ * hash, never depends on table order.
  */
 function pushPayloadHash(payload) {
+  const sidecarKeys = Object.keys(ENVELOPE_PENDING_KEYS).sort();
   return simplePayloadHash({
     record: payload.record,
     issues: payload.issues ?? null,
     linkedCollection: payload.linkedCollection ?? null,
-    linkedTrack: payload.linkedTrack ?? null,
-    manuscriptReview: payload.manuscriptReview ?? null,
-    reverseOutline: payload.reverseOutline ?? null,
+    ...Object.fromEntries(sidecarKeys.map((k) => [k, payload[k] ?? null])),
     assetManifest: payload.assetManifest ?? [],
     draftBodyManifest: payload.draftBodyManifest ?? [],
   });

--- a/server/services/sharing/peerSyncReceive.js
+++ b/server/services/sharing/peerSyncReceive.js
@@ -38,6 +38,7 @@ import {
   ERR_VALIDATION,
   ERR_SCHEMA_VERSION_AHEAD,
   PEER_SUBSCRIBABLE_KINDS,
+  ENVELOPE_PENDING_KEYS,
 } from './peerSyncShared.js';
 import { isStr, isNonBlankStr } from '../../lib/textUtils.js';
 
@@ -246,17 +247,18 @@ export async function applyIncomingPush(payload) {
   // the merge fns fall back to `{ via:'sync', peerId:null }` and the
   // attribution is lost).
   const source = { via: 'peer-push', peerId: sourceInstanceId };
-  // Set true when a bundled manuscript-review merge throws — returned to the
-  // sender so it withholds lastPushedHash and retries (the review has no other
-  // reconciliation path; see the merge block below).
-  let reviewSyncPending = false;
-  // Same contract as reviewSyncPending, for the bundled reverse-outline doc.
-  let outlineSyncPending = false;
-  // Same contract again, for the #1858 bundled linked-track record: a
-  // musicVideoProjects-only subscriber has NO independent `tracks` sync cycle,
-  // so a swallowed merge failure would strand the record the receiver needs to
-  // render. Signal so the sender withholds lastPushedHash and re-sends.
-  let trackSyncPending = false;
+  // ENVELOPE_EXTENSIONS pending flags to echo to the sender: each is a bundled
+  // sidecar doc whose merge threw AFTER the record itself merged. None of the
+  // sidecars — the review, the outline, or the #1858 linked track a
+  // musicVideoProjects-only subscriber has no `tracks` cycle for — has an
+  // independent reconciliation path, so the sender withholds lastPushedHash
+  // on the flag and re-sends next cycle; a swallowed failure behind a saved
+  // hash would strand the doc. The record push itself never fails on these.
+  const pending = new Set();
+  const markPending = (key) => (err) => {
+    console.log(`⚠️ peerSync: ${key} merge failed: ${err.message}`);
+    pending.add(ENVELOPE_PENDING_KEYS[key]);
+  };
   // #1922: true only once the bundled linkedTrack merge actually RAN and
   // succeeded — gates whether `linkedTrack` may contribute to
   // `ackedDeletesUpTo` below. Stays false on every skip path (mismatched id,
@@ -300,10 +302,7 @@ export async function applyIncomingPush(payload) {
     // Dynamic import keeps the arcPlanner graph off peerSync's load path.
     if (!localEphemeral && record.deleted !== true && isPlainObject(manuscriptReview)) {
       const { mergeReviewFromSync } = await import('../pipeline/manuscriptReview.js');
-      await mergeReviewFromSync(record.id, manuscriptReview).catch((err) => {
-        console.log(`⚠️ peerSync: manuscriptReview merge failed: ${err.message}`);
-        reviewSyncPending = true;
-      });
+      await mergeReviewFromSync(record.id, manuscriptReview).catch(markPending('manuscriptReview'));
     }
     // Merge the bundled reverse-outline sibling doc, whole-doc LWW on
     // generatedAt. Same ephemeral/tombstone guards + pending-signal contract as
@@ -312,10 +311,7 @@ export async function applyIncomingPush(payload) {
     // cycle. Dynamic import keeps the arcPlanner graph off peerSync's load path.
     if (!localEphemeral && record.deleted !== true && isPlainObject(reverseOutline)) {
       const { mergeOutlineFromSync } = await import('../pipeline/reverseOutline.js');
-      await mergeOutlineFromSync(record.id, reverseOutline).catch((err) => {
-        console.log(`⚠️ peerSync: reverseOutline merge failed: ${err.message}`);
-        outlineSyncPending = true;
-      });
+      await mergeOutlineFromSync(record.id, reverseOutline).catch(markPending('reverseOutline'));
     }
   } else if (kind === 'writersRoomWork') {
     // Did the receiver accept the remote work (insert / remote-won LWW)? This
@@ -338,10 +334,7 @@ export async function applyIncomingPush(payload) {
         && linkedTrack.id === record.trackId) {
       await RECORD_KINDS.track.merge([linkedTrack], { source }).then(() => {
         linkedTrackApplied = true;
-      }).catch((err) => {
-        console.log(`⚠️ peerSync: linkedTrack merge failed: ${err.message}`);
-        trackSyncPending = true;
-      });
+      }).catch(markPending('linkedTrack'));
     }
   }
 
@@ -484,9 +477,9 @@ export async function applyIncomingPush(payload) {
     ...(missingDraftBodies.length > 0 ? { missingDraftBodies } : {}),
     reverseSubscriptionCreated,
     ackedDeletesUpTo,
-    ...(reviewSyncPending ? { reviewSyncPending: true } : {}),
-    ...(outlineSyncPending ? { outlineSyncPending: true } : {}),
-    ...(trackSyncPending ? { trackSyncPending: true } : {}),
+    // One `<pendingKey>: true` per sidecar doc whose merge threw, keyed off the
+    // same ENVELOPE_EXTENSIONS table the sender reads them back from.
+    ...Object.fromEntries([...pending].map((k) => [k, true])),
   };
 }
 

--- a/server/services/sharing/peerSyncReceive.js
+++ b/server/services/sharing/peerSyncReceive.js
@@ -247,13 +247,10 @@ export async function applyIncomingPush(payload) {
   // the merge fns fall back to `{ via:'sync', peerId:null }` and the
   // attribution is lost).
   const source = { via: 'peer-push', peerId: sourceInstanceId };
-  // ENVELOPE_EXTENSIONS pending flags to echo to the sender: each is a bundled
-  // sidecar doc whose merge threw AFTER the record itself merged. None of the
-  // sidecars — the review, the outline, or the #1858 linked track a
-  // musicVideoProjects-only subscriber has no `tracks` cycle for — has an
-  // independent reconciliation path, so the sender withholds lastPushedHash
-  // on the flag and re-sends next cycle; a swallowed failure behind a saved
-  // hash would strand the doc. The record push itself never fails on these.
+  // ENVELOPE_EXTENSIONS pending flags to echo to the sender: a bundled sidecar
+  // doc whose merge threw AFTER the record itself merged is still owed, and
+  // the sender withholds lastPushedHash on the flag until it lands. The record
+  // push itself never fails on these.
   const pending = new Set();
   const markPending = (key) => (err) => {
     console.log(`⚠️ peerSync: ${key} merge failed: ${err.message}`);
@@ -297,7 +294,7 @@ export async function applyIncomingPush(payload) {
     // NOT fail the push (the series/issues already merged) — but unlike the
     // linkedCollection bundle, the review has NO independent reconciliation
     // cycle, so a swallowed failure could never resend once the sender saves
-    // lastPushedHash. Signal `reviewSyncPending` so the sender withholds the
+    // lastPushedHash. Raise the row's pending flag so the sender withholds the
     // hash (mirrors the missing-assets guard) and retries next cycle.
     // Dynamic import keeps the arcPlanner graph off peerSync's load path.
     if (!localEphemeral && record.deleted !== true && isPlainObject(manuscriptReview)) {

--- a/server/services/sharing/peerSyncShared.js
+++ b/server/services/sharing/peerSyncShared.js
@@ -36,7 +36,9 @@ export const PEER_SUBSCRIBABLE_KINDS = Object.freeze(['universe', 'series', 'med
  *   3. WITHHOLD — while a row is pending the sender withholds `lastPushedHash`
  *      so the next cycle re-sends instead of short-circuiting as `unchanged`
  *      (`resolvePushWatermarks` in peerSyncPush.js, including #3928's
- *      `lastPushedLegacyHash` for the stable strip case).
+ *      `lastPushedLegacyHash` for the stable strip case). The same sidecar
+ *      rows form the sender's change-hash input (`pushPayloadHash`): a doc
+ *      with no cycle of its own is delivered only by that hash moving.
  *
  * `pendingKey: null` marks a key with its OWN reconciliation cycle — the
  * version-gate handshake re-includes `portosMeta` on every push, and catalog

--- a/server/services/sharing/peerSyncShared.js
+++ b/server/services/sharing/peerSyncShared.js
@@ -51,10 +51,18 @@ export const PEER_SUBSCRIBABLE_KINDS = Object.freeze(['universe', 'series', 'med
  * fails until every row has a carrier on both sides.
  */
 export const ENVELOPE_EXTENSIONS = Object.freeze([
+  // The schema-version handshake (`buildPortosMeta`); a pre-version-gate
+  // receiver's strict schema has no field for it.
   Object.freeze({ key: 'portosMeta', pendingKey: null }),
+  // Catalog-federation enrichment riding a universe push; a peer newer than
+  // the version gate but older than catalog federation rejects it.
   Object.freeze({ key: 'catalogBundle', pendingKey: null }),
+  // The "Finish the draft" manuscript-review doc riding a series push.
   Object.freeze({ key: 'manuscriptReview', pendingKey: 'reviewSyncPending' }),
+  // The scene-by-scene reverse outline riding a series push (#1348).
   Object.freeze({ key: 'reverseOutline', pendingKey: 'outlineSyncPending' }),
+  // The linked track record riding a musicVideoProject push (#1858) — a
+  // musicVideoProjects-only subscriber has no `tracks` cycle to fall back on.
   Object.freeze({ key: 'linkedTrack', pendingKey: 'trackSyncPending' }),
 ]);
 

--- a/server/services/sharing/peerSyncShared.js
+++ b/server/services/sharing/peerSyncShared.js
@@ -18,6 +18,55 @@ import { getPeers, resolveEffectiveCategories } from '../instances.js';
 export const PEER_SUBSCRIBABLE_KINDS = Object.freeze(['universe', 'series', 'mediaCollection', 'author', 'artist', 'album', 'track', 'creativeDirectorProject', 'moodBoard', 'fableLoom', 'writersRoomWork', 'writersRoomFolder', 'writersRoomExercise', 'musicVideoProject', 'commissionFeedback', 'creativeCommission']);
 
 /**
+ * The optional top-level keys a NEWER sender may attach to a push envelope
+ * beyond the `{ kind, record, assetManifest, sourceInstanceId }` core. These
+ * are the mechanism the schema-version design relies on for "degrades
+ * gracefully on older peers" (`server/lib/schemaVersions.js`), and every row
+ * shares ONE lifecycle that both sides of the wire drive off this table
+ * (#6844) instead of a hand-written flag pair per key:
+ *
+ *   1. STRIP — an older receiver's `.strict()` push schema predates the key,
+ *      so it 400-rejects the whole envelope at Zod, naming the key. The
+ *      sender drops whichever listed keys the receiver named and retries
+ *      once so the record still lands; the stripped feature reaches that
+ *      peer once it upgrades, because the next push re-includes the key.
+ *   2. PENDING — `pendingKey` is the response flag the RECEIVER raises when
+ *      that bundle's merge threw after the record itself merged (2xx). The
+ *      sender reads the same flag back, and counts its own strip as pending.
+ *   3. WITHHOLD — while a row is pending the sender withholds `lastPushedHash`
+ *      so the next cycle re-sends instead of short-circuiting as `unchanged`
+ *      (`resolvePushWatermarks` in peerSyncPush.js, including #3928's
+ *      `lastPushedLegacyHash` for the stable strip case).
+ *
+ * `pendingKey: null` marks a key with its OWN reconciliation cycle — the
+ * version-gate handshake re-includes `portosMeta` on every push, and catalog
+ * sync reconciles `catalogBundle`'s rows — so a strip there is not pending
+ * and the hash saves normally. The three sidecar docs have no independent
+ * cycle; they are the ones a saved hash would strand.
+ *
+ * The wire names are frozen: older senders and receivers read exactly these
+ * `pendingKey`s, and `server/lib/peerSyncValidation.js` validates the
+ * envelope keys. Adding a bundled doc is one row here plus its build/merge
+ * hooks — never a new flag pair. `peerSync.test.js` ("envelope extensions")
+ * fails until every row has a carrier on both sides.
+ */
+export const ENVELOPE_EXTENSIONS = Object.freeze([
+  Object.freeze({ key: 'portosMeta', pendingKey: null }),
+  Object.freeze({ key: 'catalogBundle', pendingKey: null }),
+  Object.freeze({ key: 'manuscriptReview', pendingKey: 'reviewSyncPending' }),
+  Object.freeze({ key: 'reverseOutline', pendingKey: 'outlineSyncPending' }),
+  Object.freeze({ key: 'linkedTrack', pendingKey: 'trackSyncPending' }),
+]);
+
+/**
+ * Envelope key → the receiver's pending flag, for the sidecar rows only
+ * (derived from ENVELOPE_EXTENSIONS; the self-reconciling keys are absent).
+ */
+export const ENVELOPE_PENDING_KEYS = Object.freeze(Object.fromEntries(
+  ENVELOPE_EXTENSIONS.filter((e) => e.pendingKey).map((e) => [e.key, e.pendingKey]),
+));
+
+/**
  * Cross-cutting event bus for the peer-sync receiver. The asset-pull worker
  * emits `asset-arrived` ({ filename, kind, peerId }) when a previously-missing
  * file lands locally; `sharing/index.js` wires that to a socket emission so


### PR DESCRIPTION
## Summary

`pushRecordToPeer` hand-mirrored one three-step lifecycle (strip on a legacy peer's strict-schema 400 → pending flag → withhold `lastPushedHash`) for each optional envelope key a newer sender may attach, and `applyIncomingPush` mirrored the flag set by hand on the receiver. Which keys withhold the hash and which don't was expressed only by which copied arm happened to set a flag — the copy that missed a step has bitten before (82812b41a, #3928) and only reproduces across two installs on different versions.

- **`ENVELOPE_EXTENSIONS`** (`peerSyncShared.js`) declares the five keys once, with `pendingKey` naming the receiver flag for the three sidecar docs and `null` for the two keys with their own reconciliation cycle (`portosMeta`, `catalogBundle`).
- **Sender:** `classifyEnvelopeRejection` parses a 400 once and returns the rows the receiver named *and* the payload carries (one retry without exactly those) or the unknown-kind signal; `resolvePushWatermarks` states the #3928 contract once (`settled && !stripped` → `lastPushedHash`, `settled && stripped` → `lastPushedLegacyHash`) and hands back the pending set for #1922's bundled-track GC floor; `pushPayloadHash` derives its sidecar keys from the table (sorted, so every stored hash stays byte-identical — no re-push on upgrade).
- **Receiver:** each throwing sidecar merge adds its row's `pendingKey` to one set, spread into the response.
- **Wire contract unchanged:** `reviewSyncPending` / `outlineSyncPending` / `trackSyncPending`, `lastPushedHash` / `lastPushedLegacyHash` / `lastConfirmedTrackBundleAtMs`, and `server/lib/peerSyncValidation.js` are untouched.
- Own-body cyclomatic complexity of `pushRecordToPeer`: **101 → 57** (target ≤ 65); `applyIncomingPush` 43 → 40.
- One deliberate delta: a `VALIDATION_ERROR` naming an extension key the payload never carried used to re-POST the identical envelope once before reporting `http-400`; it now reports `http-400` directly (same outcome, one fewer request).

Commit shape: (1) the table plus table-driven boundary cases pinned **before** the rewrite — carrier guards fail the suite when a row is added without a fixture on either side, and the previously untested stripped-`linkedTrack` → `lastConfirmedTrackBundleAtMs` case is covered; (2) the rewrite, with every pre-existing case passing unmodified; (3) the `/simplify` pass on the source; (4) the per-key test twins the table-driven block subsumes are removed, their two unique assertions folded into one deep-equal, plus the one case no twin had (a single 400 naming two keys → one retry without both).

## Test plan

- [x] `server/services/sharing/peerSync.test.js` — every pre-existing case passed unmodified against the rewrite (commits 1–2) before the twins were pruned (commit 4)
- [x] `cd server && vitest run services/sharing routes/peerSync.test.js` — 27 files / 800 tests green
- [x] `lib/importScoping.test.js`, `lib/index.test.js`, `lib/generatedManifests.test.js` green (no new module edges)
- [x] Hash-input parity checked on four payload shapes (table-derived vs. the previous literal order: byte-identical)
- [x] Own-body CC re-measured after the last edit (57)
- [x] Tool-free `opencode` review (plan agent, all tools denied) on the final diff: `NO FINDINGS`
- [ ] CI

Closes #6844
