### PR TITLE
fix: gate brain tombstone sweeps to six-hour cadence (#6852)

### DIFF
--- a/server/services/syncOrchestrator.js
+++ b/server/services/syncOrchestrator.js
@@ -37,6 +37,7 @@ const FETCH_TIMEOUT_MS = 15000;
 // firing every tick; the manual `POST /tombstones/sweep` route stays unthrottled
 // (it calls sweepTombstones() directly, never through this gate).
 const TOMBSTONE_SWEEP_INTERVAL_MS = 60 * 60 * 1000;
+export const BRAIN_TOMBSTONE_SWEEP_INTERVAL_MS = 6 * 60 * 60 * 1000;
 
 const withLock = createMutex();
 let syncTimer = null;
@@ -48,6 +49,7 @@ const syncingPeers = new Set();
 // initSyncOrchestrator/stopSyncOrchestrator so a restart (and each test) starts
 // from "first tick runs".
 let lastTombstoneSweepAt = 0;
+let lastBrainSweepAt = 0;
 
 // --- Realtime sync progress ---
 //
@@ -959,9 +961,10 @@ export async function syncAllPeers() {
  * Initialize the sync orchestrator
  */
 export function initSyncOrchestrator() {
-  // Fresh start (boot, or a test's init after a prior stop) always runs the
-  // tombstone sweep on the first tick — see TOMBSTONE_SWEEP_INTERVAL_MS above.
+  // Fresh start (boot, or a test's init after a prior stop) always runs both
+  // tombstone sweeps on the first tick — see their interval constants above.
   lastTombstoneSweepAt = 0;
+  lastBrainSweepAt = 0;
   // Sync immediately when a peer comes online
   peerOnlineHandler = (peer) => {
     if (!hasAnySyncEnabled(peer)) return;
@@ -986,8 +989,9 @@ export function initSyncOrchestrator() {
     runTombstoneSweep().catch(err => {
       console.error(`❌ Tombstone sweep tick failed: ${err.message}`);
     });
-    // Brain entity tombstones ride the same tick — same once-a-minute cadence,
-    // same rejection (a rejected dynamic import would otherwise crash the tick).
+    // Brain entity tombstones ride the same tick but are gated to their much
+    // slower grace-period cadence. The outer catch owns unexpected failures
+    // (such as a rejected dynamic import) so the interval never leaks one.
     runBrainTombstoneSweep().catch(err => {
       console.error(`❌ Brain tombstone sweep tick failed: ${err.message}`);
     });
@@ -1047,11 +1051,16 @@ async function runTombstoneSweep() {
  * was actually pruned — quiet on no-op cycles.
  */
 async function runBrainTombstoneSweep() {
-  const { sweepBrainTombstones } = await import('./brainTombstoneGc.js');
-  const result = await sweepBrainTombstones().catch((err) => {
-    console.error(`❌ Brain tombstone sweep failed: ${err.message}`);
-    return null;
-  });
+  const now = Date.now();
+  if (lastBrainSweepAt !== 0 && now - lastBrainSweepAt < BRAIN_TOMBSTONE_SWEEP_INTERVAL_MS) return;
+  lastBrainSweepAt = now;
+  const result = await import('./brainTombstoneGc.js')
+    .then(({ sweepBrainTombstones }) => sweepBrainTombstones())
+    .catch((err) => {
+      console.error(`❌ Brain tombstone sweep failed: ${err.message}`);
+      lastBrainSweepAt = 0;
+      return null;
+    });
   if (result && result.pruned > 0) {
     console.log(`🪦 Brain tombstone GC: pruned ${result.pruned} tombstone${result.pruned === 1 ? '' : 's'}`);
   }
@@ -1062,6 +1071,7 @@ async function runBrainTombstoneSweep() {
  */
 export function stopSyncOrchestrator() {
   lastTombstoneSweepAt = 0;
+  lastBrainSweepAt = 0;
   if (peerOnlineHandler) {
     instanceEvents.removeListener('peer:online', peerOnlineHandler);
     peerOnlineHandler = null;

--- a/server/services/syncOrchestrator.js
+++ b/server/services/syncOrchestrator.js
@@ -1058,7 +1058,6 @@ async function runBrainTombstoneSweep() {
     .then(({ sweepBrainTombstones }) => sweepBrainTombstones())
     .catch((err) => {
       console.error(`❌ Brain tombstone sweep failed: ${err.message}`);
-      lastBrainSweepAt = 0;
       return null;
     });
   if (result && result.pruned > 0) {

--- a/server/services/syncOrchestrator.test.js
+++ b/server/services/syncOrchestrator.test.js
@@ -1170,18 +1170,37 @@ describe('syncOrchestrator', () => {
     });
 
     it('runs syncAllPeers every tick but gates brain tombstone sweeps to six hours', async () => {
+      const tickMs = 60 * 1000;
+      const sixHoursMs = 6 * 60 * 60 * 1000;
+      expect(BRAIN_TOMBSTONE_SWEEP_INTERVAL_MS).toBe(sixHoursMs);
+
       initSyncOrchestrator();
       getPeers.mockResolvedValue([]);
-      for (let tick = 0; tick < 60; tick += 1) {
-        await vi.advanceTimersByTimeAsync(60000);
+      await vi.advanceTimersByTimeAsync(tickMs);
+      expect(sweepBrainTombstones).toHaveBeenCalledTimes(1); // first tick after boot
+      for (let tick = 1; tick < 60; tick += 1) {
+        await vi.advanceTimersByTimeAsync(tickMs);
       }
       expect(getPeers).toHaveBeenCalledTimes(60); // syncAllPeers fires every tick
       expect(compactLog).toHaveBeenCalledTimes(60); // brain-sync-log compaction stays on every tick
-      expect(sweepBrainTombstones).toHaveBeenCalledTimes(1); // first tick only within six hours
+      expect(sweepBrainTombstones).toHaveBeenCalledTimes(1); // no repeat across 60 one-minute ticks
       expect(sweepTombstones).toHaveBeenCalledTimes(1); // gated on the second tick
 
-      await vi.advanceTimersByTimeAsync(BRAIN_TOMBSTONE_SWEEP_INTERVAL_MS);
+      await vi.advanceTimersByTimeAsync(sixHoursMs - (60 * tickMs));
+      expect(sweepBrainTombstones).toHaveBeenCalledTimes(1); // still before six hours since the first sweep
+      await vi.advanceTimersByTimeAsync(tickMs);
       expect(sweepBrainTombstones).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not retry a failed brain sweep before six hours', async () => {
+      initSyncOrchestrator();
+      getPeers.mockResolvedValue([]);
+      sweepBrainTombstones.mockRejectedValueOnce(new Error('db blip'));
+
+      await vi.advanceTimersByTimeAsync(60 * 1000);
+      await vi.advanceTimersByTimeAsync(60 * 1000);
+
+      expect(sweepBrainTombstones).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/server/services/syncOrchestrator.test.js
+++ b/server/services/syncOrchestrator.test.js
@@ -132,7 +132,14 @@ import { getCurrentSeq, compactLog } from './brainSyncLog.js';
 import { getBrainChecksum, applyBrainSnapshot } from './brainReconcile.js';
 import { getMaxSequence } from './memorySync.js';
 import { peerFetch } from '../lib/peerHttpClient.js';
-import { syncWithPeer, syncAllPeers, getSyncStatus, initSyncOrchestrator, stopSyncOrchestrator } from './syncOrchestrator.js';
+import {
+  syncWithPeer,
+  syncAllPeers,
+  getSyncStatus,
+  initSyncOrchestrator,
+  stopSyncOrchestrator,
+  BRAIN_TOMBSTONE_SWEEP_INTERVAL_MS,
+} from './syncOrchestrator.js';
 
 const mockFetch = vi.fn();
 
@@ -1162,14 +1169,19 @@ describe('syncOrchestrator', () => {
       expect(sweepTombstones).toHaveBeenCalledTimes(2);
     });
 
-    it('runs syncAllPeers and the brain tombstone sweep on every tick regardless of the tombstone-sweep gate', async () => {
+    it('runs syncAllPeers every tick but gates brain tombstone sweeps to six hours', async () => {
       initSyncOrchestrator();
       getPeers.mockResolvedValue([]);
-      await vi.advanceTimersByTimeAsync(60000); // t=60s — tombstone sweep runs (first tick)
-      await vi.advanceTimersByTimeAsync(60000); // t=120s — tombstone sweep gated
-      expect(getPeers).toHaveBeenCalledTimes(2); // syncAllPeers fires every tick
-      expect(sweepBrainTombstones).toHaveBeenCalledTimes(2); // brain sweep is untouched by this gate
+      for (let tick = 0; tick < 60; tick += 1) {
+        await vi.advanceTimersByTimeAsync(60000);
+      }
+      expect(getPeers).toHaveBeenCalledTimes(60); // syncAllPeers fires every tick
+      expect(compactLog).toHaveBeenCalledTimes(60); // brain-sync-log compaction stays on every tick
+      expect(sweepBrainTombstones).toHaveBeenCalledTimes(1); // first tick only within six hours
       expect(sweepTombstones).toHaveBeenCalledTimes(1); // gated on the second tick
+
+      await vi.advanceTimersByTimeAsync(BRAIN_TOMBSTONE_SWEEP_INTERVAL_MS);
+      expect(sweepBrainTombstones).toHaveBeenCalledTimes(2);
     });
   });
 


### PR DESCRIPTION
## Summary
- Gate the brain tombstone sweep behind a six-hour elapsed-time interval while preserving the first post-boot sweep.
- Keep federation tombstone sweeping and brain sync-log compaction on every existing sync tick.
- Preserve the cadence after failed attempts so persistent errors cannot reintroduce minute-level full-brain reads.

## Test plan
- `PATH=/opt/homebrew/bin:/usr/bin:/bin ./node_modules/.bin/vitest run services/syncOrchestrator.test.js` (56 passed)
- `PATH=/opt/homebrew/bin:/usr/bin:/bin ./node_modules/.bin/vitest run services/brainTombstoneGc.test.js services/brainStorage.test.js` (46 passed)
- Full server suite: 42,995 passed; its one unrelated `services/videoGen/fal.test.js` failure passed when rerun in isolation (13 passed).

Closes #6852