### PR TITLE
fix(pipeline): give narrative bible repairs time to finish

### DIFF
--- a/server/services/universeBuilderExpand.effort.test.js
+++ b/server/services/universeBuilderExpand.effort.test.js
@@ -50,6 +50,7 @@ describe('expandWorldTemplate reasoning effort', () => {
       effort: 'ultra',
       source: 'universe-builder-expansion',
     }));
+    expect(runPromptThroughProviderMock.mock.calls[0][0]).not.toHaveProperty('timeout');
   });
 
   it('uses a narrative-only contract for foundation world repairs', async () => {
@@ -66,6 +67,7 @@ describe('expandWorldTemplate reasoning effort', () => {
     expect(call).toMatchObject({
       effort: 'ultra',
       source: 'universe-builder-narrative-repair',
+      timeout: 900_000,
     });
     expect(call.prompt).toContain('exact costs');
     expect(call.prompt).toContain('Define the relay hops and their metabolic cost.');
@@ -103,6 +105,7 @@ describe('expandWorldTemplate reasoning effort', () => {
     });
 
     expect(runPromptThroughProviderMock).toHaveBeenCalledTimes(2);
+    expect(runPromptThroughProviderMock.mock.calls.every(([call]) => call.timeout === 900_000)).toBe(true);
     expect(runPromptThroughProviderMock.mock.calls[1][0].prompt).toContain('premise exceeds 20000 characters (got 20001)');
     expect(runPromptThroughProviderMock.mock.calls[1][0].prompt).toContain(`"premise": "${'x'.repeat(200)}`);
     expect(runPromptThroughProviderMock.mock.calls[1][0].prompt).toContain('premise: at most 18000 characters');

--- a/server/services/universeBuilderExpand.js
+++ b/server/services/universeBuilderExpand.js
@@ -42,6 +42,10 @@ import {
 const LABEL_MAX = 80;
 const NARRATIVE_REPAIR_MAX_ATTEMPTS = 3;
 const NARRATIVE_REPAIR_HEADROOM = [0.9, 0.8];
+// Reconcile the full narrative bible before returning its replacement. The
+// runner's five-minute default can terminate a healthy reasoning-model repair
+// and trigger a provider fallback before it has produced the corrected text.
+const NARRATIVE_REPAIR_TIMEOUT_MS = 15 * 60_000;
 
 // A judge-directed narrative repair must ADD material — an operational ruleset,
 // a missing cost, a named hard limit — to a bible field that EARLIER repairs may
@@ -587,6 +591,7 @@ export async function expandWorldTemplate({
       onRunCreated,
       onRunSettled,
       prompt,
+      ...(narrativeOnly ? { timeout: NARRATIVE_REPAIR_TIMEOUT_MS } : {}),
       source: narrativeOnly ? "universe-builder-narrative-repair" : "universe-builder-expansion",
     });
     raw = result.text;


### PR DESCRIPTION
Foundation worldbuilding repair inherited the provider runner’s five-minute default. In a live high-effort Codex run, the deadline terminated the narrative-bible repair and triggered fallback before the corrected JSON was returned.

Give narrative-only universe repair a fifteen-minute deadline, including its existing compression retries. Ordinary universe expansion keeps its existing provider/default timeout. The repair scope, retry count, and persistence contract are unchanged.

Validation: 161 universe-expansion and foundation-judge tests passed. Full-file local review found no remaining issues; syntax and whitespace checks passed. Biome reports four pre-existing warnings.
