### PR TITLE
fix: classify quality federation refusals as warnings (#7064)

### DIFF
--- a/server/routes/apps/crud.js
+++ b/server/routes/apps/crud.js
@@ -35,7 +35,11 @@ const router = Router();
 router.get('/quality-federation', asyncHandler(async (req, res) => {
   const { days, repository } = validateRequest(appQualityFederationQuerySchema, req.query);
   const payload = await exportPortosQuality(req.get('X-PortOS-Instance-Id'), days, {}, repository);
-  if (!payload) throw new ServerError('Quality sharing requires a registered enabled sync peer and a known repository', { status: 403 });
+  if (!payload) throw new ServerError('Quality sharing requires a registered enabled sync peer and a known repository', {
+    status: 403,
+    code: 'PEER_PULL_FORBIDDEN',
+    severity: 'warning',
+  });
   res.json(payload);
 }));
 

--- a/server/routes/apps/crud.test.js
+++ b/server/routes/apps/crud.test.js
@@ -4,6 +4,7 @@ vi.mock('../../services/appQuality.js', () => ({ getAppQualityHistory: vi.fn(asy
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import express from 'express';
 import { request } from '../../lib/testHelper.js';
+import { errorEvents } from '../../lib/errorHandler.js';
 import crudRoutes from './crud.js';
 import { enrichAppsWithQuality, getAppQualityHistory } from '../../services/appQuality.js';
 
@@ -70,7 +71,29 @@ describe('Apps CRUD Routes', () => {
     expect((await request(app).get('/api/apps/quality-federation?repository=invalid')).status).toBe(400);
     expect((await request(app).get('/api/apps/quality-federation?days=999')).status).toBe(400);
     exportPortosQuality.mockResolvedValue(null);
-    expect((await request(app).get('/api/apps/quality-federation')).status).toBe(403);
+    const emit = vi.fn();
+    app.set('io', { emit });
+    const onError = vi.fn();
+    errorEvents.on('error', onError);
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const refused = await request(app).get('/api/apps/quality-federation');
+      expect(refused.status).toBe(403);
+      expect(refused.body.code).toBe('PEER_PULL_FORBIDDEN');
+      expect(onError).toHaveBeenCalledWith(expect.objectContaining({
+        code: 'PEER_PULL_FORBIDDEN',
+        severity: 'warning',
+      }), expect.anything());
+      expect(emit).toHaveBeenCalledWith('error:occurred', expect.objectContaining({
+        code: 'PEER_PULL_FORBIDDEN',
+        status: 403,
+        severity: 'warning',
+      }));
+      expect(consoleErrorSpy).not.toHaveBeenCalled();
+    } finally {
+      errorEvents.off('error', onError);
+      consoleErrorSpy.mockRestore();
+    }
   });
 
   describe('GET /api/apps', () => {


### PR DESCRIPTION
## Summary
- Classify unauthorized quality-federation requests as peer-pull policy refusals.
- Preserve the HTTP 403 response while preventing recurring policy denials from polluting server error logs and client error notifications.

## Test plan
- `./node_modules/.bin/vitest run routes/apps/crud.test.js`

Closes #7064