### PR TITLE
fix: exclude known unavailable quality checks from suggestions

### DIFF
--- a/client/src/components/apps/AppQualityRunner.jsx
+++ b/client/src/components/apps/AppQualityRunner.jsx
@@ -9,7 +9,10 @@ import { familyForProvider } from '../../../../server/lib/providerFamilies';
 import { getMaintenanceRuns, startMaintenanceRun, stopMaintenanceRun } from '../../services/apiAgents';
 
 const eligibleProvider = provider => provider.enabled && isProcessProvider(provider) && familyForProvider(provider);
-const needsCheck = category => category.score == null || category.stale || category.coverage !== 'broad' || category.confidence === 'low';
+const needsCheck = category => {
+  if (category.coverage === 'not-applicable' || (category.coverage === 'unavailable' && category.assessedAt)) return false;
+  return category.score == null || category.stale || category.coverage !== 'broad' || category.confidence === 'low';
+};
 
 export default function AppQualityRunner({ app, children }) {
   const categories = app.quality?.categories || [];
@@ -75,7 +78,7 @@ export default function AppQualityRunner({ app, children }) {
       onModelChange={picker.setSelectedModel} effort={effort} onEffortChange={setEffort} loading={picker.loading} disabled={busy}
       emptyProviderOption="Select a subscription provider" emptyModelOption="Select a model" highlightToolUse />
     <p className="text-xs text-gray-400">{taskTypes.length} scheduled agents, run sequentially within this batch. Launch another batch to run checks in parallel. {mode === 'fix' ? 'Each selected audit can change code and open a PR.' : 'Findings become issues; no fixes or backlog claim jobs.'} Schedules can stay disabled. The Improve setting still applies.</p>
-    <details className="text-xs"><summary className="cursor-pointer text-port-accent">Selected checks ({taskTypes.length})</summary><p className="mt-1">{categories.filter(category => taskTypes.includes(category.id)).map(category => category.label).join(', ') || 'All categories have qualifying evidence.'}</p></details>
+    <details className="text-xs"><summary className="cursor-pointer text-port-accent">Selected checks ({taskTypes.length})</summary><p className="mt-1">{categories.filter(category => taskTypes.includes(category.id)).map(category => category.label).join(', ') || 'No checks need evidence. Unavailable assessments and N/A categories are excluded.'}</p></details>
     <button type="button" onClick={start} disabled={busy || picker.loading || !picker.selectedProviderId || !picker.selectedModel || !taskTypes.length || app.quality?.unavailable}
       className="px-3 py-2 rounded bg-port-accent text-port-bg text-sm font-medium disabled:opacity-50">{taskTypes.length === 1 ? 'Run now' : `Run ${taskTypes.length} checks now`}</button>
     {!loaded && <p className="text-xs" role="status">Loading runner status… <button type="button" className="text-port-accent" onClick={loadRuns}>Retry</button></p>}

--- a/client/src/components/apps/AppQualityRunner.test.jsx
+++ b/client/src/components/apps/AppQualityRunner.test.jsx
@@ -69,3 +69,30 @@ it('launches alongside pending runners and stops each run independently', async 
   await waitFor(() => expect(screen.getAllByRole('button', { name: 'Stop remaining checks' })).toHaveLength(1));
   expect(button).toBeEnabled();
 });
+
+it('excludes known unavailable and N/A assessments from suggestions while allowing explicit reruns', async () => {
+  const categories = [
+    { id: 'typing', label: 'Typing', score: null, coverage: 'not-applicable', stale: true },
+    { id: 'console-errors', label: 'Console errors', score: null, coverage: 'unavailable', assessedAt: '2026-09-01T00:00:00Z' },
+  ];
+  startMaintenanceRun.mockResolvedValue({ run: { id: 'run-3', status: 'running', steps: [] } });
+  const { rerender } = render(<MemoryRouter><AppQualityRunner app={{ ...app, quality: { categories } }} /></MemoryRouter>);
+  await waitFor(() => expect(screen.queryByText('Loading runner status…')).not.toBeInTheDocument());
+  expect(screen.getByRole('button', { name: 'Run 0 checks now' })).toBeDisabled();
+  expect(screen.getByText(/No checks need evidence/)).toBeInTheDocument();
+
+  // The same unavailable coverage without an assessment means it has never run.
+  rerender(<MemoryRouter><AppQualityRunner app={{ ...app, quality: { categories: [...categories,
+    { id: 'security', label: 'Security', score: null, coverage: 'unavailable', assessedAt: null },
+  ] } }} /></MemoryRouter>);
+  fireEvent.click(screen.getByRole('button', { name: 'Run now' }));
+  await waitFor(() => expect(startMaintenanceRun).toHaveBeenLastCalledWith(expect.objectContaining({ taskTypes: ['security'] }), { silent: true }));
+  await waitFor(() => expect(screen.getByLabelText('Checks')).toBeEnabled());
+  fireEvent.change(screen.getByLabelText('Checks'), { target: { value: 'typing' } });
+  fireEvent.click(screen.getByRole('button', { name: 'Run now' }));
+  await waitFor(() => expect(startMaintenanceRun).toHaveBeenLastCalledWith(expect.objectContaining({ taskTypes: ['typing'] }), { silent: true }));
+  await waitFor(() => expect(screen.getByLabelText('Checks')).toBeEnabled());
+  fireEvent.change(screen.getByLabelText('Checks'), { target: { value: 'all' } });
+  fireEvent.click(screen.getByRole('button', { name: 'Run 3 checks now' }));
+  await waitFor(() => expect(startMaintenanceRun).toHaveBeenLastCalledWith(expect.objectContaining({ taskTypes: ['typing', 'console-errors', 'security'] }), { silent: true }));
+});


### PR DESCRIPTION
## Summary
The quality runner suggested N/A and unavailable audit results because their scores are null. Exclude not-applicable categories and saved unavailable assessments from the default missing/outdated evidence batch, while retaining never-assessed checks and explicit category/all-category reruns.

The empty selection now explains the exclusions instead of claiming every category has qualifying evidence.

## Test plan
- 12 tests passed across AppQualityRunner.test.jsx and AppQuality.test.jsx.
- Regression coverage verifies excluded assessments, never-assessed checks, disabled empty batches, and explicit reruns.
- Focused client Biome lint and git diff --check passed.
