### PR TITLE
fix: preserve original withTransaction error and evict dead pool clients

### DIFF
--- a/server/lib/db.js
+++ b/server/lib/db.js
@@ -240,6 +240,7 @@ export async function withTransaction(fn) {
   // GUARDED_CLIENT_HANDLER reads the SQL out of both.
   const guardedClient = new Proxy(client, GUARDED_CLIENT_HANDLER);
   let began = false;
+  let releaseErr;
   try {
     await client.query('BEGIN');
     began = true;
@@ -247,10 +248,16 @@ export async function withTransaction(fn) {
     await client.query('COMMIT');
     return result;
   } catch (err) {
-    if (began) await client.query('ROLLBACK');
+    // Swallow a secondary ROLLBACK failure (closed socket, statement_timeout
+    // abort, backend termination) so the caller sees the original fn/COMMIT
+    // error instead of a masking "query on closed connection" from ROLLBACK.
+    // Pass that original error to release() so pg destroys a damaged client
+    // rather than returning it to the idle pool for the next checkout to inherit.
+    releaseErr = err;
+    if (began) await client.query('ROLLBACK').catch(() => {});
     throw err;
   } finally {
-    client.release();
+    client.release(releaseErr);
   }
 }
 

--- a/server/lib/db.transaction.test.js
+++ b/server/lib/db.transaction.test.js
@@ -36,7 +36,7 @@ describe('withTransaction', () => {
     await expect(withTransaction(vi.fn())).rejects.toBe(beginError);
 
     expect(client.query.mock.calls).toEqual([['BEGIN']]);
-    expect(client.release).toHaveBeenCalledOnce();
+    expect(client.release).toHaveBeenCalledWith(beginError);
   });
 
   it('rolls back and releases the client when the handler throws', async () => {
@@ -47,7 +47,7 @@ describe('withTransaction', () => {
     await expect(withTransaction(async () => { throw handlerError; })).rejects.toBe(handlerError);
 
     expect(client.query.mock.calls).toEqual([['BEGIN'], ['ROLLBACK']]);
-    expect(client.release).toHaveBeenCalledOnce();
+    expect(client.release).toHaveBeenCalledWith(handlerError);
   });
 
   it('commits, releases, and returns the handler result on success', async () => {
@@ -57,7 +57,7 @@ describe('withTransaction', () => {
     await expect(withTransaction(async () => 'saved')).resolves.toBe('saved');
 
     expect(client.query.mock.calls).toEqual([['BEGIN'], ['COMMIT']]);
-    expect(client.release).toHaveBeenCalledOnce();
+    expect(client.release).toHaveBeenCalledWith(undefined);
   });
 
   it('keeps savepoint queries available to transaction handlers', async () => {
@@ -75,6 +75,36 @@ describe('withTransaction', () => {
       ['ROLLBACK TO SAVEPOINT nested_work'],
       ['COMMIT'],
     ]);
-    expect(client.release).toHaveBeenCalledOnce();
+    expect(client.release).toHaveBeenCalledWith(undefined);
+  });
+
+  it('rethrows the original error when ROLLBACK also fails', async () => {
+    const handlerError = new Error('statement timeout');
+    const rollbackError = new Error('Connection terminated unexpectedly');
+    const client = makeClient(
+      vi.fn()
+        .mockResolvedValueOnce({})
+        .mockRejectedValueOnce(rollbackError),
+    );
+    pool.client = client;
+
+    await expect(withTransaction(async () => { throw handlerError; })).rejects.toBe(handlerError);
+
+    expect(client.query.mock.calls).toEqual([['BEGIN'], ['ROLLBACK']]);
+    expect(client.release).toHaveBeenCalledWith(handlerError);
+  });
+
+  it('passes a connection-drop error to release so pg evicts the client', async () => {
+    const dropError = new Error('Connection terminated unexpectedly');
+    const client = makeClient(
+      vi.fn()
+        .mockResolvedValueOnce({})
+        .mockRejectedValueOnce(new Error('ROLLBACK on closed socket')),
+    );
+    pool.client = client;
+
+    await expect(withTransaction(async () => { throw dropError; })).rejects.toBe(dropError);
+
+    expect(client.release).toHaveBeenCalledWith(dropError);
   });
 });


### PR DESCRIPTION
## Summary
- `withTransaction` no longer loses the original query/handler error when `ROLLBACK` itself fails on a closed socket or terminated backend.
- A failed transaction now calls `client.release(err)` so node-postgres destroys the damaged client instead of returning it to the idle pool for the next checkout to inherit.

## Test plan
- [x] `server/lib/db.transaction.test.js` — original error rethrown when ROLLBACK also fails
- [x] `server/lib/db.transaction.test.js` — connection-drop path calls `client.release(err)`
- [x] Existing BEGIN-fail / handler-throw / success / savepoint cases still pass
- [x] `lib/db.guards.test.js` and `lib/db.schemaLifecycle.test.js` still pass

Closes #7008