### PR TITLE
fix: keep keyboard-selected entity options visible

### DIFF
--- a/client/src/components/EntityCombobox.jsx
+++ b/client/src/components/EntityCombobox.jsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { Search, ChevronDown, Check, Plus, Loader2 } from 'lucide-react';
 import useClickOutside from '../hooks/useClickOutside';
 
@@ -38,6 +38,8 @@ export default function EntityCombobox({
   className = 'flex-1 min-w-[200px]',
 }) {
   const wrapRef = useRef(null);
+  const listboxRef = useRef(null);
+  const activeOptionRef = useRef(null);
   const [open, setOpen] = useState(false);
   const [activeIdx, setActiveIdx] = useState(0);
   // Memoize the close callback so useClickOutside doesn't rebind its window
@@ -86,6 +88,23 @@ export default function EntityCombobox({
       ? optionId(filtered[activeIdx]?.id)
       : (showCreateOption ? createOptionId : undefined))
     : undefined;
+
+  useLayoutEffect(() => {
+    const listbox = listboxRef.current;
+    const option = activeOptionRef.current;
+    if (!open || !listbox || !option) return;
+
+    // Scroll only the listbox: scrollIntoView can also move the outer page.
+    const viewportTop = listbox.getBoundingClientRect().top + listbox.clientTop;
+    const viewportBottom = viewportTop + listbox.clientHeight;
+    const rect = option.getBoundingClientRect();
+    const delta = rect.top < viewportTop
+      ? rect.top - viewportTop
+      : Math.max(0, rect.bottom - viewportBottom);
+    if (delta) {
+      listbox.scrollTo({ top: listbox.scrollTop + delta, behavior: 'instant' });
+    }
+  }, [open, activeOptionId, filtered, trimmed]);
 
   const handleKeyDown = (e) => {
     if (!open && (e.key === 'ArrowDown' || e.key === 'ArrowUp')) {
@@ -151,6 +170,7 @@ export default function EntityCombobox({
       </div>
       {open && (
         <ul
+          ref={listboxRef}
           id={listId}
           role="listbox"
           className="absolute left-0 right-0 top-full mt-1 z-30 max-h-80 overflow-y-auto bg-port-card border border-port-border rounded shadow-lg"
@@ -166,6 +186,7 @@ export default function EntityCombobox({
             <li key={u.id}>
               <button
                 type="button"
+                ref={i === activeIdx ? activeOptionRef : null}
                 id={optionId(u.id)}
                 role="option"
                 aria-selected={u.id === selectedId}
@@ -187,6 +208,7 @@ export default function EntityCombobox({
             <li>
               <button
                 type="button"
+                ref={activeIdx === filtered.length ? activeOptionRef : null}
                 id={createOptionId}
                 role="option"
                 aria-selected={false}

--- a/client/src/components/EntityCombobox.test.jsx
+++ b/client/src/components/EntityCombobox.test.jsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -11,6 +12,57 @@ const items = [
 ];
 
 describe('EntityCombobox', () => {
+  it('keeps keyboard focus and Enter aligned through navigation, filtering and reopening', async () => {
+    const user = userEvent.setup();
+    const onPick = vi.fn();
+    const onCreate = vi.fn();
+    const manyItems = Array.from({ length: 20 }, (_, i) => ({
+      id: String(i), name: `Option ${i}`,
+    }));
+    function Picker() {
+      const [value, setValue] = useState('Option');
+      return (
+        <EntityCombobox
+          items={manyItems}
+          value={value}
+          onChange={setValue}
+          onPick={onPick}
+          onCreate={onCreate}
+          inputId="keyboard-picker"
+        />
+      );
+    }
+    render(<Picker />);
+    const input = screen.getByRole('combobox');
+    const expectActive = (name) => {
+      expect(input).toHaveFocus();
+      expect(input).toHaveAttribute('aria-activedescendant', screen.getByRole('option', { name }).id);
+    };
+
+    await user.click(input);
+    await user.keyboard('{ArrowDown>20/}');
+    expectActive('Create “Option”');
+    await user.keyboard('{ArrowUp}');
+    expectActive('Option 19');
+    await user.keyboard('{Enter}');
+    expect(onPick).toHaveBeenCalledWith(manyItems[19]);
+    expect(screen.queryByRole('listbox')).toBeNull();
+
+    await user.keyboard('{ArrowDown}');
+    expectActive('Option 19');
+    await user.clear(input);
+    await user.type(input, 'Missing');
+    expectActive('Create “Missing”');
+    await user.keyboard('{Escape}');
+    expect(input).not.toHaveAttribute('aria-activedescendant');
+    await user.keyboard('{ArrowUp}');
+    expectActive('Create “Missing”');
+    await user.keyboard('{Enter}');
+    expect(onCreate).toHaveBeenCalledTimes(1);
+    expect(input).toHaveFocus();
+    expect(screen.queryByRole('listbox')).toBeNull();
+  });
+
   it('lists every item (except the selected one) when opened on a selection', async () => {
     const user = userEvent.setup();
     render(


### PR DESCRIPTION
## Summary

Keyboard navigation in shared entity pickers now reveals the active option at the nearest listbox edge, including the create row. Scrolling is immediate and confined to the dropdown, preserving input focus and the existing match/create selection behavior.

Closes #7137

## Test plan

- All 6 EntityCombobox component tests pass, including navigation, Enter selection, filtering, closing, and reopening.
- Scoped client lint and diff whitespace checks pass.
- Chromium with synthetic overflowing options at 1440×1000 and 720×500 (200% desktop zoom equivalent), with reduced motion enabled: every ArrowDown/ArrowUp step kept the active option fully visible; input focus and aria-activedescendant matched Enter selection; create, filtering, and reopening passed; outer-page scroll remained unchanged. No records were saved.
- Local Codex review at low reasoning effort returned CLEAN in a read-only sandbox.
