### PR TITLE
fix: add lean app list projections

### DIFF
--- a/client/src/components/Layout.test.jsx
+++ b/client/src/components/Layout.test.jsx
@@ -120,6 +120,12 @@ const renderLayout = async (initialPath = '/brain/inbox') => {
 const pinnedSection = () => screen.queryByTestId('pinned-section');
 
 describe('Layout — manifest-derived sidebar structure', () => {
+  it('loads sidebar apps through the lean navigation projection', async () => {
+    await renderLayout();
+
+    expect(api.getApps).toHaveBeenCalledWith({ silent: true, view: 'nav' });
+  });
+
   it('keeps NAV_PRESENTATION presentation-only and keyed to live manifest paths', () => {
     const manifestPaths = new Set(NAV_COMMANDS.map((command) => command.path));
     expect(Object.keys(NAV_PRESENTATION).filter((path) => !manifestPaths.has(path))).toEqual([]);

--- a/client/src/components/sprites/PublishWorkflow.jsx
+++ b/client/src/components/sprites/PublishWorkflow.jsx
@@ -86,7 +86,9 @@ export default function PublishWorkflow({
   const seedCell = savedContract?.cellSize != null ? String(savedContract.cellSize) : '';
   const seedCols = savedContract?.columnCount != null ? String(savedContract.columnCount) : '';
 
-  const apps = useSidebarApps();
+  // This picker shows each app's repository path, so retain the full list
+  // contract while the Layout/sidebar callers use the lean nav projection.
+  const apps = useSidebarApps({ includeDetails: true });
   const [appId, setAppId] = useState(saved?.appId || '');
   const [destPath, setDestPath] = useState(saved?.atlasDestPath || '');
   const [portraitPath, setPortraitPath] = useState(saved?.portraitDestPath || '');

--- a/client/src/hooks/useSidebarApps.js
+++ b/client/src/hooks/useSidebarApps.js
@@ -6,12 +6,15 @@ import socket from '../services/socket';
 // `apps:changed`. Archived apps are filtered out and the rest sorted by name.
 // Unlike the series/universes lists this is socket-driven (not focus-debounced)
 // because app create/rename/archive events are pushed live.
-export function useSidebarApps() {
+// The default is the cheap navigation projection. A detail-oriented consumer
+// can opt into the frozen full list with includeDetails without changing the
+// hook's socket refresh behavior.
+export function useSidebarApps({ includeDetails = false } = {}) {
   const [apps, setApps] = useState([]);
   useEffect(() => {
     let cancelled = false;
     const fetchApps = () => {
-      api.getApps({ silent: true })
+      api.getApps({ silent: true, ...(includeDetails ? {} : { view: 'nav' }) })
         .then((result) => {
           if (cancelled) return;
           setApps((result || [])
@@ -28,6 +31,6 @@ export function useSidebarApps() {
       cancelled = true;
       socket.off('apps:changed', fetchApps);
     };
-  }, []);
+  }, [includeDetails]);
   return apps;
 }

--- a/client/src/services/apiApps.js
+++ b/client/src/services/apiApps.js
@@ -1,8 +1,15 @@
 import toast from '../components/ui/Toast';
 import { request, API_BASE } from './apiCore.js';
 
-// Apps
-export const getApps = ({ includeQuality = false, ...options } = {}) => request(includeQuality ? '/apps?includeQuality=true' : '/apps', options);
+// Apps. The default response remains the PM2-enriched list; `view=nav` and
+// `view=probe` are explicit projections for hot name-only and peer callers.
+export const getApps = ({ includeQuality = false, view, ...options } = {}) => {
+  const query = new URLSearchParams();
+  if (includeQuality) query.set('includeQuality', 'true');
+  if (view) query.set('view', view);
+  const suffix = query.toString() ? `?${query}` : '';
+  return request(`/apps${suffix}`, options);
+};
 export const getApp = (id, { includeQuality = false, ...options } = {}) => request(includeQuality ? `/apps/${id}?includeQuality=true` : `/apps/${id}`, options);
 export const getAppQualityHistory = (id, days, options) => request(`/apps/${id}/quality-history?days=${days}`, { silent: true, ...options });
 // Managed checkout topology: returns sanitized local/fork/upstream revision

--- a/client/src/services/apiApps.test.js
+++ b/client/src/services/apiApps.test.js
@@ -63,8 +63,9 @@ it('requests quality only for opted-in views and preserves caller request option
   await getApp('portos-default');
   await getApps({ includeQuality: true, signal });
   await getApp('portos-default', { includeQuality: true, signal });
+  await getApps({ view: 'nav' });
   expect(fetch.mock.calls.map(([url]) => url)).toEqual([
-    '/api/apps', '/api/apps/portos-default', '/api/apps?includeQuality=true', '/api/apps/portos-default?includeQuality=true',
+    '/api/apps', '/api/apps/portos-default', '/api/apps?includeQuality=true', '/api/apps/portos-default?includeQuality=true', '/api/apps?view=nav',
   ]);
   expect(fetch.mock.calls[2][1]).toMatchObject({ signal });
   expect(fetch.mock.calls[2][1]).not.toHaveProperty('includeQuality');

--- a/docs/API.md
+++ b/docs/API.md
@@ -72,13 +72,20 @@ credentials, local paths, or build identity to these responses.
 | Method | Endpoint | Stable request and response contract |
 |--------|----------|--------------------------------------|
 | GET | `/system/health/details` | Returns an object containing `instanceId` and `version` (each may be `null`) for peer identity and compatibility display. The health summary remains an object so an older prober can retain it as its last-known health snapshot. |
-| GET | `/apps` | Returns either the legacy app array or `{ apps: [...] }`. Each app entry used by peers retains `id`, `name`, `icon`, `overallStatus`, `uiPort`, `apiPort`, and `type`; fields may be absent or `null` when unknown. |
+| GET | `/apps?view=probe` | The periodic probe requests `view=probe`; returns either the legacy app array or `{ apps: [...] }`. Each app entry used by peers retains `id`, `name`, `icon`, `overallStatus`, `uiPort`, `apiPort`, and `type`; fields may be absent or `null` when unknown. Older peers may ignore the query and return the legacy enriched list, which remains compatible with the same field mapping. |
 | GET | `/instances/sync-status?forPeer=<instance-id>` | `forPeer` is optional and remains lenient: an unknown or legacy identifier, blank value, or omitted value must degrade to the unscoped status response rather than fail the probe. A recognized peer receives its `cursorForYou` alongside the normal sync status. |
 
 The separate `/federation/media/v1` surface is already versioned and has its
 own wire contract in [FEDERATED_MEDIA_PROVIDERS.md](./FEDERATED_MEDIA_PROVIDERS.md).
 
 ### Apps
+
+The app list keeps the legacy PM2-enriched response when no `view` is given.
+Use `view=nav` for name/icon/archive/type pickers that do not need runtime
+status or repository details; it reads the registry without PM2 or repository
+enrichment. Use `view=probe` for the PM2-backed seven-field projection used by
+federated peer probes. `includeQuality=true` remains an explicit opt-in on the
+legacy list for local Apps/Dashboard views.
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|

--- a/server/lib/auditQuality.js
+++ b/server/lib/auditQuality.js
@@ -51,6 +51,14 @@ Allowed coverage: broad, partial, unavailable, not-applicable. Allowed confidenc
 
 export const appQualityQuerySchema = z.object({ includeQuality: z.enum(['true', 'false']).optional() });
 
+// The list endpoint has two intentionally narrow projections in addition to
+// its frozen default response: the sidebar/navigation shape and the PM2-backed
+// peer-probe shape. Keep the detail endpoint on appQualityQuerySchema so a
+// view flag cannot silently change its response contract.
+export const appListQuerySchema = appQualityQuerySchema.extend({
+  view: z.enum(['nav', 'probe']).optional(),
+});
+
 export const auditQualityReportSchema = z.object({
   version: z.literal(1),
   category: z.string().refine(value => Object.hasOwn(AUDIT_DEFINITIONS, value)),

--- a/server/routes/apps/crud.js
+++ b/server/routes/apps/crud.js
@@ -1,4 +1,4 @@
-import { appQualityQuerySchema, appQualityHistoryQuerySchema, appQualityFederationQuerySchema } from '../../lib/auditQuality.js';
+import { appListQuerySchema, appQualityQuerySchema, appQualityHistoryQuerySchema, appQualityFederationQuerySchema } from '../../lib/auditQuality.js';
 import { exportPortosQuality } from '../../services/appQualityFederation.js';
 import { enrichAppsWithQuality, getAppQualityHistory } from '../../services/appQuality.js';
 /**
@@ -39,11 +39,25 @@ router.get('/quality-federation', asyncHandler(async (req, res) => {
   res.json(payload);
 }));
 
-// GET /api/apps - List all apps. The route fetches the raw records; the
-// appListEnrichment service owns the PM2 status/port/process enrichment.
+// GET /api/apps - List all apps. The bare response is the frozen PM2-enriched
+// peer-probe contract. `view=nav` is the cheap sidebar projection; `view=probe`
+// keeps PM2 enrichment but returns only the fields the peer UI consumes.
 router.get('/', asyncHandler(async (req, res) => {
-  const { includeQuality } = validateRequest(appQualityQuerySchema, req.query);
-  const apps = await enrichAppsWithPm2Status(await appsService.getAllApps());
+  const { includeQuality, view } = validateRequest(appListQuerySchema, req.query);
+  const rawApps = await appsService.getAllApps();
+  if (view === 'nav') {
+    res.json(rawApps.map(({ id, name, icon, archived, type }) => ({ id, name, icon, archived, type })));
+    return;
+  }
+
+  const apps = await enrichAppsWithPm2Status(rawApps);
+  if (view === 'probe') {
+    res.json(apps.map(({ id, name, icon, overallStatus, uiPort, apiPort, type }) => ({
+      id, name, icon, overallStatus, uiPort, apiPort, type,
+    })));
+    return;
+  }
+
   // The bare list is the frozen peer-probe contract. Local UI opts into
   // assessment prose explicitly so it never rides automatic federation probes.
   res.json(includeQuality === 'true' ? await enrichAppsWithQuality(apps) : apps);

--- a/server/routes/apps/crud.test.js
+++ b/server/routes/apps/crud.test.js
@@ -93,6 +93,40 @@ describe('Apps CRUD Routes', () => {
       expect(response.body[0].overallStatus).toBe('online');
     });
 
+    it('returns the nav projection without invoking PM2 enrichment', async () => {
+      const mockApps = [{
+        id: 'app-001', name: 'Test App', icon: 'package', archived: false, type: 'express',
+        repoPath: '/tmp/test', pm2ProcessNames: ['test-app'],
+      }];
+      appsService.getAllApps.mockResolvedValue(mockApps);
+
+      const response = await request(app).get('/api/apps?view=nav');
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual([{
+        id: 'app-001', name: 'Test App', icon: 'package', archived: false, type: 'express',
+      }]);
+      expect(pm2Service.listProcessesStrict).not.toHaveBeenCalled();
+    });
+
+    it('returns the PM2-backed probe projection without the enriched body', async () => {
+      appsService.getAllApps.mockResolvedValue([{
+        id: 'app-001', name: 'Test App', icon: 'package', type: 'express',
+        uiPort: 5555, apiPort: 5551, pm2ProcessNames: ['test-app'], processes: [],
+      }]);
+      pm2Service.listProcessesStrict.mockResolvedValue([{ name: 'test-app', status: 'online' }]);
+
+      const response = await request(app).get('/api/apps?view=probe');
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual([{
+        id: 'app-001', name: 'Test App', icon: 'package', overallStatus: 'online',
+        uiPort: 5555, apiPort: 5551, type: 'express',
+      }]);
+      expect(pm2Service.listProcessesStrict).toHaveBeenCalledTimes(1);
+      expect(response.body[0].pm2Status).toBeUndefined();
+    });
+
     it('keeps quality reports off peer probes and returns them only for explicit local UI reads', async () => {
       appsService.getAllApps.mockResolvedValue([{ id: 'portos-default', name: 'PortOS', type: 'ios-native', repoPath: '/tmp/test' }]);
       const peer = await request(app).get('/api/apps');
@@ -102,6 +136,8 @@ describe('Apps CRUD Routes', () => {
       expect(local.body[0].quality).toEqual({ score: 75 });
       const invalid = await request(app).get('/api/apps?includeQuality=anything');
       expect(invalid.status).toBe(400);
+      const invalidView = await request(app).get('/api/apps?view=anything');
+      expect(invalidView.status).toBe(400);
       appsService.getAppById.mockResolvedValue({ id: 'portos-default', name: 'PortOS', type: 'ios-native' });
       const detail = await request(app).get('/api/apps/portos-default?includeQuality=true');
       expect(detail.body.quality).toEqual({ score: 75 });

--- a/server/services/instances.js
+++ b/server/services/instances.js
@@ -722,7 +722,7 @@ export async function probePeer(peer) {
     const forPeerQs = typeof ourInstanceId === 'string' && ourInstanceId && ourInstanceId !== UNKNOWN_INSTANCE_ID
       ? `?forPeer=${encodeURIComponent(ourInstanceId)}`
       : '';
-    // Fetch health details, apps, sync status, and opted-in media capacity in
+    // Fetch health details, the PM2-backed app probe projection, sync status, and opted-in media capacity in
     // parallel under the same bounded probe budget. The first three paths are
     // the frozen peer-probe contract documented in docs/API.md: deployed peers
     // call them across independently upgraded installs, so remove/rename or
@@ -731,7 +731,7 @@ export async function probePeer(peer) {
     // request.
     const [healthRes, appsRes, syncRes, mediaProviderStatus] = await Promise.all([
       peerFetch(`${baseUrl}/api/system/health/details`, { signal }, peer),
-      peerFetch(`${baseUrl}/api/apps`, { signal }, peer).catch(() => null),
+      peerFetch(`${baseUrl}/api/apps?view=probe`, { signal }, peer).catch(() => null),
       peerFetch(`${baseUrl}/api/instances/sync-status${forPeerQs}`, { signal }, peer).catch(() => null),
       normalizePeerMediaProviderConfig(peer).enabled
         ? probeFederatedMediaProvider(peer, { signal })

--- a/server/services/instances.test.js
+++ b/server/services/instances.test.js
@@ -1149,7 +1149,10 @@ describe('instances.js', () => {
       readJSONFile.mockResolvedValue({ self: null, peers });
 
       const healthData = { instanceId: 'remote-id', version: '1.0.0', hostname: 'remote-host' };
-      const appsData = [{ id: 'app1', name: 'MyApp', overallStatus: 'running' }];
+      const appsData = [{
+        id: 'app1', name: 'MyApp', icon: 'package', overallStatus: 'online',
+        uiPort: 3000, apiPort: 3001, type: 'express',
+      }];
 
       fetch
         .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(healthData) }) // health
@@ -1162,8 +1165,10 @@ describe('instances.js', () => {
       expect(result.instanceId).toBe('remote-id');
       expect(result.version).toBe('1.0.0');
       expect(result.lastSeen).toBeDefined();
+      expect(result.lastApps).toEqual(appsData);
       expect(connectToPeer).toHaveBeenCalledWith(peer);
       expect(fetch).toHaveBeenCalledTimes(3);
+      expect(fetch.mock.calls[1][0]).toBe('http://10.0.0.1:5555/api/apps?view=probe');
     });
 
     it('discovers and persists capacity only for an opted-in media provider peer', async () => {
@@ -1193,7 +1198,7 @@ describe('instances.js', () => {
         if (String(url).endsWith('/api/system/health/details')) {
           return { ok: true, json: async () => ({ instanceId: 'remote-id', version: '1.0.0' }) };
         }
-        if (String(url).endsWith('/api/apps')) return { ok: true, json: async () => [] };
+        if (String(url).includes('/api/apps?view=probe')) return { ok: true, json: async () => [] };
         if (String(url).includes('/api/instances/sync-status')) return { ok: true, json: async () => ({}) };
         if (String(url).includes('/api/federation/media/v1/status')) {
           return { ok: true, status: 200, text: async () => JSON.stringify(providerStatus) };


### PR DESCRIPTION
Closes #7043

## Summary
- add a raw `view=nav` app projection for sidebar/name-only navigation
- add a PM2-backed `view=probe` projection for federation while preserving the default list contract
- classify the sidebar/publish callers and document the version-compatible API shapes

## Tests
- `server/node_modules/.bin/vitest run server/routes/apps/crud.test.js server/services/instances.test.js` (163 passed)
- `client/node_modules/.bin/vitest run client/src/services/apiApps.test.js client/src/components/Layout.test.jsx client/src/components/sprites/PublishWorkflow.test.jsx` (100 passed)
- full server suite (43,335 passed, 36 skipped)
- full client suite (11,429 passed, 6 skipped)
- `npm run lint` (client)
- `npm run build` (client)