### PR TITLE
feat: add agent operations provider model and effort overrides

### DIFF
--- a/client/src/components/apps/SlashDoPanel.jsx
+++ b/client/src/components/apps/SlashDoPanel.jsx
@@ -4,6 +4,9 @@ import { Terminal, Loader2 } from 'lucide-react';
 import toast from '../ui/Toast';
 import { NON_PM2_TYPES } from './constants';
 import { slashdoLabel, slashdoWorkflowsForApp } from '../../lib/slashdoCatalog';
+import ProviderModelSelector from '../ProviderModelSelector';
+import useProviderModels from '../../hooks/useProviderModels';
+import { enabledProcessProviderFilter } from '../../utils/providers';
 import SlashDoRunDrawer from './SlashDoRunDrawer';
 import * as api from '../../services/api';
 
@@ -14,6 +17,9 @@ import * as api from '../../services/api';
 
 export default function SlashDoPanel({ appId, appName, appType }) {
   const [loading, setLoading] = useState(null);
+  const picker = useProviderModels({ filter: enabledProcessProviderFilter, allowDefault: true, silent: true, withEffort: true });
+  const [effort, setEffort] = useState('');
+  const agentPicker = { ...picker, effort, setEffort };
   // A `configurable` command opens a pre-flight drawer instead of firing
   // immediately: the run's provider / model / effort / reviewer / simplify
   // settings, plus (for `/do:next`) which work item to claim. Holds the whole
@@ -37,7 +43,11 @@ export default function SlashDoPanel({ appId, appName, appType }) {
     }
     const label = slashdoLabel(command.command);
     setLoading(command.command);
-    const result = await api.createSlashdoTask(command.command, appId, {}, { silent: true }).catch(err => {
+    const result = await api.createSlashdoTask(command.command, appId, {
+      provider: picker.selectedProviderId || undefined,
+      model: picker.selectedModel || undefined,
+      effort: effort || undefined
+    }, { silent: true }).catch(err => {
       toast.error(err.message || `Failed to queue ${label}`);
       return null;
     });
@@ -48,6 +58,24 @@ export default function SlashDoPanel({ appId, appName, appType }) {
   return (
     <div>
       <div className="text-xs text-gray-500 uppercase tracking-wide mb-2">Agent Operations</div>
+      <div className="mb-3 max-w-3xl">
+        <ProviderModelSelector
+          providers={picker.providers}
+          selectedProviderId={picker.selectedProviderId}
+          selectedModel={picker.selectedModel}
+          availableModels={picker.availableModels}
+          onProviderChange={id => { picker.setSelectedProviderId(id); setEffort(''); }}
+          onModelChange={picker.setSelectedModel}
+          effort={effort}
+          onEffortChange={setEffort}
+          loading={picker.loading}
+          disabled={!!loading}
+          emptyProviderOption="Auto (default)"
+          emptyModelOption="Default model"
+          highlightToolUse
+        />
+        <p className="mt-1 text-xs text-gray-500">Overrides apply to all actions below for this session.</p>
+      </div>
       <div className="flex flex-wrap gap-2">
         {commands.map(cmd => (
           <button
@@ -62,8 +90,7 @@ export default function SlashDoPanel({ appId, appName, appType }) {
           </button>
         ))}
       </div>
-      {/* Mounted only while open — the drawer fetches providers on mount, and
-          unmounting is what resets the form between runs. */}
+      {/* Task settings reset between runs; agent overrides stay in the panel. */}
       {drawerCommand && (
         <SlashDoRunDrawer
           open
@@ -71,6 +98,7 @@ export default function SlashDoPanel({ appId, appName, appType }) {
           label={slashdoLabel(drawerCommand.command)}
           appId={appId}
           appName={appName}
+          agentPicker={agentPicker}
           onClose={() => setDrawerCommand(null)}
           onQueued={() => {
             const label = slashdoLabel(drawerCommand.command);

--- a/client/src/components/apps/SlashDoRunDrawer.jsx
+++ b/client/src/components/apps/SlashDoRunDrawer.jsx
@@ -24,9 +24,10 @@ import * as api from '../../services/api';
  * server-side rather than pinning whatever this form happened to display.
  *
  * Mount only while open (the parent conditionally renders it): the provider fetch
- * runs on mount, and unmounting is what resets the form between runs.
+ * runs on mount unless the overview supplies its shared agent picker. Task
+ * settings reset on unmount; a supplied picker retains the overview overrides.
  */
-function SlashDoRunDrawerBody({ open, command, label, appId, appName, onClose, onQueued }) {
+function SlashDoRunDrawerBody({ open, command, label, appId, appName, onClose, onQueued, agentPicker }) {
   const codeReviewDefaults = useCodeReviewDefaults();
   // What a claim actually resolves for this app — the claim-work override layer
   // the defaults above cannot see. Only `/do:next` reads reviewers server-side,
@@ -36,14 +37,17 @@ function SlashDoRunDrawerBody({ open, command, label, appId, appName, onClose, o
   // Resolved model lists for the reviewer table's Model column (the picker never
   // fetches — see its `modelOptions` prop).
   const reviewerModelOptions = useReviewerModelOptions();
+  const localPicker = useProviderModels({ filter: enabledProcessProviderFilter, allowDefault: true, preselectDefaults: true, silent: true, withEffort: true, enabled: !agentPicker });
   const {
     providers, selectedProviderId, selectedModel, availableModels,
     setSelectedProviderId, setSelectedModel
     // This picker renders the effort control and sends the value, so Antigravity
     // lists base models with the effort picked separately.
-  } = useProviderModels({ filter: enabledProcessProviderFilter, allowDefault: true, preselectDefaults: true, silent: true, withEffort: true });
+  } = agentPicker ?? localPicker;
 
-  const [effort, setEffort] = useState('');
+  const [localEffort, setLocalEffort] = useState('');
+  const effort = agentPicker ? agentPicker.effort : localEffort;
+  const setEffort = agentPicker ? agentPicker.setEffort : setLocalEffort;
   const [simplify, setSimplify] = useState(true);
   // Seeded from what the RUN will resolve for display. `review` staying null is
   // what gates whether the fields are SENT — see the component doc.

--- a/client/src/components/apps/SlashDoRunDrawer.test.jsx
+++ b/client/src/components/apps/SlashDoRunDrawer.test.jsx
@@ -3,6 +3,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router';
 import SlashDoRunDrawer from './SlashDoRunDrawer';
+import SlashDoPanel from './SlashDoPanel';
 
 const api = vi.hoisted(() => ({
   getCodeReviewDefaults: vi.fn(),
@@ -62,6 +63,31 @@ describe('SlashDoRunDrawer', () => {
       reviewerMaxRounds: {}, reviewerModels: {}, reviewerEfforts: {}, csv: 'copilot'
     });
     api.createSlashdoTask.mockResolvedValue({ id: 'task-1', status: 'pending' });
+  });
+
+  it('uses overview overrides for direct actions and keeps them when opening run settings', async () => {
+    api.getProviders.mockResolvedValue({ providers: [
+      { id: 'codex', name: 'Codex', type: 'cli', enabled: true, models: ['gpt-5'], defaultModel: 'gpt-5' }
+    ] });
+    render(<MemoryRouter><SlashDoPanel appId="acme" appName="Acme App" appType="node" /></MemoryRouter>);
+    await screen.findByRole('option', { name: 'Codex' });
+    await userEvent.selectOptions(screen.getByLabelText('Provider'), 'codex');
+    await userEvent.selectOptions(screen.getByLabelText('Model'), 'gpt-5');
+    await userEvent.selectOptions(screen.getByLabelText('Thinking effort'), 'high');
+    await userEvent.click(screen.getByRole('button', { name: '/do:plan-task' }));
+    await waitFor(() => expect(api.createSlashdoTask).toHaveBeenCalledWith(
+      'plan-task', 'acme', { provider: 'codex', model: 'gpt-5', effort: 'high' }, { silent: true }
+    ));
+    await userEvent.click(screen.getByRole('button', { name: '/do:next' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Queue /do:next' }));
+    await waitFor(() => expect(api.createSlashdoTask).toHaveBeenLastCalledWith(
+      'next', 'acme', expect.objectContaining({ provider: 'codex', model: 'gpt-5', effort: 'high' }), { silent: true }
+    ));
+    await userEvent.selectOptions(screen.getByLabelText('Provider'), '');
+    await userEvent.click(screen.getByRole('button', { name: '/do:plan-task' }));
+    await waitFor(() => expect(api.createSlashdoTask).toHaveBeenLastCalledWith(
+      'plan-task', 'acme', { provider: undefined, model: undefined, effort: undefined }, { silent: true }
+    ));
   });
 
   it('queues an agent-picks run without fetching the tracker', async () => {


### PR DESCRIPTION
## Summary
Add a provider, model, and thinking-effort picker above the app overview's Agent Operations buttons. The selection overrides every direct action and stays shared with configurable actions' run-settings drawer. Auto restores default routing; overrides last while the overview is mounted.

## Test plan
- 49 tests passed across SlashDoRunDrawer and ProviderModelSelector, including overview interaction coverage for direct actions, drawer submission, and resetting overrides.
- Biome lint passed for all three changed files.
- Reviewed changes for reuse, default compatibility, and unnecessary provider requests.
