### PR TITLE
perf: avoid loading stage history for pipeline issue lists

### DIFF
--- a/server/routes/pipeline.test.js
+++ b/server/routes/pipeline.test.js
@@ -878,7 +878,7 @@ describe('pipeline routes', () => {
       const r = await request(app).get('/api/pipeline/issues/recent?limit=5');
       expect(r.status).toBe(200);
       expect(spy).toHaveBeenCalledTimes(1);
-      expect(spy).toHaveBeenCalledWith(expect.objectContaining({ withHistory: false }));
+      expect(spy).toHaveBeenCalledWith(expect.objectContaining({ withHistory: false, summary: true }));
       expect(r.body[0]).not.toHaveProperty('stages');
       spy.mockRestore();
     });

--- a/server/routes/pipeline/issues.js
+++ b/server/routes/pipeline/issues.js
@@ -397,10 +397,8 @@ router.get('/issues/recent', asyncHandler(async (req, res) => {
   // via the route but clamps to 1 in the service). Pass through and let
   // listRecentIssues coerce.
   const [issues, series] = await Promise.all([
-    // The route's projection below drops `stages` entirely, but pass
-    // withHistory: false anyway so the service stays light on a sidebar
-    // refresh and the contract matches `GET /series/:id/issues`.
-    issuesSvc.listRecentIssues({ limit: req.query.limit, withHistory: false }),
+    // Fetch only the fields this endpoint returns, with the limit in SQL.
+    issuesSvc.listRecentIssues({ limit: req.query.limit, withHistory: false, summary: true }),
     seriesSvc.listSeries(),
   ]);
   const seriesById = new Map(series.map((s) => [s.id, s.name]));

--- a/server/services/pipeline/issueCrud.js
+++ b/server/services/pipeline/issueCrud.js
@@ -17,7 +17,7 @@ import * as seriesSvc from './series.js';
 import {
   store, queueSeriesIssuesWrite, readState, readStateForSeries,
   saveIssueNow, saveIssuesNow, renumberInline, sanitizeIssue,
-  snapshotRunHistory, stripRunHistoryFromIssue, makeErr, ISSUE_ID_RE,
+  snapshotRunHistory, makeErr, ISSUE_ID_RE,
   ERR_NOT_FOUND, ERR_VALIDATION, ERR_DUPLICATE, ERR_SEASON_LOCKED,
   TITLE_MAX, SERIES_ID_MAX, ISSUES_PER_RESPONSE_MAX,
 } from './issuesShared.js';
@@ -34,25 +34,24 @@ export async function listIssues({
   // Scope the read to one series when filtering by it — avoids loading every
   // issue in the install just to discard the rest (the `seriesId.localeCompare`
   // tiebreak below is a no-op within a single series).
-  const { issues } = seriesId ? await readStateForSeries(seriesId) : await readState();
+  const { issues } = seriesId ? await readStateForSeries(seriesId, { withHistory }) : await readState({ withHistory });
   const live = includeDeleted ? issues : issues.filter((i) => !i.deleted);
   const filtered = seriesId ? live.filter((i) => i.seriesId === seriesId) : live;
   const sorted = [...filtered].sort((a, b) => {
     if (a.seriesId !== b.seriesId) return a.seriesId.localeCompare(b.seriesId);
     return (a.number || 0) - (b.number || 0);
   });
-  const project = withHistory ? (i) => i : stripRunHistoryFromIssue;
   const safeLimit = Math.min(Math.max(1, limit), ISSUES_PER_RESPONSE_MAX);
   const safeOffset = Math.max(0, offset);
   if (paginated) {
     return {
-      items: sorted.slice(safeOffset, safeOffset + safeLimit).map(project),
+      items: sorted.slice(safeOffset, safeOffset + safeLimit),
       total: sorted.length,
       offset: safeOffset,
       limit: safeLimit,
     };
   }
-  return sorted.slice(0, ISSUES_PER_RESPONSE_MAX).map(project);
+  return sorted.slice(0, ISSUES_PER_RESPONSE_MAX);
 }
 
 /**
@@ -96,10 +95,10 @@ export async function listAllIssues({ includeDeleted = false, withHistory = true
     ? [...new Set(seriesIds.filter((id) => typeof id === 'string' && id))]
     : null;
   const issues = scopedSeriesIds
-    ? await store().loadAllForSeriesIds(scopedSeriesIds)
-    : (await readState()).issues;
+    ? await store().loadAllForSeriesIds(scopedSeriesIds, { withHistory })
+    : (await readState({ withHistory })).issues;
   const live = includeDeleted ? issues : issues.filter((i) => !i.deleted);
-  return withHistory ? live : live.map(stripRunHistoryFromIssue);
+  return live;
 }
 
 /**
@@ -119,34 +118,25 @@ export async function listAllIssues({ includeDeleted = false, withHistory = true
  * @param {boolean} [options.withHistory=true] - false strips per-stage run history
  */
 export async function listIssuesForSeries(seriesId, { includeDeleted = false, withHistory = true } = {}) {
-  const { issues } = await readStateForSeries(seriesId);
+  const { issues } = await readStateForSeries(seriesId, { withHistory });
   const live = includeDeleted ? issues : issues.filter((i) => !i.deleted);
   const sorted = [...live].sort((a, b) => (a.number || 0) - (b.number || 0));
-  return withHistory ? sorted : sorted.map(stripRunHistoryFromIssue);
+  return sorted;
 }
 
 /**
- * Recently-updated issues across all series. Sorts the FULL issue set by
- * `updatedAt` desc before applying `limit` — unlike `listIssues`, which
- * sorts by `seriesId/number` then caps at `ISSUES_PER_RESPONSE_MAX`. That
- * cap would silently miss the most-recent issues once the dataset grows
- * beyond 1000, so the sidebar's recent-issues view needs this dedicated
- * helper.
+ * Recently updated issues, bounded at the store before PG records reach Node.
+ * Full records remain the default for internal callers; summary is the HTTP
+ * list's explicit projection and never changes detail/export/sync reads.
  */
-export async function listRecentIssues({ limit = 10, withHistory = true, includeDeleted = false } = {}) {
-  const { issues } = await readState();
-  const live = includeDeleted ? issues : issues.filter((i) => !i.deleted);
+export async function listRecentIssues({ limit = 10, withHistory = true, includeDeleted = false, summary = false } = {}) {
   // Coerce in two passes so non-finite inputs ('abc', undefined) fall to
   // the default rather than letting JS's `0 || 10` short-circuit return
   // 10 for an explicit limit=0.
   const raw = Number(limit);
   const fallback = Number.isFinite(raw) ? Math.floor(raw) : 10;
   const clamped = Math.max(1, Math.min(50, fallback));
-  const project = withHistory ? (i) => i : stripRunHistoryFromIssue;
-  return [...live]
-    .sort((a, b) => (b.updatedAt || '').localeCompare(a.updatedAt || ''))
-    .slice(0, clamped)
-    .map(project);
+  return store().loadRecent({ limit: clamped, withHistory, includeDeleted, summary });
 }
 
 export async function getIssue(id, { includeDeleted = false } = {}) {

--- a/server/services/pipeline/issuesShared.js
+++ b/server/services/pipeline/issuesShared.js
@@ -18,7 +18,7 @@
  * data/pipeline-issues/{id}/index.json (PG-backed via the store facade).
  */
 
-import { getIssuesStore } from './issuesStore/store.js';
+import { getIssuesStore, stripRunHistoryFromIssue } from './issuesStore/store.js';
 import { createKeyCachedQueue } from '../../lib/createKeyCachedQueue.js';
 import { IMAGE_GEN_MODE, QUEUEABLE_IMAGE_MODES } from '../imageGen/modes.js';
 import {
@@ -333,23 +333,6 @@ export function snapshotRunHistory(prevStage, patch, stageId, { force = false } 
   return [snapshot, ...dedupedPrior].slice(0, STAGE_RUN_HISTORY_MAX);
 }
 
-// Strip per-stage `runHistory` from a sanitized issue so list-shaped
-// endpoints can opt out of shipping each stage's full version history. Text
-// stages can hold up to STAGE_RUN_HISTORY_MAX (5) entries × ~600KB each, so
-// a maxed-out issue is ~12MB of payload that the sidebar + per-series list
-// never render. Opt-in via `withHistory: false` on `listIssues` /
-// `listRecentIssues` — the default is full-shape because internal callers
-// (notably `exportSeries`) round-trip every stored field through the bucket
-// export, and dropping history there would lose it on the receiving peer.
-const stripRunHistoryFromIssue = (issue) => {
-  if (!issue || typeof issue !== 'object' || !issue.stages) return issue;
-  const strippedStages = {};
-  for (const [stageId, stage] of Object.entries(issue.stages)) {
-    strippedStages[stageId] = stage?.runHistory?.length ? { ...stage, runHistory: [] } : stage;
-  }
-  return { ...issue, stages: strippedStages };
-};
-
 // Episode-video render settings the user chose at kickoff time. Persisted
 // on the stage so a page reload doesn't reset them to the defaults — the
 // restart flow can render the same pickers populated with the user's
@@ -640,15 +623,15 @@ const sanitizeIssue = (raw) => {
   };
 };
 
-async function readState() {
-  return { issues: await store().loadAll() };
+async function readState(options) {
+  return { issues: await store().loadAll(options) };
 }
 
 // Series-scoped read — uses the indexed `idx_issues_series` query (PG) so a
 // per-series scan doesn't load + sanitize every issue in the install. Callers
 // that already filter by seriesId in JS should source from here instead.
-async function readStateForSeries(seriesId) {
-  return { issues: await store().loadAllForSeries(seriesId) };
+async function readStateForSeries(seriesId, options) {
+  return { issues: await store().loadAllForSeries(seriesId, options) };
 }
 
 async function saveIssueNow(issue) {

--- a/server/services/pipeline/issuesStore/db.js
+++ b/server/services/pipeline/issuesStore/db.js
@@ -11,7 +11,7 @@
  * snapshot ephemeral-filter, and LWW staleness.
  *
  * PURE leaf I/O — the store facade owns serialization + sanitize; reads return
- * `data` verbatim (the columns are a queryable mirror, never read back).
+ * full `data` verbatim by default, or explicit lean/summary projections.
  */
 
 import { query } from '../../../lib/db.js';
@@ -20,8 +20,11 @@ import { PIPELINE_STAGE_IDS } from '../../../lib/pipelineStages.js';
 
 // Only trusted, closed stage IDs form SQL paths. PostgreSQL removes history
 // before serializing JSONB for Node; every other field remains lossless.
+// A malformed stage is left for the sanitizer, never traversed as a JSON array.
 const LEAN_DATA = PIPELINE_STAGE_IDS.reduce(
-  (sql, stageId) => `${sql} #- '{stages,${stageId},runHistory}'`, 'data',
+  (sql, stageId) => `${sql} #- CASE
+    WHEN jsonb_typeof(data->'stages'->'${stageId}') = 'object'
+    THEN '{stages,${stageId},runHistory}'::text[] ELSE '{}'::text[] END`, 'data',
 );
 
 /** Raw on-disk-equivalent record (the `data` JSONB), or null. No sanitize. */
@@ -83,12 +86,12 @@ export async function listRawBySeriesIds(seriesIds, { withHistory = true } = {})
  */
 export async function listRecentRaw({ limit, withHistory = true, includeDeleted = false, summary = false }) {
   const projection = summary
-    ? "jsonb_build_object('id', id, 'title', data->'title', 'number', number, 'seriesId', series_id, 'updatedAt', data->'updatedAt')"
+    ? "jsonb_build_object('id', id, 'title', data->'title', 'number', number, 'seriesId', series_id, 'updatedAt', data->'updatedAt', 'createdAt', data->'createdAt')"
     : withHistory ? 'data' : LEAN_DATA;
   const { rows } = await query(
     `SELECT ${projection} AS data FROM pipeline_issues
-     ${includeDeleted ? '' : 'WHERE deleted = FALSE'}
-     ORDER BY updated_at DESC LIMIT $1`,
+     ${includeDeleted ? '' : 'WHERE deleted IS NOT TRUE'}
+     ORDER BY updated_at DESC NULLS LAST, id DESC LIMIT $1`,
     [limit],
   );
   return rows.map((r) => r.data);

--- a/server/services/pipeline/issuesStore/db.js
+++ b/server/services/pipeline/issuesStore/db.js
@@ -16,6 +16,13 @@
 
 import { query } from '../../../lib/db.js';
 import { mirrorTimestamp } from '../../../lib/pgTimestamp.js';
+import { PIPELINE_STAGE_IDS } from '../../../lib/pipelineStages.js';
+
+// Only trusted, closed stage IDs form SQL paths. PostgreSQL removes history
+// before serializing JSONB for Node; every other field remains lossless.
+const LEAN_DATA = PIPELINE_STAGE_IDS.reduce(
+  (sql, stageId) => `${sql} #- '{stages,${stageId},runHistory}'`, 'data',
+);
 
 /** Raw on-disk-equivalent record (the `data` JSONB), or null. No sanitize. */
 export async function readRaw(id) {
@@ -40,8 +47,8 @@ export async function listIds({ includeDeleted = true } = {}) {
 }
 
 /** Every record's raw `data` JSONB in one query (live/ephemeral/tombstones). */
-export async function listRaw() {
-  const { rows } = await query(`SELECT data FROM pipeline_issues`);
+export async function listRaw({ withHistory = true } = {}) {
+  const { rows } = await query(`SELECT ${withHistory ? 'data' : LEAN_DATA} AS data FROM pipeline_issues`);
   return rows.map((r) => r.data);
 }
 
@@ -51,8 +58,8 @@ export async function listRaw() {
  * Returns live/ephemeral/tombstones (the service applies the `deleted` filter),
  * matching `listRaw`'s contract but scoped.
  */
-export async function listRawBySeries(seriesId) {
-  const { rows } = await query(`SELECT data FROM pipeline_issues WHERE series_id = $1`, [seriesId]);
+export async function listRawBySeries(seriesId, { withHistory = true } = {}) {
+  const { rows } = await query(`SELECT ${withHistory ? 'data' : LEAN_DATA} AS data FROM pipeline_issues WHERE series_id = $1`, [seriesId]);
   return rows.map((r) => r.data);
 }
 
@@ -61,11 +68,28 @@ export async function listRawBySeries(seriesId) {
  * an uncapped cross-series scan use this instead of loading the whole table or
  * issuing one query per series.
  */
-export async function listRawBySeriesIds(seriesIds) {
+export async function listRawBySeriesIds(seriesIds, { withHistory = true } = {}) {
   if (seriesIds.length === 0) return [];
   const { rows } = await query(
-    `SELECT data FROM pipeline_issues WHERE series_id = ANY($1::text[])`,
+    `SELECT ${withHistory ? 'data' : LEAN_DATA} AS data FROM pipeline_issues WHERE series_id = ANY($1::text[])`,
     [seriesIds],
+  );
+  return rows.map((r) => r.data);
+}
+
+/**
+ * Limit in PostgreSQL before transferring records. Summary reads extract only
+ * the recent HTTP endpoint's fields; title has no mirrored column.
+ */
+export async function listRecentRaw({ limit, withHistory = true, includeDeleted = false, summary = false }) {
+  const projection = summary
+    ? "jsonb_build_object('id', id, 'title', data->'title', 'number', number, 'seriesId', series_id, 'updatedAt', data->'updatedAt')"
+    : withHistory ? 'data' : LEAN_DATA;
+  const { rows } = await query(
+    `SELECT ${projection} AS data FROM pipeline_issues
+     ${includeDeleted ? '' : 'WHERE deleted = FALSE'}
+     ORDER BY updated_at DESC LIMIT $1`,
+    [limit],
   );
   return rows.map((r) => r.data);
 }

--- a/server/services/pipeline/issuesStore/db.test.js
+++ b/server/services/pipeline/issuesStore/db.test.js
@@ -3,9 +3,22 @@
  * SKIPS cleanly when no DB is reachable. Snapshots + restores the table.
  */
 
-import { describe, it, expect, afterAll, beforeAll, beforeEach } from 'vitest';
+import { describe, it, expect, afterAll, beforeAll, beforeEach, vi } from 'vitest';
 import { checkHealth, ensureSchema, query, close } from '../../../lib/db.js';
+import * as dbConnection from '../../../lib/db.js';
+import { PIPELINE_STAGE_IDS } from '../../../lib/pipelineStages.js';
 import { requireDbOrSkip } from '../../../lib/dbTestGate.js';
+
+// Exercise the real PG facade/service without importing this install's legacy
+// files. The dedicated DB runner still enforces portos_test for all SQL.
+vi.mock('../../../lib/pgFileFacade.js', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    createPgFileFacade: (options) => actual.createPgFileFacade({ ...options, isFile: () => false }),
+    resolvePgBackend: async ({ loadDb, makePg }) => makePg(await loadDb()),
+  };
+});
 
 let dbReady = false;
 let skipReason = '';
@@ -57,6 +70,82 @@ describe.skipIf(!runDb)('pipeline issues DB adapter round-trip', () => {
     const rec = I('iss-1', { stages: { idea: { status: 'ready', output: 'beats', lastRunId: 'run-7' } } });
     await db.writeRaw('iss-1', rec);
     expect(await db.readRaw('iss-1')).toEqual(rec);
+  });
+
+  it('lean reads remove only known stage histories while full reads remain lossless', async () => {
+    const stages = Object.fromEntries(PIPELINE_STAGE_IDS.map((id) => [id, {
+      output: 'active', runHistory: [{ output: 'older', runId: 'run-1' }],
+      cover: { prompt: 'cover' }, custom: { nested: true },
+    }]));
+    const rec = I('iss-history', { stages, custom: { retained: true } });
+    await db.writeRaw(rec.id, rec);
+    await db.writeRaw('iss-other', I('iss-other', { seriesId: 'ser-other', stages: null }));
+    const lean = { ...rec, stages: Object.fromEntries(PIPELINE_STAGE_IDS.map((id) => {
+      const { runHistory, ...stage } = stages[id];
+      return [id, stage];
+    })) };
+    expect(await db.listRawBySeries('ser-1', { withHistory: false })).toEqual([lean]);
+    expect(await db.listRawBySeriesIds(['ser-1'], { withHistory: false })).toEqual([lean]);
+    expect((await db.listRaw({ withHistory: false })).find((r) => r.id === rec.id)).toEqual(lean);
+    expect(await db.readRaw(rec.id)).toEqual(rec);
+    expect(await db.listRawBySeries('ser-1')).toEqual([rec]);
+    expect((await db.listRaw({ withHistory: false })).find((r) => r.id === 'iss-other').stages).toBeNull();
+  });
+
+  it('recent reads limit in SQL and summaries never transfer stage data', async () => {
+    for (let n = 0; n < 60; n += 1) {
+      await db.writeRaw(`iss-${n}`, I(`iss-${n}`, {
+        updatedAt: new Date(Date.UTC(2026, 0, 1, 0, n)).toISOString(),
+        stages: { idea: { output: 'active', runHistory: [{ output: 'older' }] } },
+        deleted: n === 59,
+      }));
+    }
+    const querySpy = vi.spyOn(dbConnection, 'query');
+    const summaries = await db.listRecentRaw({ limit: 2, summary: true });
+    expect(summaries.map((r) => r.id)).toEqual(['iss-58', 'iss-57']);
+    expect(Object.keys(summaries[0]).sort()).toEqual(['id', 'number', 'seriesId', 'title', 'updatedAt']);
+    expect(querySpy).toHaveBeenCalledTimes(1);
+    const [sql, params] = querySpy.mock.calls[0];
+    expect(sql).toMatch(/WHERE deleted = FALSE\s+ORDER BY updated_at DESC LIMIT \$1/);
+    expect(sql).toContain('jsonb_build_object');
+    expect(params).toEqual([2]);
+    querySpy.mockRestore();
+    const full = await db.listRecentRaw({ limit: 1, includeDeleted: true });
+    expect(full[0].id).toBe('iss-59');
+    expect(full[0].stages.idea.runHistory).toHaveLength(1);
+    const lean = await db.listRecentRaw({ limit: 1, withHistory: false });
+    expect(lean[0].stages.idea).toEqual({ output: 'active' });
+  });
+
+  it('public PG lists project before transfer while detail keeps history', async () => {
+    const svc = await import('../issueCrud.js');
+    const record = I('iss-service', { stages: { idea: {
+      output: 'active', runHistory: [{ runId: 'run-old', output: 'older' }],
+    } } });
+    await db.writeRaw(record.id, record);
+    const querySpy = vi.spyOn(dbConnection, 'query');
+    const lists = [
+      await svc.listIssues({ seriesId: 'ser-1', withHistory: false }),
+      await svc.listIssues({ withHistory: false }),
+      await svc.listAllIssues({ withHistory: false }),
+      await svc.listAllIssues({ seriesIds: ['ser-1'], withHistory: false }),
+      await svc.listIssuesForSeries('ser-1', { withHistory: false }),
+      await svc.listRecentIssues({ withHistory: false }),
+    ];
+    for (const list of lists) {
+      expect(list[0].stages.idea).toMatchObject({ output: 'active', runHistory: [] });
+    }
+    // Assert on actual PostgreSQL results, before the facade can strip history.
+    for (const result of querySpy.mock.results) {
+      expect((await result.value).rows[0].data.stages.idea).not.toHaveProperty('runHistory');
+    }
+    querySpy.mockRestore();
+    expect((await svc.getIssue(record.id)).stages.idea.runHistory).toHaveLength(1);
+    expect((await svc.listAllIssues())[0].stages.idea.runHistory).toHaveLength(1);
+    expect(await svc.listRecentIssues({ limit: 1, summary: true })).toEqual([{
+      id: record.id, title: record.title, number: record.number,
+      seriesId: record.seriesId, updatedAt: record.updatedAt,
+    }]);
   });
 
   it('upsert updates the record and the mirror columns (series_id/number/status)', async () => {

--- a/server/services/pipeline/issuesStore/db.test.js
+++ b/server/services/pipeline/issuesStore/db.test.js
@@ -103,10 +103,10 @@ describe.skipIf(!runDb)('pipeline issues DB adapter round-trip', () => {
     const querySpy = vi.spyOn(dbConnection, 'query');
     const summaries = await db.listRecentRaw({ limit: 2, summary: true });
     expect(summaries.map((r) => r.id)).toEqual(['iss-58', 'iss-57']);
-    expect(Object.keys(summaries[0]).sort()).toEqual(['id', 'number', 'seriesId', 'title', 'updatedAt']);
+    expect(Object.keys(summaries[0]).sort()).toEqual(['createdAt', 'id', 'number', 'seriesId', 'title', 'updatedAt']);
     expect(querySpy).toHaveBeenCalledTimes(1);
     const [sql, params] = querySpy.mock.calls[0];
-    expect(sql).toMatch(/WHERE deleted = FALSE\s+ORDER BY updated_at DESC LIMIT \$1/);
+    expect(sql).toMatch(/WHERE deleted IS NOT TRUE\s+ORDER BY updated_at DESC NULLS LAST, id DESC LIMIT \$1/);
     expect(sql).toContain('jsonb_build_object');
     expect(params).toEqual([2]);
     querySpy.mockRestore();
@@ -146,6 +146,29 @@ describe.skipIf(!runDb)('pipeline issues DB adapter round-trip', () => {
       id: record.id, title: record.title, number: record.number,
       seriesId: record.seriesId, updatedAt: record.updatedAt,
     }]);
+  });
+
+  it('lean SQL tolerates malformed stage containers and recent summaries sanitize legacy fields', async () => {
+    const svc = await import('../issueCrud.js');
+    for (const [n, stages] of [[], 'invalid', { idea: [] }, { idea: 'invalid' }].entries()) {
+      await db.writeRaw(`iss-malformed-${n}`, I(`iss-malformed-${n}`, { stages }));
+    }
+    expect(await svc.listIssues({ withHistory: false })).toHaveLength(4);
+    await db.writeRaw('iss-legacy', I('iss-legacy', {
+      title: '  Legacy title  ', number: null, updatedAt: '2026-02-01T00:00:00.000Z',
+    }));
+    await query("UPDATE pipeline_issues SET deleted = NULL WHERE id = 'iss-legacy'");
+    const summary = await svc.listRecentIssues({ limit: 1, summary: true });
+    expect(summary).toEqual([{
+      id: 'iss-legacy', title: 'Legacy title', number: 0, seriesId: 'ser-1',
+      updatedAt: '2026-02-01T00:00:00.000Z',
+    }]);
+    await query("UPDATE pipeline_issues SET updated_at = NULL WHERE id = 'iss-legacy'");
+    expect((await svc.listRecentIssues({ limit: 1 }))[0].id).not.toBe('iss-legacy');
+    await db.writeRaw('iss-invalid-title', I('iss-invalid-title', {
+      title: 123, updatedAt: '2026-03-01T00:00:00.000Z',
+    }));
+    expect(await svc.listRecentIssues({ limit: 1, summary: true })).toEqual([]);
   });
 
   it('upsert updates the record and the mirror columns (series_id/number/status)', async () => {

--- a/server/services/pipeline/issuesStore/store.js
+++ b/server/services/pipeline/issuesStore/store.js
@@ -30,6 +30,18 @@ import { createPgFileFacade, resolvePgBackend, isFileBackend } from '../../../li
 import { createFileWriteQueue } from '../../../lib/fileWriteQueue.js';
 import { bumpPipelineMutationEpoch } from '../syncEpoch.js';
 
+// Strip history before file-backend sanitization; PG already removes it in
+// SQL. Full records remain the default because exports and sync must retain
+// every version. Public sanitized list stages still expose runHistory: [].
+export const stripRunHistoryFromIssue = (issue) => {
+  if (!issue || typeof issue !== 'object' || !issue.stages) return issue;
+  const strippedStages = {};
+  for (const [stageId, stage] of Object.entries(issue.stages)) {
+    strippedStages[stageId] = stage?.runHistory?.length ? { ...stage, runHistory: [] } : stage;
+  }
+  return { ...issue, stages: strippedStages };
+};
+
 const TYPE_SCHEMA_VERSION = 1;
 const ID_PATTERN = /^iss-[A-Za-z0-9-]+$/;
 
@@ -99,6 +111,7 @@ function makePgBackend(db, sanitizeRecord) {
     listRaw: db.listRaw,
     listRawBySeries: db.listRawBySeries,
     listRawBySeriesIds: db.listRawBySeriesIds,
+    listRecentRaw: db.listRecentRaw,
     writeRaw: db.writeRaw,
     deleteRaw: db.deleteRaw,
     verify: async () => ({ ok: true, type: 'pipelineIssues', onDisk: null, expected: null,
@@ -143,6 +156,10 @@ function createFacade({ dir, sanitizeRecord }) {
     bumpPipelineMutationEpoch();
   };
 
+  const sanitizeList = (raw, { withHistory = true } = {}) => raw
+    .map((r) => sanitizer(withHistory ? r : stripRunHistoryFromIssue(r)))
+    .filter((r) => r != null);
+
   return {
     dir,
     type: 'pipelineIssues',
@@ -153,17 +170,34 @@ function createFacade({ dir, sanitizeRecord }) {
       if (typeof id !== 'string' || !ID_PATTERN.test(id)) return null;
       return (await getBackend()).readOne(id);
     },
-    loadAll: async () => {
-      const raw = await (await getBackend()).listRaw();
-      return raw.map((r) => sanitizer(r)).filter((r) => r != null);
+    loadAll: async (options) => {
+      const raw = await (await getBackend()).listRaw(options);
+      return sanitizeList(raw, options);
     },
-    loadAllForSeries: async (seriesId) => {
-      const raw = await (await getBackend()).listRawBySeries(seriesId);
-      return raw.map((r) => sanitizer(r)).filter((r) => r != null);
+    loadAllForSeries: async (seriesId, options) => {
+      const raw = await (await getBackend()).listRawBySeries(seriesId, options);
+      return sanitizeList(raw, options);
     },
-    loadAllForSeriesIds: async (seriesIds) => {
-      const raw = await (await getBackend()).listRawBySeriesIds(seriesIds);
-      return raw.map((r) => sanitizer(r)).filter((r) => r != null);
+    loadAllForSeriesIds: async (seriesIds, options) => {
+      const raw = await (await getBackend()).listRawBySeriesIds(seriesIds, options);
+      return sanitizeList(raw, options);
+    },
+
+    loadRecent: async (options) => {
+      const backend = await getBackend();
+      if (backend.listRecentRaw) {
+        const raw = await backend.listRecentRaw(options);
+        return options.summary ? raw : sanitizeList(raw, options);
+      }
+      // Dev/test file backend has no timestamp index. Sanitize before sorting
+      // to retain its legacy-record behavior, then match the HTTP projection.
+      const live = sanitizeList(await backend.listRaw(), options)
+        .filter((r) => options.includeDeleted || !r.deleted);
+      const recent = live.sort((a, b) => (b.updatedAt || '').localeCompare(a.updatedAt || ''))
+        .slice(0, options.limit);
+      return options.summary
+        ? recent.map(({ id, title, number, seriesId, updatedAt }) => ({ id, title, number, seriesId, updatedAt }))
+        : recent;
     },
 
     saveOneNow,

--- a/server/services/pipeline/issuesStore/store.js
+++ b/server/services/pipeline/issuesStore/store.js
@@ -183,18 +183,19 @@ function createFacade({ dir, sanitizeRecord }) {
       return sanitizeList(raw, options);
     },
 
-    loadRecent: async (options) => {
+    loadRecent: async ({ limit = 10, ...options } = {}) => {
       const backend = await getBackend();
+      let recent;
       if (backend.listRecentRaw) {
-        const raw = await backend.listRecentRaw(options);
-        return options.summary ? raw : sanitizeList(raw, options);
+        recent = sanitizeList(await backend.listRecentRaw({ ...options, limit }), options);
+      } else {
+        // Dev/test file backend has no timestamp index. Sanitize before sorting
+        // to retain its legacy-record behavior, then match the HTTP projection.
+        const live = sanitizeList(await backend.listRaw(), options)
+          .filter((r) => options.includeDeleted || !r.deleted);
+        recent = live.sort((a, b) => (b.updatedAt || '').localeCompare(a.updatedAt || ''))
+          .slice(0, limit);
       }
-      // Dev/test file backend has no timestamp index. Sanitize before sorting
-      // to retain its legacy-record behavior, then match the HTTP projection.
-      const live = sanitizeList(await backend.listRaw(), options)
-        .filter((r) => options.includeDeleted || !r.deleted);
-      const recent = live.sort((a, b) => (b.updatedAt || '').localeCompare(a.updatedAt || ''))
-        .slice(0, options.limit);
       return options.summary
         ? recent.map(({ id, title, number, seriesId, updatedAt }) => ({ id, title, number, seriesId, updatedAt }))
         : recent;

--- a/server/services/pipeline/issuesStore/store.test.js
+++ b/server/services/pipeline/issuesStore/store.test.js
@@ -69,6 +69,34 @@ describe('pipeline issues store facade — file backend', () => {
     expect(await s.loadAllForSeriesIds([])).toEqual([]);
   });
 
+  it('lean lists keep active fields and never alter persisted history', async () => {
+    const s = getIssuesStore(passthroughSanitize);
+    const record = { id: 'iss-1', seriesId: 'ser-1', title: 'One',
+      stages: { idea: { output: 'active', runHistory: [{ output: 'older' }] } } };
+    await s.saveOneNow(record.id, record);
+    for (const rows of [
+      await s.loadAll({ withHistory: false }),
+      await s.loadAllForSeries('ser-1', { withHistory: false }),
+      await s.loadAllForSeriesIds(['ser-1'], { withHistory: false }),
+    ]) {
+      expect(rows[0].stages.idea).toEqual({ output: 'active', runHistory: [] });
+    }
+    expect((await s.loadOne(record.id)).stages).toEqual(record.stages);
+    expect((await s.loadAll())[0].stages).toEqual(record.stages);
+  });
+
+  it('recent file reads match the bounded live summary contract', async () => {
+    const s = getIssuesStore(passthroughSanitize);
+    for (let n = 0; n < 5; n += 1) {
+      await s.saveOneNow(`iss-${n}`, { id: `iss-${n}`, seriesId: 'ser-1', title: 'One', number: n,
+        updatedAt: `2026-01-0${n + 1}T00:00:00.000Z`, deleted: n === 4, stages: {} });
+    }
+    const rows = await s.loadRecent({ limit: 2, summary: true });
+    expect(rows.map((r) => r.id)).toEqual(['iss-3', 'iss-2']);
+    expect(Object.keys(rows[0]).sort()).toEqual(['id', 'number', 'seriesId', 'title', 'updatedAt']);
+    expect((await s.loadRecent({ limit: 1, includeDeleted: true }))[0].id).toBe('iss-4');
+  });
+
   it('listIds({ includeDeleted: false }) drops tombstones; default keeps them (#2540)', async () => {
     const s = getIssuesStore(passthroughSanitize);
     await s.saveOneNow('iss-live', { id: 'iss-live', seriesId: 'ser-1', title: 'Live' });


### PR DESCRIPTION
Pipeline issue lists now remove stage history inside PostgreSQL before transferring JSONB to Node. Recent issues use a SQL order/limit and a small summary projection for the HTTP endpoint. Full detail, export, and sync reads retain history.

The existing store methods accept the history option, including multi-series lists. File-backed lists preserve the same response shape. Legacy summary fields still pass through sanitization, and malformed stage containers cannot break lean queries.

Validation: 304 service/route/file tests and 12 PostgreSQL tests passed against the dedicated test database. PG tests verify the actual returned rows contain no history, full reads retain it, and recent queries apply their limit in SQL. Claude reviewed at medium effort with tools disabled; actionable legacy-record findings were fixed and regression-tested within the configured single review round.

Closes #7042
