### PR TITLE
feat: allow scheduled claims to leave PRs open for review

### DIFF
--- a/client/src/components/cos/tabs/schedule/AppOverrideRow.jsx
+++ b/client/src/components/cos/tabs/schedule/AppOverrideRow.jsx
@@ -25,6 +25,7 @@ const AppOverrideRow = memo(function AppOverrideRow({ app, taskType, globalInter
   const hasCron = isCronExpression(currentInterval);
   // Same effective-value rule the AGENT_OPTIONS buttons use: this app's override
   // wins, else the global config. No PR, nothing to decide about one.
+  const claimFlow = !!globalTaskMetadata?.claimFlow || ISSUE_AUTHOR_FILTER_TASK_TYPES.has(taskType);
   const opensPR = (override?.taskMetadata?.openPR ?? globalTaskMetadata?.openPR) === true;
 
   // A per-app provider/model pin OUTRANKS the task's own provider pin at spawn,
@@ -228,7 +229,7 @@ const AppOverrideRow = memo(function AppOverrideRow({ app, taskType, globalInter
           />
         </div>
 
-        {opensPR && (
+        {(opensPR || claimFlow) && (
           <select
             value={pinnedPrCompletion(override?.taskMetadata)}
             onChange={(e) => handleOverrideChange('prCompletion', e.target.value)}
@@ -237,8 +238,8 @@ const AppOverrideRow = memo(function AppOverrideRow({ app, taskType, globalInter
             title="What happens to the PR this app's runs open"
             className="bg-port-card border border-port-border rounded px-2 py-1.5 text-xs text-white min-w-[120px] min-h-[40px]"
           >
-            <option value="">Inherit ({prCompletionOption(pinnedPrCompletion(globalTaskMetadata))?.label || 'app default'})</option>
-            {PR_COMPLETION_OPTIONS.map(opt => (
+            <option value="">Inherit ({prCompletionOption(pinnedPrCompletion(globalTaskMetadata))?.label || (claimFlow ? 'Automatic merge after reviews and CI' : 'app default')})</option>
+            {PR_COMPLETION_OPTIONS.filter(opt => !claimFlow || opt.value !== 'merge-on-green').map(opt => (
               <option key={opt.value} value={opt.value}>{opt.label}</option>
             ))}
           </select>

--- a/client/src/components/cos/tabs/schedule/AppOverrideRow.test.jsx
+++ b/client/src/components/cos/tabs/schedule/AppOverrideRow.test.jsx
@@ -305,3 +305,10 @@ describe('AppOverrideRow — enabled toggle', () => {
     expect(onUpdate).toHaveBeenCalledWith('app-1', 'feature-ideas', { enabled: true, interval: 'on-demand' });
   });
 });
+
+it('allows an app to override the claim PR handoff policy', async () => {
+   const onUpdate = renderRow({ taskType: 'claim-issue', globalTaskMetadata: { claimFlow: true, openPR: false, prCompletion: 'leave-open' } });
+   expect(screen.getByRole('option', { name: 'Inherit (Leave PR open)' })).toBeInTheDocument();
+   await act(async () => { fireEvent.change(prSelect(), { target: { value: 'review-then-merge' } }); });
+   expect(onUpdate).toHaveBeenCalledWith(APP.id, 'claim-issue', expect.objectContaining({ taskMetadata: { prCompletion: 'review-then-merge' } }));
+});

--- a/client/src/components/cos/tabs/schedule/GlobalConfigControls.jsx
+++ b/client/src/components/cos/tabs/schedule/GlobalConfigControls.jsx
@@ -217,6 +217,7 @@ export default function GlobalConfigControls({ taskType, config, onUpdate, onTri
     setUpdating(false);
   };
 
+  const claimFlow = !!config.taskMetadata?.claimFlow || ISSUE_AUTHOR_FILTER_TASK_TYPES.has(taskType);
   const prCompletion = pinnedPrCompletion(config.taskMetadata);
   // Reviewers only run under review-then-merge, so the picker hides for the two
   // policies that never reach them — but an unpinned ('') task may still inherit
@@ -228,7 +229,7 @@ export default function GlobalConfigControls({ taskType, config, onUpdate, onTri
   // Without this the picker — and the "Use system Code Review Defaults" reset
   // beside it — never render for claim-work, leaving a reviewer override that
   // every claim obeys with no control anywhere that can clear it.
-  const reviewersApply = config.taskMetadata?.claimFlow
+  const reviewersApply = claimFlow
     ? true
     : config.taskMetadata?.openPR
       ? prCompletion === '' || prCompletion === 'review-then-merge'
@@ -647,7 +648,7 @@ export default function GlobalConfigControls({ taskType, config, onUpdate, onTri
             );
           })}
         </div>
-        {config.taskMetadata?.openPR && (
+        {(config.taskMetadata?.openPR || claimFlow) && (
           <FormField label="After opening PR" className="mt-3" labelClassName="text-sm text-gray-400 block mb-2">
             <select
               value={prCompletion}
@@ -655,13 +656,13 @@ export default function GlobalConfigControls({ taskType, config, onUpdate, onTri
               disabled={updating}
               className="w-full bg-port-card border border-port-border rounded px-3 py-2 text-white text-sm"
             >
-              <option value="">App default</option>
-              {PR_COMPLETION_OPTIONS.map(option => (
+              <option value="">{claimFlow ? 'Automatic merge after reviews and CI (default)' : 'App default'}</option>
+              {PR_COMPLETION_OPTIONS.filter(option => !claimFlow || option.value !== 'merge-on-green').map(option => (
                 <option key={option.value} value={option.value}>{option.label}</option>
               ))}
             </select>
             <p className="text-xs text-gray-500 mt-1">
-              {prCompletionOption(prCompletion)?.description || PR_COMPLETION_INHERIT_HINT}
+              {claimFlow ? 'Configured reviews and CI still run. Leave open hands the PR to you for further review without merging or closing the issue.' : prCompletionOption(prCompletion)?.description || PR_COMPLETION_INHERIT_HINT}
             </p>
           </FormField>
         )}

--- a/client/src/components/cos/tabs/schedule/GlobalConfigControls.test.jsx
+++ b/client/src/components/cos/tabs/schedule/GlobalConfigControls.test.jsx
@@ -348,3 +348,12 @@ describe('GlobalConfigControls — external issue isolation', () => {
     expect(onUpdate).toHaveBeenCalledWith('issue-watcher', { providerId: null, model: null, effort: null });
   });
 });
+
+it('persists leave-open for claim-issue while keeping configured reviews available', () => {
+   const taskMetadata = { useWorktree: false, openPR: false, claimFlow: true };
+   const onUpdate = renderControls({ taskType: 'claim-issue', taskMetadata });
+   expect(prSelect()).toHaveValue('');
+   fireEvent.change(prSelect(), { target: { value: 'leave-open' } });
+   expect(onUpdate).toHaveBeenCalledWith('claim-issue', { taskMetadata: { ...taskMetadata, prCompletion: 'leave-open' } });
+   expect(screen.getByTestId('reviewer-picker')).toBeInTheDocument();
+});

--- a/server/services/agentPromptBuilder.js
+++ b/server/services/agentPromptBuilder.js
@@ -604,6 +604,7 @@ ${buildResumeSection(task, worktreeInfo)}` : '';
     [COMPLETION_MODES.DISCARD_WORKTREE]: () => buildProgrammaticOutputCompletionSection(sentinelPath),
     [COMPLETION_MODES.CLAIM_FLOW]: () => buildClaimFlowCompletionSection({
       isTui, sentinelPath, reviewersCsv: claimReviewersCsv(task, codeReviewDefaults, defaultReviewers),
+      leavePrOpen: resolvePrCompletion(task.metadata) === PR_COMPLETIONS.LEAVE_OPEN || leavesPrForHuman(task),
     }),
     [COMPLETION_MODES.RELEASE_FLOW]: () => buildReleaseFlowCompletionSection({ isTui, sentinelPath }),
     [COMPLETION_MODES.TUI_SLASHDO_FREE]: buildFullPathTuiCompletion,
@@ -1138,6 +1139,7 @@ function buildLightContextSections(task, workspaceDir, worktreeInfo, isTruthyMet
     [COMPLETION_MODES.DISCARD_WORKTREE]: () => contractSections.push(buildProgrammaticOutputCompletionSection(lightSentinelPath())),
     [COMPLETION_MODES.CLAIM_FLOW]: () => contractSections.push(buildClaimFlowCompletionSection({
       isTui, sentinelPath: lightSentinelPath(), reviewersCsv: claimReviewersCsv(task, codeReviewDefaults, defaultReviewers),
+      leavePrOpen: resolvePrCompletion(task.metadata) === PR_COMPLETIONS.LEAVE_OPEN || leavesPrForHuman(task),
     })),
     [COMPLETION_MODES.READ_ONLY]: () => contractSections.push(buildReadOnlyCompletionSection({ isTui, sentinelPath: lightSentinelPath() })),
     [COMPLETION_MODES.REVIEW_LOOP_FOLLOW_UP]: () => {

--- a/server/services/agentPromptBuilder.test.js
+++ b/server/services/agentPromptBuilder.test.js
@@ -442,6 +442,17 @@ describe('no-code / API-action task completion (CD agents must NOT be told to /d
 });
 
 describe('claim-flow completion handoff', () => {
+  it.each([true, false])('honors leave-open on the %s light/full claim path', async (light) => {
+    const task = makeTask({ metadata: { analysisType: 'claim-issue', claimFlow: true, useWorktree: false, openPR: false, prCompletion: 'leave-open' } });
+    const prompt = light
+      ? buildLightContextPrompt(task, '/repo', null, isTruthyMeta, { isTui: true, providerId: 'codex-tui', providerCommand: 'codex' })
+      : await buildAgentPrompt(task, {}, '/repo', null, isTruthyMeta, { providerType: 'api' });
+    expect(prompt).toContain('PR completion policy: LEAVE OPEN');
+    expect(prompt).toContain('Complete implementation, configured reviews, publication, and CI checks as usual');
+    expect(prompt).toContain('preserve the claim markers, issue state, branch, and worktree');
+    expect(prompt).toContain('do not wait for a human or require MERGED status');
+  });
+
   it('keeps self-managed claim work out of the generic false/false handoff', () => {
     const prompt = buildLightContextPrompt(
       makeTask({ metadata: { claimFlow: true, useWorktree: false, openPR: false, simplify: true } }),
@@ -450,6 +461,7 @@ describe('claim-flow completion handoff', () => {
     );
 
     expect(prompt).toMatch(/## Claim Workflow Handoff/);
+    expect(prompt).not.toContain('PR completion policy: LEAVE OPEN');
     expect(prompt).toMatch(/owns its claim worktree, branch, PR\/MR, review, merge or human-handoff, and cleanup/);
     expect(prompt).toMatch(/\.agent-done/);
     expect(prompt).not.toMatch(/PortOS will merge it back after completion/);
@@ -464,6 +476,7 @@ describe('claim-flow completion handoff', () => {
     );
 
     expect(prompt).toMatch(/## Claim Workflow Handoff/);
+    expect(prompt).not.toContain('PR completion policy: LEAVE OPEN');
     expect(prompt).toMatch(/follow the claim workflow prompt above/i);
     expect(prompt).not.toMatch(/PortOS will merge it back after completion/);
   });

--- a/server/services/promptSections/completion.js
+++ b/server/services/promptSections/completion.js
@@ -433,12 +433,18 @@ export function claimReviewersCsv(task, codeReviewDefaults, defaultReviewers) {
  *
  * @param {string} [reviewersCsv] - the emitted `--review-with` token list to pin;
  *   empty suppresses the block (`buildReviewerPinNote` returns '').
+ * @param {boolean} [leavePrOpen] - keep reviews and CI, but hand off before merge.
  */
-export function buildClaimFlowCompletionSection({ isTui = false, sentinelPath = null, reviewersCsv = '' } = {}) {
+export function buildClaimFlowCompletionSection({ isTui = false, sentinelPath = null, reviewersCsv = '', leavePrOpen = false } = {}) {
   const pin = buildReviewerPinNote(reviewersCsv);
   const lines = [
     ...(pin ? [pin, ''] : []),
     '## Claim Workflow Handoff',
+    ...(leavePrOpen ? [
+      'PR completion policy: LEAVE OPEN for further human review. This overrides any merge, auto-merge, issue-close, or merged-branch cleanup instruction in the claim prompt and delegated slashdo commands. Do not pass --merge, enable auto-merge, merge the PR/MR, or close the issue/ticket.',
+      'Complete implementation, configured reviews, publication, and CI checks as usual. Once those gates pass, leave the PR/MR open, report its URL and review/CI results, and preserve the claim markers, issue state, branch, and worktree for the human handoff. This is a successful completion; do not wait for a human or require MERGED status. Apply this policy to every child claim in a swarm.',
+      '',
+    ] : []),
     'This is a self-managed claim flow. The claim prompt above owns its claim worktree, branch, PR/MR, review, merge or human-handoff, and cleanup. Follow its phase-specific exit conditions — do NOT stop after a code commit or hand the lifecycle back to PortOS.',
     '',
     'Required-review publication rule: if a required local reviewer cannot return a verdict because of a missing CLI, quota/provider or transport failure, timeout, malformed/empty response, or no-verdict result, record the local phase as `review-blocked` rather than substituting a self-review. Still push and open the PR/MR, post a comment saying it is intentionally left open and will not be merged until the required review completes, preserve the claim markers and branch, and stop before merge. A substantive rejection, failed build/test, unpushed fix, or state/publication failure still blocks publication.',


### PR DESCRIPTION
## Summary
Expose the existing After opening PR policy for claim-issue and claim-work schedules, including per-app overrides. Automatic merging after configured reviews and CI remains the default; selecting Leave PR open retains those checks and hands the PR to a human without merging, closing the issue, or deleting the claim branch/worktree.

Both full API and light CLI prompts apply the policy to the self-managed claim lifecycle, including delegated commands and swarm claims. Existing metadata validation and override resolution carry the setting without a migration.

## Test plan
- Server: agentPromptBuilder and cosTaskGenerator suites — 440 tests passed.
- Client: GlobalConfigControls and AppOverrideRow suites — 51 tests passed.
- Biome lint for all four changed UI files passed.
- Reviewed configuration inheritance, legacy automatic defaults, review preservation, and claim completion verification.
