### PR TITLE
fix(video-gen): use video backend enum for Grok submission (#6897)

### DIFF
--- a/server/services/videoGen/submitJob.js
+++ b/server/services/videoGen/submitJob.js
@@ -19,7 +19,6 @@ import {
   compileFableLoomVisualRequest,
   fableLoomVideoCapabilities,
 } from '../fableLoom/visualConditioning.js';
-import { IMAGE_GEN_MODE } from '../imageGen/modes.js';
 import { VIDEO_GEN_MODE } from './modes.js';
 import { enqueueJob } from '../mediaJobQueue/index.js';
 import {
@@ -116,7 +115,7 @@ const submitValidatedVideoGenJob = async (body, uploads) => {
   const { backend, cleanupStaged } = prepared;
 
   if (body.fableLoom) {
-    const conditioningModel = backend === IMAGE_GEN_MODE.GROK
+    const conditioningModel = backend === VIDEO_GEN_MODE.GROK
       ? { id: 'grok-video', supportedModes: ['image'] }
       : backend === VIDEO_GEN_MODE.FAL
         ? { id: 'fal-video', supportedModes: ['text', 'image'] }
@@ -165,12 +164,12 @@ const submitValidatedVideoGenJob = async (body, uploads) => {
     () => enqueueJob({ kind: 'video', params }),
   );
 
-  if (backend === IMAGE_GEN_MODE.GROK) {
+  if (backend === VIDEO_GEN_MODE.GROK) {
     const { grok: g, sourceImagePath, uploadedTempPath } = prepared;
     const { jobId, position, status } = await enqueue({
       // This literal is the queue discriminator. Local jobs use mode for their
       // t2v/i2v semantic, while the Grok lane stores that as videoMode.
-      mode: IMAGE_GEN_MODE.GROK,
+      mode: VIDEO_GEN_MODE.GROK,
       videoMode: sourceImagePath ? 'image' : 'text',
       grokPath: g.grokPath,
       aspectRatio: body.visualConditioning?.render?.parameters?.aspectRatio || g.aspectRatio,


### PR DESCRIPTION
## Summary

- Use `VIDEO_GEN_MODE.GROK` for all video Grok backend comparisons and queue tagging.
- Remove the video submitter dependency on the image-generation mode module while preserving the shared `grok` discriminator value.

## Test plan

- `npm test --prefix server -- services/videoGen/submitJob.test.js`
- `git diff --check`

Closes #6897