### PR TITLE
feat: add empty briefing generation action (#6949)

### DIFF
--- a/client/src/components/EmptyState.jsx
+++ b/client/src/components/EmptyState.jsx
@@ -15,6 +15,7 @@ import { Info } from 'lucide-react';
  *   actionTo    — internal route for the call-to-action Link
  *   actionLabel — text for the call-to-action
  *   onAction    — render a <button> instead of a Link (in-page action)
+ *   actionDisabled — disable the in-page action while it is processing
  */
 export default function EmptyState({
   icon: Icon = Info,
@@ -34,7 +35,13 @@ export default function EmptyState({
       {title && <h3 className="text-white font-semibold mb-1">{title}</h3>}
       {message && <p className="text-gray-400 text-sm max-w-xs">{message}</p>}
       {actionLabel && (onAction ? (
-        <button type="button" onClick={onAction} disabled={actionDisabled} className={actionClass}>
+        <button
+          type="button"
+          onClick={onAction}
+          disabled={actionDisabled}
+          aria-busy={actionDisabled || undefined}
+          className={`${actionClass} disabled:cursor-not-allowed disabled:opacity-50`}
+        >
           {actionLabel}
         </button>
       ) : actionTo ? (

--- a/client/src/components/EmptyState.jsx
+++ b/client/src/components/EmptyState.jsx
@@ -23,6 +23,7 @@ export default function EmptyState({
   actionTo,
   actionLabel,
   onAction,
+  actionDisabled = false,
 }) {
   const actionClass =
     'mt-4 px-4 py-2 rounded-lg text-sm font-medium bg-port-accent/10 text-port-accent hover:bg-port-accent/20 transition-colors';
@@ -33,7 +34,7 @@ export default function EmptyState({
       {title && <h3 className="text-white font-semibold mb-1">{title}</h3>}
       {message && <p className="text-gray-400 text-sm max-w-xs">{message}</p>}
       {actionLabel && (onAction ? (
-        <button type="button" onClick={onAction} className={actionClass}>
+        <button type="button" onClick={onAction} disabled={actionDisabled} className={actionClass}>
           {actionLabel}
         </button>
       ) : actionTo ? (

--- a/client/src/components/cos/tabs/BriefingTab.jsx
+++ b/client/src/components/cos/tabs/BriefingTab.jsx
@@ -166,7 +166,7 @@ export default function BriefingTab() {
   const generationInFlightRef = useRef(false);
 
   const [generateBriefing, generatingBriefing] = useAsyncAction(async () => {
-    if (generationPending || generatingBriefing || generationInFlightRef.current) return;
+    if (generationPending || generationInFlightRef.current) return;
     generationInFlightRef.current = true;
     try {
       const result = await api.triggerCosJob('job-daily-briefing', { silent: true });
@@ -279,7 +279,7 @@ export default function BriefingTab() {
             />
           )}
           <button
-            onClick={() => loadData().then((latest) => {
+            onClick={() => loadData({ showLoading: false }).then((latest) => {
               if (latest) setGenerationPending(false);
             })}
             className="flex items-center gap-2 px-3 py-1.5 text-sm bg-port-card border border-port-border hover:border-port-accent/50 text-gray-300 rounded-lg transition-colors"

--- a/client/src/components/cos/tabs/BriefingTab.jsx
+++ b/client/src/components/cos/tabs/BriefingTab.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { Link } from 'react-router';
 import {
   Newspaper,
@@ -20,6 +20,7 @@ import { formatWeekdayDate } from '../../../utils/formatters';
 import EmptyState from '../../EmptyState';
 import { useAsyncAction } from '../../../hooks/useAsyncAction';
 import { useAutoRefetch } from '../../../hooks/useAutoRefetch';
+import toast from '../../ui/Toast';
 
 const SECTION_ICONS = {
   'Task Queue': CheckCircle,
@@ -163,16 +164,22 @@ export default function BriefingTab() {
   const [loading, setLoading] = useState(true);
   const [expandedSections, setExpandedSections] = useState({});
   const [generationPending, setGenerationPending] = useState(false);
+  const generationInFlightRef = useRef(false);
 
   const [generateBriefing, generatingBriefing] = useAsyncAction(async () => {
-    if (generationPending || generatingBriefing) return;
-    const result = await api.triggerCosJob('job-daily-briefing', { silent: true });
-    if (!result || result.success === false) {
-      throw new Error(result?.reason || 'The briefing could not be generated');
+    if (generationPending || generatingBriefing || generationInFlightRef.current) return;
+    generationInFlightRef.current = true;
+    try {
+      const result = await api.triggerCosJob('job-daily-briefing', { silent: true });
+      if (!result || result.success === false) {
+        throw new Error(result?.reason || 'The briefing could not be generated');
+      }
+      setGenerationPending(true);
+      const latest = await loadData({ showLoading: false });
+      if (latest) setGenerationPending(false);
+    } finally {
+      generationInFlightRef.current = false;
     }
-    setGenerationPending(true);
-    const latest = await loadData({ showLoading: false });
-    if (latest) setGenerationPending(false);
   });
 
   useEffect(() => {
@@ -205,9 +212,18 @@ export default function BriefingTab() {
       if (latest) setGenerationPending(false);
       return latest;
     },
-    2000,
+    5000,
     { enabled: generationPending, immediate: false, pollOnly: true },
   );
+
+  useEffect(() => {
+    if (!generationPending) return undefined;
+    const timeoutId = setTimeout(() => {
+      setGenerationPending(false);
+      toast.error('Briefing generation is taking longer than expected. Try again or check the Daily Briefing job.');
+    }, 60000);
+    return () => clearTimeout(timeoutId);
+  }, [generationPending]);
 
   const loadBriefing = async (date) => {
     setLoading(true);

--- a/client/src/components/cos/tabs/BriefingTab.jsx
+++ b/client/src/components/cos/tabs/BriefingTab.jsx
@@ -20,7 +20,6 @@ import { formatWeekdayDate } from '../../../utils/formatters';
 import EmptyState from '../../EmptyState';
 import { useAsyncAction } from '../../../hooks/useAsyncAction';
 import { useAutoRefetch } from '../../../hooks/useAutoRefetch';
-import toast from '../../ui/Toast';
 
 const SECTION_ICONS = {
   'Task Queue': CheckCircle,
@@ -182,6 +181,11 @@ export default function BriefingTab() {
     }
   });
 
+  const handleGenerateBriefing = () => {
+    if (generationPending || generatingBriefing || generationInFlightRef.current) return;
+    generateBriefing();
+  };
+
   useEffect(() => {
     loadData();
   }, []);
@@ -215,15 +219,6 @@ export default function BriefingTab() {
     5000,
     { enabled: generationPending, immediate: false, pollOnly: true },
   );
-
-  useEffect(() => {
-    if (!generationPending) return undefined;
-    const timeoutId = setTimeout(() => {
-      setGenerationPending(false);
-      toast.error('Briefing generation is taking longer than expected. Try again or check the Daily Briefing job.');
-    }, 60000);
-    return () => clearTimeout(timeoutId);
-  }, [generationPending]);
 
   const loadBriefing = async (date) => {
     setLoading(true);
@@ -284,7 +279,7 @@ export default function BriefingTab() {
             />
           )}
           <button
-            onClick={loadData}
+            onClick={() => loadData()}
             className="flex items-center gap-2 px-3 py-1.5 text-sm bg-port-card border border-port-border hover:border-port-accent/50 text-gray-300 rounded-lg transition-colors"
           >
             <RefreshCw size={14} />
@@ -301,7 +296,7 @@ export default function BriefingTab() {
             message="Generate today’s briefing now, or open the Daily Briefing job to change its schedule."
             actionLabel={generationPending || generatingBriefing ? 'Generating today’s briefing…' : 'Generate today’s briefing'}
             actionDisabled={generationPending || generatingBriefing}
-            onAction={generateBriefing}
+            onAction={handleGenerateBriefing}
           />
           <Link to="/cos/jobs" className="-mt-10 mb-8 text-sm text-port-accent hover:underline">
             Open Daily Briefing job

--- a/client/src/components/cos/tabs/BriefingTab.jsx
+++ b/client/src/components/cos/tabs/BriefingTab.jsx
@@ -170,7 +170,7 @@ export default function BriefingTab() {
     generationInFlightRef.current = true;
     try {
       const result = await api.triggerCosJob('job-daily-briefing', { silent: true });
-      if (!result || result.success === false || result.status === 'skipped') {
+      if (!result || result.success === false || (result.status === 'skipped' && !result.duplicate)) {
         throw new Error(result?.reason || 'The briefing could not be generated');
       }
       setGenerationPending(true);
@@ -279,7 +279,9 @@ export default function BriefingTab() {
             />
           )}
           <button
-            onClick={() => loadData()}
+            onClick={() => loadData().then((latest) => {
+              if (latest) setGenerationPending(false);
+            })}
             className="flex items-center gap-2 px-3 py-1.5 text-sm bg-port-card border border-port-border hover:border-port-accent/50 text-gray-300 rounded-lg transition-colors"
           >
             <RefreshCw size={14} />
@@ -300,14 +302,14 @@ export default function BriefingTab() {
             actionDisabled={generationPending || generatingBriefing}
             onAction={handleGenerateBriefing}
           />
-          {generationPending && (
-            <p role="status" aria-live="polite" className="-mt-10 mb-8 text-sm text-gray-400">
-              Briefing generation is still in progress.
+          <div className="-mt-10 mb-8 flex flex-col items-center gap-3">
+            <p role="status" aria-live="polite" className="text-sm text-gray-400">
+              {generationPending ? 'Briefing generation is still in progress.' : ''}
             </p>
-          )}
-          <Link to="/cos/jobs" className="-mt-10 mb-8 text-sm text-port-accent hover:underline">
-            Open Daily Briefing job
-          </Link>
+            <Link to="/cos/jobs" className="text-sm text-port-accent hover:underline">
+              Open Daily Briefing job
+            </Link>
+          </div>
         </div>
       ) : (
         <>

--- a/client/src/components/cos/tabs/BriefingTab.jsx
+++ b/client/src/components/cos/tabs/BriefingTab.jsx
@@ -170,7 +170,7 @@ export default function BriefingTab() {
     generationInFlightRef.current = true;
     try {
       const result = await api.triggerCosJob('job-daily-briefing', { silent: true });
-      if (!result || result.success === false) {
+      if (!result || result.success === false || result.status === 'skipped') {
         throw new Error(result?.reason || 'The briefing could not be generated');
       }
       setGenerationPending(true);
@@ -293,11 +293,18 @@ export default function BriefingTab() {
           <EmptyState
             icon={Newspaper}
             title="No briefing yet"
-            message="Generate today’s briefing now, or open the Daily Briefing job to change its schedule."
+            message={generationPending
+              ? 'Your briefing is still being generated. You can open the Daily Briefing job to check its status.'
+              : 'Generate today’s briefing now, or open the Daily Briefing job to change its schedule.'}
             actionLabel={generationPending || generatingBriefing ? 'Generating today’s briefing…' : 'Generate today’s briefing'}
             actionDisabled={generationPending || generatingBriefing}
             onAction={handleGenerateBriefing}
           />
+          {generationPending && (
+            <p role="status" aria-live="polite" className="-mt-10 mb-8 text-sm text-gray-400">
+              Briefing generation is still in progress.
+            </p>
+          )}
           <Link to="/cos/jobs" className="-mt-10 mb-8 text-sm text-port-accent hover:underline">
             Open Daily Briefing job
           </Link>

--- a/client/src/components/cos/tabs/BriefingTab.jsx
+++ b/client/src/components/cos/tabs/BriefingTab.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { Link } from 'react-router';
 import {
   Newspaper,
   RefreshCw,
@@ -16,6 +17,8 @@ import * as api from '../../../services/api';
 import { RapidReaderTrigger } from '../../RapidReader';
 import BrailleSpinner from '../../BrailleSpinner';
 import { formatWeekdayDate } from '../../../utils/formatters';
+import EmptyState from '../../EmptyState';
+import { useAsyncAction } from '../../../hooks/useAsyncAction';
 
 const SECTION_ICONS = {
   'Task Queue': CheckCircle,
@@ -159,6 +162,11 @@ export default function BriefingTab() {
   const [loading, setLoading] = useState(true);
   const [expandedSections, setExpandedSections] = useState({});
 
+  const [generateBriefing, generatingBriefing] = useAsyncAction(async () => {
+    await api.triggerCosJob('job-daily-briefing', { silent: true });
+    await loadData();
+  });
+
   useEffect(() => {
     loadData();
   }, []);
@@ -251,10 +259,17 @@ export default function BriefingTab() {
       </div>
 
       {!parsed ? (
-        <div className="bg-port-card border border-port-border rounded-lg p-8 text-center">
-          <Newspaper className="w-12 h-12 text-gray-600 mx-auto mb-3" />
-          <p className="text-gray-400">No briefings available yet.</p>
-          <p className="text-gray-500 text-sm mt-1">Briefings are generated automatically by the Daily Briefing job.</p>
+        <div className="flex flex-col items-center">
+          <EmptyState
+            icon={Newspaper}
+            title="No briefing yet"
+            message="Generate today’s briefing now, or open the Daily Briefing job to change its schedule."
+            actionLabel={generatingBriefing ? 'Generating today’s briefing…' : 'Generate today’s briefing'}
+            onAction={generateBriefing}
+          />
+          <Link to="/cos/jobs" className="-mt-10 mb-8 text-sm text-port-accent hover:underline">
+            Open Daily Briefing job
+          </Link>
         </div>
       ) : (
         <>

--- a/client/src/components/cos/tabs/BriefingTab.jsx
+++ b/client/src/components/cos/tabs/BriefingTab.jsx
@@ -19,6 +19,7 @@ import BrailleSpinner from '../../BrailleSpinner';
 import { formatWeekdayDate } from '../../../utils/formatters';
 import EmptyState from '../../EmptyState';
 import { useAsyncAction } from '../../../hooks/useAsyncAction';
+import { useAutoRefetch } from '../../../hooks/useAutoRefetch';
 
 const SECTION_ICONS = {
   'Task Queue': CheckCircle,
@@ -161,18 +162,25 @@ export default function BriefingTab() {
   const [selectedDate, setSelectedDate] = useState(null);
   const [loading, setLoading] = useState(true);
   const [expandedSections, setExpandedSections] = useState({});
+  const [generationPending, setGenerationPending] = useState(false);
 
   const [generateBriefing, generatingBriefing] = useAsyncAction(async () => {
-    await api.triggerCosJob('job-daily-briefing', { silent: true });
-    await loadData();
+    if (generationPending || generatingBriefing) return;
+    const result = await api.triggerCosJob('job-daily-briefing', { silent: true });
+    if (!result || result.success === false) {
+      throw new Error(result?.reason || 'The briefing could not be generated');
+    }
+    setGenerationPending(true);
+    const latest = await loadData({ showLoading: false });
+    if (latest) setGenerationPending(false);
   });
 
   useEffect(() => {
     loadData();
   }, []);
 
-  const loadData = async () => {
-    setLoading(true);
+  const loadData = async ({ showLoading = true } = {}) => {
+    if (showLoading) setLoading(true);
     const [listResult, latest] = await Promise.all([
       api.getCosBriefings().catch(() => ({ briefings: [] })),
       api.getCosLatestBriefing().catch(() => null)
@@ -187,8 +195,19 @@ export default function BriefingTab() {
       parsed.sections.forEach((_s, i) => { expanded[i] = true; });
       setExpandedSections(expanded);
     }
-    setLoading(false);
+    if (showLoading) setLoading(false);
+    return latest;
   };
+
+  useAutoRefetch(
+    async () => {
+      const latest = await loadData({ showLoading: false });
+      if (latest) setGenerationPending(false);
+      return latest;
+    },
+    2000,
+    { enabled: generationPending, immediate: false, pollOnly: true },
+  );
 
   const loadBriefing = async (date) => {
     setLoading(true);
@@ -264,7 +283,8 @@ export default function BriefingTab() {
             icon={Newspaper}
             title="No briefing yet"
             message="Generate today’s briefing now, or open the Daily Briefing job to change its schedule."
-            actionLabel={generatingBriefing ? 'Generating today’s briefing…' : 'Generate today’s briefing'}
+            actionLabel={generationPending || generatingBriefing ? 'Generating today’s briefing…' : 'Generate today’s briefing'}
+            actionDisabled={generationPending || generatingBriefing}
             onAction={generateBriefing}
           />
           <Link to="/cos/jobs" className="-mt-10 mb-8 text-sm text-port-accent hover:underline">

--- a/client/src/components/cos/tabs/BriefingTab.test.jsx
+++ b/client/src/components/cos/tabs/BriefingTab.test.jsx
@@ -66,7 +66,7 @@ describe('BriefingTab empty state', () => {
     await act(async () => {});
     expect(screen.getByRole('button', { name: 'Generating today’s briefing…' })).toBeDisabled();
 
-    await act(async () => { await vi.advanceTimersByTimeAsync(2000); });
+    await act(async () => { await vi.advanceTimersByTimeAsync(5000); });
     expect(screen.getByText('Today')).toBeInTheDocument();
   });
 

--- a/client/src/components/cos/tabs/BriefingTab.test.jsx
+++ b/client/src/components/cos/tabs/BriefingTab.test.jsx
@@ -81,6 +81,7 @@ describe('BriefingTab empty state', () => {
     await act(async () => { fireEvent.click(generate); });
 
     expect(api.triggerCosJob).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole('button', { name: 'Generating today’s briefing…' })).toBeDisabled();
     resolveTrigger({ started: true });
     await act(async () => {});
   });

--- a/client/src/components/cos/tabs/BriefingTab.test.jsx
+++ b/client/src/components/cos/tabs/BriefingTab.test.jsx
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router';
+import BriefingTab from './BriefingTab';
+
+const api = vi.hoisted(() => ({
+  getCosBriefings: vi.fn(),
+  getCosLatestBriefing: vi.fn(),
+  triggerCosJob: vi.fn(),
+}));
+
+vi.mock('../../../services/api', () => api);
+
+const renderTab = () => render(
+  <MemoryRouter>
+    <BriefingTab />
+  </MemoryRouter>,
+);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  api.getCosBriefings.mockResolvedValue({ briefings: [] });
+  api.getCosLatestBriefing.mockResolvedValue(null);
+  api.triggerCosJob.mockResolvedValue({ started: true });
+});
+
+describe('BriefingTab empty state', () => {
+  it('offers generation and the Daily Briefing job settings link', async () => {
+    const user = userEvent.setup();
+    renderTab();
+
+    const generate = await screen.findByRole('button', { name: 'Generate today’s briefing' });
+    expect(screen.getByText('No briefing yet')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Open Daily Briefing job' })).toHaveAttribute('href', '/cos/jobs');
+
+    await user.click(generate);
+
+    await waitFor(() => expect(api.triggerCosJob).toHaveBeenCalledWith(
+      'job-daily-briefing',
+      { silent: true },
+    ));
+    await waitFor(() => expect(api.getCosLatestBriefing).toHaveBeenCalledTimes(2));
+  });
+});

--- a/client/src/components/cos/tabs/BriefingTab.test.jsx
+++ b/client/src/components/cos/tabs/BriefingTab.test.jsx
@@ -1,5 +1,5 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router';
 import BriefingTab from './BriefingTab';
@@ -9,8 +9,10 @@ const api = vi.hoisted(() => ({
   getCosLatestBriefing: vi.fn(),
   triggerCosJob: vi.fn(),
 }));
+const toast = vi.hoisted(() => ({ error: vi.fn() }));
 
 vi.mock('../../../services/api', () => api);
+vi.mock('../../ui/Toast', () => ({ default: toast }));
 
 const renderTab = () => render(
   <MemoryRouter>
@@ -20,9 +22,14 @@ const renderTab = () => render(
 
 beforeEach(() => {
   vi.clearAllMocks();
-  api.getCosBriefings.mockResolvedValue({ briefings: [] });
-  api.getCosLatestBriefing.mockResolvedValue(null);
-  api.triggerCosJob.mockResolvedValue({ started: true });
+  api.getCosBriefings.mockReset().mockResolvedValue({ briefings: [] });
+  api.getCosLatestBriefing.mockReset().mockResolvedValue(null);
+  api.triggerCosJob.mockReset().mockResolvedValue({ started: true });
+  toast.error.mockReset();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
 });
 
 describe('BriefingTab empty state', () => {
@@ -41,5 +48,51 @@ describe('BriefingTab empty state', () => {
       { silent: true },
     ));
     await waitFor(() => expect(api.getCosLatestBriefing).toHaveBeenCalledTimes(2));
+  });
+
+  it('keeps the action pending until the triggered briefing is persisted', async () => {
+    vi.useFakeTimers();
+    api.getCosLatestBriefing
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({
+        date: '2026-09-11',
+        content: '# Today\n## Focus\nA generated briefing',
+      });
+    renderTab();
+
+    await act(async () => {});
+    fireEvent.click(screen.getByRole('button', { name: 'Generate today’s briefing' }));
+    await act(async () => {});
+    expect(screen.getByRole('button', { name: 'Generating today’s briefing…' })).toBeDisabled();
+
+    await act(async () => { await vi.advanceTimersByTimeAsync(2000); });
+    expect(screen.getByText('Today')).toBeInTheDocument();
+  });
+
+  it('does not trigger twice while generation is pending', async () => {
+    let resolveTrigger;
+    api.triggerCosJob.mockReturnValue(new Promise((resolve) => { resolveTrigger = resolve; }));
+    renderTab();
+    await act(async () => {});
+    const generate = await screen.findByRole('button', { name: 'Generate today’s briefing' });
+
+    await act(async () => { fireEvent.click(generate); });
+    await act(async () => { fireEvent.click(generate); });
+
+    expect(api.triggerCosJob).toHaveBeenCalledTimes(1);
+    resolveTrigger({ started: true });
+    await act(async () => {});
+  });
+
+  it('shows a rejected trigger reason once', async () => {
+    const user = userEvent.setup();
+    api.triggerCosJob.mockResolvedValue({ success: false, status: 'skipped', reason: 'No provider available' });
+    renderTab();
+
+    await user.click(await screen.findByRole('button', { name: 'Generate today’s briefing' }));
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith('No provider available'));
+    expect(toast.error).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary

The empty Briefing page now offers “Generate today’s briefing” and a link to its job settings. The action handles queued and duplicate jobs, prevents repeat submissions while pending, and refreshes until the briefing is persisted. Failed triggers show their reason once.

The shared EmptyState button now accepts an optional disabled state so pending actions remain accessible.

## Test plan

- From `client`: focused BriefingTab and EmptyState Vitest suites — 10 tests passed.
- Targeted Biome lint passed.

Closes #6949
