### PR TITLE
fix: acknowledge manual app tasks immediately and log admission timing

### DIFF
--- a/client/src/components/apps/tabs/AutomationTab.jsx
+++ b/client/src/components/apps/tabs/AutomationTab.jsx
@@ -129,12 +129,13 @@ export default function AutomationTab({ appId, appName }) {
   };
 
   const handleTrigger = async (taskType) => {
+    const toastId = toast.loading(`Sending ${taskType} request for ${appName}…`);
     const result = await api.triggerCosOnDemandTask(taskType, appId, { silent: true }).catch(err => {
       toast.error(err.message);
       return null;
-    });
+    }).finally(() => toast.dismiss(toastId));
     if (result?.success) {
-      toast.success(`Triggered ${taskType} for ${appName}`);
+      toast.success(`Queued ${taskType} request for ${appName} — checks and available capacity determine when an agent appears`);
     }
     return result?.success ? result : null;
   };

--- a/client/src/components/apps/tabs/AutomationTab.test.jsx
+++ b/client/src/components/apps/tabs/AutomationTab.test.jsx
@@ -75,6 +75,39 @@ beforeEach(() => {
 });
 
 describe('AutomationTab per-app options', () => {
+  it('acknowledges a slow run immediately, prevents duplicate clicks, and retains the queued receipt', async () => {
+    await renderTab({ security: { enabled: true } });
+    let resolveRun;
+    api.triggerCosOnDemandTask.mockReturnValueOnce(new Promise(resolve => { resolveRun = resolve; }));
+    mockToast.loading.mockReturnValueOnce('run-toast');
+    const row = rowFor('security');
+    fireEvent.click(within(row).getByRole('button', { name: 'Run Now' }));
+    expect(mockToast.loading).toHaveBeenCalledWith('Sending security request for MyApp…');
+    const sending = within(row).getByRole('button', { name: 'Sending…' });
+    expect(sending).toBeDisabled();
+    fireEvent.click(sending);
+    expect(api.triggerCosOnDemandTask).toHaveBeenCalledTimes(1);
+    expect(mockToast.success).not.toHaveBeenCalled();
+    await act(async () => resolveRun({ success: true, request: { id: 'request-1' } }));
+    expect(mockToast.dismiss).toHaveBeenCalledWith('run-toast');
+    expect(mockToast.success).toHaveBeenCalledWith(expect.stringContaining('Queued security request for MyApp'));
+    expect(within(row).getByText('Request queued')).toBeVisible();
+    expect(within(row).getByRole('button', { name: 'Run Now' })).toBeEnabled();
+  });
+
+  it('clears sending feedback on rejection without claiming the run was queued', async () => {
+    await renderTab({ security: { enabled: true } });
+    api.triggerCosOnDemandTask.mockRejectedValueOnce(new Error('CoS unavailable'));
+    mockToast.loading.mockReturnValueOnce('failed-run-toast');
+    const row = rowFor('security');
+    fireEvent.click(within(row).getByRole('button', { name: 'Run Now' }));
+    await waitFor(() => expect(mockToast.dismiss).toHaveBeenCalledWith('failed-run-toast'));
+    expect(mockToast.error).toHaveBeenCalledWith('CoS unavailable');
+    expect(mockToast.success).not.toHaveBeenCalled();
+    expect(within(row).queryByText('Request queued')).toBeNull();
+    expect(within(row).getByRole('button', { name: 'Run Now' })).toBeEnabled();
+  });
+
   it('puts custom automations before the shared schedule cards and shows app cadence', async () => {
     await renderTab({ security: { enabled: true, interval: 'on-demand' } });
     const custom = screen.getByText('Custom Tasks');

--- a/client/src/components/cos/tabs/ScheduleTab.test.jsx
+++ b/client/src/components/cos/tabs/ScheduleTab.test.jsx
@@ -97,7 +97,7 @@ describe('ScheduleTab on-demand feedback', () => {
     expect(toast.success).toHaveBeenCalledWith(
       'Queued review request for Example App — it will appear in Tasks when evaluation begins',
     );
-    expect(await screen.findByText('Request sent to Example App')).toBeVisible();
+    expect(await screen.findByText('Request queued for Example App')).toBeVisible();
     expect(screen.getByText('Pending On-Demand Tasks')).toBeVisible();
     expect(screen.getByText(/review \(Example App\) - requested/)).toBeVisible();
   });

--- a/client/src/components/cos/tabs/schedule/RunTaskButton.jsx
+++ b/client/src/components/cos/tabs/schedule/RunTaskButton.jsx
@@ -72,8 +72,8 @@ export default function RunTaskButton({ taskType, apps, onTrigger, installWide =
       setTriggering(false);
       if (!result) return;
       setLastRequest(app?.name
-        ? `Request sent to ${app.name}`
-        : installWide ? 'Request sent for all apps' : 'Request sent');
+        ? `Request queued for ${app.name}`
+        : installWide ? 'Request queued for all apps' : 'Request queued');
     };
 
     // ScheduleTab owns error feedback and always resolves to null on failure.
@@ -88,12 +88,15 @@ export default function RunTaskButton({ taskType, apps, onTrigger, installWide =
     <span
       role="status"
       title={lastRequest || undefined}
-      className={lastRequest
-        ? 'mt-1 flex min-w-0 max-w-48 items-center gap-1 text-[11px] text-port-success'
+      className={lastRequest || triggering
+        ? `mt-1 flex min-w-0 max-w-48 flex-col items-start gap-1 text-[11px] ${lastRequest ? 'text-port-success' : 'text-gray-400'}`
         : 'sr-only'}
     >
-      {lastRequest && <CheckCircle2 size={12} className="shrink-0" />}
-      <span className={lastRequest ? 'min-w-0 flex-1 truncate' : ''}>{triggering ? 'Sending request' : lastRequest}</span>
+      <span className="flex items-start gap-1">
+        {lastRequest && <CheckCircle2 size={12} className="shrink-0" />}
+        <span>{triggering ? 'Sending request' : lastRequest}</span>
+      </span>
+      {lastRequest && <span className="text-gray-400">Checks and available capacity determine when {programmatic ? 'work starts' : 'an agent appears'}. See CoS for progress.</span>}
     </span>
   );
 

--- a/client/src/components/cos/tabs/schedule/RunTaskButton.test.jsx
+++ b/client/src/components/cos/tabs/schedule/RunTaskButton.test.jsx
@@ -88,8 +88,9 @@ describe('RunTaskButton', () => {
 
     await act(async () => { resolveTrigger({ id: 'request-1' }); });
 
-    expect(screen.getByRole('status')).toHaveTextContent('Request sent to Example App');
-    expect(screen.getByText('Request sent to Example App')).toBeVisible();
+    expect(screen.getByRole('status')).toHaveTextContent('Request queued for Example App');
+    expect(screen.getByText('Request queued for Example App')).toBeVisible();
+    expect(screen.getByRole('status')).toHaveTextContent('Checks and available capacity determine when an agent appears');
     expect(screen.getByRole('button', { name: /Run on App/i })).toBeEnabled();
   });
 

--- a/server/services/onDemandDrain.js
+++ b/server/services/onDemandDrain.js
@@ -131,6 +131,10 @@ export async function drainOnDemandRequests(ctx, adapter) {
 
     await taskScheduleMod.clearOnDemandRequest(request.id);
 
+    const preparationStartedAt = performance.now();
+    const requestedAt = Date.parse(request.requestedAt);
+    const queueWaitMs = Number.isFinite(requestedAt) ? Math.max(0, Date.now() - requestedAt) : null;
+
     // A HUMAN "Run" re-checks live state (park + convergence signature + dispatch
     // budget all cleared); an automated refill (origin: 'refill') inherits them,
     // or the drain has no brakes left. The origin check lives inside
@@ -221,6 +225,16 @@ export async function drainOnDemandRequests(ctx, adapter) {
       // and nobody is waiting on it, so toasting "nothing to do" for every automated
       // hop would turn a healthy overnight drain into a pile of notifications.
       await emitOnDemandEmpty({ taskScheduleMod, request, targetApp, taskConfig: schedule.tasks[request.taskType] });
+    }
+    if (userInitiated) {
+      const preparationMs = Math.round(performance.now() - preparationStartedAt);
+      emitLog('info', `On-demand preparation finished: ${request.taskType} (${request.id}) — queue wait ${queueWaitMs ?? 'unknown'}ms, preparation ${preparationMs}ms, ${task ? 'task generated' : 'no task generated'}`, {
+        requestId: request.id,
+        appId: targetApp?.id ?? null,
+        queueWaitMs,
+        preparationMs,
+        taskGenerated: !!task,
+      });
     }
   }
 


### PR DESCRIPTION
## Summary
Manual scheduled runs on an app now show a loading notification immediately and keep a visible queued receipt explaining why an agent may appear later. Failed requests dismiss the loading notification without claiming admission, and in-flight clicks remain disabled.

Traced AutomationTab → schedule/trigger → persisted on-demand request → setImmediate dequeue → capacity checks → repository/forge preparation → task creation. There is no polling timer on this path. Capacity holds and preflight/work-detector probes (including forge calls with 15-second timeouts) can delay agent creation. Add per-request queue-wait and preparation durations to CoS logs for manual agent-producing runs, without changing scheduling or safety gates. This is a feedback and observability fix; no live latency reduction is claimed.

## Test plan
- Client: AutomationTab, RunTaskButton, AppTaskCard, ScheduleTab — 60 tests passed, including slow-response feedback, duplicate-click prevention, and rejection recovery.
- Server: onDemandDrain — 55 tests passed across both admission adapters.
- Biome lint passed for all changed client files; git diff --check passed.
- Reviewed changed code for reuse, lifecycle cleanup, truthful receipt semantics, and scheduling compatibility. No live AI work was triggered for benchmarking.
