### PR TITLE
fix: avoid false GitHub failures during shutdown

### DIFF
--- a/server/lib/execGit.js
+++ b/server/lib/execGit.js
@@ -14,7 +14,7 @@ import { spawn } from './childProcess.js';
  * @param {number} [options.maxBuffer] - Max output buffer size in bytes (default 10 MB)
  * @param {number} [options.timeout] - Timeout in ms (default 30s)
  * @param {boolean} [options.ignoreExitCode] - Resolve instead of reject on non-zero exit
- * @returns {Promise<{stdout: string, stderr: string, exitCode: number}>}
+ * @returns {Promise<{stdout: string, stderr: string, exitCode: number|null, signal?: string, terminated?: boolean}>}
  */
 export function execGit(args, cwd, options = {}) {
   return new Promise((resolve, reject) => {
@@ -69,10 +69,18 @@ export function execGit(args, cwd, options = {}) {
       guardOverflow();
     });
 
-    child.on('close', (code) => {
+    child.on('close', (code, signal) => {
       clearTimeout(timer);
       if (killed) return;
-      if (code !== 0 && !options.ignoreExitCode) {
+      if (code === null && signal) {
+        if (options.ignoreExitCode) {
+          resolve({ stdout, stderr, exitCode: null, signal, terminated: true });
+        } else {
+          reject(Object.assign(new Error(`git command cancelled by ${signal}`), {
+            name: 'AbortError', signal, terminated: true
+          }));
+        }
+      } else if (code !== 0 && !options.ignoreExitCode) {
         reject(new Error(stderr || `git exited with code ${code}`));
       } else {
         resolve({ stdout, stderr, exitCode: code });

--- a/server/lib/execGit.test.js
+++ b/server/lib/execGit.test.js
@@ -74,6 +74,28 @@ describe('execGit', () => {
     });
   });
 
+  it('preserves signal termination and partial output when ignoring exit codes', async () => {
+    const child = makeChild();
+    spawn.mockReturnValue(child);
+    const promise = execGit(['ls-remote'], '/repo', { ignoreExitCode: true });
+    child.stdout.emit('data', 'partial');
+    child.emit('close', null, 'SIGTERM');
+    await expect(promise).resolves.toEqual({
+      stdout: 'partial', stderr: '', exitCode: null, signal: 'SIGTERM', terminated: true
+    });
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('rejects a signal exit with cancellation metadata', async () => {
+    const child = makeChild();
+    spawn.mockReturnValue(child);
+    const promise = execGit(['fetch'], '/repo');
+    child.emit('close', null, 'SIGTERM');
+    await expect(promise).rejects.toMatchObject({
+      name: 'AbortError', message: 'git command cancelled by SIGTERM', signal: 'SIGTERM', terminated: true
+    });
+  });
+
   it('rejects with a timeout error and kills the child after the timeout', async () => {
     const child = makeChild();
     spawn.mockReturnValue(child);

--- a/server/lib/importScoping.test.js
+++ b/server/lib/importScoping.test.js
@@ -408,7 +408,12 @@ describe('deferred imports stay deferred (#6156)', () => {
 // ~30 modules). Measured against current main: 103,462 -> 101,702 (-1,760);
 // suites whose closure reaches services/instances.js: 181 -> 33. Lower the
 // ceiling to the new measured total plus the standard ~1.5k allowance.
-const MAX_STATIC_INSTANTIATIONS = 103202;
+// #6992 adds the existing hostShutdown latch to GitHub command completion and
+// branch reconciliation. Its dependencies were already in these callers'
+// closures; the measured baseline 103,190 -> 103,228 is the shutdown module
+// itself in 38 additional suite closures, not a new heavy subtree. Preserve
+// the existing headroom by accounting for exactly that additive lifecycle edge.
+const MAX_STATIC_INSTANTIATIONS = 103240;
 
 
 const SKIP_DIRS = new Set(['node_modules', 'coverage', 'dist', 'data']);

--- a/server/services/branchReconcile.js
+++ b/server/services/branchReconcile.js
@@ -23,6 +23,7 @@
  */
 
 import { stat } from 'node:fs/promises';
+import { isHostShuttingDown } from '../lib/hostShutdown.js';
 import { getBranches, getDefaultBranch, hasBranchMergeEvidence, deleteBranch } from './git.js';
 import { execGit } from '../lib/execGit.js';
 import { listWorktrees, forceRemoveWorktreeDir, classifyWorktreeDirt, reapMergedWorktrees } from './worktreeManager.js';
@@ -248,7 +249,9 @@ async function getOpenPrsByHead(repoPath, providedOrigin) {
     '--limit', String(PR_LIST_LIMIT),
     '--json', 'number,headRefName,mergeable,isDraft,url'
   ], undefined, { backoffKey: repoSpec }).catch((err) => {
-    console.error(`❌ branch-reconcile: gh pr list failed for ${repoSpec}: ${err.message}`);
+    if (!isHostShuttingDown() && err.name !== 'AbortError') {
+      console.error(`❌ branch-reconcile: gh pr list failed for ${repoSpec}: ${err.message}`);
+    }
     return null;
   });
   if (raw === null) return null;
@@ -557,13 +560,14 @@ export function parseRemoteHeads(stdout) {
  */
 export async function listRemoteHeads(repoPath) {
   const res = await execGit(['ls-remote', '--heads', RECONCILED_REMOTE], repoPath, { ignoreExitCode: true })
-    .catch((err) => ({ error: err.message }));
+    .catch((err) => ({ error: err.message, signal: err.signal }));
   if (!res || res.exitCode !== 0) {
+    if (isHostShuttingDown() || res?.signal === 'SIGTERM') return null;
     // One log line serves every caller across every managed app, so it has to
     // name the repo that went unread and git's own reason — without both, a
     // network blip, an unauthenticated remote and a repo with no `origin` at
     // all are one indistinguishable line and the operator has nothing to act on.
-    const why = (res?.error || res?.stderr || '').trim().split('\n')[0] || `exit ${res?.exitCode}`;
+    const why = (res?.error || res?.stderr || '').trim().split('\n')[0] || (res?.signal ? `signal ${res.signal}` : `exit ${res?.exitCode}`);
     console.error(`❌ branch-reconcile: git ls-remote ${RECONCILED_REMOTE} failed in ${repoPath} (${why}) — remote branch state unknown this cycle`);
     return null;
   }

--- a/server/services/branchReconcile.test.js
+++ b/server/services/branchReconcile.test.js
@@ -8,7 +8,7 @@
  *   inFlight / wip correctly).
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 vi.mock('./git.js', () => ({
   getBranches: vi.fn(),
@@ -94,12 +94,13 @@ import {
   limitBranchesForAgent,
   branchPriorityRank, prioritizeBranches, worktreeProtectionExpiresAt, describeIdleReconcilePark,
   SHIPPED_CLAIM_IDLE_MS, STALE_CLAIM_IDLE_MS,
-  upstreamBranchName, parseRemoteHeads, partitionRemoteOrphans, reapOrphanedRemotes
+  listRemoteHeads, upstreamBranchName, parseRemoteHeads, partitionRemoteOrphans, reapOrphanedRemotes
 } from './branchReconcile.js';
 import * as git from './git.js';
 import * as wt from './worktreeManager.js';
 import { execGit } from '../lib/execGit.js';
 import { execGh } from './github.js';
+import { markHostShuttingDown, resetHostShutdownFlagForTests } from '../lib/hostShutdown.js';
 import { getOriginInfo } from '../lib/gitRemote.js';
 
 beforeEach(() => {
@@ -2098,5 +2099,44 @@ describe('describeIdleReconcilePark', () => {
     const out = describeIdleReconcilePark([{ branch: 'a', reason: 'worktree-locked' }], []);
     expect(out.reason).toBe('merged-branches-held-back');
     expect(out.notLaterThan).toBeNull();
+  });
+});
+
+describe('shutdown interruption (#6992)', () => {
+  afterEach(() => {
+    resetHostShutdownFlagForTests();
+    vi.restoreAllMocks();
+  });
+
+  it('keeps PR state unknown without reporting a cancellation as a forge error', async () => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+    git.getBranches.mockResolvedValue([
+      { name: 'claim/issue-1', isDefault: false, current: false, tracking: 'origin/claim/issue-1', merged: false }
+    ]);
+    wt.listWorktrees.mockResolvedValue([]);
+    execGh.mockRejectedValue(Object.assign(new Error('gh command cancelled by SIGTERM'), { name: 'AbortError', signal: 'SIGTERM' }));
+    git.hasBranchMergeEvidence.mockResolvedValue(false);
+    const inputs = await gatherBranchState('/repo', { defaultBranch: 'main' });
+    expect(inputs[0].prStateUnavailable).toBe(true);
+    expect(classifyBranches(inputs)[0].state).toBe('WIP');
+    expect(error).not.toHaveBeenCalled();
+  });
+
+  it('never treats interrupted partial remote output as an answered branch list', async () => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+    execGit.mockResolvedValue({ stdout: 'abc\trefs/heads/main', stderr: '', exitCode: null, signal: 'SIGTERM', terminated: true });
+    await expect(listRemoteHeads('/repo')).resolves.toBeNull();
+    expect(error).not.toHaveBeenCalled();
+    markHostShuttingDown();
+    execGit.mockRejectedValue(new Error('child gone'));
+    await expect(listRemoteHeads('/repo')).resolves.toBeNull();
+    expect(error).not.toHaveBeenCalled();
+  });
+
+  it('still reports unexpected signals outside shutdown with their signal name', async () => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+    execGit.mockResolvedValue({ stdout: '', stderr: '', exitCode: null, signal: 'SIGSEGV', terminated: true });
+    await expect(listRemoteHeads('/repo')).resolves.toBeNull();
+    expect(error).toHaveBeenCalledWith(expect.stringContaining('signal SIGSEGV'));
   });
 });

--- a/server/services/github.js
+++ b/server/services/github.js
@@ -162,7 +162,9 @@ export function execGh(args, timeoutMs = DEFAULT_EXEC_GH_TIMEOUT_MS, { cwd = nul
     child.on('close', (code, signal) => {
       if (timedOut || settled) return;
       clearTimeout(timer);
-      if (signal === 'SIGTERM' || isHostShuttingDown()) {
+      if (signal === 'SIGTERM' || (code !== 0 && isHostShuttingDown())) {
+        // PM2 may deliver SIGTERM to the child before the host latch is set.
+        // Other signals count as failures unless the host confirms shutdown.
         // Cancellation says nothing about forge health; preserve prior backoff.
         settle(null);
         reject(Object.assign(new Error(signal ? `gh command cancelled by ${signal}` : 'gh command cancelled during host shutdown'), {

--- a/server/services/github.js
+++ b/server/services/github.js
@@ -1,4 +1,5 @@
 import { spawn } from '../lib/childProcess.js';
+import { isHostShuttingDown } from '../lib/hostShutdown.js';
 import { join } from 'path';
 import { atomicWrite, readJSONFile, PATHS, ensureDir, safeJSONParse } from '../lib/fileUtils.js';
 import { withSpawnCwdEnv } from '../lib/spawnCwd.js';
@@ -146,7 +147,7 @@ export function execGh(args, timeoutMs = DEFAULT_EXEC_GH_TIMEOUT_MS, { cwd = nul
     const settle = (ok) => {
       if (settled) return;
       settled = true;
-      if (backoffKey !== null) recordGhCallOutcome(backoffKey, ok, backoffMaxMs);
+      if (backoffKey !== null && ok !== null) recordGhCallOutcome(backoffKey, ok, backoffMaxMs);
     };
     const timer = setTimeout(() => {
       timedOut = true;
@@ -158,12 +159,18 @@ export function execGh(args, timeoutMs = DEFAULT_EXEC_GH_TIMEOUT_MS, { cwd = nul
     }, timeoutMs);
     child.stdout.on('data', (d) => { stdout += d.toString(); });
     child.stderr.on('data', (d) => { stderr += d.toString(); });
-    child.on('close', (code) => {
-      if (timedOut) return;
+    child.on('close', (code, signal) => {
+      if (timedOut || settled) return;
       clearTimeout(timer);
-      if (code !== 0) {
+      if (signal === 'SIGTERM' || isHostShuttingDown()) {
+        // Cancellation says nothing about forge health; preserve prior backoff.
+        settle(null);
+        reject(Object.assign(new Error(signal ? `gh command cancelled by ${signal}` : 'gh command cancelled during host shutdown'), {
+          name: 'AbortError', signal, terminated: Boolean(signal)
+        }));
+      } else if (code !== 0) {
         settle(false);
-        const error = new Error(stderr.trim() || `gh exited with code ${code}`);
+        const error = new Error(stderr.trim() || `gh exited with ${signal ? `signal ${signal}` : `code ${code}`}`);
         error.ghExitCode = code;
         error.ghStderr = stderr.trim();
         reject(error);

--- a/server/services/github.test.js
+++ b/server/services/github.test.js
@@ -228,6 +228,18 @@ describe('execGh backoffKey', () => {
     expect(spawn).toHaveBeenCalledTimes(2);
   });
 
+  it('preserves a successful result completed during graceful shutdown', async () => {
+    const child = makeChild();
+    spawn.mockReturnValue(child);
+    const pending = execGh(['pr', 'list'], 5000, { backoffKey: 'finishing-repo' });
+    child.stdout.emit('data', '[]');
+    markHostShuttingDown();
+    child.emit('close', 0, null);
+    resetHostShutdownFlagForTests();
+    await expect(pending).resolves.toBe('[]');
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
   it('keeps unexpected signal failures visible and subject to backoff', async () => {
     const child = makeChild();
     spawn.mockReturnValue(child);

--- a/server/services/github.test.js
+++ b/server/services/github.test.js
@@ -32,6 +32,7 @@ vi.mock('./settings.js', () => {
 });
 
 import { spawn } from '../lib/childProcess.js';
+import { markHostShuttingDown, resetHostShutdownFlagForTests } from '../lib/hostShutdown.js';
 import {
   __resetGitHubDataCache,
   __resetGhCallBackoff,
@@ -203,6 +204,37 @@ describe('execGh backoffKey', () => {
     await expect(execGh(['pr', 'list'], 5000, { backoffKey: 'github.com/o/r' }))
       .rejects.toThrow(/backing off/);
     expect(spawn).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    [null, 'SIGTERM', false],
+    [null, 'SIGKILL', true],
+    [1, null, true]
+  ])('does not back off cancellation (code %s, signal %s, shutdown %s)', async (code, signal, shutdown) => {
+    const child = makeChild();
+    spawn.mockReturnValue(child);
+    const pending = execGh(['pr', 'list'], 5000, { backoffKey: 'cancelled-repo' });
+    if (shutdown) markHostShuttingDown();
+    child.emit('close', code, signal);
+    resetHostShutdownFlagForTests();
+    await expect(pending).rejects.toMatchObject({ name: 'AbortError' });
+    expect(vi.getTimerCount()).toBe(0);
+
+    const retryChild = makeChild();
+    spawn.mockReturnValue(retryChild);
+    const retry = execGh(['pr', 'list'], 5000, { backoffKey: 'cancelled-repo' });
+    retryChild.emit('close', 0);
+    await expect(retry).resolves.toBe('');
+    expect(spawn).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps unexpected signal failures visible and subject to backoff', async () => {
+    const child = makeChild();
+    spawn.mockReturnValue(child);
+    const pending = execGh(['pr', 'list'], 5000, { backoffKey: 'crashed-repo' });
+    child.emit('close', null, 'SIGSEGV');
+    await expect(pending).rejects.toThrow('signal SIGSEGV');
+    await expect(execGh(['pr', 'list'], 5000, { backoffKey: 'crashed-repo' })).rejects.toThrow('backing off');
   });
 
   it('spawns again once the backoff window elapses', async () => {


### PR DESCRIPTION
## Summary

Shutdown SIGTERM no longer counts as a GitHub CLI failure or starts forge backoff. Git signal exits retain termination metadata, and branch reconciliation keeps interrupted PR/remote state unknown without logging shutdown errors. Successful commands completing during graceful shutdown still succeed; genuine command failures, unexpected signals, and timeouts remain visible.

The import budget accounts for the measured 38 additional suite imports of the existing shutdown module, preserving its prior headroom.

Closes #6992

## Test plan

- 333 tests passed across execGit, github, github.ghHealth, branchReconcile, and importScoping.
- Added regressions for cancellation without backoff, signal metadata, partial remote output remaining unknown, unexpected signal diagnostics, and successful completion during shutdown.
- Claude review at medium effort completed; its successful-exit finding was fixed and regression-tested.
