### PR TITLE
fix: support managed app release topologies in dashboard workflow

### DIFF
--- a/server/lib/slashdoLoader.test.js
+++ b/server/lib/slashdoLoader.test.js
@@ -68,6 +68,21 @@ describe.skipIf(!hasSubmodule)('slashdo rendering adapter', () => {
     expect(prompt).toContain('Reviewer applies (off)');
   });
 
+  it('delivers documented release topology and publication ownership through the staged bundle', async () => {
+    const root = fileURLToPath(new URL('../../lib/slashdo/', import.meta.url));
+    cpSync(join(root, 'lib'), join(fixtureRoot, 'lib'), { recursive: true });
+    write(join(fixtureRoot, 'commands/do/release.md'), readFileSync(join(root, 'commands/do/release.md'), 'utf8'));
+    const bundle = await loadSlashdoBundle('release', { stripFrontmatter: true });
+    const staged = await writeResolvedSlashdoBody('release', bundle.body, { files: bundle.files });
+    const body = readFileSync(staged, 'utf8');
+    expect(body.indexOf('## Select the Project Release Procedure')).toBeGreaterThanOrEqual(0);
+    expect(body.indexOf('## Select the Project Release Procedure')).toBeLessThan(body.indexOf('## Detect Release Workflow'));
+    expect(body).toContain('temporary `release/vX.Y.Z` branch into `main`');
+    expect(body).toContain('When automation creates the tag or release, wait for it; do not pre-create');
+    expect(body).toContain('Do not fall through into the generic promotion workflow');
+    expect(body).toContain('preserve their verdict and optionality');
+  });
+
   it('keeps inline reviewer recipes limited to explicit reads', async () => {
     write(join(fixtureRoot, 'lib/recipe.md'), 'Recipe\n!read lib/required.md\nSee `lib/unrelated.md`.');
     write(join(fixtureRoot, 'lib/required.md'), 'Required verification');


### PR DESCRIPTION
## Summary

The dashboard release run `agent-e1e5c0d9` stopped before preparing Critical Mass because the bundled slashdo workflow assumed promotion between two long-lived branches. Critical Mass already documents a temporary version-bump PR into main, where its automation publishes the release.

Update slashdo to the fix in https://github.com/atomantic/slashdo/pull/252. The workflow selects documented project procedures before generic branch detection, carries release recovery and review/CI gates through publication, and leaves tag creation to the owning automation. Add a staged-bundle regression check so the dashboard cannot silently receive the old topology restriction again. No Critical Mass changes are needed.

## Test plan

- Server Vitest: `lib/slashdoLoader.test.js lib/slashdoInvocation.test.js` — 87 tests passed.
- Upstream release contract tests — 8 passed; full upstream suite and CI tracked in slashdo PR #252.
- Read the failed agent's completion report, its rendered workflow, Critical Mass release documentation, and its main-triggered publication workflow.
- No live app release or version bump was performed; this fixes future release invocations.
