### PR TITLE
test: make killWithEscalation unref regression detectable (#7016)

### DIFF
--- a/server/lib/killWithEscalation.test.js
+++ b/server/lib/killWithEscalation.test.js
@@ -102,5 +102,6 @@ describe('killWithEscalation', () => {
     const timer = killWithEscalation(proc, { label: 'test job', stillRunning: () => true });
     // Node timers expose unref(); assert we returned a timer handle.
     expect(timer).toBeDefined();
+    expect(timer.hasRef?.()).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- Assert the escalation timer is unref'd so it cannot keep the Node process alive.
- Closes #7016.

## Test plan
- `./node_modules/.bin/vitest run lib/killWithEscalation.test.js` (8 passed)
- Mutation probe with `timer.unref?.()` disabled (1 expected failure), then restored
- Four previously timing-sensitive server files with `--testTimeout=30000` (346 passed)
- `npm test --prefix server` (2164 files passed, 4 unrelated 10s timeout failures under the full-suite load)

The full-suite timeout failures are in `jsonWritebackConventions.test.js`, `lib/eidoverseCitySurface.test.js`, `lib/validationSplit.test.js`, and `services/sharing/peerSync.test.js`; all four pass independently with the higher timeout.