### PR TITLE
feat: wake persistent mind manually and when sending messages

### DIFF
--- a/client/src/components/cos/PersistentMindTemporaryRoute.jsx
+++ b/client/src/components/cos/PersistentMindTemporaryRoute.jsx
@@ -90,7 +90,7 @@ export default function PersistentMindTemporaryRoute({
             <p className="mt-1 text-[11px] text-port-warning">Sending is what authorizes this route — nothing runs until you press send.</p>
           )}
           {paused && (
-            <p className="mt-1 text-[11px] text-port-text-muted">The mind is paused. This message queues on the selected route and only runs once you resume it.</p>
+            <p className="mt-1 text-[11px] text-port-text-muted">The mind is paused. Sending this message resumes it and requests an immediate wake on the selected route.</p>
           )}
           {imageCount > 0 && (
             <p className="mt-1 text-[11px] text-port-text-muted">

--- a/client/src/components/cos/tabs/MindTab.jsx
+++ b/client/src/components/cos/tabs/MindTab.jsx
@@ -568,9 +568,11 @@ export default function MindTab() {
   };
 
   const runLifecycle = async (action) => {
+    if (lifecyclePending) return;
     setLifecyclePending(action);
     setLifecycleError(null);
     try {
+      if (action === 'wake') await api.wakePersistentMind({ silent: true });
       if (action === 'start') await api.startPersistentMind({ silent: true });
       if (action === 'pause') await api.pausePersistentMind('Paused from Mind page', { silent: true });
       if (action === 'resume') await api.resumePersistentMind({ silent: true });
@@ -722,6 +724,7 @@ export default function MindTab() {
               : mind?.profile?.model}
           />
           {!state?.started && <ActionButton label={profileReady ? 'Start' : 'Configure'} icon={profileReady ? CirclePlay : Settings2} pending={profileReady && lifecyclePending === 'start'} disabled={loading || setupSaving} onClick={() => (profileReady ? runLifecycle('start') : openPanel('settings'))} />}
+          <ActionButton label="Wake now" icon={CirclePlay} pending={lifecyclePending === 'wake'} disabled={loading || setupSaving || !profileReady || Boolean(lifecyclePending) || Boolean(state?.activeTurn)} onClick={() => runLifecycle('wake')} />
           {state?.started && !isPaused && <ActionButton label="Pause" icon={CirclePause} pending={lifecyclePending === 'pause'} onClick={() => runLifecycle('pause')} />}
           {state?.started && isPaused && <ActionButton label="Resume" icon={CirclePlay} pending={lifecyclePending === 'resume'} onClick={() => runLifecycle('resume')} />}
           {state?.started && <ActionButton label="Stop" icon={Square} pending={lifecyclePending === 'stop'} onClick={() => runLifecycle('stop')} />}

--- a/client/src/components/cos/tabs/MindTab.temporaryRoute.test.jsx
+++ b/client/src/components/cos/tabs/MindTab.temporaryRoute.test.jsx
@@ -141,7 +141,7 @@ describe('MindTab temporary thinking sessions', () => {
     expect(api.resumePersistentMind).not.toHaveBeenCalled();
   });
 
-  it('keeps a paused mind paused while previewing, and says the message will queue', async () => {
+  it('keeps previewing inert and explains that sending resumes a paused mind', async () => {
     const user = userEvent.setup();
     api.getPersistentMind.mockResolvedValue(response({
       state: { ...response().state, status: 'paused', pauseReason: 'Paused by user' },
@@ -151,7 +151,7 @@ describe('MindTab temporary thinking sessions', () => {
 
     await user.selectOptions(screen.getByLabelText('Send with another model'), 'deep-think');
 
-    await waitFor(() => expect(screen.getByText(/The mind is paused\./)).toBeTruthy());
+    await waitFor(() => expect(screen.getByText(/Sending this message resumes it/)).toBeTruthy());
     expect(api.resumePersistentMind).not.toHaveBeenCalled();
     expect(api.startPersistentMind).not.toHaveBeenCalled();
     expect(api.sendPersistentMindMessage).not.toHaveBeenCalled();

--- a/client/src/components/cos/tabs/MindTab.test.jsx
+++ b/client/src/components/cos/tabs/MindTab.test.jsx
@@ -10,6 +10,7 @@ const api = vi.hoisted(() => ({
   uploadPersistentMindAttachment: vi.fn(),
   deletePersistentMindAttachment: vi.fn(),
   addPersistentMindAnnotation: vi.fn(),
+  wakePersistentMind: vi.fn(),
   startPersistentMind: vi.fn(),
   pausePersistentMind: vi.fn(),
   resumePersistentMind: vi.fn(),
@@ -171,6 +172,16 @@ describe('MindTab', () => {
       runtimeResidueCleared: true,
       state: { enabled: true, started: false, status: 'idle', pauseReason: null },
     });
+  });
+
+  it('offers an immediate wake and displays failures', async () => {
+    api.wakePersistentMind.mockRejectedValue(new Error('Wake unavailable'));
+    renderTab();
+    const button = await screen.findByRole('button', { name: 'Wake now' });
+    await waitFor(() => expect(button).not.toBeDisabled());
+    fireEvent.click(button);
+    await screen.findByText('Wake unavailable');
+    expect(api.wakePersistentMind).toHaveBeenCalledWith({ silent: true });
   });
 
   it('restores event details from the URL and keeps the chat composer single-purpose', async () => {

--- a/client/src/services/apiAgents.js
+++ b/client/src/services/apiAgents.js
@@ -75,6 +75,7 @@ export const deletePersistentMindAttachment = (attachmentId, options = {}) =>
   request(`/cos/mind/attachments/${encodeURIComponent(attachmentId)}`, { method: 'DELETE', ...options });
 export const addPersistentMindAnnotation = (body, options = {}) =>
   request('/cos/mind/annotations', { method: 'POST', body: JSON.stringify(body), ...options });
+export const wakePersistentMind = (options = {}) => request('/cos/mind/wake', { method: 'POST', ...options });
 export const startPersistentMind = (options = {}) => request('/cos/mind/start', { method: 'POST', ...options });
 export const pausePersistentMind = (reason, options = {}) => request('/cos/mind/pause', {
   method: 'POST', body: JSON.stringify({ reason }), ...options,

--- a/server/routes/cosMindRoutes.js
+++ b/server/routes/cosMindRoutes.js
@@ -60,6 +60,7 @@ import {
   resumePersistentMind,
   startPersistentMind,
   stopPersistentMind,
+  wakePersistentMind,
 } from '../services/persistentMindSupervisor.js';
 
 const router = Router();
@@ -344,6 +345,10 @@ router.post('/mind/annotations', asyncHandler(async (req, res) => {
   const result = await appendPersistentMindAnnotation(input);
   if (result.error) throw new ServerError(result.error, { status: 409, code: 'INVALID_STATE' });
   res.status(202).json({ success: true, duplicate: result.duplicate === true, annotationId: input.id });
+}));
+
+router.post('/mind/wake', asyncHandler(async (_req, res) => {
+  res.json(requireSuccess(await wakePersistentMind()));
 }));
 
 router.post('/mind/start', asyncHandler(async (_req, res) => {

--- a/server/routes/cosMindRoutes.test.js
+++ b/server/routes/cosMindRoutes.test.js
@@ -19,6 +19,7 @@ const mocks = vi.hoisted(() => ({
   getProviderById: vi.fn(),
   createPersistentMindAttachment: vi.fn(),
   deletePersistentMindAttachment: vi.fn(),
+  wakePersistentMind: vi.fn(),
   startPersistentMind: vi.fn(),
   pausePersistentMind: vi.fn(),
   resumePersistentMind: vi.fn(),
@@ -71,6 +72,7 @@ vi.mock('../services/persistentMindSupervisor.js', () => ({
   deletePersistentMindAttachment: mocks.deletePersistentMindAttachment,
   getPersistentMindState: mocks.getPersistentMindState,
   enqueuePersistentMindMessage: mocks.enqueuePersistentMindMessage,
+  wakePersistentMind: mocks.wakePersistentMind,
   startPersistentMind: mocks.startPersistentMind,
   pausePersistentMind: mocks.pausePersistentMind,
   resumePersistentMind: mocks.resumePersistentMind,
@@ -172,6 +174,14 @@ describe('persistent mind routes', () => {
       apps: [{ id: 'demo-app', name: 'Demo App', planOnly: true }],
       providers: [{ id: 'codex', name: 'Codex', type: 'cli', models: [{ id: 'gpt-5', efforts: ['low', 'high'] }] }],
     });
+  });
+
+  it('requests an immediate manual wake', async () => {
+    mocks.wakePersistentMind.mockResolvedValue({ success: true });
+    const res = await post('/mind/wake');
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(mocks.wakePersistentMind).toHaveBeenCalledOnce();
   });
 
   it('serves a bounded cursor snapshot with only the safe profile fields', async () => {

--- a/server/services/persistentMindSupervisor.js
+++ b/server/services/persistentMindSupervisor.js
@@ -1119,6 +1119,33 @@ export async function startPersistentMind() {
   return result.value;
 }
 
+/** A deliberate user wake retries now through the normal admission gates. */
+export async function wakePersistentMind() {
+  const result = await mutateMindState((mind) => {
+    // A running turn already satisfies this request; never interrupt or queue
+    // an extra billable turn for repeated clicks while it is thinking.
+    if (mind.activeTurn) return { mind, value: { success: true, alreadyRunning: true } };
+    return {
+      mind: {
+        ...mind,
+        enabled: true,
+        started: true,
+        status: 'waiting',
+        pauseReason: null,
+        nextEligibleWakeAt: null,
+        selfWake: mind.queuedMessages.length > 0 ? mind.selfWake : initialSelfWake('explicit-wake'),
+      },
+      value: { success: true, alreadyRunning: false },
+    };
+  });
+  cancelUsageLimitProbe();
+  usageLimitProbeAttempt = 0;
+  armWatchdog();
+  await scheduleNextWake();
+  emitMindStatus(result.state);
+  return result.value;
+}
+
 export async function pausePersistentMind(reason = 'Paused by user') {
   const { state, interrupted } = await interruptActiveTurn(reason, 'paused');
   if (!interrupted) {
@@ -1403,7 +1430,13 @@ export async function enqueuePersistentMindMessage({
         ...mind,
         pendingAttachments,
         queuedMessages: [...mind.queuedMessages, message],
-        status: mind.started && mind.status !== 'paused' ? 'waiting' : mind.status,
+        // Sending a new message is explicit consent to start/resume. Keep an
+        // in-flight turn intact; FIFO admission picks this message up next.
+        enabled: true,
+        started: true,
+        status: mind.activeTurn ? mind.status : 'waiting',
+        pauseReason: null,
+        nextEligibleWakeAt: null,
       },
       value: { success: true, duplicate: false, messageId, acceptedMessage: message },
     };
@@ -1430,6 +1463,11 @@ export async function enqueuePersistentMindMessage({
           : [],
       },
     });
+  }
+  if (result.value.success && !result.value.duplicate) {
+    cancelUsageLimitProbe();
+    usageLimitProbeAttempt = 0;
+    armWatchdog();
   }
   if (result.value.success && result.state.started) await scheduleNextWake();
   emitMindStatus(result.state);

--- a/server/services/persistentMindSupervisor.test.js
+++ b/server/services/persistentMindSupervisor.test.js
@@ -213,6 +213,55 @@ describe('persistent mind supervisor', () => {
     expect(mock.appendMindEvent.mock.calls.some(([event]) => event.kind === 'mind.wake')).toBe(false);
   });
 
+  it('wakes immediately on demand and leaves an active turn intact', async () => {
+    const pending = deferred();
+    const run = vi.fn(() => pending.promise);
+    await supervisor.registerPersistentMindTurnAdapter({ prepare: vi.fn(async () => ({ ok: true, provider: { id: 'example-cloud' }, model: 'example-model', effort: 'high' })), run });
+    await supervisor.startPersistentMind();
+    mock.root.persistentMind.selfWake.notBefore = new Date(Date.now() + 60_000).toISOString();
+    mock.root.persistentMind.nextEligibleWakeAt = new Date(Date.now() + 120_000).toISOString();
+    await supervisor.pausePersistentMind();
+
+    await supervisor.wakePersistentMind();
+    expect(mock.scheduled.get(supervisor.PERSISTENT_MIND_WAKE_EVENT_ID).delayMs).toBe(1);
+    const running = supervisor.drainPersistentMind();
+    await vi.waitFor(() => expect(run).toHaveBeenCalledTimes(1));
+    const activeTurn = mock.root.persistentMind.activeTurn;
+    expect(await supervisor.wakePersistentMind()).toMatchObject({ alreadyRunning: true });
+    expect(mock.root.persistentMind.activeTurn).toEqual(activeTurn);
+    pending.resolve({});
+    await running;
+  });
+
+  it('starts and resumes for new messages without allowing retries to undo a later pause', async () => {
+    const run = vi.fn(async () => ({}));
+    await supervisor.registerPersistentMindTurnAdapter({ prepare: vi.fn(async () => ({ ok: true, provider: { id: 'example-cloud' }, model: 'example-model', effort: 'high' })), run });
+    await supervisor.enqueuePersistentMindMessage({ id: 'first', text: 'Wake up.' });
+    expect(mock.root.persistentMind).toMatchObject({ enabled: true, started: true, status: 'waiting' });
+    expect(mock.scheduled.get(supervisor.PERSISTENT_MIND_WAKE_EVENT_ID).delayMs).toBe(1);
+    await supervisor.drainPersistentMind();
+    await supervisor.pausePersistentMind();
+    await supervisor.enqueuePersistentMindMessage({ id: 'first', text: 'Wake up.' });
+    expect(mock.root.persistentMind.status).toBe('paused');
+    mock.root.persistentMind.nextEligibleWakeAt = new Date(Date.now() + 60_000).toISOString();
+    await supervisor.enqueuePersistentMindMessage({ id: 'second', text: 'Continue.' });
+    expect(mock.scheduled.get(supervisor.PERSISTENT_MIND_WAKE_EVENT_ID).delayMs).toBe(1);
+    await supervisor.drainPersistentMind();
+    expect(run.mock.calls.map(([turn]) => turn.wake.message.id)).toEqual(['first', 'second']);
+  });
+
+  it('keeps explicit wakes behind the global CoS pause', async () => {
+    const run = vi.fn(async () => ({}));
+    await supervisor.registerPersistentMindTurnAdapter({ prepare: vi.fn(async () => ({ ok: true, provider: { id: 'example-cloud' }, model: 'example-model', effort: 'high' })), run });
+    mock.root.paused = true;
+    await supervisor.wakePersistentMind();
+    await supervisor.enqueuePersistentMindMessage({ id: 'held', text: 'Wait for CoS.' });
+    await supervisor.drainPersistentMind();
+    expect(run).not.toHaveBeenCalled();
+    expect(mock.scheduled.has(supervisor.PERSISTENT_MIND_WAKE_EVENT_ID)).toBe(false);
+    expect(mock.root.persistentMind.queuedMessages).toHaveLength(1);
+  });
+
   it('accepts a message durably, deduplicates retries, and runs only one turn', async () => {
     const pending = deferred();
     const prepare = vi.fn(async () => ({ ok: true, provider: { id: 'example-cloud' }, model: 'example-model', effort: 'high' }));
@@ -964,6 +1013,9 @@ describe('persistent mind supervisor', () => {
     await supervisor.pausePersistentMind();
     const input = { id: 'accepted-route', text: 'Use this exact route.', thinkingPresetId: 'deep', thinkingPreset: selection };
     expect(await supervisor.enqueuePersistentMindMessage(input)).toMatchObject({ success: true, duplicate: false });
+    expect(mock.root.persistentMind.status).toBe('waiting');
+    await supervisor.pausePersistentMind();
+    expect(await supervisor.enqueuePersistentMindMessage(input)).toMatchObject({ success: true, duplicate: true });
     expect(mock.root.persistentMind.status).toBe('paused');
     expect(run).not.toHaveBeenCalled();
     mock.root = JSON.parse(JSON.stringify(mock.root));


### PR DESCRIPTION
## Summary
- Add a Wake now control to start or resume the persistent mind immediately through its existing scheduler.
- Newly accepted messages start/resume the mind and clear the wake delay; retries preserve later pauses and active turns remain serialized.
- Keep global CoS pause, budgets, provider readiness, and capacity admission intact, and update the paused composer hint.

## Test plan
- Server supervisor and route suites: 82 tests passed, including manual wakes, message activation, retry deduplication, and global pause.
- MindTab and temporary-route suites: 47 tests passed.
- Changed client files pass Biome lint; git diff --check passes.
