### PR TITLE
test: cover genome deletion and epigenetic tracking (#6903)

### DIFF
--- a/server/routes/genome.test.js
+++ b/server/routes/genome.test.js
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import express from 'express';
+import { request } from '../lib/testHelper.js';
+import { errorMiddleware } from '../lib/errorHandler.js';
+
+vi.mock('../services/genome.js', () => ({
+  deleteGenome: vi.fn(async () => undefined),
+}));
+
+vi.mock('../services/clinvar.js', () => ({
+  deleteClinvar: vi.fn(async () => undefined),
+}));
+
+vi.mock('../services/epigenetic.js', () => ({
+  logEntry: vi.fn(async () => ({
+    id: 'log-1',
+    date: '2026-09-11',
+    amount: 5,
+    unit: 'mg',
+    notes: '',
+    loggedAt: '2026-09-11T12:00:00.000Z',
+  })),
+}));
+
+const { deleteGenome } = await import('../services/genome.js');
+const { deleteClinvar } = await import('../services/clinvar.js');
+const { logEntry } = await import('../services/epigenetic.js');
+const { default: genomeRoutes } = await import('./genome.js');
+
+const makeApp = () => {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/meatspace/genome', genomeRoutes);
+  app.use(errorMiddleware);
+  return app;
+};
+
+describe('genome deletion routes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('deletes both the uploaded genome and ClinVar data before returning 204', async () => {
+    const response = await request(makeApp()).delete('/api/meatspace/genome');
+
+    expect(response.status).toBe(204);
+    expect(response.text).toBe('');
+    expect(deleteGenome).toHaveBeenCalledOnce();
+    expect(deleteClinvar).toHaveBeenCalledOnce();
+    expect(deleteGenome.mock.invocationCallOrder[0]).toBeLessThan(deleteClinvar.mock.invocationCallOrder[0]);
+  });
+
+  it('deletes only ClinVar data from the scoped endpoint', async () => {
+    const response = await request(makeApp()).delete('/api/meatspace/genome/clinvar');
+
+    expect(response.status).toBe(204);
+    expect(response.text).toBe('');
+    expect(deleteClinvar).toHaveBeenCalledOnce();
+    expect(deleteGenome).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /api/meatspace/genome/epigenetic/:id/log', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('validates and forwards a log entry to the requested intervention', async () => {
+    const response = await request(makeApp())
+      .post('/api/meatspace/genome/epigenetic/vitamin-d/log')
+      .send({ amount: 5, date: '2026-09-11', notes: 'with breakfast' });
+
+    expect(response.status).toBe(201);
+    expect(response.body).toMatchObject({ id: 'log-1', amount: 5, date: '2026-09-11' });
+    expect(logEntry).toHaveBeenCalledWith('vitamin-d', {
+      amount: 5,
+      date: '2026-09-11',
+      notes: 'with breakfast',
+    });
+  });
+
+  it('returns the route error contract when the intervention is missing', async () => {
+    logEntry.mockResolvedValueOnce({ error: 'Intervention not found' });
+
+    const response = await request(makeApp())
+      .post('/api/meatspace/genome/epigenetic/missing/log')
+      .send({ amount: 1 });
+
+    expect(response.status).toBe(404);
+    expect(response.body).toMatchObject({
+      error: 'Intervention not found',
+      code: 'INTERVENTION_NOT_FOUND',
+    });
+  });
+});

--- a/server/services/epigenetic.test.js
+++ b/server/services/epigenetic.test.js
@@ -1,0 +1,135 @@
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { rm } from 'fs/promises';
+import { join } from 'path';
+import { mockPathsDataRoot } from '../lib/mockPathsDataRoot.js';
+
+const { tempRoot, makeProxy, cleanup } = mockPathsDataRoot({ prefix: 'portos-epigenetic-' });
+
+vi.mock('../lib/fileUtils.js', async () => {
+  const actual = await vi.importActual('../lib/fileUtils.js');
+  return makeProxy(actual);
+});
+
+const {
+  addIntervention,
+  deleteIntervention,
+  getComplianceSummary,
+  getInterventions,
+  logEntry,
+} = await import('./epigenetic.js');
+
+const meatspaceRoot = join(tempRoot, 'meatspace');
+
+const dayKey = (daysAgo) => {
+  const date = new Date();
+  date.setDate(date.getDate() - daysAgo);
+  return date.toISOString().split('T')[0];
+};
+
+const addTracked = (id, frequency = 'daily') => addIntervention({
+  id,
+  name: id,
+  category: 'custom',
+  frequency,
+  trackingUnit: 'dose',
+});
+
+describe('epigenetic intervention persistence', () => {
+  beforeEach(async () => {
+    await rm(meatspaceRoot, { recursive: true, force: true });
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  afterAll(cleanup);
+
+  it('persists an added intervention and removes it with all associated data', async () => {
+    await addTracked('strength-training', 'weekly');
+    await logEntry('strength-training', { amount: 45, date: '2026-09-10' });
+
+    await expect(getInterventions()).resolves.toMatchObject({
+      interventions: {
+        'strength-training': {
+          id: 'strength-training',
+          frequency: 'weekly',
+          logs: [{ amount: 45, date: '2026-09-10' }],
+        },
+      },
+      trackedCount: 1,
+    });
+
+    await expect(deleteIntervention('strength-training')).resolves.toEqual({ success: true });
+    await expect(getInterventions()).resolves.toMatchObject({ interventions: {}, trackedCount: 0 });
+  });
+
+  it('replaces a same-day entry and keeps the remaining logs in date order', async () => {
+    await addTracked('vitamin-d');
+    await logEntry('vitamin-d', { amount: 3, date: '2026-09-12', notes: 'first' });
+    await logEntry('vitamin-d', { amount: 1, date: '2026-09-10' });
+    await logEntry('vitamin-d', { amount: 5, date: '2026-09-12', notes: 'corrected' });
+
+    const { interventions } = await getInterventions();
+    expect(interventions['vitamin-d'].logs).toHaveLength(2);
+    expect(interventions['vitamin-d'].logs.map(({ date }) => date)).toEqual([
+      '2026-09-10',
+      '2026-09-12',
+    ]);
+    expect(interventions['vitamin-d'].logs[1]).toMatchObject({ amount: 5, notes: 'corrected' });
+  });
+
+  it('uses daily and weekly schedules to calculate compliance over the same window', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-15T12:00:00.000Z'));
+    await addTracked('daily-habit', 'daily');
+    await addTracked('weekly-habit', 'weekly');
+    await logEntry('daily-habit', { amount: 1, date: dayKey(0) });
+    await logEntry('daily-habit', { amount: 1, date: dayKey(1) });
+    await logEntry('daily-habit', { amount: 1, date: dayKey(8) });
+    await logEntry('weekly-habit', { amount: 1, date: dayKey(2) });
+
+    const result = await getComplianceSummary(7);
+
+    expect(result).toMatchObject({ periodDays: 7, startDate: dayKey(7) });
+    expect(result.summary['daily-habit']).toMatchObject({
+      compliance: 2 / 7,
+      daysCovered: 2,
+      expectedDays: 7,
+      recentLogCount: 2,
+      lastLogged: dayKey(0),
+    });
+    expect(result.summary['weekly-habit']).toMatchObject({
+      compliance: 1,
+      daysCovered: 1,
+      expectedDays: 1,
+      recentLogCount: 1,
+      lastLogged: dayKey(2),
+    });
+  });
+
+  it('reports active, grace-period, broken, and empty streaks', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-15T12:00:00.000Z'));
+    await addTracked('active');
+    await addTracked('grace');
+    await addTracked('broken');
+    await addTracked('empty');
+
+    for (const daysAgo of [0, 1, 2]) {
+      await logEntry('active', { amount: 1, date: dayKey(daysAgo) });
+    }
+    for (const daysAgo of [1, 2]) {
+      await logEntry('grace', { amount: 1, date: dayKey(daysAgo) });
+    }
+    await logEntry('broken', { amount: 1, date: dayKey(2) });
+
+    const { summary } = await getComplianceSummary(7);
+    expect(summary.active.streak).toBe(3);
+    expect(summary.grace.streak).toBe(2);
+    expect(summary.broken.streak).toBe(0);
+    expect(summary.empty.streak).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

- verify full and ClinVar-only genome deletion routes invoke the intended destructive services and return empty 204 responses
- verify epigenetic log route validation, success response, and missing-intervention error contract
- cover isolated intervention persistence, same-day deduplication, chronological ordering, daily and weekly compliance, and streak grace rules

## Test plan

- `cd server && node_modules/.bin/vitest run lib/genomeValidation.test.js services/clinvar.test.js routes/genome.test.js services/epigenetic.test.js`

Configured optional reviewer `codex[gpt-6-astra]~opt~max=1~effort=low`: inconclusive. Complete isolation from inherited tool, plugin, and network capabilities could not be verified, so no clean external-review verdict is claimed.

Closes #6903

