### PR TITLE
make the TUI agent session's phase an explicit value instead of 21 closure flags

### DIFF
--- a/server/lib/tuiHandshake.js
+++ b/server/lib/tuiHandshake.js
@@ -495,6 +495,135 @@ export function createInputReadyTracker({ readyTextPattern = null, directLaunch 
 }
 
 
+// ─── Startup-dialog answers ───────────────────────────────────────────────
+
+// One row per modal a TUI can paint before (or just after) its composer
+// exists, in the exact order the spawner's poll must try them. Adding a
+// provider's next dialog is a row here plus the `needs…`/`ack…` pair on
+// createInputReadyTracker — not another boolean in the spawner's closure and
+// another arm hundreds of lines away from it.
+//
+// `stage` says WHEN the dialog paints, which is also which providers see it:
+//   'before-composer' — runs for every TUI. Codex takes the idle/deadline
+//     paste path and these dialogs go quiet the instant they paint, so the
+//     idle heuristic reads that silence as "ready" and pastes the task into
+//     the menu, which swallows it and all three paste retries (2026-08-21,
+//     `paste-not-rendered`). Answering first is what lets the composer appear.
+//   'after-composer' — claude's auto-mode offer paints once the composer is
+//     already live, so it only concerns the positive-input-ready providers.
+//
+// `keys` is the answer written to the PTY. `\x1b[B` is arrow-down, so
+// `'\x1b[B\r'` picks option 2 and `'\x1b[B\x1b[B\r'` option 3; a bare Enter is
+// deliberately never sent, because it would accept whatever the TUI happened
+// to highlight (which can be "No, exit", or rewriting the user's global
+// permission default).
+const STARTUP_DIALOGS = [
+  // Claude can discover PortOS's parent AGENTS.md (via CLAUDE.md) from a
+  // managed-app worktree nested under data/cos/worktrees, then ask whether to
+  // allow that file's external AGENTS.md import. Decline it: the parent
+  // repository's instructions must not leak into the target app, and option 2
+  // leaves the target's own instruction files intact.
+  {
+    id: 'external-imports',
+    stage: 'before-composer',
+    answered: 'externalImportsDeclined',
+    asks: (inputReady) => inputReady.needsExternalImportsChoice,
+    keys: () => '\x1b[B\r',
+    ack: (inputReady) => inputReady.ackExternalImportsChoice(),
+    describe: (command) => `Declined ${command} external instruction imports`,
+  },
+  // Codex can present a hook-review selector before its composer exists. Do
+  // not trust hooks from an unattended run: option 3 keeps them disabled for
+  // this session and lets the agent continue without executing code outside
+  // its sandbox.
+  {
+    id: 'hook-review',
+    stage: 'before-composer',
+    answered: 'hookReviewDeclined',
+    asks: (inputReady) => inputReady.needsHookReview,
+    keys: () => '\x1b[B\x1b[B\r',
+    ack: (inputReady) => inputReady.ackHookReview(),
+    describe: (command) => `Continued ${command} without trusting startup hooks`,
+  },
+  // Auto-confirm the first-run "trust this folder?" gate so agents can run in
+  // fresh worktrees. Waits for the choices themselves to paint: Claude Code
+  // releases disagree about their ordering and newer builds can highlight
+  // "No, exit" by default, so `trustSelectionKey` — derived from the painted
+  // options — is what moves to the affirmative one before submitting.
+  {
+    id: 'folder-trust',
+    stage: 'before-composer',
+    answered: 'trustAccepted',
+    asks: (inputReady) => inputReady.needsTrust && inputReady.trustChoiceReady,
+    keys: (inputReady) => `${inputReady.trustSelectionKey}${SUBMIT_KEY}`,
+    ack: (inputReady) => inputReady.ackTrustChoice(),
+    describe: (command) => `Auto-confirmed ${command} folder-trust prompt`,
+  },
+  // Decline claude's "make auto mode your default permission mode?" offer
+  // (v2.1.233+). Unlike the trust gate this one paints AFTER the composer is
+  // live, so it swallows the paste and every retry unless it is cleared first
+  // — see TUI_AUTO_MODE_PROMPT_PATTERN. Arrow-down + Enter rather than the
+  // digit `2`: it lands on "No, keep don't ask" under both of Ink's selection
+  // models (digit-immediate-select and navigate-then-confirm).
+  {
+    id: 'auto-mode',
+    stage: 'after-composer',
+    answered: 'autoModeDeclined',
+    asks: (inputReady) => inputReady.needsAutoModeChoice,
+    keys: () => '\x1b[B\r',
+    ack: (inputReady) => inputReady.ackAutoModeChoice(),
+    describe: (command) => `Declined ${command} auto-mode default offer`,
+  },
+];
+
+/**
+ * A fresh "which startup dialogs has this session already answered?" record —
+ * one value per STARTUP_DIALOGS row, so a new row needs no caller edit.
+ *
+ * The tracker's own `needs…` getters go false on ack, so they already stop a
+ * second answer on their own. These latches are the second guard the spawner
+ * carried as four sibling booleans, kept rather than reasoned away in a change
+ * whose contract is that nothing behaves differently.
+ */
+export const createStartupDialogAnswers = () =>
+  Object.fromEntries(STARTUP_DIALOGS.map((dialog) => [dialog.answered, false]));
+
+/**
+ * Answer at most ONE unanswered startup dialog for `stage`, in table order.
+ *
+ * One per call on purpose: answering changes what the TUI is showing, so the
+ * caller returns to its poll and re-reads the tracker before trying the next.
+ * The stage split is also what preserves the caller's original ordering — the
+ * "trust heading painted but its choices are unrecognized" failure check sits
+ * between the two stages and must keep winning over the after-composer arm.
+ *
+ * Mutates `answers` in place: the record is the session's, not this call's.
+ *
+ * @param {object} args
+ * @param {object} args.inputReady - createInputReadyTracker instance.
+ * @param {object} args.answers - createStartupDialogAnswers() record.
+ * @param {'before-composer'|'after-composer'} args.stage
+ * @param {string} args.command - TUI command name, for the transcript line.
+ * @param {(keys: string) => void} args.write - writes the answer to the PTY.
+ * @returns {{ id: string, message: string } | null} the dialog answered and
+ *   the transcript phrase for it, or null when there was nothing to answer.
+ *   The caller owns the log line and the idle-clock rewind, which differ by
+ *   stage.
+ */
+export function answerStartupDialogs({ inputReady, answers, stage, command, write }) {
+  for (const dialog of STARTUP_DIALOGS) {
+    if (dialog.stage !== stage) continue;
+    if (answers[dialog.answered]) continue;
+    if (!dialog.asks(inputReady)) continue;
+    answers[dialog.answered] = true;
+    write(dialog.keys(inputReady));
+    dialog.ack(inputReady);
+    return { id: dialog.id, message: dialog.describe(command) };
+  }
+  return null;
+}
+
+
 // Claude Code and Codex render a bulleted elapsed counter while a model request
 // is in flight; agy uses its own `Generating…` indicator.
 export const WORK_COUNTER_PATTERN = /\(\s*(\d+)\s*s\s*[·•]/g;

--- a/server/lib/tuiHandshake.test.js
+++ b/server/lib/tuiHandshake.test.js
@@ -43,6 +43,9 @@ import {
   isPasteConfirmed,
   isCollapsedPasteChip,
   createInputReadyTracker,
+  createStartupDialogAnswers,
+  answerStartupDialogs,
+  SUBMIT_KEY,
   AGY_INPUT_READY_PATTERN,
   createRetryStallGate,
   RETRY_STALL_MS,
@@ -1854,5 +1857,127 @@ describe('createOomNudgeGate', () => {
     const gate = createOomNudgeGate();
     expect(gate.arm(null, 0)).toBeNull();
     expect(gate.takeNudge(OOM_NUDGE_SETTLE_MS + 1, 0)).toBe(0);
+  });
+});
+
+// The four modals a TUI can paint before its prompt can be delivered used to
+// be four booleans in spawnTuiAgent's closure plus four inline arms in its
+// 300ms poll. They are one table here now, so these pin the contract the
+// spawner depends on: table order, one answer per call, the stage split that
+// keeps the "trust choices unrecognized" failure between the two groups, and
+// the per-session record that stops a second answer.
+describe('answerStartupDialogs', () => {
+  const PASTE_OFF = '\x1b[?2004l';
+  const PASTE_ON = '\x1b[?2004h';
+
+  const EXTERNAL_IMPORTS_OFFER = "This project's CLAUDE" + '.md imports files outside the current working directory.\n'
+    + '1. Yes, allow external imports\n2. No, disable external imports\n';
+  const HOOK_REVIEW_OFFER = 'Hooks need review\n1. Review hooks\n'
+    + "3. Continue without trusting (hooks won't run)\n";
+  const TRUST_GATE = 'Is this a project you trust?\n❯ 1. Yes, I trust this folder\n2. No, exit\n';
+  const AUTO_MODE_OFFER = 'Make auto mode your default permission mode?\n'
+    + '   ❯ 1. Yes, set auto mode as my default permission mode\n'
+    + "     2. No, keep don't ask\n";
+
+  // A live tracker, so each row's `asks`/`keys`/`ack` is checked against the
+  // real createInputReadyTracker API rather than a stub that could drift.
+  const composerLive = (...chunks) => {
+    const tracker = createInputReadyTracker();
+    tracker.observe(`${PASTE_OFF}${PASTE_ON}`, '');
+    for (const chunk of chunks) tracker.observe('', chunk);
+    return tracker;
+  };
+
+  const answerOnce = (inputReady, answers, stage = 'before-composer') => {
+    const written = [];
+    const result = answerStartupDialogs({
+      inputReady, answers, stage, command: 'claude', write: (keys) => written.push(keys),
+    });
+    return { result, written };
+  };
+
+  it('starts with every dialog unanswered and answers nothing when none is showing', () => {
+    const answers = createStartupDialogAnswers();
+    expect(Object.values(answers).every((v) => v === false)).toBe(true);
+
+    const tracker = composerLive('Try "fix lint errors"');
+    expect(answerOnce(tracker, answers).result).toBeNull();
+    expect(answerOnce(tracker, answers, 'after-composer').result).toBeNull();
+  });
+
+  it('answers one before-composer dialog per call, in table order, and acks the tracker each time', () => {
+    // All three up at once: order is what stops a later arm from answering a
+    // modal that is not the one currently owning the terminal's input.
+    const tracker = composerLive(EXTERNAL_IMPORTS_OFFER, HOOK_REVIEW_OFFER, TRUST_GATE);
+    const answers = createStartupDialogAnswers();
+
+    const first = answerOnce(tracker, answers);
+    expect(first.result).toEqual({ id: 'external-imports', message: 'Declined claude external instruction imports' });
+    expect(first.written).toEqual(['\x1b[B\r']); // arrow-down to option 2, never a bare Enter
+    expect(tracker.needsExternalImportsChoice).toBe(false);
+
+    const second = answerOnce(tracker, answers);
+    expect(second.result).toEqual({ id: 'hook-review', message: 'Continued claude without trusting startup hooks' });
+    expect(second.written).toEqual(['\x1b[B\x1b[B\r']); // option 3
+    expect(tracker.needsHookReview).toBe(false);
+
+    const third = answerOnce(tracker, answers);
+    expect(third.result).toEqual({ id: 'folder-trust', message: 'Auto-confirmed claude folder-trust prompt' });
+    expect(third.written).toEqual([`${tracker.trustSelectionKey}${SUBMIT_KEY}`]);
+    expect(tracker.needsTrust).toBe(false);
+
+    // Every dialog cleared, so the composer is finally reachable.
+    expect(answerOnce(tracker, answers).result).toBeNull();
+    expect(tracker.ready).toBe(true);
+  });
+
+  it('leaves the folder-trust gate alone until its choices have painted', () => {
+    // The heading matched but no recognizable option did, so trustSelectionKey
+    // has nothing to derive from. Answering here would submit whatever the TUI
+    // highlighted — which can be "No, exit". The spawner's own deadline check
+    // owns this state, and it only runs because nothing was answered.
+    const tracker = composerLive('Is this a project you trust?\n');
+    expect(tracker.needsTrust).toBe(true);
+    expect(tracker.trustChoiceReady).toBe(false);
+
+    const answers = createStartupDialogAnswers();
+    expect(answerOnce(tracker, answers).result).toBeNull();
+    expect(answers.trustAccepted).toBe(false);
+
+    tracker.observe('', '❯ 1. Yes, I trust this folder\n2. No, exit\n');
+    expect(answerOnce(tracker, answers).result?.id).toBe('folder-trust');
+  });
+
+  it('keeps the two stages disjoint so neither can answer the other\'s dialog', () => {
+    // The stage split is load-bearing: the spawner runs before-composer for
+    // every provider, then its trust-choice-unrecognized failure check, and
+    // only then after-composer — for the positive input-ready providers.
+    const trustUp = composerLive(TRUST_GATE);
+    expect(answerOnce(trustUp, createStartupDialogAnswers(), 'after-composer').result).toBeNull();
+    expect(trustUp.needsTrust).toBe(true);
+
+    const autoModeUp = composerLive(AUTO_MODE_OFFER);
+    expect(answerOnce(autoModeUp, createStartupDialogAnswers()).result).toBeNull();
+    expect(autoModeUp.needsAutoModeChoice).toBe(true);
+
+    const answered = answerOnce(autoModeUp, createStartupDialogAnswers(), 'after-composer');
+    expect(answered.result).toEqual({ id: 'auto-mode', message: 'Declined claude auto-mode default offer' });
+    expect(answered.written).toEqual(['\x1b[B\r']);
+    expect(autoModeUp.ready).toBe(true);
+  });
+
+  it('answers each dialog at most once per session, even if the question comes back', () => {
+    // The record is the guard the tracker cannot be: a TUI that re-asks (or a
+    // tracker that re-arms from its rolling tail) must not start a keystroke
+    // loop that outlives the paste deadline.
+    const reAsking = { needsHookReview: true, ackHookReview: () => {} };
+    const answers = createStartupDialogAnswers();
+
+    expect(answerOnce(reAsking, answers).result?.id).toBe('hook-review');
+    expect(answers.hookReviewDeclined).toBe(true);
+
+    const second = answerOnce(reAsking, answers);
+    expect(second.result).toBeNull();
+    expect(second.written).toEqual([]);
   });
 });

--- a/server/services/agentTuiSpawning.js
+++ b/server/services/agentTuiSpawning.js
@@ -350,8 +350,8 @@ export function buildTuiSpawnConfig(provider, model, {
 // paste-marker/verify timers, and the submit-Enter backstop timer.
 //
 // `isFinalized`/`markPromptSent`/`markPromptSubmitted` are accessors into
-// spawnTuiAgent's own `finalized`/`promptSentAt`/`promptSubmittedAt` — those
-// are read by handleData and the provider-signal timer well outside this
+// spawnTuiAgent's own `sessionPhase`/`promptSentAt`/`promptSubmittedAt` —
+// those are read by handleData and the provider-signal timer well outside this
 // cluster, so they stay owned by spawnTuiAgent and are threaded through rather
 // than duplicated here. `finishStartupFailure`/`appendLine` are likewise
 // spawnTuiAgent's own closures, passed in rather than re-implemented.
@@ -731,14 +731,38 @@ export async function spawnTuiAgent({
   });
   const promptPreview = prompt.replace(/\s+/g, ' ').slice(0, 100);
   const commandName = tuiConfig.command.split('/').pop();
-  let finalized = false;
-  // Synchronous re-entrancy guard for finish() — see its own comment for why
-  // `finalized` alone isn't enough once the merge-gate check adds awaits
-  // before it (#5876).
-  let finishing = false;
-  // A finish() call's args, dropped by the `finishing` guard while an earlier
-  // call was still deciding whether to finalize — replayed if that call ends
-  // up NOT finalizing (see finish()'s own comments on both).
+  /**
+   * Where this session is in its lifecycle — the one value every path that
+   * ends a run reads and writes.
+   *
+   *   'running'   — live; finish() accepts a trigger.
+   *   'finishing' — a finish() call is mid-decision. The merge-gate contract
+   *                 check (#5876) adds awaits before that call can say whether
+   *                 it finalizes at all, so this is set SYNCHRONOUSLY to park a
+   *                 second trigger arriving in that window. Goes back to
+   *                 'running' if the call decides not to finalize after all.
+   *   'finalized' — an outcome was recorded.
+   *   'abandoned' — PortOS went down mid-run (#3202): no outcome recorded, the
+   *                 worktree preserved for the resume.
+   *
+   * Named `sessionPhase`, not `phase`, because `abandonForHostShutdown` also
+   * writes a `phase: 'interrupted'` breadcrumb into the agent RECORD's
+   * metadata a few lines from where it sets this — two different phases with
+   * two different vocabularies, and collapsing their names is the mistake this
+   * value exists to undo.
+   */
+  let sessionPhase = 'running';
+  /**
+   * Both end states are terminal: the run is over, and the sentinel watcher,
+   * the PTY data handler, the prompt and provider-signal timers and the paste
+   * controller must all become no-ops for the rest of this process's life. An
+   * abandoned run is no less over than a finalized one — it just has no
+   * outcome — so both stop everything.
+   */
+  const isTerminal = () => sessionPhase === 'finalized' || sessionPhase === 'abandoned';
+  // A finish() call's args, parked because the session was already 'finishing'
+  // when it arrived — replayed if the call that was deciding ends up NOT
+  // finalizing (see finish()'s own comments on both).
   let pendingFinish = null;
   // Caps the merge-gate re-prompt (#5876) at once per run — a local closure
   // counter is enough: the check only ever runs from this same live process,
@@ -765,7 +789,7 @@ export async function spawnTuiAgent({
   // once the session goes quiet. See createToolPermissionGate.
   const toolPermissionGate = createToolPermissionGate();
   // Guards ingestDoneSentinel to a single read. finish() is its only caller and
-  // is itself guarded by `finalized`, so this is defensive — it pins the
+  // is itself guarded by `sessionPhase`, so this is defensive — it pins the
   // read-at-most-once invariant at the helper.
   let sentinelIngested = false;
   let hasStartedWorking = false;
@@ -926,7 +950,7 @@ export async function spawnTuiAgent({
   // await a SECOND completion needs a brand-new watcher, not a re-trigger of
   // this one. Factored out so both call sites build the exact same watcher.
   const armSentinelWatcher = () => (doneSentinelPath ? watchForFile(doneSentinelPath, async () => {
-    if (finalized) return;
+    if (isTerminal()) return;
     await finish({ success: true, exitCode: 0, reason: 'agent-signaled-done' });
   }) : null);
 
@@ -1032,27 +1056,27 @@ export async function spawnTuiAgent({
   };
 
   const finish = async ({ success, exitCode = 0, error = null, reason = 'completed' }) => {
-    // `finalized` alone used to be the whole re-entrancy guard, safe because it
-    // was set SYNCHRONOUSLY as this function's first act. The merge-gate check
-    // below needs `ingestDoneSentinel`'s summary before it can decide whether
-    // to finalize at all, which pushes `finalized = true` past several awaits —
-    // wide enough for a second trigger (the shell exiting right after the
-    // sentinel appears) to also pass the `if (finalized)` gate before the first
-    // call sets it, double-firing `finalizeAgent`. `finishing` closes that
-    // window synchronously; `finalized` still means "truly done" and is what
-    // `pasteController.resubmit()` reads, so it must stay false while a
-    // re-prompt is still possible.
+    // A terminal check alone used to be the whole re-entrancy guard, safe
+    // because it was set SYNCHRONOUSLY as this function's first act. The
+    // merge-gate check below needs `ingestDoneSentinel`'s summary before it can
+    // decide whether to finalize at all, which pushes the terminal transition
+    // past several awaits — wide enough for a second trigger (the shell exiting
+    // right after the sentinel appears) to also pass the gate before the first
+    // call sets it, double-firing `finalizeAgent`. 'finishing' closes that
+    // window synchronously while staying NON-terminal, which is what
+    // `pasteController.resubmit()` depends on: a re-prompt must still be
+    // possible while this call is deciding.
     //
-    // A trigger dropped here while the first call is mid-decision is not
+    // A trigger parked here while the first call is mid-decision is not
     // discarded: it's the one call that could carry news the first call
     // doesn't have (the shell exiting right in this window), so it's replayed
     // once that call settles on "not finalizing after all" — see below.
-    if (finalized) return;
-    if (finishing) {
+    if (isTerminal()) return;
+    if (sessionPhase === 'finishing') {
       pendingFinish = { success, exitCode, error, reason };
       return;
     }
-    finishing = true;
+    sessionPhase = 'finishing';
     // PortOS is going down. Whatever path got here — the PTY exiting under
     // TreeKill, a provider-signal failure, a paste that failed because the shell died —
     // the cause is the host restart, not the agent, so there is no outcome to
@@ -1092,11 +1116,11 @@ export async function spawnTuiAgent({
     if (success && sentinelSummary !== null && await checkMergeGateCompliance(sentinelSummary)) {
       // Not finalizing — reopen the re-entrancy gate for the next completion
       // signal the re-prompt is expected to produce. A trigger that arrived
-      // WHILE this call was deciding (dropped by the `finishing` guard above)
+      // WHILE this call was deciding (parked by the 'finishing' guard above)
       // is the only thing that could tell us the session actually died during
       // that window, so replay it now rather than losing it — otherwise the
       // run would sit waiting for a nudge with nothing left alive to receive it.
-      finishing = false;
+      sessionPhase = 'running';
       if (pendingFinish) {
         const replay = pendingFinish;
         pendingFinish = null;
@@ -1105,7 +1129,7 @@ export async function spawnTuiAgent({
       return;
     }
 
-    finalized = true;
+    sessionPhase = 'finalized';
 
     const agentData = stopRunMachinery();
 
@@ -1235,13 +1259,15 @@ export async function spawnTuiAgent({
    * agent named in it, and requeues the task as *interrupted* — resumable, and
    * without charging it orphan-retry budget.
    *
-   * Sets `finalized` so every other path (provider-signal timer, sentinel watcher, paste
-   * retry) becomes a no-op for the rest of this process's life.
+   * Moves the session to the terminal 'abandoned' phase so every other path
+   * (provider-signal timer, sentinel watcher, paste retry) becomes a no-op for
+   * the rest of this process's life — a full stop, under the name that says no
+   * outcome was recorded.
    */
   const abandonForHostShutdown = async () => {
-    // No `finalized` guard: finish() — the only caller — already returned if it
-    // was set, and this sets it below.
-    finalized = true;
+    // No terminal guard: finish() — the only caller — already returned if the
+    // session had reached one, and this sets it below.
+    sessionPhase = 'abandoned';
     stopRunMachinery();
 
     appendLine('🛑 PortOS restarted while this agent was running — the run was interrupted, not completed. Its worktree is preserved and the task will resume.');
@@ -1302,7 +1328,7 @@ export async function spawnTuiAgent({
   const resubmitAfterSignal = () => {
     // A banner that paints during startup (before the prompt was ever submitted)
     // has nothing to re-send — the ordinary paste path still owns first delivery.
-    if (finalized || !promptSubmittedAt) return;
+    if (isTerminal() || !promptSubmittedAt) return;
     const attempt = selfClearingGate.takeResubmit(Date.now());
     if (!attempt) return;
     // Only claim the re-submission that actually went out — a false return means
@@ -1321,10 +1347,11 @@ export async function spawnTuiAgent({
     // See skill: nodejs-async-event-listener-unhandled-rejection.
     try {
       // node-pty can deliver chunks between finalize starting and the shell
-      // session being killed in finalize's finally block. Once finalized, drop
-      // them — appending to the spool, growing the post-paste accumulator, or
-      // mutating timing state is all pointless after finish has settled.
-      if (finalized) return;
+      // session being killed in finalize's finally block. Once the run has
+      // reached a terminal phase, drop them — appending to the spool, growing
+      // the post-paste accumulator, or mutating timing state is all pointless
+      // after finish has settled.
+      if (isTerminal()) return;
       // node-pty surfaces output as already-decoded UTF-8 strings via
       // shellService's onData hook (StringDecoder handles multi-byte
       // boundaries internally), so `data` is a string here in normal use.
@@ -1480,7 +1507,7 @@ export async function spawnTuiAgent({
   };
 
   const handleExit = async ({ exitCode, killed, signal = null, outputTail = '' }) => {
-    if (finalized) return;
+    if (isTerminal()) return;
     // A durable runner can retain a startup error even when its matching
     // `tui:output` socket event lost the race with process exit. Preserve its
     // bounded tail before finish() drains raw.txt for error analysis. Cap again
@@ -1668,7 +1695,7 @@ export async function spawnTuiAgent({
   // is still awaiting that response. Do not revive the finalized agent by
   // registering its returned session, timers, or active-agent record; release
   // the external shell session that was registered during the late response.
-  if (finalized) {
+  if (isTerminal()) {
     if (sessionId && shellService.getSession(sessionId)) shellService.killSession(sessionId);
     return null;
   }
@@ -1707,7 +1734,7 @@ export async function spawnTuiAgent({
   // shell. Shared by the liveness guard (command exited) and the readiness cap
   // (claude never showed its input prompt).
   const finishStartupFailure = async (reason, summary) => {
-    if (finalized) return;
+    if (isTerminal()) return;
     // Flush any debounced raw-PTY chunks first so the captured tail includes
     // the CLI's most recent output (e.g. claude's final error before exiting),
     // not just whatever happened to be on disk before the last 250ms window.
@@ -1729,9 +1756,10 @@ export async function spawnTuiAgent({
   // timers — see
   // createPasteRetryController's own comment for why that cluster lives
   // outside this closure. `isFinalized`/`markPromptSent`/`markPromptSubmitted`
-  // are accessors into THIS closure's `finalized`/`promptSentAt`/
+  // are accessors into THIS closure's `sessionPhase`/`promptSentAt`/
   // `promptSubmittedAt`, which handleData and the provider-signal timer below
-  // still read directly.
+  // still read directly. `isFinalized` is the controller's own name for "the
+  // run is over", which is what BOTH terminal phases mean.
   pasteController = createPasteRetryController({
     agentId,
     sessionId,
@@ -1741,7 +1769,7 @@ export async function spawnTuiAgent({
     tuiConfig,
     mcpBoot,
     appendLine,
-    isFinalized: () => finalized,
+    isFinalized: isTerminal,
     markPromptSent: () => { promptSentAt = Date.now(); },
     markPromptSubmitted: () => { if (promptSubmittedAt === null) promptSubmittedAt = Date.now(); },
     finishStartupFailure,
@@ -1784,7 +1812,7 @@ export async function spawnTuiAgent({
   // rather than rebuilt on every 300ms poll tick.
   const writeToTuiSession = (keys) => shellService.writeToSession(sessionId, keys);
   const promptTimer = setInterval(() => {
-    if (finalized || promptSentAt) {
+    if (isTerminal() || promptSentAt) {
       clearInterval(promptTimer);
       return;
     }
@@ -1884,7 +1912,7 @@ export async function spawnTuiAgent({
   // Provider-handshake retry timer. It is deliberately not an idle watchdog:
   // a CoS TUI may remain silent for as long as the provider needs.
   const providerSignalTimer = setInterval(() => {
-    if (finalized) return;
+    if (isTerminal()) return;
     const expired = selfClearingGate.takeExpired(Date.now());
     if (expired) {
       // setInterval can't await, and an unhandled rejection here would crash the

--- a/server/services/agentTuiSpawning.js
+++ b/server/services/agentTuiSpawning.js
@@ -1193,7 +1193,7 @@ export async function spawnTuiAgent({
     // best-effort posture).
     let cleanupSuccess = finalSuccess;
     try {
-      const finalized = await finalizeAgent({
+      const finalizeVerdict = await finalizeAgent({
         agentId,
         task,
         runId,
@@ -1212,9 +1212,9 @@ export async function spawnTuiAgent({
         // The run window the commit criterion is evaluated against (#3637).
         startedAt: agentData?.startedAt ?? null,
       });
-      if (finalized && typeof finalized.success === 'boolean') cleanupSuccess = finalized.success;
-      prClaimVerified = prClaimWasVerified(finalized?.prVerdict);
-      noChangesToShip = finalized?.prVerdict?.noChangesToShip === true;
+      if (finalizeVerdict && typeof finalizeVerdict.success === 'boolean') cleanupSuccess = finalizeVerdict.success;
+      prClaimVerified = prClaimWasVerified(finalizeVerdict?.prVerdict);
+      noChangesToShip = finalizeVerdict?.prVerdict?.noChangesToShip === true;
     } finally {
       await releaseRunResources({ agentData, cleanupSuccess, prOwnership, prClaimVerified, noChangesToShip });
     }

--- a/server/services/agentTuiSpawning.js
+++ b/server/services/agentTuiSpawning.js
@@ -55,6 +55,8 @@ import {
   MCP_BOOT_PASTE_DEADLINE_MS,
   MCP_BOOT_PASTE_RETRY_DELAY_MS,
   createInputReadyTracker,
+  createStartupDialogAnswers,
+  answerStartupDialogs,
   AGY_INPUT_READY_PATTERN,
   PASTE_TO_ENTER_MIN_DELAY_MS,
   PASTE_TO_ENTER_FALLBACK_MS,
@@ -830,10 +832,11 @@ export async function spawnTuiAgent({
     ...(isAntigravityCommand(tuiConfig.command) ? { readyTextPattern: AGY_INPUT_READY_PATTERN } : {}),
     directLaunch,
   });
-  let trustAccepted = false;
-  let autoModeDeclined = false;
-  let externalImportsDeclined = false;
-  let hookReviewDeclined = false;
+  // Which of the TUI's startup dialogs this session has already answered. One
+  // record instead of four sibling booleans declared ~1,000 lines above the
+  // arms that set them; the arms themselves live in answerStartupDialogs, so a
+  // provider's next dialog is a row there rather than a fifth flag here.
+  const dialogAnswers = createStartupDialogAnswers();
   // True once shell.js actually injects the `claude` command (after its
   // round-trip readiness probe). The probe runs its OWN shell command first,
   // which toggles bracketed-paste mode and would otherwise advance the
@@ -1777,6 +1780,9 @@ export async function spawnTuiAgent({
     emitLog('error', `TUI agent ${agentId} sendPrompt(${reason}) failed: ${err?.message || err}`, { agentId }));
   const safeFinishStartupFailure = (reason, summary) => finishStartupFailure(reason, summary).catch((err) =>
     emitLog('error', `TUI agent ${agentId} finishStartupFailure(${reason}) failed: ${err?.message || err}`, { agentId }));
+  // The one PTY writer the startup-dialog answers go through, bound once
+  // rather than rebuilt on every 300ms poll tick.
+  const writeToTuiSession = (keys) => shellService.writeToSession(sessionId, keys);
   const promptTimer = setInterval(() => {
     if (finalized || promptSentAt) {
       clearInterval(promptTimer);
@@ -1785,68 +1791,30 @@ export async function spawnTuiAgent({
     const now = Date.now();
     const elapsed = now - startedAt;
 
-    // Every dismissal below rewinds the idle clock (`lastOutputAt`) AND clears
-    // `firstOutputAt`, which re-arms the idle path's "has it printed anything?"
-    // gate. The idle heuristic that governs codex reads silence as readiness,
-    // and a dialog is at its quietest right after it paints — so the dismissal
-    // keystroke and an idle paste can otherwise go out inside the same window,
-    // landing the prompt in a menu that has not repainted. Demanding fresh
-    // output-then-silence AFTER the keystroke makes the paste wait for whatever
-    // the dismissal reveals; if the TUI ignores the keystroke entirely,
-    // PASTE_DEADLINE_MS still backstops delivery.
-
-    // Claude can discover PortOS's parent AGENTS.md (via CLAUDE.md) from a managed-app worktree
-    // nested under data/cos/worktrees, then ask whether to allow that file's
-    // external AGENTS.md import. Decline it: the parent repository's instructions
-    // must not leak into the target app, and option 2 leaves the target's own
-    // instruction files intact. Like the auto-mode offer, arrow-down + Enter
-    // avoids accepting the highlighted option 1.
-    if (inputReady.needsExternalImportsChoice && !externalImportsDeclined) {
-      externalImportsDeclined = true;
-      shellService.writeToSession(sessionId, '\x1b[B\r');
-      inputReady.ackExternalImportsChoice();
-      lastOutputAt = now;
-      firstOutputAt = null;
-      appendLine(`📟 Declined ${tuiConfig.command} external instruction imports for session ${sessionId.slice(0, 8)}`);
-      return;
-    }
-
-    // Codex can present a hook-review selector before its composer exists.
-    // Do not trust hooks from an unattended run: option 3 keeps them disabled
-    // for this session and lets the agent continue without executing code
-    // outside its sandbox. This must run for every TUI, not only the positive
-    // input-ready providers below — Codex currently uses the idle/deadline path.
-    if (inputReady.needsHookReview && !hookReviewDeclined) {
-      hookReviewDeclined = true;
-      shellService.writeToSession(sessionId, '\x1b[B\x1b[B\r');
-      inputReady.ackHookReview();
-      lastOutputAt = now;
-      firstOutputAt = null;
-      appendLine(`📟 Continued ${tuiConfig.command} without trusting startup hooks for session ${sessionId.slice(0, 8)}`);
-      return;
-    }
-
-    // Auto-confirm the first-run "trust this folder?" gate so agents can run in
-    // fresh worktrees. Wait for the choices themselves to paint: Claude Code
-    // releases disagree about their ordering, and newer builds can highlight
-    // "No, exit" by default. Move to the affirmative option when necessary,
-    // then submit it once.
+    // Answer whatever startup dialog the TUI is showing — one per tick, in the
+    // order answerStartupDialogs declares (external imports, hook review,
+    // folder trust). These run for EVERY provider, not only the positive
+    // input-ready ones below, because codex takes the idle/deadline paste path
+    // and a dialog is at its quietest right after it paints.
     //
-    // Like the hook-review selector this runs for EVERY TUI, not only the
-    // positive input-ready providers below: codex takes the idle/deadline path,
-    // and its trust dialog goes quiet the instant it paints, so the idle
-    // heuristic reads that silence as "ready" and pastes the task straight into
-    // the menu — which swallows it and all three paste retries
-    // (agent-671af38f, 2026-08-21, `paste-not-rendered`). Answering the dialog
-    // first is what lets the composer appear at all.
-    if (inputReady.needsTrust && inputReady.trustChoiceReady && !trustAccepted) {
-      trustAccepted = true;
-      const trustInput = `${inputReady.trustSelectionKey}${SUBMIT_KEY}`;
-      shellService.writeToSession(sessionId, trustInput);
-      inputReady.ackTrustChoice();
+    // Answering rewinds the idle clock (`lastOutputAt`) AND clears
+    // `firstOutputAt`, which re-arms the idle path's "has it printed anything?"
+    // gate. Without that, the dismissal keystroke and an idle paste can go out
+    // inside the same window, landing the prompt in a menu that has not
+    // repainted. Demanding fresh output-then-silence AFTER the keystroke makes
+    // the paste wait for whatever the dismissal reveals; if the TUI ignores the
+    // keystroke entirely, PASTE_DEADLINE_MS still backstops delivery.
+    const answeredBeforeComposer = answerStartupDialogs({
+      inputReady,
+      answers: dialogAnswers,
+      stage: 'before-composer',
+      command: tuiConfig.command,
+      write: writeToTuiSession,
+    });
+    if (answeredBeforeComposer) {
       lastOutputAt = now;
       firstOutputAt = null;
-      appendLine(`📟 Auto-confirmed ${tuiConfig.command} folder-trust prompt for session ${sessionId.slice(0, 8)}`);
+      appendLine(`📟 ${answeredBeforeComposer.message} for session ${sessionId.slice(0, 8)}`);
       return;
     }
 
@@ -1868,19 +1836,20 @@ export async function spawnTuiAgent({
     }
 
     if (requireInputReady) {
-      // Decline claude's "make auto mode your default permission mode?" offer
-      // (v2.1.233+). Unlike the trust gate this one paints AFTER the composer is
-      // live, so it swallows the paste and every retry unless it is cleared
-      // first — see TUI_AUTO_MODE_PROMPT_PATTERN. Arrow-down + Enter rather than
-      // the digit `2`: it lands on "No, keep don't ask" under both of Ink's
-      // selection models (digit-immediate-select and navigate-then-confirm),
-      // whereas a bare `\r` would accept the highlighted option 1 and rewrite the
-      // user's global permission default.
-      if (inputReady.needsAutoModeChoice && !autoModeDeclined) {
-        autoModeDeclined = true;
-        shellService.writeToSession(sessionId, '\x1b[B\r');
-        inputReady.ackAutoModeChoice();
-        appendLine(`📟 Declined ${tuiConfig.command} auto-mode default offer for session ${sessionId.slice(0, 8)}`);
+      // Claude's auto-mode offer paints AFTER the composer is live, so it only
+      // reaches the positive input-ready providers — and unlike a dialog that
+      // paints before the composer, no idle rewind is needed here: this path
+      // gates on `inputReady.ready`, which the offer itself suppresses until
+      // it is acked.
+      const answeredAtComposer = answerStartupDialogs({
+        inputReady,
+        answers: dialogAnswers,
+        stage: 'after-composer',
+        command: tuiConfig.command,
+        write: writeToTuiSession,
+      });
+      if (answeredAtComposer) {
+        appendLine(`📟 ${answeredAtComposer.message} for session ${sessionId.slice(0, 8)}`);
         return;
       }
       if (inputReady.ready && elapsed >= tuiConfig.promptDelayMs) {

--- a/server/services/agentTuiSpawning.test.js
+++ b/server/services/agentTuiSpawning.test.js
@@ -2554,6 +2554,30 @@ describe('spawnTuiAgent runtime', () => {
       )).toBe(true);
     });
 
+    // An abandoned run is as over as a finalized one — it just has no outcome
+    // — so nothing may record one afterwards. The shutdown flag is cleared
+    // before the second trigger so the abandoned session itself, not the flag,
+    // is the only thing between that trigger and finalizeAgent.
+    it('stays abandoned: a trigger arriving after the abandon records no outcome and runs no cleanup', async () => {
+      const spawnPromise = runSpawn();
+      await flushMicrotasks();
+
+      markHostShuttingDown();
+      await capturedOnExit({ exitCode: 0, killed: false });
+      await flushMicrotasks();
+      await spawnPromise;
+      expect(agentLifecycle.finalizeAgent).not.toHaveBeenCalled();
+
+      resetHostShutdownFlagForTests();
+      await capturedOnExit({ exitCode: 1, killed: true });
+      await flushMicrotasks();
+
+      // Still no outcome — and still no completion cleanup, so the worktree
+      // the resume needs is untouched.
+      expect(agentLifecycle.finalizeAgent).not.toHaveBeenCalled();
+      expect(runSpawnerCompletionCleanup).not.toHaveBeenCalled();
+    });
+
     it('still finalizes as success when the agent had already written its sentinel', async () => {
       vi.mocked(existsSync).mockReturnValue(true);
       vi.mocked(readFile).mockImplementation(async (p) =>
@@ -2952,6 +2976,45 @@ describe('spawnTuiAgent runtime', () => {
       expect(agentLifecycle.finalizeAgent).toHaveBeenCalledWith(
         expect.objectContaining({ success: false })
       );
+    });
+
+    // The nudge's reset to 'running' has to reopen the finish gate for EVERY
+    // trigger — not only the parked replay above, and not only the re-armed
+    // sentinel watcher. After a nudge the session is live again, and the next
+    // thing to happen may be the PTY simply dying with no new sentinel at all.
+    // Swallow that and the run holds its lane to the max-runtime ceiling with
+    // no outcome recorded.
+    it('finalizes a plain PTY exit arriving after the merge-gate nudge, and ignores anything after that', async () => {
+      vi.mocked(shellService.pasteToSession).mockReturnValue(999);
+      vi.mocked(probePrForBranch).mockResolvedValue({
+        prState: 'OPEN', prUrl: 'https://example.com/pr/1', prNumber: 1, cli: 'gh', readable: true,
+      });
+      withSentinel('## Summary\nShipped the fix and opened the PR.');
+
+      const spawnPromise = runSpawn({ task: openPrTask, workspacePath: '/tmp/ws' });
+      await flushMicrotasks(); // initial watcher arms while quiet — must not self-fire
+
+      sentinelExists = true; // the agent writes .agent-done
+      await capturedOnExit({ exitCode: 0, killed: false });
+      await settle();
+      expect(shellService.pasteToSession).toHaveBeenCalledTimes(1);
+      expect(agentLifecycle.finalizeAgent).not.toHaveBeenCalled();
+
+      // The nudge deleted the sentinel, so this exit carries no completion
+      // signal of its own: nothing but the session phase decides whether it
+      // is heard.
+      await capturedOnExit({ exitCode: 1, killed: true });
+      await settle();
+      await spawnPromise;
+
+      expect(shellService.pasteToSession).toHaveBeenCalledTimes(1); // one nudge per run
+      expect(agentLifecycle.finalizeAgent).toHaveBeenCalledTimes(1);
+      expect(agentLifecycle.finalizeAgent).toHaveBeenCalledWith(expect.objectContaining({ success: false }));
+
+      // ...and now the run really is over — a late trigger finalizes nothing.
+      await capturedOnExit({ exitCode: 0, killed: false });
+      await settle();
+      expect(agentLifecycle.finalizeAgent).toHaveBeenCalledTimes(1);
     });
 
     it('finalizes on the first sentinel with no re-prompt when the PR is already merged', async () => {


### PR DESCRIPTION
## Summary

`spawnTuiAgent` kept its session lifecycle in 21 closure flags, and `finalized`
named two unrelated things inside one function. Three behavior-identical
commits, one per step, so each is reviewable and revertable on its own:

- **`finalizeVerdict` rename.** Inside `finish()`, `const finalized = await
  finalizeAgent(...)` shadowed the closure's `finalized` re-entrancy flag, so
  `finalized.success` sat a few lines below `finalized = true` with nothing to
  say they were unrelated values.
- **Startup dialogs are one table.** The four booleans and four near-identical
  arms in the 300ms prompt poll became `STARTUP_DIALOGS` +
  `answerStartupDialogs()` + `createStartupDialogAnswers()` in
  `server/lib/tuiHandshake.js`, beside the `createInputReadyTracker` that
  raises those questions. Adding a provider's next dialog is now a row there,
  not a fifth flag ~1,000 lines from a fifth arm. The `stage` field
  (`before-composer` / `after-composer`) preserves the poll's original
  ordering, including the trust-choice-unrecognized failure check that sits
  between the two groups.
- **One `sessionPhase`.** `'running' | 'finishing' | 'finalized' | 'abandoned'`
  replaces the `finalized`/`finishing` pair, with `isTerminal()` for the "run
  is over" question all ten guards actually ask. That mapping is the load-
  bearing part: the old `finalized` was set by both the finalize path and
  `abandonForHostShutdown`, so an abandoned run has to keep reading as
  terminal everywhere. The guard-for-guard table is in that commit's body.
  Named `sessionPhase` rather than `phase` because `abandonForHostShutdown`
  writes an unrelated `phase: 'interrupted'` breadcrumb into the agent
  record's metadata three lines away.

Nothing else moved: the output and idle measurements (`firstOutputAt`,
`promptSubmittedAt`, `hasStartedWorking`, …) are measurements rather than
phase and stay as they are.

## Test plan

- `server/services/agentTuiSpawning.test.js` — 113 passed (111 pre-existing,
  unchanged, plus 2 new). Green at each of the three commits individually.
- `server/lib/tuiHandshake.test.js` — 275 passed (270 pre-existing, unchanged,
  plus 5 new for `answerStartupDialogs`).
- `server/lib/index.test.js` (barrel/catalog guard) — 3 passed.
- Every suite importing either changed module (18 files) — 1,297 passed.
- Full server suite — 2,137 files, 42,907 passed, 35 skipped, 0 failed.
- Baseline probe at `5e91fb688`: the 5 `answerStartupDialogs` cases fail there
  (`TypeError: createStartupDialogAnswers is not a function`). The 2 new
  `agentTuiSpawning.test.js` cases pass at base by design — they characterize
  behavior this refactor must not change, so their sensitivity was proven by
  mutation instead:
  - drop `'abandoned'` from `isTerminal()` → **only** the new "stays abandoned"
    case fails (1 of 113). The abandon path's terminality had no coverage
    before this PR.
  - reset to `'running'` only when a trigger was parked → the new
    "finalizes a plain PTY exit arriving after the merge-gate nudge" case fails.
  - drop `'finalized'` from `isTerminal()` → that same new case fails, with two
    pre-existing ones.
- Local reviewer (opencode, effort xhigh): `clean`, 0 findings, tree unchanged.

Closes #6872
