### PR TITLE
fix: bound model download metadata lookups

### DIFF
--- a/server/services/slotstreamModelManager.js
+++ b/server/services/slotstreamModelManager.js
@@ -22,6 +22,8 @@
 import { rm, stat } from 'fs/promises';
 import { join, resolve, sep } from 'path';
 import { ServerError } from '../lib/errorHandler.js';
+import { withAbortTimeout } from '../lib/abortTimeout.js';
+import { anyAbortSignal } from '../lib/requestAbort.js';
 import {
   assessDownloadPreflight,
   assertDownloadFits,
@@ -125,7 +127,20 @@ const isFinishedOnDisk = async (destPath, expectedBytes) =>
  * "already on disk" would disable the very button that completes it.
  */
 async function planRepoDownload({ repo, token, signal, cacheDir }) {
-  const model = await fetchHuggingfaceModel(repo, { token, signal, blobs: true });
+  const model = await withAbortTimeout(METADATA_FETCH_TIMEOUT_MS, async (deadline) => {
+    const boundedSignal = anyAbortSignal([signal, deadline]);
+    try {
+      return await fetchHuggingfaceModel(repo, { token, signal: boundedSignal, blobs: true });
+    } catch (err) {
+      if (deadline.aborted && !signal?.aborted) {
+        throw new ServerError(
+          `Hugging Face metadata lookup for ${repo} timed out — retry the download.`,
+          { status: 504, code: 'SLOTSTREAM_METADATA_TIMEOUT' },
+        );
+      }
+      throw err;
+    }
+  });
   const siblings = Array.isArray(model?.siblings) ? model.siblings : [];
   const files = selectSlotstreamRepoFiles(siblings);
   // A repo whose only surviving files are config/tokenizer would otherwise
@@ -183,7 +198,6 @@ export async function previewSlotstreamDownload({ model = null, cacheDir } = {})
   const plan = await planRepoDownload({
     repo,
     token,
-    signal: AbortSignal.timeout(METADATA_FETCH_TIMEOUT_MS),
     cacheDir,
   });
   const remaining = Math.max(0, plan.totalBytes - plan.finishedBytes - plan.partialBytes);

--- a/server/services/slotstreamModelManager.test.js
+++ b/server/services/slotstreamModelManager.test.js
@@ -58,6 +58,7 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
+  vi.useRealTimers();
   await rm(cacheDir, { recursive: true, force: true });
   vi.unstubAllGlobals();
 });
@@ -182,6 +183,100 @@ describe('downloadSlotstreamModel', () => {
     expect(result.error).toBeTruthy();
     expect(frames.at(-1).event).toBe('error');
     expect(isSlotstreamDownloadInFlight(join(cacheDir, DIR_NAME))).toBe(false);
+  });
+
+  it.each(['headers', 'body'])('times out hanging metadata %s, emits an error, and releases the exclusive slot', async (phase) => {
+    vi.useFakeTimers();
+    vi.stubGlobal('fetch', vi.fn(async (_url, { signal }) => {
+      if (phase === 'headers') {
+        return new Promise((_resolve, reject) => {
+          signal.addEventListener('abort', () => reject(signal.reason), { once: true });
+        });
+      }
+      return {
+        ok: true,
+        status: 200,
+        text: () => new Promise((_resolve, reject) => {
+          signal.addEventListener('abort', () => reject(signal.reason), { once: true });
+        }),
+      };
+    }));
+    const frames = [];
+    const download = downloadSlotstreamModel({ model: REPO, cacheDir, onProgress: (frame) => frames.push(frame) });
+
+    await vi.waitFor(() => expect(globalThis.fetch).toHaveBeenCalledOnce());
+    await vi.advanceTimersByTimeAsync(15_000);
+    await expect(download).resolves.toMatchObject({
+      success: false,
+      cancelled: false,
+      code: 'SLOTSTREAM_METADATA_TIMEOUT',
+    });
+    expect(frames.at(-1)).toMatchObject({ event: 'error' });
+    expect(frames.at(-1).message).toMatch(/metadata lookup.*timed out.*retry/i);
+    expect(isSlotstreamDownloadInFlight(join(cacheDir, DIR_NAME))).toBe(false);
+  });
+
+  it('times out a hanging metadata body during preview', async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal('fetch', vi.fn(async (_url, { signal }) => ({
+      ok: true,
+      status: 200,
+      text: () => new Promise((_resolve, reject) => {
+        signal.addEventListener('abort', () => reject(signal.reason), { once: true });
+      }),
+    })));
+    const preview = previewSlotstreamDownload({ model: REPO, cacheDir });
+    const assertion = expect(preview).rejects.toMatchObject({ code: 'SLOTSTREAM_METADATA_TIMEOUT', status: 504 });
+
+    await vi.waitFor(() => expect(globalThis.fetch).toHaveBeenCalledOnce());
+    await vi.advanceTimersByTimeAsync(15_000);
+    await assertion;
+  });
+
+  it('preserves explicit cancellation while metadata is pending', async () => {
+    vi.stubGlobal('fetch', vi.fn((_url, { signal }) => (
+      new Promise((_resolve, reject) => signal.addEventListener('abort', () => reject(signal.reason), { once: true }))
+    )));
+    const frames = [];
+    const download = downloadSlotstreamModel({ model: REPO, cacheDir, onProgress: (frame) => frames.push(frame) });
+    await vi.waitFor(() => expect(globalThis.fetch).toHaveBeenCalledOnce());
+    expect(cancelSlotstreamModelDownload({ model: REPO, cacheDir })).toBe(true);
+
+    await expect(download).resolves.toMatchObject({
+      success: false,
+      cancelled: true,
+      code: 'SLOTSTREAM_DOWNLOAD_CANCELLED',
+    });
+    expect(frames.at(-1).event).toBe('cancelled');
+  });
+
+  it('does not apply the metadata deadline to a checkpoint transfer', async () => {
+    vi.useFakeTimers();
+    let transferSignal;
+    let finishShard;
+    vi.stubGlobal('fetch', vi.fn(async (url, options) => {
+      const href = String(url);
+      if (href.startsWith('https://huggingface.co/api/models/')) return metadataResponse();
+      const name = Object.keys(FILES).find((file) => href.endsWith(`/${file}`));
+      if (name === 'config.json') return new Response(CONFIG, { headers: { 'content-length': String(CONFIG.length) } });
+      transferSignal = options.signal;
+      const body = new ReadableStream({
+        start(controller) {
+          finishShard = () => {
+            controller.enqueue(new TextEncoder().encode(SHARD));
+            controller.close();
+          };
+        },
+      });
+      return new Response(body, { headers: { 'content-length': String(SHARD.length) } });
+    }));
+    const download = downloadSlotstreamModel({ model: REPO, cacheDir });
+    await vi.waitFor(() => expect(transferSignal).toBeDefined());
+
+    await vi.advanceTimersByTimeAsync(15_000);
+    expect(transferSignal.aborted).toBe(false);
+    finishShard();
+    await expect(download).resolves.toMatchObject({ success: true });
   });
 
   it('refuses a second download of the same checkpoint while one is running', async () => {

--- a/server/services/specDecodeModels.js
+++ b/server/services/specDecodeModels.js
@@ -17,6 +17,8 @@ import { resolve } from 'path';
 import { expandHome } from '../lib/fileUtils.js';
 import { isProjectorName, isShardedGguf } from '../lib/localLlmDisk.js';
 import { ServerError } from '../lib/errorHandler.js';
+import { withAbortTimeout } from '../lib/abortTimeout.js';
+import { anyAbortSignal } from '../lib/requestAbort.js';
 import {
   assessDownloadPreflight,
   assertDownloadFits,
@@ -184,23 +186,36 @@ const siblingFor = (model, filename) => {
   return siblings.find((row) => row?.rfilename === filename) || null;
 };
 
-// The preview path (previewSpecDecodeDownload) calls this with no signal —
-// a real download's own abort chain covers the actual transfer, but a
-// metadata/size lookup that just blocks the confirm modal needs its own
-// bound, or a stalled-but-reachable HF hangs the preview indefinitely.
+// Planning is short-lived whether it serves the preview or a confirmed download.
+// Its deadline is separate from the transfer watchdog: multi-gigabyte weights may
+// stream for hours, while metadata headers/body and the size fallback must settle.
 const METADATA_FETCH_TIMEOUT_MS = 10_000;
 
 const resolveSpecDownloadPlan = async ({ source, destPath, token, signal }) => {
-  const boundedSignal = signal || AbortSignal.timeout(METADATA_FETCH_TIMEOUT_MS);
   const headers = buildHfAuthHeaders(token);
-  const model = await fetchHuggingfaceModel(source.repo, { token, signal: boundedSignal });
-  const file = pickGgufSibling(model, { file: source.file, quant: source.quant, repo: source.repo });
-  const url = buildHfResolveUrl(source.repo, 'main', file);
-  let meta = siblingDownloadMeta(siblingFor(model, file));
-  if (!meta.bytes) {
-    const probed = await probeRemoteSize(url, { headers, signal: boundedSignal });
-    meta = { bytes: probed.bytes || meta.bytes, sha256: meta.sha256 || probed.sha256 };
-  }
+  const { file, url, meta } = await withAbortTimeout(METADATA_FETCH_TIMEOUT_MS, async (deadline) => {
+    const boundedSignal = anyAbortSignal([signal, deadline]);
+    try {
+      const model = await fetchHuggingfaceModel(source.repo, { token, signal: boundedSignal });
+      const selectedFile = pickGgufSibling(model, { file: source.file, quant: source.quant, repo: source.repo });
+      const selectedUrl = buildHfResolveUrl(source.repo, 'main', selectedFile);
+      let selectedMeta = siblingDownloadMeta(siblingFor(model, selectedFile));
+      if (!selectedMeta.bytes) {
+        const probed = await probeRemoteSize(selectedUrl, { headers, signal: boundedSignal });
+        boundedSignal.throwIfAborted();
+        selectedMeta = { bytes: probed.bytes || selectedMeta.bytes, sha256: selectedMeta.sha256 || probed.sha256 };
+      }
+      return { file: selectedFile, url: selectedUrl, meta: selectedMeta };
+    } catch (err) {
+      if (deadline.aborted && !signal?.aborted) {
+        throw new ServerError(
+          `Hugging Face metadata lookup for ${source.repo} timed out — retry the download.`,
+          { status: 504, code: 'SPEC_METADATA_TIMEOUT' },
+        );
+      }
+      throw err;
+    }
+  });
   const preflight = await assessDownloadPreflight({ destPath, expectedBytes: meta.bytes });
   return { file, url, headers, meta, preflight };
 };

--- a/server/services/specDecodeModels.test.js
+++ b/server/services/specDecodeModels.test.js
@@ -143,6 +143,7 @@ describe('downloadSpecDecodeModel', () => {
   });
 
   afterEach(async () => {
+    vi.useRealTimers();
     _resetSpecDecodeDownloadsForTests();
     vi.restoreAllMocks();
     await rm(dir, { recursive: true, force: true });
@@ -304,6 +305,111 @@ describe('downloadSpecDecodeModel', () => {
 
     const status = await getSpecDecodePresetStatus();
     expect(status.every((p) => !p.model?.downloading && !p.draftModel?.downloading)).toBe(true);
+  });
+
+  it.each(['headers', 'body'])('times out hanging metadata %s, emits an error, and releases the slot for retry', async (phase) => {
+    vi.useFakeTimers();
+    stubPreset();
+    let metadataCalls = 0;
+    vi.stubGlobal('fetch', vi.fn(async (_url, { signal }) => {
+      metadataCalls += 1;
+      if (metadataCalls > 1) return new Response(JSON.stringify(siblings('Example-Q4_K_M.gguf')));
+      if (phase === 'headers') {
+        return new Promise((_resolve, reject) => {
+          signal.addEventListener('abort', () => reject(signal.reason), { once: true });
+        });
+      }
+      return {
+        ok: true,
+        status: 200,
+        text: () => new Promise((_resolve, reject) => {
+          signal.addEventListener('abort', () => reject(signal.reason), { once: true });
+        }),
+      };
+    }));
+    const frames = [];
+    const first = downloadSpecDecodeModel({
+      presetId: 'test-preset', role: 'model', onProgress: (frame) => frames.push(frame),
+    });
+    const assertion = expect(first).rejects.toMatchObject({ code: 'SPEC_METADATA_TIMEOUT', status: 504 });
+
+    await vi.waitFor(() => expect(globalThis.fetch).toHaveBeenCalledOnce());
+    await vi.advanceTimersByTimeAsync(10_000);
+    await assertion;
+    expect(frames.at(-1)).toMatchObject({ event: 'error' });
+    expect(frames.at(-1).message).toMatch(/metadata lookup.*timed out.*retry/i);
+
+    vi.useRealTimers();
+    vi.spyOn(huggingfaceLora, 'fetchHuggingfaceModel').mockResolvedValue(siblings('Example-Q4_K_M.gguf'));
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: { get: () => '2' },
+      body: Readable.toWeb(Readable.from([Buffer.from('gg')])),
+    });
+    await expect(downloadSpecDecodeModel({ presetId: 'test-preset', role: 'model' }))
+      .resolves.toMatchObject({ success: true });
+  });
+
+  it('keeps the size-probe fallback inside the metadata deadline', async () => {
+    vi.useFakeTimers();
+    stubPreset();
+    vi.spyOn(huggingfaceLora, 'fetchHuggingfaceModel').mockResolvedValue({
+      siblings: [{ rfilename: 'Example-Q4_K_M.gguf' }],
+    });
+    let aborted = false;
+    vi.spyOn(globalThis, 'fetch').mockImplementation((_url, { signal }) => {
+      if (aborted || signal.aborted) return Promise.reject(signal.reason);
+      return new Promise((_resolve, reject) => {
+        signal.addEventListener('abort', () => {
+          aborted = true;
+          reject(signal.reason);
+        }, { once: true });
+      });
+    });
+    const download = downloadSpecDecodeModel({ presetId: 'test-preset', role: 'model' });
+    const assertion = expect(download).rejects.toMatchObject({ code: 'SPEC_METADATA_TIMEOUT' });
+    await vi.waitFor(() => expect(globalThis.fetch).toHaveBeenCalled());
+
+    await vi.advanceTimersByTimeAsync(10_000);
+    await assertion;
+  });
+
+  it('preserves explicit cancellation while metadata headers are pending', async () => {
+    stubPreset();
+    vi.spyOn(huggingfaceLora, 'fetchHuggingfaceModel').mockImplementation((_repo, { signal }) => (
+      new Promise((_resolve, reject) => signal.addEventListener('abort', () => reject(signal.reason), { once: true }))
+    ));
+    const frames = [];
+    const download = downloadSpecDecodeModel({
+      presetId: 'test-preset', role: 'model', onProgress: (frame) => frames.push(frame),
+    });
+    await vi.waitFor(() => expect(frames).toHaveLength(1));
+    expect(cancelSpecDecodeModelDownload({ presetId: 'test-preset', role: 'model' })).toBe(true);
+
+    await expect(download).rejects.toMatchObject({ code: 'SPEC_DOWNLOAD_CANCELLED' });
+    expect(frames.at(-1).event).toBe('cancelled');
+  });
+
+  it('does not apply the metadata deadline to the weight transfer', async () => {
+    vi.useFakeTimers();
+    stubPreset();
+    vi.spyOn(huggingfaceLora, 'fetchHuggingfaceModel').mockResolvedValue(siblings('Example-Q4_K_M.gguf'));
+    let transferSignal;
+    let finish;
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (_url, { signal }) => {
+      transferSignal = signal;
+      const body = new Readable({ read() {} });
+      finish = () => body.push(Buffer.from('gg')) && body.push(null);
+      return { ok: true, status: 200, headers: { get: () => '2' }, body: Readable.toWeb(body) };
+    });
+    const download = downloadSpecDecodeModel({ presetId: 'test-preset', role: 'model' });
+    await vi.waitFor(() => expect(transferSignal).toBeDefined());
+
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(transferSignal.aborted).toBe(false);
+    finish();
+    await expect(download).resolves.toMatchObject({ success: true });
   });
 
   it('short-circuits when the weights are already on disk', async () => {


### PR DESCRIPTION
## Summary

- combine each model download slot's cancellation signal with a short metadata deadline
- report typed, retryable metadata timeout failures while releasing held slots
- keep multi-gigabyte transfer streams outside the metadata deadline

## Test plan

- `cd server && node_modules/.bin/vitest run services/specDecodeModels.test.js services/slotstreamModelManager.test.js`
- optional Codex static review: APPROVE

Closes #7210
