### PR TITLE
fix: make calendar agenda empty state actionable

### DIFF
--- a/client/src/components/calendar/AgendaTab.jsx
+++ b/client/src/components/calendar/AgendaTab.jsx
@@ -6,6 +6,7 @@ import socket from '../../services/socket';
 import EventDetail from './EventDetail';
 import { formatTimeOfDay as formatTime, formatWeekdayDate } from '../../utils/formatters';
 import BrailleSpinner from '../BrailleSpinner';
+import EmptyState from '../EmptyState';
 import useUrlParams from '../../hooks/useUrlParams';
 
 const RSVP_STYLES = {
@@ -72,9 +73,10 @@ export default function AgendaTab({ accounts }) {
     };
   }, [fetchEvents]);
 
+  const enabledAccounts = accounts.filter(a => a.enabled);
+
   const handleSync = async () => {
     setSyncing(true);
-    const enabledAccounts = accounts.filter(a => a.enabled);
     await Promise.allSettled(enabledAccounts.map(a => api.syncCalendarAccount(a.id)));
     setSyncing(false);
     toast.success('Calendar sync started');
@@ -114,7 +116,7 @@ export default function AgendaTab({ accounts }) {
         )}
         <button
           onClick={handleSync}
-          disabled={syncing || accounts.filter(a => a.enabled).length === 0}
+          disabled={syncing || enabledAccounts.length === 0}
           className="flex items-center gap-2 px-3 py-2 bg-port-accent/10 text-port-accent rounded-lg text-sm hover:bg-port-accent/20 transition-colors disabled:opacity-50"
         >
           <RefreshCw size={14} className={syncing ? 'animate-spin' : ''} />
@@ -128,11 +130,24 @@ export default function AgendaTab({ accounts }) {
           <BrailleSpinner text="Loading" />
         </div>
       ) : grouped.length === 0 ? (
-        <div className="text-center py-12 text-gray-500">
-          <Clock size={48} className="mx-auto mb-4 opacity-50" />
-          <p>No upcoming events</p>
-          <p className="text-sm mt-1">Sync your calendar accounts to see events here</p>
-        </div>
+        enabledAccounts.length === 0 ? (
+          <EmptyState
+            icon={Clock}
+            title="No calendar connected"
+            message="Connect a calendar account to see upcoming events."
+            actionTo="/calendar/sync"
+            actionLabel="Connect a calendar"
+          />
+        ) : (
+          <EmptyState
+            icon={Clock}
+            title="No upcoming events"
+            message="Sync now to pull upcoming events"
+            onAction={handleSync}
+            actionLabel="Sync now"
+            actionDisabled={syncing}
+          />
+        )
       ) : (
         <div className="space-y-6">
           {grouped.map((group) => (

--- a/client/src/components/calendar/AgendaTab.jsx
+++ b/client/src/components/calendar/AgendaTab.jsx
@@ -85,6 +85,7 @@ export default function AgendaTab({ accounts }) {
   const grouped = groupEventsByDay(events);
   const selectedEventKey = searchParams.get('event');
   const selectedEvent = events.find((event) => `${event.accountId}:${event.id}` === selectedEventKey) || null;
+  const hasActiveFilter = Boolean(search || accountFilter);
 
   return (
     <div className="space-y-4">
@@ -130,7 +131,18 @@ export default function AgendaTab({ accounts }) {
           <BrailleSpinner text="Loading" />
         </div>
       ) : grouped.length === 0 ? (
-        enabledAccounts.length === 0 ? (
+        hasActiveFilter ? (
+          <EmptyState
+            icon={Clock}
+            title="No matching events"
+            message="Try clearing your search or account filter."
+            actionLabel="Clear filters"
+            onAction={() => {
+              setSearch('');
+              setAccountFilter('');
+            }}
+          />
+        ) : enabledAccounts.length === 0 ? (
           <EmptyState
             icon={Clock}
             title="No calendar connected"

--- a/client/src/components/calendar/AgendaTab.test.jsx
+++ b/client/src/components/calendar/AgendaTab.test.jsx
@@ -1,0 +1,63 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter, Routes, Route, useLocation } from 'react-router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { socketMock } = vi.hoisted(() => ({
+  socketMock: { on: vi.fn(), off: vi.fn() },
+}));
+
+vi.mock('../../services/socket', () => ({ default: socketMock }));
+vi.mock('../../services/api', () => ({
+  getCalendarEvents: vi.fn(),
+  syncCalendarAccount: vi.fn(),
+}));
+vi.mock('../ui/Toast', () => ({ default: { success: vi.fn(), error: vi.fn() } }));
+
+import * as api from '../../services/api';
+import AgendaTab from './AgendaTab';
+
+function LocationProbe() {
+  return <output data-testid="pathname">{useLocation().pathname}</output>;
+}
+
+async function renderAgenda(accounts) {
+  render(
+    <MemoryRouter initialEntries={['/calendar/agenda']}>
+      <Routes>
+        <Route
+          path="*"
+          element={<><AgendaTab accounts={accounts} /><LocationProbe /></>}
+        />
+      </Routes>
+    </MemoryRouter>
+  );
+  await act(async () => {});
+}
+
+describe('AgendaTab empty states', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    api.getCalendarEvents.mockResolvedValue({ events: [] });
+  });
+
+  it('directs users without an enabled account to calendar sync', async () => {
+    await renderAgenda([{ id: 'disabled', name: 'Personal', enabled: false }]);
+
+    const connectLink = await screen.findByRole('link', { name: 'Connect a calendar' });
+    expect(connectLink.getAttribute('href')).toBe('/calendar/sync');
+    expect(screen.getByText('No calendar connected')).toBeTruthy();
+    expect(screen.queryByText('Sync your calendar accounts to see events here')).toBeNull();
+    expect(screen.getByRole('button', { name: 'Sync' })).toBeDisabled();
+
+    fireEvent.click(connectLink);
+    expect(screen.getByTestId('pathname')).toHaveTextContent('/calendar/sync');
+  });
+
+  it('offers an enabled in-page sync action when accounts have no events', async () => {
+    await renderAgenda([{ id: 'enabled', name: 'Personal', enabled: true }]);
+
+    expect(await screen.findByText('Sync now to pull upcoming events')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Sync' })).not.toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Sync now' })).not.toBeDisabled();
+  });
+});

--- a/client/src/components/calendar/AgendaTab.test.jsx
+++ b/client/src/components/calendar/AgendaTab.test.jsx
@@ -60,4 +60,16 @@ describe('AgendaTab empty states', () => {
     expect(screen.getByRole('button', { name: 'Sync' })).not.toBeDisabled();
     expect(screen.getByRole('button', { name: 'Sync now' })).not.toBeDisabled();
   });
+
+  it('offers to clear active filters instead of suggesting a sync', async () => {
+    await renderAgenda([{ id: 'enabled', name: 'Personal', enabled: true }]);
+
+    fireEvent.change(await screen.findByRole('textbox', { name: 'Search events' }), {
+      target: { value: 'missing' },
+    });
+
+    expect(await screen.findByText('No matching events')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Clear filters' })).not.toBeDisabled();
+    expect(screen.queryByRole('button', { name: 'Sync now' })).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary

- Make Agenda’s no-account state link directly to Calendar Sync.
- Keep the empty state actionable for connected accounts and distinguish filtered no-results with a clear-filters action.

## Tests

- `npm test -- src/components/calendar/AgendaTab.test.jsx src/components/calendar/calendarEventChips.test.jsx src/components/EmptyState.test.jsx`
- `npm run lint`
- `npm run build`

Closes #6946