### PR TITLE
fix: stop telling operators to check a working abuse guard

### DIFF
--- a/server/services/untrustedContent.js
+++ b/server/services/untrustedContent.js
@@ -19,7 +19,13 @@ export async function screenUntrustedContent({ content, source, policy: override
   if (content.length > policy.maxInputChars) return failure('untrusted-content-too-large', 'The complete content exceeds the configured limit; no partial analysis was accepted.');
   const { runModelAbuseScan } = await import('./modelAbuseGuard.js');
   const screening = await runModelAbuseScan({ content, classifierMode: policy.classifierMode, minBenignScore: policy.minBenignScore });
-  if (!screening.ok || screening.safe !== true) return { ...failure(screening.code || 'untrusted-content-screening-failed', 'External content was blocked or screening was unavailable. Check Models > LLMs > Abuse Guard.'), screening };
+  // A completed scan that flags content (deterministic findings, or a
+  // classifier verdict of malicious/low-confidence) means the guard is
+  // working correctly — that is a distinct outcome from the guard failing to
+  // run at all, and telling the operator to "check the abuse guard" for a
+  // legitimate block sends them to a status panel that will just say ready.
+  if (!screening.ok) return { ...failure(screening.code || 'untrusted-content-screening-failed', 'Model-abuse screening could not run. Check Models > LLMs > Abuse Guard.'), screening };
+  if (screening.safe !== true) return { ...failure(screening.code || 'untrusted-content-blocked', 'The model-abuse guard flagged this content and blocked it. This is expected screening behavior, not a guard setup problem.'), screening };
   return { ok: true, safe: true, policy, screening, fingerprint: modelAbuseContentFingerprint(source, {}, content) };
 }
 

--- a/server/services/untrustedContent.test.js
+++ b/server/services/untrustedContent.test.js
@@ -38,6 +38,13 @@ describe('shared external-content boundary', () => {
       mocks.scan.mockResolvedValue(verdict);
       expect(await runUntrustedContentAnalysis(args)).toMatchObject({ ok: false });
     }
+    // A completed scan that flags content is a distinct outcome from the guard
+    // failing to run — telling an operator to "check the abuse guard" for a
+    // working, correct block is misleading (it reports ready either way).
+    mocks.scan.mockResolvedValue({ ok: true, safe: false, code: 'security-guard-classified-malicious' });
+    expect(await runUntrustedContentAnalysis(args)).toMatchObject({ code: 'security-guard-classified-malicious', message: expect.stringContaining('expected screening behavior') });
+    mocks.scan.mockResolvedValue({ ok: false, code: 'security-guard-not-ready' });
+    expect(await runUntrustedContentAnalysis(args)).toMatchObject({ code: 'security-guard-not-ready', message: expect.stringContaining('could not run') });
     expect(await runUntrustedContentAnalysis({ ...args, content: 'x'.repeat(1001), policy: { maxInputChars: 1000 } })).toMatchObject({ code: 'untrusted-content-too-large' });
     mocks.scan.mockResolvedValue({ ok: true, safe: true });
     expect(await runUntrustedContentAnalysis({ ...args, content: 'x'.repeat(4096) })).toMatchObject({ code: 'untrusted-content-context-too-small' });


### PR DESCRIPTION
## Summary
- `screenUntrustedContent()` used one hardcoded message for two different outcomes: the model-abuse guard failing to run, and the guard running fine and correctly blocking flagged content (deterministic findings, or a classifier verdict of malicious/low-confidence). Both cases told the operator to "Check Models > LLMs > Abuse Guard" — which is misleading when the guard is actually fine and just did its job; the status panel reads that same `ready` field and reports ready either way.
- Splits the message on `screening.ok`: a genuine guard failure still points at the guard status panel, while a completed scan that blocked content now says so plainly instead of implying a setup problem.

## Test plan
- [x] `vitest run server/services/untrustedContent.test.js` — added coverage asserting distinct `code`/`message` for the guard-unavailable vs. content-blocked branches
- [x] `vitest run server/services/messageEvaluator.test.js server/services/modelAbuseGuard.test.js server/services/modelAbuseGuard.runtime.test.js server/services/modelAbuseGuard.materialize.test.js server/services/issueWatcher.test.js server/services/forgeMaintenanceEvidence.test.js server/services/prReviewerSecurity.test.js server/routes/messages.test.js` — all consumers of this scanning chain still pass