### PR TITLE
completion sections: branch on the resolved mode, not re-derived slashdo flags

### DIFF
--- a/server/lib/agentCompletionMode.js
+++ b/server/lib/agentCompletionMode.js
@@ -71,7 +71,7 @@ export const COMPLETION_MODES = Object.freeze({
   TUI: 'tui',
   /** Worktree with no PR: commit only, PortOS merges the branch back. */
   PORTOS_MERGES: 'portos-merges',
-  /** Worktree with a PR: commit only, the system pushes and opens it. */
+  /** Worktree with a PR: commit only; `/do:pr` when the host can type it, otherwise the system pushes and opens it. */
   WORKTREE_NO_PUSH: 'worktree-no-push',
   /** Plain checkout: commit and push. */
   COMMIT_AND_PUSH: 'commit-and-push',

--- a/server/lib/slashdoInvocation.js
+++ b/server/lib/slashdoInvocation.js
@@ -379,8 +379,9 @@ export function slashdoSkillName(command) {
 
 /**
  * Which invocation shape a provider gets — the single home for the
- * provider→slashdo-shape decision (`hasSlashdo` / `tuiSlashdoFree` in
- * `agentPromptBuilder.js` derive from this rather than re-deriving it).
+ * provider→slashdo-shape decision (`agentPromptBuilder.js`'s
+ * `canTypeSlashCommands` capability flag, and the completion `mode` it feeds,
+ * derive from this rather than re-deriving it).
  *
  * Detection reuses the shared provider predicates, so a path-configured or
  * renamed binary is recognised. An unidentified provider falls through to
@@ -447,11 +448,12 @@ export function resolveSlashdoStyle({
  * gets `SKILL` because it skips command discovery entirely.
  *
  * This is the single home for the completion-workflow gates in
- * `agentPromptBuilder.js` (formerly three inline provider-id allowlists:
- * `hasSlashdo`, `tuiSlashdoFree`, and the guideline-bullet `slashdoFree`). It
- * uses the `assumeClaudeWhenUnknown` posture because those gates describe a
- * session the spawners are about to launch, and every spawner resolves a blank
- * command to `claude`.
+ * `agentPromptBuilder.js` (formerly three inline provider-id allowlists, and
+ * later a trio of per-shape capability flags the completion sections
+ * re-derived; both collapsed to this predicate plus the resolved completion
+ * `mode` — see #6873). It uses the `assumeClaudeWhenUnknown` posture because
+ * those gates describe a session the spawners are about to launch, and every
+ * spawner resolves a blank command to `claude`.
  *
  * `assumeClaudeWhenUnknown` defaults to `true` here (unlike `resolveSlashdoStyle`)
  * because the callers are describing a CLI/TUI session about to be spawned. An

--- a/server/services/agentCompletionCleanup.test.js
+++ b/server/services/agentCompletionCleanup.test.js
@@ -145,7 +145,7 @@ describe('handlePipelineProgression', () => {
 
 // #3114 — `agentOwnsPR` decides whether PortOS skips its own push+PR because the
 // agent was told to run `/do:pr` itself. It MUST derive from the same
-// `canTypeSlashCommands` predicate the prompt's `hasSlashdo` gate used: when the
+// `canTypeSlashCommands` predicate the prompt's completion-mode gate used: when the
 // two disagree, PortOS fires `gh pr create` on a branch that already has a PR
 // ("a pull request already exists" preserves the worktree as a false-positive
 // failure), or conversely never opens the PR the agent was told not to open.

--- a/server/services/agentPromptBuilder.js
+++ b/server/services/agentPromptBuilder.js
@@ -457,7 +457,7 @@ export async function buildAgentPrompt(task, config, workspaceDir, worktreeInfo 
   const worktreeCommitNote = worktreeInfo
     ? worktreeCommitGuidance({
         isTui,
-        hasSlashdo: false,
+        canTypeSlashCommands: false,
         ownsPrWorkflow: false,
         isWorktreeOnExistingBranch,
         willOpenPR,
@@ -560,7 +560,7 @@ ${buildResumeSection(task, worktreeInfo)}` : '';
   // fallback template stays pure interpolation.
   const guidelineBullet = buildCompletionGuidelineBullet({
     mode: completionMode, whenDone,
-    tuiCompletionCommand, slashdoFree: isTui && !canRunSlashCommands,
+    tuiCompletionCommand,
     worktreeInfo, willOpenPR, prCompletion, noChangeSuccess,
     leavePrOpen: leavesPrForHuman(task),
   });
@@ -570,11 +570,11 @@ ${buildResumeSection(task, worktreeInfo)}` : '';
   // light path's `buildTuiCompletionSection` call is the live one). Kept
   // provider-aware anyway so this can't become the ONE call site that silently
   // promises `/do:pr` to a host that can't type it if the routing ever changes
-  // — this arm previously passed no slashdoFree at all, which is how gates like
-  // it drift (#3114).
+  // — this arm previously passed no slashdo-capability signal at all, which is
+  // how gates like it drift (#3114).
   const buildFullPathTuiCompletion = () => buildTuiCompletionSection({
     willOpenPR, prCompletion, simplifyEnabled, noChangeSuccess, portosMergesBranch,
-    slashdoFree: !canRunSlashCommands,
+    mode: completionMode,
     branchName: worktreeInfo?.branchName || null,
     baseBranch: worktreeInfo?.baseBranch || null,
     sentinelPath,
@@ -996,18 +996,18 @@ function buildLightContextSections(task, workspaceDir, worktreeInfo, isTruthyMet
   // path-configured `claude` binary under a custom provider id used to be denied
   // the slashdo workflow).
   const canTypeSlash = canTypeSlashCommands({ providerId, providerCommand, leanMode });
-  // CLI (non-TUI): a Claude Code session drives `/simplify` + `/do:pr` itself
-  // (the slashdo submodule mounts those as project-level slash commands). Other
-  // CLI providers (codex, antigravity, grok, opencode) get the legacy commit-only
-  // block where PortOS handles push+PR on exit.
-  const hasSlashdo = !isTui && canTypeSlash;
-  // TUI: a session that does NOT load Claude Code slash commands can't run
-  // `/do:pr` / `/do:push`, so its completion workflow uses plain git and hands
-  // the post-exit push / PR lifecycle back to PortOS
-  // — an OpenCode TUI, a codex/antigravity/grok TUI, or a lean-mode Claude
-  // session (`--bare` skips project command discovery, and the small local models
-  // lean mode targets fumble multi-step slashdo flows anyway).
-  const tuiSlashdoFree = isTui && !canTypeSlash;
+  // THE completion decision, made once. Every section below renders this key
+  // (`mode`) plus the `canTypeSlash` capability flag; no section re-derives a
+  // per-shape boolean of its own. See lib/agentCompletionMode.js for the rule
+  // order — this is the branch that matters in production, since every
+  // `tui`/`cli` provider returns from the light path and never reaches the
+  // full one, so a fix applied only there is no fix at all for anything a
+  // subscription-quota job can run.
+  const completionMode = resolveCompletionMode({
+    toolFreeReasoning, sentinelPayloadOutput, noCodeOutput, discardWorktree, claimFlow,
+    isReadOnly, isReviewLoopFollowUp, isTui, canRunSlashCommands: canTypeSlash,
+    portosMergesBranch, worktreeInfo, willOpenPR,
+  });
   // Does this session drive commit → push → PR → review → merge itself?
   //
   // ONE value answers both "emit the manual PR steps" and "emit the Review Loop
@@ -1102,26 +1102,17 @@ function buildLightContextSections(task, workspaceDir, worktreeInfo, isTruthyMet
 
   // --- Worktree / pipeline / JIRA context --------------------------------
   contractSections.push(...buildLightTaskContextSections({
-    task, worktreeInfo, isWorktreeOnExistingBranch, isTui, hasSlashdo, ownsPrWorkflow,
+    task, worktreeInfo, isWorktreeOnExistingBranch, isTui, mode: completionMode, canTypeSlashCommands: canTypeSlash, ownsPrWorkflow,
     willOpenPR, discardWorktree, claimFlow, noChangeSuccess,
   }));
 
   // --- Completion / review-loop ------------------------------------------
-  // THIS is the branch that matters in production — every `tui`/`cli` provider
-  // returns from the light path and never reaches the full one, so a fix
-  // applied only there is no fix at all for anything a subscription-quota job
-  // can run. The precedence itself lives in `resolveCompletionMode`.
-  const completionMode = resolveCompletionMode({
-    toolFreeReasoning, sentinelPayloadOutput, noCodeOutput, discardWorktree, claimFlow,
-    isReadOnly, isReviewLoopFollowUp, isTui, canRunSlashCommands: canTypeSlash,
-    portosMergesBranch, worktreeInfo, willOpenPR,
-  });
   const lightSentinelPath = () => resolveSentinelPath(worktreeInfo, workspaceDir, agentId);
   // Both TUI modes render the same section — `buildTuiCompletionSection` takes
-  // `slashdoFree` and adapts the workflow itself. Likewise the three commit/push
+  // `mode` and adapts the workflow itself. Likewise the three commit/push
   // modes: `buildCliCompletionSection` already reads `worktreeInfo`/`willOpenPR`.
   const pushTuiCompletion = () => contractSections.push(buildTuiCompletionSection({
-    willOpenPR, prCompletion, simplifyEnabled, noChangeSuccess, slashdoFree: tuiSlashdoFree, ownsPrWorkflow, portosMergesBranch,
+    willOpenPR, prCompletion, simplifyEnabled, noChangeSuccess, mode: completionMode, ownsPrWorkflow, portosMergesBranch,
     sentinelPath: lightSentinelPath(),
     branchName: worktreeInfo?.branchName || null,
     baseBranch: worktreeInfo?.baseBranch || null,
@@ -1129,7 +1120,7 @@ function buildLightContextSections(task, workspaceDir, worktreeInfo, isTruthyMet
     reviewers: lightReviewers, usernames: lightReviewerUsernames, optionalReviewers: lightOptionalReviewers, reviewerMaxRounds: lightReviewerMaxRounds, reviewerModels: lightReviewerModels, reviewerEfforts: lightReviewerEfforts, reviewStopMode: lightReviewStopMode, reviewerApplies: lightReviewerApplies,
     forgeCli: resolvedForgeCli, localReviewSection, localReviewRequired, postPrReview: ownsPrWorkflow ? runsPrSideReviewLoop : null
   }));
-  const pushCliCompletion = () => contractSections.push(buildCliCompletionSection({ worktreeInfo, willOpenPR, prCompletion, hasSlashdo, ownsPrWorkflow, simplifyEnabled, noChangeSuccess, leavePrOpen: leavesPrForHuman(task), reviewers: lightReviewers, usernames: lightReviewerUsernames, optionalReviewers: lightOptionalReviewers, reviewerMaxRounds: lightReviewerMaxRounds, reviewerModels: lightReviewerModels, reviewerEfforts: lightReviewerEfforts, reviewStopMode: lightReviewStopMode, reviewerApplies: lightReviewerApplies, forgeCli: resolvedForgeCli, localReviewSection, localReviewRequired, postPrReview: ownsPrWorkflow ? runsPrSideReviewLoop : null }));
+  const pushCliCompletion = () => contractSections.push(buildCliCompletionSection({ worktreeInfo, willOpenPR, prCompletion, mode: completionMode, canTypeSlashCommands: canTypeSlash, ownsPrWorkflow, simplifyEnabled, noChangeSuccess, leavePrOpen: leavesPrForHuman(task), reviewers: lightReviewers, usernames: lightReviewerUsernames, optionalReviewers: lightOptionalReviewers, reviewerMaxRounds: lightReviewerMaxRounds, reviewerModels: lightReviewerModels, reviewerEfforts: lightReviewerEfforts, reviewStopMode: lightReviewStopMode, reviewerApplies: lightReviewerApplies, forgeCli: resolvedForgeCli, localReviewSection, localReviewRequired, postPrReview: ownsPrWorkflow ? runsPrSideReviewLoop : null }));
 
   ({
     [COMPLETION_MODES.TOOL_FREE]: () => contractSections.push(buildToolFreeReasoningCompletionSection()),
@@ -1205,7 +1196,7 @@ function buildLightContextSections(task, workspaceDir, worktreeInfo, isTruthyMet
  * `buildLightContextSections`.
  */
 function buildLightTaskContextSections({
-  task, worktreeInfo, isWorktreeOnExistingBranch, isTui, hasSlashdo, ownsPrWorkflow,
+  task, worktreeInfo, isWorktreeOnExistingBranch, isTui, mode, canTypeSlashCommands, ownsPrWorkflow,
   willOpenPR, discardWorktree, claimFlow, noChangeSuccess,
 }) {
   const sections = [];
@@ -1217,7 +1208,7 @@ function buildLightTaskContextSections({
       `- **Path**: \`${worktreeInfo.worktreePath}\``,
       worktreeInfo.baseBranch ? `- **Based on**: \`${worktreeInfo.baseBranch}\`` : null,
       '',
-      worktreeCommitGuidance({ isTui, hasSlashdo, ownsPrWorkflow, isWorktreeOnExistingBranch, willOpenPR, discardWorktree, claimFlow, noChangeSuccess }),
+      worktreeCommitGuidance({ isTui, mode, canTypeSlashCommands, ownsPrWorkflow, isWorktreeOnExistingBranch, willOpenPR, discardWorktree, claimFlow, noChangeSuccess }),
       'Do NOT manually switch branches or modify the worktree configuration.',
       // Resuming a previous failed agent's branch: establish what's already done
       // before writing code (see buildResumeSection). '' when not a resume.

--- a/server/services/agentPromptBuilder.test.js
+++ b/server/services/agentPromptBuilder.test.js
@@ -1353,8 +1353,8 @@ describe('buildLightContextPrompt', () => {
     // allowlists got wrong are now asserted.
     it('a codex TUI gets the plain git/gh completion workflow, never /do:pr', () => {
       // codex installs slashdo as Agent Skills, not slash commands, so telling it
-      // to run `/do:pr` handed it an uninvokable line. The old `tuiSlashdoFree`
-      // gate only recognized OpenCode + lean mode, so codex fell through to the
+      // to run `/do:pr` handed it an uninvokable line. The old is-TUI-slashdo-free
+      // check only recognized OpenCode + lean mode, so codex fell through to the
       // slashdo path.
       const prompt = buildLightContextPrompt(
         makeTask({ metadata: { openPR: true, reviewLoop: true, reviewers: ['copilot'] } }),
@@ -1526,7 +1526,7 @@ describe('buildLightContextPrompt', () => {
     });
 
     it('a path-configured claude binary under a custom provider id gets the slashdo workflow', () => {
-      // The old `hasSlashdo` gate was an id allowlist (`claude-code` /
+      // The old slashdo-capability gate was an id allowlist (`claude-code` /
       // `claude-code-bedrock`), so a renamed or path-configured claude provider
       // was denied `/simplify` + `/do:pr` even though it launches claude.
       const prompt = buildLightContextPrompt(
@@ -2362,7 +2362,7 @@ describe('buildLightContextPrompt', () => {
       expect(prompt).not.toMatch(/## Resuming Unfinished Work/);
     });
 
-    it('worktreeCommitGuidance: hasSlashdo + !willOpenPR says commit only — PortOS merges the branch back', () => {
+    it('worktreeCommitGuidance: canTypeSlashCommands + !willOpenPR says commit only — PortOS merges the branch back', () => {
       // Claude Code CLI with a worktree but no PR is the auto-merge posture: the
       // worktree guidance must not point the agent at a push nothing consumes.
       const prompt = buildLightContextPrompt(
@@ -2710,7 +2710,7 @@ describe('buildCompletionGuidelineBullet', () => {
   it('read-only short-circuits regardless of other flags', () => {
     const bullet = buildCompletionGuidelineBullet({
       mode: resolveCompletionMode({ isReadOnly: true, isTui: true, worktreeInfo: null, willOpenPR: true }),
-      slashdoFree: true, tuiCompletionCommand: '/do:pr', worktreeInfo: null, willOpenPR: true,
+      tuiCompletionCommand: '/do:pr', worktreeInfo: null, willOpenPR: true,
     });
     expect(bullet).toMatch(/read-only task/i);
   });
@@ -2718,7 +2718,7 @@ describe('buildCompletionGuidelineBullet', () => {
   it('slashdo TUI bullet references the slashdo command', () => {
     const bullet = buildCompletionGuidelineBullet({
       mode: resolveCompletionMode({ isTui: true, worktreeInfo: { worktreePath: '/wt' }, willOpenPR: true }),
-      slashdoFree: false, tuiCompletionCommand: '/do:pr', worktreeInfo: { worktreePath: '/wt' }, willOpenPR: true,
+      tuiCompletionCommand: '/do:pr', worktreeInfo: { worktreePath: '/wt' }, willOpenPR: true,
     });
     expect(bullet).toMatch(/`\/do:pr`/);
     expect(bullet).not.toMatch(/plain `git`\/`gh`/);
@@ -2728,7 +2728,7 @@ describe('buildCompletionGuidelineBullet', () => {
   it('slashdo-free TUI bullet points at the commit + PortOS handoff, not a /do:* command', () => {
     const bullet = buildCompletionGuidelineBullet({
       mode: resolveCompletionMode({ isTui: true, canRunSlashCommands: false, worktreeInfo: { worktreePath: '/wt' }, willOpenPR: true }),
-      slashdoFree: true, tuiCompletionCommand: '/do:pr', worktreeInfo: { worktreePath: '/wt' }, willOpenPR: true,
+      tuiCompletionCommand: '/do:pr', worktreeInfo: { worktreePath: '/wt' }, willOpenPR: true,
     });
     expect(bullet).toMatch(/plain `git` commit \+ PortOS handoff/);
     expect(bullet).toMatch(/no slashdo commands/);

--- a/server/services/promptSections/completion.js
+++ b/server/services/promptSections/completion.js
@@ -38,12 +38,12 @@ const DISCARD_WORKTREE_HYGIENE = '- **Do NOT commit, push, or open a PR.** This 
  * or `null` when the mode produces no text (the legacy empty-string tail).
  *
  * @param {Object} opts
- * @param {string} opts.mode - a `COMPLETION_MODES` key
+ * @param {string} opts.mode - a `COMPLETION_MODES` key. `COMPLETION_MODES.TUI_SLASHDO_FREE`
+ *   is what points the bullet at the manual commit + system-handoff workflow
+ *   instead of a `/do:*` command.
  * @param {string|null} opts.tuiCompletionCommand - `/do:pr` or `/do:push`; `null`
  *   when PortOS merges the branch back itself and the workflow is commit-only
  *   (see `portosMergesBranchOnExit`)
- * @param {boolean} [opts.slashdoFree] - TUI without slashdo: the bullet points
- *   at the manual commit + system-handoff workflow instead of a `/do:*` command.
  * @param {Object|null} opts.worktreeInfo
  * @param {boolean} opts.willOpenPR
  * @param {'review-then-merge'|'merge-on-green'|'leave-open'} opts.prCompletion
@@ -52,7 +52,7 @@ const DISCARD_WORKTREE_HYGIENE = '- **Do NOT commit, push, or open a PR.** This 
  * @returns {string|null}
  */
 export function buildCompletionGuidelineBullet({
-  mode, tuiCompletionCommand, slashdoFree = false,
+  mode, tuiCompletionCommand,
   worktreeInfo, willOpenPR, prCompletion = PR_COMPLETIONS.MERGE_ON_GREEN,
   leavePrOpen = false, noChangeSuccess = false, whenDone = null,
 }) {
@@ -62,7 +62,7 @@ export function buildCompletionGuidelineBullet({
   // buildTuiCompletionSection — not this bullet). They're kept host-aware and
   // directly unit-tested so the guideline stays correct if that routing changes.
   const tuiBullet = () => {
-    const howTo = slashdoFree
+    const howTo = mode === COMPLETION_MODES.TUI_SLASHDO_FREE
       ? 'the Completion Workflow above (plain `git` commit + PortOS handoff — this provider has no slashdo commands)'
       : tuiCompletionCommand
         ? `the Completion Workflow above (\`${tuiCompletionCommand}\`)`
@@ -463,18 +463,24 @@ export function buildAutoMergeCommitStep(baseBranch = null) {
  * single-sentence instruction based on whether the agent will run its own
  * push workflow (TUI or Claude Code CLI with slashdo), reuse an existing PR
  * branch (review fixes), or hand off to PortOS's post-exit push.
+ *
+ * `mode` is the resolver's decision (see `lib/agentCompletionMode.js`); by the
+ * time the TUI and existing-branch arms above have already returned, `mode`
+ * being `WORKTREE_NO_PUSH` / `PORTOS_MERGES` implies a non-TUI host, so
+ * `canTypeSlashCommands` alone (no separate `isTui` re-check) tells the two
+ * apart from their non-slashdo equivalents.
  */
-export function worktreeCommitGuidance({ isTui, hasSlashdo, ownsPrWorkflow = false, isWorktreeOnExistingBranch, willOpenPR, discardWorktree, claimFlow = false, noChangeSuccess = false }) {
+export function worktreeCommitGuidance({ isTui, mode = null, canTypeSlashCommands = false, ownsPrWorkflow = false, isWorktreeOnExistingBranch, willOpenPR, discardWorktree, claimFlow = false, noChangeSuccess = false }) {
   if (discardWorktree) return DISCARD_WORKTREE_NOTE;
   if (claimFlow) return 'The claim workflow in the Completion section owns the push, PR/MR, review, merge or human-handoff, and cleanup steps.';
   if (isTui) return withNoChangeAuditGuidance('Commit your changes to this branch — see **Completion Workflow** below.', noChangeSuccess);
   if (isWorktreeOnExistingBranch) {
     return withNoChangeAuditGuidance('Commit and **push** any review-fix commits to this branch (the PR points at it). Use `git pull --rebase` before pushing if needed.', noChangeSuccess);
   }
-  if (hasSlashdo && willOpenPR) {
+  if (canTypeSlashCommands && mode === COMPLETION_MODES.WORKTREE_NO_PUSH) {
     return withNoChangeAuditGuidance('Commit your changes here — the **Completion** section below drives the push and PR.', noChangeSuccess);
   }
-  if (hasSlashdo) {
+  if (canTypeSlashCommands && mode === COMPLETION_MODES.PORTOS_MERGES) {
     // Reached in a worktree with no PR: the auto-merge posture
     // (portosMergesBranchOnExit) — nothing drives a push, so say so.
     return withNoChangeAuditGuidance('Commit your changes here — do NOT push. PortOS merges this branch back after you exit; the **Completion** section below has the exact step.', noChangeSuccess);
@@ -602,18 +608,19 @@ function localReviewCompletionInstruction(localReviewRequired = true) {
  * TUI completion-workflow block. The TUI owns its own commit → push → PR
  * pipeline via slashdo commands and signals "done" with a sentinel file.
  *
- * When `slashdoFree` is set — any TUI that does NOT load Claude Code slash
- * commands: OpenCode, codex/antigravity/grok/kimi, or a lean `--bare` Claude
- * session — the agent can't run `/do:pr` / `/do:push`, so it delegates to the
- * plain-git/`gh` variant below (same sentinel handshake, no slashdo). The caller
- * resolves that flag once via `canTypeSlashCommands` (#3114); past the early
- * return this IS a Claude session, so `/simplify` and `/do:pr` are both safe to
- * emit without a second provider check.
+ * When `mode` is `COMPLETION_MODES.TUI_SLASHDO_FREE` — any TUI that does NOT
+ * load Claude Code slash commands: OpenCode, codex/antigravity/grok/kimi, or a
+ * lean `--bare` Claude session — the agent can't run `/do:pr` / `/do:push`, so
+ * it delegates to the plain-git/`gh` variant below (same sentinel handshake,
+ * no slashdo). The caller resolves that mode once via `resolveCompletionMode`,
+ * itself derived from `canTypeSlashCommands` (#3114); past the early return
+ * this IS a Claude session, so `/simplify` and `/do:pr` are both safe to emit
+ * without a second provider check.
  */
-export function buildTuiCompletionSection({ willOpenPR, prCompletion = PR_COMPLETIONS.MERGE_ON_GREEN, simplifyEnabled, sentinelPath, slashdoFree = false, ownsPrWorkflow = false, portosMergesBranch = false, branchName = null, baseBranch = null, leavePrOpen = false, reviewers = DEFAULT_REVIEWERS, usernames = [], optionalReviewers = [], reviewerMaxRounds = {}, reviewerModels = {}, reviewerEfforts = {}, reviewStopMode = DEFAULT_REVIEW_STOP_MODE, reviewerApplies = false, forgeCli = 'gh', noChangeSuccess = false, localReviewSection = '', localReviewRequired = true, postPrReview = null }) {
+export function buildTuiCompletionSection({ willOpenPR, prCompletion = PR_COMPLETIONS.MERGE_ON_GREEN, simplifyEnabled, sentinelPath, mode = COMPLETION_MODES.TUI, ownsPrWorkflow = false, portosMergesBranch = false, branchName = null, baseBranch = null, leavePrOpen = false, reviewers = DEFAULT_REVIEWERS, usernames = [], optionalReviewers = [], reviewerMaxRounds = {}, reviewerModels = {}, reviewerEfforts = {}, reviewStopMode = DEFAULT_REVIEW_STOP_MODE, reviewerApplies = false, forgeCli = 'gh', noChangeSuccess = false, localReviewSection = '', localReviewRequired = true, postPrReview = null }) {
   const policyLeavesOpen = prCompletion === PR_COMPLETIONS.LEAVE_OPEN;
   const runsReviewLoop = prCompletion === PR_COMPLETIONS.REVIEW_THEN_MERGE;
-  if (slashdoFree) {
+  if (mode === COMPLETION_MODES.TUI_SLASHDO_FREE) {
     // Plain `git`/`gh` instead of `/do:pr` — but still the whole lifecycle when
     // the session is a real coding harness (`ownsPrWorkflow`); the reviewer
     // procedure it needs is inlined in the Review Loop section that follows.
@@ -644,8 +651,8 @@ export function buildTuiCompletionSection({ willOpenPR, prCompletion = PR_COMPLE
         ? ` — \`/do:pr\` runs the Copilot review loop after the PR opens.${requiredLocalReviewBlockedNote}`
         : ` — \`/do:pr\` runs the review loop for ${reviewerListLabel} in order: local reviewers before it opens the PR, then the PR-side reviewers (Copilot / \`@login\`) once it is open.${requiredLocalReviewBlockedNote}`)
     : (willOpenPR ? ' — external review is disabled for this task.' : '');
-  // Reached only for a Claude TUI (a non-Claude one took the slashdoFree branch
-  // above), so `/simplify` — a Claude Code built-in — is invokable here.
+  // Reached only for a Claude TUI (a non-Claude one took the TUI_SLASHDO_FREE
+  // branch above), so `/simplify` — a Claude Code built-in — is invokable here.
   const simplifyStep = simplifyEnabled ? '1. `/simplify`' : '1. (simplify disabled — skip)';
   const sentinelTail = willOpenPR
     ? (noChangeSuccess
@@ -959,16 +966,20 @@ export function buildInlineReviewLoopSection({
  * CLI (non-TUI) completion block.
  *
  * Claude Code CLI agents have slashdo commands available (the submodule
- * mounts them as project-level slash commands), so when `hasSlashdo` is
- * true and a PR is expected, the agent owns the full `/simplify` → `/do:pr`
- * sequence and PortOS skips its post-exit push+PR. Codex/Antigravity and other
- * CLI providers fall through to the legacy commit-only block where PortOS
- * handles push+PR on exit.
+ * mounts them as project-level slash commands), so when `mode` is
+ * `COMPLETION_MODES.WORKTREE_NO_PUSH` and `canTypeSlashCommands` is true, the
+ * agent owns the full `/simplify` → `/do:pr` sequence and PortOS skips its
+ * post-exit push+PR. Codex/Antigravity and other CLI providers fall through
+ * to the legacy commit-only block where PortOS handles push+PR on exit.
+ *
+ * Branches on `mode` first, mirroring the resolver's own rule order
+ * (`lib/agentCompletionMode.js`) rather than re-testing `worktreeInfo` /
+ * `willOpenPR` — the caller already resolved those into `mode`.
  */
-export function buildCliCompletionSection({ worktreeInfo, willOpenPR, prCompletion = PR_COMPLETIONS.MERGE_ON_GREEN, hasSlashdo = false, ownsPrWorkflow = false, simplifyEnabled = false, leavePrOpen = false, reviewers = DEFAULT_REVIEWERS, usernames = [], optionalReviewers = [], reviewerMaxRounds = {}, reviewerModels = {}, reviewerEfforts = {}, reviewStopMode = DEFAULT_REVIEW_STOP_MODE, reviewerApplies = false, forgeCli = 'gh', noChangeSuccess = false, localReviewSection = '', localReviewRequired = true, postPrReview = null }) {
+export function buildCliCompletionSection({ worktreeInfo, willOpenPR, prCompletion = PR_COMPLETIONS.MERGE_ON_GREEN, mode = null, canTypeSlashCommands = false, ownsPrWorkflow = false, simplifyEnabled = false, leavePrOpen = false, reviewers = DEFAULT_REVIEWERS, usernames = [], optionalReviewers = [], reviewerMaxRounds = {}, reviewerModels = {}, reviewerEfforts = {}, reviewStopMode = DEFAULT_REVIEW_STOP_MODE, reviewerApplies = false, forgeCli = 'gh', noChangeSuccess = false, localReviewSection = '', localReviewRequired = true, postPrReview = null }) {
   const policyLeavesOpen = prCompletion === PR_COMPLETIONS.LEAVE_OPEN;
   const runsReviewLoop = postPrReview ?? (prCompletion === PR_COMPLETIONS.REVIEW_THEN_MERGE);
-  if (hasSlashdo && worktreeInfo && willOpenPR) {
+  if (canTypeSlashCommands && mode === COMPLETION_MODES.WORKTREE_NO_PUSH) {
     const lines = ['## Completion', ...(noChangeSuccess ? ['', NO_CHANGE_AUDIT_GUIDANCE, ''] : []), 'When finished, run these in order:'];
     let step = 1;
     if (simplifyEnabled) {
@@ -1001,7 +1012,7 @@ export function buildCliCompletionSection({ worktreeInfo, willOpenPR, prCompleti
     }
     return lines.join('\n');
   }
-  if (hasSlashdo && worktreeInfo) {
+  if (canTypeSlashCommands && mode === COMPLETION_MODES.PORTOS_MERGES) {
     const lines = ['## Completion', ...(noChangeSuccess ? ['', NO_CHANGE_AUDIT_GUIDANCE, ''] : []), 'When finished, run these in order:'];
     let step = 1;
     if (simplifyEnabled) {


### PR DESCRIPTION
## Summary

- `buildTuiCompletionSection` and `buildCliCompletionSection` (`server/services/promptSections/completion.js`) now branch on the resolver's `COMPLETION_MODES` key plus one `canTypeSlashCommands` capability flag, instead of each re-deriving its own `hasSlashdo` / `tuiSlashdoFree` / `slashdoFree` boolean.
- `worktreeCommitGuidance` and the light path's `buildLightTaskContextSections` take the same `mode` + `canTypeSlashCommands` pair.
- The light prompt path now resolves `completionMode` once (moved earlier in `buildLightContextSections`) and reuses it, instead of computing it a second time further down.
- Fixed the `WORKTREE_NO_PUSH` mode's doc comment in `server/lib/agentCompletionMode.js` — it said the system always pushes and opens the PR, but the CLI section this mode renders tells a slashdo-capable host to run `/do:pr` itself.
- Removed the `slashdoFree` / `hasSlashdo` / `tuiSlashdoFree` identifiers from code, comments, and test titles (none remain under `server/`).
- `ownsPrWorkflow` is deliberately untouched — a separate sibling issue (#6869) owns renaming/re-deriving it.

## Test plan

- `cd server && ./node_modules/.bin/vitest run services/agentPromptBuilder.test.js lib/agentCompletionMode.test.js lib/slashdoInvocation.test.js services/agentCompletionCleanup.test.js` → 399/399 passed, including every byte-for-byte prompt assertion (no snapshot regeneration needed).
- Also ran the other importers of the touched modules (`cosValidation`, `importScoping`, `reviewerConfig`, `slashdoCatalog`, `agentCliSpawning`, `agentLifecycle`, `agentTuiSpawning`, `cosTaskIntake`, `taskTemplates`, `promptSections/reviewLifecycle`) → 488/488 passed.
- Baseline probe: copied the updated `agentPromptBuilder.test.js` onto the pre-change commit and ran it there — exactly one test failed (`slashdo-free TUI bullet points at the commit + PortOS handoff, not a /do:* command`), confirming the test edit is coupled to the production change rather than vacuous. The other two edited call sites already agreed with `mode` and passed at both revisions.
- Local reviewer (opencode, effort medium): `clean`, 0 findings.

Closes #6873
