### PR TITLE
fix: expose command palette active results to assistive technology

### DIFF
--- a/client/src/components/CmdKSearch.jsx
+++ b/client/src/components/CmdKSearch.jsx
@@ -612,7 +612,10 @@ export default function CmdKSearch() {
           {!loading && searchResults.filter((source) => source.results.length > 3 && !expandedSources.has(source.id)).map((source) => (
             <button
               key={source.id}
-              onClick={() => setExpandedSources((prev) => new Set(prev).add(source.id))}
+              onClick={() => {
+                inputRef.current?.focus();
+                setExpandedSources((prev) => new Set(prev).add(source.id));
+              }}
               className="text-xs text-port-accent px-3 py-1 hover:underline"
             >
               Show {source.results.length - 3} more from {source.label}

--- a/client/src/components/CmdKSearch.jsx
+++ b/client/src/components/CmdKSearch.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
+import { useState, useEffect, useRef, useCallback, useMemo, useId } from 'react';
 import { createPortal } from 'react-dom';
 import { useLocation, useNavigate } from 'react-router';
 import { Brain, Cpu, Package, History, HeartPulse, Search, Loader2, Navigation, Play, LayoutGrid, BookMarked, Send } from 'lucide-react';
@@ -69,6 +69,9 @@ export default function CmdKSearch() {
   const { open, setOpen } = useCmdKSearch();
   const navigate = useNavigate();
   const location = useLocation();
+  const paletteId = useId();
+  const listboxId = `${paletteId}-results`;
+  const optionId = (item) => `${paletteId}-option-${encodeURIComponent(JSON.stringify([item.kind, item.sourceId, item.type, item.id, item.path ?? item.url]))}`;
   const inputRef = useRef(null);
   const modalRef = useRef(null);
 
@@ -252,11 +255,11 @@ export default function CmdKSearch() {
   }, [manifest, gatedNav, query, recentPaths, location.pathname]);
 
   const flatSearchResults = useMemo(
-    () => searchResults.flatMap((source) => {
+    () => (loading ? [] : searchResults).flatMap((source) => {
       const visible = expandedSources.has(source.id) ? source.results : source.results.slice(0, 3);
       return visible.map((r) => ({ ...r, kind: 'search', sourceId: source.id }));
     }),
-    [searchResults, expandedSources]
+    [searchResults, expandedSources, loading]
   );
 
   const catalogHits = useMemo(
@@ -275,10 +278,13 @@ export default function CmdKSearch() {
     [combined, catalogHits, flatSearchResults]
   );
 
+  const activeIndex = focusable.length ? Math.min(focusedIndex, focusable.length - 1) : -1;
+  const activeResult = focusable[activeIndex];
+
   useEffect(() => {
-    const el = resultRefs.current[focusedIndex];
+    const el = resultRefs.current[activeIndex];
     if (el) el.scrollIntoView({ block: 'nearest' });
-  }, [focusedIndex]);
+  }, [activeIndex, focusable]);
 
   useEffect(() => {
     if (open) inputRef.current?.focus();
@@ -388,14 +394,16 @@ export default function CmdKSearch() {
       return;
     }
 
+    if (e.target !== inputRef.current && e.key !== 'Escape') return;
+
     if (e.key === 'ArrowDown') {
       e.preventDefault();
       if (focusable.length > 0) setFocusedIndex((i) => Math.min(i + 1, focusable.length - 1));
     } else if (e.key === 'ArrowUp') {
       e.preventDefault();
-      if (focusable.length > 0) setFocusedIndex((i) => Math.max(i - 1, 0));
+      if (focusable.length > 0) setFocusedIndex(Math.max(activeIndex - 1, 0));
     } else if (e.key === 'Enter') {
-      const item = focusable[focusedIndex];
+      const item = activeResult;
       if (item) dispatchCommand(item);
     } else if (e.key === 'Escape') {
       close();
@@ -408,10 +416,11 @@ export default function CmdKSearch() {
 
   const renderRow = (item, { icon: Icon, title, subtitle, badge }) => {
     const currentIdx = flatIdx++;
-    const isFocused = focusedIndex === currentIdx;
+    const isFocused = activeIndex === currentIdx;
     return (
       <div
-        key={`${item.kind}:${item.path ?? item.id ?? item.sourceId + ':' + title}`}
+        key={optionId(item)}
+        id={optionId(item)}
         ref={(el) => { resultRefs.current[currentIdx] = el; }}
         onClick={() => dispatchCommand(item)}
         className={`flex items-start gap-3 px-3 py-2 min-h-[44px] rounded-lg cursor-pointer transition-colors ${
@@ -437,7 +446,7 @@ export default function CmdKSearch() {
   };
 
   const renderGroup = (headerIcon, headerLabel, rows) => rows.length > 0 && (
-    <div className="mb-2">
+    <div role="group" aria-label={headerLabel} className="mb-2">
       <div className="flex items-center gap-2 px-3 py-2 text-xs text-gray-400 uppercase tracking-wide">
         {headerIcon}
         <span>{headerLabel}</span>
@@ -491,6 +500,11 @@ export default function CmdKSearch() {
                 onChange={(e) => setQuery(e.target.value)}
                 placeholder="Go to page, run an action, or search Brain / Memory / Apps…"
                 className="w-full bg-transparent text-white placeholder-gray-500 outline-hidden text-sm"
+                role="combobox"
+                aria-expanded="true"
+                aria-autocomplete="list"
+                aria-controls={listboxId}
+                aria-activedescendant={activeResult ? optionId(activeResult) : undefined}
                 aria-label="Command palette"
               />
             )}
@@ -514,95 +528,96 @@ export default function CmdKSearch() {
         </div>
 
         {!captureMode && <div className="max-h-96 overflow-y-auto p-2">
-          {renderGroup(
-            <History size={14} />,
-            'Recent destinations',
-            combined.recentNav.map((c) =>
-              renderRow(c, { icon: History, title: c.label, subtitle: `${c.section} · ${c.path}`, badge: 'RECENT' })
-            )
-          )}
+          <div id={listboxId} role="listbox" aria-label="Command palette results">
+            {renderGroup(
+              <History size={14} />,
+              'Recent destinations',
+              combined.recentNav.map((c) =>
+                renderRow(c, { icon: History, title: c.label, subtitle: `${c.section} · ${c.path}`, badge: 'RECENT' })
+              )
+            )}
 
-          {renderGroup(
-            <Navigation size={14} />,
-            'Go to',
-            combined.nav.map((c) =>
-              renderRow(c, { icon: Navigation, title: c.label, subtitle: `${c.section} · ${c.path}`, badge: 'GO' })
-            )
-          )}
+            {renderGroup(
+              <Navigation size={14} />,
+              'Go to',
+              combined.nav.map((c) =>
+                renderRow(c, { icon: Navigation, title: c.label, subtitle: `${c.section} · ${c.path}`, badge: 'GO' })
+              )
+            )}
 
-          {renderGroup(
-            <Play size={14} />,
-            'Run',
-            combined.actions.map((a) =>
-              renderRow(a, { icon: Play, title: a.label, subtitle: (a.description || a.section || '').slice(0, 80), badge: 'RUN' })
-            )
-          )}
+            {renderGroup(
+              <Play size={14} />,
+              'Run',
+              combined.actions.map((a) =>
+                renderRow(a, { icon: Play, title: a.label, subtitle: (a.description || a.section || '').slice(0, 80), badge: 'RUN' })
+              )
+            )}
 
-          {renderGroup(
-            <LayoutGrid size={14} />,
-            'Dashboard layout',
-            combined.layouts.map((l) =>
-              renderRow(l, { icon: LayoutGrid, title: l.label, subtitle: 'Switch dashboard layout', badge: 'LAYOUT' })
-            )
-          )}
+            {renderGroup(
+              <LayoutGrid size={14} />,
+              'Dashboard layout',
+              combined.layouts.map((l) =>
+                renderRow(l, { icon: LayoutGrid, title: l.label, subtitle: 'Switch dashboard layout', badge: 'LAYOUT' })
+              )
+            )}
 
-          {renderGroup(
-            <BookMarked size={14} />,
-            'Catalog',
-            catalogHits.map((c) =>
-              renderRow(c, { icon: BookMarked, title: c.name, subtitle: c.type, badge: c.type.toUpperCase() })
-            )
-          )}
+            {renderGroup(
+              <BookMarked size={14} />,
+              'Catalog',
+              catalogHits.map((c) =>
+                renderRow(c, { icon: BookMarked, title: c.name, subtitle: c.type, badge: c.type.toUpperCase() })
+              )
+            )}
 
-          {loading && (
-            <div className="flex items-center justify-center py-4">
-              <Loader2 size={18} className="animate-spin text-gray-400" />
-            </div>
-          )}
-
-          {!loading && query.length >= 2 && searchResults.length === 0 && catalogHits.length === 0 && combined.commandCount === 0 && (
-            <div className="text-center text-sm text-gray-500 py-8">
-              No results for &ldquo;{query}&rdquo;
-            </div>
-          )}
-
-          {!loading && !query && combined.commandCount === 0 && (
-            <div className="text-center text-sm text-gray-600 py-8">
-              Start typing to go to a page, run an action, or search.
-            </div>
-          )}
-
-          {!loading && searchResults.map((source) => {
-            const SourceIcon = ICON_MAP[source.icon] ?? Search;
-            const isExpanded = expandedSources.has(source.id);
-            const visible = isExpanded ? source.results : source.results.slice(0, 3);
-            const hasMore = source.results.length > 3 && !isExpanded;
-
-            return (
-              <div key={source.id} className="mb-2">
-                <div className="flex items-center gap-2 px-3 py-2 text-xs text-gray-400 uppercase tracking-wide">
-                  <SourceIcon size={14} />
-                  <span>{source.label}</span>
-                </div>
-
-                {visible.map((result) =>
-                  renderRow(
-                    { ...result, kind: 'search' },
-                    { title: result.title, subtitle: result.snippet }
-                  )
-                )}
-
-                {hasMore && (
-                  <button
-                    onClick={() => setExpandedSources((prev) => new Set(prev).add(source.id))}
-                    className="text-xs text-port-accent px-3 py-1 hover:underline"
-                  >
-                    Show {source.results.length - 3} more
-                  </button>
-                )}
+            {loading && (
+              <div className="flex items-center justify-center py-4">
+                <Loader2 size={18} className="animate-spin text-gray-400" />
               </div>
-            );
-          })}
+            )}
+
+            {!loading && query.length >= 2 && searchResults.length === 0 && catalogHits.length === 0 && combined.commandCount === 0 && (
+              <div className="text-center text-sm text-gray-500 py-8">
+                No results for &ldquo;{query}&rdquo;
+              </div>
+            )}
+
+            {!loading && !query && combined.commandCount === 0 && (
+              <div className="text-center text-sm text-gray-600 py-8">
+                Start typing to go to a page, run an action, or search.
+              </div>
+            )}
+
+            {!loading && searchResults.map((source) => {
+              const SourceIcon = ICON_MAP[source.icon] ?? Search;
+              const isExpanded = expandedSources.has(source.id);
+              const visible = isExpanded ? source.results : source.results.slice(0, 3);
+
+              return (
+                <div key={source.id} role="group" aria-label={source.label} className="mb-2">
+                  <div className="flex items-center gap-2 px-3 py-2 text-xs text-gray-400 uppercase tracking-wide">
+                    <SourceIcon size={14} />
+                    <span>{source.label}</span>
+                  </div>
+
+                  {visible.map((result) =>
+                    renderRow(
+                      { ...result, kind: 'search', sourceId: source.id },
+                      { title: result.title, subtitle: result.snippet }
+                    )
+                  )}
+                </div>
+              );
+            })}
+          </div>
+          {!loading && searchResults.filter((source) => source.results.length > 3 && !expandedSources.has(source.id)).map((source) => (
+            <button
+              key={source.id}
+              onClick={() => setExpandedSources((prev) => new Set(prev).add(source.id))}
+              className="text-xs text-port-accent px-3 py-1 hover:underline"
+            >
+              Show {source.results.length - 3} more from {source.label}
+            </button>
+          ))}
         </div>}
 
         {captureMode && (

--- a/client/src/components/CmdKSearch.test.jsx
+++ b/client/src/components/CmdKSearch.test.jsx
@@ -99,6 +99,8 @@ describe('CmdKSearch inline Brain capture', () => {
     const input = screen.getByRole('textbox', { name: 'Capture to Brain' });
     expect(input).toHaveFocus();
     expect(input).toHaveAttribute('placeholder', 'Thought or URL…');
+    expect(input).not.toHaveAttribute('aria-activedescendant');
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
     expect(toast).not.toHaveBeenCalled();
   });
 
@@ -116,7 +118,7 @@ describe('CmdKSearch inline Brain capture', () => {
 
   it('enters capture mode from the keyboard', async () => {
     await renderBrainCapturePalette();
-    const input = screen.getByRole('textbox', { name: 'Command palette' });
+    const input = screen.getByRole('combobox', { name: 'Command palette' });
 
     fireEvent.keyDown(input, { key: 'Enter' });
 
@@ -198,7 +200,7 @@ describe('CmdKSearch inline Brain capture', () => {
 
   it('uses Escape to return to the prior query before closing the palette', async () => {
     await renderBrainCapturePalette();
-    const searchInput = screen.getByRole('textbox', { name: 'Command palette' });
+    const searchInput = screen.getByRole('combobox', { name: 'Command palette' });
     fireEvent.change(searchInput, { target: { value: 'capture' } });
     fireEvent.keyDown(searchInput, { key: 'Enter' });
     const captureInput = screen.getByRole('textbox', { name: 'Capture to Brain' });
@@ -210,7 +212,7 @@ describe('CmdKSearch inline Brain capture', () => {
     window.removeEventListener('keydown', leakedEscape);
 
     expect(screen.getByRole('dialog', { name: 'Command palette' })).toBeInTheDocument();
-    const restoredSearch = screen.getByRole('textbox', { name: 'Command palette' });
+    const restoredSearch = screen.getByRole('combobox', { name: 'Command palette' });
     expect(restoredSearch).toHaveValue('capture');
     expect(restoredSearch).toHaveFocus();
     expect(leakedEscape).not.toHaveBeenCalled();
@@ -229,7 +231,7 @@ describe('CmdKSearch inline Brain capture', () => {
     fireEvent.keyDown(captureInput, { key: 'Enter' });
 
     fireEvent.keyDown(captureInput, { key: 'Escape' });
-    const searchInput = screen.getByRole('textbox', { name: 'Command palette' });
+    const searchInput = screen.getByRole('combobox', { name: 'Command palette' });
     fireEvent.change(searchInput, { target: { value: 'keep searching' } });
     await act(async () => { resolveCapture({ ok: true, result: { summary: 'Captured.' } }); });
 
@@ -247,13 +249,81 @@ describe('CmdKSearch inline Brain capture', () => {
     await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
 
     fireEvent.keyDown(document, { key: 'k', metaKey: true });
-    expect(await screen.findByRole('textbox', { name: 'Command palette' })).toHaveValue('');
+    expect(await screen.findByRole('combobox', { name: 'Command palette' })).toHaveValue('');
     fireEvent.click(await screen.findByRole('option', { name: /Capture to Brain/ }));
     expect(screen.getByRole('textbox', { name: 'Capture to Brain' })).toHaveValue('');
   });
 });
 
 describe('CmdKSearch dialog accessibility', () => {
+  it('keeps the active option stable through filtering and executes the indicated destination', async () => {
+    render(
+      <MemoryRouter initialEntries={['/current']}>
+        <CmdKSearch />
+        <LocationProbe />
+      </MemoryRouter>,
+    );
+    fireEvent.keyDown(document, { key: 'k', metaKey: true });
+    const input = await screen.findByRole('combobox', { name: 'Command palette' });
+    const listbox = screen.getByRole('listbox', { name: 'Command palette results' });
+    await screen.findByRole('option', { name: /Brain Inbox/ });
+    expect(input).toHaveAttribute('aria-controls', listbox.id);
+    expect(input).toHaveAttribute('aria-expanded', 'true');
+    const options = within(listbox).getAllByRole('option');
+    expect(new Set(options.map((option) => option.id)).size).toBe(options.length);
+    expect(options.every((option) => option.id)).toBe(true);
+    expect(input).toHaveAttribute('aria-activedescendant', options[0].id);
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    expect(input).toHaveAttribute('aria-activedescendant', options[1].id);
+    expect(options[1]).toHaveAttribute('aria-selected', 'true');
+    expect(input).toHaveFocus();
+    fireEvent.keyDown(input, { key: 'ArrowUp' });
+    expect(input).toHaveAttribute('aria-activedescendant', options[0].id);
+
+    const brainId = screen.getByRole('option', { name: /Brain Inbox/ }).id;
+    fireEvent.change(input, { target: { value: 'brain' } });
+    expect(input).toHaveAttribute('aria-activedescendant', brainId);
+    fireEvent.change(input, { target: { value: 'zzzzzz' } });
+    expect(input).not.toHaveAttribute('aria-activedescendant');
+    fireEvent.change(input, { target: { value: 'brain' } });
+    expect(input).toHaveAttribute('aria-activedescendant', brainId);
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(screen.getByTestId('location')).toHaveTextContent('/brain/inbox');
+  });
+
+  it('clears hidden search selections during loading and owns expanded results without owning buttons', async () => {
+    vi.useFakeTimers();
+    const source = (title) => ({
+      id: 'brain', label: 'Brain', icon: 'Brain',
+      results: Array.from({ length: 4 }, (_, i) => ({ id: String(i), title: title + i, url: '/brain/' + title })),
+    });
+    search.mockResolvedValueOnce({ sources: [source('First')] })
+      .mockResolvedValueOnce({ sources: [source('Next')] });
+    render(<MemoryRouter><CmdKSearch /></MemoryRouter>);
+    await act(async () => { fireEvent.keyDown(document, { key: 'k', metaKey: true }); });
+    const input = screen.getByRole('combobox');
+    fireEvent.change(input, { target: { value: 'zz' } });
+    await act(async () => { await vi.advanceTimersByTimeAsync(300); });
+    const first = screen.getByRole('option', { name: 'First0' });
+    expect(input).toHaveAttribute('aria-activedescendant', first.id);
+    const listbox = screen.getByRole('listbox');
+    expect(within(listbox).queryByRole('button')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Show 1 more from Brain' }));
+    const expanded = within(listbox).getAllByRole('option');
+    expect(expanded).toHaveLength(4);
+    expect(new Set(expanded.map((option) => option.id)).size).toBe(4);
+    expect(screen.getByRole('option', { name: 'First0' }).id).toBe(first.id);
+    fireEvent.change(input, { target: { value: 'yy' } });
+    expect(input).not.toHaveAttribute('aria-activedescendant');
+    expect(screen.queryByRole('option')).not.toBeInTheDocument();
+    await act(async () => { await vi.advanceTimersByTimeAsync(300); });
+    const next = screen.getByRole('option', { name: 'Next0' });
+    expect(input).toHaveAttribute('aria-activedescendant', next.id);
+    expect(document.getElementById(first.id)).toBeNull();
+    expect(input).toHaveFocus();
+    vi.useRealTimers();
+  });
+
   it('traps focus inside the modal and restores it to the opener on close', async () => {
     render(
       <MemoryRouter>
@@ -269,7 +339,7 @@ describe('CmdKSearch dialog accessibility', () => {
     const dialog = await screen.findByRole('dialog', { name: 'Command palette' });
     expect(dialog).toHaveAttribute('aria-modal', 'true');
 
-    const input = within(dialog).getByRole('textbox', { name: 'Command palette' });
+    const input = within(dialog).getByRole('combobox', { name: 'Command palette' });
     expect(input).toHaveFocus();
 
     fireEvent.keyDown(input, { key: 'Tab' });
@@ -328,7 +398,7 @@ describe('CmdKSearch instance feature gating', () => {
       </MemoryRouter>,
     );
     fireEvent.keyDown(document, { key: 'k', metaKey: true });
-    const input = await screen.findByRole('textbox', { name: 'Command palette' });
+    const input = await screen.findByRole('combobox', { name: 'Command palette' });
     fireEvent.change(input, { target: { value: query } });
     await act(async () => {});
   };

--- a/client/src/components/CmdKSearch.test.jsx
+++ b/client/src/components/CmdKSearch.test.jsx
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { MemoryRouter, useLocation } from 'react-router';
 import { RECENT_KEY } from '../utils/navWorkingSet.js';
 
@@ -292,7 +293,6 @@ describe('CmdKSearch dialog accessibility', () => {
   });
 
   it('clears hidden search selections during loading and owns expanded results without owning buttons', async () => {
-    vi.useFakeTimers();
     const source = (title) => ({
       id: 'brain', label: 'Brain', icon: 'Brain',
       results: Array.from({ length: 4 }, (_, i) => ({ id: String(i), title: title + i, url: '/brain/' + title })),
@@ -303,12 +303,14 @@ describe('CmdKSearch dialog accessibility', () => {
     await act(async () => { fireEvent.keyDown(document, { key: 'k', metaKey: true }); });
     const input = screen.getByRole('combobox');
     fireEvent.change(input, { target: { value: 'zz' } });
-    await act(async () => { await vi.advanceTimersByTimeAsync(300); });
-    const first = screen.getByRole('option', { name: 'First0' });
+    const first = await screen.findByRole('option', { name: 'First0' });
     expect(input).toHaveAttribute('aria-activedescendant', first.id);
     const listbox = screen.getByRole('listbox');
     expect(within(listbox).queryByRole('button')).not.toBeInTheDocument();
-    fireEvent.click(screen.getByRole('button', { name: 'Show 1 more from Brain' }));
+    const user = userEvent.setup();
+    screen.getByRole('button', { name: 'Show 1 more from Brain' }).focus();
+    await user.keyboard('[Enter]');
+    expect(input).toHaveFocus();
     const expanded = within(listbox).getAllByRole('option');
     expect(expanded).toHaveLength(4);
     expect(new Set(expanded.map((option) => option.id)).size).toBe(4);
@@ -316,12 +318,10 @@ describe('CmdKSearch dialog accessibility', () => {
     fireEvent.change(input, { target: { value: 'yy' } });
     expect(input).not.toHaveAttribute('aria-activedescendant');
     expect(screen.queryByRole('option')).not.toBeInTheDocument();
-    await act(async () => { await vi.advanceTimersByTimeAsync(300); });
-    const next = screen.getByRole('option', { name: 'Next0' });
+    const next = await screen.findByRole('option', { name: 'Next0' });
     expect(input).toHaveAttribute('aria-activedescendant', next.id);
     expect(document.getElementById(first.id)).toBeNull();
     expect(input).toHaveFocus();
-    vi.useRealTimers();
   });
 
   it('traps focus inside the modal and restores it to the opener on close', async () => {


### PR DESCRIPTION
## Summary
Expose the command palette search as a labeled combobox controlling grouped listbox options. Arrow selection now identifies the actual result through stable option IDs, including loading, filtering, and capture transitions.

Keep expansion buttons outside the listbox and return focus to search after keyboard expansion. Hidden loading results cannot be executed.

Closes #7135

## Test plan
- 18 rendered CmdKSearch tests passed, including keyboard expansion, selection, loading/replacement, capture, and focus containment.
- Targeted Biome lint and production build passed (chunk-size warnings).
- Chromium 153 accessibility-tree check with fixture data verified the active option changes with ArrowDown while combobox focus remains; also checked Tab, empty results, capture, and Escape restoration.
- Read-only Codex review completed; its expansion-focus finding was fixed and the rendered suite rerun.
