### PR TITLE
fix: keep universe canon names and actions readable on mobile

### DIFF
--- a/client/src/components/pipeline/CanonCard.jsx
+++ b/client/src/components/pipeline/CanonCard.jsx
@@ -429,10 +429,7 @@ export default function CanonCard({
 
   const title = (
     <div className="flex items-center gap-2 flex-wrap">
-      {/* Wrap rather than truncate: the title column is what gives way to the
-          action strip on a phone, and a name clipped to its first word hides
-          which entry the card is. `min-w-0` is what lets `break-words` engage —
-          a flex item can otherwise not shrink below its longest word. */}
+      {/* Preserve the full name, including unbroken names, within the title slot. */}
       <span className="min-w-0 text-sm text-white font-medium break-words">{entry.name}</span>
       {entry.aliases?.length ? (
         <span className="min-w-0 text-[10px] text-gray-500 break-words">
@@ -588,7 +585,7 @@ export default function CanonCard({
   // accent-on-locked styling for the lock toggle. Keeps the canon section
   // visually consistent with the bucket cards above it.
   const actions = (
-    <div className="flex items-center gap-2">
+    <div className="flex flex-wrap items-center gap-1 sm:gap-2">
       <button
         type="button"
         onClick={onRender}

--- a/client/src/components/universe/EntryCard.jsx
+++ b/client/src/components/universe/EntryCard.jsx
@@ -5,11 +5,10 @@
  *
  * Slot contract:
  * - `title`, `body`, `actions`, `footer` — ReactNode. `thumbnail` is the only
- *   left-hand column; `title` + `actions` share one row to its right and `body`
- *   runs full-width underneath them. So `actions` should be a horizontal strip
- *   (a column-shaped one makes the title row tall), and `title` must stay
- *   shrinkable — wrap it, don't fix a width — since it's the slot that yields
- *   when the action strip is wide on a narrow screen.
+ *   left-hand column; `title` + `actions` stack on phones and share a wrapping
+ *   row on wider screens. `body` runs full-width underneath them. Actions
+ *   should wrap within their slot; the title retains a readable line width
+ *   instead of yielding all its space to a wide action strip.
  * - `thumbnail` — either a descriptor object `{ filename, alt?, onClick?,
  *   isPrimary?, fallbackRefs? }` OR a React element. The descriptor flows
  *   through `EntryCardThumbnail` (12x12 frame, primary-star badge, walk-back
@@ -80,11 +79,10 @@ export default function EntryCard({
             : <EntryCardThumbnail {...thumbnail} />
         ) : null}
         <div className="flex-1 min-w-0">
-          {/* Actions ride the title row, not a third outer column, so `body`
-              spans the full width beside the thumbnail. */}
-          <div className="flex items-start gap-2">
-            <div className="min-w-0 flex-1">{title}</div>
-            {actions ? <div className="relative z-10 shrink-0">{actions}</div> : null}
+          {/* Keep the name readable even when a card has many actions. */}
+          <div className="flex flex-col sm:flex-row sm:flex-wrap items-start gap-2">
+            <div className="min-w-0 w-full sm:w-auto sm:flex-1 sm:basis-48">{title}</div>
+            {actions ? <div className="relative z-10 min-w-0 max-w-full">{actions}</div> : null}
           </div>
           {body}
         </div>

--- a/client/src/components/universe/UniverseCanonSection.jsx
+++ b/client/src/components/universe/UniverseCanonSection.jsx
@@ -1063,7 +1063,7 @@ function KindSection() {
           title={`Add a ${kind.singular} manually`}
           aria-label={`Add ${kind.singular}`}
           aria-expanded={adding}
-          className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] text-gray-400 hover:text-port-accent disabled:opacity-30 disabled:cursor-not-allowed border border-port-border hover:border-port-accent/50"
+          className="inline-flex shrink-0 min-h-11 sm:min-h-0 items-center gap-1 px-1.5 py-0.5 rounded text-[10px] text-gray-400 hover:text-port-accent disabled:opacity-30 disabled:cursor-not-allowed border border-port-border hover:border-port-accent/50"
         >
           {creating ? <Loader2 size={11} className="animate-spin" /> : <Plus size={11} />}
           Add
@@ -1076,7 +1076,7 @@ function KindSection() {
           disabled={catalogLinking}
           title={`Add an existing ${kind.singular} from the shared Catalog`}
           aria-label={`Pick ${kind.singular} from Catalog`}
-          className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] text-gray-400 hover:text-port-accent disabled:opacity-30 disabled:cursor-not-allowed border border-port-border hover:border-port-accent/50"
+          className="inline-flex shrink-0 min-h-11 sm:min-h-0 items-center gap-1 px-1.5 py-0.5 rounded text-[10px] text-gray-400 hover:text-port-accent disabled:opacity-30 disabled:cursor-not-allowed border border-port-border hover:border-port-accent/50"
         >
           {catalogLinking ? <Loader2 size={11} className="animate-spin" /> : <Sparkles size={11} />}
           Pick from Catalog
@@ -1091,7 +1091,7 @@ function KindSection() {
             ? `Every ${kind.singular} already has a reference image`
             : `Queue reference renders for ${renderableCount} ${renderableCount === 1 ? kind.singular : kind.label.toLowerCase()} without an image yet`}
           aria-label={`Render all ${kind.label}`}
-          className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] text-gray-400 hover:text-port-accent disabled:opacity-30 disabled:cursor-not-allowed border border-port-border hover:border-port-accent/50"
+          className="inline-flex shrink-0 min-h-11 sm:min-h-0 items-center gap-1 px-1.5 py-0.5 rounded text-[10px] text-gray-400 hover:text-port-accent disabled:opacity-30 disabled:cursor-not-allowed border border-port-border hover:border-port-accent/50"
         >
           {renderingAll ? <Loader2 size={11} className="animate-spin" /> : <ImagePlus size={11} />}
           Render all{renderableCount > 0 ? ` (${renderableCount})` : ''}
@@ -1111,7 +1111,7 @@ function KindSection() {
             : `Lock all ${kind.label.toLowerCase()} — AI refine / differentiate will skip them`}
           aria-label={allLocked ? `Unlock all ${kind.label}` : `Lock all ${kind.label}`}
           aria-pressed={allLocked}
-          className={`p-1 rounded disabled:opacity-30 disabled:cursor-not-allowed ${
+          className={`min-h-11 min-w-11 sm:min-h-0 sm:min-w-0 shrink-0 inline-flex items-center justify-center p-1 rounded disabled:opacity-30 disabled:cursor-not-allowed ${
             allLocked
               ? 'text-port-accent hover:bg-port-accent/20'
               : 'text-gray-500 hover:text-gray-300'
@@ -1187,8 +1187,8 @@ function KindSection() {
   if (compact) {
     return (
       <div>
-        <div className="flex items-center justify-end gap-1.5 mb-2">
-          <span className="text-[10px] text-gray-500 mr-auto">
+        <div className="flex flex-wrap items-center gap-1.5 mb-2">
+          <span className="text-[10px] text-gray-500 mr-auto shrink-0">
             {filtered ? `${all.length} / ${totalCount}` : all.length} {all.length === 1 ? kind.singular : kind.label.toLowerCase()}
           </span>
           {controls}
@@ -1201,13 +1201,13 @@ function KindSection() {
 
   return (
     <section className="rounded border border-port-border bg-port-bg/60">
-      <div className="flex items-center gap-2 px-3 py-2 border-b border-port-border">
+      <div className="flex flex-wrap items-center gap-2 px-3 py-2 border-b border-port-border">
         <Icon size={14} className="text-gray-400" />
         <h3 className="text-sm font-semibold text-white">{kind.label}</h3>
         <span className="text-[10px] text-gray-500">
           {filtered ? `${all.length} / ${totalCount}` : all.length}
         </span>
-        <div className="ml-auto flex items-center gap-1.5">
+        <div className="ml-auto flex flex-wrap items-center gap-1.5">
           {controls}
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Keep canon entry names on their own row on phones, with a wrapping title/action row on wider screens so dense controls cannot squeeze a name into a vertical column.
- Wrap character actions and canon section toolbars while preserving mobile touch targets and existing action behavior.

## Test plan
- 64 focused tests passed across EntryCard, CanonCard, canon add/picker/remove flows, and category editing.
- Biome lint and git diff whitespace checks passed.
- Rendered the actual character card with synthetic data in Chrome at 320, 390, 768, and 1280 pixels: no horizontal overflow, readable full name, and six 44px action targets. Visually inspected the 390px capture. Native iPhone Safari was not tested.
