### PR TITLE
fix: remove redundant @testing-library/dom devDependency

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -26,7 +26,6 @@
       "devDependencies": {
         "@biomejs/biome": "2.5.12",
         "@tailwindcss/postcss": "4.3.3",
-        "@testing-library/dom": "10.4.1",
         "@testing-library/jest-dom": "7.0.1",
         "@testing-library/react": "16.3.3",
         "@testing-library/user-event": "14.6.7",

--- a/client/package.json
+++ b/client/package.json
@@ -37,7 +37,6 @@
   "devDependencies": {
     "@biomejs/biome": "2.5.12",
     "@tailwindcss/postcss": "4.3.3",
-    "@testing-library/dom": "10.4.1",
     "@testing-library/jest-dom": "7.0.1",
     "@testing-library/react": "16.3.3",
     "@testing-library/user-event": "14.6.7",

--- a/client/src/components/writers-room/ExercisePanel.test.jsx
+++ b/client/src/components/writers-room/ExercisePanel.test.jsx
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { act, render, screen } from '@testing-library/react';
-import { fireEvent } from '@testing-library/dom';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 
 // The "Add to draft" promotion (#5300) only offers itself for a finished
 // sprint that (a) actually captured prose, (b) belongs to the work currently

--- a/client/src/components/writers-room/WorkEditor.perf.test.jsx
+++ b/client/src/components/writers-room/WorkEditor.perf.test.jsx
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { act, render } from '@testing-library/react';
-import { fireEvent } from '@testing-library/dom';
+import { act, fireEvent, render } from '@testing-library/react';
 import { createMemoryRouter, RouterProvider } from 'react-router';
 
 // Regression guard for #3387: typing in the WorkEditor body must NOT re-render

--- a/client/src/components/writers-room/WorkEditor.test.jsx
+++ b/client/src/components/writers-room/WorkEditor.test.jsx
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { act, render, screen, within } from '@testing-library/react';
-import { fireEvent } from '@testing-library/dom';
+import { act, fireEvent, render, screen, within } from '@testing-library/react';
 import { createMemoryRouter, RouterProvider } from 'react-router';
 
 // Header layout contract for #3568: on a ~375px phone the WorkEditor header

--- a/docs/DEPS.md
+++ b/docs/DEPS.md
@@ -78,7 +78,7 @@ Before removing a Tier 3 candidate, run a transitive-dep check (`npm ls <pkg>`).
 | `vitest` | 1 | KEEP | client test runner | happy-dom environment |
 | `happy-dom` | 1 | KEEP | test DOM | Paired with vitest. Replaced `jsdom` in #6144 — same suite, ~65% less time in `environment` |
 | `@testing-library/jest-dom` | 1 | KEEP | test matchers | |
-| `@testing-library/dom` | 1 | KEEP | DOM test utilities | Foundation for the client Testing Library stack |
+| `@testing-library/dom` | — | REMOVED (direct) | DOM test utilities | 2026-09-12 → imported through `@testing-library/react`; remains in the tree transitively, so this removes only the redundant direct pin |
 | `@testing-library/react` | 1 | KEEP | component tests | |
 | `@testing-library/user-event` | 1 | KEEP | interaction tests | |
 | `rollup-plugin-visualizer` | 2 | KEEP | bundle-size analysis | Dev-only, opt-in |


### PR DESCRIPTION
## Summary

- Use `fireEvent` from `@testing-library/react` in the three writers-room tests that still imported it from `@testing-library/dom`.
- Remove the redundant direct `@testing-library/dom` devDependency from the client manifest and lockfile root entry while retaining its transitive package entries.
- Document the direct dependency removal.

Closes #7015

## Validation

- Affected writers-room tests: 3 files, 26 tests passed.
- `cd client && npm run lint` passed (2536 files).
- `cd client && npm run build` passed.
- Full `cd client && npm test` was attempted locally but encountered unrelated existing `localhost:3000` connection-refused/time-out failures; the affected tests pass independently.
