### PR TITLE
move the quality card off the main dashboard into its own app detail tab

### DIFF
--- a/client/src/components/AppTile.jsx
+++ b/client/src/components/AppTile.jsx
@@ -1,4 +1,3 @@
-import AppQuality from './apps/AppQuality';
 import { useState, memo } from 'react';
 import { Link } from 'react-router';
 import StatusBadge from './StatusBadge';
@@ -70,7 +69,6 @@ const AppTile = memo(function AppTile({ app, onUpdate }) {
         <StatusBadge status={app.overallStatus} size="sm" />
       </div>
 
-      <div className="mb-2"><AppQuality app={app} /></div>
       {/* Ports */}
       <div className="mb-2 flex flex-wrap gap-1">
         {app.uiPort && (

--- a/client/src/components/apps/AppDetailView.jsx
+++ b/client/src/components/apps/AppDetailView.jsx
@@ -23,6 +23,7 @@ import IssuesTab from './tabs/IssuesTab';
 import PullRequestsTab from './tabs/PullRequestsTab';
 import JiraTab from './tabs/JiraTab';
 import ProcessesTab from './tabs/ProcessesTab';
+import QualityTab from './tabs/QualityTab';
 import ReferencesTab from './tabs/ReferencesTab';
 import SubmodulesTab from './tabs/SubmodulesTab';
 import DatadogTab from './tabs/DatadogTab';
@@ -277,6 +278,8 @@ export default function AppDetailView() {
         return <JiraTab app={app} onRefresh={fetchApp} />;
       case 'processes':
         return <ProcessesTab appId={app.id} pm2ProcessNames={app.pm2ProcessNames} />;
+      case 'quality':
+        return <QualityTab app={app} />;
       case 'references':
         return <ReferencesTab appId={appId} appName={app.name} />;
       case 'submodules':

--- a/client/src/components/apps/AppQuality.jsx
+++ b/client/src/components/apps/AppQuality.jsx
@@ -10,7 +10,7 @@ export default function AppQuality({ app, detail = false }) {
   const label = quality?.unavailable ? 'Quality unavailable'
     : score == null ? unscoredLabel : `Quality: ${score}/100`;
   if (!detail) return (
-    <Link to={`/apps/${app.id}/overview`} className="text-xs text-port-accent hover:underline" title="View audit scores and coverage">
+    <Link to={`/apps/${app.id}/quality`} className="text-xs text-port-accent hover:underline" title="View audit scores and coverage">
       {label}{score != null && ` · ${quality.ratedCategories}/${quality.totalCategories} categories`}
     </Link>
   );

--- a/client/src/components/apps/AppQuality.test.jsx
+++ b/client/src/components/apps/AppQuality.test.jsx
@@ -17,9 +17,9 @@ it('shows zero as a real score and explains excluded categories in the breakdown
   expect(screen.getByRole('link', { name: /Configure/ })).toHaveAttribute('href', '/apps/portos-default/tasks');
 });
 
-it('links an unassessed tile to its app overview without inventing a score', () => {
+it('links an unassessed tile to its app quality tab without inventing a score', () => {
   render(<MemoryRouter><AppQuality app={{ id: 'other' }} /></MemoryRouter>);
-  expect(screen.getByRole('link', { name: 'Quality: not assessed' })).toHaveAttribute('href', '/apps/other/overview');
+  expect(screen.getByRole('link', { name: 'Quality: not assessed' })).toHaveAttribute('href', '/apps/other/quality');
 });
 
 it('explains why completed maintenance can still have no saved assessment', async () => {

--- a/client/src/components/apps/constants.js
+++ b/client/src/components/apps/constants.js
@@ -184,6 +184,7 @@ export const APP_DETAIL_TABS = [
   { id: 'pull-requests', label: 'PRs / MRs' },
   { id: 'jira', label: 'JIRA', feature: 'jira' },
   { id: 'processes', label: 'Processes' },
+  { id: 'quality', label: 'Quality' },
   { id: 'references', label: 'References' },
   // Only repos that declare submodules (a .gitmodules file) get the tab — most
   // managed apps have none, and an always-empty tab is just noise.

--- a/client/src/components/apps/tabs/OverviewTab.jsx
+++ b/client/src/components/apps/tabs/OverviewTab.jsx
@@ -1,4 +1,3 @@
-import AppQuality from '../AppQuality';
 import { useState, useEffect, useMemo } from 'react';
 import { Link, useNavigate } from 'react-router';
 import { FolderOpen, Gamepad2, Terminal, Code, RefreshCw, Wrench, Archive, ArchiveRestore, Download, Tag, AlertTriangle, Rocket, Camera, Image, Sparkles, Trash2 } from 'lucide-react';
@@ -125,7 +124,6 @@ export default function OverviewTab({ app, onRefresh }) {
           Kanban board, which needed the full page width, now live on the app's
           own JIRA tab.) */}
       <div className="space-y-6 max-w-5xl">
-      <AppQuality app={app} detail />
       {/* Details Grid */}
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 sm:gap-6">
         <div>

--- a/client/src/components/apps/tabs/QualityTab.jsx
+++ b/client/src/components/apps/tabs/QualityTab.jsx
@@ -1,0 +1,9 @@
+import AppQuality from '../AppQuality';
+
+export default function QualityTab({ app }) {
+  return (
+    <div className="max-w-5xl">
+      <AppQuality app={app} detail />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Removed the compact quality link from `AppTile` (used on the main Dashboard's Apps Grid widget)
- Removed the full quality card from the app's Overview tab
- Added a new dedicated Quality tab (`/apps/:appId/quality`) that renders the quality detail card
- Updated the compact quality link (still shown on the Apps list page) to point at the new Quality tab

## Test plan
- `vitest run` on the affected client suites (OverviewTab, AppQuality, Apps, constants, AppDetailView, Layout, dashboard widgets) — all passing
- Full client test suite (`vitest run`) — 927 files / 11333 tests passing