### PR TITLE
feat: show global pause state on schedule cards

### DIFF
--- a/client/src/components/cos/tabs/schedule/AppTaskCard.jsx
+++ b/client/src/components/cos/tabs/schedule/AppTaskCard.jsx
@@ -1,10 +1,11 @@
-import { Clock, AlertTriangle, SlidersHorizontal, GitMerge } from 'lucide-react';
+import { Clock, AlertTriangle, SlidersHorizontal, GitMerge, PauseCircle } from 'lucide-react';
 import { timeAgo } from '../../../../utils/formatters';
 import useTaskModelPins from '../../../../hooks/useTaskModelPins';
 import { describeNextRun, coverageTone, pipelineStages, IMPROVEMENT_DISABLED_TITLE, SAVING_TITLE } from './scheduleConstants';
 import TaskHeader from './TaskHeader';
 import RunTaskButton from './RunTaskButton';
 import TaskModelQuickControls from './TaskModelQuickControls';
+import Banner from '../../../ui/Banner';
 
 // One scheduled task rendered as a status-rich card. Browsing plus the common
 // "retarget the model and run it" loop happen here; the rest of the
@@ -74,6 +75,18 @@ export default function AppTaskCard({ taskType, config, apps, onTrigger, onConfi
           )}
         </div>
       </button>
+
+      {config.enabled === false && (
+        <Banner
+          tone="warning"
+          icon={PauseCircle}
+          title="Global pause active"
+          role="status"
+          className="mx-4 mb-3"
+        >
+          Scheduled runs are paused for this task.
+        </Banner>
+      )}
 
       {/* Quick model pins — the drawer's Global defaults, inline */}
       {userInvokable && onUpdate && (stageCount > 0 ? (

--- a/client/src/components/cos/tabs/schedule/AppTaskCard.test.jsx
+++ b/client/src/components/cos/tabs/schedule/AppTaskCard.test.jsx
@@ -109,6 +109,17 @@ describe('AppTaskCard', () => {
     expect(screen.getByText('Paused')).toBeTruthy();
   });
 
+  it('shows the global pause state on the card', () => {
+    renderCard({ enabled: false });
+    const indicator = screen.getByText('Global pause active').closest('[role="status"]');
+    expect(indicator).toHaveTextContent('Scheduled runs are paused for this task.');
+  });
+
+  it('does not show a global pause indicator for an enabled task', () => {
+    renderCard();
+    expect(screen.queryByText('Global pause active')).toBeNull();
+  });
+
   it('marks an automation-only task and removes direct actions', () => {
     const { onTrigger, onConfigure } = renderCard({
       invocation: {


### PR DESCRIPTION
## Summary
- Add an at-a-glance warning indicator to scheduled-task cards when the task-level global pause is active.
- Reuse the shared Banner primitive and retain the existing paused next-run text.

## Test plan
- `./node_modules/.bin/vitest run src/components/cos/tabs/schedule/AppTaskCard.test.jsx`
- `./node_modules/.bin/vitest run src/components/cos/tabs/ScheduleTab.test.jsx src/components/cos/tabs/schedule`
- `npm run lint`
- `npm run build