### PR TITLE
feat: configure Eidoverse runtime origin and tracking branch

### DIFF
--- a/client/src/components/settings/InstanceFeaturesTab.jsx
+++ b/client/src/components/settings/InstanceFeaturesTab.jsx
@@ -145,15 +145,16 @@ export function InstanceFeaturesTab() {
     if (!worldsRepoUrl || !isGitHubRepoUrl(worldsRepoUrl)) return;
     setUpdatingEidoverseSource(true);
     setSavingId(feature.id);
-    const result = await updateEidoverseWorldsSource(worldsRepoUrl, { silent: true }).catch((err) => {
+    const result = await updateEidoverseWorldsSource(worldsRepoUrl, { silent: true }, eidoverseBranch ?? feature?.setup?.worldsBranch ?? '').catch((err) => {
       toast.error(err.message || 'Could not update the Eidoverse Worlds source');
       return null;
     });
 
     if (result) {
       setEidoverseRepoUrl(null);
+      setEidoverseBranch(null);
       publishInstanceFeatures(result.features, { featureId: feature.id, enabled: feature.enabled });
-      toast.success('Eidoverse Worlds GitHub origin updated');
+      toast.success('Eidoverse Worlds source saved. Update or restart the managed app to reload the runtime.');
     }
     setUpdatingEidoverseSource(false);
     setSavingId(null);
@@ -224,7 +225,7 @@ export function InstanceFeaturesTab() {
     const repoIsValid = isGitHubRepoUrl(selectedRepoUrl);
     const canInstall = repoIsValid && setup?.registryAvailable !== false;
     const canUpdateSource = repoIsValid
-      && normalizeGitHubRepo(selectedRepoUrl) !== setup?.worldsRepoUrl
+      && (normalizeGitHubRepo(selectedRepoUrl) !== setup?.worldsRepoUrl || (eidoverseBranch !== null && eidoverseBranch.trim() !== (setup?.worldsBranch ?? '')))
       && setup?.registryAvailable !== false;
     const launchUrl = setup?.appId && setup?.uiPort
       ? getPrimaryLaunchUrl({ id: setup.appId, uiPort: setup.uiPort })
@@ -259,6 +260,7 @@ export function InstanceFeaturesTab() {
                   Worlds GitHub repository
                 </label>
                 <span className="flex flex-wrap gap-2 mb-2">
+                  <SourceChoiceButton active={selectedRepo?.owner === 'atomantic' && (eidoverseBranch ?? setup?.worldsBranch) === 'portos'} disabled={savingId !== null} onClick={() => { setEidoverseRepoUrl(buildEidoverseRepoUrl('atomantic', selectedTransport)); setEidoverseBranch('portos'); }}>Recommended (portos)</SourceChoiceButton>
                   <span role="group" aria-label="Worlds repository owner" className="inline-flex gap-1 rounded-lg border border-port-border p-1">
                     <SourceChoiceButton
                       active={Boolean(selfOwner) && selectedRepo?.owner?.toLowerCase() === selfOwner.toLowerCase()}
@@ -305,9 +307,9 @@ export function InstanceFeaturesTab() {
                   placeholder="https://github.com/example-owner/eidoverse-worlds"
                 />
               </div>
-              {needsInstall && (
+              {(
                 <div className="pt-2">
-                  <label className="block text-gray-300 mb-1" htmlFor="eidoverse-worlds-branch">Worlds clone branch</label>
+                  <label className="block text-gray-300 mb-1" htmlFor="eidoverse-worlds-branch">Worlds runtime / tracking branch</label>
                   <input
                     id="eidoverse-worlds-branch"
                     type="text"
@@ -319,7 +321,7 @@ export function InstanceFeaturesTab() {
                     aria-describedby="eidoverse-worlds-branch-help"
                     className="w-full px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white focus:border-port-accent focus:outline-hidden disabled:opacity-50"
                   />
-                  <p id="eidoverse-worlds-branch-help" className="mt-1">Leave blank to use the repository’s default branch. Applies to new clones; existing checkouts keep their current branch.</p>
+                  <p id="eidoverse-worlds-branch-help" className="mt-1">Select the branch used by app updates. Update source switches a clean checkout to that branch; restart the app to load it. Leave blank to follow the repository default on the next app update.</p>
                 </div>
               )}
               {!repoIsValid && (
@@ -332,7 +334,7 @@ export function InstanceFeaturesTab() {
               <p>
                 {needsInstall
                   ? 'Use your own fork if you want PortOS agents to prepare changes and PRs against it.'
-                  : 'Changing this updates the installed checkout’s Git origin in place. Local work, the managed-app path, and world data stay untouched.'}
+                  : 'Changing this updates the installed checkout’s Git origin in place. Branch changes require a clean checkout and preserve local commits and world data.'}
               </p>
               {!needsInstall && (
                 <button

--- a/client/src/components/settings/InstanceFeaturesTab.test.jsx
+++ b/client/src/components/settings/InstanceFeaturesTab.test.jsx
@@ -171,7 +171,7 @@ describe('InstanceFeaturesTab', () => {
 
     const repoInput = await screen.findByRole('textbox', { name: 'Worlds GitHub repository' });
     fireEvent.change(repoInput, { target: { value: 'https://github.com/example-owner/eidoverse-worlds' } });
-    fireEvent.change(screen.getByRole('textbox', { name: 'Worlds clone branch' }), { target: { value: 'feature/worlds' } });
+    fireEvent.change(screen.getByRole('textbox', { name: 'Worlds runtime / tracking branch' }), { target: { value: 'feature/worlds' } });
     fireEvent.click(screen.getByRole('button', { name: 'Install & enable' }));
 
     await waitFor(() => expect(mock.installEidoverseFeature).toHaveBeenCalledWith(
@@ -233,11 +233,13 @@ describe('InstanceFeaturesTab', () => {
 
     const repoInput = await screen.findByRole('textbox', { name: 'Worlds GitHub repository' });
     fireEvent.change(repoInput, { target: { value: 'https://github.com/example-owner/eidoverse-worlds' } });
+    fireEvent.change(screen.getByRole('textbox', { name: 'Worlds runtime / tracking branch' }), { target: { value: 'portos' } });
     fireEvent.click(screen.getByRole('button', { name: 'Update source' }));
 
     await waitFor(() => expect(mock.updateEidoverseWorldsSource).toHaveBeenCalledWith(
       'https://github.com/example-owner/eidoverse-worlds',
       { silent: true },
+      'portos',
     ));
     expect(await screen.findByDisplayValue('https://github.com/example-owner/eidoverse-worlds')).toBeInTheDocument();
   });

--- a/client/src/services/apiSystem.js
+++ b/client/src/services/apiSystem.js
@@ -86,9 +86,9 @@ export const installEidoverseFeature = (worldsRepoUrl, options = {}, worldsBranc
   body: JSON.stringify({ worldsRepoUrl, worldsBranch }),
   ...options,
 });
-export const updateEidoverseWorldsSource = (worldsRepoUrl, options = {}) => request('/settings/features/eidoverse/source', {
+export const updateEidoverseWorldsSource = (worldsRepoUrl, options = {}, worldsBranch) => request('/settings/features/eidoverse/source', {
   method: 'PUT',
-  body: JSON.stringify({ worldsRepoUrl }),
+  body: JSON.stringify({ worldsRepoUrl, worldsBranch }),
   ...options,
 });
 export const startEidoverseHost = (options = {}) => request('/settings/features/eidoverse/host', {

--- a/docs/features/eidoverse.md
+++ b/docs/features/eidoverse.md
@@ -10,8 +10,9 @@ platform installer under the PortOS service account on Windows, macOS, or Linux.
 ## What PortOS installs
 
 The installer keeps the two AGPL-3.0 projects as independent git checkouts. The
-Worlds repository is selected per PortOS instance; the canonical upstream is
-the default, while an instance owner can enter their own fork before installing:
+Worlds repository is selected per PortOS instance. The recommended default is
+`https://github.com/atomantic/eidoverse-worlds` on branch `portos`; an instance
+owner can enter another GitHub origin and branch before installing:
 
 - `data/repos/{owner}/{repo}` — the selected Worlds repository and the checkout
   PortOS registers under **Apps**. Ordinary GitHub forks retain the
@@ -26,10 +27,15 @@ at its durable world store. PortOS does not copy either project's source into
 the PortOS repository, combine the codebases, or relicense them; each checkout
 retains its own upstream license and git history.
 
-After installation, the **Worlds GitHub repository** field remains available on
-**Settings → Features**. Updating it changes the installed checkout's `origin`
-in place, so the managed-app path, local working tree, and world data stay
-untouched. The companion video checkout remains on its upstream repository.
+After installation, **Worlds GitHub repository** and **Worlds runtime / tracking
+branch** remain available on **Settings → Features**. **Recommended (portos)**
+selects the recommended origin and branch; **Update source** applies the choice
+in place. Branch changes require a clean checkout and refuse to overwrite local
+commits absent from the target. Restart or update the managed app to load the
+changed code. App updates honor the selected branch using the checkout-local
+`portos.runtimeBranch` Git setting; clearing the field restores the origin default
+branch on the next update. Existing saved choices are preserved. The managed-app
+path, world data, and companion video origin remain unchanged.
 
 The managed app's **Git** tab makes that two-repository topology explicit. It
 shows the checked-out branch and revision for Worlds and Video, compares each

--- a/server/routes/scaffold.test.js
+++ b/server/routes/scaffold.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { join } from 'path';
+import { join, resolve } from 'path';
+import { existsSync } from 'fs';
 import express from 'express';
 import { EventEmitter } from 'events';
 import { request } from '../lib/testHelper.js';
@@ -226,6 +227,7 @@ describe('POST /api/scaffold — request validation before filesystem mutation (
 
 describe('GET /api/scaffold/directories', () => {
   it('includes selectable files only when requested, preserving directory-only responses', async () => {
+    existsSync.mockImplementation((p) => p === resolve('/tmp/workspace'));
     readdir.mockResolvedValue([
       { name: 'Chromium.app', isDirectory: () => true, isFile: () => false, isSymbolicLink: () => false },
       { name: 'chrome', isDirectory: () => false, isFile: () => true, isSymbolicLink: () => false },
@@ -237,7 +239,7 @@ describe('GET /api/scaffold/directories', () => {
     expect(folders.body).not.toHaveProperty('files');
     const files = await request(app).get('/api/scaffold/directories?path=/tmp/workspace&includeFiles=true');
     expect(files.status).toBe(200);
-    expect(files.body.files).toEqual([{ name: 'chrome', path: join('/tmp/workspace', 'chrome') }]);
+    expect(files.body.files).toEqual([{ name: 'chrome', path: join(resolve('/tmp/workspace'), 'chrome') }]);
     expect(files.body.directories).toEqual(folders.body.directories);
   });
 });

--- a/server/routes/settings.js
+++ b/server/routes/settings.js
@@ -35,6 +35,8 @@ const aiAssignmentUpdateSchema = z.object({
 
 const eidoverseRepoSchema = z.object({
   worldsRepoUrl: z.string().trim().max(500).refine(isGitHubRepoUrl, 'Must be a GitHub repository URL'),
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: reject control characters in Git branch input
+  worldsBranch: z.string().trim().max(255).regex(/^[^\u0000-\u001f\u007f]*$/).optional(),
 }).strict();
 
 // Server-authoritative bounds the client UI can render directly so the form
@@ -235,22 +237,18 @@ router.put('/credentials/:id', asyncHandler(async (req, res) => {
 // Explicit consent boundary: no Eidoverse checkout or dependency install occurs
 // until the user presses Install in Settings > Features.
 router.post('/features/eidoverse/install', asyncHandler(async (req, res) => {
-  const { worldsRepoUrl, worldsBranch } = validateRequest(eidoverseRepoSchema.extend({
-    // biome-ignore lint/suspicious/noControlCharactersInRegex: reject control characters in Git branch input
-    worldsBranch: z.string().trim().max(255).regex(/^[^\u0000-\u001f\u007f]*$/).optional(),
-  }), req.body || {});
+  const { worldsRepoUrl, worldsBranch } = validateRequest(eidoverseRepoSchema, req.body || {});
   const normalizedRepoUrl = await updateEidoverseWorldsRepo(worldsRepoUrl, worldsBranch);
   await installEidoverse({ worldsRepoUrl: normalizedRepoUrl, ...(worldsBranch !== undefined ? { worldsBranch } : {}) });
   res.status(201).json(await updateInstanceFeature('eidoverse', true));
 }));
 
 // PUT /api/settings/features/eidoverse/source
-// Update the origin of the existing Worlds checkout in place. The working tree,
-// managed-app path, and world data remain untouched; future app updates pull
-// from the newly selected repository.
+// Update the origin and optional runtime branch in place. Branch switches
+// require a clean checkout; future app updates honor the selected branch.
 router.put('/features/eidoverse/source', asyncHandler(async (req, res) => {
-  const { worldsRepoUrl } = validateRequest(eidoverseRepoSchema, req.body || {});
-  await updateEidoverseWorldsSource(worldsRepoUrl);
+  const { worldsRepoUrl, worldsBranch } = validateRequest(eidoverseRepoSchema, req.body || {});
+  await updateEidoverseWorldsSource(worldsRepoUrl, worldsBranch);
   res.json(await getInstanceFeatures());
 }));
 

--- a/server/routes/settings.test.js
+++ b/server/routes/settings.test.js
@@ -318,7 +318,7 @@ describe('Settings routes — instance feature participation', () => {
       .send({ worldsRepoUrl });
 
     expect(res.status).toBe(200);
-    expect(setEidoverseWorldsOrigin).toHaveBeenCalledWith(worldsRepoUrl);
+    expect(setEidoverseWorldsOrigin).toHaveBeenCalledWith(worldsRepoUrl, undefined);
     expect(store.instanceFeatures.eidoverse).toMatchObject({ enabled: true, worldsRepoUrl });
   });
 

--- a/server/services/eidoverse.js
+++ b/server/services/eidoverse.js
@@ -10,7 +10,7 @@ import { cloneRepo } from './repoCloner.js';
 import { createApp, getAllApps, notifyAppsChanged, updateApp } from './apps.js';
 import { getAppStatusStrict } from './pm2.js';
 
-export const DEFAULT_EIDOVERSE_WORLDS_REPO = 'https://github.com/anima-research/eidoverse-worlds';
+export const DEFAULT_EIDOVERSE_WORLDS_REPO = 'https://github.com/atomantic/eidoverse-worlds';
 export const EIDOVERSE_VIDEO_REPO = 'https://github.com/anima-research/eidoverse-video';
 export const EIDOVERSE_PORT = 8940;
 export const EIDOVERSE_PROCESS_NAME = 'eidoverse-worlds';
@@ -202,7 +202,7 @@ async function performInstall(worldsRepoUrl, worldsBranch) {
     paths.worlds === configuredPaths.worlds ? cloneRepo(worldsRepoUrl, { branch: worldsBranch }) : Promise.resolve(),
     cloneRepo(EIDOVERSE_VIDEO_REPO),
   ]);
-  await updateOriginAtPath(paths.worlds, worldsRepoUrl);
+  await applyWorldsSource(paths.worlds, worldsRepoUrl, worldsBranch || undefined);
 
   await Promise.all([
     installDependencies(paths.worlds, bun),
@@ -223,7 +223,7 @@ async function performInstall(worldsRepoUrl, worldsBranch) {
  * a managed-app record. A process-local promise collapses double-clicks into
  * one clone/install operation.
  */
-export async function installEidoverse({ worldsRepoUrl = DEFAULT_EIDOVERSE_WORLDS_REPO, worldsBranch = '' } = {}) {
+export async function installEidoverse({ worldsRepoUrl = DEFAULT_EIDOVERSE_WORLDS_REPO, worldsBranch = worldsRepoUrl === DEFAULT_EIDOVERSE_WORLDS_REPO ? 'portos' : '' } = {}) {
   const normalizedRepoUrl = normalizeEidoverseWorldsRepo(worldsRepoUrl);
   if (installInFlight) return installInFlight;
   installInFlight = performInstall(normalizedRepoUrl, worldsBranch.trim()).finally(() => {
@@ -317,14 +317,47 @@ async function updateOriginAtPath(repoPath, worldsRepoUrl) {
   }
 }
 
+async function applyWorldsSource(repoPath, normalizedRepoUrl, worldsBranch) {
+  if (worldsBranch !== undefined) {
+    const branch = worldsBranch.trim();
+    if (branch) {
+      const valid = await execGit(['check-ref-format', '--branch', branch], repoPath, { ignoreExitCode: true });
+      if (branch.startsWith('-') || branch.startsWith('@') || valid.exitCode !== 0) {
+        throw new ServerError('Choose a valid branch name.', { status: 400, code: 'EIDOVERSE_BRANCH_INVALID' });
+      }
+      const dirty = await execGit(['status', '--porcelain'], repoPath);
+      if (dirty.stdout.trim()) throw new ServerError('Commit or stash local changes before switching the runtime branch.', { status: 409, code: 'EIDOVERSE_CHECKOUT_DIRTY' });
+      // Fetch from the proposed URL first so a missing branch cannot change origin.
+      await execGit(['fetch', '--', normalizedRepoUrl, `refs/heads/${branch}`], repoPath);
+      const local = await execGit(['show-ref', '--verify', '--quiet', `refs/heads/${branch}`], repoPath, { ignoreExitCode: true });
+      if (local.exitCode === 0) {
+        const ancestor = await execGit(['merge-base', '--is-ancestor', `refs/heads/${branch}`, 'FETCH_HEAD'], repoPath, { ignoreExitCode: true });
+        if (ancestor.exitCode !== 0) throw new ServerError('The target local branch has commits absent from the selected origin. Reconcile it before switching.', { status: 409, code: 'EIDOVERSE_BRANCH_DIVERGED' });
+        await execGit(['switch', '--', branch], repoPath);
+        await execGit(['merge', '--ff-only', 'FETCH_HEAD'], repoPath);
+      } else {
+        await execGit(['switch', '-c', branch, '--no-track', 'FETCH_HEAD'], repoPath);
+      }
+      await updateOriginAtPath(repoPath, normalizedRepoUrl);
+      await execGit(['config', '--replace-all', 'remote.origin.fetch', '+refs/heads/*:refs/remotes/origin/*'], repoPath);
+      await execGit(['fetch', 'origin'], repoPath);
+      await execGit(['config', `branch.${branch}.remote`, 'origin'], repoPath);
+      await execGit(['config', `branch.${branch}.merge`, `refs/heads/${branch}`], repoPath);
+    } else {
+      await updateOriginAtPath(repoPath, normalizedRepoUrl);
+    }
+    await execGit(['config', 'portos.runtimeBranch', branch], repoPath);
+  } else {
+    await updateOriginAtPath(repoPath, normalizedRepoUrl);
+  }
+}
+
 /**
- * Change the Worlds checkout's fetch origin without moving the checkout or
- * touching its working tree. This is intentionally separate from installation:
+ * Change the Worlds checkout's origin and optional runtime branch in place. This is intentionally separate from installation:
  * changing a remote must not silently clone a second copy or delete local work.
  */
-export async function setEidoverseWorldsOrigin(worldsRepoUrl) {
+export async function setEidoverseWorldsOrigin(worldsRepoUrl, worldsBranch) {
   const normalizedRepoUrl = normalizeEidoverseWorldsRepo(worldsRepoUrl);
-  const configuredPaths = getEidoversePaths(normalizedRepoUrl);
   const apps = await getAllApps();
   const app = findManagedApp(apps);
 
@@ -343,7 +376,7 @@ export async function setEidoverseWorldsOrigin(worldsRepoUrl) {
     });
   }
 
-  await updateOriginAtPath(repoPath, normalizedRepoUrl);
+  await applyWorldsSource(repoPath, normalizedRepoUrl, worldsBranch);
 
   notifyAppsChanged('update', app.id);
   return { appId: app.id, worldsRepoUrl: normalizedRepoUrl };

--- a/server/services/eidoverse.test.js
+++ b/server/services/eidoverse.test.js
@@ -1,5 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { join } from 'path';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { execFileSync } from 'node:child_process';
 
 const mock = vi.hoisted(() => ({
   existing: new Set(),
@@ -186,8 +189,8 @@ describe('Eidoverse managed-app installer', () => {
   });
 
   it('uses the canonical upstream by default and preserves the selected Git transport', () => {
-    expect(getEidoversePaths().worlds).toBe(join('/example/data/repos', 'anima-research', 'eidoverse-worlds'));
-    expect(DEFAULT_EIDOVERSE_WORLDS_REPO).toBe('https://github.com/anima-research/eidoverse-worlds');
+    expect(getEidoversePaths().worlds).toBe(join('/example/data/repos', 'atomantic', 'eidoverse-worlds'));
+    expect(DEFAULT_EIDOVERSE_WORLDS_REPO).toBe('https://github.com/atomantic/eidoverse-worlds');
     expect(normalizeEidoverseWorldsRepo('https://github.com/example-owner/eidoverse-worlds.git'))
       .toBe(SELECTED_WORLDS_REPO);
     expect(normalizeEidoverseWorldsRepo('git@github.com:example-owner/eidoverse-worlds.git'))
@@ -279,6 +282,43 @@ describe('Eidoverse managed-app installer', () => {
       appRegistered: null,
       registryError: 'Managed-app registry unavailable',
     });
+  });
+
+  it('applies a new tracking branch to a real single-branch clone', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'eidoverse-source-'));
+    const remote = join(root, 'remote');
+    const checkout = join(root, 'checkout');
+    const git = (args, cwd = root) => execFileSync('git', args, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+    try {
+      git(['init', '-b', 'main', remote]);
+      git(['-c', 'user.name=Test', '-c', 'user.email=test@example.com', 'commit', '--allow-empty', '-m', 'Initial'], remote);
+      git(['branch', 'portos'], remote);
+      git(['clone', '--single-branch', '--branch', 'main', remote, checkout]);
+      mock.apps = [{ id: 'worlds', repoPath: checkout, pm2ProcessNames: ['eidoverse-worlds'] }];
+      mock.existing.add(join(checkout, '.git'));
+      const { execGit } = await vi.importActual('../lib/execGit.js');
+      mock.execGit.mockImplementation((args, cwd, options) => execGit(args.map(arg => arg === SELECTED_WORLDS_REPO ? remote : arg), cwd, options));
+      await setEidoverseWorldsOrigin(SELECTED_WORLDS_REPO, 'portos');
+      expect(git(['branch', '--show-current'], checkout).trim()).toBe('portos');
+      expect(git(['rev-parse', '--abbrev-ref', '@{upstream}'], checkout).trim()).toBe('origin/portos');
+      expect(git(['config', '--get', 'portos.runtimeBranch'], checkout).trim()).toBe('portos');
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('switches and tracks the selected runtime branch without resetting local work', async () => {
+    mock.apps = [{ id: 'worlds', repoPath: selectedPaths.worlds, pm2ProcessNames: ['eidoverse-worlds'] }];
+    mock.existing.add(join(selectedPaths.worlds, '.git'));
+    await setEidoverseWorldsOrigin(SELECTED_WORLDS_REPO, 'portos');
+    expect(mock.execGit).toHaveBeenCalledWith(['switch', '--', 'portos'], selectedPaths.worlds);
+    expect(mock.execGit).toHaveBeenCalledWith(['config', 'branch.portos.merge', 'refs/heads/portos'], selectedPaths.worlds);
+    expect(mock.execGit).toHaveBeenCalledWith(['config', 'portos.runtimeBranch', 'portos'], selectedPaths.worlds);
+
+    mock.execGit.mockClear();
+    mock.execGit.mockImplementation(async (args) => ({ stdout: args[0] === 'status' ? ' M local.txt' : '', exitCode: 0 }));
+    await expect(setEidoverseWorldsOrigin(SELECTED_WORLDS_REPO, 'main')).rejects.toMatchObject({ code: 'EIDOVERSE_CHECKOUT_DIRTY' });
+    expect(mock.execGit.mock.calls.some(([args]) => ['switch', 'remote', 'fetch'].includes(args[0]))).toBe(false);
   });
 
   it('changes the origin of an existing checkout without moving or cloning it', async () => {

--- a/server/services/git.js
+++ b/server/services/git.js
@@ -743,7 +743,8 @@ export async function updateDefaultBranch(dir) {
     .join('\n') || fallback;
 
   await execGit(['fetch', 'origin'], dir);
-  const branch = await getDefaultBranch(dir, { strict: true });
+  const runtimeBranch = await execGit(['config', '--get', 'portos.runtimeBranch'], dir, { ignoreExitCode: true });
+  const branch = runtimeBranch.stdout.trim() || await getDefaultBranch(dir, { strict: true });
   if (!branch) throw new ServerError('could not determine origin default branch', { status: 400, code: 'NO_DEFAULT_BRANCH' });
 
   const currentBranch = await getBranch(dir);

--- a/server/services/git.updateDefaultBranch.test.js
+++ b/server/services/git.updateDefaultBranch.test.js
@@ -33,6 +33,13 @@ beforeEach(() => {
 });
 
 describe('updateDefaultBranch', () => {
+  it('keeps managed runtime updates on the configured branch', async () => {
+    withGit({ 'config --get portos.runtimeBranch': ok('portos') });
+    expect(await updateDefaultBranch('/repo')).toMatchObject({ success: true, branch: 'portos' });
+    expect(commands()).toContain('pull --ff-only origin portos');
+    expect(commands()).not.toContain('checkout main');
+  });
+
   it('checks out origin default branch and fast-forwards it without a rebase', async () => {
     const result = await updateDefaultBranch('/repo');
 

--- a/server/services/instanceFeatures.js
+++ b/server/services/instanceFeatures.js
@@ -194,7 +194,7 @@ const attachSetupStatus = async (features, settings) => {
     getEidoverseStatus({ worldsRepoUrl: configuredEidoverseRepo(settings) }),
     getOriginInfo(),
   ]);
-  const upstream = parseGitHubUrl(DEFAULT_EIDOVERSE_WORLDS_REPO)?.owner || null;
+  const upstream = 'anima-research';
   const sourceOwners = {
     // A stock clone points at atomantic/PortOS, which identifies the project
     // owner rather than the current user's GitHub account. Only a non-upstream
@@ -203,7 +203,7 @@ const attachSetupStatus = async (features, settings) => {
     upstream,
   };
   return features.map((feature) => (
-    feature.id === 'eidoverse' ? { ...feature, setup: { ...eidoverse, worldsBranch: settings?.instanceFeatures?.eidoverse?.worldsBranch ?? '', sourceOwners } } : feature
+    feature.id === 'eidoverse' ? { ...feature, setup: { ...eidoverse, worldsBranch: settings?.instanceFeatures?.eidoverse?.worldsBranch ?? (settings?.instanceFeatures?.eidoverse?.worldsRepoUrl || eidoverse.appRegistered ? '' : 'portos'), sourceOwners } } : feature
   ));
 };
 
@@ -238,10 +238,10 @@ export async function updateEidoverseWorldsRepo(worldsRepoUrl, worldsBranch) {
   return normalizedRepoUrl;
 }
 
-export async function updateEidoverseWorldsSource(worldsRepoUrl) {
+export async function updateEidoverseWorldsSource(worldsRepoUrl, worldsBranch) {
   const normalizedRepoUrl = normalizeEidoverseWorldsRepo(worldsRepoUrl);
-  await setEidoverseWorldsOrigin(normalizedRepoUrl);
-  return updateEidoverseWorldsRepo(normalizedRepoUrl);
+  await setEidoverseWorldsOrigin(normalizedRepoUrl, worldsBranch);
+  return updateEidoverseWorldsRepo(normalizedRepoUrl, worldsBranch);
 }
 
 // The same precedence ladder as `resolveInstanceFeatures`, but probing only this

--- a/server/services/instanceFeatures.test.js
+++ b/server/services/instanceFeatures.test.js
@@ -154,7 +154,7 @@ describe('instance features', () => {
     const selected = 'https://github.com/example-owner/eidoverse-worlds';
 
     await expect(updateEidoverseWorldsSource(selected)).resolves.toBe(selected);
-    expect(mock.setEidoverseWorldsOrigin).toHaveBeenCalledWith(selected);
+    expect(mock.setEidoverseWorldsOrigin).toHaveBeenCalledWith(selected, undefined);
     expect(mock.settings.instanceFeatures.eidoverse.worldsRepoUrl).toBe(selected);
   });
 


### PR DESCRIPTION
## Summary
Expose the Eidoverse runtime/tracking branch after installation alongside its configurable GitHub origin. Recommend atomantic/eidoverse-worlds on portos while preserving existing saved choices.

Update source switches clean checkouts without resetting local commits, configures branch tracking, and makes subsequent managed-app updates honor the selected branch. A blank branch restores repository-default updates. The UI explains restarting the runtime after switching.

## Test plan
- 152 server tests passed across Eidoverse installation/source switching, feature settings, settings routes, and managed branch updates.
- 21 rendered settings tests passed; client lint passed.
- Real temporary Git single-branch clone verifies switching from main to portos and tracking origin/portos.
- Dirty checkout guard tested; git diff --check passed.

## CI follow-up and merge blocker
The first two CI attempts were cancelled by a Windows scaffold directory test failure: its filesystem mock compared `/tmp/workspace` with a native resolved Windows path. Commit 7350dd3ef fixes that fixture; all 11 scaffold route tests pass locally.

The required repeat OpenCode review was attempted against the full updated diff. Its configured Bedrock model returned no output or verdict after approximately five minutes, so the process was stopped. The review is inconclusive and the PR must remain open until a valid review and green CI are available.
