### PR TITLE
fix: open complete day lists from calendar month overflow

### DIFF
--- a/client/src/components/calendar/MonthView.jsx
+++ b/client/src/components/calendar/MonthView.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useMemo, useRef } from 'react';
 import {ChevronLeft, ChevronRight} from 'lucide-react';
 import * as api from '../../services/api';
 import socket from '../../services/socket';
@@ -100,10 +100,20 @@ export default function MonthView({ accounts }) {
   const selectedEventKey = searchParams.get('event');
   const selectedEvent = events.find((event) => `${event.accountId}:${event.id}` === selectedEventKey) || null;
   const todayStr = now.toDateString();
+  const dayTriggerRef = useRef(null);
   // Matching against the visible grid rejects impossible and stale day keys.
   const selectedDay = cells.find(cell => localDateKey(cell.date) === searchParams.get('day'));
   const selectedDayEvents = [...(eventsByDay[selectedDay?.date.toDateString()] || [])]
     .sort((a, b) => Number(b.isAllDay) - Number(a.isAllDay) || new Date(a.startTime) - new Date(b.startTime));
+  // Event details temporarily replace the day drawer, so preserve the original
+  // month trigger across that intermediate drawer's focus-restoration cycle.
+  useEffect(() => {
+    if (!selectedDay && !selectedEvent && dayTriggerRef.current) {
+      dayTriggerRef.current.focus();
+      dayTriggerRef.current = null;
+    }
+  }, [selectedDay, selectedEvent]);
+
   const openEvent = (event) => updateParams({ month: monthKey, event: `${event.accountId}:${event.id}` });
 
   return (
@@ -182,7 +192,10 @@ export default function MonthView({ accounts }) {
                       <button
                         type="button"
                         aria-label={`View all ${dayEvents.length} events for ${formatDateFull(cell.date)}`}
-                        onClick={() => updateParams({ month: monthKey, day: localDateKey(cell.date), event: null })}
+                        onClick={(e) => {
+                          dayTriggerRef.current = e.currentTarget;
+                          updateParams({ month: monthKey, day: localDateKey(cell.date), event: null });
+                        }}
                         className="w-full text-left text-[10px] text-port-accent pl-1 py-1 rounded hover:bg-port-border focus-visible:outline focus-visible:outline-port-accent"
                       >
                         +{dayEvents.length - 3} more
@@ -197,7 +210,7 @@ export default function MonthView({ accounts }) {
       )}
 
       <Drawer
-        open={!!selectedDay && !selectedEvent}
+        open={!!selectedDay && !selectedEvent && !loading}
         onClose={() => updateParams({ day: null, event: null })}
         title={selectedDay ? formatDateFull(selectedDay.date) : ''}
         subtitle={`${selectedDayEvents.length} events`}

--- a/client/src/components/calendar/MonthView.jsx
+++ b/client/src/components/calendar/MonthView.jsx
@@ -1,12 +1,13 @@
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import {ChevronLeft, ChevronRight} from 'lucide-react';
 import * as api from '../../services/api';
 import socket from '../../services/socket';
 import EventDetail from './EventDetail';
+import Drawer from '../Drawer';
 import { buildSubcalendarColorMap, eventChipStyle } from './calendarUtils';
 import BrailleSpinner from '../BrailleSpinner';
 import { useThemeContext } from '../ThemeContext';
-import { formatMonthYear, formatTimeOfDay } from '../../utils/formatters';
+import { formatMonthYear, formatTimeOfDay, formatDateFull, localDateKey } from '../../utils/formatters';
 import useUrlParams from '../../hooks/useUrlParams';
 
 function getMonthGrid(year, month) {
@@ -37,46 +38,54 @@ const DAY_NAMES = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
 
 export default function MonthView({ accounts }) {
   const now = new Date();
-  const [year, setYear] = useState(now.getFullYear());
-  const [month, setMonth] = useState(now.getMonth());
+
   const [events, setEvents] = useState([]);
   const [loading, setLoading] = useState(true);
   const [searchParams, updateParams] = useUrlParams();
   const { theme } = useThemeContext();
+  const monthParam = searchParams.get('month');
+  const monthKey = /^[1-9]\d{3}-(0[1-9]|1[0-2])$/.test(monthParam || '')
+    ? monthParam : localDateKey(now).slice(0, 7);
+  const [year, monthNumber] = monthKey.split('-').map(Number);
+  const month = monthNumber - 1;
 
   const cells = getMonthGrid(year, month);
   const monthLabel = formatMonthYear(new Date(year, month));
 
-  const fetchEvents = useCallback(async () => {
-    const grid = getMonthGrid(year, month);
-    const startDate = grid[0].date.toISOString();
-    const endDate = new Date(grid[grid.length - 1].date.getTime() + 24 * 60 * 60 * 1000).toISOString();
-    const data = await api.getCalendarEvents({ startDate, endDate, limit: 500 }).catch(() => ({ events: [] }));
-    setEvents(data?.events || []);
-    setLoading(false);
+  useEffect(() => {
+    let active = true;
+    let request = 0;
+    const fetchEvents = async () => {
+      const currentRequest = ++request;
+      const grid = getMonthGrid(year, month);
+      const last = grid[grid.length - 1].date;
+      const startDate = grid[0].date.toISOString();
+      const endDate = new Date(last.getFullYear(), last.getMonth(), last.getDate() + 1).toISOString();
+      const data = await api.getCalendarEvents({ startDate, endDate, limit: 500 }).catch(() => ({ events: [] }));
+      if (!active || currentRequest !== request) return;
+      setEvents(data?.events || []);
+      setLoading(false);
+    };
+    setEvents([]);
+    setLoading(true);
+    fetchEvents();
+    socket.on('calendar:sync:completed', fetchEvents);
+    return () => {
+      active = false;
+      socket.off('calendar:sync:completed', fetchEvents);
+    };
   }, [year, month]);
 
-  useEffect(() => { fetchEvents(); }, [fetchEvents]);
-  useEffect(() => {
-    socket.on('calendar:sync:completed', fetchEvents);
-    return () => socket.off('calendar:sync:completed', fetchEvents);
-  }, [fetchEvents]);
-
   const navigate = (dir) => {
-    setLoading(true);
-    if (dir === -1) {
-      if (month === 0) { setMonth(11); setYear(y => y - 1); }
-      else setMonth(m => m - 1);
-    } else {
-      if (month === 11) { setMonth(0); setYear(y => y + 1); }
-      else setMonth(m => m + 1);
-    }
+    updateParams({
+      month: localDateKey(new Date(year, month + dir, 1)).slice(0, 7),
+      day: null,
+      event: null,
+    });
   };
 
   const goToday = () => {
-    setYear(now.getFullYear());
-    setMonth(now.getMonth());
-    setLoading(true);
+    updateParams({ month: localDateKey(now).slice(0, 7), day: null, event: null });
   };
 
   // Group events by day string
@@ -91,6 +100,11 @@ export default function MonthView({ accounts }) {
   const selectedEventKey = searchParams.get('event');
   const selectedEvent = events.find((event) => `${event.accountId}:${event.id}` === selectedEventKey) || null;
   const todayStr = now.toDateString();
+  // Matching against the visible grid rejects impossible and stale day keys.
+  const selectedDay = cells.find(cell => localDateKey(cell.date) === searchParams.get('day'));
+  const selectedDayEvents = [...(eventsByDay[selectedDay?.date.toDateString()] || [])]
+    .sort((a, b) => Number(b.isAllDay) - Number(a.isAllDay) || new Date(a.startTime) - new Date(b.startTime));
+  const openEvent = (event) => updateParams({ month: monthKey, event: `${event.accountId}:${event.id}` });
 
   return (
     <div className="space-y-4">
@@ -151,7 +165,7 @@ export default function MonthView({ accounts }) {
                       return (
                         <button
                           key={`${event.accountId}-${event.id}`}
-                          onClick={() => updateParams({ event: `${event.accountId}:${event.id}` })}
+                          onClick={() => openEvent(event)}
                           className="w-full text-left px-1 py-0.5 rounded text-[10px] truncate transition-colors hover:brightness-125"
                           style={eventChipStyle(evColor, theme?.mode)}
                         >
@@ -165,7 +179,14 @@ export default function MonthView({ accounts }) {
                       );
                     })}
                     {dayEvents.length > 3 && (
-                      <div className="text-[10px] text-gray-500 pl-1">+{dayEvents.length - 3} more</div>
+                      <button
+                        type="button"
+                        aria-label={`View all ${dayEvents.length} events for ${formatDateFull(cell.date)}`}
+                        onClick={() => updateParams({ month: monthKey, day: localDateKey(cell.date), event: null })}
+                        className="w-full text-left text-[10px] text-port-accent pl-1 py-1 rounded hover:bg-port-border focus-visible:outline focus-visible:outline-port-accent"
+                      >
+                        +{dayEvents.length - 3} more
+                      </button>
                     )}
                   </div>
                 </div>
@@ -175,6 +196,31 @@ export default function MonthView({ accounts }) {
         </div>
       )}
 
+      <Drawer
+        open={!!selectedDay && !selectedEvent}
+        onClose={() => updateParams({ day: null, event: null })}
+        title={selectedDay ? formatDateFull(selectedDay.date) : ''}
+        subtitle={`${selectedDayEvents.length} events`}
+        closeLabel="Close day events"
+      >
+        {loading ? <BrailleSpinner text="Loading" /> : (
+          <div className="space-y-2">
+            {selectedDayEvents.length === 0 && <p className="text-sm text-gray-400">No events available for this date.</p>}
+            {selectedDayEvents.map(event => (
+              <button
+                key={`${event.accountId}:${event.id}`}
+                type="button"
+                onClick={() => openEvent(event)}
+                className="w-full min-h-[44px] text-left px-3 py-2 rounded transition-colors hover:brightness-125"
+                style={eventChipStyle(colorMap.get(event.subcalendarId) || null, theme?.mode)}
+              >
+                <span className="block text-xs">{event.isAllDay ? 'All day' : formatTimeOfDay(event.startTime)}</span>
+                <span className="block text-sm break-words">{event.title}</span>
+              </button>
+            ))}
+          </div>
+        )}
+      </Drawer>
       {selectedEvent && <EventDetail event={selectedEvent} onClose={() => updateParams({ event: null })} />}
     </div>
   );

--- a/client/src/components/calendar/calendarEventChips.test.jsx
+++ b/client/src/components/calendar/calendarEventChips.test.jsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, cleanup, act, fireEvent, within } from '@testing-library/react';
-import { MemoryRouter } from 'react-router';
+import { MemoryRouter, useLocation, useNavigate } from 'react-router';
 
 // One suite for the three views because the thing under test is one contract
 // shared across them: a subcalendar color is external Google Calendar data, so
@@ -249,5 +249,83 @@ describe('ChronotypeOverlay zone labels', () => {
     // zone is recognized by, and it carries no ink of its own.
     const band = container.querySelector('div[style*="opacity"]');
     expect(parseColor(band.style.backgroundColor)).toEqual(parseColor('#f59e0b'));
+  });
+});
+
+function MonthHistory() {
+  const location = useLocation();
+  const navigate = useNavigate();
+  return <>
+    <button onClick={() => navigate(-1)}>Browser Back</button>
+    <output data-testid="month-url">{location.search}</output>
+    <MonthView accounts={ACCOUNTS} />
+  </>;
+}
+
+describe('MonthView overflow navigation', () => {
+  beforeEach(() => {
+    api.getCalendarEvents.mockResolvedValue({ events: [
+      { ...TIMED, id: 'late', title: 'Example late appointment', startTime: new Date(2027, 0, 12, 18).toISOString() },
+      { ...ALL_DAY, id: 'day', title: 'Example all-day entry', startTime: new Date(2027, 0, 12).toISOString() },
+      { ...TIMED, id: 'early', title: 'Example early appointment', startTime: new Date(2027, 0, 12, 8).toISOString() },
+      { ...TIMED, id: 'hidden', title: 'Example hidden appointment', startTime: new Date(2027, 0, 12, 12).toISOString() },
+    ] });
+  });
+
+  it('opens overflow, reloads details, returns to the day, and restores month/day history', async () => {
+    const mounted = render(<MemoryRouter initialEntries={['/calendar/month?month=2027-01']}><MonthHistory /></MemoryRouter>);
+    await act(async () => {});
+    expect(screen.getByRole('heading', { name: 'January 2027' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Example hidden appointment/ })).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /View all 4 events/ }));
+    const day = screen.getByRole('dialog');
+    expect(within(day).getByText('4 events')).toBeInTheDocument();
+    expect(within(day).getAllByRole('button').slice(1).map(button => button.textContent)).toEqual([
+      expect.stringContaining('Example all-day entry'),
+      expect.stringContaining('Example early appointment'),
+      expect.stringContaining('Example hidden appointment'),
+      expect.stringContaining('Example late appointment'),
+    ]);
+    fireEvent.click(within(day).getByRole('button', { name: /Example hidden appointment/ }));
+    expect(screen.getAllByRole('dialog')).toHaveLength(1);
+    expect(screen.getByRole('dialog', { name: 'Example hidden appointment' })).toBeInTheDocument();
+    const reloadUrl = screen.getByTestId('month-url').textContent;
+    mounted.unmount();
+    render(<MemoryRouter initialEntries={['/calendar/month' + reloadUrl]}><MonthHistory /></MemoryRouter>);
+    await act(async () => {});
+    fireEvent.click(within(screen.getByRole('dialog')).getByRole('button', { name: 'Close' }));
+    for (const title of ['Example all-day entry', 'Example early appointment', 'Example late appointment']) {
+      fireEvent.click(within(screen.getByRole('dialog')).getByRole('button', { name: new RegExp(title) }));
+      expect(screen.getByRole('dialog', { name: title })).toBeInTheDocument();
+      fireEvent.click(within(screen.getByRole('dialog')).getByRole('button', { name: 'Close' }));
+    }
+    fireEvent.click(screen.getByRole('button', { name: 'Close day events' }));
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'January 2027' })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Browser Back' }));
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Close day events' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Next month' }));
+    await act(async () => {});
+    expect(screen.getByRole('heading', { name: 'February 2027' })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Browser Back' }));
+    await act(async () => {});
+    expect(screen.getByRole('heading', { name: 'January 2027' })).toBeInTheDocument();
+  });
+
+  it.each(['2027-02-30', '2020-01-01', 'garbage'])('ignores malformed or off-grid day %s', async day => {
+    render(<MemoryRouter initialEntries={['/calendar/month?month=2027-01&day=' + day]}><MonthView accounts={ACCOUNTS} /></MemoryRouter>);
+    await act(async () => {});
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /View all 4 events/ })).toBeInTheDocument();
+  });
+
+  it('falls back from an invalid month and keeps a short day directly actionable', async () => {
+    api.getCalendarEvents.mockResolvedValue({ events: [ALL_DAY, TIMED] });
+    render(<MemoryRouter initialEntries={['/calendar/month?month=2027-99']}><MonthView accounts={ACCOUNTS} /></MemoryRouter>);
+    await act(async () => {});
+    expect(screen.queryByRole('button', { name: /View all/ })).not.toBeInTheDocument();
+    fireEvent.click(chipFor('Quarter Close'));
+    expect(screen.getByRole('dialog', { name: 'Quarter Close' })).toBeInTheDocument();
   });
 });

--- a/client/src/components/calendar/calendarEventChips.test.jsx
+++ b/client/src/components/calendar/calendarEventChips.test.jsx
@@ -313,6 +313,29 @@ describe('MonthView overflow navigation', () => {
     expect(screen.getByRole('heading', { name: 'January 2027' })).toBeInTheDocument();
   });
 
+  it('restores keyboard focus to overflow after the nested detail journey', async () => {
+    render(<MemoryRouter initialEntries={['/calendar/month?month=2027-01']}><MonthView accounts={ACCOUNTS} /></MemoryRouter>);
+    await act(async () => {});
+    const trigger = screen.getByRole('button', { name: /View all 4 events/ });
+    trigger.focus();
+    fireEvent.click(trigger);
+    fireEvent.click(within(screen.getByRole('dialog')).getByRole('button', { name: /Example hidden appointment/ }));
+    fireEvent.click(screen.getByRole('button', { name: 'Close', exact: true }));
+    fireEvent.click(screen.getByRole('button', { name: 'Close day events' }));
+    expect(trigger).toHaveFocus();
+  });
+
+  it('waits for bookmarked event data before exposing a dismissible drawer', async () => {
+    let finish;
+    api.getCalendarEvents.mockReturnValue(new Promise(resolve => { finish = resolve; }));
+    render(<MemoryRouter initialEntries={['/calendar/month?month=2027-01&day=2027-01-12&event=acct-1:hidden']}><MonthView accounts={ACCOUNTS} /></MemoryRouter>);
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    await act(async () => finish({ events: [{ ...TIMED, id: 'hidden', title: 'Example hidden appointment', startTime: new Date(2027, 0, 12, 12).toISOString() }] }));
+    expect(screen.getByRole('dialog', { name: 'Example hidden appointment' })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Close', exact: true }));
+    expect(screen.getByRole('button', { name: 'Close day events' })).toBeInTheDocument();
+  });
+
   it.each(['2027-02-30', '2020-01-01', 'garbage'])('ignores malformed or off-grid day %s', async day => {
     render(<MemoryRouter initialEntries={['/calendar/month?month=2027-01&day=' + day]}><MonthView accounts={ACCOUNTS} /></MemoryRouter>);
     await act(async () => {});


### PR DESCRIPTION
Busy month cells now open a complete day list from “+N more”, with all-day entries first and timed events in order. Every entry opens the existing event details; closing returns through the day list to the same month.

Month and day selections persist in URL parameters for reload and Back. Invalid or off-grid dates fall back safely, and the drawer journey restores focus to its original overflow control. The existing fetch cap remains unchanged.

Validation:
- 39 calendar chip, overflow/history, keyboard focus, delayed deep-link loading, and EventDetail tests pass.
- Focused Biome lint and diff checks pass.
- Chromium at 1440×900 and 375×812 with invented events: overflow → hidden event → reload → close details → close day → Back; no horizontal overflow.
- Read-only Codex review at low effort completed; both findings addressed with regression tests.

Closes #7126
