### PR TITLE
fix: add keyboard navigation to TabPills (claim/issue-6910)

### DIFF
--- a/client/src/components/ui/TabPills.jsx
+++ b/client/src/components/ui/TabPills.jsx
@@ -16,6 +16,7 @@
 // `controlsIdPrefix` wires `aria-controls` (and `id="tab-<id>"`) to matching tabpanels — pass
 // `'tabpanel'` to mirror ChiefOfStaff's wiring. `t.trailing` is an optional
 // ReactNode rendered after the count (e.g. PipelineIssue's per-stage status dot).
+import { useRef } from 'react';
 import { Loader2 } from 'lucide-react';
 
 const SIZE = {
@@ -44,6 +45,37 @@ export default function TabPills({
 }) {
   const sz = SIZE[size] || SIZE.md;
   const visibleTabs = tabs.filter(Boolean);
+  const tabRefs = useRef([]);
+  const enabledTabIndexes = visibleTabs
+    .map((tab, index) => (tab.disabled ? null : index))
+    .filter((index) => index !== null);
+
+  const handleTabKeyDown = (event, index) => {
+    if (!['ArrowRight', 'ArrowDown', 'ArrowLeft', 'ArrowUp', 'Home', 'End'].includes(event.key)) {
+      return;
+    }
+
+    const currentPosition = enabledTabIndexes.indexOf(index);
+    if (currentPosition === -1 || enabledTabIndexes.length === 0) {
+      return;
+    }
+
+    let targetPosition;
+    if (event.key === 'Home') {
+      targetPosition = 0;
+    } else if (event.key === 'End') {
+      targetPosition = enabledTabIndexes.length - 1;
+    } else {
+      const direction = event.key === 'ArrowRight' || event.key === 'ArrowDown' ? 1 : -1;
+      targetPosition = (currentPosition + direction + enabledTabIndexes.length) % enabledTabIndexes.length;
+    }
+
+    const targetIndex = enabledTabIndexes[targetPosition];
+    const targetTab = visibleTabs[targetIndex];
+    event.preventDefault();
+    onChange(targetTab.id);
+    tabRefs.current[targetIndex]?.focus();
+  };
 
   // Mobile `<select>` collapse, shared by both variants so `mobileDropdown` works
   // regardless of `variant` (the underline tab bar just overflow-scrolls without it).
@@ -78,7 +110,7 @@ export default function TabPills({
           role={isFilter ? 'group' : 'tablist'}
           aria-label={ariaLabel}
         >
-          {visibleTabs.map((t) => {
+          {visibleTabs.map((t, index) => {
             const Icon = t.icon;
             const active = t.id === activeTab;
             const running = runningKind && t.runningKind === runningKind;
@@ -91,8 +123,11 @@ export default function TabPills({
                 aria-pressed={isFilter ? active : undefined}
                 aria-controls={!isFilter && controlsIdPrefix ? `${controlsIdPrefix}-${t.id}` : undefined}
                 id={!isFilter && controlsIdPrefix ? `tab-${t.id}` : undefined}
+                ref={!isFilter ? (node) => { tabRefs.current[index] = node; } : undefined}
+                tabIndex={!isFilter ? (active ? 0 : -1) : undefined}
                 disabled={t.disabled}
                 onClick={() => onChange(t.id)}
+                onKeyDown={!isFilter ? (event) => handleTabKeyDown(event, index) : undefined}
                 className={`flex items-center ${sz.gap} ${sz.padding} rounded ${sz.text} transition-colors whitespace-nowrap ${
                   active
                     ? 'bg-port-accent/20 text-port-accent border border-port-accent/40'
@@ -128,7 +163,7 @@ export default function TabPills({
         role="tablist"
         aria-label={ariaLabel}
       >
-      {visibleTabs.map((t) => {
+      {visibleTabs.map((t, index) => {
         const Icon = t.icon;
         const active = t.id === activeTab;
         const running = runningKind && t.runningKind === runningKind;
@@ -140,8 +175,11 @@ export default function TabPills({
             aria-selected={active}
             aria-controls={controlsIdPrefix ? `${controlsIdPrefix}-${t.id}` : undefined}
             id={controlsIdPrefix ? `tab-${t.id}` : undefined}
+            ref={(node) => { tabRefs.current[index] = node; }}
+            tabIndex={active ? 0 : -1}
             disabled={t.disabled}
             onClick={() => onChange(t.id)}
+            onKeyDown={(event) => handleTabKeyDown(event, index)}
             title={hideLabelOnMobile ? t.label : undefined}
             className={`flex items-center ${stretch ? 'flex-1 min-w-0 justify-center' : 'shrink-0 justify-center'} ${sz.gap} ${sz.padding} ${sz.text} font-medium transition-colors whitespace-nowrap min-h-[44px] sm:min-h-[40px] border-b-2 -mb-px ${
               active

--- a/client/src/components/ui/TabPills.test.jsx
+++ b/client/src/components/ui/TabPills.test.jsx
@@ -29,6 +29,82 @@ describe('TabPills — underline variant (default)', () => {
     expect(onChange).toHaveBeenCalledWith('places');
   });
 
+  it.each(['underline', 'pills'])('uses a roving tabindex for the %s variant', (variant) => {
+    render(<TabPills variant={variant} tabs={sampleTabs} activeTab="places" onChange={() => {}} />);
+    expect(screen.getByRole('tab', { name: /Cast/i })).toHaveAttribute('tabindex', '-1');
+    expect(screen.getByRole('tab', { name: /Places/i })).toHaveAttribute('tabindex', '0');
+    expect(screen.getByRole('tab', { name: /Objects/i })).toHaveAttribute('tabindex', '-1');
+  });
+
+  it.each(['underline', 'pills'])('navigates tabs with arrow keys and wraps for the %s variant', async (variant) => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(<TabPills variant={variant} tabs={sampleTabs} activeTab="cast" onChange={onChange} />);
+
+    const castTab = screen.getByRole('tab', { name: /Cast/i });
+    const placesTab = screen.getByRole('tab', { name: /Places/i });
+    const objectsTab = screen.getByRole('tab', { name: /Objects/i });
+
+    castTab.focus();
+    await user.keyboard('{ArrowRight}');
+    expect(onChange).toHaveBeenLastCalledWith('places');
+    expect(document.activeElement).toBe(placesTab);
+
+    await user.keyboard('{ArrowDown}');
+    expect(onChange).toHaveBeenLastCalledWith('objects');
+    expect(document.activeElement).toBe(objectsTab);
+
+    await user.keyboard('{ArrowLeft}');
+    expect(onChange).toHaveBeenLastCalledWith('places');
+    expect(document.activeElement).toBe(placesTab);
+
+    await user.keyboard('{ArrowUp}');
+    expect(onChange).toHaveBeenLastCalledWith('cast');
+    expect(document.activeElement).toBe(castTab);
+
+    objectsTab.focus();
+    await user.keyboard('{ArrowRight}');
+    expect(onChange).toHaveBeenLastCalledWith('cast');
+    expect(document.activeElement).toBe(castTab);
+  });
+
+  it('uses Home and End to move to the first and last enabled tabs', async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(<TabPills tabs={sampleTabs} activeTab="places" onChange={onChange} />);
+
+    const castTab = screen.getByRole('tab', { name: /Cast/i });
+    const placesTab = screen.getByRole('tab', { name: /Places/i });
+    const objectsTab = screen.getByRole('tab', { name: /Objects/i });
+
+    placesTab.focus();
+    await user.keyboard('{Home}');
+    expect(onChange).toHaveBeenLastCalledWith('cast');
+    expect(document.activeElement).toBe(castTab);
+
+    await user.keyboard('{End}');
+    expect(onChange).toHaveBeenLastCalledWith('objects');
+    expect(document.activeElement).toBe(objectsTab);
+  });
+
+  it('skips disabled tabs during keyboard navigation', async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    const tabs = [
+      { id: 'a', label: 'A' },
+      { id: 'b', label: 'B', disabled: true },
+      { id: 'c', label: 'C' },
+    ];
+    render(<TabPills tabs={tabs} activeTab="a" onChange={onChange} />);
+
+    const aTab = screen.getByRole('tab', { name: 'A' });
+    const cTab = screen.getByRole('tab', { name: 'C' });
+    aTab.focus();
+    await user.keyboard('{ArrowRight}');
+    expect(onChange).toHaveBeenCalledWith('c');
+    expect(document.activeElement).toBe(cTab);
+  });
+
   it('shows the count next to the label when count > 0, hides it at 0 or undefined', () => {
     render(<TabPills tabs={sampleTabs} activeTab="cast" onChange={() => {}} />);
     const castBtn = screen.getByRole('tab', { name: /Cast/i });


### PR DESCRIPTION
## Summary

- add roving tabindex and WAI-ARIA keyboard navigation to semantic TabPills
- preserve native filter-toggle behavior while skipping disabled tabs
- cover both variants, wrapping, Home/End, and disabled-tab navigation

## Validation

- `cd client && npm test` (11,370 passed, 8 skipped)
- `cd client && npm run lint`
- `git diff --check`
- local Codex review: clean

Closes #6910