### PR TITLE
fix: use platform-specific Piper binary in health check

### DIFF
--- a/server/services/voice/health.js
+++ b/server/services/voice/health.js
@@ -3,7 +3,7 @@
 
 import { existsSync } from 'fs';
 import { join } from 'path';
-import { getVoiceConfig, expandPath, voiceHome } from './config.js';
+import { getVoiceConfig, expandPath, voiceHome, PIPER_BIN_NAME } from './config.js';
 import { readyState as kokoroReadyState } from './tts-kokoro.js';
 import { which } from './bootstrap.js';
 import { resolveLlmEndpoint, authHeaders } from './llm.js';
@@ -63,7 +63,7 @@ export const checkAll = async (cfg) => {
 
   if (voice.tts.engine === 'piper') {
     // CLI-mode piper has no server to probe — check binary + selected voice.
-    const localPiper = join(voiceHome(), 'piper', 'piper');
+    const localPiper = join(voiceHome(), 'piper', PIPER_BIN_NAME);
     const [hasBin, voicePath] = [existsSync(localPiper) || !!(await which('piper')), expandPath(voice.tts.piper?.voicePath || '')];
     const hasVoice = voicePath && existsSync(voicePath);
     out.piper = hasBin && hasVoice

--- a/server/services/voice/health.test.js
+++ b/server/services/voice/health.test.js
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  existsSync: vi.fn(() => true),
+  getVoiceConfig: vi.fn(),
+  expandPath: vi.fn((value) => value),
+  voiceHome: vi.fn(() => '/voice'),
+  readyState: vi.fn(() => 'loaded'),
+  which: vi.fn(),
+  resolveLlmEndpoint: vi.fn(async () => ({ apiBase: 'http://llm.test/v1', apiKey: '' })),
+  authHeaders: vi.fn(() => ({})),
+  fetchWithTimeout: vi.fn(async () => ({ ok: true, status: 200 })),
+  checkSetup: vi.fn(async () => ({})),
+}));
+
+vi.mock('fs', () => ({ existsSync: mocks.existsSync }));
+vi.mock('./config.js', () => ({
+  getVoiceConfig: mocks.getVoiceConfig,
+  expandPath: mocks.expandPath,
+  voiceHome: mocks.voiceHome,
+  PIPER_BIN_NAME: 'piper.exe',
+}));
+vi.mock('./tts-kokoro.js', () => ({ readyState: mocks.readyState }));
+vi.mock('./bootstrap.js', () => ({ which: mocks.which }));
+vi.mock('./llm.js', () => ({ resolveLlmEndpoint: mocks.resolveLlmEndpoint, authHeaders: mocks.authHeaders }));
+vi.mock('../../lib/fetchWithTimeout.js', () => ({ fetchWithTimeout: mocks.fetchWithTimeout }));
+vi.mock('./facetimeBridge.js', () => ({ checkSetup: mocks.checkSetup }));
+
+const { checkAll, invalidateHealthCache } = await import('./health.js');
+
+describe('voice health Piper probe', () => {
+  beforeEach(() => {
+    invalidateHealthCache();
+    vi.clearAllMocks();
+    mocks.existsSync.mockReturnValue(true);
+  });
+
+  it('uses the platform-specific Piper binary name for local detection', async () => {
+    await checkAll({
+      stt: { engine: 'web-speech', endpoint: '' },
+      llm: { provider: 'lmstudio' },
+      tts: { engine: 'piper', piper: { voicePath: '/voice/en.onnx' } },
+    });
+
+    expect(mocks.existsSync).toHaveBeenCalledWith('/voice/piper/piper.exe');
+  });
+});


### PR DESCRIPTION
## Summary

Use the existing `PIPER_BIN_NAME` constant when checking for the local Piper binary, so Windows health checks look for `piper.exe`. Add a focused regression test.

Closes #6894

## Testing

- `npm test --prefix server -- services/voice/health.test.js`
- `git diff --check`