### PR TITLE
fix: keep Mind identity readable while thinking

### DIFF
--- a/client/src/components/cos/PersistentMindRuntimePanel.jsx
+++ b/client/src/components/cos/PersistentMindRuntimePanel.jsx
@@ -29,12 +29,12 @@ export function PersistentMindThoughtStatus({ state, model }) {
     <span
       role="status"
       aria-busy={thinking}
-      className={`inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-xs font-medium ${thinking ? 'border-port-accent/60 bg-port-accent/10 text-port-accent' : 'border-port-border text-port-text-muted'}`}
+      className={`inline-flex min-w-0 max-w-full items-center gap-2 rounded-full border px-3 py-1.5 text-xs font-medium ${thinking ? 'border-port-accent/60 bg-port-accent/10 text-port-accent' : 'border-port-border text-port-text-muted'}`}
     >
-      <Brain size={14} className={thinking ? 'animate-pulse motion-reduce:animate-none' : ''} aria-hidden="true" />
-      <span>{label}</span>
+      <Brain size={14} className={thinking ? 'shrink-0 animate-pulse motion-reduce:animate-none' : 'shrink-0'} aria-hidden="true" />
+      <span className="truncate" title={label}>{label}</span>
       {thinking && (
-        <span className="inline-flex gap-0.5" aria-hidden="true">
+        <span className="inline-flex shrink-0 gap-0.5" aria-hidden="true">
           {[0, 1, 2].map((index) => (
             <span
               key={index}

--- a/client/src/components/cos/tabs/MindTab.jsx
+++ b/client/src/components/cos/tabs/MindTab.jsx
@@ -704,8 +704,8 @@ export default function MindTab() {
 
   return (
     <section aria-labelledby="mind-heading" className="mx-auto flex h-full min-h-0 w-full max-w-[100rem] flex-col gap-4 pb-4 xl:pb-0">
-      <header className="flex flex-col gap-3 rounded-2xl border border-port-border bg-port-card/70 p-3 sm:flex-row sm:items-center sm:justify-between sm:p-4">
-        <div className="flex min-w-0 flex-1 items-center gap-3">
+      <header className="flex shrink-0 flex-wrap items-center gap-3 rounded-2xl border border-port-border bg-port-card/70 p-3 sm:p-4">
+        <div className="flex min-w-0 flex-[1_0_min(100%,20rem)] items-center gap-3">
           <span className="relative flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-port-accent/15 text-port-accent ring-1 ring-port-accent/30">
             <Brain size={23} aria-hidden="true" />
             <span className={`absolute bottom-0 right-0 h-3 w-3 rounded-full border-2 border-port-card ${state?.started && !isPaused ? 'bg-port-success' : 'bg-port-text-muted'}`} aria-hidden="true" />
@@ -721,7 +721,7 @@ export default function MindTab() {
             </p>
           </div>
         </div>
-        <div className="flex flex-wrap items-center gap-2" role="group" aria-label="Persistent mind lifecycle">
+        <div className="flex min-w-0 max-w-full flex-wrap items-center gap-2" role="group" aria-label="Persistent mind lifecycle">
           <PersistentMindThoughtStatus
             state={state}
             model={state?.activeTurnId && state.activeTurnId === runtime?.inference?.turnId


### PR DESCRIPTION
## Summary
- Prevent the thinking status and lifecycle controls from squeezing the Mind identity into a narrow column.
- Wrap the header around a readable identity width and constrain long model labels, preserving the full label on hover.

## Test plan
- 49 existing MindTab and temporary-route tests passed.
- Client production build passed.
- Reviewed the layout changes against the supplied screenshot; no live browser visual verification performed.
