### PR TITLE
fix: make mobile navigation and skip link keyboard accessible

### DIFF
--- a/client/src/components/Layout.jsx
+++ b/client/src/components/Layout.jsx
@@ -1217,8 +1217,8 @@ export default function Layout() {
       </a>
       {/* Mobile overlay */}
       {mobileNavActive && (
-        <div
-          role="button"
+        <button
+          type="button"
           tabIndex={-1}
           aria-label="Close sidebar"
           className="fixed inset-0 bg-black/50 z-40 lg:hidden"

--- a/client/src/components/Layout.jsx
+++ b/client/src/components/Layout.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useLayoutEffect, useMemo, useRef, useCallback } from 'react';
+import useFocusTrap from '../hooks/useFocusTrap.js';
 import { Outlet, NavLink, useLocation, useNavigate } from 'react-router';
 import {
   Home,
@@ -681,6 +682,22 @@ export default function Layout() {
   const navigate = useNavigate();
   const [collapsed, setCollapsed] = useState(() => safeReadStorage(SIDEBAR_KEY) === 'true');
   const [mobileOpen, setMobileOpen] = useState(false);
+  const [desktopNav, setDesktopNav] = useState(() => window.matchMedia('(min-width: 1024px)').matches);
+  const sidebarRef = useRef(null);
+  const menuButtonRef = useRef(null);
+  const mainRef = useRef(null);
+  const mobileNavActive = mobileOpen && !desktopNav;
+  useFocusTrap(mobileNavActive, sidebarRef);
+  useEffect(() => {
+    const media = window.matchMedia('(min-width: 1024px)');
+    const syncViewport = () => {
+      setDesktopNav(media.matches);
+      if (media.matches) setMobileOpen(false);
+    };
+    syncViewport();
+    media.addEventListener('change', syncViewport);
+    return () => media.removeEventListener('change', syncViewport);
+  }, []);
   const [expandedSections, setExpandedSections] = useState({});
   const [expandedSubSections, setExpandedSubSections] = useState({});
   // Collapsed-sidebar flyout: hovering or focusing a section icon opens a
@@ -1193,15 +1210,16 @@ export default function Layout() {
       {/* Skip to main content link for keyboard users */}
       <a
         href="#main-content"
+        onClick={() => mainRef.current?.focus()}
         className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-[100] focus:px-4 focus:py-2 focus:bg-port-accent focus:text-white focus:rounded-lg focus:outline-hidden"
       >
         Skip to main content
       </a>
       {/* Mobile overlay */}
-      {mobileOpen && (
+      {mobileNavActive && (
         <div
           role="button"
-          tabIndex={0}
+          tabIndex={-1}
           aria-label="Close sidebar"
           className="fixed inset-0 bg-black/50 z-40 lg:hidden"
           onClick={() => setMobileOpen(false)}
@@ -1211,6 +1229,16 @@ export default function Layout() {
 
       {/* Sidebar */}
       <aside
+        ref={sidebarRef}
+        id="app-sidebar"
+        inert={!desktopNav && !mobileNavActive}
+        aria-hidden={!desktopNav && !mobileNavActive ? true : undefined}
+        onKeyDown={(event) => {
+          if (mobileNavActive && event.key === 'Escape' && !event.defaultPrevented) {
+            event.stopPropagation();
+            setMobileOpen(false);
+          }
+        }}
         className={`
           port-app-sidebar
           fixed inset-y-0 left-0 z-50 h-dvh-screen print:hidden
@@ -1417,10 +1445,15 @@ export default function Layout() {
         {/* Mobile header */}
         <header className="port-app-topbar lg:hidden flex items-center justify-between px-2 py-1.5 border-b border-port-border bg-port-card print:hidden">
           <button
-            onClick={() => setMobileOpen(true)}
+            ref={menuButtonRef}
+            onClick={() => {
+              menuButtonRef.current?.focus();
+              setMobileOpen(true);
+            }}
             className="inline-flex items-center justify-center min-w-[44px] min-h-[44px] -ml-1 rounded-lg text-gray-400 hover:text-white"
             aria-label="Open navigation menu"
-            aria-expanded={mobileOpen}
+            aria-expanded={mobileNavActive}
+            aria-controls="app-sidebar"
           >
             <Menu size={20} aria-hidden="true" />
           </button>
@@ -1455,7 +1488,7 @@ export default function Layout() {
         {(() => {
           const isFullWidth = isFullWidthRoute(location.pathname);
           return (
-            <main id="main-content" className={`flex-1 min-h-0 print:overflow-visible print:min-h-0 ${isFullWidth ? 'relative overflow-hidden' : 'overflow-auto p-4 md:p-6'}`}>
+            <main ref={mainRef} id="main-content" tabIndex={-1} className={`focus:outline-none flex-1 min-h-0 print:overflow-visible print:min-h-0 ${isFullWidth ? 'relative overflow-hidden' : 'overflow-auto p-4 md:p-6'}`}>
               <Outlet />
             </main>
           );

--- a/client/src/components/Layout.jsx
+++ b/client/src/components/Layout.jsx
@@ -1234,7 +1234,8 @@ export default function Layout() {
         inert={!desktopNav && !mobileNavActive}
         aria-hidden={!desktopNav && !mobileNavActive ? true : undefined}
         onKeyDown={(event) => {
-          if (mobileNavActive && event.key === 'Escape' && !event.defaultPrevented) {
+          // Portaled child popovers own their Escape dismissal.
+          if (mobileNavActive && event.key === 'Escape' && !event.defaultPrevented && event.currentTarget.contains(event.target)) {
             event.stopPropagation();
             setMobileOpen(false);
           }

--- a/client/src/components/Layout.test.jsx
+++ b/client/src/components/Layout.test.jsx
@@ -36,7 +36,13 @@ vi.mock('../hooks/useNotifications', () => ({
 
 // --- Theme context: Layout reads `theme.mode` for the day/night toggle. ---
 vi.mock('./ThemeContext', () => ({
-  useThemeContext: () => ({ theme: { mode: 'night', label: 'Test', pair: null }, toggleMode: vi.fn() }),
+  useThemeContext: () => ({
+    theme: { mode: 'night', label: 'Test', pair: null },
+    themeId: 'test',
+    themeList: [{ id: 'test', label: 'Test', family: 'classic', shortLabel: 'Test', density: 'comfortable' }],
+    setTheme: vi.fn(),
+    toggleMode: vi.fn(),
+  }),
 }));
 
 // --- Heavy child widgets: render nothing so they don't open sockets / fetch. ---
@@ -623,6 +629,25 @@ describe('Layout — keyboard navigation shell', () => {
     expect(opener).toHaveFocus();
     fireEvent.click(opener);
     fireEvent.click(screen.getAllByRole('button', { name: 'Close sidebar' }).find(el => !sidebar.contains(el)));
+    expect(opener).toHaveFocus();
+    expect(sidebar).toHaveAttribute('inert');
+  });
+
+  it('dismisses a portaled theme picker before closing its mobile sidebar', async () => {
+    desktopMedia.matches = false;
+    const { container } = await renderLayout();
+    const sidebar = container.querySelector('#app-sidebar');
+    const opener = screen.getByRole('button', { name: 'Open navigation menu' });
+    fireEvent.click(opener);
+    const themeButton = within(sidebar).getByRole('button', { name: 'Switch theme. Current theme: Test' });
+    fireEvent.click(themeButton);
+    const option = screen.getByRole('menuitemradio', { name: /Test/ });
+    expect(option).toHaveFocus();
+    fireEvent.keyDown(option, { key: 'Escape' });
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+    expect(themeButton).toHaveFocus();
+    expect(opener).toHaveAttribute('aria-expanded', 'true');
+    fireEvent.keyDown(themeButton, { key: 'Escape' });
     expect(opener).toHaveFocus();
     expect(sidebar).toHaveAttribute('inert');
   });

--- a/client/src/components/Layout.test.jsx
+++ b/client/src/components/Layout.test.jsx
@@ -157,7 +157,11 @@ describe('Layout — manifest-derived sidebar structure', () => {
   });
 });
 
+let desktopMedia;
+
 beforeEach(() => {
+  desktopMedia = Object.assign(new EventTarget(), { matches: true });
+  vi.stubGlobal('matchMedia', vi.fn(() => desktopMedia));
   localStorage.clear();
   // The feature list is cached at module scope so every consumer shares one
   // fetch — drop it between tests so a case that flips a flag cannot leak.
@@ -576,5 +580,79 @@ describe('Layout — sidebar section grouping', () => {
         .filter((section) => section && !UNGROUPED_SECTIONS.has(section)),
     );
     expect(alphabetical([...presented])).toEqual(alphabetical(grouped));
+  });
+});
+
+describe('Layout — keyboard navigation shell', () => {
+  it('moves skip-link focus into main content', async () => {
+    await renderLayout();
+    const skipLink = screen.getByRole('link', { name: 'Skip to main content' });
+    skipLink.focus();
+    fireEvent.click(skipLink);
+    expect(screen.getByRole('main')).toHaveFocus();
+    expect(screen.getByRole('main')).toHaveAttribute('tabindex', '-1');
+  });
+
+  it('hides closed mobile links, traps open navigation, and restores the menu button on dismissal', async () => {
+    desktopMedia.matches = false;
+    const { container } = await renderLayout();
+    const sidebar = container.querySelector('#app-sidebar');
+    const opener = screen.getByRole('button', { name: 'Open navigation menu' });
+    expect(sidebar).toHaveAttribute('inert');
+    expect(sidebar).toHaveAttribute('aria-hidden', 'true');
+    expect(screen.queryByRole('navigation')).not.toBeInTheDocument();
+
+    fireEvent.click(opener);
+    expect(sidebar).not.toHaveAttribute('inert');
+    expect(sidebar).not.toHaveAttribute('aria-hidden');
+    expect(sidebar.contains(document.activeElement)).toBe(true);
+    const first = document.activeElement;
+    fireEvent.keyDown(first, { key: 'Tab', shiftKey: true });
+    const last = document.activeElement;
+    expect(last).not.toBe(first);
+    expect(sidebar.contains(last)).toBe(true);
+    fireEvent.keyDown(last, { key: 'Tab' });
+    expect(first).toHaveFocus();
+    fireEvent.keyDown(first, { key: 'Escape' });
+    expect(opener).toHaveFocus();
+    expect(opener).toHaveAttribute('aria-expanded', 'false');
+    expect(sidebar).toHaveAttribute('inert');
+
+    fireEvent.click(opener);
+    fireEvent.click(within(sidebar).getByRole('button', { name: 'Close sidebar' }));
+    expect(opener).toHaveFocus();
+    fireEvent.click(opener);
+    fireEvent.click(screen.getAllByRole('button', { name: 'Close sidebar' }).find(el => !sidebar.contains(el)));
+    expect(opener).toHaveFocus();
+    expect(sidebar).toHaveAttribute('inert');
+  });
+
+  it('keeps desktop navigation accessible and releases the mobile trap on a breakpoint change', async () => {
+    const { container } = await renderLayout();
+    const sidebar = container.querySelector('#app-sidebar');
+    expect(sidebar).not.toHaveAttribute('inert');
+    expect(sidebar).not.toHaveAttribute('aria-hidden');
+    act(() => {
+      desktopMedia.matches = false;
+      desktopMedia.dispatchEvent(new Event('change'));
+    });
+    expect(sidebar).toHaveAttribute('inert');
+    const opener = screen.getByRole('button', { name: 'Open navigation menu' });
+    fireEvent.click(opener);
+    act(() => {
+      desktopMedia.matches = true;
+      desktopMedia.dispatchEvent(new Event('change'));
+    });
+    expect(opener).toHaveAttribute('aria-expanded', 'false');
+    expect(sidebar).not.toHaveAttribute('inert');
+    expect(sidebar).not.toHaveAttribute('aria-hidden');
+    const link = within(sidebar).getAllByRole('link')[0];
+    link.focus();
+    expect(fireEvent.keyDown(link, { key: 'Tab', shiftKey: true })).toBe(true);
+    act(() => {
+      desktopMedia.matches = false;
+      desktopMedia.dispatchEvent(new Event('change'));
+    });
+    expect(sidebar).toHaveAttribute('inert');
   });
 });


### PR DESCRIPTION
Mobile navigation now removes its closed sidebar from keyboard navigation and screen readers, traps focus while open, and restores the menu button when dismissed. The skip link focuses main content. Switching to desktop releases the mobile trap, and Escape in a portaled theme picker dismisses the picker before the sidebar.

Validation: 144 Layout, focus-trap, theme-picker, and accessibility convention tests passed; changed-file Biome lint and the production client build passed. The configured optional Codex review identified the popover Escape interaction, which was corrected and covered by a rendered regression test.

Closes #6909
