### PR TITLE
feat: expose app quality audit controls beside category evidence

### DIFF
--- a/client/src/components/apps/AppQuality.jsx
+++ b/client/src/components/apps/AppQuality.jsx
@@ -1,10 +1,18 @@
 import AppQualityRunner from './AppQualityRunner';
 import AppQualityHistory from './AppQualityHistory';
-import { Link } from 'react-router';
+import { Fragment } from 'react';
+import { Link, useSearchParams } from 'react-router';
 import { formatDateShort } from '../../utils/formatters';
 
 export default function AppQuality({ app, detail = false }) {
+  const [params] = useSearchParams();
   const quality = app.quality;
+  const selectedCategory = quality?.categories?.find(category => category.id === params.get('qualityCheck'));
+  const runnerLink = categoryId => {
+    const next = new URLSearchParams(params);
+    next.set('qualityCheck', categoryId);
+    return { search: next.toString(), hash: '#quality-runner' };
+  };
   const score = quality?.score;
   const hasAssessments = quality?.categories?.some(category => category.assessedAt);
   const unscoredLabel = hasAssessments ? 'Quality: no qualifying score' : 'Quality: not assessed';
@@ -40,8 +48,8 @@ export default function AppQuality({ app, detail = false }) {
       <div className="flex flex-wrap gap-4 text-sm text-port-accent"><Link to="/cos/schedule" className="hover:underline">Scheduled audit runners</Link><Link to="/cos/agents" className="hover:underline">View agents</Link></div>
       <div className="grid grid-cols-1 xl:grid-cols-2 gap-5 items-start">
       <div className="min-w-0 space-y-4">
+        {!selectedCategory && <AppQualityRunner key={app.id} app={app} />}
         <AppQualityHistory appId={app.id} categories={quality?.categories} />
-        <AppQualityRunner key={app.id} app={app} />
       </div>
       {!!quality?.categories?.length && (
         <section aria-label="Category breakdown" className="min-w-0">
@@ -50,18 +58,23 @@ export default function AppQuality({ app, detail = false }) {
           <table className="w-full text-sm text-left">
             <thead className="text-gray-400 sticky top-0 bg-port-card"><tr><th className="py-2 pr-3">Category</th><th className="pr-3">Score</th><th>Evidence</th></tr></thead>
             <tbody>{quality.categories.map(category => (
-              <tr key={category.id} className="border-t border-port-border align-top">
+              <Fragment key={category.id}><tr className="border-t border-port-border align-top">
                 <th scope="row" className="py-2 pr-3 font-medium">{category.label}<Link className="block text-xs font-normal text-port-accent hover:underline" to={`/cos/schedule?task=${encodeURIComponent(category.id)}`} aria-label={`${category.label} runner`}>Runner settings</Link></th>
                 <td className="py-2 pr-3 whitespace-nowrap">{category.score == null ? '—' : `${category.score}/100`}</td>
                 <td className="py-2 text-xs text-gray-400">
                   <div>{category.stale ? 'Stale · ' : ''}{category.coverage}{category.confidence && ` · ${category.confidence} confidence`}
                     {category.assessedAt && ` · ${formatDateShort(category.assessedAt)}`}</div>
+                  <Link to={runnerLink(category.id)} aria-label={`Configure and run ${category.label}`} className="block mt-1 text-port-accent hover:underline">Configure and run</Link>
                   {category.summary && <details className="mt-1"><summary className="cursor-pointer text-port-accent">Assessment details</summary><p className="break-words">{category.summary}</p></details>}
                   {category.totalFiles > 0 && <div>{category.scannedFiles}/{category.totalFiles} files scanned · Worst severity: {category.worstSeverity}/10</div>}
                   {category.sourcePeerId && <div>Source: {category.sourcePeerName || 'federated peer'} · <Link className="text-port-accent hover:underline" to="/instances">View instances</Link></div>}
                   {!category.sourcePeerId && category.agentId && <Link className="text-port-accent hover:underline" to={`/cos/agents/${category.agentId}`}>Audit run</Link>}
                 </td>
               </tr>
+              {selectedCategory?.id === category.id && <tr><td colSpan={3} className="pb-3">
+                <AppQualityRunner key={app.id} app={app} />
+              </td></tr>}
+              </Fragment>
             ))}</tbody>
           </table>
           </div>

--- a/client/src/components/apps/AppQuality.jsx
+++ b/client/src/components/apps/AppQuality.jsx
@@ -24,7 +24,7 @@ export default function AppQuality({ app, detail = false }) {
     </Link>
   );
   return (
-    <section aria-label="App quality" className="bg-port-card border border-port-border rounded-lg p-4 space-y-3">
+    <AppQualityRunner key={app.id} app={app}>{runner => <section aria-label="App quality" className="bg-port-card border border-port-border rounded-lg p-4 space-y-3">
       <h3 className="font-semibold text-white">{label}</h3>
       <p className="text-xs text-gray-400">
         Assessments describe the code before fixes. The overall score is the equal-weight mean of broad, medium/high-confidence assessments from the last 30 days.
@@ -48,7 +48,7 @@ export default function AppQuality({ app, detail = false }) {
       <div className="flex flex-wrap gap-4 text-sm text-port-accent"><Link to="/cos/schedule" className="hover:underline">Scheduled audit runners</Link><Link to="/cos/agents" className="hover:underline">View agents</Link></div>
       <div className="grid grid-cols-1 xl:grid-cols-2 gap-5 items-start">
       <div className="min-w-0 space-y-4">
-        {!selectedCategory && <AppQualityRunner key={app.id} app={app} />}
+        {!selectedCategory && runner}
         <AppQualityHistory appId={app.id} categories={quality?.categories} />
       </div>
       {!!quality?.categories?.length && (
@@ -72,7 +72,7 @@ export default function AppQuality({ app, detail = false }) {
                 </td>
               </tr>
               {selectedCategory?.id === category.id && <tr><td colSpan={3} className="pb-3">
-                <AppQualityRunner key={app.id} app={app} />
+                {runner}
               </td></tr>}
               </Fragment>
             ))}</tbody>
@@ -81,6 +81,6 @@ export default function AppQuality({ app, detail = false }) {
         </section>
       )}
       </div>
-    </section>
+    </section>}</AppQualityRunner>
   );
 }

--- a/client/src/components/apps/AppQuality.test.jsx
+++ b/client/src/components/apps/AppQuality.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
 import { it, expect, vi } from 'vitest';
 import AppQuality from './AppQuality';
@@ -51,4 +51,20 @@ it('identifies federated evidence and incomplete scores without linking to a loc
   expect(screen.getByText(/1 peers unavailable or incompatible/)).toBeInTheDocument();
   expect(screen.getByRole('link', { name: 'View instances' })).toHaveAttribute('href', '/instances');
   expect(screen.queryByRole('link', { name: 'Audit run' })).not.toBeInTheDocument();
+});
+
+it('opens the shared runner beside unavailable category evidence while preserving URL filters', async () => {
+  const app = { id: 'example', quality: { categories: [
+    { id: 'security', label: 'Security', score: null, coverage: 'unavailable' },
+    { id: 'ux', label: 'UX', score: null, coverage: 'unavailable' },
+  ] } };
+  render(<MemoryRouter initialEntries={['/apps/example/quality?period=30']}><AppQuality app={app} detail /></MemoryRouter>);
+  await screen.findByText(/No scored assessments/);
+  const link = screen.getByRole('link', { name: 'Configure and run Security' });
+  expect(link).toHaveAttribute('href', '/apps/example/quality?period=30&qualityCheck=security#quality-runner');
+  fireEvent.click(link);
+  const table = screen.getByRole('table');
+  expect(within(table).getByText('Runner')).toBeInTheDocument();
+  expect(screen.getAllByText('Runner')).toHaveLength(1);
+  expect(screen.getAllByText('unavailable')).toHaveLength(2);
 });

--- a/client/src/components/apps/AppQuality.test.jsx
+++ b/client/src/components/apps/AppQuality.test.jsx
@@ -2,7 +2,7 @@ import { fireEvent, render, screen, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
 import { it, expect, vi } from 'vitest';
 import AppQuality from './AppQuality';
-vi.mock('./AppQualityRunner', () => ({ default: () => <div>Runner</div> }));
+vi.mock('./AppQualityRunner', () => ({ default: ({ children }) => children(<div>Runner</div>) }));
 vi.mock('../../services/apiApps', () => ({ getAppQualityHistory: vi.fn().mockResolvedValue({ points: [], totalCategories: 25 }) }));
 
 it('shows zero as a real score and explains excluded categories in the breakdown', async () => {

--- a/client/src/components/apps/AppQualityRunner.jsx
+++ b/client/src/components/apps/AppQualityRunner.jsx
@@ -55,7 +55,7 @@ export default function AppQualityRunner({ app }) {
     if (response) setRun(response.run);
     setBusy(false);
   };
-  return <section aria-label="Run quality checks" className="border-t border-port-border pt-3 space-y-3">
+  return <section id="quality-runner" aria-label="Run quality checks" className="border-t border-port-border pt-3 space-y-3">
     <h4 className="font-medium">Run quality checks</h4>
     <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 text-sm">
       <label htmlFor="quality-checks">Checks
@@ -77,7 +77,7 @@ export default function AppQualityRunner({ app }) {
     <p className="text-xs text-gray-400">{taskTypes.length} scheduled agents, run sequentially with these overrides. {mode === 'fix' ? 'Each selected audit can change code and open a PR.' : 'Findings become issues; no fixes or backlog claim jobs.'} Existing task enablement and Improve settings apply.</p>
     <details className="text-xs"><summary className="cursor-pointer text-port-accent">Selected checks ({taskTypes.length})</summary><p className="mt-1">{categories.filter(category => taskTypes.includes(category.id)).map(category => category.label).join(', ') || 'All categories have qualifying evidence.'}</p></details>
     <button type="button" onClick={start} disabled={busy || !loaded || picker.loading || !picker.selectedProviderId || !picker.selectedModel || !taskTypes.length || run?.status === 'running' || app.quality?.unavailable}
-      className="px-3 py-2 rounded bg-port-accent text-port-bg text-sm font-medium disabled:opacity-50">Run {taskTypes.length} checks now</button>
+      className="px-3 py-2 rounded bg-port-accent text-port-bg text-sm font-medium disabled:opacity-50">{taskTypes.length === 1 ? 'Run now' : `Run ${taskTypes.length} checks now`}</button>
     {!loaded && <p className="text-xs" role="status">Loading runner status… <button type="button" className="text-port-accent" onClick={loadRuns}>Retry</button></p>}
     {error && <p role="alert" className="text-sm text-port-error">{error}</p>}
     {run && <div className="space-y-2">

--- a/client/src/components/apps/AppQualityRunner.jsx
+++ b/client/src/components/apps/AppQualityRunner.jsx
@@ -11,7 +11,7 @@ import { getMaintenanceRuns, startMaintenanceRun, stopMaintenanceRun } from '../
 const eligibleProvider = provider => provider.enabled && isProcessProvider(provider) && familyForProvider(provider);
 const needsCheck = category => category.score == null || category.stale || category.coverage !== 'broad' || category.confidence === 'low';
 
-export default function AppQualityRunner({ app }) {
+export default function AppQualityRunner({ app, children }) {
   const categories = app.quality?.categories || [];
   const [params, setParams] = useSearchParams();
   const requested = params.get('qualityCheck');
@@ -55,7 +55,7 @@ export default function AppQualityRunner({ app }) {
     if (response) setRun(response.run);
     setBusy(false);
   };
-  return <section id="quality-runner" aria-label="Run quality checks" className="border-t border-port-border pt-3 space-y-3">
+  const controls = <section id="quality-runner" aria-label="Run quality checks" className="border-t border-port-border pt-3 space-y-3">
     <h4 className="font-medium">Run quality checks</h4>
     <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 text-sm">
       <label htmlFor="quality-checks">Checks
@@ -86,4 +86,5 @@ export default function AppQualityRunner({ app }) {
       {run.status === 'running' && <button type="button" className="text-xs text-port-accent" disabled={busy} onClick={stop}>Stop remaining checks</button>}
     </div>}
   </section>;
+  return children ? children(controls) : controls;
 }

--- a/client/src/components/apps/AppQualityRunner.test.jsx
+++ b/client/src/components/apps/AppQualityRunner.test.jsx
@@ -28,7 +28,7 @@ it('allows one category and recovers from launch failure without reporting a run
   startMaintenanceRun.mockRejectedValue(new Error('Provider unavailable'));
   render(<MemoryRouter><AppQualityRunner app={app} /></MemoryRouter>);
   fireEvent.change(screen.getByLabelText('Checks'), { target: { value: 'performance' } });
-  const button = screen.getByRole('button', { name: 'Run 1 checks now' });
+  const button = screen.getByRole('button', { name: 'Run now' });
   await waitFor(() => expect(button).toBeEnabled());
   fireEvent.click(button);
   expect(await screen.findByRole('alert')).toHaveTextContent('Provider unavailable');

--- a/client/src/components/apps/AppQualityRunner.test.jsx
+++ b/client/src/components/apps/AppQualityRunner.test.jsx
@@ -2,6 +2,8 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
 import { beforeEach, expect, it, vi } from 'vitest';
 import AppQualityRunner from './AppQualityRunner';
+import AppQuality from './AppQuality';
+vi.mock('./AppQualityHistory', () => ({ default: () => null }));
 import { getMaintenanceRuns, startMaintenanceRun } from '../../services/apiAgents';
 vi.mock('../../services/apiAgents', () => ({ getMaintenanceRuns: vi.fn(), startMaintenanceRun: vi.fn(), stopMaintenanceRun: vi.fn() }));
 vi.mock('../../hooks/useProviderModels', () => ({ default: () => ({ providers: [], selectedProviderId: 'codex', selectedModel: 'gpt-5', availableModels: [], loading: false }) }));
@@ -34,4 +36,20 @@ it('allows one category and recovers from launch failure without reporting a run
   expect(await screen.findByRole('alert')).toHaveTextContent('Provider unavailable');
   expect(button).toBeEnabled();
   expect(startMaintenanceRun.mock.calls[0][0]).toMatchObject({ mode: 'file-issues', taskTypes: ['performance'] });
+});
+
+it('preserves run overrides when moving controls into a category row', async () => {
+  startMaintenanceRun.mockResolvedValue({ run: { id: 'run-2', status: 'running', steps: [] } });
+  render(<MemoryRouter><AppQuality app={app} detail /></MemoryRouter>);
+  await waitFor(() => expect(screen.getByRole('button', { name: 'Run 2 checks now' })).toBeEnabled());
+  fireEvent.change(screen.getByLabelText('Mode'), { target: { value: 'fix' } });
+  fireEvent.click(screen.getByText('Use high effort'));
+  fireEvent.click(screen.getByRole('link', { name: 'Configure and run Security' }));
+  expect(screen.getByLabelText('Checks')).toHaveValue('security');
+  expect(screen.getByLabelText('Mode')).toHaveValue('fix');
+  fireEvent.click(screen.getByRole('button', { name: 'Run now' }));
+  await waitFor(() => expect(startMaintenanceRun).toHaveBeenCalledWith(
+    { appId: 'app-1', providerId: 'codex', model: 'gpt-5', effort: 'high', mode: 'fix', claimBetweenAudits: false, taskTypes: ['security'] },
+    { silent: true }
+  ));
 });


### PR DESCRIPTION
## Summary
Expose the existing provider/model/effort audit runner directly from each app quality category with a shareable Configure and run link. The selected category opens its controls beneath its evidence, with Run now scoped to that app and scheduled audit. Bulk controls appear above the history chart.

## Test plan
- Nine focused AppQuality and AppQualityRunner tests passed, covering category navigation with preserved run overrides, app-scoped launch payloads, effort overrides, active runs, and launch failure recovery.
- Biome lint and git diff whitespace checks passed.
