### PR TITLE
fix: route media pipeline failures to stderr

### DIFF
--- a/server/lib/sseUtils.js
+++ b/server/lib/sseUtils.js
@@ -129,7 +129,7 @@ export const createJobFailureFinalizer = ({
     if (slotOwner == null || activeSlots.get(jobId) === slotOwner) activeSlots.delete(jobId);
     job.status = 'error';
     activeJobs.delete(jobId);
-    console.log(`❌ ${label} failed [${jobId.slice(0, 8)}]: ${reason.split('\n')[0]}`);
+    console.error(`❌ ${label} failed [${jobId.slice(0, 8)}]: ${reason.split('\n')[0]}`);
     broadcastSse(job, { type: 'error', error: reason });
     events.emit('failed', failedPayload(jobId, reason));
     closeJobAfterDelay(jobs, jobId);

--- a/server/routes/continuousVideoEpisode.js
+++ b/server/routes/continuousVideoEpisode.js
@@ -127,7 +127,7 @@ router.post('/', asyncHandler(async (req, res) => {
       pythonPath: settings.imageGen?.local?.pythonPath || null,
     },
   }).catch((err) => {
-    console.log(`❌ Continuous video episode [${jobId.slice(0, 8)}] orchestration crashed: ${err.message}`);
+    console.error(`❌ Continuous video episode [${jobId.slice(0, 8)}] orchestration crashed: ${err.message}`);
   });
 
   res.json({ jobId, generationId: jobId, status: 'running' });

--- a/server/services/creativeDirector/completionHook.js
+++ b/server/services/creativeDirector/completionHook.js
@@ -146,7 +146,7 @@ export async function handleCreativeDirectorCompletion(task, agentId, success) {
     const reason = `${meta.kind} agent task failed (taskId=${task.id || '?'}, agent=${agentId || '?'})`;
     await updateProject(project.id, { status: 'failed', failureReason: reason })
       .catch((e) => console.log(`⚠️ CD updateProject(failed) for ${project.id} failed: ${e.message}`));
-    console.log(`❌ CD project ${project.id} marked failed (task ${meta.kind} failed)`);
+    console.error(`❌ CD project ${project.id} marked failed (task ${meta.kind} failed)`);
     return;
   }
 
@@ -345,7 +345,7 @@ export async function advanceAfterSceneSettled(projectId, opts = {}) {
     s.status === 'evaluating' && !isSafeJobId(s.renderedJobId) && noLiveEvaluateRun(s),
   );
   for (const w of wedged) {
-    console.log(`❌ CD scene ${w.sceneId} on ${project.id} is 'evaluating' with an unsafe renderedJobId (${JSON.stringify(w.renderedJobId)}) — marking failed to prevent project wedge.`);
+    console.error(`❌ CD scene ${w.sceneId} on ${project.id} is 'evaluating' with an unsafe renderedJobId (${JSON.stringify(w.renderedJobId)}) — marking failed to prevent project wedge.`);
     await updateScene(project.id, w.sceneId, {
       status: 'failed',
       evaluation: {
@@ -391,7 +391,7 @@ export async function advanceAfterSceneSettled(projectId, opts = {}) {
       // crash on a missing input file.
       const videoStillExists = existsSync(join(PATHS.videos, `${orphanedEvaluating.renderedJobId}.mp4`));
       if (!videoStillExists) {
-        console.log(`❌ CD resume: rendered video missing for scene ${orphanedEvaluating.sceneId} on ${project.id} — video deleted while paused, marking scene failed`);
+        console.error(`❌ CD resume: rendered video missing for scene ${orphanedEvaluating.sceneId} on ${project.id} — video deleted while paused, marking scene failed`);
         let sceneFailed = false;
         await updateScene(project.id, orphanedEvaluating.sceneId, {
           status: 'failed',
@@ -599,7 +599,7 @@ export async function advanceAfterSceneSettled(projectId, opts = {}) {
   if (!accepted.length) {
     await updateProject(project.id, { status: 'failed' })
       .catch((e) => console.log(`⚠️ CD updateProject(failed) for ${projectId} failed: ${e.message}`));
-    console.log(`❌ CD project ${projectId}: every scene failed — marking project failed`);
+    console.error(`❌ CD project ${projectId}: every scene failed — marking project failed`);
     return;
   }
   if (project.finalVideoId) {

--- a/server/services/creativeDirector/planAdvance.js
+++ b/server/services/creativeDirector/planAdvance.js
@@ -414,7 +414,7 @@ async function runPlanStep(project, step) {
     await finishRun(projectId, run?.runId, 'failed', resolved.error);
     const bumped = (step.retryCount || 0) + 1;
     await updatePlanStep(projectId, step.stepId, { ...(step.expectedProductionRevision === undefined ? {} : { expectedProductionRevision: step.expectedProductionRevision }), status: 'failed', retryCount: bumped, result: { error: resolved.error } });
-    console.log(`❌ CD plan ${projectId}: step "${step.stepId}" ${resolved.error}`);
+    console.error(`❌ CD plan ${projectId}: step "${step.stepId}" ${resolved.error}`);
     return handlePlanStepFailure(projectId, { ...step, retryCount: bumped });
   }
   const resolvedStep = { ...step, args: resolved.args };

--- a/server/services/creativeDirector/sceneRunner.js
+++ b/server/services/creativeDirector/sceneRunner.js
@@ -115,7 +115,7 @@ export async function runSceneRender(project, scene) {
     const detail = lapsedPin && lapsedPin !== videoPin.mode
       ? ` This project is pinned to '${lapsedPin}', but that backend is not enabled, so the render fell back to local.`
       : '';
-    console.log(`❌ CD scene ${scene.sceneId}: local video gen not configured (settings.imageGen.local.pythonPath missing)${detail}`);
+    console.error(`❌ CD scene ${scene.sceneId}: local video gen not configured (settings.imageGen.local.pythonPath missing)${detail}`);
     await updateScene(project.id, scene.sceneId, {
       ...(project.workspace === 'video' ? { expectedWorkRevision: scene.workRevision || 0 } : {}),
       status: 'failed',
@@ -360,7 +360,7 @@ async function handleRenderCompleted(projectId, sceneId, jobId, opts = {}) {
     // completion hook decide what to do next.
     if (opts.continuationFellBack && scene.useContinuationFromPrior) {
       const reason = `scene ${sceneId} requested continuation but fell back to text-to-video`;
-      console.log(`❌ CD auto-accept: ${reason} — failing the entire smoke project so the regression is visible immediately (one accepted scene + later failures would still stitch + complete and hide this).`);
+      console.error(`❌ CD auto-accept: ${reason} — failing the entire smoke project so the regression is visible immediately (one accepted scene + later failures would still stitch + complete and hide this).`);
       // Failing only the scene isn't enough: advanceAfterSceneSettled keeps
       // going as long as at least one scene was accepted, which would then
       // stitch the surviving clips into a `complete` project and report the
@@ -384,7 +384,7 @@ async function handleRenderCompleted(projectId, sceneId, jobId, opts = {}) {
     const playable = await verifyVideoPlayable(videoPath);
     if (!playable.ok) {
       const reason = playable.reason || 'video file unplayable';
-      console.log(`❌ CD auto-accept: video unplayable for ${jobId.slice(0, 8)}: ${reason} — failing smoke project directly (retrying would waste renders; a broken render must not produce a green smoke result).`);
+      console.error(`❌ CD auto-accept: video unplayable for ${jobId.slice(0, 8)}: ${reason} — failing smoke project directly (retrying would waste renders; a broken render must not produce a green smoke result).`);
       await updateScene(projectId, sceneId, { ...(opts.workRevision === undefined ? {} : { expectedWorkRevision: opts.workRevision }),
         status: 'failed',
         evaluation: {
@@ -508,7 +508,7 @@ async function handleRenderFailed(projectId, sceneId, errorMsg, { retry = true, 
     await runSceneRender(fresh, updated);
     return;
   }
-  console.log(`❌ CD scene ${sceneId} render failed terminally: ${errorMsg}`);
+  console.error(`❌ CD scene ${sceneId} render failed terminally: ${errorMsg}`);
   await updateScene(projectId, sceneId, { ...(workRevision === undefined ? {} : { expectedWorkRevision: workRevision }),
     status: 'failed',
     evaluation: {

--- a/server/services/creativeDirector/stitchRunner.js
+++ b/server/services/creativeDirector/stitchRunner.js
@@ -100,7 +100,7 @@ export async function runStitch(projectId) {
       const jobStatus = getRenderJobStatus(jobId);
       if (jobStatus && (jobStatus.status === 'error' || jobStatus.status === 'canceled')) {
         const reason = jobStatus.error ?? `Render ${jobStatus.status}`;
-        console.log(`❌ CD stitch: timeline render ${jobStatus.status} for ${timeline.id}: ${reason}`);
+        console.error(`❌ CD stitch: timeline render ${jobStatus.status} for ${timeline.id}: ${reason}`);
         await updateProject(projectId, { status: 'failed', failureReason: reason });
         return;
       }
@@ -139,7 +139,7 @@ export async function runStitch(projectId) {
     console.log(`✅ CD stitch complete: ${projectId} → ${finalEntry.id.slice(0, 8)}`);
   } catch (err) {
     const reason = err?.message ?? String(err);
-    console.log(`❌ CD stitch error for ${projectId}: ${reason}`);
+    console.error(`❌ CD stitch error for ${projectId}: ${reason}`);
     await updateProject(projectId, { status: 'failed', failureReason: reason }).catch(() => {});
   }
 }

--- a/server/services/imageGen/agy.js
+++ b/server/services/imageGen/agy.js
@@ -290,7 +290,7 @@ export async function generateImage({
     cleanC2PA,
     denoise,
   }).catch((err) => {
-    console.log(`❌ agy run failed [${jobId.slice(0, 8)}]: ${err?.message}`);
+    console.error(`❌ agy run failed [${jobId.slice(0, 8)}]: ${err?.message}`);
   });
 
   return {

--- a/server/services/imageGen/codex.js
+++ b/server/services/imageGen/codex.js
@@ -283,7 +283,7 @@ export async function generateImage({
   // child runs out-of-band so the HTTP response can ship while the client
   // attaches to the per-job SSE stream (mirrors local.js).
   runCodex(job, jobId, bin, args, outputPath, filename, meta, { cleanC2PA, denoise }).catch((err) => {
-    console.log(`❌ codex run failed [${jobId.slice(0, 8)}]: ${err?.message}`);
+    console.error(`❌ codex run failed [${jobId.slice(0, 8)}]: ${err?.message}`);
   });
 
   return {

--- a/server/services/imageGen/grok.js
+++ b/server/services/imageGen/grok.js
@@ -294,7 +294,7 @@ export async function generateImage({
     useStdin, fullPrompt, cleanupPromptFile, scratchDir, stagingPath, outputPath, filename, meta, cleanC2PA, denoise,
     toolName: grokImageTool(inputImages.paths.length > 0),
   }).catch((err) => {
-    console.log(`❌ grok run failed [${jobId.slice(0, 8)}]: ${err?.message}`);
+    console.error(`❌ grok run failed [${jobId.slice(0, 8)}]: ${err?.message}`);
   });
 
   return {

--- a/server/services/imageGen/local.js
+++ b/server/services/imageGen/local.js
@@ -717,7 +717,7 @@ export async function generateImage({ pythonPath, prompt = '', negativePrompt = 
     finalized = true;
     job.status = 'error';
     const reason = `Failed to spawn ${bin}: ${err.message}`;
-    console.log(`❌ Image generation spawn error [${jobId.slice(0, 8)}]: ${reason}`);
+    console.error(`❌ Image generation spawn error [${jobId.slice(0, 8)}]: ${reason}`);
     broadcastSse(job, { type: 'error', error: reason });
     imageGenEvents.emit('failed', { mode: IMAGE_GEN_MODE.LOCAL, generationId: jobId, error: reason });
     activeProcess = null;
@@ -918,7 +918,7 @@ export async function generateImage({ pythonPath, prompt = '', negativePrompt = 
     if (emptyFrame) {
       job.status = 'error';
       job.error = emptyFrame;
-      console.log(`❌ Image generation failed [${jobId.slice(0, 8)}]: ${emptyFrame}`);
+      console.error(`❌ Image generation failed [${jobId.slice(0, 8)}]: ${emptyFrame}`);
       broadcastSse(job, { type: 'error', error: emptyFrame });
       imageGenEvents.emit('failed', { mode: IMAGE_GEN_MODE.LOCAL, generationId: jobId, error: emptyFrame });
       closeJobAfterDelay(jobs, jobId);
@@ -982,7 +982,7 @@ export async function generateImage({ pythonPath, prompt = '', negativePrompt = 
       const errorText = userMessage
         ? `${userMessage}\n\n(diagnostic) ${reason}`
         : `Generation failed: ${reason}\n${tail}`;
-      console.log(`❌ Image generation failed [${jobId.slice(0, 8)}]: ${userMessage || reason}`);
+      console.error(`❌ Image generation failed [${jobId.slice(0, 8)}]: ${userMessage || reason}`);
       job.error = userMessage || reason;
       job.errorKind = userKind;
       job.errorRepo = userRepo;

--- a/server/services/mediaJobQueue/index.js
+++ b/server/services/mediaJobQueue/index.js
@@ -621,7 +621,7 @@ function startWorker() {
   workerStarted = true;
   // Detach from awaiting so init can return; the loop runs forever.
   drainLoop().catch((err) => {
-    console.log(`❌ mediaJobQueue worker crashed: ${err.message}`);
+    console.error(`❌ mediaJobQueue worker crashed: ${err.message}`, err.stack || '');
     workerStarted = false;
   });
 }
@@ -665,7 +665,7 @@ function startLaneJob(job, { lane }) {
     } catch (err) {
       // runJob threw before its own terminal handlers ran (e.g. PYTHON
       // not configured). Recover so a single bad job can't freeze its lane.
-      console.log(`❌ media-job [${job.id.slice(0, 8)}] ${label} runJob threw: ${err.message}`);
+      console.error(`❌ media-job [${job.id.slice(0, 8)}] ${label} runJob threw: ${err.message}`, err.stack || '');
       if (job.status === 'running') {
         job.status = job.cancelRequested ? 'canceled' : 'failed';
         videoHolds.captureFailure(job, err);

--- a/server/services/videoGen/chainedVideo.js
+++ b/server/services/videoGen/chainedVideo.js
@@ -444,7 +444,7 @@ export async function generateChainedVideo({ chunks, chunkPrompts, contextFrames
       chainedFrom: chunkIds,
     });
   })().catch((err) => {
-    console.log(`❌ chain orchestration crashed [${outerJobId.slice(0, 8)}]: ${err.message}`);
+    console.error(`❌ chain orchestration crashed [${outerJobId.slice(0, 8)}]: ${err.message}`);
     finishFail(err.message, normalizeVideoFailure(err, failureOptions));
   });
 

--- a/server/services/videoGen/fal.js
+++ b/server/services/videoGen/fal.js
@@ -208,7 +208,7 @@ export async function generateVideo({
 
   runFalVideo(job, jobId, { apiKey, modelId, prompt, negativePrompt, duration, aspectRatio: effectiveAspectRatio, sourceImagePath, outputPath, filename, meta })
     .catch((err) => {
-      console.log(`❌ fal video run failed [${jobId.slice(0, 8)}]: ${err?.message}`);
+      console.error(`❌ fal video run failed [${jobId.slice(0, 8)}]: ${err?.message}`);
     });
 
   return {

--- a/server/services/videoGen/generateVideo.js
+++ b/server/services/videoGen/generateVideo.js
@@ -861,7 +861,7 @@ export async function generateVideo({ pythonPath, prompt, negativePrompt = '', m
   } catch (err) {
     job.status = 'error';
     const reason = err.message || 'Failed to build video gen args';
-    console.log(`❌ Video generation buildArgs error [${jobId.slice(0, 8)}]: ${reason}`);
+    console.error(`❌ Video generation buildArgs error [${jobId.slice(0, 8)}]: ${reason}`);
     broadcastSse(job, { type: 'error', error: reason });
     videoGenEvents.emit('failed', { generationId: jobId, error: reason, failure: normalizeVideoFailure(err, { prompts: [prompt, negativePrompt] }) });
     void cleanupTempFiles({ includeUploads: true, includeUntrackedAudio: true });

--- a/server/services/videoGen/grok.js
+++ b/server/services/videoGen/grok.js
@@ -187,7 +187,7 @@ export async function generateVideo({
   runGrokVideo(job, jobId, bin, args, {
     useStdin, fullPrompt, cleanupPromptFile, scratchDir, stagingPath, outputPath, filename, meta, uploadedTempPath,
   }).catch((err) => {
-    console.log(`❌ grok video run failed [${jobId.slice(0, 8)}]: ${err?.message}`);
+    console.error(`❌ grok video run failed [${jobId.slice(0, 8)}]: ${err?.message}`);
   });
 
   return {

--- a/server/services/videoGen/reactor.js
+++ b/server/services/videoGen/reactor.js
@@ -258,7 +258,7 @@ export async function generateVideo({
   runReactorVideo(job, jobId, {
     apiKey, ...request, sourceImagePath, outputPath, filename, meta,
   }).catch((err) => {
-    console.log(`❌ reactor video run failed [${jobId.slice(0, 8)}]: ${err?.message}`);
+    console.error(`❌ reactor video run failed [${jobId.slice(0, 8)}]: ${err?.message}`);
   });
 
   return {

--- a/server/services/videoGen/spawnWatch.js
+++ b/server/services/videoGen/spawnWatch.js
@@ -238,7 +238,7 @@ export async function spawnAndWatchVideo({
       clearCompletionWatchdog();
       job.status = 'error';
       const reason = `Failed to spawn ${bin}: ${err.message}`;
-      console.log(`❌ Video generation spawn error [${jobId.slice(0, 8)}]: ${reason}`);
+      console.error(`❌ Video generation spawn error [${jobId.slice(0, 8)}]: ${reason}`);
       broadcastSse(job, { type: 'error', error: reason });
       videoGenEvents.emit('failed', { generationId: jobId, error: reason, failure: normalizeVideoFailure(err, { prompts: [meta?.prompt, meta?.negativePrompt] }) });
       videoJobState.activeProcess = null;
@@ -467,7 +467,7 @@ export async function spawnAndWatchVideo({
             reason = `Exit code ${code}${diagnostic ? `: ${diagnostic}` : ''}`;
           }
           if (batch) reason += ` (${batchResults.length}/${batch.length} videos saved to history)`;
-          console.log(`❌ Video generation failed [${jobId.slice(0, 8)}]: ${reason}`);
+          console.error(`❌ Video generation failed [${jobId.slice(0, 8)}]: ${reason}`);
           broadcastSse(job, { type: 'error', error: `Generation failed: ${reason}` });
           videoGenEvents.emit('failed', { generationId: jobId, error: reason, failure: missingPyModule ? normalizeVideoFailure(reason) : failure, ...(batch ? { results: batchResults } : {}) });
         } else {
@@ -678,7 +678,7 @@ export async function spawnAndWatchVideo({
     await releaseHeavyClaim();
     job.status = 'error';
     const reason = err.message || 'Video generation failed before the render child was wired';
-    console.log(`❌ Video generation setup error [${jobId.slice(0, 8)}]: ${reason}`);
+    console.error(`❌ Video generation setup error [${jobId.slice(0, 8)}]: ${reason}`);
     broadcastSse(job, { type: 'error', error: reason });
     videoGenEvents.emit('failed', { generationId: jobId, error: reason, failure: normalizeVideoFailure(err, { prompts: [meta?.prompt, meta?.negativePrompt] }) });
     void cleanupTempFiles({ includeUploads: true, includeUntrackedAudio: true });

--- a/server/services/videoGen/upscaleJob.js
+++ b/server/services/videoGen/upscaleJob.js
@@ -469,7 +469,7 @@ export async function runVideoUpscale({
       if (path) await unlinkGuarded(path).catch(() => {});
     }
     const reason = entry.canceled ? 'Canceled while running' : (err.message || 'Upscale failed');
-    console.log(`❌ Video upscale ${entry.canceled ? 'canceled' : 'failed'} [${jobId.slice(0, 8)}]: ${reason}`);
+    console.error(`❌ Video upscale ${entry.canceled ? 'canceled' : 'failed'} [${jobId.slice(0, 8)}]: ${reason}`);
     videoGenEvents.emit('failed', { generationId: jobId, error: reason });
     return null;
   } finally {


### PR DESCRIPTION
## Summary

- Routes media-generation and Creative Director error logs through stderr with `console.error`.
- Preserves actionable stack traces when the media worker or a job runner crashes.

## Validation

- `cd server && npm test` (43,003 passed, 35 skipped)
- `git diff --check`

Closes #6935
