### PR TITLE
fix: keep time-capsule snapshots working when index or twin files are corrupt

### DIFF
--- a/server/services/timeCapsule.js
+++ b/server/services/timeCapsule.js
@@ -5,28 +5,43 @@
  * Supports creating, listing, viewing, comparing, and deleting snapshots.
  */
 
-import { readFile, unlink, readdir, stat } from 'fs/promises';
-import { existsSync } from 'fs';
+import { unlink, readdir } from 'fs/promises';
 import { join } from 'path';
 import { createHash } from 'crypto';
 import { v4 as uuidv4 } from '../lib/uuid.js';
-import { atomicWrite, ensureDir, PATHS } from '../lib/fileUtils.js';
+import { atomicWrite, ensureDir, PATHS, readJSONFile, tryReadFile } from '../lib/fileUtils.js';
+import { createFileWriteQueue } from '../lib/fileWriteQueue.js';
 
 const DIGITAL_TWIN_DIR = PATHS.digitalTwin;
 const SNAPSHOTS_DIR = join(DIGITAL_TWIN_DIR, 'snapshots');
 const INDEX_FILE = join(SNAPSHOTS_DIR, 'index.json');
+const JSON_TWIN_FILES = [
+  'meta.json', 'identity.json', 'goals.json', 'taste-profile.json',
+  'feedback.json', 'genome.json', 'longevity.json', 'chronotype.json',
+];
+
+// One tail for every index.json read-modify-write so two snapshot creates or
+// deletes cannot load the same pre-image and clobber each other on save.
+const queueIndexWrite = createFileWriteQueue();
 
 async function ensureSnapshotsDir() {
   await ensureDir(SNAPSHOTS_DIR);
 }
 
-async function loadIndex() {
-  await ensureSnapshotsDir();
-  if (!existsSync(INDEX_FILE)) {
+function normalizeIndex(parsed) {
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
     return { snapshots: [] };
   }
-  const raw = await readFile(INDEX_FILE, 'utf-8');
-  return JSON.parse(raw);
+  return {
+    snapshots: Array.isArray(parsed.snapshots) ? parsed.snapshots : [],
+  };
+}
+
+async function loadIndex() {
+  await ensureSnapshotsDir();
+  // Missing, empty, or corrupt index recovers as empty rather than throwing —
+  // a truncated index.json used to disable every snapshot operation.
+  return normalizeIndex(await readJSONFile(INDEX_FILE, null));
 }
 
 async function saveIndex(index) {
@@ -39,32 +54,31 @@ async function saveIndex(index) {
  */
 async function collectTwinData() {
   const files = {};
-  const jsonFiles = ['meta.json', 'identity.json', 'goals.json', 'taste-profile.json',
-    'feedback.json', 'genome.json', 'longevity.json', 'chronotype.json'];
 
   // Read the fixed JSON set plus the autobiography stories concurrently — they
   // are independent files, so a sequential loop just serialized disk latency on
-  // snapshot creation.
+  // snapshot creation. Each file is optional: missing, unreadable, or malformed
+  // JSON is omitted so one bad twin file cannot abort the whole snapshot.
   const jsonTargets = [
-    ...jsonFiles.map(filename => ({ key: filename, path: join(DIGITAL_TWIN_DIR, filename) })),
+    ...JSON_TWIN_FILES.map(filename => ({ key: filename, path: join(DIGITAL_TWIN_DIR, filename) })),
     { key: 'autobiography/stories.json', path: join(DIGITAL_TWIN_DIR, 'autobiography', 'stories.json') }
   ];
   await Promise.all(jsonTargets.map(async ({ key, path }) => {
-    if (!existsSync(path)) return;
-    const content = await readFile(path, 'utf-8');
-    files[key] = JSON.parse(content);
+    const parsed = await readJSONFile(path, null);
+    if (parsed == null) return;
+    files[key] = parsed;
   }));
 
-  // Collect all markdown documents in parallel as well.
+  // Collect markdown documents in parallel. tryReadFile collapses the TOCTOU
+  // window of exists/stat-then-read (a vanished or non-file entry is skipped).
   const entries = await readdir(DIGITAL_TWIN_DIR).catch(() => []);
   const mdEntries = await Promise.all(
     entries
       .filter(entry => entry.endsWith('.md'))
       .map(async entry => {
-        const filePath = join(DIGITAL_TWIN_DIR, entry);
-        const info = await stat(filePath);
-        if (!info.isFile()) return null;
-        return { entry, content: await readFile(filePath, 'utf-8') };
+        const content = await tryReadFile(join(DIGITAL_TWIN_DIR, entry));
+        if (content == null) return null;
+        return { entry, content };
       })
   );
   const mdFiles = {};
@@ -126,13 +140,13 @@ export async function createSnapshot(label, description = '') {
   const snapshotFile = join(SNAPSHOTS_DIR, `${snapshot.id}.json`);
   await atomicWrite(snapshotFile, { ...snapshot, data });
 
-  // Update index
-  const index = await loadIndex();
-  index.snapshots.unshift(snapshot);
-  await saveIndex(index);
-
-  console.log(`📸 Time capsule created: "${label}" (${snapshot.id.slice(0, 8)})`);
-  return snapshot;
+  return queueIndexWrite(async () => {
+    const index = await loadIndex();
+    index.snapshots.unshift(snapshot);
+    await saveIndex(index);
+    console.log(`📸 Time capsule created: "${label}" (${snapshot.id.slice(0, 8)})`);
+    return snapshot;
+  });
 }
 
 /**
@@ -148,29 +162,27 @@ export async function listSnapshots() {
  */
 export async function getSnapshot(id) {
   const snapshotFile = join(SNAPSHOTS_DIR, `${id}.json`);
-  if (!existsSync(snapshotFile)) return null;
-  const raw = await readFile(snapshotFile, 'utf-8');
-  return JSON.parse(raw);
+  return readJSONFile(snapshotFile, null);
 }
 
 /**
  * Delete a snapshot
  */
 export async function deleteSnapshot(id) {
-  const index = await loadIndex();
-  const exists = index.snapshots.find(s => s.id === id);
-  if (!exists) return false;
+  return queueIndexWrite(async () => {
+    const index = await loadIndex();
+    const exists = index.snapshots.find(s => s.id === id);
+    if (!exists) return false;
 
-  const snapshotFile = join(SNAPSHOTS_DIR, `${id}.json`);
-  if (existsSync(snapshotFile)) {
-    await unlink(snapshotFile);
-  }
+    const snapshotFile = join(SNAPSHOTS_DIR, `${id}.json`);
+    await unlink(snapshotFile).catch(() => {});
 
-  index.snapshots = index.snapshots.filter(s => s.id !== id);
-  await saveIndex(index);
+    index.snapshots = index.snapshots.filter(s => s.id !== id);
+    await saveIndex(index);
 
-  console.log(`🗑️ Time capsule deleted: "${exists.label}" (${id.slice(0, 8)})`);
-  return true;
+    console.log(`🗑️ Time capsule deleted: "${exists.label}" (${id.slice(0, 8)})`);
+    return true;
+  });
 }
 
 /**

--- a/server/services/timeCapsule.js
+++ b/server/services/timeCapsule.js
@@ -9,7 +9,7 @@ import { unlink, readdir } from 'fs/promises';
 import { join } from 'path';
 import { createHash } from 'crypto';
 import { v4 as uuidv4 } from '../lib/uuid.js';
-import { atomicWrite, ensureDir, PATHS, readJSONFile, tryReadFile } from '../lib/fileUtils.js';
+import { atomicWrite, ensureDir, PATHS, readJSONFile, readJSONFileStrict, tryReadFile } from '../lib/fileUtils.js';
 import { createFileWriteQueue } from '../lib/fileWriteQueue.js';
 
 const DIGITAL_TWIN_DIR = PATHS.digitalTwin;
@@ -28,20 +28,43 @@ async function ensureSnapshotsDir() {
   await ensureDir(SNAPSHOTS_DIR);
 }
 
-function normalizeIndex(parsed) {
-  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
-    return { snapshots: [] };
+function indexEntryFromSnapshotFile(parsed) {
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed) || !parsed.id) return null;
+  const meta = { ...parsed };
+  delete meta.data;
+  return meta;
+}
+
+async function recoverIndexFromSnapshotFiles(reason) {
+  const entries = await readdir(SNAPSHOTS_DIR).catch(() => []);
+  const metas = await Promise.all(
+    entries
+      .filter(name => name.endsWith('.json') && name !== 'index.json')
+      .map(async name => indexEntryFromSnapshotFile(
+        await readJSONFile(join(SNAPSHOTS_DIR, name), null)
+      ))
+  );
+  const snapshots = metas
+    .filter(Boolean)
+    .sort((a, b) => String(b.createdAt || '').localeCompare(String(a.createdAt || '')));
+  if (reason || snapshots.length > 0) {
+    console.warn(`⚠️ Time-capsule index ${reason || 'missing'} — rebuilt listing of ${snapshots.length} snapshot file(s)`);
   }
-  return {
-    snapshots: Array.isArray(parsed.snapshots) ? parsed.snapshots : [],
-  };
+  return { snapshots };
+}
+
+function isUsableIndex(parsed) {
+  return parsed && typeof parsed === 'object' && !Array.isArray(parsed) && Array.isArray(parsed.snapshots);
 }
 
 async function loadIndex() {
   await ensureSnapshotsDir();
-  // Missing, empty, or corrupt index recovers as empty rather than throwing —
-  // a truncated index.json used to disable every snapshot operation.
-  return normalizeIndex(await readJSONFile(INDEX_FILE, null));
+  const { ok, value } = await readJSONFileStrict(INDEX_FILE, null);
+  if (ok && isUsableIndex(value)) return { snapshots: value.snapshots };
+  // Missing, empty, corrupt, or wrong-shaped index must not throw (that used
+  // to disable every snapshot op). Rebuild from on-disk snapshot files so a
+  // later save does not orphan listings that the bytes still hold.
+  return recoverIndexFromSnapshotFiles(ok ? (value == null ? null : 'malformed') : 'unreadable');
 }
 
 async function saveIndex(index) {
@@ -136,12 +159,13 @@ export async function createSnapshot(label, description = '') {
     summary: buildSummary(data)
   };
 
-  // Save snapshot data
-  const snapshotFile = join(SNAPSHOTS_DIR, `${snapshot.id}.json`);
-  await atomicWrite(snapshotFile, { ...snapshot, data });
-
   return queueIndexWrite(async () => {
+    // Load (and maybe rebuild) the index BEFORE writing this snapshot file so
+    // a recovery scan cannot pick up the file we are about to add, then
+    // unshift a duplicate of it.
     const index = await loadIndex();
+    const snapshotFile = join(SNAPSHOTS_DIR, `${snapshot.id}.json`);
+    await atomicWrite(snapshotFile, { ...snapshot, data });
     index.snapshots.unshift(snapshot);
     await saveIndex(index);
     console.log(`📸 Time capsule created: "${label}" (${snapshot.id.slice(0, 8)})`);

--- a/server/services/timeCapsule.test.js
+++ b/server/services/timeCapsule.test.js
@@ -1,0 +1,144 @@
+/**
+ * Time capsule snapshot store — corrupt/missing files must not crash ops (#7010).
+ */
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdirSync, rmSync, writeFileSync, existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { cleanupTempDataRoots, lazyTempDataRoot, makePathsProxy } from '../lib/mockPathsDataRoot.js';
+
+vi.mock('../lib/fileUtils.js', async (importOriginal) =>
+  makePathsProxy(await importOriginal(), { dataRoot: () => lazyTempDataRoot('portos-time-capsule-') }));
+
+const { PATHS } = await import('../lib/fileUtils.js');
+const {
+  listSnapshots,
+  createSnapshot,
+  getSnapshot,
+  deleteSnapshot,
+} = await import('./timeCapsule.js');
+
+const twinDir = () => PATHS.digitalTwin;
+const snapshotsDir = () => join(twinDir(), 'snapshots');
+const indexPath = () => join(snapshotsDir(), 'index.json');
+
+function resetTwinDir() {
+  rmSync(twinDir(), { recursive: true, force: true });
+  mkdirSync(twinDir(), { recursive: true });
+}
+
+function writeTwinJson(name, value) {
+  writeFileSync(join(twinDir(), name), typeof value === 'string' ? value : JSON.stringify(value));
+}
+
+function readIndex() {
+  return JSON.parse(readFileSync(indexPath(), 'utf-8'));
+}
+
+beforeAll(() => {
+  resetTwinDir();
+});
+
+beforeEach(() => {
+  resetTwinDir();
+});
+
+afterAll(() => cleanupTempDataRoots());
+
+describe('listSnapshots', () => {
+  it('returns an empty list when the index file is missing', async () => {
+    await expect(listSnapshots()).resolves.toEqual([]);
+  });
+
+  it('returns an empty list when the index file is empty', async () => {
+    mkdirSync(snapshotsDir(), { recursive: true });
+    writeFileSync(indexPath(), '');
+    await expect(listSnapshots()).resolves.toEqual([]);
+  });
+
+  it('returns an empty list when the index file is invalid JSON', async () => {
+    mkdirSync(snapshotsDir(), { recursive: true });
+    writeFileSync(indexPath(), '{not-json');
+    await expect(listSnapshots()).resolves.toEqual([]);
+  });
+
+  it('returns an empty list when snapshots is not an array', async () => {
+    mkdirSync(snapshotsDir(), { recursive: true });
+    writeFileSync(indexPath(), JSON.stringify({ snapshots: 'nope' }));
+    await expect(listSnapshots()).resolves.toEqual([]);
+  });
+});
+
+describe('createSnapshot', () => {
+  it('omits a malformed twin JSON file and still writes the snapshot', async () => {
+    writeTwinJson('identity.json', { name: 'Example Twin' });
+    writeTwinJson('goals.json', '{truncated');
+    writeTwinJson('notes.md', '# Notes');
+
+    const snapshot = await createSnapshot('baseline', 'first capture');
+
+    expect(snapshot.label).toBe('baseline');
+    expect(snapshot.summary.hasIdentity).toBe(true);
+    expect(snapshot.summary.goalsCount).toBe(0);
+    expect(snapshot.summary.markdownFiles).toBe(1);
+
+    const stored = await getSnapshot(snapshot.id);
+    expect(stored.data['identity.json']).toEqual({ name: 'Example Twin' });
+    expect(stored.data['goals.json']).toBeUndefined();
+    expect(stored.data.documents['notes.md']).toBe('# Notes');
+    expect(readIndex().snapshots).toHaveLength(1);
+  });
+
+  it('recovers from a corrupt index instead of crashing', async () => {
+    mkdirSync(snapshotsDir(), { recursive: true });
+    writeFileSync(indexPath(), '');
+    writeTwinJson('identity.json', { name: 'Example Twin' });
+
+    const snapshot = await createSnapshot('recovered');
+    expect(snapshot.id).toBeTruthy();
+    expect(readIndex().snapshots.map(s => s.id)).toEqual([snapshot.id]);
+  });
+
+  it('skips a markdown directory that would fail a TOCTOU stat-then-read', async () => {
+    mkdirSync(join(twinDir(), 'journal.md'), { recursive: true });
+    writeTwinJson('identity.json', { name: 'Example Twin' });
+
+    const snapshot = await createSnapshot('no-md-dir');
+    expect(snapshot.summary.markdownFiles).toBe(0);
+    expect((await getSnapshot(snapshot.id)).data.documents).toBeUndefined();
+  });
+
+  it('keeps both snapshots when two creates overlap', async () => {
+    writeTwinJson('identity.json', { name: 'Example Twin' });
+    const [a, b] = await Promise.all([
+      createSnapshot('one'),
+      createSnapshot('two'),
+    ]);
+    const listed = await listSnapshots();
+    expect(listed).toHaveLength(2);
+    expect(listed.map(s => s.id).sort()).toEqual([a.id, b.id].sort());
+  });
+});
+
+describe('getSnapshot / deleteSnapshot', () => {
+  it('returns null for a corrupt snapshot file instead of throwing', async () => {
+    mkdirSync(snapshotsDir(), { recursive: true });
+    writeFileSync(join(snapshotsDir(), 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee.json'), '{nope');
+    await expect(getSnapshot('aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee')).resolves.toBeNull();
+  });
+
+  it('deletes from a recovered empty index without throwing', async () => {
+    mkdirSync(snapshotsDir(), { recursive: true });
+    writeFileSync(indexPath(), '{truncated');
+    await expect(deleteSnapshot('aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee')).resolves.toBe(false);
+  });
+
+  it('removes a snapshot from the index and disk', async () => {
+    writeTwinJson('identity.json', { name: 'Example Twin' });
+    const snapshot = await createSnapshot('keep-me');
+    expect(existsSync(join(snapshotsDir(), `${snapshot.id}.json`))).toBe(true);
+
+    await expect(deleteSnapshot(snapshot.id)).resolves.toBe(true);
+    await expect(listSnapshots()).resolves.toEqual([]);
+    expect(existsSync(join(snapshotsDir(), `${snapshot.id}.json`))).toBe(false);
+  });
+});

--- a/server/services/timeCapsule.test.js
+++ b/server/services/timeCapsule.test.js
@@ -66,6 +66,25 @@ describe('listSnapshots', () => {
     writeFileSync(indexPath(), JSON.stringify({ snapshots: 'nope' }));
     await expect(listSnapshots()).resolves.toEqual([]);
   });
+
+  it('rebuilds the listing from on-disk snapshot files when the index is corrupt', async () => {
+    mkdirSync(snapshotsDir(), { recursive: true });
+    const kept = {
+      id: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+      label: 'kept',
+      createdAt: '2026-01-02T00:00:00.000Z',
+      data: { 'identity.json': { name: 'Example Twin' } },
+    };
+    writeFileSync(join(snapshotsDir(), `${kept.id}.json`), JSON.stringify(kept));
+    writeFileSync(indexPath(), '{truncated');
+
+    const listed = await listSnapshots();
+    expect(listed).toEqual([{
+      id: kept.id,
+      label: 'kept',
+      createdAt: kept.createdAt,
+    }]);
+  });
 });
 
 describe('createSnapshot', () => {
@@ -96,6 +115,22 @@ describe('createSnapshot', () => {
     const snapshot = await createSnapshot('recovered');
     expect(snapshot.id).toBeTruthy();
     expect(readIndex().snapshots.map(s => s.id)).toEqual([snapshot.id]);
+  });
+
+  it('keeps prior snapshot files in the index when creating after corruption', async () => {
+    mkdirSync(snapshotsDir(), { recursive: true });
+    const kept = {
+      id: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+      label: 'kept',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      data: { 'identity.json': { name: 'Example Twin' } },
+    };
+    writeFileSync(join(snapshotsDir(), `${kept.id}.json`), JSON.stringify(kept));
+    writeFileSync(indexPath(), '{truncated');
+    writeTwinJson('identity.json', { name: 'Example Twin' });
+
+    const snapshot = await createSnapshot('after-corrupt');
+    expect(readIndex().snapshots.map(s => s.id).sort()).toEqual([kept.id, snapshot.id].sort());
   });
 
   it('skips a markdown directory that would fail a TOCTOU stat-then-read', async () => {


### PR DESCRIPTION
## Summary

- Snapshot listing, create, and delete no longer throw on an empty or invalid `index.json`. A corrupt index is rebuilt from on-disk snapshot files so the next write cannot orphan existing capsules.
- Digital-twin JSON and markdown files that are missing, unreadable, or malformed are omitted from a new snapshot instead of aborting the whole operation.
- Index mutations go through a single-file write queue so overlapping creates cannot clobber each other.

Closes #7010

## Test plan

- [x] `cd server && npx vitest run services/timeCapsule.test.js` (13 tests)
- [ ] Empty `index.json` still lists snapshots (recovers as empty or from files)
- [ ] Invalid twin JSON is skipped; remaining files still land in the snapshot
- [ ] Two overlapping snapshot creates both appear in the index