### PR TITLE
Put installed LoRAs first instead of behind the whole discovery catalog

### DIFF
--- a/client/src/pages/Loras.jsx
+++ b/client/src/pages/Loras.jsx
@@ -8,9 +8,11 @@
  */
 
 import { useState, useEffect, useCallback, useRef } from 'react';
-import { Link } from 'react-router';
-import { Trash2, Download, ExternalLink, Sparkles, AlertTriangle, KeyRound, Check, X, RefreshCw, Wand2, Search, Activity, PlayCircle } from 'lucide-react';
+import { Link, useSearchParams } from 'react-router';
+import { Trash2, Download, ExternalLink, Sparkles, AlertTriangle, KeyRound, Check, X, RefreshCw, Wand2, Search, Activity, PlayCircle, Package, Compass } from 'lucide-react';
 import BrailleSpinner from '../components/BrailleSpinner';
+import EmptyState from '../components/EmptyState';
+import TabPills from '../components/ui/TabPills';
 import PageSkeleton from '../components/ui/PageSkeleton';
 import toast from '../components/ui/Toast';
 import Modal from '../components/ui/Modal';
@@ -60,6 +62,22 @@ const RUNNER_BADGE_CLASS = {
   [VIDEO_LORA_FAMILIES.MINIMAX_H3]: 'bg-teal-600/20 text-teal-300 border-teal-500/30',
 };
 
+// Top-level view split (#7231). Discovery — curated picks, six per-family
+// Civitai lists, the video catalog, and two live searches — used to render
+// ABOVE the installed grid, so managing an already-installed adapter meant
+// scrolling past thousands of pixels of recommendations that grow as results
+// arrive. Installed is now its own view and the default one; discovery is one
+// labeled click away. The chosen view lives in `?loraView` (not local state) so
+// it survives reload and Back/Forward, per the URL-is-the-source-of-truth
+// convention in `client/src/AGENTS.md`.
+const VIEW_PARAM = 'loraView';
+const VIEW_INSTALLED = 'installed';
+const VIEW_DISCOVER = 'discover';
+const DEFAULT_VIEW = VIEW_INSTALLED;
+const VIEW_IDS = [VIEW_INSTALLED, VIEW_DISCOVER];
+// `id="tab-<view>"` / `aria-controls="lorapanel-<view>"` pairing for TabPills.
+const VIEW_PANEL_PREFIX = 'lorapanel';
+
 // Image/Video filter applied to BOTH the suggestion panel and the installed
 // list (see the user request: filter suggestions + installed by media type).
 const MEDIA_FILTERS = [
@@ -98,6 +116,22 @@ const HF_FAMILY_OVERRIDES = [
 const pctOf = (progress) => (progress && typeof progress.progress === 'number' ? Math.round(progress.progress * 100) : null);
 
 export default function Loras() {
+  // Active view. An unknown/hand-edited `?loraView=` degrades to Installed
+  // rather than rendering a blank panel.
+  const [searchParams, setSearchParams] = useSearchParams();
+  const rawView = searchParams.get(VIEW_PARAM);
+  const view = VIEW_IDS.includes(rawView) ? rawView : DEFAULT_VIEW;
+  // A PUSH, not `replace` — switching views is a navigation the user expects
+  // Back to undo (the acceptance criterion), unlike the in-view media filter.
+  // Writing the default drops the param so a pristine URL stays clean.
+  const setView = useCallback((next) => {
+    setSearchParams((prev) => {
+      const params = new URLSearchParams(prev);
+      if (!next || next === DEFAULT_VIEW) params.delete(VIEW_PARAM);
+      else params.set(VIEW_PARAM, next);
+      return params;
+    });
+  }, [setSearchParams]);
   const [loras, setLoras] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -129,8 +163,15 @@ export default function Loras() {
   const [authPrompt, setAuthPrompt] = useState(null);
   // suggestions: { runners: { mflux: [...], flux2: [...], 'z-image': [...] }, video: [...], fetchedAt }
   const [suggestions, setSuggestions] = useState(null);
+  // Stays true until the first fetch settles — nothing is requested before the
+  // Discover view is opened, so this reads as "no catalog result yet" and the
+  // panel's first frame shows the loader instead of flashing empty sections.
   const [loadingSuggestions, setLoadingSuggestions] = useState(true);
   const [installingSuggestion, setInstallingSuggestion] = useState(null);
+  // Name of the most recent successful install, cleared once the user acts on
+  // it. Drives the Discover view's "View installed" hand-off so a finished
+  // download doesn't leave the user hunting the catalog for its result.
+  const [lastInstalled, setLastInstalled] = useState(null);
   const { confirm: downloadConfirm, request: requestDownloadConfirm, cancel: cancelDownloadConfirm, confirmRun: runDownloadConfirm } = useDownloadPreflightConfirm();
   // Repo+file key of the video suggestion currently installing. A single HF
   // repo can publish multiple versions that must remain independently selectable.
@@ -160,8 +201,22 @@ export default function Loras() {
   useEffect(() => {
     refresh();
     getCivitaiAuth().then(setAuth).catch(() => {});
+  }, [refresh]);
+
+  // Discovery is fetched the first time its view is opened, not on mount —
+  // the default Installed view never needs it, and a ref (not `suggestions`)
+  // gates the fetch so a legitimately empty catalog response isn't re-requested
+  // on every switch back.
+  const suggestionsRequested = useRef(false);
+  useEffect(() => {
+    // Reaching Installed retires the install hand-off — however the user got
+    // there (the tab, the banner's own button, or Back), the banner has done
+    // its job and must not reappear on the next visit to Discover.
+    if (view === VIEW_INSTALLED) setLastInstalled(null);
+    if (view !== VIEW_DISCOVER || suggestionsRequested.current) return;
+    suggestionsRequested.current = true;
     refreshSuggestions();
-  }, [refresh, refreshSuggestions]);
+  }, [view, refreshSuggestions]);
 
   // silent:true so the auth-error path goes through the modal instead of a
   // one-shot toast the user can't act on. Shared by the initial install
@@ -205,6 +260,7 @@ export default function Loras() {
     await installLoraFromCivitai({ url, silent: true })
       .then((sidecar) => {
         toast.success(`Installed ${sidecar.name}`);
+        setLastInstalled(sidecar.name);
         setInstallUrl('');
         refresh();
       })
@@ -252,6 +308,7 @@ export default function Loras() {
     await installLoraFromHuggingfaceStream({ url, family, onProgress: setHfProgress })
       .then((sidecar) => {
         toast.success(`Installed ${sidecar.name}`);
+        setLastInstalled(sidecar.name);
         setHfUrl('');
         setHfFamilyPrompt(null);
         refresh();
@@ -295,6 +352,7 @@ export default function Loras() {
     })
       .then((sidecar) => {
         toast.success(`Installed ${sidecar.name}`);
+        setLastInstalled(sidecar.name);
         refresh();
       })
       .catch((err) => toast.error(err?.message || 'HuggingFace install failed'))
@@ -358,115 +416,235 @@ export default function Loras() {
         </p>
       </div>
 
-      <form
-        onSubmit={handleInstall}
-        className="bg-port-card border border-port-border rounded-lg p-4 space-y-3"
-      >
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-2 text-sm font-medium text-gray-300">
-            <Download size={16} />
-            <span>Install from Civitai</span>
-          </div>
-          <CivitaiKeyBadge auth={auth} onManage={() => setAuthPrompt({ url: null, message: '' })} />
+      {/* View switch + primary action, directly under the heading so both are
+          above the fold on a phone. Discovery lives behind the second tab, so
+          no amount of catalog growth can push the installed list down. */}
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <TabPills
+          tabs={[
+            { id: VIEW_INSTALLED, label: 'Installed', icon: Package, count: loras.length },
+            { id: VIEW_DISCOVER, label: 'Discover / install', icon: Compass },
+          ]}
+          activeTab={view}
+          onChange={setView}
+          variant="pills"
+          size="sm"
+          ariaLabel="LoRA view"
+          controlsIdPrefix={VIEW_PANEL_PREFIX}
+        />
+        <div className="flex items-center gap-3">
+          <MediaFilter value={mediaFilter} onChange={setMediaFilter} />
+          {view === VIEW_INSTALLED && (
+            <button
+              type="button"
+              onClick={() => setView(VIEW_DISCOVER)}
+              className="bg-port-accent text-white px-3 py-1.5 rounded text-sm font-medium hover:bg-port-accent/90 flex items-center gap-2"
+            >
+              <Download size={14} aria-hidden="true" />
+              Install LoRA
+            </button>
+          )}
         </div>
-        <div className="flex gap-2">
-          <input
-            type="text"
-            value={installUrl}
-            onChange={(e) => setInstallUrl(e.target.value)}
-            aria-label="Civitai model URL"
-            placeholder="https://civitai.com/models/2600698/realstagram"
-            className="flex-1 bg-port-bg border border-port-border rounded px-3 py-2 text-sm text-gray-200 placeholder:text-gray-600"
-            disabled={installing}
-            autoFocus
-          />
-          <button
-            type="submit"
-            disabled={installing || !installUrl.trim()}
-            className="bg-port-accent text-white px-4 py-2 rounded text-sm font-medium hover:bg-port-accent/90 disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
-          >
-            {installing ? 'Downloading…' : 'Install'}
-          </button>
-        </div>
-        <p className="text-xs text-gray-500">
-          Paste any <code className="bg-port-bg px-1 rounded">civitai.com</code> /{' '}
-          <code className="bg-port-bg px-1 rounded">civitai.red</code> model URL — or just the
-          numeric model id. Restricted LoRAs need an API key — PortOS will prompt you for one if a download is rejected.
-        </p>
-      </form>
+      </div>
 
-      <form
-        onSubmit={handleHfInstall}
-        className="bg-port-card border border-port-border rounded-lg p-4 space-y-3"
-      >
-        <div className="flex items-center gap-2 text-sm font-medium text-gray-300">
-          <Download size={16} />
-          <span>Install LoRA from HuggingFace</span>
-        </div>
-        <div className="flex gap-2">
-          <input
-            type="text"
-            value={hfUrl}
-            onChange={(e) => setHfUrl(e.target.value)}
-            aria-label="HuggingFace LoRA URL"
-            placeholder="https://huggingface.co/Alissonerdx/CharacterSheet"
-            className="flex-1 bg-port-bg border border-port-border rounded px-3 py-2 text-sm text-gray-200 placeholder:text-gray-600"
-            disabled={hfInstalling}
-          />
-          <button
-            type="submit"
-            disabled={hfInstalling || !!installingVideoKey || !hfUrl.trim()}
-            className="bg-port-accent text-white px-4 py-2 rounded text-sm font-medium hover:bg-port-accent/90 disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
-          >
-            {hfInstalling ? (hfPct != null ? `Downloading ${hfPct}%` : 'Downloading…') : 'Install'}
-          </button>
-        </div>
-        {hfInstalling && <HfDownloadProgress progress={hfProgress} />}
-        <p className="text-xs text-gray-500">
-          Paste a <code className="bg-port-bg px-1 rounded">huggingface.co</code> repo URL — or an{' '}
-          <code className="bg-port-bg px-1 rounded">org/name</code> id — for an image or video LoRA
-          (e.g. <code className="bg-port-bg px-1 rounded">Alissonerdx/CharacterSheet</code> or{' '}
-          <code className="bg-port-bg px-1 rounded">fal/ltx2.3-audio-reactive-lora</code>).
-          Flux.2 Klein adapters apply in <Link to="/media/image" className="text-port-accent hover:underline">Image Gen</Link>;
-          LTX-Video LoRAs apply in <Link to="/media/video" className="text-port-accent hover:underline">Video Gen</Link>.
-          Gated repos use your HuggingFace token from Image Gen settings.
-        </p>
-        {hfFamilyPrompt && (
-          <div className="rounded border border-port-warning/40 bg-port-warning/10 px-3 py-2 space-y-2">
-            <span className="text-xs text-gray-300">
-              Couldn&apos;t detect the model family for <code className="bg-port-bg px-1 rounded">{hfFamilyPrompt}</code>. Choose the runner this LoRA targets:
-            </span>
-            <div className="flex flex-wrap items-center gap-2">
-              {HF_FAMILY_OVERRIDES.map(({ family, label }) => (
+      {view === VIEW_DISCOVER && (
+        <div id={`${VIEW_PANEL_PREFIX}-${VIEW_DISCOVER}`} role="tabpanel" aria-labelledby={`tab-${VIEW_DISCOVER}`} className="space-y-6">
+          {lastInstalled && (
+            <Banner
+              tone="success"
+              size="md"
+              icon={Check}
+              align="center"
+              actions={(
                 <button
-                  key={family}
                   type="button"
-                  onClick={() => requestLoraDownload(
-                    'Install HuggingFace LoRA',
-                    hfFamilyPrompt,
-                    'huggingface',
-                    () => runHfInstall(hfFamilyPrompt, family),
-                    { family },
-                  )}
-                  disabled={hfInstalling}
-                  className="bg-port-accent text-white px-3 py-1 rounded text-xs font-medium hover:bg-port-accent/90 disabled:opacity-50"
+                  onClick={() => setView(VIEW_INSTALLED)}
+                  className="text-xs font-medium px-3 py-1 rounded bg-port-success/20 hover:bg-port-success/30 whitespace-nowrap"
                 >
-                  {hfInstalling ? (hfPct != null ? `Installing ${hfPct}%` : 'Installing…') : `Install as ${label}`}
+                  View installed
                 </button>
-              ))}
+              )}
+            >
+              Installed {lastInstalled}.
+            </Banner>
+          )}
+
+          <form
+            onSubmit={handleInstall}
+            className="bg-port-card border border-port-border rounded-lg p-4 space-y-3"
+          >
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2 text-sm font-medium text-gray-300">
+                <Download size={16} />
+                <span>Install from Civitai</span>
+              </div>
+              <CivitaiKeyBadge auth={auth} onManage={() => setAuthPrompt({ url: null, message: '' })} />
+            </div>
+            <div className="flex gap-2">
+              <input
+                type="text"
+                value={installUrl}
+                onChange={(e) => setInstallUrl(e.target.value)}
+                aria-label="Civitai model URL"
+                placeholder="https://civitai.com/models/2600698/realstagram"
+                className="flex-1 bg-port-bg border border-port-border rounded px-3 py-2 text-sm text-gray-200 placeholder:text-gray-600"
+                disabled={installing}
+                autoFocus
+              />
               <button
-                type="button"
-                onClick={() => setHfFamilyPrompt(null)}
-                disabled={hfInstalling}
-                className="text-gray-400 hover:text-gray-200 px-2 py-1 rounded text-xs disabled:opacity-50"
+                type="submit"
+                disabled={installing || !installUrl.trim()}
+                className="bg-port-accent text-white px-4 py-2 rounded text-sm font-medium hover:bg-port-accent/90 disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
               >
-                Cancel
+                {installing ? 'Downloading…' : 'Install'}
               </button>
             </div>
-          </div>
-        )}
-      </form>
+            <p className="text-xs text-gray-500">
+              Paste any <code className="bg-port-bg px-1 rounded">civitai.com</code> /{' '}
+              <code className="bg-port-bg px-1 rounded">civitai.red</code> model URL — or just the
+              numeric model id. Restricted LoRAs need an API key — PortOS will prompt you for one if a download is rejected.
+            </p>
+          </form>
 
+          <form
+            onSubmit={handleHfInstall}
+            className="bg-port-card border border-port-border rounded-lg p-4 space-y-3"
+          >
+            <div className="flex items-center gap-2 text-sm font-medium text-gray-300">
+              <Download size={16} />
+              <span>Install LoRA from HuggingFace</span>
+            </div>
+            <div className="flex gap-2">
+              <input
+                type="text"
+                value={hfUrl}
+                onChange={(e) => setHfUrl(e.target.value)}
+                aria-label="HuggingFace LoRA URL"
+                placeholder="https://huggingface.co/Alissonerdx/CharacterSheet"
+                className="flex-1 bg-port-bg border border-port-border rounded px-3 py-2 text-sm text-gray-200 placeholder:text-gray-600"
+                disabled={hfInstalling}
+              />
+              <button
+                type="submit"
+                disabled={hfInstalling || !!installingVideoKey || !hfUrl.trim()}
+                className="bg-port-accent text-white px-4 py-2 rounded text-sm font-medium hover:bg-port-accent/90 disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
+              >
+                {hfInstalling ? (hfPct != null ? `Downloading ${hfPct}%` : 'Downloading…') : 'Install'}
+              </button>
+            </div>
+            {hfInstalling && <HfDownloadProgress progress={hfProgress} />}
+            <p className="text-xs text-gray-500">
+              Paste a <code className="bg-port-bg px-1 rounded">huggingface.co</code> repo URL — or an{' '}
+              <code className="bg-port-bg px-1 rounded">org/name</code> id — for an image or video LoRA
+              (e.g. <code className="bg-port-bg px-1 rounded">Alissonerdx/CharacterSheet</code> or{' '}
+              <code className="bg-port-bg px-1 rounded">fal/ltx2.3-audio-reactive-lora</code>).
+              Flux.2 Klein adapters apply in <Link to="/media/image" className="text-port-accent hover:underline">Image Gen</Link>;
+              LTX-Video LoRAs apply in <Link to="/media/video" className="text-port-accent hover:underline">Video Gen</Link>.
+              Gated repos use your HuggingFace token from Image Gen settings.
+            </p>
+            {hfFamilyPrompt && (
+              <div className="rounded border border-port-warning/40 bg-port-warning/10 px-3 py-2 space-y-2">
+                <span className="text-xs text-gray-300">
+                  Couldn&apos;t detect the model family for <code className="bg-port-bg px-1 rounded">{hfFamilyPrompt}</code>. Choose the runner this LoRA targets:
+                </span>
+                <div className="flex flex-wrap items-center gap-2">
+                  {HF_FAMILY_OVERRIDES.map(({ family, label }) => (
+                    <button
+                      key={family}
+                      type="button"
+                      onClick={() => requestLoraDownload(
+                        'Install HuggingFace LoRA',
+                        hfFamilyPrompt,
+                        'huggingface',
+                        () => runHfInstall(hfFamilyPrompt, family),
+                        { family },
+                      )}
+                      disabled={hfInstalling}
+                      className="bg-port-accent text-white px-3 py-1 rounded text-xs font-medium hover:bg-port-accent/90 disabled:opacity-50"
+                    >
+                      {hfInstalling ? (hfPct != null ? `Installing ${hfPct}%` : 'Installing…') : `Install as ${label}`}
+                    </button>
+                  ))}
+                  <button
+                    type="button"
+                    onClick={() => setHfFamilyPrompt(null)}
+                    disabled={hfInstalling}
+                    className="text-gray-400 hover:text-gray-200 px-2 py-1 rounded text-xs disabled:opacity-50"
+                  >
+                    Cancel
+                  </button>
+                </div>
+              </div>
+            )}
+          </form>
+
+          <SuggestionsPanel
+            suggestions={suggestions}
+            loading={loadingSuggestions}
+            mediaFilter={mediaFilter}
+            installedFilenames={new Set(loras.map((l) => l.filename))}
+            installedHfKeys={new Set(loras.filter((l) => l.huggingface?.repo).map(installedHfKey))}
+            installingSuggestionKey={installingSuggestion}
+            installingVideoKey={installingVideoKey}
+            installingVideoProgress={hfProgress}
+            videoInstallBusy={hfInstalling}
+            onRefresh={() => refreshSuggestions({ force: true })}
+            onInstallVideo={installVideoSuggestion}
+            onInstall={(card, url, versionId) => {
+              // Curated cards pass a family-specific (url, versionId); non-curated
+              // cards omit versionId and we fall back to the card's primary.
+              const vid = versionId ?? card.versionId;
+              const key = suggestionKey(card.modelId, vid);
+              setInstallingSuggestion(key);
+              // performInstall() resolves once the PREVIEW is ready (the confirm
+              // modal is now showing) — the actual install can run far later, so
+              // clearing this card's spinner belongs to that install's own
+              // lifecycle (startCivitaiInstall's finally) and the cancel/auth-
+              // redirect paths that can end this attempt before it ever starts,
+              // not to this promise settling.
+              performInstall(url || card.installUrl);
+            }}
+          />
+        </div>
+      )}
+
+      {view === VIEW_INSTALLED && (
+        <div id={`${VIEW_PANEL_PREFIX}-${VIEW_INSTALLED}`} role="tabpanel" aria-labelledby={`tab-${VIEW_INSTALLED}`}>
+          <h2 className="text-lg font-semibold text-white mb-3">Installed</h2>
+          {loading && <PageSkeleton header="none" label="Loading installed LoRAs" layout="grid" cards={6} />}
+          {error && (
+            <Banner tone="error" size="md" icon={AlertTriangle} align="center">{error}</Banner>
+          )}
+          {/* The empty state names the next action rather than pointing at
+              "the suggestions above" — discovery is now a view away, not a
+              scroll away. */}
+          {!loading && !error && visibleLoras.length === 0 && (
+            <EmptyState
+              icon={Package}
+              title={loras.length === 0 ? 'No LoRAs installed yet' : `No ${mediaFilter} LoRAs installed`}
+              message={loras.length === 0
+                ? 'Browse curated picks and Civitai / HuggingFace search, or paste a model URL, to install your first adapter.'
+                : `You have other LoRAs installed — switch the Show filter, or install a ${mediaFilter} LoRA.`}
+              actionLabel="Discover LoRAs to install"
+              onAction={() => setView(VIEW_DISCOVER)}
+            />
+          )}
+          {/* On "All", split installed LoRAs into Video/Image subsections (with the
+              same header style as the suggestion panel) so it's self-evident which
+              renders each applies to. A specific filter already scopes the list, so
+              render it flat. */}
+          {visibleLoras.length > 0 && (
+            mediaFilter === 'all'
+              ? <InstalledGroups loras={visibleLoras} deleting={deleting} onDelete={handleDelete} onMeasured={handleMeasured} deleteConfirm={deleteConfirm} />
+              : <LoraGrid loras={visibleLoras} deleting={deleting} onDelete={handleDelete} onMeasured={handleMeasured} deleteConfirm={deleteConfirm} />
+          )}
+        </div>
+      )}
+
+      {/* Both overlays stay OUTSIDE the view gate: an install started in
+          Discover can still hit a 401 (or finish its preflight) after the user
+          has switched to Installed, and unmounting the dialog would strand
+          that attempt with no way to recover the key. */}
       {authPrompt && (
         <CivitaiAuthModal
           pendingUrl={authPrompt.url}
@@ -484,64 +662,6 @@ export default function Loras() {
           }}
         />
       )}
-
-      <MediaFilter value={mediaFilter} onChange={setMediaFilter} />
-
-      <SuggestionsPanel
-        suggestions={suggestions}
-        loading={loadingSuggestions}
-        mediaFilter={mediaFilter}
-        installedFilenames={new Set(loras.map((l) => l.filename))}
-        installedHfKeys={new Set(loras.filter((l) => l.huggingface?.repo).map(installedHfKey))}
-        installingSuggestionKey={installingSuggestion}
-        installingVideoKey={installingVideoKey}
-        installingVideoProgress={hfProgress}
-        videoInstallBusy={hfInstalling}
-        onRefresh={() => refreshSuggestions({ force: true })}
-        onInstallVideo={installVideoSuggestion}
-        onInstall={(card, url, versionId) => {
-          // Curated cards pass a family-specific (url, versionId); non-curated
-          // cards omit versionId and we fall back to the card's primary.
-          const vid = versionId ?? card.versionId;
-          const key = suggestionKey(card.modelId, vid);
-          setInstallingSuggestion(key);
-          // performInstall() resolves once the PREVIEW is ready (the confirm
-          // modal is now showing) — the actual install can run far later, so
-          // clearing this card's spinner belongs to that install's own
-          // lifecycle (startCivitaiInstall's finally) and the cancel/auth-
-          // redirect paths that can end this attempt before it ever starts,
-          // not to this promise settling.
-          performInstall(url || card.installUrl);
-        }}
-      />
-
-      {/* Border-top divides "Installed" from the suggestion panel above — the
-          curated "Video LoRAs" suggestions used to butt straight up against a
-          flat Installed grid, making installed image LoRAs read as if they were
-          part of the video section. */}
-      <div className="border-t border-port-border pt-6">
-        <h2 className="text-lg font-semibold text-white mb-3">Installed</h2>
-        {loading && <PageSkeleton header="none" label="Loading installed LoRAs" layout="grid" cards={6} />}
-        {error && (
-          <Banner tone="error" size="md" icon={AlertTriangle} align="center">{error}</Banner>
-        )}
-        {!loading && !error && visibleLoras.length === 0 && (
-          <div className="text-sm text-gray-500 italic">
-            {loras.length === 0
-              ? 'No LoRAs installed yet — pick one from the suggestions above, or paste a Civitai URL.'
-              : `No ${mediaFilter} LoRAs installed.`}
-          </div>
-        )}
-        {/* On "All", split installed LoRAs into Video/Image subsections (with the
-            same header style as the suggestion panel) so it's self-evident which
-            renders each applies to. A specific filter already scopes the list, so
-            render it flat. */}
-        {visibleLoras.length > 0 && (
-          mediaFilter === 'all'
-            ? <InstalledGroups loras={visibleLoras} deleting={deleting} onDelete={handleDelete} onMeasured={handleMeasured} deleteConfirm={deleteConfirm} />
-            : <LoraGrid loras={visibleLoras} deleting={deleting} onDelete={handleDelete} onMeasured={handleMeasured} deleteConfirm={deleteConfirm} />
-        )}
-      </div>
       <DownloadPreflightConfirm
         open={Boolean(downloadConfirm)}
         title={downloadConfirm?.title}

--- a/client/src/pages/Loras.jsx
+++ b/client/src/pages/Loras.jsx
@@ -447,6 +447,17 @@ export default function Loras() {
         </div>
       </div>
 
+      {/* A HuggingFace download keeps running when the user leaves Discover,
+          but every readout of it (the form's bar, the card's percent) lives in
+          that panel — so a multi-gigabyte transfer would silently have no
+          indicator anywhere. Mirror it here, and only while Discover is closed,
+          so the two are never on screen at once. */}
+      {view !== VIEW_DISCOVER && (hfInstalling || installingVideoKey) && (
+        <div className="bg-port-card border border-port-border rounded-lg p-3">
+          <HfDownloadProgress progress={hfProgress} />
+        </div>
+      )}
+
       {view === VIEW_DISCOVER && (
         <div id={`${VIEW_PANEL_PREFIX}-${VIEW_DISCOVER}`} role="tabpanel" aria-labelledby={`tab-${VIEW_DISCOVER}`} className="space-y-6">
           {lastInstalled && (
@@ -480,6 +491,10 @@ export default function Loras() {
               </div>
               <CivitaiKeyBadge auth={auth} onManage={() => setAuthPrompt({ url: null, message: '' })} />
             </div>
+            {/* No `autoFocus`: this form used to mount once with the page, so
+                focusing it was a landing convenience. It now remounts on every
+                switch into Discover, where it would steal focus from the tab
+                the user just activated and swallow their next arrow key. */}
             <div className="flex gap-2">
               <input
                 type="text"
@@ -489,7 +504,6 @@ export default function Loras() {
                 placeholder="https://civitai.com/models/2600698/realstagram"
                 className="flex-1 bg-port-bg border border-port-border rounded px-3 py-2 text-sm text-gray-200 placeholder:text-gray-600"
                 disabled={installing}
-                autoFocus
               />
               <button
                 type="submit"

--- a/client/src/pages/Loras.test.jsx
+++ b/client/src/pages/Loras.test.jsx
@@ -133,6 +133,43 @@ describe('Loras Installed / Discover views', () => {
     expect(screen.queryByLabelText('Civitai model URL')).not.toBeInTheDocument();
   });
 
+  it('does not steal focus from the tab that opened Discover', async () => {
+    renderPage();
+    await screen.findByText('Example LoRA');
+
+    const discoverTab = screen.getByRole('tab', { name: /Discover \/ install/ });
+    fireEvent.click(discoverTab);
+    await screen.findByLabelText('Civitai model URL');
+
+    // The install form remounts on every switch now, so an autoFocus on it
+    // would swallow the arrow key that should walk back to Installed.
+    expect(screen.getByLabelText('Civitai model URL')).not.toHaveFocus();
+  });
+
+  // A multi-gigabyte HuggingFace download survives the switch to Installed,
+  // but every readout of it lives in the Discover panel — without a mirror the
+  // transfer runs with no indicator anywhere on the page.
+  it('keeps an in-flight download visible after switching away from Discover', async () => {
+    listLorasFull.mockResolvedValue([]);
+    let reportProgress;
+    installLoraFromHuggingfaceStream.mockImplementation(({ onProgress }) => new Promise(() => {
+      reportProgress = onProgress;
+    }));
+    await renderDiscover();
+
+    const input = await screen.findByLabelText('HuggingFace LoRA URL');
+    fireEvent.change(input, { target: { value: 'https://huggingface.co/example-org/example-lora' } });
+    fireEvent.submit(input.closest('form'));
+    await clickStartDownload();
+    await waitFor(() => expect(reportProgress).toBeTypeOf('function'));
+    act(() => reportProgress({ received: 512, total: 1024, progress: 0.5 }));
+    expect(await screen.findByText('Downloading… 50%')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('tab', { name: /Installed/ }));
+
+    expect(await screen.findByText('Downloading… 50%')).toBeInTheDocument();
+  });
+
   it('offers a discovery hand-off from the empty Installed state', async () => {
     listLorasFull.mockResolvedValue([]);
     renderPage();

--- a/client/src/pages/Loras.test.jsx
+++ b/client/src/pages/Loras.test.jsx
@@ -1,11 +1,16 @@
 /**
- * Delete-confirmation tests for the installed-LoRA cards (#3519). A LoRA is a
- * multi-gigabyte file with no undo, so the trash icon must only arm an inline
- * confirm pair — one stray tap can never reach deleteLoraFull.
+ * Loras page contracts:
+ *  - the Installed / Discover view split and its `?loraView` URL contract (#7231)
+ *  - delete confirmation on the installed cards (#3519) — a LoRA is a
+ *    multi-gigabyte file with no undo, so the trash icon must only arm an
+ *    inline confirm pair; one stray tap can never reach deleteLoraFull.
+ *
+ * Discovery now lives behind its own view, so every install/search case below
+ * renders through `renderDiscover()` rather than the default Installed view.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor, fireEvent, within } from '@testing-library/react';
-import { MemoryRouter } from 'react-router';
+import { render, screen, waitFor, fireEvent, within, act } from '@testing-library/react';
+import { MemoryRouter, useLocation, useNavigate } from 'react-router';
 import { clickStartDownload } from '../test/downloadPreflightConfirm.js';
 import Loras from './Loras';
 import {
@@ -44,7 +49,120 @@ const LORA = {
 };
 const OTHER_LORA = { ...LORA, filename: 'second-lora.safetensors', name: 'Second LoRA' };
 
-const renderPage = () => render(<MemoryRouter><Loras /></MemoryRouter>);
+// Exposes the live location (for the `?loraView` contract) and a navigate()
+// handle so a test can exercise Back the way the browser button does.
+const router = { search: '', navigate: null };
+function RouterProbe() {
+  router.search = useLocation().search;
+  router.navigate = useNavigate();
+  return null;
+}
+
+const renderPage = (entry = '/models/loras') => render(
+  <MemoryRouter initialEntries={[entry]}>
+    <Loras />
+    <RouterProbe />
+  </MemoryRouter>,
+);
+
+// Installed is the default view; everything install/search related lives one
+// click away under "Discover / install".
+const renderDiscover = async () => {
+  const result = renderPage();
+  fireEvent.click(await screen.findByRole('tab', { name: /Discover \/ install/ }));
+  // Opening Discover is what kicks off the suggestions fetch — settle it here
+  // so its state update lands inside act() rather than after the test's first
+  // synchronous assertion.
+  await act(async () => {});
+  return result;
+};
+
+const goBack = () => act(() => { router.navigate(-1); });
+
+// #7231 — discovery (curated picks, six per-family Civitai lists, the video
+// catalog, two live searches) used to render ABOVE the installed grid, so
+// managing an installed adapter meant scrolling past every recommendation, at
+// a distance that grew as results arrived. Installed is now the default view
+// and discovery is a sibling, which makes that distance structurally zero.
+describe('Loras Installed / Discover views', () => {
+  const SUGGESTION_CARD = { modelId: 42, versionId: 7, name: 'Suggested LoRA', installUrl: 'https://civitai.com/models/42' };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    listLorasFull.mockResolvedValue([LORA]);
+    getCivitaiSuggestions.mockResolvedValue({ runners: { mflux: [SUGGESTION_CARD] }, video: [], fetchedAt: null });
+  });
+
+  it('opens on Installed with the cards rendered and no discovery above them', async () => {
+    renderPage();
+
+    expect(await screen.findByText('Example LoRA')).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /Installed/ })).toHaveAttribute('aria-selected', 'true');
+    // Not merely below the fold — discovery is not mounted at all, so no
+    // number of results can push the installed controls anywhere.
+    expect(screen.queryByLabelText('Civitai model URL')).not.toBeInTheDocument();
+    expect(screen.queryByText('Suggested LoRA')).not.toBeInTheDocument();
+    // And nothing was fetched for a view the user never opened.
+    expect(getCivitaiSuggestions).not.toHaveBeenCalled();
+  });
+
+  it('switches to Discover, records it in the URL, and restores Installed on Back', async () => {
+    renderPage();
+    await screen.findByText('Example LoRA');
+
+    fireEvent.click(screen.getByRole('tab', { name: /Discover \/ install/ }));
+
+    expect(await screen.findByLabelText('Civitai model URL')).toBeInTheDocument();
+    expect(await screen.findByText('Suggested LoRA')).toBeInTheDocument();
+    expect(router.search).toBe('?loraView=discover');
+
+    goBack();
+
+    expect(await screen.findByText('Example LoRA')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Civitai model URL')).not.toBeInTheDocument();
+    expect(router.search).toBe('');
+  });
+
+  it('restores Discover from the URL on load, and falls back to Installed for an unknown view', async () => {
+    const { unmount } = renderPage('/models/loras?loraView=discover');
+    expect(await screen.findByLabelText('Civitai model URL')).toBeInTheDocument();
+    unmount();
+
+    renderPage('/models/loras?loraView=bogus');
+    expect(await screen.findByText('Example LoRA')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Civitai model URL')).not.toBeInTheDocument();
+  });
+
+  it('offers a discovery hand-off from the empty Installed state', async () => {
+    listLorasFull.mockResolvedValue([]);
+    renderPage();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Discover LoRAs to install' }));
+
+    expect(await screen.findByLabelText('Civitai model URL')).toBeInTheDocument();
+  });
+
+  it('hands the user to Installed after a successful install instead of leaving them in the catalog', async () => {
+    listLorasFull.mockResolvedValueOnce([]).mockResolvedValue([LORA]);
+    installLoraFromCivitai.mockResolvedValue({ name: 'example-lora.safetensors' });
+    await renderDiscover();
+
+    const input = await screen.findByLabelText('Civitai model URL');
+    fireEvent.change(input, { target: { value: 'https://civitai.com/models/123/example' } });
+    fireEvent.submit(input.closest('form'));
+    await clickStartDownload();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'View installed' }));
+
+    expect(await screen.findByText('Example LoRA')).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /Installed/ })).toHaveAttribute('aria-selected', 'true');
+
+    // The hand-off is spent — returning to Discover must not re-offer it.
+    fireEvent.click(screen.getByRole('tab', { name: /Discover \/ install/ }));
+    expect(await screen.findByLabelText('Civitai model URL')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'View installed' })).not.toBeInTheDocument();
+  });
+});
 
 describe('Loras installed-card delete confirmation', () => {
   beforeEach(() => {
@@ -132,7 +250,7 @@ describe('Loras HuggingFace family picker', () => {
   });
 
   it('offers image and video families when autodetection fails, not just LTX-Video', async () => {
-    renderPage();
+    await renderDiscover();
     const input = await screen.findByLabelText('HuggingFace LoRA URL');
     fireEvent.change(input, { target: { value: 'https://huggingface.co/Alissonerdx/CharacterSheet' } });
     fireEvent.submit(input.closest('form'));
@@ -159,7 +277,7 @@ describe('Loras Civitai auth recovery through preflight', () => {
     previewLoraInstall.mockRejectedValueOnce(
       Object.assign(new Error('This LoRA needs an API key.'), { code: 'CIVITAI_AUTH' }),
     );
-    renderPage();
+    await renderDiscover();
     const input = await screen.findByLabelText('Civitai model URL');
     fireEvent.change(input, { target: { value: 'https://civitai.com/models/123/gated' } });
     fireEvent.submit(input.closest('form'));
@@ -186,7 +304,7 @@ describe('Loras suggestion card busy state', () => {
   it('keeps the card "Installing…" through the confirm step and clears only once the install settles', async () => {
     let resolveInstall;
     installLoraFromCivitai.mockReturnValue(new Promise((resolve) => { resolveInstall = resolve; }));
-    renderPage();
+    await renderDiscover();
 
     fireEvent.click(await screen.findByRole('button', { name: 'Quick install' }));
     // Preview resolved (the confirm modal opened) — the card must still read
@@ -201,7 +319,7 @@ describe('Loras suggestion card busy state', () => {
   });
 
   it('clears the spinner when the confirm is cancelled instead of leaving it stuck', async () => {
-    renderPage();
+    await renderDiscover();
     fireEvent.click(await screen.findByRole('button', { name: 'Quick install' }));
     await screen.findByRole('button', { name: 'Start download' });
 
@@ -237,7 +355,7 @@ describe('Loras video suggestion quick-install preflight', () => {
   });
 
   it('shows the disk-preflight confirm before starting the stream install', async () => {
-    renderPage();
+    await renderDiscover();
     fireEvent.click(await screen.findByRole('button', { name: 'Quick install' }));
 
     expect(await screen.findByRole('button', { name: 'Start download' })).toBeInTheDocument();
@@ -294,7 +412,7 @@ describe('Loras video LoRA search-to-install', () => {
   });
 
   it('searches HuggingFace, lets the user pick a non-default file, and installs that exact file', async () => {
-    renderPage();
+    await renderDiscover();
 
     const searchInput = await screen.findByLabelText('Search HuggingFace video LoRAs by name or repository');
     const searchForm = searchInput.closest('form');
@@ -324,7 +442,7 @@ describe('Loras video LoRA search-to-install', () => {
 
   it('shows a retryable error banner when the search request fails', async () => {
     searchVideoLoras.mockRejectedValueOnce(new Error('HuggingFace search failed: 503'));
-    renderPage();
+    await renderDiscover();
 
     const searchInput = await screen.findByLabelText('Search HuggingFace video LoRAs by name or repository');
     const searchForm = searchInput.closest('form');


### PR DESCRIPTION
## Summary

- **Installed is now the LoRA Manager's default view**, with **Discover / install** as a sibling tab and an **Install LoRA** button beside it, both directly under the page heading.
- Discovery (curated picks, six per-family Civitai lists, the video catalog, two live searches) is **not mounted at all** in the Installed view, so no amount of catalog growth can push installed controls down — the ordering problem this issue reported is structural, not a matter of reordering.
- The chosen view lives in `?loraView`, so **reload and Back/Forward restore it** and an unknown value falls back to Installed.
- Discovery no longer fetches on mount — the Civitai suggestions request fires the first time Discover is opened, so landing on Installed makes no catalog round-trip.
- The empty Installed state now names the next action and opens Discover; a finished install offers a **View installed** hand-off instead of leaving the user to find the result in the catalog.

Install preflight, Civitai key recovery, HuggingFace download progress, installed badges, media filtering and inline delete confirmation all survive view switches — operation state stays parent-owned, and the auth and preflight dialogs render outside the view gate so an install started in Discover can still be recovered from Installed.

### Measured fold

Built the branch and measured in Chrome against synthetic data (9 installed adapters, 150+ suggestions):

| viewport | Installed heading | installed card visible |
| --- | --- | --- |
| 1440×900 | y=263 | yes |
| 375×812 | y=386 | yes |

The audit recorded y≈5,673 and y≈15,237 for the same heading before this change.

### From local review

Two regressions the split introduced, both fixed in the second commit:

- The Civitai input's `autoFocus` was a landing convenience when the form mounted once with the page. It now remounts on every switch into Discover, where it steals focus from the tab the user just activated — removed.
- A HuggingFace download keeps running across a switch to Installed, but every readout of it lived in the Discover panel. The progress bar is now mirrored above the panels while Discover is closed.

Per-view ephemeral state (a typed HF search query, its result page) is intentionally not preserved across switches — that matches the repo's existing tabbed-panel convention, where the body remounts per tab.

## Test plan

- `client/src/pages/Loras.test.jsx` extended with the view-switch/URL contract: default view, `?loraView` write on switch, Back restoring Installed, deep link, invalid-value fallback, empty-state hand-off, post-install "View installed", focus not stolen, and progress visible off Discover. Existing destructive-action (delete confirmation) and install/search boundary tests retained, rerouted through the Discover view.
- Both new review-driven tests verified to fail against the unfixed code before being kept.
- Full client suite green: 948 files / 11,591 tests. `biome lint` clean on both changed files.
- Fold verified in a real browser at both viewports (table above).

Closes #7231