### PR TITLE
fix: verify Ollama Homebrew upgrades reach the available version

### DIFF
--- a/server/services/localLlm.js
+++ b/server/services/localLlm.js
@@ -514,20 +514,34 @@ export async function upgradeBackend(backend, onProgress = () => {}) {
   if (!(await commandExists('brew', ['--version']))) {
     return { success: false, error: `Homebrew not found — install it from https://brew.sh first, or ${downloadHint.toLowerCase()}` }
   }
+  const before = backend === 'ollama' ? await readOllamaVersion() : null
+  const target = backend === 'ollama' ? await getLatestOllamaVersion() : null
+  emit('Refreshing Homebrew package metadata…')
+  const refresh = await runStreaming('brew', ['update'], emit, BACKEND_INSTALL_TIMEOUT_MS)
+  if (!refresh.success) return { success: false, error: `Homebrew refresh failed: ${refresh.error}` }
   emit(`Upgrading ${label} via Homebrew (${source.packageName}) — this can take a few minutes…`)
   const r = await runStreaming('brew', source.upgradeArgs, emit, BACKEND_INSTALL_TIMEOUT_MS)
   if (!r.success) {
     console.error(`⚠️ ${label} upgrade via brew ${source.upgradeArgs.join(' ')} failed: ${r.error}`)
     return { success: false, error: `Homebrew upgrade failed: ${r.error}` }
   }
-  console.log(`🍺 Upgraded ${label} via Homebrew (${source.source})`)
+  console.log(`🍺 Homebrew upgrade command completed for ${label} (${source.source})`)
   if (backend === 'ollama') {
     const stop = await ollamaManager.stopPersistentService().catch((err) => ({ success: false, error: err.message }))
     const restart = await ollamaManager.startPersistentService().catch((err) => ({ success: false, error: err.message }))
-    const note = restart.success
-      ? 'Restarted Ollama service so the new binary is now serving requests.'
-      : `Upgraded, but PortOS could not restart the Ollama service (${restart.error || stop.error}). Restart it from the Local LLMs tab.`
-    return { success: true, backend, note }
+    if (!restart.success) {
+      return { success: false, backend, error: `Could not verify the Ollama upgrade because its service could not restart (${restart.error || stop.error}). Restart it from the Local LLMs tab.` }
+    }
+    const after = await waitForOllamaVersion()
+    if (!after) return { success: false, backend, error: 'Could not verify the Ollama upgrade: the service did not come back online within 30s.' }
+    if ((target && compareSemver(target, after) > 0) || (!target && (!before || compareSemver(after, before) <= 0))) {
+      return {
+        success: false,
+        backend,
+        error: `Ollama is still running ${after}${target ? `; the available release is ${target}` : '; no newer running version was verified'}. Homebrew may not have packaged the latest release yet, or another Ollama installation may be serving requests. Retry when Homebrew catches up, or install the official app from ${DOWNLOAD_URL.ollama}.`
+      }
+    }
+    return { success: true, backend, note: `Ollama ${before ? `${before} → ` : ''}${after}. The verified binary is now serving requests.` }
   }
   return { success: true, backend, note: 'Restart LM Studio so the new binary is loaded.' }
 }

--- a/server/services/localLlm.test.js
+++ b/server/services/localLlm.test.js
@@ -47,6 +47,8 @@ vi.mock('../lib/fileUtils.js', async () => {
   const fsMod = await import('fs');
   return {
     PATHS: state,
+    pathExists: async () => false,
+    sleep: async () => {},
     atomicWrite: async (file, data) => fsMod.writeFileSync(file, data),
   };
 });
@@ -672,6 +674,45 @@ describe('localLlm', () => {
         expect(r.success).toBe(false);
         expect(r.error).toMatch(/lmstudio\.ai/); // surfaces the manual download link
       } finally {
+        restorePlatform();
+      }
+    });
+
+    it.each([
+      ['0.33.3', false],
+      ['0.34.0', true],
+    ])('verifies Homebrew upgrade against the running version %s', async (after, success) => {
+      const restorePlatform = pinPlatform('darwin');
+      vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, json: async () => ({ tag_name: 'v0.34.0' }) })));
+      cp.execFile = (_cmd, _args, _opts, cb) => cb(null, { stdout: 'ollama 0.33.3', stderr: '' });
+      cp.spawn = vi.fn(() => fakeChild({ lines: ['Warning: ollama 0.33.3 already installed'] }));
+      mocks.ollama.getStatus.mockResolvedValueOnce({ version: '0.33.3' }).mockResolvedValueOnce({ version: after });
+      try {
+        const result = await svc.upgradeBackend('ollama');
+        expect(result.success).toBe(success);
+        expect(cp.spawn.mock.calls.map(([cmd, args]) => [cmd, args])).toEqual([
+          ['brew', ['update']], ['brew', ['upgrade', 'ollama']]
+        ]);
+        if (!success) expect(result.error).toMatch(/still running 0.33.3.*available release is 0.34.0/);
+        else expect(result.note).toContain('0.33.3 → 0.34.0');
+      } finally {
+        vi.unstubAllGlobals();
+        restorePlatform();
+      }
+    });
+
+    it('stops an upgrade when Homebrew metadata cannot be refreshed', async () => {
+      const restorePlatform = pinPlatform('darwin');
+      vi.stubGlobal('fetch', vi.fn(async () => ({ ok: false })));
+      cp.execFile = (_cmd, _args, _opts, cb) => cb(null, { stdout: '', stderr: '' });
+      cp.spawn = vi.fn(() => fakeChild({ code: 1 }));
+      try {
+        const result = await svc.upgradeBackend('ollama');
+        expect(result).toMatchObject({ success: false, error: expect.stringContaining('Homebrew refresh failed') });
+        expect(cp.spawn).toHaveBeenCalledTimes(1);
+        expect(mocks.ollama.stopPersistentService).not.toHaveBeenCalled();
+      } finally {
+        vi.unstubAllGlobals();
         restorePlatform();
       }
     });


### PR DESCRIPTION
## Summary
The Local LLMs update button advertises Ollama's latest release, but Homebrew can exit successfully with the older version already installed. Refresh package metadata before upgrading and verify the running version after restart before reporting success. Explain package lag or a different serving installation when the target remains unmet; restart and verification failures also remain failures.

## Test plan
- Server Vitest: services/localLlm.test.js and routes/localLlm.test.js — 139 tests passed.
- Regression coverage reproduces the 0.33.3 → 0.34.0 no-op, verifies a successful upgrade, and ensures metadata refresh failures stop before service disruption.
- Reviewed the diff for reuse, compatibility and error handling; git diff --check passed.
- Installer commands and Ollama services are mocked; no live upgrade was run.
