### PR TITLE
feat: edit pending maintenance stage provider model and effort

### DIFF
--- a/client/src/components/cos/tabs/schedule/MaintenanceRunForm.jsx
+++ b/client/src/components/cos/tabs/schedule/MaintenanceRunForm.jsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { Link } from 'react-router';
 import socket from '../../../../services/socket';
+import MaintenanceStepSettings from './MaintenanceStepSettings';
 import MaintenanceRunStatus from './MaintenanceRunStatus';
 import MaintenanceStepChecklist from './MaintenanceStepChecklist';
 import { buildMaintenanceSteps } from '../../../../../../server/lib/maintenanceSequence';
@@ -128,7 +129,7 @@ export default function MaintenanceRunForm({ schedule, apps = [], providers = []
   const applyRun = updated => {
     if (!updated) return;
     revision.current += 1;
-    setRuns(current => (current || []).map(entry => (entry.id === updated.id ? updated : entry)));
+    setRuns(current => (current || []).map(entry => (entry.id === updated.id && !(entry.updatedAt > updated.updatedAt) ? updated : entry)));
   };
   const stop = async id => {
     const response = await api.stopMaintenanceRun(id, { silent: true }).catch(error => {
@@ -236,7 +237,10 @@ export default function MaintenanceRunForm({ schedule, apps = [], providers = []
           return <li key={entry.id} className="border border-port-border rounded p-2 flex flex-wrap items-center gap-x-3 gap-y-1">
             <span className="font-medium">{getAppName(entry.appId, apps, entry.appId)}</span>
             <span className="text-xs">{entry.providerId}{entry.model ? ` · ${entry.model}` : ''}</span>
-            <MaintenanceRunStatus run={entry} showSteps />
+            <MaintenanceRunStatus run={entry} showSteps renderStepSettings={step => (
+              <MaintenanceStepSettings key={`${step.id}:${JSON.stringify(step.overrides)}`} run={entry} step={step}
+                providers={availableProviders} loading={!providersLoaded} onSaved={applyRun} />
+            )} />
             <button type="button" onClick={() => stop(entry.id)} className="px-2 py-1 text-xs bg-port-border rounded">Stop</button>
           </li>;
         })}

--- a/client/src/components/cos/tabs/schedule/MaintenanceRunStatus.jsx
+++ b/client/src/components/cos/tabs/schedule/MaintenanceRunStatus.jsx
@@ -23,7 +23,7 @@ export function maintenanceRunProgress(run = {}) {
 }
 
 /** Shared live progress content for the schedule card and corner notification. */
-export default function MaintenanceRunStatus({ run, showSteps = false }) {
+export default function MaintenanceRunStatus({ run, showSteps = false, renderStepSettings }) {
   const { current, done, total, step } = maintenanceRunProgress(run);
   return <div className={`space-y-1 text-xs min-w-0 ${showSteps ? 'w-full' : ''}`} role="status">
     <p>{run.status} · {current}/{total} steps{run.status === 'running' && step ? ` · ${step}` : ''}</p>
@@ -34,6 +34,6 @@ export default function MaintenanceRunStatus({ run, showSteps = false }) {
       {run.active.agentId && <a className="underline" href={`/cos/agents/${encodeURIComponent(run.active.agentId)}`} target="_blank" rel="noopener noreferrer">Open agent in new tab</a>}
     </p>}
     {run.reason && <details><summary className="cursor-pointer">Run details</summary><p className="break-all">{run.reason}</p></details>}
-    {showSteps && <MaintenanceStepChecklist steps={run.steps} completed={run.completed} activeStepId={run.active?.stepId} />}
+    {showSteps && <MaintenanceStepChecklist steps={run.steps} completed={run.completed} activeStepId={run.active?.stepId} renderStepSettings={renderStepSettings} />}
   </div>;
 }

--- a/client/src/components/cos/tabs/schedule/MaintenanceStepChecklist.jsx
+++ b/client/src/components/cos/tabs/schedule/MaintenanceStepChecklist.jsx
@@ -1,16 +1,17 @@
 import { CheckCircle2, Circle, LoaderCircle } from 'lucide-react';
 
 /** Preview and saved progress both render the runner's actual ordered steps. */
-export default function MaintenanceStepChecklist({ steps = [], completed = {}, activeStepId, label = 'Maintenance steps' }) {
+export default function MaintenanceStepChecklist({ steps = [], completed = {}, activeStepId, label = 'Maintenance steps', renderStepSettings }) {
   return <ol aria-label={label} className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2 text-xs">
     {steps.map((step, index) => {
       const done = Object.hasOwn(completed, step.id);
       const active = !done && step.id === activeStepId;
       const Icon = done ? CheckCircle2 : active ? LoaderCircle : Circle;
-      return <li key={step.id} aria-current={active ? 'step' : undefined} className={`flex items-center gap-2 rounded border p-2 ${active ? 'border-port-accent bg-port-accent/10' : 'border-port-border'}`}>
+      return <li key={step.id} aria-current={active ? 'step' : undefined} className={`flex flex-wrap items-center gap-2 rounded border p-2 ${active ? 'border-port-accent bg-port-accent/10' : 'border-port-border'}`}>
         <Icon size={16} aria-hidden="true" className={`shrink-0 ${done || active ? 'text-port-accent' : 'text-port-text-muted'} ${active ? 'motion-safe:animate-spin' : ''}`} />
         <span className="min-w-0 break-words">{index + 1}. {step.taskRef.taskType}</span>
         <span className="sr-only">{done ? 'Completed' : active ? 'Current' : 'Pending'}</span>
+        {renderStepSettings?.(step)}
       </li>;
     })}
   </ol>;

--- a/client/src/components/cos/tabs/schedule/MaintenanceStepSettings.jsx
+++ b/client/src/components/cos/tabs/schedule/MaintenanceStepSettings.jsx
@@ -1,0 +1,39 @@
+import { useState } from 'react';
+import ProviderModelSelector from '../../../ProviderModelSelector';
+import { effortAwareModelOptions } from '../../../../utils/providers';
+import { updateMaintenanceStep } from '../../../../services/apiAgents';
+
+/** Drafts apply to this run only, and only before the runner dispatches the stage. */
+export default function MaintenanceStepSettings({ run, step, providers, loading, onSaved }) {
+  const [draft, setDraft] = useState(() => ({ providerId: step.overrides?.providerId || '', model: step.overrides?.model || '', effort: step.overrides?.effort || '' }));
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState('');
+  const editable = run.status === 'running' && !run.completed?.[step.id] && !step.startedAt && run.active?.stepId !== step.id;
+  const provider = providers.find(entry => entry.id === draft.providerId);
+  const dirty = ['providerId', 'model', 'effort'].some(key => draft[key] !== (step.overrides?.[key] || ''));
+  const save = async () => {
+    if (!editable || saving || !dirty || !provider || !draft.model) return;
+    setSaving(true);
+    setError('');
+    const response = await updateMaintenanceStep(run.id, step.id, { ...draft, effort: draft.effort || null }, { silent: true })
+      .catch(err => { setError(err.message); return null; });
+    if (response?.run) onSaved(response.run);
+    setSaving(false);
+  };
+  return <div className="w-full min-w-0">
+    {editable ? <fieldset disabled={saving} className="space-y-2">
+      <legend className="sr-only">Handler for {step.taskRef.taskType}</legend>
+      <ProviderModelSelector providers={providers} selectedProviderId={draft.providerId} selectedModel={draft.model}
+        availableModels={provider ? effortAwareModelOptions(provider, draft.model) : []}
+        onProviderChange={providerId => setDraft({ providerId, model: '', effort: '' })}
+        onModelChange={model => setDraft(current => ({ ...current, model }))}
+        effort={draft.effort} onEffortChange={effort => setDraft(current => ({ ...current, effort }))}
+        emptyProviderOption="Select a subscription provider" emptyModelOption="Select a model"
+        alwaysShowModel layout="stacked" loading={loading} disabled={saving} />
+      <p className="text-port-text-muted">Blank effort uses the task’s saved setting. Applies to this stage only.</p>
+      <button type="button" onClick={save} disabled={saving || loading || !dirty || !provider || !draft.model}
+        className="px-2 py-1 rounded bg-port-border disabled:opacity-50">{saving ? 'Saving…' : 'Save stage'}</button>
+    </fieldset> : <p className="text-port-text-muted break-words">{step.overrides?.providerId} · {step.overrides?.model}{step.overrides?.effort ? ` · ${step.overrides.effort}` : ''}</p>}
+    {error && <p role="alert">{error}</p>}
+  </div>;
+}

--- a/client/src/components/cos/tabs/schedule/MaintenanceStepSettings.test.jsx
+++ b/client/src/components/cos/tabs/schedule/MaintenanceStepSettings.test.jsx
@@ -1,0 +1,37 @@
+import { beforeEach, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import MaintenanceStepSettings from './MaintenanceStepSettings';
+import { updateMaintenanceStep } from '../../../../services/apiAgents';
+
+vi.mock('../../../../services/apiAgents', () => ({ updateMaintenanceStep: vi.fn() }));
+const providers = [{ id: 'codex', name: 'Codex', type: 'cli', command: 'codex', enabled: true, models: ['example-one', 'example-two'] }];
+const step = { id: 'step-2', taskRef: { taskType: 'simplify' }, overrides: { providerId: 'codex', model: 'example-one', effort: 'high' } };
+const run = { id: 'maint-1', status: 'running', completed: {}, active: { stepId: 'step-1' } };
+beforeEach(() => vi.resetAllMocks());
+
+it('saves pending stage settings and surfaces rejection without applying failed edits', async () => {
+  const user = userEvent.setup();
+  const onSaved = vi.fn();
+  render(<MaintenanceStepSettings run={run} step={step} providers={providers} onSaved={onSaved} />);
+  expect(screen.getByRole('button', { name: 'Save stage' })).toBeDisabled();
+  await user.selectOptions(screen.getByLabelText('Model'), 'example-two');
+  await user.selectOptions(screen.getByRole('combobox', { name: /effort/i }), 'low');
+  updateMaintenanceStep.mockRejectedValueOnce(new Error('Stage already started'));
+  await user.click(screen.getByRole('button', { name: 'Save stage' }));
+  expect(await screen.findByRole('alert')).toHaveTextContent('Stage already started');
+  expect(onSaved).not.toHaveBeenCalled();
+  updateMaintenanceStep.mockResolvedValueOnce({ run });
+  await user.click(screen.getByRole('button', { name: 'Save stage' }));
+  expect(updateMaintenanceStep).toHaveBeenLastCalledWith('maint-1', 'step-2', { providerId: 'codex', model: 'example-two', effort: 'low' }, { silent: true });
+  expect(onSaved).toHaveBeenCalledWith(run);
+});
+
+it('removes editing when a live update marks the stage dispatched', () => {
+  const { rerender } = render(<MaintenanceStepSettings run={run} step={step} providers={providers} />);
+  expect(screen.getByLabelText('Provider')).toBeInTheDocument();
+  rerender(<MaintenanceStepSettings run={{ ...run, active: { stepId: step.id } }} step={step} providers={providers} />);
+  expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
+  rerender(<MaintenanceStepSettings run={run} step={{ ...step, startedAt: '2026-01-01' }} providers={providers} />);
+  expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
+});

--- a/client/src/services/apiAgents.js
+++ b/client/src/services/apiAgents.js
@@ -362,3 +362,7 @@ export const triggerFeatureAgent = (id, options = {}) => request(`/feature-agent
 export const stopFeatureAgent = (id, options = {}) => request(`/feature-agents/${id}/stop`, { method: 'POST', ...options });
 export const getFeatureAgentRuns = (id, limit) => request(`/feature-agents/${id}/runs${limit ? `?limit=${limit}` : ''}`);
 export const getFeatureAgentOutput = (id) => request(`/feature-agents/${id}/output`);
+
+export const updateMaintenanceStep = (id, stepId, settings, options = {}) => request(`/cos/schedule/maintenance-runs/${encodeURIComponent(id)}/steps/${encodeURIComponent(stepId)}`, {
+  method: 'PATCH', body: JSON.stringify(settings), ...options,
+});

--- a/server/routes/cosScheduleRoutes.js
+++ b/server/routes/cosScheduleRoutes.js
@@ -13,7 +13,7 @@ import { EFFORT_LEVELS } from '../lib/providerModels.js';
 import { INTERVAL_TYPES, decodeIntervalType, isCronExpression, isKnownIntervalType } from '../services/taskScheduleConstants.js';
 import { normalizeSuggestedAfter, SUGGESTED_AFTER_MAX } from '../lib/scheduleRunOrder.js';
 import { findCronExpressionError } from '../lib/cronValidation.js';
-import { listMaintenanceRuns, resumeMaintenanceRun, startMaintenanceRun, stopMaintenanceRun } from '../services/maintenanceRun.js';
+import { updateMaintenanceStep, listMaintenanceRuns, resumeMaintenanceRun, startMaintenanceRun, stopMaintenanceRun } from '../services/maintenanceRun.js';
 
 const templateTaskSchema = z.object({
   name: z.string().min(1),
@@ -273,6 +273,13 @@ router.get('/schedule/maintenance-runs', asyncHandler(async (_req, res) => {
 router.post('/schedule/maintenance-runs', asyncHandler(async (req, res) => {
   const body = validateRequest(maintenanceRunStartSchema, req.body || {});
   res.status(201).json(await startMaintenanceRun(body));
+}));
+
+router.patch('/schedule/maintenance-runs/:id/steps/:stepId', asyncHandler(async (req, res) => {
+  const body = validateRequest(maintenanceRunStartSchema.pick({ providerId: true, model: true, effort: true }), req.body || {});
+  const run = await updateMaintenanceStep(req.params.id, req.params.stepId, body);
+  if (!run) throw new ServerError('Maintenance run or stage not found', { status: 404 });
+  res.json({ run });
 }));
 
 router.post('/schedule/maintenance-runs/:id/stop', asyncHandler(async (req, res) => {

--- a/server/routes/cosScheduleRoutes.test.js
+++ b/server/routes/cosScheduleRoutes.test.js
@@ -5,7 +5,7 @@ import scheduleRoutes from './cosScheduleRoutes.js';
 
 const recordUserAction = vi.hoisted(() => vi.fn(async () => ({ id: 'evt' })));
 vi.mock('../services/userActions.js', () => ({ recordUserAction }));
-const maintenance = vi.hoisted(() => ({ listMaintenanceRuns: vi.fn(), startMaintenanceRun: vi.fn(), stopMaintenanceRun: vi.fn(), resumeMaintenanceRun: vi.fn() }));
+const maintenance = vi.hoisted(() => ({ updateMaintenanceStep: vi.fn(), listMaintenanceRuns: vi.fn(), startMaintenanceRun: vi.fn(), stopMaintenanceRun: vi.fn(), resumeMaintenanceRun: vi.fn() }));
 vi.mock('../services/maintenanceRun.js', () => maintenance);
 
 vi.mock('../services/taskSchedule.js', () => ({
@@ -75,6 +75,17 @@ describe('CoS Schedule Routes', () => {
   });
 
   describe('manual maintenance runs', () => {
+    it('validates stage settings and returns the saved run or not-found', async () => {
+      const url = '/api/cos/schedule/maintenance-runs/maint-1/steps/step-2';
+      const settings = { providerId: 'codex', model: 'example-model', effort: null };
+      maintenance.updateMaintenanceStep.mockResolvedValue({ id: 'maint-1' });
+      expect((await request(app).patch(url).send(settings)).body.run.id).toBe('maint-1');
+      expect(maintenance.updateMaintenanceStep).toHaveBeenCalledWith('maint-1', 'step-2', settings);
+      expect((await request(app).patch(url).send({ ...settings, effort: 'invalid' })).status).toBe(400);
+      expect((await request(app).patch(url).send({ ...settings, completed: {} })).status).toBe(400);
+      maintenance.updateMaintenanceStep.mockResolvedValue(null);
+      expect((await request(app).patch(url).send(settings)).status).toBe(404);
+    });
     it('accepts fix mode and rejects unknown modes', async () => {
       maintenance.startMaintenanceRun.mockResolvedValue({ run: { id: 'maint-1' } });
       const body = { appId: 'app-1', providerId: 'codex', model: 'gpt-5', mode: 'fix', claimBetweenAudits: false, claimHandler: { providerId: 'claude', model: 'sonnet', effort: 'low' } };

--- a/server/services/maintenanceRun.js
+++ b/server/services/maintenanceRun.js
@@ -201,6 +201,27 @@ export function stopMaintenanceRun(id) {
   });
 }
 
+/** Editing shares the dispatch queue: a stale browser cannot change a started step. */
+export function updateMaintenanceStep(id, stepId, { providerId, model, effort = null }) {
+  return perRun(id, async () => {
+    const run = await getMaintenanceRun(id);
+    const step = run?.steps.find(entry => entry.id === stepId);
+    if (!step) return null;
+    if (run.status !== MAINTENANCE_RUN_STATUS.RUNNING || run.completed?.[stepId] || step.startedAt || run.active?.stepId === stepId) {
+      throw new ServerError('Only pending stages in a running maintenance run can be edited', { status: 409, code: 'MAINTENANCE_STEP_STARTED' });
+    }
+    const [{ getProviderById }, { resolveBurnProvider }] = await Promise.all([
+      import('./providers.js'), import('./scheduledHandlers/providerPick.js'),
+    ]);
+    const familyId = familyForProvider(await getProviderById(providerId));
+    const provider = familyId ? await resolveBurnProvider({ job: { providerId }, family: { id: familyId } }) : null;
+    if (!provider) throw new ServerError(`provider "${providerId}" is not an enabled subscription CLI/TUI provider`, { status: 400, code: 'MAINTENANCE_RUN_PROVIDER_UNAVAILABLE' });
+    return patchRun(id, { steps: run.steps.map(entry => entry.id === stepId
+      ? { ...entry, familyId, overrides: { ...entry.overrides, providerId, model, effort } }
+      : entry) });
+  });
+}
+
 export async function resumeMaintenanceRun(id) {
   const resumed = await perRun(id, async () => {
     const run = await getMaintenanceRun(id);
@@ -266,11 +287,12 @@ async function evaluate(id, { ignoreTaskId }) {
       }
       if (!probe.job) return hold(probe.reason);
     }
-    const result = await invokeQuotaBurnStep({ step, family: { id: step.drain ? (run.claimFamilyId || run.familyId) : run.familyId }, catalog, maintenanceRunId: id });
+    const result = await invokeQuotaBurnStep({ step, family: { id: step.familyId || (step.drain ? (run.claimFamilyId || run.familyId) : run.familyId) }, catalog, maintenanceRunId: id });
     if (!result.dispatched) return hold(result.reason, { completed });
     const taskType = step.taskRef.taskType;
     await patchRun(id, {
       completed,
+      steps: run.steps.map(entry => entry.id === step.id ? { ...entry, startedAt: entry.startedAt || new Date().toISOString() } : entry),
       reason: null,
       active: { stepId: step.id, taskType, status: 'queued', requestId: result.awaiting?.requestId ?? null, at: new Date().toISOString() },
     });

--- a/server/services/maintenanceRun.test.js
+++ b/server/services/maintenanceRun.test.js
@@ -31,7 +31,7 @@ vi.mock('./quotaBurnStore.js', () => ({ getQuotaBurnConfig: vi.fn(async () => { 
 const { getQuotaBurnConfig } = await import('./quotaBurnStore.js');
 const { invokeQuotaBurnStep } = await import('./quotaBurnInvoke.js');
 const {
-  startMaintenanceRun, stopMaintenanceRun, resumeMaintenanceRun, evaluateMaintenanceRun, getMaintenanceRun, listMaintenanceRuns,
+  updateMaintenanceStep, startMaintenanceRun, stopMaintenanceRun, resumeMaintenanceRun, evaluateMaintenanceRun, getMaintenanceRun, listMaintenanceRuns,
   __onMaintenanceAgentSpawned, __onMaintenanceAgentCompleted, __retryMaintenanceRuns, __resetMaintenanceRunScheduler,
 } = await import('./maintenanceRun.js');
 
@@ -52,6 +52,32 @@ beforeEach(async () => {
 afterAll(cleanup);
 
 describe('manual maintenance run', () => {
+  it('dispatches an edited stage through its own provider family', async () => {
+    const { run } = await start();
+    const { getProviderById } = await import('./providers.js');
+    const { resolveBurnProvider } = await import('./scheduledHandlers/providerPick.js');
+    getProviderById.mockResolvedValueOnce({ id: 'claude', command: 'claude', type: 'cli', enabled: true });
+    resolveBurnProvider.mockResolvedValueOnce({ id: 'claude' });
+    await updateMaintenanceStep(run.id, run.steps[1].id, { providerId: 'claude', model: 'example-model', effort: 'low' });
+    await __onMaintenanceAgentCompleted(agentFor(run, 0));
+    expect(state.invoked.at(-1)).toMatchObject({ family: { id: 'claude' }, step: { overrides: { providerId: 'claude', effort: 'low' } } });
+  });
+
+  it('persists pending stage settings and dispatches them without changing other stages', async () => {
+    const { run } = await start();
+    const settings = { providerId: 'codex', model: 'example-model', effort: null };
+    const updated = await updateMaintenanceStep(run.id, run.steps[1].id, settings);
+    expect(updated.steps[0]).toEqual(run.steps[0]);
+    expect((await getMaintenanceRun(run.id)).steps[1].overrides).toEqual({ ...run.steps[1].overrides, ...settings });
+    await __onMaintenanceAgentCompleted(agentFor(run, 0));
+    expect(state.invoked.at(-1).step.overrides).toMatchObject(settings);
+    await expect(updateMaintenanceStep(run.id, run.steps[0].id, settings)).rejects.toMatchObject({ status: 409 });
+    await expect(updateMaintenanceStep(run.id, run.steps[1].id, settings)).rejects.toMatchObject({ status: 409 });
+    await expect(updateMaintenanceStep(run.id, run.steps[2].id, { ...settings, providerId: 'missing' })).rejects.toMatchObject({ status: 400 });
+    await stopMaintenanceRun(run.id);
+    await expect(updateMaintenanceStep(run.id, run.steps[2].id, settings)).rejects.toMatchObject({ status: 409 });
+  });
+
   it('walks the whole ladder to completion on agent completions and drain probes, never touching the burn plan', async () => {
     const { run, result } = await start();
     expect(result).toMatchObject({ dispatched: true, taskType: 'better-structural-drift' });


### PR DESCRIPTION
## Summary
Allow editing provider, model, and effort for each pending stage directly in the recommended maintenance live status checklist. Saved choices apply only to that stage in the current run, including switches between subscription provider families.

Serialize edits with dispatch and reject changes to queued, started, completed, or stopped stages. Preserve task parameters and existing run defaults, and retain newer live status when a save response arrives late.

## Test plan
- 61 server workflow and route tests passed, covering persistence, dispatch settings, cross-family selection, validation, and stage edit guards.
- 14 rendered UI tests passed, covering selection, save errors, live locking, and existing maintenance launch behavior.
- Changed client files pass Biome lint; git diff passes whitespace checks.
