### PR TITLE
feat: explain stalled scenes through tactics (#7205)

### DIFF
--- a/data.reference/prompts/stage-config.json
+++ b/data.reference/prompts/stage-config.json
@@ -932,7 +932,7 @@
     },
     "pipeline-editorial-plot-structure": {
       "name": "Pipeline — Editorial Check: Plot structure & momentum",
-      "description": "Editorial check (#1310): the macro pathologies editors flag at the manuscript/arc level — a passive protagonist, deus ex machina / convenient coincidence, idiot plot, flat or unclear stakes that never escalate, a sagging middle with no try-fail rhythm, and dropped subplots. Reads the stitched manuscript plus the reverse-outline scene map + plotline coverage (reconciling fizzled threads against tagged plotlines) and the authored reader-map hooks/payoffs; degrades to a whole-manuscript scan when no outline exists. Returns issue-anchored findings.",
+      "description": "Editorial check (#1310, #7205): structural pathologies at the manuscript, arc, and scene level — a passive protagonist, deus ex machina / convenient coincidence, idiot plot, flat or unclear stakes, a sagging middle, dropped subplots, and scenes that stall because characters repeat a tactic without an action, response, discovery, consequence, or material change. Distinguishes repeated strategy from repeated wording, preserves purposeful quiet/connective/static passages, and omits whole-scene judgments when chunk context is incomplete. Reads the stitched manuscript plus the reverse-outline scene map + plotline coverage and authored reader-map hooks/payoffs; degrades to a whole-manuscript scan when no outline exists. Returns issue-anchored findings with a concrete structural repair.",
       "model": "default",
       "returnsJson": true,
       "variables": []

--- a/data.reference/prompts/stages/pipeline-editorial-plot-structure.md
+++ b/data.reference/prompts/stages/pipeline-editorial-plot-structure.md
@@ -2,10 +2,12 @@
 
 You are a developmental editor doing a single focused pass for ONE concern:
 **plot structure and momentum** — the macro pathologies that make a story drag,
-cheat, or fall flat. These are arc-level problems, not line-level ones. Judge the
-story as a whole: does the protagonist drive it, are the stakes clear and rising,
-does the middle keep escalating, and does every thread the author opened get
-resolved?
+cheat, or fall flat, plus scene-level passages that stall because nobody changes
+tactic and nothing alters the dramatic situation. These are structural problems,
+not line-level ones. Judge the story as a whole: does the protagonist drive it,
+are the stakes clear and rising, does the middle keep escalating, does every
+thread the author opened get resolved, and do the scenes that carry those beats
+progress through action and reaction?
 
 Flag only these pathologies (each is a distinct finding category):
 
@@ -26,6 +28,13 @@ Flag only these pathologies (each is a distinct finding category):
   marks time. A strong middle runs on escalating try-fail cycles (the hero tries,
   fails, and the failure raises the cost of the next attempt); flag a stretch with
   no such rhythm.
+- **Stalled scene / repeated tactic** — a scene loops even though its dialogue may
+  be fluent and differently worded. Identify the character's immediate objective,
+  what they do to pursue it, the opposing response, and the next action or tactic.
+  Flag only when the passage supplies enough of that sequence to show the same
+  approach cycling without a useful change in knowledge, leverage, commitment,
+  relationship, or available choices, weakening the scene's intended dramatic job.
+  The defect is repeated strategy or a missing causal turn, not repeated wording.
 - **Dropped subplot / unresolved thread** — a plotline or promise that starts and
   then fizzles without a resolution scene. Reconcile against the tagged plotlines
   below: a plotline whose scenes stop partway through the story and never return
@@ -34,7 +43,31 @@ Flag only these pathologies (each is a distinct finding category):
 Do NOT flag: line-level prose problems (other checks own those); a deliberately
 quiet/literary structure where low external stakes are the point; an unresolved
 thread that is clearly a setup for a planned later installment when the manuscript
-is mid-arc.
+is mid-arc; or a quiet, contemplative, connective, or deliberately static scene
+that earns its place. A scene need not reverse from positive to negative, feature
+an overt antagonist, contain visible physical action, or produce permanent
+character growth. Repetition can progress a scene by changing audience knowledge,
+pressure, meaning, or relationship even when the characters repeat the same words.
+Read the neighboring context before deciding that nothing changes.
+
+## Scene-progression calibration
+
+Use these original synthetic cases to keep the distinction precise:
+
+- **Flag — one tactic in new words:** Mara asks Ivo to trust her, restates her
+  loyalty, then makes the same appeal more urgently. Ivo refuses each version and
+  no deed, discovery, leverage, decision, or consequence changes their position.
+- **Do not flag — repeated phrase gains leverage:** Ivo repeats “You promised,”
+  first as a plea, then while producing the falsified receipt, then after a witness
+  enters. The wording repeats, but each beat changes what Mara and the audience
+  know and what choices remain.
+- **Do not flag — quiet relationship turn:** Two sisters silently mend a coat until
+  one leaves the family key beside the other. Little is said and nobody wins an
+  argument, but their relationship and future options have changed.
+- **Do not flag — honest transition:** A short train-platform passage moves the
+  cast to the next confrontation, establishes the missed last train, and gives the
+  reader a needed breath. It performs its connective job without manufacturing a
+  dramatic reversal.
 
 {{#authoredSetups}}
 ## Authored hooks & payoffs
@@ -66,8 +99,10 @@ reconcile your dropped-thread findings against this list.
 ## Scene segmentation
 
 The reverse outline below segments the manuscript into scenes (with the recorded
-setting, POV character, and characters present). Use it to attribute pacing and
-stakes findings to a scene and its issue; judge the structure itself from the prose.
+setting, POV character, and characters present). Use it to attribute pacing,
+stakes, and progression findings to a scene and its issue; judge the structure
+itself from the prose. The map may be absent or trimmed to fit the provider window,
+so a missing map entry is never proof that a scene lacks a turn.
 
 ```
 {{sceneMap}}
@@ -90,6 +125,17 @@ whole-story judgments: a genuinely sagging middle, an arc whose stakes never
 escalate, and a subplot that is dropped (opened earlier and never resolved by the
 end). The "setup so far" digest above tells you what earlier parts opened.
 {{/finalPart}}
+
+## Chunk-boundary discipline for scene findings
+
+A manuscript part may begin after a scene's opening or end before its resolution.
+Do not infer a whole-scene failure from a missing opening, missing ending, or a
+trimmed/absent scene-map entry. Report a stalled-scene finding only when the
+supplied prose itself contains enough consecutive action/reaction beats to prove
+the repeated tactic or missing causal turn. If the relevant objective, response,
+or change may sit outside the supplied part, omit the claim. A local loop fully
+evidenced inside the supplied passage may still be reported, including in a
+non-final part; name only what that passage proves.
 {{^finalPart}}
 You are seeing an EARLIER part of a long manuscript reviewed in pieces. Do NOT
 yet flag a dropped subplot, a flat-stakes arc, or a sagging middle — a later part
@@ -101,15 +147,22 @@ so far" digest above carries what earlier parts opened so you don't re-flag them
 ## Task
 
 Identify the plot-structure pathologies above. For each finding set `location` to
-the pathology + a pointer, e.g. `Passive protagonist — Issue 4`, `Deus ex machina
-— the rescue at the docks`, `Dropped subplot — the missing-brother thread`. Quote
-a short verbatim anchor (≤ 200 chars) at the relevant moment where one exists
-(omit `anchorQuote` for a whole-arc judgment like a sagging middle or a flat
-stakes arc). Severity: a passive central protagonist, a deus-ex-machina climax, or
-a dropped major subplot is high; a minor coincidence or a single slack scene is
-low. If the plot is well-structured — an active protagonist, clear escalating
-stakes, a taut middle, and every thread resolved — return an empty `findings`
-array. Do not invent structural problems where the story is sound.
+the pathology + a pointer, e.g. `Passive protagonist — Issue 4`, `Stalled scene —
+the kitchen appeal`, `Deus ex machina — the rescue at the docks`, `Dropped subplot
+— the missing-brother thread`. Quote a short verbatim anchor (≤ 200 chars) at the
+relevant moment where one exists (omit `anchorQuote` for a whole-arc judgment like
+a sagging middle or a flat stakes arc). For a stalled scene, `problem` must name
+the repeated tactic and explain how the action/reaction sequence fails to change
+the situation; do not diagnose it as repeated wording. Its `suggestion` must name
+one concrete action, discovery, consequence, change of tactic, or better entry/exit
+point that serves the scene's existing purpose. Do not recommend deleting a scene
+solely because it is quiet or static; the separate cuts check owns safe removal,
+and this pass proposes structural repairs without bypassing author intent or locks.
+Severity: a passive central protagonist, a deus-ex-machina climax, or a dropped
+major subplot is high; a minor coincidence or a single slack scene is low. If the
+plot is well-structured — an active protagonist, clear escalating stakes, a taut
+middle, purposeful scene progression, and every thread resolved — return an empty
+`findings` array. Do not invent structural problems where the story is sound.
 
 ## Output contract
 
@@ -123,8 +176,8 @@ commentary:
       "severity": "high|medium|low",
       "issueNumber": 4,
       "location": "string — pathology + pointer (e.g. 'Passive protagonist — Issue 4' or 'Dropped subplot — the missing-brother thread')",
-      "problem": "1–3 sentences naming the structural problem and why it weakens the story",
-      "suggestion": "1–3 sentences proposing how to fix it (give the lead a decision, plant the payoff earlier, resolve or cut the thread, raise the stakes)",
+      "problem": "1–3 sentences naming the structural problem and why it weakens the story; for a stalled scene, distinguish the repeated tactic from repeated wording",
+      "suggestion": "1–3 sentences proposing how to fix it (give the lead a decision, change a tactic, introduce an action/discovery/consequence, choose a better entry/exit point, plant the payoff earlier, resolve a thread, raise the stakes)",
       "anchorQuote": "short verbatim quote at the moment (≤ 200 chars); omit for a whole-arc judgment"
     }
   ]

--- a/scripts/migrations/385-pipeline-scene-progression.js
+++ b/scripts/migrations/385-pipeline-scene-progression.js
@@ -1,0 +1,21 @@
+/** Teach existing Pipeline installs to diagnose stalled scene tactics (#7205). */
+import { makePromptReplaceMigration } from './_lib.js';
+
+export const ACCEPTED_OLD_MD5 = {
+  'pipeline-editorial-plot-structure.md': ['400d829dd291753a299fa08d6afbe561'],
+};
+
+export const NEW_SHIPPED_MD5 = {
+  'pipeline-editorial-plot-structure.md': '2a4fe67b7b5e128314c385bb458decf2',
+};
+
+const { applyMigration, up } = makePromptReplaceMigration({
+  accepted: ACCEPTED_OLD_MD5,
+  current: NEW_SHIPPED_MD5,
+  label: 'Pipeline stalled-scene progression',
+  customizedHint: (filename) =>
+    `   Merge the stalled-scene tactic and chunk-boundary guidance from data.reference/prompts/stages/${filename}.`,
+});
+
+export { applyMigration };
+export default { up };

--- a/scripts/migrations/385-pipeline-scene-progression.test.js
+++ b/scripts/migrations/385-pipeline-scene-progression.test.js
@@ -1,0 +1,17 @@
+import { describe } from 'vitest';
+import { runPromptMigrationTests } from './_testHelpers.js';
+import migration, {
+  applyMigration,
+  ACCEPTED_OLD_MD5,
+  NEW_SHIPPED_MD5,
+} from './385-pipeline-scene-progression.js';
+
+describe('migration 385 — Pipeline stalled-scene progression', () => {
+  runPromptMigrationTests({
+    migration,
+    applyMigration,
+    ACCEPTED_OLD_MD5,
+    NEW_SHIPPED_MD5,
+    prefix: 'migration-385-',
+  });
+});

--- a/scripts/setup-data-drift.test.js
+++ b/scripts/setup-data-drift.test.js
@@ -78,6 +78,7 @@ const EXPECTED_STAGE_OLD = {
   'pipeline-editorial-arc-transitions.md': ['72e27707f0dc82eab84eed74e9707587'],
   'pipeline-editorial-arc-regression.md': ['85b15c9e913fe8a436d407f1562a2b10'],
   'pipeline-editorial-climax-agency.md': ['1bca84f9a0b7cde84e20e43702a12ffa'],
+  'pipeline-editorial-plot-structure.md': ['400d829dd291753a299fa08d6afbe561'],
 };
 const EXPECTED_STAGE_NEW = {
   'cd-evaluate.md': 'a86de29e186581d3508662569c8acbf6',
@@ -134,6 +135,7 @@ const EXPECTED_STAGE_NEW = {
   'pipeline-editorial-arc-transitions.md': '46cb5444f41d05fb7bdbc219d62619b2',
   'pipeline-editorial-arc-regression.md': '8e34b3a84cd7f948592a2a94b28caee4',
   'pipeline-editorial-climax-agency.md': '255ad29214f48e6dd1c17adbb5887478',
+  'pipeline-editorial-plot-structure.md': '2a4fe67b7b5e128314c385bb458decf2',
 };
 const EXPECTED_PARTIAL_OLD = {
   'bible-deference.md': ['218f0e85643609ed85a12b1ccc7b5a8d'],

--- a/server/lib/editorial/checkInfra/llmRunner.js
+++ b/server/lib/editorial/checkInfra/llmRunner.js
@@ -288,6 +288,8 @@ async function runChunkedManuscriptCheck(ctx, { chunks, category, max, callChunk
 //     trimmable context (a plain whole-manuscript scan). MUST account for every
 //     non-manuscript prompt var, on top of EDITORIAL_PROMPT_OVERHEAD_TOKENS.
 //
+// `promptOverheadTokens` may raise the shared fixed reserve for an unusually
+// detailed stage template; it does not affect the trimmable context blocks.
 // `buildVars(chunk, meta, context)` returns the stage vars — only the manuscript
 // var changes per chunk; `meta.isFinal` is true on the last (or only) chunk so a
 // check can gate whole-corpus judgments to it (the Chekhov "planted, never fired"
@@ -295,7 +297,7 @@ async function runChunkedManuscriptCheck(ctx, { chunks, category, max, callChunk
 // check). Existing checks ignore the extra args. These checks are all
 // manuscript-scoped, so findings keep a model-supplied issue number
 // (`withIssueNumber: true`).
-export async function runManuscriptLlmCheck(ctx, { stage, category, overheadTokens = 0, context = null, buildVars, crossChunkDigest = false, crossChunkSetup = false, setupFocus = '', reserveSetupDigest = false, subtypes = null }) {
+export async function runManuscriptLlmCheck(ctx, { stage, category, overheadTokens = 0, promptOverheadTokens = EDITORIAL_PROMPT_OVERHEAD_TOKENS, context = null, buildVars, crossChunkDigest = false, crossChunkSetup = false, setupFocus = '', reserveSetupDigest = false, subtypes = null }) {
   const max = ctx.config?.maxFindings ?? 12;
   // Chunks are planned at the full usable budget; the digest is fitted into each
   // later chunk's spare room inside runChunkedManuscriptCheck (it yields to the
@@ -303,7 +305,7 @@ export async function runManuscriptLlmCheck(ctx, { stage, category, overheadToke
   // trimmed to keep the manuscript a budget floor; the trimmed blocks come back on
   // `chunks.context` so they're what we feed the model.
   const chunks = context
-    ? await ctx.planManuscriptChunks(stage, { context, fixedOverheadTokens: EDITORIAL_PROMPT_OVERHEAD_TOKENS })
+    ? await ctx.planManuscriptChunks(stage, { context, fixedOverheadTokens: promptOverheadTokens })
     : await ctx.planManuscriptChunks(stage, { overheadTokens });
   // The runner returns the (possibly trimmed) context on `chunks.context`; fall back
   // to the originals if it didn't echo them (a chunker that doesn't implement the
@@ -438,4 +440,3 @@ export async function runManuscriptLlmCheckInline(ctx, { category, instructions 
     },
   });
 }
-

--- a/server/lib/editorial/checkRegistry.test.js
+++ b/server/lib/editorial/checkRegistry.test.js
@@ -1286,7 +1286,7 @@ describe('plot.structure-momentum — LLM check (#1310)', () => {
         expect(opts.context).toHaveProperty('sceneMap');
         expect(opts.context).toHaveProperty('plotlineMap');
         expect(opts.context).toHaveProperty('authoredSetups');
-        expect(opts.fixedOverheadTokens).toBeGreaterThan(0);
+        expect(opts.fixedOverheadTokens).toBe(2_750);
         return ['# Issue 1\n\nThe brother thread is never mentioned again.'];
       },
       callStagedLLM: async (_stage, vars) => {
@@ -1334,6 +1334,38 @@ describe('plot.structure-momentum — LLM check (#1310)', () => {
     });
     await getCheck(PLOT_STRUCTURE).run(ctx);
     expect(finals).toEqual(['', '', 'true']);
+  });
+
+  it('normalizes and deduplicates an anchored repeated-tactic finding across manuscript parts', async () => {
+    let calls = 0;
+    const rawFinding = {
+      severity: 'medium',
+      issueNumber: 7,
+      location: 'Stalled scene — the kitchen appeal',
+      problem: 'Mara repeats the same appeal after each refusal, so neither tactic nor leverage changes.',
+      suggestion: 'Have Mara produce the receipt, forcing Ivo to choose between exposure and cooperation.',
+      anchorQuote: 'You have to trust me this time.',
+    };
+    const ctx = wholeCtx({
+      config: { maxFindings: 2 },
+      planManuscriptChunks: async () => [
+        '# Issue 7\n\nYou have to trust me this time.',
+        '# Issue 7\n\nI am asking you again to trust me.',
+      ],
+      callStagedLLM: async () => {
+        calls += 1;
+        return { content: { findings: [rawFinding] } };
+      },
+    });
+
+    const findings = await getCheck(PLOT_STRUCTURE).run(ctx);
+
+    expect(findings).toEqual([{
+      ...rawFinding,
+      category: 'plot',
+      subtype: null,
+    }]);
+    expect(calls).toBe(2);
   });
 });
 

--- a/server/lib/editorial/checks/scene.js
+++ b/server/lib/editorial/checks/scene.js
@@ -22,6 +22,11 @@ import {
   z,
 } from '../checkInfra.js';
 
+// The scene-progression calibration makes this stage materially larger than the
+// shared editorial-template reserve. Keep the chunk planner honest so manuscript
+// text never crowds the prompt itself out of a small provider window.
+const PLOT_STRUCTURE_PROMPT_OVERHEAD_TOKENS = 2_750;
+
 export const sceneChecks = [
   {
     id: 'scene.component-balance',
@@ -265,7 +270,7 @@ export const sceneChecks = [
     sources: ['manuscript', 'reverseOutline', 'reverseOutline.plotlines', 'series.arc.readerMap'],
     label: 'Plot structure & momentum',
     description:
-      'LLM scan for the macro pathologies editors flag at the manuscript/arc level: a passive protagonist (events happen TO them), deus ex machina / convenient coincidence, idiot plot (conflict that only persists because characters avoid the obvious), flat or unclear stakes that never escalate, a sagging middle with no try-fail rhythm, and dropped subplots. Reads the stitched manuscript plus the reverse-outline scene map + plotline coverage (reconciling fizzled threads against tagged plotlines) and the authored reader-map hooks/payoffs; degrades to a whole-manuscript scan when no outline exists.',
+      'LLM scan for structural pathologies at the manuscript, arc, and scene level: a passive protagonist, deus ex machina / convenient coincidence, idiot plot, flat or unclear stakes, a sagging middle with no try-fail rhythm, dropped subplots, and scenes that stall because characters repeat a tactic without an action, response, discovery, consequence, or change in the situation. Distinguishes repeated strategy from repeated wording and preserves purposeful quiet, connective, contemplative, and static passages. Reads the stitched manuscript plus the reverse-outline scene map + plotline coverage and authored reader-map hooks/payoffs; degrades to a whole-manuscript scan when no outline exists and omits whole-scene judgments when chunk context is incomplete.',
     scope: 'series',
     kind: 'llm',
     category: 'plot',
@@ -304,6 +309,7 @@ export const sceneChecks = [
       return runManuscriptLlmCheck(ctx, {
         stage: PLOT_STRUCTURE_STAGE,
         category: 'plot',
+        promptOverheadTokens: PLOT_STRUCTURE_PROMPT_OVERHEAD_TOKENS,
         // sceneMap grows unbounded with scene count; plotlineMap and authoredSetups
         // are bounded — so largest-first trimming absorbs the cut into sceneMap.
         context: { sceneMap, plotlineMap, authoredSetups },

--- a/server/lib/editorial/checks/sceneProgression.test.js
+++ b/server/lib/editorial/checks/sceneProgression.test.js
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+import { applyTemplate } from '../../promptTemplate.js';
+
+const PROMPT = readFileSync(
+  join(
+    dirname(fileURLToPath(import.meta.url)),
+    '../../../../data.reference/prompts/stages/pipeline-editorial-plot-structure.md',
+  ),
+  'utf-8',
+);
+
+const render = (overrides = {}) => applyTemplate(PROMPT, {
+  manuscript: '# Issue 7\n\nMara asks Ivo to trust her again.',
+  authoredSetups: '',
+  plotlineMap: '',
+  sceneMap: 'Scenes (from the reverse outline):\n- Issue 7: Kitchen appeal',
+  finalPart: 'true',
+  ...overrides,
+});
+
+describe('plot-structure scene-progression prompt (#7205)', () => {
+  it('distinguishes a repeated tactic from repeated wording and requires a concrete repair', () => {
+    const out = render();
+
+    expect(out).toContain('The defect is repeated strategy or a missing causal turn, not repeated wording.');
+    expect(out).toMatch(/`problem` must name\s+the repeated tactic/);
+    expect(out).toMatch(/one concrete action, discovery, consequence, change of tactic, or better entry\/exit/);
+  });
+
+  // These assertions pin the shipped reviewer instructions; they do not pretend
+  // a stubbed model response can prove literary judgment.
+  it.each([
+    ['one tactic in new words', 'no deed, discovery, leverage, decision, or consequence'],
+    ['repeated phrase gains leverage', /each beat changes what Mara and the audience\s+know/],
+    ['quiet relationship turn', 'their relationship and future options have changed'],
+    ['honest transition', 'It performs its connective job'],
+  ])('ships the original %s calibration case', (_name, evidence) => {
+    expect(render()).toMatch(evidence instanceof RegExp ? evidence : new RegExp(evidence));
+  });
+
+  it('forbids whole-scene claims from incomplete chunks or a trimmed scene map', () => {
+    const out = render({ finalPart: '', sceneMap: '' });
+
+    expect(out).toContain("may begin after a scene's opening or end before its resolution");
+    expect(out).toContain('trimmed/absent scene-map entry');
+    expect(out).toMatch(/including in a\s+non-final part/);
+    expect(out).toContain('You are seeing an EARLIER part');
+    expect(out).not.toMatch(/\{\{[#^/]?[\w.]+\}\}/);
+  });
+
+  it('preserves quiet, static, connective, and repetition-with-new-meaning passages', () => {
+    const out = render();
+
+    expect(out).toContain('quiet, contemplative, connective, or deliberately static scene');
+    expect(out).toContain('changing audience knowledge');
+    expect(out).toMatch(/Do not recommend deleting a scene\s+solely because it is quiet or static/);
+  });
+});


### PR DESCRIPTION
## Summary

- expand the existing Plot structure & momentum editorial pass to explain scenes that stall because characters repeat a tactic without changing the situation
- preserve purposeful quiet, connective, contemplative, and repetition-with-new-meaning passages while requiring complete local evidence across manuscript chunks
- reserve the larger prompt accurately and migrate uncustomized installed prompts without overwriting user edits

## Test plan

- `cd server && node_modules/.bin/vitest run lib/editorial/checkRegistry.test.js lib/editorial/checks/sceneProgression.test.js ../scripts/migrations/385-pipeline-scene-progression.test.js ../scripts/migrations/_shippedHashDrift.test.js`
- `cd server && node_modules/.bin/vitest run services/pipeline/editorial/checkRunner.test.js`
- validate the reference stage-config JSON and prompt migration hash

Closes #7205
