### PR TITLE
fix: keep Review Hub status tabs in sync with socket updates (#6925)

### DIFF
--- a/client/src/pages/Review.jsx
+++ b/client/src/pages/Review.jsx
@@ -251,11 +251,18 @@ export default function Review() {
   // without memoization every one of these filter/sort passes over `items` reruns
   // on unrelated re-renders (typing, hover state). Hooks must run before the
   // loading early-return, so they live here above it.
-  const grouped = useMemo(() => items.reduce((acc, item) => {
+  // Keep the detailed list aligned with the active status tab while socket
+  // events update the cached items from every status.
+  const visibleItems = useMemo(() => {
+    if (filter === 'all') return items;
+    return items.filter(item => item.status === filter);
+  }, [items, filter]);
+
+  const grouped = useMemo(() => visibleItems.reduce((acc, item) => {
     if (!acc[item.type]) acc[item.type] = [];
     acc[item.type].push(item);
     return acc;
-  }, {}), [items]);
+  }, {}), [visibleItems]);
 
   const queueItems = useMemo(
     () => (queue?.items || []).filter(i => !dismissedQueueIds.has(i.id)),
@@ -511,10 +518,10 @@ export default function Review() {
         })}
         </div>
 
-        {items.length === 0 && (
+        {visibleItems.length === 0 && (
           <div className="text-center py-12 text-gray-500">
             <ClipboardList size={48} className="mx-auto mb-3 opacity-30" />
-            <p className="text-lg">No review items yet</p>
+            <p className="text-lg">No review items in this view</p>
             <p className="text-sm mt-1">This hub will fill up as agents surface alerts, actions, and briefing context.</p>
           </div>
         )}

--- a/client/src/pages/Review.test.jsx
+++ b/client/src/pages/Review.test.jsx
@@ -42,8 +42,23 @@ const SHORT_ITEM = {
   metadata: {}
 };
 
+const COMPLETED_ITEM = {
+  ...ITEM,
+  id: 'item-3',
+  status: 'completed',
+  title: 'Completed review item',
+  description: 'Already completed.'
+};
+
+const CREATED_PENDING_ITEM = {
+  ...ITEM,
+  id: 'item-4',
+  title: 'New pending review item',
+  description: 'Created after the completed view loaded.'
+};
+
 vi.mock('../services/api', () => ({
-  getReviewItems: vi.fn(() => Promise.resolve([ITEM, SHORT_ITEM])),
+  getReviewItems: vi.fn(() => Promise.resolve([ITEM, SHORT_ITEM, COMPLETED_ITEM])),
   getReviewBriefing: vi.fn(() => Promise.resolve(null)),
   getReviewQueue: vi.fn(() => Promise.resolve({ items: [], sources: {} })),
   createReviewTodo: vi.fn(() => Promise.resolve({})),
@@ -195,6 +210,8 @@ describe('Review Hub bulk status updates (#6853)', () => {
     await waitFor(() => {
       expect(actionQueueBody()).toBeFalsy();
       expect(document.getElementById(`review-item-body-action-queue-${SHORT_ITEM.id}`)).toBeFalsy();
+      expect(screen.queryByText(ITEM.title)).not.toBeInTheDocument();
+      expect(screen.queryByText(SHORT_ITEM.title)).not.toBeInTheDocument();
     });
   });
 
@@ -206,5 +223,48 @@ describe('Review Hub bulk status updates (#6853)', () => {
 
     unmount();
     expect(socket.off.mock.calls.some(([name]) => name === 'review:items:bulk-updated')).toBe(true);
+  });
+});
+
+describe('Review Hub status-filtered socket items (#6925)', () => {
+  it('removes individually updated items from the active status list', async () => {
+    render(<Review />);
+    await waitFor(() => expect(screen.getAllByText(ITEM.title).length).toBeGreaterThan(0));
+
+    const handler = [...socket.on.mock.calls]
+      .reverse()
+      .find(([name]) => name === 'review:item:updated')?.[1];
+    expect(handler).toBeTypeOf('function');
+
+    act(() => {
+      handler({ ...ITEM, status: 'completed' });
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText(ITEM.title)).not.toBeInTheDocument();
+      expect(screen.queryByText(COMPLETED_ITEM.title)).not.toBeInTheDocument();
+    });
+  });
+
+  it('keeps socket-created pending items out of the completed view', async () => {
+    render(<Review />);
+    const filterSelect = await screen.findByLabelText('Filter review items by status');
+    fireEvent.change(filterSelect, { target: { value: 'completed' } });
+
+    await waitFor(() => expect(screen.getByText(COMPLETED_ITEM.title)).toBeInTheDocument());
+
+    const handler = [...socket.on.mock.calls]
+      .reverse()
+      .find(([name]) => name === 'review:item:created')?.[1];
+    expect(handler).toBeTypeOf('function');
+
+    act(() => {
+      handler(CREATED_PENDING_ITEM);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(COMPLETED_ITEM.title)).toBeInTheDocument();
+      expect(document.getElementById(`review-item-title-section-alert-${CREATED_PENDING_ITEM.id}`)).not.toBeInTheDocument();
+    });
   });
 });


### PR DESCRIPTION
## Summary
- filter Review Hub items before grouping and rendering so socket updates respect the active status tab
- cover individual status changes and newly created pending items with regression tests

## Validation
- `npm test -- --run src/pages/Review.test.jsx` (10 passed)
- full client Vitest suite (931 files, 11,383 passed; 1 skipped file set, 8 skipped tests)
- client lint passed

Closes #6925