### PR TITLE
fix: guard Media3DDetail route races

### DIFF
--- a/client/src/pages/Media3DDetail.jsx
+++ b/client/src/pages/Media3DDetail.jsx
@@ -49,15 +49,36 @@ export default function Media3DDetail() {
   const [normalMap, setNormalMap] = useState(false);
   const [subjectScale, setSubjectScale] = useState(SUBJECT_SCALE_DEFAULT);
   const optionsSeededFor = useRef(null);
+  const routeIdRef = useRef(id);
+  const routeGenerationRef = useRef(0);
+  // Invalidate an older request during render so it cannot win between the
+  // route commit and the passive effect that starts the replacement request.
+  if (routeIdRef.current !== id) {
+    routeIdRef.current = id;
+    routeGenerationRef.current += 1;
+  }
+  const routeGeneration = routeGenerationRef.current;
+  const updateRecordForRoute = useCallback((next) => {
+    if (!next || !mountedRef.current || routeIdRef.current !== id
+      || routeGenerationRef.current !== routeGeneration || String(next.id) !== id) return;
+    setRecord(next);
+  }, [id, mountedRef, routeGeneration]);
 
   const load = useCallback(async ({ initial = false } = {}) => {
+    const requestedId = id;
+    const requestedGeneration = routeGenerationRef.current;
+    const isCurrentRoute = () => mountedRef.current
+      && routeIdRef.current === requestedId
+      && routeGenerationRef.current === requestedGeneration;
     const next = await getImageTo3dModel(id, { silent: true }).catch((err) => {
-      if (err?.status === 404) { if (mountedRef.current) setNotFound(true); }
-      else if (initial) toast.error(err?.message || 'Failed to load 3D model');
+      if (err?.status === 404) { if (isCurrentRoute()) setNotFound(true); }
+      else if (initial && isCurrentRoute()) toast.error(err?.message || 'Failed to load 3D model');
       return null;
     });
-    if (next && mountedRef.current) { setRecord(next); setNotFound(false); }
-    if (initial && mountedRef.current) setLoading(false);
+    if (next && isCurrentRoute() && String(next.id) === requestedId) {
+      setRecord(next); setNotFound(false);
+    }
+    if (initial && isCurrentRoute()) setLoading(false);
     return next;
   }, [id, mountedRef]);
 
@@ -66,6 +87,12 @@ export default function Media3DDetail() {
   // the previous record's content (and doesn't carry a stale not-found flag).
   useEffect(() => {
     setLoading(true); setNotFound(false);
+    setRecord(null);
+    setBusy(false); setConfirmingDelete(false);
+    optionsSeededFor.current = null;
+    setSteps(''); setSeed(''); setKeyBackground(false); setDetail('auto');
+    setAlphaMode(''); setNormalMap(false); setSubjectScale(SUBJECT_SCALE_DEFAULT);
+    setLoadedScene(null);
     load({ initial: true });
   }, [load]);
 
@@ -81,8 +108,8 @@ export default function Media3DDetail() {
 
   // Seed the option fields from the latest run once per id.
   useEffect(() => {
-    if (!record || optionsSeededFor.current === record.id) return;
-    optionsSeededFor.current = record.id;
+    if (!record || String(record.id) !== id || optionsSeededFor.current === id) return;
+    optionsSeededFor.current = id;
     const fields = fieldsFromRun(record.runs?.at?.(-1));
     setSteps(fields.steps);
     setSeed(fields.seed);
@@ -91,33 +118,46 @@ export default function Media3DDetail() {
     setAlphaMode(fields.alphaMode);
     setNormalMap(fields.normalMap);
     setSubjectScale(fields.subjectScale);
-  }, [record]);
+  }, [id, record]);
 
   const handleRegenerate = useCallback(async () => {
     if (busy || record?.status === 'generating') return;
+    const requestedId = id;
+    const requestedGeneration = routeGenerationRef.current;
+    const isCurrentRoute = () => mountedRef.current
+      && routeIdRef.current === requestedId
+      && routeGenerationRef.current === requestedGeneration;
     setBusy(true);
     const next = await generateImageTo3dModel(
-      id,
+      requestedId,
       renderOptionsBody({ steps, seed, keyBackground, detail, alphaMode, normalMap, subjectScale }),
       { silent: true },
     ).catch((err) => {
-      toast.error(err?.message || 'Could not start the render.');
+      if (isCurrentRoute()) toast.error(err?.message || 'Could not start the render.');
       return null;
     });
-    if (mountedRef.current) setBusy(false);
-    if (next && mountedRef.current) setRecord(next);
+    if (isCurrentRoute()) {
+      setBusy(false);
+      if (next && String(next.id) === requestedId) setRecord(next);
+    }
   }, [busy, record?.status, id, steps, seed, keyBackground, detail, alphaMode, normalMap,
     subjectScale, mountedRef]);
 
   const handleDelete = useCallback(async () => {
-    const ok = await deleteImageTo3dModel(id, { silent: true }).then(() => true).catch((err) => {
-      toast.error(err?.message || 'Delete failed');
+    const requestedId = id;
+    const requestedGeneration = routeGenerationRef.current;
+    const isCurrentRoute = () => mountedRef.current
+      && routeIdRef.current === requestedId
+      && routeGenerationRef.current === requestedGeneration;
+    const ok = await deleteImageTo3dModel(requestedId, { silent: true }).then(() => true).catch((err) => {
+      if (isCurrentRoute()) toast.error(err?.message || 'Delete failed');
       return false;
     });
-    if (ok) navigate('/3d');
-  }, [id, navigate]);
+    if (ok && isCurrentRoute()) navigate('/3d');
+  }, [id, navigate, mountedRef]);
 
-  if (loading) {
+  const recordMatchesRoute = record && String(record.id) === id;
+  if (loading || (record && !recordMatchesRoute)) {
     return (
       <div className="mx-auto max-w-4xl">
         <PageSkeleton
@@ -286,9 +326,9 @@ export default function Media3DDetail() {
         </div>
       </section>
 
-      <ArExportPanel record={record} scene={loadedScene} onRecordChange={setRecord} />
+      <ArExportPanel record={record} scene={loadedScene} onRecordChange={updateRecordForRoute} />
 
-      <RigPanel record={record} onRecordChange={setRecord} />
+      <RigPanel record={record} onRecordChange={updateRecordForRoute} />
     </div>
   );
 }

--- a/client/src/pages/Media3DDetail.test.jsx
+++ b/client/src/pages/Media3DDetail.test.jsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
-import { MemoryRouter, Routes, Route } from 'react-router';
+import { MemoryRouter, Routes, Route, useNavigate } from 'react-router';
 import Media3DDetail from './Media3DDetail';
 
 const getImageTo3dModel = vi.fn();
@@ -30,7 +30,17 @@ vi.mock('../components/media/GlbViewer', () => ({
 // stubbing it keeps this suite about the page — but it echoes whether the scene
 // reached it, which is the page's half of the contract.
 vi.mock('../components/media/ArExportPanel', () => ({
-  default: ({ scene }) => <div data-testid="ar-export-panel" data-has-scene={String(Boolean(scene))} />,
+  default: ({ scene, onRecordChange }) => {
+    const initialOnRecordChange = useRef(onRecordChange);
+    return (
+      <>
+        <div data-testid="ar-export-panel" data-has-scene={String(Boolean(scene))} />
+        <button type="button" onClick={() => initialOnRecordChange.current?.({ id: 'image3d-1', name: 'Stale AR update' })}>
+          Simulate stale AR update
+        </button>
+      </>
+    );
+  },
 }));
 vi.mock('../components/MediaImage', () => ({ default: ({ alt, src }) => <img alt={alt} src={src} /> }));
 // The rig panel owns its own readiness fetch + feature gate (covered by
@@ -59,6 +69,37 @@ function renderAt(id = 'image3d-1') {
       </Routes>
     </MemoryRouter>,
   );
+}
+
+function RouteSwitcher() {
+  const navigate = useNavigate();
+  return (
+    <>
+      <button type="button" onClick={() => navigate('/3d/image3d-2')}>Switch model</button>
+      <Media3DDetail />
+    </>
+  );
+}
+
+function renderWithSwitcher(id = 'image3d-1') {
+  return render(
+    <MemoryRouter initialEntries={[`/3d/${id}`]}>
+      <Routes>
+        <Route path="/3d" element={<div>3D index</div>} />
+        <Route path="/3d/:id" element={<RouteSwitcher />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+function deferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
 }
 
 describe('Media3DDetail', () => {
@@ -93,6 +134,74 @@ describe('Media3DDetail', () => {
     getImageTo3dModel.mockRejectedValue(Object.assign(new Error('nope'), { status: 404 }));
     renderAt('gone');
     expect(await screen.findByText(/no longer exists/i)).toBeInTheDocument();
+  });
+
+  it('ignores a slower response from the previous routed model', async () => {
+    const first = deferred();
+    const second = deferred();
+    getImageTo3dModel.mockImplementation((id) => (id === 'image3d-1' ? first.promise : second.promise));
+    renderWithSwitcher();
+
+    await waitFor(() => expect(getImageTo3dModel).toHaveBeenCalledWith('image3d-1', { silent: true }));
+    fireEvent.click(screen.getByRole('button', { name: /switch model/i }));
+    await waitFor(() => expect(getImageTo3dModel).toHaveBeenCalledWith('image3d-2', { silent: true }));
+
+    second.resolve(record({ id: 'image3d-2', name: 'Second Beacon' }));
+    expect(await screen.findByText('Second Beacon')).toBeInTheDocument();
+    first.resolve(record({ id: 'image3d-1', name: 'First Beacon' }));
+
+    await waitFor(() => expect(screen.getByText('Second Beacon')).toBeInTheDocument());
+    expect(screen.queryByText('First Beacon')).toBeNull();
+  });
+
+  it('does not let a previous route 404 the newly selected model', async () => {
+    const first = deferred();
+    const second = deferred();
+    getImageTo3dModel.mockImplementation((id) => (id === 'image3d-1' ? first.promise : second.promise));
+    renderWithSwitcher();
+
+    await waitFor(() => expect(getImageTo3dModel).toHaveBeenCalledWith('image3d-1', { silent: true }));
+    fireEvent.click(screen.getByRole('button', { name: /switch model/i }));
+    await waitFor(() => expect(getImageTo3dModel).toHaveBeenCalledWith('image3d-2', { silent: true }));
+
+    second.resolve(record({ id: 'image3d-2', name: 'Second Beacon' }));
+    expect(await screen.findByText('Second Beacon')).toBeInTheDocument();
+    first.reject(Object.assign(new Error('gone'), { status: 404 }));
+
+    await waitFor(() => expect(screen.getByText('Second Beacon')).toBeInTheDocument());
+    expect(screen.queryByText(/no longer exists/i)).toBeNull();
+  });
+
+  it('ignores async panel updates started for the previous routed model', async () => {
+    getImageTo3dModel.mockImplementation((id) => Promise.resolve(record({
+      id,
+      name: id === 'image3d-1' ? 'First Beacon' : 'Second Beacon',
+    })));
+    renderWithSwitcher();
+
+    expect(await screen.findByText('First Beacon')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /switch model/i }));
+    expect(await screen.findByText('Second Beacon')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /simulate stale ar update/i }));
+
+    expect(screen.getByText('Second Beacon')).toBeInTheDocument();
+    expect(screen.queryByText('Stale AR update')).toBeNull();
+  });
+
+  it('clears and reseeds render options for the active routed model', async () => {
+    getImageTo3dModel.mockImplementation((id) => Promise.resolve(record({
+      id,
+      name: id === 'image3d-1' ? 'First Beacon' : 'Second Beacon',
+      runs: [{ steps: id === 'image3d-1' ? 48 : 24 }],
+    })));
+    renderWithSwitcher();
+
+    expect(await screen.findByText('First Beacon')).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByLabelText(/quality/i)).toHaveValue('48'));
+    fireEvent.click(screen.getByRole('button', { name: /switch model/i }));
+
+    expect(await screen.findByText('Second Beacon')).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByLabelText(/quality/i)).toHaveValue('24'));
   });
 
   it('deletes and navigates back to the index', async () => {


### PR DESCRIPTION
## Summary
- invalidate in-flight detail loads when the routed model ID changes
- reset and reseed render options only for the active model
- guard async regenerate, delete, AR export, and rigging updates from stale routes

## Tests
- npm test --prefix client -- --run src/pages/Media3DDetail.test.jsx
- npm run lint --prefix client
- npm run build --prefix client
- Full client suite was not usable in this isolated worktree because unrelated accessibility checks require an unavailable localhost:3000 service.

Closes #6999