### PR TITLE
fix: keep app details aligned with navigation

### DIFF
--- a/client/src/components/apps/AppDetailView.jsx
+++ b/client/src/components/apps/AppDetailView.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { Link, useParams, useNavigate, useSearchParams } from 'react-router';
 import { ArrowLeft, Play, Square, RotateCcw, ExternalLink, Gamepad2, Hammer, RefreshCw, Pencil, AlertTriangle, Sparkles } from 'lucide-react';
 import DeployPanel from './DeployPanel';
@@ -30,6 +30,12 @@ import DatadogTab from './tabs/DatadogTab';
 import UpdateTab from './tabs/UpdateTab';
 
 export default function AppDetailView() {
+  const { appId } = useParams();
+  // Route identity owns all detail state, including child tabs and async actions.
+  return <AppDetail key={appId} />;
+}
+
+function AppDetail() {
   const { appId, tab } = useParams();
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
@@ -52,10 +58,13 @@ export default function AppDetailView() {
   const [viteFixing, setViteFixing] = useState(null); // 'allow-all' | 'ai' while a fix is in flight
   const { features: instanceFeatures, error: instanceFeaturesError } = useInstanceFeatures();
 
+  const fetchSeqRef = useRef(0);
   const fetchApp = useCallback(async () => {
-    const data = await api.getApp(appId, { includeQuality: true }).catch(() => null);
+    const seq = ++fetchSeqRef.current;
+    const data = await api.getApp(appId, { includeQuality: true, silent: true }).catch(() => null);
+    if (seq !== fetchSeqRef.current) return;
+    setNotFound(!data);
     if (!data) {
-      setNotFound(true);
       setLoading(false);
       return;
     }
@@ -65,21 +74,13 @@ export default function AppDetailView() {
 
   useEffect(() => {
     fetchApp();
+    return () => { ++fetchSeqRef.current; };
   }, [fetchApp]);
-
-  // Close the edit drawer when navigating to a different app so its stale
-  // form state (initialized from the previous app) can't be saved against the
-  // newly loaded app id. Keyed on appId only — a same-app socket refresh must
-  // not interrupt an in-progress edit.
-  useEffect(() => {
-    setEditing(false);
-  }, [appId]);
 
   // Deep-link into the Edit App drawer (e.g. the Layered Intelligence overview
   // links here with `?edit=1&appTab=intelligence` to open the Intelligence tab).
   // The `edit` trigger is consumed immediately so closing the drawer doesn't
   // re-open it; `appTab` is preserved for the drawer's own useDrawerTab to read.
-  // Declared AFTER the appId-close effect so it wins on the same-commit mount.
   useEffect(() => {
     if (searchParams.get('edit') == null) return;
     setEditing(true);
@@ -91,6 +92,8 @@ export default function AppDetailView() {
   // Real-time updates
   useEffect(() => {
     const handleAppsChanged = (change) => {
+      // Unscoped events invalidate the fleet; scoped events affect only one app.
+      if (change?.appId != null && change.appId !== appId) return;
       // The delete event reaches this mounted detail view before the DELETE
       // response can navigate it away. Avoid refetching the known-deleted app,
       // which would turn the expected 404 into an error toast beside success.

--- a/client/src/components/apps/AppDetailView.test.jsx
+++ b/client/src/components/apps/AppDetailView.test.jsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { act, render, screen } from '@testing-library/react';
-import { MemoryRouter, Route, Routes, useLocation } from 'react-router';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes, useLocation, useNavigate } from 'react-router';
 
 const socketHandlers = new Map();
 const instanceFeatureMock = vi.hoisted(() => ({
@@ -42,7 +42,7 @@ vi.mock('../StatusBadge', () => ({ default: () => null }));
 vi.mock('./DeployPanel', () => ({ default: () => null }));
 vi.mock('./EditAppDrawer', () => ({ default: () => null }));
 vi.mock('./DesktopLaunchProgress', () => ({ default: () => null }));
-vi.mock('./tabs/OverviewTab', () => ({ default: () => null }));
+vi.mock('./tabs/OverviewTab', () => ({ default: ({ app }) => <output data-testid="overview-app">{app.id}</output> }));
 vi.mock('./tabs/TasksTab', () => ({ default: () => null }));
 vi.mock('./tabs/AutomationTab', () => ({ default: () => null }));
 vi.mock('./tabs/DocumentsTab', () => ({ default: () => null }));
@@ -70,7 +70,11 @@ const APP = {
 
 function LocationProbe() {
   const { pathname } = useLocation();
-  return <output data-testid="location">{pathname}</output>;
+  const navigate = useNavigate();
+  return <>
+    <output data-testid="location">{pathname}</output>
+    <button onClick={() => navigate('/apps/app-2/overview')}>View second app</button>
+  </>;
 }
 
 function renderDetail(initialEntry = '/apps/app-1/overview') {
@@ -187,5 +191,72 @@ describe('AppDetailView managed-app feature tabs', () => {
     await screen.findByRole('heading', { name: 'Example App' });
     expect(screen.queryByRole('button', { name: 'DataDog' })).toBeNull();
     expect(screen.getByTestId('datadog-tab')).toBeInTheDocument();
+  });
+});
+
+describe('AppDetailView fetch lifecycle', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    socketHandlers.clear();
+    api.getApp.mockReset();
+  });
+
+  it('clears old child props immediately on navigation and ignores a late old-app refresh', async () => {
+    let resolveOld;
+    let resolveNew;
+    api.getApp.mockResolvedValueOnce(APP)
+      .mockImplementationOnce(() => new Promise(resolve => { resolveOld = resolve; }))
+      .mockImplementationOnce(() => new Promise(resolve => { resolveNew = resolve; }));
+    renderDetail();
+    await screen.findByRole('heading', { name: APP.name });
+    await act(async () => socketHandlers.get('apps:changed')({ appId: APP.id }));
+    fireEvent.click(screen.getByRole('button', { name: 'View second app' }));
+    expect(screen.queryByTestId('overview-app')).toBeNull();
+    await act(async () => resolveNew({ ...APP, id: 'app-2', name: 'Second App' }));
+    expect(screen.getByTestId('overview-app')).toHaveTextContent('app-2');
+    await act(async () => resolveOld(APP));
+    expect(screen.getByRole('heading', { name: 'Second App' })).toBeInTheDocument();
+    expect(screen.getByTestId('overview-app')).toHaveTextContent('app-2');
+  });
+
+  it('ignores a failed previous-route request and recovers from a current-app failed refresh', async () => {
+    let rejectOld;
+    api.getApp.mockImplementationOnce(() => new Promise((_, reject) => { rejectOld = reject; }))
+      .mockResolvedValueOnce({ ...APP, id: 'app-2', name: 'Second App' });
+    renderDetail();
+    fireEvent.click(screen.getByRole('button', { name: 'View second app' }));
+    await screen.findByRole('heading', { name: 'Second App' });
+    await act(async () => rejectOld(new Error('Old request failed')));
+    expect(screen.getByTestId('overview-app')).toHaveTextContent('app-2');
+
+    api.getApp.mockRejectedValueOnce(new Error('Refresh failed'));
+    await act(async () => socketHandlers.get('apps:changed')({ appId: 'app-2' }));
+    expect(screen.queryByTestId('overview-app')).toBeNull();
+    api.getApp.mockResolvedValueOnce({ ...APP, id: 'app-2', name: 'Recovered App' });
+    await act(async () => socketHandlers.get('apps:changed')({ appId: 'app-2' }));
+    expect(screen.getByRole('heading', { name: 'Recovered App' })).toBeInTheDocument();
+  });
+
+  it('filters other-app events, preserves fleet invalidation, and keeps the newest refresh', async () => {
+    let resolveOlder;
+    api.getApp.mockResolvedValueOnce(APP)
+      .mockImplementationOnce(() => new Promise(resolve => { resolveOlder = resolve; }))
+      .mockResolvedValueOnce({ ...APP, name: 'Updated App' });
+    renderDetail();
+    await screen.findByRole('heading', { name: APP.name });
+    const changed = socketHandlers.get('apps:changed');
+    await act(async () => {
+      changed({ action: 'update', appId: 'app-2' });
+      changed({ action: 'delete', appId: 'app-2' });
+    });
+    expect(api.getApp).toHaveBeenCalledTimes(1);
+    await act(async () => changed({ action: 'update', appId: APP.id }));
+    await act(async () => changed({ action: 'update-task-types' }));
+    expect(api.getApp).toHaveBeenCalledTimes(3);
+    await act(async () => resolveOlder(APP));
+    expect(screen.getByRole('heading', { name: 'Updated App' })).toBeInTheDocument();
+    api.getApp.mockResolvedValueOnce(APP);
+    await act(async () => changed());
+    expect(api.getApp).toHaveBeenCalledTimes(4);
   });
 });


### PR DESCRIPTION
Switching between apps now resets the detail view and its child state immediately, so delayed responses cannot show the previous app under the new route. Superseded same-app requests are discarded, unrelated app socket events are ignored, and fleet-wide invalidations still refresh the view.

Validation: all 8 AppDetailView tests pass, including route races, stale failures, recovery, socket filtering, and child-prop checks. Focused Biome lint passes. Claude reviewed at medium effort and approved.

Closes #6998
