### PR TITLE
fix: serialize Writers Room bible writes (#6944)

### DIFF
--- a/server/lib/storyBible.test.js
+++ b/server/lib/storyBible.test.js
@@ -1558,6 +1558,23 @@ describe('storyBible — createBibleStore (single-primary-field kind)', () => {
     expect(entries.find((entry) => entry.id === aria.id)?.role).toBe('antagonist');
     expect(entries.find((entry) => entry.id === voss.id)?.role).toBe('protagonist');
   });
+
+  it('allows writes for different works to proceed independently', async () => {
+    const store = characterStore();
+    const otherWorkId = 'wr-work-bbbbbbbb-cccc-dddd-eeee-ffffffffffff';
+    const [aria, voss] = await Promise.all([
+      store.create(WORK_ID, { name: 'Aria' }),
+      store.create(otherWorkId, { name: 'Voss' }),
+    ]);
+
+    await Promise.all([
+      store.update(WORK_ID, aria.id, { role: 'protagonist' }),
+      store.update(otherWorkId, voss.id, { role: 'antagonist' }),
+    ]);
+
+    expect((await store.list(WORK_ID))[0].role).toBe('protagonist');
+    expect((await store.list(otherWorkId))[0].role).toBe('antagonist');
+  });
 });
 
 describe('storyBible — createBibleStore (multi-primary-field kind / settings)', () => {

--- a/server/lib/storyBible.test.js
+++ b/server/lib/storyBible.test.js
@@ -1530,6 +1530,34 @@ describe('storyBible — createBibleStore (single-primary-field kind)', () => {
     expect(merged).toHaveLength(2);
     expect(merged.every((e) => e.source === 'ai')).toBe(true);
   });
+
+  it('serializes overlapping edits and extraction on the same bible file', async () => {
+    const store = characterStore();
+    const existing = await store.create(WORK_ID, { name: 'Aria', role: 'protagonist' });
+
+    const updatePromise = store.update(WORK_ID, existing.id, { role: 'antagonist' });
+    const mergePromise = store.mergeExtracted(WORK_ID, [{ name: 'Voss', role: 'antagonist' }]);
+    await Promise.all([updatePromise, mergePromise]);
+
+    const entries = await store.list(WORK_ID);
+    expect(entries.find((entry) => entry.id === existing.id)?.role).toBe('antagonist');
+    expect(entries.some((entry) => entry.name === 'Voss')).toBe(true);
+  });
+
+  it('preserves concurrent updates to different entries in one bible file', async () => {
+    const store = characterStore();
+    const aria = await store.create(WORK_ID, { name: 'Aria', role: 'protagonist' });
+    const voss = await store.create(WORK_ID, { name: 'Voss', role: 'supporting' });
+
+    await Promise.all([
+      store.update(WORK_ID, aria.id, { role: 'antagonist' }),
+      store.update(WORK_ID, voss.id, { role: 'protagonist' }),
+    ]);
+
+    const entries = await store.list(WORK_ID);
+    expect(entries.find((entry) => entry.id === aria.id)?.role).toBe('antagonist');
+    expect(entries.find((entry) => entry.id === voss.id)?.role).toBe('protagonist');
+  });
 });
 
 describe('storyBible — createBibleStore (multi-primary-field kind / settings)', () => {

--- a/server/services/bibleStore.js
+++ b/server/services/bibleStore.js
@@ -62,11 +62,15 @@ export function createBibleStore(opts) {
     return { ...parsed, [listKey]: sanitizeBibleList(parsed[listKey], kind, { idPrefix }) };
   }
 
-  async function save(workId, state) {
+  // Call only from inside withBibleWrite. The queue wraps the complete
+  // read-modify-write cycle, so this helper must not enqueue again.
+  async function saveNow(workId, state) {
     await ensureDir(wrDir(workId));
-    await withBibleWrite(filePath(workId), () => atomicWrite(filePath(workId), { ...state, updatedAt: nowIso() }));
+    await atomicWrite(filePath(workId), { ...state, updatedAt: nowIso() });
     emitRecordUpdated('writersRoomWork', workId);
   }
+
+  const withWorkWrite = (workId, work) => withBibleWrite(filePath(workId), work);
 
   async function list(workId) {
     const state = await load(workId);
@@ -84,78 +88,86 @@ export function createBibleStore(opts) {
   async function create(workId, patch = {}) {
     const requireErr = requireOnCreate(patch);
     if (requireErr) throw badReq(requireErr);
-    const state = await load(workId);
-    const keyOfPatch = dedupKey(patch);
-    if (keyOfPatch && state[listKey].some((e) => dedupKey(e) === keyOfPatch)) {
-      throw badReq(conflictMessage(patch));
-    }
-    const draft = { id: `${idPrefix}${randomUUID()}`, source: 'user' };
-    for (const field of primaryFields) {
-      if (patch[field] !== undefined) draft[field] = String(patch[field] || '').trim();
-    }
-    for (const field of editableFields) {
-      if (patch[field] !== undefined) draft[field] = patch[field];
-    }
-    // Places: if both name and slugline are primary, missing name + present
-    // slugline → mirror slugline → name (preserves old createPlace behavior).
-    if (primaryFields.includes('name') && primaryFields.includes('slugline') && !draft.name && draft.slugline) {
-      draft.name = draft.slugline;
-    }
-    const profile = sanitizer(draft, { idPrefix, preserveTimestamps: false });
-    state[listKey].push(profile);
-    await save(workId, state);
-    return profile;
+    return withWorkWrite(workId, async () => {
+      const state = await load(workId);
+      const keyOfPatch = dedupKey(patch);
+      if (keyOfPatch && state[listKey].some((e) => dedupKey(e) === keyOfPatch)) {
+        throw badReq(conflictMessage(patch));
+      }
+      const draft = { id: `${idPrefix}${randomUUID()}`, source: 'user' };
+      for (const field of primaryFields) {
+        if (patch[field] !== undefined) draft[field] = String(patch[field] || '').trim();
+      }
+      for (const field of editableFields) {
+        if (patch[field] !== undefined) draft[field] = patch[field];
+      }
+      // Places: if both name and slugline are primary, missing name + present
+      // slugline → mirror slugline → name (preserves old createPlace behavior).
+      if (primaryFields.includes('name') && primaryFields.includes('slugline') && !draft.name && draft.slugline) {
+        draft.name = draft.slugline;
+      }
+      const profile = sanitizer(draft, { idPrefix, preserveTimestamps: false });
+      state[listKey].push(profile);
+      await saveNow(workId, state);
+      return profile;
+    });
   }
 
   async function update(workId, entryId, patch = {}) {
     assertId(entryId);
-    const state = await load(workId);
-    const idx = state[listKey].findIndex((e) => e.id === entryId);
-    if (idx < 0) throw notFoundErr(notFoundLabel);
-    const next = { ...state[listKey][idx] };
-    // Primary fields: single-primary kinds reject blank; multi-primary
-    // places allow blanks here and rely on validateAfterUpdate for the
-    // combined-blank invariant.
-    for (const field of primaryFields) {
-      if (patch[field] === undefined) continue;
-      const newVal = String(patch[field] || '').trim();
-      if (primaryFields.length === 1 && !newVal) {
-        throw badReq(`${notFoundLabel} ${field} cannot be blank`);
-      }
-      if (newVal) {
-        const newKey = dedupKey({ ...next, [field]: newVal });
-        if (newKey && state[listKey].some((e) => e.id !== entryId && dedupKey(e) === newKey)) {
-          throw badReq(conflictMessage({ [field]: newVal }));
+    return withWorkWrite(workId, async () => {
+      const state = await load(workId);
+      const idx = state[listKey].findIndex((e) => e.id === entryId);
+      if (idx < 0) throw notFoundErr(notFoundLabel);
+      const next = { ...state[listKey][idx] };
+      // Primary fields: single-primary kinds reject blank; multi-primary
+      // places allow blanks here and rely on validateAfterUpdate for the
+      // combined-blank invariant.
+      for (const field of primaryFields) {
+        if (patch[field] === undefined) continue;
+        const newVal = String(patch[field] || '').trim();
+        if (primaryFields.length === 1 && !newVal) {
+          throw badReq(`${notFoundLabel} ${field} cannot be blank`);
         }
+        if (newVal) {
+          const newKey = dedupKey({ ...next, [field]: newVal });
+          if (newKey && state[listKey].some((e) => e.id !== entryId && dedupKey(e) === newKey)) {
+            throw badReq(conflictMessage({ [field]: newVal }));
+          }
+        }
+        next[field] = newVal;
       }
-      next[field] = newVal;
-    }
-    for (const field of editableFields) {
-      if (patch[field] !== undefined) next[field] = patch[field];
-    }
-    if (validateAfterUpdate) validateAfterUpdate(next);
-    next.source = 'user';
-    state[listKey][idx] = sanitizer({ ...next, updatedAt: nowIso() }, { idPrefix, preserveTimestamps: true });
-    await save(workId, state);
-    return state[listKey][idx];
+      for (const field of editableFields) {
+        if (patch[field] !== undefined) next[field] = patch[field];
+      }
+      if (validateAfterUpdate) validateAfterUpdate(next);
+      next.source = 'user';
+      state[listKey][idx] = sanitizer({ ...next, updatedAt: nowIso() }, { idPrefix, preserveTimestamps: true });
+      await saveNow(workId, state);
+      return state[listKey][idx];
+    });
   }
 
   async function remove(workId, entryId) {
     assertId(entryId);
-    const state = await load(workId);
-    const before = state[listKey].length;
-    state[listKey] = state[listKey].filter((e) => e.id !== entryId);
-    if (state[listKey].length === before) throw notFoundErr(notFoundLabel);
-    await save(workId, state);
-    return { ok: true };
+    return withWorkWrite(workId, async () => {
+      const state = await load(workId);
+      const before = state[listKey].length;
+      state[listKey] = state[listKey].filter((e) => e.id !== entryId);
+      if (state[listKey].length === before) throw notFoundErr(notFoundLabel);
+      await saveNow(workId, state);
+      return { ok: true };
+    });
   }
 
   async function mergeExtracted(workId, extracted) {
     if (!Array.isArray(extracted)) return list(workId);
-    const state = await load(workId);
-    state[listKey] = mergeExtractedBible(state[listKey], extracted, kind, { idPrefix });
-    await save(workId, state);
-    return state[listKey];
+    return withWorkWrite(workId, async () => {
+      const state = await load(workId);
+      state[listKey] = mergeExtractedBible(state[listKey], extracted, kind, { idPrefix });
+      await saveNow(workId, state);
+      return state[listKey];
+    });
   }
 
   return { list, get, create, update, remove, mergeExtracted };


### PR DESCRIPTION
## Summary
Serialize Writers Room bible read-modify-write operations per work and file so concurrent Cast edits and extraction merges preserve both changes.

## Changes
- Queue `create`, `update`, `remove`, and `mergeExtracted` through the existing keyed bible write queue.
- Add a direct `saveNow` path for queued operations to avoid nested queue deadlocks.
- Add boundary tests for overlapping extraction/edit writes and concurrent updates to separate entries.

## Tests
- `storyBible.test.js` — 151 tests passed, including same-file overlapping writes and independent work IDs
- Writers Room route suites were attempted but require an unavailable PostgreSQL instance.

Optional Claude review timed out without a verdict; no external approval is claimed.

Closes #6944

