### PR TITLE
fix: route emitLog levels to matching streams

### DIFF
--- a/server/services/cosEvents.js
+++ b/server/services/cosEvents.js
@@ -29,7 +29,8 @@ export function emitLog(level, message, data = {}, prefix = '') {
   if (level !== 'debug' || process.env.COS_LOG_LEVEL === 'debug') {
     const emoji = level === 'error' ? '❌' : level === 'warn' ? '⚠️' : level === 'success' ? '✅' : level === 'debug' ? '🔍' : 'ℹ️';
     const prefixStr = prefix ? ` ${prefix}` : '';
-    console.log(`${emoji}${prefixStr} ${message}`);
+    const logFn = level === 'error' ? console.error : level === 'warn' ? console.warn : console.log;
+    logFn(`${emoji}${prefixStr} ${message}`);
   }
   cosEvents.emit('log', logEntry);
 }


### PR DESCRIPTION
## Summary

Route error and warning messages through `console.error` and `console.warn`, while keeping informational, success, and debug output on `console.log`. Socket events remain unchanged.

Closes #6933

## Testing

- Inline Node assertion covers error, warn, and info console routing.
- `git diff --check`