### PR TITLE
cache the review store, archive stale items, and batch bulk-status socket events

### DIFF
--- a/client/src/components/ReviewHubCard.jsx
+++ b/client/src/components/ReviewHubCard.jsx
@@ -14,11 +14,13 @@ export default function ReviewHubCard() {
     socket.on('review:item:created', refresh);
     socket.on('review:item:updated', refresh);
     socket.on('review:item:deleted', refresh);
+    socket.on('review:items:bulk-updated', refresh);
 
     return () => {
       socket.off('review:item:created', refresh);
       socket.off('review:item:updated', refresh);
       socket.off('review:item:deleted', refresh);
+      socket.off('review:items:bulk-updated', refresh);
     };
   }, []);
 

--- a/client/src/components/ReviewHubCard.test.jsx
+++ b/client/src/components/ReviewHubCard.test.jsx
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { act, render, screen } from '@testing-library/react';
+
+const api = vi.hoisted(() => ({
+  getReviewCounts: vi.fn()
+}));
+
+const socket = vi.hoisted(() => ({
+  on: vi.fn(),
+  off: vi.fn(),
+  emit: vi.fn()
+}));
+
+vi.mock('../services/api', () => api);
+vi.mock('../services/socket', () => ({ default: socket }));
+vi.mock('react-router', () => ({
+  Link: ({ children, to, ...props }) => <a href={to} {...props}>{children}</a>
+}));
+
+import ReviewHubCard from './ReviewHubCard';
+
+// Invokes the handler the component registered for `event` via socket.on,
+// the same pattern as client/src/hooks/useNotifications.test.jsx.
+function deliver(event, payload) {
+  const handler = socket.on.mock.calls.find(([name]) => name === event)?.[1];
+  expect(handler).toBeTypeOf('function');
+  handler(payload);
+}
+
+const ZERO_COUNTS = { total: 0, alert: 0, todo: 0, briefing: 0, cos: 0 };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  api.getReviewCounts.mockResolvedValue(ZERO_COUNTS);
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('ReviewHubCard', () => {
+  it('subscribes to every review socket event, including the bulk-update event, on mount', async () => {
+    render(<ReviewHubCard />);
+    await act(async () => { await Promise.resolve(); });
+
+    const events = socket.on.mock.calls.map(([name]) => name);
+    expect(events).toEqual(expect.arrayContaining([
+      'review:item:created',
+      'review:item:updated',
+      'review:item:deleted',
+      'review:items:bulk-updated'
+    ]));
+  });
+
+  it('renders the all-caught-up state when there are no pending items', async () => {
+    render(<ReviewHubCard />);
+    expect(await screen.findByText('All caught up!')).toBeInTheDocument();
+  });
+
+  it('renders the total badge and per-type breakdown once counts resolve', async () => {
+    api.getReviewCounts.mockResolvedValue({ total: 3, alert: 1, todo: 1, briefing: 0, cos: 1 });
+    render(<ReviewHubCard />);
+
+    expect(await screen.findByText('3')).toBeInTheDocument();
+    expect(screen.getByText('1 alert')).toBeInTheDocument();
+    expect(screen.getByText('1 todo')).toBeInTheDocument();
+    expect(screen.getByText('1 CoS')).toBeInTheDocument();
+  });
+
+  it('refetches counts exactly once when a review:items:bulk-updated event arrives', async () => {
+    render(<ReviewHubCard />);
+    await act(async () => { await Promise.resolve(); });
+    expect(api.getReviewCounts).toHaveBeenCalledTimes(1); // the initial mount fetch
+
+    api.getReviewCounts.mockResolvedValue({ total: 5, alert: 0, todo: 5, briefing: 0, cos: 0 });
+    await act(async () => {
+      deliver('review:items:bulk-updated', { ids: ['a', 'b'], status: 'dismissed', updatedAt: new Date().toISOString() });
+      await Promise.resolve();
+    });
+
+    expect(api.getReviewCounts).toHaveBeenCalledTimes(2);
+    expect(await screen.findByText('5')).toBeInTheDocument();
+  });
+
+  it('unsubscribes every review event, including the bulk-update event, on unmount', async () => {
+    const { unmount } = render(<ReviewHubCard />);
+    await act(async () => { await Promise.resolve(); });
+
+    unmount();
+
+    const offEvents = socket.off.mock.calls.map(([name]) => name);
+    expect(offEvents).toEqual(expect.arrayContaining([
+      'review:item:created',
+      'review:item:updated',
+      'review:item:deleted',
+      'review:items:bulk-updated'
+    ]));
+  });
+});

--- a/client/src/pages/Review.jsx
+++ b/client/src/pages/Review.jsx
@@ -144,15 +144,23 @@ export default function Review() {
     const handleDeleted = (item) => {
       setItems(prev => prev.filter(i => i.id !== item.id));
     };
+    // Bulk status change ("Mark all read" / "Complete all") — one state
+    // update for every affected id instead of N per-item events.
+    const handleBulkUpdated = ({ ids, status, updatedAt }) => {
+      const idSet = new Set(ids);
+      setItems(prev => prev.map(i => idSet.has(i.id) ? { ...i, status, updatedAt } : i));
+    };
 
     socket.on('review:item:created', handleCreated);
     socket.on('review:item:updated', handleUpdated);
     socket.on('review:item:deleted', handleDeleted);
+    socket.on('review:items:bulk-updated', handleBulkUpdated);
 
     return () => {
       socket.off('review:item:created', handleCreated);
       socket.off('review:item:updated', handleUpdated);
       socket.off('review:item:deleted', handleDeleted);
+      socket.off('review:items:bulk-updated', handleBulkUpdated);
     };
   }, [fetchItems]);
 

--- a/client/src/pages/Review.test.jsx
+++ b/client/src/pages/Review.test.jsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 // A CoS action body is arbitrary agent-authored markdown — thousands of words,
 // its own heading outline, and raw technical payloads. This is the shape that
@@ -66,6 +66,7 @@ vi.mock('react-router', () => ({
 }));
 
 import Review from './Review';
+import socket from '../services/socket';
 
 // jsdom reports 0 for scrollHeight/clientHeight, so nothing measures as
 // overflowing unless we force it.
@@ -173,5 +174,37 @@ describe('Review Hub queue-card triage (#3282)', () => {
     // The same actionable item renders twice: Action Queue + its Alerts section.
     expect(document.getElementById(`review-item-body-section-alert-${ITEM.id}`)).toBeTruthy();
     expect(document.querySelectorAll(`[id="review-item-body-action-queue-${ITEM.id}"]`)).toHaveLength(1);
+  });
+});
+
+describe('Review Hub bulk status updates (#6853)', () => {
+  it('applies a review:items:bulk-updated event to every affected item in one update', async () => {
+    render(<Review />);
+    await waitFor(() => expect(actionQueueBody()).toBeTruthy());
+    await waitFor(() => expect(document.getElementById(`review-item-body-action-queue-${SHORT_ITEM.id}`)).toBeTruthy());
+
+    const handler = socket.on.mock.calls.find(([name]) => name === 'review:items:bulk-updated')?.[1];
+    expect(handler).toBeTypeOf('function');
+
+    act(() => {
+      handler({ ids: [ITEM.id, SHORT_ITEM.id], status: 'dismissed', updatedAt: new Date().toISOString() });
+    });
+
+    // Both items are no longer pending, so — in the same render — both drop
+    // out of the Action Queue, which is built from pendingItems.
+    await waitFor(() => {
+      expect(actionQueueBody()).toBeFalsy();
+      expect(document.getElementById(`review-item-body-action-queue-${SHORT_ITEM.id}`)).toBeFalsy();
+    });
+  });
+
+  it('subscribes to and unsubscribes from review:items:bulk-updated', async () => {
+    const { unmount } = render(<Review />);
+    await waitFor(() => expect(actionQueueBody()).toBeTruthy());
+
+    expect(socket.on.mock.calls.some(([name]) => name === 'review:items:bulk-updated')).toBe(true);
+
+    unmount();
+    expect(socket.off.mock.calls.some(([name]) => name === 'review:items:bulk-updated')).toBe(true);
   });
 });

--- a/server/services/review.js
+++ b/server/services/review.js
@@ -40,21 +40,25 @@ const ARCHIVE_ELIGIBLE_STATUSES = new Set(['completed', 'dismissed']);
 // re-stats after every write and seeds the cache directly from what it just
 // wrote, so a read immediately following a write is a cache hit, not a re-parse.
 //
-// Every mutation path below (createItem/updateItemStatus/bulkUpdateStatus/
-// updateItem/deleteItem/updateStatusByReferenceId) mutates the array/items
-// returned by `loadItems()` in place and then immediately calls `saveItems`
-// with that same array — never mutates without saving. That invariant is what
-// makes it safe for `loadItems()` to hand back the cached array/objects
-// directly instead of deep-cloning on every read: a caller either treats it as
-// read-only, or mutates it and persists the result in the same call, which
-// `saveItems` then adopts as the new cache. Keep that invariant true for any
-// new mutation path.
+// `loadItems()` hands every caller a fresh shallow clone (see `cloneItems`),
+// never the cached array/objects themselves — `getItems` is a public export
+// with callers outside this module's own mutate-then-save discipline, and a
+// caller that decorated or edited a returned item in place would otherwise
+// silently pollute the cache, later persisted by the next unrelated
+// `saveItems` call. The internal mutation paths below (createItem/
+// updateItemStatus/bulkUpdateStatus/updateItem/deleteItem/
+// updateStatusByReferenceId) mutate the clone `loadItems()` gave them and
+// then immediately call `saveItems` with it — `saveItems` adopts whatever
+// array it is given as the new cache, so this costs nothing extra there.
 let itemsCache = null; // { mtimeMs, size, items }
 let lastRetentionAt = 0; // 0 so the first save after boot always evaluates retention
 
+const cloneItems = (items) => items.map(i => ({ ...i, metadata: { ...(i.metadata || {}) } }));
+
 /**
  * Load all review items from file, reusing the cached parse when the file's
- * mtime/size haven't changed since the last read.
+ * mtime/size haven't changed since the last read. Always returns a clone —
+ * see the cache comment above.
  */
 // STRICT (#4115): `getPendingCounts()` reduces this list into the Review Hub's
 // total/alert/todo/briefing/cos tiles, so a swallowed unreadable read reports a
@@ -73,21 +77,39 @@ async function loadItems() {
   }
 
   if (itemsCache && itemsCache.mtimeMs === stats.mtimeMs && itemsCache.size === stats.size) {
-    return itemsCache.items;
+    return cloneItems(itemsCache.items);
   }
 
   const items = await readJSONFile(ITEMS_FILE, [], { strict: true });
   itemsCache = { mtimeMs: stats.mtimeMs, size: stats.size, items };
-  return items;
+  return cloneItems(items);
 }
 
 /**
  * Load the archived (retired) items. Never cached — only read from the
  * history views (`getItems` for a completed/dismissed/unfiltered query,
  * and `createItem`'s duplicate-alert check when the live scan misses).
+ * Strict: a caller that must not silently treat "unreadable" as "empty"
+ * (`applyRetention`, before it trusts the file enough to write over it)
+ * awaits this directly. A read-only view that can safely degrade instead
+ * uses `loadArchiveOrEmpty`.
  */
 async function loadArchive() {
   return readJSONFile(ARCHIVE_FILE, [], { strict: true });
+}
+
+/**
+ * Read-only archive access for history views: on a corrupt/unreadable
+ * archive.json, log and continue without archived items rather than 500ing
+ * every completed/dismissed/unfiltered review read. Never used by the write
+ * path (`applyRetention`), which must not mistake "unreadable" for "empty"
+ * and overwrite real archived history with just the newest batch.
+ */
+async function loadArchiveOrEmpty(context) {
+  return loadArchive().catch((err) => {
+    console.error(`⚠️ Review archive unreadable (${context}), continuing without archived items: ${err.message}`);
+    return [];
+  });
 }
 
 /**
@@ -99,12 +121,14 @@ async function loadArchive() {
  * that duplication self-heal on the very next retention pass instead of
  * accumulating a second archive.json copy forever.
  *
- * An unreadable archive.json is isolated to THIS function rather than left to
- * throw: `saveItems` calls this on every create/status-flip/bulk/delete, so a
- * corrupt archive.json must not block every live review write. On that
- * failure this returns `items` untouched (items.json is not rewritten either)
- * and leaves `lastRetentionAt` alone so the very next write retries retention
- * instead of waiting out the full interval against a file nobody fixed yet.
+ * Both the archive READ and the archive WRITE are isolated to THIS function
+ * rather than left to throw: `saveItems` calls this on every
+ * create/status-flip/bulk/delete, so a corrupt archive.json — or a failed
+ * write to it (disk full, permission error) — must not block every live
+ * review write. Either failure returns `items` untouched (items.json is not
+ * rewritten either) and leaves `lastRetentionAt` alone, so the very next
+ * write retries retention instead of waiting out the full interval against a
+ * problem nobody has fixed yet.
  */
 async function applyRetention(items) {
   const now = Date.now();
@@ -131,10 +155,18 @@ async function applyRetention(items) {
 
   const archivedIds = new Set(archive.map(i => i.id));
   const fresh = toArchive.filter(i => !archivedIds.has(i.id));
-  if (fresh.length > 0) {
-    await atomicWrite(ARCHIVE_FILE, [...archive, ...fresh]);
-    console.log(`📦 Review items archived: ${fresh.length}`);
+  if (fresh.length === 0) {
+    lastRetentionAt = now;
+    return remaining;
   }
+
+  const archived = await atomicWrite(ARCHIVE_FILE, [...archive, ...fresh]).then(() => true).catch((err) => {
+    console.error(`⚠️ Failed to write review archive, skipping retention this cycle: ${err.message}`);
+    return false;
+  });
+  if (!archived) return items;
+
+  console.log(`📦 Review items archived: ${fresh.length}`);
   lastRetentionAt = now;
   return remaining;
 }
@@ -154,12 +186,19 @@ async function saveItems(items) {
 /**
  * Get all review items, sorted by type then creation date (newest first).
  * A completed/dismissed or unfiltered query also merges in archive.json —
- * archive never holds a pending item, so a pending-only query skips it.
+ * archive never holds a pending item, so a pending-only query skips it. A
+ * corrupt archive.json degrades to "no archived items" rather than failing
+ * the whole read (`loadArchiveOrEmpty`) — unlike the retention write path,
+ * a read can safely omit history it could not trust. Deduped by id
+ * (live copy wins) in case a crash left the same item in both files
+ * mid-retention; see `applyRetention`'s doc comment.
  */
 export async function getItems({ status, type } = {}) {
   let items = await loadItems();
   if (!status || ARCHIVE_ELIGIBLE_STATUSES.has(status)) {
-    items = items.concat(await loadArchive());
+    const archived = await loadArchiveOrEmpty('getItems');
+    const liveIds = new Set(items.map(i => i.id));
+    items = items.concat(archived.filter(i => !liveIds.has(i.id)));
   }
   if (status) items = items.filter(i => i.status === status);
   if (type) items = items.filter(i => i.type === type);
@@ -200,14 +239,16 @@ export async function createItem({ type, title, description = '', metadata = {} 
   // window in practice — but check it anyway rather than silently narrowing
   // the dedup window the day an item crosses into archive.json. Only
   // consulted when the live scan misses, so the common case (no dedup match,
-  // or a live match) never touches the archive file.
+  // or a live match) never touches the archive file. A corrupt archive.json
+  // degrades to "no archived duplicate found" (`loadArchiveOrEmpty`) rather
+  // than blocking item creation entirely.
   if (type === 'alert' && metadata?.referenceId) {
     const oneDayAgo = Date.now() - 24 * 60 * 60 * 1000;
     const isDuplicate = (i) =>
       i.type === 'alert' &&
       i.metadata?.referenceId === metadata.referenceId &&
       new Date(i.createdAt).getTime() > oneDayAgo;
-    const duplicate = items.find(isDuplicate) ?? (await loadArchive()).find(isDuplicate);
+    const duplicate = items.find(isDuplicate) ?? (await loadArchiveOrEmpty('createItem duplicate check')).find(isDuplicate);
     if (duplicate) return duplicate;
   }
 

--- a/server/services/review.js
+++ b/server/services/review.js
@@ -95,13 +95,20 @@ async function loadArchive() {
  * items.json and into archive.json, at most once per `RETENTION_INTERVAL_MS`.
  * Writes the archive FIRST and only then returns the trimmed list for
  * `saveItems` to persist — so a crash between the two writes can duplicate an
- * item across both files (harmless, self-heals on the next read) but can
- * never lose one.
+ * item across both files, never lose one. The dedupe-by-id below then makes
+ * that duplication self-heal on the very next retention pass instead of
+ * accumulating a second archive.json copy forever.
+ *
+ * An unreadable archive.json is isolated to THIS function rather than left to
+ * throw: `saveItems` calls this on every create/status-flip/bulk/delete, so a
+ * corrupt archive.json must not block every live review write. On that
+ * failure this returns `items` untouched (items.json is not rewritten either)
+ * and leaves `lastRetentionAt` alone so the very next write retries retention
+ * instead of waiting out the full interval against a file nobody fixed yet.
  */
 async function applyRetention(items) {
   const now = Date.now();
   if (now - lastRetentionAt < RETENTION_INTERVAL_MS) return items;
-  lastRetentionAt = now;
 
   const cutoff = now - RETENTION_AGE_MS;
   const remaining = [];
@@ -111,11 +118,24 @@ async function applyRetention(items) {
     (eligible ? toArchive : remaining).push(item);
   }
 
-  if (toArchive.length === 0) return items;
+  if (toArchive.length === 0) {
+    lastRetentionAt = now;
+    return items;
+  }
 
-  const archive = await loadArchive();
-  await atomicWrite(ARCHIVE_FILE, [...archive, ...toArchive]);
-  console.log(`📦 Review items archived: ${toArchive.length}`);
+  const archive = await loadArchive().catch((err) => {
+    console.error(`⚠️ Review archive unreadable, skipping retention this cycle: ${err.message}`);
+    return null;
+  });
+  if (!archive) return items;
+
+  const archivedIds = new Set(archive.map(i => i.id));
+  const fresh = toArchive.filter(i => !archivedIds.has(i.id));
+  if (fresh.length > 0) {
+    await atomicWrite(ARCHIVE_FILE, [...archive, ...fresh]);
+    console.log(`📦 Review items archived: ${fresh.length}`);
+  }
+  lastRetentionAt = now;
   return remaining;
 }
 

--- a/server/services/review.js
+++ b/server/services/review.js
@@ -5,7 +5,7 @@
  * Aggregates items requiring user attention into a single hub.
  */
 
-import { readFile, readdir } from 'fs/promises';
+import { readFile, readdir, stat } from 'fs/promises';
 import { join } from 'path';
 import { v4 as uuidv4 } from '../lib/uuid.js';
 import { EventEmitter } from 'events';
@@ -15,6 +15,10 @@ import { GOAL_FIDELITY_HOLD_EVENT, formatGoalFidelitySummary } from '../lib/goal
 
 const DATA_DIR = join(PATHS.data, 'review');
 const ITEMS_FILE = join(DATA_DIR, 'items.json');
+// Cold storage for completed/dismissed items retention moves out of items.json
+// (see `applyRetention` below) — same file-backed record kind, split by age,
+// inside the existing `data/review/` directory rather than a new data store.
+const ARCHIVE_FILE = join(DATA_DIR, 'archive.json');
 
 export const reviewEvents = new EventEmitter();
 
@@ -22,8 +26,35 @@ export const reviewEvents = new EventEmitter();
 const ITEM_TYPES = ['alert', 'todo', 'briefing', 'cos'];
 const ITEM_STATUSES = ['pending', 'completed', 'dismissed'];
 
+// Retention: on a daily debounce, move completed/dismissed items older than
+// this out of items.json and into archive.json (see `applyRetention`).
+const RETENTION_INTERVAL_MS = 24 * 60 * 60 * 1000;
+const RETENTION_AGE_MS = 30 * 24 * 60 * 60 * 1000;
+const ARCHIVE_ELIGIBLE_STATUSES = new Set(['completed', 'dismissed']);
+
+// Module-level cache of the parsed items.json, keyed on file identity (mtime +
+// size) rather than an in-process "loaded" flag: `dataManager.js` registers
+// `review` as archivable/deletable, so `data/review/` can be archived or
+// deleted out from under this process while it runs, and a flag-based cache
+// would keep serving a since-deleted file's contents forever. `saveItems`
+// re-stats after every write and seeds the cache directly from what it just
+// wrote, so a read immediately following a write is a cache hit, not a re-parse.
+//
+// Every mutation path below (createItem/updateItemStatus/bulkUpdateStatus/
+// updateItem/deleteItem/updateStatusByReferenceId) mutates the array/items
+// returned by `loadItems()` in place and then immediately calls `saveItems`
+// with that same array — never mutates without saving. That invariant is what
+// makes it safe for `loadItems()` to hand back the cached array/objects
+// directly instead of deep-cloning on every read: a caller either treats it as
+// read-only, or mutates it and persists the result in the same call, which
+// `saveItems` then adopts as the new cache. Keep that invariant true for any
+// new mutation path.
+let itemsCache = null; // { mtimeMs, size, items }
+let lastRetentionAt = 0; // 0 so the first save after boot always evaluates retention
+
 /**
- * Load all review items from file
+ * Load all review items from file, reusing the cached parse when the file's
+ * mtime/size haven't changed since the last read.
  */
 // STRICT (#4115): `getPendingCounts()` reduces this list into the Review Hub's
 // total/alert/todo/briefing/cos tiles, so a swallowed unreadable read reports a
@@ -31,22 +62,85 @@ const ITEM_STATUSES = ['pending', 'completed', 'dismissed'];
 // read-modify-write (createItem/status updates → `saveItems`), where an
 // unreadable file collapsing to `[]` would destroy every stored review item.
 async function loadItems() {
-  return readJSONFile(ITEMS_FILE, [], { strict: true });
+  const stats = await stat(ITEMS_FILE).catch((err) => {
+    if (err.code === 'ENOENT') return null;
+    throw err;
+  });
+
+  if (!stats) {
+    itemsCache = null;
+    return [];
+  }
+
+  if (itemsCache && itemsCache.mtimeMs === stats.mtimeMs && itemsCache.size === stats.size) {
+    return itemsCache.items;
+  }
+
+  const items = await readJSONFile(ITEMS_FILE, [], { strict: true });
+  itemsCache = { mtimeMs: stats.mtimeMs, size: stats.size, items };
+  return items;
 }
 
 /**
- * Save items to file atomically
+ * Load the archived (retired) items. Never cached — only read from the
+ * history views (`getItems` for a completed/dismissed/unfiltered query,
+ * and `createItem`'s duplicate-alert check when the live scan misses).
+ */
+async function loadArchive() {
+  return readJSONFile(ARCHIVE_FILE, [], { strict: true });
+}
+
+/**
+ * Move completed/dismissed items older than `RETENTION_AGE_MS` out of
+ * items.json and into archive.json, at most once per `RETENTION_INTERVAL_MS`.
+ * Writes the archive FIRST and only then returns the trimmed list for
+ * `saveItems` to persist — so a crash between the two writes can duplicate an
+ * item across both files (harmless, self-heals on the next read) but can
+ * never lose one.
+ */
+async function applyRetention(items) {
+  const now = Date.now();
+  if (now - lastRetentionAt < RETENTION_INTERVAL_MS) return items;
+  lastRetentionAt = now;
+
+  const cutoff = now - RETENTION_AGE_MS;
+  const remaining = [];
+  const toArchive = [];
+  for (const item of items) {
+    const eligible = ARCHIVE_ELIGIBLE_STATUSES.has(item.status) && new Date(item.updatedAt).getTime() < cutoff;
+    (eligible ? toArchive : remaining).push(item);
+  }
+
+  if (toArchive.length === 0) return items;
+
+  const archive = await loadArchive();
+  await atomicWrite(ARCHIVE_FILE, [...archive, ...toArchive]);
+  console.log(`📦 Review items archived: ${toArchive.length}`);
+  return remaining;
+}
+
+/**
+ * Save items to file atomically, applying retention first and re-priming the
+ * read cache from what was actually written.
  */
 async function saveItems(items) {
   await ensureDir(DATA_DIR);
-  await atomicWrite(ITEMS_FILE, items);
+  const retained = await applyRetention(items);
+  await atomicWrite(ITEMS_FILE, retained);
+  const stats = await stat(ITEMS_FILE).catch(() => null);
+  itemsCache = stats ? { mtimeMs: stats.mtimeMs, size: stats.size, items: retained } : null;
 }
 
 /**
- * Get all review items, sorted by type then creation date (newest first)
+ * Get all review items, sorted by type then creation date (newest first).
+ * A completed/dismissed or unfiltered query also merges in archive.json —
+ * archive never holds a pending item, so a pending-only query skips it.
  */
 export async function getItems({ status, type } = {}) {
   let items = await loadItems();
+  if (!status || ARCHIVE_ELIGIBLE_STATUSES.has(status)) {
+    items = items.concat(await loadArchive());
+  }
   if (status) items = items.filter(i => i.status === status);
   if (type) items = items.filter(i => i.type === type);
   return items.sort((a, b) => {
@@ -81,14 +175,19 @@ export async function createItem({ type, title, description = '', metadata = {} 
 
   const items = await loadItems();
 
-  // Prevent duplicate alerts for same reference within 24 hours
+  // Prevent duplicate alerts for same reference within 24 hours. Archive only
+  // ever holds items >=30 days old, so it can never actually match this 24h
+  // window in practice — but check it anyway rather than silently narrowing
+  // the dedup window the day an item crosses into archive.json. Only
+  // consulted when the live scan misses, so the common case (no dedup match,
+  // or a live match) never touches the archive file.
   if (type === 'alert' && metadata?.referenceId) {
     const oneDayAgo = Date.now() - 24 * 60 * 60 * 1000;
-    const duplicate = items.find(i =>
+    const isDuplicate = (i) =>
       i.type === 'alert' &&
       i.metadata?.referenceId === metadata.referenceId &&
-      new Date(i.createdAt).getTime() > oneDayAgo
-    );
+      new Date(i.createdAt).getTime() > oneDayAgo;
+    const duplicate = items.find(isDuplicate) ?? (await loadArchive()).find(isDuplicate);
     if (duplicate) return duplicate;
   }
 
@@ -155,6 +254,10 @@ export async function dismissItem(id) {
  * Concurrent per-item POSTs race on saveItems and silently drop updates;
  * this endpoint handles the "Complete All" / "Dismiss All" cases atomically.
  * Pass `ids` to target specific items, or omit to target every pending item.
+ * Emits ONE `items:bulk-updated` event carrying every affected id rather than
+ * one `item:updated` per item — "Mark all read" over N pending items used to
+ * fan out N socket broadcasts, each triggering a full counts re-parse on
+ * every connected dashboard client.
  */
 export async function bulkUpdateStatus({ ids, status }) {
   if (!ITEM_STATUSES.includes(status)) {
@@ -179,7 +282,7 @@ export async function bulkUpdateStatus({ ids, status }) {
 
   await saveItems(items);
   console.log(`📋 Review items bulk-${status}: ${updated.length}`);
-  for (const item of updated) reviewEvents.emit('item:updated', item);
+  reviewEvents.emit('items:bulk-updated', { ids: updated.map(i => i.id), status, updatedAt: now });
   return updated;
 }
 

--- a/server/services/review.js
+++ b/server/services/review.js
@@ -37,8 +37,13 @@ const ARCHIVE_ELIGIBLE_STATUSES = new Set(['completed', 'dismissed']);
 // `review` as archivable/deletable, so `data/review/` can be archived or
 // deleted out from under this process while it runs, and a flag-based cache
 // would keep serving a since-deleted file's contents forever. `saveItems`
-// re-stats after every write and seeds the cache directly from what it just
-// wrote, so a read immediately following a write is a cache hit, not a re-parse.
+// INVALIDATES the cache after every write rather than seeding it from what it
+// wrote: two saveItems calls can interleave (a route and a cosEvents handler
+// — the same window as the documented lost-update race), and a post-write
+// stat could then pin one writer's content under the other writer's identity
+// and serve it until the next write. Invalidation keeps the invariant simple —
+// the cache only ever holds content read from the file under its own identity
+// — at the cost of one re-parse per write.
 //
 // `loadItems()` hands every caller a fresh shallow clone (see `cloneItems`),
 // never the cached array/objects themselves — `getItems` is a public export
@@ -48,9 +53,9 @@ const ARCHIVE_ELIGIBLE_STATUSES = new Set(['completed', 'dismissed']);
 // `saveItems` call. The internal mutation paths below (createItem/
 // updateItemStatus/bulkUpdateStatus/updateItem/deleteItem/
 // updateStatusByReferenceId) mutate the clone `loadItems()` gave them and
-// then immediately call `saveItems` with it — `saveItems` seeds the cache
-// from a clone of what it wrote, so the objects those paths return to their
-// callers are theirs to mutate too.
+// then immediately call `saveItems` with it — nothing they hold is ever
+// cached, so the objects those paths return to their callers are theirs to
+// mutate too.
 let itemsCache = null; // { mtimeMs, size, items }
 let lastRetentionAt = 0; // 0 so the first save after boot always evaluates retention
 
@@ -171,18 +176,15 @@ async function applyRetention(items) {
 }
 
 /**
- * Save items to file atomically, applying retention first and re-priming the
- * read cache from what was actually written.
+ * Save items to file atomically, applying retention first and invalidating
+ * the read cache (see the cache comment above for why it is not re-seeded
+ * from what was written).
  */
 async function saveItems(items) {
   await ensureDir(DATA_DIR);
   const retained = await applyRetention(items);
   await atomicWrite(ITEMS_FILE, retained);
-  const stats = await stat(ITEMS_FILE).catch(() => null);
-  // Seed from a clone, not the caller's array: the mutation paths return the
-  // objects they just saved to their callers, and the cache must never share
-  // a reference with anything outside this module (see the cache comment).
-  itemsCache = stats ? { mtimeMs: stats.mtimeMs, size: stats.size, items: cloneItems(retained) } : null;
+  itemsCache = null;
 }
 
 /**

--- a/server/services/review.js
+++ b/server/services/review.js
@@ -48,8 +48,9 @@ const ARCHIVE_ELIGIBLE_STATUSES = new Set(['completed', 'dismissed']);
 // `saveItems` call. The internal mutation paths below (createItem/
 // updateItemStatus/bulkUpdateStatus/updateItem/deleteItem/
 // updateStatusByReferenceId) mutate the clone `loadItems()` gave them and
-// then immediately call `saveItems` with it — `saveItems` adopts whatever
-// array it is given as the new cache, so this costs nothing extra there.
+// then immediately call `saveItems` with it — `saveItems` seeds the cache
+// from a clone of what it wrote, so the objects those paths return to their
+// callers are theirs to mutate too.
 let itemsCache = null; // { mtimeMs, size, items }
 let lastRetentionAt = 0; // 0 so the first save after boot always evaluates retention
 
@@ -71,17 +72,19 @@ async function loadItems() {
     throw err;
   });
 
-  if (!stats) {
-    itemsCache = null;
-    return [];
-  }
-
-  if (itemsCache && itemsCache.mtimeMs === stats.mtimeMs && itemsCache.size === stats.size) {
+  if (stats && itemsCache && itemsCache.mtimeMs === stats.mtimeMs && itemsCache.size === stats.size) {
     return cloneItems(itemsCache.items);
   }
 
+  // A stat ENOENT is NOT collapsed to `[]` here: on win32 an `atomicWrite`
+  // swap in flight (temp file renamed over the target) reports ENOENT for a
+  // moment too, and only readJSONFile's swap-aware retry can tell that apart
+  // from a genuinely absent file (which it returns `[]` for). Short-circuiting
+  // would hand a concurrent read-modify-write (a cosEvents `task:ready` burst)
+  // an empty list to save over every stored item. Nothing is cached under an
+  // unknown identity — the next read re-stats and re-parses.
   const items = await readJSONFile(ITEMS_FILE, [], { strict: true });
-  itemsCache = { mtimeMs: stats.mtimeMs, size: stats.size, items };
+  itemsCache = stats ? { mtimeMs: stats.mtimeMs, size: stats.size, items } : null;
   return cloneItems(items);
 }
 
@@ -180,7 +183,10 @@ async function saveItems(items) {
   const retained = await applyRetention(items);
   await atomicWrite(ITEMS_FILE, retained);
   const stats = await stat(ITEMS_FILE).catch(() => null);
-  itemsCache = stats ? { mtimeMs: stats.mtimeMs, size: stats.size, items: retained } : null;
+  // Seed from a clone, not the caller's array: the mutation paths return the
+  // objects they just saved to their callers, and the cache must never share
+  // a reference with anything outside this module (see the cache comment).
+  itemsCache = stats ? { mtimeMs: stats.mtimeMs, size: stats.size, items: cloneItems(retained) } : null;
 }
 
 /**

--- a/server/services/review.js
+++ b/server/services/review.js
@@ -120,9 +120,10 @@ async function loadArchiveOrEmpty(context) {
  * items.json and into archive.json, at most once per `RETENTION_INTERVAL_MS`.
  * Writes the archive FIRST and only then returns the trimmed list for
  * `saveItems` to persist — so a crash between the two writes can duplicate an
- * item across both files, never lose one. The dedupe-by-id below then makes
- * that duplication self-heal on the very next retention pass instead of
- * accumulating a second archive.json copy forever.
+ * item across both files, never lose one. The archive write below upserts by
+ * id with the live copy winning, so that duplication self-heals on the very
+ * next retention pass — one archive entry per id, and never a stale archived
+ * snapshot shadowing a live copy that was edited in the meantime.
  *
  * Both the archive READ and the archive WRITE are isolated to THIS function
  * rather than left to throw: `saveItems` calls this on every
@@ -156,20 +157,15 @@ async function applyRetention(items) {
   });
   if (!archive) return items;
 
-  const archivedIds = new Set(archive.map(i => i.id));
-  const fresh = toArchive.filter(i => !archivedIds.has(i.id));
-  if (fresh.length === 0) {
-    lastRetentionAt = now;
-    return remaining;
-  }
-
-  const archived = await atomicWrite(ARCHIVE_FILE, [...archive, ...fresh]).then(() => true).catch((err) => {
+  const merged = new Map(archive.map(i => [i.id, i]));
+  for (const item of toArchive) merged.set(item.id, item); // live copy wins
+  const archived = await atomicWrite(ARCHIVE_FILE, [...merged.values()]).then(() => true).catch((err) => {
     console.error(`⚠️ Failed to write review archive, skipping retention this cycle: ${err.message}`);
     return false;
   });
   if (!archived) return items;
 
-  console.log(`📦 Review items archived: ${fresh.length}`);
+  console.log(`📦 Review items archived: ${toArchive.length}`);
   lastRetentionAt = now;
   return remaining;
 }

--- a/server/services/review.test.js
+++ b/server/services/review.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { readFile, readdir, stat } from 'fs/promises';
-import { atomicWrite } from '../lib/fileUtils.js';
+import { atomicWrite, readJSONFile } from '../lib/fileUtils.js';
 
 vi.mock('fs/promises', () => ({
   readFile: vi.fn(),
@@ -481,6 +481,79 @@ describe('review service', () => {
       const counts = await getPendingCounts();
       expect(counts.total).toBe(2); // p1 + the new item createItem just added
       expect(readFile).toHaveBeenCalledTimes(2); // items.json once + archive.json once — no third parse
+    });
+
+    it('does not block a live write when archive.json is unreadable — retention is skipped, items.json still saves', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(Date.now() + 1000 * 60 * 60 * 24 * 500);
+
+      const now = Date.now();
+      const old = new Date(now - 31 * 24 * 60 * 60 * 1000).toISOString();
+      const fixture = [
+        { id: 'c-old', type: 'todo', status: 'completed', metadata: {}, createdAt: old, updatedAt: old }
+      ];
+
+      // Drive readJSONFile directly, keyed on path rather than call count/
+      // order (items.json always resolves, archive.json always rejects) —
+      // simulates a corrupt archive.json, since the real
+      // readJSONFile(..., { strict: true }) throws on unparseable content
+      // rather than degrading to the [] fallback.
+      readJSONFile.mockImplementation((path) =>
+        String(path).endsWith('archive.json')
+          ? Promise.reject(new Error('Unreadable JSON file: archive.json'))
+          : Promise.resolve(fixture));
+
+      try {
+        const created = await createItem({ type: 'todo', title: 'trigger a save while archive is corrupt' });
+        expect(created.title).toBe('trigger a save while archive is corrupt');
+
+        // The live write was NOT blocked by the corrupt archive...
+        expect(atomicWrite).toHaveBeenCalledTimes(1);
+        expect(atomicWrite.mock.calls[0][0]).toMatch(/items\.json$/);
+        // ...and c-old was left in items.json rather than silently dropped,
+        // since retention could not safely move it anywhere.
+        const written = atomicWrite.mock.calls[0][1];
+        expect(written.some(i => i.id === 'c-old')).toBe(true);
+      } finally {
+        // This test overrides readJSONFile itself (not just readFile), so
+        // restore the shared default — later tests in this file rely on it
+        // delegating to the mocked readFile the normal way.
+        readJSONFile.mockImplementation(async (path, fallback) => {
+          try {
+            return JSON.parse(await readFile(path));
+          } catch {
+            return fallback;
+          }
+        });
+      }
+    });
+
+    it('does not write a duplicate archive entry when the same id is archived twice', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(Date.now() + 1000 * 60 * 60 * 24 * 600);
+
+      const now = Date.now();
+      const old = new Date(now - 31 * 24 * 60 * 60 * 1000).toISOString();
+      const fixture = [
+        { id: 'c-old', type: 'todo', status: 'completed', metadata: {}, createdAt: old, updatedAt: old }
+      ];
+      // Models the crash-recovery case: a prior retention pass wrote the
+      // archive but items.json was never rewritten, so the same eligible
+      // item resurfaces in items.json on this pass.
+      const existingArchive = [{ id: 'c-old', type: 'todo', status: 'completed', metadata: {}, createdAt: old, updatedAt: old }];
+
+      stat.mockResolvedValue({ mtimeMs: 821001, size: 1 });
+      readFile.mockImplementation((path) =>
+        Promise.resolve(String(path).endsWith('archive.json') ? JSON.stringify(existingArchive) : JSON.stringify(fixture)));
+
+      await createItem({ type: 'todo', title: 'trigger a save' });
+
+      // c-old is already archived — no second archive write for the same id.
+      const archiveWrites = atomicWrite.mock.calls.filter(([path]) => String(path).endsWith('archive.json'));
+      expect(archiveWrites).toHaveLength(0);
+      // It still leaves items.json — it is stale/archived either way.
+      const itemsWrite = atomicWrite.mock.calls.find(([path]) => String(path).endsWith('items.json'));
+      expect(itemsWrite[1].some(i => i.id === 'c-old')).toBe(false);
     });
   });
 

--- a/server/services/review.test.js
+++ b/server/services/review.test.js
@@ -352,10 +352,13 @@ describe('review service', () => {
     it('treats a missing items.json as an empty, cache-cleared list', async () => {
       const enoent = Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
       stat.mockRejectedValueOnce(enoent);
+      readFile.mockRejectedValueOnce(enoent);
 
       const whileMissing = await getPendingCounts();
       expect(whileMissing.total).toBe(0);
-      expect(readFile).not.toHaveBeenCalled();
+      // The read still goes through the swap-aware reader (which returns [] for
+      // a genuinely absent file) rather than short-circuiting on the stat alone.
+      expect(readJSONFile).toHaveBeenCalledTimes(1);
 
       // The file reappears — the cleared cache must not keep reporting the
       // pre-deletion (or pre-existence) state.
@@ -363,6 +366,25 @@ describe('review service', () => {
       readFile.mockResolvedValueOnce(JSON.stringify([{ id: 'a', type: 'todo', status: 'pending' }]));
       const afterRecreate = await getPendingCounts();
       expect(afterRecreate.total).toBe(1);
+    });
+
+    it('does not collapse a stat ENOENT to an empty list while the file is still readable (win32 atomicWrite swap window)', async () => {
+      const enoent = Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+      stat.mockRejectedValueOnce(enoent);
+      readFile.mockResolvedValueOnce(JSON.stringify([{ id: 'a', type: 'todo', status: 'pending' }]));
+
+      const midSwap = await getPendingCounts();
+      expect(midSwap.total).toBe(1);
+
+      // Nothing was cached under an unknown file identity — the next read re-parses.
+      stat.mockResolvedValueOnce({ mtimeMs: 813101, size: 1 });
+      readFile.mockResolvedValueOnce(JSON.stringify([
+        { id: 'a', type: 'todo', status: 'pending' },
+        { id: 'b', type: 'todo', status: 'pending' }
+      ]));
+      const afterSwap = await getPendingCounts();
+      expect(afterSwap.total).toBe(2);
+      expect(readFile).toHaveBeenCalledTimes(2);
     });
 
     it('reflects a write in the very next read without a second parse', async () => {
@@ -646,6 +668,18 @@ describe('review service', () => {
       expect(original).toBeTruthy();
       expect(original.injected).toBeUndefined();
       expect(original.metadata.injected).toBeUndefined();
+    });
+
+    it('does not let a caller mutating a createItem() result pollute the cache seeded by that save', async () => {
+      stat.mockResolvedValue({ mtimeMs: 829001, size: 1 });
+      readFile.mockResolvedValue('[]');
+
+      const created = await createItem({ type: 'todo', title: 'Original title' });
+      created.title = 'mutated after return';
+
+      // Same file identity → cache hit: the cached copy must not carry the mutation.
+      const [cached] = await getItems({ status: 'pending' });
+      expect(cached.title).toBe('Original title');
     });
   });
 

--- a/server/services/review.test.js
+++ b/server/services/review.test.js
@@ -585,19 +585,20 @@ describe('review service', () => {
       }
     });
 
-    it('does not write a duplicate archive entry when the same id is archived twice', async () => {
+    it('upserts by id when the same item is archived twice — one archive entry, the live copy winning', async () => {
       vi.useFakeTimers();
       vi.setSystemTime(Date.now() + 1000 * 60 * 60 * 24 * 600);
 
       const now = Date.now();
       const old = new Date(now - 31 * 24 * 60 * 60 * 1000).toISOString();
       const fixture = [
-        { id: 'c-old', type: 'todo', status: 'completed', metadata: {}, createdAt: old, updatedAt: old }
+        { id: 'c-old', type: 'todo', title: 'edited live copy', status: 'completed', metadata: {}, createdAt: old, updatedAt: old }
       ];
       // Models the crash-recovery case: a prior retention pass wrote the
       // archive but items.json was never rewritten, so the same eligible
-      // item resurfaces in items.json on this pass.
-      const existingArchive = [{ id: 'c-old', type: 'todo', status: 'completed', metadata: {}, createdAt: old, updatedAt: old }];
+      // item resurfaces in items.json on this pass — edited since, so the
+      // archived snapshot is the stale one.
+      const existingArchive = [{ id: 'c-old', type: 'todo', title: 'stale snapshot', status: 'completed', metadata: {}, createdAt: old, updatedAt: old }];
 
       stat.mockResolvedValue({ mtimeMs: 821001, size: 1 });
       readFile.mockImplementation((path) =>
@@ -605,9 +606,13 @@ describe('review service', () => {
 
       await createItem({ type: 'todo', title: 'trigger a save' });
 
-      // c-old is already archived — no second archive write for the same id.
+      // One archive entry for c-old, and it is the live (newer) copy — not a
+      // second entry, and not the stale archived snapshot.
       const archiveWrites = atomicWrite.mock.calls.filter(([path]) => String(path).endsWith('archive.json'));
-      expect(archiveWrites).toHaveLength(0);
+      expect(archiveWrites).toHaveLength(1);
+      const archivedCopies = archiveWrites[0][1].filter(i => i.id === 'c-old');
+      expect(archivedCopies).toHaveLength(1);
+      expect(archivedCopies[0].title).toBe('edited live copy');
       // It is still dropped from items.json — it is archived either way, so
       // there is no reason to keep the stale live-side copy around.
       const itemsWrite = atomicWrite.mock.calls.find(([path]) => String(path).endsWith('items.json'));

--- a/server/services/review.test.js
+++ b/server/services/review.test.js
@@ -403,6 +403,41 @@ describe('review service', () => {
       const pendingView = await getItems({ status: 'pending' });
       expect(pendingView.map(i => i.id)).toEqual(['live-pending']);
     });
+
+    it('dedupes by id when the same item is (transiently) in both files, preferring the live copy', async () => {
+      stat.mockResolvedValue({ mtimeMs: 825001, size: 1 });
+      // Models the crash-recovery window applyRetention's doc comment
+      // describes: the same id present in both items.json and archive.json.
+      const liveCopy = { id: 'dup-1', type: 'todo', status: 'completed', title: 'live version', createdAt: '2026-01-01T00:00:00Z' };
+      const archiveCopy = { id: 'dup-1', type: 'todo', status: 'completed', title: 'archived version', createdAt: '2026-01-01T00:00:00Z' };
+      readFile.mockImplementation((path) =>
+        Promise.resolve(String(path).endsWith('archive.json') ? JSON.stringify([archiveCopy]) : JSON.stringify([liveCopy])));
+
+      const result = await getItems({});
+      expect(result).toHaveLength(1);
+      expect(result[0].title).toBe('live version');
+    });
+
+    it('degrades to no archived items when archive.json is unreadable, instead of failing the whole read', async () => {
+      stat.mockResolvedValue({ mtimeMs: 826001, size: 1 });
+      readJSONFile.mockImplementation((path) =>
+        String(path).endsWith('archive.json')
+          ? Promise.reject(new Error('Unreadable JSON file: archive.json'))
+          : Promise.resolve([{ id: 'live-1', type: 'todo', status: 'completed', createdAt: '2026-01-01T00:00:00Z' }]));
+
+      try {
+        const result = await getItems({ status: 'completed' });
+        expect(result.map(i => i.id)).toEqual(['live-1']);
+      } finally {
+        readJSONFile.mockImplementation(async (path, fallback) => {
+          try {
+            return JSON.parse(await readFile(path));
+          } catch {
+            return fallback;
+          }
+        });
+      }
+    });
   });
 
   describe('createItem duplicate check reaches the archive', () => {
@@ -551,9 +586,66 @@ describe('review service', () => {
       // c-old is already archived — no second archive write for the same id.
       const archiveWrites = atomicWrite.mock.calls.filter(([path]) => String(path).endsWith('archive.json'));
       expect(archiveWrites).toHaveLength(0);
-      // It still leaves items.json — it is stale/archived either way.
+      // It is still dropped from items.json — it is archived either way, so
+      // there is no reason to keep the stale live-side copy around.
       const itemsWrite = atomicWrite.mock.calls.find(([path]) => String(path).endsWith('items.json'));
       expect(itemsWrite[1].some(i => i.id === 'c-old')).toBe(false);
+    });
+
+    it('does not block a live write when the archive WRITE fails — retention is skipped, items.json still saves', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(Date.now() + 1000 * 60 * 60 * 24 * 700);
+
+      const now = Date.now();
+      const old = new Date(now - 31 * 24 * 60 * 60 * 1000).toISOString();
+      const fixture = [
+        { id: 'c-old', type: 'todo', status: 'completed', metadata: {}, createdAt: old, updatedAt: old }
+      ];
+
+      stat.mockResolvedValue({ mtimeMs: 827001, size: 1 });
+      readFile.mockImplementation((path) =>
+        Promise.resolve(String(path).endsWith('archive.json') ? '[]' : JSON.stringify(fixture)));
+      // The archive write itself fails (disk full, permission error, ...).
+      atomicWrite.mockImplementationOnce(() => Promise.reject(new Error('ENOSPC: no space left on device')));
+
+      const created = await createItem({ type: 'todo', title: 'trigger a save while archive write fails' });
+      expect(created.title).toBe('trigger a save while archive write fails');
+
+      // The archive write was attempted and failed (consuming the rejection
+      // above), then the live write still landed as a second, successful
+      // atomicWrite — with c-old left in items.json since retention could
+      // not confirm the archive write actually succeeded.
+      expect(atomicWrite).toHaveBeenCalledTimes(2);
+      expect(atomicWrite.mock.calls[0][0]).toMatch(/archive\.json$/);
+      expect(atomicWrite.mock.calls[1][0]).toMatch(/items\.json$/);
+      expect(atomicWrite.mock.calls[1][1].some(i => i.id === 'c-old')).toBe(true);
+    });
+  });
+
+  describe('read results do not leak a mutable cache reference', () => {
+    it('does not let a caller mutating a getItems() result pollute a later unrelated save', async () => {
+      stat.mockResolvedValue({ mtimeMs: 828001, size: 1 });
+      // Persisting (not "once"): item 'a' is served identically whether a
+      // later loadItems() call is a cache hit or a fresh parse, so this test
+      // pins the actual property under test (no leaked mutation) rather than
+      // an incidental call count.
+      readFile.mockResolvedValue(JSON.stringify([
+        { id: 'a', type: 'todo', status: 'pending', metadata: {} }
+      ]));
+
+      const items = await getItems({});
+      // Simulates a caller decorating/editing a returned item in place —
+      // must not reach the module's internal cache.
+      items[0].injected = 'leaked';
+      items[0].metadata.injected = 'leaked-meta';
+
+      await createItem({ type: 'todo', title: 'unrelated new item' });
+
+      const written = atomicWrite.mock.calls[0][1];
+      const original = written.find(i => i.id === 'a');
+      expect(original).toBeTruthy();
+      expect(original.injected).toBeUndefined();
+      expect(original.metadata.injected).toBeUndefined();
     });
   });
 

--- a/server/services/review.test.js
+++ b/server/services/review.test.js
@@ -387,19 +387,19 @@ describe('review service', () => {
       expect(readFile).toHaveBeenCalledTimes(2);
     });
 
-    it('reflects a write in the very next read without a second parse', async () => {
+    it('invalidates the cache on a write, so the very next read re-parses the file', async () => {
       stat.mockResolvedValueOnce({ mtimeMs: 814001, size: 1 }); // loadItems() inside createItem
       readFile.mockResolvedValueOnce('[]');
-      stat.mockResolvedValueOnce({ mtimeMs: 814002, size: 2 }); // saveItems' post-write stat
-      stat.mockResolvedValueOnce({ mtimeMs: 814002, size: 2 }); // getPendingCounts' loadItems — same identity
+      stat.mockResolvedValueOnce({ mtimeMs: 814002, size: 2 }); // getPendingCounts' loadItems after the write
+      readFile.mockResolvedValueOnce(JSON.stringify([{ id: 'a', type: 'todo', status: 'pending' }]));
 
       await createItem({ type: 'todo', title: 'First item' });
       const counts = await getPendingCounts();
 
       expect(counts.total).toBe(1);
-      // Only createItem's own cache-miss read — getPendingCounts hit the
-      // cache saveItems seeded from the write, not a re-parse.
-      expect(readFile).toHaveBeenCalledTimes(1);
+      // createItem's own cache-miss read plus the re-parse the write forces —
+      // never the pre-write cached list.
+      expect(readFile).toHaveBeenCalledTimes(2);
     });
   });
 
@@ -533,11 +533,14 @@ describe('review service', () => {
       expect(survivingIds).not.toEqual(expect.arrayContaining(['c-old']));
       expect(survivingIds).not.toEqual(expect.arrayContaining(['d-old']));
 
-      // getPendingCounts must still be correct post-retention, and served
-      // from the cache saveItems just seeded rather than a fresh parse.
+      // The write invalidated the cache: the next read re-parses items.json —
+      // now holding exactly what retention left behind — so the counts reflect
+      // the trimmed list, not the pre-retention fixture.
+      readFile.mockImplementation((path) =>
+        Promise.resolve(String(path).endsWith('archive.json') ? JSON.stringify(archiveData) : JSON.stringify(itemsData)));
       const counts = await getPendingCounts();
       expect(counts.total).toBe(2); // p1 + the new item createItem just added
-      expect(readFile).toHaveBeenCalledTimes(2); // items.json once + archive.json once — no third parse
+      expect(readFile).toHaveBeenCalledTimes(3); // items.json + archive.json during the save, items.json again after it
     });
 
     it('does not block a live write when archive.json is unreadable — retention is skipped, items.json still saves', async () => {
@@ -673,18 +676,6 @@ describe('review service', () => {
       expect(original).toBeTruthy();
       expect(original.injected).toBeUndefined();
       expect(original.metadata.injected).toBeUndefined();
-    });
-
-    it('does not let a caller mutating a createItem() result pollute the cache seeded by that save', async () => {
-      stat.mockResolvedValue({ mtimeMs: 829001, size: 1 });
-      readFile.mockResolvedValue('[]');
-
-      const created = await createItem({ type: 'todo', title: 'Original title' });
-      created.title = 'mutated after return';
-
-      // Same file identity → cache hit: the cached copy must not carry the mutation.
-      const [cached] = await getItems({ status: 'pending' });
-      expect(cached.title).toBe('Original title');
     });
   });
 

--- a/server/services/review.test.js
+++ b/server/services/review.test.js
@@ -1,14 +1,13 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { readFile, readdir } from 'fs/promises';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { readFile, readdir, stat } from 'fs/promises';
 import { atomicWrite } from '../lib/fileUtils.js';
 
 vi.mock('fs/promises', () => ({
   readFile: vi.fn(),
-  readdir: vi.fn()
+  readdir: vi.fn(),
+  stat: vi.fn()
 }));
 
-const emit = vi.fn();
-const reviewEvents = { emit };
 const registeredHandlers = {};
 const cosEvents = {
   on: vi.fn((event, handler) => { registeredHandlers[event] = handler; })
@@ -26,9 +25,9 @@ tryReadFile: vi.fn().mockResolvedValue(null),
     reports: '/test/data/cos/reports',
     root: '/test'
   },
-  readJSONFile: vi.fn(async (_path, fallback) => {
+  readJSONFile: vi.fn(async (path, fallback) => {
     try {
-      return JSON.parse(await readFile());
+      return JSON.parse(await readFile(path));
     } catch {
       return fallback;
     }
@@ -43,12 +42,26 @@ const {
   dismissItem,
   updateItem,
   deleteItem,
-  getBriefing
+  getBriefing,
+  bulkUpdateStatus,
+  reviewEvents
 } = await import('./review.js');
+
+// `stat()` backs review.js's module-level items.json cache, which persists
+// across every test in this file (it is process/module state, not a vitest
+// mock). The default implementation below returns a fresh, never-repeating
+// value on every call, so — absent a test explicitly overriding it — every
+// `loadItems()` call in this file is a guaranteed cache MISS and re-reads via
+// `readFile`, exactly matching this suite's pre-caching expectations. Tests
+// that exercise the cache itself override `stat` locally to hold a value
+// steady (a hit) or change it (a miss/invalidation).
+let statCounter = 0;
+const freshStat = () => Promise.resolve({ mtimeMs: ++statCounter, size: statCounter });
 
 describe('review service', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    stat.mockImplementation(freshStat);
   });
 
   describe('createItem', () => {
@@ -302,6 +315,203 @@ describe('review service', () => {
       await new Promise(r => setImmediate(r));
 
       expect(atomicWrite).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('items.json read cache', () => {
+    it('parses the file once across two consecutive getPendingCounts calls with no write between', async () => {
+      stat.mockResolvedValue({ mtimeMs: 811001, size: 1 });
+      readFile.mockResolvedValueOnce(JSON.stringify([{ id: 'a', type: 'todo', status: 'pending' }]));
+
+      const first = await getPendingCounts();
+      const second = await getPendingCounts();
+
+      expect(first.total).toBe(1);
+      expect(second.total).toBe(1);
+      expect(readFile).toHaveBeenCalledTimes(1);
+    });
+
+    it('detects an external rewrite (changed mtime/size) and re-parses', async () => {
+      stat.mockResolvedValueOnce({ mtimeMs: 812001, size: 100 });
+      readFile.mockResolvedValueOnce(JSON.stringify([{ id: 'a', type: 'todo', status: 'pending' }]));
+      const first = await getPendingCounts();
+      expect(first.total).toBe(1);
+
+      // A different process rewrote items.json — stat now reports a new identity.
+      stat.mockResolvedValueOnce({ mtimeMs: 812002, size: 140 });
+      readFile.mockResolvedValueOnce(JSON.stringify([
+        { id: 'a', type: 'todo', status: 'pending' },
+        { id: 'b', type: 'alert', status: 'pending' }
+      ]));
+      const second = await getPendingCounts();
+
+      expect(second.total).toBe(2);
+      expect(readFile).toHaveBeenCalledTimes(2);
+    });
+
+    it('treats a missing items.json as an empty, cache-cleared list', async () => {
+      const enoent = Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+      stat.mockRejectedValueOnce(enoent);
+
+      const whileMissing = await getPendingCounts();
+      expect(whileMissing.total).toBe(0);
+      expect(readFile).not.toHaveBeenCalled();
+
+      // The file reappears — the cleared cache must not keep reporting the
+      // pre-deletion (or pre-existence) state.
+      stat.mockResolvedValueOnce({ mtimeMs: 813001, size: 1 });
+      readFile.mockResolvedValueOnce(JSON.stringify([{ id: 'a', type: 'todo', status: 'pending' }]));
+      const afterRecreate = await getPendingCounts();
+      expect(afterRecreate.total).toBe(1);
+    });
+
+    it('reflects a write in the very next read without a second parse', async () => {
+      stat.mockResolvedValueOnce({ mtimeMs: 814001, size: 1 }); // loadItems() inside createItem
+      readFile.mockResolvedValueOnce('[]');
+      stat.mockResolvedValueOnce({ mtimeMs: 814002, size: 2 }); // saveItems' post-write stat
+      stat.mockResolvedValueOnce({ mtimeMs: 814002, size: 2 }); // getPendingCounts' loadItems — same identity
+
+      await createItem({ type: 'todo', title: 'First item' });
+      const counts = await getPendingCounts();
+
+      expect(counts.total).toBe(1);
+      // Only createItem's own cache-miss read — getPendingCounts hit the
+      // cache saveItems seeded from the write, not a re-parse.
+      expect(readFile).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('getItems merges archive.json', () => {
+    it('includes archive for completed/dismissed and unfiltered queries, but not a pending-only query', async () => {
+      stat.mockResolvedValue({ mtimeMs: 816001, size: 1 });
+      const liveItems = [
+        { id: 'live-pending', type: 'todo', status: 'pending', createdAt: '2026-01-01T00:00:00Z' },
+        { id: 'live-completed', type: 'todo', status: 'completed', createdAt: '2026-01-02T00:00:00Z' }
+      ];
+      const archivedItems = [
+        { id: 'archived-completed', type: 'todo', status: 'completed', createdAt: '2025-01-01T00:00:00Z' }
+      ];
+      readFile.mockImplementation((path) =>
+        Promise.resolve(String(path).endsWith('archive.json') ? JSON.stringify(archivedItems) : JSON.stringify(liveItems)));
+
+      const completedView = await getItems({ status: 'completed' });
+      expect(completedView.map(i => i.id).sort()).toEqual(['archived-completed', 'live-completed']);
+
+      const allView = await getItems({});
+      expect(allView.map(i => i.id).sort()).toEqual(['archived-completed', 'live-completed', 'live-pending']);
+
+      const pendingView = await getItems({ status: 'pending' });
+      expect(pendingView.map(i => i.id)).toEqual(['live-pending']);
+    });
+  });
+
+  describe('createItem duplicate check reaches the archive', () => {
+    it('finds a duplicate alert in archive.json when the live scan misses', async () => {
+      stat.mockResolvedValue({ mtimeMs: 817001, size: 1 });
+      // Synthetic fixture: a real archived item is always >=30 days old and
+      // could never actually land inside this 24h dedup window. This exists
+      // to prove createItem's duplicate check reaches archive.json at all
+      // when the live scan misses — not to model a realistic timestamp.
+      const archivedAlert = {
+        id: 'archived-1',
+        type: 'alert',
+        status: 'dismissed',
+        metadata: { referenceId: 'ref-archived' },
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString()
+      };
+      readFile.mockImplementation((path) =>
+        Promise.resolve(String(path).endsWith('archive.json') ? JSON.stringify([archivedAlert]) : '[]'));
+
+      const item = await createItem({
+        type: 'alert',
+        title: 'New alert for same ref',
+        metadata: { referenceId: 'ref-archived' }
+      });
+
+      expect(item.id).toBe('archived-1');
+      expect(atomicWrite).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('retention', () => {
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('moves completed/dismissed items older than 30 days into archive.json and keeps pending/recent items in items.json', async () => {
+      vi.useFakeTimers();
+      // Push the clock far enough ahead that the 24h retention-interval gate
+      // is guaranteed open, however recently an earlier test in this file
+      // triggered a save — `lastRetentionAt` is module state shared across
+      // the whole file, not reset between tests.
+      vi.setSystemTime(Date.now() + 1000 * 60 * 60 * 24 * 400);
+
+      const now = Date.now();
+      const old = new Date(now - 31 * 24 * 60 * 60 * 1000).toISOString();
+      const recent = new Date(now - 1 * 24 * 60 * 60 * 1000).toISOString();
+      const fixture = [
+        { id: 'p1', type: 'todo', status: 'pending', metadata: {}, createdAt: old, updatedAt: old },
+        { id: 'c-old', type: 'todo', status: 'completed', metadata: {}, createdAt: old, updatedAt: old },
+        { id: 'd-old', type: 'alert', status: 'dismissed', metadata: {}, createdAt: old, updatedAt: old },
+        { id: 'c-recent', type: 'todo', status: 'completed', metadata: {}, createdAt: recent, updatedAt: recent }
+      ];
+
+      stat.mockResolvedValue({ mtimeMs: 815001, size: 1 });
+      readFile.mockImplementation((path) =>
+        Promise.resolve(String(path).endsWith('archive.json') ? '[]' : JSON.stringify(fixture)));
+
+      await createItem({ type: 'todo', title: 'trigger a save' });
+
+      expect(atomicWrite).toHaveBeenCalledTimes(2);
+      const [archivePath, archiveData] = atomicWrite.mock.calls[0];
+      const [itemsPath, itemsData] = atomicWrite.mock.calls[1];
+
+      expect(archivePath).toMatch(/archive\.json$/);
+      expect(archiveData.map(i => i.id).sort()).toEqual(['c-old', 'd-old']);
+
+      expect(itemsPath).toMatch(/items\.json$/);
+      const survivingIds = itemsData.map(i => i.id);
+      expect(survivingIds).toEqual(expect.arrayContaining(['p1', 'c-recent']));
+      expect(survivingIds).not.toEqual(expect.arrayContaining(['c-old']));
+      expect(survivingIds).not.toEqual(expect.arrayContaining(['d-old']));
+
+      // getPendingCounts must still be correct post-retention, and served
+      // from the cache saveItems just seeded rather than a fresh parse.
+      const counts = await getPendingCounts();
+      expect(counts.total).toBe(2); // p1 + the new item createItem just added
+      expect(readFile).toHaveBeenCalledTimes(2); // items.json once + archive.json once — no third parse
+    });
+  });
+
+  describe('bulkUpdateStatus events', () => {
+    it('emits exactly one items:bulk-updated event and zero per-item item:updated events', async () => {
+      const emitSpy = vi.spyOn(reviewEvents, 'emit');
+      try {
+        stat.mockResolvedValue({ mtimeMs: 818001, size: 1 });
+        const items = [
+          { id: 'a', status: 'pending', metadata: {} },
+          { id: 'b', status: 'pending', metadata: {} },
+          { id: 'c', status: 'completed', metadata: {} }
+        ];
+        readFile.mockResolvedValue(JSON.stringify(items));
+
+        const updated = await bulkUpdateStatus({ status: 'dismissed' });
+
+        expect(updated).toHaveLength(2);
+        const bulkCalls = emitSpy.mock.calls.filter(([event]) => event === 'items:bulk-updated');
+        const perItemCalls = emitSpy.mock.calls.filter(([event]) => event === 'item:updated');
+        expect(bulkCalls).toHaveLength(1);
+        expect(perItemCalls).toHaveLength(0);
+        expect(bulkCalls[0][1]).toEqual({
+          ids: expect.arrayContaining(['a', 'b']),
+          status: 'dismissed',
+          updatedAt: expect.any(String)
+        });
+        expect(bulkCalls[0][1].ids).toHaveLength(2);
+      } finally {
+        emitSpy.mockRestore();
+      }
     });
   });
 });

--- a/server/services/socket.js
+++ b/server/services/socket.js
@@ -529,6 +529,11 @@ function setupReviewEventForwarding() {
   reviewEvents.on('item:deleted', (data) => {
     if (ioInstance) ioInstance.emit('review:item:deleted', data?.metadata?.privateSecurity ? { id: data.id, metadata: { privateSecurity: true } } : data);
   });
+  // Bulk status changes ("Mark all read" / "Complete all") carry only ids, a
+  // status and a timestamp — nothing to redact.
+  reviewEvents.on('items:bulk-updated', (data) => {
+    if (ioInstance) ioInstance.emit('review:items:bulk-updated', data);
+  });
 }
 
 // Set up update event forwarding (idempotent — safe if called more than once)


### PR DESCRIPTION
## Summary
- `review.js` re-parsed and rewrote the whole `data/review/items.json` (10MB+ on a real install) on every read and mutation, and `bulkUpdateStatus` fanned out one socket event per item — "Mark all read" over hundreds of pending items meant hundreds of full-file re-parses on every connected dashboard.
- `loadItems()` now caches the parsed array keyed on `stat()` mtime/size, so a read costs a stat instead of a parse until the file actually changes. The cache clears on ENOENT (so an archived/deleted `data/review/` can't serve stale contents) and re-primes from what `saveItems` just wrote. Every read hands back a shallow clone, never the cached objects, so a caller can't silently pollute the cache.
- `saveItems` moves completed/dismissed items older than 30 days into `data/review/archive.json` on a daily debounce. This is the same file-backed record kind split by age inside its existing directory, not a new data store — `data/review/` is already registered as an archivable/deletable category in `dataManager.js`, so `archive.json` rides along automatically. `getItems` and `createItem`'s 24h duplicate-alert check still see archived items when relevant, deduped by id in case a crash leaves the same item in both files transiently. Both the archive read and write are isolated from the live write/read paths, so a corrupt or unwritable `archive.json` degrades gracefully instead of blocking every review operation.
- `bulkUpdateStatus` now emits one `items:bulk-updated` event (`{ ids, status, updatedAt }`) instead of one `item:updated` per item; `socket.js` forwards it as `review:items:bulk-updated`, and both the Review page and Review Hub dashboard card apply it in a single update/refetch.

## Test plan
- `server/services/review.test.js` — 34 tests (20 pre-existing + 14 new), all passing. Baseline check: 9 of the 14 new/changed cases fail against the pre-fix code at the base commit; the other 5 pass there too as legitimate characterization pins (they guard behavior in code that doesn't exist at all pre-fix — e.g. external-rewrite cache invalidation is trivially true when nothing is cached yet, and archive-read isolation has no analog when nothing reads `archive.json` yet).
- `server/services/socket.test.js`, `server/lib/socketEventInventory.test.js`, `server/lib/socketEventCatalog.test.js` — 89 tests, all passing (socket event inventory is source-derived, so the new `review:items:bulk-updated` emit is picked up automatically).
- `client/src/pages/Review.test.jsx` (extended) and `client/src/components/ReviewHubCard.test.jsx` (new) — 13 tests, all passing. Both new cases fail against the pre-fix client code at the base commit (the bulk-update socket subscription doesn't exist there).
- `client/src/components/dashboard/widgetRegistry.test.jsx` — unaffected, 4 tests passing.
- Local review (opencode, high effort): two rounds. Round 1 found a critical gap (a corrupt `archive.json` could block every live review write) plus a crash-duplicate risk in the archive write, both fixed. Round 2 found the same class of gap on the read side (`getItems`/`createItem`'s archive reads were unprotected) plus a cache-reference-mutation risk in `loadItems()`, both fixed; one finding was a misread of an already-present no-op guard, and one was rejected as an already-decided scope boundary (archive items are read-only for status-flip/edit/delete, unreachable through the UI since those actions are all gated on pending status).

Closes #6853
