### PR TITLE
fix: allow parallel app quality check runs

### DIFF
--- a/client/src/components/apps/AppQualityRunner.jsx
+++ b/client/src/components/apps/AppQualityRunner.jsx
@@ -25,7 +25,7 @@ export default function AppQualityRunner({ app, children }) {
   const [effort, setEffort] = useState('');
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState('');
-  const [run, setRun] = useState(null);
+  const [runs, setRuns] = useState([]);
   const [loaded, setLoaded] = useState(false);
   const revision = useRef(0);
   const picker = useProviderModels({ filter: eligibleProvider, withEffort: true });
@@ -34,7 +34,7 @@ export default function AppQualityRunner({ app, children }) {
     const requestedRevision = revision.current;
     const response = await getMaintenanceRuns({ silent: true }).catch(() => null);
     if (!response || requestedRevision !== revision.current) return;
-    setRun(response.runs.find(entry => entry.appId === app.id) || null);
+    setRuns(response.runs.filter(entry => entry.appId === app.id));
     setLoaded(true);
   }, [app.id]);
   useAutoRefetch(loadRuns, 15000, { enabled: !busy, immediate: !loaded, pollOnly: true });
@@ -44,15 +44,15 @@ export default function AppQualityRunner({ app, children }) {
     setError('');
     const response = await startMaintenanceRun({ appId: app.id, providerId: picker.selectedProviderId, model: picker.selectedModel,
       effort: effort || null, mode, claimBetweenAudits: false, taskTypes }, { silent: true }).catch(err => { setError(err.message); return null; });
-    if (response) setRun(response.run);
+    if (response) setRuns(previous => [response.run, ...previous.filter(entry => entry.id !== response.run.id)]);
     setBusy(false);
   };
-  const stop = async () => {
+  const stop = async (id) => {
     revision.current += 1;
     setBusy(true);
     setError('');
-    const response = await stopMaintenanceRun(run.id, { silent: true }).catch(err => { setError(err.message); return null; });
-    if (response) setRun(response.run);
+    const response = await stopMaintenanceRun(id, { silent: true }).catch(err => { setError(err.message); return null; });
+    if (response) setRuns(previous => previous.map(entry => entry.id === response.run.id ? response.run : entry));
     setBusy(false);
   };
   const controls = <section id="quality-runner" aria-label="Run quality checks" className="border-t border-port-border pt-3 space-y-3">
@@ -74,17 +74,17 @@ export default function AppQualityRunner({ app, children }) {
       availableModels={picker.availableModels} onProviderChange={value => { picker.setSelectedProviderId(value); setEffort(''); }}
       onModelChange={picker.setSelectedModel} effort={effort} onEffortChange={setEffort} loading={picker.loading} disabled={busy}
       emptyProviderOption="Select a subscription provider" emptyModelOption="Select a model" highlightToolUse />
-    <p className="text-xs text-gray-400">{taskTypes.length} scheduled agents, run sequentially with these overrides. {mode === 'fix' ? 'Each selected audit can change code and open a PR.' : 'Findings become issues; no fixes or backlog claim jobs.'} Existing task enablement and Improve settings apply.</p>
+    <p className="text-xs text-gray-400">{taskTypes.length} scheduled agents, run sequentially within this batch. Launch another batch to run checks in parallel. {mode === 'fix' ? 'Each selected audit can change code and open a PR.' : 'Findings become issues; no fixes or backlog claim jobs.'} Existing task enablement and Improve settings apply.</p>
     <details className="text-xs"><summary className="cursor-pointer text-port-accent">Selected checks ({taskTypes.length})</summary><p className="mt-1">{categories.filter(category => taskTypes.includes(category.id)).map(category => category.label).join(', ') || 'All categories have qualifying evidence.'}</p></details>
-    <button type="button" onClick={start} disabled={busy || !loaded || picker.loading || !picker.selectedProviderId || !picker.selectedModel || !taskTypes.length || run?.status === 'running' || app.quality?.unavailable}
+    <button type="button" onClick={start} disabled={busy || picker.loading || !picker.selectedProviderId || !picker.selectedModel || !taskTypes.length || app.quality?.unavailable}
       className="px-3 py-2 rounded bg-port-accent text-port-bg text-sm font-medium disabled:opacity-50">{taskTypes.length === 1 ? 'Run now' : `Run ${taskTypes.length} checks now`}</button>
     {!loaded && <p className="text-xs" role="status">Loading runner status… <button type="button" className="text-port-accent" onClick={loadRuns}>Retry</button></p>}
     {error && <p role="alert" className="text-sm text-port-error">{error}</p>}
-    {run && <div className="space-y-2">
+    {runs.filter((run, index) => run.status === 'running' || index === 0).map(run => <div key={run.id} className="space-y-2">
       <MaintenanceRunStatus run={run} />
       {run.reason && <p className="text-xs break-words">{run.reason} <Link className="text-port-accent underline" to="/cos/schedule">Open runner settings</Link></p>}
-      {run.status === 'running' && <button type="button" className="text-xs text-port-accent" disabled={busy} onClick={stop}>Stop remaining checks</button>}
-    </div>}
+      {run.status === 'running' && <button type="button" className="text-xs text-port-accent" disabled={busy} onClick={() => stop(run.id)}>Stop remaining checks</button>}
+    </div>)}
   </section>;
   return children ? children(controls) : controls;
 }

--- a/client/src/components/apps/AppQualityRunner.test.jsx
+++ b/client/src/components/apps/AppQualityRunner.test.jsx
@@ -4,7 +4,7 @@ import { beforeEach, expect, it, vi } from 'vitest';
 import AppQualityRunner from './AppQualityRunner';
 import AppQuality from './AppQuality';
 vi.mock('./AppQualityHistory', () => ({ default: () => null }));
-import { getMaintenanceRuns, startMaintenanceRun } from '../../services/apiAgents';
+import { getMaintenanceRuns, startMaintenanceRun, stopMaintenanceRun } from '../../services/apiAgents';
 vi.mock('../../services/apiAgents', () => ({ getMaintenanceRuns: vi.fn(), startMaintenanceRun: vi.fn(), stopMaintenanceRun: vi.fn() }));
 vi.mock('../../hooks/useProviderModels', () => ({ default: () => ({ providers: [], selectedProviderId: 'codex', selectedModel: 'gpt-5', availableModels: [], loading: false }) }));
 vi.mock('../ProviderModelSelector', () => ({ default: ({ onEffortChange }) => <button onClick={() => onEffortChange('high')}>Use high effort</button> }));
@@ -24,7 +24,7 @@ it('launches missing checks with visible mode and effort, then exposes held runn
   fireEvent.click(button);
   await screen.findByRole('link', { name: 'Open runner settings' });
   expect(startMaintenanceRun).toHaveBeenCalledWith({ appId: 'app-1', providerId: 'codex', model: 'gpt-5', effort: 'high', mode: 'fix', claimBetweenAudits: false, taskTypes: ['security', 'ux'] }, { silent: true });
-  expect(button).toBeDisabled();
+  expect(button).toBeEnabled();
 });
 it('allows one category and recovers from launch failure without reporting a run', async () => {
   startMaintenanceRun.mockRejectedValue(new Error('Provider unavailable'));
@@ -52,4 +52,20 @@ it('preserves run overrides when moving controls into a category row', async () 
     { appId: 'app-1', providerId: 'codex', model: 'gpt-5', effort: 'high', mode: 'fix', claimBetweenAudits: false, taskTypes: ['security'] },
     { silent: true }
   ));
+});
+
+it('launches alongside pending runners and stops each run independently', async () => {
+  getMaintenanceRuns.mockResolvedValue({ runs: [{ id: 'pending', appId: app.id, status: 'running', steps: [], reason: 'Waiting for capacity' }] });
+  startMaintenanceRun.mockResolvedValue({ run: { id: 'new', appId: app.id, status: 'running', steps: [] } });
+  stopMaintenanceRun.mockResolvedValue({ run: { id: 'pending', appId: app.id, status: 'stopped', steps: [] } });
+  render(<MemoryRouter><AppQualityRunner app={app} /></MemoryRouter>);
+  await screen.findByText(/Waiting for capacity/, { selector: 'p.break-words' });
+  const button = screen.getByRole('button', { name: 'Run 2 checks now' });
+  expect(button).toBeEnabled();
+  fireEvent.click(button);
+  await waitFor(() => expect(screen.getAllByRole('button', { name: 'Stop remaining checks' })).toHaveLength(2));
+  fireEvent.click(screen.getAllByRole('button', { name: 'Stop remaining checks' })[1]);
+  await waitFor(() => expect(stopMaintenanceRun).toHaveBeenCalledWith('pending', { silent: true }));
+  await waitFor(() => expect(screen.getAllByRole('button', { name: 'Stop remaining checks' })).toHaveLength(1));
+  expect(button).toBeEnabled();
 });

--- a/server/services/maintenanceRun.js
+++ b/server/services/maintenanceRun.js
@@ -133,7 +133,8 @@ async function assertNoRunningRun(appId) {
  * when the app is unknown or archived, the provider is not an enabled
  * subscription CLI/TUI provider in a known family — the SAME gate every dispatch
  * re-applies (`resolveBurnProvider`), so a run can never start on a provider
- * its steps would then refuse — or the app already has a running run.
+ * its steps would then refuse — or a full ladder targets an app with a running run.
+ * Explicit quality selections may run alongside other runs; they never claim backlog issues.
  *
  * The first evaluation runs before this returns, so the caller learns whether
  * step one actually went out (or why it is holding) in the same response.
@@ -155,13 +156,14 @@ export async function startMaintenanceRun({ appId, providerId, model = null, eff
     const claimProvider = claimFamilyId ? await resolveBurnProvider({ job: effectiveClaimHandler, family: { id: claimFamilyId } }) : null;
     if (!claimProvider) throw new ServerError(`provider "${effectiveClaimHandler.providerId}" is not an enabled subscription CLI/TUI provider`, { status: 400, code: 'MAINTENANCE_RUN_PROVIDER_UNAVAILABLE' });
   }
-  await assertNoRunningRun(appId);
+  if (!taskTypes) await assertNoRunningRun(appId);
 
   const id = `maint-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`;
   const now = new Date().toISOString();
   const pins = { providerId, model: model || null, effort: effort || null };
   const run = await insertRun({
     id, appId, familyId, claimFamilyId, ...pins,
+    taskTypes,
     status: MAINTENANCE_RUN_STATUS.RUNNING,
     steps: buildMaintenanceSteps({ appId, idPrefix: id, ...pins, mode, claimBetweenAudits, claimHandler: effectiveClaimHandler, taskTypes }),
     completed: {},
@@ -226,7 +228,7 @@ export async function resumeMaintenanceRun(id) {
   const resumed = await perRun(id, async () => {
     const run = await getMaintenanceRun(id);
     if (!run || run.status === MAINTENANCE_RUN_STATUS.RUNNING) return run;
-    await assertNoRunningRun(run.appId);
+    if (!run.taskTypes) await assertNoRunningRun(run.appId);
     console.log(`🧹 Maintenance run ${id} resumed`);
     return patchRun(id, { status: MAINTENANCE_RUN_STATUS.RUNNING, finishedAt: null, reason: null });
   });

--- a/server/services/maintenanceRun.test.js
+++ b/server/services/maintenanceRun.test.js
@@ -276,3 +276,18 @@ it('rejects an unavailable claim provider before starting any work', async () =>
   await expect(startMaintenanceRun({ appId: 'app-1', providerId: 'codex', claimHandler: { providerId: 'unavailable', model: 'example' } })).rejects.toMatchObject({ code: 'MAINTENANCE_RUN_PROVIDER_UNAVAILABLE' });
   expect(state.invoked).toEqual([]);
 });
+
+it('dispatches independent quality runs while another run is pending and resumes them independently', async () => {
+  const { run: ladder } = await start();
+  state.requests = [{ id: 'demand-1', burn: { maintenanceRunId: ladder.id } }];
+  const { run: security } = await startMaintenanceRun({ appId: 'app-1', providerId: 'codex', taskTypes: ['security'] });
+  const { run: performance } = await startMaintenanceRun({ appId: 'app-1', providerId: 'codex', taskTypes: ['performance'], mode: 'fix' });
+  expect(dispatchedTypes()).toEqual(['better-structural-drift', 'security', 'performance']);
+  await stopMaintenanceRun(security.id);
+  expect((await getMaintenanceRun(performance.id)).status).toBe('running');
+  expect((await resumeMaintenanceRun(security.id)).run.status).toBe('running');
+  await __onMaintenanceAgentCompleted(agentFor(performance, 0));
+  expect((await getMaintenanceRun(performance.id)).status).toBe('completed');
+  expect((await getMaintenanceRun(security.id)).status).toBe('running');
+  expect((await getMaintenanceRun(ladder.id)).completed).toEqual({});
+});


### PR DESCRIPTION
## Summary
Allow Apps > Quality to launch additional selected checks while existing runners are pending or active. Track every active run with its own stop control, and allow selected quality runs to start and resume independently on the server.

Each batch retains sequential execution; separate launches can overlap subject to existing scheduler capacity and duplicate-task gates. Full maintenance ladders retain their existing per-app guard.

## Test plan
- Client AppQualityRunner suite: 4 tests passed, including launch beside pending work and independent stop controls.
- Server maintenanceRun suite: 16 tests passed, including independent dispatch, resume, and completion beside a pending ladder.
- Changed-file lint and diff whitespace checks passed; local code review completed.
