### PR TITLE
fix: bound scheduled task prompt preview layout

### DIFF
--- a/client/src/components/cos/tabs/schedule/PromptEditor.jsx
+++ b/client/src/components/cos/tabs/schedule/PromptEditor.jsx
@@ -77,12 +77,12 @@ export default function PromptEditor({ config, promptValue, setPromptValue, edit
         ) : (
           <button
             type="button"
-            className="w-full bg-port-bg border border-port-border rounded px-3 py-2 text-xs text-gray-400 font-mono max-h-32 overflow-y-auto cursor-pointer hover:border-port-accent/50 text-left"
+            className="block w-full bg-port-bg border border-port-border rounded text-xs text-gray-400 font-mono cursor-pointer hover:border-port-accent/50 text-left"
             onClick={() => setEditingPrompt(true)}
             title="Click to edit prompt"
             aria-label="Edit prompt"
           >
-            <pre className="whitespace-pre-wrap break-words">{promptValue || 'No prompt configured'}</pre>
+            <pre className="max-h-32 overflow-y-auto px-3 py-2 whitespace-pre-wrap break-words">{promptValue || 'No prompt configured'}</pre>
           </button>
         )}
       </div>


### PR DESCRIPTION
## Summary
Bound the scheduled-task prompt text inside its own scroll container and make the preview button a block. The button now sizes to the capped text viewport, avoiding reliance on native button overflow and inline baseline layout for long prompts on mobile.

## Test plan
- PromptEditor and GlobalConfigControls: 29 tests passed.
- Focused Biome lint and git diff whitespace checks passed.
- Synthetic layout check with Tailwind preflight in WebKit and Chrome at 360, 390, and 1280 pixels: 128px text viewport, compact parent, full text scrollable, button keyboard-focusable.
- The original gap was not reproduced in current desktop engines; physical mobile verification remains unavailable.
