### PR TITLE
fix([issue-6926]): preserve Review Hub triage counts across filters

### DIFF
--- a/client/src/pages/Review.jsx
+++ b/client/src/pages/Review.jsx
@@ -94,6 +94,7 @@ export default function Review() {
   const [editingId, setEditingId] = useState(null);
   const [filter, setFilter] = useState('pending');
   const [briefingFullscreen, setBriefingFullscreen] = useState(false);
+  const [counts, setCounts] = useState(null);
 
   // Cross-domain live queue (M42 P5). These rows are derived live from each
   // producer, not stored, so "dismiss" is a per-session client-side hide rather
@@ -112,6 +113,10 @@ export default function Review() {
     setLoading(false);
   }, [filter]);
 
+  const fetchCounts = useCallback(() => {
+    api.getReviewCounts({ silent: true }).then(setCounts).catch(() => null);
+  }, []);
+
   const fetchBriefing = useCallback(async () => {
     const data = await api.getReviewBriefing().catch(() => null);
     setBriefing(data);
@@ -125,12 +130,14 @@ export default function Review() {
 
   useEffect(() => {
     fetchItems();
+    fetchCounts();
     fetchBriefing();
     fetchQueue();
-  }, [fetchItems, fetchBriefing, fetchQueue]);
+  }, [fetchItems, fetchCounts, fetchBriefing, fetchQueue]);
 
   useEffect(() => {
     const handleCreated = (item) => {
+      fetchCounts();
       if (item.metadata?.privateSecurity) { fetchItems(); return; }
       setItems(prev => {
         if (prev.some(i => i.id === item.id)) return prev;
@@ -138,15 +145,18 @@ export default function Review() {
       });
     };
     const handleUpdated = (item) => {
+      fetchCounts();
       if (item.metadata?.privateSecurity) { fetchItems(); return; }
       setItems(prev => prev.map(i => i.id === item.id ? item : i));
     };
     const handleDeleted = (item) => {
+      fetchCounts();
       setItems(prev => prev.filter(i => i.id !== item.id));
     };
     // Bulk status change ("Mark all read" / "Complete all") — one state
     // update for every affected id instead of N per-item events.
     const handleBulkUpdated = ({ ids, status, updatedAt }) => {
+      fetchCounts();
       const idSet = new Set(ids);
       setItems(prev => prev.map(i => idSet.has(i.id) ? { ...i, status, updatedAt } : i));
     };
@@ -162,7 +172,7 @@ export default function Review() {
       socket.off('review:item:deleted', handleDeleted);
       socket.off('review:items:bulk-updated', handleBulkUpdated);
     };
-  }, [fetchItems]);
+  }, [fetchCounts, fetchItems]);
 
   // Live-invalidate the cross-domain queue. A burst of producer events (e.g.
   // a draft sent fires both messages:draft:sent and messages:changed) coalesces
@@ -294,13 +304,12 @@ export default function Review() {
   }
 
   // Cheap derivations off the memoized `pendingItems`/`actionableItems` — plain
-  // consts, not memos: each is O(n) filter or O(8) slice with no consumer that
+  // consts, not memos: the action list is an O(8) slice with no consumer that
   // needs referential stability, so a hook here would be pure ceremony.
-  const pendingAlerts = pendingItems.filter(i => i.type === 'alert');
-  const pendingCos = pendingItems.filter(i => i.type === 'cos');
-  const pendingTodos = pendingItems.filter(i => i.type === 'todo');
   const topActionItems = actionableItems.slice(0, 8);
 
+  // This count controls actions for the currently loaded filter; the global
+  // triage summary below comes from the unfiltered counts endpoint.
   const pendingCount = pendingItems.length;
   const remainingActionCount = Math.max(0, actionableItems.length - topActionItems.length);
 
@@ -348,10 +357,10 @@ export default function Review() {
 
         {/* Triage summary */}
         <section className="flex flex-wrap gap-2">
-          <SummaryPill icon={BellRing} label="Pending" value={pendingCount} tone="text-white" />
-          <SummaryPill icon={AlertTriangle} label="Alerts" value={pendingAlerts.length} tone="text-port-warning" urgent={pendingAlerts.length > 0} />
-          <SummaryPill icon={Crown} label="CoS" value={pendingCos.length} tone="text-port-accent" />
-          <SummaryPill icon={ClipboardList} label="Todos" value={pendingTodos.length} tone="text-port-success" />
+          <SummaryPill icon={BellRing} label="Pending" value={counts?.total ?? 0} tone="text-white" />
+          <SummaryPill icon={AlertTriangle} label="Alerts" value={counts?.alert ?? 0} tone="text-port-warning" urgent={(counts?.alert ?? 0) > 0} />
+          <SummaryPill icon={Crown} label="CoS" value={counts?.cos ?? 0} tone="text-port-accent" />
+          <SummaryPill icon={ClipboardList} label="Todos" value={counts?.todo ?? 0} tone="text-port-success" />
         </section>
 
         {/* Cross-domain "Needs Attention" queue (M42 P5) — live-pulled from

--- a/client/src/pages/Review.jsx
+++ b/client/src/pages/Review.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { useNavigate } from 'react-router';
 import {
   ClipboardList,
@@ -95,6 +95,7 @@ export default function Review() {
   const [filter, setFilter] = useState('pending');
   const [briefingFullscreen, setBriefingFullscreen] = useState(false);
   const [counts, setCounts] = useState(null);
+  const countsRequestId = useRef(0);
 
   // Cross-domain live queue (M42 P5). These rows are derived live from each
   // producer, not stored, so "dismiss" is a per-session client-side hide rather
@@ -114,7 +115,10 @@ export default function Review() {
   }, [filter]);
 
   const fetchCounts = useCallback(() => {
-    api.getReviewCounts({ silent: true }).then(setCounts).catch(() => null);
+    const requestId = ++countsRequestId.current;
+    api.getReviewCounts({ silent: true }).then(data => {
+      if (requestId === countsRequestId.current) setCounts(data);
+    }).catch(() => null);
   }, []);
 
   const fetchBriefing = useCallback(async () => {

--- a/client/src/pages/Review.test.jsx
+++ b/client/src/pages/Review.test.jsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 // A CoS action body is arbitrary agent-authored markdown — thousands of words,
@@ -59,6 +59,7 @@ const CREATED_PENDING_ITEM = {
 
 vi.mock('../services/api', () => ({
   getReviewItems: vi.fn(() => Promise.resolve([ITEM, SHORT_ITEM, COMPLETED_ITEM])),
+  getReviewCounts: vi.fn(),
   getReviewBriefing: vi.fn(() => Promise.resolve(null)),
   getReviewQueue: vi.fn(() => Promise.resolve({ items: [], sources: {} })),
   createReviewTodo: vi.fn(() => Promise.resolve({})),
@@ -81,7 +82,16 @@ vi.mock('react-router', () => ({
 }));
 
 import Review from './Review';
+import * as api from '../services/api';
 import socket from '../services/socket';
+
+const SUMMARY_COUNTS = { total: 8, alert: 3, todo: 1, briefing: 0, cos: 4 };
+
+const summaryValue = (label) => {
+  const labelNode = screen.getAllByText(label, { exact: true })
+    .find(node => node.matches('span.text-xs'));
+  return labelNode?.parentElement?.querySelector('span.text-sm')?.textContent;
+};
 
 // jsdom reports 0 for scrollHeight/clientHeight, so nothing measures as
 // overflowing unless we force it.
@@ -89,6 +99,11 @@ const forceOverflow = () =>
   vi.spyOn(HTMLElement.prototype, 'scrollHeight', 'get').mockReturnValue(500);
 
 afterEach(() => vi.restoreAllMocks());
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  api.getReviewCounts.mockResolvedValue(SUMMARY_COUNTS);
+});
 
 const actionQueueBody = () => document.getElementById(`review-item-body-action-queue-${ITEM.id}`);
 
@@ -266,5 +281,45 @@ describe('Review Hub status-filtered socket items (#6925)', () => {
       expect(screen.getByText(COMPLETED_ITEM.title)).toBeInTheDocument();
       expect(document.getElementById(`review-item-title-section-alert-${CREATED_PENDING_ITEM.id}`)).not.toBeInTheDocument();
     });
+  });
+});
+
+describe('Review Hub triage summary (#6926)', () => {
+  it('keeps global pending counts when the list filter changes', async () => {
+    render(<Review />);
+    await waitFor(() => expect(summaryValue('Pending')).toBe('8'));
+
+    fireEvent.change(screen.getByRole('combobox', { name: 'Filter review items by status' }), {
+      target: { value: 'completed' }
+    });
+    await waitFor(() => expect(api.getReviewItems).toHaveBeenLastCalledWith({ status: 'completed' }));
+
+    expect(summaryValue('Pending')).toBe('8');
+    expect(summaryValue('Alerts')).toBe('3');
+    expect(summaryValue('CoS')).toBe('4');
+    expect(summaryValue('Todos')).toBe('1');
+  });
+
+  it('refreshes global pending counts when a review item changes', async () => {
+    const updatedCounts = { total: 7, alert: 2, todo: 1, briefing: 0, cos: 4 };
+    api.getReviewCounts
+      .mockReset()
+      .mockResolvedValueOnce(SUMMARY_COUNTS)
+      .mockResolvedValueOnce(updatedCounts);
+
+    render(<Review />);
+    await waitFor(() => expect(summaryValue('Pending')).toBe('8'));
+
+    const handler = socket.on.mock.calls.find(([name]) => name === 'review:item:updated')?.[1];
+    expect(handler).toBeTypeOf('function');
+
+    await act(async () => {
+      handler({ ...ITEM, status: 'completed' });
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(summaryValue('Pending')).toBe('7'));
+    expect(summaryValue('Alerts')).toBe('2');
+    expect(api.getReviewCounts).toHaveBeenCalledTimes(2);
   });
 });

--- a/client/src/pages/Review.test.jsx
+++ b/client/src/pages/Review.test.jsx
@@ -322,4 +322,34 @@ describe('Review Hub triage summary (#6926)', () => {
     expect(summaryValue('Alerts')).toBe('2');
     expect(api.getReviewCounts).toHaveBeenCalledTimes(2);
   });
+
+  it('keeps the newest count response when refreshes resolve out of order', async () => {
+    let resolveInitial;
+    let resolveRefresh;
+    api.getReviewCounts
+      .mockReset()
+      .mockImplementationOnce(() => new Promise(resolve => { resolveInitial = resolve; }))
+      .mockImplementationOnce(() => new Promise(resolve => { resolveRefresh = resolve; }));
+
+    render(<Review />);
+    await waitFor(() => expect(resolveInitial).toBeTypeOf('function'));
+
+    const handler = socket.on.mock.calls.find(([name]) => name === 'review:item:updated')?.[1];
+    expect(handler).toBeTypeOf('function');
+    act(() => handler({ ...ITEM, status: 'completed' }));
+    await waitFor(() => expect(resolveRefresh).toBeTypeOf('function'));
+
+    await act(async () => {
+      resolveRefresh({ total: 7, alert: 2, todo: 1, briefing: 0, cos: 4 });
+      await Promise.resolve();
+    });
+    expect(summaryValue('Pending')).toBe('7');
+
+    await act(async () => {
+      resolveInitial(SUMMARY_COUNTS);
+      await Promise.resolve();
+    });
+    expect(summaryValue('Pending')).toBe('7');
+    expect(summaryValue('Alerts')).toBe('2');
+  });
 });

--- a/client/src/services/apiReview.js
+++ b/client/src/services/apiReview.js
@@ -8,7 +8,7 @@ export const getReviewItems = (params) => {
   const query = qs.toString();
   return request(`/review/items${query ? `?${query}` : ''}`);
 };
-export const getReviewCounts = () => request('/review/counts');
+export const getReviewCounts = (options = {}) => request('/review/counts', options);
 export const getReviewBriefing = () => request('/review/briefing');
 // Cross-domain live queue (brain inbox, ask, CoS approvals, drafts, health, backups)
 export const getReviewQueue = (options = {}) => request('/review/queue', options);


### PR DESCRIPTION
## Summary

- Keeps the Review Hub header triage pills backed by the global pending-count endpoint instead of the currently filtered list.
- Refreshes counts for review item socket updates and ignores stale out-of-order responses.
- Adds filter, reactive-update, and response-order regression coverage.

## Validation

- `npm test -- --run src/pages/Review.test.jsx`
- `npm test` (client)
- `npm run lint` (client)
- `npm run build` (client)

Closes #6926