### PR TITLE
feat: show live agent cards in active CoS tasks

### DIFF
--- a/client/src/components/cos/tabs/TaskItem.jsx
+++ b/client/src/components/cos/tabs/TaskItem.jsx
@@ -34,6 +34,7 @@ import { extractCosTaskType } from '../../../lib/cosTaskType';
 import InstancePicker from '../InstancePicker';
 import EffortSelect from '../EffortSelect';
 import RelaunchAgentModal from './RelaunchAgentModal';
+import AgentCard from './AgentCard';
 
 const statusIcons = {
   pending: <Clock size={16} aria-hidden="true" className="text-yellow-500" />,
@@ -141,7 +142,7 @@ function getSuccessRateStyle(rate) {
   return { bg: 'bg-port-error/15', text: 'text-port-error', label: 'low' };
 }
 
-export default function TaskItem({ task, agent = null, isSystem, spawning = false, selected = false, onRefresh, onTaskUnblocked, providers, providersLoaded, durations, dragHandleProps, apps, instances = null, onEditingChange }) {
+export default function TaskItem({ task, agent = null, liveOutput, isSystem, spawning = false, selected = false, onRefresh, onTaskUnblocked, providers, providersLoaded, durations, dragHandleProps, apps, instances = null, onEditingChange }) {
   // System tasks are persisted in COS-TASKS.md. Every task
   // mutation must name that source; otherwise the API's user-queue default
   // searches TASKS.md and reports the system task as missing.
@@ -391,6 +392,9 @@ export default function TaskItem({ task, agent = null, isSystem, spawning = fals
     onRefresh();
   };
 
+  const showAgent = agent?.status === 'running' && (task.status === 'in_progress' || spawning);
+  const TaskDetails = showAgent ? 'details' : 'div';
+
   return (
     <div
       id={taskRowId(task.id, taskSource)}
@@ -402,6 +406,10 @@ export default function TaskItem({ task, agent = null, isSystem, spawning = fals
           : requiresApproval ? 'border-yellow-500/50' : 'border-port-border'
       }`}
     >
+      {showAgent && <AgentCard agent={agent} liveOutput={liveOutput} durations={durations}
+        onRelaunch={() => setRelaunching(true)} />}
+      <TaskDetails className={showAgent ? 'mt-3' : undefined}>
+        {showAgent && <summary className="cursor-pointer text-sm text-gray-400">Task details and actions</summary>}
       {/* The icon rail and the task body cannot share a row on a phone: up to
           five 44px targets leave the body ~120px wide, so the task id breaks a
           few characters per line and every badge lands on its own row. The
@@ -836,6 +844,8 @@ export default function TaskItem({ task, agent = null, isSystem, spawning = fals
           )}
         </div>
       </div>
+
+      </TaskDetails>
 
       {relaunching && agent && (
         <RelaunchAgentModal

--- a/client/src/components/cos/tabs/TasksTab.jsx
+++ b/client/src/components/cos/tabs/TasksTab.jsx
@@ -38,7 +38,7 @@ function SectionGlyph({ status }) {
   return <MicroGlyph variant={spec.variant} state={spec.state} animated={spec.animated} size={13} />;
 }
 
-export default function TasksTab({ tasks, agents = [], onRefresh, onTaskAdded, onTaskUnblocked, providers, providersLoaded, apps }) {
+export default function TasksTab({ tasks, agents = [], liveOutputs = {}, onRefresh, onTaskAdded, onTaskUnblocked, providers, providersLoaded, apps }) {
   const [searchParams] = useSearchParams();
   const [userTasksLocal, setUserTasksLocal] = useState([]);
   const [durations, setDurations] = useState(null);
@@ -282,7 +282,7 @@ export default function TasksTab({ tasks, agents = [], onRefresh, onTaskAdded, o
                 </div>
                 <div className="p-2 space-y-1.5">
                   {activeUserTasksLocal.map(task => (
-                    <TaskItem key={task.id} task={task} agent={runningAgentByTaskId.get(task.id)} spawning={isSpawning(task)} selected={isTaskSelected(task, 'user')} onRefresh={onRefresh} onTaskUnblocked={onTaskUnblocked} providers={providers} providersLoaded={providersLoaded} durations={durations} apps={apps} instances={assignableInstances} />
+                    <TaskItem key={task.id} task={task} agent={runningAgentByTaskId.get(task.id)} liveOutput={liveOutputs[runningAgentByTaskId.get(task.id)?.id]} spawning={isSpawning(task)} selected={isTaskSelected(task, 'user')} onRefresh={onRefresh} onTaskUnblocked={onTaskUnblocked} providers={providers} providersLoaded={providersLoaded} durations={durations} apps={apps} instances={assignableInstances} />
                   ))}
                 </div>
               </div>
@@ -372,7 +372,7 @@ export default function TasksTab({ tasks, agents = [], onRefresh, onTaskAdded, o
                 </div>
                 <div className="p-2 space-y-1.5">
                   {activeSystemTasks.map(task => (
-                    <TaskItem key={task.id} task={task} isSystem agent={runningAgentByTaskId.get(task.id)} spawning={isSpawning(task)} selected={isTaskSelected(task, 'internal')} onRefresh={onRefresh} onTaskUnblocked={onTaskUnblocked} providers={providers} providersLoaded={providersLoaded} durations={durations} apps={apps} instances={assignableInstances} />
+                    <TaskItem key={task.id} task={task} isSystem agent={runningAgentByTaskId.get(task.id)} liveOutput={liveOutputs[runningAgentByTaskId.get(task.id)?.id]} spawning={isSpawning(task)} selected={isTaskSelected(task, 'internal')} onRefresh={onRefresh} onTaskUnblocked={onTaskUnblocked} providers={providers} providersLoaded={providersLoaded} durations={durations} apps={apps} instances={assignableInstances} />
                   ))}
                 </div>
               </div>

--- a/client/src/components/cos/tabs/TasksTab.test.jsx
+++ b/client/src/components/cos/tabs/TasksTab.test.jsx
@@ -13,6 +13,7 @@ const toast = vi.hoisted(() => ({ success: vi.fn(), error: vi.fn() }));
 vi.mock('../../../services/api', () => api);
 vi.mock('../../ui/Toast', () => ({ default: toast }));
 // TaskAddForm pulls in provider/model plumbing not under test — stub it out.
+vi.mock('./AgentCard', () => ({ default: ({ agent, liveOutput }) => <div>Active agent {agent.id}{liveOutput?.map((entry, i) => <p key={i}>{entry.line}</p>)}</div> }));
 vi.mock('../TaskAddForm', () => ({ default: () => null }));
 
 const TasksTab = (await import('./TasksTab')).default;
@@ -74,11 +75,14 @@ describe('TasksTab spawning window', () => {
     renderTab({
       tasks: { user: { tasks: [pendingTask('task-spawning'), pendingTask('task-waiting')] }, cos: { tasks: [] } },
       agents: [{ id: 'agent-1', status: 'running', taskId: 'task-spawning' }],
+      liveOutputs: { 'agent-1': [{ line: 'Implementing the change' }] },
     });
 
     await waitFor(() => expect(screen.getByText(/^Pending \(/)).toBeInTheDocument());
     expect(screen.getByText('Pending (1)')).toBeInTheDocument();
     expect(screen.getByText('Active (1)')).toBeInTheDocument();
+    expect(screen.getByText(/Active agent agent-1/)).toBeInTheDocument();
+    expect(screen.getByText('Implementing the change')).toBeInTheDocument();
   });
 
   it('leaves a pending system task pending when its agent has already completed', async () => {
@@ -98,6 +102,7 @@ describe('TasksTab spawning window', () => {
     });
 
     await waitFor(() => expect(screen.getByText('Active (1)')).toBeInTheDocument());
+    fireEvent.click(screen.getByText('Task details and actions'));
     // An agent stuck at `running` (the zombie state cleanupZombieAgents clears)
     // would otherwise leave the row with no way to re-dispatch it. Duplicate
     // dispatch is refused server-side by forceSpawnTask, not by hiding this.

--- a/client/src/pages/ChiefOfStaff.jsx
+++ b/client/src/pages/ChiefOfStaff.jsx
@@ -1213,7 +1213,7 @@ export default function ChiefOfStaff() {
         {activeTab === 'tasks' && (
           <div role="tabpanel" id="tabpanel-tasks" aria-labelledby="tab-tasks">
             <ActionableInsightsBanner insights={insights} onTaskUnblocked={handleTaskUnblocked} onRefresh={fetchData} />
-            <TasksTab tasks={tasks} agents={agents} onRefresh={fetchData} onTaskAdded={handleUserTaskAdded} onTaskUnblocked={handleTaskUnblocked} providers={providers} providersLoaded={providersLoaded} apps={apps} />
+            <TasksTab tasks={tasks} agents={agents} liveOutputs={liveOutputs} onRefresh={fetchData} onTaskAdded={handleUserTaskAdded} onTaskUnblocked={handleTaskUnblocked} providers={providers} providersLoaded={providersLoaded} apps={apps} />
           </div>
         )}
         {activeTab === 'agents' && (


### PR DESCRIPTION
## Summary
Active user and system tasks now render the shared CoS AgentCard with live output and provider/model relaunch. Existing task controls remain available in an expandable details section; tasks without a running agent keep their existing presentation.

Assumes the requested loading card refers to the active task card on CoS Tasks, since no page or screenshot was attached.

## Test plan
- 93 focused tests passed across TasksTab, TaskItem, and AgentCard.
- Added coverage for rendering the running agent and live output during the pending-to-running transition, retaining recovery actions.
- Client production build and changed-file Biome lint passed.
