### PR TITLE
fix: cancel stale AgentDetail loads (#7000)

### DIFF
--- a/client/src/components/agents/AgentDetail.jsx
+++ b/client/src/components/agents/AgentDetail.jsx
@@ -13,6 +13,11 @@ import SchedulesTab from './tabs/SchedulesTab';
 import ActivityTab from './tabs/ActivityTab';
 
 export default function AgentDetail() {
+  const { agentId } = useParams();
+  return <AgentDetailContent key={agentId} />;
+}
+
+function AgentDetailContent() {
   const { agentId, tab } = useParams();
   const navigate = useNavigate();
   const activeTab = tab || 'overview';

--- a/client/src/components/agents/AgentDetail.jsx
+++ b/client/src/components/agents/AgentDetail.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { Link, useParams, useNavigate } from 'react-router';
 import { ArrowLeft } from 'lucide-react';
 import BrailleSpinner from '../BrailleSpinner';
@@ -21,9 +21,32 @@ export default function AgentDetail() {
   const [loading, setLoading] = useState(true);
   const [notFound, setNotFound] = useState(false);
   const [platformAccounts, setPlatformAccounts] = useState([]);
+  const mountedRef = useRef(false);
+  const latestAgentIdRef = useRef(agentId);
+  const agentRequestRef = useRef(0);
+  const platformRequestRef = useRef(0);
 
-  const fetchAgent = useCallback(async () => {
-    const data = await api.getAgentPersonality(agentId).catch(() => null);
+  latestAgentIdRef.current = agentId;
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const fetchAgent = useCallback(async (isCurrent = () => true) => {
+    const requestId = ++agentRequestRef.current;
+    const requestedAgentId = agentId;
+    const data = await api.getAgentPersonality(requestedAgentId).catch(() => null);
+    if (
+      !isCurrent() ||
+      !mountedRef.current ||
+      requestId !== agentRequestRef.current ||
+      latestAgentIdRef.current !== requestedAgentId
+    ) {
+      return;
+    }
     if (!data) {
       setNotFound(true);
       setLoading(false);
@@ -34,11 +57,35 @@ export default function AgentDetail() {
   }, [agentId]);
 
   useEffect(() => {
-    fetchAgent();
+    let cancelled = false;
+    setAgent(null);
+    setPlatformAccounts([]);
+    setLoading(true);
+    setNotFound(false);
+    fetchAgent(() => !cancelled);
+    return () => {
+      cancelled = true;
+    };
   }, [fetchAgent]);
 
   useEffect(() => {
-    api.getPlatformAccounts(agentId).then(setPlatformAccounts).catch(() => {});
+    let cancelled = false;
+    const requestId = ++platformRequestRef.current;
+    const requestedAgentId = agentId;
+    api.getPlatformAccounts(requestedAgentId).then(accounts => {
+      if (
+        cancelled ||
+        !mountedRef.current ||
+        requestId !== platformRequestRef.current ||
+        latestAgentIdRef.current !== requestedAgentId
+      ) {
+        return;
+      }
+      setPlatformAccounts(accounts);
+    }).catch(() => {});
+    return () => {
+      cancelled = true;
+    };
   }, [agentId]);
 
   const hasMoltbookAccount = useMemo(

--- a/client/src/components/agents/AgentDetail.test.jsx
+++ b/client/src/components/agents/AgentDetail.test.jsx
@@ -2,6 +2,7 @@ import { act, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { MemoryRouter, Route, Routes, useNavigate } from 'react-router';
 
+const mockOverviewRender = vi.fn();
 const mockAgentDeferreds = {};
 const mockPlatformDeferreds = {};
 
@@ -24,7 +25,10 @@ vi.mock('../BrailleSpinner', () => ({
   default: ({ text }) => <div role="status" aria-label={text}>{text}</div>,
 }));
 
-vi.mock('./tabs/OverviewTab', () => ({ default: () => null }));
+vi.mock('./tabs/OverviewTab', () => ({ default: props => {
+  mockOverviewRender(props);
+  return null;
+} }));
 vi.mock('./tabs/ToolsTab', () => ({ default: () => null }));
 vi.mock('./tabs/WorldTab', () => ({ default: () => null }));
 vi.mock('./tabs/PublishedTab', () => ({ default: () => null }));
@@ -103,6 +107,7 @@ describe('AgentDetail route lifecycle', () => {
     await act(async () => {
       screen.getByText('go-b').click();
     });
+    expect(mockOverviewRender.mock.calls.every(([props]) => props.agentId === props.agent.id)).toBe(true);
     expect(screen.queryByText('Agent Alpha')).not.toBeInTheDocument();
     expect(screen.getByRole('status', { name: 'Loading agent' })).toBeInTheDocument();
 
@@ -116,5 +121,26 @@ describe('AgentDetail route lifecycle', () => {
       screen.getByRole('button', { name: 'Enabled' }).click();
     });
     expect(api.toggleAgentPersonality).toHaveBeenCalledWith('agent-b', false);
+  });
+
+  it('keeps the new agent load active when an old toggle completes', async () => {
+    renderAgentDetail();
+    await act(async () => {
+      mockAgentDeferreds['agent-a'].resolve({ id: 'agent-a', name: 'Agent Alpha', enabled: true });
+      mockPlatformDeferreds['agent-a'].resolve([]);
+    });
+    let completeToggle;
+    api.toggleAgentPersonality.mockImplementationOnce(() => new Promise(resolve => {
+      completeToggle = resolve;
+    }));
+    await act(async () => { screen.getByRole('button', { name: 'Enabled' }).click(); });
+    await act(async () => { screen.getByText('go-b').click(); });
+    await act(async () => { completeToggle(); });
+    await act(async () => {
+      mockAgentDeferreds['agent-b'].resolve({ id: 'agent-b', name: 'Agent Beta', enabled: true });
+      mockPlatformDeferreds['agent-b'].resolve([]);
+    });
+    expect(screen.getByText('Agent Beta')).toBeInTheDocument();
+    expect(screen.queryByRole('status', { name: 'Loading agent' })).not.toBeInTheDocument();
   });
 });

--- a/client/src/components/agents/AgentDetail.test.jsx
+++ b/client/src/components/agents/AgentDetail.test.jsx
@@ -1,0 +1,120 @@
+import { act, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MemoryRouter, Route, Routes, useNavigate } from 'react-router';
+
+const mockAgentDeferreds = {};
+const mockPlatformDeferreds = {};
+
+function makeDeferred(registry, id) {
+  let resolve;
+  const promise = new Promise(resolution => {
+    resolve = resolution;
+  });
+  registry[id] = { promise, resolve };
+  return promise;
+}
+
+vi.mock('../../services/api', () => ({
+  getAgentPersonality: vi.fn(id => makeDeferred(mockAgentDeferreds, id)),
+  getPlatformAccounts: vi.fn(id => makeDeferred(mockPlatformDeferreds, id)),
+  toggleAgentPersonality: vi.fn(),
+}));
+
+vi.mock('../BrailleSpinner', () => ({
+  default: ({ text }) => <div role="status" aria-label={text}>{text}</div>,
+}));
+
+vi.mock('./tabs/OverviewTab', () => ({ default: () => null }));
+vi.mock('./tabs/ToolsTab', () => ({ default: () => null }));
+vi.mock('./tabs/WorldTab', () => ({ default: () => null }));
+vi.mock('./tabs/PublishedTab', () => ({ default: () => null }));
+vi.mock('./tabs/SchedulesTab', () => ({ default: () => null }));
+vi.mock('./tabs/ActivityTab', () => ({ default: () => null }));
+
+import * as api from '../../services/api';
+import AgentDetail from './AgentDetail';
+
+function Harness() {
+  const navigate = useNavigate();
+  return (
+    <>
+      <button onClick={() => navigate('/agents/agent-b/overview')}>go-b</button>
+      <Routes>
+        <Route path="/agents/:agentId/:tab" element={<AgentDetail />} />
+      </Routes>
+    </>
+  );
+}
+
+function renderAgentDetail() {
+  return render(
+    <MemoryRouter initialEntries={['/agents/agent-a/overview']}>
+      <Harness />
+    </MemoryRouter>,
+  );
+}
+
+describe('AgentDetail route lifecycle', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.keys(mockAgentDeferreds).forEach(id => delete mockAgentDeferreds[id]);
+    Object.keys(mockPlatformDeferreds).forEach(id => delete mockPlatformDeferreds[id]);
+  });
+
+  it('ignores personality and platform responses from a previous agent', async () => {
+    renderAgentDetail();
+
+    await act(async () => {
+      screen.getByText('go-b').click();
+    });
+    await waitFor(() => {
+      expect(api.getAgentPersonality).toHaveBeenLastCalledWith('agent-b');
+      expect(api.getPlatformAccounts).toHaveBeenLastCalledWith('agent-b');
+    });
+
+    await act(async () => {
+      mockAgentDeferreds['agent-b'].resolve({ id: 'agent-b', name: 'Agent Beta', enabled: true });
+      mockPlatformDeferreds['agent-b'].resolve([{ platform: 'moltworld' }]);
+    });
+    await waitFor(() => expect(screen.getByText('Agent Beta')).toBeInTheDocument());
+    expect(screen.getByRole('button', { name: /World/ })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Moltbook/ })).not.toBeInTheDocument();
+
+    await act(async () => {
+      mockAgentDeferreds['agent-a'].resolve({ id: 'agent-a', name: 'Agent Alpha', enabled: true });
+      mockPlatformDeferreds['agent-a'].resolve([{ platform: 'moltbook' }]);
+    });
+
+    expect(screen.getByText('Agent Beta')).toBeInTheDocument();
+    expect(screen.queryByText('Agent Alpha')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /World/ })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Moltbook/ })).not.toBeInTheDocument();
+  });
+
+  it('clears the old agent before loading the next route and toggles the active agent', async () => {
+    renderAgentDetail();
+
+    await act(async () => {
+      mockAgentDeferreds['agent-a'].resolve({ id: 'agent-a', name: 'Agent Alpha', enabled: true });
+      mockPlatformDeferreds['agent-a'].resolve([]);
+    });
+    await waitFor(() => expect(screen.getByText('Agent Alpha')).toBeInTheDocument());
+
+    await act(async () => {
+      screen.getByText('go-b').click();
+    });
+    expect(screen.queryByText('Agent Alpha')).not.toBeInTheDocument();
+    expect(screen.getByRole('status', { name: 'Loading agent' })).toBeInTheDocument();
+
+    await act(async () => {
+      mockAgentDeferreds['agent-b'].resolve({ id: 'agent-b', name: 'Agent Beta', enabled: true });
+      mockPlatformDeferreds['agent-b'].resolve([]);
+    });
+    await waitFor(() => expect(screen.getByText('Agent Beta')).toBeInTheDocument());
+
+    await act(async () => {
+      screen.getByRole('button', { name: 'Enabled' }).click();
+    });
+    expect(api.toggleAgentPersonality).toHaveBeenCalledWith('agent-b', false);
+  });
+});


### PR DESCRIPTION
## Summary
- Cancel stale personality and platform-account updates when the AgentDetail route changes.
- Clear the previous agent and account state during transitions so tabs and actions stay scoped to the URL agent.
- Add regression coverage for out-of-order responses, transition clearing, and active-agent toggling.

## Test plan
- `npm test -- --run src/components/agents/AgentDetail.test.jsx`
- `node_modules/.bin/biome lint --error-on-warnings src/components/agents/AgentDetail.jsx src/components/agents/AgentDetail.test.jsx`
- Full client suite: 933 files passed; one unrelated `a11yConventions.test.js` case timed out while probing unavailable `localhost:3000`.

Closes #7000