### PR TITLE
fix: let app quality categories use page scrolling

### DIFF
--- a/client/src/components/apps/AppQuality.jsx
+++ b/client/src/components/apps/AppQuality.jsx
@@ -54,7 +54,6 @@ export default function AppQuality({ app, detail = false }) {
       {!!quality?.categories?.length && (
         <section aria-label="Category breakdown" className="min-w-0">
           <h4 className="text-sm font-medium mb-2">Category breakdown</h4>
-          <div className="overflow-auto xl:max-h-[calc(100vh-19rem)]">
           <table className="w-full text-sm text-left">
             <thead className="text-gray-400 sticky top-0 bg-port-card"><tr><th className="py-2 pr-3">Category</th><th className="pr-3">Score</th><th>Evidence</th></tr></thead>
             <tbody>{quality.categories.map(category => (
@@ -77,7 +76,6 @@ export default function AppQuality({ app, detail = false }) {
               </Fragment>
             ))}</tbody>
           </table>
-          </div>
         </section>
       )}
       </div>

--- a/client/src/components/apps/AppQuality.test.jsx
+++ b/client/src/components/apps/AppQuality.test.jsx
@@ -16,6 +16,7 @@ it('shows zero as a real score and explains excluded categories in the breakdown
   expect(screen.getByText('Stale · partial')).toBeInTheDocument();
   expect(screen.getByText(/1\/25 categories contribute/)).toBeInTheDocument();
   expect(screen.getByRole('link', { name: /Scheduled audit runners/ })).toHaveAttribute('href', '/cos/schedule');
+  expect(screen.getByRole('table').parentElement).not.toHaveClass('overflow-auto', 'xl:max-h-[calc(100vh-19rem)]');
 });
 
 it('links an unassessed tile to its app quality tab without inventing a score', () => {


### PR DESCRIPTION
## Summary
- Remove the nested overflow and viewport-height cap from the App Quality category breakdown.
- Keep the category table in the page flow so the main scrollbar handles long breakdowns.
- Add a regression assertion for the removed scroll container.

## Test plan
- `./node_modules/.bin/vitest run src/components/apps/AppQuality.test.jsx` (client)