### PR TITLE
fix: keep failed backup snapshots out of restore

### DIFF
--- a/client/src/components/BackupWidget.jsx
+++ b/client/src/components/BackupWidget.jsx
@@ -230,7 +230,7 @@ function SnapshotList({ restoringSnapshotId, onRestoreStateChange }) {
       // the oldest — walk every rendered tuple (id + fileCount) so a stale
       // server-side fileCount recount or a middle-row mutation can't hide
       // behind the head/tail id check.
-      compare: (prev, next) => equalListByKeys(prev, next, ['id', 'fileCount', 'incomplete']),
+      compare: (prev, next) => equalListByKeys(prev, next, ['id', 'fileCount', 'incomplete', 'failed']),
     },
   );
   const [selectedId, setSelectedId] = useState(null);
@@ -267,7 +267,11 @@ function SnapshotList({ restoringSnapshotId, onRestoreStateChange }) {
             <div className="min-w-0 flex-1">
               <div className="text-xs text-gray-300 font-mono truncate">{snap.id}</div>
               <div className="text-xs text-gray-600">
-                {snap.incomplete ? 'Still being written…' : `${snap.fileCount} files`}
+                {snap.incomplete
+                  ? 'Still being written…'
+                  : snap.failed
+                    ? 'Backup failed — download available for salvage'
+                    : `${snap.fileCount} files`}
               </div>
             </div>
             <div className="flex shrink-0 items-center gap-1">
@@ -285,7 +289,8 @@ function SnapshotList({ restoringSnapshotId, onRestoreStateChange }) {
               </button>
               <button
                 onClick={() => setSelectedId(selectedId === snap.id ? null : snap.id)}
-                disabled={snap.incomplete || restoringSnapshotId !== null}
+                disabled={snap.incomplete || snap.failed || restoringSnapshotId !== null}
+                title={snap.failed ? 'Failed backup snapshots can only be downloaded for salvage' : undefined}
                 className="flex items-center gap-1 px-2 py-1 text-xs text-port-accent hover:text-port-accent/80 transition-colors disabled:opacity-50 disabled:cursor-not-allowed min-h-[32px]"
               >
                 <RotateCcw size={12} />
@@ -293,7 +298,7 @@ function SnapshotList({ restoringSnapshotId, onRestoreStateChange }) {
               </button>
             </div>
           </div>
-          {selectedId === snap.id && (
+          {selectedId === snap.id && !snap.incomplete && !snap.failed && (
             <RestorePanel
               snapshot={snap}
               onClose={() => setSelectedId(null)}

--- a/client/src/components/BackupWidget.test.jsx
+++ b/client/src/components/BackupWidget.test.jsx
@@ -69,6 +69,24 @@ describe('BackupWidget snapshots', () => {
     expect(screen.getByRole('button', { name: 'Restore' })).toBeDisabled();
   });
 
+  it('keeps failed snapshots downloadable for salvage but disables restore', async () => {
+    mockGetBackupSnapshots.mockResolvedValue([
+      { id: '2026-08-25T12-00-00', fileCount: 2, failed: true, incomplete: false },
+    ]);
+    renderWidget();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Snapshots' }));
+    expect(await screen.findByText('Backup failed — download available for salvage')).toBeInTheDocument();
+    const download = screen.getByRole('button', { name: /Download snapshot/ });
+    const restore = screen.getByRole('button', { name: 'Restore' });
+    expect(download).toBeEnabled();
+    expect(restore).toBeDisabled();
+
+    fireEvent.click(download);
+    await waitFor(() => expect(mockDownloadBackupSnapshot).toHaveBeenCalledWith('2026-08-25T12-00-00'));
+    expect(mockRestoreBackup).not.toHaveBeenCalled();
+  });
+
   it('offers a download action for each snapshot and confirms success', async () => {
     renderWidget();
 

--- a/client/src/components/settings/BackupTab.jsx
+++ b/client/src/components/settings/BackupTab.jsx
@@ -366,10 +366,20 @@ export function BackupTab() {
           <ul className="space-y-1.5">
             {snapshots.slice(0, 10).map((snap) => (
               <li key={snap.id} className="flex items-center justify-between gap-2 text-xs bg-port-bg border border-port-border rounded-lg px-2.5 py-1.5">
-                <span className="text-gray-300 truncate">{snap.id}</span>
+                <span className="min-w-0">
+                  <span className="block text-gray-300 truncate">{snap.id}</span>
+                  {snap.failed && (
+                    <span className="block text-port-error">Backup failed — download only</span>
+                  )}
+                  {snap.incomplete && (
+                    <span className="block text-gray-500">Still being written…</span>
+                  )}
+                </span>
                 <button
                   onClick={() => handleRestoreDb(snap.id)}
-                  className="shrink-0 px-2 py-1 bg-port-border hover:bg-port-border/70 text-white rounded transition-colors"
+                  disabled={snap.failed || snap.incomplete}
+                  title={snap.failed ? 'Failed backup snapshots can only be downloaded for salvage' : undefined}
+                  className="shrink-0 px-2 py-1 bg-port-border hover:bg-port-border/70 text-white rounded transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                 >
                   Restore DB
                 </button>

--- a/client/src/components/settings/BackupTab.test.jsx
+++ b/client/src/components/settings/BackupTab.test.jsx
@@ -94,6 +94,17 @@ describe('BackupTab', () => {
       getBackupSnapshots.mockResolvedValue([{ id: 'snap-2026-06-09' }]);
     };
 
+    it('labels failed snapshots and does not offer database restore', async () => {
+      getBackupSnapshots.mockResolvedValue([{ id: 'snap-failed', failed: true }]);
+      await renderTab();
+
+      expect(await screen.findByText('Backup failed — download only')).toBeInTheDocument();
+      const restore = screen.getByRole('button', { name: /Restore DB/i });
+      expect(restore).toBeDisabled();
+      fireEvent.click(restore);
+      expect(restoreDatabase).not.toHaveBeenCalled();
+    });
+
     it('runs a dry-run and opens the confirm modal — without restoring', async () => {
       withSnapshot();
       restoreDatabase.mockResolvedValue({ status: 'ok', sizeBytes: 2048, tableCount: 12 });

--- a/docs/BACKUP.md
+++ b/docs/BACKUP.md
@@ -17,7 +17,8 @@ A backup run (`runBackup` in `server/services/backup.js`) writes to:
 <destPath>/snapshots/<hostname>/<snapshotId>/
 ├── data/             # rsync mirror of ./data/ (minus excludes)
 ├── portos-db.sql     # pg_dump logical dump
-└── manifest.json     # SHA-256 of every data/ file AND ../portos-db.sql
+├── manifest.json     # SHA-256 of every data/ file AND ../portos-db.sql
+└── .failed           # present only when snapshot creation failed
 ```
 
 - Snapshots are namespaced by `<hostname>` so one shared destination (e.g. an iCloud folder) can host backups from several federated machines without `snapshotId` collisions.
@@ -61,6 +62,8 @@ Key behaviors, accurate to the code:
 ## How restore works
 
 Restore is two independent operations — restoring files and restoring the DB are separate decisions. Both are **dry-run by default** and validate `snapshotId` against path traversal before touching anything.
+
+A backup run that fails after creating its snapshot directory records a durable `.failed` marker before releasing its `.in-progress` guards. Failed snapshots are never eligible for file or database restore (`SNAPSHOT_FAILED`); they remain downloadable so their partial files can be inspected or recovered manually. If PortOS cannot write the failed marker, it keeps the existing incomplete markers instead, which also block restore. Snapshots created by older PortOS versions without a manifest or failure marker retain their legacy behavior because an unmarked historical failure cannot be distinguished reliably from a genuine pre-manifest snapshot.
 
 ### Files — `restoreSnapshot()`
 

--- a/server/services/backup.js
+++ b/server/services/backup.js
@@ -42,33 +42,70 @@ const STATE_PATH = join(PATHS.data, 'backup', 'state.json');
 //   - `activeSnapshotId` catches the in-process case with no I/O.
 //   - the `.in-progress` marker survives a hard crash or PM2 restart, which
 //     resets module state while the partial directory stays on the drive.
-// The marker is removed on BOTH the success and failure paths — clearing it only
-// on success is what previously left a failed run's snapshot blocked forever.
+// A finished failure replaces these guards with `.failed`: downloads remain
+// available for manual salvage, while restore paths can distinguish the partial
+// tree from both completed and legacy snapshots after a restart.
 const SNAPSHOT_IN_PROGRESS_MARKER = '.in-progress';
+const SNAPSHOT_FAILED_MARKER = '.failed';
 let activeSnapshotId = null;
 
 const markerPath = (snapshotDir) => join(snapshotDir, SNAPSHOT_IN_PROGRESS_MARKER);
+const failedMarkerPath = (snapshotDir) => join(snapshotDir, SNAPSHOT_FAILED_MARKER);
 const parentMarkerPath = (snapshotDir, snapshotId) =>
   join(resolve(snapshotDir, '..'), `.${snapshotId}${SNAPSHOT_IN_PROGRESS_MARKER}`);
+const markerExistsAt = (path) =>
+  access(path).then(
+    () => true,
+    (err) => err?.code === 'ENOENT' || err?.code === 'ENOTDIR' ? false : true,
+  );
 const markerExists = (snapshotDir, snapshotId) =>
   Promise.all([
-    access(markerPath(snapshotDir)).then(() => true, () => false),
+    markerExistsAt(markerPath(snapshotDir)),
     snapshotId
-      ? access(parentMarkerPath(snapshotDir, snapshotId)).then(() => true, () => false)
+      ? markerExistsAt(parentMarkerPath(snapshotDir, snapshotId))
       : false,
   ]).then(([snapshotMarker, parentMarker]) => snapshotMarker || parentMarker);
 
-/**
- * Reject a snapshot that is still being written. Every consumer that reads a
- * snapshot as if it were finished — download, file restore, DB restore — must
- * call this; restoring half a backup over live data is the worst outcome here.
- */
+const failedMarkerExists = (snapshotDir) =>
+  markerExistsAt(failedMarkerPath(snapshotDir));
+
+async function snapshotState(snapshotDir, snapshotId) {
+  const [markedInProgress, failed] = await Promise.all([
+    markerExists(snapshotDir, snapshotId),
+    failedMarkerExists(snapshotDir),
+  ]);
+  return {
+    failed,
+    // Once `.failed` exists the run is finished even if marker cleanup was
+    // interrupted. The durable failed state still blocks every restore.
+    incomplete: snapshotId === activeSnapshotId || (markedInProgress && !failed),
+  };
+}
+
+/** Reject a snapshot that is still being written before any consumer reads it. */
 async function assertSnapshotComplete(snapshotDir, snapshotId) {
-  const incomplete = snapshotId === activeSnapshotId || await markerExists(snapshotDir, snapshotId);
+  const { incomplete } = await snapshotState(snapshotDir, snapshotId);
   if (incomplete) {
     throw new ServerError(`Snapshot is still being written: ${snapshotId}`, {
       status: 409,
       code: 'SNAPSHOT_INCOMPLETE',
+    });
+  }
+}
+
+/** Reject snapshots whose backup run finished unsuccessfully before restoring. */
+async function assertSnapshotRestorable(snapshotDir, snapshotId) {
+  const { incomplete, failed } = await snapshotState(snapshotDir, snapshotId);
+  if (incomplete) {
+    throw new ServerError(`Snapshot is still being written: ${snapshotId}`, {
+      status: 409,
+      code: 'SNAPSHOT_INCOMPLETE',
+    });
+  }
+  if (failed) {
+    throw new ServerError(`Snapshot backup failed: ${snapshotId}. Choose a completed backup to restore.`, {
+      status: 409,
+      code: 'SNAPSHOT_FAILED',
     });
   }
 }
@@ -408,20 +445,32 @@ export async function runBackup(destPath, io = null, { excludePaths = [], disabl
   let changedFiles = [];
   let manifest;
 
-  const clearInProgress = async () => {
+  const clearInProgressMarkers = async () => {
     if (snapshotDir) await unlink(markerPath(snapshotDir)).catch(() => {});
     if (parentMarker) await unlink(parentMarker).catch(() => {});
+  };
+
+  const releaseActiveSnapshot = () => {
     activeSnapshotId = null;
   };
 
   const complete = async (result) => {
-    await clearInProgress();
+    if (snapshotDir) await unlink(failedMarkerPath(snapshotDir)).catch(() => {});
+    await clearInProgressMarkers();
+    releaseActiveSnapshot();
     isRunning = false;
     return result;
   };
 
   const fail = async (err) => {
-    await clearInProgress();
+    // Persist failure BEFORE removing the incomplete guards. If the marker
+    // cannot be written, retain those guards so a partial tree never becomes a
+    // restore source. The process lock is independent and is always released.
+    const failureRecorded = snapshotDir
+      ? await writeFile(failedMarkerPath(snapshotDir), '').then(() => true, () => false)
+      : false;
+    if (failureRecorded) await clearInProgressMarkers();
+    releaseActiveSnapshot();
     isRunning = false;
     await saveState({ lastRun: new Date().toISOString(), status: 'error', error: err.message, pgBackup: null }).catch(() => {});
     if (io) io.emit('backup:failed', { snapshotId, error: err.message });
@@ -700,7 +749,7 @@ export async function generateManifest(snapshotDataDir, manifestPath, pgDumpPath
 /**
  * List all snapshots in the backup destination.
  * @param {string} destPath - Path to external drive backup root
- * @returns {Array<{ id, createdAt, fileCount }>} sorted newest-first
+ * @returns {Array<{ id, createdAt, fileCount, incomplete, failed }>} sorted newest-first
  */
 export async function listSnapshots(destPath) {
   if (!destPath) return [];
@@ -725,12 +774,13 @@ export async function listSnapshots(destPath) {
       // Report a still-being-written snapshot rather than hiding it: the row is
       // real and the user should see the run in flight, but download and restore
       // must not be offered for it. Mirrors assertSnapshotComplete's two signals.
-      const incomplete = id === activeSnapshotId || await markerExists(snapshotDir, id);
+      const { incomplete, failed } = await snapshotState(snapshotDir, id);
       return {
         id,
         createdAt: manifest?.generatedAt ?? null,
         fileCount: manifest?.fileCount ?? 0,
-        incomplete
+        incomplete,
+        failed,
       };
     })
   );
@@ -838,7 +888,7 @@ export async function openSnapshotStream(destPath, snapshotId) {
  */
 export async function restoreSnapshot(destPath, snapshotId, { dryRun = true, subdirFilter = null } = {}) {
   const { snapshotsRoot, snapshotDir } = resolveSnapshotPath(destPath, snapshotId);
-  await assertSnapshotComplete(snapshotDir, snapshotId);
+  await assertSnapshotRestorable(snapshotDir, snapshotId);
   const srcDir = join(snapshotDir, 'data');
 
   // Defense-in-depth for non-route callers (the route already validates via
@@ -901,7 +951,7 @@ export async function restoreSnapshot(destPath, snapshotId, { dryRun = true, sub
  */
 export async function restorePostgres(destPath, snapshotId, { dryRun = true } = {}) {
   const { snapshotDir } = resolveSnapshotPath(destPath, snapshotId);
-  await assertSnapshotComplete(snapshotDir, snapshotId);
+  await assertSnapshotRestorable(snapshotDir, snapshotId);
   const sqlPath = join(snapshotDir, 'portos-db.sql');
 
   const info = await stat(sqlPath).catch(() => null);

--- a/server/services/backup.test.js
+++ b/server/services/backup.test.js
@@ -76,7 +76,13 @@ vi.mock('../lib/childProcess.js', async (importOriginal) => ({
 // used by backup.js + fileUtils.js keeps its real implementation.
 vi.mock('fs/promises', async (importOriginal) => {
   const actual = await importOriginal();
-  return { ...actual, stat: vi.fn(actual.stat), readFile: vi.fn(actual.readFile), access: vi.fn(actual.access) };
+  return {
+    ...actual,
+    stat: vi.fn(actual.stat),
+    readFile: vi.fn(actual.readFile),
+    access: vi.fn(actual.access),
+    writeFile: vi.fn(actual.writeFile),
+  };
 });
 
 import { checkHealth, getServerMajorVersion } from '../lib/db.js';
@@ -106,6 +112,7 @@ import { DEFAULT_EXCLUDES, computeEffectiveExcludes, listSnapshots, openSnapshot
 beforeEach(async () => {
   const actual = await vi.importActual('fs/promises');
   fs.access.mockImplementation(actual.access);
+  fs.writeFile.mockImplementation(actual.writeFile);
 });
 
 // Mirrors backup.js's MACHINE_HOST derivation so expected paths can be built
@@ -308,14 +315,14 @@ describe('openSnapshotStream', () => {
   });
 
   beforeEach(() => {
-    fs.access.mockRejectedValue(new Error('ENOENT'));
+    fs.access.mockRejectedValue(Object.assign(new Error('missing'), { code: 'ENOENT' }));
   });
 
   // An existing, COMPLETE snapshot directory, ready for tar: the directory stats
   // fine while the .in-progress marker is absent.
   function readySnapshot() {
     fs.stat.mockResolvedValue({ isDirectory: () => true });
-    fs.access.mockRejectedValue(new Error('ENOENT'));   // no .in-progress marker
+    fs.access.mockRejectedValue(Object.assign(new Error('missing'), { code: 'ENOENT' }));
     const proc = fakeProc();
     spawn.mockReturnValue(proc);
     return proc;
@@ -324,7 +331,9 @@ describe('openSnapshotStream', () => {
   // Same directory, but a marker left behind by a crashed run.
   function crashedSnapshot() {
     fs.stat.mockResolvedValue({ isDirectory: () => true });
-    fs.access.mockResolvedValue(undefined);             // .in-progress present
+    fs.access.mockImplementation((path) => String(path).endsWith('.failed')
+      ? Promise.reject(Object.assign(new Error('missing'), { code: 'ENOENT' }))
+      : Promise.resolve());                             // .in-progress present
   }
 
   const ended = (stream) => new Promise((resolveEnd) => stream.once('end', resolveEnd));
@@ -749,7 +758,9 @@ describe('restorePostgres', () => {
   // dump into the live database is the most destructive thing this module can
   // do, so the guard has to cover it — not just download and file restore.
   it('refuses an incomplete snapshot before reading the dump', async () => {
-    fs.access.mockResolvedValue(undefined);            // .in-progress present
+    fs.access.mockImplementation((path) => String(path).endsWith('.failed')
+      ? Promise.reject(Object.assign(new Error('missing'), { code: 'ENOENT' }))
+      : Promise.resolve());                            // .in-progress present
     const statSpy = vi.spyOn(fs, 'stat');
 
     await expect(restorePostgres('/dest', '2026-06-05T00-00-00', { dryRun: false }))
@@ -1864,13 +1875,10 @@ describe('runBackup lifecycle', () => {
     await pending;
   });
 
-  // The old on-disk '.in-progress' marker was never removed on failure, which
-  // left a failed snapshot permanently un-downloadable with no recovery path.
-  it('clears the in-progress guard when a run fails, leaving the snapshot downloadable', async () => {
+  it('persists a failed snapshot across restart, blocks both restores, and keeps salvage download available', async () => {
     const io = { emit: vi.fn() };
     const proc = fakeProc();
     spawn.mockReturnValue(proc);
-    const { openSnapshotStream: open } = await import('./backup.js');
 
     const pending = runBackup(destRoot, io);
     await waitFor(() => spawn.mock.calls.length === 1, 'rsync spawn');
@@ -1878,11 +1886,89 @@ describe('runBackup lifecycle', () => {
     proc.emit('close', 23);
     await expect(pending).rejects.toThrow(/rsync exited with code 23/);
 
+    const snapshotDir = await findSnapshotDir();
+    const fsp = await actualFs();
+    await expect(fsp.access(joinPath(snapshotDir, '.failed'))).resolves.toBeUndefined();
+    await expect(fsp.access(joinPath(snapshotDir, '.in-progress'))).rejects.toMatchObject({ code: 'ENOENT' });
+    await expect(fsp.access(joinPath(destRoot, 'snapshots', machineHost, `.${snapshotId}.in-progress`)))
+      .rejects.toMatchObject({ code: 'ENOENT' });
+
+    // Module restart clears activeSnapshotId; the on-disk marker remains the
+    // sole source of failure classification and restore refusal.
+    vi.resetModules();
+    const {
+      listSnapshots: listAfterRestart,
+      openSnapshotStream: openAfterRestart,
+      restoreSnapshot: restoreFilesAfterRestart,
+      restorePostgres: restoreDbAfterRestart,
+    } = await import('./backup.js');
+
+    await expect(listAfterRestart(destRoot)).resolves.toContainEqual(expect.objectContaining({
+      id: snapshotId,
+      failed: true,
+      incomplete: false,
+    }));
+    spawn.mockClear();
+    await expect(restoreFilesAfterRestart(destRoot, snapshotId, { dryRun: true }))
+      .rejects.toMatchObject({
+        status: 409,
+        code: 'SNAPSHOT_FAILED',
+        message: expect.stringContaining('Choose a completed backup'),
+      });
+    await expect(restoreDbAfterRestart(destRoot, snapshotId, { dryRun: true }))
+      .rejects.toMatchObject({
+        status: 409,
+        code: 'SNAPSHOT_FAILED',
+        message: expect.stringContaining('Choose a completed backup'),
+      });
+    expect(spawn).not.toHaveBeenCalled();
+
     const tar = fakeProc();
     spawn.mockReturnValue(tar);
-    const stream = await open(destRoot, snapshotId);
+    const stream = await openAfterRestart(destRoot, snapshotId);
     expect(stream).toBeDefined();
     stream.destroy();
+  });
+
+  it('retains incomplete guards when the failed marker cannot be written while releasing the process lock', async () => {
+    const io = { emit: vi.fn() };
+    const proc = fakeProc();
+    spawn.mockReturnValue(proc);
+
+    const pending = runBackup(destRoot, io);
+    await waitFor(() => spawn.mock.calls.length === 1, 'rsync spawn');
+    const snapshotDir = await findSnapshotDir();
+    const snapshotId = basename(snapshotDir);
+    const fsp = await actualFs();
+    fs.writeFile.mockImplementation((path, ...args) => String(path).endsWith('.failed')
+      ? Promise.reject(Object.assign(new Error('read-only destination'), { code: 'EACCES' }))
+      : fsp.writeFile(path, ...args));
+
+    proc.emit('close', 23);
+    await expect(pending).rejects.toThrow(/rsync exited with code 23/);
+
+    await expect(fsp.access(joinPath(snapshotDir, '.failed'))).rejects.toMatchObject({ code: 'ENOENT' });
+    await expect(fsp.access(joinPath(snapshotDir, '.in-progress'))).resolves.toBeUndefined();
+    await expect(fsp.access(joinPath(destRoot, 'snapshots', machineHost, `.${snapshotId}.in-progress`)))
+      .resolves.toBeUndefined();
+
+    const { openSnapshotStream: open, restoreSnapshot: restore } = await import('./backup.js');
+    spawn.mockClear();
+    await expect(open(destRoot, snapshotId))
+      .rejects.toMatchObject({ status: 409, code: 'SNAPSHOT_INCOMPLETE' });
+    await expect(restore(destRoot, snapshotId, { dryRun: true }))
+      .rejects.toMatchObject({ status: 409, code: 'SNAPSHOT_INCOMPLETE' });
+    expect(spawn).not.toHaveBeenCalled();
+
+    // Failure-state persistence cannot strand the process-level running lock.
+    const retryRoot = await fsp.mkdtemp(joinPath(tmpdir(), 'portos-backup-retry-'));
+    const retryProc = fakeProc();
+    spawn.mockReturnValue(retryProc);
+    const retry = runBackup(retryRoot, io);
+    await waitFor(() => spawn.mock.calls.length === 1, 'retry rsync spawn');
+    retryProc.emit('close', 0);
+    await expect(retry).resolves.toMatchObject({ status: 'ok' });
+    await fsp.rm(retryRoot, { recursive: true, force: true });
   });
 
   it('on rsync failure: releases the lock, records status error, emits backup:failed, and rethrows', async () => {


### PR DESCRIPTION
## Summary

- persist a per-snapshot `.failed` marker before releasing incomplete guards when backup creation fails
- keep failed snapshots downloadable for manual salvage while refusing file and database restore with `SNAPSHOT_FAILED`
- expose failed state in both backup UIs, disable restore actions, and document legacy snapshot compatibility

Related overlap: #7168 describes the same failed-snapshot lifecycle and is covered by this change without closing it.

## Validation

- `cd server && node_modules/.bin/vitest run services/backup.test.js` (117 passed)
- `cd client && node_modules/.bin/vitest run src/components/BackupWidget.test.jsx src/components/settings/BackupTab.test.jsx` (45 passed)
- `cd client && npm run lint`
- `cd client && npm run build`
- optional Codex review at low effort: no actionable findings

Closes #7163
