### PR TITLE
feat: support manual starts for perpetual scheduled task drains

### DIFF
--- a/client/src/components/cos/tabs/schedule/AppTaskCard.test.jsx
+++ b/client/src/components/cos/tabs/schedule/AppTaskCard.test.jsx
@@ -86,9 +86,16 @@ describe('AppTaskCard', () => {
 
   it('labels on-demand perpetual tasks as automatic drains', () => {
     renderCard({ type: 'on-demand', perpetual: true });
-    expect(screen.getByText('Automatic drain')).toHaveAttribute('title', expect.stringContaining('Turn Perpetual off'));
+    expect(screen.getByText('Automatic drain')).toHaveAttribute('title', expect.stringContaining('Turn automatic starts off'));
     expect(screen.queryByText('On Demand')).toBeNull();
     expect(screen.queryByText('Manual trigger only')).toBeNull();
+  });
+
+  it('labels manual perpetual tasks as on demand with no automatic next run', () => {
+    renderCard({ type: 'on-demand', perpetual: true, autoStart: false });
+    expect(screen.queryByText('Automatic drain')).toBeNull();
+    expect(screen.getByText('On Demand')).toBeTruthy();
+    expect(screen.getByText('Manual trigger only')).toBeTruthy();
   });
 
   it('renders BOTH badges for a scheduled task that also drains perpetually', () => {

--- a/client/src/components/cos/tabs/schedule/GlobalConfigControls.jsx
+++ b/client/src/components/cos/tabs/schedule/GlobalConfigControls.jsx
@@ -117,7 +117,7 @@ export default function GlobalConfigControls({ taskType, config, onUpdate, onTri
     setCronEditing(false);
     setUpdating(true);
     setSelectedType(newType);
-    await onUpdate(taskType, { type: newType, cronExpression: null }).catch(() => {
+    await onUpdate(taskType, { type: newType, cronExpression: null, autoStart: false }).catch(() => {
       setSelectedType(config.type);
     });
     setUpdating(false);
@@ -129,7 +129,7 @@ export default function GlobalConfigControls({ taskType, config, onUpdate, onTri
   // handleToggleEnabled rather than attaching its own rejection handler.
   const handlePerpetualToggle = async () => {
     setUpdating(true);
-    await onUpdate(taskType, { perpetual: !config.perpetual });
+    await onUpdate(taskType, { perpetual: !config.perpetual, ...(config.type === 'on-demand' && !config.perpetual ? { autoStart: config.autoStart ?? false } : {}) });
     setUpdating(false);
   };
 
@@ -293,7 +293,7 @@ export default function GlobalConfigControls({ taskType, config, onUpdate, onTri
           disabled={updating}
           className="w-full bg-port-card border border-port-border rounded px-3 py-2 text-white text-sm"
         >
-          <option value="on-demand">{config.perpetual ? ON_DEMAND_PERPETUAL_LABEL : 'On Demand (manual trigger only)'}</option>
+          <option value="on-demand">{config.perpetual && config.autoStart !== false ? ON_DEMAND_PERPETUAL_LABEL : 'On Demand (manual trigger only)'}</option>
           <option value="cron">Scheduled (cron)</option>
         </select>
         {(selectedType === 'cron' && (cronEditing || config.type === 'cron')) ? (
@@ -304,7 +304,7 @@ export default function GlobalConfigControls({ taskType, config, onUpdate, onTri
             className="mt-2"
           />
         ) : (
-          <p className="text-xs text-gray-500 mt-1">{selectedType === 'on-demand' && config.perpetual ? ON_DEMAND_PERPETUAL_DESCRIPTION : INTERVAL_DESCRIPTIONS[selectedType]}</p>
+          <p className="text-xs text-gray-500 mt-1">{selectedType === 'on-demand' && config.perpetual && config.autoStart !== false ? ON_DEMAND_PERPETUAL_DESCRIPTION : INTERVAL_DESCRIPTIONS[selectedType]}</p>
         )}
       </FormField>
 
@@ -313,7 +313,7 @@ export default function GlobalConfigControls({ taskType, config, onUpdate, onTri
           <span className="text-sm text-gray-400">Perpetual</span>
           <InfoTooltip label="What does Perpetual do?">
             {PERPETUAL_DESCRIPTION}. It applies to either cadence: an On-Demand
-            perpetual task drains whenever it isn&apos;t parked, and a Scheduled
+            perpetual task starts manually when automatic starts are off, and a Scheduled
             one starts its drain on the cron slot and rechecks on the same schedule.
           </InfoTooltip>
         </div>
@@ -333,6 +333,20 @@ export default function GlobalConfigControls({ taskType, config, onUpdate, onTri
       )}
 
       {config.perpetual && selectedType === 'on-demand' && (
+        <label className="flex items-center justify-between gap-3 text-sm text-gray-400">
+          Automatic starts and rechecks
+          <input type="checkbox" checked={config.autoStart !== false} disabled={updating}
+            onChange={async event => {
+              setUpdating(true);
+              await onUpdate(taskType, { autoStart: event.target.checked }).catch(() => {}).finally(() => setUpdating(false));
+            }} />
+        </label>
+      )}
+      {config.perpetual && selectedType === 'on-demand' && config.autoStart === false && (
+        <p className="text-xs text-gray-500">Run Now starts a drain until no actionable work remains. No timer starts or resumes it.</p>
+      )}
+
+      {config.perpetual && selectedType === 'on-demand' && config.autoStart !== false && (
         <div>
           <span className="text-sm text-gray-400 block mb-2">Recheck Cadence</span>
           {(recheckEditing || config.recheckCron) ? (

--- a/client/src/components/cos/tabs/schedule/GlobalConfigControls.test.jsx
+++ b/client/src/components/cos/tabs/schedule/GlobalConfigControls.test.jsx
@@ -296,11 +296,23 @@ describe('GlobalConfigControls — cadence + perpetual', () => {
     expect(onUpdate).toHaveBeenCalledWith('feature-ideas', { perpetual: true });
   });
 
+  it('lets on-demand tasks drain manually without exposing a recheck timer', async () => {
+    const onUpdate = renderControls({ config: { type: 'on-demand', perpetual: false } });
+    await act(async () => fireEvent.click(screen.getByLabelText('Enable perpetual drain')));
+    expect(onUpdate).toHaveBeenCalledWith('feature-ideas', { perpetual: true, autoStart: false });
+    cleanup();
+    renderControls({ config: { type: 'on-demand', perpetual: true, autoStart: false } });
+    expect(screen.getByRole('option', { name: 'On Demand (manual trigger only)' }).selected).toBe(true);
+    expect(screen.getByLabelText('Automatic starts and rechecks')).not.toBeChecked();
+    expect(screen.queryByText('Recheck Cadence')).not.toBeInTheDocument();
+    expect(screen.getByText(/No timer starts or resumes it/)).toBeInTheDocument();
+  });
+
   it('explains automatic rechecks without claiming manual-only execution', () => {
     renderControls({ config: { type: 'on-demand', cronExpression: null, perpetual: true } });
     expect(screen.getByText('Recheck Cadence')).toBeInTheDocument();
     expect(screen.getByRole('option', { name: 'Automatic drain' }).selected).toBe(true);
-    expect(screen.getByText(/Turn Perpetual off for manual-only runs/)).toBeInTheDocument();
+    expect(screen.getByText(/Turn automatic starts off/)).toBeInTheDocument();
     expect(screen.queryByText('Only runs when manually triggered')).not.toBeInTheDocument();
 
     cleanup();

--- a/client/src/components/cos/tabs/schedule/IntervalBadge.jsx
+++ b/client/src/components/cos/tabs/schedule/IntervalBadge.jsx
@@ -5,8 +5,8 @@ import { badge, INTERVAL_LABELS, INTERVAL_BADGE_VARIANT, PERPETUAL_BADGE_VARIANT
  * The cadence chip, plus a separate Perpetual chip when the task carries the
  * drain flag — the two are orthogonal, so a Scheduled + Perpetual task shows both.
  */
-export default function IntervalBadge({ type, cronExpression, perpetual }) {
-  const automaticDrain = type === 'on-demand' && perpetual;
+export default function IntervalBadge({ type, cronExpression, perpetual, autoStart }) {
+  const automaticDrain = type === 'on-demand' && perpetual && autoStart !== false;
   const label = automaticDrain ? ON_DEMAND_PERPETUAL_LABEL : INTERVAL_LABELS[type] || type;
   const cronDesc = type === 'cron' && cronExpression ? describeCron(cronExpression) : null;
   const title = type === 'cron' && cronExpression

--- a/client/src/components/cos/tabs/schedule/TaskHeader.jsx
+++ b/client/src/components/cos/tabs/schedule/TaskHeader.jsx
@@ -69,7 +69,7 @@ export default function TaskHeader({ taskType, config, orderStep }) {
               {stages.length}
             </span>
           )}
-          <IntervalBadge type={config.type} cronExpression={config.cronExpression} perpetual={config.perpetual} />
+          <IntervalBadge type={config.type} cronExpression={config.cronExpression} perpetual={config.perpetual} autoStart={config.autoStart} />
         </div>
       </div>
       {config.description && (

--- a/client/src/components/cos/tabs/schedule/scheduleConstants.js
+++ b/client/src/components/cos/tabs/schedule/scheduleConstants.js
@@ -20,11 +20,11 @@ export const INTERVAL_DESCRIPTIONS = {
 
 export const ON_DEMAND_PERPETUAL_LABEL = 'Automatic drain';
 export const ON_DEMAND_PERPETUAL_DESCRIPTION =
-  'Perpetual runs this task automatically while work remains, then resumes on the recheck cadence. Turn Perpetual off for manual-only runs.';
+  'Perpetual runs this task automatically while work remains, then resumes on the recheck cadence. Turn automatic starts off to start each drain manually.';
 
 export const PERPETUAL_LABEL = 'Perpetual';
 export const PERPETUAL_DESCRIPTION =
-  'Drains actionable work back-to-back until none remains, then rechecks on a cadence';
+  'Drains actionable work back-to-back until none remains, then waits for the next manual or automatic start';
 
 // `cyan` is kept as a raw Tailwind hue (not a port-* token) on purpose: it is
 // the 'cron' cadence tone in INTERVAL_BADGE_VARIANT below, and every other tone
@@ -145,7 +145,7 @@ export const STATUS_GROUPS = {
 export function getTaskStatusGroup(config) {
   if (!config?.enabled) return 'disabled';
   if (config.status?.reason === 'waiting-on-dependencies') return 'waiting';
-  if (config.type === 'on-demand' && !config.perpetual) return 'on-demand';
+  if (config.type === 'on-demand' && (!config.perpetual || config.autoStart === false)) return 'on-demand';
   return 'active';
 }
 

--- a/client/src/components/cos/tabs/workflow/ScheduleEditor.jsx
+++ b/client/src/components/cos/tabs/workflow/ScheduleEditor.jsx
@@ -43,12 +43,13 @@ export default function ScheduleEditor({ node, allNodes, timezone, onClose, onSa
       // because recheckCron takes precedence over recheckIntervalMs.
       recheckCron: schedule.recheckCron || '',
       perpetual: !!schedule.perpetual,
+      autoStart: schedule.autoStart ?? !!schedule.perpetual,
       interval: node.kind === 'job' ? (schedule.type || 'daily') : 'daily',
       scheduledTime: schedule.scheduledTime || '',
       weekdaysOnly: !!schedule.weekdaysOnly,
       runAfter: [...(node.runAfter || [])]
     });
-  }, [node, schedule.cronExpression, schedule.cronSchedule, schedule.perpetual, schedule.recheckCron, schedule.scheduledTime, schedule.type, schedule.weekdaysOnly]);
+  }, [node, schedule.autoStart, schedule.cronExpression, schedule.cronSchedule, schedule.perpetual, schedule.recheckCron, schedule.scheduledTime, schedule.type, schedule.weekdaysOnly]);
 
   const dependencyOptions = useMemo(() => {
     if (!node) return [];
@@ -73,6 +74,7 @@ export default function ScheduleEditor({ node, allNodes, timezone, onClose, onSa
   const setMode = (mode) => setForm(current => ({
     ...current,
     mode,
+    autoStart: mode === 'on-demand' ? false : current.autoStart,
     cronExpression: mode === 'cron' && !current.cronExpression ? DEFAULT_CRON : current.cronExpression
   }));
   const validateCron = (value) => String(value || '').trim().split(/\s+/).length === 5;
@@ -83,7 +85,7 @@ export default function ScheduleEditor({ node, allNodes, timezone, onClose, onSa
       toast.error('Cron schedules need five fields');
       return;
     }
-    if (node.kind === 'task' && form.perpetual && form.mode === 'on-demand' && form.recheckCron && !validateCron(form.recheckCron)) {
+    if (node.kind === 'task' && form.perpetual && form.autoStart && form.mode === 'on-demand' && form.recheckCron && !validateCron(form.recheckCron)) {
       toast.error('The perpetual recheck schedule needs five fields');
       return;
     }
@@ -96,6 +98,7 @@ export default function ScheduleEditor({ node, allNodes, timezone, onClose, onSa
         type: form.mode,
         cronExpression: form.mode === 'cron' ? String(form.cronExpression || '').trim() || null : null,
         perpetual: form.perpetual,
+        autoStart: form.autoStart,
         recheckCron: form.recheckCron.trim() || null,
         runAfter: form.runAfter
       };
@@ -162,7 +165,7 @@ export default function ScheduleEditor({ node, allNodes, timezone, onClose, onSa
           <label htmlFor="workflow-task-cadence" className="block text-xs text-gray-400">
             Scheduling behavior
             <select id="workflow-task-cadence" value={form.mode} onChange={event => setMode(event.target.value)} className="mt-1.5 w-full rounded border border-port-border bg-port-bg px-3 py-2 text-sm text-white">
-              {TASK_MODES.map(([value, label]) => <option key={value} value={value}>{value === 'on-demand' && form.perpetual ? ON_DEMAND_PERPETUAL_LABEL : label}</option>)}
+              {TASK_MODES.map(([value, label]) => <option key={value} value={value}>{value === 'on-demand' && form.perpetual && form.autoStart ? ON_DEMAND_PERPETUAL_LABEL : label}</option>)}
             </select>
           </label>
         ) : (
@@ -178,7 +181,7 @@ export default function ScheduleEditor({ node, allNodes, timezone, onClose, onSa
           </div>
         )}
 
-        {node.kind === 'task' && form.mode === 'on-demand' && form.perpetual && (
+        {node.kind === 'task' && form.mode === 'on-demand' && form.perpetual && form.autoStart && (
           <p className="text-xs text-gray-400">{ON_DEMAND_PERPETUAL_DESCRIPTION}</p>
         )}
 
@@ -219,6 +222,16 @@ export default function ScheduleEditor({ node, allNodes, timezone, onClose, onSa
         )}
 
         {node.kind === 'task' && form.perpetual && form.mode === 'on-demand' && (
+          <label className="flex items-center justify-between gap-3 text-sm text-gray-300">
+            Automatic starts and rechecks
+            <input type="checkbox" checked={form.autoStart} onChange={event => set('autoStart', event.target.checked)} />
+          </label>
+        )}
+        {node.kind === 'task' && form.perpetual && !form.autoStart && form.mode === 'on-demand' && (
+          <p className="text-xs text-gray-400">Run Now starts a drain until no actionable work remains. No timer starts or resumes it.</p>
+        )}
+
+        {node.kind === 'task' && form.perpetual && form.autoStart && form.mode === 'on-demand' && (
           <div className="space-y-2 rounded border border-port-warning/20 bg-port-warning/5 p-3">
             <p className="text-xs text-gray-400">
               Drains work back-to-back. Once parked, this is its reset/recheck time — leave blank to keep the default interval-based recheck cadence.

--- a/client/src/components/cos/tabs/workflow/ScheduleEditor.test.jsx
+++ b/client/src/components/cos/tabs/workflow/ScheduleEditor.test.jsx
@@ -60,6 +60,7 @@ describe('ScheduleEditor task cadence', () => {
       type: 'cron',
       cronExpression: '0 9 * * *',
       perpetual: true,
+      autoStart: false,
       recheckCron: null,
       runAfter: [],
     }, { silent: true });
@@ -70,14 +71,15 @@ describe('ScheduleEditor task cadence', () => {
     renderEditor(taskNode({ perpetual: true, recheckCron: '0 11 * * *' }));
 
     fireEvent.change(screen.getByLabelText('Scheduling behavior'), { target: { value: 'on-demand' } });
-    expect(screen.getByRole('option', { name: 'Automatic drain' }).selected).toBe(true);
-    expect(screen.getByText(/Turn Perpetual off for manual-only runs/)).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'On Demand' }).selected).toBe(true);
+    expect(screen.getByText(/No timer starts or resumes it/)).toBeInTheDocument();
     await act(async () => fireEvent.click(screen.getByRole('button', { name: 'Save schedule' })));
 
     expect(api.updateCosTaskInterval).toHaveBeenCalledWith('review', expect.objectContaining({
       type: 'on-demand',
       cronExpression: null,
       perpetual: true,
+      autoStart: false,
       recheckCron: '0 11 * * *',
     }), { silent: true });
   });

--- a/docs/API.md
+++ b/docs/API.md
@@ -266,7 +266,7 @@ Context tools remain read-only. Semantic reads and writes are independent, defau
 | GET | `/cos/schedule/due` | List all tasks due to run |
 | GET | `/cos/schedule/due/:appId` | List tasks due for specific app |
 | GET | `/cos/schedule/task/:taskType` | Get interval and schedule settings for a task type |
-| PUT | `/cos/schedule/task/:taskType` | Update schedule settings for a task type (`type`: `on-demand` \| `cron`; `cronExpression`: 5-field or null; `perpetual`: boolean drain flag, orthogonal to `type`) |
+| PUT | `/cos/schedule/task/:taskType` | Update schedule settings for a task type (`type`: `on-demand` \| `cron`; `cronExpression`: 5-field or null; `perpetual`: boolean drain flag, orthogonal to `type`; `autoStart`: set false for manual-only on-demand drains, omitted preserves legacy automatic starts/rechecks) |
 | POST | `/cos/schedule/trigger` | Trigger an on-demand task run |
 | GET | `/cos/schedule/maintenance-runs` | List manual maintenance runs (the Schedule tab's "Run maintenance now"; running first, then recent history) |
 | POST | `/cos/schedule/maintenance-runs` | Start a manual maintenance run for one app (`appId`, `providerId`, `model`, optional `effort`); returns the run and its first dispatch or hold reason. Independent of Quota Burn |

--- a/server/routes/cosScheduleRoutes.js
+++ b/server/routes/cosScheduleRoutes.js
@@ -50,7 +50,7 @@ const maintenanceRunStartSchema = z.object({
 
 const router = Router();
 
-const SCHEDULE_FIELDS = ['type', 'perpetual', 'enabled', 'intervalMs', 'cronExpression', 'providerId', 'model', 'effort', 'prompt', 'description', 'labels', 'dataInputs', 'taskMetadata', 'runAfter',
+const SCHEDULE_FIELDS = ['type', 'autoStart', 'perpetual', 'enabled', 'intervalMs', 'cronExpression', 'providerId', 'model', 'effort', 'prompt', 'description', 'labels', 'dataInputs', 'taskMetadata', 'runAfter',
   // Advisory run order — which OTHER scheduled tasks a user should generally run
   // first. Editable and unenforced; `runAfter` above is the enforced gate.
   'suggestedAfter',
@@ -75,6 +75,9 @@ function pickScheduleSettings(body, taskType) {
   }
   if (settings.enabled !== undefined && typeof settings.enabled !== 'boolean') {
     throw new ServerError('enabled must be a boolean', { status: 400, code: 'VALIDATION_ERROR' });
+  }
+  if (settings.autoStart !== undefined && typeof settings.autoStart !== 'boolean') {
+    throw new ServerError('autoStart must be a boolean', { status: 400, code: 'VALIDATION_ERROR' });
   }
   if (settings.perpetual !== undefined && typeof settings.perpetual !== 'boolean') {
     throw new ServerError('perpetual must be a boolean', { status: 400, code: 'VALIDATION_ERROR' });
@@ -358,7 +361,7 @@ router.get('/schedule/interval-types', (req, res) => {
       cron: 'Scheduled on a cron expression (minute hour dayOfMonth month dayOfWeek)'
     },
     // `perpetual` is an orthogonal flag, not a type — it applies to either.
-    perpetual: 'Drains actionable work back-to-back until none remains, then rechecks on a cadence (its own cron expression when scheduled, else recheckCron / recheckIntervalMs, default daily)'
+    perpetual: 'Drains actionable work back-to-back until none remains. On-demand tasks with autoStart false wait for another explicit trigger; otherwise rechecks on a cadence (its own cron expression when scheduled, else recheckCron / recheckIntervalMs, default daily)'
   });
 });
 

--- a/server/routes/cosScheduleRoutes.test.js
+++ b/server/routes/cosScheduleRoutes.test.js
@@ -528,6 +528,15 @@ describe('CoS Schedule Routes', () => {
       }));
     });
 
+    it('accepts manual perpetual starts and rejects malformed start flags', async () => {
+      const settings = { type: 'on-demand', perpetual: true, autoStart: false };
+      const response = await request(app).put('/api/cos/schedule/task/security').send(settings);
+      expect(response.status).toBe(200);
+      expect(taskSchedule.updateTaskInterval).toHaveBeenCalledWith('security', settings);
+      const invalid = await request(app).put('/api/cos/schedule/task/security').send({ autoStart: 'false' });
+      expect(invalid.status).toBe(400);
+    });
+
     it('rejects an unrecognized cadence name rather than silently making it manual-only', async () => {
       const response = await request(app).put('/api/cos/schedule/task/security').send({ type: 'hourly-ish' });
       expect(response.status).toBe(400);

--- a/server/services/taskSchedule.js
+++ b/server/services/taskSchedule.js
@@ -12,7 +12,9 @@
  *   actionable, then PARK on a recheck cadence. An on-demand+perpetual task
  *   rechecks on `recheckCron` / `recheckIntervalMs` (default daily); a
  *   cron+perpetual task's cron slot INITIATES the drain and the same expression
- *   gates the next attempt once it parks.
+ *   gates the next attempt once it parks. With `autoStart: false`, on-demand
+ *   drains start only on explicit dispatch and never wake on a recheck timer.
+ *   Omitted autoStart preserves legacy automatic on-demand drains.
  *   See server/services/perpetualWork.js for the detector registry and the
  *   perpetual gate in cosTaskGenerator.generateManagedAppImprovementTaskForType.
  */
@@ -868,7 +870,7 @@ async function evaluateTaskReadiness(taskType, appId, { featureEnabled, continui
   // A perpetual task's park record is the drain's brake: the work-detector at
   // DISPATCH time writes `parkedUntil` when nothing is actionable, and this only
   // READS it (so readiness checks never do network I/O). Shared by both cadence
-  // variants — an on-demand+perpetual task is due whenever it isn't parked, a
+  // variants — an automatic on-demand drain is due whenever it is not parked; a
   // cron+perpetual task additionally needs a cron slot to initiate a drain.
   const perpetualParkResult = () => {
     const parkUntil = parkedUntilMs(appExecution);
@@ -888,7 +890,9 @@ async function evaluateTaskReadiness(taskType, appId, { featureEnabled, continui
     case INTERVAL_TYPES.ON_DEMAND:
       // Drain-until-done when perpetual; otherwise a manual trigger is the only
       // way this ever runs.
-      result = isPerpetual
+      // Missing autoStart preserves existing automatic drains across upgrades.
+      // Manual drains only refill after their own successful completion.
+      result = isPerpetual && (interval.autoStart !== false || continuingPerpetualDrain)
         ? (perpetualParkResult() || { shouldRun: true, reason: 'perpetual-drain' })
         : { shouldRun: false, reason: 'on-demand-only' };
       break;
@@ -1452,7 +1456,7 @@ export async function getUpcomingTasks(limit = 10) {
     if (getTaskTypeInvocation(taskType).visibility === 'hidden') continue;
     // On-demand tasks have no wall-clock position — unless they are perpetual,
     // whose park/recheck boundary IS the schedule the daemon must wake on.
-    if (interval.type === INTERVAL_TYPES.ON_DEMAND && !interval.perpetual) continue;
+    if (interval.type === INTERVAL_TYPES.ON_DEMAND && (!interval.perpetual || interval.autoStart === false)) continue;
 
     const check = await shouldRunTask(taskType, null, { featureEnabled });
     const execution = schedule.executions[`task:${taskType}`] || { lastRun: null, count: 0 };

--- a/server/services/taskSchedule.test.js
+++ b/server/services/taskSchedule.test.js
@@ -2435,6 +2435,23 @@ describe('taskSchedule', () => {
     })
 
     describe('shouldContinuePerpetualDrain', () => {
+      it('only continues an explicitly started manual drain and never schedules its recheck', async () => {
+        mockSchedule({ tasks: {
+          ...PAUSED_SHIPPED_DRAINS,
+          'claim-issue': { type: 'on-demand', perpetual: true, autoStart: false, enabled: true }
+        } })
+        expect(await shouldRunTask('claim-issue')).toMatchObject({ shouldRun: false, reason: 'on-demand-only' })
+        expect(await shouldContinuePerpetualDrain('claim-issue')).toMatchObject({ shouldRun: true, reason: 'perpetual-drain' })
+        expect(await getDueTasks()).not.toEqual(expect.arrayContaining([expect.objectContaining({ taskType: 'claim-issue' })]))
+        expect(await getDueTasks(null, { continuingTaskType: 'claim-issue' })).toEqual(expect.arrayContaining([expect.objectContaining({ taskType: 'claim-issue' })]))
+        await parkPerpetual('claim-issue', null, { reason: 'no-actionable-work', actionableCount: 0 })
+        expect(await shouldContinuePerpetualDrain('claim-issue')).toMatchObject({ shouldRun: false, reason: 'perpetual-parked' })
+        expect(await getUpcomingTasks()).not.toEqual(expect.arrayContaining([expect.objectContaining({ taskType: 'claim-issue' })]))
+        vi.spyOn(Date, 'now').mockReturnValue(Date.now() + 2 * 86400000)
+        expect(await shouldRunTask('claim-issue')).toMatchObject({ shouldRun: false, reason: 'on-demand-only' })
+        vi.restoreAllMocks()
+      })
+
       it('does not force a non-perpetual task past its normal cadence', async () => {
         cronNotDueYet()
         mockSchedule({

--- a/server/services/taskScheduleConstants.js
+++ b/server/services/taskScheduleConstants.js
@@ -10,7 +10,7 @@ const DAY_MS = 24 * HOUR_MS;
 /**
  * The cadence model is exactly two variants. `perpetual` is an ORTHOGONAL
  * boolean on the same record, not a type — so a task can be on-demand+perpetual
- * (drain whenever unparked) or cron+perpetual (a cron slot INITIATES a drain,
+ * (manual start when autoStart is false, otherwise drain whenever unparked) or cron+perpetual (a cron slot INITIATES a drain,
  * and the same expression gates the next attempt once it parks).
  */
 export const INTERVAL_TYPES = {

--- a/server/services/workflow.js
+++ b/server/services/workflow.js
@@ -157,6 +157,7 @@ export async function getWorkflowGraph({ horizonHours = 24, from = new Date() } 
       schedule: {
         type: info.type,
         perpetual: info.perpetual === true,
+        autoStart: info.autoStart ?? (info.perpetual === true),
         intervalMs: info.intervalMs ?? null,
         effectiveIntervalMs: info.adjustedIntervalMs ?? info.intervalMs ?? null,
         cronExpression: info.cronExpression ?? null,
@@ -294,6 +295,7 @@ export function projectWorkflowTimeline(nodes, { start, end, timezone = 'UTC' })
 
   for (const node of nodes.filter(item => item.enabled)) {
     const schedule = node.schedule || {};
+    if (node.kind === 'task' && schedule.type === 'on-demand' && schedule.autoStart === false) continue;
     if (node.kind === 'task' && schedule.perpetual) {
       projectPerpetual(node, startMs, endMs, timezone, occurrences, windows);
       continue;

--- a/server/services/workflow.test.js
+++ b/server/services/workflow.test.js
@@ -327,6 +327,15 @@ describe('projectWorkflowTimeline', () => {
     ]);
   });
 
+  it('does not project automatic launches or rechecks for manual drains', () => {
+    const timeline = projectWorkflowTimeline([{
+      id: 'task:drain', kind: 'task', enabled: true,
+      schedule: { type: 'on-demand', perpetual: true, autoStart: false, recheckCron: '0 9 * * *' }
+    }], range);
+    expect(timeline.windows).toEqual([]);
+    expect(timeline.occurrences).toEqual([]);
+  });
+
   it('renders an active perpetual task as an open-ended drain window and its reset', () => {
     const timeline = projectWorkflowTimeline([{
       id: 'task:drain', kind: 'task', enabled: true, shouldRun: true,


### PR DESCRIPTION
## Summary
On-demand scheduled tasks can now run once or drain actionable work after Run Now without a timer starting or resuming them. Both schedule editors expose automatic starts separately from Perpetual, and manual drains have no projected recheck on cards or the workflow timeline.

The additive `autoStart: false` setting preserves existing automatic drains when omitted. Completion refill, parking, failure, and work-detector gates remain in effect.

## Test plan
- 493 server tests passed across taskSchedule, cosScheduleRoutes, workflow, and cos.
- 107 client tests passed across GlobalConfigControls, AppTaskCard, scheduleConstants, and ScheduleEditor.
- Client lint and git diff whitespace checks passed.
- Regression coverage verifies manual continuation, parking, no timer restart after park expiry, API validation, editor payloads, and timeline/card presentation.
