### PR TITLE
fix: prevent stale GSD document responses from clobbering edits

### DIFF
--- a/client/src/components/gsd/GsdDocumentsPanel.jsx
+++ b/client/src/components/gsd/GsdDocumentsPanel.jsx
@@ -22,13 +22,29 @@ export default function GsdDocumentsPanel({ appId, selectedDoc, onSelectDoc }) {
   const [saving, setSaving] = useState(false);
 
   useEffect(() => {
-    if (!selectedDoc) return;
+    let cancelled = false;
+
     setEditing(false);
+    setContent(null);
+
+    if (!selectedDoc) {
+      setLoading(false);
+      return () => { cancelled = true; };
+    }
+
     setLoading(true);
     api.getGsdDocument(appId, selectedDoc)
-      .then(data => setContent(data?.content || null))
-      .catch(() => setContent(null))
-      .finally(() => setLoading(false));
+      .then(data => {
+        if (!cancelled) setContent(data?.content || null);
+      })
+      .catch(() => {
+        if (!cancelled) setContent(null);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => { cancelled = true; };
   }, [appId, selectedDoc]);
 
   const enterEditMode = () => {

--- a/client/src/components/gsd/GsdDocumentsPanel.test.jsx
+++ b/client/src/components/gsd/GsdDocumentsPanel.test.jsx
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+const api = vi.hoisted(() => ({
+  getGsdDocument: vi.fn(),
+  saveGsdDocument: vi.fn(),
+}));
+
+vi.mock('../../services/api', () => api);
+
+import GsdDocumentsPanel from './GsdDocumentsPanel';
+
+const flushMicrotasks = () => new Promise(resolve => setTimeout(resolve, 0));
+
+const renderPanel = (selectedDoc = 'PROJECT.md') => render(
+  <GsdDocumentsPanel
+    appId="example-app"
+    selectedDoc={selectedDoc}
+    onSelectDoc={vi.fn()}
+  />
+);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('GsdDocumentsPanel document loading', () => {
+  it('discards stale responses and loading state after switching documents', async () => {
+    let resolveProject;
+    let resolveRoadmap;
+    api.getGsdDocument.mockImplementation((_appId, document) => (
+      document === 'PROJECT.md'
+        ? new Promise(resolve => { resolveProject = resolve; })
+        : new Promise(resolve => { resolveRoadmap = resolve; })
+    ));
+
+    const { rerender } = renderPanel();
+    await waitFor(() => expect(api.getGsdDocument).toHaveBeenCalledWith('example-app', 'PROJECT.md'));
+
+    rerender(
+      <GsdDocumentsPanel
+        appId="example-app"
+        selectedDoc="ROADMAP.md"
+        onSelectDoc={vi.fn()}
+      />
+    );
+    await waitFor(() => expect(api.getGsdDocument).toHaveBeenCalledWith('example-app', 'ROADMAP.md'));
+
+    await act(async () => {
+      resolveProject({ content: 'Project body' });
+      await flushMicrotasks();
+    });
+    expect(screen.getByText('Loading document')).toBeInTheDocument();
+    expect(screen.queryByText('Project body')).not.toBeInTheDocument();
+
+    await act(async () => {
+      resolveRoadmap({ content: 'Roadmap body' });
+      await flushMicrotasks();
+    });
+    expect(screen.getByText('Roadmap body')).toBeInTheDocument();
+    expect(screen.queryByText('Project body')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /edit/i }));
+    expect(screen.getByRole('textbox', { name: 'Document content' })).toHaveValue('Roadmap body');
+  });
+
+  it('ignores an in-flight response after unmount', async () => {
+    let resolveDocument;
+    api.getGsdDocument.mockReturnValue(new Promise(resolve => { resolveDocument = resolve; }));
+
+    const { unmount } = renderPanel();
+    await waitFor(() => expect(api.getGsdDocument).toHaveBeenCalled());
+    unmount();
+
+    await act(async () => {
+      resolveDocument({ content: 'Unmounted body' });
+      await flushMicrotasks();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Ignore stale GSD document responses after a document or app selection changes.
- Clear document content before loading and guard loading completion during cleanup.
- Add async race, edit-content, and unmount regression coverage.

## Test plan
- npm test --prefix client -- --run src/components/gsd/GsdDocumentsPanel.test.jsx
- npm run lint --prefix client

Closes #6996