### PR TITLE
fix: recognize Vitest in database backend gates

### DIFF
--- a/server/services/bootstrap.js
+++ b/server/services/bootstrap.js
@@ -22,6 +22,7 @@
  * queue an AI provider call. Boot only loads on-disk state and ARMS schedulers;
  * every scheduler here is off by default or user-configured.
  */
+import { isTestRunner } from '../lib/runtimeEnv.js';
 import { readPortosEnvValue } from '../lib/portosEnv.js';
 import { join } from 'path';
 import { resolveInstallRoot } from '../lib/dataRoot.js';
@@ -645,7 +646,7 @@ const initMediaJobDependentHooks = () => {
  * the real migration scripts, and the real stores.
  *
  * Escape hatches for the health gate (dev/tests only, UNSUPPORTED for
- * production): `MEMORY_BACKEND=file` (explicit file backend) and `NODE_ENV=test`
+ * production): `MEMORY_BACKEND=file` (explicit file backend) and test runners
  * (test suites boot without a database). Both downgrade "PostgreSQL is required"
  * from a fail-fast to a warning.
  *
@@ -659,7 +660,7 @@ const runDatabaseBootPhase = () => runDatabasePhase({
     const { dbReady } = await gateOnDatabase({
       checkHealth,
       ensureSchema,
-      escapeHatch: process.env.MEMORY_BACKEND === 'file' || process.env.NODE_ENV === 'test'
+      escapeHatch: process.env.MEMORY_BACKEND === 'file' || isTestRunner()
     });
     // ensureSchema is threaded through to the migrations below so the phase
     // resolves the db.js module exactly once.

--- a/server/services/mediaAssetIndex/index.js
+++ b/server/services/mediaAssetIndex/index.js
@@ -15,11 +15,12 @@
  * `videoGenEvents` 'completed' emitters that already fire on every render. The
  * handlers read the just-written sidecar / history entry and upsert one row.
  *
- * Escape hatch: under MEMORY_BACKEND=file or NODE_ENV=test there's no Postgres,
+ * Escape hatch: under MEMORY_BACKEND=file or a test runner there's no Postgres,
  * so the index is simply not maintained — the gallery/history still serve from
  * disk. init() no-ops in that case (mirrors how catalog features disable).
  */
 
+import { isTestRunner } from '../../lib/runtimeEnv.js';
 import { checkHealth, ensureSchema } from '../../lib/db.js';
 import { imageGenEvents } from '../imageGenEvents.js';
 import { videoGenEvents } from '../videoGen/events.js';
@@ -31,7 +32,7 @@ export { reconcileMediaAssets } from './db.js';
 let subscribed = false;
 
 function isEscapeHatch() {
-  return process.env.MEMORY_BACKEND === 'file' || process.env.NODE_ENV === 'test';
+  return process.env.MEMORY_BACKEND === 'file' || isTestRunner();
 }
 
 // Index a single just-generated image. The 'completed' event carries the

--- a/server/services/mediaAssetIndex/index.test.js
+++ b/server/services/mediaAssetIndex/index.test.js
@@ -5,7 +5,7 @@
  * generated asset into one upsert with the right key/shape.
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 const upsertAsset = vi.fn(async () => {});
 const removeAsset = vi.fn(async () => {});
@@ -25,21 +25,24 @@ import { videoGenEvents } from '../videoGen/events.js';
 
 beforeEach(() => {
   vi.clearAllMocks();
+  vi.stubEnv('VITEST', undefined);
   checkHealth.mockResolvedValue({ connected: true });
 });
+
+afterEach(() => vi.unstubAllEnvs());
 
 // A tiny tick helper so the fire-and-forget event handlers settle.
 const flush = () => new Promise((r) => setTimeout(r, 0));
 
 describe('initMediaAssetIndex', () => {
-  it('no-ops under the escape hatch (no DB, no reconcile)', async () => {
-    vi.stubEnv('NODE_ENV', 'test');
+  it.each([['test', undefined], [undefined, '1'], ['development', '1']])('no-ops with NODE_ENV=%s and VITEST=%s', async (nodeEnv, vitest) => {
+    vi.stubEnv('NODE_ENV', nodeEnv);
+    vi.stubEnv('VITEST', vitest);
     const { initMediaAssetIndex } = await import('./index.js');
     const res = await initMediaAssetIndex();
     expect(res.reason).toBe('escape-hatch');
     expect(reconcileMediaAssets).not.toHaveBeenCalled();
     expect(checkHealth).not.toHaveBeenCalled();
-    vi.unstubAllEnvs();
   });
 
   it('bails when Postgres is unreachable', async () => {
@@ -49,7 +52,6 @@ describe('initMediaAssetIndex', () => {
     const res = await initMediaAssetIndex();
     expect(res.reason).toBe('db-unreachable');
     expect(reconcileMediaAssets).not.toHaveBeenCalled();
-    vi.unstubAllEnvs();
   });
 
   it('ensures schema + reconciles, and indexes a completed image/video via the hooks', async () => {
@@ -74,7 +76,6 @@ describe('initMediaAssetIndex', () => {
     expect(upsertAsset).toHaveBeenCalledWith(expect.objectContaining({
       mediaKey: 'video:job-1', kind: 'video', ref: 'job-1',
     }));
-    vi.unstubAllEnvs();
   });
 });
 
@@ -97,7 +98,6 @@ describe('unindexImage / unindexVideo (delete hooks, #2738)', () => {
     expect(removeAsset.mock.calls.map(([key]) => key)).toEqual(indexedKeys);
     // A video is keyed by job id, NOT its filename — the easy derivation to get wrong.
     expect(removeAsset).toHaveBeenCalledWith('video:job-1');
-    vi.unstubAllEnvs();
   });
 
   it('is non-fatal: a failing removal does not reject the caller (the delete already happened)', async () => {
@@ -109,7 +109,6 @@ describe('unindexImage / unindexVideo (delete hooks, #2738)', () => {
     await expect(unindexImage('img-1.png')).resolves.toBeUndefined();
     expect(errSpy).toHaveBeenCalledWith(expect.stringContaining('db down'));
     errSpy.mockRestore();
-    vi.unstubAllEnvs();
   });
 
   it('no-ops under the escape hatch and on an unusable ref', async () => {
@@ -117,7 +116,6 @@ describe('unindexImage / unindexVideo (delete hooks, #2738)', () => {
     const { unindexImage } = await import('./index.js');
     await unindexImage('img-1.png');
     expect(removeAsset).not.toHaveBeenCalled();
-    vi.unstubAllEnvs();
 
     // A ref-less asset never produced a row, so there's nothing to delete.
     vi.stubEnv('NODE_ENV', 'production');
@@ -125,6 +123,5 @@ describe('unindexImage / unindexVideo (delete hooks, #2738)', () => {
     await liveUnindex(undefined);
     await liveUnindexVideo('');
     expect(removeAsset).not.toHaveBeenCalled();
-    vi.unstubAllEnvs();
   });
 });

--- a/server/services/memoryBackend.js
+++ b/server/services/memoryBackend.js
@@ -5,13 +5,14 @@
  * is mandatory; when MEMORY_BACKEND is unset we require a healthy DB and do NOT
  * silently fall back to file storage — an unavailable DB throws. The file
  * backend (memory.js) is reachable only via the explicit MEMORY_BACKEND=file
- * escape hatch or NODE_ENV=test (both unsupported for production).
+ * escape hatch or a test runner (both unsupported for production).
  *
  * Usage:
  *   import * as memory from './memoryBackend.js';
  *   // All functions are the same regardless of backend
  */
 
+import { isTestRunner } from '../lib/runtimeEnv.js';
 import { checkHealth, ensureSchema } from '../lib/db.js';
 import { DEFAULT_MEMORY_CONFIG } from './memoryConfig.js';
 
@@ -58,7 +59,7 @@ async function getBackend() {
   // earlier conditional-on-unavailable form silently wrote to a dev's real DB
   // whenever Postgres happened to be up. An explicit `MEMORY_BACKEND=postgres`
   // (handled above) still opts a suite into the PG path.
-  if (process.env.NODE_ENV === 'test') {
+  if (isTestRunner()) {
     backend = await import('./memory.js');
     backendName = 'file';
     console.log('🧠 Memory backend: file-based (test mode — Postgres deliberately bypassed)');

--- a/server/services/memoryBackend.test.js
+++ b/server/services/memoryBackend.test.js
@@ -34,6 +34,7 @@ describe('memoryBackend backend selection', () => {
     // Start each test from a clean env; individual tests opt in to flags.
     delete process.env.MEMORY_BACKEND;
     delete process.env.NODE_ENV;
+    delete process.env.VITEST;
   });
 
   afterEach(() => {
@@ -91,13 +92,14 @@ describe('memoryBackend backend selection', () => {
     expect(name).toBe('file');
   });
 
-  it('uses the file backend in test mode even when Postgres is HEALTHY — never probes a live dev DB', async () => {
+  it.each([['test', undefined], [undefined, '1'], ['development', '1']])('bypasses a healthy DB with NODE_ENV=%s and VITEST=%s', async (nodeEnv, vitest) => {
     // Regression guard: a developer's machine commonly has a live `portos` DB
     // running (federated to real peers). The test runner must never write to
     // it — fixture creation would pollute the DB and fan out to peers, and
     // cleanup tombstones would delete real records. Test mode must short-circuit
     // to the file backend BEFORE the health probe runs.
-    process.env.NODE_ENV = 'test';
+    if (nodeEnv !== undefined) process.env.NODE_ENV = nodeEnv;
+    if (vitest !== undefined) process.env.VITEST = vitest;
     checkHealth.mockResolvedValue({ connected: true, hasSchema: true });
     const mod = await loadFresh();
     const name = await mod.ensureBackend();


### PR DESCRIPTION
Use the shared test-runner detector for memory backend selection, media indexing, and the boot database escape hatch. Vitest now keeps these gates in test mode when NODE_ENV is unset or development; explicit backend selection and normal-install fail-fast behavior are preserved.

Validation: 102 tests passed across memory backend selection, media index lifecycle, database guards, and bootstrap sequencing. Added environment regression cases with VITEST=1. Optional Codex gpt-6-astra review at low effort returned clean.

Closes #6895
