### PR TITLE
fix: stage client builds before publishing served index (#7182)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ node_modules/
 # Build output
 dist/
 build/
+/client/.dist-stage-*/
 
 # Runtime data (app registry, history, runs, migration state). Override the
 # directory-level `data/` rule from the global ~/.gitignore so git descends

--- a/client/package.json
+++ b/client/package.json
@@ -9,8 +9,8 @@
   },
   "scripts": {
     "dev": "vite --host 0.0.0.0 --port 5554",
-    "build": "vite build",
-    "build:analyze": "ANALYZE=true vite build",
+    "build": "node ../scripts/publish-client-build.js",
+    "build:analyze": "node ../scripts/publish-client-build.js --analyze",
     "lint": "biome lint --error-on-warnings src",
     "preview": "vite preview",
     "test": "vitest run",

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -15,6 +15,7 @@ import {
 
 const ANALYZE_BUNDLE = process.env.ANALYZE === 'true';
 const CONFIG_DIR = import.meta.dirname;
+const BUILD_OUT_DIR = process.env.PORTOS_CLIENT_BUILD_OUT_DIR || resolve(CONFIG_DIR, 'dist');
 
 const rootPkg = JSON.parse(readFileSync(resolve(CONFIG_DIR, '../package.json'), 'utf-8'));
 
@@ -152,7 +153,7 @@ export default defineConfig(({ command, mode }) => {
     plugins: [
       react(),
       ANALYZE_BUNDLE && visualizer({
-        filename: 'dist/bundle-report.html',
+        filename: resolve(BUILD_OUT_DIR, 'bundle-report.html'),
         gzipSize: true,
         brotliSize: true,
         template: 'treemap',

--- a/scripts/publish-client-build.js
+++ b/scripts/publish-client-build.js
@@ -1,0 +1,214 @@
+/**
+ * Build the client away from the served dist directory, then publish it with
+ * index.html last. The old index and its content-hashed assets stay usable
+ * throughout a build, including when Vite fails after it starts rendering.
+ */
+import { spawn } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import {
+  copyFileSync,
+  closeSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  openSync,
+  readFileSync,
+  readSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+  statSync,
+} from 'node:fs';
+import { dirname, join, relative, resolve, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { isDirectlyInvoked } from './lib/directInvocation.js';
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const ROOT_DIR = dirname(SCRIPT_DIR);
+const DEFAULT_CLIENT_DIR = join(ROOT_DIR, 'client');
+const STAGE_PREFIX = '.dist-stage-';
+const ABANDONED_STAGE_AGE_MS = 24 * 60 * 60 * 1000;
+
+function localReferencePath(reference, stageDir) {
+  if (!reference || reference.startsWith('//')) return null;
+  let url;
+  try {
+    url = new URL(reference, 'https://portos.invalid/');
+  } catch {
+    throw new Error(`Client index contains an invalid asset reference: ${reference}`);
+  }
+  if (url.origin !== 'https://portos.invalid') return null;
+  let pathname;
+  try {
+    pathname = decodeURIComponent(url.pathname);
+  } catch {
+    throw new Error(`Client index contains an invalid encoded asset reference: ${reference}`);
+  }
+  const candidate = resolve(stageDir, pathname.replace(/^\/+/, ''));
+  const withinStage = candidate === stageDir || candidate.startsWith(`${stageDir}${sep}`);
+  if (!withinStage) throw new Error(`Client index asset escapes the staged build: ${reference}`);
+  return candidate;
+}
+
+export function validateStagedBuild(stageDir) {
+  const indexPath = join(stageDir, 'index.html');
+  if (!existsSync(indexPath) || !statSync(indexPath).isFile()) {
+    throw new Error('Client build did not produce index.html');
+  }
+  const html = readFileSync(indexPath, 'utf8');
+  const references = [...html.matchAll(/<(?:script|link|img|source)\b[^>]*>/gi)]
+    .flatMap((tag) => [...tag[0].matchAll(/\b(?:src|href)=["']([^"']+)["']/gi)])
+    .map((match) => match[1]);
+  for (const reference of references) {
+    const assetPath = localReferencePath(reference, stageDir);
+    if (assetPath && (!existsSync(assetPath) || !statSync(assetPath).isFile())) {
+      throw new Error(`Client index references a missing staged asset: ${reference}`);
+    }
+  }
+  return { html, references };
+}
+
+export function cleanAbandonedStages(clientDir, now = Date.now()) {
+  if (!existsSync(clientDir)) return;
+  for (const entry of readdirSync(clientDir, { withFileTypes: true })) {
+    if (!entry.isDirectory() || !entry.name.startsWith(STAGE_PREFIX)) continue;
+    const path = join(clientDir, entry.name);
+    if (now - statSync(path).mtimeMs >= ABANDONED_STAGE_AGE_MS) rmSync(path, { recursive: true, force: true });
+  }
+}
+
+function filesEqual(leftPath, rightPath) {
+  const leftStat = statSync(leftPath);
+  const rightStat = statSync(rightPath);
+  if (!leftStat.isFile() || !rightStat.isFile() || leftStat.size !== rightStat.size) return false;
+
+  const left = openSync(leftPath, 'r');
+  const right = openSync(rightPath, 'r');
+  const leftBuffer = Buffer.allocUnsafe(64 * 1024);
+  const rightBuffer = Buffer.allocUnsafe(64 * 1024);
+  try {
+    let position = 0;
+    while (position < leftStat.size) {
+      const bytes = Math.min(leftBuffer.length, leftStat.size - position);
+      const leftRead = readSync(left, leftBuffer, 0, bytes, position);
+      const rightRead = readSync(right, rightBuffer, 0, bytes, position);
+      if (leftRead === 0 || leftRead !== rightRead || !leftBuffer.subarray(0, leftRead).equals(rightBuffer.subarray(0, rightRead))) {
+        return false;
+      }
+      position += leftRead;
+    }
+    return true;
+  } finally {
+    closeSync(left);
+    closeSync(right);
+  }
+}
+
+function publishEntry(source, destination) {
+  const sourceStat = lstatSync(source);
+  if (sourceStat.isDirectory()) {
+    mkdirSync(destination, { recursive: true });
+    for (const entry of readdirSync(source)) publishEntry(join(source, entry), join(destination, entry));
+    return;
+  }
+  if (!sourceStat.isFile()) throw new Error(`Client build produced an unsupported output entry: ${source}`);
+  if (existsSync(destination) && lstatSync(destination).isFile() && filesEqual(source, destination)) return;
+
+  mkdirSync(dirname(destination), { recursive: true });
+  const temporary = join(dirname(destination), `.${relative(dirname(destination), destination)}.${process.pid}.${randomUUID()}`);
+  try {
+    copyFileSync(source, temporary);
+    renameSync(temporary, destination);
+  } finally {
+    rmSync(temporary, { force: true });
+  }
+}
+
+export function publishStagedBuild(stageDir, distDir, { beforeIndexPublish } = {}) {
+  validateStagedBuild(stageDir);
+  mkdirSync(distDir, { recursive: true });
+  for (const entry of readdirSync(stageDir, { withFileTypes: true })) {
+    if (entry.name === 'index.html') continue;
+    const source = join(stageDir, entry.name);
+    const destination = join(distDir, entry.name);
+    publishEntry(source, destination);
+  }
+
+  // Revalidate against the served tree after copying. This makes the ordering
+  // explicit: every local reference is readable before the new index appears.
+  const { references } = validateStagedBuild(stageDir);
+  for (const reference of references) {
+    const stagedAsset = localReferencePath(reference, stageDir);
+    if (!stagedAsset) continue;
+    const relativeAsset = relative(stageDir, stagedAsset);
+    const publishedAsset = join(distDir, relativeAsset);
+    if (!existsSync(publishedAsset) || !statSync(publishedAsset).isFile()) {
+      throw new Error(`Client asset was not published before index.html: ${reference}`);
+    }
+  }
+
+  beforeIndexPublish?.();
+  const temporaryIndex = join(distDir, `.index.html.${process.pid}.${randomUUID()}`);
+  try {
+    copyFileSync(join(stageDir, 'index.html'), temporaryIndex);
+    renameSync(temporaryIndex, join(distDir, 'index.html'));
+  } finally {
+    rmSync(temporaryIndex, { force: true });
+  }
+}
+
+export async function publishClientBuild({
+  clientDir = DEFAULT_CLIENT_DIR,
+  distDir = join(clientDir, 'dist'),
+  runBuild = runViteBuild,
+  beforeIndexPublish,
+} = {}) {
+  cleanAbandonedStages(clientDir);
+  const stageDir = mkdtempSync(join(clientDir, STAGE_PREFIX));
+  try {
+    await runBuild(stageDir, clientDir);
+    publishStagedBuild(stageDir, distDir, { beforeIndexPublish });
+  } finally {
+    rmSync(stageDir, { recursive: true, force: true });
+  }
+}
+
+function runViteBuild(stageDir, clientDir) {
+  const args = process.argv.slice(2);
+  const analyze = args[0] === '--analyze';
+  const viteArgs = analyze ? args.slice(1) : args;
+  if (viteArgs.some((arg) => arg === '--outDir' || arg.startsWith('--outDir='))) {
+    throw new Error('publish-client-build owns Vite --outDir; remove the custom value');
+  }
+  const viteBin = join(clientDir, 'node_modules', 'vite', 'bin', 'vite.js');
+  const child = spawn(process.execPath, [viteBin, 'build', ...viteArgs, '--outDir', stageDir, '--emptyOutDir'], {
+    cwd: clientDir,
+    env: {
+      ...process.env,
+      ...(analyze ? { ANALYZE: 'true' } : {}),
+      PORTOS_CLIENT_BUILD_OUT_DIR: stageDir,
+    },
+    stdio: 'inherit',
+  });
+  return new Promise((resolvePromise, reject) => {
+    child.once('error', reject);
+    child.once('exit', (code, signal) => {
+      if (code === 0) resolvePromise();
+      else reject(new Error(signal ? `Vite build terminated by ${signal}` : `Vite build exited with code ${code}`));
+    });
+  });
+}
+
+async function runCli() {
+  await publishClientBuild();
+  console.log('📦 Published client build to client/dist');
+}
+
+if (isDirectlyInvoked(import.meta.url)) {
+  runCli().catch((error) => {
+    console.error(`❌ Client build failed: ${error.message}`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/publish-client-build.test.js
+++ b/scripts/publish-client-build.test.js
@@ -1,0 +1,160 @@
+import { createRequire } from 'node:module';
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  utimesSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  cleanAbandonedStages,
+  publishClientBuild,
+  validateStagedBuild,
+} from './publish-client-build.js';
+
+const requireFromServer = createRequire(new URL('../server/package.json', import.meta.url));
+const express = requireFromServer('express');
+
+function writeBuild(directory, name) {
+  mkdirSync(join(directory, 'assets'), { recursive: true });
+  writeFileSync(join(directory, 'index.html'), `<!doctype html><script type="module" src="/assets/${name}.js"></script>`);
+  writeFileSync(join(directory, 'assets', `${name}.js`), `window.BUILD = '${name}';`);
+}
+
+describe('staged client build publication', () => {
+  let root;
+  let clientDir;
+  let distDir;
+  let server;
+  let baseUrl;
+
+  beforeEach(async () => {
+    root = mkdtempSync(join(tmpdir(), 'portos-client-publish-'));
+    clientDir = join(root, 'client');
+    distDir = join(clientDir, 'dist');
+    writeBuild(distDir, 'old');
+
+    const app = express();
+    app.use('/assets', express.static(join(distDir, 'assets')));
+    app.use(express.static(distDir, { index: false }));
+    app.use((req, res) => res.sendFile(join(distDir, 'index.html')));
+    server = await new Promise((resolvePromise) => {
+      const listening = app.listen(0, '127.0.0.1', () => resolvePromise(listening));
+    });
+    baseUrl = `http://127.0.0.1:${server.address().port}`;
+  });
+
+  afterEach(async () => {
+    if (server) await new Promise((resolvePromise) => server.close(resolvePromise));
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('keeps the previous page and chunks served until every new chunk is published', async () => {
+    const oldChunk = join(distDir, 'assets', 'old.js');
+    const oldChunkMtime = statSync(oldChunk).mtimeMs;
+    await publishClientBuild({
+      clientDir,
+      distDir,
+      runBuild: async (stageDir) => {
+        writeBuild(stageDir, 'new');
+        writeFileSync(join(stageDir, 'assets', 'old.js'), "window.BUILD = 'old';");
+        expect(await fetch(baseUrl).then((response) => response.text())).toContain('/assets/old.js');
+        expect(await fetch(`${baseUrl}/assets/old.js`).then((response) => response.text())).toContain("'old'");
+      },
+      beforeIndexPublish: () => {
+        expect(readFileSync(join(distDir, 'index.html'), 'utf8')).toContain('/assets/old.js');
+        expect(readFileSync(join(distDir, 'assets', 'new.js'), 'utf8')).toContain("'new'");
+        expect(statSync(oldChunk).mtimeMs).toBe(oldChunkMtime);
+      },
+    });
+
+    expect(await fetch(baseUrl).then((response) => response.text())).toContain('/assets/new.js');
+    expect(await fetch(`${baseUrl}/assets/new.js`).then((response) => response.text())).toContain("'new'");
+    expect(await fetch(`${baseUrl}/assets/old.js`).then((response) => response.text())).toContain("'old'");
+  });
+
+  it('keeps a shared old chunk intact when publication fails before the index switch', async () => {
+    const oldChunk = join(distDir, 'assets', 'old.js');
+    const oldChunkMtime = statSync(oldChunk).mtimeMs;
+    await expect(publishClientBuild({
+      clientDir,
+      distDir,
+      runBuild: async (stageDir) => {
+        writeBuild(stageDir, 'new');
+        writeFileSync(join(stageDir, 'assets', 'old.js'), "window.BUILD = 'old';");
+      },
+      beforeIndexPublish: () => {
+        throw new Error('injected publication failure');
+      },
+    })).rejects.toThrow('injected publication failure');
+
+    expect(await fetch(baseUrl).then((response) => response.text())).toContain('/assets/old.js');
+    expect(await fetch(`${baseUrl}/assets/old.js`).then((response) => response.text())).toContain("'old'");
+    expect(statSync(oldChunk).mtimeMs).toBe(oldChunkMtime);
+  });
+
+  it('leaves the complete previous build served when rendering fails', async () => {
+    await expect(publishClientBuild({
+      clientDir,
+      distDir,
+      runBuild: async (stageDir) => {
+        writeBuild(stageDir, 'broken');
+        expect(await fetch(baseUrl).then((response) => response.text())).toContain('/assets/old.js');
+        throw new Error('injected render failure');
+      },
+    })).rejects.toThrow('injected render failure');
+
+    expect(await fetch(baseUrl).then((response) => response.text())).toContain('/assets/old.js');
+    expect(await fetch(`${baseUrl}/assets/old.js`).then((response) => response.text())).toContain("'old'");
+    expect(readFileSync(join(distDir, 'index.html'), 'utf8')).toContain('/assets/old.js');
+    expect(readdirSync(clientDir).filter((name) => name.startsWith('.dist-stage-'))).toEqual([]);
+  });
+
+  it('rejects a staged index with a missing local asset before publication', async () => {
+    await expect(publishClientBuild({
+      clientDir,
+      distDir,
+      runBuild: async (stageDir) => {
+        mkdirSync(stageDir, { recursive: true });
+        writeFileSync(join(stageDir, 'index.html'), '<script src="/assets/missing.js"></script>');
+      },
+    })).rejects.toThrow('missing staged asset');
+
+    expect(readFileSync(join(distDir, 'index.html'), 'utf8')).toContain('/assets/old.js');
+  });
+
+  it('validates local boot assets while allowing external references', () => {
+    const stageDir = join(clientDir, '.fixture');
+    writeBuild(stageDir, 'valid');
+    writeFileSync(
+      join(stageDir, 'index.html'),
+      '<link href="https://example.com/font.css"><script src="/assets/valid.js"></script>',
+    );
+    expect(validateStagedBuild(stageDir).references).toEqual([
+      'https://example.com/font.css',
+      '/assets/valid.js',
+    ]);
+  });
+
+  it('removes abandoned stage directories without touching a recent build', () => {
+    const stale = join(clientDir, '.dist-stage-stale');
+    const recent = join(clientDir, '.dist-stage-recent');
+    mkdirSync(stale);
+    mkdirSync(recent);
+    const now = Date.now();
+    const oldSeconds = (now - 25 * 60 * 60 * 1000) / 1000;
+    utimesSync(stale, oldSeconds, oldSeconds);
+
+    cleanAbandonedStages(clientDir, now);
+
+    expect(() => statSync(stale)).toThrow();
+    expect(statSync(recent).isDirectory()).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Build the client in a unique staging directory and validate `index.html` plus every same-origin boot asset before publication.
- Publish changed files through atomic sibling renames, keep byte-identical and previous hashed chunks intact, then replace the served index last.
- Route normal and analysis builds through the publisher, including staged analyzer output and cleanup for failed or abandoned stages.

## Test plan

- `server/node_modules/.bin/vitest run scripts/publish-client-build.test.js scripts/direct-invocation-drift.test.js scripts/clientBuildEnv.test.js`
- Production-mode analysis build into an isolated temporary output directory; verified 40 local index references, analyzer report output, and embedded branch build identity.
- `node --check scripts/publish-client-build.js`
- `git diff --check`

Closes #7182
