### PR TITLE
fix: bound Beeper JSON response reads (#7176)

### DIFF
--- a/server/lib/fetchWithTimeout.js
+++ b/server/lib/fetchWithTimeout.js
@@ -35,8 +35,30 @@ export function fetchWithTimeout(url, options = {}, timeoutMs = 15000, retry = {
   // exhausted one.
   return fetchOnce(url, options, timeoutMs).catch((err) => {
     if (retries < 1 || typeof shouldRetry !== 'function' || !shouldRetry(err)) throw err;
-    return new Promise((resolve) => setTimeout(resolve, retryDelayMs))
+    return waitForRetry(retryDelayMs, options.signal)
       .then(() => fetchWithTimeout(url, options, timeoutMs, { ...retry, retries: retries - 1 }));
+  });
+}
+
+/**
+ * Pause before a retry while honoring the same caller cancellation signal as
+ * the fetch attempts. This keeps a caller-owned total deadline authoritative
+ * even when it expires between attempts.
+ */
+function waitForRetry(delayMs, signal) {
+  if (!signal) return new Promise((resolve) => setTimeout(resolve, delayMs));
+  if (signal.aborted) return Promise.reject(signal.reason || new DOMException('aborted', 'AbortError'));
+
+  return new Promise((resolve, reject) => {
+    const onAbort = () => {
+      clearTimeout(timeoutId);
+      reject(signal.reason || new DOMException('aborted', 'AbortError'));
+    };
+    const timeoutId = setTimeout(() => {
+      signal.removeEventListener('abort', onAbort);
+      resolve();
+    }, delayMs);
+    signal.addEventListener('abort', onAbort, { once: true });
   });
 }
 

--- a/server/services/beeperClient.js
+++ b/server/services/beeperClient.js
@@ -282,37 +282,49 @@ async function beeperRequest(path, {
   const reqHeaders = { 'Content-Type': 'application/json', ...headers };
   if (resolved.token) reqHeaders.Authorization = `Bearer ${resolved.token}`;
 
-  let response;
-  try {
-    response = await fetchWithTimeout(`${resolved.baseUrl}${path}`, {
-      method,
-      headers: reqHeaders,
-      redirect: 'error',
-      body: body === undefined ? undefined : JSON.stringify(body),
-    }, timeoutMs, allowRetry ? READ_RETRY : {});
-  } catch (err) {
-    const description = describeFetchError(err);
-    // AbortController firing (the timeout above, or a caller-supplied
-    // `signal`) is the one network failure that means "no answer arrived in
-    // time" rather than "nothing is listening" — the distinction
-    // `probeBeeperInfo` needs to tell `slow` from `unreachable` (fork issue
-    // #61, decision 7). Node/undici's own AbortError always carries "abort" in
-    // its name or message; `describeFetchError` folds both into this string.
-    const timedOut = /\babort/i.test(description);
-    throw new BeeperApiError(`Beeper request failed: ${description}`, {
-      status: 0, code: 'NETWORK_ERROR', retryable: allowRetry && isReplayableConnectionError(err),
-      details: timedOut ? { timedOut: true } : undefined,
-    });
-  }
+  // fetchWithTimeout owns the deadline only until response headers arrive. Keep
+  // a caller-owned signal alive through body consumption as well, so a local
+  // bridge cannot hold a request open indefinitely after answering headers.
+  const requestController = new AbortController();
+  const hasDeadline = Number.isFinite(timeoutMs) && timeoutMs > 0;
+  const deadlineId = hasDeadline ? setTimeout(() => requestController.abort(), timeoutMs) : null;
 
-  if (response.status === 204) {
+  let response;
+  let data;
+  try {
+    try {
+      response = await fetchWithTimeout(`${resolved.baseUrl}${path}`, {
+        method,
+        headers: reqHeaders,
+        redirect: 'error',
+        body: body === undefined ? undefined : JSON.stringify(body),
+        signal: requestController.signal,
+      }, timeoutMs, allowRetry ? READ_RETRY : {});
+
+      if (response.status === 204) {
+        noteSuccess();
+        return null;
+      }
+      data = await readResponseJson(response, { fallback: (text) => ({ message: text }) });
+    } catch (err) {
+      const description = describeFetchError(err);
+      // AbortController firing (during headers OR body consumption) is the one
+      // network failure that means "no answer arrived in time" rather than
+      // "nothing is listening" — the distinction `probeBeeperInfo` needs to
+      // tell `slow` from `unreachable` (fork issue #61, decision 7).
+      const timedOut = /\babort/i.test(description);
+      throw new BeeperApiError(`Beeper request failed: ${description}`, {
+        status: 0, code: 'NETWORK_ERROR', retryable: allowRetry && isReplayableConnectionError(err),
+        details: timedOut ? { timedOut: true } : undefined,
+      });
+    }
+
+    if (!response.ok) throw mapBeeperResponseError(response.status, data, { isAssetEndpoint, retryEligible: allowRetry });
     noteSuccess();
-    return null;
+    return data;
+  } finally {
+    if (deadlineId !== null) clearTimeout(deadlineId);
   }
-  const data = await readResponseJson(response, { fallback: (text) => ({ message: text }) });
-  if (!response.ok) throw mapBeeperResponseError(response.status, data, { isAssetEndpoint, retryEligible: allowRetry });
-  noteSuccess();
-  return data;
 }
 
 // ---------------------------------------------------------------------------

--- a/server/services/beeperClient.test.js
+++ b/server/services/beeperClient.test.js
@@ -366,18 +366,33 @@ describe('beeperClient', () => {
   // -------------------------------------------------------------------------
 
   describe('timeout behavior (fake timers)', () => {
-    function bodyThatRejectsOnAbort(status, signal, { trickle = false } = {}) {
+    function bodyThatRejectsOnAbort(status, signal) {
       return {
         ok: status >= 200 && status < 300,
         status,
         text: () => new Promise((_resolve, reject) => {
-          const trickleId = trickle ? setInterval(() => {}, 5) : null;
           signal.addEventListener('abort', () => {
-            if (trickleId !== null) clearInterval(trickleId);
             reject(new DOMException('aborted while reading body', 'AbortError'));
           }, { once: true });
         }),
       };
+    }
+
+    function tricklingJsonResponse(status, signal) {
+      let chunksSent = 0;
+      const stream = new ReadableStream({
+        start(controller) {
+          const trickleId = setInterval(() => {
+            chunksSent++;
+            controller.enqueue(new TextEncoder().encode(' '));
+          }, 5);
+          signal.addEventListener('abort', () => {
+            clearInterval(trickleId);
+            controller.error(signal.reason || new DOMException('aborted', 'AbortError'));
+          }, { once: true });
+        },
+      });
+      return { response: new Response(stream, { status }), chunksSent: () => chunksSent };
     }
 
     // Fork issue #61, decision 7: 1s proved too tight for a briefly-busy Beeper
@@ -482,9 +497,12 @@ describe('beeperClient', () => {
       vi.useFakeTimers();
       try {
         let requestSignal;
+        let chunksSent;
         vi.stubGlobal('fetch', vi.fn().mockImplementation((_url, opts) => {
           requestSignal = opts.signal;
-          return Promise.resolve(bodyThatRejectsOnAbort(200, requestSignal, { trickle: true }));
+          const trickle = tricklingJsonResponse(200, requestSignal);
+          chunksSent = trickle.chunksSent;
+          return Promise.resolve(trickle.response);
         }));
 
         const request = getInfo({ baseUrl: DEFAULT_BASE_URL, timeoutMs: 30 });
@@ -495,6 +513,7 @@ describe('beeperClient', () => {
         await vi.advanceTimersByTimeAsync(30);
 
         await rejection;
+        expect(chunksSent()).toBeGreaterThan(1);
         expect(requestSignal.aborted).toBe(true);
       } finally {
         vi.useRealTimers();

--- a/server/services/beeperClient.test.js
+++ b/server/services/beeperClient.test.js
@@ -428,6 +428,31 @@ describe('beeperClient', () => {
       }
     });
 
+    it('a total deadline cancels retry backoff before another read attempt starts', async () => {
+      vi.useFakeTimers();
+      try {
+        const fetchMock = vi.fn().mockRejectedValue(
+          Object.assign(new TypeError('fetch failed'), { cause: { code: 'ECONNRESET' } }),
+        );
+        vi.stubGlobal('fetch', fetchMock);
+
+        const request = listChatsPage({
+          baseUrl: DEFAULT_BASE_URL, token: 't', timeoutMs: 25,
+        });
+        const rejection = expect(request).rejects.toMatchObject({
+          code: 'NETWORK_ERROR',
+          context: { details: { timedOut: true } },
+        });
+        await vi.advanceTimersByTimeAsync(25);
+
+        await rejection;
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        expect(vi.getTimerCount()).toBe(0);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it.each([200, 500])('bounds a stalled JSON body after immediate HTTP %s headers', async (status) => {
       vi.useFakeTimers();
       try {

--- a/server/services/beeperClient.test.js
+++ b/server/services/beeperClient.test.js
@@ -366,6 +366,20 @@ describe('beeperClient', () => {
   // -------------------------------------------------------------------------
 
   describe('timeout behavior (fake timers)', () => {
+    function bodyThatRejectsOnAbort(status, signal, { trickle = false } = {}) {
+      return {
+        ok: status >= 200 && status < 300,
+        status,
+        text: () => new Promise((_resolve, reject) => {
+          const trickleId = trickle ? setInterval(() => {}, 5) : null;
+          signal.addEventListener('abort', () => {
+            if (trickleId !== null) clearInterval(trickleId);
+            reject(new DOMException('aborted while reading body', 'AbortError'));
+          }, { once: true });
+        }),
+      };
+    }
+
     // Fork issue #61, decision 7: 1s proved too tight for a briefly-busy Beeper
     // Desktop, so the cap moved to 3s.
     it('probeBeeperInfo caps at 3s and resolves reachable:false/timedOut:true without throwing, and without a real sleep', async () => {
@@ -409,6 +423,94 @@ describe('beeperClient', () => {
 
         expect(result).toEqual({ items: [], hasMore: false });
         expect(fetchMock).toHaveBeenCalledTimes(2);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it.each([200, 500])('bounds a stalled JSON body after immediate HTTP %s headers', async (status) => {
+      vi.useFakeTimers();
+      try {
+        let requestSignal;
+        const fetchMock = vi.fn().mockImplementation((_url, opts) => {
+          requestSignal = opts.signal;
+          return Promise.resolve(bodyThatRejectsOnAbort(status, requestSignal));
+        });
+        vi.stubGlobal('fetch', fetchMock);
+
+        const request = getInfo({ baseUrl: DEFAULT_BASE_URL, timeoutMs: 25 });
+        const rejection = expect(request).rejects.toMatchObject({
+          code: 'NETWORK_ERROR',
+          context: { details: { timedOut: true } },
+        });
+        await vi.advanceTimersByTimeAsync(25);
+
+        await rejection;
+        expect(requestSignal.aborted).toBe(true);
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('keeps one total deadline when a JSON body keeps trickling data', async () => {
+      vi.useFakeTimers();
+      try {
+        let requestSignal;
+        vi.stubGlobal('fetch', vi.fn().mockImplementation((_url, opts) => {
+          requestSignal = opts.signal;
+          return Promise.resolve(bodyThatRejectsOnAbort(200, requestSignal, { trickle: true }));
+        }));
+
+        const request = getInfo({ baseUrl: DEFAULT_BASE_URL, timeoutMs: 30 });
+        const rejection = expect(request).rejects.toMatchObject({
+          code: 'NETWORK_ERROR',
+          context: { details: { timedOut: true } },
+        });
+        await vi.advanceTimersByTimeAsync(30);
+
+        await rejection;
+        expect(requestSignal.aborted).toBe(true);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('clears the total deadline after a successful JSON read', async () => {
+      vi.useFakeTimers();
+      try {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse(200, {
+          app: { name: 'Beeper' }, server: { status: 'running' },
+        })));
+
+        await expect(getInfo({ baseUrl: DEFAULT_BASE_URL, timeoutMs: 50 })).resolves.toMatchObject({
+          app: { name: 'Beeper' },
+        });
+        expect(vi.getTimerCount()).toBe(0);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('aborts a stalled send body after one POST without retrying it', async () => {
+      vi.useFakeTimers();
+      try {
+        let requestSignal;
+        const fetchMock = vi.fn().mockImplementation((_url, opts) => {
+          requestSignal = opts.signal;
+          return Promise.resolve(bodyThatRejectsOnAbort(200, requestSignal));
+        });
+        vi.stubGlobal('fetch', fetchMock);
+
+        const request = sendMessage('chat1', { text: 'hi' }, {
+          baseUrl: DEFAULT_BASE_URL, token: 't', timeoutMs: 25,
+        });
+        const rejection = expect(request).rejects.toMatchObject({ code: 'NETWORK_ERROR', retryable: false });
+        await vi.advanceTimersByTimeAsync(25);
+
+        await rejection;
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        expect(fetchMock.mock.calls[0][1].method).toBe('POST');
       } finally {
         vi.useRealTimers();
       }


### PR DESCRIPTION
## Summary

- keep Beeper request deadlines active through JSON response-body consumption
- cancel read retry backoff when the request's total deadline expires
- preserve typed timeout errors and the single-attempt contract for message sends

## Test plan

- `server/node_modules/.bin/vitest run server/lib/fetchWithTimeout.test.js server/services/beeperClient.test.js server/services/beeperSync.test.js`
- `cd server && node_modules/.bin/vitest run`

Closes #7176
