### PR TITLE
fix: make browser recovery visible and prevent controls overflow

### DIFF
--- a/client/src/pages/Browser.jsx
+++ b/client/src/pages/Browser.jsx
@@ -43,13 +43,18 @@ export default function BrowserPage() {
   const [configDraft, setConfigDraft] = useState(null);
   const [navUrl, setNavUrl] = useState('');
   const [showDownloads, setShowDownloads] = useState(true);
+  const [statusError, setStatusError] = useState(null);
 
   const fetchStatus = useCallback(async () => {
-    const data = await getBrowserStatus().catch(() => null);
+    const data = await getBrowserStatus({ silent: true }).catch(err => {
+      setStatusError(err.message);
+      return null;
+    });
     if (data) {
       setStatus(data);
-      setLoading(false);
+      setStatusError(null);
     }
+    setLoading(false);
   }, []);
 
   const fetchLogs = useCallback(async () => {
@@ -84,7 +89,11 @@ export default function BrowserPage() {
       return null;
     });
     if (result) {
-      toast.success(`Browser ${action} successful`);
+      if ((action === 'launch' || action === 'restart') && !result.connected) {
+        toast.error('Browser process started, but Chrome is not connected yet. Check the recovery steps below if it stays disconnected.');
+      } else {
+        toast.success(`Browser ${action} successful`);
+      }
       // Refresh full status after action
       await fetchStatus();
     }
@@ -148,7 +157,7 @@ export default function BrowserPage() {
           </h2>
           <p className="text-gray-500">Manage the authenticated CDP/Playwright browser</p>
         </div>
-        <div className="flex items-center gap-2 flex-wrap">
+        <div className="flex items-center gap-2 flex-wrap shrink-0">
           <button
             onClick={() => setShowConfig(s => !s)}
             className={`flex items-center gap-2 px-3 py-1.5 text-sm rounded-lg transition-colors ${
@@ -158,7 +167,7 @@ export default function BrowserPage() {
             }`}
           >
             <Settings size={16} />
-            <span className="hidden sm:inline">Config</span>
+            <span>Config</span>
           </button>
           <button
             onClick={() => { setShowLogs(s => !s); }}
@@ -169,7 +178,7 @@ export default function BrowserPage() {
             }`}
           >
             <FileText size={16} />
-            <span className="hidden sm:inline">Logs</span>
+            <span>Logs</span>
           </button>
           <button
             onClick={fetchStatus}
@@ -177,10 +186,16 @@ export default function BrowserPage() {
             className="flex items-center gap-2 px-3 py-1.5 text-sm rounded-lg bg-port-card border border-port-border text-gray-400 hover:text-white hover:border-port-accent/50 transition-colors disabled:opacity-50"
           >
             <RefreshCw size={16} className={loading ? 'animate-spin' : ''} />
-            <span className="hidden sm:inline">Refresh</span>
+            <span>Refresh</span>
           </button>
         </div>
       </div>
+
+      {statusError && (
+        <p role="alert" className="mb-4 text-sm text-port-error">
+          Could not refresh browser status: {statusError}. Use Refresh to try again.
+        </p>
+      )}
 
       {/* Config panel */}
       {showConfig && configDraft && (
@@ -304,10 +319,73 @@ export default function BrowserPage() {
       {/* Main grid */}
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
         {/* Status + Controls */}
-        <div className="lg:col-span-2 space-y-6">
+        <div className="lg:col-span-2 min-w-0 space-y-6">
+          {/* Controls */}
+          <div className="bg-port-card border border-port-border rounded-xl p-5">
+            <h3 className="text-lg font-semibold text-white mb-4">Controls</h3>
+            {isRunning && !isConnected && (
+              <div role="status" className="mb-4 rounded-lg border border-port-warning/30 bg-port-warning/10 p-3 text-sm">
+                <p className="font-medium text-port-warning">Chrome is not reachable</p>
+                <p className="mt-1 text-gray-400">
+                  The launcher is running, but Chrome’s control connection is unavailable. Startup can take a few seconds.
+                  If this persists, restart the browser below. Restart may interrupt browser tasks.
+                </p>
+                {status.error && <p className="mt-2 text-port-warning break-words">{status.error}</p>}
+                <p className="mt-2 text-gray-400">
+                  If restarting does not help, open Logs for the launch error and Config to check the Chrome binary path
+                  and ports. On a machine without a desktop session, enable Headless mode, save, then restart.
+                </p>
+                <div className="mt-3 flex flex-wrap gap-3">
+                  <button onClick={() => setShowLogs(true)} className="text-port-accent underline">Show logs</button>
+                  <button onClick={() => setShowConfig(true)} className="text-port-accent underline">Edit configuration</button>
+                </div>
+              </div>
+            )}
+            <div className="flex flex-wrap gap-2">
+              {!isRunning ? (
+                <button
+                  onClick={() => handleAction('launch', launchBrowser)}
+                  disabled={loading || !status || actionLoading !== null}
+                  className="flex items-center gap-1.5 px-3 py-1.5 text-sm bg-port-success text-white rounded-lg hover:bg-port-success/80 transition-colors disabled:opacity-50"
+                >
+                  {actionLoading === 'launch'
+                    ? <RefreshCw size={14} className="animate-spin" />
+                    : <Play size={14} />
+                  }
+                  Launch
+                </button>
+              ) : (
+                <>
+                  <button
+                    onClick={() => handleAction('stop', stopBrowser)}
+                    disabled={loading || !status || actionLoading !== null}
+                    className="flex items-center gap-1.5 px-3 py-1.5 text-sm bg-port-error text-white rounded-lg hover:bg-port-error/80 transition-colors disabled:opacity-50"
+                  >
+                    {actionLoading === 'stop'
+                      ? <RefreshCw size={14} className="animate-spin" />
+                      : <Square size={14} />
+                    }
+                    Stop
+                  </button>
+                  <button
+                    onClick={() => handleAction('restart', restartBrowser)}
+                    disabled={loading || !status || actionLoading !== null}
+                    className="flex items-center gap-1.5 px-3 py-1.5 text-sm bg-port-warning text-white rounded-lg hover:bg-port-warning/80 transition-colors disabled:opacity-50"
+                  >
+                    {actionLoading === 'restart'
+                      ? <RefreshCw size={14} className="animate-spin" />
+                      : <RefreshCw size={14} />
+                    }
+                    {isConnected ? 'Restart' : 'Restart browser to reconnect'}
+                  </button>
+                </>
+              )}
+            </div>
+          </div>
+
           {/* Status card */}
           <div className="bg-port-card border border-port-border rounded-xl p-5">
-            <div className="flex items-center justify-between mb-4">
+            <div className="flex flex-wrap items-center justify-between gap-3 mb-4">
               <h3 className="text-lg font-semibold text-white flex items-center gap-2">
                 <Activity size={20} className="text-port-accent" />
                 Browser Status
@@ -320,7 +398,7 @@ export default function BrowserPage() {
                     : 'bg-port-error/10 text-port-error'
               }`}>
                 {isConnected ? <Wifi size={14} /> : <WifiOff size={14} />}
-                {isConnected ? 'Connected' : isRunning ? 'Running (not connected)' : 'Stopped'}
+                {isConnected ? 'Connected' : isRunning ? 'Running (not connected)' : loading ? 'Checking…' : !status ? 'Unknown' : 'Stopped'}
               </div>
             </div>
 
@@ -387,51 +465,6 @@ export default function BrowserPage() {
             )}
           </div>
 
-          {/* Controls */}
-          <div className="bg-port-card border border-port-border rounded-xl p-5">
-            <h3 className="text-lg font-semibold text-white mb-4">Controls</h3>
-            <div className="flex flex-wrap gap-2">
-              {!isRunning ? (
-                <button
-                  onClick={() => handleAction('launch', launchBrowser)}
-                  disabled={actionLoading !== null}
-                  className="flex items-center gap-1.5 px-3 py-1.5 text-sm bg-port-success text-white rounded-lg hover:bg-port-success/80 transition-colors disabled:opacity-50"
-                >
-                  {actionLoading === 'launch'
-                    ? <RefreshCw size={14} className="animate-spin" />
-                    : <Play size={14} />
-                  }
-                  Launch
-                </button>
-              ) : (
-                <>
-                  <button
-                    onClick={() => handleAction('stop', stopBrowser)}
-                    disabled={actionLoading !== null}
-                    className="flex items-center gap-1.5 px-3 py-1.5 text-sm bg-port-error text-white rounded-lg hover:bg-port-error/80 transition-colors disabled:opacity-50"
-                  >
-                    {actionLoading === 'stop'
-                      ? <RefreshCw size={14} className="animate-spin" />
-                      : <Square size={14} />
-                    }
-                    Stop
-                  </button>
-                  <button
-                    onClick={() => handleAction('restart', restartBrowser)}
-                    disabled={actionLoading !== null}
-                    className="flex items-center gap-1.5 px-3 py-1.5 text-sm bg-port-warning text-white rounded-lg hover:bg-port-warning/80 transition-colors disabled:opacity-50"
-                  >
-                    {actionLoading === 'restart'
-                      ? <RefreshCw size={14} className="animate-spin" />
-                      : <RefreshCw size={14} />
-                    }
-                    Restart
-                  </button>
-                </>
-              )}
-            </div>
-          </div>
-
           {/* Navigate to URL */}
           {isConnected && (
             <div className="bg-port-card border border-port-border rounded-xl p-5">
@@ -449,7 +482,7 @@ export default function BrowserPage() {
                   value={navUrl}
                   onChange={e => setNavUrl(e.target.value)}
                   placeholder="https://example.com"
-                  className="flex-1 px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white text-sm focus:outline-hidden focus:border-port-accent placeholder-gray-600"
+                  className="min-w-0 flex-1 px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white text-sm focus:outline-hidden focus:border-port-accent placeholder-gray-600"
                 />
                 <button
                   type="submit"
@@ -480,7 +513,7 @@ export default function BrowserPage() {
                       }).catch(err => toast.error(`Failed to navigate: ${err.message}`))
                         .finally(() => setActionLoading(null));
                     }}
-                    disabled={actionLoading !== null}
+                    disabled={loading || !status || actionLoading !== null}
                     className="flex items-center gap-1.5 px-3 py-1.5 text-sm bg-port-bg border border-port-border text-gray-400 rounded-lg hover:text-white hover:border-port-accent/50 transition-colors disabled:opacity-50 cursor-pointer"
                   >
                     <Icon size={14} />

--- a/client/src/pages/Browser.test.jsx
+++ b/client/src/pages/Browser.test.jsx
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import BrowserPage from './Browser';
+import * as api from '../services/api';
+import toast from '../components/ui/Toast';
+
+vi.mock('../services/api', () => ({
+  getBrowserStatus: vi.fn(), getBrowserConfig: vi.fn(), updateBrowserConfig: vi.fn(),
+  launchBrowser: vi.fn(), stopBrowser: vi.fn(), restartBrowser: vi.fn(),
+  getBrowserLogs: vi.fn(), navigateBrowser: vi.fn(),
+  browserDownloadUrl: vi.fn(), deleteBrowserDownload: vi.fn()
+}));
+vi.mock('../components/ui/Toast', () => ({ default: { success: vi.fn(), error: vi.fn() } }));
+
+const disconnected = {
+  connected: false, process: { status: 'online' }, pages: [],
+  error: 'Health check returned 503', config: { headless: false }
+};
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  api.getBrowserStatus.mockResolvedValue(disconnected);
+  api.getBrowserLogs.mockResolvedValue({ stderr: 'Chrome binary not found' });
+  api.getBrowserConfig.mockResolvedValue({ cdpPort: 5556, healthPort: 5557, cdpHost: '127.0.0.1', headless: false, autoConnect: true });
+});
+
+describe('Browser recovery', () => {
+  it('exposes diagnostics and config and restores navigation after a successful restart', async () => {
+    const user = userEvent.setup();
+    render(<BrowserPage />);
+    expect(await screen.findByText('Chrome is not reachable')).toBeInTheDocument();
+    expect(screen.getByText('Health check returned 503')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Show logs' }));
+    expect(await screen.findByText('Chrome binary not found')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Edit configuration' }));
+    expect(await screen.findByRole('checkbox', { name: 'Headless mode' })).toBeInTheDocument();
+    api.restartBrowser.mockResolvedValue({ connected: true });
+    api.getBrowserStatus.mockResolvedValue({ ...disconnected, connected: true });
+    await user.click(screen.getByRole('button', { name: 'Restart browser to reconnect' }));
+    expect(await screen.findByRole('textbox', { name: 'URL to open' })).toBeInTheDocument();
+    expect(screen.queryByText('Chrome is not reachable')).not.toBeInTheDocument();
+    expect(api.restartBrowser).toHaveBeenCalledWith({ silent: true });
+  });
+
+  it('keeps recovery available and avoids a success toast when restarting does not connect', async () => {
+    api.restartBrowser.mockResolvedValue({ connected: false });
+    render(<BrowserPage />);
+    await userEvent.click(await screen.findByRole('button', { name: 'Restart browser to reconnect' }));
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith(expect.stringContaining('not connected yet')));
+    expect(toast.success).not.toHaveBeenCalled();
+    expect(screen.getByText('Chrome is not reachable')).toBeInTheDocument();
+  });
+
+  it('allows a failed initial status request to be retried without offering a blind launch', async () => {
+    api.getBrowserStatus.mockRejectedValueOnce(new Error('Offline'));
+    render(<BrowserPage />);
+    expect(await screen.findByRole('alert')).toHaveTextContent('Offline');
+    expect(screen.getByRole('button', { name: 'Launch' })).toBeDisabled();
+    await userEvent.click(screen.getByRole('button', { name: 'Refresh' }));
+    expect(await screen.findByText('Chrome is not reachable')).toBeInTheDocument();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+});

--- a/client/src/services/apiSystem.js
+++ b/client/src/services/apiSystem.js
@@ -318,7 +318,7 @@ export const updateTelegramMethod = (method, options) => request('/telegram/meth
 });
 
 // Browser - CDP browser management
-export const getBrowserStatus = () => request('/browser');
+export const getBrowserStatus = (options) => request('/browser', options);
 export const getBrowserConfig = () => request('/browser/config');
 export const updateBrowserConfig = (config, options = {}) => request('/browser/config', {
   method: 'PUT',


### PR DESCRIPTION
## Summary
- Keep Browser toolbar labels visible, wrap the status heading, and constrain the URL input so controls fit on narrow screens.
- Put Controls first and explain running-but-disconnected status with a restart action, launch diagnostics, and configuration guidance.
- Report disconnected launch/restart results honestly and let users retry a failed initial status request.

## Test plan
- Browser rendered interaction tests: successful recovery, persistent disconnection, and initial status request retry.
- Responsive grid and polling convention checks: 11 tests passed in total.
- Targeted Biome lint and production Vite build passed.
- Headless Chrome visual checks with simulated status at 360, 768, and 1280 pixels: no horizontal overflow; mobile Go button stays inside its card.
