### PR TITLE
fix: surface save-backed General settings first

### DIFF
--- a/client/src/components/settings/GeneralTab.jsx
+++ b/client/src/components/settings/GeneralTab.jsx
@@ -166,11 +166,6 @@ export function GeneralTab() {
         onDiscard={discardAndExit}
       />
       <div className="bg-port-card border border-port-border rounded-lg p-4 sm:p-6">
-        <h3 className="text-lg font-semibold text-white mb-4">Interface Theme</h3>
-        <ThemePickerPanel />
-      </div>
-
-      <div className="bg-port-card border border-port-border rounded-lg p-4 sm:p-6">
         <h3 className="text-lg font-semibold text-white mb-4">Timezone</h3>
         <p className="text-sm text-gray-400 mb-4">
           Used for job scheduling (cron expressions & scheduled times) and briefing dates.
@@ -287,6 +282,11 @@ export function GeneralTab() {
             </span>
           )}
         </div>
+      </div>
+
+      <div className="bg-port-card border border-port-border rounded-lg p-4 sm:p-6">
+        <h3 className="text-lg font-semibold text-white mb-4">Interface Theme</h3>
+        <ThemePickerPanel />
       </div>
     </div>
   );

--- a/client/src/components/settings/GeneralTab.test.jsx
+++ b/client/src/components/settings/GeneralTab.test.jsx
@@ -65,6 +65,7 @@ describe('GeneralTab unsaved changes', () => {
     await renderTab();
 
     const headings = screen.getAllByRole('heading').map(heading => heading.textContent);
+    expect(headings).toEqual(expect.arrayContaining(['Timezone', 'Interface Theme']));
     expect(headings.indexOf('Timezone')).toBeLessThan(headings.indexOf('Interface Theme'));
   });
 

--- a/client/src/components/settings/GeneralTab.test.jsx
+++ b/client/src/components/settings/GeneralTab.test.jsx
@@ -61,6 +61,13 @@ beforeEach(() => {
 });
 
 describe('GeneralTab unsaved changes', () => {
+  it('places save-backed settings before the instant theme picker', async () => {
+    await renderTab();
+
+    const headings = screen.getAllByRole('heading').map(heading => heading.textContent);
+    expect(headings.indexOf('Timezone')).toBeLessThan(headings.indexOf('Interface Theme'));
+  });
+
   it('guards edits made against the displayed fallback after loading fails', async () => {
     getSettings.mockRejectedValueOnce(new Error('settings offline'));
     const router = await renderTab({ expectedTimezone: null });


### PR DESCRIPTION
## Summary
- Reorder General settings so Timezone and Location appear before the instant-apply Interface Theme gallery.
- Preserve the existing theme picker, save actions, and unsaved-change guards.
- Add a regression assertion requiring both headings and their document order.

## Test plan
- `./node_modules/.bin/vitest run src/components/settings/GeneralTab.test.jsx`
- `npm run lint`
- `npm run build`
- Full `npm test` was attempted; an unrelated accessibility convention test repeatedly probed an unavailable local port 3000.

Closes #6948