### PR TITLE
fix: preserve CoS scroll and focus during background updates

### DIFF
--- a/client/src/components/cos/tabs/TasksTab.jsx
+++ b/client/src/components/cos/tabs/TasksTab.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useState, useRef, useEffect, useCallback, useMemo } from 'react';
 import { useSearchParams } from 'react-router';
 import { Play, ChevronDown, ChevronRight } from 'lucide-react';
 import toast from '../../ui/Toast';
@@ -137,11 +137,16 @@ export default function TasksTab({ tasks, agents = [], liveOutputs = {}, onRefre
     setUserTasksLocal(userTasks);
   }, [userTasks]);
 
+  const focusedSelection = useRef(false);
+  useEffect(() => {
+    focusedSelection.current = false;
+  }, [selectedTaskId, selectedTaskSource]);
+
   // Queue summary links identify one concrete task. Completed sections are
   // collapsed by default, so open the relevant one before attempting to focus
   // and center the row.
   useEffect(() => {
-    if (!selectedTaskId || !selectedTaskSource) return;
+    if (!selectedTaskId || !selectedTaskSource || focusedSelection.current) return;
     const selected = (selectedTaskSource === 'user' ? userTasks : cosTasks)
       .find((task) => task.id === selectedTaskId);
     if (selected?.status !== 'completed') return;
@@ -150,11 +155,12 @@ export default function TasksTab({ tasks, agents = [], liveOutputs = {}, onRefre
   }, [cosTasks, selectedTaskId, selectedTaskSource, userTasks]);
 
   useEffect(() => {
-    if (!selectedTaskId || !selectedTaskSource) return;
+    if (!selectedTaskId || !selectedTaskSource || focusedSelection.current) return;
     const row = document.getElementById(taskRowId(selectedTaskId, selectedTaskSource));
     if (!row) return;
     row.scrollIntoView?.({ block: 'center' });
     row.focus({ preventScroll: true });
+    focusedSelection.current = true;
   }, [
     cosTasks,
     selectedTaskId,

--- a/client/src/components/cos/tabs/TasksTab.test.jsx
+++ b/client/src/components/cos/tabs/TasksTab.test.jsx
@@ -119,3 +119,21 @@ describe('TasksTab spawning window', () => {
     expect(screen.getByRole('button', { name: /Process task now/i })).toBeInTheDocument();
   });
 });
+
+it('focuses a deep link when its task arrives, then preserves user focus on refresh', async () => {
+  const task = { id: 'task-example', description: 'Review an example task', status: 'completed', metadata: {} };
+  const view = (tasks) => <MemoryRouter initialEntries={['/cos/tasks?task=task-example&source=user']}>
+    <input aria-label="Draft" />
+    <TasksTab tasks={tasks} onRefresh={vi.fn()} providers={[]} apps={[]} />
+  </MemoryRouter>;
+  const { rerender } = render(view(emptyTasks));
+  rerender(view({ user: { tasks: [task] }, cos: { tasks: [] } }));
+  await waitFor(() => expect(document.getElementById('cos-task-user-task-example')).toHaveFocus());
+  const draft = screen.getByRole('textbox', { name: 'Draft' });
+  draft.focus();
+  const row = document.getElementById('cos-task-user-task-example');
+  const scroll = vi.spyOn(row, 'scrollIntoView');
+  rerender(view({ user: { tasks: [{ ...task }] }, cos: { tasks: [] } }));
+  await waitFor(() => expect(draft).toHaveFocus());
+  expect(scroll).not.toHaveBeenCalled();
+});

--- a/client/src/components/ui/TabPills.jsx
+++ b/client/src/components/ui/TabPills.jsx
@@ -50,8 +50,10 @@ export default function TabPills({
     .map((tab, index) => (tab.disabled ? null : index))
     .filter((index) => index !== null);
 
+  const activeIndex = visibleTabs.findIndex((t) => t.id === activeTab);
+
+  // Fresh tab arrays and live counts must not pull the page back to the bar.
   useEffect(() => {
-    const activeIndex = visibleTabs.findIndex((t) => t.id === activeTab);
     if (activeIndex !== -1 && tabRefs.current[activeIndex]?.scrollIntoView) {
       tabRefs.current[activeIndex].scrollIntoView({
         behavior: 'smooth',
@@ -59,7 +61,7 @@ export default function TabPills({
         inline: 'nearest',
       });
     }
-  }, [activeTab, visibleTabs]);
+  }, [activeTab, activeIndex, variant]);
 
   const handleTabKeyDown = (event, index) => {
     if (!['ArrowRight', 'ArrowDown', 'ArrowLeft', 'ArrowUp', 'Home', 'End'].includes(event.key)) {

--- a/client/src/components/ui/TabPills.test.jsx
+++ b/client/src/components/ui/TabPills.test.jsx
@@ -228,3 +228,22 @@ describe('TabPills — filter variant', () => {
     expect(onChange).toHaveBeenCalledWith('objects');
   });
 });
+
+it('reveals selections without scrolling again for refreshed tab data', () => {
+  const scroll = vi.spyOn(HTMLElement.prototype, 'scrollIntoView').mockImplementation(() => {});
+  try {
+    const view = (activeTab, tabs) => <><TabPills tabs={tabs} activeTab={activeTab} onChange={vi.fn()} /><input aria-label="Draft" /></>;
+    const { rerender } = render(view('cast', []));
+    expect(scroll).not.toHaveBeenCalled();
+    rerender(view('cast', sampleTabs));
+    expect(scroll).toHaveBeenCalledTimes(1);
+    screen.getByRole('textbox', { name: 'Draft' }).focus();
+    rerender(view('cast', sampleTabs.map(tab => ({ ...tab, count: 10 }))));
+    expect(scroll).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole('textbox', { name: 'Draft' })).toHaveFocus();
+    rerender(view('places', sampleTabs));
+    expect(scroll).toHaveBeenCalledTimes(2);
+  } finally {
+    scroll.mockRestore();
+  }
+});


### PR DESCRIPTION
## Summary
Background renders on CoS Tasks and Agents repeatedly scrolled the shared tab bar into view, pulling the page back to the top. Tab scrolling now responds to selection/availability changes instead of fresh descriptor arrays or counts.

Task deep links reveal and focus their row once per selection, including when data arrives later, so subsequent refreshes preserve the user's focus and completed-section choices.

## Test plan
- TabPills and TasksTab: 26 tests passed, including refresh and delayed-data regressions.
- ChiefOfStaff page: 40 tests passed.
- Changed-file Biome lint and git diff whitespace check passed.
