### PR TITLE
fix: preserve explicit TUI cancellation without an exit signal

### DIFF
--- a/server/services/tuiPromptRunner.js
+++ b/server/services/tuiPromptRunner.js
@@ -707,9 +707,12 @@ ${prompt}`;
       // for a bogus quota marker, bench the provider, or launch a fallback.
       const stopRequested = consumeRunStopRequested(runId);
       const hostInterrupted = killed && isHostShuttingDown();
-      const canceled = killed && (stopRequested || hostInterrupted);
+      // A CLI can handle SIGTERM and exit through its shell with code 143
+      // (or cleanly), leaving node-pty's signal at 0. The explicit stop marker
+      // is authoritative regardless of how that process reports its exit.
+      const canceled = stopRequested || hostInterrupted;
       const finalExitCode = typeof exitCode === 'number' ? exitCode : (killed ? 130 : 0);
-      const success = !killed && finalExitCode === 0;
+      const success = !canceled && !killed && finalExitCode === 0;
       // The terminal-timeout detector holds a candidate banner until a real line
       // terminator proves the line is finished (#3715). Process exit IS that
       // proof — no further byte can turn `⎿ Request timed out` into a
@@ -734,7 +737,7 @@ ${prompt}`;
       if (hostInterrupted) {
         error = `TUI interrupted by PortOS shutdown (signal ${signal})`;
       } else if (stopRequested) {
-        error = `TUI canceled (signal ${signal})`;
+        error = killed ? `TUI canceled (signal ${signal})` : `TUI canceled (exit code ${finalExitCode})`;
       } else if (killed) {
         error = `TUI killed (signal ${signal})`;
       } else if (!success) {

--- a/server/services/tuiPromptRunner.test.js
+++ b/server/services/tuiPromptRunner.test.js
@@ -1551,14 +1551,18 @@ describe('executeTuiRun', () => {
       }));
     });
 
-    it('finalizes an explicit stop as canceled instead of a provider failure', async () => {
+    it.each([
+      { exitCode: null, signal: 'SIGTERM' },
+      { exitCode: 143, signal: 0 },
+      { exitCode: 0, signal: 0 },
+    ])('finalizes an explicit stop as canceled for PTY exit %j', async (exit) => {
       const provider = { id: 'claude', type: 'tui', command: 'echo' };
       const onComplete = vi.fn();
       runnerMocks.consumeRunStopRequested.mockReturnValueOnce(true);
       const promise = executeTuiRun({ runId: 'run-stopped', provider, prompt: 'a prompt long enough', workspacePath: TEST_WORKSPACE, onComplete, timeout: 60000 });
       await flushAsync();
 
-      ptyInstances[0].emitExit({ exitCode: null, signal: 'SIGTERM' });
+      ptyInstances[0].emitExit(exit);
 
       await promise;
       expect(runnerMocks.finalizeRunRecord).toHaveBeenCalledWith(expect.objectContaining({


### PR DESCRIPTION
## Summary
An explicit stop of a Claude Code TUI run returned exit code 143 with signal 0. The TUI runner recorded a canceled completion reason but omitted the cancellation flag, causing the shared runner to escalate it as an unknown provider failure.

Treat the explicit stop marker as authoritative regardless of the PTY signal, including a clean process exit. Report the exit code when no signal is available. Existing host-shutdown and unsolicited-exit handling retain their behavior.

## Test plan
- Passed 145 tests: server Vitest suites services/tuiPromptRunner.test.js and services/runner.test.js.
- Expanded the explicit-stop lifecycle test to cover SIGTERM, exit 143/signal 0, and clean exit/signal 0.
- Verified the shared finalization contract suppresses provider-failure hooks for canceled runs.
- Checked the incident metadata, output, and server logs; the provider was running when series autopilot cancellation occurred.
