### PR TITLE
test: validate milestone completion timestamp (#7017)

### DIFF
--- a/server/services/identity.test.js
+++ b/server/services/identity.test.js
@@ -1005,7 +1005,9 @@ describe('Integration: Goal CRUD', () => {
     const milestone = await addMilestone(goal.id, { title: 'Complete me' });
     const completed = await completeMilestone(goal.id, milestone.id);
 
-    expect(completed.completedAt).toBeDefined();
+    expect(completed.completedAt).not.toBeNull();
+    expect(typeof completed.completedAt).toBe('string');
+    expect(Number.isNaN(Date.parse(completed.completedAt))).toBe(false);
   });
 
   it('should return null for completing non-existent milestone', async () => {


### PR DESCRIPTION
## Summary
- Strengthen milestone completion coverage so a completed milestone must include a non-null timestamp.
- Verify the returned value is a string containing a parseable timestamp.

## Tests
- npm test --prefix server -- services/identity.test.js -t "should complete a milestone"
- npm test --prefix server -- services/identity.test.js
- Mutation probe: disabling the production timestamp assignment failed the test as expected.

Closes #7017