### PR TITLE
fix: preserve complete arc revisions that fit after compression

### DIFF
--- a/server/services/pipeline/arcPlanner.test.js
+++ b/server/services/pipeline/arcPlanner.test.js
@@ -1056,6 +1056,39 @@ describe('arcPlanner — resolveVerifyIssues', () => {
     expect(out.mutations).toEqual({ arcFieldsEdited: 0, volumesEdited: 0, characterArcsEdited: 0, episodesEdited: 0 });
   });
 
+  it('persists the complete repair when later compression brings the field under its cap', async () => {
+    const s = await setupSeries();
+    const padding = 'x'.repeat(7960);
+    const summary = `Old motive. ${padding} Redundant explanation.`;
+    await seriesSvc.updateSeries(s.id, { arc: { logline: 'L', summary } });
+    const replacement = 'A costly choice earns the rescue.';
+    stageRunnerSpy = vi.fn(async () => ({
+      content: {
+        patchMode: 'exact-text-v1',
+        arc: {
+          resolves: ['f1'],
+          summaryEdits: [
+            { find: 'Old motive.', replace: replacement },
+            { find: ' Redundant explanation.', replace: '' },
+          ],
+        },
+      },
+      runId: 'r-net-fitting', providerId: 'p', model: 'm',
+    }));
+    const out = await planner.resolveVerifyIssues(s.id, {
+      findings: [{ id: 'f1', severity: 'medium', problem: 'The rescue is unearned.' }],
+    });
+    expect(out).toMatchObject({ applied: true, rejectedExactEdits: 0 });
+    expect((await seriesSvc.getSeries(s.id)).arc.summary).toBe(`${replacement} ${padding}`);
+  });
+
+  it('preserves the whole field when the final replacement set still exceeds the cap', () => {
+    expect(planner.applyExactTextEdits('first and second', [
+      { find: 'first', replace: 'a larger first choice' },
+      { find: 'second', replace: 'last' },
+    ], 20)).toEqual({ value: 'first and second', applied: 0, rejected: 2 });
+  });
+
   it('counts what a spine-scope resolve wrote, per record kind (#3843)', async () => {
     // An arc-spine resolver may not touch episodes at all, so `episodesEdited`
     // is 0 on every one of its rounds — the gate reported that alone and a

--- a/server/services/pipeline/arcPlanner/arcCore.js
+++ b/server/services/pipeline/arcPlanner/arcCore.js
@@ -457,9 +457,10 @@ const EXACT_TEXT_EDITS_MAX = 12;
  * wholesale gave a one-sentence repair thousands of unrelated words of blast
  * radius, and an over-limit rewrite could then be truncated mid-sentence by the
  * canonical sanitizer. Exact replacements keep the untouched text byte-for-byte
- * stable. Ambiguous/missing anchors and over-limit results are skipped rather
- * than guessed at; the next verification round will leave the original finding
- * visible instead of persisting a speculative rewrite.
+ * stable. Ambiguous/missing anchors are skipped rather than guessed at. Check
+ * capacity after all replacements: an early expansion may rely on a later
+ * compression. If the final field exceeds its limit, preserve the original
+ * field instead of persisting a partial version of the proposed change.
  */
 export function applyExactTextEdits(current, rawEdits, maxLength) {
   const original = typeof current === 'string' ? current : '';
@@ -480,15 +481,13 @@ export function applyExactTextEdits(current, rawEdits, maxLength) {
       rejected += 1;
       continue;
     }
-    const candidate = `${value.slice(0, first)}${replacement}${value.slice(first + find.length)}`;
-    if (candidate.length > maxLength) {
-      rejected += 1;
-      continue;
-    }
-    value = candidate;
+    value = `${value.slice(0, first)}${replacement}${value.slice(first + find.length)}`;
     applied += 1;
   }
   rejected += Math.max(0, rawEdits.length - EXACT_TEXT_EDITS_MAX);
+  if (value.length > maxLength) {
+    return { value: original, applied: 0, rejected: rejected + applied };
+  }
   return { value, applied, rejected };
 }
 


### PR DESCRIPTION
Arc repair could reject an early expansion at the field limit even when later replacements in the same response shortened the completed field enough to fit. This persisted only part of a coordinated revision and left summaries inconsistent with their episode plans.

Validate the final field length after applying its bounded exact replacements. A completed field that still exceeds its limit keeps its original text and reports all proposed edits as rejected. Existing anchor checks, field limits and legacy response handling remain in place.

Validation: all 211 arc-planner tests passed, including a persisted expansion-then-compression regression and preservation when the final field remains oversized. Full-file local review and simplification review found no further changes needed.
