### PR TITLE
fix: federate Writers Room bibles with their works

### DIFF
--- a/server/lib/conflictJournal.js
+++ b/server/lib/conflictJournal.js
@@ -481,6 +481,9 @@ export const RESTORABLE_FIELDS = Object.freeze({
   // their own helpers). The whole manifest is hashed for DETECTION by
   // contentHashForRecord (no scalar narrowing); this set is what the Conflicts UI
   // offers for restore. `writersRoomWork` matches the record kind.
+  writersRoomCharacters: ['characters'],
+  writersRoomPlaces: ['places'],
+  writersRoomObjects: ['objects'],
   writersRoomWork: ['title', 'kind', 'status', 'folderId', 'imageStyle', 'liveMode'],
   // Writers Room folders (#1645): the user-authored structural fields the merge
   // can restore through `restoreFolder`. Server-owned / structural fields are

--- a/server/lib/importScoping.test.js
+++ b/server/lib/importScoping.test.js
@@ -38,6 +38,10 @@ const reaches = (entry, target) => staticImportClosure(abs(entry)).files.has(abs
 
 // Each row: the entry that was narrowed, the module it must no longer
 const NARROWED = [
+  ['services/sharing/peerSyncPush.js', 'services/writersRoom/bibleSync.js',
+    'loads bible asset handling only for Writers Room work pushes'],
+  ['services/sharing/peerSyncReceive.js', 'services/writersRoom/bibleSync.js',
+    'loads bible asset handling only for Writers Room work receives'],
   ['services/persistentMindAttachments.js', 'services/persistentMindSupervisor.js',
     'owns screenshot attachment lifecycle without supervisor turn execution'],
   ['services/mtplxModelManager.js', 'services/huggingFaceCatalog.js',

--- a/server/lib/peerSyncValidation.js
+++ b/server/lib/peerSyncValidation.js
@@ -230,6 +230,12 @@ const writersRoomWorkPushSchema = z.object({
   kind: z.literal('writersRoomWork'),
   ...peerSyncPushBase,
   ...draftBodyManifestField,
+  bibleManifest: z.array(z.object({
+    workId: z.string().trim().min(1).max(120),
+    kind: z.enum(['character', 'place', 'object']),
+    sha256: hex64,
+    updatedAt: z.string().datetime({ offset: true }),
+  }).strict()).max(3).optional(),
 }).strict();
 // Writers Room folders + exercises (#1645) push the bare record — body-less, no
 // asset manifest entries, no draft bodies, no bundled children. The base shape

--- a/server/lib/schemaVersions.js
+++ b/server/lib/schemaVersions.js
@@ -489,6 +489,10 @@ export const PORTOS_SCHEMA_VERSIONS = Object.freeze({
   // decomposed draft-version metadata in drafts[]) is LWW-overwritten whole; the
   // file-primary `.md` draft prose bodies ride a separate body manifest (SHA256
   // diff + receiver-pull), never round-tripped through the record.
+  // Bible JSON siblings also ride an optional bibleManifest (#6943), with
+  // independent file updatedAt LWW. Older receivers retry without that key;
+  // omission never deletes files. The first incompatible bible shape needs its
+  // own version gate before it can cross peers; this additive transport stays v1.
   writersRoomWorks: 1,
   // v1 = Writers Room folders (PostgreSQL `writers_room_folders`) federated via
   // the per-record peer-sync push pipeline (record kind `writersRoomFolder`,

--- a/server/routes/peerSync.test.js
+++ b/server/routes/peerSync.test.js
@@ -175,7 +175,7 @@ describe('peer-sync routes', () => {
       }));
     });
 
-    it('accepts a writersRoomWork push that bundles a draftBodyManifest', async () => {
+    it('accepts a writersRoomWork push that bundles draft and bible manifests', async () => {
       // Regression: writersRoomWorkPushSchema is `.strict()`, so without the
       // draftBodyManifest field (and without the kind in the discriminated
       // union) the production body-bearing work push 400s at the Zod boundary
@@ -190,12 +190,14 @@ describe('peer-sync routes', () => {
           draftBodyManifest: [
             { kind: 'writers-room-draft', workId: 'wr-work-1', draftId: 'wr-draft-1', sha256: 'a'.repeat(64) },
           ],
+          bibleManifest: [{ workId: 'wr-work-1', kind: 'character', sha256: 'b'.repeat(64), updatedAt: '2026-09-01T00:00:00Z' }],
           sourceInstanceId: 'peer-a',
         });
       expect(res.status).toBe(200);
       expect(svc.applyIncomingPush).toHaveBeenCalledWith(expect.objectContaining({
         kind: 'writersRoomWork',
         draftBodyManifest: expect.any(Array),
+        bibleManifest: expect.any(Array),
       }));
     });
 

--- a/server/services/assetMounts.js
+++ b/server/services/assetMounts.js
@@ -47,12 +47,12 @@ const ASSET_STATIC_OPTS = { acceptRanges: true };
 const IMMUTABLE_MAX_AGE_MS = 365 * 24 * 60 * 60 * 1000;
 const CLIENT_ASSET_STATIC_OPTS = { immutable: true, maxAge: IMMUTABLE_MAX_AGE_MS, index: false };
 
-// Only `<workId>/drafts/<draftId>.md` is needed for federation body pulls.
-// Without this gate the static root would also serve adjacent work-metadata
-// JSON (manifest.json / manifest.imported.json on file-backend/migrated
-// installs) to any client that knows a work id.
-const writersRoomDraftBodiesOnly = (req, res, next) => {
-  if (!/^\/[^/]+\/drafts\/[^/]+\.md$/.test(req.path)) return res.status(404).end();
+// Federation may pull draft prose and the three authored bible siblings only.
+// Metadata/import backups and regenerable analysis snapshots stay inaccessible.
+const writersRoomAssetsOnly = (req, res, next) => {
+  const draft = /^\/[^/]+\/drafts\/[^/]+\.md$/.test(req.path);
+  const bible = /^\/wr-work-[0-9a-f-]+\/(characters|places|objects)\.json$/i.test(req.path);
+  if (!draft && !bible) return res.status(404).end();
   next();
 };
 
@@ -97,7 +97,7 @@ const ASSET_DIRS = {
   '/data/writers-room/works': wrWorksDir,
 };
 
-const ASSET_GATES = { '/data/writers-room/works': writersRoomDraftBodiesOnly };
+const ASSET_GATES = { '/data/writers-room/works': writersRoomAssetsOnly };
 
 /** The routes `ASSET_DIRS` knows a directory for — exported so a key that never
  *  reaches `ASSET_ROUTE_PREFIXES` (and is therefore never mounted) fails a test

--- a/server/services/assetMounts.js
+++ b/server/services/assetMounts.js
@@ -19,7 +19,7 @@ import { join } from 'path';
 import { PATHS } from '../lib/fileUtils.js';
 import { ServerError, sendErrorResponse } from '../lib/errorHandler.js';
 import { ASSET_ROUTE_PREFIXES, SERVER_OWNED_PREFIXES } from '../lib/assetRoutePrefixes.js';
-import { wrWorksDir } from './writersRoom/_shared.js';
+import { wrWorksDir, WORK_ID_RE } from './writersRoom/_shared.js';
 import { escapeRegExp } from '../lib/textUtils.js';
 
 // `acceptRanges: true` is the serve-static default already, but we set it
@@ -51,7 +51,8 @@ const CLIENT_ASSET_STATIC_OPTS = { immutable: true, maxAge: IMMUTABLE_MAX_AGE_MS
 // Metadata/import backups and regenerable analysis snapshots stay inaccessible.
 const writersRoomAssetsOnly = (req, res, next) => {
   const draft = /^\/[^/]+\/drafts\/[^/]+\.md$/.test(req.path);
-  const bible = /^\/wr-work-[0-9a-f-]+\/(characters|places|objects)\.json$/i.test(req.path);
+  const bibleMatch = /^\/([^/]+)\/(characters|places|objects)\.json$/.exec(req.path);
+  const bible = bibleMatch && WORK_ID_RE.test(bibleMatch[1]);
   if (!draft && !bible) return res.status(404).end();
   next();
 };

--- a/server/services/assetMounts.test.js
+++ b/server/services/assetMounts.test.js
@@ -55,6 +55,9 @@ beforeAll(() => {
   mkdirSync(join(drafts, 'drafts'), { recursive: true });
   writeFileSync(join(drafts, 'drafts', 'd1.md'), '# body');
   writeFileSync(join(drafts, 'manifest.json'), '{"private":true}');
+  for (const kind of ['characters', 'places', 'objects']) writeFileSync(join(drafts, `${kind}.json`), JSON.stringify({ [kind]: [] }));
+  mkdirSync(join(drafts, 'analysis'), { recursive: true });
+  writeFileSync(join(drafts, 'analysis', 'evaluate.json'), '{"private":true}');
 
   app = express();
   mountAssetRoutes(app);
@@ -151,6 +154,14 @@ describe('the writers-room draft-body gate', () => {
     const manifest = await request(app).get('/data/writers-room/works/wr-work-1/manifest.json');
     expect(manifest.status).toBe(404);
     expect(manifest.text).not.toContain('private');
+    for (const kind of ['characters', 'places', 'objects']) {
+      const bible = await request(app).get(`/data/writers-room/works/wr-work-1/${kind}.json`);
+      expect(bible.status).toBe(200);
+      expect(bible.body).toEqual({ [kind]: [] });
+    }
+    const analysis = await request(app).get('/data/writers-room/works/wr-work-1/analysis/evaluate.json');
+    expect(analysis.status).toBe(404);
+    expect(analysis.text).not.toContain('private');
   });
 });
 

--- a/server/services/bibleStore.js
+++ b/server/services/bibleStore.js
@@ -9,6 +9,7 @@
  * directly from here, and the pure sanitizer names from lib/storyBible.js.
  */
 
+import { emitRecordUpdated } from './sharing/recordEvents.js';
 import { randomUUID } from 'crypto';
 import { join } from 'path';
 import { PATHS, atomicWrite, ensureDir, readJSONFile } from '../lib/fileUtils.js';
@@ -60,6 +61,7 @@ export function createBibleStore(opts) {
   async function save(workId, state) {
     await ensureDir(wrDir(workId));
     await atomicWrite(filePath(workId), { ...state, updatedAt: nowIso() });
+    emitRecordUpdated('writersRoomWork', workId);
   }
 
   async function list(workId) {

--- a/server/services/bibleStore.js
+++ b/server/services/bibleStore.js
@@ -9,10 +9,11 @@
  * directly from here, and the pure sanitizer names from lib/storyBible.js.
  */
 
-import { emitRecordUpdated } from './sharing/recordEvents.js';
 import { randomUUID } from 'crypto';
 import { join } from 'path';
 import { PATHS, atomicWrite, ensureDir, readJSONFile } from '../lib/fileUtils.js';
+import { emitRecordUpdated } from './sharing/recordEvents.js';
+import { createKeyCachedQueue } from '../lib/createKeyCachedQueue.js';
 import { ServerError } from '../lib/errorHandler.js';
 import {
   SANITIZERS,
@@ -21,6 +22,9 @@ import {
   sanitizeBibleList,
   mergeExtractedBible,
 } from '../lib/storyBible.js';
+
+// Shared with peer bible commits: a local save and an incoming file cannot interleave.
+export const withBibleWrite = createKeyCachedQueue();
 
 const WORK_ID_RE = /^wr-work-[0-9a-f-]+$/i;
 const ID_SUFFIX_RE = /^[0-9a-f-]+$/i;
@@ -60,7 +64,7 @@ export function createBibleStore(opts) {
 
   async function save(workId, state) {
     await ensureDir(wrDir(workId));
-    await atomicWrite(filePath(workId), { ...state, updatedAt: nowIso() });
+    await withBibleWrite(filePath(workId), () => atomicWrite(filePath(workId), { ...state, updatedAt: nowIso() }));
     emitRecordUpdated('writersRoomWork', workId);
   }
 

--- a/server/services/conflictJournalResolver.js
+++ b/server/services/conflictJournalResolver.js
@@ -145,6 +145,10 @@ async function applyToRecord(kind, recordId, patch, { replace = false } = {}) {
     // same path. It validates `status` and rejects a missing/tombstoned row with
     // the generic ServerError 'NOT_FOUND' (→ translateGone → ERR_TARGET_GONE).
     await updateMusicVideoProject(recordId, patch).catch(translateGone);
+  } else if (['writersRoomCharacters', 'writersRoomPlaces', 'writersRoomObjects'].includes(kind)) {
+    const { restoreWorkBible, BIBLE_CONFLICT_KINDS } = await import('./writersRoom/bibleSync.js');
+    const bibleKind = Object.keys(BIBLE_CONFLICT_KINDS).find((key) => BIBLE_CONFLICT_KINDS[key] === kind);
+    await restoreWorkBible(recordId, bibleKind, patch).catch(translateGone);
   } else if (kind === 'writersRoomWork') {
     // updateWork applies the snapshot's title/kind/status/folderId/imageStyle/
     // liveMode (the RESTORABLE_FIELDS set) through its allow-list + the liveMode

--- a/server/services/sharing/peerSync.test.js
+++ b/server/services/sharing/peerSync.test.js
@@ -168,6 +168,10 @@ vi.mock('../fableLoom/index.js', () => ({
   listLooms: vi.fn().mockResolvedValue([]),
   mergeLoomsFromSync: vi.fn().mockResolvedValue({ applied: true, count: 1 }),
 }));
+vi.mock('../writersRoom/bibleSync.js', async (importOriginal) => ({
+  ...(await importOriginal()),
+  diffWorkBibleManifest: vi.fn().mockResolvedValue([]),
+}));
 vi.mock('../writersRoom/sync.js', async (importOriginal) => ({
   ...(await importOriginal()),
   listWorksForSync: vi.fn().mockResolvedValue([]),
@@ -290,6 +294,7 @@ import {
   listFoldersForSync, getFolderForSync, mergeFoldersFromSync,
   listExercisesForSync, getExerciseForSync, mergeExercisesFromSync,
 } from '../writersRoom/sync.js';
+import { diffWorkBibleManifest } from '../writersRoom/bibleSync.js';
 import { listCommissionFeedbackForSync, getCommissionFeedbackForSync, mergeCommissionFeedbackFromSync } from '../creativeCommissions/feedbackStore.js';
 import { listCommissionsForSync, getCommissionForSync, mergeCommissionsFromSync } from '../creativeCommissions/store.js';
 import { peerFetch } from '../../lib/peerHttpClient.js';
@@ -4394,6 +4399,19 @@ describe('peerSync', () => {
           });
         },
       },
+      bibleManifest: {
+        recordKind: 'writersRoomWork', recordId: 'wr-work-aaaa',
+        arm: async () => {
+          vi.mocked(getPeers).mockResolvedValue([{
+            instanceId: 'peer-a', name: 'Peer A', address: '192.0.2.10', port: 5555,
+            enabled: true, syncEnabled: true, directions: ['outbound', 'inbound'], syncCategories: { writersRoomWorks: true },
+          }]);
+          vi.mocked(getWorkForSync).mockResolvedValue({ id: 'wr-work-aaaa', title: 'Example work', drafts: [] });
+          const dir = join(PATHS.data, 'writers-room', 'works', 'wr-work-aaaa');
+          await mkdir(dir, { recursive: true });
+          await writeFile(join(dir, 'characters.json'), JSON.stringify({ characters: [], updatedAt: '2026-06-02T00:00:00Z' }));
+        },
+      },
       linkedTrack: {
         recordKind: 'musicVideoProject', recordId: 'mv-1',
         arm: async () => {
@@ -4417,6 +4435,18 @@ describe('peerSync', () => {
     const refresh = ({ recordKind, recordId }) => findPeerSubscription('peer-a', recordKind, recordId);
     const payloadOf = (call) => JSON.parse(call[1].body);
 
+    it('re-pushes a bible-only edit even when the work record is unchanged', async () => {
+      const carrier = CARRIERS.bibleManifest;
+      await carrier.arm();
+      vi.mocked(peerFetch).mockResolvedValue(acceptsPush());
+      await pushRecordToPeer(await claim(carrier));
+      vi.mocked(peerFetch).mockClear();
+      const file = join(PATHS.data, 'writers-room', 'works', carrier.recordId, 'characters.json');
+      await writeFile(file, JSON.stringify({ characters: [{ name: 'New cast member' }], updatedAt: '2026-06-03T00:00:00Z' }));
+      expect((await pushRecordToPeer(await refresh(carrier))).pushed).toBe(true);
+      expect(payloadOf(vi.mocked(peerFetch).mock.calls[0]).bibleManifest).toHaveLength(1);
+    });
+
     it('pins the wire vocabulary older peers depend on', () => {
       // Older senders and receivers read exactly these names off the wire — a
       // rename here is a cross-version break, not a refactor.
@@ -4427,6 +4457,7 @@ describe('peerSync', () => {
         ['manuscriptReview', 'reviewSyncPending'],
         ['reverseOutline', 'outlineSyncPending'],
         ['linkedTrack', 'trackSyncPending'],
+        ['bibleManifest', 'bibleSyncPending'],
       ]));
     });
 
@@ -4548,6 +4579,14 @@ describe('peerSync', () => {
     describe('receiver — applyIncomingPush', () => {
       // How each sidecar reaches the receiver, and the merge that can throw.
       const RECEIVE_CARRIERS = {
+        bibleManifest: {
+          merge: diffWorkBibleManifest,
+          payload: () => ({
+            kind: 'writersRoomWork', record: { id: 'wr-work-aaaa', drafts: [] },
+            bibleManifest: [{ workId: 'wr-work-aaaa', kind: 'character', sha256: 'a'.repeat(64), updatedAt: '2026-06-02T00:00:00Z' }],
+            assetManifest: [], sourceInstanceId: 'peer-a',
+          }),
+        },
         manuscriptReview: {
           merge: mergeReviewFromSync,
           payload: () => ({
@@ -4581,6 +4620,20 @@ describe('peerSync', () => {
           }),
         },
       };
+
+      it('scopes bible pulls to the pushed work and keeps pending pulls retryable', async () => {
+        const payload = RECEIVE_CARRIERS.bibleManifest.payload();
+        const own = payload.bibleManifest[0];
+        payload.bibleManifest.push({ ...own, workId: 'wr-work-bbbb' });
+        // No peer fetch in this test: diff returns a pending target with no registered peer.
+        vi.mocked(diffWorkBibleManifest).mockResolvedValueOnce([own]);
+        const result = await applyIncomingPush(payload);
+        expect(vi.mocked(diffWorkBibleManifest)).toHaveBeenLastCalledWith([own]);
+        expect(result.bibleSyncPending).toBe(true);
+        payload.bibleManifest = undefined;
+        await applyIncomingPush(payload);
+        expect(vi.mocked(diffWorkBibleManifest)).toHaveBeenLastCalledWith([]);
+      });
 
       it('has a receiver-side carrier for every sidecar row', () => {
         expect(Object.keys(RECEIVE_CARRIERS).sort()).toEqual(SIDECARS.map((e) => e.key).sort());

--- a/server/services/sharing/peerSync.test.js
+++ b/server/services/sharing/peerSync.test.js
@@ -4445,6 +4445,13 @@ describe('peerSync', () => {
       await writeFile(file, JSON.stringify({ characters: [{ name: 'New cast member' }], updatedAt: '2026-06-03T00:00:00Z' }));
       expect((await pushRecordToPeer(await refresh(carrier))).pushed).toBe(true);
       expect(payloadOf(vi.mocked(peerFetch).mock.calls[0]).bibleManifest).toHaveLength(1);
+      // A corrupt optional sibling must not hold the work and its prose hostage.
+      vi.mocked(peerFetch).mockClear();
+      await writeFile(file, '{');
+      expect((await pushRecordToPeer(await refresh(carrier))).pushed).toBe(true);
+      const withoutBible = payloadOf(vi.mocked(peerFetch).mock.calls[0]);
+      expect(withoutBible.record.id).toBe(carrier.recordId);
+      expect(withoutBible).not.toHaveProperty('bibleManifest');
     });
 
     it('pins the wire vocabulary older peers depend on', () => {
@@ -4628,11 +4635,11 @@ describe('peerSync', () => {
         // No peer fetch in this test: diff returns a pending target with no registered peer.
         vi.mocked(diffWorkBibleManifest).mockResolvedValueOnce([own]);
         const result = await applyIncomingPush(payload);
-        expect(vi.mocked(diffWorkBibleManifest)).toHaveBeenLastCalledWith([own]);
+        expect(vi.mocked(diffWorkBibleManifest)).toHaveBeenLastCalledWith([own], expect.any(Object));
         expect(result.bibleSyncPending).toBe(true);
         payload.bibleManifest = undefined;
         await applyIncomingPush(payload);
-        expect(vi.mocked(diffWorkBibleManifest)).toHaveBeenLastCalledWith([]);
+        expect(vi.mocked(diffWorkBibleManifest)).toHaveBeenLastCalledWith([], expect.any(Object));
       });
 
       it('has a receiver-side carrier for every sidecar row', () => {

--- a/server/services/sharing/peerSyncAssets.js
+++ b/server/services/sharing/peerSyncAssets.js
@@ -969,3 +969,27 @@ async function doPullOneAsset(peer, base, entry, urlPrefix, localDir, safeName) 
     await reconcileVideoThumbnail(safeName, fullPath, peer.instanceId);
   }
 }
+
+/** Pull only the three authored bible files; analysis snapshots never enter this path. */
+export async function pullMissingWorkBibles(senderInstanceId, entries) {
+  if (!isStr(senderInstanceId) || !Array.isArray(entries) || !entries.length) return;
+  const peer = await findPeerById(senderInstanceId);
+  if (!peer) return;
+  const { workBiblePath, BIBLE_FILES, applyWorkBibleBytes } = await import('../writersRoom/bibleSync.js');
+  for (const entry of entries) {
+    if (!workBiblePath(entry?.workId, entry?.kind)) continue;
+    const filename = `${BIBLE_FILES[entry.kind]}.json`;
+    const key = `writers-room-bible:${entry.workId}:${entry.kind}`;
+    // Destination queue serializes incoming peers; the apply step rechecks local LWW.
+    await assetWriteQueue(key, async () => {
+      const url = `${peerBaseUrl(peer)}/data/writers-room/works/${encodeURIComponent(entry.workId)}/${filename}`;
+      const buffer = await fetchCappedAssetBuffer(peer, url, filename, WORK_BODY_PULL_MAX_BYTES);
+      if (!buffer) return;
+      const current = await getWorkForSync(entry.workId);
+      if (!current || current.deleted || current.ephemeral) return;
+      if (await applyWorkBibleBytes(entry, buffer, { via: 'peer-sync', peerId: senderInstanceId })) {
+        peerSyncEvents.emit('asset-arrived', { filename, kind: 'writers-room-bible', workId: entry.workId, peerId: senderInstanceId });
+      }
+    }).catch((err) => console.error(`❌ peerSync: bible pull failed: ${err.message}`));
+  }
+}

--- a/server/services/sharing/peerSyncPush.js
+++ b/server/services/sharing/peerSyncPush.js
@@ -26,7 +26,6 @@ import {
   findCollectionBySeriesId,
 } from '../mediaCollections.js';
 import { getTrack } from '../tracks/index.js';
-import { buildWorkBibleManifest } from '../writersRoom/bibleSync.js';
 import { buildWorkBodyManifest } from '../writersRoom/sync.js';
 import { ackDeletesUpTo } from './peerTombstoneCursors.js';
 import {
@@ -711,6 +710,7 @@ export async function buildPushPayload(sub, sourceInstanceId) {
     return { ...envelope, ...(linkedTrack ? { linkedTrack } : {}) };
   }
   if (sub.recordKind === 'writersRoomWork') {
+    const { buildWorkBibleManifest } = await import('../writersRoom/bibleSync.js');
     // The work manifest carries draft-version METADATA; the file-primary `.md`
     // prose bodies ride a separate `draftBodyManifest` (SHA256 per draft) the
     // receiver diffs + pulls. A tombstone ships neither asset manifest.

--- a/server/services/sharing/peerSyncPush.js
+++ b/server/services/sharing/peerSyncPush.js
@@ -26,6 +26,7 @@ import {
   findCollectionBySeriesId,
 } from '../mediaCollections.js';
 import { getTrack } from '../tracks/index.js';
+import { buildWorkBibleManifest } from '../writersRoom/bibleSync.js';
 import { buildWorkBodyManifest } from '../writersRoom/sync.js';
 import { ackDeletesUpTo } from './peerTombstoneCursors.js';
 import {
@@ -714,7 +715,8 @@ export async function buildPushPayload(sub, sourceInstanceId) {
     // prose bodies ride a separate `draftBodyManifest` (SHA256 per draft) the
     // receiver diffs + pulls. A tombstone ships neither asset manifest.
     const draftBodyManifest = record.deleted === true ? [] : await buildWorkBodyManifest(record);
-    return { ...envelope, draftBodyManifest };
+    const bibleManifest = record.deleted === true ? [] : await buildWorkBibleManifest(record);
+    return { ...envelope, draftBodyManifest, ...(bibleManifest.length ? { bibleManifest } : {}) };
   }
   return envelope;
 }

--- a/server/services/sharing/peerSyncReceive.js
+++ b/server/services/sharing/peerSyncReceive.js
@@ -463,9 +463,12 @@ export async function applyIncomingPush(payload) {
       : [];
     missingDraftBodies = await diffWorkBodyManifest(ownBodies, { includeMismatched: workMergeApplied });
     const ownBibles = Array.isArray(bibleManifest) ? bibleManifest.filter((e) => e?.workId === record.id) : [];
-    const missingBibles = await diffWorkBibleManifest(ownBibles).catch((err) => {
+    const bibleDiffFailed = (err) => {
       pending.add('bibleSyncPending');
       console.error(`❌ peerSync: bible diff failed: ${err.message}`);
+    };
+    const missingBibles = await diffWorkBibleManifest(ownBibles, { onError: bibleDiffFailed }).catch((err) => {
+      bibleDiffFailed(err);
       return [];
     });
     if (missingBibles.length) {

--- a/server/services/sharing/peerSyncReceive.js
+++ b/server/services/sharing/peerSyncReceive.js
@@ -9,6 +9,7 @@
  *
  * Split out of the former 4,004-line peerSync.js (#1830).
  */
+import { diffWorkBibleManifest } from '../writersRoom/bibleSync.js';
 import { isPlainObject } from '../../lib/objects.js';
 import {
   PORTOS_SCHEMA_VERSIONS,
@@ -28,6 +29,7 @@ import {
   diffAssetManifestAgainstLocal,
   pullMissingAssetsFromPeer,
   pullMissingWorkBodies,
+  pullMissingWorkBibles,
 } from './peerSyncAssets.js';
 import { RECORD_KINDS } from './recordKinds.js';
 import { findPeerSubscription, subscribePeer } from './peerSubscriptions.js';
@@ -204,7 +206,7 @@ export async function applyIncomingPush(payload) {
   if (!isPlainObject(payload)) {
     throw makeErr('payload must be an object', ERR_VALIDATION);
   }
-  const { kind, record, issues, linkedCollection, linkedTrack, catalogBundle, manuscriptReview, reverseOutline, assetManifest, draftBodyManifest, sourceInstanceId, portosMeta } = payload;
+  const { kind, record, issues, linkedCollection, linkedTrack, catalogBundle, manuscriptReview, reverseOutline, assetManifest, draftBodyManifest, bibleManifest, sourceInstanceId, portosMeta } = payload;
   if (!PEER_SUBSCRIBABLE_KINDS.includes(kind)) {
     throw makeErr(`unknown kind: ${kind}`, ERR_VALIDATION);
   }
@@ -460,6 +462,18 @@ export async function applyIncomingPush(payload) {
       ? draftBodyManifest.filter((e) => e && e.workId === record.id)
       : [];
     missingDraftBodies = await diffWorkBodyManifest(ownBodies, { includeMismatched: workMergeApplied });
+    const ownBibles = Array.isArray(bibleManifest) ? bibleManifest.filter((e) => e?.workId === record.id) : [];
+    const missingBibles = await diffWorkBibleManifest(ownBibles).catch((err) => {
+      pending.add('bibleSyncPending');
+      console.error(`❌ peerSync: bible diff failed: ${err.message}`);
+      return [];
+    });
+    if (missingBibles.length) {
+      pending.add('bibleSyncPending');
+      pullMissingWorkBibles(sourceInstanceId, missingBibles).catch((err) => {
+        console.error(`❌ peerSync: bible pull failed: ${err.message}`);
+      });
+    }
     if (missingDraftBodies.length > 0) {
       pullMissingWorkBodies(sourceInstanceId, missingDraftBodies).catch((err) => {
         console.log(`⚠️ peerSync: draft-body pull from ${sourceInstanceId} failed: ${err.message}`);

--- a/server/services/sharing/peerSyncReceive.js
+++ b/server/services/sharing/peerSyncReceive.js
@@ -9,7 +9,6 @@
  *
  * Split out of the former 4,004-line peerSync.js (#1830).
  */
-import { diffWorkBibleManifest } from '../writersRoom/bibleSync.js';
 import { isPlainObject } from '../../lib/objects.js';
 import {
   PORTOS_SCHEMA_VERSIONS,
@@ -453,6 +452,7 @@ export async function applyIncomingPush(payload) {
   // Same guards as the asset path: skip for local-ephemeral and tombstone pushes.
   let missingDraftBodies = [];
   if (kind === 'writersRoomWork' && !localEphemeral && record.deleted !== true) {
+    const { diffWorkBibleManifest } = await import('../writersRoom/bibleSync.js');
     // Scope the manifest to THIS work: a body entry's path is works/<workId>/...,
     // so an entry whose workId != the pushed record's id would write bytes into a
     // DIFFERENT local work's draft (clobbering unrelated prose when the merge

--- a/server/services/sharing/peerSyncShared.js
+++ b/server/services/sharing/peerSyncShared.js
@@ -66,6 +66,7 @@ export const ENVELOPE_EXTENSIONS = Object.freeze([
   // The linked track record riding a musicVideoProject push (#1858) — a
   // musicVideoProjects-only subscriber has no `tracks` cycle to fall back on.
   Object.freeze({ key: 'linkedTrack', pendingKey: 'trackSyncPending' }),
+  Object.freeze({ key: 'bibleManifest', pendingKey: 'bibleSyncPending' }),
 ]);
 
 /**

--- a/server/services/writersRoom/bibleSync.js
+++ b/server/services/writersRoom/bibleSync.js
@@ -1,0 +1,88 @@
+/** File-primary Writers Room bibles: optional peer assets, independent LWW per file. */
+import { readFile } from 'fs/promises';
+import { createHash } from 'crypto';
+import { join } from 'path';
+import { atomicWrite } from '../../lib/fileUtils.js';
+import { compareNewerWins } from '../../lib/lwwTimestamp.js';
+import { isPlainObject } from '../../lib/objects.js';
+import { journalConflict } from '../../lib/conflictJournal.js';
+import { WORK_ID_RE, wrWorkDir } from './_shared.js';
+import { emitRecordUpdated } from '../sharing/recordEvents.js';
+
+export const BIBLE_FILES = Object.freeze({ character: 'characters', place: 'places', object: 'objects' });
+export const BIBLE_CONFLICT_KINDS = Object.freeze({ character: 'writersRoomCharacters', place: 'writersRoomPlaces', object: 'writersRoomObjects' });
+const hash = (bytes) => createHash('sha256').update(bytes).digest('hex');
+const validTarget = (workId, kind) => typeof workId === 'string' && WORK_ID_RE.test(workId) && Object.hasOwn(BIBLE_FILES, kind);
+export const workBiblePath = (workId, kind) => validTarget(workId, kind) ? join(wrWorkDir(workId), `${BIBLE_FILES[kind]}.json`) : null;
+const validDoc = (doc, kind) => isPlainObject(doc) && Array.isArray(doc[BIBLE_FILES[kind]]) && typeof doc.updatedAt === 'string' && Number.isFinite(Date.parse(doc.updatedAt));
+const parseDoc = (bytes, kind) => {
+  const doc = JSON.parse(bytes.toString('utf8'));
+  if (!validDoc(doc, kind)) throw new Error('Invalid Writers Room bible document');
+  return doc;
+};
+const readBytes = (path) => readFile(path).catch((err) => {
+  if (err.code === 'ENOENT') return null;
+  throw err; // unreadable/corrupt local data must never be treated as absent
+});
+
+export async function buildWorkBibleManifest(work) {
+  if (!WORK_ID_RE.test(work?.id || '') || work.deleted) return [];
+  const manifest = [];
+  for (const kind of Object.keys(BIBLE_FILES)) {
+    const bytes = await readBytes(workBiblePath(work.id, kind));
+    if (!bytes) continue;
+    const doc = parseDoc(bytes, kind);
+    manifest.push({ workId: work.id, kind, sha256: hash(bytes), updatedAt: doc.updatedAt });
+  }
+  return manifest;
+}
+
+export async function diffWorkBibleManifest(manifest) {
+  const missing = [];
+  for (const entry of Array.isArray(manifest) ? manifest : []) {
+    if (!validTarget(entry?.workId, entry?.kind) || !/^[a-f0-9]{64}$/i.test(entry.sha256 || '') || !Number.isFinite(Date.parse(entry.updatedAt))) continue;
+    const { workId, kind, sha256, updatedAt } = entry;
+    const bytes = await readBytes(workBiblePath(workId, kind));
+    if (!bytes || (hash(bytes) !== sha256 && compareNewerWins(updatedAt, parseDoc(bytes, kind).updatedAt))) {
+      missing.push({ workId, kind, sha256, updatedAt });
+    }
+  }
+  return missing;
+}
+
+/** Recheck the incumbent after download; a local edit during the pull still wins. */
+export async function applyWorkBibleBytes(entry, bytes, source) {
+  const path = workBiblePath(entry?.workId, entry?.kind);
+  if (!path || hash(bytes) !== entry.sha256) return false;
+  const remote = parseDoc(bytes, entry.kind);
+  if (remote.updatedAt !== entry.updatedAt) return false;
+  const localBytes = await readBytes(path);
+  if (localBytes) {
+    if (hash(localBytes) === entry.sha256) return false;
+    const local = parseDoc(localBytes, entry.kind);
+    if (!compareNewerWins(remote.updatedAt, local.updatedAt)) return false;
+    // Preserve the complete losing file, including fields unknown to this version.
+    // Unlike record merges, file assets have no shared base: archive every replacement.
+    await journalConflict({ kind: BIBLE_CONFLICT_KINDS[entry.kind], id: entry.workId, local, remote, source,
+      hashes: { localHash: hash(localBytes), remoteHash: entry.sha256 } });
+    // Journal I/O may overlap another local edit; never overwrite moved bytes.
+    const current = await readBytes(path);
+    if (!current || hash(current) !== hash(localBytes)) return false;
+  }
+  await atomicWrite(path, bytes);
+  emitRecordUpdated('writersRoomWork', entry.workId);
+  return true;
+}
+
+/** Conflict restore is a fresh whole-file edit, so it propagates like an authored bible. */
+export async function restoreWorkBible(workId, kind, patch) {
+  const path = workBiblePath(workId, kind);
+  if (!path || !Array.isArray(patch?.[BIBLE_FILES[kind]])) throw new Error('Invalid Writers Room bible restore');
+  const { getWorkForSync } = await import('./sync.js');
+  const work = await getWorkForSync(workId);
+  if (!work || work.deleted) throw Object.assign(new Error('Work not found'), { code: 'NOT_FOUND' });
+  const bytes = await readBytes(path);
+  const local = bytes ? parseDoc(bytes, kind) : {};
+  await atomicWrite(path, { ...local, ...patch, updatedAt: new Date().toISOString() });
+  emitRecordUpdated('writersRoomWork', workId);
+}

--- a/server/services/writersRoom/bibleSync.js
+++ b/server/services/writersRoom/bibleSync.js
@@ -1,4 +1,6 @@
 /** File-primary Writers Room bibles: optional peer assets, independent LWW per file. */
+import { z } from 'zod';
+import { withBibleWrite } from '../bibleStore.js';
 import { readFile } from 'fs/promises';
 import { createHash } from 'crypto';
 import { join } from 'path';
@@ -14,7 +16,8 @@ export const BIBLE_CONFLICT_KINDS = Object.freeze({ character: 'writersRoomChara
 const hash = (bytes) => createHash('sha256').update(bytes).digest('hex');
 const validTarget = (workId, kind) => typeof workId === 'string' && WORK_ID_RE.test(workId) && Object.hasOwn(BIBLE_FILES, kind);
 export const workBiblePath = (workId, kind) => validTarget(workId, kind) ? join(wrWorkDir(workId), `${BIBLE_FILES[kind]}.json`) : null;
-const validDoc = (doc, kind) => isPlainObject(doc) && Array.isArray(doc[BIBLE_FILES[kind]]) && typeof doc.updatedAt === 'string' && Number.isFinite(Date.parse(doc.updatedAt));
+const timestampSchema = z.string().datetime({ offset: true });
+const validDoc = (doc, kind) => isPlainObject(doc) && Array.isArray(doc[BIBLE_FILES[kind]]) && timestampSchema.safeParse(doc.updatedAt).success;
 const parseDoc = (bytes, kind) => {
   const doc = JSON.parse(bytes.toString('utf8'));
   if (!validDoc(doc, kind)) throw new Error('Invalid Writers Room bible document');
@@ -29,21 +32,30 @@ export async function buildWorkBibleManifest(work) {
   if (!WORK_ID_RE.test(work?.id || '') || work.deleted) return [];
   const manifest = [];
   for (const kind of Object.keys(BIBLE_FILES)) {
-    const bytes = await readBytes(workBiblePath(work.id, kind));
-    if (!bytes) continue;
-    const doc = parseDoc(bytes, kind);
-    manifest.push({ workId: work.id, kind, sha256: hash(bytes), updatedAt: doc.updatedAt });
+    const entry = await readBibleManifestEntry(work.id, kind).catch((err) => {
+      console.error(`❌ Writers Room ${kind} bible unavailable for sync: ${err.message}`);
+      return null; // omission cannot delete the receiver's file; other assets still ship
+    });
+    if (entry) manifest.push(entry);
   }
   return manifest;
 }
 
-export async function diffWorkBibleManifest(manifest) {
+async function readBibleManifestEntry(workId, kind) {
+  const bytes = await readBytes(workBiblePath(workId, kind));
+  if (!bytes) return null;
+  const doc = parseDoc(bytes, kind);
+  return { workId, kind, sha256: hash(bytes), updatedAt: doc.updatedAt };
+}
+
+export async function diffWorkBibleManifest(manifest, { onError = (err) => { throw err; } } = {}) {
   const missing = [];
   for (const entry of Array.isArray(manifest) ? manifest : []) {
     if (!validTarget(entry?.workId, entry?.kind) || !/^[a-f0-9]{64}$/i.test(entry.sha256 || '') || !Number.isFinite(Date.parse(entry.updatedAt))) continue;
     const { workId, kind, sha256, updatedAt } = entry;
-    const bytes = await readBytes(workBiblePath(workId, kind));
-    if (!bytes || (hash(bytes) !== sha256 && compareNewerWins(updatedAt, parseDoc(bytes, kind).updatedAt))) {
+    const local = await readBibleManifestEntry(workId, kind).catch((err) => { onError(err); return false; });
+    if (local === false) continue; // unreadable incumbent stays intact; process the other files
+    if (!local || (local.sha256 !== sha256 && compareNewerWins(updatedAt, local.updatedAt))) {
       missing.push({ workId, kind, sha256, updatedAt });
     }
   }
@@ -54,6 +66,10 @@ export async function diffWorkBibleManifest(manifest) {
 export async function applyWorkBibleBytes(entry, bytes, source) {
   const path = workBiblePath(entry?.workId, entry?.kind);
   if (!path || hash(bytes) !== entry.sha256) return false;
+  return withBibleWrite(path, () => commitWorkBible(entry, bytes, source, path));
+}
+
+async function commitWorkBible(entry, bytes, source, path) {
   const remote = parseDoc(bytes, entry.kind);
   if (remote.updatedAt !== entry.updatedAt) return false;
   const localBytes = await readBytes(path);
@@ -65,9 +81,6 @@ export async function applyWorkBibleBytes(entry, bytes, source) {
     // Unlike record merges, file assets have no shared base: archive every replacement.
     await journalConflict({ kind: BIBLE_CONFLICT_KINDS[entry.kind], id: entry.workId, local, remote, source,
       hashes: { localHash: hash(localBytes), remoteHash: entry.sha256 } });
-    // Journal I/O may overlap another local edit; never overwrite moved bytes.
-    const current = await readBytes(path);
-    if (!current || hash(current) !== hash(localBytes)) return false;
   }
   await atomicWrite(path, bytes);
   emitRecordUpdated('writersRoomWork', entry.workId);
@@ -81,8 +94,10 @@ export async function restoreWorkBible(workId, kind, patch) {
   const { getWorkForSync } = await import('./sync.js');
   const work = await getWorkForSync(workId);
   if (!work || work.deleted) throw Object.assign(new Error('Work not found'), { code: 'NOT_FOUND' });
-  const bytes = await readBytes(path);
-  const local = bytes ? parseDoc(bytes, kind) : {};
-  await atomicWrite(path, { ...local, ...patch, updatedAt: new Date().toISOString() });
+  await withBibleWrite(path, async () => {
+    const bytes = await readBytes(path);
+    const local = bytes ? parseDoc(bytes, kind) : {};
+    await atomicWrite(path, { ...local, ...patch, updatedAt: new Date().toISOString() });
+  });
   emitRecordUpdated('writersRoomWork', workId);
 }

--- a/server/services/writersRoom/bibleSync.test.js
+++ b/server/services/writersRoom/bibleSync.test.js
@@ -101,7 +101,13 @@ describe('bible asset delivery', () => {
     expect(await diffWorkBibleManifest([{ ...manifest[0], workId: '../other' }, { ...manifest[0], kind: 'analysis' }])).toEqual([]);
     writeFileSync(workBiblePath(WORK, 'character'), '{');
     await expect(diffWorkBibleManifest(manifest)).rejects.toThrow();
-    await expect(buildWorkBibleManifest({ id: WORK })).rejects.toThrow();
+    expect(await buildWorkBibleManifest({ id: WORK })).toEqual([]);
     expect(readFileSync(workBiblePath(WORK, 'character'), 'utf8')).toBe('{');
+    const errors = [];
+    const place = { workId: WORK, kind: 'place', sha256: 'c'.repeat(64), updatedAt: remote.updatedAt };
+    expect(await diffWorkBibleManifest([...manifest, place], { onError: (err) => errors.push(err) })).toEqual([place]);
+    expect(errors).toHaveLength(1);
+    write('character', doc('2026-02-01'));
+    expect(await buildWorkBibleManifest({ id: WORK })).toEqual([]);
   });
 });

--- a/server/services/writersRoom/bibleSync.test.js
+++ b/server/services/writersRoom/bibleSync.test.js
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { makePathsProxy, mockNoPeerSync } from '../../lib/mockPathsDataRoot.js';
+
+const root = mkdtempSync(join(tmpdir(), 'wr-bible-sync-'));
+vi.mock('../../lib/fileUtils.js', async (original) => makePathsProxy(await original(), { dataRoot: () => root }));
+vi.mock('../instances.js', () => ({ getPeers: vi.fn(async () => [{ instanceId: 'peer-a', address: '192.0.2.10', port: 5555 }]) }));
+vi.mock('../sharing/peerSync.js', () => mockNoPeerSync());
+vi.mock('../../lib/peerHttpClient.js', () => ({ peerFetch: vi.fn() }));
+const { peerFetch } = await import('../../lib/peerHttpClient.js');
+const { pullMissingWorkBibles } = await import('../sharing/peerSyncAssets.js');
+const { buildWorkBibleManifest, diffWorkBibleManifest, workBiblePath } = await import('./bibleSync.js');
+const { mergeWorksFromSync } = await import('./sync.js');
+const { conflictJournalStore } = await import('../../lib/conflictJournal.js');
+const { resolveConflict } = await import('../conflictJournalResolver.js');
+const { listCharacters } = await import('./characters.js');
+const { PORTOS_SCHEMA_VERSIONS } = await import('../../lib/schemaVersions.js');
+const WORK = 'wr-work-aaaa';
+const doc = (updatedAt, name = 'Example hero') => ({ characters: [{ id: 'wr-char-bbbb', name, psychology: { theoryOfControl: 'Planning brings safety' }, evolution: { outcome: 'full-change', stages: [{ stageId: 'final-proof', characterChoice: 'Trust the crew' }] } }], updatedAt });
+function write(kind, value) {
+  const path = workBiblePath(WORK, kind);
+  mkdirSync(join(root, 'writers-room', 'works', WORK), { recursive: true });
+  writeFileSync(path, JSON.stringify(value));
+}
+function serve(value, duringFetch) {
+  const bytes = Buffer.from(JSON.stringify(value));
+  vi.mocked(peerFetch).mockImplementation(async () => {
+    duringFetch?.();
+    return { ok: true, headers: new Headers({ 'content-length': String(bytes.length) }), arrayBuffer: async () => bytes };
+  });
+}
+beforeEach(async () => {
+  rmSync(join(root, 'writers-room'), { force: true, recursive: true });
+  rmSync(join(root, 'conflict-journal'), { force: true, recursive: true });
+  vi.clearAllMocks();
+  await mergeWorksFromSync([{ id: WORK, title: 'Example work', drafts: [], updatedAt: '2026-01-01T00:00:00Z' }]);
+});
+afterAll(() => rmSync(root, { recursive: true, force: true }));
+
+describe('bible asset delivery', () => {
+  it('ships only authored sibling files, pulls missing files, and preserves full cast fields for readers', async () => {
+    const remote = doc('2026-02-01T00:00:00Z');
+    write('character', remote);
+    write('place', { places: [], updatedAt: remote.updatedAt });
+    write('object', { objects: [], updatedAt: remote.updatedAt });
+    mkdirSync(join(root, 'writers-room', 'works', WORK, 'analysis'), { recursive: true });
+    writeFileSync(join(root, 'writers-room', 'works', WORK, 'analysis', 'private.json'), '{}');
+    const manifest = await buildWorkBibleManifest({ id: WORK });
+    expect(manifest.map((e) => e.kind)).toEqual(['character', 'place', 'object']);
+    expect(PORTOS_SCHEMA_VERSIONS.writersRoomWorks).toBe(1);
+    rmSync(workBiblePath(WORK, 'character'));
+    const missing = await diffWorkBibleManifest(manifest);
+    expect(missing).toEqual([manifest[0]]);
+    serve(remote);
+    await pullMissingWorkBibles('peer-a', missing);
+    expect(JSON.parse(readFileSync(workBiblePath(WORK, 'character')))).toEqual(remote);
+    expect((await listCharacters(WORK))[0].psychology.theoryOfControl).toBe('Planning brings safety');
+    expect((await listCharacters(WORK))[0].evolution.stages[0].characterChoice).toBe('Trust the crew');
+    expect(await diffWorkBibleManifest(manifest)).toEqual([]);
+  });
+
+  it('keeps newer local files, omission, and an edit that lands during download', async () => {
+    const remote = doc('2026-02-01T00:00:00Z');
+    write('character', remote);
+    const manifest = await buildWorkBibleManifest({ id: WORK });
+    const local = doc('2026-03-01T00:00:00Z', 'Local hero');
+    write('character', local);
+    expect(await diffWorkBibleManifest(manifest)).toEqual([]);
+    expect(await diffWorkBibleManifest(undefined)).toEqual([]);
+    write('character', doc('2026-01-01T00:00:00Z'));
+    const missing = await diffWorkBibleManifest(manifest);
+    serve(remote, () => write('character', local));
+    await pullMissingWorkBibles('peer-a', missing);
+    expect(JSON.parse(readFileSync(workBiblePath(WORK, 'character')))).toEqual(local);
+  });
+
+  it('keeps a corrupt download retryable and archives an overwritten file for restore', async () => {
+    const remote = doc('2026-02-01T00:00:00Z');
+    write('character', remote);
+    const manifest = await buildWorkBibleManifest({ id: WORK });
+    const local = doc('2026-01-01T00:00:00Z', 'Local hero');
+    write('character', local);
+    serve(doc(remote.updatedAt, 'Wrong bytes'));
+    await pullMissingWorkBibles('peer-a', await diffWorkBibleManifest(manifest));
+    expect(await diffWorkBibleManifest(manifest)).toEqual(manifest);
+    serve(remote);
+    await pullMissingWorkBibles('peer-a', manifest);
+    const entries = await conflictJournalStore().loadAll();
+    expect(entries).toHaveLength(1);
+    expect(entries[0].localSnapshot).toEqual(local);
+    await resolveConflict(entries[0].id, { action: 'restore-all' });
+    expect((await listCharacters(WORK))[0].name).toBe('Local hero');
+  });
+
+  it('rejects traversal, analysis kinds, and corrupted incumbent files', async () => {
+    const remote = doc('2026-02-01T00:00:00Z');
+    write('character', remote);
+    const manifest = await buildWorkBibleManifest({ id: WORK });
+    expect(await diffWorkBibleManifest([{ ...manifest[0], workId: '../other' }, { ...manifest[0], kind: 'analysis' }])).toEqual([]);
+    writeFileSync(workBiblePath(WORK, 'character'), '{');
+    await expect(diffWorkBibleManifest(manifest)).rejects.toThrow();
+    await expect(buildWorkBibleManifest({ id: WORK })).rejects.toThrow();
+    expect(readFileSync(workBiblePath(WORK, 'character'), 'utf8')).toBe('{');
+  });
+});

--- a/server/services/writersRoom/promoteToPipeline.test.js
+++ b/server/services/writersRoom/promoteToPipeline.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { mkdtempSync, rmSync, existsSync } from 'fs';
+import { mkdtempSync, rmSync, existsSync, readFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { makePathsProxy, mockNoPeerSync, mockNoPeers } from '../../lib/mockPathsDataRoot.js';
@@ -20,6 +20,7 @@ vi.mock('../sharing/peerSync.js', () => mockNoPeerSync());
 
 const wrLocal = await import('./local.js');
 const { promoteWorkToPipeline, ERR_NO_DRAFT_BODY } = await import('./promoteToPipeline.js');
+const { buildWorkBibleManifest, applyWorkBibleBytes, workBiblePath } = await import('./bibleSync.js');
 const { createCharacter } = await import('./characters.js');
 const { createPlace } = await import('./places.js');
 const { createObject } = await import('./objects.js');
@@ -128,6 +129,13 @@ describe('promoteWorkToPipeline', () => {
       sliders: { proactivity: 8, competence: 6 },
       relationshipLinks: [{ targetCharacterId: ines.id, type: 'rival', description: 'Same salvage claim.' }],
     });
+
+    // Simulate the receiver's missing bible landing before promotion.
+    const biblePath = workBiblePath(work.id, 'character');
+    const bytes = readFileSync(biblePath);
+    const [entry] = await buildWorkBibleManifest(work);
+    rmSync(biblePath);
+    expect(await applyWorkBibleBytes(entry, bytes, { via: 'peer-sync', peerId: 'peer-example' })).toBe(true);
 
     const { series } = await promoteWorkToPipeline(work.id);
     const universe = await universeSvc.getUniverse(series.universeId);


### PR DESCRIPTION
Writers Room works now carry their authored character, place, and object bibles as optional hashed sibling assets. Receivers pull missing or newer files, retain newer local edits, and archive overwritten files in the conflict journal with a restore action. Analysis and work metadata remain outside the static asset allowlist.

The work schema stays at version 1. Older peers that reject the additive manifest receive the work through the existing strip-and-retry path; omitted manifests never delete local bibles. Bible-only edits trigger pushes and failed pulls remain retryable.

Test plan:
- 624 tests across Writers Room sync/CRUD/promotion, peer push/receive/routes, conflict handling, import boundaries, and static asset gates.
- Delivery regressions cover newer local data, in-flight edits, corrupt downloads/incumbents, partial file failure, restore, and analysis denial.
- One optional Claude review at medium effort; validated findings fixed before publication.

Closes #6943
