### PR TITLE
refactor: make peer delivery evidence explicit

### DIFF
--- a/server/services/sharing/peerSubscriptions.js
+++ b/server/services/sharing/peerSubscriptions.js
@@ -188,7 +188,7 @@ export async function subscribePeer({ peerId, recordKind, recordId }, opts = {})
         // #1922: same contract as `lastConfirmedPushedAt`, scoped to confirmed
         // delivery of a BUNDLED `linkedTrack` tombstone/record (#1858) on a
         // musicVideoProject subscription — see peerSyncPush.js
-        // `persistPushSuccess` and tombstoneGc.js's `track` cutoff. Stays
+        // `persistPushDeliveryEvidence` and tombstoneGc.js's `track` cutoff. Stays
         // `null` for every other recordKind.
         lastConfirmedTrackBundleAtMs: null,
         adoptedFromReverse: opts.adoptedFromReverse === true,

--- a/server/services/sharing/peerSync.test.js
+++ b/server/services/sharing/peerSync.test.js
@@ -1379,7 +1379,7 @@ describe('peerSync', () => {
       await subscribePeer({ peerId: 'peer-a', recordKind: 'universe', recordId: 'u1' });
       // Poll for the fire-and-forget initial push to persist its hash. A fixed
       // sleep OR a single writeTail drain (__drainForTests) is racy in slower CI
-      // because the push's peerFetch + persistPushSuccess chain may not have even
+      // because the push's peerFetch + persistPushDeliveryEvidence chain may not have even
       // started when we read — vi.waitFor retries the real condition deterministically.
       let sub;
       await vi.waitFor(async () => {

--- a/server/services/sharing/peerSyncPush.js
+++ b/server/services/sharing/peerSyncPush.js
@@ -278,7 +278,7 @@ export async function pushRecordToPeer(sub, options = {}) {
   // #1922: a musicVideoProject subscription is also a delivery vehicle for
   // its bundled `linkedTrack` (#1858) — the receiver has no independent
   // `track` subscription to ack through. Stamp a SEPARATE floor
-  // (`trackBundleConfirmed`) tombstoneGc's `track` cutoff reads off
+  // (`lastConfirmedTrackBundleAtMs`) tombstoneGc's `track` cutoff reads off
   // musicVideoProject rows, distinct from `lastConfirmedPushedAt` because the
   // latter advances even when the bundled track merge failed or was stripped
   // for a legacy peer (`trackSyncPending`) — using it here would let GC treat
@@ -296,14 +296,19 @@ export async function pushRecordToPeer(sub, options = {}) {
   // included in this push.
   const trackOwed = isStr(payload.record?.trackId);
   const trackSyncPending = pending.has(ENVELOPE_PENDING_KEYS.linkedTrack);
-  const trackBundleConfirmed = sub.recordKind === 'musicVideoProject'
+  const linkedTrackObligationSatisfied = sub.recordKind === 'musicVideoProject'
     && !trackSyncPending
     && (!trackOwed || Boolean(payload.linkedTrack));
-  await persistPushSuccess(sub.id, pushedHash, {
-    confirmedAtMs: Date.now(),
-    trackBundleConfirmed,
-    legacyStrippedHash,
-  });
+  const recordPushAcceptedAtMs = Date.now();
+  const deliveryEvidence = {
+    recordPushAcceptedAtMs,
+    linkedTrackObligationSatisfiedAtMs: linkedTrackObligationSatisfied ? recordPushAcceptedAtMs : null,
+    retrySuppression: {
+      fullPayloadHash: pushedHash,
+      legacyStrippedPayloadHash: legacyStrippedHash,
+    },
+  };
+  await persistPushDeliveryEvidence(sub.id, deliveryEvidence);
   if (Number.isFinite(body?.ackedDeletesUpTo) && body.ackedDeletesUpTo > 0) {
     await ackDeletesUpTo(sub.peerId, body.ackedDeletesUpTo).catch(() => {});
   }
@@ -427,33 +432,38 @@ function resolvePushWatermarks({ hash, missingCount, stripped, body }) {
   };
 }
 
-async function persistPushSuccess(subId, hash, { confirmedAtMs = Date.now(), trackBundleConfirmed = false, legacyStrippedHash = null } = {}) {
+// Adapt delivery evidence to the existing subscription storage contract.
+async function persistPushDeliveryEvidence(subId, {
+  recordPushAcceptedAtMs,
+  linkedTrackObligationSatisfiedAtMs,
+  retrySuppression: { fullPayloadHash, legacyStrippedPayloadHash },
+}) {
   await withStateLock(async () => {
     const state = await readState();
     const sub = state.subscriptions.find((s) => s.id === subId);
     if (!sub) return;
     const now = new Date().toISOString();
     sub.lastPushedAt = now;
-    sub.lastPushedHash = hash;
+    sub.lastPushedHash = fullPayloadHash;
     // #3928: the legacy-stripped water-mark. Set when this push only landed
     // with a newer top-level key stripped for an older peer; cleared on every
     // other successful push so a peer that has since upgraded (or a record
     // whose content moved) can never be held back by a stale entry.
-    sub.lastPushedLegacyHash = isNonBlankStr(legacyStrippedHash) ? legacyStrippedHash : null;
+    sub.lastPushedLegacyHash = isNonBlankStr(legacyStrippedPayloadHash) ? legacyStrippedPayloadHash : null;
     sub.updatedAt = now;
     // Advance the per-record confirmed-delivery water-mark monotonically — an
     // out-of-order retry must not retract it (mirrors ackDeletesUpTo's
     // never-move-backward guarantee). tombstoneGc reads MIN-of-this across a
     // kind's rows, so a regression here would let a stale tombstone prune.
-    if (Number.isFinite(confirmedAtMs) && confirmedAtMs > (sub.lastConfirmedPushedAt ?? 0)) {
-      sub.lastConfirmedPushedAt = confirmedAtMs;
+    if (Number.isFinite(recordPushAcceptedAtMs) && recordPushAcceptedAtMs > (sub.lastConfirmedPushedAt ?? 0)) {
+      sub.lastConfirmedPushedAt = recordPushAcceptedAtMs;
     }
-    // #1922: same monotonic-floor treatment, but scoped to confirmed delivery
-    // of a BUNDLED linkedTrack (musicVideoProject subscriptions only — see the
-    // call site). tombstoneGc's `track` cutoff reads this instead of
+    // #1922: same monotonic-floor treatment for a satisfied linked-track
+    // obligation (including no track owed, musicVideoProject rows only).
+    // tombstoneGc's `track` cutoff reads this instead of
     // `lastConfirmedPushedAt` for musicVideoProject rows.
-    if (trackBundleConfirmed && Number.isFinite(confirmedAtMs) && confirmedAtMs > (sub.lastConfirmedTrackBundleAtMs ?? 0)) {
-      sub.lastConfirmedTrackBundleAtMs = confirmedAtMs;
+    if (Number.isFinite(linkedTrackObligationSatisfiedAtMs) && linkedTrackObligationSatisfiedAtMs > (sub.lastConfirmedTrackBundleAtMs ?? 0)) {
+      sub.lastConfirmedTrackBundleAtMs = linkedTrackObligationSatisfiedAtMs;
     }
     // A successful push (or even a no-asset-stranded push) clears any prior
     // schema-version block — the peer can receive again.

--- a/server/services/sharing/peerSyncShared.js
+++ b/server/services/sharing/peerSyncShared.js
@@ -130,7 +130,7 @@ export async function writeState(state) {
 
 // Serialize every readState→modify→writeState pair through a single tail
 // promise. The push pipeline runs fire-and-forget after each subscribe; its
-// `persistPushSuccess` writes race the subscribe's own writes for the same
+// `persistPushDeliveryEvidence` writes race the subscribe's own writes for the same
 // file, and a naive concurrent run can clobber a just-persisted record
 // (subscribe-s1 reads [u1] from file, push-u1 finishes by writing [u1+meta],
 // subscribe-s1 writes [u1, s1] from its stale in-memory copy, AND VICE VERSA

--- a/server/services/sharing/tombstoneGc.js
+++ b/server/services/sharing/tombstoneGc.js
@@ -248,26 +248,9 @@ function peerIdsSubscribedToKind(subs, peers, recordKind) {
 // unchanged. Every other recordKind/targetKind pairing also keeps using
 // `lastConfirmedPushedAt` as before.
 //
-// Upgrade compat: an existing musicVideoProject subscription row created
-// BEFORE this field existed has no `lastConfirmedTrackBundleAtMs` at all —
-// and if its project content hasn't changed since, `pushRecordToPeer`'s
-// `unchanged`-hash short-circuit means it may NEVER take another real push
-// that would stamp the field, pinning the `track` floor at that row's old
-// `createdAt` indefinitely. A non-null `lastPushedHash` on the row is a safe
-// historical proxy: `persistPushSuccess` has ALWAYS withheld the hash when
-// `trackSyncPending` was true (#1858, predating this field), so a saved hash
-// means that row's most recent successful push already had its bundled track
-// merge confirmed — `lastConfirmedPushedAt` is a sound backfilled stand-in.
-// A row with neither field set (no hash yet, or hash withheld) still floors
-// conservatively to `createdAt`.
 function confirmedFloorForSub(sub, targetKind) {
   if (targetKind === 'track' && sub.recordKind === 'musicVideoProject') {
-    if (Number.isFinite(sub.lastConfirmedTrackBundleAtMs)) return sub.lastConfirmedTrackBundleAtMs;
-    if (typeof sub.lastPushedHash === 'string' && Number.isFinite(sub.lastConfirmedPushedAt)) {
-      return sub.lastConfirmedPushedAt;
-    }
-    const createdMs = Date.parse(sub.createdAt || '');
-    return Number.isFinite(createdMs) ? createdMs : 0;
+    return bundledTrackConfirmationFloorForSub(sub);
   }
   let confirmed = sub.lastConfirmedPushedAt;
   if (!Number.isFinite(confirmed)) {
@@ -276,6 +259,27 @@ function confirmedFloorForSub(sub, targetKind) {
     confirmed = Number.isFinite(createdMs) ? createdMs : 0;
   }
   return confirmed;
+}
+
+// Upgrade compat: an existing musicVideoProject subscription row created
+// BEFORE this field existed has no `lastConfirmedTrackBundleAtMs` at all —
+// and if its project content hasn't changed since, `pushRecordToPeer`'s
+// `unchanged`-hash short-circuit means it may NEVER take another real push
+// that would stamp the field, pinning the `track` floor at that row's old
+// `createdAt` indefinitely. A non-null `lastPushedHash` on the row is a safe
+// historical proxy: the push delivery writer has ALWAYS withheld the hash when
+// `trackSyncPending` was true (#1858, predating this field), so a saved hash
+// means that row's most recent successful push already had its bundled track
+// merge confirmed — `lastConfirmedPushedAt` is a sound backfilled stand-in.
+// A row with neither field set (no hash yet, or hash withheld) still floors
+// conservatively to `createdAt`.
+function bundledTrackConfirmationFloorForSub(sub) {
+  if (Number.isFinite(sub.lastConfirmedTrackBundleAtMs)) return sub.lastConfirmedTrackBundleAtMs;
+  if (typeof sub.lastPushedHash === 'string' && Number.isFinite(sub.lastConfirmedPushedAt)) {
+    return sub.lastConfirmedPushedAt;
+  }
+  const createdMs = Date.parse(sub.createdAt || '');
+  return Number.isFinite(createdMs) ? createdMs : 0;
 }
 
 // Returns Infinity when there are no eligible rows for the kind (no per-record

--- a/server/services/sharing/tombstoneGc.test.js
+++ b/server/services/sharing/tombstoneGc.test.js
@@ -1025,7 +1025,7 @@ describe('sweepTombstones — track GC cohort widened by musicVideoProject bundl
     // `unchanged`-hash short-circuit means it may NEVER take another real push
     // that would stamp the field — pinning the track cutoff at the row's old
     // createdAt forever. A saved lastPushedHash is a safe historical proxy:
-    // persistPushSuccess has always withheld the hash when trackSyncPending was
+    // persistPushDeliveryEvidence has always withheld the hash when trackSyncPending was
     // true (#1858, predating this field), so a non-null hash means that row's
     // last successful push already had its bundled track merge confirmed.
     getMinAckAcrossPeers.mockResolvedValue(NOW);


### PR DESCRIPTION
## Summary
Make peer push completion explicitly distinguish accepted records, satisfied linked-track obligations, and retry-suppression hashes. The storage adapter retains existing subscription fields and monotonic updates; GC names its bundled-track floor and preserves the legacy hash and creation-time fallbacks.

This is a behavior-preserving refactor with no wire, persisted-schema, receiver, or deletion-policy changes.

Closes #7123

## Test plan
- All 494 tests passed across peerSync, tombstoneGc, syncOrchestrator, and sharing integration suites using the server Vitest configuration.
- Existing boundary coverage exercises pending, stripped, omitted-but-owed, no-track-owed, complete delivery, and mixed subscription cohorts.
- Local Codex static review: APPROVE, no actionable findings.
