### PR TITLE
fix: fill the desktop viewport on the CoS Persistent Mind page and auto-grow its composer

### DIFF
--- a/client/src/components/cos/tabs/MindTab.jsx
+++ b/client/src/components/cos/tabs/MindTab.jsx
@@ -11,6 +11,7 @@ import * as api from '../../../services/api';
 import { formatDateTime, timeUntil } from '../../../utils/formatters';
 import BrailleSpinner from '../../BrailleSpinner';
 import Drawer from '../../Drawer';
+import AutoSizeTextarea from '../../ui/AutoSizeTextarea';
 import Banner from '../../ui/Banner';
 import FilePickerButton from '../../ui/FilePickerButton';
 import TabPills from '../../ui/TabPills';
@@ -554,7 +555,7 @@ export default function MindTab() {
   };
 
   const handleMessageKeyDown = (event) => {
-    if (event.key !== 'Enter' || event.altKey || event.nativeEvent.isComposing || event.keyCode === 229) return;
+    if (event.key !== 'Enter' || event.altKey || event.shiftKey || event.nativeEvent.isComposing || event.keyCode === 229) return;
     void submitMessage(event);
   };
 
@@ -699,8 +700,8 @@ export default function MindTab() {
   });
 
   return (
-    <section aria-labelledby="mind-heading" className="mx-auto max-w-[100rem] space-y-4 pb-4">
-      <header className="flex flex-col gap-3 rounded-2xl border border-port-border bg-port-card/70 p-3 sm:flex-row sm:items-center sm:justify-between sm:p-4">
+    <section aria-labelledby="mind-heading" className="mx-auto flex h-full min-h-0 w-full max-w-[100rem] flex-col gap-4 pb-4 xl:pb-0">
+      <header className="flex shrink-0 flex-col gap-3 rounded-2xl border border-port-border bg-port-card/70 p-3 sm:flex-row sm:items-center sm:justify-between sm:p-4">
         <div className="flex min-w-0 items-center gap-3">
           <span className="relative flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-port-accent/15 text-port-accent ring-1 ring-port-accent/30">
             <Brain size={23} aria-hidden="true" />
@@ -736,6 +737,7 @@ export default function MindTab() {
 
       {callState?.active && (
         <Banner
+          className="shrink-0"
           tone="info"
           icon={PhoneCall}
           title="On a FaceTime Audio call"
@@ -754,12 +756,12 @@ export default function MindTab() {
         </Banner>
       )}
 
-      {gap && <Banner tone="warning" title="History gap detected">The saved cursor is no longer retained. The visible trace was reloaded from the newest bounded snapshot.</Banner>}
-      {loadError && <Banner tone="error" title="Conversation unavailable">{loadError}. Existing messages are preserved; retry when the connection recovers.</Banner>}
-      {lifecycleError && <Banner tone="error" title="Action failed">{lifecycleError}</Banner>}
+      {gap && <Banner className="shrink-0" tone="warning" title="History gap detected">The saved cursor is no longer retained. The visible trace was reloaded from the newest bounded snapshot.</Banner>}
+      {loadError && <Banner className="shrink-0" tone="error" title="Conversation unavailable">{loadError}. Existing messages are preserved; retry when the connection recovers.</Banner>}
+      {lifecycleError && <Banner className="shrink-0" tone="error" title="Action failed">{lifecycleError}</Banner>}
 
-      <div className="grid items-start gap-4 xl:grid-cols-[minmax(0,1fr)_19rem]">
-        <section data-testid="mind-chat" aria-label="Persistent mind chat" className="flex h-[68dvh] min-h-[30rem] max-h-[54rem] flex-col overflow-hidden rounded-[1.5rem] border border-port-border bg-port-card shadow-lg shadow-black/10 sm:min-h-[34rem]">
+      <div className="grid min-h-0 flex-1 items-stretch gap-4 xl:grid-cols-[minmax(0,1fr)_19rem]">
+        <section data-testid="mind-chat" aria-label="Persistent mind chat" className="flex min-h-[30rem] flex-col overflow-hidden rounded-[1.5rem] border border-port-border bg-port-card shadow-lg shadow-black/10 sm:min-h-[34rem] xl:h-full xl:min-h-0">
           <header className="flex shrink-0 items-center justify-between gap-3 border-b border-port-border bg-port-card/95 px-3 py-2.5 sm:px-4">
             <h3 className="flex items-center gap-2 text-sm font-medium text-port-text">Conversation {state?.status === 'thinking' && <MindTypingIndicator />}</h3>
             <label htmlFor="mind-show-activity" className="flex shrink-0 items-center gap-2 rounded-full border border-port-border px-2.5 py-1.5 text-[11px] text-port-text-muted">
@@ -834,7 +836,7 @@ export default function MindTab() {
                 {messageImagesUploading ? <RefreshCw size={17} className="animate-spin" aria-hidden="true" /> : <ImagePlus size={18} aria-hidden="true" />}
               </FilePickerButton>
               <label htmlFor="mind-input-text" className="sr-only">Message</label>
-              <textarea id="mind-input-text" value={messageText} onChange={(event) => changeMessageText(event.target.value)} onKeyDown={handleMessageKeyDown} maxLength={8000} rows={1} className="min-h-[36px] max-h-32 flex-1 resize-y bg-transparent py-2 text-sm leading-5 text-port-text outline-none placeholder:text-port-text-muted" placeholder="Message Persistent Mind" />
+              <AutoSizeTextarea id="mind-input-text" value={messageText} onChange={(event) => changeMessageText(event.target.value)} onKeyDown={handleMessageKeyDown} maxLength={8000} rows={1} className="min-h-[36px] max-h-[40vh] flex-1 overflow-y-auto bg-transparent py-2 text-sm leading-5 text-port-text outline-none placeholder:text-port-text-muted" placeholder="Message Persistent Mind" />
               <button type="submit" disabled={(!messageText.trim() && messageImages.length === 0) || submitting || messageImagesUploading} aria-label={submitting ? 'Sending message' : submitError ? 'Retry' : selectedPreset ? `Send with ${selectedPreset.label}` : 'Send message'} title={selectedPreset ? `Send this one message with ${selectedPreset.label}` : undefined} className={`flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-white transition-colors disabled:cursor-not-allowed disabled:bg-port-border disabled:text-port-text-muted ${selectedPreset ? 'bg-port-warning hover:bg-port-warning/85' : 'bg-port-accent hover:bg-port-accent/85'}`}>
                 {submitting ? <RefreshCw size={17} className="animate-spin" aria-hidden="true" /> : <ArrowUp size={19} strokeWidth={2.5} aria-hidden="true" />}
               </button>
@@ -842,7 +844,7 @@ export default function MindTab() {
           </form>
         </section>
 
-        <aside aria-labelledby="mind-state-heading" className="space-y-3 xl:sticky xl:top-0">
+        <aside aria-labelledby="mind-state-heading" className="space-y-3 xl:min-h-0 xl:overflow-y-auto">
           <section className="rounded-2xl border border-port-border bg-port-card p-4">
             <div className="flex items-center justify-between gap-3">
               <div>

--- a/client/src/components/cos/tabs/MindTab.jsx
+++ b/client/src/components/cos/tabs/MindTab.jsx
@@ -761,7 +761,7 @@ export default function MindTab() {
       {lifecycleError && <Banner className="shrink-0" tone="error" title="Action failed">{lifecycleError}</Banner>}
 
       <div className="grid min-h-0 flex-1 items-stretch gap-4 xl:grid-cols-[minmax(0,1fr)_19rem]">
-        <section data-testid="mind-chat" aria-label="Persistent mind chat" className="flex min-h-[30rem] flex-col overflow-hidden rounded-[1.5rem] border border-port-border bg-port-card shadow-lg shadow-black/10 sm:min-h-[34rem] xl:h-full xl:min-h-0">
+        <section data-testid="mind-chat" aria-label="Persistent mind chat" className="flex h-[68dvh] min-h-[30rem] flex-col overflow-hidden rounded-[1.5rem] border border-port-border bg-port-card shadow-lg shadow-black/10 sm:min-h-[34rem] xl:h-full xl:min-h-0">
           <header className="flex shrink-0 items-center justify-between gap-3 border-b border-port-border bg-port-card/95 px-3 py-2.5 sm:px-4">
             <h3 className="flex items-center gap-2 text-sm font-medium text-port-text">Conversation {state?.status === 'thinking' && <MindTypingIndicator />}</h3>
             <label htmlFor="mind-show-activity" className="flex shrink-0 items-center gap-2 rounded-full border border-port-border px-2.5 py-1.5 text-[11px] text-port-text-muted">

--- a/client/src/components/cos/tabs/MindTab.jsx
+++ b/client/src/components/cos/tabs/MindTab.jsx
@@ -701,7 +701,7 @@ export default function MindTab() {
 
   return (
     <section aria-labelledby="mind-heading" className="mx-auto flex h-full min-h-0 w-full max-w-[100rem] flex-col gap-4 pb-4 xl:pb-0">
-      <header className="flex shrink-0 flex-col gap-3 rounded-2xl border border-port-border bg-port-card/70 p-3 sm:flex-row sm:items-center sm:justify-between sm:p-4">
+      <header className="flex flex-col gap-3 rounded-2xl border border-port-border bg-port-card/70 p-3 sm:flex-row sm:items-center sm:justify-between sm:p-4">
         <div className="flex min-w-0 items-center gap-3">
           <span className="relative flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-port-accent/15 text-port-accent ring-1 ring-port-accent/30">
             <Brain size={23} aria-hidden="true" />
@@ -737,7 +737,6 @@ export default function MindTab() {
 
       {callState?.active && (
         <Banner
-          className="shrink-0"
           tone="info"
           icon={PhoneCall}
           title="On a FaceTime Audio call"
@@ -756,9 +755,9 @@ export default function MindTab() {
         </Banner>
       )}
 
-      {gap && <Banner className="shrink-0" tone="warning" title="History gap detected">The saved cursor is no longer retained. The visible trace was reloaded from the newest bounded snapshot.</Banner>}
-      {loadError && <Banner className="shrink-0" tone="error" title="Conversation unavailable">{loadError}. Existing messages are preserved; retry when the connection recovers.</Banner>}
-      {lifecycleError && <Banner className="shrink-0" tone="error" title="Action failed">{lifecycleError}</Banner>}
+      {gap && <Banner tone="warning" title="History gap detected">The saved cursor is no longer retained. The visible trace was reloaded from the newest bounded snapshot.</Banner>}
+      {loadError && <Banner tone="error" title="Conversation unavailable">{loadError}. Existing messages are preserved; retry when the connection recovers.</Banner>}
+      {lifecycleError && <Banner tone="error" title="Action failed">{lifecycleError}</Banner>}
 
       <div className="grid min-h-0 flex-1 items-stretch gap-4 xl:grid-cols-[minmax(0,1fr)_19rem]">
         <section data-testid="mind-chat" aria-label="Persistent mind chat" className="flex h-[68dvh] min-h-[30rem] flex-col overflow-hidden rounded-[1.5rem] border border-port-border bg-port-card shadow-lg shadow-black/10 sm:min-h-[34rem] xl:h-full xl:min-h-0">

--- a/client/src/components/cos/tabs/MindTab.test.jsx
+++ b/client/src/components/cos/tabs/MindTab.test.jsx
@@ -183,6 +183,23 @@ describe('MindTab', () => {
     expect(within(screen.getByTestId('mind-chat')).getByLabelText('Message')).toBeInTheDocument();
   });
 
+  it('fills remaining desktop height and auto-grows the composer', async () => {
+    renderTab();
+    await screen.findByText('Review the next bounded slice.');
+
+    const chat = screen.getByTestId('mind-chat');
+    expect(chat.className).toContain('xl:h-full');
+    expect(chat.className).toContain('xl:min-h-0');
+    expect(chat.className).not.toMatch(/h-\[68dvh\]/);
+    expect(chat.className).not.toMatch(/max-h-\[54rem\]/);
+
+    const message = within(chat).getByLabelText('Message');
+    expect(message.tagName).toBe('TEXTAREA');
+    expect(message).toHaveClass('resize-none');
+    expect(message).toHaveClass('overflow-hidden');
+    expect(message.className).not.toMatch(/resize-y/);
+  });
+
   it('keeps annotations in message details instead of the primary composer', async () => {
     const user = userEvent.setup();
     renderTab('/cos/mind?event=mind-message%3Amessage-1');
@@ -432,7 +449,7 @@ describe('MindTab', () => {
     expect(api.sendPersistentMindMessage.mock.calls[1][0].id).toBe(firstId);
   });
 
-  it('sends on Enter while preserving a newline for Option+Enter', async () => {
+  it('sends on Enter while preserving a newline for Option+Enter and Shift+Enter', async () => {
     const user = userEvent.setup();
     renderTab();
     await screen.findByText('Review the next bounded slice.');
@@ -442,6 +459,11 @@ describe('MindTab', () => {
     const optionEnter = createEvent.keyDown(message, { key: 'Enter', altKey: true });
     fireEvent(message, optionEnter);
     expect(optionEnter.defaultPrevented).toBe(false);
+    expect(api.sendPersistentMindMessage).not.toHaveBeenCalled();
+
+    const shiftEnter = createEvent.keyDown(message, { key: 'Enter', shiftKey: true });
+    fireEvent(message, shiftEnter);
+    expect(shiftEnter.defaultPrevented).toBe(false);
     expect(api.sendPersistentMindMessage).not.toHaveBeenCalled();
 
     await user.clear(message);

--- a/client/src/components/cos/tabs/MindTab.test.jsx
+++ b/client/src/components/cos/tabs/MindTab.test.jsx
@@ -188,9 +188,11 @@ describe('MindTab', () => {
     await screen.findByText('Review the next bounded slice.');
 
     const chat = screen.getByTestId('mind-chat');
+    // Desktop fills the leftover column height; narrower viewports keep the
+    // dvh-relative box, and neither is capped by the old 54rem ceiling.
     expect(chat.className).toContain('xl:h-full');
     expect(chat.className).toContain('xl:min-h-0');
-    expect(chat.className).not.toMatch(/h-\[68dvh\]/);
+    expect(chat.className).toContain('h-[68dvh]');
     expect(chat.className).not.toMatch(/max-h-\[54rem\]/);
 
     const message = within(chat).getByLabelText('Message');

--- a/client/src/components/cos/tabs/MindTab.test.jsx
+++ b/client/src/components/cos/tabs/MindTab.test.jsx
@@ -195,10 +195,10 @@ describe('MindTab', () => {
     expect(chat.className).toContain('h-[68dvh]');
     expect(chat.className).not.toMatch(/max-h-\[54rem\]/);
 
+    // AutoSizeTextarea sets the height from content, so the composer must not
+    // be a hand-resized fixed box any more.
     const message = within(chat).getByLabelText('Message');
-    expect(message.tagName).toBe('TEXTAREA');
     expect(message).toHaveClass('resize-none');
-    expect(message).toHaveClass('overflow-hidden');
     expect(message.className).not.toMatch(/resize-y/);
   });
 

--- a/client/src/pages/ChiefOfStaff.jsx
+++ b/client/src/pages/ChiefOfStaff.jsx
@@ -1129,11 +1129,13 @@ export default function ChiefOfStaff() {
         </div>
       )}
 
-      {/* Content Panel */}
-      <div className="flex-1 min-h-0 min-w-0 overflow-y-auto overflow-x-hidden p-3 lg:p-4">
+      {/* Content Panel. Flex column so the Mind tab can fill leftover height
+          on desktop (its chat pane owns the internal scroll); other tabs still
+          grow this region and scroll here as before. */}
+      <div className="flex flex-1 min-h-0 min-w-0 flex-col overflow-y-auto overflow-x-hidden p-3 lg:p-4">
         {/* Stats Bar - hidden for SVG/canvas modes (now integrated into CoS sidebar);
             ascii/terminal mode keeps it because TerminalCoSPanel doesn't host the cards. */}
-        <div className={`grid grid-cols-3 gap-1.5 sm:grid-cols-5 sm:gap-2 lg:gap-3 mb-3 sm:mb-4 lg:mb-6 ${avatarStyle !== 'ascii' ? 'hidden' : ''}`}>
+        <div className={`grid shrink-0 grid-cols-3 gap-1.5 sm:grid-cols-5 sm:gap-2 lg:gap-3 mb-3 sm:mb-4 lg:mb-6 ${avatarStyle !== 'ascii' ? 'hidden' : ''}`}>
           <StatCard
             label="Active"
             value={activeAgentCount}
@@ -1168,7 +1170,7 @@ export default function ChiefOfStaff() {
         </div>
 
         {/* Tabs - scrollable with arrow navigation */}
-        <div className="relative mb-4 lg:mb-6">
+        <div className="relative mb-4 shrink-0 lg:mb-6">
           {/* Left scroll button */}
           {canScrollLeft && (
             <button
@@ -1243,7 +1245,7 @@ export default function ChiefOfStaff() {
           </div>
         )}
         {activeTab === 'mind' && (
-          <div role="tabpanel" id="tabpanel-mind" aria-labelledby="tab-mind">
+          <div role="tabpanel" id="tabpanel-mind" aria-labelledby="tab-mind" className="flex min-h-0 flex-col xl:flex-1">
             <Suspense fallback={<TabLoadFallback label="mind" />}>
               <MindTab />
             </Suspense>

--- a/client/src/pages/ChiefOfStaff.test.jsx
+++ b/client/src/pages/ChiefOfStaff.test.jsx
@@ -73,6 +73,9 @@ vi.mock('../components/cos/MiniCharacterCoSAvatar', () => ({
     />
   ),
 }));
+vi.mock('../components/cos/tabs/MindTab', () => ({
+  default: () => <div data-testid="mind-tab">Mind</div>,
+}));
 
 const { default: ChiefOfStaff, SPEAKING_MS, LAZY_AVATARS, INLINE_RENDERED_AVATAR_STYLES } = await import('./ChiefOfStaff');
 const { AVATAR_STYLE_IDS } = await import('../lib/avatarStyles');
@@ -197,6 +200,17 @@ describe('ChiefOfStaff loading skeleton', () => {
     await act(async () => {
       releaseInsights({ insights: [] });
     });
+  });
+});
+
+describe('ChiefOfStaff mind tab layout', () => {
+  it('fills leftover desktop height so the chat can use the viewport', async () => {
+    const { container } = await renderSettledAt('mind');
+    const content = container.querySelector('.overflow-y-auto.overflow-x-hidden');
+    expect(content.className).toContain('flex-col');
+    const panel = document.getElementById('tabpanel-mind');
+    expect(panel.className).toContain('xl:flex-1');
+    expect(panel.className).toContain('min-h-0');
   });
 });
 


### PR DESCRIPTION
## Summary

The Persistent Mind page (`/cos/mind`) left a large band of empty space at the bottom on desktop, and its message box was a fixed single-line `resize-y` textarea that clipped anything longer than two lines behind an internal scrollbar.

**Viewport fill.** The chat pane was capped at `h-[68dvh]` with a hard `max-h-[54rem]` ceiling, so on a tall desktop it stopped well short of the available height. The tab now stretches into the leftover column height at `xl`: the CoS content panel became a flex column, the mind tabpanel takes `xl:flex-1`, and the chat pane switches to `xl:h-full` while its message list keeps owning the internal scroll. Below `xl` the pane keeps its original `h-[68dvh]` sizing, so narrow and tablet viewports are unchanged.

**Auto-growing composer.** The composer now uses the existing `AutoSizeTextarea` component — the same dynamic-height standard used elsewhere in the app — so the field grows with its content instead of scrolling inside a fixed box. It caps at `max-h-[40vh]` and scrolls past that. `Shift+Enter` now inserts a newline alongside the existing `Option+Enter`, which multi-line entry makes worth having.

No new helper or component was introduced — this reuses `AutoSizeTextarea` / `useAutoSizeTextarea`.

## Test plan

- `client` suite: **927 files / 11,338 tests passing**, no new failures.
- New coverage in `MindTab.test.jsx` pins the desktop fill (`xl:h-full`, no `54rem` ceiling), the retained `h-[68dvh]` for narrow viewports, the composer's non-resizable auto-grow behavior, and `Shift+Enter` producing a newline rather than sending.
- New coverage in `ChiefOfStaff.test.jsx` pins the content panel's flex column and the mind tabpanel's `xl:flex-1`, so the height chain can't silently regress.
- `npm run build --prefix client` succeeds.