### PR TITLE
fix: clarify peer removal confirmation (#7003)

### DIFF
--- a/client/src/components/ui/ConfirmButtonPair.jsx
+++ b/client/src/components/ui/ConfirmButtonPair.jsx
@@ -30,6 +30,8 @@ export default function ConfirmButtonPair({
   busyText,
   tone = 'error',
   ariaLabel,
+  confirmAriaLabel,
+  cancelAriaLabel,
   className = '',
   largeTouchTargets = false,
 }) {
@@ -53,6 +55,7 @@ export default function ConfirmButtonPair({
         type="button"
         onClick={onConfirm}
         disabled={busy}
+        aria-label={confirmAriaLabel}
         className={`inline-flex ${buttonSizeClass} items-center gap-1 px-2 py-1 text-xs rounded transition-colors disabled:opacity-50 ${confirmTone}`}
       >
         {busy ? (
@@ -66,6 +69,7 @@ export default function ConfirmButtonPair({
         type="button"
         onClick={onCancel}
         disabled={busy}
+        aria-label={cancelAriaLabel}
         className={`${buttonSizeClass} px-2 py-1 text-xs text-gray-400 hover:text-white transition-colors disabled:opacity-50`}
       >
         {cancelText}

--- a/client/src/components/ui/ConfirmButtonPair.test.jsx
+++ b/client/src/components/ui/ConfirmButtonPair.test.jsx
@@ -77,6 +77,17 @@ describe('ConfirmButtonPair', () => {
     expect(screen.getByRole('group', { name: 'Confirm deletion of My App' })).toBeTruthy();
   });
 
+  it('supports action-specific accessible labels', () => {
+    render(
+      <ConfirmButtonPair
+        confirmAriaLabel="Confirm removing Living Room"
+        cancelAriaLabel="Cancel removing Living Room"
+      />,
+    );
+    expect(screen.getByRole('button', { name: 'Confirm removing Living Room' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Cancel removing Living Room' })).toBeTruthy();
+  });
+
   it('merges passthrough className onto the container', () => {
     render(<ConfirmButtonPair ariaLabel="x" className="shrink-0" />);
     expect(screen.getByRole('group', { name: 'x' }).className).toContain('shrink-0');

--- a/client/src/pages/Instances.jsx
+++ b/client/src/pages/Instances.jsx
@@ -11,6 +11,7 @@ import {
 } from 'lucide-react';
 import toast from '../components/ui/Toast';
 import Pill from '../components/ui/Pill';
+import ConfirmButtonPair from '../components/ui/ConfirmButtonPair';
 import EmptyState from '../components/EmptyState';
 import socket from '../services/socket';
 import {
@@ -1157,7 +1158,7 @@ function ProbeDiagnostics({ peer, probing, onProbe }) {
   );
 }
 
-function PeerCard({ peer, onRefresh, syncStatus, tailnetInfo, parityReport }) {
+export function PeerCard({ peer, onRefresh, syncStatus, tailnetInfo, parityReport }) {
   const [editingName, setEditingName] = useState(false);
   const [name, setName] = useState('');
   const [probing, setProbing] = useState(false);
@@ -1260,6 +1261,7 @@ function PeerCard({ peer, onRefresh, syncStatus, tailnetInfo, parityReport }) {
 
   const StatusIcon = STATUS_ICONS[peer.status] || CircleDot;
   const isInboundOnly = peer.directions?.includes('inbound') && !peer.directions?.includes('outbound');
+  const peerLabel = peer.name || peer.address;
 
   const handleConnect = async () => {
     setConnecting(true);
@@ -1403,10 +1405,18 @@ function PeerCard({ peer, onRefresh, syncStatus, tailnetInfo, parityReport }) {
             {peer.enabled ? 'ON' : 'OFF'}
           </button>
           {confirmRemove ? (
-            <div className="flex items-center gap-1">
-              <button onClick={handleRemove} className="text-port-error hover:text-port-error/80 text-xs">Yes</button>
-              <button onClick={() => setConfirmRemove(false)} className="text-gray-500 hover:text-white text-xs">No</button>
-            </div>
+            <ConfirmButtonPair
+              prompt={`Remove peer "${peerLabel}"?`}
+              confirmText="Remove"
+              confirmIcon={Trash2}
+              cancelText="Cancel"
+              ariaLabel={`Confirm removing peer ${peerLabel}`}
+              confirmAriaLabel={`Confirm removing peer ${peerLabel}`}
+              cancelAriaLabel={`Cancel removing peer ${peerLabel}`}
+              largeTouchTargets
+              onConfirm={handleRemove}
+              onCancel={() => setConfirmRemove(false)}
+            />
           ) : (
             <button
               onClick={() => setConfirmRemove(true)}

--- a/client/src/pages/Instances.test.jsx
+++ b/client/src/pages/Instances.test.jsx
@@ -2,10 +2,10 @@ import { TailcatServeProvider } from '../components/instances/TailcatServeProvid
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render as renderUI, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import TailcatServePanel from '../components/instances/TailcatServePanel';
-import { AddPeerForm } from './Instances.jsx';
+import { AddPeerForm, PeerCard } from './Instances.jsx';
 import { DEFAULT_TAILCAT_REMOTE_PORT } from '../lib/ports.js';
 import { DEFAULT_PEER_PORT, DEFAULT_TAILCAT_LOCAL_PORT } from '../lib/ports.js';
-import { addPeer, addTailcatPeer, startTailcatServe, getTailcatServe, stopTailcatServe } from '../services/api';
+import { addPeer, addTailcatPeer, startTailcatServe, getTailcatServe, stopTailcatServe, removePeer, listPeerSubscriptions } from '../services/api';
 
 vi.mock('../services/api', () => ({
   getInstances: vi.fn(),
@@ -166,4 +166,40 @@ it('shares start and stop receipts between both serve controls', async () => {
   fireEvent.click(await screen.findByRole('button', { name: 'Stop' }));
   await waitFor(() => expect(screen.getAllByRole('button', { name: 'Start serve' })).toHaveLength(2));
   expect(screen.queryByRole('button', { name: 'Serve running' })).not.toBeInTheDocument();
+});
+
+describe('PeerCard removal confirmation', () => {
+  it('uses explicit, peer-specific confirmation actions', async () => {
+    const onRefresh = vi.fn();
+    removePeer.mockResolvedValue({ ok: true });
+    listPeerSubscriptions.mockResolvedValue({ subscriptions: [] });
+
+    render(
+      <PeerCard
+        peer={{
+          id: 'peer-1',
+          name: 'Living Room',
+          address: '192.0.2.10',
+          port: 5555,
+          status: 'offline',
+          enabled: true,
+          directions: [],
+          lastSeen: new Date().toISOString(),
+          consecutiveFailures: 0,
+        }}
+        onRefresh={onRefresh}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove peer' }));
+
+    expect(screen.queryByRole('button', { name: 'Yes' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'No' })).not.toBeInTheDocument();
+    expect(screen.getByText('Remove peer "Living Room"?')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Confirm removing peer Living Room' })).toHaveClass('text-port-error');
+    expect(screen.getByRole('button', { name: 'Cancel removing peer Living Room' })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm removing peer Living Room' }));
+    await waitFor(() => expect(removePeer).toHaveBeenCalledWith('peer-1'));
+  });
 });


### PR DESCRIPTION
## Summary
- Replace ambiguous peer removal Yes/No controls with the shared explicit confirmation pair.
- Show the peer name in the confirmation prompt and accessible action labels.
- Add rendered regression coverage for the Instances peer card and shared control labels.

## Tests
- `npm test -- --run src/components/ui/ConfirmButtonPair.test.jsx src/pages/Instances.test.jsx`
- `npm run lint`

Closes #7003