### PR TITLE
fix: document managed updates that rebase and autostash local work

### DIFF
--- a/docs/MANAGED_APP_UPDATES.md
+++ b/docs/MANAGED_APP_UPDATES.md
@@ -3,13 +3,30 @@
 PortOS updates itself through `update.sh` or `update.ps1`. That lifecycle is
 specific to PortOS and is never assumed for a separately managed app.
 
-When a managed app is updated, PortOS first fetches `origin`, checks out that
-repository's default branch, fast-forwards it, and restarts the app's configured
-PM2 processes. It does not automatically run `npm install`, `setup`, migrations,
-or a production build. If the checkout has local changes, the update stops
-without stashing or discarding them.
+When a managed app is updated, PortOS fetches `origin` and checks out the
+repository's configured `portos.runtimeBranch`, or origin's default branch when
+that setting is absent. It first tries `git pull --ff-only origin <branch>`.
+If that fails, it retries with `git pull --rebase --autostash origin <branch>`:
+local commits can be rebased, and tracked uncommitted changes can be temporarily
+stashed and reapplied. Local changes do **not** automatically stop an update;
+non-conflicting changes can also carry across the branch switch. Commit work
+before updating if you need a durable recovery point, and preserve untracked
+files separately — `--autostash` is not an untracked-file backup.
 
-An app can opt into its own lifecycle in either of these ways:
+A blocked checkout, failed rebase, or conflict while reapplying the autostash
+stops the update before lifecycle commands or process restart. PortOS attempts
+to abort a failed rebase and queues a CoS conflict-resolution task. An autostash
+reapply conflict can leave unmerged files after the rebase has completed; the
+update does not treat Git's zero exit status as success in that case. Review
+the reported conflict and task outcome before retrying. Configured companion
+repositories follow the same pull sequence; a later conflict does not roll
+back repositories already updated.
+
+After successful pulls, PortOS runs any opted-in lifecycle below and restarts
+the app's configured PM2 processes. Without that lifecycle, it does not
+automatically run `npm install`, `setup`, migrations, or a production build.
+
+An app can opt into its own lifecycle in these ways:
 
 1. Add an executable `update.sh` (or `update.ps1` on Windows) at the repository
    root. PortOS recognizes these conventional scripts automatically.
@@ -32,10 +49,11 @@ When more than one is present, the configured **Update Command** wins, then
 The PortOS record appears in App Management like any other app, so **Update**
 there runs the same `appUpdater` flow described above. It is the one app whose
 update routine deletes the process running that flow, so it takes a different
-launcher: the conventional-script branch delegates to `executeUpdate()` in
-`server/services/updateExecutor.js`, whose double-fork keeps `update.sh` alive
-through its own `pm2 delete` step, and the trailing PM2 restart is skipped
-because the script starts the ecosystem itself. See
+launcher: when the record points at the running PortOS checkout and uses its
+conventional update script, it delegates to `startPortosSelfUpdate()` in
+`server/services/portosSelfUpdate.js` with mode `refresh`. The shared detached
+launcher keeps the update alive through its own PM2 shutdown. The trailing
+PM2 restart is skipped because the script starts the ecosystem itself. See
 [Self-Update Flow](SELF_UPDATE.md#every-portos-update-goes-through-the-detached-launcher).
 
 A custom **Update Command** on the PortOS record keeps the ordinary attached


### PR DESCRIPTION
## Summary
Correct the managed-app update guide's false guarantee that dirty checkouts stop without stashing. Explain the actual fast-forward/rebase/autostash sequence, configured runtime branch, conflict recovery, companion repository limits, and shared PortOS launcher. Runtime behavior is unchanged.

## Test plan
- Server Vitest: `services/git.updateDefaultBranch.test.js services/appUpdater.test.js` — 23 tests passed.
- `git diff --check` passed; documentation checked against callers and current implementation.

## Documentation audit
Pre-fix documentation health: **78/100**; worst verified severity **7/10**. Significant false update guarantees are localized; setup prerequisites, PostgreSQL requirement, and database transaction safeguards were consistent with code. Unresolved documentation debt remains after this bounded fix.

Signal scan: `git ls-files -z`, Python UTF-8 content scan, `rg` command/contract searches, npm-script cross-check, targeted `git log`, and open-issue search. All 7,598 eligible tracked text files were scanned (21,364 matching lines). Roots: server, client, scripts, autofixer, browser, shell, first-party lib, docs, root configuration/launchers, and repository tooling. Excluded dependencies, build output, vendored aiToolkit/slashdo, generated manifests, lockfiles, reference seeds, release notes, and historical plans/research. Binary assets excluded. Broad signal coverage is not a deep review of every file.

Ranked candidates (documentation line references are pre-fix):

| Rank | Candidate and measured signal | Impact / reach | Confidence / severity | Disposition |
|---|---|---|---|---|
| 1 | `docs/MANAGED_APP_UPDATES.md:6-10`: two false guarantees (fast-forward only and dirty checkout refusal); contradicted by `server/services/git.js:753-768`, called at `server/services/appUpdater.js:230` | Unexpected local history/working-tree changes for managed-app updates | High; 7/10 | Fixed; false recovery guarantee outranks missing details |
| 2 | Same guide `:6-7`: one unconditional default-branch claim; `server/services/git.js:731-733` honors `portos.runtimeBranch` first | Misidentifies updated branch for configured runtimes | High; 6/10 | Fixed within the same update contract |
| 3 | `docs/BACKUP.md:67,75`: restore preview limitations omitted; `server/services/backup.js:313,827-835,901-908` shows file restore can partially overwrite and DB dry-run returns before health/SQL execution | Recovery readers may overestimate preview assurances | High; 5/10 | Deferred; missing detail ranks below verified false update guarantees |
| 4 | `docs/CONTRIBUTING.md:23-24`: one bare global `pm2` alternative; `package.json:19` uses repository-local PM2 | Alternative startup command fails without a global install; documented npm development path works | High; 4/10 | Deferred |
| 5 | `docs/MANAGED_APP_UPDATES.md:35-39`: stale direct `executeUpdate` launcher reference; `server/services/appUpdater.js:307-311` uses shared `startPortosSelfUpdate` with refresh mode | Maintainers follow wrong lifecycle entry point | High; 3/10 | Fixed in same guide |

Validation included `git.updateDefaultBranch.test.js` (branch override, rebase, checkout and autostash conflicts), `appUpdater.test.js` (stop/queue behavior and lifecycle routing), and history commit `10759b927` introducing the dirty-checkout change. The focused open-issue search returned no matching managed-update documentation issue; no issues were filed. npm-floor and auth/DB safety signals were examined and excluded as current/documented behavior, not defects. Existing optional private-network protections were honored as non-issues.

Deep-reviewed paths: README, AGENTS, changelog conventions, setup/contributing/API/backup/self-update/managed-update/storage/troubleshooting guides; package scripts; npm advisory; updateDefaultBranch and appUpdater plus tests; backup service/routes/tests and BackupTab; authGate. Remaining source/features received signal scanning only. Stopped after correcting the highest-impact verified coherent update contract; no claim of a globally worst defect or clean repository.
