### PR TITLE
fix: retain canon introduced in saved issue plans

### DIFF
--- a/server/services/pipeline/arcPlanner/context.js
+++ b/server/services/pipeline/arcPlanner/context.js
@@ -20,7 +20,7 @@ import {
 import { describeStructure, recommendStructure } from '../../../lib/seasonStructure.js';
 import { computeIssueTargets, CUSTOM_PAGE_MIN, CUSTOM_PAGE_MAX, CUSTOM_MINUTE_MIN, CUSTOM_MINUTE_MAX, DEFAULT_LENGTH_PROFILE, LENGTH_PROFILE_NAMES } from '../../../lib/issueLength.js';
 import { getUniverse } from '../../universeBuilder.js';
-import { getSeriesPlanningCanon, scopeCanonForSeries } from '../seriesCanon.js';
+import { getSeriesPlanningCanon } from '../seriesCanon.js';
 import { CHARACTER_NARRATIVE_ARC_MAX, renderCanonForPrompt, renderCategoriesForPrompt, renderCharacterNarrativeContext, renderCompositesForPrompt, renderEntitiesSummary } from '../../../lib/universePromptRenderers.js';
 import { trimToClause } from '../../../lib/textUtils.js';
 
@@ -103,7 +103,7 @@ export async function loadWorldContext(series) {
   if (!series?.universeId) return null;
   const world = await getUniverse(series.universeId).catch(() => null);
   if (!world) return null;
-  const planningCanon = scopeCanonForSeries(world, series);
+  const planningCanon = await getSeriesPlanningCanon(series, world);
   const scopedWorld = { ...world, ...planningCanon };
 
   const embrace = Array.isArray(world.influences?.embrace) ? world.influences.embrace : [];

--- a/server/services/pipeline/arcPlannerCanonScope.test.js
+++ b/server/services/pipeline/arcPlannerCanonScope.test.js
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi } from 'vitest';
+import { mockNoPeerSync, mockNoPeers } from '../../lib/mockPathsDataRoot.js';
+
+const fileStore = new Map();
+let stageRunnerSpy;
+
+vi.mock('../../lib/fileUtils.js', () => ({
+  tryReadFile: vi.fn().mockResolvedValue(null),
+  PATHS: { data: '/mock/data' },
+  ensureDir: vi.fn().mockResolvedValue(undefined),
+  atomicWrite: vi.fn(async (path, data) => { fileStore.set(path, data); }),
+  readJSONFile: vi.fn(async (path, fallback) => (fileStore.has(path) ? fileStore.get(path) : fallback)),
+}));
+
+vi.mock('../instances.js', () => mockNoPeers());
+vi.mock('../sharing/peerSync.js', () => mockNoPeerSync());
+
+vi.mock('../stageRunner.js', () => ({
+  runStagedLLM: vi.fn((...args) => stageRunnerSpy(...args)),
+  extractJson: (raw) => JSON.parse(raw),
+  resolveStageContext: vi.fn(),
+}));
+
+const seriesSvc = await import('./series.js');
+const issuesSvc = await import('./issues.js');
+const seasonsSvc = await import('./seasons.js');
+const worldSvc = await import('../universeBuilder.js');
+const planner = await import('./arcPlanner.js');
+
+async function setupSeries(overrides = {}) {
+  return seriesSvc.createSeries({
+    name: 'Salt Run',
+    logline: 'A foundry city goes silent.',
+    premise: 'Long-form premise.',
+    styleNotes: 'moebius linework',
+    issueCountTarget: 24,
+    ...overrides,
+  });
+}
+
+describe('planning canon at verifier boundaries', () => {
+  it('keeps canon named only by current issue plans without admitting sibling or obsolete draft cast', async () => {
+    const world = await worldSvc.createUniverse({
+      name: 'Shared World',
+      characters: [{ name: 'Jo Mercy' }, { name: 'Lio Fen' }, { name: 'Old Director' }, { name: 'Sibling Scout' }],
+      places: [{ name: 'Lantern Archive' }],
+      objects: [{ name: 'Brass Stamp' }],
+    });
+    const s = await setupSeries({ universeId: world.id });
+    await seriesSvc.updateSeries(s.id, { arc: { logline: 'A disputed testimony' } });
+    const sea = await seasonsSvc.createSeason(s.id, { title: 'V1', logline: 'The hearing' });
+    await issuesSvc.createIssue({
+      seriesId: s.id, seasonId: sea.id, title: 'The witness',
+      stages: { idea: { input: 'Jo Mercy and Lio Fen enter the Lantern Archive with the Brass Stamp.', output: 'Old Director commands them.' }, prose: { output: 'Old Director wins.' } },
+    });
+    const sibling = await setupSeries({ universeId: world.id });
+    await issuesSvc.createIssue({
+      seriesId: sibling.id, title: 'Other series', stages: { idea: { input: 'Sibling Scout arrives.' } },
+    });
+    stageRunnerSpy = vi.fn(async () => ({ content: { issues: [] }, runId: 'rv', providerId: 'p', model: 'm' }));
+
+    await planner.verifyVolume(s.id, sea.id, { synopsisOnly: true });
+    await planner.verifyArc(s.id);
+
+    for (const [, ctx] of stageRunnerSpy.mock.calls) {
+      for (const name of ['Jo Mercy', 'Lio Fen', 'Lantern Archive', 'Brass Stamp']) {
+        expect(ctx.worldCanonText).toContain(name);
+      }
+      expect(ctx.worldCanonText).not.toContain('Old Director');
+      expect(ctx.worldCanonText).not.toContain('Sibling Scout');
+    }
+    const arcContext = stageRunnerSpy.mock.calls[1][1];
+    expect(JSON.parse(arcContext.existingCharactersJson).map((c) => c.name)).toEqual(['Jo Mercy', 'Lio Fen']);
+  });
+});

--- a/server/services/pipeline/seriesCanon.js
+++ b/server/services/pipeline/seriesCanon.js
@@ -33,7 +33,7 @@ const referencedByName = (entry, referenceText) => {
   return name.length >= 2 && referenceText.includes(name);
 };
 
-const seriesPlanningText = (series, universe) => normalizeReferenceText(JSON.stringify({
+const seriesPlanningText = (series, universe, issues) => normalizeReferenceText(JSON.stringify({
   protectedWorldIntent: {
     starterPrompt: universe?.starterPrompt || '',
     logline: universe?.logline || '',
@@ -47,6 +47,10 @@ const seriesPlanningText = (series, universe) => normalizeReferenceText(JSON.str
     seasons: series?.seasons || [],
     characterArcs: series?.characterArcs || [],
   },
+  // Current issue plans can introduce supporting cast absent from the macro
+  // summaries. Old prose, beat outputs and sibling-series issues are not roots.
+  issuePlans: issues.filter((issue) => series?.id && issue?.seriesId === series.id)
+    .map((issue) => ({ title: issue.title, synopsis: issue.stages?.idea?.input || '' })),
 }));
 
 /**
@@ -56,16 +60,16 @@ const seriesPlanningText = (series, universe) => normalizeReferenceText(JSON.str
  * entity into a new arc prompt makes those records look equally authoritative
  * and can resurrect an incompatible plot.
  *
- * Stable character-arc ids/names and explicit mentions in protected world or
- * series fields are the roots. The selected characters' authored records then
+ * Stable character-arc ids/names and explicit mentions in protected world,
+ * series fields, or current issue plans are the roots. Selected records then
  * provide one bounded relationship hop to supporting characters, places, and
  * objects. Nothing is deleted from the universe or catalog — this only narrows
  * generative prompt context. An empty result is intentional: protected premise
  * text is safer than guessing that unrelated legacy canon belongs to the story.
  */
-export function scopeCanonForSeries(universe, series) {
+export function scopeCanonForSeries(universe, series, issues = []) {
   const canon = pickCanon(universe);
-  let referenceText = seriesPlanningText(series, universe);
+  let referenceText = seriesPlanningText(series, universe, issues);
   const arcCharacterIds = new Set((series?.characterArcs || [])
     .map((arc) => arc?.characterId)
     .filter(Boolean));
@@ -123,10 +127,13 @@ export async function getSeriesCanon(series) {
   return pickCanon(universe);
 }
 
-/** Series-scoped canon for generative planning prompts. */
-export async function getSeriesPlanningCanon(series) {
+/** Series-scoped canon, including current issue plans; accepts an already-read world. */
+export async function getSeriesPlanningCanon(series, preloadedUniverse) {
   if (!series?.universeId) return EMPTY;
-  const universe = await getUniverse(series.universeId).catch(() => null);
+  const universe = preloadedUniverse || await getUniverse(series.universeId).catch(() => null);
   if (!universe) return EMPTY;
-  return scopeCanonForSeries(universe, series);
+  // Keep issue-store imports out of the widely used full-canon reader's graph.
+  const { listIssues } = await import('./issues.js');
+  const issues = series.id ? await listIssues({ seriesId: series.id }) : [];
+  return scopeCanonForSeries(universe, series, issues);
 }


### PR DESCRIPTION
Volume verification incorrectly reported that existing Bible characters were noncanonical when their names appeared only in saved issue plans. Autopilot could then remove those characters as a continuity repair.

Series planning canon now includes names from the current series's issue titles and synopsis inputs, with the existing bounded relationship expansion. Both rendered world canon and structured planning canon use the same reader. Sibling-series issues and obsolete prose or beat outputs remain excluded, and the issue-store import stays lazy for callers of the full-canon reader.

Validation: 308 focused tests passed across arc planning, volume prompt contracts, the new verifier-boundary regression and import-scoping checks. Full-file local review and simplification review found no blockers. No prompt template or persisted schema changes.
