### PR TITLE
fix: restore focus when icon choices are dismissed

### DIFF
--- a/client/src/components/IconPicker.jsx
+++ b/client/src/components/IconPicker.jsx
@@ -1,25 +1,38 @@
-import { useState, useEffect } from 'react';
+import { useState, useRef, useId } from 'react';
 import AppIcon, { iconNames } from './AppIcon';
 
 export default function IconPicker({ value, onChange }) {
   const [isOpen, setIsOpen] = useState(false);
 
-  useEffect(() => {
-    if (!isOpen) return;
-    const handleKeyDown = (e) => {
-      if (e.key === 'Escape') setIsOpen(false);
-    };
-    window.addEventListener('keydown', handleKeyDown);
-    return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [isOpen]);
+  const triggerRef = useRef(null);
+  const choicesRef = useRef(null);
+  const choicesId = useId();
+
+  const close = () => {
+    if (choicesRef.current?.contains(document.activeElement)) {
+      triggerRef.current?.focus();
+    }
+    setIsOpen(false);
+  };
+
+  const handleKeyDown = (event) => {
+    if (isOpen && event.key === 'Escape') {
+      event.preventDefault();
+      event.stopPropagation();
+      close();
+    }
+  };
 
   return (
-    <div className="relative">
+    <div className="relative" onKeyDown={handleKeyDown}>
       <span className="block text-sm text-gray-400 mb-1">Icon</span>
       <button
         type="button"
+        ref={triggerRef}
         aria-label="Icon picker"
-        onClick={() => setIsOpen(!isOpen)}
+        aria-expanded={isOpen}
+        aria-controls={isOpen ? choicesId : undefined}
+        onClick={() => isOpen ? close() : setIsOpen(true)}
         className="flex items-center gap-3 w-full px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white hover:border-port-accent/50 focus:border-port-accent focus:outline-hidden transition-colors"
       >
         <div className="w-8 h-8 rounded bg-port-border flex items-center justify-center text-port-accent">
@@ -33,10 +46,10 @@ export default function IconPicker({ value, onChange }) {
         <>
           <div
             className="fixed inset-0 z-40"
-            onClick={() => setIsOpen(false)}
+            onClick={close}
             aria-hidden="true"
           />
-          <div className="absolute top-full left-0 mt-1 w-full bg-port-card border border-port-border rounded-lg shadow-xl z-50 p-2 max-h-64 overflow-auto">
+          <div ref={choicesRef} id={choicesId} className="absolute top-full left-0 mt-1 w-full bg-port-card border border-port-border rounded-lg shadow-xl z-50 p-2 max-h-64 overflow-auto">
             <div className="grid grid-cols-3 gap-1 sm:grid-cols-5">
               {iconNames.map(name => (
                 <button
@@ -44,7 +57,7 @@ export default function IconPicker({ value, onChange }) {
                   type="button"
                   onClick={() => {
                     onChange(name);
-                    setIsOpen(false);
+                    close();
                   }}
                   className={`p-2 rounded-lg flex flex-col items-center gap-1 transition-colors ${
                     value === name

--- a/client/src/components/IconPicker.test.jsx
+++ b/client/src/components/IconPicker.test.jsx
@@ -1,0 +1,64 @@
+import { useState } from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import IconPicker from './IconPicker';
+import Drawer from './Drawer';
+
+function Form() {
+  const [icon, setIcon] = useState('package');
+  return <><IconPicker value={icon} onChange={setIcon} /><button type="button">Next field</button></>;
+}
+
+describe('IconPicker', () => {
+  it('keeps Escape inside the picker and resumes tabbing within its drawer', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    render(<Drawer open title="Edit App" onClose={onClose}><Form /></Drawer>);
+    const trigger = screen.getByRole('button', { name: 'Icon picker' });
+    trigger.focus();
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    expect(trigger).not.toHaveAttribute('aria-controls');
+    await user.keyboard('{Enter}');
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    const choices = document.getElementById(trigger.getAttribute('aria-controls'));
+    expect(choices).toBeInTheDocument();
+    await user.tab();
+    expect(choices).toContainElement(document.activeElement);
+    await user.keyboard('{Escape}');
+    expect(onClose).not.toHaveBeenCalled();
+    expect(trigger).toHaveFocus();
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    expect(trigger).not.toHaveAttribute('aria-controls');
+    expect(choices).not.toBeInTheDocument();
+    await user.tab();
+    expect(screen.getByRole('button', { name: 'Next field' })).toHaveFocus();
+    await user.keyboard('{Escape}');
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('updates the controlled value and restores focus when a choice is activated', async () => {
+    const user = userEvent.setup();
+    render(<Form />);
+    const trigger = screen.getByRole('button', { name: 'Icon picker' });
+    await user.click(trigger);
+    const choice = screen.getByRole('button', { name: 'web' });
+    choice.focus();
+    await user.keyboard('{Enter}');
+    expect(trigger).toHaveTextContent('web');
+    expect(trigger).toHaveFocus();
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('dismisses by pointer without stealing focus from another form field', async () => {
+    const user = userEvent.setup();
+    const { container } = render(<Form />);
+    const trigger = screen.getByRole('button', { name: 'Icon picker' });
+    await user.click(trigger);
+    const next = screen.getByRole('button', { name: 'Next field' });
+    next.focus();
+    fireEvent.click(container.querySelector('.fixed[aria-hidden="true"]'));
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    expect(next).toHaveFocus();
+  });
+});


### PR DESCRIPTION
Closing icon choices now returns focus to the picker trigger when the focused choice is removed. Escape dismisses only the picker, so an enclosing drawer stays open and Tab continues through its form. The trigger exposes expanded state and a stable relationship to the mounted choices.

Validation: 23 IconPicker/Drawer tests pass, changed-file lint passes, and the client production build passes. Codex local review returned CLEAN. Regression coverage includes controlled selection, Escape inside the shared Drawer, subsequent Tab navigation, and pointer dismissal without stealing another field's focus.

Closes #7138
