### PR TITLE
fix: recover Codex frame queue after write failures

### DIFF
--- a/server/services/codexAppServer.js
+++ b/server/services/codexAppServer.js
@@ -331,14 +331,16 @@ const handleFrame = (target, line) => {
  * JSON lines into one unparseable stream.
  */
 const writeFrame = (target, frame) => {
-  target.writeTail = target.writeTail.then(() => new Promise((resolve, reject) => {
+  const write = target.writeTail.then(() => new Promise((resolve, reject) => {
     if (target.closed || target.child.stdin.destroyed) {
       reject(codexError(CODEX_ERROR_CODES.exited, 'The Codex app-server is no longer running.'));
       return;
     }
     target.child.stdin.write(`${JSON.stringify(frame)}\n`, (err) => (err ? reject(err) : resolve()));
   }));
-  return target.writeTail;
+  // Keep the queue usable after failure while preserving this caller's error.
+  target.writeTail = write.catch(() => {});
+  return write;
 };
 
 /** A JSON-RPC request with its own deadline. Settles exactly once. */

--- a/server/services/codexAppServer.test.js
+++ b/server/services/codexAppServer.test.js
@@ -372,6 +372,25 @@ describe('the ChatGPT sign-in flow', () => {
 });
 
 describe('failure paths settle exactly once', () => {
+  it('reports a failed write but allows the next request on the same connection', async () => {
+    const initial = getCodexAccountReadiness();
+    await scripted(child, initial, [['initialize', {}], ['account/read', { account: null }]]);
+
+    vi.spyOn(child.stdin, 'write').mockImplementationOnce((_line, callback) => {
+      callback(new Error('Injected write failure'));
+      return false;
+    });
+    const failed = await getCodexAccountReadiness({ fresh: true });
+    expect(failed.status).toBe(CODEX_ACCOUNT_STATUS.unknown);
+    expect(failed.error.message).toContain('Injected write failure');
+
+    const recovered = getCodexAccountReadiness({ fresh: true });
+    await scripted(child, recovered, [['account/read', READY_ACCOUNT], ['account/rateLimits/read', { rateLimits: {} }]]);
+    expect((await recovered).status).toBe(CODEX_ACCOUNT_STATUS.ready);
+    expect(spawn).toHaveBeenCalledTimes(1);
+    expect(child.kill).not.toHaveBeenCalled();
+  });
+
   it('fails every pending request when the child exits mid-flight', async () => {
     const promise = getCodexAccountReadiness();
     await vi.waitFor(() => expect(child.lastRequest('initialize')).toBeTruthy());


### PR DESCRIPTION
A failed Codex app-server frame write previously rejected the shared queue permanently, causing every subsequent request on that connection to fail. Keep the shared tail recoverable while returning the original write result to its caller.

Validation: the new service-level regression failed before the fix and passes afterward; all 30 codexAppServer tests pass. Claude review at medium effort returned CLEAN.

Closes #7007
