### PR TITLE
feat: reuse schedule cards for app automation overrides

### DIFF
--- a/client/src/components/apps/tabs/AutomationTab.jsx
+++ b/client/src/components/apps/tabs/AutomationTab.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useNavigate } from 'react-router';
-import { RefreshCw, Play, PauseCircle, Settings, ChevronDown, ChevronRight, Sparkles, AlertTriangle } from 'lucide-react';
+import { RefreshCw, Play, PauseCircle, Sparkles, AlertTriangle } from 'lucide-react';
 import toast from '../../ui/Toast';
 import BrailleSpinner from '../../BrailleSpinner';
 import CronInput from '../../CronInput';
@@ -10,6 +10,7 @@ import * as api from '../../../services/api';
 import { AGENT_OPTIONS, hasProviderPin, providerPinDivergesFromSchedule, toggleAppMetadataOverride, agentOptionButtonClass } from '../../cos/constants';
 import { isCronExpression, describeCron } from '../../../utils/cronHelpers';
 import { PROVIDER_TYPES, providerDisplayName } from '../../../utils/providers';
+import AppTaskCard from '../../cos/tabs/schedule/AppTaskCard';
 import CustomTasksSection from './CustomTasksSection';
 
 const RUNNABLE_PROVIDER_TYPES = Object.values(PROVIDER_TYPES);
@@ -30,7 +31,7 @@ export default function AutomationTab({ appId, appName }) {
   const [paused, setPaused] = useState(false);
   const [resuming, setResuming] = useState(false);
   const [loading, setLoading] = useState(true);
-  const [triggering, setTriggering] = useState(null);
+  const [saving, setSaving] = useState(false);
   const [cronEditing, setCronEditing] = useState({});
   // Only one Configure panel open at a time — a per-task disclosure holding the
   // per-app provider/model override (and, for layered-intelligence, a link to
@@ -74,16 +75,21 @@ export default function AutomationTab({ appId, appName }) {
     }
   };
 
-  const handleToggle = async (taskType, isEnabled) => {
-    const newEnabled = !isEnabled;
-    await api.updateAppTaskTypeOverride(appId, taskType, { enabled: newEnabled }, { silent: true }).catch(err => {
+  const saveOverride = async (taskType, patch) => {
+    setSaving(true);
+    const result = await api.updateAppTaskTypeOverride(appId, taskType, patch, { silent: true }).catch(err => {
       toast.error(err.message);
       return null;
     });
-    setOverrides(prev => ({
-      ...prev,
-      [taskType]: { ...prev[taskType], enabled: newEnabled }
-    }));
+    setSaving(false);
+    if (!result) return false;
+    setOverrides(prev => ({ ...prev, [taskType]: { ...prev[taskType], ...patch } }));
+    return true;
+  };
+
+  const handleToggle = async (taskType, isEnabled) => {
+    const newEnabled = !isEnabled;
+    await saveOverride(taskType, { enabled: newEnabled });
   };
 
   const handleIntervalChange = async (taskType, interval) => {
@@ -95,26 +101,12 @@ export default function AutomationTab({ appId, appName }) {
     }
     setCronEditing(prev => { const n = { ...prev }; delete n[taskType]; return n; });
     const value = interval === 'null' ? null : interval;
-    await api.updateAppTaskTypeOverride(appId, taskType, { interval: value }, { silent: true }).catch(err => {
-      toast.error(err.message);
-      return null;
-    });
-    setOverrides(prev => ({
-      ...prev,
-      [taskType]: { ...prev[taskType], interval: value }
-    }));
+    await saveOverride(taskType, { interval: value });
   };
 
   const handleCronSave = async (taskType, expr) => {
-    await api.updateAppTaskTypeOverride(appId, taskType, { interval: expr }, { silent: true }).catch(err => {
-      toast.error(err.message);
-      return null;
-    });
-    setOverrides(prev => ({
-      ...prev,
-      [taskType]: { ...prev[taskType], interval: expr }
-    }));
-    setCronEditing(prev => { const n = { ...prev }; delete n[taskType]; return n; });
+    const saved = await saveOverride(taskType, { interval: expr });
+    if (saved) setCronEditing(prev => { const n = { ...prev }; delete n[taskType]; return n; });
   };
 
   const handleMetaToggle = async (taskType, field, globalTaskMetadata) => {
@@ -126,40 +118,25 @@ export default function AutomationTab({ appId, appName }) {
     if (field === 'fileIssues' && nextFileIssues === true && taskMetadata) {
       taskMetadata = { ...taskMetadata, useWorktree: false, openPR: false, simplify: false };
     }
-    await api.updateAppTaskTypeOverride(appId, taskType, { taskMetadata }, { silent: true }).catch(err => {
-      toast.error(err.message);
-      return null;
-    });
-    setOverrides(prev => ({
-      ...prev,
-      [taskType]: { ...prev[taskType], taskMetadata }
-    }));
+    await saveOverride(taskType, { taskMetadata });
   };
 
   // One mutation for the whole pin — AppProviderPin hands back an already
   // normalized { providerId, model }, so the clear rule lives in the control
   // rather than being re-derived here (#4783).
   const handlePinChange = async (taskType, patch) => {
-    await api.updateAppTaskTypeOverride(appId, taskType, patch, { silent: true }).catch(err => {
-      toast.error(err.message);
-      return null;
-    });
-    setOverrides(prev => ({
-      ...prev,
-      [taskType]: { ...prev[taskType], ...patch }
-    }));
+    await saveOverride(taskType, patch);
   };
 
   const handleTrigger = async (taskType) => {
-    setTriggering(taskType);
     const result = await api.triggerCosOnDemandTask(taskType, appId, { silent: true }).catch(err => {
       toast.error(err.message);
       return null;
     });
-    setTriggering(null);
     if (result?.success) {
       toast.success(`Triggered ${taskType} for ${appName}`);
     }
+    return result?.success ? result : null;
   };
 
   if (loading) {
@@ -170,11 +147,13 @@ export default function AutomationTab({ appId, appName }) {
   const allEnabled = taskTypes.length > 0 && taskTypes.every(t => (overrides[t] || {}).enabled === true);
 
   const handleToggleAll = async () => {
+    setSaving(true);
     const newEnabled = !allEnabled;
     const result = await api.toggleAllAppTaskTypes(appId, newEnabled, { silent: true }).catch(err => {
       toast.error(err.message);
       return null;
     });
+    setSaving(false);
     if (!result) return;
     setOverrides(prev => {
       const updated = { ...prev };
@@ -187,6 +166,14 @@ export default function AutomationTab({ appId, appName }) {
 
   return (
     <div className="max-w-5xl space-y-4">
+      <div className="border-b border-port-border pb-4">
+        <CustomTasksSection
+          appId={appId}
+          appName={appName}
+          providerCatalog={providerCatalog}
+          activeProviderId={activeProviderId}
+        />
+      </div>
       {paused && (
         <div className="bg-port-warning/10 border border-port-warning/40 rounded-lg p-3 flex items-start gap-3">
           <PauseCircle size={18} className="text-port-warning shrink-0 mt-0.5" />
@@ -215,10 +202,11 @@ export default function AutomationTab({ appId, appName }) {
               leave one on <em>Inherit</em> and it follows the global schedule defaults.
             </p>
           </div>
-          <ToggleSwitch enabled={allEnabled} onChange={handleToggleAll} size="sm" activeColor="bg-port-success" ariaLabel={allEnabled ? 'Disable every scheduled task for this app' : 'Enable every scheduled task for this app'} />
+          <ToggleSwitch enabled={allEnabled} onChange={handleToggleAll} size="sm" activeColor="bg-port-success" disabled={saving} ariaLabel={allEnabled ? 'Disable every scheduled task for this app' : 'Enable every scheduled task for this app'} />
         </div>
         <button
           onClick={fetchData}
+          disabled={saving}
           className="px-3 py-1.5 bg-port-border hover:bg-port-border/80 text-white rounded-lg text-xs flex items-center gap-1"
         >
           <RefreshCw size={14} /> Refresh
@@ -230,7 +218,7 @@ export default function AutomationTab({ appId, appName }) {
           No task types configured in the schedule
         </div>
       ) : (
-        <div className="space-y-2">
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
           {taskTypes.map(taskType => {
             const override = overrides[taskType] || {};
             const globalConfig = schedule.tasks[taskType] || {};
@@ -259,59 +247,30 @@ export default function AutomationTab({ appId, appName }) {
             const providerDivergesFromSchedule = providerPinDivergesFromSchedule(override, globalConfig);
 
             return (
-              <div key={taskType} className="bg-port-card border border-port-border rounded-lg p-3 space-y-2">
-                {/* Row 1: name + toggle + configure + run now */}
-                <div className="flex items-center gap-3">
-                  {/* Labelled "Enabled", not "Run" — the row already has a Run
-                      (trigger now) button, and this switch is the on/off state
-                      that gates both the schedule and that button. */}
-                  <span
-                    className="flex items-center gap-1.5 shrink-0"
-                    title={isEnabled
-                      ? `${taskType} runs for this app on the schedule below. Turn off to stop scheduling it.`
-                      : `${taskType} does not run for this app. Turn on to schedule it.`}
-                  >
-                    <span className="text-[10px] uppercase tracking-wide text-gray-500">Enabled</span>
-                    <ToggleSwitch
-                      enabled={isEnabled}
-                      onChange={() => handleToggle(taskType, isEnabled)}
-                      size="sm"
-                      activeColor="bg-port-success"
-                      ariaLabel={`${taskType} enabled for this app: ${isEnabled ? 'on' : 'off'}`}
-                    />
+              <AppTaskCard
+                key={`${appId}:${taskType}`}
+                taskType={taskType}
+                config={globalConfig}
+                providers={providers}
+                activeProviderId={activeProviderId}
+                onConfigure={() => setExpandedTaskType(prev => prev === taskType ? null : taskType)}
+                onTrigger={handleTrigger}
+                appContext={{
+                  enabled: isEnabled,
+                  onToggle: () => handleToggle(taskType, isEnabled),
+                  saving,
+                  expanded: isExpanded,
+                  interval: overrideInterval,
+                  cadence: `${effectiveLabel}${intervalSuffix}`,
+                  taskMetadata: override.taskMetadata,
+                }}
+              >
+                {providerDivergesFromSchedule && (
+                  <span className="inline-flex items-center gap-1 text-port-warning" title={`Runs on ${effectiveProviderName} — the schedule default is ${taskProviderName}`}>
+                    <AlertTriangle size={11} />
+                    <span className="text-[10px] uppercase tracking-wide">Provider override</span>
                   </span>
-                  <div className="flex-1 min-w-0">
-                    <span className="text-white font-mono text-xs">{taskType}</span>
-                    {providerDivergesFromSchedule && (
-                      <span
-                        className="inline-flex items-center gap-1 ml-2 text-port-warning"
-                        title={`Runs on ${effectiveProviderName} — the schedule's default is ${taskProviderName}, but this app's provider override wins`}
-                      >
-                        <AlertTriangle size={11} />
-                        <span className="text-[10px] uppercase tracking-wide">Provider override</span>
-                      </span>
-                    )}
-                    <div className="text-xs text-gray-500">{effectiveLabel}{intervalSuffix}</div>
-                  </div>
-                  <button
-                    onClick={() => setExpandedTaskType(prev => prev === taskType ? null : taskType)}
-                    aria-expanded={isExpanded}
-                    aria-label={`${isExpanded ? 'Hide' : 'Show'} provider and model options for ${taskType}`}
-                    className="px-2 py-1 bg-port-border/60 text-gray-300 hover:bg-port-border rounded text-xs inline-flex items-center gap-1 shrink-0"
-                  >
-                    {isExpanded ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
-                    <Settings size={12} />
-                    Configure
-                  </button>
-                  <button
-                    onClick={() => handleTrigger(taskType)}
-                    disabled={triggering === taskType || !isEnabled}
-                    className="px-2 py-1 bg-port-accent/20 text-port-accent hover:bg-port-accent/30 rounded text-xs disabled:opacity-50 inline-flex items-center gap-1 shrink-0"
-                  >
-                    <Play size={12} />
-                    {triggering === taskType ? '...' : 'Run'}
-                  </button>
-                </div>
+                )}
                 {/* Row 2: interval + cron + agent options */}
                 <div className="flex flex-wrap items-center gap-2">
                   <select
@@ -339,7 +298,7 @@ export default function AutomationTab({ appId, appName }) {
                       {overrideInterval}
                     </button>
                   ) : null}
-                  <div className="flex items-center gap-1 ml-auto">
+                  <div className="flex flex-wrap items-center gap-1">
                     {globalConfig.fileIssuesCapable && (() => {
                       const effective = override.taskMetadata?.fileIssues ?? globalConfig.taskMetadata?.fileIssues ?? globalConfig.defaultFileIssues === true;
                       const hasOverride = override.taskMetadata?.fileIssues !== undefined;
@@ -415,20 +374,13 @@ export default function AutomationTab({ appId, appName }) {
                     )}
                   </div>
                 )}
-              </div>
+              </AppTaskCard>
             );
           })}
         </div>
       )}
 
-      <div className="border-t border-port-border pt-4">
-        <CustomTasksSection
-          appId={appId}
-          appName={appName}
-          providerCatalog={providerCatalog}
-          activeProviderId={activeProviderId}
-        />
-      </div>
+
     </div>
   );
 }

--- a/client/src/components/apps/tabs/AutomationTab.test.jsx
+++ b/client/src/components/apps/tabs/AutomationTab.test.jsx
@@ -75,6 +75,36 @@ beforeEach(() => {
 });
 
 describe('AutomationTab per-app options', () => {
+  it('puts custom automations before the shared schedule cards and shows app cadence', async () => {
+    await renderTab({ security: { enabled: true, interval: 'on-demand' } });
+    const custom = screen.getByText('Custom Tasks');
+    const scheduled = screen.getByText('Scheduled Task Options');
+    expect(custom.compareDocumentPosition(scheduled) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    const row = rowFor('security');
+    expect(within(row).getByRole('button', { name: 'Run Now' })).toBeEnabled();
+    expect(within(row).queryByText('Never run')).toBeNull();
+    expect(within(row).queryByText('App coverage')).toBeNull();
+    expect(within(row).getByText('on-demand')).toBeInTheDocument();
+  });
+
+  it('saves the selected app toggle before permitting a run and preserves state on failure', async () => {
+    await renderTab();
+    const row = rowFor('security');
+    let rejectSave;
+    api.updateAppTaskTypeOverride.mockReturnValueOnce(new Promise((_resolve, reject) => { rejectSave = reject; }));
+    fireEvent.click(within(row).getByRole('switch', { name: 'security enabled for this app: off' }));
+    expect(api.updateAppTaskTypeOverride).toHaveBeenCalledWith('app-1', 'security', { enabled: true }, { silent: true });
+    expect(within(row).getByRole('button', { name: 'Run Now' })).toBeDisabled();
+    await act(async () => rejectSave(new Error('Save failed')));
+    expect(within(row).getByRole('switch', { name: 'security enabled for this app: off' })).toHaveAttribute('aria-checked', 'false');
+    fireEvent.click(within(row).getByRole('switch', { name: 'security enabled for this app: off' }));
+    api.updateAppTaskTypeOverride.mockResolvedValue({ success: true });
+    await waitFor(() => expect(within(row).getByRole('button', { name: 'Run Now' })).toBeEnabled());
+    api.triggerCosOnDemandTask.mockResolvedValue({ success: true });
+    fireEvent.click(within(row).getByRole('button', { name: 'Run Now' }));
+    await waitFor(() => expect(api.triggerCosOnDemandTask).toHaveBeenCalledWith('security', 'app-1', { silent: true }));
+  });
+
   it('Configure toggle expands the provider override panel', async () => {
     await renderTab();
     const row = rowFor('layered-intelligence');

--- a/client/src/components/cos/tabs/schedule/AppTaskCard.jsx
+++ b/client/src/components/cos/tabs/schedule/AppTaskCard.jsx
@@ -5,12 +5,17 @@ import { describeNextRun, coverageTone, pipelineStages, IMPROVEMENT_DISABLED_TIT
 import TaskHeader from './TaskHeader';
 import RunTaskButton from './RunTaskButton';
 import TaskModelQuickControls from './TaskModelQuickControls';
+import ToggleSwitch from '../../../ToggleSwitch';
+import { isCronExpression } from '../../../../utils/cronHelpers';
 import Banner from '../../../ui/Banner';
 
 // One scheduled task rendered as a status-rich card. Browsing plus the common
 // "retarget the model and run it" loop happen here; the rest of the
 // configuration lives in the slide-over drawer (opened via Configure).
-export default function AppTaskCard({ taskType, config, apps, onTrigger, onConfigure, onUpdate, providers, providersLoaded = true, activeProviderId, improvementDisabled, orderStep }) {
+// appContext embeds the same card on a selected app's Automation tab: the
+// caller owns app-scoped saves/runs and supplies override controls as children.
+// Keep global coverage/history and global pin writes out of that context.
+export default function AppTaskCard({ taskType, config, apps, onTrigger, onConfigure, onUpdate, providers, providersLoaded = true, activeProviderId, improvementDisabled, orderStep, appContext, children }) {
   // Owned here, not in the controls, so Run can gate on the same `saving` flag —
   // it reads the server-side config, so a run fired mid-write uses the old pins.
   const pins = useTaskModelPins({ taskType, config, providers, activeProviderId, onUpdate });
@@ -19,7 +24,19 @@ export default function AppTaskCard({ taskType, config, apps, onTrigger, onConfi
   const hasApps = totalCount > 0;
   const coverage = coverageTone(enabledCount, totalCount);
   const coveragePct = hasApps ? Math.round((enabledCount / totalCount) * 100) : 0;
-  const nextRun = describeNextRun(config);
+  const displayConfig = appContext ? {
+    ...config,
+    enabled: appContext.enabled,
+    taskMetadata: { ...config.taskMetadata, ...appContext.taskMetadata },
+    ...(appContext.interval ? {
+      type: isCronExpression(appContext.interval) ? 'cron' : appContext.interval,
+      cronExpression: isCronExpression(appContext.interval) ? appContext.interval : undefined,
+      perpetual: false,
+    } : {}),
+  } : config;
+  const nextRun = appContext
+    ? { text: appContext.cadence, tone: 'text-gray-400' }
+    : describeNextRun(config);
   const userInvokable = config.invocation?.userInvokable !== false;
   const invocationDescription = config.invocation?.description || 'Runs as part of another automation and is not directly invokable.';
   // A pipeline task resolves provider/model per stage — a single card-level pin
@@ -36,7 +53,7 @@ export default function AppTaskCard({ taskType, config, apps, onTrigger, onConfi
         onClick={() => onConfigure(taskType)}
         className="flex-1 flex flex-col items-stretch gap-3 text-left p-4 rounded-t-lg hover:bg-port-card/60 transition-colors"
       >
-        <TaskHeader taskType={taskType} config={config} orderStep={orderStep} />
+        <TaskHeader taskType={taskType} config={displayConfig} orderStep={orderStep} />
 
         {/* Next run */}
         <div className="flex items-center gap-1.5 text-xs min-w-0">
@@ -48,7 +65,7 @@ export default function AppTaskCard({ taskType, config, apps, onTrigger, onConfi
         </div>
 
         {/* App coverage — kept prominent with a mini bar */}
-        {hasApps && (
+        {!appContext && hasApps && (
           <div className="space-y-1">
             <div className="flex items-center justify-between text-xs">
               <span className="text-gray-400">App coverage</span>
@@ -61,7 +78,7 @@ export default function AppTaskCard({ taskType, config, apps, onTrigger, onConfi
         )}
 
         {/* Last run + dependencies */}
-        <div className="text-xs text-gray-500 space-y-0.5">
+        {!appContext && <div className="text-xs text-gray-500 space-y-0.5">
           <div>
             {config.globalLastRun
               ? `Last run ${timeAgo(config.globalLastRun)} · ${config.globalRunCount || 0}×`
@@ -73,7 +90,7 @@ export default function AppTaskCard({ taskType, config, apps, onTrigger, onConfi
           {config.runAfter?.length > 0 && (
             <div className="truncate" title={`Blocked until these run: ${config.runAfter.join(', ')}`}>waits for: {config.runAfter.join(', ')}</div>
           )}
-        </div>
+        </div>}
       </button>
 
       {config.enabled === false && (
@@ -88,8 +105,22 @@ export default function AppTaskCard({ taskType, config, apps, onTrigger, onConfi
         </Banner>
       )}
 
+      {appContext && (
+        <div className="flex items-center gap-2 px-4 pb-3">
+          <span className="text-xs text-gray-400">Enabled</span>
+          <ToggleSwitch
+            enabled={appContext.enabled}
+            onChange={appContext.onToggle}
+            disabled={appContext.saving}
+            size="sm"
+            ariaLabel={`${taskType} enabled for this app: ${appContext.enabled ? 'on' : 'off'}`}
+          />
+        </div>
+      )}
+      {children && <fieldset disabled={appContext?.saving} className="min-w-0 px-4 pb-3 space-y-3">{children}</fieldset>}
+
       {/* Quick model pins — the drawer's Global defaults, inline */}
-      {userInvokable && onUpdate && (stageCount > 0 ? (
+      {!appContext && userInvokable && onUpdate && (stageCount > 0 ? (
         <button
           type="button"
           onClick={() => onConfigure(taskType)}
@@ -108,15 +139,17 @@ export default function AppTaskCard({ taskType, config, apps, onTrigger, onConfi
           <>
             <RunTaskButton
               taskType={taskType}
-              apps={apps}
+              apps={appContext ? undefined : apps}
               onTrigger={onTrigger}
-              installWide={config.installWide}
+              installWide={!appContext && config.installWide}
               programmatic={config.programmatic}
-              disabledReason={improvementDisabled ? IMPROVEMENT_DISABLED_TITLE : (pins.saving ? SAVING_TITLE : '')}
+              disabledReason={appContext?.saving ? SAVING_TITLE : appContext && !appContext.enabled ? 'Enable this task for this app first' : improvementDisabled ? IMPROVEMENT_DISABLED_TITLE : (pins.saving ? SAVING_TITLE : '')}
             />
             <button
               type="button"
               onClick={() => onConfigure(taskType)}
+              aria-expanded={appContext?.expanded}
+              aria-label={appContext ? `${appContext.expanded ? 'Hide' : 'Show'} provider and model options for ${taskType}` : undefined}
               className="ml-auto flex items-center gap-1.5 px-3 py-1.5 text-sm rounded text-gray-300 hover:text-white hover:bg-port-border/50 transition-colors"
             >
               <SlidersHorizontal size={13} />


### PR DESCRIPTION
## Summary
Custom app tasks now appear first on the Automation tab. Scheduled automations reuse the CoS schedule cards with an app override context that shows the enabled toggle and effective cadence, retains provider and agent options, and runs against the selected app.

Override saves update the UI only after success and disable dependent controls while pending. Global coverage and history stay confined to the global schedule view.

## Test plan
- 47 focused AutomationTab and AppTaskCard tests passed, including ordering, failed toggle persistence, selected-app dispatch, and existing global card behavior.
- Changed-file Biome lint and client production build passed.
- Optional Codex review attempted in read-only mode; unavailable due to local MCP configuration error (`invalid transport`).
