### PR TITLE
test: assert unchanged goal on missing calendar (#7018)

### DIFF
--- a/server/services/identity.test.js
+++ b/server/services/identity.test.js
@@ -1264,7 +1264,7 @@ describe('Integration: Calendar Linking', () => {
   it('should return goal unchanged when unlinking non-existent calendar', async () => {
     const goal = await createGoal({ title: 'Exercise' });
     const updated = await unlinkCalendarFromGoal(goal.id, 'nonexistent');
-    expect(updated).toBeDefined();
+    expect(updated).toEqual(goal);
   });
 
   it('should return null when unlinking from non-existent goal', async () => {


### PR DESCRIPTION
## Summary
- Strengthen the missing-calendar unlink regression test to require the returned goal to remain deeply unchanged.

## Test plan
- `node_modules/.bin/vitest run services/identity.test.js` (108 passed)
- Mutation probe: returning `{}` from the unknown-calendar path fails the strengthened assertion.

Closes #7018