### PR TITLE
fix: share Wan frame validation across local and federated jobs

### DIFF
--- a/server/services/federatedMediaProvider.js
+++ b/server/services/federatedMediaProvider.js
@@ -44,6 +44,7 @@ import {
 import { listMusicEngineCapabilities } from './musicEngineCapabilities.js';
 import { BYOV_VIDEO_RUNTIMES, isByovRuntimeReady } from './videoGen/runtimes.js';
 import { minimaxH3ControlError } from './videoGen/minimaxH3Controls.js';
+import { wan22FrameCountError } from './videoGen/wan22Controls.js';
 import { readCallerInstanceId } from './sharing/peerPullAuthorization.js';
 import { findPeerById } from './sharing/peerSyncShared.js';
 
@@ -282,16 +283,8 @@ const validateFederatedVideoControls = (input, model) => {
     });
     if (controlError) throw controlError;
   }
-  if (model.runtime === 'wan22') {
-    const frameStride = Number(model.frameStride);
-    if (Number.isFinite(frameStride) && frameStride > 0 && (Number(numFrames) - 1) % frameStride !== 0) {
-      unavailable(
-        `${model.name} requires a ${frameStride}n+1 frame count; got ${numFrames}.`,
-        'WAN22_INVALID_FRAME_COUNT',
-        400,
-      );
-    }
-  }
+  const frameCountError = wan22FrameCountError(model, numFrames);
+  if (frameCountError) unavailable(frameCountError.message, frameCountError.code, frameCountError.status);
 };
 
 export function normalizeFederatedMediaProviderConfig(settings) {

--- a/server/services/federatedMediaProvider.test.js
+++ b/server/services/federatedMediaProvider.test.js
@@ -910,6 +910,30 @@ describe('federated media provider — prompt-free status and projection payload
     expect(payload(completed)).not.toContain(scenario.sentinel);
   });
 
+  it.each(['wan22', 'wan22_cuda'])('rejects off-grid %s frames before federated enqueue', async (runtime) => {
+    state.videoModels = [{
+      id: 'wan_test', name: 'Test Wan', runtime, repo: 'example/wan-test',
+      supportedModes: ['text'], frameStride: 4, defaultFrames: 120,
+    }];
+    state.cachedRepos = new Set(['example/wan-test']);
+    const providerConfig = {
+      ...config(), audioModels: [], videoModels: [{ engine: 'local', modelId: 'wan_test' }],
+    };
+    state.settings = { federation: { mediaProvider: providerConfig } };
+    const submit = (frames) => submitFederatedMediaJob({
+      callerId: 'peer-example', config: providerConfig,
+      input: { kind: 'video', engine: 'local', modelId: 'wan_test', prompt: 'a lighthouse', ...frames },
+    });
+    const error = {
+      status: 400, code: 'WAN22_INVALID_FRAME_COUNT',
+      message: 'Test Wan requires a 4n+1 frame count; got 120.',
+    };
+    await expect(submit({ numFrames: 120 })).rejects.toMatchObject(error);
+    await expect(submit({})).rejects.toMatchObject(error);
+    expect(enqueueJob).not.toHaveBeenCalled();
+    await expect(submit({ numFrames: 81 })).resolves.toHaveProperty('job');
+  });
+
   it('populates frameStride, maxNumFrames, and resolutionOptions for visual models and null for audio', async () => {
     state.videoModels = [{
       id: 'wan22_t2v_a14b',

--- a/server/services/videoGen/generateVideo.js
+++ b/server/services/videoGen/generateVideo.js
@@ -20,6 +20,7 @@ import { randomUUID } from 'crypto';
 import { promisify } from 'util';
 import { ensureDir, PATHS, unlinkGuarded, rmGuarded } from '../../lib/fileUtils.js';
 import { ServerError } from '../../lib/errorHandler.js';
+import { wan22FrameCountError } from './wan22Controls.js';
 import {
   isDefaultI2vReferenceMode, normalizeI2vReferenceMode, resolveI2vReferenceStrength,
 } from '../../lib/videoReferenceModes.js';
@@ -198,16 +199,11 @@ export async function generateVideo({ pythonPath, prompt, negativePrompt = '', m
   // argument when the caller deliberately leaves the resolution unset.
   ({ width, height } = resolveVideoDimensions(model, width, height));
   numFrames = numFrames ?? model.defaultFrames ?? DEFAULT_NUM_FRAMES;
+  const frameCountError = wan22FrameCountError(model, numFrames);
+  if (frameCountError) throw frameCountError;
   let wanModelPath = null;
   const wanRequiredWeights = [];
   if (model.runtime === 'wan22' || model.runtime === 'wan22_cuda') {
-    const frameStride = Number(model.frameStride);
-    if (Number.isFinite(frameStride) && frameStride > 0 && (Number(numFrames) - 1) % frameStride !== 0) {
-      throw new ServerError(
-        `${model.name} requires a ${frameStride}n+1 frame count; got ${numFrames}.`,
-        { status: 400, code: 'WAN22_INVALID_FRAME_COUNT' },
-      );
-    }
     wanModelPath = await resolvePinnedSnapshotPath(model, {
       notCachedCode: 'WAN22_MODEL_NOT_CACHED',
       onMissingRevision: 'throw',

--- a/server/services/videoGen/local.test.js
+++ b/server/services/videoGen/local.test.js
@@ -2865,6 +2865,24 @@ describe('generateVideo — close-handler resilience (issue #1334)', () => {
   });
 });
 
+describe.each(['wan22', 'wan22_cuda'])('generateVideo — Wan frame defaults %s', (runtime) => {
+  it.each([undefined, 120])('rejects off-grid frames (%s) before spawn', async (numFrames) => {
+    const { getVideoModels } = await import('../../lib/mediaModels.js');
+    const { spawnDetached } = await import('../../lib/detachedSpawn.js');
+    vi.mocked(getVideoModels).mockReturnValueOnce([{
+      id: 'wan_test', name: 'Test Wan', runtime,
+      supportedModes: ['text'], frameStride: 4, defaultFrames: 120,
+    }]);
+    await expect(generateVideo({
+      modelId: 'wan_test', prompt: 'test', mode: 'text', numFrames,
+    })).rejects.toMatchObject({
+      status: 400, code: 'WAN22_INVALID_FRAME_COUNT',
+      message: 'Test Wan requires a 4n+1 frame count; got 120.',
+    });
+    expect(spawnDetached).not.toHaveBeenCalled();
+  });
+});
+
 describe('generateVideo — Wan MLX-Gen contract', () => {
   it('passes the locked Lightning sampler and exact high/low adapter pair', async () => {
     const { spawnDetached } = await import('../../lib/detachedSpawn.js');

--- a/server/services/videoGen/prepareParams.js
+++ b/server/services/videoGen/prepareParams.js
@@ -638,8 +638,12 @@ async function resolvePreparedParams({
       throw controlError;
     }
   }
-  // Persist the same resolved count the worker will render and validate.
-  let effectiveNumFrames = body.numFrames ?? effectiveModel?.defaultFrames ?? DEFAULT_NUM_FRAMES;
+  // Pin Wan's validated count for the worker while preserving other runtimes'
+  // existing behavior of leaving omitted controls unset in persisted params.
+  const isWan = effectiveModel?.runtime === 'wan22' || effectiveModel?.runtime === 'wan22_cuda';
+  let effectiveNumFrames = isWan
+    ? body.numFrames ?? effectiveModel.defaultFrames ?? DEFAULT_NUM_FRAMES
+    : body.numFrames;
   const frameCountError = wan22FrameCountError(effectiveModel, effectiveNumFrames);
   if (frameCountError) {
     await cleanupStaged();

--- a/server/services/videoGen/prepareParams.js
+++ b/server/services/videoGen/prepareParams.js
@@ -42,6 +42,7 @@ import {
   isStockTextEncoder, supportsVideoTextEncoder, videoTextEncoderUnsupportedError,
 } from '../../lib/videoTextEncoders.js';
 import { minimaxH3ControlError } from './minimaxH3Controls.js';
+import { wan22FrameCountError } from './wan22Controls.js';
 import { resolveContextFrames } from '../../lib/videoContinuity.js';
 import {
   IC_LORA_MODE_VALUES, icLoraSpecForMode,
@@ -172,15 +173,8 @@ export async function validateVideoRetryParams(params = {}) {
     });
     if (controlError) throw controlError;
   }
-  if (model.runtime === 'wan22' || model.runtime === 'wan22_cuda') {
-    const frameStride = Number(model.frameStride);
-    if (Number.isFinite(frameStride) && frameStride > 0 && (Number(numFrames) - 1) % frameStride !== 0) {
-      throw new ServerError(
-        `${model.name} requires a ${frameStride}n+1 frame count; got ${numFrames}.`,
-        { status: 400, code: 'WAN22_INVALID_FRAME_COUNT' },
-      );
-    }
-  }
+  const frameCountError = wan22FrameCountError(model, numFrames);
+  if (frameCountError) throw frameCountError;
 }
 
 /**
@@ -644,26 +638,17 @@ async function resolvePreparedParams({
       throw controlError;
     }
   }
-  // Wan profiles have a narrower temporal-shape contract than the shared
-  // request schema can express (the mode side is the shared gate above). Mirror
-  // the worker's frame-grid guard here so a direct API caller cannot persist a
-  // job that is already known to fail.
-  if (effectiveModel?.runtime === 'wan22' || effectiveModel?.runtime === 'wan22_cuda') {
-    const numFrames = body.numFrames != null ? Number(body.numFrames) : DEFAULT_NUM_FRAMES;
-    const frameStride = Number(effectiveModel.frameStride);
-    if (Number.isFinite(frameStride) && frameStride > 0 && (numFrames - 1) % frameStride !== 0) {
-      await cleanupStaged();
-      throw new ServerError(
-        `${effectiveModel.name} requires a ${frameStride}n+1 frame count; got ${numFrames}.`,
-        { status: 400, code: 'WAN22_INVALID_FRAME_COUNT' },
-      );
-    }
+  // Persist the same resolved count the worker will render and validate.
+  let effectiveNumFrames = body.numFrames ?? effectiveModel?.defaultFrames ?? DEFAULT_NUM_FRAMES;
+  const frameCountError = wan22FrameCountError(effectiveModel, effectiveNumFrames);
+  if (frameCountError) {
+    await cleanupStaged();
+    throw frameCountError;
   }
 
   let sourceImagePath = null;
   let lastImagePath = null;
   let audioFilePath = null;
-  let effectiveNumFrames = body.numFrames;
   let icReferenceUploadPath = null;
   let uploadedTempPath = null;
   const extraUploadedTempPaths = [];

--- a/server/services/videoGen/prepareParams.test.js
+++ b/server/services/videoGen/prepareParams.test.js
@@ -511,6 +511,13 @@ describe.each(['wan22', 'wan22_cuda'])('Wan frame admission — %s', (runtime) =
   });
 });
 
+it('leaves omitted frame counts unset for other runtimes', async () => {
+  listVideoModels.mockReturnValue([{
+    id: 'ltx_test', name: 'Test LTX', runtime: 'ltx2', defaultFrames: 81,
+  }]);
+  await expect(prepare({ modelId: 'ltx_test' })).resolves.toMatchObject({ effectiveNumFrames: undefined });
+});
+
 describe('validateVideoRetryParams', () => {
   it('keeps an explicit null model sentinel unknown instead of selecting the default', async () => {
     await expect(validateVideoRetryParams({ modelId: null })).rejects.toMatchObject({

--- a/server/services/videoGen/prepareParams.test.js
+++ b/server/services/videoGen/prepareParams.test.js
@@ -476,6 +476,41 @@ describe('prepareVideoGenParams', () => {
   });
 });
 
+describe.each(['wan22', 'wan22_cuda'])('Wan frame admission — %s', (runtime) => {
+  beforeEach(() => {
+    listVideoModels.mockReturnValue([{
+      id: 'wan_test', name: 'Test Wan', runtime,
+      supportedModes: ['text'], frameStride: 4, defaultFrames: 120,
+    }]);
+  });
+
+  it('rejects explicit and default off-grid frames in prepare and retry', async () => {
+    const params = { modelId: 'wan_test', mode: 'text' };
+    const error = {
+      status: 400, code: 'WAN22_INVALID_FRAME_COUNT',
+      message: 'Test Wan requires a 4n+1 frame count; got 120.',
+    };
+    await expect(prepare(params)).rejects.toMatchObject(error);
+    await expect(validateVideoRetryParams(params)).rejects.toMatchObject(error);
+    await expect(prepare({ ...params, numFrames: 120 })).rejects.toMatchObject(error);
+    await expect(validateVideoRetryParams({ ...params, numFrames: 120 })).rejects.toMatchObject(error);
+  });
+
+  it('persists the resolved model default and falls back when absent', async () => {
+    const model = { id: 'wan_test', name: 'Test Wan', runtime, supportedModes: ['text'], frameStride: 4 };
+    listVideoModels.mockReturnValue([{ ...model, defaultFrames: 81 }]);
+    await expect(prepare({ modelId: model.id })).resolves.toMatchObject({ effectiveNumFrames: 81 });
+    listVideoModels.mockReturnValue([model]);
+    await expect(prepare({ modelId: model.id })).resolves.toMatchObject({ effectiveNumFrames: 121 });
+  });
+
+  it('accepts an explicit grid count instead of an invalid model default', async () => {
+    const params = { modelId: 'wan_test', mode: 'text', numFrames: 81 };
+    await expect(prepare(params)).resolves.toMatchObject({ effectiveNumFrames: 81 });
+    await expect(validateVideoRetryParams(params)).resolves.toBeUndefined();
+  });
+});
+
 describe('validateVideoRetryParams', () => {
   it('keeps an explicit null model sentinel unknown instead of selecting the default', async () => {
     await expect(validateVideoRetryParams({ modelId: null })).rejects.toMatchObject({

--- a/server/services/videoGen/wan22Controls.js
+++ b/server/services/videoGen/wan22Controls.js
@@ -1,0 +1,14 @@
+import { ServerError } from '../../lib/errorHandler.js';
+
+/** Validate the already-resolved frame count shared by Wan admission and rendering. */
+export const wan22FrameCountError = (model, numFrames) => {
+  if (model?.runtime !== 'wan22' && model?.runtime !== 'wan22_cuda') return null;
+  const frameStride = Number(model.frameStride);
+  if (Number.isFinite(frameStride) && frameStride > 0 && (Number(numFrames) - 1) % frameStride !== 0) {
+    return new ServerError(
+      `${model.name} requires a ${frameStride}n+1 frame count; got ${numFrames}.`,
+      { status: 400, code: 'WAN22_INVALID_FRAME_COUNT' },
+    );
+  }
+  return null;
+};


### PR DESCRIPTION
Wan CUDA jobs now reject off-grid frame counts at federated admission, before enqueue. Preparation, retry, local rendering, and federation share one frame-grid predicate while preserving the existing error code, status, and message.

Wan preparation resolves and persists omitted frame counts from the model default, then the shared fallback, so admission checks the same count the worker renders.

Validation: reproduced the preparation-default and federated-CUDA failures before the fix; 652 tests pass across preparation, worker, federation, submission, and route suites. Regression coverage includes explicit counts, invalid model defaults, valid overrides, and fallback persistence, and unchanged omitted controls for other runtimes. Claude reviewed the branch at medium effort; its scope finding was addressed.

Closes #7047
