### PR TITLE
fix: derive peer sync-category validation from service defaults

### DIFF
--- a/server/routes/instances.js
+++ b/server/routes/instances.js
@@ -16,7 +16,7 @@ import { DEFAULT_PEER_PORT, DEFAULT_TAILCAT_REMOTE_PORT, PORTS } from '../lib/po
 import * as tailcatPeer from '../services/tailcatPeer.js';
 import * as tailcatServe from '../services/tailcatServe.js';
 import { getTailscaleStatus } from '../lib/tailscale.js';
-import { federatedMediaPeerSettingsSchema, validateRequest } from '../lib/validation.js';
+import { federatedMediaPeerSettingsSchema, optionalBooleanMap, validateRequest } from '../lib/validation.js';
 
 const router = Router();
 
@@ -43,39 +43,10 @@ const addPeerSchema = z.object({
   auth: peerAuthSchema
 });
 
-const syncCategoriesSchema = z.object({
-  brain: z.boolean().optional(),
-  memory: z.boolean().optional(),
-  goals: z.boolean().optional(),
-  character: z.boolean().optional(),
-  digitalTwin: z.boolean().optional(),
-  meatspace: z.boolean().optional(),
-  universe: z.boolean().optional(),
-  pipeline: z.boolean().optional(),
-  // Default Zod object parsing strips unknown keys, so every key in
-  // DEFAULT_SYNC_CATEGORIES (server/services/instances.js) MUST appear
-  // here — otherwise PATCH/PUT updates from the Instances UI silently
-  // no-op for the missing category. Same regression class as a prior
-  // universe + pipeline sync-category omission (see .changelog/v2.7.0.md).
-  mediaCollections: z.boolean().optional(),
-  videoHistory: z.boolean().optional(),
-  storyBuilder: z.boolean().optional(),
-  usage: z.boolean().optional(),
-  fableLoom: z.boolean().optional(),
-  authors: z.boolean().optional(),
-  artists: z.boolean().optional(),
-  albums: z.boolean().optional(),
-  tracks: z.boolean().optional(),
-  creativeDirectorProjects: z.boolean().optional(),
-  moodBoards: z.boolean().optional(),
-  writersRoomWorks: z.boolean().optional(),
-  writersRoomFolders: z.boolean().optional(),
-  writersRoomExercises: z.boolean().optional(),
-  musicVideoProjects: z.boolean().optional(),
-  commissionFeedback: z.boolean().optional(),
-  creativeCommissions: z.boolean().optional(),
-  catalog: z.boolean().optional()
-}).optional();
+// Derive accepted keys from the service owner so new categories survive validation.
+const syncCategoriesSchema = z.object(
+  optionalBooleanMap(Object.keys(instances.DEFAULT_SYNC_CATEGORIES))
+).optional();
 
 const updatePeerSchema = z.object({
   name: z.string().optional(),
@@ -374,7 +345,7 @@ router.post('/peers/:id/connect', asyncHandler(async (req, res) => {
 // them so the sync is bidirectional. No :id — the peer is identified by the
 // instanceId in the body (we may not know its local-peer-id mapping).
 router.post('/peers/sync-categories', asyncHandler(async (req, res) => {
-  const data = reciprocalSyncSchema.parse(req.body);
+  const data = validateRequest(reciprocalSyncSchema, req.body);
   const { changed } = await instances.applyReciprocalSync(data.instanceId, data.syncCategories, { fullSync: data.fullSync });
   // 200 even when the peer is unknown to us / nothing changed — this is a
   // best-effort convergence signal, not a command that must succeed. We return

--- a/server/routes/instances.test.js
+++ b/server/routes/instances.test.js
@@ -9,7 +9,9 @@ vi.mock('../services/syncOrchestrator.js', () => ({
   getSyncStatus: vi.fn(),
   syncWithPeer: vi.fn(),
 }));
-vi.mock('../services/instances.js', () => ({
+vi.mock('../services/instances.js', async (importOriginal) => ({
+  DEFAULT_SYNC_CATEGORIES: (await importOriginal()).DEFAULT_SYNC_CATEGORIES,
+  applyReciprocalSync: vi.fn(),
   updatePeer: vi.fn(),
   addPeer: vi.fn(),
   sanitizePeerForClient: vi.fn((peer) => peer),
@@ -187,6 +189,62 @@ describe('GET /api/instances/sync-status — forPeer scoping', () => {
     const res = await request(buildApp()).get('/api/instances/sync-status?forPeer=peer-1');
     expect(res.status).toBe(200);
     expect(res.body).toMatchObject({ brainSeq: 3, memorySeq: 5, cursorForYou: 42 });
+  });
+});
+
+describe('sync-category route validation', () => {
+  const instanceId = '191aaece-a492-41ee-a66d-d4661eadc132';
+  const categories = Object.fromEntries(
+    Object.keys(instances.DEFAULT_SYNC_CATEGORIES).map((key, index) => [key, index % 2 === 0])
+  );
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    instances.updatePeer.mockImplementation(async (id, updates) => ({ id, ...updates }));
+    instances.applyReciprocalSync.mockResolvedValue({ changed: false });
+  });
+
+  it('preserves every service category and strips unknown keys on peer updates', async () => {
+    const res = await request(buildApp()).put('/api/instances/peers/peer-1')
+      .send({ syncCategories: { ...categories, unknownCategory: true } });
+    expect(res.status).toBe(200);
+    expect(instances.updatePeer).toHaveBeenCalledWith('peer-1', { syncCategories: categories });
+  });
+
+  it('allows peer updates that omit syncCategories', async () => {
+    const res = await request(buildApp()).put('/api/instances/peers/peer-1')
+      .send({ name: 'Example peer' });
+    expect(res.status).toBe(200);
+    expect(instances.updatePeer).toHaveBeenCalledWith('peer-1', { name: 'Example peer' });
+  });
+
+  it('rejects nonboolean known values before updating a peer', async () => {
+    const key = Object.keys(categories)[0];
+    const res = await request(buildApp()).put('/api/instances/peers/peer-1')
+      .send({ syncCategories: { [key]: 'true' } });
+    expect(res.status).toBe(400);
+    expect(instances.updatePeer).not.toHaveBeenCalled();
+  });
+
+  it('preserves the category map through reciprocal validation', async () => {
+    const res = await request(buildApp()).post('/api/instances/peers/sync-categories')
+      .send({ instanceId, syncCategories: { ...categories, unknownCategory: true } });
+    expect(res.status).toBe(200);
+    expect(instances.applyReciprocalSync).toHaveBeenCalledWith(instanceId, categories, { fullSync: undefined });
+  });
+
+  it('requires the reciprocal category field but accepts an empty map', async () => {
+    const app = buildApp();
+    const missing = await request(app).post('/api/instances/peers/sync-categories')
+      .send({ instanceId });
+    expect(missing.status).toBe(400);
+    expect(instances.applyReciprocalSync).not.toHaveBeenCalled();
+
+    const empty = await request(app).post('/api/instances/peers/sync-categories')
+      .send({ instanceId, syncCategories: {} });
+    expect(empty.status).toBe(200);
+    expect(empty.body).toEqual({ applied: false });
+    expect(instances.applyReciprocalSync).toHaveBeenCalledWith(instanceId, {}, { fullSync: undefined });
   });
 });
 


### PR DESCRIPTION
Peer sync-category validation now derives its accepted keys from the service defaults, preventing future category additions from silently losing user settings. Optional update fields, required reciprocal maps, boolean validation, and unknown-key stripping are preserved. Invalid reciprocal requests now use the shared validation wrapper and return 400.

Validation: 156 tests passed across server routes/instances and services/instances, including all-category preservation and request compatibility contracts. Local review completed with no findings.

Closes #7098
