### PR TITLE
fix: promote spinning refresh icon to its own layer on Usage page

### DIFF
--- a/client/src/pages/UsagePage.jsx
+++ b/client/src/pages/UsagePage.jsx
@@ -126,7 +126,9 @@ function ProviderQuotaCard({ quota, onRefresh, refreshing, disabled }) {
             title={`Refresh ${quota.label} usage`}
             aria-label={`Refresh ${quota.label} usage`}
           >
-            <RefreshCw size={14} className={`w-3 h-3 sm:w-3.5 sm:h-3.5 ${refreshing ? 'animate-spin' : ''}`} />
+            {/* `will-change-transform` — see the section-level Refresh button's
+                comment on the compositor-layer artifact this avoids. */}
+            <RefreshCw size={14} className={`w-3 h-3 sm:w-3.5 sm:h-3.5 will-change-transform ${refreshing ? 'animate-spin' : ''}`} />
           </button>
         </div>
       </div>
@@ -309,7 +311,11 @@ function ProviderQuotaSection() {
           className="flex items-center gap-1.5 px-2 sm:px-3 py-1.5 text-xs sm:text-sm text-gray-400 hover:text-white disabled:opacity-50"
           title="Refresh every provider's usage"
         >
-          <RefreshCw size={15} className={loading ? 'animate-spin' : ''} /> Refresh all
+          {/* `will-change-transform` promotes the icon to its own compositor
+              layer before `animate-spin` starts — without it this button's
+              continuous rotate restarts each poll and can leave a stale
+              rasterized frame behind the live one on some GPUs. */}
+          <RefreshCw size={15} className={`will-change-transform ${loading ? 'animate-spin' : ''}`} /> Refresh all
         </button>
       </div>
 


### PR DESCRIPTION
## Summary

- The subscription usage page's Refresh All icon (and each provider card's per-family refresh icon) toggles Tailwind's `animate-spin` on and off frequently — the section-level refresh, plus the per-card poll that auto-refreshes while a reading is pending.
- Without a compositor-layer hint, restarting a CSS transform animation this often can leave a stale rasterized frame behind the freshly-spinning icon, which reads as the animation rendering over a static duplicate of itself.
- Added `will-change-transform` to both `RefreshCw` icons so the browser promotes them to their own GPU layer before the spin starts, avoiding the artifact.

## Test plan

- `cd client && npx vitest run src/pages/UsagePage.test.jsx` — 16/16 pass, unchanged.
- Verified live: ran the client dev server in an isolated worktree with the `/api/**` calls mocked (playwright), navigated to `/devtools/usage`, clicked Refresh All, and confirmed the button renders exactly one `RefreshCw` SVG with a single continuous `animate-spin` animation (`element.getAnimations()`), no pseudo-element or duplicate icon in the DOM.