### PR TITLE
fix: allow explicit selection of provider default models

### DIFF
--- a/client/src/components/ProviderModelSelector.jsx
+++ b/client/src/components/ProviderModelSelector.jsx
@@ -38,6 +38,8 @@
  *   value `""` and this label, letting the caller represent a "no explicit
  *   provider / use the default" choice. Omit (the default) to force a selection.
  * @param {string} [props.emptyModelOption] - Same idea for the model select.
+ * @param {boolean} [props.includeDefaultModel] - Offer the configured default as
+ *   an explicit pin on required-model forms, even when absent from the catalog.
  * @param {boolean} [props.alwaysShowModel] - Render the model select even when
  *   `availableModels` is empty (default: only render it when there are models).
  *   Pair with `emptyModelOption` when the default choice is itself meaningful.
@@ -109,6 +111,7 @@ export default function ProviderModelSelector({
   emptyProviderOption,
   emptyModelOption,
   alwaysShowModel = false,
+  includeDefaultModel = false,
   layout = 'row',
   highlightToolUse = false,
   effort,
@@ -158,7 +161,7 @@ export default function ProviderModelSelector({
   // pin as well as the blank inheritance option, including on required forms.
   const catalogModels = Array.isArray(availableModels) ? availableModels : [];
   const defaultModel = selectedProvider?.defaultModel;
-  const selectableModels = defaultModel
+  const selectableModels = includeDefaultModel && defaultModel
     && !catalogModels.some((model) => modelOption(model)?.value === defaultModel)
     ? [defaultModel, ...catalogModels]
     : catalogModels;

--- a/client/src/components/ProviderModelSelector.jsx
+++ b/client/src/components/ProviderModelSelector.jsx
@@ -154,7 +154,15 @@ export default function ProviderModelSelector({
   // pinned to a now-disabled provider still renders its value instead of
   // silently blanking the select (`selectableProviders` is the one rule).
   const visibleProviders = selectableProviders(providerList, { selectedId: selectedProviderId, allowed: providerAllowed });
-  const compatibleModels = filterHardwareCompatibleProviderModels(availableModels, selectedProvider)
+  // Defaults may be omitted from a provider's browsable catalog. Offer a real
+  // pin as well as the blank inheritance option, including on required forms.
+  const catalogModels = Array.isArray(availableModels) ? availableModels : [];
+  const defaultModel = selectedProvider?.defaultModel;
+  const selectableModels = defaultModel
+    && !catalogModels.some((model) => modelOption(model)?.value === defaultModel)
+    ? [defaultModel, ...catalogModels]
+    : catalogModels;
+  const compatibleModels = filterHardwareCompatibleProviderModels(selectableModels, selectedProvider)
     .filter((model) => !modelAllowed || modelAllowed(model, selectedProvider));
   // Keep a configured default visible even when it is a CLI-default sentinel
   // omitted from the browsable catalog, alongside unavailable saved pins.

--- a/client/src/components/ProviderModelSelector.test.jsx
+++ b/client/src/components/ProviderModelSelector.test.jsx
@@ -56,7 +56,7 @@ describe('ProviderModelSelector', () => {
     const props = {
       providers: [{ id: 'codex', name: 'Codex', defaultModel: 'gpt-6-astra' }],
       selectedProviderId: 'codex', selectedModel: '',
-      availableModels: ['another-model'], emptyModelOption: 'Select a model',
+      availableModels: ['another-model'], emptyModelOption: 'Select a model', includeDefaultModel: true,
       onModelChange,
     };
     const { rerender } = renderSelector(props);
@@ -73,7 +73,7 @@ describe('ProviderModelSelector', () => {
   it('does not duplicate catalog defaults or offer a policy-disallowed default', () => {
     const props = {
       providers: [{ id: 'p1', defaultModel: 'm1' }], selectedProviderId: 'p1',
-      selectedModel: '', availableModels: [{ id: 'm1', name: 'Model One' }],
+      selectedModel: '', availableModels: [{ id: 'm1', name: 'Model One' }], includeDefaultModel: true,
       emptyModelOption: 'Default model', onProviderChange: () => {}, onModelChange: () => {},
     };
     const { rerender } = renderSelector(props);
@@ -81,6 +81,11 @@ describe('ProviderModelSelector', () => {
     rerender(<ProviderModelSelector {...props} availableModels={['m2']}
       selectionPolicy={{ model: model => model !== 'm1' }} />);
     expect(screen.getAllByRole('option').some(option => option.value === 'm1')).toBe(false);
+  });
+
+  it('preserves caller-filtered catalogs unless the form opts into default pins', () => {
+    renderSelector({ providers: [{ id: 'p1', defaultModel: 'text-only' }], availableModels: ['vision-model'], selectedModel: '' });
+    expect(screen.getAllByRole('option').some(option => option.value === 'text-only')).toBe(false);
   });
 
   it('renders only the provider options by default (no empty sentinel)', () => {

--- a/client/src/components/ProviderModelSelector.test.jsx
+++ b/client/src/components/ProviderModelSelector.test.jsx
@@ -51,6 +51,38 @@ describe('ProviderModelSelector', () => {
     expect(onEffortChange).toHaveBeenCalledWith('low');
   });
 
+  it('lets a required form pin a default omitted from the catalog without changing it on mount', () => {
+    const onModelChange = vi.fn();
+    const props = {
+      providers: [{ id: 'codex', name: 'Codex', defaultModel: 'gpt-6-astra' }],
+      selectedProviderId: 'codex', selectedModel: '',
+      availableModels: ['another-model'], emptyModelOption: 'Select a model',
+      onModelChange,
+    };
+    const { rerender } = renderSelector(props);
+    const select = screen.getByRole('combobox', { name: 'Model' });
+    expect(select.value).toBe('');
+    expect(onModelChange).not.toHaveBeenCalled();
+    expect(screen.getByRole('option', { name: 'gpt-6-astra', exact: true }).disabled).toBe(false);
+    fireEvent.change(select, { target: { value: 'gpt-6-astra' } });
+    expect(onModelChange).toHaveBeenCalledWith('gpt-6-astra');
+    rerender(<ProviderModelSelector {...props} selectedModel="gpt-6-astra" onProviderChange={() => {}} />);
+    expect(select.value).toBe('gpt-6-astra');
+  });
+
+  it('does not duplicate catalog defaults or offer a policy-disallowed default', () => {
+    const props = {
+      providers: [{ id: 'p1', defaultModel: 'm1' }], selectedProviderId: 'p1',
+      selectedModel: '', availableModels: [{ id: 'm1', name: 'Model One' }],
+      emptyModelOption: 'Default model', onProviderChange: () => {}, onModelChange: () => {},
+    };
+    const { rerender } = renderSelector(props);
+    expect(screen.getAllByRole('option').filter(option => option.value === 'm1')).toHaveLength(1);
+    rerender(<ProviderModelSelector {...props} availableModels={['m2']}
+      selectionPolicy={{ model: model => model !== 'm1' }} />);
+    expect(screen.getAllByRole('option').some(option => option.value === 'm1')).toBe(false);
+  });
+
   it('renders only the provider options by default (no empty sentinel)', () => {
     renderSelector();
     const options = screen.getAllByRole('option').map((o) => o.textContent);

--- a/client/src/components/apps/AppQualityRunner.jsx
+++ b/client/src/components/apps/AppQualityRunner.jsx
@@ -76,7 +76,7 @@ export default function AppQualityRunner({ app, children }) {
     <ProviderModelSelector providers={picker.providers} selectedProviderId={picker.selectedProviderId} selectedModel={picker.selectedModel}
       availableModels={picker.availableModels} onProviderChange={value => { picker.setSelectedProviderId(value); setEffort(''); }}
       onModelChange={picker.setSelectedModel} effort={effort} onEffortChange={setEffort} loading={picker.loading} disabled={busy}
-      emptyProviderOption="Select a subscription provider" emptyModelOption="Select a model" highlightToolUse />
+      emptyProviderOption="Select a subscription provider" emptyModelOption="Select a model" includeDefaultModel highlightToolUse />
     <p className="text-xs text-gray-400">{taskTypes.length} scheduled agents, run sequentially within this batch. Launch another batch to run checks in parallel. {mode === 'fix' ? 'Each selected audit can change code and open a PR.' : 'Findings become issues; no fixes or backlog claim jobs.'} Schedules can stay disabled. The Improve setting still applies.</p>
     <details className="text-xs"><summary className="cursor-pointer text-port-accent">Selected checks ({taskTypes.length})</summary><p className="mt-1">{categories.filter(category => taskTypes.includes(category.id)).map(category => category.label).join(', ') || 'No checks need evidence. Unavailable assessments and N/A categories are excluded.'}</p></details>
     <button type="button" onClick={start} disabled={busy || picker.loading || !picker.selectedProviderId || !picker.selectedModel || !taskTypes.length || app.quality?.unavailable}

--- a/client/src/components/cos/PersistentMindProfileControls.jsx
+++ b/client/src/components/cos/PersistentMindProfileControls.jsx
@@ -194,7 +194,7 @@ export default function PersistentMindProfileControls({
         effort={draft.effort}
         disabled={disabled || saving || !draft.enabled}
         emptyProviderOption="Select an AI provider"
-        emptyModelOption="Select a model"
+        emptyModelOption="Select a model" includeDefaultModel
         alwaysShowModel
         highlightToolUse
         layout="stacked"

--- a/client/src/components/cos/PersistentMindThinkingPresets.jsx
+++ b/client/src/components/cos/PersistentMindThinkingPresets.jsx
@@ -238,7 +238,7 @@ export default function PersistentMindThinkingPresets({
             loading={providersLoading}
             disabled={disabled || saving}
             emptyProviderOption="Select an AI provider"
-            emptyModelOption="Select a model"
+            emptyModelOption="Select a model" includeDefaultModel
             alwaysShowModel
             highlightToolUse
             layout="stacked"

--- a/client/src/components/cos/tabs/schedule/MaintenanceRunForm.jsx
+++ b/client/src/components/cos/tabs/schedule/MaintenanceRunForm.jsx
@@ -183,7 +183,7 @@ export default function MaintenanceRunForm({ schedule, apps = [], providers = []
         effort={effort}
         onEffortChange={next => { setEffort(next); setConsent(false); }}
         emptyProviderOption="Select a subscription provider"
-        emptyModelOption="Select a model"
+        emptyModelOption="Select a model" includeDefaultModel
         alwaysShowModel
         loading={!providersLoaded}
         disabled={busy}
@@ -201,7 +201,7 @@ export default function MaintenanceRunForm({ schedule, apps = [], providers = []
           effort={claimHandler.effort}
           onEffortChange={next => { setClaimHandler(current => ({ ...current, effort: next })); setConsent(false); }}
           emptyProviderOption="Same as audit handler"
-          emptyModelOption="Select a model"
+          emptyModelOption="Select a model" includeDefaultModel
           alwaysShowModel={Boolean(claimHandler.providerId)}
           loading={!providersLoaded}
           disabled={busy}

--- a/client/src/components/cos/tabs/schedule/MaintenanceStepSettings.jsx
+++ b/client/src/components/cos/tabs/schedule/MaintenanceStepSettings.jsx
@@ -28,7 +28,7 @@ export default function MaintenanceStepSettings({ run, step, providers, loading,
         onProviderChange={providerId => setDraft({ providerId, model: '', effort: '' })}
         onModelChange={model => setDraft(current => ({ ...current, model }))}
         effort={draft.effort} onEffortChange={effort => setDraft(current => ({ ...current, effort }))}
-        emptyProviderOption="Select a subscription provider" emptyModelOption="Select a model"
+        emptyProviderOption="Select a subscription provider" emptyModelOption="Select a model" includeDefaultModel
         alwaysShowModel layout="stacked" loading={loading} disabled={saving} />
       <p className="text-port-text-muted">Blank effort uses the task’s saved setting. Applies to this stage only.</p>
       <button type="button" onClick={save} disabled={saving || loading || !dirty || !provider || !draft.model}


### PR DESCRIPTION
## Summary
The shared model selector showed a configured default beside its empty option but omitted the actual model when absent from the catalog. Forms requiring a pin, including persistent mind settings, could therefore remain disabled with no way to choose that model.

Offer the configured default as an explicit option on required-model forms (persistent mind profiles/presets, maintenance runs/steps, and App Quality), before applying hardware and selection-policy filters. Other callers retain their filtered catalogs. Preserve blank inheritance, avoid duplicate catalog entries, and retain existing unavailable-pin behavior.

## Test plan
- Six affected component suites: 63 tests passed.
- Biome lint passed for all seven changed files.
- Regression coverage verifies selecting an omitted default, no automatic override on mount, catalog deduplication, and policy filtering.
