### PR TITLE
fix([issue-6994]): extend server close grace period for TLS teardown

### DIFF
--- a/server/services/bootstrap.js
+++ b/server/services/bootstrap.js
@@ -923,14 +923,15 @@ const withGrace = (label, ms, run) => new Promise((resolve) => {
   setTimeout(() => finishWithError(`⚠️ ${label} close exceeded ${ms}ms — proceeding`), ms).unref?.();
 });
 
-// graceMs is deliberately short: closeAllConnections() force-drops every
-// connection, so there is no graceful drain left to wait for — the only thing that
-// can outlast it is a WebSocket-upgraded socket the server no longer tracks (and
+// graceMs is deliberately bounded: closeAllConnections() force-drops every
+// connection, so there is no graceful drain left to wait for. The close callback
+// still needs a short window for TLS/socket teardown — the only thing that can
+// outlast it is a WebSocket-upgraded socket the server no longer tracks (and
 // io.close()'s engine.close() already tore those down protocol-side; the OS reaps
-// the TCP remnant on process.exit). So don't tax every restart waiting on it.
+// the TCP remnant on process.exit).
 // ERR_SERVER_NOT_RUNNING means it was already closed (io.close() closes whichever
 // server is its current this.httpServer) — success for us, not a failure.
-const closeServer = (server, label, graceMs = 250) => withGrace(label, graceMs, ({ finish, finishWithError }) => {
+const closeServer = (server, label, graceMs = 1000) => withGrace(label, graceMs, ({ finish, finishWithError }) => {
   if (!server) return finish();
   server.close((err) => {
     if (err && err.code !== 'ERR_SERVER_NOT_RUNNING') finishWithError(`⚠️ Error closing ${label}`, err);

--- a/server/services/bootstrap.shutdown.test.js
+++ b/server/services/bootstrap.shutdown.test.js
@@ -114,12 +114,12 @@ describe('bounded server shutdown', () => {
     let onClose;
     const settled = vi.fn();
     const closing = closeServer({ close: (done) => { onClose = done; } }, 'HTTP server').then(settled);
-    await vi.advanceTimersByTimeAsync(249);
+    await vi.advanceTimersByTimeAsync(999);
     expect(settled).not.toHaveBeenCalled();
     await vi.advanceTimersByTimeAsync(1);
     await closing;
     expect(settled).toHaveBeenCalledTimes(1);
-    expect(error.mock.calls).toEqual([['⚠️ HTTP server close exceeded 250ms — proceeding']]);
+    expect(error.mock.calls).toEqual([['⚠️ HTTP server close exceeded 1000ms — proceeding']]);
     onClose();
     onClose(new Error('late failure'));
     expect(log).not.toHaveBeenCalled();


### PR DESCRIPTION
Closes #6994

## Summary

- Extend the default `closeServer` grace window from 250ms to 1000ms so TLS/socket teardown can complete without routine false error warnings.
- Keep the shutdown path bounded and preserve the existing late-callback/error handling behavior.

## Verification

- `npm test --prefix server -- services/bootstrap.shutdown.test.js`
- 6 tests passed

## Review

- Local code review completed cleanly.
- Requested Claude review was run with medium effort; its output was malformed for the strict verdict format, so it is recorded as an optional no-verdict pass.
