### PR TITLE
fix: show snapshot sync lag even with outbound subscriptions

### DIFF
--- a/client/src/pages/Instances.jsx
+++ b/client/src/pages/Instances.jsx
@@ -773,20 +773,9 @@ function SyncCategoriesPanel({ peer, onRefresh }) {
   );
 }
 
-function SnapshotSyncBadge({ label, icon: Icon, cursorChecksum, remoteChecksum, livePushCovered, subsLoaded = true, syncing = false }) {
-  // `livePushCovered` is true when this peer has at least one per-record
-  // peer-sync subscription for a record kind that maps to this category
-  // (universe-subs → 'universe', series-subs → 'pipeline'). The orchestrator
-  // intentionally SKIPS the 60s snapshot loop for those categories — the push
-  // pipeline is authoritative — so cursor.checksums[cat] stays frozen at
-  // whatever it was when peer-subs took over and the cursor-vs-remote diff
-  // would always read "behind" even when the records are actually converged.
-  // Render a distinct "live-push" state instead so the badge stops lying.
+function SnapshotSyncBadge({ label, icon: Icon, cursorChecksum, remoteChecksum, syncing = false }) {
   const synced = cursorChecksum && remoteChecksum && cursorChecksum === remoteChecksum;
-  // Suppress "behind" until peer subs have loaded — `livePushCovered` is derived
-  // from them, so before they resolve a live-push category would briefly mislabel
-  // itself "behind". Until then it falls through to the neutral "pending" state.
-  const behind = subsLoaded && cursorChecksum && remoteChecksum && cursorChecksum !== remoteChecksum;
+  const behind = cursorChecksum && remoteChecksum && cursorChecksum !== remoteChecksum;
 
   return (
     <div className="flex items-center gap-1.5 text-xs">
@@ -796,13 +785,6 @@ function SnapshotSyncBadge({ label, icon: Icon, cursorChecksum, remoteChecksum, 
         <>
           <RefreshCw size={11} className="text-port-accent animate-spin" />
           <span className="text-port-accent">syncing…</span>
-        </>
-      ) : livePushCovered ? (
-        <>
-          <ArrowLeftRight size={11} className="text-port-accent" />
-          <span className="text-port-accent" title="Per-record push pipeline owns this category; snapshot cursor is intentionally stale">
-            live-push
-          </span>
         </>
       ) : synced ? (
         <>
@@ -824,7 +806,7 @@ function SnapshotSyncBadge({ label, icon: Icon, cursorChecksum, remoteChecksum, 
   );
 }
 
-function SyncStatusSection({ peer, syncStatus, peerSubs = [], peerSubsLoaded = true, syncing = false }) {
+function SyncStatusSection({ peer, syncStatus, syncing = false }) {
   if (!syncStatus || !peer.instanceId) return null;
 
   const cursor = syncStatus.cursors?.[peer.instanceId];
@@ -850,19 +832,6 @@ function SyncStatusSection({ peer, syncStatus, peerSubs = [], peerSubsLoaded = t
   // Show snapshot category sync status for all enabled snapshot categories
   const cursorChecksums = cursor?.checksums || {};
   const remoteChecksums = remoteSyncSeqs?.checksums || {};
-
-  // Derive the set of snapshot categories that are "covered" by the
-  // per-record peer-sync push pipeline. Mirrors the inverse mapping in
-  // `server/services/sharing/peerSync.js` KIND_TO_CATEGORY — universe-subs
-  // cover 'universe', series-subs cover 'pipeline' (which bundles series +
-  // issues). The orchestrator skips snapshot pulls for these, so the
-  // cursor checksum stays stale and the cursor-vs-remote diff is a lie.
-  // Render those categories as "live-push" instead.
-  const livePushCovered = new Set();
-  for (const s of peerSubs) {
-    if (s.recordKind === 'universe') livePushCovered.add('universe');
-    if (s.recordKind === 'series') livePushCovered.add('pipeline');
-  }
 
   const enabledSnapshots = SNAPSHOT_CATEGORIES
     .map(m => m.key)
@@ -912,8 +881,6 @@ function SyncStatusSection({ peer, syncStatus, peerSubs = [], peerSubsLoaded = t
               icon={meta.icon}
               cursorChecksum={cursorChecksums[cat]}
               remoteChecksum={remoteChecksums[cat]}
-              livePushCovered={livePushCovered.has(cat)}
-              subsLoaded={peerSubsLoaded}
               syncing={syncing}
             />
           );
@@ -1165,17 +1132,8 @@ export function PeerCard({ peer, onRefresh, syncStatus, tailnetInfo, parityRepor
   const [forwardBusy, setForwardBusy] = useState(false);
   const [connecting, setConnecting] = useState(false);
   const [confirmRemove, setConfirmRemove] = useState(false);
-  // Peer subs are loaded once at this level and shared with SchemaGapBadge and
-  // SyncStatusSection (which uses the sub set to decide which snapshot badges
-  // render as "live-push" instead of a misleading "behind"). Without sharing,
-  // every card would issue duplicate /sharing/peer-subs fetches. (The verbose
-  // per-record "Live-pushed records" list that used to render these was removed
-  // — it grew unbounded and the Sync Details drawer covers per-record status.)
+  // Outbound subscriptions inform per-record schema compatibility.
   const [peerSubs, setPeerSubs] = useState([]);
-  // Track whether the first subs fetch has settled — until it has, `peerSubs`
-  // is [] and SyncStatusSection can't tell a live-push category from a behind
-  // one, so it would flash "behind". Gates the snapshot badges' "behind" state.
-  const [peerSubsLoaded, setPeerSubsLoaded] = useState(false);
   // Live sync activity, driven by the `sync:progress` socket event. `syncing`
   // is true between this peer's `start` and `complete`; while it's true every
   // enabled category badge shows "syncing…". On `complete` it clears and the
@@ -1210,13 +1168,8 @@ export function PeerCard({ peer, onRefresh, syncStatus, tailnetInfo, parityRepor
   useEffect(() => {
     if (!peer.instanceId) {
       setPeerSubs([]);
-      setPeerSubsLoaded(true); // no instanceId → nothing to load; don't suppress forever
       return;
     }
-    // instanceId just became available or changed — re-suppress "behind" until
-    // this peer's first fetch settles, otherwise the stale [] would mislabel a
-    // live-push category. Cleared in the .finally() below.
-    setPeerSubsLoaded(false);
     let cancelled = false;
     const refetch = () => listPeerSubscriptions({ peerId: peer.instanceId }, { silent: true })
       .then((r) => {
@@ -1224,9 +1177,6 @@ export function PeerCard({ peer, onRefresh, syncStatus, tailnetInfo, parityRepor
       })
       .catch(() => {
         if (!cancelled) setPeerSubs([]);
-      })
-      .finally(() => {
-        if (!cancelled) setPeerSubsLoaded(true);
       });
     refetch();
     // When a per-record schema block is persisted server-side, the
@@ -1491,7 +1441,7 @@ export function PeerCard({ peer, onRefresh, syncStatus, tailnetInfo, parityRepor
 
       <SyncCategoriesPanel peer={peer} onRefresh={onRefresh} />
 
-      <SyncStatusSection peer={peer} syncStatus={syncStatus} peerSubs={peerSubs} peerSubsLoaded={peerSubsLoaded} syncing={syncing} />
+      <SyncStatusSection peer={peer} syncStatus={syncStatus} syncing={syncing} />
 
       <BrainParityPanel peer={peer} report={parityReport} />
 

--- a/client/src/pages/Instances.test.jsx
+++ b/client/src/pages/Instances.test.jsx
@@ -1,11 +1,11 @@
 import { TailcatServeProvider } from '../components/instances/TailcatServeProvider';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render as renderUI, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { render as renderUI, screen, within, fireEvent, waitFor, act } from '@testing-library/react';
 import TailcatServePanel from '../components/instances/TailcatServePanel';
 import { AddPeerForm, PeerCard } from './Instances.jsx';
 import { DEFAULT_TAILCAT_REMOTE_PORT } from '../lib/ports.js';
 import { DEFAULT_PEER_PORT, DEFAULT_TAILCAT_LOCAL_PORT } from '../lib/ports.js';
-import { addPeer, addTailcatPeer, startTailcatServe, getTailcatServe, stopTailcatServe, removePeer, listPeerSubscriptions } from '../services/api';
+import { addPeer, addTailcatPeer, startTailcatServe, getTailcatServe, stopTailcatServe, removePeer, listPeerSubscriptions, getPeerFullSyncCoverage, syncPeer } from '../services/api';
 
 vi.mock('../services/api', () => ({
   getInstances: vi.fn(),
@@ -201,5 +201,78 @@ describe('PeerCard removal confirmation', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Confirm removing peer Living Room' }));
     await waitFor(() => expect(removePeer).toHaveBeenCalledWith('peer-1'));
+  });
+});
+
+describe('PeerCard snapshot progress', () => {
+  const peer = {
+    id: 'peer-snapshot', instanceId: 'remote-snapshot', name: 'Snapshot peer',
+    address: '192.0.2.20', port: 5555, status: 'online', enabled: true,
+    directions: ['outbound'], syncCategories: { universe: true, pipeline: true },
+    remoteSyncSeqs: { checksums: { universe: 'new', pipeline: 'same' } },
+  };
+  const syncStatus = {
+    cursors: { 'remote-snapshot': { checksums: { universe: 'old', pipeline: 'same' } } },
+  };
+  const subscriptions = [
+    { recordKind: 'universe', recordId: 'universe-1', peerId: peer.instanceId },
+    { recordKind: 'series', recordId: 'series-1', peerId: peer.instanceId },
+  ];
+  const badge = label => within(screen.getByText(label + ':').parentElement);
+
+  beforeEach(() => {
+    listPeerSubscriptions.mockResolvedValue({ subscriptions });
+    getPeerFullSyncCoverage.mockResolvedValue({ fullyMirrored: true, total: 2 });
+  });
+
+  // Outbound delivery coverage must never replace inbound snapshot progress.
+  it('uses checksums with loaded subscriptions and independent full-sync coverage', async () => {
+    const props = { peer: { ...peer, fullSync: true }, syncStatus, onRefresh: vi.fn() };
+    const view = renderUI(<PeerCard {...props} />);
+    fireEvent.click(screen.getByRole('button', { name: /sync categories/i }));
+    expect(await screen.findByText('Fully mirrored · 2 records')).toBeInTheDocument();
+    await act(async () => {});
+    expect(badge('Universe').getByText('behind')).toBeInTheDocument();
+    expect(badge('Pipeline').getByText('synced')).toBeInTheDocument();
+    expect(screen.queryByText('live-push')).not.toBeInTheDocument();
+
+    view.rerender(<PeerCard {...props} syncStatus={{
+      cursors: { [peer.instanceId]: { checksums: { universe: 'new', pipeline: 'old' } } },
+    }} />);
+    expect(badge('Universe').getByText('synced')).toBeInTheDocument();
+    expect(badge('Pipeline').getByText('behind')).toBeInTheDocument();
+
+    view.rerender(<PeerCard {...props}
+      peer={{ ...props.peer, remoteSyncSeqs: { checksums: { universe: 'new' } } }}
+      syncStatus={{ cursors: { [peer.instanceId]: { checksums: { pipeline: 'same' } } } }}
+    />);
+    expect(badge('Universe').getByText('pending')).toBeInTheDocument();
+    expect(badge('Pipeline').getByText('pending')).toBeInTheDocument();
+  });
+
+  // A slow or failed subscription endpoint must not hide a known mismatch.
+  it('shows known status while subscriptions are unresolved and after they fail', async () => {
+    let rejectSubscriptions;
+    listPeerSubscriptions.mockReturnValue(new Promise((_, reject) => { rejectSubscriptions = reject; }));
+    renderUI(<PeerCard peer={peer} syncStatus={syncStatus} onRefresh={vi.fn()} />);
+    expect(badge('Universe').getByText('behind')).toBeInTheDocument();
+    expect(badge('Pipeline').getByText('synced')).toBeInTheDocument();
+    await act(async () => { rejectSubscriptions(new Error('Subscriptions unavailable')); });
+    expect(badge('Universe').getByText('behind')).toBeInTheDocument();
+    expect(badge('Pipeline').getByText('synced')).toBeInTheDocument();
+  });
+
+  // Active sync takes precedence until the user-triggered request completes.
+  it('shows syncing ahead of checksum status and restores status on completion', async () => {
+    let resolveSync;
+    syncPeer.mockReturnValue(new Promise(resolve => { resolveSync = resolve; }));
+    renderUI(<PeerCard peer={peer} syncStatus={syncStatus} onRefresh={vi.fn()} />);
+    await act(async () => {});
+    fireEvent.click(screen.getByRole('button', { name: /sync now/i }));
+    expect(badge('Universe').getByText('syncing…')).toBeInTheDocument();
+    expect(badge('Pipeline').getByText('syncing…')).toBeInTheDocument();
+    await act(async () => { resolveSync({}); });
+    expect(badge('Universe').getByText('behind')).toBeInTheDocument();
+    expect(badge('Pipeline').getByText('synced')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
Snapshot badges now show checksum-based progress even when the peer has outbound universe or series subscriptions. Known mismatches remain visible while subscriptions load or fail; matching checksums show synced, missing values remain pending, and active sync takes precedence.

Removed the obsolete live-push inference and loading gate. Subscription schema warnings, per-record details, full-sync coverage, and peer APIs remain unchanged.

## Test plan
- Instances: 13 tests passed; the 3 new rendered regressions fail against the original component.
- syncOrchestrator: 56 tests passed.
- SchemaGapBadge: 6 tests passed.
- Client lint and production build passed.
- Local Codex review at low reasoning effort: no actionable findings.

Closes #7097
