### PR TITLE
fix([issue-6911]): enable keyboard ticket dragging

### DIFF
--- a/client/src/components/KanbanBoard.jsx
+++ b/client/src/components/KanbanBoard.jsx
@@ -1,10 +1,11 @@
-import { useState, useEffect, useCallback, useMemo, memo } from 'react';
+import { useState, useEffect, useCallback, useMemo, useRef, memo } from 'react';
 import {
   DndContext,
   DragOverlay,
   closestCenter,
   KeyboardSensor,
   PointerSensor,
+  rectIntersection,
   useDraggable,
   useDroppable,
   useSensor,
@@ -59,7 +60,6 @@ export function kanbanKeyboardCoordinates(event, { active, context }) {
   }[event.code];
   if (!direction) return undefined;
 
-  const activeId = typeof active === 'object' ? active.id : active;
   const activeData = context?.active?.data?.current || active?.data?.current || {};
   const overData = context?.over?.data?.current || {};
   const currentColumnId = overData.columnId || activeData.columnId;
@@ -80,7 +80,7 @@ export function kanbanKeyboardCoordinates(event, { active, context }) {
     .filter(({ entry, rect }) => !entry.disabled && rect) || [];
 
   const ticketEntries = entries
-    .filter(({ data }) => data.type === 'ticket' && String(data.ticketKey) !== String(activeId))
+    .filter(({ data }) => data.type === 'ticket')
     .sort((left, right) => left.data.position - right.data.position);
   const columnEntries = entries
     .filter(({ data }) => data.type === 'column')
@@ -109,15 +109,33 @@ export function kanbanKeyboardCoordinates(event, { active, context }) {
   }
 
   if (!target) return undefined;
-  return { x: target.rect.left, y: target.rect.top };
+
+  // KeyboardSensor interprets the result as the dragged node's top-left
+  // coordinate. Center it on the selected slot/column so closestCenter cannot
+  // prefer a nearby ticket when an empty destination is tall.
+  const activeRect = context?.active?.rect?.current?.translated
+    || context?.active?.rect?.current?.initial;
+  const activeWidth = activeRect?.width || 0;
+  const activeHeight = activeRect?.height || 0;
+  return {
+    x: target.rect.left + (target.rect.width - activeWidth) / 2,
+    y: target.rect.top + (target.rect.height - activeHeight) / 2,
+  };
 }
 
-/** Keep the active ticket's own slot from winning collision detection. */
+/**
+ * Keep pointer drags from selecting their own slot while preserving the
+ * keyboard drag's source slot as its initial collision target.
+ */
 export function kanbanCollisionDetection(args) {
   const activeDropId = ticketDropId(args.active?.id);
-  return closestCenter({
+  const isPointerDrag = Boolean(args.pointerCoordinates);
+  const collisionDetection = isPointerDrag ? rectIntersection : closestCenter;
+  return collisionDetection({
     ...args,
-    droppableContainers: args.droppableContainers.filter(entry => entry.id !== activeDropId),
+    droppableContainers: isPointerDrag
+      ? args.droppableContainers.filter(entry => entry.id !== activeDropId)
+      : args.droppableContainers,
   });
 }
 
@@ -181,7 +199,7 @@ const TicketCard = memo(function TicketCard({ ticket, isDragOverlay }) {
 
 // Memoized for the same reason as TicketCard: only the card actively being
 // dragged changes; the rest keep stable ticket/disabled/appId/canQueue props.
-const DraggableTicket = memo(function DraggableTicket({ ticket, disabled, appId, canQueue, columnId, columnName, columnIndex, position }) {
+const DraggableTicket = memo(function DraggableTicket({ ticket, disabled, appId, canQueue, columnId, columnName, columnIndex, position, onActivatorRef }) {
   const { setNodeRef: setDropNodeRef } = useDroppable({
     id: ticketDropId(ticket.key),
     data: { type: 'ticket', ticketKey: ticket.key, columnId, columnName, columnIndex, position },
@@ -193,6 +211,10 @@ const DraggableTicket = memo(function DraggableTicket({ ticket, disabled, appId,
     disabled
   });
   const [queuing, setQueuing] = useState(false);
+  const handleActivatorRef = useCallback((node) => {
+    setActivatorNodeRef(node);
+    onActivatorRef?.(ticket.key, node);
+  }, [onActivatorRef, setActivatorNodeRef, ticket.key]);
 
   const style = transform ? {
     transform: `translate3d(${transform.x}px, ${transform.y}px, 0)`,
@@ -216,7 +238,7 @@ const DraggableTicket = memo(function DraggableTicket({ ticket, disabled, appId,
       <div ref={setNodeRef} className="flex items-stretch gap-0">
         <button
           type="button"
-          ref={setActivatorNodeRef}
+          ref={handleActivatorRef}
           {...listeners}
           {...attributes}
           className={`flex items-center px-1 text-gray-600 hover:text-gray-400 shrink-0 ${disabled ? 'cursor-not-allowed opacity-50' : 'cursor-grab active:cursor-grabbing'}`}
@@ -252,7 +274,7 @@ const DraggableTicket = memo(function DraggableTicket({ ticket, disabled, appId,
   );
 });
 
-function DroppableColumn({ column, isOver, disabled, appId, columnIndex }) {
+function DroppableColumn({ column, isOver, disabled, appId, columnIndex, onActivatorRef }) {
   const { setNodeRef } = useDroppable({
     id: column.id,
     data: { type: 'column', columnId: column.id, columnName: column.name, columnIndex },
@@ -289,6 +311,7 @@ function DroppableColumn({ column, isOver, disabled, appId, columnIndex }) {
             columnName={column.name}
             columnIndex={columnIndex}
             position={position}
+            onActivatorRef={onActivatorRef}
           />
         ))}
         {column.tickets.length === 0 && (
@@ -307,6 +330,55 @@ export default function KanbanBoard({ tickets: initialTickets = [], instanceId, 
   const [transitioning, setTransitioning] = useState(null);
   const [overColumn, setOverColumn] = useState(null);
   const [boardColumns, setBoardColumns] = useState(null);
+  const activatorRefs = useRef(new Map());
+  const previousTransitioning = useRef(null);
+  const pendingKeyboardFocus = useRef(null);
+
+  const registerActivator = useCallback((ticketKey, node) => {
+    if (node) {
+      activatorRefs.current.set(ticketKey, node);
+    } else {
+      activatorRefs.current.delete(ticketKey);
+    }
+  }, []);
+
+  useEffect(() => {
+    const handleFocusIn = (event) => {
+      const focusRequest = pendingKeyboardFocus.current;
+      if (!focusRequest) return;
+      if (event.target === document.body || event.target === document.documentElement) return;
+
+      const activator = activatorRefs.current.get(focusRequest.ticketKey);
+      const isExpectedTicketFocus = event.target === activator
+        || (event.target?.tagName === 'A' && activator?.parentElement?.contains(event.target));
+      if (!isExpectedTicketFocus) focusRequest.userMovedFocus = true;
+    };
+
+    document.addEventListener('focusin', handleFocusIn);
+    return () => document.removeEventListener('focusin', handleFocusIn);
+  }, []);
+
+  // dnd-kit restores focus as soon as the drag ends, while this board disables
+  // all handles during the async Jira transition. Re-focus the moved handle
+  // after success or rollback, once the controls are enabled again.
+  useEffect(() => {
+    const completedTicket = previousTransitioning.current;
+    previousTransitioning.current = transitioning;
+    if (!completedTicket || transitioning) return;
+
+    const focusRequest = pendingKeyboardFocus.current;
+    if (!focusRequest || focusRequest.ticketKey !== completedTicket || focusRequest.userMovedFocus) {
+      pendingKeyboardFocus.current = null;
+      return;
+    }
+
+    requestAnimationFrame(() => {
+      if (pendingKeyboardFocus.current !== focusRequest || focusRequest.userMovedFocus) return;
+      pendingKeyboardFocus.current = null;
+      const activator = activatorRefs.current.get(completedTicket);
+      if (activator && !activator.disabled) activator.focus();
+    });
+  }, [transitioning]);
 
   // Sync if parent re-fetches
   useEffect(() => { setTickets(initialTickets); }, [initialTickets]);
@@ -336,6 +408,9 @@ export default function KanbanBoard({ tickets: initialTickets = [], instanceId, 
   const handleDragStart = useCallback((event) => {
     const ticket = event.active.data.current?.ticket;
     setActiveTicket(ticket || null);
+    pendingKeyboardFocus.current = event.activatorEvent?.type === 'keydown'
+      ? { ticketKey: ticket?.key || event.active.id, userMovedFocus: false }
+      : null;
   }, []);
 
   const handleDragOver = useCallback((event) => {
@@ -348,18 +423,31 @@ export default function KanbanBoard({ tickets: initialTickets = [], instanceId, 
     setActiveTicket(null);
     setOverColumn(null);
 
-    if (!over) return;
+    if (!over) {
+      pendingKeyboardFocus.current = null;
+      return;
+    }
 
     const targetColumn = columns.find(c => c.id === columnIdForTarget(over, columns));
-    if (!targetColumn) return;
+    if (!targetColumn) {
+      pendingKeyboardFocus.current = null;
+      return;
+    }
 
     const ticket = active.data.current?.ticket;
-    if (!ticket) return;
+    if (!ticket) {
+      pendingKeyboardFocus.current = null;
+      return;
+    }
 
     // Already in this column? Nothing to do.
-    if (ticketInColumn(ticket, targetColumn)) return;
+    if (ticketInColumn(ticket, targetColumn)) {
+      pendingKeyboardFocus.current = null;
+      return;
+    }
 
     if (!instanceId) {
+      pendingKeyboardFocus.current = null;
       toast.error('Cannot transition: no JIRA instance configured');
       return;
     }
@@ -414,6 +502,7 @@ export default function KanbanBoard({ tickets: initialTickets = [], instanceId, 
   const handleDragCancel = useCallback(() => {
     setActiveTicket(null);
     setOverColumn(null);
+    pendingKeyboardFocus.current = null;
   }, []);
 
   return (
@@ -435,6 +524,7 @@ export default function KanbanBoard({ tickets: initialTickets = [], instanceId, 
             disabled={!!transitioning}
             appId={appId}
             columnIndex={columnIndex}
+            onActivatorRef={registerActivator}
           />
         ))}
       </div>

--- a/client/src/components/KanbanBoard.jsx
+++ b/client/src/components/KanbanBoard.jsx
@@ -1,9 +1,155 @@
 import { useState, useEffect, useCallback, useMemo, memo } from 'react';
-import { DndContext, DragOverlay, useDraggable, useDroppable, PointerSensor, useSensor, useSensors } from '@dnd-kit/core';
+import {
+  DndContext,
+  DragOverlay,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useDraggable,
+  useDroppable,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core';
 import { GripVertical, Play } from 'lucide-react';
 import toast from './ui/Toast';
 import * as api from '../services/api';
 import { FALLBACK_COLUMNS, ticketInColumn, bucketTickets } from '../lib/kanbanColumns.js';
+
+const TICKET_DROP_PREFIX = 'ticket:';
+
+const ticketDropId = (ticketKey) => `${TICKET_DROP_PREFIX}${ticketKey}`;
+
+function dropTargetData(target) {
+  return target?.data?.current || {};
+}
+
+function columnIdForTarget(target, columns) {
+  const columnId = dropTargetData(target).columnId;
+  if (columnId) return columnId;
+  return columns.some(column => column.id === target?.id) ? target.id : null;
+}
+
+function dropTargetLabel(target) {
+  const data = dropTargetData(target);
+  if (!target) return null;
+  if (data.columnName) {
+    const position = Number.isInteger(data.position) ? `, position ${data.position + 1}` : '';
+    return `${data.columnName}${position}`;
+  }
+  return `workflow column ${target.id}`;
+}
+
+function activeTicketLabel(active) {
+  return active?.data?.current?.ticket?.key || active?.id || 'ticket';
+}
+
+/**
+ * Move keyboard drags between ticket slots and workflow columns.
+ *
+ * Columns are the fallback target for empty columns. When a destination has
+ * tickets, horizontal movement preserves the current slot where possible;
+ * vertical movement selects the adjacent slot in the current column.
+ */
+export function kanbanKeyboardCoordinates(event, { active, context }) {
+  const direction = {
+    ArrowDown: 1,
+    ArrowUp: -1,
+    ArrowRight: 1,
+    ArrowLeft: -1,
+  }[event.code];
+  if (!direction) return undefined;
+
+  const activeId = typeof active === 'object' ? active.id : active;
+  const activeData = context?.active?.data?.current || active?.data?.current || {};
+  const overData = context?.over?.data?.current || {};
+  const currentColumnId = overData.columnId || activeData.columnId;
+  if (!currentColumnId) return undefined;
+
+  const fallbackPosition = Number.isInteger(activeData.position) ? activeData.position : 0;
+  const currentPosition = overData.type === 'ticket' && Number.isInteger(overData.position)
+    ? overData.position
+    : overData.columnId && overData.columnId !== activeData.columnId
+      ? 0
+      : fallbackPosition;
+  const entries = context?.droppableContainers?.getEnabled?.()
+    ?.map(entry => ({
+      entry,
+      data: entry.data?.current || {},
+      rect: context.droppableRects.get(entry.id),
+    }))
+    .filter(({ entry, rect }) => !entry.disabled && rect) || [];
+
+  const ticketEntries = entries
+    .filter(({ data }) => data.type === 'ticket' && String(data.ticketKey) !== String(activeId))
+    .sort((left, right) => left.data.position - right.data.position);
+  const columnEntries = entries
+    .filter(({ data }) => data.type === 'column')
+    .sort((left, right) => left.data.columnIndex - right.data.columnIndex);
+
+  let target;
+  if (event.code === 'ArrowUp' || event.code === 'ArrowDown') {
+    const candidates = ticketEntries.filter(({ data }) => data.columnId === currentColumnId);
+    target = direction > 0
+      ? candidates.find(({ data }) => data.position > currentPosition)
+      : [...candidates].reverse().find(({ data }) => data.position < currentPosition);
+  } else {
+    const currentColumnIndex = columnEntries.findIndex(({ data }) => data.columnId === currentColumnId);
+    const destinationColumn = columnEntries[currentColumnIndex + direction];
+    if (!destinationColumn) return undefined;
+
+    const destinationTickets = ticketEntries
+      .filter(({ data }) => data.columnId === destinationColumn.data.columnId)
+      .sort((left, right) => left.data.position - right.data.position);
+    if (destinationTickets.length) {
+      const destinationPosition = Math.min(Math.max(currentPosition, 0), destinationTickets.length - 1);
+      target = destinationTickets[destinationPosition];
+    } else {
+      target = destinationColumn;
+    }
+  }
+
+  if (!target) return undefined;
+  return { x: target.rect.left, y: target.rect.top };
+}
+
+/** Keep the active ticket's own slot from winning collision detection. */
+export function kanbanCollisionDetection(args) {
+  const activeDropId = ticketDropId(args.active?.id);
+  return closestCenter({
+    ...args,
+    droppableContainers: args.droppableContainers.filter(entry => entry.id !== activeDropId),
+  });
+}
+
+const KANBAN_ACCESSIBILITY = {
+  announcements: {
+    onDragStart({ active }) {
+      const ticket = activeTicketLabel(active);
+      const source = active?.data?.current?.columnName || 'its current column';
+      return `Picked up ticket ${ticket} from ${source}. Use arrow keys to move it, Space to drop, or Escape to cancel.`;
+    },
+    onDragOver({ active, over }) {
+      const ticket = activeTicketLabel(active);
+      const destination = dropTargetLabel(over);
+      return destination
+        ? `Ticket ${ticket} moved over ${destination}.`
+        : `Ticket ${ticket} is no longer over a workflow column.`;
+    },
+    onDragEnd({ active, over }) {
+      const ticket = activeTicketLabel(active);
+      const destination = dropTargetLabel(over);
+      return destination
+        ? `Dropped ticket ${ticket} in ${destination}.`
+        : `Ticket ${ticket} was dropped outside a workflow column.`;
+    },
+    onDragCancel({ active }) {
+      return `Cancelled dragging ticket ${activeTicketLabel(active)}. It returned to its original column.`;
+    },
+  },
+  screenReaderInstructions: {
+    draggable: 'To pick up a ticket, press Space or Enter. While dragging, use the arrow keys to move it between columns and card positions. Press Space to drop the ticket, or Escape to cancel.',
+  },
+};
 
 // Memoized: rendered once per ticket inside a dnd-kit board that re-renders on
 // every pointer move during a drag. Props are a stable ticket object + a
@@ -35,10 +181,15 @@ const TicketCard = memo(function TicketCard({ ticket, isDragOverlay }) {
 
 // Memoized for the same reason as TicketCard: only the card actively being
 // dragged changes; the rest keep stable ticket/disabled/appId/canQueue props.
-const DraggableTicket = memo(function DraggableTicket({ ticket, disabled, appId, canQueue }) {
-  const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({
+const DraggableTicket = memo(function DraggableTicket({ ticket, disabled, appId, canQueue, columnId, columnName, columnIndex, position }) {
+  const { setNodeRef: setDropNodeRef } = useDroppable({
+    id: ticketDropId(ticket.key),
+    data: { type: 'ticket', ticketKey: ticket.key, columnId, columnName, columnIndex, position },
+    disabled,
+  });
+  const { attributes, listeners, setNodeRef, setActivatorNodeRef, transform, isDragging } = useDraggable({
     id: ticket.key,
-    data: { ticket },
+    data: { ticket, columnId, columnName, columnIndex, position },
     disabled
   });
   const [queuing, setQueuing] = useState(false);
@@ -58,13 +209,14 @@ const DraggableTicket = memo(function DraggableTicket({ ticket, disabled, appId,
 
   return (
     <div
-      ref={setNodeRef}
+      ref={setDropNodeRef}
       style={style}
       className={`group relative ${isDragging ? 'opacity-30' : ''}`}
     >
-      <div className="flex items-stretch gap-0">
+      <div ref={setNodeRef} className="flex items-stretch gap-0">
         <button
           type="button"
+          ref={setActivatorNodeRef}
           {...listeners}
           {...attributes}
           className={`flex items-center px-1 text-gray-600 hover:text-gray-400 shrink-0 ${disabled ? 'cursor-not-allowed opacity-50' : 'cursor-grab active:cursor-grabbing'}`}
@@ -100,8 +252,12 @@ const DraggableTicket = memo(function DraggableTicket({ ticket, disabled, appId,
   );
 });
 
-function DroppableColumn({ column, isOver, disabled, appId }) {
-  const { setNodeRef } = useDroppable({ id: column.id, disabled });
+function DroppableColumn({ column, isOver, disabled, appId, columnIndex }) {
+  const { setNodeRef } = useDroppable({
+    id: column.id,
+    data: { type: 'column', columnId: column.id, columnName: column.name, columnIndex },
+    disabled,
+  });
   const config = column.config;
   const totalPoints = column.tickets.reduce((sum, t) => sum + (Number(t.storyPoints) || 0), 0);
   // The play button (queue a CoS agent for a ticket) only makes sense for
@@ -122,8 +278,18 @@ function DroppableColumn({ column, isOver, disabled, appId }) {
         )}
       </div>
       <div className="space-y-2">
-        {column.tickets.map(ticket => (
-          <DraggableTicket key={ticket.key} ticket={ticket} disabled={disabled} appId={appId} canQueue={canQueue} />
+        {column.tickets.map((ticket, position) => (
+          <DraggableTicket
+            key={ticket.key}
+            ticket={ticket}
+            disabled={disabled}
+            appId={appId}
+            canQueue={canQueue}
+            columnId={column.id}
+            columnName={column.name}
+            columnIndex={columnIndex}
+            position={position}
+          />
         ))}
         {column.tickets.length === 0 && (
           <div className={`text-xs text-center py-4 ${isOver ? 'text-gray-300' : 'text-gray-500'}`}>
@@ -161,7 +327,8 @@ export default function KanbanBoard({ tickets: initialTickets = [], instanceId, 
   }, [instanceId, projectKey, boardId]);
 
   const sensors = useSensors(
-    useSensor(PointerSensor, { activationConstraint: { distance: 8 } })
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: kanbanKeyboardCoordinates })
   );
 
   const columns = useMemo(() => bucketTickets(boardColumns || FALLBACK_COLUMNS, tickets), [boardColumns, tickets]);
@@ -173,7 +340,7 @@ export default function KanbanBoard({ tickets: initialTickets = [], instanceId, 
 
   const handleDragOver = useCallback((event) => {
     const { over } = event;
-    setOverColumn(over?.id && columns.some(c => c.id === over.id) ? over.id : null);
+    setOverColumn(columnIdForTarget(over, columns));
   }, [columns]);
 
   const handleDragEnd = useCallback(async (event) => {
@@ -183,7 +350,7 @@ export default function KanbanBoard({ tickets: initialTickets = [], instanceId, 
 
     if (!over) return;
 
-    const targetColumn = columns.find(c => c.id === over.id);
+    const targetColumn = columns.find(c => c.id === columnIdForTarget(over, columns));
     if (!targetColumn) return;
 
     const ticket = active.data.current?.ticket;
@@ -252,19 +419,22 @@ export default function KanbanBoard({ tickets: initialTickets = [], instanceId, 
   return (
     <DndContext
       sensors={sensors}
+      collisionDetection={kanbanCollisionDetection}
+      accessibility={KANBAN_ACCESSIBILITY}
       onDragStart={handleDragStart}
       onDragOver={handleDragOver}
       onDragEnd={handleDragEnd}
       onDragCancel={handleDragCancel}
     >
       <div className="flex gap-3 overflow-x-auto pb-2">
-        {columns.map(column => (
+        {columns.map((column, columnIndex) => (
           <DroppableColumn
             key={column.id}
             column={column}
             isOver={overColumn === column.id}
             disabled={!!transitioning}
             appId={appId}
+            columnIndex={columnIndex}
           />
         ))}
       </div>

--- a/client/src/components/KanbanBoard.test.jsx
+++ b/client/src/components/KanbanBoard.test.jsx
@@ -1,4 +1,4 @@
-import { act, render } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 
 const dndState = vi.hoisted(() => ({ context: null }));
@@ -19,6 +19,7 @@ vi.mock('@dnd-kit/core', () => ({
   },
   DragOverlay: ({ children }) => <>{children}</>,
   closestCenter: vi.fn(() => []),
+  rectIntersection: vi.fn(() => []),
   KeyboardSensor: function KeyboardSensorStub() {},
   PointerSensor: function PointerSensorStub() {},
   useDraggable: () => ({
@@ -34,7 +35,7 @@ vi.mock('@dnd-kit/core', () => ({
   useSensors: (...sensors) => sensors,
 }));
 
-import { closestCenter, KeyboardSensor } from '@dnd-kit/core';
+import { closestCenter, KeyboardSensor, rectIntersection } from '@dnd-kit/core';
 import KanbanBoard, { kanbanCollisionDetection, kanbanKeyboardCoordinates } from './KanbanBoard';
 
 const TICKETS = [
@@ -117,21 +118,45 @@ describe('KanbanBoard keyboard drag and drop', () => {
       droppableContainers: { getEnabled: () => entries },
       over: { id: 'ticket:PORT-1', data: { current: ticketData(TICKETS[0], 'col-0', 0, 0) } },
     };
+    context.active.rect = { current: { initial: { width: 196, height: 60 } } };
 
     const downEvent = { code: 'ArrowDown', preventDefault: vi.fn() };
     expect(kanbanKeyboardCoordinates(downEvent, { active, context })).toEqual({ x: 12, y: 120 });
     expect(downEvent.preventDefault).not.toHaveBeenCalled();
 
     context.over = { id: 'ticket:PORT-2', data: { current: ticketData(TICKETS[1], 'col-0', 0, 1) } };
+    const upEvent = { code: 'ArrowUp', preventDefault: vi.fn() };
+    expect(kanbanKeyboardCoordinates(upEvent, { active, context })).toEqual({ x: 12, y: 48 });
+
     const rightEvent = { code: 'ArrowRight', preventDefault: vi.fn() };
     expect(kanbanKeyboardCoordinates(rightEvent, { active, context })).toEqual({ x: 252, y: 48 });
 
     context.over = { id: 'ticket:PORT-3', data: { current: ticketData(TICKETS[2], 'col-1', 1, 0) } };
     const rightToEmptyColumn = { code: 'ArrowRight', preventDefault: vi.fn() };
-    expect(kanbanKeyboardCoordinates(rightToEmptyColumn, { active, context })).toEqual({ x: 480, y: 0 });
+    expect(kanbanKeyboardCoordinates(rightToEmptyColumn, { active, context })).toEqual({ x: 492, y: 120 });
   });
 
-  it('excludes the active ticket slot from collision candidates', () => {
+  it('uses intersection collision for pointer drags without the active ticket slot', () => {
+    const activeDrop = { id: 'ticket:PORT-1' };
+    const otherDrop = { id: 'ticket:PORT-2' };
+    const columnDrop = { id: 'col-0' };
+    const args = {
+      active: { id: 'PORT-1' },
+      collisionRect: {},
+      droppableRects: new Map(),
+      droppableContainers: [activeDrop, otherDrop, columnDrop],
+      pointerCoordinates: { x: 10, y: 10 },
+    };
+
+    kanbanCollisionDetection(args);
+
+    expect(args.droppableContainers).toEqual([activeDrop, otherDrop, columnDrop]);
+    expect(rectIntersection).toHaveBeenCalledWith(expect.objectContaining({
+      droppableContainers: [otherDrop, columnDrop],
+    }));
+  });
+
+  it('keeps the active slot as the initial keyboard collision target', () => {
     const activeDrop = { id: 'ticket:PORT-1' };
     const otherDrop = { id: 'ticket:PORT-2' };
     const columnDrop = { id: 'col-0' };
@@ -145,10 +170,29 @@ describe('KanbanBoard keyboard drag and drop', () => {
 
     kanbanCollisionDetection(args);
 
-    expect(args.droppableContainers).toEqual([activeDrop, otherDrop, columnDrop]);
     expect(closestCenter).toHaveBeenCalledWith(expect.objectContaining({
+      droppableContainers: [activeDrop, otherDrop, columnDrop],
+    }));
+  });
+
+  it('keeps pointer drops outside the board from selecting the nearest column', () => {
+    const activeDrop = { id: 'ticket:PORT-1' };
+    const otherDrop = { id: 'ticket:PORT-2' };
+    const columnDrop = { id: 'col-0' };
+    const args = {
+      active: { id: 'PORT-1' },
+      collisionRect: {},
+      droppableRects: new Map(),
+      droppableContainers: [activeDrop, otherDrop, columnDrop],
+      pointerCoordinates: { x: -100, y: -100 },
+    };
+
+    kanbanCollisionDetection(args);
+
+    expect(rectIntersection).toHaveBeenCalledWith(expect.objectContaining({
       droppableContainers: [otherDrop, columnDrop],
     }));
+    expect(closestCenter).not.toHaveBeenCalled();
   });
 
   it('resolves a card-slot drop to its destination column and transitions the ticket', async () => {
@@ -172,5 +216,73 @@ describe('KanbanBoard keyboard drag and drop', () => {
       status: 'In Progress',
       statusCategory: 'In Progress',
     });
+  });
+
+  it('restores keyboard focus after an async transition when focus stayed with the ticket', async () => {
+    let resolveTransitions;
+    api.getJiraTicketTransitions.mockReturnValue(new Promise(resolve => {
+      resolveTransitions = resolve;
+    }));
+    api.transitionJiraTicket.mockResolvedValue({});
+    renderBoard();
+
+    const dragButton = screen.getByRole('button', { name: 'Drag PORT-1' });
+    dragButton.focus();
+    let dragEndPromise;
+    await act(async () => {
+      dndState.context.onDragStart({
+        activatorEvent: { type: 'keydown' },
+        active: { id: 'PORT-1', data: { current: { ticket: TICKETS[0] } } },
+      });
+      dragEndPromise = dndState.context.onDragEnd({
+        active: { id: 'PORT-1', data: { current: { ticket: TICKETS[0] } } },
+        over: { id: 'ticket:PORT-3', data: { current: ticketData(TICKETS[2], 'col-1', 1, 0) } },
+      });
+      await Promise.resolve();
+    });
+
+    const ticketLink = document.querySelector('a[href="https://jira.example/PORT-1"]');
+    ticketLink.focus();
+    expect(document.activeElement).toBe(ticketLink);
+
+    await act(async () => {
+      resolveTransitions([{ id: 'transition-1', to: 'In Progress', toCategory: 'In Progress' }]);
+      await dragEndPromise;
+      await new Promise(resolve => requestAnimationFrame(resolve));
+    });
+
+    expect(document.activeElement).toBe(screen.getByRole('button', { name: 'Drag PORT-1' }));
+  });
+
+  it('restores keyboard focus when a failed transition rolls the ticket back', async () => {
+    let resolveTransitions;
+    api.getJiraTicketTransitions.mockReturnValue(new Promise(resolve => {
+      resolveTransitions = resolve;
+    }));
+    renderBoard();
+
+    const dragButton = screen.getByRole('button', { name: 'Drag PORT-1' });
+    dragButton.focus();
+    let dragEndPromise;
+    await act(async () => {
+      dndState.context.onDragStart({
+        activatorEvent: { type: 'keydown' },
+        active: { id: 'PORT-1', data: { current: { ticket: TICKETS[0] } } },
+      });
+      dragEndPromise = dndState.context.onDragEnd({
+        active: { id: 'PORT-1', data: { current: { ticket: TICKETS[0] } } },
+        over: { id: 'ticket:PORT-3', data: { current: ticketData(TICKETS[2], 'col-1', 1, 0) } },
+      });
+      await Promise.resolve();
+    });
+
+    document.querySelector('a[href="https://jira.example/PORT-1"]').focus();
+    await act(async () => {
+      resolveTransitions([]);
+      await dragEndPromise;
+      await new Promise(resolve => requestAnimationFrame(resolve));
+    });
+
+    expect(document.activeElement).toBe(screen.getByRole('button', { name: 'Drag PORT-1' }));
   });
 });

--- a/client/src/components/KanbanBoard.test.jsx
+++ b/client/src/components/KanbanBoard.test.jsx
@@ -1,0 +1,176 @@
+import { act, render } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+const dndState = vi.hoisted(() => ({ context: null }));
+const api = vi.hoisted(() => ({
+  getJiraBoardColumns: vi.fn(),
+  createJiraTicketTask: vi.fn(),
+  getJiraTicketTransitions: vi.fn(),
+  transitionJiraTicket: vi.fn(),
+}));
+const toast = vi.hoisted(() => ({ success: vi.fn(), error: vi.fn() }));
+
+vi.mock('../services/api', () => api);
+vi.mock('./ui/Toast', () => ({ default: toast }));
+vi.mock('@dnd-kit/core', () => ({
+  DndContext: ({ children, ...props }) => {
+    dndState.context = props;
+    return <>{children}</>;
+  },
+  DragOverlay: ({ children }) => <>{children}</>,
+  closestCenter: vi.fn(() => []),
+  KeyboardSensor: function KeyboardSensorStub() {},
+  PointerSensor: function PointerSensorStub() {},
+  useDraggable: () => ({
+    attributes: {},
+    listeners: {},
+    setNodeRef: () => {},
+    setActivatorNodeRef: () => {},
+    transform: null,
+    isDragging: false,
+  }),
+  useDroppable: () => ({ setNodeRef: () => {} }),
+  useSensor: (sensor, options) => ({ sensor, options }),
+  useSensors: (...sensors) => sensors,
+}));
+
+import { closestCenter, KeyboardSensor } from '@dnd-kit/core';
+import KanbanBoard, { kanbanCollisionDetection, kanbanKeyboardCoordinates } from './KanbanBoard';
+
+const TICKETS = [
+  { key: 'PORT-1', summary: 'First ticket', status: 'Backlog', statusCategory: 'To Do', issueType: 'Task', url: 'https://jira.example/PORT-1' },
+  { key: 'PORT-2', summary: 'Second ticket', status: 'Selected', statusCategory: 'To Do', issueType: 'Task', url: 'https://jira.example/PORT-2' },
+  { key: 'PORT-3', summary: 'Working ticket', status: 'In Progress', statusCategory: 'In Progress', issueType: 'Task', url: 'https://jira.example/PORT-3' },
+];
+
+const ticketData = (ticket, columnId, columnIndex, position) => ({
+  type: 'ticket',
+  ticketKey: ticket.key,
+  columnId,
+  columnName: columnId === 'col-0' ? 'To Do' : columnId === 'col-1' ? 'In Progress' : 'Done',
+  columnIndex,
+  position,
+});
+
+const makeEntry = (id, data, rect, disabled = false) => ({
+  id,
+  data: { current: data },
+  rect,
+  disabled,
+});
+
+function renderBoard(props = {}) {
+  return render(<KanbanBoard tickets={TICKETS} instanceId="jira-1" {...props} />);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  dndState.context = null;
+  api.getJiraBoardColumns.mockResolvedValue({ columns: [] });
+  api.getJiraTicketTransitions.mockResolvedValue([]);
+  api.transitionJiraTicket.mockResolvedValue({});
+});
+
+describe('KanbanBoard keyboard drag and drop', () => {
+  it('registers a keyboard sensor with column-aware collision and accessibility contracts', () => {
+    renderBoard();
+
+    const keyboardSensor = dndState.context.sensors.find(({ sensor }) => sensor === KeyboardSensor);
+    expect(keyboardSensor).toBeDefined();
+    expect(keyboardSensor.options).toEqual({ coordinateGetter: kanbanKeyboardCoordinates });
+    expect(dndState.context.collisionDetection).toBe(kanbanCollisionDetection);
+
+    const active = { id: 'PORT-1', data: { current: { ticket: TICKETS[0], columnName: 'To Do' } } };
+    const over = { id: 'ticket:PORT-3', data: { current: ticketData(TICKETS[2], 'col-1', 1, 0) } };
+    const { announcements, screenReaderInstructions } = dndState.context.accessibility;
+
+    expect(announcements.onDragStart({ active })).toMatch(/Picked up ticket PORT-1 from To Do/);
+    expect(announcements.onDragOver({ active, over })).toMatch(/PORT-1 moved over In Progress, position 1/);
+    expect(announcements.onDragEnd({ active, over })).toMatch(/Dropped ticket PORT-1 in In Progress, position 1/);
+    expect(announcements.onDragCancel({ active })).toMatch(/Cancelled dragging ticket PORT-1/);
+    expect(screenReaderInstructions.draggable).toMatch(/Space or Enter/);
+    expect(screenReaderInstructions.draggable).toMatch(/arrow keys/);
+    expect(screenReaderInstructions.draggable).toMatch(/Escape to cancel/);
+  });
+
+  it('moves to adjacent ticket slots vertically and preserves the slot horizontally', () => {
+    const rects = new Map([
+      ['col-0', { left: 0, top: 0, width: 220, height: 300 }],
+      ['col-1', { left: 240, top: 0, width: 220, height: 300 }],
+      ['col-2', { left: 480, top: 0, width: 220, height: 300 }],
+      ['ticket:PORT-1', { left: 12, top: 48, width: 196, height: 60 }],
+      ['ticket:PORT-2', { left: 12, top: 120, width: 196, height: 60 }],
+      ['ticket:PORT-3', { left: 252, top: 48, width: 196, height: 60 }],
+    ]);
+    const entries = [
+      makeEntry('col-0', { type: 'column', columnId: 'col-0', columnIndex: 0 }, rects.get('col-0')),
+      makeEntry('ticket:PORT-1', ticketData(TICKETS[0], 'col-0', 0, 0), rects.get('ticket:PORT-1')),
+      makeEntry('ticket:PORT-2', ticketData(TICKETS[1], 'col-0', 0, 1), rects.get('ticket:PORT-2')),
+      makeEntry('col-1', { type: 'column', columnId: 'col-1', columnIndex: 1 }, rects.get('col-1')),
+      makeEntry('ticket:PORT-3', ticketData(TICKETS[2], 'col-1', 1, 0), rects.get('ticket:PORT-3')),
+      makeEntry('col-2', { type: 'column', columnId: 'col-2', columnIndex: 2 }, rects.get('col-2')),
+    ];
+    const active = 'PORT-1';
+    const context = {
+      active: { id: active, data: { current: { columnId: 'col-0', columnIndex: 0, position: 0 } } },
+      droppableRects: rects,
+      droppableContainers: { getEnabled: () => entries },
+      over: { id: 'ticket:PORT-1', data: { current: ticketData(TICKETS[0], 'col-0', 0, 0) } },
+    };
+
+    const downEvent = { code: 'ArrowDown', preventDefault: vi.fn() };
+    expect(kanbanKeyboardCoordinates(downEvent, { active, context })).toEqual({ x: 12, y: 120 });
+    expect(downEvent.preventDefault).not.toHaveBeenCalled();
+
+    context.over = { id: 'ticket:PORT-2', data: { current: ticketData(TICKETS[1], 'col-0', 0, 1) } };
+    const rightEvent = { code: 'ArrowRight', preventDefault: vi.fn() };
+    expect(kanbanKeyboardCoordinates(rightEvent, { active, context })).toEqual({ x: 252, y: 48 });
+
+    context.over = { id: 'ticket:PORT-3', data: { current: ticketData(TICKETS[2], 'col-1', 1, 0) } };
+    const rightToEmptyColumn = { code: 'ArrowRight', preventDefault: vi.fn() };
+    expect(kanbanKeyboardCoordinates(rightToEmptyColumn, { active, context })).toEqual({ x: 480, y: 0 });
+  });
+
+  it('excludes the active ticket slot from collision candidates', () => {
+    const activeDrop = { id: 'ticket:PORT-1' };
+    const otherDrop = { id: 'ticket:PORT-2' };
+    const columnDrop = { id: 'col-0' };
+    const args = {
+      active: { id: 'PORT-1' },
+      collisionRect: {},
+      droppableRects: new Map(),
+      droppableContainers: [activeDrop, otherDrop, columnDrop],
+      pointerCoordinates: null,
+    };
+
+    kanbanCollisionDetection(args);
+
+    expect(args.droppableContainers).toEqual([activeDrop, otherDrop, columnDrop]);
+    expect(closestCenter).toHaveBeenCalledWith(expect.objectContaining({
+      droppableContainers: [otherDrop, columnDrop],
+    }));
+  });
+
+  it('resolves a card-slot drop to its destination column and transitions the ticket', async () => {
+    const onTicketsChange = vi.fn();
+    api.getJiraTicketTransitions.mockResolvedValue([
+      { id: 'transition-1', to: 'In Progress', toCategory: 'In Progress' },
+    ]);
+    renderBoard({ onTicketsChange });
+
+    await act(async () => {
+      await dndState.context.onDragEnd({
+        active: { id: 'PORT-1', data: { current: { ticket: TICKETS[0] } } },
+        over: { id: 'ticket:PORT-3', data: { current: ticketData(TICKETS[2], 'col-1', 1, 0) } },
+      });
+    });
+
+    expect(api.getJiraTicketTransitions).toHaveBeenCalledWith('jira-1', 'PORT-1', { silent: true });
+    expect(api.transitionJiraTicket).toHaveBeenCalledWith('jira-1', 'PORT-1', 'transition-1', { silent: true });
+    const finalTickets = onTicketsChange.mock.calls.at(-1)[0];
+    expect(finalTickets.find(ticket => ticket.key === 'PORT-1')).toMatchObject({
+      status: 'In Progress',
+      statusCategory: 'In Progress',
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add dnd-kit keyboard dragging for Jira Kanban tickets with column-aware slot navigation.
- Keep pointer drops constrained to real intersections and preserve reversible keyboard collision targets.
- Add screen-reader announcements plus focus restoration across async Jira success and rollback paths.

## Test plan

- `cd client && npm test`
- `cd client && npm run lint`
- `cd client && npm run build`

Closes #6911