### PR TITLE
fix: keep non-PM2 repository paths readable on Apps cards at phone width

### DIFF
--- a/client/src/pages/Apps.jsx
+++ b/client/src/pages/Apps.jsx
@@ -352,7 +352,7 @@ export default function Apps() {
                       <AppQuality app={app} />
                       <div className="text-xs text-gray-500 flex flex-wrap gap-x-2 mt-1">
                         {isNonPm2 ? (
-                          <span className="text-gray-500">{app.repoPath}</span>
+                          <span className="break-all">{app.repoPath}</span>
                         ) : (
                           (app.pm2ProcessNames || []).map((procName, i) => {
                             const procInfo = app.processes?.find(p => p.name === procName);

--- a/client/src/pages/Apps.test.jsx
+++ b/client/src/pages/Apps.test.jsx
@@ -171,6 +171,27 @@ describe('Apps row action hierarchy', () => {
     await waitFor(() => expect(api.openAppInXcode).toHaveBeenCalledWith('app-ios'));
   });
 
+  it('keeps a long non-PM2 repository path wrapping within its column instead of overflowing', async () => {
+    // A single unbroken directory segment can't rely on slash-based line
+    // breaking, so the fix must allow mid-word wrapping (break-all) — which
+    // also drops the flex item's min-content width enough for it to shrink
+    // to the available column instead of forcing the row wider.
+    api.getApps.mockResolvedValue([{
+      ...APPS[0],
+      id: 'app-longpath',
+      name: 'Example Long Path App',
+      type: 'ios-native',
+      repoPath: '/srv/thisisaverylongsingledirectorysegmentwithnobreakpoints/example-ios',
+      pm2ProcessNames: [],
+      processes: [],
+    }]);
+    render(<MemoryRouter><Apps /></MemoryRouter>);
+    await screen.findByRole('link', { name: 'Example Long Path App' });
+
+    const repoPathSpan = screen.getByText('/srv/thisisaverylongsingledirectorysegmentwithnobreakpoints/example-ios');
+    expect(repoPathSpan.className).toEqual(expect.stringContaining('break-all'));
+  });
+
   it('withholds the overflow menu for the PortOS baseline app', async () => {
     api.getApps.mockResolvedValue([{ ...APPS[0], id: 'portos-default', name: 'PortOS' }]);
     render(<MemoryRouter><Apps /></MemoryRouter>);


### PR DESCRIPTION
## Summary

- At 360px, a non-PM2 app's `repoPath` text on `/apps` overflowed its card and was clipped by the card's `overflow-hidden`.
- The span is a flex item of a `flex flex-wrap` row; flex items default to `min-width: auto`, which pins them to their min-content width even when the row is allowed to wrap. An unbroken directory segment's min-content width is the whole segment, so the span never actually shrank to the available text column.
- Added `break-all` to the repo-path span (`client/src/pages/Apps.jsx`), which drops the item's min-content width to ~1 character so it can shrink to the column and wrap mid-word when needed. Layout at 768px/1440px is unaffected since the path already fits on one line there.

## Test plan

- `client/src/pages/Apps.test.jsx`: added a case with a long, unbroken directory segment asserting the repo-path span carries `break-all`; full suite passes (32/32).
- Verified visually in a real browser (Chrome via Playwright) against the production Tailwind build at 360px, 768px, and 1440px using a synthetic non-PM2 app with a long repo path containing a single unbroken directory segment: before the fix the path overflowed the card and was clipped; after the fix, every character including the final directory name is readable and the row stays within the card, with no change at 768px/1440px.

Closes #6931