### PR TITLE
fix: preserve PR review preflight failures and expose recovery

### DIFF
--- a/client/src/components/apps/tabs/PullRequestsTab.jsx
+++ b/client/src/components/apps/tabs/PullRequestsTab.jsx
@@ -17,7 +17,7 @@ import { timeAgo } from '../../../utils/formatters';
 
 const FORGE_LABEL = { github: 'GitHub', gitlab: 'GitLab' };
 
-const ACTION_STATUS_RANK = { queuing: 0, queued: 1, active: 2, completed: 3, blocked: 3 };
+const ACTION_STATUS_RANK = { queuing: 0, queued: 1, active: 2, completed: 3, blocked: 3, failed: 3 };
 const ACTION_STATUS_LABEL = {
   queued: 'Queued — view',
   active: 'Active — view',
@@ -30,6 +30,7 @@ const actionStatusForTask = status => ({
   in_progress: 'active',
   completed: 'completed',
   blocked: 'blocked',
+  failed: 'failed',
 }[status] || null);
 
 // The two per-row agent actions. They share every piece of state machinery —
@@ -171,7 +172,7 @@ export default function PullRequestsTab({ appId, appName }) {
 
   const applyTaskUpdate = useCallback(task => {
     if (!task?.id) return;
-    const nextStatus = actionStatusForTask(task.status);
+    const nextStatus = task.metadata?.preflightFailure ? 'failed' : actionStatusForTask(task.status);
     if (!nextStatus) return;
 
     replaceActions(current => {
@@ -183,7 +184,7 @@ export default function PullRequestsTab({ appId, appName }) {
           const matches = action.taskId === task.id
             || (!action.taskId && ACTION_KINDS[kind].matches(task, appId, Number(number)));
           if (!matches || actionRank(nextStatus) < actionRank(action.status)) continue;
-          updated[number] = { ...action, taskId: action.taskId || task.id, status: nextStatus };
+          updated[number] = { ...action, taskId: action.taskId || task.id, status: nextStatus, error: task.metadata?.note };
           changed = true;
         }
         next[kind] = updated;
@@ -224,6 +225,7 @@ export default function PullRequestsTab({ appId, appName }) {
               ...(current || {}),
               taskId: current?.taskId || record.taskId || null,
               status: serverAction,
+              error: record.error,
             };
           }
         }
@@ -487,7 +489,20 @@ export default function PullRequestsTab({ appId, appName }) {
                   <div className="shrink-0 lg:pt-0.5 flex flex-wrap items-start gap-2">
                     {rowActionsFor(pullRequest).map(({ kind, onQueue }) => {
                       const { label, Icon, title } = ACTION_KINDS[kind];
-                      const actionStatus = actions[kind][pullRequest.number]?.status;
+                      const action = actions[kind][pullRequest.number];
+                      const actionStatus = action?.status;
+                      if (actionStatus === 'failed') {
+                        return (
+                          <div key={kind} className="max-w-md text-xs text-port-error space-y-2" role="alert">
+                            <p>{action.error || 'PR review preflight failed before an agent started.'}</p>
+                            <div className="flex flex-wrap gap-3">
+                              <Link className="underline" to={`/cos/tasks?task=${encodeURIComponent(action.taskId)}&source=internal`}>View failure record</Link>
+                              <Link className="underline" to="/models/llms/abuse">Abuse Guard setup</Link>
+                              <button type="button" className="underline" onClick={() => onQueue(pullRequest)}>Retry PR review</button>
+                            </div>
+                          </div>
+                        );
+                      }
                       if (actionStatus && actionStatus !== 'queuing') {
                         return (
                           <Link

--- a/client/src/components/apps/tabs/PullRequestsTab.test.jsx
+++ b/client/src/components/apps/tabs/PullRequestsTab.test.jsx
@@ -307,6 +307,31 @@ describe('PullRequestsTab', () => {
     expect(await screen.findByRole('link', { name: /PR review: Active/ })).toBeInTheDocument();
   });
 
+  it('restores the preflight explanation after reloading the PR list', async () => {
+    api.getAppPullRequests.mockResolvedValue(okPayload([{ ...PULL_REQUEST,
+      reviewAction: { taskId: 'preflight-17', status: 'failed', error: 'Prompt Guard stopped before an agent started.' },
+    }]));
+    await renderTab();
+    expect(await screen.findByRole('alert')).toHaveTextContent('Prompt Guard stopped');
+    expect(screen.getByRole('button', { name: 'Retry PR review' })).toBeInTheDocument();
+  });
+
+  it('replaces a queued review with a durable preflight explanation and retry', async () => {
+    await renderTab();
+    fireEvent.click(await screen.findByRole('button', { name: /PR review/ }));
+    await screen.findByRole('link', { name: /PR review: Queued/ });
+    act(() => socketHandlers.get('cos:tasks:changed')({ task: {
+      id: 'preflight-17', status: 'completed',
+      metadata: { app: 'app-1', analysisType: 'pr-reviewer', targetPullRequest: 17,
+        preflightFailure: 'security-guard-process-failed', note: 'Prompt Guard stopped before an agent started.' },
+    } }));
+    expect(screen.getByRole('alert')).toHaveTextContent('before an agent started');
+    expect(screen.getByRole('link', { name: 'View failure record' })).toHaveAttribute('href', '/cos/tasks?task=preflight-17&source=internal');
+    fireEvent.click(screen.getByRole('button', { name: 'Retry PR review' }));
+    await waitFor(() => expect(api.reviewAppPullRequest).toHaveBeenCalledTimes(2));
+    expect(await screen.findByRole('link', { name: /PR review: Queued/ })).toBeInTheDocument();
+  });
+
   it('hydrates an in-flight pr-reviewer run without offering the button again', async () => {
     api.getAppPullRequests.mockResolvedValue(okPayload([{
       ...PULL_REQUEST,

--- a/client/src/hooks/useOnDemandTaskToast.js
+++ b/client/src/hooks/useOnDemandTaskToast.js
@@ -34,6 +34,7 @@ const PR_REVIEWER_REASON_LABELS = {
   'no-external-open-prs': 'no open external pull requests to review',
   'target-pull-request-not-reviewable': "that pull request isn't eligible right now (not open against the default branch, or authored by a trusted collaborator)",
   'security-scan-report-pending': 'a security scan for this pull request is already in progress',
+  'security-guard-process-failed': 'Prompt Guard stopped before an agent started. Open Models → LLMs → Abuse Guard to check or repair setup, then retry PR review. The failure record is in CoS → Tasks',
   'security-guard-not-ready': "the local model-abuse classifier (Settings → Models → LLMs → Abuse Guard) isn't ready — finish or repair its setup, then try again",
 };
 

--- a/server/routes/apps/pullRequests.js
+++ b/server/routes/apps/pullRequests.js
@@ -129,7 +129,12 @@ function reviewActionFor(pullRequest, tasks, requests, appId) {
   const task = tasks?.find(candidate => isReviewTaskFor(candidate, appId, pullRequest));
   if (task) return { taskId: task.id, status: task.status };
   const queued = requests?.find(request => isReviewRequestFor(request, appId, pullRequest));
-  return queued ? { taskId: null, status: 'pending' } : null;
+  if (queued) return { taskId: null, status: 'pending' };
+  const failure = tasks?.findLast(candidate => candidate.status === 'completed'
+    && candidate.metadata?.analysisType === PR_REVIEWER_TASK_TYPE
+    && candidate.metadata?.app === appId
+    && Number(candidate.metadata?.targetPullRequest) === pullRequest.number);
+  return failure?.metadata?.preflightFailure ? { taskId: failure.id, status: 'failed', error: failure.metadata.note } : null;
 }
 
 const taskResponse = task => task ? {
@@ -369,7 +374,7 @@ router.post('/:id/pull-requests/:number/review', loadApp, asyncHandler(async (re
     });
   }
   const existing = reviewActionFor({ number }, tasks, requests, app.id);
-  if (existing) {
+  if (existing && existing.status !== 'failed') {
     res.json({ appId: app.id, appName: app.name, number, reviewAction: existing, duplicate: true });
     return;
   }

--- a/server/routes/apps/pullRequests.test.js
+++ b/server/routes/apps/pullRequests.test.js
@@ -408,6 +408,19 @@ describe('app pull-request routes', () => {
     expect(triggerOnDemandTask).not.toHaveBeenCalled();
   });
 
+  it('retains a failed preflight on the row and lets retry run the scan again', async () => {
+    getAllTasks.mockResolvedValue({ user: { tasks: [] }, cos: { tasks: [{
+      id: 'preflight-17', status: 'completed',
+      metadata: { app: 'app-001', analysisType: 'pr-reviewer', targetPullRequest: 17,
+        preflightFailure: 'security-guard-process-failed', note: 'Prompt Guard stopped before an agent started.' },
+    }] } });
+    const listed = await request(app).get('/api/apps/app-001/pull-requests');
+    expect(listed.body.pullRequests[0].reviewAction).toMatchObject({ status: 'failed', taskId: 'preflight-17', error: expect.stringContaining('before an agent') });
+    const retried = await request(app).post('/api/apps/app-001/pull-requests/17/review');
+    expect(retried.status).toBe(202);
+    expect(triggerOnDemandTask).toHaveBeenCalledWith('pr-reviewer', 'app-001', { targetPullRequest: 17 });
+  });
+
   it('queues a pr-reviewer run scoped to one request', async () => {
     const response = await request(app).post('/api/apps/app-001/pull-requests/17/review');
 

--- a/server/services/cosTaskGenerator.js
+++ b/server/services/cosTaskGenerator.js
@@ -2205,6 +2205,30 @@ export async function emitOnDemandEmpty({ taskScheduleMod, request, targetApp, t
     if (health && !health.ok && health.remedy) forge = { cli: 'gh', remedy: health.remedy };
   }
 
+  // A preflight has no agent lifecycle, but an explicit failed run still needs
+  // a durable record. Terminal status prevents either spawn engine from running
+  // this diagnostic as a task; retry must enter through the security scan again.
+  if (request.taskType === 'pr-reviewer' && appId && reason?.startsWith('security-') && reason !== 'security-scan-report-pending') {
+    const note = `PR review stopped before an agent started (${reason}). No PR actions were taken. `
+      + (reason.startsWith('security-guard-')
+        ? 'Open Models → LLMs → Abuse Guard, check its setup and repair it if needed, then retry PR review. The classifier did not return a usable safety verdict; this is not a finding against the PR.'
+        : 'Check the repository connection and security scan configuration, then retry PR review.');
+    await addTask({
+      id: `pr-review-preflight-${request.id}`,
+      status: 'completed',
+      priority: 'MEDIUM',
+      priorityValue: 2,
+      taskType: 'internal',
+      description: `PR review preflight failed for ${targetApp.name}${request.targetPullRequest ? ` #${request.targetPullRequest}` : ''}`,
+      metadata: {
+        app: appId, analysisType: 'pr-reviewer',
+        targetPullRequest: request.targetPullRequest ?? null,
+        preflightFailure: reason, note,
+        completedAt: new Date().toISOString(),
+      },
+    }, 'internal', { raw: true, suppressDequeue: true });
+  }
+
   cosEvents.emit('schedule:on-demand-empty', {
     requestId: request.id,
     taskType: request.taskType,

--- a/server/services/cosTaskGenerator.test.js
+++ b/server/services/cosTaskGenerator.test.js
@@ -13,6 +13,7 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { readFileSync } from 'fs';
+import * as taskStore from './cosTaskStore.js';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
 
@@ -1156,6 +1157,7 @@ describe('emitOnDemandEmpty', () => {
   });
 
   it("surfaces the pr-reviewer preflight's recorded skip reason on an idle outcome", async () => {
+    const persist = vi.spyOn(taskStore, 'addTask').mockResolvedValue({ id: 'diagnostic' });
     recordPerpetualTransient('pr-reviewer', 'app-1', { reason: 'security-guard-not-ready' });
     const events = [];
     const handler = (d) => events.push(d);
@@ -1171,6 +1173,11 @@ describe('emitOnDemandEmpty', () => {
       cosEvents.off('schedule:on-demand-empty', handler);
     }
     expect(events[0]).toMatchObject({ taskType: 'pr-reviewer', outcome: 'idle', reason: 'security-guard-not-ready' });
+    expect(persist).toHaveBeenCalledWith(expect.objectContaining({
+      status: 'completed',
+      metadata: expect.objectContaining({ preflightFailure: 'security-guard-not-ready', note: expect.stringContaining('before an agent started') }),
+    }), 'internal', { raw: true, suppressDequeue: true });
+    persist.mockRestore();
   });
 
   it('consumes the pr-reviewer skip reason on read, so a stale one cannot be reported twice', async () => {


### PR DESCRIPTION
## Summary
PR review could stop in the local security preflight before any agent existed, leaving only an opaque toast and a PR row stuck on “Queued.” Preserve explicit security-preflight failures as terminal CoS task records and show the explanation, a direct record link, Abuse Guard setup, and retry on the PR row. Retry always re-enters the security preflight; no safety gate is bypassed.

The observed helper exited with code 1. This change fixes diagnostics and recovery navigation; it does not claim to repair that runtime failure. Raw classifier exceptions and PR content remain excluded from diagnostics.

## Test plan
- Server: 188 passing tests across cosTaskGenerator and apps/pullRequests.
- Client: 37 passing tests across PullRequestsTab and useOnDemandTaskToast, including live failure, reload, and retry.
- Client Biome lint passes for changed client files; git diff --check passes.
- Reviewed changes locally for task lifecycle, retry behavior, reuse, and privacy.
