### PR TITLE
fix: restore differing file bytes by checksum

### DIFF
--- a/docs/BACKUP.md
+++ b/docs/BACKUP.md
@@ -72,7 +72,7 @@ Before rsync can read or overwrite live data, PortOS strictly reads `manifest.js
 
 Snapshots from PortOS versions that predate `manifest.json` remain restorable as an explicit compatibility case. Restore responses report `verification.status` as `verified` (with `checkedFiles`) or `unverified` with reason `manifest_absent`; the confirmation panel warns when a legacy restore cannot be verified. An existing manifest that is malformed or unreadable fails closed and is never treated as legacy absence.
 
-After the preflight, rsync copies `<snapshot>/data/` back to `./data/`. `dryRun: true` (the default) reports what would change without writing; an optional `subdirFilter` limits the restore to one subdirectory.
+After the preflight, rsync copies `<snapshot>/data/` back to `./data/`. Restore always passes `--checksum`, so rsync compares file contents even when the live file has the same size and modification time as the snapshot; equal-content files remain skippable, while differing bytes appear in previews and are restored. This applies to dry-run and live restores, including selective subdirectory restores and legacy snapshots without a manifest. `dryRun: true` (the default) reports what would change without writing; an optional `subdirFilter` limits the restore to one subdirectory.
 
 ### Database — `restorePostgres()`
 

--- a/server/services/backup.js
+++ b/server/services/backup.js
@@ -1140,7 +1140,10 @@ export async function restoreSnapshot(destPath, snapshotId, { dryRun = true, sub
   // between requests, especially on removable or network-backed destinations.
   const verification = await verifySnapshotFiles(snapshotDir, srcDir, snapshotId, subdirFilter);
 
-  const flags = ['--itemize-changes'];
+  // Restore must compare destination bytes even when size and mtime match.
+  // Rsync's default quick-check would otherwise report a successful no-op for
+  // equal-length edits that retain the snapshot timestamp.
+  const flags = ['--itemize-changes', '--checksum'];
   if (dryRun) flags.push('--dry-run');
   if (subdirFilter) {
     flags.push(`--include=${subdirFilter}/***`);

--- a/server/services/backup.test.js
+++ b/server/services/backup.test.js
@@ -1466,6 +1466,7 @@ describe('restoreSnapshot manifest verification', () => {
     await expect(finishRestore({ dryRun: true })).resolves.toMatchObject({
       verification: { status: 'unverified', reason: 'manifest_absent', checkedFiles: 0 },
     });
+    expect(spawn.mock.calls[0][1]).toContain('--checksum');
 
     const targetHash = await writeSnapshotFile('example.txt', 'example');
     await realFs.symlink('example.txt', joinPath(snapshotDataDir, 'readable-link'));
@@ -1479,6 +1480,57 @@ describe('restoreSnapshot manifest verification', () => {
     await expect(finishRestore({ dryRun: true })).resolves.toMatchObject({
       verification: { status: 'verified', checkedFiles: 2 },
     });
+  });
+
+  it('restores differing bytes when size and mtime match through real rsync', async () => {
+    const relativePath = 'brain/example.json';
+    const snapshotContent = '{"value":"old"}';
+    const liveContent = '{"value":"new"}';
+    const sourcePath = joinPath(snapshotDataDir, relativePath);
+    const livePath = joinPath(PATHS.data, relativePath);
+    const snapshotHash = await writeSnapshotFile(relativePath, snapshotContent);
+    await writeManifest({ [relativePath]: snapshotHash });
+    await realFs.mkdir(joinPath(livePath, '..'), { recursive: true });
+    await realFs.writeFile(livePath, liveContent);
+
+    const matchingMtime = new Date('2026-09-12T00:00:00.000Z');
+    await realFs.utimes(sourcePath, matchingMtime, matchingMtime);
+    await realFs.utimes(livePath, matchingMtime, matchingMtime);
+
+    const previousRsync = process.env.PORTOS_RSYNC;
+    delete process.env.PORTOS_RSYNC;
+    spawn.mockImplementation((...args) => spawnChild(...args));
+
+    try {
+      const fullPreview = await restoreSnapshot(tmpRoot, 'snap-1', { dryRun: true });
+      expect(fullPreview.changedFiles.some(line => line.includes(relativePath))).toBe(true);
+      expect(await realFs.readFile(livePath, 'utf8')).toBe(liveContent);
+
+      await restoreSnapshot(tmpRoot, 'snap-1', { dryRun: false });
+      expect(await realFs.readFile(livePath, 'utf8')).toBe(snapshotContent);
+
+      await realFs.writeFile(livePath, liveContent);
+      await realFs.utimes(livePath, matchingMtime, matchingMtime);
+      const selectivePreview = await restoreSnapshot(tmpRoot, 'snap-1', {
+        dryRun: true,
+        subdirFilter: 'brain',
+      });
+      expect(selectivePreview.changedFiles.some(line => line.includes(relativePath))).toBe(true);
+      expect(await realFs.readFile(livePath, 'utf8')).toBe(liveContent);
+
+      await restoreSnapshot(tmpRoot, 'snap-1', { dryRun: false, subdirFilter: 'brain' });
+      expect(await realFs.readFile(livePath, 'utf8')).toBe(snapshotContent);
+
+      const equalPreview = await restoreSnapshot(tmpRoot, 'snap-1', {
+        dryRun: true,
+        subdirFilter: 'brain',
+      });
+      expect(equalPreview.changedFiles.filter(line => line.includes(relativePath))).toEqual([]);
+    } finally {
+      if (previousRsync === undefined) delete process.env.PORTOS_RSYNC;
+      else process.env.PORTOS_RSYNC = previousRsync;
+      spawn.mockReset();
+    }
   });
 });
 
@@ -1545,7 +1597,7 @@ describe('restoreSnapshot subdirFilter guard', () => {
       });
       expect(spawn).toHaveBeenCalledWith(
         '/custom/bin/rsync',
-        expect.arrayContaining(['--archive', '--itemize-changes', '--progress', '--dry-run']),
+        expect.arrayContaining(['--archive', '--itemize-changes', '--progress', '--checksum', '--dry-run']),
         { shell: false },
       );
     } finally {
@@ -1845,6 +1897,7 @@ describe('restoreSnapshot snapshotId, filter flags, and settings re-sync', () =>
         '--itemize-changes',
         '--progress',
         '--itemize-changes',
+        '--checksum',
         '--dry-run',
         '--include=brain/***',
         '--include=*/',


### PR DESCRIPTION
Closes #7226

## Summary
- Force restore previews and executions to compare destination file contents, including selective and legacy restores.
- Keep snapshot creation on its existing metadata-based transfer policy.
- Document the content-comparison behavior and add a real-rsync regression for equal-size, equal-mtime files.

## Tests
- `./node_modules/.bin/vitest run services/backup.test.js routes/backup.test.js --reporter=dot` (183 passed)