### PR TITLE
sharing: derive processManifest's pending-signal ladder from one table

### DIFF
--- a/server/services/sharing/importer.js
+++ b/server/services/sharing/importer.js
@@ -1067,14 +1067,7 @@ export async function processManifest(bucketId, manifestFilename) {
   // when the owner record failed to import (corrupt JSON, schema-version
   // mismatch) or the manifest references an owner id not listed in
   // `recordIds`.
-  const collectionPendingUniverse = outcome?.collectionPendingUniverse || null;
-  const collectionPendingSeries = outcome?.collectionPendingSeries || null;
   const collectionTombstonedUniverse = outcome?.collectionTombstonedUniverse || null;
-  const legacyCanonPendingUniverses = outcome?.legacyCanonPendingUniverses || null;
-  const legacyCanonPendingFailures = outcome?.legacyCanonPendingFailures || null;
-  const recordImportFailures = outcome?.recordImportFailures || null;
-  const reviewMergeFailures = outcome?.reviewMergeFailures || null;
-  const outlineMergeFailures = outcome?.outlineMergeFailures || null;
   // Tombstoned universe: the collection owner IS on disk but locally deleted.
   // Unlike the truly-missing case this will never self-resolve via sync, so we
   // advance the cursor (no infinite pending loop) and emit a clear signal. The
@@ -1085,20 +1078,33 @@ export async function processManifest(bucketId, manifestFilename) {
     console.log(`⚠️ sharing: bucket=${bucket.name} manifest=${manifest.id} kind=${manifest.kind} collectionUniverse=${collectionTombstonedUniverse} is deleted locally — ${outcome.collectionItemsDeferred ?? 0} item(s) skipped; restore universe to import`);
     return { processed: true, manifest, outcome };
   }
-  if (assetCopy.missing.length > 0 || missingRecords.length > 0 || missingReviews.length > 0 || missingOutlines.length > 0 || collectionPendingUniverse || collectionPendingSeries || legacyCanonPendingUniverses || legacyCanonPendingFailures || recordImportFailures || reviewMergeFailures || outlineMergeFailures) {
-    if (assetCopy.missing.length > 0) outcome.pendingAssets = assetCopy.missing;
-    if (missingRecords.length > 0) outcome.pendingRecords = missingRecords;
-    if (missingReviews.length > 0) outcome.pendingReviews = missingReviews;
-    if (missingOutlines.length > 0) outcome.pendingOutlines = missingOutlines;
-    if (collectionPendingUniverse) outcome.pendingCollectionUniverse = collectionPendingUniverse;
-    if (collectionPendingSeries) outcome.pendingCollectionSeries = collectionPendingSeries;
-    if (legacyCanonPendingUniverses) outcome.pendingLegacyCanonUniverses = legacyCanonPendingUniverses;
-    if (legacyCanonPendingFailures) outcome.pendingLegacyCanonFailures = legacyCanonPendingFailures;
-    if (recordImportFailures) outcome.pendingRecordImportFailures = recordImportFailures;
-    if (reviewMergeFailures) outcome.pendingReviewMergeFailures = reviewMergeFailures;
-    if (outlineMergeFailures) outcome.pendingOutlineMergeFailures = outlineMergeFailures;
+  // Each row is checked once for "is this still pending?", assigned onto
+  // `outcome.<key>` once, and formatted into the `⏳ sharing:` log line once —
+  // rather than the same eleven conditions repeated across a trigger check,
+  // an assignment block, and a log-suffix template (#6845).
+  const PENDING_SIGNALS = [
+    { key: 'pendingAssets', value: assetCopy.missing, label: 'waitingForAssets', format: 'count', alwaysLog: true },
+    { key: 'pendingRecords', value: missingRecords, label: 'waitingForRecords', format: 'count', alwaysLog: true },
+    { key: 'pendingReviews', value: missingReviews, label: 'waitingForReviews', format: 'count' },
+    { key: 'pendingOutlines', value: missingOutlines, label: 'waitingForOutlines', format: 'count' },
+    { key: 'pendingCollectionUniverse', value: outcome?.collectionPendingUniverse || null, label: 'waitingForUniverse', format: 'value' },
+    { key: 'pendingCollectionSeries', value: outcome?.collectionPendingSeries || null, label: 'waitingForSeries', format: 'value' },
+    { key: 'pendingLegacyCanonUniverses', value: outcome?.legacyCanonPendingUniverses || null, label: 'waitingForLegacyCanonUniverses', format: 'list' },
+    { key: 'pendingLegacyCanonFailures', value: outcome?.legacyCanonPendingFailures || null, label: 'legacyCanonFailures', format: 'list' },
+    { key: 'pendingRecordImportFailures', value: outcome?.recordImportFailures || null, label: 'recordImportFailures', format: 'list' },
+    { key: 'pendingReviewMergeFailures', value: outcome?.reviewMergeFailures || null, label: 'reviewMergeFailures', format: 'list' },
+    { key: 'pendingOutlineMergeFailures', value: outcome?.outlineMergeFailures || null, label: 'outlineMergeFailures', format: 'list' },
+  ];
+  const isPendingSignalSet = (value) => (Array.isArray(value) ? value.length > 0 : Boolean(value));
+  const activePendingSignals = PENDING_SIGNALS.filter((signal) => isPendingSignalSet(signal.value));
+  if (activePendingSignals.length > 0) {
+    for (const { key, value } of activePendingSignals) outcome[key] = value;
+    const suffix = PENDING_SIGNALS
+      .filter((signal) => signal.alwaysLog || isPendingSignalSet(signal.value))
+      .map(({ value, label, format }) => ` ${label}=${format === 'count' ? value.length : format === 'list' ? value.join(',') : value}`)
+      .join('');
     sharingEvents.emit('manifest-processed', { bucketId, manifestId: manifest.id, manifestFilename, outcome });
-    console.log(`⏳ sharing: bucket=${bucket.name} manifest=${manifest.id} kind=${manifest.kind} mode=${bucket.mode} waitingForAssets=${assetCopy.missing.length} waitingForRecords=${missingRecords.length}${missingReviews.length > 0 ? ` waitingForReviews=${missingReviews.length}` : ''}${missingOutlines.length > 0 ? ` waitingForOutlines=${missingOutlines.length}` : ''}${collectionPendingUniverse ? ` waitingForUniverse=${collectionPendingUniverse}` : ''}${collectionPendingSeries ? ` waitingForSeries=${collectionPendingSeries}` : ''}${legacyCanonPendingUniverses ? ` waitingForLegacyCanonUniverses=${legacyCanonPendingUniverses.join(',')}` : ''}${legacyCanonPendingFailures ? ` legacyCanonFailures=${legacyCanonPendingFailures.join(',')}` : ''}${recordImportFailures ? ` recordImportFailures=${recordImportFailures.join(',')}` : ''}${reviewMergeFailures ? ` reviewMergeFailures=${reviewMergeFailures.join(',')}` : ''}${outlineMergeFailures ? ` outlineMergeFailures=${outlineMergeFailures.join(',')}` : ''}`);
+    console.log(`⏳ sharing: bucket=${bucket.name} manifest=${manifest.id} kind=${manifest.kind} mode=${bucket.mode}${suffix}`);
     return { processed: true, pending: true, manifest, outcome };
   }
   await markProcessed(bucketId, manifestFilename, manifest.id);

--- a/server/services/sharing/integration.test.js
+++ b/server/services/sharing/integration.test.js
@@ -2472,4 +2472,153 @@ describe('sharing round-trip', () => {
       expect(restored.id).toBe(s.id);
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // PENDING-SIGNAL LADDER (#6845) — processManifest derives its "still waiting
+  // on something" decision, the outcome.pending* keys, and the `⏳ sharing:`
+  // log suffix from one table (PENDING_SIGNALS) instead of three separately
+  // maintained lists. These tests pin the two signal formats not already
+  // covered above (a universe-linked collection defer, and a legacy-canon
+  // migration failure) plus the exact log-line shape and the all-clear path.
+  // ---------------------------------------------------------------------------
+  describe('processManifest pending-signal ladder (#6845)', () => {
+    it('defers when the collection payload targets a universe not yet imported locally (pendingCollectionUniverse)', async () => {
+      // `getUniverse(id, { includeDeleted: true })` distinguishes a
+      // tombstoned universe (deleteUniverse always soft-deletes) from one
+      // that never existed locally at all — only the latter produces
+      // `missingUniverse: true` → `pendingCollectionUniverse`. So the
+      // collection payload must target an id no local universe ever held;
+      // repoint the manifest's collection at a fabricated id after export.
+      const bucket = await buckets.createBucket({ name: 'UniverseCollectionDeferBucket', path: tempBucket, mode: 'auto-merge' });
+      const mediaCollections = await import('../mediaCollections.js');
+      const universeBuilder = await import('../universeBuilder.js');
+      const fs = await import('fs');
+      const { hasBeenProcessed, readCursor } = await import('./manifest.js');
+
+      const u = await universeBuilder.createUniverse({ name: 'Has A Collection Universe' });
+      fs.writeFileSync(join(tempData, 'images', 'late-universe-cover.png'), 'LATEUNI');
+      const collection = await mediaCollections.findOrCreateCollectionByName({
+        name: `Universe: ${u.name}`, description: 'Linked', universeId: u.id,
+      });
+      await mediaCollections.addItem(collection.id, { kind: 'image', ref: 'late-universe-cover.png' });
+
+      const exp = await exporter.exportUniverse(u.id, bucket.id);
+      const missingUniverseId = 'uni-not-imported-anywhere';
+      const manifestPath = join(tempBucket, 'manifests', exp.filename);
+      const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
+      manifest.collection.universeId = missingUniverseId;
+      fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2));
+
+      simulateRemoteSender(tempBucket, exp.filename);
+      const r = await importer.processManifest(bucket.id, exp.filename);
+      expect(r.pending).toBe(true);
+      expect(r.outcome.pendingCollectionUniverse).toBe(missingUniverseId);
+      const cursor = await readCursor(bucket.id);
+      expect(hasBeenProcessed(cursor, exp.filename, exp.manifestId)).toBe(false);
+    });
+
+    it('keeps a manifest retryable when the legacy-canon migration throws (pendingLegacyCanonFailures)', async () => {
+      const migrateSeriesCanon = await import('../pipeline/migrateSeriesCanon.js');
+      const { hasBeenProcessed, readCursor } = await import('./manifest.js');
+      const bucket = await buckets.createBucket({ name: 'LegacyCanonThrowBucket', path: tempBucket, mode: 'auto-merge' });
+
+      const seriesId = 'ser-legacy-canon-throws';
+      const legacySeries = {
+        id: seriesId,
+        name: 'Legacy Canon Throws Series',
+        logline: 'orphaned link',
+        premise: 'migration helper fails transiently',
+        characters: [{ name: 'Ghost', physicalDescription: 'unseen' }],
+        createdAt: '2026-05-01T00:00:00.000Z',
+        updatedAt: '2026-05-01T00:00:00.000Z',
+      };
+      mkdirSync(join(tempBucket, 'records', 'series'), { recursive: true });
+      writeFileSync(join(tempBucket, 'records', 'series', `${seriesId}.json`), JSON.stringify(legacySeries));
+      const manifest = {
+        id: 'mfst-legacy-canon-throws',
+        schemaVersion: 1,
+        sharingSchemaVersion: 1,
+        producedByVersion: '1.0.0',
+        createdAt: new Date().toISOString(),
+        kind: 'series',
+        senderInstanceId: 'legacy-canon-throws-peer',
+        source: 'Legacy Canon Throws Peer',
+        sourceBio: null,
+        bucketId: bucket.id,
+        bucketName: bucket.name,
+        recordIds: [seriesId],
+        assetRefs: [],
+        note: null,
+      };
+      const filename = `2026-05-01T00-00-00-000Z-legacy-canon-throws-peer-${manifest.id}.json`;
+      writeFileSync(join(tempBucket, 'manifests', filename), JSON.stringify(manifest));
+
+      const spy = vi.spyOn(migrateSeriesCanon, 'applyLegacySeriesCanonToUniverse')
+        .mockRejectedValueOnce(new Error('simulated migration failure'));
+      const first = await importer.processManifest(bucket.id, filename);
+      expect(first.pending).toBe(true);
+      expect(first.outcome.pendingLegacyCanonFailures).toEqual([seriesId]);
+      let cursor = await readCursor(bucket.id);
+      expect(hasBeenProcessed(cursor, filename, manifest.id)).toBe(false);
+      const stillMissing = await series.getSeries(seriesId).catch(() => null);
+      expect(stillMissing).toBeNull();
+      spy.mockRestore();
+
+      const second = await importer.processManifest(bucket.id, filename);
+      expect(second.pending).toBeFalsy();
+      cursor = await readCursor(bucket.id);
+      expect(hasBeenProcessed(cursor, filename, manifest.id)).toBe(true);
+    });
+
+    it('formats the ⏳ sharing: pending log line with always-on counts alongside a conditional count signal', async () => {
+      const bucket = await buckets.createBucket({ name: 'LogLineFormatBucket', path: tempBucket, mode: 'auto-merge' });
+      const s = await series.createSeries({ name: 'Log Line Series', logline: 'A' });
+      await issues.createIssue({ seriesId: s.id, title: 'Issue 1' });
+      await manuscriptReview.seedReviewFromFindings(s.id, [
+        { problem: 'Act II sags', severity: 'medium', anchorQuote: 'the long road', issueNumber: 1 },
+      ]);
+      const exp = await exporter.exportSeries(s.id, bucket.id);
+      const reviewFile = join(tempBucket, 'records', 'reviews', `${s.id}.json`);
+      const stashedReview = readFileSync(reviewFile, 'utf-8');
+      rmSync(reviewFile);
+      await series.deleteSeries(s.id);
+      simulateRemoteSender(tempBucket, exp.filename);
+
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const r = await importer.processManifest(bucket.id, exp.filename);
+      const pendingLine = logSpy.mock.calls.map(([line]) => line).find((line) => line.startsWith('⏳ sharing:'));
+      logSpy.mockRestore();
+
+      expect(r.pending).toBe(true);
+      expect(r.outcome.pendingReviews).toContain(s.id);
+      expect(pendingLine).toBe(
+        `⏳ sharing: bucket=${bucket.name} manifest=${exp.manifestId} kind=series mode=auto-merge ` +
+        `waitingForAssets=0 waitingForRecords=0 waitingForReviews=1`,
+      );
+
+      writeFileSync(reviewFile, stashedReview);
+      const r2 = await importer.processManifest(bucket.id, exp.filename);
+      expect(r2.pending).toBeFalsy();
+    });
+
+    it('advances the cursor and logs no ⏳ sharing: line when every signal is clear (all-clear case)', async () => {
+      const bucket = await buckets.createBucket({ name: 'AllClearBucket', path: tempBucket, mode: 'auto-merge' });
+      const { hasBeenProcessed, readCursor } = await import('./manifest.js');
+      const s = await series.createSeries({ name: 'All Clear Series', logline: 'A' });
+      const exp = await exporter.exportSeries(s.id, bucket.id);
+      await series.deleteSeries(s.id);
+      simulateRemoteSender(tempBucket, exp.filename);
+
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const r = await importer.processManifest(bucket.id, exp.filename);
+      const sawPendingLog = logSpy.mock.calls.some(([line]) => line.startsWith('⏳ sharing:'));
+      logSpy.mockRestore();
+
+      expect(r.pending).toBeFalsy();
+      expect(Object.keys(r.outcome).some((key) => key.startsWith('pending'))).toBe(false);
+      expect(sawPendingLog).toBe(false);
+      const cursor = await readCursor(bucket.id);
+      expect(hasBeenProcessed(cursor, exp.filename, exp.manifestId)).toBe(true);
+    });
+  });
 });

--- a/server/services/sharing/integration.test.js
+++ b/server/services/sharing/integration.test.js
@@ -2513,6 +2513,8 @@ describe('sharing round-trip', () => {
       const r = await importer.processManifest(bucket.id, exp.filename);
       expect(r.pending).toBe(true);
       expect(r.outcome.pendingCollectionUniverse).toBe(missingUniverseId);
+      expect(r.outcome.pendingRecords).toBeUndefined();
+      expect(r.outcome.pendingAssets).toBeUndefined();
       const cursor = await readCursor(bucket.id);
       expect(hasBeenProcessed(cursor, exp.filename, exp.manifestId)).toBe(false);
     });


### PR DESCRIPTION
## Summary

`processManifest` (`server/services/sharing/importer.js`) re-listed the same eleven pending signals three times: once in the `||` trigger condition, once in the `outcome.pending*` assignments, and once in the `waitingFor…=` log-suffix template. That let the two most recently added signals (reviews, outlines) each require editing all three spots, and the integration suite covered the three lists unevenly.

Replaces the three passes with a single `PENDING_SIGNALS` table (`key`, `value`, log `label`, `format`) that the trigger check, the outcome-key assignment, and the `⏳ sharing:` log suffix all derive from. `waitingForAssets`/`waitingForRecords` counts stay always-printed; every other signal prints only when set — matching the log's existing shape exactly (pinned by a new byte-identical assertion).

## Test plan

- Added boundary tests for the two signals the integration suite never exercised directly: `pendingCollectionUniverse` (collection payload targets a universe never imported locally) and `pendingLegacyCanonFailures` (the legacy-canon migration helper throws).
- Added a log-line-format test asserting the exact `⏳ sharing:` string for a mix of an always-on count signal and a conditional count signal.
- Added an all-clear test confirming no `pending*` key is set and no `⏳ sharing:` line is logged when nothing is pending.
- `server/services/sharing/integration.test.js`, `watcher.test.js`, and `stateConcurrency.test.js` all pass unchanged (720 tests total in `server/services/sharing/`).

Closes #6845