### PR TITLE
fix: make BrailleSpinner accessible and motion-aware (#6912)

### DIFF
--- a/client/src/components/BrailleSpinner.jsx
+++ b/client/src/components/BrailleSpinner.jsx
@@ -1,19 +1,32 @@
 import { useState, useEffect } from 'react';
+import usePrefersReducedMotion from '../hooks/usePrefersReducedMotion.js';
 
 const FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
 const INTERVAL_MS = 80;
 
 export default function BrailleSpinner({ text, className = '' }) {
   const [frame, setFrame] = useState(0);
+  const reducedMotion = usePrefersReducedMotion();
+  const accessibleLabel = text || 'Loading...';
 
   useEffect(() => {
+    if (reducedMotion) {
+      setFrame(0);
+      return undefined;
+    }
     const id = setInterval(() => setFrame(f => (f + 1) % FRAMES.length), INTERVAL_MS);
     return () => clearInterval(id);
-  }, []);
+  }, [reducedMotion]);
 
   return (
-    <span className={`text-port-accent ${className}`}>
-      {FRAMES[frame]}{text ? ` ${text}` : ''}
+    <span
+      className={`text-port-accent ${className}`}
+      role="status"
+      aria-live="polite"
+      aria-label={accessibleLabel}
+    >
+      <span aria-hidden="true">{FRAMES[reducedMotion ? 0 : frame]}</span>
+      {text ? ` ${text}` : <span className="sr-only">Loading...</span>}
     </span>
   );
 }

--- a/client/src/components/BrailleSpinner.test.jsx
+++ b/client/src/components/BrailleSpinner.test.jsx
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, render, screen } from '@testing-library/react';
+import BrailleSpinner from './BrailleSpinner';
+
+const QUERY = '(prefers-reduced-motion: reduce)';
+const originalMatchMedia = window.matchMedia;
+
+let mediaQuery;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  mediaQuery = {
+    matches: false,
+    listeners: new Set(),
+    addEventListener: vi.fn((_event, listener) => mediaQuery.listeners.add(listener)),
+    removeEventListener: vi.fn((_event, listener) => mediaQuery.listeners.delete(listener)),
+  };
+  window.matchMedia = vi.fn(() => mediaQuery);
+});
+
+afterEach(() => {
+  window.matchMedia = originalMatchMedia;
+  vi.useRealTimers();
+});
+
+const glyph = (status) => status.querySelector('[aria-hidden="true"]');
+
+describe('BrailleSpinner accessibility', () => {
+  it('announces provided text while hiding the animated glyph', () => {
+    render(<BrailleSpinner text="Loading records" />);
+
+    const status = screen.getByRole('status', { name: 'Loading records' });
+    expect(status).toHaveAttribute('aria-live', 'polite');
+    expect(screen.getByText('Loading records')).toBeInTheDocument();
+    expect(glyph(status)).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('provides a fallback accessible loading label without visible text', () => {
+    render(<BrailleSpinner />);
+
+    const status = screen.getByRole('status', { name: 'Loading...' });
+    expect(status).toHaveAttribute('aria-live', 'polite');
+    expect(screen.getByText('Loading...')).toHaveClass('sr-only');
+    expect(glyph(status)).toHaveAttribute('aria-hidden', 'true');
+  });
+});
+
+describe('BrailleSpinner motion preference', () => {
+  it('continues advancing frames when motion is allowed', () => {
+    render(<BrailleSpinner />);
+    const spinnerGlyph = glyph(screen.getByRole('status'));
+
+    expect(spinnerGlyph).toHaveTextContent('⠋');
+    act(() => { vi.advanceTimersByTime(80); });
+    expect(spinnerGlyph).toHaveTextContent('⠙');
+  });
+
+  it('freezes at the first frame when reduced motion is preferred', () => {
+    mediaQuery.matches = true;
+    render(<BrailleSpinner />);
+    const spinnerGlyph = glyph(screen.getByRole('status'));
+
+    expect(window.matchMedia).toHaveBeenCalledWith(QUERY);
+    expect(spinnerGlyph).toHaveTextContent('⠋');
+    act(() => { vi.advanceTimersByTime(240); });
+    expect(spinnerGlyph).toHaveTextContent('⠋');
+  });
+
+  it('stops and resets when the preference changes while mounted', () => {
+    render(<BrailleSpinner />);
+    const spinnerGlyph = glyph(screen.getByRole('status'));
+
+    act(() => { vi.advanceTimersByTime(80); });
+    expect(spinnerGlyph).toHaveTextContent('⠙');
+
+    act(() => {
+      mediaQuery.matches = true;
+      mediaQuery.listeners.forEach(listener => listener());
+    });
+    expect(spinnerGlyph).toHaveTextContent('⠋');
+
+    act(() => { vi.advanceTimersByTime(240); });
+    expect(spinnerGlyph).toHaveTextContent('⠋');
+  });
+});

--- a/client/src/components/cos/tabs/MindTab.test.jsx
+++ b/client/src/components/cos/tabs/MindTab.test.jsx
@@ -618,7 +618,7 @@ describe('MindTab', () => {
     });
     renderTab();
 
-    const thoughtStatus = await screen.findByRole('status');
+    const thoughtStatus = (await screen.findByText('Thinking with demo-model')).closest('[role="status"]');
     expect(thoughtStatus).toHaveTextContent('Thinking with demo-model');
     expect(thoughtStatus).toHaveAttribute('aria-busy', 'true');
     expect(thoughtStatus.querySelector('.animate-pulse')).toBeInTheDocument();


### PR DESCRIPTION
## Summary

- Give BrailleSpinner an accessible `status` live region with a useful label and an aria-hidden animated glyph.
- Honor `prefers-reduced-motion`, including live preference changes, by stopping and resetting frame updates.
- Add focused accessibility/motion coverage and make the existing MindTab status assertion specific.

## Validation

- `npm test -- src/components/BrailleSpinner.test.jsx src/components/cos/tabs/MindTab.test.jsx` — 40/40 tests passed
- `npm test -- src/a11yConventions.test.js` — 50/50 tests passed
- `npm test` — 932 files, 11,371 passed, 6 skipped
- `npm run lint` — 2,530 files checked
- `npm run build` — passed
- Local Codex review — no actionable regressions

Closes #6912