### PR TITLE
fix: delegate Codex reviewer effort ladders to server gate

### DIFF
--- a/client/src/lib/reviewerPins.js
+++ b/client/src/lib/reviewerPins.js
@@ -3,9 +3,9 @@ import {
   CODEX_EFFORT_LEVELS,
   ANTIGRAVITY_EFFORT_LEVELS,
   CURSOR_EFFORT_LEVELS,
-  GROK_EFFORT_LEVELS,
-  CODEX_ULTRA_EFFORT_LEVELS
+  GROK_EFFORT_LEVELS
 } from '../utils/providers';
+import { codexEffortLevelsForModel } from '../../../server/lib/providerModels.js';
 
 /**
  * Client mirrors of the reviewer vocabulary in `server/lib/reviewerConfig.js` —
@@ -16,7 +16,7 @@ import {
  *
  * **Why these live in a leaf module rather than in `components/cos/constants.js`.**
  * The server suite pins this mirror against the server's own derived ladders (see
- * the `client mirror of the reviewer effort ladders` test in
+ * the `client mirror of the reviewer vocabulary` test in
  * `server/lib/reviewerConfig.test.js`) — a level offered here but rejected there
  * would show the user a pin that silently never persists, and the reverse would
  * hide a tier their CLI accepts. That test runs in the SERVER workspace, which has
@@ -102,26 +102,19 @@ export const normalizeReviewerSlug = (reviewer) => {
 
 // The ladder for one reviewer token, or `null` when it takes no effort. Accepts
 // the `gemini` alias and `@username` tokens (both → null for the latter).
-// For `codex` reviewers, the ladder is gated on the pinned model: gpt-6 family
-// models reject `minimal`. Pass the model id to get the right tier set for that
-// model; omit it to get the default static ladder.
+// For `codex` reviewers, the ladder is gated on the pinned model. Pass the model
+// id to get the server-owned tier set for that model; omit it to get the default
+// static ladder.
 export const reviewerEffortLevels = (reviewer, model = null) => {
   const slug = normalizeReviewerSlug(reviewer);
   if (!slug) return null;
 
   const base = REVIEWER_EFFORT_LEVELS[slug] || null;
 
-  // For codex, gate minimal on gpt-6 family models that reject it.
-  // Mirror of codexEffortLevelsForModel from server/lib/providerModels.js.
+  // For codex, use the server's model-gated ladder so the picker and CLI stay
+  // aligned as supported model families change.
   if (slug === 'codex' && model && base) {
-    const modelId = String(model || '').trim().toLowerCase();
-    // gpt-6 and later don't accept minimal; gpt-5.6 and earlier do
-    if (/^gpt-[6-9]([.-]|$)/.test(modelId)) {
-      // Check if it's an ultra model (gpt-5.6 or gpt-6-astra)
-      const isUltra = ['gpt-5.6', 'gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-6-astra'].includes(modelId);
-      const ultraLadder = isUltra ? CODEX_ULTRA_EFFORT_LEVELS : CODEX_EFFORT_LEVELS;
-      return ultraLadder.filter(l => l !== 'minimal');
-    }
+    return codexEffortLevelsForModel(model);
   }
 
   return base;

--- a/server/lib/providerModels.js
+++ b/server/lib/providerModels.js
@@ -152,7 +152,7 @@ const withoutMinimal = (levels) => Object.freeze(levels.filter((l) => l !== 'min
 const CODEX_EFFORT_LEVELS_NO_MINIMAL = withoutMinimal(CODEX_EFFORT_LEVELS);
 const CODEX_ULTRA_EFFORT_LEVELS_NO_MINIMAL = withoutMinimal(CODEX_ULTRA_EFFORT_LEVELS);
 
-const codexEffortLevelsForModel = (model) => {
+export const codexEffortLevelsForModel = (model) => {
   const id = String(model || '').trim().toLowerCase();
   const ultra = CODEX_ULTRA_MODELS.has(id);
   if (CODEX_NO_MINIMAL_MODEL_RE.test(id)) {

--- a/server/lib/reviewerConfig.test.js
+++ b/server/lib/reviewerConfig.test.js
@@ -403,6 +403,9 @@ describe('client mirror of the reviewer vocabulary', () => {
     for (const reviewer of REVIEWER_VALUES) {
       expect(client.reviewerEffortLevels(reviewer) ?? null).toEqual(reviewerEffortLevels(reviewer) ?? null);
     }
+    for (const model of ['gpt-5.6', 'gpt-5.6-sol', 'gpt-6-astra', 'gpt-6', 'gpt-5.5', 'o3']) {
+      expect(client.reviewerEffortLevels('codex', model)).toEqual(reviewerEffortLevels('codex', model));
+    }
     // Alias parity too — the picker keys rows off stored slugs.
     expect(client.reviewerEffortLevels('gemini')).toEqual(reviewerEffortLevels('gemini'));
   });


### PR DESCRIPTION
## Summary

- Export the server-owned `codexEffortLevelsForModel` helper and reuse it from the client reviewer picker.
- Extend the server/client parity contract across the six model families named by the issue, including the gpt-5.6 ultra ladder.

## Test plan

- `npm test` (server): 42,996 passed, 35 skipped
- `npm test` (client): 11,361 passed, 8 skipped
- `git diff --check`
- Acceptance grep for `gpt-5.6|gpt-[6-9]` in `client/src/lib/reviewerPins.js`
- Required local Codex review at `gpt-6-astra`, low effort: no actionable defects

Closes #6817