### PR TITLE
fix: preserve pipeline and project sidecars (#6974)

### DIFF
--- a/server/services/askConversations.js
+++ b/server/services/askConversations.js
@@ -70,7 +70,7 @@ function truncateTitle(text) {
 }
 
 async function readConversation(id) {
-  const data = await readJSONFile(pathFor(id), null, { logError: false });
+  const data = await readJSONFile(pathFor(id), null, { logError: false, strict: true });
   if (!data || typeof data !== 'object' || data.id !== id) return null;
   return data;
 }

--- a/server/services/askConversations.js
+++ b/server/services/askConversations.js
@@ -69,8 +69,8 @@ function truncateTitle(text) {
   return trimmed.slice(0, TITLE_MAX_LENGTH - 1) + '…';
 }
 
-async function readConversation(id) {
-  const data = await readJSONFile(pathFor(id), null, { logError: false, strict: true });
+async function readConversation(id, { strict = true } = {}) {
+  const data = await readJSONFile(pathFor(id), null, { logError: false, strict });
   if (!data || typeof data !== 'object' || data.id !== id) return null;
   return data;
 }
@@ -113,7 +113,9 @@ export async function listConversations({ limit = 50 } = {}) {
     let conv = null;
     let mtime = null;
     if (headSlot) {
-      conv = await readConversation(id);
+      // Listing aggregates independent files and never rewrites a skipped
+      // record, so one unreadable conversation must not hide every healthy one.
+      conv = await readConversation(id, { strict: false });
       if (!conv) continue;
     } else {
       // Cheap check first — only open the JSON if mtime indicates the file
@@ -121,7 +123,9 @@ export async function listConversations({ limit = 50 } = {}) {
       mtime = await stat(pathFor(id)).then((s) => s.mtimeMs, () => null);
       if (mtime === null) continue;
       if ((now - mtime) <= expiryMs) continue;
-      conv = await readConversation(id);
+      // A failed read returns null and therefore cannot enter the prune path;
+      // preserve that file while the sweep continues over independent records.
+      conv = await readConversation(id, { strict: false });
       if (!conv) continue;
     }
 

--- a/server/services/bibleStore.js
+++ b/server/services/bibleStore.js
@@ -57,7 +57,7 @@ export function createBibleStore(opts) {
 
   async function load(workId) {
     const fallback = { [listKey]: [], updatedAt: null };
-    const parsed = await readJSONFile(filePath(workId), fallback);
+    const parsed = await readJSONFile(filePath(workId), fallback, { strict: true });
     if (!parsed || !Array.isArray(parsed[listKey])) return fallback;
     return { ...parsed, [listKey]: sanitizeBibleList(parsed[listKey], kind, { idPrefix }) };
   }

--- a/server/services/creative/creativeRunLedger.js
+++ b/server/services/creative/creativeRunLedger.js
@@ -79,7 +79,7 @@ export async function appendCreativeLedgerEntry(projectId, entry, { dir } = {}) 
   const record = { at: new Date().toISOString(), ...entry };
   await ledgerQueue(file, async () => {
     await ensureDir(dir || DEFAULT_LEDGER_DIR);
-    const existing = await readJSONFile(file, [], { logError: false });
+    const existing = await readJSONFile(file, [], { logError: false, strict: true });
     const list = Array.isArray(existing) ? existing : [];
     list.push(record);
     const trimmed = list.length > MAX_LEDGER_ENTRIES ? list.slice(-MAX_LEDGER_ENTRIES) : list;
@@ -96,6 +96,6 @@ export async function appendCreativeLedgerEntry(projectId, entry, { dir } = {}) 
  * @returns {Promise<Array<object>>}
  */
 export async function readCreativeLedger(projectId, { dir } = {}) {
-  const existing = await readJSONFile(fileFor(projectId, dir), [], { logError: false });
+  const existing = await readJSONFile(fileFor(projectId, dir), [], { logError: false, strict: true });
   return Array.isArray(existing) ? existing : [];
 }

--- a/server/services/pipeline/continuityBible.js
+++ b/server/services/pipeline/continuityBible.js
@@ -185,7 +185,7 @@ const emptyLedger = () => ({ schemaVersion: SCHEMA_VERSION, status: 'none', fact
 
 async function readLedger(seriesId) {
   // `null` = file absent (distinct from a present-but-empty ledger).
-  const raw = await readJSONFile(ledgerPath(seriesId), null);
+  const raw = await readJSONFile(ledgerPath(seriesId), null, { strict: true });
   if (raw == null || typeof raw !== 'object') return null;
   return raw;
 }

--- a/server/services/pipeline/editorialScore.js
+++ b/server/services/pipeline/editorialScore.js
@@ -332,7 +332,7 @@ function sanitizeLedger(raw, seriesId) {
 }
 
 async function readLedger(seriesId) {
-  const raw = await readJSONFile(ledgerPath(seriesId), null);
+  const raw = await readJSONFile(ledgerPath(seriesId), null, { strict: true });
   return raw == null ? emptyLedger(seriesId) : sanitizeLedger(raw, seriesId);
 }
 

--- a/server/services/pipeline/manuscriptComments.js
+++ b/server/services/pipeline/manuscriptComments.js
@@ -305,7 +305,13 @@ export async function locateComment(commentId) {
   if (typeof commentId !== 'string' || !commentId) return null;
   const series = await listSeries();
   for (const s of series) {
-    const comment = await getComment(s.id, commentId);
+    // Cross-series lookup is an aggregation with no write-back. Preserve and
+    // skip an unreadable sibling so it cannot hide a healthy series' finding.
+    const comment = await getComment(s.id, commentId).catch((err) => {
+      if (err?.code !== 'UNREADABLE_STORE') throw err;
+      console.warn(`⚠️ manuscript review lookup: unreadable sidecar skipped — series=${String(s.id).slice(0, 12)}`);
+      return null;
+    });
     if (comment) return { seriesId: s.id, comment };
   }
   return null;

--- a/server/services/pipeline/manuscriptComments.js
+++ b/server/services/pipeline/manuscriptComments.js
@@ -204,7 +204,7 @@ function sanitizeReview(raw) {
 
 export async function readReview(seriesId) {
   // `null` = file absent (distinct from a present-but-empty review).
-  const raw = await readJSONFile(reviewPath(seriesId), null);
+  const raw = await readJSONFile(reviewPath(seriesId), null, { strict: true });
   return raw == null ? emptyReview() : sanitizeReview(raw);
 }
 

--- a/server/services/pipeline/reverseOutline.js
+++ b/server/services/pipeline/reverseOutline.js
@@ -192,7 +192,7 @@ const emptyOutline = () => ({ schemaVersion: SCHEMA_VERSION, status: 'none', plo
 
 async function readOutline(seriesId) {
   // `null` = file absent (distinct from a present-but-empty outline).
-  const raw = await readJSONFile(outlinePath(seriesId), null);
+  const raw = await readJSONFile(outlinePath(seriesId), null, { strict: true });
   if (raw == null || typeof raw !== 'object') return null;
   return raw;
 }

--- a/server/services/projectFileStore.js
+++ b/server/services/projectFileStore.js
@@ -16,7 +16,7 @@ export function createProjectFileStore({ file, kind, idPrefix, logEmoji, logLabe
   const sync = makeSyncKind(kind);
 
   async function loadAll() {
-    const raw = await readJSONFile(file, []);
+    const raw = await readJSONFile(file, [], { strict: true });
     return Array.isArray(raw) ? raw : [];
   }
 

--- a/server/services/projectSidecarJsonWriteback.test.js
+++ b/server/services/projectSidecarJsonWriteback.test.js
@@ -5,6 +5,8 @@ import { makePathsProxy, createTempDataRoot } from '../lib/mockPathsDataRoot.js'
 
 const TEST_DATA_ROOT = createTempDataRoot('project-sidecar-writeback-');
 const readFault = vi.hoisted(() => ({ path: null }));
+const pipelineFixtures = vi.hoisted(() => ({ sections: [], seriesIds: [] }));
+const runStagedLLM = vi.hoisted(() => vi.fn());
 
 vi.mock('fs/promises', async (importOriginal) => {
   const actual = await importOriginal();
@@ -23,7 +25,7 @@ vi.mock('./sharing/recordEvents.js', () => ({ emitRecordUpdated: vi.fn() }));
 vi.mock('./pipeline/series.js', () => ({
   seriesStore: () => ({ recordDir: (id) => join(TEST_DATA_ROOT, 'pipeline-series', id) }),
   getSeries: vi.fn(async (id) => ({ id, name: 'Test series' })),
-  listSeries: vi.fn(async () => []),
+  listSeries: vi.fn(async () => pipelineFixtures.seriesIds.map((id) => ({ id }))),
 }));
 vi.mock('./pipeline/seriesCanon.js', () => ({
   getSeriesCanon: vi.fn(async () => ({
@@ -33,14 +35,14 @@ vi.mock('./pipeline/seriesCanon.js', () => ({
   })),
 }));
 vi.mock('./pipeline/arcPlanner.js', () => ({
-  collectManuscriptSections: vi.fn(async () => []),
-  sectionsCorpus: vi.fn(() => ''),
+  collectManuscriptSections: vi.fn(async () => pipelineFixtures.sections),
+  sectionsCorpus: vi.fn((sections) => sections.map((section) => section.content).join('\n')),
   REPLACEMENT_STRATEGIES: new Set(['delta', 'full-page']),
   replacementStrategyForCategory: (category) => category === 'comic-structure' ? 'full-page' : 'delta',
 }));
 vi.mock('./stageRunner.js', () => ({
-  runStagedLLM: vi.fn(),
-  resolveStageContext: vi.fn(),
+  runStagedLLM,
+  resolveStageContext: vi.fn(async () => ({ contextWindow: 100_000 })),
 }));
 vi.mock('../lib/contextBudget.js', () => ({
   manuscriptContentBudgetChars: vi.fn(() => 100_000),
@@ -220,6 +222,9 @@ const generatedSidecars = [
 
 beforeEach(() => {
   readFault.path = null;
+  pipelineFixtures.sections = [];
+  pipelineFixtures.seriesIds = [];
+  runStagedLLM.mockReset();
   rmSync(TEST_DATA_ROOT, { recursive: true, force: true });
   mkdirSync(TEST_DATA_ROOT, { recursive: true });
 });
@@ -277,4 +282,56 @@ describe.each(generatedSidecars)('$name generated sidecar', (store) => {
     await store.mutate();
     expect(store.initialized(JSON.parse(readFileSync(store.path, 'utf8')))).toBe(true);
   });
+});
+
+it('Ask listing skips an unreadable member without rewriting it or hiding healthy conversations', async () => {
+  const healthyId = 'ask_000000002_feedface';
+  const healthyPath = join(TEST_DATA_ROOT, 'ask-conversations', `${healthyId}.json`);
+  const unreadableBytes = '{"truncated":';
+  mkdirSync(dirname(paths.ask), { recursive: true });
+  writeFileSync(paths.ask, unreadableBytes);
+  writeFileSync(healthyPath, JSON.stringify({
+    id: healthyId,
+    title: 'Healthy conversation',
+    mode: 'ask',
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    promoted: false,
+    turns: [],
+  }));
+
+  expect(await ask.listConversations()).toEqual([
+    expect.objectContaining({ id: healthyId, title: 'Healthy conversation' }),
+  ]);
+  expect(readFileSync(paths.ask, 'utf8')).toBe(unreadableBytes);
+});
+
+it('cross-series manuscript lookup skips an unreadable sidecar and finds a healthy one', async () => {
+  const unreadableSeries = 'ser-unreadable';
+  const healthySeries = 'ser-healthy';
+  const unreadablePath = join(TEST_DATA_ROOT, 'pipeline-series', unreadableSeries, 'manuscript-review.json');
+  const healthyPath = join(TEST_DATA_ROOT, 'pipeline-series', healthySeries, 'manuscript-review.json');
+  const unreadableBytes = '{"truncated":';
+  pipelineFixtures.seriesIds = [unreadableSeries, healthySeries];
+  mkdirSync(dirname(unreadablePath), { recursive: true });
+  mkdirSync(dirname(healthyPath), { recursive: true });
+  writeFileSync(unreadablePath, unreadableBytes);
+  writeFileSync(healthyPath, JSON.stringify({ schemaVersion: 1, comments: [seedComment('target-comment')] }));
+
+  expect(await manuscriptComments.locateComment('target-comment')).toEqual({
+    seriesId: healthySeries,
+    comment: expect.objectContaining({ id: 'target-comment' }),
+  });
+  expect(readFileSync(unreadablePath, 'utf8')).toBe(unreadableBytes);
+});
+
+it('reverse-outline generation refuses unreadable state before invoking the model', async () => {
+  const unreadableBytes = '{"truncated":';
+  pipelineFixtures.sections = [{ issueId: 'issue-1', number: 1, title: 'One', stageId: 'prose', content: 'Draft prose.' }];
+  mkdirSync(dirname(paths.reverseOutline), { recursive: true });
+  writeFileSync(paths.reverseOutline, unreadableBytes);
+
+  await expect(reverseOutline.generateReverseOutline(SERIES_ID)).rejects.toThrow('Unreadable JSON file');
+  expect(runStagedLLM).not.toHaveBeenCalled();
+  expect(readFileSync(paths.reverseOutline, 'utf8')).toBe(unreadableBytes);
 });

--- a/server/services/projectSidecarJsonWriteback.test.js
+++ b/server/services/projectSidecarJsonWriteback.test.js
@@ -1,0 +1,280 @@
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { dirname, join } from 'path';
+import { makePathsProxy, createTempDataRoot } from '../lib/mockPathsDataRoot.js';
+
+const TEST_DATA_ROOT = createTempDataRoot('project-sidecar-writeback-');
+const readFault = vi.hoisted(() => ({ path: null }));
+
+vi.mock('fs/promises', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    readFile: (...args) => String(args[0]) === readFault.path
+      ? Promise.reject(Object.assign(new Error('injected read denial'), { code: 'EACCES' }))
+      : actual.readFile(...args),
+  };
+});
+
+vi.mock('../lib/fileUtils.js', async (importOriginal) =>
+  makePathsProxy(await importOriginal(), { dataRoot: TEST_DATA_ROOT }));
+
+vi.mock('./sharing/recordEvents.js', () => ({ emitRecordUpdated: vi.fn() }));
+vi.mock('./pipeline/series.js', () => ({
+  seriesStore: () => ({ recordDir: (id) => join(TEST_DATA_ROOT, 'pipeline-series', id) }),
+  getSeries: vi.fn(async (id) => ({ id, name: 'Test series' })),
+  listSeries: vi.fn(async () => []),
+}));
+vi.mock('./pipeline/seriesCanon.js', () => ({
+  getSeriesCanon: vi.fn(async () => ({
+    characters: [{ id: 'char-existing', name: 'Mara', physicalDescription: 'Green eyes', locked: true }],
+    places: [],
+    objects: [],
+  })),
+}));
+vi.mock('./pipeline/arcPlanner.js', () => ({
+  collectManuscriptSections: vi.fn(async () => []),
+  sectionsCorpus: vi.fn(() => ''),
+  REPLACEMENT_STRATEGIES: new Set(['delta', 'full-page']),
+  replacementStrategyForCategory: (category) => category === 'comic-structure' ? 'full-page' : 'delta',
+}));
+vi.mock('./stageRunner.js', () => ({
+  runStagedLLM: vi.fn(),
+  resolveStageContext: vi.fn(),
+}));
+vi.mock('../lib/contextBudget.js', () => ({
+  manuscriptContentBudgetChars: vi.fn(() => 100_000),
+  estimateTokens: vi.fn(() => 0),
+}));
+vi.mock('./pipeline/manuscriptReview.js', () => ({
+  getReview: vi.fn(async () => ({ comments: [] })),
+}));
+
+const ask = await import('./askConversations.js');
+const characters = await import('./writersRoom/characters.js');
+const creativeLedger = await import('./creative/creativeRunLedger.js');
+const continuityBible = await import('./pipeline/continuityBible.js');
+const editorialScore = await import('./pipeline/editorialScore.js');
+const manuscriptComments = await import('./pipeline/manuscriptComments.js');
+const reverseOutline = await import('./pipeline/reverseOutline.js');
+const { createProjectFileStore } = await import('./projectFileStore.js');
+
+const ASK_ID = 'ask_000000001_deadbeef';
+const WORK_ID = 'wr-work-acde';
+const SERIES_ID = 'ser-sidecar';
+const NOW = '2026-09-11T00:00:00.000Z';
+
+const paths = {
+  ask: join(TEST_DATA_ROOT, 'ask-conversations', `${ASK_ID}.json`),
+  bible: join(TEST_DATA_ROOT, 'writers-room', 'works', WORK_ID, 'characters.json'),
+  creativeLedger: join(TEST_DATA_ROOT, 'creative-ledger', 'project-sidecar.json'),
+  continuityBible: join(TEST_DATA_ROOT, 'pipeline-series', SERIES_ID, 'continuity-bible.json'),
+  editorialScore: join(TEST_DATA_ROOT, 'pipeline-editorial-health', `${SERIES_ID}.json`),
+  manuscriptComments: join(TEST_DATA_ROOT, 'pipeline-series', SERIES_ID, 'manuscript-review.json'),
+  reverseOutline: join(TEST_DATA_ROOT, 'pipeline-series', SERIES_ID, 'reverse-outline.json'),
+  projectFileStore: join(TEST_DATA_ROOT, 'project-file-store.json'),
+};
+
+const projectStore = createProjectFileStore({
+  file: paths.projectFileStore,
+  kind: 'testProject',
+  idPrefix: 'test-project',
+  logEmoji: 'test',
+  logLabel: 'Test',
+  logic: {
+    buildProjectRecord: (input, { id, now }) => ({ id, name: input.name, createdAt: now, updatedAt: now }),
+    applyProjectPatch: (project, patch) => ({ ...project, ...patch }),
+    mergeProjectRecord: (local, remote) => ({ next: remote || local, inserted: !local, remoteWins: true, changed: true }),
+  },
+});
+
+const seedComment = (id = 'comment-existing') => ({
+  id,
+  problem: 'Existing finding',
+  status: 'open',
+  severity: 'medium',
+  createdAt: NOW,
+  updatedAt: NOW,
+});
+
+const durableStores = [
+  {
+    name: 'Ask conversation',
+    path: paths.ask,
+    seed: {
+      id: ASK_ID,
+      title: 'Existing conversation',
+      mode: 'ask',
+      createdAt: NOW,
+      updatedAt: NOW,
+      promoted: false,
+      turns: [{ id: 'turn-existing', role: 'user', content: 'Existing turn', createdAt: NOW }],
+    },
+    mutate: () => ask.appendTurn(ASK_ID, { role: 'assistant', content: 'New turn' }),
+    preserved: (data) => data.turns.some((turn) => turn.id === 'turn-existing'),
+    initialize: async () => {
+      const created = await ask.createConversation({ title: 'Initialized' });
+      return JSON.parse(readFileSync(ask.__test.pathFor(created.id), 'utf8')).title === 'Initialized';
+    },
+  },
+  {
+    name: 'writers-room bible',
+    path: paths.bible,
+    seed: {
+      characters: [{ id: 'wr-char-acde', name: 'Existing character', source: 'user', createdAt: NOW, updatedAt: NOW }],
+      updatedAt: NOW,
+    },
+    mutate: () => characters.createCharacter(WORK_ID, { name: 'New character' }),
+    preserved: (data) => data.characters.some((character) => character.id === 'wr-char-acde'),
+    initialize: async () => {
+      await characters.createCharacter(WORK_ID, { name: 'Initialized character' });
+      return JSON.parse(readFileSync(paths.bible, 'utf8')).characters[0].name === 'Initialized character';
+    },
+  },
+  {
+    name: 'creative run ledger',
+    path: paths.creativeLedger,
+    seed: [{ tool: 'existing.tool', outcome: 'executed', at: NOW }],
+    mutate: () => creativeLedger.appendCreativeLedgerEntry(
+      'project-sidecar',
+      { tool: 'new.tool', outcome: 'planned' },
+      { dir: dirname(paths.creativeLedger) },
+    ),
+    preserved: (data) => data.some((entry) => entry.tool === 'existing.tool'),
+    initialize: async () => {
+      await creativeLedger.appendCreativeLedgerEntry(
+        'project-sidecar',
+        { tool: 'initialized.tool', outcome: 'executed' },
+        { dir: dirname(paths.creativeLedger) },
+      );
+      return JSON.parse(readFileSync(paths.creativeLedger, 'utf8'))[0].tool === 'initialized.tool';
+    },
+  },
+  {
+    name: 'editorial trend ledger',
+    path: paths.editorialScore,
+    seed: {
+      schemaVersion: 1,
+      seriesId: SERIES_ID,
+      snapshots: [{ runId: 'existing-run', at: NOW, score: 95, ready: true, open: 1, openBySeverity: { high: 0, medium: 1, low: 0 }, openByCategory: { pacing: 1 } }],
+    },
+    mutate: () => editorialScore.recordTrendSnapshot(SERIES_ID, { runId: 'new-run', comments: [] }),
+    preserved: (data) => data.snapshots.some((snapshot) => snapshot.runId === 'existing-run'),
+    initialize: async () => {
+      await editorialScore.recordTrendSnapshot(SERIES_ID, { runId: 'initialized-run', comments: [] });
+      return JSON.parse(readFileSync(paths.editorialScore, 'utf8')).snapshots[0].runId === 'initialized-run';
+    },
+  },
+  {
+    name: 'manuscript review',
+    path: paths.manuscriptComments,
+    seed: { schemaVersion: 1, comments: [seedComment()] },
+    mutate: () => manuscriptComments.mergeReviewFromSync(SERIES_ID, {
+      schemaVersion: 1,
+      comments: [seedComment('comment-new')],
+    }),
+    preserved: (data) => data.comments.some((comment) => comment.id === 'comment-existing'),
+    initialize: async () => {
+      await manuscriptComments.mergeReviewFromSync(SERIES_ID, {
+        schemaVersion: 1,
+        comments: [seedComment('comment-initialized')],
+      });
+      return JSON.parse(readFileSync(paths.manuscriptComments, 'utf8')).comments[0].id === 'comment-initialized';
+    },
+  },
+  {
+    name: 'generic project file store',
+    path: paths.projectFileStore,
+    seed: [{ id: 'project-existing', name: 'Existing project', createdAt: NOW, updatedAt: NOW }],
+    mutate: () => projectStore.createProject({ name: 'New project' }),
+    preserved: (data) => data.some((project) => project.id === 'project-existing'),
+    initialize: async () => {
+      await projectStore.createProject({ name: 'Initialized project' });
+      return JSON.parse(readFileSync(paths.projectFileStore, 'utf8'))[0].name === 'Initialized project';
+    },
+  },
+];
+
+const generatedSidecars = [
+  {
+    name: 'continuity bible',
+    path: paths.continuityBible,
+    repair: { schemaVersion: 1, seriesId: SERIES_ID, status: 'none', facts: [] },
+    mutate: () => continuityBible.generateContinuityBible(SERIES_ID, { force: true }),
+    initialized: (data) => data.status === 'complete' && data.facts.some((fact) => fact.subject === 'Mara'),
+  },
+  {
+    name: 'reverse outline',
+    path: paths.reverseOutline,
+    repair: { schemaVersion: 1, seriesId: SERIES_ID, status: 'complete', generatedAt: '2026-09-10T00:00:00.000Z', plotlines: [], scenes: [] },
+    mutate: () => reverseOutline.mergeOutlineFromSync(SERIES_ID, {
+      schemaVersion: 1,
+      status: 'complete',
+      generatedAt: '2026-09-11T00:00:00.000Z',
+      plotlines: [],
+      scenes: [],
+    }),
+    initialized: (data) => data.generatedAt === '2026-09-11T00:00:00.000Z',
+  },
+];
+
+beforeEach(() => {
+  readFault.path = null;
+  rmSync(TEST_DATA_ROOT, { recursive: true, force: true });
+  mkdirSync(TEST_DATA_ROOT, { recursive: true });
+});
+
+afterAll(() => rmSync(TEST_DATA_ROOT, { recursive: true, force: true }));
+
+describe.each(durableStores)('$name durable write-back', (store) => {
+  it.each(['{"truncated":', ''])('preserves unreadable bytes (%j), then retries without losing valid records', async (bytes) => {
+    mkdirSync(dirname(store.path), { recursive: true });
+    writeFileSync(store.path, bytes);
+    await expect(store.mutate()).rejects.toThrow('Unreadable JSON file');
+    expect(readFileSync(store.path, 'utf8')).toBe(bytes);
+
+    writeFileSync(store.path, JSON.stringify(store.seed));
+    await store.mutate();
+    expect(store.preserved(JSON.parse(readFileSync(store.path, 'utf8')))).toBe(true);
+  });
+
+  it('preserves existing bytes on an injected filesystem read failure', async () => {
+    mkdirSync(dirname(store.path), { recursive: true });
+    const bytes = JSON.stringify(store.seed);
+    writeFileSync(store.path, bytes);
+    readFault.path = store.path;
+    await expect(store.mutate()).rejects.toThrow('Unreadable JSON file');
+    expect(readFileSync(store.path, 'utf8')).toBe(bytes);
+  });
+
+  it('initializes an absent file through its creation boundary', async () => {
+    expect(await store.initialize()).toBe(true);
+  });
+});
+
+describe.each(generatedSidecars)('$name generated sidecar', (store) => {
+  it.each(['{"truncated":', ''])('refuses to rebuild over unreadable bytes (%j) and retries after repair', async (bytes) => {
+    mkdirSync(dirname(store.path), { recursive: true });
+    writeFileSync(store.path, bytes);
+    await expect(store.mutate()).rejects.toThrow('Unreadable JSON file');
+    expect(readFileSync(store.path, 'utf8')).toBe(bytes);
+
+    writeFileSync(store.path, JSON.stringify(store.repair));
+    await store.mutate();
+    expect(store.initialized(JSON.parse(readFileSync(store.path, 'utf8')))).toBe(true);
+  });
+
+  it('preserves existing bytes on an injected filesystem read failure', async () => {
+    mkdirSync(dirname(store.path), { recursive: true });
+    const bytes = JSON.stringify(store.repair);
+    writeFileSync(store.path, bytes);
+    readFault.path = store.path;
+    await expect(store.mutate()).rejects.toThrow('Unreadable JSON file');
+    expect(readFileSync(store.path, 'utf8')).toBe(bytes);
+  });
+
+  it('initializes an absent file through the rebuild boundary', async () => {
+    await store.mutate();
+    expect(store.initialized(JSON.parse(readFileSync(store.path, 'utf8')))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- make the eight owned pipeline and project-sidecar loaders reject present unreadable JSON before any read-modify-write persistence
- preserve normal ENOENT initialization, compatibility sanitizers, storage routing, schema versions, and write queues
- keep multi-record discovery available by explicitly skipping an unreadable Ask conversation or manuscript-review sidecar only in read-only aggregation paths
- add real temporary-file boundary coverage for truncated/empty JSON, injected filesystem read failures, repair-and-retry, valid-record preservation, and absent-file initialization

## Store classification

| Owned path | Classification and reason |
| --- | --- |
| `askConversations.js` / `pathFor(id)` | Durable transcript record. `appendTurn` and `setPromoted` read then rewrite it, so single-record reads are strict. The listing sweep is the documented non-strict exception: it aggregates independent files and cannot rewrite or prune a record whose read returned null. |
| `bibleStore.js` / `filePath(workId)` | Durable user-editable story-bible record. CRUD and extracted-bible merges preserve existing entries through a read-modify-write cycle. |
| `creativeRunLedger.js` / `file` | Durable bounded audit ledger. Every dispatch appends to the existing history; both append and direct reads now reject unreadable storage. |
| `continuityBible.js` / `ledgerPath(seriesId)` | Authoritative rebuild cache derived from manuscript and canon. Generation can replace the sidecar after consulting it, so an unreadable present file blocks that replacement while an absent file still initializes. |
| `editorialScore.js` / `ledgerPath(seriesId)` | Durable revision-trend ledger. Each editorial boundary appends or replaces one run snapshot while retaining prior history. |
| `manuscriptComments.js` / `reviewPath(seriesId)` | Durable user decisions, fixes, and sync-merged findings. Per-series reads are strict before mutation. Cross-series `locateComment` is the documented read-only aggregation exception and skips only an `UNREADABLE_STORE` member. |
| `reverseOutline.js` / `outlinePath(seriesId)` | Authoritative rebuild cache plus whole-document sync LWW state. Both generation and sync merge can replace the sidecar, so unreadable local state blocks either write. |
| `projectFileStore.js` / `file` | Durable project arrays. Create, update, delete, sync merge, and tombstone prune all depend on the current record set. |

No owned candidate remains on an unclassified non-strict write-back read. The development-only Writers Room file backend uses separate paths outside this issue's exact ownership.

## Test plan

- `cd server && node_modules/.bin/vitest run services/projectSidecarJsonWriteback.test.js services/askConversations.test.js services/creative/creativeRunLedger.test.js services/writersRoom/characters.test.js services/writersRoom/places.test.js services/writersRoom/objects.test.js services/pipeline/continuityBible.test.js services/pipeline/editorialScore.test.js services/pipeline/manuscriptReview.test.js services/pipeline/reverseOutline.test.js lib/importScoping.test.js`
- Result: 11 test files passed, 295 tests passed

Closes #6974
