### PR TITLE
fix: auto-select the only model on the CoS task form

### DIFF
--- a/client/src/components/cos/TaskAddForm.jsx
+++ b/client/src/components/cos/TaskAddForm.jsx
@@ -51,6 +51,14 @@ const reviewOverridePayload = (reviewOverrides) => Object.fromEntries(
     .map(([pickerKey, payloadKey]) => [payloadKey, reviewOverrides[pickerKey]])
 );
 
+// A picker whose only real choice is one model (Grok listing grok-4.6, a
+// sentinel-stripped catalog of one) should pin that model rather than leave
+// "Select model..." as a required extra click.
+const soleSelectableModel = (provider, selectedModel = '') => {
+  const models = resolveProviderModelOptions(provider, selectedModel).models;
+  return models.length === 1 ? models[0] : '';
+};
+
 const readTaskDescriptionDraft = (defaultApp) => {
   const raw = safeReadStorage(TASK_DESCRIPTION_DRAFT_KEY);
   if (raw === null) return { description: '', app: defaultApp };
@@ -176,8 +184,10 @@ export default function TaskAddForm({ providers, providersLoaded = true, apps, o
       const roleData = prev[roleKey] || {};
       let updatedRole = { ...roleData, [field]: val };
       if (field === 'provider') {
-        updatedRole.model = '';
-        updatedRole.effort = '';
+        const prov = providers?.find((p) => p.id === val);
+        const sole = soleSelectableModel(prov);
+        updatedRole.model = sole;
+        updatedRole.effort = sole ? effortSurvivingModel(prov, sole, '') : '';
       } else if (field === 'model') {
         const prov = providers?.find((p) => p.id === roleData.provider);
         updatedRole.effort = effortSurvivingModel(prov, val, roleData.effort);
@@ -411,6 +421,25 @@ export default function TaskAddForm({ providers, providersLoaded = true, apps, o
   // other state falls back to the shipped list, and the note below says which.
   const { models: availableModels, source: modelSource, unlistedSelection } =
     resolveProviderModelOptions(selectedProvider, newTask.model);
+  const soleAvailableModel = availableModels.length === 1 ? availableModels[0] : '';
+  const selectedModelOrSole = newTask.model || soleAvailableModel;
+
+  // Pin the only listed model as soon as a provider has a one-option catalog
+  // (provider change, template, or a Codex account catalog that resolved to
+  // a single id). Leave a deliberate multi-model pick, including empty
+  // "Select model...", alone when there is more than one choice.
+  useEffect(() => {
+    if (!soleAvailableModel) return;
+    setNewTask((t) => {
+      if (!t.provider || t.model === soleAvailableModel) return t;
+      if (t.model) return t;
+      return {
+        ...t,
+        model: soleAvailableModel,
+        effort: effortSurvivingModel(selectedProvider, soleAvailableModel, t.effort),
+      };
+    });
+  }, [soleAvailableModel, selectedProvider]);
   const NO_ACCOUNT_MODELS_NOTE = 'Your signed-in ChatGPT account exposes no models.';
   const modelSourceNote = (() => {
     if (!isCodexSubscriptionProvider(selectedProvider)) return '';
@@ -555,7 +584,7 @@ export default function TaskAddForm({ providers, providersLoaded = true, apps, o
       name: templateNameInput.trim(),
       description: newTask.description,
       provider: newTask.provider,
-      model: newTask.model,
+      model: newTask.model || soleAvailableModel,
       effort: newTask.effort,
       app: newTask.app,
       ...(planOnly ? {
@@ -580,7 +609,7 @@ export default function TaskAddForm({ providers, providersLoaded = true, apps, o
         .then(data => setTemplates(data.templates || []))
         .catch(err => console.warn('refresh templates:', err?.message ?? String(err)));
     }
-  }, [newTask, planOnly, templateNameInput, showTemplateSave]);
+  }, [newTask, planOnly, soleAvailableModel, templateNameInput, showTemplateSave]);
 
   // Delete a user template
   const deleteTemplate = useCallback(async (templateId, e) => {
@@ -653,7 +682,7 @@ export default function TaskAddForm({ providers, providersLoaded = true, apps, o
 
     const result = await api.addCosTask({
       description: finalDescription,
-      model: newTask.model || undefined,
+      model: selectedModelOrSole || undefined,
       provider: newTask.provider || undefined,
       effort: newTask.effort || undefined,
       orchestrationMode: orchestrationMode === 'orchestrated' ? 'orchestrated' : undefined,
@@ -1138,12 +1167,12 @@ export default function TaskAddForm({ providers, providersLoaded = true, apps, o
 
                       <select
                         aria-label={`${label} model`}
-                        value={roleData.model || ''}
+                        value={roleData.model || (models.length === 1 ? models[0] : '')}
                         disabled={!selectedProv || models.length === 0}
                         onChange={(e) => updateOrchestrationRoleField(key, 'model', e.target.value)}
                         className="px-2 py-1.5 bg-port-bg border border-port-border rounded-lg text-white text-xs disabled:opacity-50"
                       >
-                        <option value="">Default Model</option>
+                        {models.length !== 1 && <option value="">Default Model</option>}
                         {models.map((m) => (
                           <option key={m} value={m}>{m.replace('claude-', '').replace(/-\d+$/, '')}</option>
                         ))}
@@ -1173,7 +1202,19 @@ export default function TaskAddForm({ providers, providersLoaded = true, apps, o
               <select
                 id="task-provider"
                 value={newTask.provider}
-                onChange={e => setNewTask(t => ({ ...t, provider: e.target.value, model: '', effort: '', temperature: '', thinking: '' }))}
+                onChange={e => {
+                  const provider = e.target.value;
+                  const prov = providers?.find(p => p.id === provider);
+                  const model = soleSelectableModel(prov);
+                  setNewTask(t => ({
+                    ...t,
+                    provider,
+                    model,
+                    effort: model ? effortSurvivingModel(prov, model, '') : '',
+                    temperature: '',
+                    thinking: '',
+                  }));
+                }}
                 className="w-full px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white text-sm min-h-[44px]"
                 disabled={!providersLoaded}
               >
@@ -1190,7 +1231,7 @@ export default function TaskAddForm({ providers, providersLoaded = true, apps, o
                 <label htmlFor="task-model" className="sr-only">AI model</label>
                 <select
                   id="task-model"
-                  value={newTask.model}
+                  value={selectedModelOrSole}
                   onChange={e => setNewTask(t => ({
                     ...t,
                     model: e.target.value,
@@ -1200,7 +1241,7 @@ export default function TaskAddForm({ providers, providersLoaded = true, apps, o
                   }))}
                   className="w-full px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white text-sm min-h-[44px]"
                 >
-                  <option value="">Select model...</option>
+                  {availableModels.length !== 1 && <option value="">Select model...</option>}
                   {availableModels.map(m => (
                     <option key={m} value={m}>
                       {unlistedSelection && m === newTask.model
@@ -1220,7 +1261,7 @@ export default function TaskAddForm({ providers, providersLoaded = true, apps, o
             ) : null}
             <EffortSelect
               provider={selectedProvider}
-              model={effectiveModelFor(selectedProvider, newTask.model)}
+              model={effectiveModelFor(selectedProvider, selectedModelOrSole)}
               value={newTask.effort}
               onChange={effort => setNewTask(t => ({ ...t, effort }))}
               className="@lg:w-40 w-full px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white text-sm min-h-[44px]"

--- a/client/src/components/cos/TaskAddForm.test.jsx
+++ b/client/src/components/cos/TaskAddForm.test.jsx
@@ -795,3 +795,81 @@ describe('TaskAddForm Codex model catalog', () => {
     expect(screen.getByText(/exposes no models/i)).toBeInTheDocument();
   });
 });
+
+describe('TaskAddForm sole model auto-select', () => {
+  const grok = {
+    id: 'grok-cli',
+    name: 'Grok',
+    enabled: true,
+    type: 'cli',
+    command: 'grok',
+    models: ['grok-configured-default', 'grok-4.6'],
+    defaultModel: 'grok-4.6',
+  };
+  const multi = {
+    id: 'claude',
+    name: 'Claude Code',
+    enabled: true,
+    type: 'cli',
+    command: 'claude',
+    models: ['claude-opus-4-6', 'claude-sonnet-4-6'],
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    api.getCosPopularTemplates.mockResolvedValue({ templates: [] });
+    api.getCodeReviewDefaults.mockResolvedValue(null);
+    api.getLocalLlmStatus.mockResolvedValue({ ollama: { models: [] }, lmstudio: { models: [] } });
+    api.getProviders.mockResolvedValue({ providers: [] });
+    api.getAppWorkTracker.mockResolvedValue({ resolved: 'github' });
+    api.getAppRepositorySources.mockResolvedValue({
+      issueTargets: { default: 'origin', canChoose: false, origin: { fullName: 'example-org/example-app' }, upstream: { fullName: 'example-org/example-app' } },
+    });
+    api.getOrchestrationProfiles.mockResolvedValue({ profiles: [] });
+    apiSystem.getAssignableInstances.mockResolvedValue({ instances: [] });
+    api.addCosTask.mockResolvedValue({ success: true });
+  });
+
+  it('selects grok-4.6 when it is the only real model option', async () => {
+    const user = userEvent.setup();
+    render(<TaskAddForm providers={[grok]} apps={[]} onTaskAdded={vi.fn()} />);
+
+    await user.selectOptions(screen.getByLabelText('AI provider'), 'grok-cli');
+    const model = screen.getByLabelText('AI model');
+    expect(model).toHaveValue('grok-4.6');
+    expect(Array.from(model.querySelectorAll('option')).map((option) => option.value)).toEqual(['grok-4.6']);
+
+    await user.type(screen.getByPlaceholderText('Task description *'), 'Ship the change');
+    await user.click(screen.getByRole('button', { name: /^Add$/ }));
+    await waitFor(() => expect(api.addCosTask).toHaveBeenCalled());
+    expect(api.addCosTask.mock.calls.at(-1)[0]).toMatchObject({
+      provider: 'grok-cli',
+      model: 'grok-4.6',
+    });
+  });
+
+  it('leaves the model unset when the provider lists more than one option', async () => {
+    const user = userEvent.setup();
+    render(<TaskAddForm providers={[multi]} apps={[]} onTaskAdded={vi.fn()} />);
+
+    await user.selectOptions(screen.getByLabelText('AI provider'), 'claude');
+    const model = screen.getByLabelText('AI model');
+    expect(model).toHaveValue('');
+    expect(Array.from(model.querySelectorAll('option')).map((option) => option.value)).toEqual([
+      '',
+      'claude-opus-4-6',
+      'claude-sonnet-4-6',
+    ]);
+  });
+
+  it('clears an auto-selected model when switching to a multi-model provider', async () => {
+    const user = userEvent.setup();
+    render(<TaskAddForm providers={[grok, multi]} apps={[]} onTaskAdded={vi.fn()} />);
+
+    await user.selectOptions(screen.getByLabelText('AI provider'), 'grok-cli');
+    expect(screen.getByLabelText('AI model')).toHaveValue('grok-4.6');
+
+    await user.selectOptions(screen.getByLabelText('AI provider'), 'claude');
+    expect(screen.getByLabelText('AI model')).toHaveValue('');
+  });
+});


### PR DESCRIPTION
## Summary
- The CoS user task form left the model on "Select model..." even when a provider listed a single real option (for example Grok after `grok-configured-default` is stripped, leaving `grok-4.6`).
- Selecting such a provider now pins that model in the picker, omits the empty placeholder, and submits it with the task. Multi-model providers still require an explicit pick.
- Orchestration role pickers follow the same one-option pin when a role's provider changes.

## Test plan
- [x] `cd client && ./node_modules/.bin/vitest run src/components/cos/TaskAddForm.test.jsx`
- [ ] On the CoS task form, pick Grok (or any provider with one listed model) and confirm the model select shows `grok-4.6` (or that sole id) without an extra click, and that Add sends it.
- [ ] Pick a provider with multiple models and confirm the form still starts on "Select model...".
- [ ] Switch from a one-model provider to a multi-model provider and confirm the previous auto-pin clears.