### PR TITLE
fix: reset browser paths and add host file pickers

### DIFF
--- a/client/src/components/FolderPicker.jsx
+++ b/client/src/components/FolderPicker.jsx
@@ -1,14 +1,15 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
-import { Folder, FolderOpen, ChevronUp, HardDrive, Home, X, Check, AlertCircle } from 'lucide-react';
+import { File, Folder, FolderOpen, ChevronUp, HardDrive, Home, X, Check, AlertCircle } from 'lucide-react';
 import * as api from '../services/api';
 import BrailleSpinner from './BrailleSpinner';
 import Modal from './ui/Modal.jsx';
 
-export default function FolderPicker({ value, onChange, defaultPath }) {
+export default function FolderPicker({ value, onChange, defaultPath, mode = 'directory', ariaLabel = 'Browse folders' }) {
   const [isOpen, setIsOpen] = useState(false);
   const [currentPath, setCurrentPath] = useState('');
   const [parentPath, setParentPath] = useState(null);
   const [directories, setDirectories] = useState([]);
+  const [files, setFiles] = useState([]);
   const [drives, setDrives] = useState(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
@@ -37,17 +38,18 @@ export default function FolderPicker({ value, onChange, defaultPath }) {
       setCurrentPath(result.currentPath);
       setParentPath(result.parentPath);
       setDirectories(result.directories || []);
+      setFiles(result.files || []);
       setDrives(result.drives ?? null);
     };
     let lastError = null;
-    let result = await api.getDirectories(path).catch((err) => {
+    let result = await api.getDirectories(path, { includeFiles: mode === 'file' }).catch((err) => {
       lastError = err;
       return null;
     });
     if (!result && fallbackToDefault && path != null && isPathAbsentError(lastError)) {
       defaultPathUnavailableRef.current = true;
       lastError = null;
-      result = await api.getDirectories(null).catch((err) => {
+      result = await api.getDirectories(null, { includeFiles: mode === 'file' }).catch((err) => {
         lastError = err;
         return null;
       });
@@ -58,16 +60,17 @@ export default function FolderPicker({ value, onChange, defaultPath }) {
       setError(lastError.message || 'Failed to load directory');
     }
     setLoading(false);
-  }, []);
+  }, [mode]);
 
   // Load initial directory when opened
   useEffect(() => {
     if (isOpen) {
       const useDefault = !value && !!defaultPath && !defaultPathUnavailableRef.current;
-      const initialPath = value || (useDefault ? defaultPath : null);
+      const selectedDirectory = mode === 'file' && value ? value.replace(/[/\\][^/\\]+$/, '') : value;
+      const initialPath = selectedDirectory || (useDefault ? defaultPath : null);
       loadDirectory(initialPath, { fallbackToDefault: useDefault });
     }
-  }, [isOpen, loadDirectory, value, defaultPath]);
+  }, [isOpen, loadDirectory, value, defaultPath, mode]);
 
   // Reset the "default unavailable" cache when the caller changes which
   // defaultPath to try — a different path is worth probing again.
@@ -90,8 +93,8 @@ export default function FolderPicker({ value, onChange, defaultPath }) {
         type="button"
         onClick={() => setIsOpen(true)}
         className="px-3 py-3 bg-port-border hover:bg-port-border/80 text-white rounded-lg transition-colors"
-        title="Browse folders"
-        aria-label="Browse folders"
+        title={ariaLabel}
+        aria-label={ariaLabel}
       >
         <Folder size={20} />
       </button>
@@ -114,7 +117,7 @@ export default function FolderPicker({ value, onChange, defaultPath }) {
         >
           {/* Header */}
           <div className="flex items-center justify-between p-4 border-b border-port-border">
-            <h3 id="folder-picker-title" className="text-lg font-semibold text-white">Select Folder</h3>
+            <h3 id="folder-picker-title" className="text-lg font-semibold text-white">{mode === 'file' ? 'Select File' : 'Select Folder'}</h3>
             <button
               type="button"
               onClick={() => setIsOpen(false)}
@@ -208,6 +211,15 @@ export default function FolderPicker({ value, onChange, defaultPath }) {
                   </button>
                 ))}
 
+                {files.map(file => (
+                  <button key={file.path} type="button"
+                    onClick={() => { onChange(file.path); setIsOpen(false); }}
+                    className="w-full flex items-center gap-3 px-3 py-2 text-left rounded-lg hover:bg-port-border/50 text-white">
+                    <File size={18} className="shrink-0" />
+                    <span className="truncate">{file.name}</span>
+                  </button>
+                ))}
+
                 {directories.length === 0 && !parentPath && (
                   <div className="text-center text-gray-500 py-8">
                     No subdirectories
@@ -229,11 +241,11 @@ export default function FolderPicker({ value, onChange, defaultPath }) {
             <button
               type="button"
               onClick={handleSelect}
-              disabled={!currentPath || loading || !!error}
+              disabled={mode === 'file' || !currentPath || loading || !!error}
               className="flex items-center gap-2 px-4 py-2 bg-port-accent hover:bg-port-accent/80 text-white rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
             >
               <Check size={18} />
-              Select This Folder
+              {mode === 'file' ? 'Choose a file above' : 'Select This Folder'}
             </button>
           </div>
         </Modal>

--- a/client/src/pages/Browser.jsx
+++ b/client/src/pages/Browser.jsx
@@ -12,6 +12,7 @@ import {
   getBrowserLogs, navigateBrowser,
   browserDownloadUrl, deleteBrowserDownload
 } from '../services/api';
+import FolderPicker from '../components/FolderPicker';
 import BrailleSpinner from '../components/BrailleSpinner';
 import toast from '../components/ui/Toast';
 import { FormField } from '../components/ui/FormField';
@@ -99,6 +100,14 @@ export default function BrowserPage() {
     }
     setActionLoading(null);
   }, [fetchStatus]);
+
+  const handleChromePathChange = (chromePath) => setConfigDraft(d => {
+    const currentAppBundle = deriveMacAppBundle(d.chromePath);
+    const macAppBundle = !d.macAppBundle || d.macAppBundle === currentAppBundle
+      ? deriveMacAppBundle(chromePath)
+      : d.macAppBundle;
+    return { ...d, chromePath, macAppBundle };
+  });
 
   const handleSaveConfig = useCallback(async () => {
     if (!configDraft) return;
@@ -251,24 +260,19 @@ export default function BrowserPage() {
                 Chrome binary path
                 <span className="ml-2 text-xs text-gray-600">(leave empty to use system default)</span>
               </label>
-              <input
-                id="chromePath"
-                type="text"
-                value={configDraft.chromePath || ''}
-                onChange={e => setConfigDraft(d => {
-                  const chromePath = e.target.value;
-                  const nextAppBundle = deriveMacAppBundle(chromePath);
-                  const currentAppBundle = deriveMacAppBundle(d.chromePath);
-                  const macAppBundle = !d.macAppBundle || d.macAppBundle === currentAppBundle
-                    ? nextAppBundle
-                    : d.macAppBundle;
-                  return { ...d, chromePath, macAppBundle };
-                })}
-                placeholder="/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary"
-                className="w-full px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white text-sm font-mono focus:outline-hidden focus:border-port-accent placeholder-gray-600"
-              />
+              <div className="flex items-center gap-2">
+                <input
+                  id="chromePath"
+                  type="text"
+                  value={configDraft.chromePath || ''}
+                  onChange={e => handleChromePathChange(e.target.value)}
+                  placeholder="/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary"
+                  className="w-full px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white text-sm font-mono focus:outline-hidden focus:border-port-accent placeholder-gray-600"
+                />
+                <FolderPicker value={configDraft.chromePath || ''} mode="file" ariaLabel="Browse Chrome binary" onChange={handleChromePathChange} />
+              </div>
               <p className="text-xs text-gray-500 mt-1">
-                Point at Chrome Canary, Chromium, Brave, or any Chromium-based browser to differentiate the PortOS-managed browser from your daily-driver Chrome.
+                Browse files on the PortOS host. Point at Chrome Canary, Chromium, Brave, or any Chromium-based browser to differentiate the PortOS-managed browser from your daily-driver Chrome.
               </p>
             </div>
             <div className="sm:col-span-2 lg:col-span-3">
@@ -276,14 +280,17 @@ export default function BrowserPage() {
                 macOS app bundle
                 <span className="ml-2 text-xs text-gray-600">(headed mode only; leave empty for system default)</span>
               </label>
-              <input
-                id="macAppBundle"
-                type="text"
-                value={configDraft.macAppBundle || ''}
-                onChange={e => setConfigDraft(d => ({ ...d, macAppBundle: e.target.value }))}
-                placeholder="/Applications/Google Chrome Canary.app"
-                className="w-full px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white text-sm font-mono focus:outline-hidden focus:border-port-accent placeholder-gray-600"
-              />
+              <div className="flex items-center gap-2">
+                <input
+                  id="macAppBundle"
+                  type="text"
+                  value={configDraft.macAppBundle || ''}
+                  onChange={e => setConfigDraft(d => ({ ...d, macAppBundle: e.target.value }))}
+                  placeholder="/Applications/Google Chrome Canary.app"
+                  className="w-full px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white text-sm font-mono focus:outline-hidden focus:border-port-accent placeholder-gray-600"
+                />
+                <FolderPicker value={configDraft.macAppBundle || ''} ariaLabel="Browse macOS app bundle" onChange={macAppBundle => setConfigDraft(d => ({ ...d, macAppBundle }))} />
+              </div>
             </div>
           </div>
           <div className="mt-4 flex justify-end">

--- a/client/src/pages/Browser.test.jsx
+++ b/client/src/pages/Browser.test.jsx
@@ -9,7 +9,7 @@ vi.mock('../services/api', () => ({
   getBrowserStatus: vi.fn(), getBrowserConfig: vi.fn(), updateBrowserConfig: vi.fn(),
   launchBrowser: vi.fn(), stopBrowser: vi.fn(), restartBrowser: vi.fn(),
   getBrowserLogs: vi.fn(), navigateBrowser: vi.fn(),
-  browserDownloadUrl: vi.fn(), deleteBrowserDownload: vi.fn()
+  getDirectories: vi.fn(), browserDownloadUrl: vi.fn(), deleteBrowserDownload: vi.fn()
 }));
 vi.mock('../components/ui/Toast', () => ({ default: { success: vi.fn(), error: vi.fn() } }));
 
@@ -41,6 +41,29 @@ describe('Browser recovery', () => {
     expect(await screen.findByRole('textbox', { name: 'URL to open' })).toBeInTheDocument();
     expect(screen.queryByText('Chrome is not reachable')).not.toBeInTheDocument();
     expect(api.restartBrowser).toHaveBeenCalledWith({ silent: true });
+  });
+
+  it('picks a browser executable, derives its bundle, and saves cleared defaults', async () => {
+    const user = userEvent.setup();
+    const chromePath = '/Applications/Chromium.app/Contents/MacOS/Chromium';
+    api.getDirectories.mockResolvedValue({
+      currentPath: '/Applications/Chromium.app/Contents/MacOS',
+      parentPath: '/Applications/Chromium.app/Contents',
+      directories: [], files: [{ name: 'Chromium', path: chromePath }],
+    });
+    api.updateBrowserConfig.mockImplementation(async config => config);
+    render(<BrowserPage />);
+    await user.click(await screen.findByRole('button', { name: 'Edit configuration' }));
+    await user.click(await screen.findByRole('button', { name: 'Browse Chrome binary' }));
+    await user.click(await screen.findByRole('button', { name: 'Chromium' }));
+    expect(screen.getByLabelText(/Chrome binary path/)).toHaveValue(chromePath);
+    expect(screen.getByRole('textbox', { name: /macOS app bundle/ })).toHaveValue('/Applications/Chromium.app');
+    expect(api.getDirectories).toHaveBeenCalledWith(null, { includeFiles: true });
+    await user.click(screen.getByRole('button', { name: 'Save Config' }));
+    expect(api.updateBrowserConfig).toHaveBeenLastCalledWith(expect.objectContaining({ chromePath, macAppBundle: '/Applications/Chromium.app' }), { silent: true });
+    await user.clear(screen.getByLabelText(/Chrome binary path/));
+    await user.click(screen.getByRole('button', { name: 'Save Config' }));
+    expect(api.updateBrowserConfig).toHaveBeenLastCalledWith(expect.objectContaining({ chromePath: '', macAppBundle: null }), { silent: true });
   });
 
   it('keeps recovery available and avoids a success toast when restarting does not connect', async () => {

--- a/client/src/services/apiScaffold.js
+++ b/client/src/services/apiScaffold.js
@@ -3,9 +3,11 @@ import { request } from './apiCore.js';
 // Templates & Scaffold
 export const getTemplates = () => request('/scaffold/templates');
 
-export const getDirectories = (path = null) => {
-  const params = path ? `?path=${encodeURIComponent(path)}` : '';
-  return request(`/scaffold/directories${params}`);
+export const getDirectories = (path = null, { includeFiles = false } = {}) => {
+  const params = new URLSearchParams();
+  if (path) params.set('path', path);
+  if (includeFiles) params.set('includeFiles', 'true');
+  return request(`/scaffold/directories${params.size ? `?${params}` : ''}`);
 };
 
 export const createFromTemplate = (data) => request('/scaffold/templates/create', {

--- a/server/routes/browser.js
+++ b/server/routes/browser.js
@@ -33,10 +33,10 @@ const navigateSchema = z.object({
     .refine(isSafeIngestUrl, 'only http(s) URLs to non-loopback/non-link-local hosts are allowed')
 });
 
-// Empty string from a "clear" UI action → unset (undefined), so the launcher
+// Empty string or null from a "clear" UI action → unset (undefined), so the launcher
 // falls back to the platform default Chrome instead of trying to spawn "".
 const optionalPath = z.preprocess(
-  v => (v === '' ? undefined : v),
+  v => (v === '' || v === null ? undefined : v),
   z.string().max(1024).refine(
     v => !v || !v.includes('..'),
     { message: 'path must not contain path traversal' }
@@ -89,7 +89,7 @@ router.get('/config', asyncHandler(async (req, res) => {
 
 // PUT /api/browser/config - Update browser config
 router.put('/config', asyncHandler(async (req, res) => {
-  const updates = updateConfigSchema.parse(req.body);
+  const updates = validateRequest(updateConfigSchema, req.body);
   const config = await browserService.updateConfig(updates);
   res.json(config);
 }));

--- a/server/routes/scaffold.js
+++ b/server/routes/scaffold.js
@@ -86,6 +86,10 @@ router.get('/directories', asyncHandler(async (req, res) => {
     currentPath: targetPath,
     parentPath: canGoUp ? parentPath : null,
     directories,
+    ...(req.query.includeFiles === 'true' && { files: entries
+      .filter(entry => (entry.isFile() || entry.isSymbolicLink()) && !entry.name.startsWith('.'))
+      .map(entry => ({ name: entry.name, path: join(targetPath, entry.name) }))
+      .sort((a, b) => a.name.localeCompare(b.name)) }),
     ...(drives && { drives })
   });
 }));

--- a/server/routes/scaffold.test.js
+++ b/server/routes/scaffold.test.js
@@ -57,7 +57,7 @@ vi.mock('../services/xcodeScripts.js', () => ({ toTargetName: vi.fn(() => 'TestA
 
 import scaffoldRoutes from './scaffold.js';
 import { ensureDir } from '../lib/fileUtils.js';
-import { writeFile } from 'fs/promises';
+import { writeFile, readdir } from 'fs/promises';
 import { spawn, exec } from '../lib/childProcess.js';
 import { createApp } from '../services/apps.js';
 import { scaffoldVite } from './scaffoldVite.js';
@@ -220,5 +220,24 @@ describe('POST /api/scaffold — request validation before filesystem mutation (
       expect.any(Function),
       { platforms: ['ios'] }
     );
+  });
+});
+
+
+describe('GET /api/scaffold/directories', () => {
+  it('includes selectable files only when requested, preserving directory-only responses', async () => {
+    readdir.mockResolvedValue([
+      { name: 'Chromium.app', isDirectory: () => true, isFile: () => false, isSymbolicLink: () => false },
+      { name: 'chrome', isDirectory: () => false, isFile: () => true, isSymbolicLink: () => false },
+      { name: '.hidden', isDirectory: () => false, isFile: () => true, isSymbolicLink: () => false },
+    ]);
+    const app = makeApp();
+    const folders = await request(app).get('/api/scaffold/directories?path=/tmp/workspace');
+    expect(folders.status).toBe(200);
+    expect(folders.body).not.toHaveProperty('files');
+    const files = await request(app).get('/api/scaffold/directories?path=/tmp/workspace&includeFiles=true');
+    expect(files.status).toBe(200);
+    expect(files.body.files).toEqual([{ name: 'chrome', path: join('/tmp/workspace', 'chrome') }]);
+    expect(files.body.directories).toEqual(folders.body.directories);
   });
 });

--- a/server/services/browserService.test.js
+++ b/server/services/browserService.test.js
@@ -3,6 +3,9 @@ import { mkdir, readFile, rm, utimes, writeFile } from 'fs/promises';
 import { createServer } from 'http';
 import { join } from 'path';
 import { WebSocketServer } from 'ws';
+import express from 'express';
+import { request } from '../lib/testHelper.js';
+import { errorMiddleware } from '../lib/errorHandler.js';
 import { createTempDataRoot, makePathsProxy } from '../lib/mockPathsDataRoot.js';
 
 // Shape captured from Chrome 150 when a second top-level navigation supersedes
@@ -48,6 +51,39 @@ describe('browserService config persistence', () => {
     expect(saved.macAppBundle).toBe('/Applications/Google Chrome Canary.app');
     const onDisk = JSON.parse(await readFile(join(tempRoot, 'browser-config.json'), 'utf-8'));
     expect(onDisk.macAppBundle).toBe('/Applications/Google Chrome Canary.app');
+  });
+
+  it('clears custom browser paths through the config API and preserves omitted paths', async () => {
+    const service = await importService();
+    const router = (await import('../routes/browser.js')).default;
+    const app = express();
+    app.use(express.json());
+    app.use('/api/browser', router);
+    app.use(errorMiddleware);
+    const customPaths = {
+      chromePath: '/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary',
+      macAppBundle: '/Applications/Google Chrome Canary.app',
+    };
+    await service.saveConfig(customPaths);
+
+    const unchanged = await request(app).put('/api/browser/config').send({ headless: true });
+    expect(unchanged.status).toBe(200);
+    expect(unchanged.body).toMatchObject(customPaths);
+
+    // Clearing the binary input also clears its derived bundle to null.
+    const cleared = await request(app).put('/api/browser/config').send({
+      chromePath: '', macAppBundle: null,
+    });
+    expect(cleared.status).toBe(200);
+    expect(cleared.body).not.toHaveProperty('chromePath');
+    expect(cleared.body).not.toHaveProperty('macAppBundle');
+    const onDisk = JSON.parse(await readFile(join(tempRoot, 'browser-config.json'), 'utf-8'));
+    expect(onDisk).not.toHaveProperty('chromePath');
+    expect(onDisk).not.toHaveProperty('macAppBundle');
+    expect(onDisk.headless).toBe(true);
+
+    const invalid = await request(app).put('/api/browser/config').send({ macAppBundle: 42 });
+    expect(invalid.status).toBe(400);
   });
 
   it('reloads config after the setup script writes browser-config.json directly', async () => {


### PR DESCRIPTION
## Summary
- Accept both empty strings and null when clearing browser paths, removing saved overrides so the launcher uses system defaults.
- Add host file and folder browsing for the Chrome executable and macOS app bundle, reusing the existing picker and preserving automatic bundle derivation.
- Return standard validation errors for invalid config values. File listings are opt-in, preserving existing folder picker responses.

## Test plan
- 74 focused tests passed across browser config persistence/routes, scaffold routes, Browser UI, and FolderPicker.
- Changed client files pass Biome lint; git diff --check passes.
