### PR TITLE
fix: show upcoming Agenda events and make history fully browsable

### DIFF
--- a/client/src/components/calendar/AgendaTab.jsx
+++ b/client/src/components/calendar/AgendaTab.jsx
@@ -1,10 +1,10 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { RefreshCw, Search, MapPin, Users, Clock } from 'lucide-react';
 import toast from '../ui/Toast';
 import * as api from '../../services/api';
 import socket from '../../services/socket';
 import EventDetail from './EventDetail';
-import { formatTimeOfDay as formatTime, formatWeekdayDate } from '../../utils/formatters';
+import { formatTimeOfDay as formatTime, formatWeekdayDate, localDateKey } from '../../utils/formatters';
 import BrailleSpinner from '../BrailleSpinner';
 import EmptyState from '../EmptyState';
 import useUrlParams from '../../hooks/useUrlParams';
@@ -50,25 +50,65 @@ export default function AgendaTab({ accounts }) {
   const [searchParams, updateParams] = useUrlParams();
   const [syncing, setSyncing] = useState(false);
 
-  const fetchEvents = useCallback(async () => {
-    const params = {};
+  const today = localDateKey();
+  const requestedDate = searchParams.get('from');
+  const parsedDate = new Date(`${requestedDate}T00:00:00`);
+  const fromDate = /^\d{4}-\d{2}-\d{2}$/.test(requestedDate)
+    && Number.isFinite(parsedDate.getTime()) && localDateKey(parsedDate) === requestedDate
+    ? requestedDate : today;
+  const [total, setTotal] = useState(0);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [failed, setFailed] = useState(false);
+  const requestGeneration = useRef(0);
+  const nextOffset = useRef(0);
+  const pending = useRef(false);
+
+  const fetchEvents = useCallback(async (append = false) => {
+    if (append && pending.current) return;
+    const generation = ++requestGeneration.current;
+    pending.current = true;
+    setFailed(false);
+    setLoadingMore(append);
+    if (!append) {
+      nextOffset.current = 0;
+      setEvents([]);
+      setTotal(0);
+      setLoading(true);
+    }
+    const offset = nextOffset.current;
+    const params = {
+      startDate: new Date(`${fromDate}T00:00:00`).toISOString(),
+      limit: 50,
+      offset,
+    };
     if (accountFilter) params.accountId = accountFilter;
     if (search) params.search = search;
-    const data = await api.getCalendarEvents(params).catch(() => ({ events: [] }));
-    setEvents(data?.events || []);
+    // The API owns the error toast; retain loaded pages and offer a retry.
+    const data = await api.getCalendarEvents(params).catch(() => null);
+    if (generation !== requestGeneration.current) return;
+    if (data) {
+      const page = data.events || [];
+      nextOffset.current = offset + page.length;
+      setEvents(previous => {
+        const combined = append ? [...previous, ...page] : page;
+        return [...new Map(combined.map(event => [`${event.accountId}:${event.id}`, event])).values()];
+      });
+      setTotal(data.total ?? page.length);
+    } else {
+      setFailed(true);
+    }
+    pending.current = false;
     setLoading(false);
-  }, [accountFilter, search]);
+    setLoadingMore(false);
+  }, [accountFilter, search, fromDate]);
 
   useEffect(() => {
     fetchEvents();
-  }, [fetchEvents]);
-
-  useEffect(() => {
-    const onSyncCompleted = () => {
-      fetchEvents();
-    };
+    const onSyncCompleted = () => fetchEvents();
     socket.on('calendar:sync:completed', onSyncCompleted);
     return () => {
+      ++requestGeneration.current;
+      pending.current = false;
       socket.off('calendar:sync:completed', onSyncCompleted);
     };
   }, [fetchEvents]);
@@ -91,6 +131,22 @@ export default function AgendaTab({ accounts }) {
     <div className="space-y-4">
       {/* Controls */}
       <div className="flex flex-wrap items-center gap-3">
+        <div className="flex flex-wrap items-center gap-2">
+          <label htmlFor="agenda-from" className="text-sm text-gray-400">From date</label>
+          <input
+            id="agenda-from"
+            type="date"
+            value={fromDate}
+            onChange={e => updateParams({ from: e.target.value || null })}
+            className="min-w-0 px-3 py-2 bg-port-card border border-port-border rounded-lg text-sm text-white"
+          />
+          <button
+            onClick={() => updateParams({ from: null })}
+            className="px-3 py-2 text-port-accent rounded-lg text-sm hover:bg-port-accent/10"
+          >
+            Today
+          </button>
+        </div>
         <div className="relative flex-1 min-w-[200px]">
           <Search size={16} className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-500" />
           <input
@@ -125,12 +181,19 @@ export default function AgendaTab({ accounts }) {
         </button>
       </div>
 
+      {failed && (
+        <div role="alert" className="flex flex-wrap items-center gap-3 text-sm text-port-error">
+          Could not load events.
+          <button onClick={() => fetchEvents(nextOffset.current > 0)} className="underline">Retry</button>
+        </div>
+      )}
+
       {/* Event list */}
       {loading ? (
         <div className="flex items-center justify-center py-12">
           <BrailleSpinner text="Loading" />
         </div>
-      ) : grouped.length === 0 ? (
+      ) : failed && grouped.length === 0 ? null : grouped.length === 0 ? (
         hasActiveFilter ? (
           <EmptyState
             icon={Clock}
@@ -214,6 +277,21 @@ export default function AgendaTab({ accounts }) {
               </div>
             </div>
           ))}
+        </div>
+      )}
+
+      {!loading && events.length > 0 && (
+        <div className="flex flex-wrap items-center justify-center gap-3">
+          <p role="status" className="text-sm text-gray-400">{events.length} of {total} events loaded</p>
+          {nextOffset.current < total && (
+            <button
+              onClick={() => fetchEvents(true)}
+              disabled={loadingMore}
+              className="px-3 py-2 bg-port-accent/10 text-port-accent rounded-lg text-sm hover:bg-port-accent/20 disabled:opacity-50"
+            >
+              {loadingMore ? 'Loading more…' : 'Load more'}
+            </button>
+          )}
         </div>
       )}
 

--- a/client/src/components/calendar/AgendaTab.test.jsx
+++ b/client/src/components/calendar/AgendaTab.test.jsx
@@ -1,5 +1,5 @@
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import { MemoryRouter, Routes, Route, useLocation } from 'react-router';
+import { MemoryRouter, Routes, Route, useLocation, useNavigate } from 'react-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const { socketMock } = vi.hoisted(() => ({
@@ -17,12 +17,18 @@ import * as api from '../../services/api';
 import AgendaTab from './AgendaTab';
 
 function LocationProbe() {
-  return <output data-testid="pathname">{useLocation().pathname}</output>;
+  const location = useLocation();
+  const navigate = useNavigate();
+  return <>
+    <span data-testid="pathname">{location.pathname}</span>
+    <span data-testid="query">{location.search}</span>
+    <button onClick={() => navigate(-1)}>Back</button>
+  </>;
 }
 
-async function renderAgenda(accounts) {
+async function renderAgenda(accounts, entry = '/calendar/agenda') {
   render(
-    <MemoryRouter initialEntries={['/calendar/agenda']}>
+    <MemoryRouter initialEntries={[entry]}>
       <Routes>
         <Route
           path="*"
@@ -71,5 +77,154 @@ describe('AgendaTab empty states', () => {
     expect(await screen.findByText('No matching events')).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Clear filters' })).not.toBeDisabled();
     expect(screen.queryByRole('button', { name: 'Sync now' })).toBeNull();
+  });
+});
+
+const accounts = [
+  { id: 'personal', name: 'Personal', enabled: true },
+  { id: 'work', name: 'Work', enabled: true },
+];
+const event = (id, startTime, endTime = startTime, extra = {}) => ({
+  id, accountId: 'personal', title: `Event ${id}`, startTime, endTime, ...extra,
+});
+
+function serveEvents(records) {
+  api.getCalendarEvents.mockImplementation(async ({ startDate, search, accountId, offset, limit }) => {
+    const matching = records.filter(record => new Date(record.endTime) >= new Date(startDate)
+      && (!search || record.title.includes(search))
+      && (!accountId || record.accountId === accountId))
+      .sort((a, b) => new Date(a.startTime) - new Date(b.startTime));
+    return { events: matching.slice(offset, offset + limit), total: matching.length };
+  });
+}
+
+describe('AgendaTab date scope and paging', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('starts at local midnight, keeps overnight/all-day events, and browses history with URL Back and Today', async () => {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    const yesterday = new Date(today);
+    yesterday.setDate(yesterday.getDate() - 1);
+    const tomorrow = new Date(today);
+    tomorrow.setDate(tomorrow.getDate() + 1);
+    const history = event('history', yesterday.toISOString());
+    serveEvents([
+      history,
+      event('overnight', yesterday.toISOString(), new Date(today.getTime() + 3600000).toISOString()),
+      event('all-day', today.toISOString(), tomorrow.toISOString(), { isAllDay: true }),
+      event('future', tomorrow.toISOString()),
+    ]);
+    await renderAgenda(accounts);
+    expect(api.getCalendarEvents).toHaveBeenLastCalledWith({ startDate: today.toISOString(), limit: 50, offset: 0 });
+    expect(screen.queryByText(history.title)).toBeNull();
+    expect(screen.getByText('Event overnight')).toBeTruthy();
+    expect(screen.getByText('All day')).toBeTruthy();
+    expect(screen.getByText('Event future')).toBeTruthy();
+
+    fireEvent.change(screen.getByLabelText('From date'), { target: { value: '2000-01-02' } });
+    expect(await screen.findByText(history.title)).toBeTruthy();
+    expect(screen.getByTestId('query')).toHaveTextContent('from=2000-01-02');
+    expect(api.getCalendarEvents).toHaveBeenLastCalledWith({
+      startDate: new Date(2000, 0, 2).toISOString(), limit: 50, offset: 0,
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Today' }));
+    await act(async () => {});
+    expect(screen.queryByText(history.title)).toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: 'Back' }));
+    expect(await screen.findByText(history.title)).toBeTruthy();
+    expect(screen.getByLabelText('From date')).toHaveValue('2000-01-02');
+  });
+
+  it('recovers history from the upcoming-empty state', async () => {
+    serveEvents([event('history', '2000-01-02T12:00:00')]);
+    await renderAgenda(accounts);
+    expect(screen.getByText('No upcoming events')).toBeTruthy();
+    fireEvent.change(screen.getByLabelText('From date'), { target: { value: '2000-01-02' } });
+    expect(await screen.findByText('Event history')).toBeTruthy();
+  });
+
+  it('reads the selected date from the URL without UTC day shifting and clears back to today', async () => {
+    api.getCalendarEvents.mockResolvedValue({ events: [], total: 0 });
+    await renderAgenda(accounts, '/calendar/agenda?from=2026-03-08');
+    expect(screen.getByLabelText('From date')).toHaveValue('2026-03-08');
+    expect(api.getCalendarEvents).toHaveBeenLastCalledWith({
+      startDate: new Date(2026, 2, 8).toISOString(), limit: 50, offset: 0,
+    });
+    fireEvent.change(screen.getByLabelText('From date'), { target: { value: '' } });
+    await act(async () => {});
+    expect(screen.getByTestId('query')).not.toHaveTextContent('from=');
+  });
+
+  it('loads every page in order and resets on account, search, date, and completed sync', async () => {
+    const records = Array.from({ length: 105 }, (_, i) => event(String(i).padStart(3, '0'),
+      new Date(2099, 0, 1, 0, i).toISOString()));
+    serveEvents(records);
+    await renderAgenda(accounts);
+    expect(screen.getByRole('status')).toHaveTextContent('50 of 105');
+    fireEvent.click(screen.getByRole('button', { name: 'Load more' }));
+    await act(async () => {});
+    expect(screen.getByRole('status')).toHaveTextContent('100 of 105');
+    fireEvent.click(screen.getByRole('button', { name: 'Load more' }));
+    await act(async () => {});
+    expect(screen.getByRole('status')).toHaveTextContent('105 of 105');
+    expect(screen.queryByRole('button', { name: 'Load more' })).toBeNull();
+    expect(screen.getAllByRole('button', { name: /^Event / }).map(button => button.textContent.slice(0, 9)))
+      .toEqual(records.map(record => record.title));
+    expect(api.getCalendarEvents.mock.calls.map(([params]) => params.offset)).toEqual([0, 50, 100]);
+
+    fireEvent.change(screen.getByLabelText('Filter by account'), { target: { value: 'work' } });
+    expect(await screen.findByText('No matching events')).toBeTruthy();
+    expect(api.getCalendarEvents).toHaveBeenLastCalledWith(expect.objectContaining({ accountId: 'work', offset: 0 }));
+    fireEvent.click(screen.getByRole('button', { name: 'Clear filters' }));
+    await act(async () => {});
+    fireEvent.click(screen.getByRole('button', { name: 'Load more' }));
+    await act(async () => {});
+    fireEvent.change(screen.getByLabelText('Search events'), { target: { value: '104' } });
+    expect(await screen.findByText('Event 104')).toBeTruthy();
+    expect(screen.getByRole('status')).toHaveTextContent('1 of 1');
+    expect(api.getCalendarEvents).toHaveBeenLastCalledWith(expect.objectContaining({ search: '104', offset: 0 }));
+
+    fireEvent.change(screen.getByLabelText('Search events'), { target: { value: '' } });
+    await act(async () => {});
+    fireEvent.click(screen.getByRole('button', { name: 'Load more' }));
+    await act(async () => {});
+    fireEvent.change(screen.getByLabelText('From date'), { target: { value: '2099-01-01' } });
+    await act(async () => {});
+    expect(screen.getByRole('status')).toHaveTextContent('50 of 105');
+    fireEvent.click(screen.getByRole('button', { name: 'Load more' }));
+    await act(async () => {});
+    const syncHandler = socketMock.on.mock.calls.filter(([name]) => name === 'calendar:sync:completed').at(-1)[1];
+    await act(async () => syncHandler());
+    expect(screen.getByRole('status')).toHaveTextContent('50 of 105');
+    expect(api.getCalendarEvents).toHaveBeenLastCalledWith(expect.objectContaining({ offset: 0 }));
+  });
+
+  it('ignores a late previous-filter page and retries failed pages without losing loaded events', async () => {
+    const first = event('first', '2099-01-01T12:00:00');
+    api.getCalendarEvents.mockResolvedValue({ events: [first], total: 2 });
+    await renderAgenda(accounts);
+    let finishOldPage;
+    api.getCalendarEvents.mockImplementationOnce(() => new Promise(resolve => { finishOldPage = resolve; }));
+    fireEvent.click(screen.getByRole('button', { name: 'Load more' }));
+    api.getCalendarEvents.mockResolvedValue({ events: [event('new', '2099-01-02T12:00:00')], total: 2 });
+    fireEvent.change(screen.getByLabelText('Search events'), { target: { value: 'new' } });
+    await act(async () => {});
+    await act(async () => finishOldPage({ events: [event('stale', '2099-01-01T13:00:00')], total: 2 }));
+    expect(screen.queryByText('Event stale')).toBeNull();
+    expect(screen.queryByText('Event first')).toBeNull();
+    expect(screen.getByText('Event new')).toBeTruthy();
+
+    api.getCalendarEvents.mockRejectedValueOnce(new Error('offline'));
+    fireEvent.click(screen.getByRole('button', { name: 'Load more' }));
+    expect(await screen.findByRole('alert')).toHaveTextContent('Could not load events');
+    expect(screen.getByText('Event new')).toBeTruthy();
+    api.getCalendarEvents.mockResolvedValueOnce({ events: [event('last', '2099-01-03T12:00:00')], total: 2 });
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+    expect(await screen.findByText('Event last')).toBeTruthy();
+    expect(api.getCalendarEvents).toHaveBeenLastCalledWith(expect.objectContaining({ offset: 1 }));
+    expect(screen.queryByRole('button', { name: 'Load more' })).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

Agenda now starts at today's local midnight instead of the oldest historical page. A visible From date field and Today action support history browsing, URL reloads, and browser Back. A loaded count and Load more expose every matching page; date, search, account, and completed-sync changes reset paging and discard stale responses. Failed pages retain loaded events and offer Retry.

Closes #7125

## Test plan

- 8 rendered Agenda tests cover existing empty states, local-day and overnight/all-day scope, URL navigation, 105-event pagination, filter/sync resets, stale responses, and retry.
- Focused tests plus responsive-grid conventions: 12 passed under America/Los_Angeles.
- Changed-file Biome lint and production client build passed.
- Toolbar uses wrapping controls; a live browser viewport check was not performed.

## Review

Codex ran locally in a read-only sandbox at low reasoning effort. Its sole finding requested changing the endpoint's inclusive end-time overlap at midnight. Static inspection confirmed this is the existing calendarSync contract that #7125 explicitly requires preserving; the finding was not adopted. Endpoint defaults, overlap semantics, and other calendar consumers remain unchanged.
