### PR TITLE
fix: keep tab reveal scrolling inside the horizontal strip

### DIFF
--- a/client/src/components/ui/TabPills.jsx
+++ b/client/src/components/ui/TabPills.jsx
@@ -52,15 +52,20 @@ export default function TabPills({
 
   const activeIndex = visibleTabs.findIndex((t) => t.id === activeTab);
 
-  // Fresh tab arrays and live counts must not pull the page back to the bar.
+  // Reveal only inside the horizontal tab strip. scrollIntoView also scrolls
+  // ancestors, pulling a mobile page away from its task form/content.
   useEffect(() => {
-    if (activeIndex !== -1 && tabRefs.current[activeIndex]?.scrollIntoView) {
-      tabRefs.current[activeIndex].scrollIntoView({
-        behavior: 'smooth',
-        block: 'nearest',
-        inline: 'nearest',
-      });
-    }
+    const tab = tabRefs.current[activeIndex];
+    const strip = tab?.parentElement;
+    if (!strip || variant === 'filter') return;
+    const bounds = strip.getBoundingClientRect();
+    const tabBounds = tab.getBoundingClientRect();
+    const left = bounds.left + strip.clientLeft;
+    const right = left + strip.clientWidth;
+    const delta = tabBounds.left < left
+      ? tabBounds.left - left
+      : Math.max(0, tabBounds.right - right);
+    if (delta) strip.scrollBy({ left: delta, behavior: 'smooth' });
   }, [activeTab, activeIndex, variant]);
 
   const handleTabKeyDown = (event, index) => {
@@ -87,7 +92,7 @@ export default function TabPills({
     const targetTab = visibleTabs[targetIndex];
     event.preventDefault();
     onChange(targetTab.id);
-    tabRefs.current[targetIndex]?.focus();
+    tabRefs.current[targetIndex]?.focus({ preventScroll: true });
   };
 
   // Mobile `<select>` collapse, shared by both variants so `mobileDropdown` works

--- a/client/src/components/ui/TabPills.test.jsx
+++ b/client/src/components/ui/TabPills.test.jsx
@@ -229,21 +229,29 @@ describe('TabPills — filter variant', () => {
   });
 });
 
-it('reveals selections without scrolling again for refreshed tab data', () => {
-  const scroll = vi.spyOn(HTMLElement.prototype, 'scrollIntoView').mockImplementation(() => {});
-  try {
-    const view = (activeTab, tabs) => <><TabPills tabs={tabs} activeTab={activeTab} onChange={vi.fn()} /><input aria-label="Draft" /></>;
-    const { rerender } = render(view('cast', []));
-    expect(scroll).not.toHaveBeenCalled();
-    rerender(view('cast', sampleTabs));
-    expect(scroll).toHaveBeenCalledTimes(1);
-    screen.getByRole('textbox', { name: 'Draft' }).focus();
-    rerender(view('cast', sampleTabs.map(tab => ({ ...tab, count: 10 }))));
-    expect(scroll).toHaveBeenCalledTimes(1);
-    expect(screen.getByRole('textbox', { name: 'Draft' })).toHaveFocus();
-    rerender(view('places', sampleTabs));
-    expect(scroll).toHaveBeenCalledTimes(2);
-  } finally {
-    scroll.mockRestore();
-  }
+it('reveals tabs horizontally without moving ancestors or stealing draft focus', () => {
+  const ancestorScroll = vi.spyOn(HTMLElement.prototype, 'scrollIntoView');
+  const view = (activeTab, tabs) => <><TabPills tabs={tabs} activeTab={activeTab} onChange={vi.fn()} /><input aria-label="Draft" /></>;
+  const { rerender } = render(view('cast', []));
+  const strip = screen.getByRole('tablist');
+  const scroll = vi.spyOn(strip, 'scrollBy').mockImplementation(() => {});
+  vi.spyOn(strip, 'getBoundingClientRect').mockReturnValue({ left: 0 });
+  Object.defineProperty(strip, 'clientWidth', { configurable: true, value: 200 });
+  rerender(view('cast', sampleTabs));
+  const places = screen.getByRole('tab', { name: /Places/ });
+  vi.spyOn(places, 'getBoundingClientRect').mockReturnValue({ left: 180, right: 260 });
+  const draft = screen.getByRole('textbox', { name: 'Draft' });
+  draft.focus();
+  rerender(view('places', sampleTabs));
+  expect(scroll).toHaveBeenLastCalledWith({ left: 60, behavior: 'smooth' });
+  rerender(view('places', sampleTabs.map(tab => ({ ...tab, count: 10 }))));
+  expect(scroll).toHaveBeenCalledTimes(1);
+  expect(draft).toHaveFocus();
+  expect(ancestorScroll).not.toHaveBeenCalled();
+  // Selecting a tab clipped at the left edge reveals it in the other direction.
+  const cast = screen.getByRole('tab', { name: /Cast/ });
+  vi.spyOn(cast, 'getBoundingClientRect').mockReturnValue({ left: -80, right: 20 });
+  rerender(view('cast', sampleTabs));
+  expect(scroll).toHaveBeenLastCalledWith({ left: -80, behavior: 'smooth' });
+  ancestorScroll.mockRestore();
 });


### PR DESCRIPTION
## Summary
The CoS mobile scroll report overlaps the background-update fix already on main. Close the remaining ancestor-scroll path in TabPills: reveal clipped tabs by scrolling only their horizontal strip instead of using scrollIntoView, which can move the page vertically. Keyboard tab focus now also prevents implicit page scrolling.

## Test plan
- Passed 26 tests across TabPills and TasksTab, including horizontal reveal in both directions, no ancestor scrolling, and draft focus preservation during refreshed counts.
- Biome lint passed for both changed files; git diff --check passed.
- Physical mobile browser verification was unavailable. TasksTab tests emit existing localhost API connection warnings but pass.
