### PR TITLE
fix: unify agent completion verdicts and preserve failed runs

### DIFF
--- a/server/services/agentFinalization.goalFidelity.test.js
+++ b/server/services/agentFinalization.goalFidelity.test.js
@@ -83,9 +83,11 @@ vi.mock('./codeReview.js', async (importOriginal) => ({
 }));
 
 import { execGit } from '../lib/execGit.js';
-import { execGh } from './github.js';
+import { execGh, findPullRequestForBranch } from './github.js';
 import { execGlab } from './gitlab.js';
 import { resolveForgeForRepo } from './git.js';
+import { getAgentRecord } from './cosAgentLifecycle.js';
+import { detectPrimaryCheckoutDrift, PRIMARY_CHECKOUT_MUTATED_REASON } from '../lib/primaryCheckoutGuard.js';
 import { finalizeAgent } from './agentFinalization.js';
 import { cosEvents } from './cosEvents.js';
 import { completeAgentRun } from './agentRunTracking.js';
@@ -293,6 +295,47 @@ describe('finalizeAgent — goal-fidelity gate', () => {
       taskId: 'task-1',
       review: expect.objectContaining({ verdict: 'rethink' }),
     }));
+  });
+
+  it('preserves a drift diagnosis over a missing PR and skips fidelity', async () => {
+    getAgentRecord.mockResolvedValueOnce({ metadata: { primaryCheckoutBaseline: {} } });
+    detectPrimaryCheckoutDrift.mockResolvedValueOnce({
+      drifted: true, category: 'primary-checkout-mutated', message: 'Primary checkout changed',
+    });
+    findPullRequestForBranch.mockResolvedValueOnce({ status: 'none' });
+    const finished = await finalize({ prExpected: true, runId: 'drift-and-pr' });
+    expect(finished).toMatchObject({ success: false, prVerdict: { ok: false } });
+    expect(completion()).toMatchObject({
+      error: 'Primary checkout changed', completionReason: PRIMARY_CHECKOUT_MUTATED_REASON,
+    });
+    expect(runLocalGoalFidelityReviewMock).not.toHaveBeenCalled();
+    expect(completeAgentRun.mock.calls[0][5]).toBe(false);
+  });
+
+  it('preserves a missing PR diagnosis without running fidelity', async () => {
+    findPullRequestForBranch.mockResolvedValueOnce({ status: 'none' });
+    await finalize({ prExpected: true });
+    expect(completion()).toMatchObject({ success: false, completionReason: 'pr-missing' });
+    expect(runLocalGoalFidelityReviewMock).not.toHaveBeenCalled();
+  });
+
+  it.each([false, true])('keeps a reported failure authoritative in run history (terminated: %s)', async terminatedByUser => {
+    const analysis = { category: 'unknown', message: 'Run did not complete' };
+    const finished = await finalize({
+      success: false, terminatedByUser, runId: 'failed-run', errorAnalysis: analysis,
+      completionReason: terminatedByUser ? 'user-terminated' : 'failed',
+    });
+    expect(finished).toMatchObject({ success: false, prVerdict: { ok: true } });
+    expect(completeAgentRun).toHaveBeenCalledWith('failed-run', 'done', 0, 1000, analysis, false);
+    expect(completion()).toMatchObject({
+      success: false, completionReason: terminatedByUser ? 'user-terminated' : 'failed',
+    });
+    if (terminatedByUser) {
+      expect(updateTaskMock).toHaveBeenCalledWith('task-1', expect.objectContaining({
+        status: 'blocked', metadata: expect.objectContaining({ blockedCategory: 'user-terminated' }),
+      }), 'internal');
+    }
+    expect(runLocalGoalFidelityReviewMock).not.toHaveBeenCalled();
   });
 
   it('fails OPEN: a gate that is off, a diff git could not read, or a reviewer that errored leaves the run alone', async () => {

--- a/server/services/agentFinalization.goalFidelity.test.js
+++ b/server/services/agentFinalization.goalFidelity.test.js
@@ -19,7 +19,7 @@ vi.mock('../lib/execGit.js', () => ({
 }));
 vi.mock('./github.js', () => ({
   execGh: vi.fn(),
-  findPullRequestForBranch: vi.fn(async () => ({ status: 'found', number: 7, url: 'https://example.com/pr/7' })),
+  findPullRequestForBranch: vi.fn(async () => ({ status: 'found', number: 7, url: 'https://example.com/pr/7', body: 'Closes #42' })),
   ensureForgeReachable: vi.fn(async () => ({ ok: true, status: 'ok' })),
 }));
 vi.mock('./gitlab.js', () => ({ findMergeRequestForBranch: vi.fn(), execGlab: vi.fn() }));
@@ -61,6 +61,7 @@ vi.mock('../lib/gitCommitProbe.js', () => ({
   committedDuringRun: vi.fn(async () => true),
   runWindowDiff: (...args) => runWindowDiffMock(...args),
 }));
+vi.mock('./agentRunEventLog.js', () => ({ appendRunEvent: vi.fn(async () => null) }));
 vi.mock('./agentRunTracking.js', () => ({ createAgentRun: vi.fn(), completeAgentRun: vi.fn(async () => null) }));
 vi.mock('./taskTypeHooks.js', () => ({
   canRunTaskOutputHookWithoutPayload: vi.fn(() => false),
@@ -275,7 +276,10 @@ describe('finalizeAgent — goal-fidelity gate', () => {
       missing: ['the retry'],
       unrequested: ['an unrelated logging refactor'],
     }));
-    await finalize();
+    const finalized = await finalize({ runId: 'fidelity-held-run', prExpected: true });
+    expect(finalized).toMatchObject({ success: false, prVerdict: { ok: true } });
+    expect(completeAgentRun).toHaveBeenCalledWith('fidelity-held-run', 'done', 0, 1000,
+      expect.objectContaining({ category: GOAL_FIDELITY_CATEGORY }), false);
 
     const result = completion();
     expect(result.success).toBe(false);

--- a/server/services/agentFinalization.js
+++ b/server/services/agentFinalization.js
@@ -799,6 +799,23 @@ export async function stampLiExecutionVerdict(taskUpdate, task, { success, valid
   return taskUpdate;
 }
 
+// A no-change audit needs forge + empty-branch proof even when its spawner
+// leaves PR creation to cleanup. Reuse a completed primary check; a thrown
+// check is inconclusive, never proof that there was nothing to ship.
+async function resolveNoChangeProof({
+  noChangeAudit, prExpected, prCheckThrew, prVerdict,
+  task, workspacePath, success, agentId,
+}) {
+  if (!noChangeAudit) return null;
+  const inconclusive = { ok: false, category: FORGE_UNREACHABLE_CATEGORY, inconclusive: true };
+  if (prExpected) return prCheckThrew ? inconclusive : prVerdict;
+  return verifyPrClaim({ task, workspacePath, success, prExpected: true })
+    .catch(err => {
+      emitLog('warn', `⚠️ No-change verification failed for ${agentId}: ${err.message}`, { agentId });
+      return inconclusive;
+    });
+}
+
 /**
  * Shared end-of-run state writes for all three spawn paths
  * (`handleAgentCompletion` runner-mode, TUI `finish`, direct-CLI `close`).
@@ -861,17 +878,10 @@ export async function finalizeAgent({
   // a clean exit can satisfy its no-change success criterion. Keep this
   // auxiliary verdict separate: a non-empty branch must remain eligible for
   // cleanup to open the PR after finalize rather than being downgraded here.
-  const noChangeProof = noChangeAudit
-    ? prExpected
-      ? (prCheckThrew
-          ? { ok: false, category: FORGE_UNREACHABLE_CATEGORY, inconclusive: true }
-          : prVerdict)
-      : await verifyPrClaim({ task, workspacePath, success: reportedSuccess, prExpected: true })
-        .catch(err => {
-          emitLog('warn', `⚠️ No-change verification failed for ${agentId}: ${err.message}`, { agentId });
-          return { ok: false, category: FORGE_UNREACHABLE_CATEGORY, inconclusive: true };
-        })
-    : null;
+  const noChangeProof = await resolveNoChangeProof({
+    noChangeAudit, prExpected, prCheckThrew, prVerdict,
+    task, workspacePath, success: reportedSuccess, agentId,
+  });
   const effectivePrVerdict = typeof prVerdict.branch === 'string'
     ? prVerdict
     : (noChangeProof?.noChangesToShip === true ? noChangeProof : prVerdict);
@@ -950,10 +960,31 @@ export async function finalizeAgent({
   // side effect. Same reason `terminatedByUser` keeps its own verdict.
   const driftDowngrade = drift.drifted && reportedSuccess && !terminatedByUser;
 
-  let success = reportedSuccess && prVerdict.ok && !driftDowngrade;
-  let errorAnalysis = driftDowngrade
-    ? primaryCheckoutDriftAnalysis(drift)
-    : prVerdict.ok ? reportedErrorAnalysis : prVerificationAnalysis(prVerdict);
+  // One accumulator owns every completion write and the caller's cleanup
+  // decision. Apply diagnoses in priority order: drift > PR > fidelity > hook
+  // > original error. Fidelity and hooks can only replace an eligible verdict.
+  // Drift demands repair of the primary checkout even if a PR exists; a
+  // missing PR is a concrete delivery failure, ahead of fidelity's judgement
+  // about what was built. Keep each diagnosis's card text and reason together.
+  const verdict = {
+    success: reportedSuccess && prVerdict.ok && !driftDowngrade,
+    errorAnalysis: reportedErrorAnalysis,
+    error,
+    completionReason,
+  };
+  if (driftDowngrade) {
+    Object.assign(verdict, {
+      errorAnalysis: primaryCheckoutDriftAnalysis(drift),
+      error: drift.message,
+      completionReason: PRIMARY_CHECKOUT_MUTATED_REASON,
+    });
+  } else if (!prVerdict.ok) {
+    Object.assign(verdict, {
+      errorAnalysis: prVerificationAnalysis(prVerdict),
+      error: prVerdict.message,
+      completionReason: prVerdict.category,
+    });
+  }
   if (!prVerdict.ok) {
     emitLog('warn', `⚠️ ${prVerdict.message} — recording ${agentId} as needs-attention (${prVerdict.category}) rather than complete`, {
       agentId, taskId: task?.id, branch: prVerdict.branch, category: prVerdict.category
@@ -975,7 +1006,7 @@ export async function finalizeAgent({
   // the diff probe's git timeouts — it holds the agent's CoS concurrency slot for
   // its duration, which is why it is skipped entirely unless the user configured
   // a local backend for it.
-  const fidelity = success && !isPrivateSecurityTask(task)
+  const fidelity = verdict.success && !isPrivateSecurityTask(task)
     ? await evaluateGoalFidelity({ task, workspacePath, startedAt: runStartedAt })
       .catch(err => {
         emitLog('warn', `⚠️ Goal-fidelity review failed for ${agentId}: ${err.message}`, { agentId });
@@ -991,15 +1022,20 @@ export async function finalizeAgent({
     emitLog('warn', `⚠️ Goal-fidelity review returned no verdict for ${agentId}: ${fidelity.error}`, { agentId, taskId: task?.id });
   }
   if (fidelityDowngrade) {
-    success = false;
-    errorAnalysis = goalFidelityAnalysis(fidelity.review);
+    const analysis = goalFidelityAnalysis(fidelity.review);
+    Object.assign(verdict, {
+      success: false,
+      errorAnalysis: analysis,
+      error: analysis.message,
+      completionReason: GOAL_FIDELITY_CATEGORY,
+    });
     // The Review Hub bridges this into a review alert: a run held because it
     // built the wrong thing is exactly the case a human has to look at, and the
     // named missing/unrequested items are what make the hold actionable.
     cosEvents.emit(GOAL_FIDELITY_HOLD_EVENT, { agentId, taskId: task?.id, review: fidelity.review });
   }
 
-  if (success && isTruthyMetaFn) {
+  if (verdict.success && isTruthyMetaFn) {
     await persistSimplifySummaries(agentId, task, outputBuffer, isTruthyMetaFn);
   }
 
@@ -1014,9 +1050,9 @@ export async function finalizeAgent({
         blockedAt: new Date().toISOString(),
       },
     }
-    : success
+    : verdict.success
       ? { status: 'completed' }
-      : await resolveFailedTaskUpdate(task, errorAnalysis, agentId);
+      : await resolveFailedTaskUpdate(task, verdict.errorAnalysis, agentId);
 
   // Programmatic-I/O task types (e.g. layered-intelligence) run a deterministic
   // post-agent step on the agent's STRUCTURED output — the parsed `.agent-done`
@@ -1040,7 +1076,7 @@ export async function finalizeAgent({
   // of awaiting here is that the agent still counts against the CoS concurrency
   // gate for the hook's duration, so the dispatch is hard-bounded — see
   // withOutputHookTimeout.
-  let hookResult = await dispatchTaskOutputHookOnce({ agentId, task, success, workspacePath });
+  let hookResult = await dispatchTaskOutputHookOnce({ agentId, task, success: verdict.success, workspacePath });
   // A private assessment's deliverable is the validated, persisted report.
   // A skipped, thrown or timed-out hook cannot establish that deliverable,
   // even when the CLI exited zero. Keep other task types' existing semantics.
@@ -1081,23 +1117,33 @@ export async function finalizeAgent({
   // (rate-limit, auth-error, a killed provider) keeps its ordinary retries —
   // that output is missing because the environment misbehaved, not because the
   // stage can never produce one.
-  const causeNamed = !success && errorAnalysis?.category && errorAnalysis.category !== 'unknown';
+  const causeNamed = !verdict.success && verdict.errorAnalysis?.category && verdict.errorAnalysis.category !== 'unknown';
   const hookPermanent = hookRejected && hookOutcome?.permanent === true && !causeNamed;
   // When the run had already failed, `taskUpdate` holds its retry decision. Only
   // escalate a decision that is still retrying — a task this run already blocked
   // is terminal, and re-resolving it would file a second investigation task.
-  const escalatePermanent = hookPermanent && !success && taskUpdate?.status !== 'blocked';
-  if (hookRejected && (success || escalatePermanent)) {
-    success = false;
-    errorAnalysis = {
+  const escalatePermanent = hookPermanent && !verdict.success && taskUpdate?.status !== 'blocked';
+  if (hookRejected && (verdict.success || escalatePermanent)) {
+    const analysis = {
       category: hookOutcome.reason || 'output-hook-rejected',
       message: hookOutcome.message || 'The scheduled task output was rejected by its validation hook',
       actionable: false,
       ...(hookPermanent && { permanent: true }),
       origin: 'task-output-hook',
     };
-    taskUpdate = await resolveFailedTaskUpdate(task, errorAnalysis, agentId);
-  } else if (hookMetadata && success && !terminatedByUser) {
+    Object.assign(verdict, {
+      success: false,
+      errorAnalysis: analysis,
+      error: analysis.message || error,
+      completionReason: analysis.category || completionReason,
+    });
+    taskUpdate = await resolveFailedTaskUpdate(task, verdict.errorAnalysis, agentId);
+  } else if (hookRejected && verdict.errorAnalysis === reportedErrorAnalysis) {
+    // A rejection on an already-failed run keeps its original diagnosis.
+    // Surface that analysis on the card too, without replacing a prior downgrade.
+    verdict.error = verdict.errorAnalysis?.message || error;
+    verdict.completionReason = verdict.errorAnalysis?.category || completionReason;
+  } else if (hookMetadata && verdict.success && !terminatedByUser) {
     taskUpdate = { ...taskUpdate, metadata: task.metadata };
   }
 
@@ -1111,7 +1157,7 @@ export async function finalizeAgent({
     terminatedByUser,
     workspacePath,
     startedAt: runStartedAt,
-    success,
+    success: verdict.success,
     hookResult,
     noChangesToShip,
     noChangeProof,
@@ -1127,61 +1173,30 @@ export async function finalizeAgent({
   // completeAgentRun writes its own runs/<id>/metadata.json (separate lock),
   // so its place in the chain is purely about progress reporting on partial
   // failure.
-  // A PR-verification downgrade carries its own error text + reason: without
-  // them the agent card would render a bare "Failed" for a run that actually
-  // did everything but land its PR (or simply couldn't reach the forge).
-  // A branch-jack downgrade (#3680) carries its own text + reason for the same
-  // reason the PR downgrade does, and outranks it: the run may well have opened
-  // its PR fine and still mutated the primary, and THAT is the thing a human has
-  // to act on.
-  // A goal-fidelity hold (#5994) sits below both: a branch-jack and a missing PR
-  // are facts about what the run did to the repo, while this is a judgement about
-  // what it built — and when a run both missed its PR and drifted, the missing PR
-  // is the more concrete thing to act on first.
-  const finalError = driftDowngrade
-    ? drift.message
-    : !prVerdict.ok
-      ? prVerdict.message
-      : fidelityDowngrade
-        ? errorAnalysis?.message
-        : hookRejected
-          ? errorAnalysis?.message || error
-          : error;
-  const finalCompletionReason = driftDowngrade
-    ? PRIMARY_CHECKOUT_MUTATED_REASON
-    : !prVerdict.ok
-      ? prVerdict.category
-      : fidelityDowngrade
-        ? GOAL_FIDELITY_CATEGORY
-        : hookRejected
-          ? errorAnalysis?.category || completionReason
-          : completionReason;
-
   await completeAgent(agentId, {
-    success,
+    success: verdict.success,
     validationPassed,
     exitCode,
     duration,
     outputLength: outputBuffer?.length ?? 0,
-    errorAnalysis,
+    errorAnalysis: verdict.errorAnalysis,
     // Recorded whatever the verdict — a `ship` is the evidence that the gate ran
     // and cleared the run, which is what makes a run with no `goalFidelity` block
     // legible as "never judged" rather than "judged fine".
     ...(fidelity.review ? { goalFidelity: fidelity.review } : {}),
-    ...(finalError !== undefined ? { error: finalError } : {}),
-    ...(finalCompletionReason !== undefined ? { completionReason: finalCompletionReason } : {}),
+    ...(verdict.error !== undefined ? { error: verdict.error } : {}),
+    ...(verdict.completionReason !== undefined ? { completionReason: verdict.completionReason } : {}),
   });
 
   if (runId) {
-    // Pass the downgrade explicitly: this run exited 0, so the run record would
-    // otherwise keep saying "success" for the one run we just concluded did not
-    // land its PR (#3358).
+    // Every failed verdict overrides exit-code/commit rescue in run tracking,
+    // so the history cannot contradict the task or the cleanup decision (#3358).
     const runOutput = isPrivateSecurityTask(task)
-      ? success
+      ? verdict.success
         ? 'Private security assessment: see the local Review Hub report.'
         : 'Private security assessment report was not verified; inspect the local assessment archive.'
       : outputBuffer;
-    await completeAgentRun(runId, runOutput, exitCode, duration, errorAnalysis, prVerdict.ok && !driftDowngrade && !fidelityDowngrade && !hookRejected ? null : false);
+    await completeAgentRun(runId, runOutput, exitCode, duration, verdict.errorAnalysis, verdict.success ? null : false);
   }
 
   // LI hand-off execution verdict (#2779): stamp the per-proposal execution outcome into
@@ -1189,7 +1204,7 @@ export async function finalizeAgent({
   // (which filed the proposal and runs LI for that app) can derive `recordProposalExecution`
   // from the terminal synced task — cross-peer parity for the #2765 LOCAL write, which only
   // lands on the peer that ran the agent.
-  await stampLiExecutionVerdict(taskUpdate, task, { success, validationPassed, errorAnalysis });
+  await stampLiExecutionVerdict(taskUpdate, task, { success: verdict.success, validationPassed, errorAnalysis: verdict.errorAnalysis });
 
   // The bounded source inventory belongs only to this run and its private
   // report. Task metadata is replicated to peers and reused in later prompts.
@@ -1199,11 +1214,11 @@ export async function finalizeAgent({
   }
   const taskResult = await updateTask(task.id, taskUpdate, taskType);
   if (taskResult?.error) {
-    const label = terminatedByUser ? 'blocked' : success ? 'completed' : 'failed';
+    const label = terminatedByUser ? 'blocked' : verdict.success ? 'completed' : 'failed';
     emitLog('warn', `⚠️ Failed to update ${label} task ${task.id}: ${taskResult.error} (taskType=${taskType})`, { taskId: task.id, agentId, error: taskResult.error });
   }
 
-  if (!success && !terminatedByUser && errorAnalysis) {
+  if (!verdict.success && !terminatedByUser && verdict.errorAnalysis) {
     // Bench the provider when the PROVIDER is what failed — not the agent's
     // work. `origin: 'provider'` is agentErrorAnalysis's provenance flag (#2642),
     // set only for structured provider chrome, never for a loose keyword sweep of
@@ -1222,7 +1237,7 @@ export async function finalizeAgent({
     // `origin: 'provider'` via their `structuredMarker`, so nothing real is lost.
     // Every finalizeAgent caller analyzes through analyzeAgentFailure or
     // detectImmediateFallbackSignal, and both stamp an origin on every branch.
-    const bench = errorAnalysis.origin === 'provider' ? resolveProviderBench(errorAnalysis) : null;
+    const bench = verdict.errorAnalysis.origin === 'provider' ? resolveProviderBench(verdict.errorAnalysis) : null;
     // Lazy provider lookup — resolve the active provider only when a marker
     // fires AND the caller didn't already know the id, keeping the ordinary
     // failure path free of a settings-file read.
@@ -1231,7 +1246,7 @@ export async function finalizeAgent({
       // `markUsageLimit` parses its own window out of the provider's message
       // ("resets 5pm"), so a usage limit keeps its dedicated marker.
       const mark = bench.marker === 'usage-limit'
-        ? markProviderUsageLimit(markerProviderId, errorAnalysis)
+        ? markProviderUsageLimit(markerProviderId, verdict.errorAnalysis)
         : markProviderUnavailable(markerProviderId, {
           reason: bench.category,
           message: bench.message || 'Provider unavailable',
@@ -1256,10 +1271,10 @@ export async function finalizeAgent({
   const scheduledType = task?.metadata?.analysisType || null;
   if (scheduledType) {
     const signal = resolveTypeFailureSignal({
-      success,
+      success: verdict.success,
       terminatedByUser,
       hookResult,
-      errorCategory: errorAnalysis?.category
+      errorCategory: verdict.errorAnalysis?.category
     });
     if (signal.record !== 'skip') {
       const ledgerAppId = task?.metadata?.app || null;
@@ -1273,7 +1288,7 @@ export async function finalizeAgent({
     }
   }
 
-  await processAgentCompletion(agentId, task, success, outputBuffer);
+  await processAgentCompletion(agentId, task, verdict.success, outputBuffer);
 
   if (usesCreativeDirectorScratchCwd(task)) {
     await removeCreativeDirectorScratchCwd(agentId).catch((err) => {
@@ -1286,7 +1301,7 @@ export async function finalizeAgent({
   // downgraded to `pr-missing` would still be cleaned up as a success — worktree
   // removed, local branch deleted, and no resume pointer recorded — destroying
   // the state the retry needs to open the PR that is missing.
-  return { success, prVerdict: effectivePrVerdict };
+  return { success: verdict.success, prVerdict: effectivePrVerdict };
 }
 
 // Tail of the agent's transcript scanned by the rescue. The deliverable, when

--- a/server/services/agentFinalization.js
+++ b/server/services/agentFinalization.js
@@ -967,6 +967,7 @@ export async function finalizeAgent({
   // missing PR is a concrete delivery failure, ahead of fidelity's judgement
   // about what was built. Keep each diagnosis's card text and reason together.
   const verdict = {
+    source: 'reported',
     success: reportedSuccess && prVerdict.ok && !driftDowngrade,
     errorAnalysis: reportedErrorAnalysis,
     error,
@@ -974,12 +975,14 @@ export async function finalizeAgent({
   };
   if (driftDowngrade) {
     Object.assign(verdict, {
+      source: 'drift',
       errorAnalysis: primaryCheckoutDriftAnalysis(drift),
       error: drift.message,
       completionReason: PRIMARY_CHECKOUT_MUTATED_REASON,
     });
   } else if (!prVerdict.ok) {
     Object.assign(verdict, {
+      source: 'pr',
       errorAnalysis: prVerificationAnalysis(prVerdict),
       error: prVerdict.message,
       completionReason: prVerdict.category,
@@ -1024,6 +1027,7 @@ export async function finalizeAgent({
   if (fidelityDowngrade) {
     const analysis = goalFidelityAnalysis(fidelity.review);
     Object.assign(verdict, {
+      source: 'fidelity',
       success: false,
       errorAnalysis: analysis,
       error: analysis.message,
@@ -1132,13 +1136,14 @@ export async function finalizeAgent({
       origin: 'task-output-hook',
     };
     Object.assign(verdict, {
+      source: 'hook',
       success: false,
       errorAnalysis: analysis,
       error: analysis.message || error,
       completionReason: analysis.category || completionReason,
     });
     taskUpdate = await resolveFailedTaskUpdate(task, verdict.errorAnalysis, agentId);
-  } else if (hookRejected && verdict.errorAnalysis === reportedErrorAnalysis) {
+  } else if (hookRejected && verdict.source === 'reported') {
     // A rejection on an already-failed run keeps its original diagnosis.
     // Surface that analysis on the card too, without replacing a prior downgrade.
     verdict.error = verdict.errorAnalysis?.message || error;

--- a/server/services/agentFinalization.outputHooks.test.js
+++ b/server/services/agentFinalization.outputHooks.test.js
@@ -30,17 +30,43 @@ vi.mock('./taskTypeHooks.js', () => ({
   resolveTaskHookType: vi.fn(task => task?.metadata?.analysisType || null),
 }));
 
-import { getAgent, updateAgent } from './cosAgentLifecycle.js';
+import { getAgent, updateAgent, completeAgent } from './cosAgentLifecycle.js';
 import { canRunTaskOutputHookWithoutPayload, getTaskOutputHook } from './taskTypeHooks.js';
 import {
+  finalizeAgent,
   dispatchRecoveredTaskOutputHook,
   dispatchTaskOutputHookOnce,
 } from './agentFinalization.js';
 
+
+vi.mock('./cos.js', () => ({
+  updateTask: vi.fn(async () => ({})),
+  addTask: vi.fn(async () => ({ id: 'investigation-test' })),
+}));
+vi.mock('./investigationTaskProducer.js', () => ({
+  investigationCircuitOpen: vi.fn(() => false),
+  noteInvestigationFiled: vi.fn(),
+  readAllTasksFlat: vi.fn(async () => []),
+  recentInvestigationCreations: vi.fn(() => []),
+}));
+vi.mock('./agentErrorAnalysis.js', async importOriginal => {
+  const actual = await importOriginal();
+  return { ...actual, resolveFailedTaskUpdate: vi.fn(actual.resolveFailedTaskUpdate) };
+});
+vi.mock('./agentRunTracking.js', () => ({ completeAgentRun: vi.fn(async () => null) }));
+vi.mock('./agentCompletion.js', () => ({ processAgentCompletion: vi.fn(async () => null) }));
+vi.mock('./cosEvents.js', () => ({ emitLog: vi.fn(), cosEvents: { emit: vi.fn(), on: vi.fn() } }));
+vi.mock('./taskSchedule.js', () => ({
+  recordTaskTypeFailure: vi.fn(async () => null),
+  recordTaskTypeSuccess: vi.fn(async () => null),
+}));
+import { updateTask, addTask } from './cos.js';
+import { completeAgentRun } from './agentRunTracking.js';
+import { resolveFailedTaskUpdate } from './agentErrorAnalysis.js';
+
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const MANAGEMENT_SOURCE = readFileSync(join(__dirname, 'agentManagement.js'), 'utf8');
 const LIFECYCLE_SOURCE = readFileSync(join(__dirname, 'agentLifecycle.js'), 'utf8');
-const FINALIZATION_SOURCE = readFileSync(join(__dirname, 'agentFinalization.js'), 'utf8');
 const TASK = {
   id: 'sys-example',
   taskType: 'internal',
@@ -241,25 +267,52 @@ describe('recovery path wiring (#3182)', () => {
 // error, so the run was already `success === false` and the permanent verdict
 // never applied — the task consumed its retries and the pipeline re-spawned.
 describe('permanent output-hook rejection (#6124)', () => {
-  const block = (() => {
-    const start = FINALIZATION_SOURCE.indexOf('const hookRejected = !terminatedByUser');
-    return FINALIZATION_SOURCE.slice(start, FINALIZATION_SOURCE.indexOf('const validationPassed = await evaluateSuccessCriteria', start));
-  })();
-
-  it('escalates a permanent rejection on a run that had ALREADY failed', () => {
-    expect(block).toContain("hookOutcome?.permanent === true");
-    expect(block).toContain('if (hookRejected && (success || escalatePermanent)) {');
-    expect(block).toContain('...(hookPermanent && { permanent: true })');
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getAgent.mockResolvedValue({ id: 'agent-rejected', metadata: {} });
+    updateAgent.mockResolvedValue(null);
+    getTaskOutputHook.mockResolvedValue(async () => ({
+      accepted: false, permanent: true, reason: 'output-missing', message: 'No parseable output',
+    }));
   });
 
-  it('leaves a NAMED failure cause on its ordinary retry path', () => {
-    // A rate-limited or unauthenticated run also writes no output; blocking it
-    // permanently would strand work that a retry would have completed.
-    expect(block).toContain("errorAnalysis.category !== 'unknown'");
-    expect(block).toContain('&& !causeNamed');
+  const finish = (errorAnalysis, metadata = {}) => finalizeAgent({
+    agentId: 'agent-rejected',
+    task: { ...TASK, metadata: { ...TASK.metadata, ...metadata } },
+    runId: 'run-rejected', success: false, exitCode: 1, duration: 1000,
+    outputBuffer: '', errorAnalysis,
   });
 
-  it('never re-resolves a decision that already blocked (no duplicate investigation task)', () => {
-    expect(block).toContain("taskUpdate?.status !== 'blocked'");
+  it('blocks an already-failed unknown run and records failure for cleanup and run history', async () => {
+    expect(await finish({ category: 'unknown' })).toMatchObject({ success: false });
+    expect(updateTask).toHaveBeenCalledWith(TASK.id, expect.objectContaining({
+      status: 'blocked', metadata: expect.objectContaining({ blockedCategory: 'output-missing' }),
+    }), 'internal');
+    expect(completeAgent).toHaveBeenCalledWith('agent-rejected', expect.objectContaining({
+      success: false, completionReason: 'output-missing', error: 'No parseable output',
+      errorAnalysis: expect.objectContaining({ permanent: true, origin: 'task-output-hook' }),
+    }));
+    expect(completeAgentRun).toHaveBeenCalledWith('run-rejected', '', 1, 1000,
+      expect.objectContaining({ category: 'output-missing', permanent: true }), false);
+    expect(addTask).not.toHaveBeenCalled();
+  });
+
+  it('leaves a named failure on its ordinary retry path', async () => {
+    await finish({ category: 'rate-limit', message: 'Try later' });
+    expect(updateTask).toHaveBeenCalledWith(TASK.id, expect.objectContaining({
+      status: 'in_progress', metadata: expect.objectContaining({ lastErrorCategory: 'rate-limit' }),
+    }), 'internal');
+    expect(completeAgent).toHaveBeenCalledWith('agent-rejected', expect.objectContaining({
+      error: 'Try later', completionReason: 'rate-limit',
+      errorAnalysis: { category: 'rate-limit', message: 'Try later' },
+    }));
+    expect(resolveFailedTaskUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not re-resolve an already-blocked task or duplicate its investigation', async () => {
+    await finish({ category: 'unknown' }, { failureCount: 3 });
+    expect(updateTask).toHaveBeenCalledWith(TASK.id, expect.objectContaining({ status: 'blocked' }), 'internal');
+    expect(resolveFailedTaskUpdate).toHaveBeenCalledTimes(1);
+    expect(addTask).toHaveBeenCalledTimes(1);
   });
 });

--- a/server/services/agentFinalization.outputHooks.test.js
+++ b/server/services/agentFinalization.outputHooks.test.js
@@ -62,7 +62,7 @@ vi.mock('./taskSchedule.js', () => ({
 }));
 import { updateTask, addTask } from './cos.js';
 import { completeAgentRun } from './agentRunTracking.js';
-import { resolveFailedTaskUpdate } from './agentErrorAnalysis.js';
+import { MAX_TASK_RETRIES, resolveFailedTaskUpdate } from './agentErrorAnalysis.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const MANAGEMENT_SOURCE = readFileSync(join(__dirname, 'agentManagement.js'), 'utf8');
@@ -310,7 +310,7 @@ describe('permanent output-hook rejection (#6124)', () => {
   });
 
   it('does not re-resolve an already-blocked task or duplicate its investigation', async () => {
-    await finish({ category: 'unknown' }, { failureCount: 3 });
+    await finish({ category: 'unknown' }, { failureCount: MAX_TASK_RETRIES - 1 });
     expect(updateTask).toHaveBeenCalledWith(TASK.id, expect.objectContaining({ status: 'blocked' }), 'internal');
     expect(resolveFailedTaskUpdate).toHaveBeenCalledTimes(1);
     expect(addTask).toHaveBeenCalledTimes(1);

--- a/server/services/agentLifecycle.test.js
+++ b/server/services/agentLifecycle.test.js
@@ -487,7 +487,7 @@ describe('self-update spawn gate — funnel coverage (#4124)', () => {
     const body = AGENT_FINALIZATION_SRC.slice(idx, updateIdx);
     // The verdict is stamped into taskUpdate via the shared helper BEFORE the updateTask
     // call, so it federates in the same write that marks the task terminal.
-    expect(body).toMatch(/await stampLiExecutionVerdict\(taskUpdate, task, \{ success, validationPassed, errorAnalysis \}\)/);
+    expect(body).toMatch(/await stampLiExecutionVerdict\(taskUpdate, task, \{ success: verdict\.success, validationPassed, errorAnalysis: verdict\.errorAnalysis \}\)/);
   });
 
   it('stampLiExecutionVerdict builds the verdict from the task liProposal marker via the shared builder (#2779)', () => {


### PR DESCRIPTION
Agent completion previously derived failure independently for task status, agent cards, run history, and cleanup. This change gives finalizeAgent one verdict accumulator and extracts the no-change proof step, keeping drift > PR > fidelity > hook precedence and sequential checks.

Run history now honors every failed completion verdict, including ordinary failures and user termination, instead of allowing exit-code/commit rescue to contradict the task and cleanup verdict. Hook rejection tests exercise the real retry resolver instead of grepping source.

Validation: 282 tests passed across all agentFinalization suites, agentLifecycle, agentRunTracking, and agentImportCycles. Claude reviewed at medium effort in tool-free plan mode; findings were checked and addressed with explicit verdict provenance and additional precedence/termination coverage.

Closes #7048
