### PR TITLE
test([issue-7020]): assert migration 314 missing-file skip

### DIFF
--- a/scripts/migrations/314-fastvideo-mlx-models.test.js
+++ b/scripts/migrations/314-fastvideo-mlx-models.test.js
@@ -1,4 +1,4 @@
-import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -17,8 +17,8 @@ describe('314-fastvideo-mlx-models migration', () => {
   });
 
   it('skips gracefully when media-models.json does not exist', async () => {
-    await migration.up({ rootDir });
-    expect(true).toBe(true);
+    await expect(migration.up({ rootDir })).resolves.toBeUndefined();
+    expect(existsSync(join(rootDir, 'data', 'media-models.json'))).toBe(false);
   });
 
   it('adds FastMetal models to an existing MLX registry', async () => {


### PR DESCRIPTION
## Summary

- replace the tautological missing-file assertion with an explicit promise-resolution check
- verify migration 314 does not create `data/media-models.json` when the source file is absent

## Tests

- `npx vitest run ../scripts/migrations/314-fastvideo-mlx-models.test.js`

Closes #7020