### PR TITLE
fix(pipeline): repair dimensions below the requested foundation score first

### DIFF
--- a/server/services/pipeline/foundationJudge.js
+++ b/server/services/pipeline/foundationJudge.js
@@ -199,9 +199,10 @@ export function computeWeightedScore(dimensions) {
 }
 
 /**
- * The dimension the improve loop should target next: the LARGEST weighted
- * deficit `weight × (10 − score)` — i.e. the single fix that moves the weighted
- * composite the most. Ties break toward the lower raw score, then rubric order.
+ * Largest weighted distance from a perfect rubric score, retained for snapshot
+ * diagnostics: `weight × (10 − score)`. Gate repair selection instead uses
+ * foundationFixTarget with the requested threshold. Ties break toward the lower
+ * raw score, then rubric order.
  * (Fixing a high-weight low-score dimension first is what converges the gate;
  * "weakest" by bare score would waste rounds polishing a 10%-weight craft nit
  * while a thin 40%-weight world drags the composite down.) Pure + unit-tested.
@@ -633,7 +634,8 @@ const CRAFT_REPAIR_MAX_ATTEMPTS = 2;
 // a smaller brief. That is the one way these differ from `renderArc`, which is
 // plain text and hard-clamps: below the JSON skeleton's own size (a few hundred
 // chars of keys and notes) these renderers overshoot the budget rather than
-// emitting something unparseable. The real budgets are 12,000.
+// emitting something unparseable. Ordinary section budgets are 12,000; a
+// complete single-character repair may use the bounded 24,000 fallback above.
 const JSON_TRUNCATION_MARK = '… [truncated to fit the prompt budget]';
 function fitJsonToBudget(payload, trimKeys, maxChars) {
   const shrunk = { ...payload };

--- a/server/services/pipeline/foundationJudge.js
+++ b/server/services/pipeline/foundationJudge.js
@@ -241,7 +241,22 @@ export function foundationGateStatus(dimensions, weightedScore, threshold = DEFA
 
 export function foundationFixTarget(dimensions, threshold = DEFAULT_FOUNDATION_THRESHOLD) {
   const { dimensionFloor, failingDimensions } = foundationGateStatus(dimensions, 0, threshold);
-  if (failingDimensions.length === 0) return weakestDimension(dimensions);
+  if (failingDimensions.length === 0) {
+    const target = Number.isFinite(threshold) ? threshold : DEFAULT_FOUNDATION_THRESHOLD;
+    // Repair the shortfall that keeps this run below its requested bar. Using
+    // distance from 10 sent a 7.8/8 foundation back to worldbuilding (already 8)
+    // while its only deficient dimension, structure (7), remained untouched.
+    const belowTarget = FOUNDATION_DIMENSIONS
+      .filter((dimension) => dimensions?.[dimension] && clampScore(dimensions[dimension].score) < target)
+      .map((dimension) => ({
+        dimension,
+        score: clampScore(dimensions[dimension].score),
+        deficit: Math.round(FOUNDATION_WEIGHTS[dimension] * (target - clampScore(dimensions[dimension].score)) * 100) / 100,
+      }))
+      .sort((a, b) => b.deficit - a.deficit || a.score - b.score
+        || FOUNDATION_DIMENSIONS.indexOf(a.dimension) - FOUNDATION_DIMENSIONS.indexOf(b.dimension));
+    return belowTarget[0] || weakestDimension(dimensions);
+  }
   return failingDimensions
     .map((dimension) => ({
       dimension,
@@ -597,6 +612,10 @@ const REPAIR_OUTLINE_MAX_CHARS = 12_000;
 // reasoning model chews through before the clock runs out, not context size.
 const REPAIR_SERIES_MAX_CHARS = 12_000;
 const REPAIR_CHARACTERS_MAX_CHARS = 12_000;
+// Split ensembles first. A single fully authored character can exceed the
+// normal section budget even with no roster attached; give that one record a
+// bounded larger envelope instead of truncating its canonical constraints.
+const REPAIR_SINGLE_CHARACTER_MAX_CHARS = 24_000;
 
 // The character-foundation stage reasons over the whole ensemble at once, so it
 // is the slowest repair stage by a wide margin. Ten minutes proved short enough
@@ -879,7 +898,7 @@ async function runFoundationRepair(series, issues, dimension, finding, character
       foundationFindingJson: JSON.stringify(findingPayload, null, 2),
       seriesJson: renderRepairSeriesJson(series),
       outline: renderArc(series, issues, { maxChars: REPAIR_OUTLINE_MAX_CHARS }),
-      charactersJson: renderRepairCharactersJson(charactersPayload),
+      charactersJson: renderRepairCharactersJson(charactersPayload, options.charactersMaxChars),
     }, {
       returnsJson: true,
       providerDefault: options.providerId,
@@ -925,10 +944,12 @@ async function repairCharacters(series, issues, universe, finding, options) {
     const batchIds = new Set(originalBatch.map((character) => character.id));
     const targetBatch = workingRoster.filter((character) => batchIds.has(character.id));
     const ensembleCharacters = [...workingRoster, ...workingNewCharacters];
-    const preview = JSON.parse(renderRepairCharactersJson({
+    const charactersPayload = {
       targetCharacters: targetBatch.map(renderPromptCharacter),
       fullSeriesRoster: ensembleCharacters.map(renderPromptCharacter),
-    }));
+    };
+    let charactersMaxChars = REPAIR_CHARACTERS_MAX_CHARS;
+    let preview = JSON.parse(renderRepairCharactersJson(charactersPayload, charactersMaxChars));
     if (preview.targetNote) {
       // Shrink the batch before shrinking the records it is allowed to edit.
       // A 40-character field cap erased whole designs in a real repair prompt.
@@ -937,10 +958,15 @@ async function repairCharacters(series, issues, universe, finding, options) {
         targetBatches.unshift(originalBatch.slice(0, midpoint), originalBatch.slice(midpoint));
         continue;
       }
-      throw new Error(`Character foundation cannot safely fit the complete repair context for ${targetBatch[0]?.name || 'the target character'} within ${REPAIR_CHARACTERS_MAX_CHARS} characters. Shorten that character's supporting detail before retrying; no truncated character repair was sent.`);
+      charactersMaxChars = REPAIR_SINGLE_CHARACTER_MAX_CHARS;
+      preview = JSON.parse(renderRepairCharactersJson(charactersPayload, charactersMaxChars));
+      if (preview.targetNote) {
+        throw new Error(`Character foundation cannot safely fit the complete repair context for ${targetBatch[0]?.name || 'the target character'} within ${charactersMaxChars} characters. Shorten that character's supporting detail before retrying; no truncated character repair was sent.`);
+      }
     }
     const proposal = await runFoundationRepair(series, issues, 'character', finding, targetBatch, {
       ...options,
+      charactersMaxChars,
       // Locked cast members are immutable constraints, but the model still
       // needs to see them when differentiating relationships and voices.
       // Later batches also see the accepted shape of earlier proposals, so two

--- a/server/services/pipeline/foundationJudge.test.js
+++ b/server/services/pipeline/foundationJudge.test.js
@@ -1242,8 +1242,39 @@ describe('applyFoundationFix — dimension → owning-service routing table', ()
     }
   });
 
-  it('refuses an oversized single-character repair before calling a provider or writing canon', async () => {
-    const universe = { id: 'uni-1', characters: [{ id: 'lead', name: 'Lead', background: 'x'.repeat(20_000) }] };
+  it('repairs a complete single character exceeding the normal batch budget without losing its constraints', async () => {
+    const character = {
+      id: 'lead', name: 'Lead', background: 'Known history. '.repeat(125).trim(),
+      physicalDescription: 'Known clothing. '.repeat(120).trim(),
+      personality: 'Known behavior. '.repeat(120).trim(),
+      motivations: 'Personal goals. '.repeat(120).trim(),
+      relationships: 'Trusted people. '.repeat(120).trim(),
+      skills: 'Learned skills. '.repeat(120).trim(),
+      silhouetteNotes: 'Visible shapes. '.repeat(120).trim(),
+      ghost: 'The specific past event. '.repeat(30).trim(),
+    };
+    const universe = { id: 'uni-1', characters: [character] };
+    universeBuilder.getUniverse.mockResolvedValue(universe);
+    let saved;
+    universeBuilder.updateUniverse.mockImplementation(async (_id, mutator) => {
+      saved = { ...universe, ...mutator(universe) }; return saved;
+    });
+    stageRunner.runStagedLLM.mockResolvedValue({ content: { characters: [{ id: 'lead', wound: 'Trust carries a personal cost.' }] } });
+
+    await applyFoundationFix('ser-1', 'character', { finding: { gap: 'Lead needs a clearer fear.' } });
+
+    expect(stageRunner.runStagedLLM).toHaveBeenCalledTimes(1);
+    const rendered = stageRunner.runStagedLLM.mock.calls[0][1].charactersJson;
+    expect(rendered.length).toBeGreaterThan(12_000);
+    expect(rendered.length).toBeLessThanOrEqual(24_000);
+    const payload = JSON.parse(rendered);
+    expect(payload.targetNote).toBeUndefined();
+    expect(payload.targetCharacters).toEqual([expect.objectContaining(character)]);
+    expect(saved.characters[0]).toMatchObject({ ...character, wound: 'Trust carries a personal cost.' });
+  });
+
+  it('refuses a single character exceeding the expanded budget before calling a provider or writing canon', async () => {
+    const universe = { id: 'uni-1', characters: [{ id: 'lead', name: 'Lead', background: 'x'.repeat(30_000) }] };
     universeBuilder.getUniverse.mockResolvedValue(universe);
     await expect(applyFoundationFix('ser-1', 'character', { finding: { gap: 'Lead needs a clearer fear.' } }))
       .rejects.toThrow('cannot safely fit the complete repair context for Lead');

--- a/server/services/pipeline/seriesAutopilot.test.js
+++ b/server/services/pipeline/seriesAutopilot.test.js
@@ -2255,6 +2255,23 @@ describe('autopilot conductor', () => {
     expect(applyFoundationFix).toHaveBeenCalledWith(seriesId, 'character', expect.any(Object));
   });
 
+  it('foundation gate: repairs the dimension below the requested bar before polishing an already-ready world', async () => {
+    foundationScore = 7.8;
+    foundationDimensionScores = { worldbuilding: 8, character: 8, structure: 7, craft: 8 };
+    applyFoundationFix.mockImplementationOnce(async (_seriesId, dimension) => {
+      foundationScore = 8;
+      foundationDimensionScores = { worldbuilding: 8, character: 8, structure: 8, craft: 8 };
+      return { dimension, applied: true };
+    });
+    const { seriesId } = await seedComplete();
+    await autopilot.startSeriesAutopilot(seriesId, { foundationThreshold: 8, maxFoundationRounds: 2 });
+    await waitFor(runFinished(seriesId));
+
+    expect(applyFoundationFix).toHaveBeenCalledTimes(1);
+    expect(applyFoundationFix).toHaveBeenCalledWith(seriesId, 'structure', expect.any(Object));
+    expect(autopilot.__testing.runs.get(seriesId)?.lastPayload?.type).toBe('complete');
+  });
+
   it('foundation gate: lets a newly surfaced target run before applying divergence patience', async () => {
     const snap = (weightedScore, scores) => ({
       seriesId: 'ser-example', status: 'complete', weightedScore,
@@ -2289,18 +2306,18 @@ describe('autopilot conductor', () => {
   });
 
   it('foundation gate: reverts a repair that leaves its target unchanged, then retries it from the checkpoint', async () => {
-    const snapshot = (weightedScore) => ({
+    const snapshot = (weightedScore, worldbuilding = 8) => ({
       seriesId: 'ser-example', status: 'complete', weightedScore,
       dimensions: {
-        worldbuilding: { score: 8, gap: 'The active-node evidence rule is undefined.', fix: 'Define it.' },
-        character: { score: 7, gap: 'Aruun privacy is mislabeled as a relapse.', fix: 'Separate privacy from safety disclosure.' },
-        structure: { score: 6, gap: 'The charter handoff is thin.', fix: 'Stage the handoff.' },
-        craft: { score: 7, gap: 'The panel grammar is thin.', fix: 'Add panel rules.' },
+        worldbuilding: { score: worldbuilding, gap: 'The active-node evidence rule is undefined.', fix: 'Define it.' },
+        character: { score: 6, gap: 'Aruun privacy is mislabeled as a relapse.', fix: 'Separate privacy from safety disclosure.' },
+        structure: { score: 7, gap: 'The charter handoff is thin.', fix: 'Stage the handoff.' },
+        craft: { score: 8, gap: 'The panel grammar is thin.', fix: 'Add panel rules.' },
       },
     });
     judgeFoundation
       .mockImplementationOnce(async () => snapshot(7.2))
-      .mockImplementationOnce(async () => snapshot(7.1));
+      .mockImplementationOnce(async () => snapshot(7.1, 7.75));
     const checkpoint = { seriesId: 'ser-example', marker: 'before-character-repair' };
     snapshotFoundationState.mockResolvedValueOnce(checkpoint);
 


### PR DESCRIPTION
Foundation repair could choose worldbuilding already at the requested score while a lower-scoring structure kept the series below its readiness threshold. Preserve the hard dimension floor, then select repairs from dimensions below the requested score using their weighted shortfall. For example, scores of 8/8/7/8 against an 8 target now repair structure.

Keep the existing weakest-dimension diagnostic and the upstream character overflow implementation unchanged. Add a conductor regression for the repair choice and retain rollback/retry coverage with scores consistent with the new selection rule.

Validation: all 402 focused foundation and autopilot tests pass. Local review found no actionable issues. Biome reports only existing diagnostics in the touched files.
