### PR TITLE
Put the local LLM playground prompt and Run action above the fold

### DIFF
--- a/client/src/pages/LocalLlmPlayground.jsx
+++ b/client/src/pages/LocalLlmPlayground.jsx
@@ -369,15 +369,20 @@ export default function LocalLlmPlayground() {
     setSelectedTargets([{ backend: installedTargets[0].backend, modelId: installedTargets[0].modelId }]);
   }, [installedTargets, selectedTargets.length]);
 
-  // With nothing selected — no installed models, a stale URL target that was
-  // dropped, or every compare target deselected — the run can't proceed, so the
-  // narrow disclosure opens on the model list (or on the "no models installed"
-  // message) instead of collapsing the prerequisite out of sight. `modelsOpen`
-  // is deliberately not a dependency: closing it by hand must not re-open it.
+  // Nothing is selectable — the install has no local models, or none that pass
+  // the hardware filter — so the narrow disclosure opens on that empty state
+  // instead of collapsing the prerequisite out of sight.
+  //
+  // Gated on the INSTALLED list, not on the selection: with models present the
+  // auto-select effect above fills an empty selection in the same flush, so
+  // keying on the momentarily-empty selection would open the inventory on every
+  // visit that carries no URL target and never close it again — which is the
+  // regression this page is being fixed for. `modelsOpen` is deliberately not a
+  // dependency: closing the empty state by hand must not re-open it.
   useEffect(() => {
-    if (loadingStatus || selectedTargets.length > 0) return;
+    if (loadingStatus || installedTargets.length > 0) return;
     setModelsOpen(true);
-  }, [loadingStatus, selectedTargets.length]);
+  }, [installedTargets.length, loadingStatus]);
 
   const selectedKeys = useMemo(() => new Set(selectedTargets.map(localLlmTargetKey)), [selectedTargets]);
   // `/api/ps` reports what's resident but not which model is mid-generation, so

--- a/client/src/pages/LocalLlmPlayground.jsx
+++ b/client/src/pages/LocalLlmPlayground.jsx
@@ -6,6 +6,7 @@ import { ArrowLeft, ArrowRightLeft, Brain, Check, ChevronDown, Clock, Copy, Cpu,
 import BrailleSpinner from '../components/BrailleSpinner';
 import PlaygroundOutput from '../components/localLlm/PlaygroundOutput';
 import ModelsTabsHeader from '../components/models/ModelsTabsHeader';
+import CollapsibleSection from '../components/ui/CollapsibleSection';
 import toast from '../components/ui/Toast';
 import { copyToClipboard } from '../lib/clipboard';
 import { localLlmTargetKey } from '../lib/localLlmTargetKey';
@@ -15,6 +16,14 @@ import { compareLocalLlmModels, getLoadedLlmModels, getLocalLlmCatalog, getLocal
 
 const BACKEND_LABEL = { ollama: 'Ollama', lmstudio: 'LM Studio' };
 const DEFAULT_PROMPT = 'Write a short, vivid paragraph about a lighthouse computer waking up at dawn.';
+// Single source for the timeout choices so the collapsed Advanced-options
+// summary names the selected one without re-deriving the label from the ms.
+const TIMEOUT_OPTIONS = [
+  { value: 60000, label: '1 minute', short: '1 min' },
+  { value: 180000, label: '3 minutes', short: '3 min' },
+  { value: 300000, label: '5 minutes', short: '5 min' },
+  { value: 600000, label: '10 minutes', short: '10 min' },
+];
 const CATEGORY_LABELS = {
   general: 'General purpose',
   coding: 'Coding & agents',
@@ -243,9 +252,12 @@ export default function LocalLlmPlayground() {
   const [chatResults, setChatResults] = useState([]);
   const [streamingChat, setStreamingChat] = useState(null);
   const [compareResult, setCompareResult] = useState(null);
-  // Models sidebar is always shown on xl+; on smaller screens it collapses so
-  // the prompt/controls stay above the fold. Open by default on first load.
-  const [modelsOpen, setModelsOpen] = useState(true);
+  // Models sidebar is always shown on xl+; on smaller screens it is a
+  // disclosure. It starts CLOSED so the prompt and the Run button are the first
+  // things a narrow viewport shows — the whole inventory expanded ahead of them
+  // pushed Run ~2,400px down a 375×812 screen (#7232). The effect below reopens
+  // it whenever there is no selection, so the prerequisite is never hidden.
+  const [modelsOpen, setModelsOpen] = useState(false);
 
   const mountedRef = useMounted();
   // Holds the AbortController for the in-flight run so the Cancel button can
@@ -357,6 +369,16 @@ export default function LocalLlmPlayground() {
     setSelectedTargets([{ backend: installedTargets[0].backend, modelId: installedTargets[0].modelId }]);
   }, [installedTargets, selectedTargets.length]);
 
+  // With nothing selected — no installed models, a stale URL target that was
+  // dropped, or every compare target deselected — the run can't proceed, so the
+  // narrow disclosure opens on the model list (or on the "no models installed"
+  // message) instead of collapsing the prerequisite out of sight. `modelsOpen`
+  // is deliberately not a dependency: closing it by hand must not re-open it.
+  useEffect(() => {
+    if (loadingStatus || selectedTargets.length > 0) return;
+    setModelsOpen(true);
+  }, [loadingStatus, selectedTargets.length]);
+
   const selectedKeys = useMemo(() => new Set(selectedTargets.map(localLlmTargetKey)), [selectedTargets]);
   // `/api/ps` reports what's resident but not which model is mid-generation, so
   // derive the "processing" flag from our own in-flight run: the streaming chat
@@ -371,6 +393,31 @@ export default function LocalLlmPlayground() {
   const primaryTarget = selectedTargets[0] || null;
   const canRunChat = Boolean(primaryTarget && prompt.trim());
   const canCompare = selectedTargets.length > 0 && prompt.trim();
+
+  // What the collapsed Models disclosure says it is hiding: the selected model
+  // by name when there is one, a count beyond that. Falls back to the raw
+  // modelId while the catalog is still loading so the header is never blank.
+  const selectionSummary = useMemo(() => {
+    if (selectedTargets.length === 0) return 'None selected';
+    if (selectedTargets.length > 1) return `${selectedTargets.length} models selected`;
+    const key = localLlmTargetKey(selectedTargets[0]);
+    const match = installedTargets.find((target) => localLlmTargetKey(target) === key);
+    return match?.name || selectedTargets[0].modelId;
+  }, [installedTargets, selectedTargets]);
+
+  // Same idea for the collapsed Advanced options header — the tuning that is
+  // out of sight still reports its current values, so a stale temperature or a
+  // set system prompt can't silently shape a run.
+  const advancedSummary = useMemo(() => {
+    const parts = [];
+    if (systemPrompt.trim()) parts.push('system prompt set');
+    parts.push(`temp ${numOr(temperature, 0.3)}`);
+    parts.push(`${numOr(maxTokens, 1000)} tokens`);
+    const timeout = TIMEOUT_OPTIONS.find((option) => option.value === numOr(timeoutMs, 300000));
+    if (timeout) parts.push(timeout.short);
+    if (activeMode === 'compare') parts.push(runMode === 'parallel' ? 'parallel' : 'round robin');
+    return parts.join(' · ');
+  }, [activeMode, maxTokens, runMode, systemPrompt, temperature, timeoutMs]);
 
   const toggleTarget = (target) => {
     const key = localLlmTargetKey(target);
@@ -485,22 +532,36 @@ export default function LocalLlmPlayground() {
       <div className="flex-1 overflow-auto p-4 space-y-4">
         <div className="grid grid-cols-1 xl:grid-cols-[320px_1fr] gap-4">
           <aside className="bg-port-card border border-port-border rounded-lg p-4 space-y-4">
-            <button
-              type="button"
-              onClick={() => setModelsOpen((v) => !v)}
-              className="w-full flex items-center justify-between gap-2 xl:cursor-default"
-              aria-expanded={modelsOpen}
-            >
-              <span className="flex items-center gap-2">
+            {/* One header slot holding both breakpoints' variants, so the
+                aside's `space-y-4` doesn't put a gap above the narrow toggle
+                for the desktop heading that is display:none beside it.
+                The list is permanently visible on xl+, so the toggle exists
+                only on narrow screens — an always-rendered button would report
+                `aria-expanded=false` while the desktop sidebar is fully open. */}
+            <div>
+              <div className="hidden xl:flex items-center justify-between gap-2">
                 <span className="text-sm font-medium text-gray-300">Models</span>
-                <span className="text-xs text-gray-500 xl:hidden">({selectedTargets.length} selected)</span>
-              </span>
-              <span className="flex items-center gap-2">
                 {loadingStatus && <BrailleSpinner />}
-                <ChevronDown size={16} className={`text-gray-500 xl:hidden transition-transform ${modelsOpen ? '' : '-rotate-90'}`} />
-              </span>
-            </button>
-            <div className={`${modelsOpen ? 'block' : 'hidden'} xl:block space-y-4`}>
+              </div>
+              <button
+                type="button"
+                onClick={() => setModelsOpen((v) => !v)}
+                className="xl:hidden w-full min-h-11 flex items-center justify-between gap-2"
+                aria-expanded={modelsOpen}
+                aria-controls="local-llm-models"
+              >
+                <span className="flex items-baseline gap-2 min-w-0">
+                  <span className="text-sm font-medium text-gray-300 shrink-0">Models</span>
+                  <span className="text-xs text-gray-500 truncate">{selectionSummary}</span>
+                </span>
+                <span className="flex items-center gap-2 shrink-0">
+                  {loadingStatus && <BrailleSpinner />}
+                  <span className="text-xs text-port-accent">{modelsOpen ? 'Hide models' : 'Change models'}</span>
+                  <ChevronDown size={16} className={`text-gray-500 transition-transform ${modelsOpen ? '' : '-rotate-90'}`} />
+                </span>
+              </button>
+            </div>
+            <div id="local-llm-models" className={`${modelsOpen ? 'block' : 'hidden'} xl:block space-y-4`}>
             {installedTargets.length === 0 && !loadingStatus ? (
               <p className={`text-sm ${modelLoadError ? 'text-port-warning' : 'text-gray-500'}`}>
                 {modelLoadError || 'No installed local models found.'}
@@ -604,8 +665,70 @@ export default function LocalLlmPlayground() {
                 })}
               </div>
 
-              <div className="grid grid-cols-1 lg:grid-cols-[1fr_280px] gap-4">
-                <div className="space-y-3">
+              {/* Prompt then Run, with nothing optional between them: the tuning
+                  fields used to sit above the action, which put Run below the
+                  fold even once the model list was collapsed (#7232). */}
+              <div className="space-y-2">
+                <label htmlFor="local-llm-prompt" className="block text-xs text-gray-500">Prompt</label>
+                <textarea
+                  id="local-llm-prompt"
+                  value={prompt}
+                  onChange={(e) => setPrompt(e.target.value)}
+                  rows={7}
+                  className="w-full bg-port-bg border border-port-border rounded-lg px-3 py-2 text-sm text-white placeholder-gray-600 focus:outline-none focus:border-port-accent resize-y"
+                />
+              </div>
+
+              <div className="flex flex-wrap items-center gap-3">
+                {busy ? (
+                  <button
+                    onClick={cancelRun}
+                    className="w-full sm:w-auto flex items-center justify-center gap-2 px-4 py-2 bg-port-error/15 hover:bg-port-error/25 text-port-error text-sm font-medium rounded-lg"
+                  >
+                    <X size={15} />
+                    Cancel
+                  </button>
+                ) : (
+                  <button
+                    onClick={activeMode === 'chat' ? runChat : runCompare}
+                    disabled={activeMode === 'chat' ? !canRunChat : !canCompare}
+                    className="w-full sm:w-auto flex items-center justify-center gap-2 px-4 py-2 bg-port-accent/20 hover:bg-port-accent/30 text-port-accent text-sm font-medium rounded-lg disabled:opacity-50"
+                  >
+                    {activeMode === 'chat' ? <Send size={15} /> : <Play size={15} />}
+                    {activeMode === 'chat' ? 'Run chat' : 'Run comparison'}
+                  </button>
+                )}
+                {activeMode === 'compare' && selectedTargets.length > 0 && (
+                  <span className="text-xs text-gray-500">
+                    Runs against {selectedTargets.length} model{selectedTargets.length === 1 ? '' : 's'}
+                  </span>
+                )}
+                {/* The run's missing prerequisite is named beside the disabled
+                    button rather than left for the user to infer from the
+                    collapsed inventory; the effect above has also reopened the
+                    picker by the time this renders. */}
+                {!loadingStatus && selectedTargets.length === 0 && (
+                  <span className="text-xs text-port-warning">
+                    {installedTargets.length === 0 ? (
+                      <>
+                        No local models installed —{' '}
+                        <Link to="/models/llms" className="text-port-accent hover:underline">install one</Link>
+                        {' '}to run a prompt.
+                      </>
+                    ) : 'No model selected — pick one under Models.'}
+                  </span>
+                )}
+              </div>
+
+              <CollapsibleSection
+                id="local-llm-advanced"
+                label="Advanced options"
+                summary={advancedSummary}
+                size="bar"
+                className="border-t border-port-border"
+                bodyClassName="pt-1 pb-1 space-y-3"
+              >
+                <div className="space-y-1">
                   <label htmlFor="local-llm-system" className="block text-xs text-gray-500">System prompt</label>
                   <textarea
                     id="local-llm-system"
@@ -615,57 +738,35 @@ export default function LocalLlmPlayground() {
                     className="w-full bg-port-bg border border-port-border rounded-lg px-3 py-2 text-sm text-white placeholder-gray-600 focus:outline-none focus:border-port-accent resize-y"
                     placeholder="Optional"
                   />
-                  <label htmlFor="local-llm-prompt" className="block text-xs text-gray-500">Prompt</label>
-                  <textarea
-                    id="local-llm-prompt"
-                    value={prompt}
-                    onChange={(e) => setPrompt(e.target.value)}
-                    rows={7}
-                    className="w-full bg-port-bg border border-port-border rounded-lg px-3 py-2 text-sm text-white placeholder-gray-600 focus:outline-none focus:border-port-accent resize-y"
-                  />
                 </div>
-
-                <div className="space-y-3">
-                  <label className="block text-xs text-gray-500" htmlFor="local-llm-temperature">Temperature</label>
-                  <input id="local-llm-temperature" type="number" min="0" max="2" step="0.1" value={temperature} onChange={(e) => setTemperature(e.target.value)} className="w-full bg-port-bg border border-port-border rounded-lg px-3 py-2 text-sm text-white" />
-                  <label className="block text-xs text-gray-500" htmlFor="local-llm-max-tokens">Max tokens</label>
-                  <input id="local-llm-max-tokens" type="number" min="1" max="8192" step="64" value={maxTokens} onChange={(e) => setMaxTokens(e.target.value)} className="w-full bg-port-bg border border-port-border rounded-lg px-3 py-2 text-sm text-white" />
-                  <label className="block text-xs text-gray-500" htmlFor="local-llm-timeout">Timeout</label>
-                  <select id="local-llm-timeout" value={timeoutMs} onChange={(e) => setTimeoutMs(Number(e.target.value))} className="w-full bg-port-bg border border-port-border rounded-lg px-3 py-2 text-sm text-white">
-                    <option value={60000}>1 minute</option>
-                    <option value={180000}>3 minutes</option>
-                    <option value={300000}>5 minutes</option>
-                    <option value={600000}>10 minutes</option>
-                  </select>
+                <div className="grid gap-3 grid-cols-[repeat(auto-fit,minmax(min(100%,11rem),1fr))]">
+                  <div className="space-y-1">
+                    <label className="block text-xs text-gray-500" htmlFor="local-llm-temperature">Temperature</label>
+                    <input id="local-llm-temperature" type="number" min="0" max="2" step="0.1" value={temperature} onChange={(e) => setTemperature(e.target.value)} className="w-full bg-port-bg border border-port-border rounded-lg px-3 py-2 text-sm text-white" />
+                  </div>
+                  <div className="space-y-1">
+                    <label className="block text-xs text-gray-500" htmlFor="local-llm-max-tokens">Max tokens</label>
+                    <input id="local-llm-max-tokens" type="number" min="1" max="8192" step="64" value={maxTokens} onChange={(e) => setMaxTokens(e.target.value)} className="w-full bg-port-bg border border-port-border rounded-lg px-3 py-2 text-sm text-white" />
+                  </div>
+                  <div className="space-y-1">
+                    <label className="block text-xs text-gray-500" htmlFor="local-llm-timeout">Timeout</label>
+                    <select id="local-llm-timeout" value={timeoutMs} onChange={(e) => setTimeoutMs(Number(e.target.value))} className="w-full bg-port-bg border border-port-border rounded-lg px-3 py-2 text-sm text-white">
+                      {TIMEOUT_OPTIONS.map((option) => (
+                        <option key={option.value} value={option.value}>{option.label}</option>
+                      ))}
+                    </select>
+                  </div>
                   {activeMode === 'compare' && (
-                    <>
+                    <div className="space-y-1">
                       <label className="block text-xs text-gray-500" htmlFor="local-llm-mode">Execution</label>
                       <select id="local-llm-mode" value={runMode} onChange={(e) => setRunMode(e.target.value)} className="w-full bg-port-bg border border-port-border rounded-lg px-3 py-2 text-sm text-white">
                         <option value="round-robin">Round robin</option>
                         <option value="parallel">Parallel</option>
                       </select>
-                    </>
-                  )}
-                  {busy ? (
-                    <button
-                      onClick={cancelRun}
-                      className="w-full flex items-center justify-center gap-2 px-3 py-2 bg-port-error/15 hover:bg-port-error/25 text-port-error text-sm font-medium rounded-lg"
-                    >
-                      <X size={15} />
-                      Cancel
-                    </button>
-                  ) : (
-                    <button
-                      onClick={activeMode === 'chat' ? runChat : runCompare}
-                      disabled={activeMode === 'chat' ? !canRunChat : !canCompare}
-                      className="w-full flex items-center justify-center gap-2 px-3 py-2 bg-port-accent/20 hover:bg-port-accent/30 text-port-accent text-sm font-medium rounded-lg disabled:opacity-50"
-                    >
-                      {activeMode === 'chat' ? <Send size={15} /> : <Play size={15} />}
-                      {activeMode === 'chat' ? 'Run chat' : 'Run comparison'}
-                    </button>
+                    </div>
                   )}
                 </div>
-              </div>
+              </CollapsibleSection>
             </section>
 
             {activeMode === 'chat' ? (

--- a/client/src/pages/LocalLlmPlayground.test.jsx
+++ b/client/src/pages/LocalLlmPlayground.test.jsx
@@ -23,6 +23,14 @@ const renderPlayground = () => render(
   </MemoryRouter>,
 );
 
+const modelsToggle = () => screen.getByRole('button', { name: /Change models|Hide models/ });
+// The narrow disclosure hides its panel with Tailwind's `hidden` class rather
+// than unmounting it (the same panel is the permanent xl+ sidebar), so the
+// collapsed state is read off the class — jsdom loads no stylesheet, so a
+// visibility query would report it visible either way.
+const modelsPanelCollapsed = () => document.getElementById('local-llm-models').className.includes('hidden');
+const advancedToggle = () => screen.getByRole('button', { name: /Advanced options/ });
+
 beforeEach(() => {
   vi.clearAllMocks();
   getLocalLlmStatus.mockResolvedValue({
@@ -56,6 +64,103 @@ beforeEach(() => {
         capabilities: ['chat', 'tools', 'multilingual'],
       },
     ],
+  });
+});
+
+// The audited fold regression (#7232): the model inventory rendered expanded
+// ahead of the task, and the optional tuning fields sat between the prompt and
+// the Run button. jsdom can't measure a fold, so these pin the two structural
+// facts that produced it — what is disclosed by default, and what order the
+// prompt, the run action, and the optional fields appear in.
+describe('LocalLlmPlayground task order', () => {
+  it('collapses the inventory and renders Run chat before the optional tuning fields', async () => {
+    renderPlayground();
+    await waitFor(() => expect(screen.getAllByText('command-r-plus:104b').length).toBeGreaterThan(0));
+
+    // A valid target is selected, so the inventory is disclosed, not expanded —
+    // and the collapsed header still names what is selected.
+    expect(modelsToggle()).toHaveAttribute('aria-expanded', 'false');
+    expect(modelsPanelCollapsed()).toBe(true);
+    expect(modelsToggle().textContent).toContain('command-r-plus:104b');
+
+    // The tuning fields are behind Advanced options, so nothing optional sits
+    // between the prompt and the action the user came for.
+    expect(screen.queryByLabelText('System prompt')).toBeNull();
+    expect(screen.queryByLabelText('Temperature')).toBeNull();
+
+    const prompt = screen.getByLabelText('Prompt');
+    const run = screen.getByRole('button', { name: 'Run chat' });
+    const advanced = advancedToggle();
+    expect(prompt.compareDocumentPosition(run) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(run.compareDocumentPosition(advanced) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it('keeps the selection and the prompt text across opening and closing the picker', async () => {
+    renderPlayground();
+    await waitFor(() => expect(screen.getAllByText('command-r-plus:104b').length).toBeGreaterThan(0));
+
+    fireEvent.change(screen.getByLabelText('Prompt'), { target: { value: 'a custom prompt' } });
+
+    fireEvent.click(modelsToggle());
+    expect(modelsToggle()).toHaveAttribute('aria-expanded', 'true');
+    expect(modelsPanelCollapsed()).toBe(false);
+
+    fireEvent.click(modelsToggle());
+    expect(modelsToggle()).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.getByLabelText('Prompt').value).toBe('a custom prompt');
+    expect(modelsToggle().textContent).toContain('command-r-plus:104b');
+    expect(screen.getByRole('button', { name: 'Run chat' }).disabled).toBe(false);
+  });
+
+  it('preserves advanced values across the disclosure and a mode switch, and summarizes them while collapsed', async () => {
+    renderPlayground();
+    await waitFor(() => expect(screen.getAllByText('command-r-plus:104b').length).toBeGreaterThan(0));
+
+    fireEvent.click(advancedToggle());
+    fireEvent.change(screen.getByLabelText('Temperature'), { target: { value: '0.9' } });
+    fireEvent.change(screen.getByLabelText('System prompt'), { target: { value: 'be terse' } });
+
+    // Collapsed, the header reports what is out of sight so a set system prompt
+    // or a stale temperature can't silently shape the run.
+    fireEvent.click(advancedToggle());
+    expect(advancedToggle().textContent).toContain('system prompt set');
+    expect(advancedToggle().textContent).toContain('temp 0.9');
+    expect(advancedToggle().textContent).toContain('1000 tokens');
+
+    // Compare mode adds the execution mode to both the summary and the panel,
+    // and the values the user already set survive the switch.
+    fireEvent.click(screen.getByRole('button', { name: 'Compare' }));
+    expect(advancedToggle().textContent).toContain('round robin');
+    fireEvent.click(advancedToggle());
+    expect(screen.getByLabelText('Temperature').value).toBe('0.9');
+    expect(screen.getByLabelText('System prompt').value).toBe('be terse');
+    expect(screen.getByLabelText('Execution')).toBeTruthy();
+  });
+
+  it('exposes the compare count and Run comparison without opening the inventory', async () => {
+    renderPlayground();
+    await waitFor(() => expect(screen.getAllByText('command-r-plus:104b').length).toBeGreaterThan(0));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Compare' }));
+
+    expect(screen.getByRole('button', { name: 'Run comparison' }).disabled).toBe(false);
+    expect(screen.getByText('Runs against 1 model')).toBeTruthy();
+    expect(modelsToggle()).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('opens the picker and names the next step when no model is available to select', async () => {
+    getLocalLlmStatus.mockResolvedValue({ backend: 'ollama', ollama: { models: [] }, lmstudio: { models: [] } });
+
+    renderPlayground();
+
+    // Nothing is selectable, so the prerequisite is disclosed rather than
+    // collapsed away, and the run action names why it is unavailable.
+    await waitFor(() => expect(modelsToggle()).toHaveAttribute('aria-expanded', 'true'));
+    expect(screen.getByText('No installed local models found.')).toBeTruthy();
+    expect(modelsPanelCollapsed()).toBe(false);
+    expect(screen.getByText(/No local models installed/)).toBeTruthy();
+    expect(screen.getByRole('link', { name: 'install one' })).toHaveAttribute('href', '/models/llms');
+    expect(screen.getByRole('button', { name: 'Run chat' }).disabled).toBe(true);
   });
 });
 

--- a/client/src/pages/LocalLlmPlayground.test.jsx
+++ b/client/src/pages/LocalLlmPlayground.test.jsx
@@ -17,8 +17,8 @@ vi.mock('../components/ui/Toast', () => ({
 import LocalLlmPlayground from './LocalLlmPlayground';
 import { getLoadedLlmModels, getLocalLlmCatalog, getLocalLlmStatus, streamLocalLlmTest } from '../services/api';
 
-const renderPlayground = () => render(
-  <MemoryRouter initialEntries={['/local-llm/playground?backend=ollama&model=command-r-plus%3A104b']}>
+const renderPlayground = (entry = '/local-llm/playground?backend=ollama&model=command-r-plus%3A104b') => render(
+  <MemoryRouter initialEntries={[entry]}>
     <LocalLlmPlayground />
   </MemoryRouter>,
 );
@@ -93,6 +93,20 @@ describe('LocalLlmPlayground task order', () => {
     const advanced = advancedToggle();
     expect(prompt.compareDocumentPosition(run) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
     expect(run.compareDocumentPosition(advanced) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it('stays collapsed when the first model is auto-selected from a URL carrying no target', async () => {
+    // The ⌘K / sidebar entry path: no backend+model params, so the selection is
+    // empty on the render where loading finishes and the auto-select effect
+    // fills it in the same flush. Keying the disclosure off that momentarily
+    // empty selection would leave the inventory expanded here — the exact
+    // above-the-fold regression being fixed.
+    renderPlayground('/local-llm/playground');
+
+    await waitFor(() => expect(modelsToggle().textContent).toContain('command-r-plus:104b'));
+    expect(modelsToggle()).toHaveAttribute('aria-expanded', 'false');
+    expect(modelsPanelCollapsed()).toBe(true);
+    expect(screen.getByRole('button', { name: 'Run chat' }).disabled).toBe(false);
   });
 
   it('keeps the selection and the prompt text across opening and closing the picker', async () => {


### PR DESCRIPTION
## Summary

`/local-llm/playground` opened as a wall of model inventory: on a 375×812 viewport the prompt began around y=2,000 and Run chat at y=2,410, and collapsing the model list by hand still left Run at y=901 because the optional tuning fields sat between the prompt and the action.

- **Model inventory is a disclosure on narrow screens**, collapsed by default whenever a valid target is selected. Its header names the selected model (or the count) and offers Change models / Hide models. The desktop `xl:` sidebar is unchanged, and the toggle now renders only at the breakpoint where it is real — previously it reported `aria-expanded="false"` while the desktop sidebar was fully open.
- **Prompt then Run, with nothing optional between them.** System prompt, temperature, max tokens, timeout and the compare execution mode moved into an `Advanced options` disclosure (the shared `CollapsibleSection` primitive) that summarizes its current values while collapsed, so a set system prompt or a non-default temperature can't silently shape a run from out of sight.
- **No-model states name the next step.** With nothing installed the inventory opens on its empty state and the disabled Run button carries a link to install a model. Compare mode reports how many models a run covers next to Run comparison.
- Selection handling, the `backend`/`model`/`targets`/`mode` URL behavior, validation, streaming and Cancel are untouched.

The second commit fixes a bug the review caught: keying the auto-open off an empty selection reopened the inventory on the most common entry path (no URL target), because the auto-select effect fills the selection in the same flush that loading finishes. It now gates on the installed-model list, so it opens only when there is genuinely nothing to select.

## Test plan

- `client/src/pages/LocalLlmPlayground.test.jsx` gains six rendered-behavior cases: default collapse plus prompt → Run → Advanced document order, the auto-selected no-URL-target entry path, selection/prompt preservation across the picker, advanced values surviving the disclosure and a mode switch (with the collapsed summary), compare count + Run comparison without traversing the inventory, and the no-models-installed next step. Existing streaming/reasoning/residency tests retained.
- Each new assertion was probed against the pre-fix behavior and fails there.
- Full client suite green: 948 files, 11,589 passed / 7 skipped.
- `biome lint --error-on-warnings` clean on both changed files.

Closes #7232