### PR TITLE
fix: bound backup subprocess stalls (#6939)

### DIFF
--- a/server/services/backup.js
+++ b/server/services/backup.js
@@ -28,6 +28,14 @@ import { invalidateAllCaches as invalidateBrainCaches } from './brainStorage.js'
 // Module-level state
 let isRunning = false;
 
+// Backups and restores can legitimately run for hours on large or remote
+// volumes, so a short elapsed-time cap would turn healthy work into failure.
+// Treat ten minutes with no observable progress as a stall, while retaining a
+// generous hard ceiling for a process that stays noisy forever.
+const BACKUP_PROCESS_IDLE_TIMEOUT_MS = 10 * 60 * 1000;
+const BACKUP_PROCESS_WALL_TIMEOUT_MS = 4 * 60 * 60 * 1000;
+const BACKUP_PROCESS_PROGRESS_POLL_MS = 30 * 1000;
+
 const STATE_PATH = join(PATHS.data, 'backup', 'state.json');
 // A snapshot mid-assembly is a truncated tree that looks like a finished backup.
 // Two signals guard it, because neither alone is sufficient:
@@ -193,6 +201,98 @@ export function backupStatusForPg(pgResult) {
 // INTERNAL HELPERS
 // =============================================================================
 
+class BackupProcessTimeoutError extends Error {
+  constructor(label, timeoutKind) {
+    const duration = timeoutKind === 'idle' ? '10 minutes without progress' : '4 hours';
+    super(`${label} timed out after ${duration}`);
+    this.name = 'BackupProcessTimeoutError';
+    this.code = 'BACKUP_PROCESS_TIMEOUT';
+    this.timeoutKind = timeoutKind;
+  }
+}
+
+/**
+ * Watch a backup subprocess for both stalled progress and runaway wall time.
+ * The watchdog only starts termination; callers still settle from `close`, so
+ * the backup lock and snapshot markers cannot clear while the child may write.
+ *
+ * pg_dump writes directly to `progressPath` and is normally silent. Polling its
+ * growing output file lets a healthy large dump reset the idle timer without
+ * adding verbose flags or buffering its SQL in memory.
+ */
+function watchBackupProcess(proc, { label, progressPath = null } = {}) {
+  let finished = false;
+  let timeoutError = null;
+  let idleTimer = null;
+  let escalationTimer = null;
+  let progressPoll = null;
+  let progressPollInFlight = false;
+  let lastProgressSize = 0;
+
+  const startTermination = (timeoutKind) => {
+    if (finished || timeoutError || proc.exitCode !== null || proc.signalCode !== null) return;
+    timeoutError = new BackupProcessTimeoutError(label, timeoutKind);
+    console.warn(`⚠️ ${timeoutError.message} — terminating child process`);
+    try {
+      escalationTimer = killWithEscalation(proc, {
+        label,
+        stillRunning: () => !finished,
+      });
+    } catch (err) {
+      // Keep the caller pending if termination itself fails. Releasing a backup
+      // lock while its child may still mutate files or the database is unsafe.
+      console.error(`❌ ${label} timeout termination failed: ${err.message}`);
+    }
+  };
+
+  const armIdleTimer = () => {
+    if (idleTimer) clearTimeout(idleTimer);
+    idleTimer = setTimeout(() => startTermination('idle'), BACKUP_PROCESS_IDLE_TIMEOUT_MS);
+    idleTimer.unref?.();
+  };
+
+  const markActivity = () => {
+    if (!finished && !timeoutError) armIdleTimer();
+  };
+
+  armIdleTimer();
+  const wallTimer = setTimeout(() => startTermination('wall'), BACKUP_PROCESS_WALL_TIMEOUT_MS);
+  wallTimer.unref?.();
+
+  if (progressPath) {
+    progressPoll = setInterval(() => {
+      if (finished || timeoutError || progressPollInFlight) return;
+      progressPollInFlight = true;
+      stat(progressPath)
+        .then((info) => {
+          if (info.size > lastProgressSize) {
+            lastProgressSize = info.size;
+            markActivity();
+          }
+        })
+        // A missing or temporarily unreadable file is no progress. The idle
+        // deadline remains authoritative and will terminate the child.
+        .catch(() => {})
+        .finally(() => { progressPollInFlight = false; });
+    }, BACKUP_PROCESS_PROGRESS_POLL_MS);
+    progressPoll.unref?.();
+  }
+
+  return {
+    markActivity,
+    getTimeoutError: () => timeoutError,
+    finish: () => {
+      if (finished) return false;
+      finished = true;
+      clearTimeout(idleTimer);
+      clearTimeout(wallTimer);
+      if (progressPoll) clearInterval(progressPoll);
+      if (escalationTimer) clearTimeout(escalationTimer);
+      return true;
+    },
+  };
+}
+
 /**
  * Run rsync from srcDir to destDir with optional flags.
  * Resolves with array of changed file lines. Rejects on non-zero exit (except 24).
@@ -212,19 +312,30 @@ function runRsync(srcDir, destDir, flags = []) {
 
     const changed = [];
     let stderr = '';
+    const watchdog = watchBackupProcess(proc, { label: 'backup rsync' });
 
     const stdoutReader = createLineReader((line) => {
       if (line.startsWith('>') || line.startsWith('<')) {
         changed.push(line);
       }
     });
-    proc.stdout.on('data', stdoutReader.push);
+    proc.stdout.on('data', (chunk) => {
+      watchdog.markActivity();
+      stdoutReader.push(chunk);
+    });
 
     proc.stderr.on('data', (chunk) => {
+      watchdog.markActivity();
       stderr += chunk.toString();
     });
 
     proc.on('close', (code) => {
+      if (!watchdog.finish()) return;
+      const timeoutError = watchdog.getTimeoutError();
+      if (timeoutError) {
+        reject(timeoutError);
+        return;
+      }
       // Exit code 24 = some files vanished mid-transfer (normal for active system)
       if (code === 0 || code === 24) {
         stdoutReader.flush();
@@ -235,6 +346,9 @@ function runRsync(srcDir, destDir, flags = []) {
     });
 
     proc.on('error', (err) => {
+      // A timeout does not settle until `close`: the child may still be alive
+      // after an error from a failed termination attempt.
+      if (watchdog.getTimeoutError() || !watchdog.finish()) return;
       reject(new Error(`rsync spawn error: ${err.message}`));
     });
   });
@@ -378,7 +492,7 @@ export async function runBackup(destPath, io = null, { excludePaths = [], disabl
  * escape hatch from "PG required but dump failed" (data at risk):
  *   { status: 'ok', sizeBytes, tableCount }
  *   { status: 'skipped', reason: 'not_configured' }   (explicit file escape hatch only)
- *   { status: 'failed', reason: 'pg_unreachable'|'pg_dump_missing'|'version_mismatch'|'dump_error'|'empty_dump', error }
+ *   { status: 'failed', reason: 'pg_unreachable'|'pg_dump_missing'|'version_mismatch'|'dump_error'|'empty_dump'|'timeout', error }
  *     (pg_unreachable fires whenever Postgres is required — i.e. not the file
  *      escape hatch — but the DB is down at backup time; version_mismatch means
  *      no installed pg_dump is new enough for the running server)
@@ -449,9 +563,20 @@ export async function dumpPostgres(outputPath) {
     });
 
     let stderr = '';
-    proc.stderr.on('data', (chunk) => { stderr += chunk.toString(); });
+    const watchdog = watchBackupProcess(proc, { label: 'PostgreSQL dump', progressPath: outputPath });
+    proc.stderr.on('data', (chunk) => {
+      watchdog.markActivity();
+      stderr += chunk.toString();
+    });
 
     proc.on('close', async (code) => {
+      if (!watchdog.finish()) return;
+      const timeoutError = watchdog.getTimeoutError();
+      if (timeoutError) {
+        await unlink(outputPath).catch(() => {});
+        resolvePromise({ status: 'failed', reason: 'timeout', error: timeoutError.message });
+        return;
+      }
       if (code !== 0) {
         console.warn(`⚠️ pg_dump failed (code ${code}): ${stderr.trim()}`);
         // pg_dump can exit non-zero after writing a partial file (e.g. mid-dump
@@ -484,6 +609,7 @@ export async function dumpPostgres(outputPath) {
     });
 
     proc.on('error', (err) => {
+      if (watchdog.getTimeoutError() || !watchdog.finish()) return;
       // pg_dump not installed — a configured-but-unbacked-up DB is at risk,
       // so this is a failure, not a silent skip.
       console.warn(`⚠️ pg_dump not available: ${err.message}`);
@@ -692,7 +818,20 @@ export async function restoreSnapshot(destPath, snapshotId, { dryRun = true, sub
     flags.push('--exclude=*');
   }
 
-  const changedFiles = await runRsync(srcDir, PATHS.data, flags);
+  let changedFiles;
+  try {
+    changedFiles = await runRsync(srcDir, PATHS.data, flags);
+  } catch (err) {
+    if (!dryRun && err?.code === 'BACKUP_PROCESS_TIMEOUT') {
+      const partialRestoreError = new Error(
+        `${err.message}. Some files may already have been overwritten because file restore is not transactional.`,
+        { cause: err },
+      );
+      partialRestoreError.code = err.code;
+      throw partialRestoreError;
+    }
+    throw err;
+  }
   if (!dryRun) {
     // A live restore writes outside normal service mutation paths. Re-sync the
     // caches whose backing files may have changed instead of serving the
@@ -715,7 +854,7 @@ export async function restoreSnapshot(destPath, snapshotId, { dryRun = true, sub
  *   { status: 'ok', dryRun, sizeBytes, tableCount }   (dry-run or applied)
  *   { status: 'skipped', reason: 'no_dump' }           (no sql file in snapshot)
  *   { status: 'skipped', reason: 'not_configured' }    (real restore, PG unreachable)
- *   { status: 'failed', reason: 'restore_error', error }
+ *   { status: 'failed', reason: 'restore_error'|'timeout', error }
  * @param {string} destPath - Backup destination root
  * @param {string} snapshotId
  * @param {{dryRun?: boolean}} [options]
@@ -779,12 +918,26 @@ export async function restorePostgres(destPath, snapshotId, { dryRun = true } = 
       '-v', 'ON_ERROR_STOP=1',
       '--single-transaction',
       '-h', pgHost, '-p', pgPort, '-U', pgUser, '-d', pgDb, '-f', sqlPath
-    ], { shell: false, stdio: ['ignore', 'ignore', 'pipe'], env: { ...process.env, PGPASSWORD: process.env.PGPASSWORD || 'portos' } });
+    ], { shell: false, stdio: ['ignore', 'pipe', 'pipe'], env: { ...process.env, PGPASSWORD: process.env.PGPASSWORD || 'portos' } });
 
     let stderr = '';
-    proc.stderr.on('data', (chunk) => { stderr += chunk.toString(); });
+    const watchdog = watchBackupProcess(proc, { label: 'PostgreSQL restore' });
+    // psql's output is never retained, but it must be drained: unread piped
+    // output can backpressure and deadlock a verbose restore. Each chunk is also
+    // the supported progress signal that keeps an active long restore alive.
+    proc.stdout.on('data', watchdog.markActivity);
+    proc.stderr.on('data', (chunk) => {
+      watchdog.markActivity();
+      stderr += chunk.toString();
+    });
 
     proc.on('close', (code) => {
+      if (!watchdog.finish()) return;
+      const timeoutError = watchdog.getTimeoutError();
+      if (timeoutError) {
+        resolveP({ status: 'failed', reason: 'timeout', error: timeoutError.message });
+        return;
+      }
       if (code === 0) {
         console.log(`💾 psql restore complete from snapshot ${snapshotId}: ${tableCount} tables`);
         resolveP({ status: 'ok', dryRun: false, sizeBytes: info.size, tableCount });
@@ -794,6 +947,7 @@ export async function restorePostgres(destPath, snapshotId, { dryRun = true } = 
       }
     });
     proc.on('error', (err) => {
+      if (watchdog.getTimeoutError() || !watchdog.finish()) return;
       console.warn(`⚠️ psql not available: ${err.message}`);
       resolveP({ status: 'failed', reason: 'restore_error', error: err.message });
     });

--- a/server/services/backup.js
+++ b/server/services/backup.js
@@ -307,7 +307,10 @@ export function resolveRsyncBinary(env = process.env) {
 
 function runRsync(srcDir, destDir, flags = []) {
   return new Promise((resolve, reject) => {
-    const args = ['--archive', '--itemize-changes', ...flags, srcDir + '/', destDir];
+    // `--itemize-changes` emits only after each file finishes. `--progress` is
+    // also supported by macOS's bundled rsync 2.6.9 and emits within a large
+    // file, giving the idle watchdog evidence that a slow transfer is healthy.
+    const args = ['--archive', '--itemize-changes', '--progress', ...flags, srcDir + '/', destDir];
     const proc = spawn(resolveRsyncBinary(), args, { shell: false });
 
     const changed = [];
@@ -822,12 +825,12 @@ export async function restoreSnapshot(destPath, snapshotId, { dryRun = true, sub
   try {
     changedFiles = await runRsync(srcDir, PATHS.data, flags);
   } catch (err) {
-    if (!dryRun && err?.code === 'BACKUP_PROCESS_TIMEOUT') {
+    if (!dryRun) {
       const partialRestoreError = new Error(
         `${err.message}. Some files may already have been overwritten because file restore is not transactional.`,
         { cause: err },
       );
-      partialRestoreError.code = err.code;
+      if (err?.code) partialRestoreError.code = err.code;
       throw partialRestoreError;
     }
     throw err;
@@ -917,14 +920,16 @@ export async function restorePostgres(destPath, snapshotId, { dryRun = true } = 
     const proc = spawn('psql', [
       '-v', 'ON_ERROR_STOP=1',
       '--single-transaction',
+      '--echo-all',
       '-h', pgHost, '-p', pgPort, '-U', pgUser, '-d', pgDb, '-f', sqlPath
     ], { shell: false, stdio: ['ignore', 'pipe', 'pipe'], env: { ...process.env, PGPASSWORD: process.env.PGPASSWORD || 'portos' } });
 
     let stderr = '';
     const watchdog = watchBackupProcess(proc, { label: 'PostgreSQL restore' });
-    // psql's output is never retained, but it must be drained: unread piped
-    // output can backpressure and deadlock a verbose restore. Each chunk is also
-    // the supported progress signal that keeps an active long restore alive.
+    // `--echo-all` echoes input as psql consumes it, including rows within a
+    // long COPY. The output is never retained, but it must be drained: unread
+    // piped output can backpressure and deadlock a verbose restore. Each chunk
+    // is also the progress signal that keeps an active long restore alive.
     proc.stdout.on('data', watchdog.markActivity);
     proc.stderr.on('data', (chunk) => {
       watchdog.markActivity();

--- a/server/services/backup.test.js
+++ b/server/services/backup.test.js
@@ -803,7 +803,7 @@ describe('restorePostgres', () => {
       expect(result).toEqual({ status: 'ok', dryRun: false, sizeBytes: 4096, tableCount: 1 });
       const [bin, args, opts] = spawn.mock.calls[0];
       expect(bin).toBe('psql');
-      expect(args).toEqual(expect.arrayContaining(['-v', 'ON_ERROR_STOP=1', '--single-transaction', '-f']));
+      expect(args).toEqual(expect.arrayContaining(['-v', 'ON_ERROR_STOP=1', '--single-transaction', '--echo-all', '-f']));
       expect(opts.shell).toBe(false);
       expect(opts.stdio).toEqual(['ignore', 'pipe', 'pipe']);
       expect(child.stdin).toBeNull();
@@ -1174,7 +1174,7 @@ describe('restoreSnapshot subdirFilter guard', () => {
       });
       expect(spawn).toHaveBeenCalledWith(
         '/custom/bin/rsync',
-        expect.arrayContaining(['--archive', '--itemize-changes', '--dry-run']),
+        expect.arrayContaining(['--archive', '--itemize-changes', '--progress', '--dry-run']),
         { shell: false },
       );
     } finally {
@@ -1462,6 +1462,7 @@ describe('restoreSnapshot snapshotId, filter flags, and settings re-sync', () =>
       expect(spawn.mock.calls[0][1]).toEqual([
         '--archive',
         '--itemize-changes',
+        '--progress',
         '--itemize-changes',
         '--dry-run',
         '--include=brain/***',
@@ -1529,7 +1530,7 @@ describe('restoreSnapshot snapshotId, filter flags, and settings re-sync', () =>
       proc.stderr.emit('data', Buffer.from('boom'));
       proc.emit('close', 1);
 
-      await expect(pending).rejects.toThrow(/rsync exited with code 1/);
+      await expect(pending).rejects.toThrow(/rsync exited with code 1.*files may already have been overwritten/i);
       expect(reloadSettings).not.toHaveBeenCalled();
     });
   });
@@ -1650,7 +1651,7 @@ describe('runBackup lifecycle', () => {
     const [bin, args, opts] = spawn.mock.calls[0];
     expect(bin).toBe('rsync');
     expect(opts).toEqual({ shell: false });
-    expect(args.slice(0, 2)).toEqual(['--archive', '--itemize-changes']);
+    expect(args.slice(0, 3)).toEqual(['--archive', '--itemize-changes', '--progress']);
     // Source is PATHS.data with a trailing slash (copy contents, not the dir);
     // destination is the snapshot's data/ subdir.
     expect(args.at(-2)).toBe(`${dataRoot}/`);

--- a/server/services/backup.test.js
+++ b/server/services/backup.test.js
@@ -639,6 +639,59 @@ describe('dumpPostgres status classification', () => {
     expect(unlinkSpy).toHaveBeenCalledWith('/tmp/x.sql');
   });
 
+  it('kills a stalled pg_dump and removes its partial SQL file', async () => {
+    vi.useFakeTimers();
+    try {
+      checkHealth.mockResolvedValue({ connected: true, hasSchema: true });
+      vi.spyOn(fs, 'stat').mockResolvedValue({ size: 0 });
+      const unlinkSpy = vi.spyOn(fs, 'unlink').mockResolvedValue();
+      const proc = fakeProc();
+      spawn.mockReturnValue(proc);
+
+      const pending = dumpPostgres('/tmp/x.sql');
+      await flush();
+      await vi.advanceTimersByTimeAsync(10 * 60 * 1000);
+
+      expect(proc.kill).toHaveBeenCalledWith('SIGTERM');
+      await vi.advanceTimersByTimeAsync(8 * 1000);
+      expect(proc.kill).toHaveBeenLastCalledWith('SIGKILL');
+      proc.emit('close', null, 'SIGTERM');
+      await expect(pending).resolves.toMatchObject({
+        status: 'failed',
+        reason: 'timeout',
+        error: expect.stringMatching(/10 minutes without progress/),
+      });
+      expect(unlinkSpy).toHaveBeenCalledWith('/tmp/x.sql');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('treats a growing pg_dump output file as progress beyond ten minutes', async () => {
+    vi.useFakeTimers();
+    try {
+      checkHealth.mockResolvedValue({ connected: true, hasSchema: true });
+      let dumpSize = 0;
+      vi.spyOn(fs, 'stat').mockImplementation(async () => ({ size: dumpSize }));
+      vi.spyOn(fs, 'readFile').mockResolvedValue('CREATE TABLE memories (...);\n');
+      const proc = fakeProc();
+      spawn.mockReturnValue(proc);
+
+      const pending = dumpPostgres('/tmp/x.sql');
+      await flush();
+      await vi.advanceTimersByTimeAsync(9 * 60 * 1000);
+      dumpSize = 2048;
+      await vi.advanceTimersByTimeAsync(30 * 1000);
+      await vi.advanceTimersByTimeAsync(9 * 60 * 1000);
+
+      expect(proc.kill).not.toHaveBeenCalled();
+      proc.emit('close', 0);
+      await expect(pending).resolves.toMatchObject({ status: 'ok', sizeBytes: 2048 });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('returns failed/empty_dump when exit 0 but file is 0 bytes', async () => {
     checkHealth.mockResolvedValue({ connected: true, hasSchema: true });
     vi.spyOn(fs, 'stat').mockResolvedValue({ size: 0 });
@@ -732,7 +785,7 @@ describe('restorePostgres', () => {
     expect(spawn).not.toHaveBeenCalled();
   });
 
-  it('completes a verbose file restore without stdin/stdout pipes', async () => {
+  it('drains verbose psql output so progress cannot stall on pipe backpressure', async () => {
     vi.spyOn(fs, 'stat').mockResolvedValue({ size: 4096, isFile: () => true });
     vi.spyOn(fs, 'readFile').mockResolvedValue('CREATE TABLE a (...);\n');
     checkHealth.mockResolvedValue({ connected: true, hasSchema: true });
@@ -752,9 +805,9 @@ describe('restorePostgres', () => {
       expect(bin).toBe('psql');
       expect(args).toEqual(expect.arrayContaining(['-v', 'ON_ERROR_STOP=1', '--single-transaction', '-f']));
       expect(opts.shell).toBe(false);
-      expect(opts.stdio).toEqual(['ignore', 'ignore', 'pipe']);
+      expect(opts.stdio).toEqual(['ignore', 'pipe', 'pipe']);
       expect(child.stdin).toBeNull();
-      expect(child.stdout).toBeNull();
+      expect(child.stdout).not.toBeNull();
     } finally {
       if (child && child.exitCode === null && child.signalCode === null) child.kill('SIGKILL');
     }
@@ -885,6 +938,54 @@ describe('restorePostgres', () => {
       reason: 'restore_error',
       error: 'spawn psql ENOENT'
     });
+  });
+
+  it('kills a silent psql restore after the idle deadline and reports timeout', async () => {
+    vi.useFakeTimers();
+    try {
+      vi.spyOn(fs, 'stat').mockResolvedValue({ size: 4096, isFile: () => true });
+      vi.spyOn(fs, 'readFile').mockResolvedValue('CREATE TABLE a (...);\n');
+      checkHealth.mockResolvedValue({ connected: true, hasSchema: true });
+      const proc = fakeProc();
+      spawn.mockReturnValue(proc);
+
+      const pending = restorePostgres('/dest', '2026-06-05T00-00-00', { dryRun: false });
+      await flush();
+      await vi.advanceTimersByTimeAsync(10 * 60 * 1000);
+
+      expect(proc.kill).toHaveBeenCalledWith('SIGTERM');
+      proc.emit('close', null, 'SIGTERM');
+      await expect(pending).resolves.toMatchObject({
+        status: 'failed',
+        reason: 'timeout',
+        error: expect.stringMatching(/10 minutes without progress/),
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('keeps a long psql restore alive while drained stdout reports progress', async () => {
+    vi.useFakeTimers();
+    try {
+      vi.spyOn(fs, 'stat').mockResolvedValue({ size: 4096, isFile: () => true });
+      vi.spyOn(fs, 'readFile').mockResolvedValue('CREATE TABLE a (...);\n');
+      checkHealth.mockResolvedValue({ connected: true, hasSchema: true });
+      const proc = fakeProc();
+      spawn.mockReturnValue(proc);
+
+      const pending = restorePostgres('/dest', '2026-06-05T00-00-00', { dryRun: false });
+      await flush();
+      await vi.advanceTimersByTimeAsync(9 * 60 * 1000);
+      proc.stdout.emit('data', Buffer.from('COPY 200000\n'));
+      await vi.advanceTimersByTimeAsync(9 * 60 * 1000);
+
+      expect(proc.kill).not.toHaveBeenCalled();
+      proc.emit('close', 0);
+      await expect(pending).resolves.toMatchObject({ status: 'ok' });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   // The atomicity contract: ON_ERROR_STOP=1 aborts on the first failed statement
@@ -1099,6 +1200,50 @@ describe('restoreSnapshot subdirFilter guard', () => {
     } finally {
       if (previous === undefined) delete process.env.PORTOS_RSYNC;
       else process.env.PORTOS_RSYNC = previous;
+    }
+  });
+
+  it('warns that a timed-out live file restore may have overwritten files', async () => {
+    vi.useFakeTimers();
+    try {
+      const proc = fakeProc();
+      spawn.mockReturnValue(proc);
+      const pending = restoreSnapshot('/dest', 'snap-1', { dryRun: false });
+      await flush();
+
+      await vi.advanceTimersByTimeAsync(10 * 60 * 1000);
+      expect(proc.kill).toHaveBeenCalledWith('SIGTERM');
+      proc.emit('close', null, 'SIGTERM');
+
+      await expect(pending).rejects.toThrow(/files may already have been overwritten/i);
+      expect(reloadSettings).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('keeps active rsync work past ten minutes but enforces the four-hour ceiling', async () => {
+    vi.useFakeTimers();
+    try {
+      const proc = fakeProc();
+      spawn.mockReturnValue(proc);
+      const pending = restoreSnapshot('/dest', 'snap-1');
+      await flush();
+
+      // Progress every nine minutes continually resets the idle deadline. The
+      // final six-minute step crosses the independent four-hour backstop.
+      for (let elapsedMinutes = 0; elapsedMinutes < 234; elapsedMinutes += 9) {
+        await vi.advanceTimersByTimeAsync(9 * 60 * 1000);
+        proc.stdout.emit('data', Buffer.from('>f.st...... still-working.json\n'));
+        expect(proc.kill).not.toHaveBeenCalled();
+      }
+      await vi.advanceTimersByTimeAsync(6 * 60 * 1000);
+
+      expect(proc.kill).toHaveBeenCalledWith('SIGTERM');
+      proc.emit('close', null, 'SIGTERM');
+      await expect(pending).rejects.toThrow(/4 hours/);
+    } finally {
+      vi.useRealTimers();
     }
   });
 });
@@ -1646,6 +1791,51 @@ describe('runBackup lifecycle', () => {
 
     // isRunning must have been reset: the next run proceeds instead of
     // short-circuiting to { skipped: true }.
+    const retryProc = fakeProc();
+    spawn.mockReturnValue(retryProc);
+    const retry = runBackup(destRoot, io);
+    await waitFor(() => spawn.mock.calls.length === 2, 'retry rsync spawn');
+    retryProc.emit('close', 0);
+    await expect(retry).resolves.toMatchObject({ status: 'ok' });
+  });
+
+  it('kills stalled rsync, waits for child close, clears markers, and permits retry', async () => {
+    const realSetTimeout = globalThis.setTimeout;
+    let fireIdleTimeout;
+    const timerSpy = vi.spyOn(globalThis, 'setTimeout').mockImplementation((callback, delay, ...args) => {
+      if (delay === 10 * 60 * 1000 && !fireIdleTimeout) {
+        fireIdleTimeout = callback;
+        const timer = realSetTimeout(() => {}, delay, ...args);
+        timer.unref?.();
+        return timer;
+      }
+      return realSetTimeout(callback, delay, ...args);
+    });
+
+    const io = { emit: vi.fn() };
+    const proc = fakeProc();
+    spawn.mockReturnValue(proc);
+    const pending = runBackup(destRoot, io);
+    let settled = false;
+    pending.then(() => { settled = true; }, () => { settled = true; });
+
+    await waitFor(() => spawn.mock.calls.length === 1 && fireIdleTimeout, 'rsync watchdog');
+    const snapshotDir = await findSnapshotDir();
+    const snapshotId = basename(snapshotDir);
+    const fsp = await actualFs();
+    fireIdleTimeout();
+
+    expect(proc.kill).toHaveBeenCalledWith('SIGTERM');
+    await Promise.resolve();
+    expect(settled).toBe(false);
+    proc.emit('close', null, 'SIGTERM');
+    await expect(pending).rejects.toThrow(/10 minutes without progress/);
+    expect(settled).toBe(true);
+    await expect(fsp.access(joinPath(snapshotDir, '.in-progress'))).rejects.toThrow();
+    await expect(fsp.access(joinPath(destRoot, 'snapshots', machineHost, `.${snapshotId}.in-progress`)))
+      .rejects.toThrow();
+
+    timerSpy.mockRestore();
     const retryProc = fakeProc();
     spawn.mockReturnValue(retryProc);
     const retry = runBackup(destRoot, io);


### PR DESCRIPTION
## What changed

- add ten-minute idle watchdogs and a four-hour wall-clock ceiling for backup rsync, `pg_dump`, and `psql` restore children
- preserve legitimate long-running work through rsync per-file progress, drained `psql --echo-all` activity, and `pg_dump` output-file growth
- terminate through the shared SIGTERM-to-SIGKILL escalation and wait for child close before releasing backup locks or markers
- delete timed-out partial SQL dumps and warn that failed live file restores may already have overwritten files

## Validation

- `server/node_modules/.bin/vitest run server/services/backup.test.js server/routes/backup.test.js server/services/backupScheduler.test.js server/timerCallbackConventions.test.js server/process-safety-net.test.js server/lib/childProcess.guards.test.js` (183 tests)
- `node --check server/services/backup.js`
- `node --check server/services/backup.test.js`

Closes #6939
