### PR TITLE
fix: preserve CLI interruptions across server shutdown

### DIFF
--- a/server/services/runner.js
+++ b/server/services/runner.js
@@ -516,7 +516,10 @@ export async function executeCliRun({ runId, provider, prompt, workspacePath, sc
     // stale markers, while this close event is the one place that can turn the
     // marker into a canceled terminal outcome.
     const stopRequested = toolkit.services.runner.consumeExternalRunStop?.(runId) === true;
-    const hostInterrupted = !!signal && isHostShuttingDown();
+    // Codex handles the shutdown signal itself and exits 1, so Node may report
+    // no signal. Preserve a graceful exit 0 while classifying that failure as
+    // interruption before echoed prompt text can be mistaken for quota output.
+    const hostInterrupted = isHostShuttingDown() && (!!signal || (exitCode != null && exitCode !== 0));
     const canceled = !spawnError && !immediateFallbackAnalysis && (stopRequested || hostInterrupted);
 
     try {

--- a/server/services/runner.test.js
+++ b/server/services/runner.test.js
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import EventEmitter from 'events';
 import { ChildProcess } from '../lib/childProcess.js';
+import { markHostShuttingDown, resetHostShutdownFlagForTests } from '../lib/hostShutdown.js';
 
 // executeCliRun validates that a requested workspace actually exists before
 // spawning (#3180 — a bad repoPath used to silently run in the PortOS root), so
@@ -123,6 +124,7 @@ function makeChild() {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  resetHostShutdownFlagForTests();
   setAIToolkit(fakeToolkit(), { dataDir: '/tmp/test-runner' });
 });
 
@@ -434,6 +436,34 @@ describe('executeCliRun — wall-clock timeout classification', () => {
 });
 
 describe('executeCliRun — intentional cancellation', () => {
+  it.each([1, 0])('handles shutdown exit %i without a Node signal or provider penalty', async (exitCode) => {
+    const child = makeChild();
+    spawn.mockReturnValue(child);
+    const errorDetection = { analyzeError: vi.fn() };
+    const onRunFailed = vi.fn();
+    setAIToolkit(fakeToolkit(errorDetection), {
+      dataDir: '/tmp/test-runner', hooks: { onRunFailed },
+    });
+    const onComplete = vi.fn();
+    await executeCliRun({
+      runId: 'run-shutdown-code',
+      provider: { id: 'codex', command: 'codex', args: [], defaultModel: 'gpt-test', timeout: 5000 },
+      prompt: 'A character readily credits competence.',
+      workspacePath: TEST_WORKSPACE,
+      onComplete,
+    });
+    child.stdout.emit('data', Buffer.from('A character readily credits competence.\nturn interrupted\n'));
+    markHostShuttingDown();
+    child.emit('close', exitCode, null);
+    await flushMicrotasks();
+
+    expect(onComplete).toHaveBeenCalledWith(expect.objectContaining(exitCode === 0
+      ? { success: true }
+      : { success: false, canceled: true, completionReason: 'host-shutdown', errorCategory: ERROR_CATEGORIES.CANCELED }));
+    expect(errorDetection.analyzeError).not.toHaveBeenCalled();
+    expect(onRunFailed).not.toHaveBeenCalled();
+  });
+
   it('skips output classification and provider-failure hooks after stopRun', async () => {
     const child = makeChild();
     spawn.mockReturnValue(child);


### PR DESCRIPTION
Codex catches a server shutdown signal and can exit with code 1 while Node reports no signal. The CLI runner treated that exit as a provider failure, scanned the echoed story prompt for error keywords, and incorrectly benched Codex for quota exhaustion during a live series autopilot run.

Treat a nonzero exit while the host is shutting down as cancellation, preserving successful exit-0 completion and existing explicit provider-fallback handling. This suppresses provider penalties and fallback work for the interrupted call.

Validation: 208 focused tests pass across the CLI runner, prompt runner and host shutdown suites. The new lifecycle cases cover exit 1 without a signal and successful exit 0 during shutdown. Focused Biome lint passes with only existing informational import suggestions; local diff review and whitespace checks are clean.
