### PR TITLE
fix: restore Media Gen shell so /video/generate can scroll

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -486,7 +486,13 @@ export default function App() {
               :id in the path) so a deep-link like /creative-director/abc?x#y
               lands on /creative-director/abc/overview?x#y intact. */}
           <Route path="video" element={<CreativeDirector browseOnly />} />
-          <Route path="video/generate" element={<VideoGen />} />
+          {/* VideoGen still uses the Media Gen tab shell (header + tabs +
+              overflow-auto body). Leaving it as a bare full-width page
+              clips the form: `/video` is a full-width prefix, and VideoGen
+              has no internal scroller of its own. */}
+          <Route path="video/generate" element={<MediaGen />}>
+            <Route index element={<VideoGen />} />
+          </Route>
           <Route path="video/:id" element={<PrefixRedirect from={VIDEO_PROJECT_PREFIX} to="/creative-director" />} />
           <Route path="video/:id/:tab/:sceneId" element={<PrefixRedirect from={VIDEO_PROJECT_PREFIX} to="/creative-director" />} />
           <Route path="video/:id/:tab" element={<PrefixRedirect from={VIDEO_PROJECT_PREFIX} to="/creative-director" />} />

--- a/client/src/App.videoRoutes.test.jsx
+++ b/client/src/App.videoRoutes.test.jsx
@@ -5,10 +5,20 @@ vi.mock('./components/Layout', () => ({ default: () => <Outlet /> }));
 vi.mock('./pages/Dashboard', () => ({ default: () => null }));
 vi.mock('./hooks/useCatalogTypes.jsx', () => ({ CatalogTypesProvider: ({ children }) => children }));
 vi.mock('./services/api', () => ({ getSettings: vi.fn(() => Promise.resolve({ timezone: 'UTC' })), updateSettings: vi.fn(), getSelfInstance: vi.fn(() => Promise.resolve({})), PORTOS_APP_ID: 'portos' }));
-vi.mock('./pages/MediaGen', () => ({ default: () => <Outlet /> }));
+vi.mock('./pages/MediaGen', () => ({ default: () => (
+  <>
+    <div data-testid="media-gen-shell" />
+    <Outlet />
+  </>
+) }));
 vi.mock('./pages/VideoGen', () => ({ default: () => { const location = useLocation(); return <pre data-testid="clip-location">{JSON.stringify({ pathname: location.pathname, search: location.search, hash: location.hash, state: location.state })}</pre>; } }));
 vi.mock('./pages/CreativeDirectorDetail', () => ({ default: () => { const location = useLocation(); return <pre data-testid="project-location">{JSON.stringify({ pathname: location.pathname, search: location.search, hash: location.hash, state: location.state })}</pre>; } }));
 import App from './App.jsx';
+it('keeps Generate Video inside the Media Gen tab shell', async () => {
+  render(<MemoryRouter initialEntries={['/video/generate']}><App /></MemoryRouter>);
+  expect(await screen.findByTestId('media-gen-shell')).toBeInTheDocument();
+  expect(screen.getByTestId('clip-location')).toBeInTheDocument();
+});
 it.each(['/media/video', '/video-gen'])('preserves clip handoff state through %s', async path => {
   const state = { remix: { ingredientIds: ['example-ingredient'] } };
   render(<MemoryRouter initialEntries={[{ pathname: path, search: '?settings=1', hash: '#clip', state }]}><App /></MemoryRouter>);

--- a/client/src/components/Layout.jsx
+++ b/client/src/components/Layout.jsx
@@ -588,7 +588,6 @@ const FULL_WIDTH_PATH_PREFIXES = [
   // so they need the bare full-width main — same as when they lived
   // under the /media tabs.
   '/creative-director',
-  '/video',
   '/brain',
   '/digital-twin',
   '/feature-agents',
@@ -648,6 +647,13 @@ const FULL_WIDTH_PATH_REGEXES = [
   // scrolling body. Keep this boundary-specific so `/music-video` retains its
   // own route classification.
   /^\/music(?:\/|$)/,
+  // Video workspace (`/video`) owns its own header+scroll shell. Generate
+  // Video (`/video/generate`) uses the MediaGen tab shell (header + tabs +
+  // overflow-auto body), so it must stay full-width with that shell — taking
+  // it off full-width double-pads; leaving it full-width without the shell
+  // clips the form. Boundary-specific so `/video-gen` (legacy redirect) is
+  // not swallowed the way a `/video` prefix would.
+  /^\/video(?:\/|$)/,
   // Only Game DETAIL workspaces own an internal scroll region; the
   // bare /game index stays on the normal padded page layout.
   /^\/game\/[^/]+\/?$/,

--- a/client/src/components/Layout.test.jsx
+++ b/client/src/components/Layout.test.jsx
@@ -518,6 +518,10 @@ describe('Layout — isFullWidthRoute classification', () => {
     // Music owns the same full-bleed title/tab/body shell as Media Gen, but
     // its similarly named Music Video route is classified independently.
     ['/music', true], ['/music/generate', true], ['/music-video', false],
+    // Video workspace index owns its own scroll; Generate Video uses the
+    // Media Gen tab shell and must stay full-width with it. `/video-gen` is
+    // a legacy redirect, not a page with an internal scroller.
+    ['/video', true], ['/video/generate', true], ['/video-gen', false],
     // Game: only a single-segment detail workspace.
     ['/game', false], ['/game/', false], ['/game/g1', true], ['/game/g1/x', false],
     // Apps: detail editor is full-width, but the Add App form is explicitly excluded

--- a/client/src/pages/MediaGen.jsx
+++ b/client/src/pages/MediaGen.jsx
@@ -26,7 +26,9 @@ export const TABS = buildPageNavTabs(getPageNavTabs('media'), TAB_PRESENTATION, 
 export default function MediaGen() {
   const navigate = useNavigate();
   const { pathname } = useLocation();
-  const activeTab = pathname.split('/')[2] || 'image';
+  // Generate Video lives at `/video/generate` (sibling of the Video workspace),
+  // not `/media/video`. The tab id is still `video`.
+  const activeTab = pathname.startsWith('/video/generate') ? 'video' : (pathname.split('/')[2] || 'image');
 
   return (
     <div className="flex min-w-0 flex-col h-full">

--- a/client/src/pages/MediaGen.test.jsx
+++ b/client/src/pages/MediaGen.test.jsx
@@ -18,6 +18,17 @@ describe('<MediaGen>', () => {
     expect(within(select).getAllByRole('option')).toHaveLength(TABS.length);
     expect(select).toHaveValue('image');
   });
+
+  it('marks the Video tab active on /video/generate', () => {
+    const { container } = render(
+      <MemoryRouter initialEntries={['/video/generate']}>
+        <MediaGen />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole('combobox', { name: 'Media Gen sections' })).toHaveValue('video');
+    expect(container.querySelector('.flex-1.overflow-auto')).toBeTruthy();
+  });
 });
 
 // Media Gen derives its tab bar from the nav manifest's `tabGroup: 'media'`


### PR DESCRIPTION
## Summary
- `/video/generate` left the Media Gen tab shell when Generate Video moved off `/media/video`, but Layout still treats `/video*` as a full-bleed page (`overflow-hidden`, no padding).
- The generate form has no internal scroller, so the page clipped below the fold and lost its header/tabs/padding.
- Nest VideoGen back under MediaGen (header, tabs, `overflow-auto` body) and classify `/video` with a path-boundary regex so `/video-gen` is not treated as full-width.

## Test plan
- [x] `cd client && npx vitest run src/components/Layout.test.jsx src/pages/MediaGen.test.jsx src/App.videoRoutes.test.jsx`
- [ ] Open `/video/generate` and confirm the Media Gen header + Video tab, page padding, and that the form/gallery scroll.
- [ ] Switch Image ↔ Video in the Media Gen tabs and confirm both pages still scroll.
- [ ] Open `/video` (Video workspace) and confirm it still owns its own full-bleed scroll.