### PR TITLE
refactor: extract AgentCard runtime presentation (#7199)

### DIFF
--- a/client/src/components/cos/tabs/AgentCard.jsx
+++ b/client/src/components/cos/tabs/AgentCard.jsx
@@ -10,15 +10,11 @@ import {
   Loader2,
   Skull,
   Pause,
-  Activity,
-  Clock,
   Brain,
   ThumbsUp,
   ThumbsDown,
   MessageSquare,
   ExternalLink,
-  Terminal,
-  Hourglass,
   Send,
   GitBranch,
   GitPullRequest,
@@ -37,10 +33,11 @@ import toast from '../../ui/Toast';
 import { copyToClipboard } from '../../../lib/clipboard';
 import { extractCosTaskType } from '../../../lib/cosTaskType';
 import { DEFAULT_REVIEWER, normalizeReviewers } from '../constants';
-import { formatBytes, formatDurationMs, formatDateTime, formatMonthDay, formatTimeOfDay } from '../../../utils/formatters';
+import { formatBytes, formatDurationMs, formatDateTime, formatTimeOfDay } from '../../../utils/formatters';
 import { useAutoRefetch } from '../../../hooks/useAutoRefetch';
 import ConfirmButtonPair from '../../ui/ConfirmButtonPair';
 import { useConfirmDelete } from '../../../hooks/useConfirmDelete';
+import { AgentProgress, AgentRuntimeStatus } from './AgentRuntimeStatus';
 
 // Pre-compiled regexes for normalizeDescriptionToMarkdown
 // Avoid lookbehind to support older Safari/iOS runtimes
@@ -701,106 +698,22 @@ export default function AgentCard({ agent, onPause, onKill, onDelete, onResume, 
           </div>
         </div>
 
-        {/* Second row: Runtime, ETA, and process stats - compact inline display */}
-        <div className="flex items-center gap-2 flex-wrap text-xs mb-2">
-          {/* Duration with ETA for running agents */}
-          {!inactive && durationEstimate ? (
-            <span
-              className="flex items-center gap-1.5 text-gray-500 whitespace-nowrap"
-              title={`Based on ${durationEstimate.basedOn} completed ${durationEstimate.taskType} tasks (avg: ${formatDurationMs(durationEstimate.avgMs)}, est: ${formatDurationMs(durationEstimate.estimatedMs)})`}
-            >
-              <Clock size={12} aria-hidden="true" className="shrink-0" />
-              <span className="font-mono">{formatDurationMs(duration)}</span>
-              {remainingTime && !remainingTime.isOvertime && (
-                <>
-                  <span className="text-gray-600">→</span>
-                  <span className="font-mono text-port-accent">~{formatDurationMs(remainingTime.remaining)} left</span>
-                </>
-              )}
-              {remainingTime?.isOvertime && (
-                <>
-                  <span className="text-gray-600">→</span>
-                  <span className="font-mono text-yellow-500">+{formatDurationMs(remainingTime.overBy)}</span>
-                </>
-              )}
-            </span>
-          ) : (
-            <span className="flex items-center gap-1 text-gray-500 whitespace-nowrap">
-              <Clock size={12} aria-hidden="true" className="shrink-0" />
-              <span className="font-mono">{formatDurationMs(duration)}</span>
-            </span>
-          )}
-          {/* Completed timestamp */}
-          {completed && agent.completedAt && (
-            <>
-              <span className="text-gray-600">|</span>
-              <span className="text-gray-500 whitespace-nowrap" title={formatDateTime(agent.completedAt)}>
-                {formatMonthDay(agent.completedAt)}{' '}
-                {formatTimeOfDay(agent.completedAt)}
-              </span>
-            </>
-          )}
-          {/* Process stats for running agents - inline */}
-          {!inactive && processStats?.active && (
-            <span className="flex items-center gap-1 px-2 py-0.5 rounded bg-port-success/20 text-port-success whitespace-nowrap"
-                  title={`PID: ${processStats.pid} | State: ${processStats.state}`}>
-              <Activity size={10} aria-hidden="true" className="shrink-0" />
-              <span className="font-mono">PID {processStats.pid}</span>
-              <span className="text-port-success/70">|</span>
-              <span className="font-mono">{processStats.cpu?.toFixed(1)}%</span>
-              <span className="text-port-success/70">|</span>
-              <span className="font-mono">{processStats.memoryMb}MB</span>
-            </span>
-          )}
-          {!inactive && agent.metadata?.tuiSessionId && (
-            <Link
-              to={`/shell?session=${encodeURIComponent(agent.metadata.tuiSessionId)}`}
-              className="flex items-center gap-1.5 px-3 py-1 rounded font-semibold bg-emerald-500 text-black hover:bg-emerald-400 shadow-sm ring-1 ring-emerald-400/50 whitespace-nowrap transition-colors"
-              title="Open the live TUI shell to inspect and interact with this agent"
-            >
-              <Terminal size={14} aria-hidden="true" className="shrink-0" />
-              <span>Open Shell</span>
-              <span className="font-mono text-[10px] text-port-on-success">{agent.metadata.tuiSessionId.slice(0, 6)}</span>
-            </Link>
-          )}
-          {!inactive && noShellReason && (
-            <span
-              className="flex items-center gap-1 px-2 py-0.5 rounded bg-port-border/40 text-gray-400 whitespace-nowrap"
-              title={noShellReason}
-            >
-              <Terminal size={10} aria-hidden="true" className="shrink-0" />
-              <span>No shell</span>
-            </span>
-          )}
-          {!inactive && prefillReason && (
-            <span
-              className="flex items-center gap-1 px-2 py-0.5 rounded bg-port-warning/20 text-port-warning whitespace-nowrap"
-              title={prefillReason}
-            >
-              <Hourglass size={10} aria-hidden="true" className="shrink-0" />
-              <span>Long prefill ~{prefillLabel}</span>
-            </span>
-          )}
-          {!remote && (
-            <button
-              onClick={openPromptModal}
-              className="flex items-center gap-1 px-2 py-0.5 rounded bg-port-border/40 text-gray-400 hover:bg-port-border/60 hover:text-white whitespace-nowrap"
-              title="View the prompt this agent was given at spawn"
-            >
-              <MessageSquare size={10} aria-hidden="true" className="shrink-0" />
-              <span>Prompt</span>
-            </button>
-          )}
-          {/* Show zombie warning if PID exists but process is dead */}
-          {!inactive && agent.pid && processStats && !processStats.active && (
-            <span className="flex items-center gap-1 px-2 py-0.5 rounded bg-port-error/20 text-port-error whitespace-nowrap"
-                  title="Process is not running - zombie agent">
-              <Skull size={10} aria-hidden="true" className="shrink-0" />
-              <span className="font-mono">PID {agent.pid}</span>
-              <span>ZOMBIE</span>
-            </span>
-          )}
-        </div>
+        <AgentRuntimeStatus
+          inactive={inactive}
+          durationEstimate={durationEstimate}
+          duration={duration}
+          remainingTime={remainingTime}
+          completed={completed}
+          completedAt={agent.completedAt}
+          processStats={processStats}
+          tuiSessionId={agent.metadata?.tuiSessionId}
+          noShellReason={noShellReason}
+          prefillReason={prefillReason}
+          prefillLabel={prefillLabel}
+          remote={remote}
+          onOpenPrompt={openPromptModal}
+          pid={agent.pid}
+        />
         <TaskDescription id={agent.id} text={agent.metadata?.taskDescription || agent.taskId} />
 
         {/* JIRA ticket info */}
@@ -972,34 +885,12 @@ export default function AgentCard({ agent, onPause, onKill, onDelete, onResume, 
           </div>
         )}
 
-        {/* Progress bar and ETA for running agents with estimates */}
-        {!inactive && durationEstimate && progress !== null && (
-          <div className="mt-2">
-            <div className="h-1.5 bg-port-border rounded-full overflow-hidden">
-              <div
-                className={`h-full transition-all duration-1000 ease-linear ${
-                  remainingTime?.isOvertime ? 'bg-yellow-500' : 'bg-port-accent'
-                }`}
-                style={{ width: `${Math.min(progress, 99)}%` }}
-              />
-            </div>
-            <div className="flex justify-between mt-1.5 text-xs">
-              <span className="text-gray-500">
-                {progress}% complete
-              </span>
-              {remainingTime && !remainingTime.isOvertime && (
-                <span className="text-port-accent font-medium">
-                  ETA: ~{formatDurationMs(remainingTime.remaining)}
-                </span>
-              )}
-              {remainingTime?.isOvertime && (
-                <span className="text-yellow-500 font-medium animate-pulse">
-                  +{formatDurationMs(remainingTime.overBy)} over estimate
-                </span>
-              )}
-            </div>
-          </div>
-        )}
+        <AgentProgress
+          inactive={inactive}
+          durationEstimate={durationEstimate}
+          progress={progress}
+          remainingTime={remainingTime}
+        />
 
         {agent.result && (
           <div className="flex items-center gap-4 flex-wrap">

--- a/client/src/components/cos/tabs/AgentCard.test.jsx
+++ b/client/src/components/cos/tabs/AgentCard.test.jsx
@@ -9,6 +9,7 @@ vi.mock('../../../services/api', () => ({
   sendCosAgentBtw: vi.fn(),
   getCosAgent: vi.fn(),
   getCosAgentPrompt: vi.fn(),
+  getCosAgentStats: vi.fn(() => new Promise(() => {})),
   addCosTask: vi.fn(),
 }));
 
@@ -40,6 +41,130 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.useRealTimers();
+});
+
+describe('AgentCard runtime presentation', () => {
+  const now = new Date('2026-07-13T10:00:00.000Z');
+  const runningAt = (elapsedMs, metadata = {}) => ({
+    ...agent,
+    status: 'running',
+    startedAt: new Date(now.getTime() - elapsedMs).toISOString(),
+    completedAt: null,
+    metadata: { ...agent.metadata, ...metadata },
+    result: null,
+  });
+  const durationHistory = {
+    'user-task': { avgDurationMs: 45_000, p80DurationMs: 60_000, completed: 8 },
+    _overall: { avgDurationMs: 90_000, p80DurationMs: 120_000, completed: 20 },
+  };
+
+  it.each([
+    ['before the estimate', 30_000, '50% complete', '~30s left', 'ETA: ~30s'],
+    ['exactly at the estimate', 60_000, '99% complete', '+0s', '+0s over estimate'],
+    ['after the estimate', 75_000, '99% complete', '+15s', '+15s over estimate'],
+  ])('renders distinct inline and footer ETA text %s', (_label, elapsedMs, progress, inlineEta, footerEta) => {
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+
+    render(
+      <MemoryRouter>
+        <AgentCard agent={runningAt(elapsedMs)} durations={durationHistory} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText(progress)).toBeInTheDocument();
+    expect(screen.getByText(inlineEta)).toHaveClass('font-mono');
+    expect(screen.getByText(footerEta)).toHaveClass('font-medium');
+  });
+
+  it('renders elapsed time without ETA or progress when duration history is absent', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+
+    render(<MemoryRouter><AgentCard agent={runningAt(30_000)} /></MemoryRouter>);
+
+    expect(screen.getByText('30s')).toBeInTheDocument();
+    expect(screen.queryByText(/complete$/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/left$/)).not.toBeInTheDocument();
+  });
+
+  it.each([
+    ['type P80', 30_000, durationHistory, '50% complete', /Based on 8 completed user-task tasks \(avg: 45s, est: 1m 0s\)/],
+    ['type average', 60_000, { 'user-task': { avgDurationMs: 60_000, completed: 3 } }, '99% complete', /Based on 3 completed user-task tasks \(avg: 1m 0s, est: 1m 0s\)/],
+    ['overall P80', 60_000, { _overall: durationHistory._overall }, '50% complete', /Based on 20 completed all tasks tasks \(avg: 1m 30s, est: 2m 0s\)/],
+  ])('uses the %s duration fallback', (_label, elapsedMs, durations, progress, title) => {
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+
+    render(
+      <MemoryRouter>
+        <AgentCard agent={runningAt(elapsedMs)} durations={durations} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText(progress)).toBeInTheDocument();
+    expect(screen.getByTitle(title)).toBeInTheDocument();
+  });
+
+  it('preserves duration and completion visibility across running, paused, and completed states', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+    const runningAgent = runningAt(30_000);
+    const { rerender } = render(
+      <MemoryRouter><AgentCard agent={runningAgent} durations={durationHistory} /></MemoryRouter>
+    );
+    expect(screen.getByText('50% complete')).toBeInTheDocument();
+    expect(screen.getByText('Working')).toBeInTheDocument();
+
+    rerender(
+      <MemoryRouter><AgentCard agent={{ ...runningAgent, status: 'paused' }} paused durations={durationHistory} /></MemoryRouter>
+    );
+    expect(screen.getByText('Paused')).toBeInTheDocument();
+    expect(screen.queryByText(/complete$/)).not.toBeInTheDocument();
+    expect(screen.getByText('30s')).toBeInTheDocument();
+
+    rerender(
+      <MemoryRouter><AgentCard agent={agent} completed durations={durationHistory} /></MemoryRouter>
+    );
+    expect(screen.getByText('1h 0m')).toBeInTheDocument();
+    expect(screen.queryByText(/complete$/)).not.toBeInTheDocument();
+    expect(screen.getByTitle((value) => value.includes('2026'))).toBeInTheDocument();
+  });
+
+  it('suppresses prompt access for remote cards while preserving the live shell destination', () => {
+    render(
+      <MemoryRouter>
+        <AgentCard
+          agent={runningAt(30_000, { executionMode: 'tui', tuiSessionId: 'sess-abcdef123' })}
+          remote
+        />
+      </MemoryRouter>
+    );
+
+    expect(screen.queryByRole('button', { name: 'Prompt' })).not.toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Open Shell/ })).toHaveAttribute('href', '/shell?session=sess-abcdef123');
+  });
+
+  it('distinguishes a live process, a zombie, and missing process stats', async () => {
+    const runningAgent = { ...runningAt(30_000), pid: 4242 };
+    api.getCosAgentStats.mockResolvedValueOnce({ active: true, pid: 4242, state: 'running', cpu: 12.3, memoryMb: 64 });
+    const { unmount } = render(<MemoryRouter><AgentCard agent={runningAgent} /></MemoryRouter>);
+    expect(await screen.findByText('12.3%')).toBeInTheDocument();
+    expect(screen.getByText('64MB')).toBeInTheDocument();
+    expect(screen.queryByText('ZOMBIE')).not.toBeInTheDocument();
+    unmount();
+
+    api.getCosAgentStats.mockResolvedValueOnce({ active: false, pid: 4242 });
+    const zombie = render(<MemoryRouter><AgentCard agent={runningAgent} /></MemoryRouter>);
+    expect(await screen.findByText('ZOMBIE')).toBeInTheDocument();
+    zombie.unmount();
+
+    api.getCosAgentStats.mockResolvedValueOnce(null);
+    render(<MemoryRouter><AgentCard agent={runningAgent} /></MemoryRouter>);
+    await waitFor(() => expect(api.getCosAgentStats).toHaveBeenCalledTimes(3));
+    expect(screen.queryByText('ZOMBIE')).not.toBeInTheDocument();
+    expect(screen.queryByText(/PID 4242/)).not.toBeInTheDocument();
+  });
 });
 
 describe('AgentCard feedback', () => {

--- a/client/src/components/cos/tabs/AgentRuntimeStatus.jsx
+++ b/client/src/components/cos/tabs/AgentRuntimeStatus.jsx
@@ -1,0 +1,177 @@
+import { Link } from 'react-router';
+import { Activity, Clock, Hourglass, MessageSquare, Skull, Terminal } from 'lucide-react';
+import { formatDateTime, formatDurationMs, formatMonthDay, formatTimeOfDay } from '../../../utils/formatters';
+
+const ETA_PRESENTATION = {
+  inline: {
+    remaining: {
+      prefix: '~',
+      suffix: ' left',
+      durationKey: 'remaining',
+      className: 'font-mono text-port-accent',
+    },
+    overtime: {
+      prefix: '+',
+      suffix: '',
+      durationKey: 'overBy',
+      className: 'font-mono text-yellow-500',
+    },
+  },
+  footer: {
+    remaining: {
+      prefix: 'ETA: ~',
+      suffix: '',
+      durationKey: 'remaining',
+      className: 'text-port-accent font-medium',
+    },
+    overtime: {
+      prefix: '+',
+      suffix: ' over estimate',
+      durationKey: 'overBy',
+      className: 'text-yellow-500 font-medium animate-pulse',
+    },
+  },
+};
+
+function AgentEtaLabel({ remainingTime, variant }) {
+  if (!remainingTime) return null;
+  const outcome = remainingTime.isOvertime ? 'overtime' : 'remaining';
+  const presentation = ETA_PRESENTATION[variant][outcome];
+  return (
+    <span className={presentation.className}>
+      {presentation.prefix}{formatDurationMs(remainingTime[presentation.durationKey])}{presentation.suffix}
+    </span>
+  );
+}
+
+export function AgentRuntimeStatus({
+  inactive,
+  durationEstimate,
+  duration,
+  remainingTime,
+  completed,
+  completedAt,
+  processStats,
+  tuiSessionId,
+  noShellReason,
+  prefillReason,
+  prefillLabel,
+  remote,
+  onOpenPrompt,
+  pid,
+}) {
+  return (
+    <div className="flex items-center gap-2 flex-wrap text-xs mb-2">
+      {!inactive && durationEstimate ? (
+        <span
+          className="flex items-center gap-1.5 text-gray-500 whitespace-nowrap"
+          title={`Based on ${durationEstimate.basedOn} completed ${durationEstimate.taskType} tasks (avg: ${formatDurationMs(durationEstimate.avgMs)}, est: ${formatDurationMs(durationEstimate.estimatedMs)})`}
+        >
+          <Clock size={12} aria-hidden="true" className="shrink-0" />
+          <span className="font-mono">{formatDurationMs(duration)}</span>
+          {remainingTime && (
+            <>
+              <span className="text-gray-600">→</span>
+              <AgentEtaLabel remainingTime={remainingTime} variant="inline" />
+            </>
+          )}
+        </span>
+      ) : (
+        <span className="flex items-center gap-1 text-gray-500 whitespace-nowrap">
+          <Clock size={12} aria-hidden="true" className="shrink-0" />
+          <span className="font-mono">{formatDurationMs(duration)}</span>
+        </span>
+      )}
+      {completed && completedAt && (
+        <>
+          <span className="text-gray-600">|</span>
+          <span className="text-gray-500 whitespace-nowrap" title={formatDateTime(completedAt)}>
+            {formatMonthDay(completedAt)}{' '}
+            {formatTimeOfDay(completedAt)}
+          </span>
+        </>
+      )}
+      {!inactive && processStats?.active && (
+        <span
+          className="flex items-center gap-1 px-2 py-0.5 rounded bg-port-success/20 text-port-success whitespace-nowrap"
+          title={`PID: ${processStats.pid} | State: ${processStats.state}`}
+        >
+          <Activity size={10} aria-hidden="true" className="shrink-0" />
+          <span className="font-mono">PID {processStats.pid}</span>
+          <span className="text-port-success/70">|</span>
+          <span className="font-mono">{processStats.cpu?.toFixed(1)}%</span>
+          <span className="text-port-success/70">|</span>
+          <span className="font-mono">{processStats.memoryMb}MB</span>
+        </span>
+      )}
+      {!inactive && tuiSessionId && (
+        <Link
+          to={`/shell?session=${encodeURIComponent(tuiSessionId)}`}
+          className="flex items-center gap-1.5 px-3 py-1 rounded font-semibold bg-emerald-500 text-black hover:bg-emerald-400 shadow-sm ring-1 ring-emerald-400/50 whitespace-nowrap transition-colors"
+          title="Open the live TUI shell to inspect and interact with this agent"
+        >
+          <Terminal size={14} aria-hidden="true" className="shrink-0" />
+          <span>Open Shell</span>
+          <span className="font-mono text-[10px] text-port-on-success">{tuiSessionId.slice(0, 6)}</span>
+        </Link>
+      )}
+      {!inactive && noShellReason && (
+        <span
+          className="flex items-center gap-1 px-2 py-0.5 rounded bg-port-border/40 text-gray-400 whitespace-nowrap"
+          title={noShellReason}
+        >
+          <Terminal size={10} aria-hidden="true" className="shrink-0" />
+          <span>No shell</span>
+        </span>
+      )}
+      {!inactive && prefillReason && (
+        <span
+          className="flex items-center gap-1 px-2 py-0.5 rounded bg-port-warning/20 text-port-warning whitespace-nowrap"
+          title={prefillReason}
+        >
+          <Hourglass size={10} aria-hidden="true" className="shrink-0" />
+          <span>Long prefill ~{prefillLabel}</span>
+        </span>
+      )}
+      {!remote && (
+        <button
+          onClick={onOpenPrompt}
+          className="flex items-center gap-1 px-2 py-0.5 rounded bg-port-border/40 text-gray-400 hover:bg-port-border/60 hover:text-white whitespace-nowrap"
+          title="View the prompt this agent was given at spawn"
+        >
+          <MessageSquare size={10} aria-hidden="true" className="shrink-0" />
+          <span>Prompt</span>
+        </button>
+      )}
+      {!inactive && pid && processStats && !processStats.active && (
+        <span
+          className="flex items-center gap-1 px-2 py-0.5 rounded bg-port-error/20 text-port-error whitespace-nowrap"
+          title="Process is not running - zombie agent"
+        >
+          <Skull size={10} aria-hidden="true" className="shrink-0" />
+          <span className="font-mono">PID {pid}</span>
+          <span>ZOMBIE</span>
+        </span>
+      )}
+    </div>
+  );
+}
+
+export function AgentProgress({ inactive, durationEstimate, progress, remainingTime }) {
+  return !inactive && durationEstimate && progress !== null && (
+    <div className="mt-2">
+      <div className="h-1.5 bg-port-border rounded-full overflow-hidden">
+        <div
+          className={`h-full transition-all duration-1000 ease-linear ${
+            remainingTime?.isOvertime ? 'bg-yellow-500' : 'bg-port-accent'
+          }`}
+          style={{ width: `${Math.min(progress, 99)}%` }}
+        />
+      </div>
+      <div className="flex justify-between mt-1.5 text-xs">
+        <span className="text-gray-500">{progress}% complete</span>
+        <AgentEtaLabel remainingTime={remainingTime} variant="footer" />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- extract the AgentCard runtime/status row and progress footer into focused presentation components
- select remaining-time versus overtime text once while preserving each location's wording, classes, arrow, and animation
- characterize running, paused, completed, remote, process, duration-history, and ETA boundary behavior through rendered AgentCard tests

## Validation

- `cd client && ./node_modules/.bin/vitest run src/components/cos/tabs/AgentCard.test.jsx src/components/cos/tabs/MindTab.test.jsx src/components/cos/tabs/TaskItem.test.jsx` (134 passed)
- `cd client && ./node_modules/.bin/biome lint --error-on-warnings src/components/cos/tabs/AgentCard.jsx src/components/cos/tabs/AgentRuntimeStatus.jsx src/components/cos/tabs/AgentCard.test.jsx`
- `cd client && npm run build`
- visually verified synthetic remaining, overtime, live-process, and remote states at desktop and 360 x 800 viewports
- optional Codex review: `REVIEW_VERDICT: clean`

Complexity targets from the issue are met: AgentCard 176 to 149, AgentRuntimeStatus 19, AgentProgress 5, and AgentEtaLabel 3 under the issue's counting rules.

Closes #7199
