### PR TITLE
fix: correct stale navigation guidance (#7002)

### DIFF
--- a/client/src/components/GenericIngredientFields.jsx
+++ b/client/src/components/GenericIngredientFields.jsx
@@ -125,7 +125,7 @@ function GenericField({ field, payload, onChange }) {
  */
 export default function GenericIngredientFields({ fields = [], payload = {}, onChange }) {
   if (!Array.isArray(fields) || fields.length === 0) {
-    return <p className="text-sm text-gray-500">This type has no fields yet — add some in Settings → Catalog.</p>;
+    return <p className="text-sm text-gray-500">This type has no fields yet — add some in Create → Catalog (Catalog Types).</p>;
   }
   return (
     <div className="space-y-3">

--- a/client/src/components/GenericIngredientFields.test.jsx
+++ b/client/src/components/GenericIngredientFields.test.jsx
@@ -58,6 +58,6 @@ describe('GenericIngredientFields', () => {
 
   it('shows an empty-state hint when the type has no fields', () => {
     render(<GenericIngredientFields fields={[]} payload={{}} onChange={() => {}} />);
-    expect(screen.getByText(/no fields yet/i)).toBeTruthy();
+    expect(screen.getByText('This type has no fields yet — add some in Create → Catalog (Catalog Types).')).toBeTruthy();
   });
 });

--- a/client/src/pages/Pipeline.jsx
+++ b/client/src/pages/Pipeline.jsx
@@ -364,7 +364,7 @@ export default function Pipeline() {
                 {form.universeId
                   ? 'Logline / premise / style notes pulled from the universe — edit below.'
                   : universes.length === 0
-                    ? 'No universes yet. Build one in Media Gen → Universe Builder before creating a series.'
+                    ? 'No universes yet. Create one under Create → Universes before creating a series.'
                     : 'Series carry style + canon from their universe — pick one to continue.'}
               </p>
             </div>

--- a/client/src/pages/Pipeline.responsive.test.jsx
+++ b/client/src/pages/Pipeline.responsive.test.jsx
@@ -1,11 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
 import Pipeline from './Pipeline';
 
 const listPipelineSeries = vi.fn();
 const listUniverses = vi.fn();
 const listLooms = vi.fn();
+const listAuthors = vi.fn();
 
 vi.mock('../services/api', () => ({
   listPipelineSeries: (...a) => listPipelineSeries(...a),
@@ -15,6 +16,7 @@ vi.mock('../services/api', () => ({
   generateSeriesConcepts: vi.fn(),
   listUniverses: (...a) => listUniverses(...a),
   listLooms: (...a) => listLooms(...a),
+  listAuthors: (...a) => listAuthors(...a),
   WORLD_LOGLINE_MAX: 400,
   WORLD_PREMISE_MAX: 2000,
   WORLD_STYLE_NOTES_MAX: 2000,
@@ -53,6 +55,7 @@ describe('Pipeline series list — mobile layout', () => {
     listPipelineSeries.mockResolvedValue([SERIES]);
     listUniverses.mockResolvedValue([]);
     listLooms.mockResolvedValue([]);
+    listAuthors.mockResolvedValue([]);
   });
 
   it('stacks the row below sm so the logline gets the full card width', async () => {
@@ -73,5 +76,13 @@ describe('Pipeline series list — mobile layout', () => {
     expect(actions).toHaveClass('shrink-0');
     expect(actions).toHaveClass('flex-wrap');
     expect(actions.parentElement).toBe(row);
+  });
+
+  it('directs an empty series form to the Create universes page', async () => {
+    listPipelineSeries.mockResolvedValue([]);
+    renderPage();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'New Series' }));
+    expect(await screen.findByText('No universes yet. Create one under Create → Universes before creating a series.')).toBeTruthy();
   });
 });

--- a/client/src/pages/VideoGen.displaySleep.test.jsx
+++ b/client/src/pages/VideoGen.displaySleep.test.jsx
@@ -44,6 +44,7 @@ describe('VideoGen per-render display-sleep control', () => {
 
     const checkbox = await screen.findByLabelText(/Sleep display during this render/i);
     await waitFor(() => expect(checkbox).toBeChecked());
+    expect(screen.getByText(/default in Media Gen Settings \(gear icon or ⌘K "Media Gen Settings"\)/i)).toBeTruthy();
 
     expect(await submitAndGetDisplaySleep()).toBe('true');
   });

--- a/client/src/pages/VideoGen.jsx
+++ b/client/src/pages/VideoGen.jsx
@@ -1814,7 +1814,7 @@ export default function VideoGen() {
                 Sleep display during this render
                 <span className="block text-[11px] text-gray-500">
                   Reduces WindowServer GPU contention on affected Apple silicon. Change the install-wide
-                  default under Settings &rarr; Media Generation.
+                  default in Media Gen Settings (gear icon or ⌘K "Media Gen Settings").
                 </span>
               </span>
             </label>


### PR DESCRIPTION
## Summary
- Update Pipeline, VideoGen, and Catalog empty-state guidance to match current navigation.
- Add focused regression assertions for each corrected instruction.

## Tests
- `cd client && npm test`
- `cd client && npm run lint`

Closes #7002