### PR TITLE
fix: clear contributor labels before manual issue claims

### DIFF
--- a/server/routes/cos.test.js
+++ b/server/routes/cos.test.js
@@ -1,3 +1,5 @@
+vi.mock('../services/appIssues.js', () => ({ prepareAppIssueClaim: vi.fn() }));
+import { prepareAppIssueClaim } from '../services/appIssues.js';
 import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest';
 import express from 'express';
 import { rmSync } from 'node:fs';
@@ -1220,6 +1222,16 @@ describe('CoS Routes', () => {
       expect(cos.addTask).not.toHaveBeenCalled();
     });
 
+    it('does not queue a manual claim when contributor-label cleanup fails', async () => {
+      getAppById.mockResolvedValue({ id: 'my-app', name: 'MyApp', repoPath: '/repo' });
+      buildClaimWorkTask.mockResolvedValue({ tracker: 'github', target: '42' });
+      prepareAppIssueClaim.mockRejectedValueOnce(new ServerError('Labels remain', { status: 502, code: 'CLAIM_LABELS_REMAIN' }));
+      const response = await request(app).post('/api/cos/tasks/slashdo')
+        .send({ command: 'next', app: 'my-app', target: '42' });
+      expect(response.status).toBe(502);
+      expect(cos.addTask).not.toHaveBeenCalled();
+    });
+
     it('routes /do:next through the app Work Tracker instead of the raw command', async () => {
       getAppById.mockResolvedValue({ id: 'my-app', name: 'MyApp', repoPath: '/repo' });
       buildClaimWorkTask.mockResolvedValue({
@@ -1251,6 +1263,7 @@ describe('CoS Routes', () => {
       expect(taskData.slashdoCommand).toBeUndefined();
       expect(taskData.description).not.toContain('/do:');
       expect(taskData.claimFlow).toBe(true);
+      expect(prepareAppIssueClaim).not.toHaveBeenCalled();
     });
 
     // The claim prompt names its reviewers as prose and emits no flag, so the
@@ -1372,6 +1385,8 @@ describe('CoS Routes', () => {
         });
 
       expect(response.status).toBe(200);
+      expect(prepareAppIssueClaim).toHaveBeenCalledWith(expect.objectContaining({ id: 'my-app' }), '412', 'github');
+      expect(prepareAppIssueClaim.mock.invocationCallOrder[0]).toBeLessThan(cos.addTask.mock.invocationCallOrder[0]);
       expect(buildClaimWorkTask).toHaveBeenCalledWith(
         expect.objectContaining({ id: 'my-app' }),
         {

--- a/server/routes/cosTaskRoutes.js
+++ b/server/routes/cosTaskRoutes.js
@@ -9,6 +9,7 @@ import * as taskWatcher from '../services/taskWatcher.js';
 import { enhanceTaskPrompt } from '../services/taskEnhancer.js';
 import { buildClaimWorkTask, buildIssueReplanTask, buildJiraTicketTask } from '../services/cosTaskGenerator.js';
 import { getAppById, getAppWorkTracker, PORTOS_APP_ID } from '../services/apps.js';
+import { prepareAppIssueClaim } from '../services/appIssues.js';
 import { getAssignableInstances } from '../services/instances.js';
 import { resolveManagedAppIssueTarget } from '../services/managedAppRepositories.js';
 import { workTrackerLabel } from '../lib/workTracker.js';
@@ -308,6 +309,9 @@ router.post('/tasks/slashdo', asyncHandler(async (req, res) => {
       reviewerModels,
       reviewerEfforts
     });
+    if (claim.target && ['github', 'gitlab'].includes(claim.tracker)) {
+      await prepareAppIssueClaim(appObj, claim.target, claim.tracker);
+    }
     const scope = claim.target
       ? `claim ${workTrackerLabel(claim.tracker)} item ${claim.target}`
       : `claim next ${workTrackerLabel(claim.tracker)} item`;

--- a/server/services/appIssues.js
+++ b/server/services/appIssues.js
@@ -24,9 +24,12 @@
  */
 
 import { execGh, ensureForgeReachable } from './github.js';
-import { execGlabJson } from './gitlab.js';
+import { execGlab, execGlabJson } from './gitlab.js';
 import { resolveAppForgeTarget } from '../lib/workTracker.js';
 import { safeJSONParse } from '../lib/fileUtils.js';
+import { CONTRIBUTOR_LABELS } from '../lib/dispatchLabels.js';
+import { withGlabJson } from '../lib/glabArgs.js';
+import { ServerError } from '../lib/errorHandler.js';
 
 // Single-user repos never realistically exceed this; `glab` caps a page at 100.
 const GH_LIST_LIMIT = 200;
@@ -229,4 +232,34 @@ export async function listAppIssues(app) {
     headline: result.headline || null,
     remedy: result.remedy || null,
   };
+}
+
+/** Release contributor invitations before a manual targeted claim can be queued. */
+export async function prepareAppIssueClaim(app, issueNumber, tracker) {
+  const { tracker: resolvedTracker, target } = await resolveAppForgeTarget(app);
+  if (!target || resolvedTracker !== tracker || target.forge !== tracker) {
+    throw new ServerError('Could not resolve the issue tracker for this claim', { status: 400, code: 'CLAIM_TRACKER_MISMATCH' });
+  }
+  const readLabels = async () => {
+    const raw = tracker === 'github'
+      ? await execGh(['issue', 'view', issueNumber, '--repo', target.repoSpec, '--json', 'labels'])
+      : await execGlab(withGlabJson(['issue', 'view', issueNumber]), app.repoPath, undefined, { rejectOnError: true });
+    const issue = safeJSONParse(raw, null);
+    if (!Array.isArray(issue?.labels) || issue.labels.some(label => typeof label !== 'string' && typeof label?.name !== 'string')) {
+      throw new ServerError('Could not read issue labels before claiming', { status: 502, code: 'CLAIM_LABELS_UNAVAILABLE' });
+    }
+    return issue.labels.map(label => typeof label === 'string' ? label : label.name)
+      .filter(name => CONTRIBUTOR_LABELS.includes(name.toLowerCase()));
+  };
+  const labels = await readLabels();
+  if (!labels.length) return;
+  if (tracker === 'github') {
+    await execGh(['issue', 'edit', issueNumber, '--repo', target.repoSpec,
+      ...labels.flatMap(label => ['--remove-label', label])]);
+  } else {
+    await execGlab(['issue', 'update', issueNumber, '--unlabel', labels.join(',')], app.repoPath, undefined, { rejectOnError: true });
+  }
+  if ((await readLabels()).length) {
+    throw new ServerError('Contributor labels remain on the issue; claim was not queued', { status: 502, code: 'CLAIM_LABELS_REMAIN' });
+  }
 }

--- a/server/services/appIssues.test.js
+++ b/server/services/appIssues.test.js
@@ -5,7 +5,7 @@ vi.mock('./github.js', () => ({
   execGh: vi.fn(async () => '[]'),
   ensureForgeReachable: (...args) => ensureForgeReachableMock(...args),
 }));
-vi.mock('./gitlab.js', () => ({ execGlabJson: vi.fn(async () => ({ rows: [], reason: 'ok' })) }));
+vi.mock('./gitlab.js', () => ({ execGlab: vi.fn(), execGlabJson: vi.fn(async () => ({ rows: [], reason: 'ok' })) }));
 // gitRemote is the only effectful dependency of the real forge classifier, so
 // mock IT and let `resolveRepoForgeTarget` run for real — the github-vs-gitlab
 // routing under test is exactly that mapping.
@@ -18,9 +18,9 @@ vi.mock('../lib/fileUtils.js', () => ({
   safeJSONParse: (raw, fallback) => { try { return JSON.parse(raw); } catch { return fallback; } },
 }));
 
-import { listAppIssues } from './appIssues.js';
+import { listAppIssues, prepareAppIssueClaim } from './appIssues.js';
 import { execGh } from './github.js';
-import { execGlabJson } from './gitlab.js';
+import { execGlab, execGlabJson } from './gitlab.js';
 import { getOriginInfo, readOriginRemoteUrl } from '../lib/gitRemote.js';
 
 // `workTracker: 'auto'` resolves to whatever the origin host is — the common case.
@@ -307,5 +307,42 @@ describe('listAppIssues — the list must match the tracker a claim would use', 
     execGh.mockResolvedValue(JSON.stringify([{ number: 1, title: 't', labels: [], assignees: [] }]));
     const result = await listAppIssues({ ...APP, workTracker: 'github' });
     expect(result).toMatchObject({ forge: 'github', tracker: 'github', reason: 'ok' });
+  });
+});
+
+describe('prepareAppIssueClaim', () => {
+  it('removes only invitations present on GitHub and verifies the result', async () => {
+    execGh.mockResolvedValueOnce(JSON.stringify({ labels: [{ name: 'Help Wanted' }, { name: 'good first issue' }, { name: 'bug' }] }))
+      .mockResolvedValueOnce('').mockResolvedValueOnce(JSON.stringify({ labels: [{ name: 'bug' }] }));
+    await prepareAppIssueClaim(APP, '42', 'github');
+    expect(execGh.mock.calls.map(([args]) => args)).toEqual([
+      ['issue', 'view', '42', '--repo', 'github.com/acme/widget', '--json', 'labels'],
+      ['issue', 'edit', '42', '--repo', 'github.com/acme/widget', '--remove-label', 'Help Wanted', '--remove-label', 'good first issue'],
+      ['issue', 'view', '42', '--repo', 'github.com/acme/widget', '--json', 'labels'],
+    ]);
+  });
+
+  it('does not mutate an issue without contributor labels', async () => {
+    execGh.mockResolvedValue(JSON.stringify({ labels: [] }));
+    await prepareAppIssueClaim(APP, '42', 'github');
+    expect(execGh).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses GitLab and preserves unrelated labels', async () => {
+    useGitlabOrigin();
+    execGlab.mockResolvedValueOnce(JSON.stringify({ labels: ['help wanted', 'bug'] }))
+      .mockResolvedValueOnce('').mockResolvedValueOnce(JSON.stringify({ labels: ['bug'] }));
+    await prepareAppIssueClaim(APP, '42', 'gitlab');
+    expect(execGlab).toHaveBeenNthCalledWith(2, ['issue', 'update', '42', '--unlabel', 'help wanted'], '/repo', undefined, { rejectOnError: true });
+    expect(execGh).not.toHaveBeenCalled();
+  });
+
+  it('rejects unreadable labels, failed edits, and labels that remain after an edit', async () => {
+    execGh.mockResolvedValueOnce('{}');
+    await expect(prepareAppIssueClaim(APP, '42', 'github')).rejects.toThrow('Could not read issue labels');
+    execGh.mockResolvedValueOnce('{"labels":["help wanted"]}').mockRejectedValueOnce(new Error('offline'));
+    await expect(prepareAppIssueClaim(APP, '42', 'github')).rejects.toThrow('offline');
+    execGh.mockResolvedValue('{"labels":["help wanted"]}');
+    await expect(prepareAppIssueClaim(APP, '42', 'github')).rejects.toThrow('Contributor labels remain');
   });
 });


### PR DESCRIPTION
## Summary
Manual targeted claims from the app Issues page now read live GitHub/GitLab labels, remove any help wanted or good first issue labels, and verify removal before queuing the agent. Assignment and in-progress marking remain in the agent claim flow, after this prerequisite succeeds. Unrelated labels are preserved; cleanup failures prevent dispatch.

## Test plan
- Server Vitest: services/appIssues.test.js and routes/cos.test.js — 171 tests passed.
- Regression coverage includes GitHub/GitLab cleanup, no-label no-op, malformed responses, edit failures, failed verification, and cleanup-before-queue ordering.
- Reviewed changes for reuse and failure handling; git diff --check passed.
