### PR TITLE
docs: fix API.md rows for endpoints the server never mounted, and guard the reference against the route graph

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -328,7 +328,6 @@ Context tools remain read-only. Semantic reads and writes are independent, defau
 | Method | Endpoint | Description |
 |--------|----------|-------------|
 | GET | `/usage` | Get usage statistics |
-| GET | `/usage/daily` | Get daily activity |
 | GET | `/usage/hourly` | Get hourly activity |
 
 ### Eidoverse Worlds
@@ -349,15 +348,10 @@ federate world records.
 
 ### Legacy OpenWorld / CyberCity
 
-The old UI routes redirect to Eidoverse; these APIs remain available as
-backward-compatible historical snapshot/introspection endpoints.
-
-| Method | Endpoint | Description |
-|--------|----------|-------------|
-| GET | `/city/snapshots` | Recorded city-state series, oldest-first (`since`, `limit` query params) |
-| POST | `/city/snapshots/capture` | Capture a city snapshot frame on demand |
-| GET | `/city/snapshots/config` | Effective snapshot capture config + next run time |
-| GET | `/city/introspection` | DB tables (rows/size/pgvector) + `data/` domain sizes for the Data Harbor district. Cached server-side; `db: null` means the database is unreachable (distinct from reachable-but-empty) |
+Retired with the OpenWorld surface (#5890): there is no `/api/openworld` or
+`/api/city` HTTP API any more, so a client still calling the old snapshot or
+introspection endpoints gets a 404. Only the UI routes survive, as redirects to
+Eidoverse — see [OpenWorld](./features/openworld.md).
 
 ### Brain (Second Brain)
 
@@ -446,19 +440,21 @@ backward-compatible historical snapshot/introspection endpoints.
 | POST | `/digital-twin/documents` | Create document |
 | PUT | `/digital-twin/documents/:id` | Update document |
 | DELETE | `/digital-twin/documents/:id` | Delete document |
-| GET | `/digital-twin/categories` | List document categories |
-| GET | `/digital-twin/export` | Export twin in various formats |
-| POST | `/digital-twin/tests/run` | Run behavioral tests |
-| GET | `/digital-twin/tests/results` | Get test results |
-| GET | `/digital-twin/enrichment/categories` | List enrichment categories |
-| POST | `/digital-twin/enrichment/generate` | Generate content from answers |
+| GET | `/digital-twin/export/formats` | List available export formats |
+| POST | `/digital-twin/export` | Export the twin in the requested format |
+| GET | `/digital-twin/tests` | Get the behavioral test suite |
+| POST | `/digital-twin/tests/run` | Run behavioral tests against one provider/model |
+| GET | `/digital-twin/tests/history` | Get test run history |
+| GET | `/digital-twin/enrich/categories` | List enrichment categories |
+| POST | `/digital-twin/enrich/question` | Get the next enrichment question for a category |
+| POST | `/digital-twin/enrich/answer` | Submit an answer and update the twin documents |
 | GET | `/digital-twin/traits` | Get extracted personality traits |
 | POST | `/digital-twin/traits/analyze` | Analyze traits from documents |
 | GET | `/digital-twin/confidence` | Get confidence scores |
 | POST | `/digital-twin/confidence/calculate` | Calculate confidence |
 | GET | `/digital-twin/gaps` | Get enrichment recommendations |
-| GET | `/digital-twin/completeness` | Get completeness validation |
-| POST | `/digital-twin/contradictions` | Detect contradictions |
+| GET | `/digital-twin/validate/completeness` | Get completeness validation |
+| POST | `/digital-twin/validate/contradictions` | Detect contradictions |
 | POST | `/digital-twin/import/spotify/browser/open` | Open Spotify privacy page in the managed browser |
 | POST | `/digital-twin/import/spotify/browser/import` | Request/read the Spotify browser export and analyze it |
 | POST | `/digital-twin/import/analyze` | Analyze external data import |
@@ -585,14 +581,17 @@ return an `{ items, total }` envelope.
 | POST | `/meatspace/genome/upload` | Upload 23andMe genome file |
 | POST | `/meatspace/genome/scan` | Scan curated SNP markers |
 | POST | `/meatspace/genome/search` | Search SNP by rsid |
-| GET | `/meatspace/genome/markers` | Get scanned markers |
-| GET | `/meatspace/genome/markers/:rsid` | Get single marker details |
-| PUT | `/meatspace/genome/markers/:rsid/notes` | Update marker notes |
-| POST | `/meatspace/genome/markers/:rsid/save` | Save marker to genome.json |
-| DELETE | `/meatspace/genome/markers/:rsid` | Remove saved marker |
-| GET | `/meatspace/genome/categories` | Get marker categories |
-| GET | `/meatspace/genome/clinvar/:rsid` | Lookup ClinVar data for rsid |
+| POST | `/meatspace/genome/markers` | Save a marker (saved markers come back in the summary) |
+| PUT | `/meatspace/genome/markers/:id/notes` | Update marker notes |
+| DELETE | `/meatspace/genome/markers/:id` | Remove saved marker |
+| DELETE | `/meatspace/genome` | Delete all genome data |
+| GET | `/meatspace/genome/clinvar/status` | ClinVar sync status |
+| POST | `/meatspace/genome/clinvar/sync` | Download and index the ClinVar database |
+| POST | `/meatspace/genome/clinvar/scan` | Scan the genome against ClinVar |
+| DELETE | `/meatspace/genome/clinvar` | Delete ClinVar data |
 | GET | `/meatspace/genome/epigenetic` | Get epigenetic interventions |
+| GET | `/meatspace/genome/epigenetic/recommendations` | Get curated intervention recommendations |
+| GET | `/meatspace/genome/epigenetic/compliance` | Get compliance summary |
 | POST | `/meatspace/genome/epigenetic` | Add epigenetic intervention |
 | PUT | `/meatspace/genome/epigenetic/:id` | Update intervention |
 | DELETE | `/meatspace/genome/epigenetic/:id` | Delete intervention |
@@ -643,7 +642,7 @@ Every mounted API prefix (see `server/index.js` for the authoritative list). Dom
 | `/api/database` | Postgres introspection |
 | `/api/image-clean` | Image metadata cleaning |
 | `/api/eidoverse/world` | Private Eidoverse identity, projection, presence, augmentation, and chat adapter |
-| `/api/openworld`, `/api/city` | Legacy OpenWorld/CyberCity snapshots and introspection |
+| `/api/eidoverse/travel` | Eidoverse travel: destinations, departing to a peer world, and the federation visit/chat/leave hops (`/guest` is the one public endpoint) |
 | `/api/cos/gsd` | CoS GSD workflow |
 | `/api/feature-agents` | Feature agent runs |
 | `/api/feeds` | RSS/content feeds |
@@ -675,6 +674,7 @@ Every mounted API prefix (see `server/index.js` for the authoritative list). Dom
 | `/api/image-gen`, `/api/video-gen`, `/api/image-video/models` | Image/video generation |
 | `/api/devtools/video-download` | Video download |
 | `/api/video-timeline` | Video timeline editor |
+| `/api/continuous-video` | Continuous-video episodes (script + bible → chained multi-clip generation) |
 | `/api/media-jobs` | Async media job queue |
 | `/api/creative-director` | Creative Director projects |
 | `/api/fableloom` | FableLoom interactive story generation |
@@ -698,6 +698,7 @@ Every mounted API prefix (see `server/index.js` for the authoritative list). Dom
 | `/api/sprites` | Sprite catalog / export |
 | `/api/threejs-models` | Procedural Three.js models |
 | `/api/image-to-3d` | Image-to-3D conversion |
+| `/api/rigging` | Auto-skin rigging and animation retargeting for image-to-3D models |
 | `/api/privacy` | PII vault / trusted-org / broker opt-out |
 | `/api/shell` | Browser PTY shells |
 | `/api/ports` | Port scan / allocation |
@@ -720,6 +721,7 @@ Every mounted API prefix (see `server/index.js` for the authoritative list). Dom
 | `/api/standardize` | App PM2 standardizer |
 | `/api/stacker-news`, `/api/x` | Social integrations |
 | `/api/model-personality` | LLM personality tests |
+| `/api/providers/comparison` | Provider/model comparison catalog — discover, import, and Artificial Analysis sync (see [MODEL-COMPARISON.md](./MODEL-COMPARISON.md)) |
 | `/api/browser` | Managed Chromium |
 | `/api/creative-commission` | Creative commissions |
 | `/api/midi-runtime` | MIDI runtime |

--- a/docs/GITHUB_ACTIONS.md
+++ b/docs/GITHUB_ACTIONS.md
@@ -53,6 +53,11 @@ server job with those files selected. Two kinds of test qualify:
   file is always some *other* file the guard sees only as a path string. Left
   off the list they are structurally unselectable and can sit red on `main`
   while every PR reports green (issue #5055).
+- **Doc-parity guards** — `docs/api-doc.test.js` and `docs/deps-doc.test.js`
+  compare the `.md` beside them with source they read rather than import
+  (the route graph, the dependency manifests). The `.md` is documentation-only
+  to the planner and the source has no import edge to the guard, so a docs-only
+  PR is exactly the one that could document a removed endpoint and merge green.
 
 `scripts/repo-scan-guards.test.js` keeps the second half honest: it re-derives
 the scanner set from the tree and fails when a new scanner is added without

--- a/docs/api-doc.test.js
+++ b/docs/api-doc.test.js
@@ -1,0 +1,121 @@
+/**
+ * Parity guard for docs/API.md.
+ *
+ * API.md is the hand-written REST reference — the page an integrator, a
+ * companion-app author, or an agent reads before calling PortOS — and its
+ * route-domain index claims to list "every mounted API prefix". Nothing
+ * enforced either claim, and the document drifted in the worst direction a
+ * reference can: it described endpoints that do not exist. Seventeen rows
+ * pointed at paths no router had — a "Legacy OpenWorld / CyberCity" section
+ * still promised that `/api/city/*` "remain[s] available" after #5890 removed
+ * the router, the Digital Twin table used `/completeness` and
+ * `/enrichment/categories` for routes that shipped as `/validate/completeness`
+ * and `/enrich/categories`, and the genome table documented a per-rsid ClinVar
+ * lookup that was never built. A reader following any of those got a 404.
+ *
+ * These assertions move that failure to the commit that introduces it. They
+ * compare the document against `buildApiRouteCatalog()` — the same
+ * source-derived inventory the API Explorer serves (`server/lib/apiRouteGraph.js`)
+ * — so the guard reads exactly the route modules the server runs and cannot
+ * itself be stale. Only paths are checked, never descriptions: a row's prose
+ * is the author's, and a wrong path is what sends a reader to a dead URL.
+ *
+ * The test is colocated with the document it guards; `server/vitest.config.js`
+ * globs `../docs/**` so `cd server && npm test` picks it up.
+ */
+import { readFileSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+import { describe, expect, it } from 'vitest';
+import { buildApiRouteCatalog } from '../server/lib/apiRouteGraph.js';
+
+const DOCS_DIR = dirname(fileURLToPath(import.meta.url));
+const DOC = readFileSync(join(DOCS_DIR, 'API.md'), 'utf8');
+const CATALOG = buildApiRouteCatalog({ repoRoot: join(DOCS_DIR, '..') });
+
+const REST_HEADING = '## REST Endpoints';
+const INDEX_HEADING = '## Route Domain Index';
+const EVENTS_HEADING = '## WebSocket Events';
+
+const section = (from, to) => {
+  const start = DOC.indexOf(from);
+  const end = DOC.indexOf(to);
+  if (start === -1 || end === -1 || end <= start) {
+    throw new Error(`API.md must keep the "${from}" section ahead of "${to}" — this guard slices on those headings`);
+  }
+  return DOC.slice(start, end);
+};
+
+/**
+ * Route params compare by position, not by name: `/markers/:id` and
+ * `/markers/:rsid` are the same operation, and renaming a param is not a
+ * change any caller can observe. Query strings are documentation, not path.
+ */
+const normalizePath = (path) => path
+  .replace(/[?#].*$/, '')
+  .replace(/:[A-Za-z0-9_]+/g, ':param')
+  .replace(/\/+$/, '') || '/';
+
+/** Endpoint cells are written relative to `/api` unless they name the mount themselves. */
+const absolutePath = (path) => (path.startsWith('/api/') || path.startsWith('/sdapi/') ? path : `/api${path}`);
+
+const isApiPath = (path) => path.startsWith('/api/') || path.startsWith('/sdapi/');
+
+/** `| METHOD | \`/path\` | description |` rows from the REST section. */
+const documentedOperations = [...section(REST_HEADING, INDEX_HEADING).matchAll(/^\|\s*(GET|POST|PUT|PATCH|DELETE)\s*\|\s*`([^`]+)`/gm)]
+  .map(([, method, path]) => ({ method, path: absolutePath(path) }));
+
+/** Every backticked prefix in the route-domain index table, `/api/*` and `/sdapi/*` only. */
+const indexedPrefixes = [...section(INDEX_HEADING, EVENTS_HEADING).matchAll(/^\|\s*((?:`[^`]+`(?:,\s*)?)+)\s*\|/gm)]
+  .flatMap(([, cell]) => [...cell.matchAll(/`([^`]+)`/g)].map(([, prefix]) => prefix))
+  .filter(isApiPath);
+
+const liveOperations = new Set(CATALOG.routes.map(({ method, path }) => `${method} ${normalizePath(path)}`));
+const livePaths = CATALOG.routes.map(({ path }) => normalizePath(path));
+
+const isUnder = (path, prefix) => path === prefix || path.startsWith(`${prefix}/`);
+
+describe('docs/API.md matches the mounted route graph', () => {
+  it('parses the tables it guards', () => {
+    // A regex that silently matches nothing would pass every assertion below.
+    expect(documentedOperations.length).toBeGreaterThan(100);
+    expect(indexedPrefixes.length).toBeGreaterThan(50);
+    expect(CATALOG.routes.length).toBeGreaterThan(500);
+  });
+
+  it('documents no endpoint the server does not mount', () => {
+    const phantom = documentedOperations
+      .filter(({ method, path }) => !liveOperations.has(`${method} ${normalizePath(path)}`))
+      .map(({ method, path }) => `${method} ${path}`);
+    expect(phantom, [
+      'docs/API.md documents endpoints no router declares. Fix the row or delete it —',
+      'the live inventory is GET /api/api-docs/catalog.json (or buildApiRouteCatalog()).',
+    ].join('\n')).toEqual([]);
+  });
+
+  it('indexes no route-domain prefix that has no live operation under it', () => {
+    const phantom = indexedPrefixes.filter((prefix) => {
+      const wanted = normalizePath(prefix);
+      return !livePaths.some((path) => isUnder(path, wanted));
+    });
+    expect(phantom, 'docs/API.md route-domain index lists prefixes the server no longer mounts').toEqual([]);
+  });
+
+  it('covers every mounted API prefix in the index or a detailed table', () => {
+    // The index says "Every mounted API prefix ... Domains documented in detail
+    // above are omitted", so a mount is covered by an index row or by an
+    // endpoint row at or below it. An ancestor row does not count: the index
+    // already lists sub-routers such as `/api/eidoverse/world` on their own.
+    const documentedPrefixes = [
+      ...indexedPrefixes.map(normalizePath),
+      ...documentedOperations.map(({ path }) => normalizePath(path)),
+    ];
+    const uncovered = CATALOG.mounts
+      .filter(isApiPath)
+      .filter((mount) => {
+        const wanted = normalizePath(mount);
+        return !documentedPrefixes.some((prefix) => isUnder(prefix, wanted));
+      });
+    expect(uncovered, 'server/index.js mounts API prefixes docs/API.md never mentions — add a route-domain index row').toEqual([]);
+  });
+});

--- a/scripts/ci-test-plan.js
+++ b/scripts/ci-test-plan.js
@@ -191,6 +191,13 @@ export const WINDOWS_CONTRACT_TESTS = [
 // documentation-only ones, where the alternative is reasoning per-scope about
 // what can reach it.
 export const ALWAYS_RUN_TESTS = [
+  // Doc-parity guards: each compares a .md next to it against source it reads
+  // rather than imports. The .md is documentation-only to the planner and the
+  // source has no import edge to the guard, so neither side of the comparison
+  // can select it — a docs-only PR that documented a removed endpoint would
+  // otherwise merge green.
+  'docs/api-doc.test.js',
+  'docs/deps-doc.test.js',
   'scripts/agent-instructions-files.test.js',
   // The union-merged catalogs are `.md` to the planner — documentation-only —
   // so a rebase that doubled a row would otherwise never be re-checked.
@@ -284,6 +291,9 @@ const RUNNER_ROOTS = {
     'scripts/',
     'lib/',
     'autofixer/',
+    // server/vitest.config.js globs ../docs/**/*.test.js for the doc-parity
+    // guards colocated with the documents they check.
+    'docs/',
   ],
   client: ['client/src/'],
 };


### PR DESCRIPTION
## Summary

- `docs/API.md` documented 17 endpoints no router declares: a "Legacy OpenWorld / CyberCity" section still promised `/api/city/*` and `/api/openworld` "remain available" after #5890 removed that router; the Digital Twin table used `/completeness`, `/contradictions`, `/enrichment/*` and `/tests/results` for routes that shipped as `/validate/*`, `/enrich/*` and `/tests/history`; the genome table listed a per-rsid ClinVar lookup and marker reads that were never built; `/usage/daily` never existed. Every one of those rows sent a reader to a 404.
- Rows now match the live routes, the retired section says the API is gone (pointing at the OpenWorld feature doc), and the route-domain index gains the four mounted prefixes it lacked (`/api/rigging`, `/api/continuous-video`, `/api/eidoverse/travel`, `/api/providers/comparison`) so its "every mounted API prefix" claim holds.
- New `docs/api-doc.test.js` (colocated like `docs/deps-doc.test.js`) checks every endpoint row and index prefix against `buildApiRouteCatalog()`, the same source-derived inventory the API Explorer serves. It fails on a documented path with no live operation, an indexed prefix with nothing under it, or a mount the document never mentions.
- The CI planner classified `docs/**` as documentation-only, so a docs-only PR (the exact case that documents a removed endpoint) would have skipped this guard and `docs/deps-doc.test.js` alike. Both are now on `ALWAYS_RUN_TESTS`, and `docs/` joins the server runner roots to match the `../docs/**/*.test.js` glob in `server/vitest.config.js`. `docs/GITHUB_ACTIONS.md` records the new always-run kind.

## Test plan

- [x] `cd server && vitest run ../docs/api-doc.test.js ../docs/deps-doc.test.js ../scripts/ci-test-plan.test.js ../scripts/repo-scan-guards.test.js ../scripts/run-ci-tests.test.js lib/apiRouteGraph.test.js` — 78 passed
- [x] Probe: with the pre-fix `API.md` swapped in, the guard fails listing all 17 phantom rows, the 2 dead index prefixes, and the 4 unmentioned mounts; with the fixed doc it passes
- [x] `buildCiTestPlan(['docs/API.md'])` now schedules both docs guards on the server runner; a `server/routes/*.js` change still gets them via always-run; this PR itself triggers the full suite (planner script changed)