### PR TITLE
feat: turn app quality into a full-width audit dashboard

### DIFF
--- a/client/src/components/apps/AppQuality.jsx
+++ b/client/src/components/apps/AppQuality.jsx
@@ -1,3 +1,4 @@
+import AppQualityRunner from './AppQualityRunner';
 import AppQualityHistory from './AppQualityHistory';
 import { Link } from 'react-router';
 import { formatDateShort } from '../../utils/formatters';
@@ -36,22 +37,26 @@ export default function AppQuality({ app, detail = false }) {
             : 'No audit assessment has been saved. Completed maintenance tasks only supply a score when they return a valid quality report. Earlier runs are not scored retroactively; run a scheduled audit to collect an assessment.'}
         </p>
       )}
-      <Link to={`/apps/${app.id}/tasks`} className="inline-block text-sm text-port-accent hover:underline">Configure or run scheduled audits</Link>
-      <AppQualityHistory appId={app.id} categories={quality?.categories} />
+      <div className="flex flex-wrap gap-4 text-sm text-port-accent"><Link to="/cos/schedule" className="hover:underline">Scheduled audit runners</Link><Link to="/cos/agents" className="hover:underline">View agents</Link></div>
+      <div className="grid grid-cols-1 xl:grid-cols-2 gap-5 items-start">
+      <div className="min-w-0 space-y-4">
+        <AppQualityHistory appId={app.id} categories={quality?.categories} />
+        <AppQualityRunner key={app.id} app={app} />
+      </div>
       {!!quality?.categories?.length && (
-        <details>
-          <summary className="cursor-pointer text-sm text-port-accent">Category breakdown</summary>
-          <div className="overflow-x-auto">
+        <section aria-label="Category breakdown" className="min-w-0">
+          <h4 className="text-sm font-medium mb-2">Category breakdown</h4>
+          <div className="overflow-auto xl:max-h-[calc(100vh-19rem)]">
           <table className="w-full text-sm text-left">
-            <thead className="text-gray-400"><tr><th className="py-2 pr-3">Category</th><th className="pr-3">Score</th><th>Evidence</th></tr></thead>
+            <thead className="text-gray-400 sticky top-0 bg-port-card"><tr><th className="py-2 pr-3">Category</th><th className="pr-3">Score</th><th>Evidence</th></tr></thead>
             <tbody>{quality.categories.map(category => (
               <tr key={category.id} className="border-t border-port-border align-top">
-                <th scope="row" className="py-2 pr-3 font-medium">{category.label}</th>
+                <th scope="row" className="py-2 pr-3 font-medium">{category.label}<Link className="block text-xs font-normal text-port-accent hover:underline" to={`/cos/schedule?task=${encodeURIComponent(category.id)}`} aria-label={`${category.label} runner`}>Runner settings</Link></th>
                 <td className="py-2 pr-3 whitespace-nowrap">{category.score == null ? '—' : `${category.score}/100`}</td>
                 <td className="py-2 text-xs text-gray-400">
                   <div>{category.stale ? 'Stale · ' : ''}{category.coverage}{category.confidence && ` · ${category.confidence} confidence`}
                     {category.assessedAt && ` · ${formatDateShort(category.assessedAt)}`}</div>
-                  {category.summary && <p className="mt-1 break-words">{category.summary}</p>}
+                  {category.summary && <details className="mt-1"><summary className="cursor-pointer text-port-accent">Assessment details</summary><p className="break-words">{category.summary}</p></details>}
                   {category.totalFiles > 0 && <div>{category.scannedFiles}/{category.totalFiles} files scanned · Worst severity: {category.worstSeverity}/10</div>}
                   {category.sourcePeerId && <div>Source: {category.sourcePeerName || 'federated peer'} · <Link className="text-port-accent hover:underline" to="/instances">View instances</Link></div>}
                   {!category.sourcePeerId && category.agentId && <Link className="text-port-accent hover:underline" to={`/cos/agents/${category.agentId}`}>Audit run</Link>}
@@ -60,8 +65,9 @@ export default function AppQuality({ app, detail = false }) {
             ))}</tbody>
           </table>
           </div>
-        </details>
+        </section>
       )}
+      </div>
     </section>
   );
 }

--- a/client/src/components/apps/AppQuality.test.jsx
+++ b/client/src/components/apps/AppQuality.test.jsx
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
 import { it, expect, vi } from 'vitest';
 import AppQuality from './AppQuality';
+vi.mock('./AppQualityRunner', () => ({ default: () => <div>Runner</div> }));
 vi.mock('../../services/apiApps', () => ({ getAppQualityHistory: vi.fn().mockResolvedValue({ points: [], totalCategories: 25 }) }));
 
 it('shows zero as a real score and explains excluded categories in the breakdown', async () => {
@@ -14,7 +15,7 @@ it('shows zero as a real score and explains excluded categories in the breakdown
   expect(screen.getByRole('heading', { name: 'Quality: 0/100' })).toBeInTheDocument();
   expect(screen.getByText('Stale · partial')).toBeInTheDocument();
   expect(screen.getByText(/1\/25 categories contribute/)).toBeInTheDocument();
-  expect(screen.getByRole('link', { name: /Configure/ })).toHaveAttribute('href', '/apps/portos-default/tasks');
+  expect(screen.getByRole('link', { name: /Scheduled audit runners/ })).toHaveAttribute('href', '/cos/schedule');
 });
 
 it('links an unassessed tile to its app quality tab without inventing a score', () => {
@@ -26,7 +27,7 @@ it('explains why completed maintenance can still have no saved assessment', asyn
   render(<MemoryRouter><AppQuality app={{ id: 'example', quality: { score: null, categories: [] } }} detail /></MemoryRouter>);
   await screen.findByText(/No scored assessments/);
   expect(screen.getByText(/Earlier runs are not scored retroactively/)).toBeInTheDocument();
-  expect(screen.getByRole('link', { name: /Configure or run scheduled audits/ })).toHaveAttribute('href', '/apps/example/tasks');
+  expect(screen.getByRole('link', { name: /Scheduled audit runners/ })).toHaveAttribute('href', '/cos/schedule');
 });
 
 it('distinguishes saved but excluded evidence from an app that was never assessed', async () => {

--- a/client/src/components/apps/AppQualityHistory.jsx
+++ b/client/src/components/apps/AppQualityHistory.jsx
@@ -34,10 +34,10 @@ export default function AppQualityHistory({ appId, categories = [] }) {
     <div className="space-y-3">
       <h4 className="text-sm font-medium">Quality over time</h4>
       <div className="flex flex-wrap gap-3 text-sm">
-        <label>Period <select className="bg-port-bg border border-port-border rounded p-1" value={days} onChange={e => change('qualityDays', e.target.value)}>
+        <label htmlFor="quality-period">Period <select id="quality-period" className="bg-port-bg border border-port-border rounded p-1" value={days} onChange={e => change('qualityDays', e.target.value)}>
           <option value="30">30 days</option><option value="90">90 days</option><option value="365">1 year</option>
         </select></label>
-        <label>Category <select className="bg-port-bg border border-port-border rounded p-1 max-w-full" value={category} onChange={e => change('qualityCategory', e.target.value)}>
+        <label htmlFor="quality-history-category" className="min-w-0">Category <select id="quality-history-category" className="bg-port-bg border border-port-border rounded p-1 max-w-full" value={category} onChange={e => change('qualityCategory', e.target.value)}>
           <option value="overall">Overall</option>{categories.map(c => <option key={c.id} value={c.id}>{c.label}</option>)}
         </select></label>
         <button type="button" className="text-port-accent hover:underline" onClick={() => setRefresh(n => n + 1)}>Refresh history</button>
@@ -45,7 +45,7 @@ export default function AppQualityHistory({ appId, categories = [] }) {
       <p className="text-xs text-gray-400">Daily snapshots (UTC), higher is healthier. Scores carry forward for up to 30 days; gaps mean no fresh evidence. Coverage changes can move the overall mean. Category views include provisional assessments.</p>
       {state.data?.federation && <p className="text-xs text-gray-400">Unified history includes {state.data.federation.available ?? 0} available full-sync peers. {state.data.federation.failed ? 'Peer quality could not be loaded; history may be incomplete.' : state.data.federation.unavailable > 0 ? `${state.data.federation.unavailable} peers unavailable or incompatible; history may be incomplete.` : 'Peer availability can change historical coverage.'}</p>}
       {state.loading ? <p role="status">Loading quality history…</p> : state.error ? <p role="alert">Quality history could not be loaded. Use Refresh history to retry.</p> : !measured.length ? <p className="text-sm text-gray-400">No scored assessments in this period. Run an audit to start the history.</p> : <>
-        <div className="h-56 w-full" role="img" aria-label="Daily quality scores from 0 to 100; values and evidence are available in the history table below">
+        <div className="h-48 w-full" role="img" aria-label="Daily quality scores from 0 to 100; values and evidence are available in the history table below">
           <ResponsiveContainer width="100%" height="100%">
             <LineChart data={points} margin={{ top: 8, right: 12, bottom: 8, left: 0 }}>
               <CartesianGrid strokeDasharray="3 3" stroke="#374151" />

--- a/client/src/components/apps/AppQualityRunner.jsx
+++ b/client/src/components/apps/AppQualityRunner.jsx
@@ -1,0 +1,89 @@
+import { useCallback, useRef, useState } from 'react';
+import { Link, useSearchParams } from 'react-router';
+import ProviderModelSelector from '../ProviderModelSelector';
+import MaintenanceRunStatus from '../cos/tabs/schedule/MaintenanceRunStatus';
+import useProviderModels from '../../hooks/useProviderModels';
+import { useAutoRefetch } from '../../hooks/useAutoRefetch';
+import { isProcessProvider } from '../../utils/providers';
+import { familyForProvider } from '../../../../server/lib/providerFamilies';
+import { getMaintenanceRuns, startMaintenanceRun, stopMaintenanceRun } from '../../services/apiAgents';
+
+const eligibleProvider = provider => provider.enabled && isProcessProvider(provider) && familyForProvider(provider);
+const needsCheck = category => category.score == null || category.stale || category.coverage !== 'broad' || category.confidence === 'low';
+
+export default function AppQualityRunner({ app }) {
+  const categories = app.quality?.categories || [];
+  const [params, setParams] = useSearchParams();
+  const requested = params.get('qualityCheck');
+  const selection = requested === 'all' || categories.some(category => category.id === requested) ? requested : 'missing';
+  const setSelection = value => setParams(previous => {
+    const next = new URLSearchParams(previous);
+    next.set('qualityCheck', value);
+    return next;
+  });
+  const [mode, setMode] = useState('file-issues');
+  const [effort, setEffort] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState('');
+  const [run, setRun] = useState(null);
+  const [loaded, setLoaded] = useState(false);
+  const revision = useRef(0);
+  const picker = useProviderModels({ filter: eligibleProvider, withEffort: true });
+  const taskTypes = categories.filter(category => selection === 'all' || (selection === 'missing' ? needsCheck(category) : category.id === selection)).map(category => category.id);
+  const loadRuns = useCallback(async () => {
+    const requestedRevision = revision.current;
+    const response = await getMaintenanceRuns({ silent: true }).catch(() => null);
+    if (!response || requestedRevision !== revision.current) return;
+    setRun(response.runs.find(entry => entry.appId === app.id) || null);
+    setLoaded(true);
+  }, [app.id]);
+  useAutoRefetch(loadRuns, 15000, { enabled: !busy, immediate: !loaded, pollOnly: true });
+  const start = async () => {
+    revision.current += 1;
+    setBusy(true);
+    setError('');
+    const response = await startMaintenanceRun({ appId: app.id, providerId: picker.selectedProviderId, model: picker.selectedModel,
+      effort: effort || null, mode, claimBetweenAudits: false, taskTypes }, { silent: true }).catch(err => { setError(err.message); return null; });
+    if (response) setRun(response.run);
+    setBusy(false);
+  };
+  const stop = async () => {
+    revision.current += 1;
+    setBusy(true);
+    setError('');
+    const response = await stopMaintenanceRun(run.id, { silent: true }).catch(err => { setError(err.message); return null; });
+    if (response) setRun(response.run);
+    setBusy(false);
+  };
+  return <section aria-label="Run quality checks" className="border-t border-port-border pt-3 space-y-3">
+    <h4 className="font-medium">Run quality checks</h4>
+    <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 text-sm">
+      <label htmlFor="quality-checks">Checks
+        <select id="quality-checks" className="block w-full bg-port-bg border border-port-border rounded p-2" value={selection} disabled={busy} onChange={event => setSelection(event.target.value)}>
+          <option value="missing">Missing or outdated evidence</option><option value="all">All categories</option>
+          {categories.map(category => <option key={category.id} value={category.id}>{category.label}</option>)}
+        </select>
+      </label>
+      <label htmlFor="quality-mode">Mode
+        <select id="quality-mode" className="block w-full bg-port-bg border border-port-border rounded p-2" value={mode} disabled={busy} onChange={event => setMode(event.target.value)}>
+          <option value="file-issues">File issues</option><option value="fix">Audit and fix</option>
+        </select>
+      </label>
+    </div>
+    <ProviderModelSelector providers={picker.providers} selectedProviderId={picker.selectedProviderId} selectedModel={picker.selectedModel}
+      availableModels={picker.availableModels} onProviderChange={value => { picker.setSelectedProviderId(value); setEffort(''); }}
+      onModelChange={picker.setSelectedModel} effort={effort} onEffortChange={setEffort} loading={picker.loading} disabled={busy}
+      emptyProviderOption="Select a subscription provider" emptyModelOption="Select a model" highlightToolUse />
+    <p className="text-xs text-gray-400">{taskTypes.length} scheduled agents, run sequentially with these overrides. {mode === 'fix' ? 'Each selected audit can change code and open a PR.' : 'Findings become issues; no fixes or backlog claim jobs.'} Existing task enablement and Improve settings apply.</p>
+    <details className="text-xs"><summary className="cursor-pointer text-port-accent">Selected checks ({taskTypes.length})</summary><p className="mt-1">{categories.filter(category => taskTypes.includes(category.id)).map(category => category.label).join(', ') || 'All categories have qualifying evidence.'}</p></details>
+    <button type="button" onClick={start} disabled={busy || !loaded || picker.loading || !picker.selectedProviderId || !picker.selectedModel || !taskTypes.length || run?.status === 'running' || app.quality?.unavailable}
+      className="px-3 py-2 rounded bg-port-accent text-port-bg text-sm font-medium disabled:opacity-50">Run {taskTypes.length} checks now</button>
+    {!loaded && <p className="text-xs" role="status">Loading runner status… <button type="button" className="text-port-accent" onClick={loadRuns}>Retry</button></p>}
+    {error && <p role="alert" className="text-sm text-port-error">{error}</p>}
+    {run && <div className="space-y-2">
+      <MaintenanceRunStatus run={run} />
+      {run.reason && <p className="text-xs break-words">{run.reason} <Link className="text-port-accent underline" to="/cos/schedule">Open runner settings</Link></p>}
+      {run.status === 'running' && <button type="button" className="text-xs text-port-accent" disabled={busy} onClick={stop}>Stop remaining checks</button>}
+    </div>}
+  </section>;
+}

--- a/client/src/components/apps/AppQualityRunner.test.jsx
+++ b/client/src/components/apps/AppQualityRunner.test.jsx
@@ -1,0 +1,37 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { beforeEach, expect, it, vi } from 'vitest';
+import AppQualityRunner from './AppQualityRunner';
+import { getMaintenanceRuns, startMaintenanceRun } from '../../services/apiAgents';
+vi.mock('../../services/apiAgents', () => ({ getMaintenanceRuns: vi.fn(), startMaintenanceRun: vi.fn(), stopMaintenanceRun: vi.fn() }));
+vi.mock('../../hooks/useProviderModels', () => ({ default: () => ({ providers: [], selectedProviderId: 'codex', selectedModel: 'gpt-5', availableModels: [], loading: false }) }));
+vi.mock('../ProviderModelSelector', () => ({ default: ({ onEffortChange }) => <button onClick={() => onEffortChange('high')}>Use high effort</button> }));
+const app = { id: 'app-1', quality: { categories: [
+  { id: 'security', label: 'Security', score: null },
+  { id: 'performance', label: 'Performance', score: 80, coverage: 'broad', confidence: 'high' },
+  { id: 'ux', label: 'UX', score: 70, coverage: 'broad', confidence: 'high', stale: true },
+] } };
+beforeEach(() => { vi.clearAllMocks(); getMaintenanceRuns.mockResolvedValue({ runs: [] }); });
+it('launches missing checks with visible mode and effort, then exposes held runner status', async () => {
+  startMaintenanceRun.mockResolvedValue({ run: { id: 'run-1', status: 'running', reason: 'Enable security in Schedule', steps: [] } });
+  render(<MemoryRouter><AppQualityRunner app={app} /></MemoryRouter>);
+  const button = screen.getByRole('button', { name: 'Run 2 checks now' });
+  await waitFor(() => expect(button).toBeEnabled());
+  fireEvent.change(screen.getByLabelText('Mode'), { target: { value: 'fix' } });
+  fireEvent.click(screen.getByText('Use high effort'));
+  fireEvent.click(button);
+  await screen.findByRole('link', { name: 'Open runner settings' });
+  expect(startMaintenanceRun).toHaveBeenCalledWith({ appId: 'app-1', providerId: 'codex', model: 'gpt-5', effort: 'high', mode: 'fix', claimBetweenAudits: false, taskTypes: ['security', 'ux'] }, { silent: true });
+  expect(button).toBeDisabled();
+});
+it('allows one category and recovers from launch failure without reporting a run', async () => {
+  startMaintenanceRun.mockRejectedValue(new Error('Provider unavailable'));
+  render(<MemoryRouter><AppQualityRunner app={app} /></MemoryRouter>);
+  fireEvent.change(screen.getByLabelText('Checks'), { target: { value: 'performance' } });
+  const button = screen.getByRole('button', { name: 'Run 1 checks now' });
+  await waitFor(() => expect(button).toBeEnabled());
+  fireEvent.click(button);
+  expect(await screen.findByRole('alert')).toHaveTextContent('Provider unavailable');
+  expect(button).toBeEnabled();
+  expect(startMaintenanceRun.mock.calls[0][0]).toMatchObject({ mode: 'file-issues', taskTypes: ['performance'] });
+});

--- a/client/src/components/apps/tabs/QualityTab.jsx
+++ b/client/src/components/apps/tabs/QualityTab.jsx
@@ -2,7 +2,7 @@ import AppQuality from '../AppQuality';
 
 export default function QualityTab({ app }) {
   return (
-    <div className="max-w-5xl">
+    <div className="w-full min-w-0">
       <AppQuality app={app} detail />
     </div>
   );

--- a/client/src/components/settings/VoiceTab.test.jsx
+++ b/client/src/components/settings/VoiceTab.test.jsx
@@ -91,7 +91,9 @@ describe('VoiceTab TTS engine registry', () => {
     expect(engineSelect).toHaveValue('qwen3-tts');
     expect(screen.getByRole('option', { name: 'Qwen3-TTS (Voice design, cloning, and streaming)' })).toBeTruthy();
 
-    fireEvent.change(await screen.findByRole('combobox', { name: 'Voice' }), {
+    // The selector mounts before its async voice catalog has loaded.
+    await screen.findByRole('option', { name: /Expressive Alto/ });
+    fireEvent.change(screen.getByRole('combobox', { name: 'Voice' }), {
       target: { value: 'expressive-alto' },
     });
     fireEvent.click(screen.getByRole('button', { name: 'Save & Reconcile' }));

--- a/client/src/services/apiAgents.js
+++ b/client/src/services/apiAgents.js
@@ -308,9 +308,9 @@ export const updateCosTaskInterval = (taskType, settings, options = {}) => reque
 // Manual maintenance runs — the Schedule tab's "Run maintenance now" (server:
 // services/maintenanceRun.js).
 export const getMaintenanceRuns = (options) => request('/cos/schedule/maintenance-runs', options);
-export const startMaintenanceRun = ({ appId, providerId, model, effort = null, mode = 'file-issues', claimBetweenAudits = true, claimHandler }, options = {}) => request('/cos/schedule/maintenance-runs', {
+export const startMaintenanceRun = ({ appId, providerId, model, effort = null, mode = 'file-issues', claimBetweenAudits = true, claimHandler, taskTypes }, options = {}) => request('/cos/schedule/maintenance-runs', {
   method: 'POST',
-  body: JSON.stringify({ appId, providerId, model, effort, mode, claimBetweenAudits, claimHandler }),
+  body: JSON.stringify({ appId, providerId, model, effort, mode, claimBetweenAudits, claimHandler, taskTypes }),
   ...options
 });
 export const stopMaintenanceRun = (id, options = {}) => request(`/cos/schedule/maintenance-runs/${id}/stop`, { method: 'POST', ...options });

--- a/server/lib/maintenanceSequence.js
+++ b/server/lib/maintenanceSequence.js
@@ -18,6 +18,8 @@
  * either runner without knowing which one asked.
  */
 
+import { AUDIT_DEFINITIONS } from './auditCatalog.js';
+
 /** The audits, in the order they should run. */
 export const MAINTENANCE_TASK_ORDER = Object.freeze([
   'better-structural-drift', 'simplify', 'module-hygiene', 'better-complexity',
@@ -54,8 +56,12 @@ export const maintenanceStepParams = (taskType, mode = 'file-issues') => (taskTy
  * invocation yields fresh step identities. An optional claimHandler replaces
  * the provider/model/effort bundle for drains only; omitted keeps legacy pins.
  */
-export function buildMaintenanceSteps({ appId, idPrefix, providerId = null, model = null, effort = null, mode = 'file-issues', claimBetweenAudits = true, claimHandler = null }) {
-  const types = mode === 'fix' ? [...MAINTENANCE_TASK_ORDER, MAINTENANCE_DRAIN_TASK] : claimBetweenAudits ? MAINTENANCE_SEQUENCE_TYPES : MAINTENANCE_TASK_ORDER;
+export function buildMaintenanceSteps({ appId, idPrefix, providerId = null, model = null, effort = null, mode = 'file-issues', claimBetweenAudits = true, claimHandler = null, taskTypes = null }) {
+  if (taskTypes !== null && (!Array.isArray(taskTypes) || !taskTypes.length || taskTypes.some(type => !Object.hasOwn(AUDIT_DEFINITIONS, type)))) {
+    throw new Error('Quality checks must name known audit categories');
+  }
+  // An explicit quality selection runs only those audits, without backlog drains.
+  const types = taskTypes ? [...new Set(taskTypes)] : mode === 'fix' ? [...MAINTENANCE_TASK_ORDER, MAINTENANCE_DRAIN_TASK] : claimBetweenAudits ? MAINTENANCE_SEQUENCE_TYPES : MAINTENANCE_TASK_ORDER;
   return types.map((taskType, index) => ({
     id: `${idPrefix}-${index}`,
     enabled: true,
@@ -64,6 +70,6 @@ export function buildMaintenanceSteps({ appId, idPrefix, providerId = null, mode
     jobType: null,
     runOnce: true,
     drain: taskType === MAINTENANCE_DRAIN_TASK,
-    overrides: { ...(taskType === MAINTENANCE_DRAIN_TASK && claimHandler ? claimHandler : { providerId, model, effort }), params: maintenanceStepParams(taskType, mode) },
+    overrides: { ...(taskType === MAINTENANCE_DRAIN_TASK && claimHandler ? claimHandler : { providerId, model, effort }), params: taskTypes ? { fileIssues: mode !== 'fix', ...(mode === 'fix' ? { useWorktree: true, openPR: true } : {}) } : maintenanceStepParams(taskType, mode) },
   }));
 }

--- a/server/routes/cosScheduleRoutes.js
+++ b/server/routes/cosScheduleRoutes.js
@@ -1,3 +1,4 @@
+import { AUDIT_DEFINITIONS } from '../lib/auditCatalog.js';
 /**
  * CoS Task Schedule Routes
  */
@@ -35,6 +36,7 @@ const suggestedAfterSchema = z.array(z.string()).max(SUGGESTED_AFTER_MAX);
 // model up front (AGENTS.md AI-policy: the click IS the consent). Blank effort
 // inherits each scheduled task's saved effort.
 const maintenanceRunStartSchema = z.object({
+  taskTypes: z.array(z.enum(Object.keys(AUDIT_DEFINITIONS))).min(1).max(Object.keys(AUDIT_DEFINITIONS).length).optional(),
   mode: z.enum(['file-issues', 'fix']).optional(),
   claimBetweenAudits: z.boolean().optional(),
   claimHandler: z.object({

--- a/server/routes/cosScheduleRoutes.test.js
+++ b/server/routes/cosScheduleRoutes.test.js
@@ -93,6 +93,10 @@ describe('CoS Schedule Routes', () => {
       expect(maintenance.startMaintenanceRun).toHaveBeenCalledWith(body);
       expect((await request(app).post('/api/cos/schedule/maintenance-runs').send({ ...body, claimHandler: { providerId: 'claude' } })).status).toBe(400);
       expect((await request(app).post('/api/cos/schedule/maintenance-runs').send({ ...body, mode: 'unknown' })).status).toBe(400);
+      for (const taskTypes of [[], ['claim-issue'], ['unknown']]) {
+        expect((await request(app).post('/api/cos/schedule/maintenance-runs').send({ ...body, taskTypes })).status).toBe(400);
+      }
+      expect((await request(app).post('/api/cos/schedule/maintenance-runs').send({ ...body, taskTypes: ['security'] })).status).toBe(201);
       expect((await request(app).post('/api/cos/schedule/maintenance-runs').send({ ...body, claimBetweenAudits: 'false' })).status).toBe(400);
     });
     it('starts a run from a validated body and reports the first dispatch', async () => {

--- a/server/services/maintenanceRun.js
+++ b/server/services/maintenanceRun.js
@@ -138,7 +138,7 @@ async function assertNoRunningRun(appId) {
  * The first evaluation runs before this returns, so the caller learns whether
  * step one actually went out (or why it is holding) in the same response.
  */
-export async function startMaintenanceRun({ appId, providerId, model = null, effort = null, mode = 'file-issues', claimBetweenAudits = true, claimHandler = null }) {
+export async function startMaintenanceRun({ appId, providerId, model = null, effort = null, mode = 'file-issues', claimBetweenAudits = true, claimHandler = null, taskTypes = null }) {
   const [{ getAppById }, { getProviderById }, { resolveBurnProvider }] = await Promise.all([
     import('./apps.js'), import('./providers.js'), import('./scheduledHandlers/providerPick.js'),
   ]);
@@ -148,7 +148,7 @@ export async function startMaintenanceRun({ appId, providerId, model = null, eff
   const pinned = familyId ? await resolveBurnProvider({ job: { providerId }, family: { id: familyId } }) : null;
   if (!pinned) throw new ServerError(`provider "${providerId}" is not an enabled subscription CLI/TUI provider`, { status: 400, code: 'MAINTENANCE_RUN_PROVIDER_UNAVAILABLE' });
   // File-only runs never validate or retain a hidden claim selection.
-  const effectiveClaimHandler = mode === 'fix' || claimBetweenAudits ? claimHandler : null;
+  const effectiveClaimHandler = !taskTypes && (mode === 'fix' || claimBetweenAudits) ? claimHandler : null;
   let claimFamilyId = familyId;
   if (effectiveClaimHandler) {
     claimFamilyId = familyForProvider(await getProviderById(effectiveClaimHandler.providerId));
@@ -163,7 +163,7 @@ export async function startMaintenanceRun({ appId, providerId, model = null, eff
   const run = await insertRun({
     id, appId, familyId, claimFamilyId, ...pins,
     status: MAINTENANCE_RUN_STATUS.RUNNING,
-    steps: buildMaintenanceSteps({ appId, idPrefix: id, ...pins, mode, claimBetweenAudits, claimHandler: effectiveClaimHandler }),
+    steps: buildMaintenanceSteps({ appId, idPrefix: id, ...pins, mode, claimBetweenAudits, claimHandler: effectiveClaimHandler, taskTypes }),
     completed: {},
     active: null,
     reason: null,

--- a/server/services/maintenanceRun.test.js
+++ b/server/services/maintenanceRun.test.js
@@ -52,6 +52,19 @@ beforeEach(async () => {
 afterAll(cleanup);
 
 describe('manual maintenance run', () => {
+  it.each(['file-issues', 'fix'])('runs only selected quality checks in %s mode with pinned overrides', async (mode) => {
+    const { run } = await startMaintenanceRun({ appId: 'app-1', providerId: 'codex', model: 'gpt-5', effort: 'high', mode, taskTypes: ['security', 'documentation'] });
+    expect(run.steps.map(step => step.taskRef.taskType)).toEqual(['security', 'documentation']);
+    for (const step of run.steps) {
+      expect(step.drain).toBe(false);
+      expect(step.overrides).toMatchObject({ providerId: 'codex', model: 'gpt-5', effort: 'high', params: { fileIssues: mode === 'file-issues' } });
+    }
+    await __onMaintenanceAgentCompleted(agentFor(run, 0));
+    await __onMaintenanceAgentCompleted(agentFor(run, 1));
+    expect(dispatchedTypes()).toEqual(['security', 'documentation']);
+    expect((await getMaintenanceRun(run.id)).status).toBe('completed');
+  });
+
   it('dispatches an edited stage through its own provider family', async () => {
     const { run } = await start();
     const { getProviderById } = await import('./providers.js');


### PR DESCRIPTION
## Summary
Use the full desktop width for the app Quality tab, placing the chart and audit controls beside an always-visible, scrollable category breakdown. Smaller screens stack naturally. Each category links directly to its scheduled runner settings, replacing the unhelpful app Tasks link.

Launch missing/outdated checks, all categories, or one category directly from the dashboard with issue-filing/fix mode and provider/model/effort overrides. Extend the existing maintenance runner with validated audit selections, preserving its status, stop controls and scheduling gates. Explicit selections run only those audits, without unrelated documentation or backlog claim passes; existing maintenance sequences remain compatible.

## Test plan
- 64 server route/service tests, including sequential selected-check dispatch in both modes and invalid selection rejection.
- 28 client tests covering launch overrides, held runs, failure recovery, existing maintenance forms and responsive/polling conventions.
- Changed client files pass Biome lint; production Vite build passes.
- Browser-rendered dashboard at 1440, 768 and 360 pixels: no horizontal overflow; desktop chart and breakdown start above the fold.

CI initially exposed a pre-existing VoiceTab test race twice: it selected a voice before the async option existed. The test now waits for the requested option; its three tests and the dashboard launch tests pass locally, and lint passes.

The required post-fix OpenCode local review was attempted using the configured Bedrock provider. It produced no review output or verdict in five minutes and was terminated. This review is unavailable, not approved; the PR must remain open until the required review returns a verdict.
