### PR TITLE
fix: align app edit action on desktop

### DIFF
--- a/client/src/components/apps/AppDetailView.jsx
+++ b/client/src/components/apps/AppDetailView.jsx
@@ -316,7 +316,7 @@ function AppDetail() {
               >
                 <ArrowLeft size={20} />
               </Link>
-              <div className="flex flex-1 min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
+              <div className="flex flex-1 lg:flex-initial min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
                 <h1
                   className="min-w-0 line-clamp-2 break-words text-xl font-bold text-white"
                   title={app.name}

--- a/client/src/components/apps/AppDetailView.test.jsx
+++ b/client/src/components/apps/AppDetailView.test.jsx
@@ -136,6 +136,14 @@ describe('AppDetailView header title', () => {
     const heading = await screen.findByRole('heading', { name: longName });
     expect(heading).toHaveAttribute('title', longName);
   });
+
+  it('keeps the edit control next to the app identity on desktop', async () => {
+    api.getApp.mockResolvedValue(APP);
+    renderDetail();
+
+    const heading = await screen.findByRole('heading', { name: APP.name });
+    expect(heading.parentElement).toHaveClass('flex-1', 'lg:flex-initial', 'min-w-0');
+  });
 });
 
 describe('AppDetailView managed-app feature tabs', () => {


### PR DESCRIPTION
## Summary

- Keep the app identity group content-sized on desktop so the Edit control stays beside the app name and status.
- Preserve the flex growth used by the compact mobile header.

## Test plan

- `./node_modules/.bin/vitest run src/components/apps/AppDetailView.test.jsx` (9 passed)
- `./node_modules/.bin/biome lint src/components/apps/AppDetailView.jsx src/components/apps/AppDetailView.test.jsx`
- `./node_modules/.bin/vite build`
- Full client suite: 11,580 passed, 6 skipped, 1 unrelated pre-existing ModelAbuseGuardPanel failure due unavailable localhost:3000.