### PR TITLE
feat: show configured defaults in provider override controls

### DIFF
--- a/client/src/components/ProviderModelSelector.jsx
+++ b/client/src/components/ProviderModelSelector.jsx
@@ -156,16 +156,14 @@ export default function ProviderModelSelector({
   const visibleProviders = selectableProviders(providerList, { selectedId: selectedProviderId, allowed: providerAllowed });
   const compatibleModels = filterHardwareCompatibleProviderModels(availableModels, selectedProvider)
     .filter((model) => !modelAllowed || modelAllowed(model, selectedProvider));
-  const selectedModelIsUnavailable = Boolean(
-    selectedModel
-    && !isProviderModelHardwareCompatible(selectedProvider, selectedModel)
+  // Keep a configured default visible even when it is a CLI-default sentinel
+  // omitted from the browsable catalog, alongside unavailable saved pins.
+  const preserveSelectedModel = selectedModel && (
+    selectedModel === selectedProvider?.defaultModel
+    || !isProviderModelHardwareCompatible(selectedProvider, selectedModel)
+    || (modelAllowed && !modelAllowed(selectedModel, selectedProvider))
   );
-  const selectedModelIsDisallowed = Boolean(
-    selectedModel
-    && modelAllowed
-    && !modelAllowed(selectedModel, selectedProvider)
-  );
-  const modelOptions = (selectedModelIsUnavailable || selectedModelIsDisallowed)
+  const modelOptions = preserveSelectedModel
     && !compatibleModels.some((model) => modelOption(model)?.value === selectedModel)
     ? [selectedModel, ...compatibleModels]
     : compatibleModels;
@@ -221,7 +219,7 @@ export default function ProviderModelSelector({
               same broken control. */}
           {loading
             ? <option value="">Loading providers…</option>
-            : emptyProviderOption != null && <option value="">{emptyProviderOption}</option>}
+            : emptyProviderOption != null && <option value="">{effectiveProviderId && selectedProvider ? `${emptyProviderOption} — ${selectedProvider.name}` : emptyProviderOption}</option>}
           {visibleProviders.map((p) => {
             const hardwareUnavailable = !isProviderHardwareCompatible(p);
             const policyDisallowed = Boolean(providerAllowed && !providerAllowed(p));
@@ -248,7 +246,7 @@ export default function ProviderModelSelector({
             aria-label={compact ? 'Model' : undefined}
             className={SELECT_CLASS}
           >
-            {emptyModelOption != null && <option value="">{emptyModelOption}</option>}
+            {emptyModelOption != null && <option value="">{selectedProvider?.defaultModel ? `${emptyModelOption} — ${selectedProvider.defaultModel}` : emptyModelOption}</option>}
             {modelOptions.map(m => {
               const opt = modelOption(m);
               if (!opt) return null;

--- a/client/src/components/ProviderModelSelector.jsx
+++ b/client/src/components/ProviderModelSelector.jsx
@@ -219,7 +219,7 @@ export default function ProviderModelSelector({
               same broken control. */}
           {loading
             ? <option value="">Loading providers…</option>
-            : emptyProviderOption != null && <option value="">{effectiveProviderId && selectedProvider ? `${emptyProviderOption} — ${selectedProvider.name}` : emptyProviderOption}</option>}
+            : emptyProviderOption != null && <option value="">{effectiveProviderId && selectedProvider?.name && typeof emptyProviderOption === 'string' && !emptyProviderOption.includes(selectedProvider.name) ? `${emptyProviderOption} — ${selectedProvider.name}` : emptyProviderOption}</option>}
           {visibleProviders.map((p) => {
             const hardwareUnavailable = !isProviderHardwareCompatible(p);
             const policyDisallowed = Boolean(providerAllowed && !providerAllowed(p));

--- a/client/src/components/ProviderModelSelector.test.jsx
+++ b/client/src/components/ProviderModelSelector.test.jsx
@@ -31,6 +31,26 @@ function renderSelector(props = {}) {
 }
 
 describe('ProviderModelSelector', () => {
+  it('shows inherited provider, model and effort without writing overrides on mount', () => {
+    const onProviderChange = vi.fn();
+    const onModelChange = vi.fn();
+    const onEffortChange = vi.fn();
+    renderSelector({
+      providers: [{ id: 'codex', name: 'Codex', type: 'cli', command: 'codex', defaultModel: 'gpt-5', effort: 'high' }],
+      selectedProviderId: '', effectiveProviderId: 'codex', selectedModel: '',
+      availableModels: ['gpt-5'], emptyProviderOption: 'Auto', emptyModelOption: 'Default model',
+      effort: '', onProviderChange, onModelChange, onEffortChange,
+    });
+    expect(screen.getByRole('option', { name: 'Auto — Codex' }).selected).toBe(true);
+    expect(screen.getByRole('option', { name: 'Default model — gpt-5' }).selected).toBe(true);
+    expect(screen.getByRole('option', { name: 'Default effort — high' }).selected).toBe(true);
+    expect(onProviderChange).not.toHaveBeenCalled();
+    expect(onModelChange).not.toHaveBeenCalled();
+    expect(onEffortChange).not.toHaveBeenCalled();
+    fireEvent.change(screen.getByRole('combobox', { name: 'Thinking effort' }), { target: { value: 'low' } });
+    expect(onEffortChange).toHaveBeenCalledWith('low');
+  });
+
   it('renders only the provider options by default (no empty sentinel)', () => {
     renderSelector();
     const options = screen.getAllByRole('option').map((o) => o.textContent);

--- a/client/src/components/apps/SlashDoRunDrawer.jsx
+++ b/client/src/components/apps/SlashDoRunDrawer.jsx
@@ -41,7 +41,7 @@ function SlashDoRunDrawerBody({ open, command, label, appId, appName, onClose, o
     setSelectedProviderId, setSelectedModel
     // This picker renders the effort control and sends the value, so Antigravity
     // lists base models with the effort picked separately.
-  } = useProviderModels({ filter: enabledProcessProviderFilter, allowDefault: true, silent: true, withEffort: true });
+  } = useProviderModels({ filter: enabledProcessProviderFilter, allowDefault: true, preselectDefaults: true, silent: true, withEffort: true });
 
   const [effort, setEffort] = useState('');
   const [simplify, setSimplify] = useState(true);

--- a/client/src/components/apps/tabs/IssuesTab.jsx
+++ b/client/src/components/apps/tabs/IssuesTab.jsx
@@ -264,7 +264,7 @@ export default function IssuesTab({ appId, appName }) {
   const {
     providers, selectedProviderId, selectedModel, availableModels,
     setSelectedProviderId, setSelectedModel
-  } = useProviderModels({ filter: enabledProcessProviderFilter, allowDefault: true, silent: true, withEffort: true });
+  } = useProviderModels({ filter: enabledProcessProviderFilter, allowDefault: true, preselectDefaults: true, silent: true, withEffort: true });
   const [effort, setEffort] = useState('');
   const [overrideContext, setOverrideContext] = useState('');
   // The reviewers a Claim launched from this tab will actually run — NOT the

--- a/client/src/components/apps/tabs/IssuesTab.test.jsx
+++ b/client/src/components/apps/tabs/IssuesTab.test.jsx
@@ -311,6 +311,24 @@ describe('IssuesTab', () => {
     expect(screen.queryByText('Reviewed by')).not.toBeInTheDocument();
   });
 
+  it('shows and submits the configured default without touching the override controls', async () => {
+    api.getProviders.mockResolvedValue({
+      activeProvider: 'codex',
+      providers: [{ id: 'codex', name: 'Codex', type: 'cli', command: 'codex', enabled: true,
+        models: ['gpt-5'], defaultModel: 'gpt-5', effort: 'high' }],
+    });
+    await renderTab();
+    await screen.findByText('Crash on save');
+    await waitFor(() => expect(screen.getByLabelText('Provider')).toHaveValue('codex'));
+    expect(screen.getByLabelText('Model')).toHaveValue('gpt-5');
+    expect(screen.getByRole('option', { name: 'Default effort — high' }).selected).toBe(true);
+    fireEvent.click(screen.getByRole('button', { name: /Claim/ }));
+    await waitFor(() => expect(api.createSlashdoTask).toHaveBeenCalledWith(
+      'next', 'app-1', expect.objectContaining({ provider: 'codex', model: 'gpt-5', effort: undefined }),
+      { silent: true }
+    ));
+  });
+
   it('sends the page-level provider/model/effort pin along with a claim', async () => {
     api.getProviders.mockResolvedValue({
       providers: [{

--- a/client/src/components/apps/tabs/PullRequestsTab.jsx
+++ b/client/src/components/apps/tabs/PullRequestsTab.jsx
@@ -138,13 +138,13 @@ export default function PullRequestsTab({ appId, appName }) {
   const requestRef = useRef(0);
 
   // Page-level provider/model/effort pin for every Resolve & merge / PR review
-  // click on this tab — left untouched (blank), a run resolves the install's
-  // active provider, same as the bare button always did. Mirrors the Issues
+  // click on this tab — initially the active provider and configured model.
+  // Auto remains available for server-side routing. Mirrors the Issues
   // tab's "Run with" picker: a session convenience, never persisted.
   const {
     providers, selectedProviderId, selectedModel, availableModels,
     setSelectedProviderId, setSelectedModel
-  } = useProviderModels({ filter: enabledProcessProviderFilter, allowDefault: true, silent: true, withEffort: true });
+  } = useProviderModels({ filter: enabledProcessProviderFilter, allowDefault: true, preselectDefaults: true, silent: true, withEffort: true });
   const [effort, setEffort] = useState('');
 
   // One writer for the whole `{ kind: { number: action } }` bag so the ref the
@@ -299,8 +299,7 @@ export default function PullRequestsTab({ appId, appName }) {
     else toast.success(message);
   };
 
-  // The "Run with" picker above the list — left untouched, every field is
-  // `undefined` and the server resolves its own default exactly as before.
+  // Submit the visible session selection; clearing Auto restores server routing.
   const providerSettings = {
     provider: selectedProviderId || undefined,
     model: selectedModel || undefined,

--- a/client/src/components/cos/EffortSelect.jsx
+++ b/client/src/components/cos/EffortSelect.jsx
@@ -77,7 +77,7 @@ export default function EffortSelect({
       title="Thinking effort — how hard the model reasons per turn"
       aria-label={label ? undefined : 'Thinking effort'}
     >
-      <option value="">Default effort</option>
+      <option value="">{provider?.effort ? `Default effort — ${resolveCliEffort(provider.effort, provider, model) || provider.effort}` : 'Default effort'}</option>
       {outOfLadder && (
         <option
           value={outOfLadder}

--- a/client/src/hooks/useProviderModels.js
+++ b/client/src/hooks/useProviderModels.js
@@ -36,6 +36,9 @@ const sourceModels = (provider, withEffort) => {
  *   the model to `''` (the "default model" sentinel) rather than the provider's
  *   `defaultModel`. Pair with the `emptyProviderOption`/`emptyModelOption` props on
  *   `ProviderModelSelector`.
+ * @param {boolean} [options.preselectDefaults] - Seed a session override with the
+ *   active provider and its configured model. If the active provider is excluded
+ *   by the picker policy, leave Auto selected rather than choosing another.
  * @param {boolean} [options.silent] - Suppress the default error toast when the
  *   provider fetch fails (the empty-list fallback still applies). Use when the
  *   picker is a secondary control whose failure shouldn't interrupt the page.
@@ -65,7 +68,7 @@ const sourceModels = (provider, withEffort) => {
  *   Disabled pickers keep an empty catalog and do not issue a provider request.
  * @returns {{ providers, activeProviderId, selectedProviderId, selectedModel, availableModels, selectedProvider, setSelectedProviderId, setSelectedModel, loading }}
  */
-export default function useProviderModels({ filter, allowDefault = false, silent = false, modelFilter, withEffort = false, enabled = true } = {}) {
+export default function useProviderModels({ filter, allowDefault = false, preselectDefaults = false, silent = false, modelFilter, withEffort = false, enabled = true } = {}) {
   const [providers, setProviders] = useState([]);
   const [activeProviderId, setActiveProviderId] = useState('');
   const [selectedProviderId, setSelectedProviderId] = useState('');
@@ -129,13 +132,18 @@ export default function useProviderModels({ filter, allowDefault = false, silent
       .filter(isProviderHardwareCompatible)
       .filter(filterFn);
     setProviders(filtered);
-    if (!allowDefault && filtered.length > 0 && !hasSetInitialRef.current) {
+    if ((!allowDefault || preselectDefaults) && filtered.length > 0 && !hasSetInitialRef.current) {
       hasSetInitialRef.current = true;
-      setSelectedProviderId(filtered[0].id);
-      setSelectedModel(pickInitialModelRef.current(filtered[0]));
+      const initial = preselectDefaults
+        ? filtered.find(provider => provider.id === data.activeProvider)
+        : filtered[0];
+      if (initial) {
+        setSelectedProviderId(initial.id);
+        setSelectedModel(pickInitialModelRef.current(initial));
+      }
     }
     setLoading(false);
-  }, [filter, allowDefault, silent]);
+  }, [filter, allowDefault, preselectDefaults, silent]);
 
   useEffect(() => {
     if (!enabled) {

--- a/client/src/hooks/useProviderModels.test.js
+++ b/client/src/hooks/useProviderModels.test.js
@@ -45,6 +45,24 @@ const mountWith = async (providers, options = { withEffort: true }) => {
 describe('useProviderModels — Antigravity base models', () => {
   beforeEach(() => vi.clearAllMocks());
 
+  it('preselects the active provider default for session overrides and preserves deliberate Auto', async () => {
+    api.getProviders.mockResolvedValue({ activeProvider: 'codex', providers: [AGY, CODEX] });
+    const { result } = renderHook(() => useProviderModels({ allowDefault: true, preselectDefaults: true }));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.selectedProviderId).toBe('codex');
+    expect(result.current.selectedModel).toBe(CODEX.defaultModel);
+    act(() => result.current.setSelectedProviderId(''));
+    expect(result.current.selectedProviderId).toBe('');
+    expect(result.current.selectedModel).toBe('');
+  });
+
+  it('does not substitute another provider when the active default is filtered out', async () => {
+    api.getProviders.mockResolvedValue({ activeProvider: 'missing', providers: [CODEX] });
+    const { result } = renderHook(() => useProviderModels({ allowDefault: true, preselectDefaults: true }));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.selectedProviderId).toBe('');
+  });
+
   it('collapses the effort-suffixed catalog into base models', async () => {
     const { result } = await mountWith([AGY]);
     expect(result.current.availableModels).toEqual([


### PR DESCRIPTION
## Summary
App Issues, Pull Requests, and slash-command run controls now start with the active provider and its configured model, so users can inspect and accept the displayed configuration. Auto remains available for server-side routing. Shared provider/model/effort selectors name known inherited defaults, including configured effort, without writing saved overrides on mount.

Configured model defaults remain visible even when omitted from the browsable model catalog. An excluded active provider does not silently select a different provider.

## Test plan
- 165 tests passed across provider selection, effort, Issues, Pull Requests, slash-command drawer, and scheduled-task card suites.
- Covered accepting defaults on Claim, deliberate return to Auto, excluded active provider, and inherited defaults without mount-time writes.
- Optional OpenCode review: inconclusive; installed CLI lacks the required enforced read-only tool isolation. No unrestricted reviewer was invoked.
