### PR TITLE
fix(pipeline): avoid stale status in autopilot shortcut

### DIFF
--- a/client/src/pages/PipelineSeries.jsx
+++ b/client/src/pages/PipelineSeries.jsx
@@ -312,7 +312,7 @@ export default function PipelineSeries() {
             )}
             {['running', 'paused'].includes(series.autopilot?.status) && (
               <button type="button" className="text-amber-400 hover:underline" onClick={() => setEditorTab('autopilot')}>
-                Autopilot {series.autopilot.status} — view progress
+                View autopilot progress
               </button>
             )}
           </div>


### PR DESCRIPTION
Resuming Autopilot left the series-header shortcut saying “paused” because it read a persisted series snapshot while the mounted Autopilot panel followed the live run. Use “View autopilot progress” for the shortcut so it opens the authoritative progress display without repeating stale status.

Validation: the series responsive navigation tests pass (2 tests); local diff review and whitespace checks pass.
