### PR TITLE
[resilience] Stop resumable retries when stale cleanup fails

### DIFF
--- a/server/lib/downloadPreflight.js
+++ b/server/lib/downloadPreflight.js
@@ -325,6 +325,8 @@ export async function streamResumableDownload({
   expectedSha256 = null,
   finalize = true,
   onHttpError = null,
+  restartBudget = 1,
+  removeFile = rm,
 } = {}) {
   const tmpPath = partialPathFor(destPath);
   const etagPath = etagPathFor(destPath);
@@ -379,8 +381,15 @@ export async function streamResumableDownload({
   // the bytes THIS discarded partial was short by, not the full payload a
   // clean restart now needs.
   const evictPartialForRestart = async (expectedBytes) => {
-    await rm(tmpPath, { force: true }).catch(() => {});
-    await rm(etagPath, { force: true }).catch(() => {});
+    for (const path of [tmpPath, etagPath]) {
+      await removeFile(path, { force: true }).catch((err) => {
+        if (err?.code === 'ENOENT') return;
+        throw new ServerError(
+          `Cannot restart download because the stale partial could not be removed (${path}); repair destination permissions and retry`,
+          { status: 500, code: 'DOWNLOAD_RECOVERY_CLEANUP_FAILED', context: { path, cause: err?.code } },
+        );
+      });
+    }
     resumeFrom = 0;
     delete reqHeaders.Range;
     delete reqHeaders['If-Range'];
@@ -393,10 +402,17 @@ export async function streamResumableDownload({
   // from the wrong offset) — drop its body and recurse into a fresh request.
   const discardAndRefetch = async (res) => {
     await res.body?.cancel?.().catch(() => {});
+    if (restartBudget <= 0) {
+      throw new ServerError(
+        `Download recovery exceeded the clean-restart limit for ${destPath}; retry after checking the remote file and destination`,
+        { status: 502, code: 'DOWNLOAD_RECOVERY_LIMIT', context: { destPath } },
+      );
+    }
     await evictPartialForRestart(parseContentRangeTotal(res.headers?.get?.('content-range')));
     return streamResumableDownload({
       url, destPath, headers, fetchImpl, onBytes, signal, onIdleStall,
       idleStallTimeoutMs, isCancelled, expectedSha256, finalize, onHttpError,
+      restartBudget: restartBudget - 1, removeFile,
     });
   };
 
@@ -426,7 +442,7 @@ export async function streamResumableDownload({
     // normalizes/ignores the exact offset) would otherwise get appended onto
     // our existing prefix at the wrong point, corrupting the file — this
     // response's body starts at the wrong offset, so it can't be reused.
-    if (resumeFrom > 0 && res.status === 206) {
+    if (res.status === 206) {
       const rangeStart = parseContentRangeStart(res.headers?.get?.('content-range'));
       if (rangeStart != null && rangeStart !== resumeFrom) return discardAndRefetch(res);
     }

--- a/server/lib/downloadPreflight.test.js
+++ b/server/lib/downloadPreflight.test.js
@@ -439,6 +439,56 @@ describe('streamResumableDownload', () => {
     expect(await readFile(destPath, 'utf8')).toBe('ggufgg');
   });
 
+  it('stops after one clean restart when the server keeps returning an incompatible 206', async () => {
+    const destPath = await makeDir();
+    await writeFile(partialPathFor(destPath), 'gg');
+    let callCount = 0;
+    const fetchImpl = async () => {
+      callCount += 1;
+      return {
+        ok: true,
+        status: 206,
+        headers: {
+          get: (name) => ({
+            'content-length': '6',
+            'content-range': callCount === 1 ? 'bytes 0-5/6' : 'bytes 2-5/6',
+          }[name] || null),
+        },
+        body: webBody('ggufgg'),
+      };
+    };
+    await expect(streamResumableDownload({
+      url: 'https://example.com/w.gguf', destPath, fetchImpl,
+    })).rejects.toMatchObject({ code: 'DOWNLOAD_RECOVERY_LIMIT' });
+    expect(callCount).toBe(2);
+  });
+
+  it('fails before refetching when stale partial cleanup is denied', async () => {
+    const destPath = await makeDir();
+    await writeFile(partialPathFor(destPath), 'gg');
+    let callCount = 0;
+    const fetchImpl = async () => {
+      callCount += 1;
+      return {
+        ok: false,
+        status: 416,
+        headers: { get: (name) => (name === 'content-range' ? 'bytes */6' : null) },
+        body: webBody(),
+      };
+    };
+    const removeFile = async (path) => {
+      if (path === partialPathFor(destPath)) throw Object.assign(new Error('permission denied'), { code: 'EACCES' });
+      await rm(path, { force: true });
+    };
+    await expect(streamResumableDownload({
+      url: 'https://example.com/w.gguf', destPath, fetchImpl, removeFile,
+    })).rejects.toMatchObject({
+      code: 'DOWNLOAD_RECOVERY_CLEANUP_FAILED',
+      message: expect.stringContaining('repair destination permissions and retry'),
+    });
+    expect(callCount).toBe(1);
+  });
+
   // A body that ends cleanly (no stream error) short of the advertised total
   // is a truncation — without a published digest to catch it (the HF LoRA
   // path has none), a short file would otherwise be renamed into place and


### PR DESCRIPTION
## Summary

- Propagate stale partial cleanup failures as an actionable typed download error.
- Bound incompatible-range recovery to one clean restart and validate 206 offsets after a restart.

## Test plan

- `server/node_modules/.bin/vitest run server/lib/downloadPreflight.test.js`

Closes #7209
