### PR TITLE
fix: validate agent personality write bodies

### DIFF
--- a/server/lib/agentValidation.js
+++ b/server/lib/agentValidation.js
@@ -79,7 +79,9 @@ export const agentUpdateSchema = partialWithoutDefaults(agentSchema).extend({
 // text has the same bounds as a persisted personality before it reaches a
 // provider prompt.
 export const agentGenerateSchema = z.object({
-  seed: agentSchema.partial().optional().default({}),
+  seed: agentSchema.partial().extend({
+    personality: partialWithoutDefaults(agentPersonalitySchema).optional(),
+  }).optional().default({}),
   providerId: z.string().min(1).max(128).nullable().optional(),
   model: z.string().min(1).max(300).nullable().optional()
 }).strict();

--- a/server/lib/agentValidation.js
+++ b/server/lib/agentValidation.js
@@ -75,6 +75,21 @@ export const agentUpdateSchema = partialWithoutDefaults(agentSchema).extend({
   personality: partialWithoutDefaults(agentPersonalitySchema).optional(),
 });
 
+// Request body for AI personality generation. Reuse the create shape so seed
+// text has the same bounds as a persisted personality before it reaches a
+// provider prompt.
+export const agentGenerateSchema = z.object({
+  seed: agentSchema.partial().optional().default({}),
+  providerId: z.string().min(1).max(128).nullable().optional(),
+  model: z.string().min(1).max(300).nullable().optional()
+}).strict();
+
+// Toggle is a separate write contract: unlike a partial agent update, enabled
+// is required and must remain a boolean all the way to storage.
+export const agentToggleSchema = z.object({
+  enabled: z.boolean()
+}).strict();
+
 // =============================================================================
 // PLATFORM ACCOUNT SCHEMAS
 // =============================================================================

--- a/server/routes/agentPersonalities.js
+++ b/server/routes/agentPersonalities.js
@@ -6,7 +6,13 @@
 
 import { Router } from 'express';
 import { asyncHandler, ServerError } from '../lib/errorHandler.js';
-import { validateRequest, agentSchema, agentUpdateSchema } from '../lib/validation.js';
+import {
+  validateRequest,
+  agentSchema,
+  agentUpdateSchema,
+  agentGenerateSchema,
+  agentToggleSchema,
+} from '../lib/validation.js';
 import * as agentPersonalities from '../services/agentPersonalities.js';
 import { generateAgentPersonality } from '../services/agentPersonalityGenerator.js';
 import { logAction } from '../services/history.js';
@@ -73,7 +79,7 @@ router.delete('/:id', asyncHandler(async (req, res) => {
 
 // POST /generate - Generate agent personality using AI
 router.post('/generate', asyncHandler(async (req, res) => {
-  const { seed = {}, providerId, model } = req.body;
+  const { seed, providerId, model } = validateRequest(agentGenerateSchema, req.body);
 
   const generated = await generateAgentPersonality(seed, providerId, model);
 
@@ -83,7 +89,7 @@ router.post('/generate', asyncHandler(async (req, res) => {
 // POST /:id/toggle - Toggle agent enabled status
 router.post('/:id/toggle', asyncHandler(async (req, res) => {
   const { id } = req.params;
-  const { enabled } = req.body;
+  const { enabled } = validateRequest(agentToggleSchema, req.body);
 
   const agent = await agentPersonalities.toggleAgent(id, enabled);
   if (!agent) {

--- a/server/routes/agentPersonalities.test.js
+++ b/server/routes/agentPersonalities.test.js
@@ -111,6 +111,25 @@ describe('Agent Personalities Routes', () => {
       );
     });
 
+    it('accepts an individual personality hint without requiring a style', async () => {
+      generateAgentPersonality.mockResolvedValue({ name: 'Generated Agent' });
+
+      const response = await request(makeApp())
+        .post('/api/agents/personalities/generate')
+        .send({ seed: { personality: { tone: 'warm and precise' } } });
+
+      expect(response.status).toBe(200);
+      expect(generateAgentPersonality).toHaveBeenCalledWith(
+        {
+          description: '',
+          enabled: true,
+          personality: { tone: 'warm and precise' },
+        },
+        undefined,
+        undefined,
+      );
+    });
+
     it('defaults an omitted seed to an empty object', async () => {
       generateAgentPersonality.mockResolvedValue({ name: 'Generated Agent' });
 

--- a/server/routes/agentPersonalities.test.js
+++ b/server/routes/agentPersonalities.test.js
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import express from 'express';
+import { request } from '../lib/testHelper.js';
+
+const agentPersonalities = vi.hoisted(() => ({
+  getAgentsByUser: vi.fn(),
+  getAllAgents: vi.fn(),
+  getAgentById: vi.fn(),
+  createAgent: vi.fn(),
+  updateAgent: vi.fn(),
+  deleteAgent: vi.fn(),
+  toggleAgent: vi.fn(),
+}));
+
+const generateAgentPersonality = vi.hoisted(() => vi.fn());
+const logAction = vi.hoisted(() => vi.fn());
+
+vi.mock('../services/agentPersonalities.js', () => agentPersonalities);
+vi.mock('../services/agentPersonalityGenerator.js', () => ({ generateAgentPersonality }));
+vi.mock('../services/history.js', () => ({ logAction }));
+
+import agentPersonalitiesRoutes from './agentPersonalities.js';
+
+const makeApp = () => {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/agents/personalities', agentPersonalitiesRoutes);
+  return app;
+};
+
+const expectValidationError = (response) => {
+  expect(response.status).toBe(400);
+  expect(response.body.code).toBe('VALIDATION_ERROR');
+  expect(response.body).toHaveProperty('timestamp');
+};
+
+describe('Agent Personalities Routes', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  describe('POST /generate', () => {
+    it.each([
+      ['null seed', { seed: null }],
+      ['null personality', { seed: { personality: null } }],
+      ['non-string name', { seed: { name: 123 } }],
+      ['unknown top-level field', { unexpected: true }],
+    ])('returns 400 for %s without calling the generator', async (_label, body) => {
+      const response = await request(makeApp())
+        .post('/api/agents/personalities/generate')
+        .send(body);
+
+      expectValidationError(response);
+      expect(generateAgentPersonality).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      ['name', { name: 'x'.repeat(101) }],
+      ['description', { description: 'x'.repeat(1001) }],
+      ['personality tone', { personality: { style: 'casual', tone: 'x'.repeat(501) } }],
+      ['personality topic', { personality: { style: 'casual', topics: ['x'.repeat(101)] } }],
+      ['personality quirk', { personality: { style: 'casual', quirks: ['x'.repeat(201)] } }],
+      ['personality prompt prefix', { personality: { style: 'casual', promptPrefix: 'x'.repeat(2001) } }],
+    ])('returns 400 when the %s seed text exceeds its persisted limit', async (_label, seed) => {
+      const response = await request(makeApp())
+        .post('/api/agents/personalities/generate')
+        .send({ seed });
+
+      expectValidationError(response);
+      expect(generateAgentPersonality).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      ['empty providerId', { providerId: '' }],
+      ['oversized providerId', { providerId: 'p'.repeat(129) }],
+      ['oversized model', { model: 'm'.repeat(301) }],
+    ])('returns 400 for %s without calling the generator', async (_label, body) => {
+      const response = await request(makeApp())
+        .post('/api/agents/personalities/generate')
+        .send(body);
+
+      expectValidationError(response);
+      expect(generateAgentPersonality).not.toHaveBeenCalled();
+    });
+
+    it('passes a validated seed and provider hints to the generator', async () => {
+      generateAgentPersonality.mockResolvedValue({ name: 'Generated Agent' });
+
+      const response = await request(makeApp())
+        .post('/api/agents/personalities/generate')
+        .send({
+          seed: {
+            name: 'Ada',
+            description: 'A careful guide',
+            personality: { style: 'casual' },
+            avatar: { emoji: '🧭' },
+          },
+          providerId: null,
+          model: null,
+        });
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({ name: 'Generated Agent' });
+      expect(generateAgentPersonality).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'Ada',
+          description: 'A careful guide',
+          personality: expect.objectContaining({ style: 'casual' }),
+          avatar: { emoji: '🧭' },
+        }),
+        null,
+        null,
+      );
+    });
+
+    it('defaults an omitted seed to an empty object', async () => {
+      generateAgentPersonality.mockResolvedValue({ name: 'Generated Agent' });
+
+      const response = await request(makeApp())
+        .post('/api/agents/personalities/generate')
+        .send({});
+
+      expect(response.status).toBe(200);
+      expect(generateAgentPersonality).toHaveBeenCalledWith({}, undefined, undefined);
+    });
+  });
+
+  describe('POST /:id/toggle', () => {
+    it.each([
+      ['missing enabled', {}],
+      ['string enabled', { enabled: 'false' }],
+      ['numeric enabled', { enabled: 1 }],
+      ['null enabled', { enabled: null }],
+    ])('returns 400 for %s without changing the agent', async (_label, body) => {
+      const response = await request(makeApp())
+        .post('/api/agents/personalities/agent-1/toggle')
+        .send(body);
+
+      expectValidationError(response);
+      expect(agentPersonalities.toggleAgent).not.toHaveBeenCalled();
+    });
+
+    it('passes a real boolean to the service', async () => {
+      const agent = { id: 'agent-1', enabled: false };
+      agentPersonalities.toggleAgent.mockResolvedValue(agent);
+
+      const response = await request(makeApp())
+        .post('/api/agents/personalities/agent-1/toggle')
+        .send({ enabled: false });
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual(agent);
+      expect(agentPersonalities.toggleAgent).toHaveBeenCalledWith('agent-1', false);
+      expect(logAction).toHaveBeenCalledWith(
+        'toggle',
+        'agent-personality',
+        'agent-1',
+        { enabled: false },
+      );
+    });
+  });
+});


### PR DESCRIPTION
Closes #6937

Summary:
- validate agent generation seeds and toggle bodies at the route boundary
- preserve independent partial personality hints during generation
- add route-level success and rejection coverage

Tests:
- cd server && npm test