### PR TITLE
fix: persist inaccessible backup destination failures

### DIFF
--- a/server/services/backup.js
+++ b/server/services/backup.js
@@ -398,16 +398,10 @@ export async function runBackup(destPath, io = null, { excludePaths = [], disabl
     throw new Error('Backup destination not configured');
   }
 
-  await access(destPath).catch(() => {
-    throw new Error(`Backup destination not found: ${destPath}`);
-  });
-
   isRunning = true;
-  const snapshotId = new Date().toISOString().replace(/:/g, '-').replace(/\..+/, '');
-  const snapshotsRoot = join(destPath, 'snapshots', MACHINE_HOST);
-  const snapshotDir = join(snapshotsRoot, snapshotId);
-  const parentMarker = parentMarkerPath(snapshotDir, snapshotId);
-  const dataDestDir = join(snapshotDir, 'data');
+  let snapshotId = null;
+  let snapshotDir;
+  let parentMarker;
 
   const effectiveExcludes = computeEffectiveExcludes({ excludePaths, disabledDefaultExcludes });
 
@@ -415,8 +409,8 @@ export async function runBackup(destPath, io = null, { excludePaths = [], disabl
   let manifest;
 
   const clearInProgress = async () => {
-    await unlink(markerPath(snapshotDir)).catch(() => {});
-    await unlink(parentMarker).catch(() => {});
+    if (snapshotDir) await unlink(markerPath(snapshotDir)).catch(() => {});
+    if (parentMarker) await unlink(parentMarker).catch(() => {});
     activeSnapshotId = null;
   };
 
@@ -435,6 +429,20 @@ export async function runBackup(destPath, io = null, { excludePaths = [], disabl
   };
 
   try {
+    await access(destPath).catch((cause) => {
+      // Never expose the filesystem message: it can include private paths.
+      const code = ['ENOENT', 'EACCES', 'EPERM', 'EIO'].includes(cause.code) ? cause.code : 'UNKNOWN';
+      const message = code === 'ENOENT' ? 'Backup destination not found' : 'Backup destination inaccessible';
+      const error = new ServerError(`${message} (${code})`, { code: `BACKUP_DESTINATION_${code}` });
+      error.cause = cause;
+      throw error;
+    });
+    snapshotId = new Date().toISOString().replace(/:/g, '-').replace(/\..+/, '');
+    const snapshotsRoot = join(destPath, 'snapshots', MACHINE_HOST);
+    snapshotDir = join(snapshotsRoot, snapshotId);
+    parentMarker = parentMarkerPath(snapshotDir, snapshotId);
+    const dataDestDir = join(snapshotDir, 'data');
+
     console.log(`💾 Backup starting: snapshot ${snapshotId} (excluding ${effectiveExcludes.length} paths)`);
     if (io) io.emit('backup:started', { snapshotId });
 

--- a/server/services/backup.test.js
+++ b/server/services/backup.test.js
@@ -1868,19 +1868,44 @@ describe('runBackup lifecycle', () => {
     await expect(retry).resolves.toMatchObject({ status: 'ok' });
   });
 
-  it('rejects a missing destination before locking, spawning, or emitting', async () => {
+  it.each(['ENOENT', 'EACCES', 'EIO'])('persists a failed preflight (%s) over prior success and permits repair', async (code) => {
+    const { saveState, getState } = await import('./backup.js');
+    const priorRun = '2026-01-01T00:00:00.000Z';
+    await saveState({ lastRun: priorRun, lastSnapshotId: 'previous-snapshot', status: 'ok', error: null });
     const io = { emit: vi.fn() };
-    await expect(runBackup(joinPath(destRoot, 'does-not-exist'), io))
-      .rejects.toThrow(/Backup destination not found/);
-    expect(spawn).not.toHaveBeenCalled();
-    expect(io.emit).not.toHaveBeenCalled();
+    const cause = Object.assign(new Error('private destination detail'), { code });
+    fs.access.mockRejectedValueOnce(cause);
+    const attemptStarted = Date.now();
 
-    // The failed precondition must not have left the lock engaged.
+    await expect(runBackup(destRoot, io)).rejects.toMatchObject({
+      code: `BACKUP_DESTINATION_${code}`,
+      cause
+    });
+    const state = await getState(); // The status route serves this persisted state.
+    expect(state).toMatchObject({
+      status: 'error',
+      lastSnapshotId: 'previous-snapshot',
+      error: `${code === 'ENOENT' ? 'Backup destination not found' : 'Backup destination inaccessible'} (${code})`
+    });
+    expect(Date.parse(state.lastRun)).toBeGreaterThanOrEqual(attemptStarted);
+    expect(JSON.stringify(state)).not.toContain('private destination detail');
+    expect(spawn).not.toHaveBeenCalled();
+    expect(io.emit.mock.calls).toEqual([['backup:failed', { snapshotId: null, error: state.error }]]);
+    expect(await (await actualFs()).readdir(destRoot)).toEqual([]);
+
+    // Scheduled runs have no socket, but must still replace stale status.
+    await saveState({ status: 'ok', lastRun: priorRun });
+    fs.access.mockRejectedValueOnce(cause);
+    await expect(runBackup(destRoot)).rejects.toMatchObject({ cause });
+    expect(await getState()).toMatchObject({ status: 'error', lastSnapshotId: 'previous-snapshot' });
+
     const proc = fakeProc();
     spawn.mockReturnValue(proc);
     const pending = runBackup(destRoot, io);
-    await waitFor(() => spawn.mock.calls.length === 1, 'rsync spawn after bad dest');
+    await waitFor(() => spawn.mock.calls.length === 1, 'rsync spawn after destination repair');
     proc.emit('close', 0);
     await expect(pending).resolves.toMatchObject({ status: 'ok' });
+    expect(await getState()).toMatchObject({ status: 'ok', error: null });
   });
+
 });


### PR DESCRIPTION
## Summary
Configured backups now persist destination preflight failures instead of leaving the previous successful status visible. Missing, permission-denied, and I/O failures receive distinct safe diagnostics while retaining the original error cause and previous snapshot ID.

Preflight failures emit failure status without creating snapshot artifacts or starting rsync, and a repaired destination can be retried.

Closes #7132

## Test plan
- 158 tests passed across backup service, scheduler, and route suites using temporary data and mocked subprocesses.
- Regression coverage includes ENOENT, EACCES, EIO, scheduled runs without sockets, safe persisted diagnostics, and successful repair/retry.
- Codex static review: approved with no actionable findings.
