### PR TITLE
feat: document contributor issue claims and PR acceptance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,53 @@
+# Contributing to PortOS
+
+Contributions are welcome. PortOS moves fast, and issues are often resolved and
+closed quickly. Please coordinate before starting so your work does not duplicate
+something already underway.
+
+## Claim an issue before starting
+
+1. Find an open issue. New contributors should ideally start with one labeled
+   **`help wanted`** or **`good first issue`**.
+2. Check its labels, assignees, and recent comments. **An issue labeled
+   `in-progress` or assigned to someone is not up for grabs.** Choose another
+   issue unless the maintainer explicitly invites you to collaborate.
+3. Comment on the issue saying you would like to claim it, with a brief outline
+   of your intended approach. For example: “I'd like to claim this issue. I plan
+   to address it by …”
+4. Wait for the maintainer to confirm the claim and assign you before starting
+   implementation. A claim comment alone does not reserve the issue.
+
+Anyone is welcome to file an issue and ask to work on it. Search existing issues
+and PRs first, then describe the bug or proposed improvement and the scope you
+would like to take on. You do not need to limit yourself to labeled starter issues.
+
+If you can no longer work on a claimed issue, leave a comment so the maintainer
+can make it available again.
+
+## Submit a pull request
+
+- Work on a feature branch in your fork and open your PR against **`main`**.
+- Keep the change focused on the agreed issue. Link the issue in the PR and
+  explain what changed, why, and how you verified it. Include screenshots for
+  visible UI changes where useful.
+- Follow the [development setup and code conventions](docs/CONTRIBUTING.md) and
+  the applicable [repository instructions](AGENTS.md). Use descriptive
+  conventional commit messages.
+- Run the checks relevant to your change and report the results and any testing
+  limitations. Add regression coverage when it meaningfully protects changed
+  behavior. DB-backed tests must use the isolated test database, never your real
+  PortOS database; see the development guide for commands.
+- Respond to review feedback and keep the PR current as needed. Required CI
+  checks must pass before merge.
+
+## How PRs are accepted
+
+The maintainer reviews contributions for fit with PortOS, correctness, scope,
+and validation. Small, focused bug fixes, documentation corrections, and
+quality-of-life improvements are the easiest starting points. Discuss larger
+features in an issue before investing significant time.
+
+PortOS is a personal, opinionated project that prioritizes its author's needs.
+Claiming an issue or passing CI does not guarantee acceptance: the maintainer
+may request changes, rework a proposal, or decline a PR that does not fit the
+project. Coordinating on the issue first helps establish expectations early.

--- a/README.md
+++ b/README.md
@@ -473,6 +473,10 @@ Full catalog (including design plans, ADRs, and research notes): [docs/README.md
 
 ## Contributing
 
+Read [CONTRIBUTING.md](./CONTRIBUTING.md) for issue claiming and PR acceptance.
+Comment to request an issue and wait for assignment before starting; issues
+labeled `in-progress` or already assigned are not up for grabs.
+
 Pull requests are welcome. This is a personal project, so:
 
 - **Breakage happens.** Major version bumps (e.g. v2.0.0) may rename pages, reorganize data directories, or change schemas in ways that require a migration pass on your local data. Check the relevant `.changelog/vX.Y.Z.md` for what changed.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,5 +1,8 @@
 # Contributing Guide
 
+Before starting work, read [how to claim an issue and submit a PR](../CONTRIBUTING.md).
+Issues labeled `in-progress` or assigned to someone are not available to claim.
+
 PortOS is a highly opinionated, personal project — a single developer's "everything app," built and maintained for that developer's own machine and workflow. It's MIT-licensed and open to the public, but it is **not** built or governed as a general-purpose open source project: there's no roadmap vote, no maintainer team, and no commitment to stability for anyone else's deployment. Read this before opening a PR so expectations are clear going in.
 
 ## Before You Open a PR


### PR DESCRIPTION
## Summary

Add a root contribution guide explaining how to claim issues before starting work, which issues are unavailable, and how PRs are reviewed and accepted. Encourage new contributors to start with help wanted or good first issue labels while welcoming new issue proposals.

Link the policy from the README and existing development guide.

## Test plan

- Reviewed the documentation against the requested claiming and acceptance policy.
- Checked local documentation link targets and existing development commands.
- `git diff --check` passed.
- Documentation only; no runtime behavior changed.
