### PR TITLE
Stage and roll back the macOS Ollama.app upgrade instead of deleting first

### DIFF
--- a/server/services/localLlm.js
+++ b/server/services/localLlm.js
@@ -28,7 +28,7 @@ import { localModelSafety } from '../lib/localModelSafety.js';
 
 import { execFile } from '../lib/childProcess.js';import { promisify } from 'util'
 import { createWriteStream } from 'fs'
-import { rm } from 'fs/promises'
+import { rename, rm, stat } from 'fs/promises'
 import { join } from 'path'
 import { tmpdir } from 'os'
 import { fileURLToPath } from 'url'
@@ -359,6 +359,13 @@ async function waitForOllamaVersion(timeoutMs = 30_000) {
  *
  * The .app keeps its own user prefs / model store (`~/.ollama`) so this is
  * non-destructive; only the bundle itself gets swapped.
+ *
+ * The swap is STAGED: the existing bundle is renamed to `<app>.portos-old-<ts>`
+ * and only removed once the replacement is verifiably a directory at the real
+ * path, so any failure downstream rolls back to the working install instead of
+ * leaving the machine with no Ollama at all. It then verifies the RUNNING
+ * version advanced, because a second install ahead of the bundle on PATH can
+ * keep serving the old binary past a perfectly successful swap.
  */
 async function upgradeOllamaMacApp(emit) {
   const appPath = '/Applications/Ollama.app'
@@ -421,13 +428,45 @@ async function upgradeOllamaMacApp(emit) {
   }
 
   emit('Installing /Applications/Ollama.app…')
-  // rm the old bundle first — `mv` can't merge with an existing directory on macOS.
-  await rm(appPath, { recursive: true, force: true }).catch(() => {})
-  const move = await runStreaming('mv', [extractedApp, appPath], emit, 60_000)
-  if (!move.success) {
+  // Stage-and-swap: move the existing bundle ASIDE rather than deleting it. `mv`
+  // still can't merge with an existing directory on macOS, so the destination has
+  // to be cleared first — but an `rm` there means a failed `mv` (timeout, ENOSPC,
+  // an MDM/SIP policy on /Applications) leaves the user with no Ollama at all.
+  // The aside copy is the rollback. Its failure is NOT swallowed either: a
+  // straggler holding the bundle open makes `rename` fail, and continuing would
+  // let `mv` nest the new bundle INSIDE the surviving old one and exit 0.
+  const asidePath = `${appPath}.portos-old-${Date.now()}`
+  const asideErr = await rename(appPath, asidePath).then(() => null, (err) => err)
+  if (asideErr && asideErr.code !== 'ENOENT') {
     await rm(tmpDir, { recursive: true, force: true }).catch(() => {})
-    return { success: false, error: `Could not install ${appPath}: ${move.error}. PortOS may not have permission to write to /Applications — try running the official installer manually.` }
+    return { success: false, error: `Could not move the existing ${appPath} aside (${asideErr.message}), so the upgrade was not attempted and your current Ollama install is untouched. Quit Ollama completely and retry, or install the official app from ${DOWNLOAD_URL.ollama}.` }
   }
+  // ENOENT above just means nothing was installed here — there is no rollback copy.
+  const movedAside = !asideErr
+  const move = await runStreaming('mv', [extractedApp, appPath], emit, 60_000)
+  // The destination was verifiably absent, so a nested Ollama.app/Ollama.app is
+  // impossible — assert the installed path really is a bundle directory anyway,
+  // since everything downstream (quarantine strip, launch) trusts it.
+  const installed = move.success && await stat(appPath).then((s) => s.isDirectory(), () => false)
+  if (!installed) {
+    // Whatever is at appPath now (nothing, a half-copied cross-device `mv`, or a
+    // non-directory) is not a usable bundle, and it is never the user's working
+    // install — that was renamed aside. Clear it unconditionally so the restore
+    // can't fail on a non-empty destination, which is the exact data loss this
+    // staging exists to prevent.
+    await rm(appPath, { recursive: true, force: true }).catch(() => {})
+    const restoreErr = movedAside ? await rename(asidePath, appPath).then(() => null, (err) => err) : null
+    const restored = !movedAside
+      ? ''
+      : restoreErr
+        ? ` Your previous Ollama install could NOT be restored (${restoreErr.message}) — it is at ${asidePath}, move it back to ${appPath} by hand.`
+        : ' Your previous Ollama install has been restored.'
+    // Keep tmpDir: the downloaded bundle is the user's only way to finish by hand.
+    const leftover = (await pathExists(extractedApp)) ? ` The downloaded bundle is still at ${extractedApp} if you want to move it into place yourself.` : ''
+    const why = move.success ? `${appPath} is not a directory after the move` : move.error
+    return { success: false, error: `Could not install ${appPath}: ${why}.${restored}${leftover} PortOS may not have permission to write to /Applications — try running the official installer manually.` }
+  }
+  if (movedAside) await rm(asidePath, { recursive: true, force: true }).catch(() => {})
   // Strip quarantine so Gatekeeper doesn't refuse to launch the freshly-downloaded bundle.
   await runStreaming('xattr', ['-dr', 'com.apple.quarantine', appPath], () => {}, 30_000).catch(() => null)
   await rm(tmpDir, { recursive: true, force: true }).catch(() => {})
@@ -447,6 +486,16 @@ async function upgradeOllamaMacApp(emit) {
       success: true,
       backend: 'ollama',
       note: `Upgraded to ${release.tag_name}, but Ollama did not come back online within 30s. Open Ollama.app if it isn't already running.`
+    }
+  }
+  // Verify the version actually moved — same check the Homebrew path below runs,
+  // and for the same reason: a second Ollama install ahead of the bundle on PATH
+  // can keep serving the old binary, so a swapped .app is not proof of upgrade.
+  if ((tagClean && compareSemver(tagClean, after) > 0) || (!tagClean && (!before || compareSemver(after, before) <= 0))) {
+    return {
+      success: false,
+      backend: 'ollama',
+      error: `Installed ${appPath} (${release.tag_name}), but the Ollama serving requests is still ${after}${before ? ` (was ${before})` : ''}. Another Ollama installation may be ahead of the app bundle on your PATH. Quit Ollama completely, relaunch it from ${appPath}, or install the official app from ${DOWNLOAD_URL.ollama}.`
     }
   }
   console.log(`⬆️ Upgraded Ollama: ${before || 'unknown'} → ${after} (${release.tag_name})`)

--- a/server/services/localLlm.test.js
+++ b/server/services/localLlm.test.js
@@ -66,12 +66,15 @@ const appFs = vi.hoisted(() => {
   const enoent = (op, p) => Object.assign(new Error(`ENOENT: ${op} '${p}'`), { code: 'ENOENT' });
   return {
     entries: new Map(), // absolute path -> 'dir' | 'file'
-    renameFailure: null, // { code, message } forced on the next /Applications rename
+    // Consumed in order, one per /Applications rename: a `{ code, message }`
+    // entry throws, `null` lets that rename through. Queued rather than a single
+    // flag so a test can fail the RESTORE rename and not just the aside one.
+    renameFailures: [],
     manages: (p) => String(p).startsWith('/Applications/'),
     enoent,
     reset() {
       this.entries.clear();
-      this.renameFailure = null;
+      this.renameFailures = [];
     },
   };
 });
@@ -80,11 +83,8 @@ vi.mock('fs/promises', async (importOriginal) => {
   const patched = {
     rename: async (from, to) => {
       if (!appFs.manages(from) && !appFs.manages(to)) return real.rename(from, to);
-      if (appFs.renameFailure) {
-        const forced = appFs.renameFailure;
-        appFs.renameFailure = null;
-        throw Object.assign(new Error(forced.message), { code: forced.code });
-      }
+      const forced = appFs.renameFailures.length ? appFs.renameFailures.shift() : null;
+      if (forced) throw Object.assign(new Error(forced.message), { code: forced.code });
       if (!appFs.entries.has(from)) throw appFs.enoent('rename', from);
       appFs.entries.set(to, appFs.entries.get(from));
       appFs.entries.delete(from);
@@ -858,7 +858,7 @@ describe('localLlm', () => {
 
     it('aborts with the install fully intact when the old bundle cannot be moved aside', async () => {
       appFs.entries.set(APP, 'dir');
-      appFs.renameFailure = { code: 'EPERM', message: 'Operation not permitted' };
+      appFs.renameFailures = [{ code: 'EPERM', message: 'Operation not permitted' }];
 
       const r = await runMacUpgrade();
 
@@ -882,6 +882,21 @@ describe('localLlm', () => {
       expect(aside()).toEqual([]);
       // …and the downloaded bundle survived, so the user can finish by hand.
       expect(r.error).toMatch(/downloaded bundle is still at .*Ollama\.app/);
+    });
+
+    it('names where the old bundle is stranded when the rollback itself fails', async () => {
+      // Worst case: the install failed AND the aside copy could not be moved back.
+      // Silence here would leave the user with no Ollama and no idea where it went,
+      // so the error has to carry the aside path as a breadcrumb.
+      appFs.entries.set(APP, 'dir');
+      appFs.renameFailures = [null, { code: 'EPERM', message: 'Operation not permitted' }];
+
+      const r = await runMacUpgrade({ mv: 'fails' });
+
+      expect(r.success).toBe(false);
+      expect(r.error).toMatch(/could NOT be restored/);
+      expect(r.error).toContain(aside()[0]); // the exact path it is stranded at
+      expect(appFs.entries.has(APP)).toBe(false); // honestly reported, not claimed restored
     });
 
     it('refuses to call a non-directory landing a successful upgrade', async () => {

--- a/server/services/localLlm.test.js
+++ b/server/services/localLlm.test.js
@@ -43,14 +43,66 @@ vi.mock('../lib/downloadPreflight.js', async (importOriginal) => {
     },
   };
 });
+// `pathExists` is what routes upgradeBackend to the macOS .app path (and what the
+// extract step asks about the unzipped bundle), so it has to be answerable per
+// test rather than a constant false.
+const pathExistsImpl = vi.hoisted(() => ({ fn: async () => false }));
 vi.mock('../lib/fileUtils.js', async () => {
   const fsMod = await import('fs');
   return {
     PATHS: state,
-    pathExists: async () => false,
+    pathExists: async (p) => pathExistsImpl.fn(p),
+    ensureDir: async (dir) => fsMod.mkdirSync(dir, { recursive: true }),
     sleep: async () => {},
     atomicWrite: async (file, data) => fsMod.writeFileSync(file, data),
   };
+});
+
+// The macOS .app upgrade renames / removes / stats REAL absolute paths under
+// /Applications. Model only those in memory — everything else (the temp dir the
+// download actually writes to) keeps the real implementation — so no test can
+// touch the developer machine's own Ollama install.
+const appFs = vi.hoisted(() => {
+  const enoent = (op, p) => Object.assign(new Error(`ENOENT: ${op} '${p}'`), { code: 'ENOENT' });
+  return {
+    entries: new Map(), // absolute path -> 'dir' | 'file'
+    renameFailure: null, // { code, message } forced on the next /Applications rename
+    manages: (p) => String(p).startsWith('/Applications/'),
+    enoent,
+    reset() {
+      this.entries.clear();
+      this.renameFailure = null;
+    },
+  };
+});
+vi.mock('fs/promises', async (importOriginal) => {
+  const real = await importOriginal();
+  const patched = {
+    rename: async (from, to) => {
+      if (!appFs.manages(from) && !appFs.manages(to)) return real.rename(from, to);
+      if (appFs.renameFailure) {
+        const forced = appFs.renameFailure;
+        appFs.renameFailure = null;
+        throw Object.assign(new Error(forced.message), { code: forced.code });
+      }
+      if (!appFs.entries.has(from)) throw appFs.enoent('rename', from);
+      appFs.entries.set(to, appFs.entries.get(from));
+      appFs.entries.delete(from);
+    },
+    rm: async (target, opts) => {
+      if (!appFs.manages(target)) return real.rm(target, opts);
+      appFs.entries.delete(target);
+    },
+    stat: async (target) => {
+      if (!appFs.manages(target)) return real.stat(target);
+      const kind = appFs.entries.get(target);
+      if (!kind) throw appFs.enoent('stat', target);
+      return { isDirectory: () => kind === 'dir' };
+    },
+  };
+  // Patch the default export too, so a module importing `fs from 'fs/promises'`
+  // can't reach the unguarded real calls through the other spelling.
+  return { ...real, ...patched, default: { ...(real.default ?? real), ...patched } };
 });
 
 const mocks = vi.hoisted(() => ({
@@ -174,6 +226,8 @@ beforeEach(async () => {
   for (const fn of Object.values(mocks.providers)) fn.mockReset();
   cp.spawn = cp.defaults.spawn; // reset child_process drivers to benign defaults
   cp.execFile = cp.defaults.execFile;
+  pathExistsImpl.fn = async () => false;
+  appFs.reset();
   delete process.env.LLM_BACKEND;
   state.root = fs.mkdtempSync(path.join(os.tmpdir(), 'portos-llm-svc-'));
   vi.resetModules();
@@ -747,6 +801,133 @@ describe('localLlm', () => {
       } finally {
         restorePlatform();
       }
+    });
+  });
+
+  // The .app swap is the only upgrade path that REPLACES a working install on
+  // disk, so each test below pins where the bundle ends up — not which commands
+  // ran. Before #7238 the old bundle was `rm`'d first and its failure swallowed,
+  // which could leave the machine with no Ollama at all, or a nested
+  // Ollama.app/Ollama.app reported as a successful upgrade.
+  describe('upgradeBackend — macOS Ollama.app swap', () => {
+    const APP = '/Applications/Ollama.app';
+    const aside = () => [...appFs.entries.keys()].filter((p) => p.startsWith(`${APP}.portos-old-`));
+
+    // Runs the .app path end to end with every shell-out stubbed. `mv` mutates the
+    // in-memory /Applications model the way the real one would, so the assertions
+    // can read the resulting filesystem shape.
+    const runMacUpgrade = async ({ mv = 'ok', running = '0.33.3' } = {}) => {
+      const restorePlatform = pinPlatform('darwin');
+      const extracted = { present: true };
+      // `pathExists(APP)` is the dispatch check that routed upgradeBackend here, so
+      // it answers true independently of the in-memory model — which lets a test
+      // exercise the bundle being gone by the time the rename runs.
+      pathExistsImpl.fn = async (p) => (p === APP ? true : p.endsWith('/Ollama.app') && extracted.present);
+      vi.stubGlobal('fetch', vi.fn(async (url) => {
+        if (String(url).includes('api.github.com')) {
+          return {
+            ok: true,
+            json: async () => ({ tag_name: 'v0.34.0', assets: [{ name: 'Ollama-darwin.zip', size: 1024, browser_download_url: 'https://example.com/Ollama-darwin.zip' }] })
+          };
+        }
+        return { ok: true, body: new ReadableStream({ start(c) { c.enqueue(new Uint8Array([0x50, 0x4b])); c.close(); } }) };
+      }));
+      cp.spawn = vi.fn((cmd, args) => {
+        if (cmd !== 'mv') return fakeChild();
+        if (mv === 'fails') return fakeChild({ code: 1, lines: ['mv: Operation not permitted'] });
+        // A real `mv` consumes the source; `mv === 'nonDirectory'` is the
+        // pathological landing this swap must refuse to call success.
+        extracted.present = false;
+        appFs.entries.set(args[1], mv === 'nonDirectory' ? 'file' : 'dir');
+        return fakeChild();
+      });
+      mocks.ollama.getStatus
+        .mockResolvedValueOnce({ version: '0.33.3' })   // `before`
+        .mockResolvedValueOnce({ version: running });   // `after`, post-relaunch
+      try {
+        return await svc.upgradeBackend('ollama');
+      } finally {
+        // An abort short-circuits before `after` is read, and `clearAllMocks` in
+        // beforeEach clears recorded calls but NOT a queued `…Once` value — so an
+        // unconsumed one would surface in whichever later test calls getStatus next.
+        mocks.ollama.getStatus.mockReset();
+        vi.unstubAllGlobals();
+        restorePlatform();
+      }
+    };
+
+    it('aborts with the install fully intact when the old bundle cannot be moved aside', async () => {
+      appFs.entries.set(APP, 'dir');
+      appFs.renameFailure = { code: 'EPERM', message: 'Operation not permitted' };
+
+      const r = await runMacUpgrade();
+
+      expect(r).toMatchObject({ success: false, error: expect.stringContaining('Could not move the existing') });
+      expect(r.error).toMatch(/untouched/);
+      // The working install is still exactly where it was, and no `mv` was tried.
+      expect(appFs.entries.get(APP)).toBe('dir');
+      expect(aside()).toEqual([]);
+      expect(cp.spawn.mock.calls.map(([cmd]) => cmd)).not.toContain('mv');
+    });
+
+    it('restores the previous bundle and keeps the download when the install fails', async () => {
+      appFs.entries.set(APP, 'dir');
+
+      const r = await runMacUpgrade({ mv: 'fails' });
+
+      expect(r.success).toBe(false);
+      expect(r.error).toMatch(/previous Ollama install has been restored/);
+      // The rollback landed: the bundle is back at its real path, nothing stranded.
+      expect(appFs.entries.get(APP)).toBe('dir');
+      expect(aside()).toEqual([]);
+      // …and the downloaded bundle survived, so the user can finish by hand.
+      expect(r.error).toMatch(/downloaded bundle is still at .*Ollama\.app/);
+    });
+
+    it('refuses to call a non-directory landing a successful upgrade', async () => {
+      // The pre-#7238 `rm`-then-`mv` could leave Ollama.app/Ollama.app and report
+      // success. Anything that is not a bundle directory must roll back instead.
+      appFs.entries.set(APP, 'dir');
+
+      const r = await runMacUpgrade({ mv: 'nonDirectory' });
+
+      expect(r).toMatchObject({ success: false, error: expect.stringContaining('not a directory') });
+      expect(appFs.entries.get(APP)).toBe('dir'); // restored, not the stray file
+      expect(aside()).toEqual([]);
+    });
+
+    it('installs over a previous bundle and clears the aside copy on success', async () => {
+      appFs.entries.set(APP, 'dir');
+
+      const r = await runMacUpgrade({ running: '0.34.0' });
+
+      expect(r).toMatchObject({ success: true, backend: 'ollama' });
+      expect(r.note).toContain('0.33.3 → 0.34.0');
+      expect(appFs.entries.get(APP)).toBe('dir');
+      expect(aside()).toEqual([]); // no `.portos-old-*` litter left in /Applications
+    });
+
+    it('reports failure when the running version did not advance', async () => {
+      // Matches the Homebrew path's check: a second install ahead of the bundle on
+      // PATH can keep serving the old binary past a perfectly successful swap.
+      appFs.entries.set(APP, 'dir');
+
+      const r = await runMacUpgrade({ running: '0.33.3' });
+
+      expect(r).toMatchObject({ success: false, backend: 'ollama' });
+      expect(r.error).toMatch(/still 0\.33\.3/);
+      expect(appFs.entries.get(APP)).toBe('dir'); // the new bundle stays installed
+    });
+
+    it('treats a missing bundle as a fresh install rather than an aside-move failure', async () => {
+      // Nothing registered at /Applications, so the rename raises ENOENT: that is
+      // "nothing to move aside", not a failure — the upgrade proceeds with no
+      // rollback copy to clean up.
+      const r = await runMacUpgrade({ running: '0.34.0' });
+
+      expect(r.success).toBe(true);
+      expect(appFs.entries.get(APP)).toBe('dir');
+      expect(aside()).toEqual([]);
     });
   });
 


### PR DESCRIPTION
## Summary

`upgradeOllamaMacApp` deleted `/Applications/Ollama.app` before it knew the replacement could land, and swallowed that delete's own failure. Two reachable outcomes from a user-triggered "upgrade Ollama":

- **`rm` succeeds, `mv` fails** (60s timeout, ENOSPC, an MDM/SIP policy on `/Applications`) — the working install was already gone, and the failure branch then deleted `tmpDir`, destroying the freshly downloaded replacement too. No Ollama at all, nothing to retry from.
- **`rm` fails and is swallowed** — `mv <src> <existing-dir>` on macOS moves the source *inside* the target and exits 0, so a corrupted `Ollama.app/Ollama.app` was reported as a successful upgrade.

Now:

- The old bundle is renamed to `<app>.portos-old-<ts>` instead of deleted, and restored on any downstream failure. A failure to move it aside **aborts** rather than being swallowed — which also guarantees the destination is absent, so nesting is impossible.
- `ENOENT` on that rename is treated as "nothing installed yet" and the upgrade proceeds.
- A failed install keeps `tmpDir` and names the extracted bundle's location in the error; if the rollback itself fails, the error names where the old bundle is stranded.
- The installed path is asserted to be a directory before the quarantine strip, and the aside copy is only removed once it is.
- The **running** version is checked against the release tag with `compareSemver`, matching the Homebrew path in the same file — a second install ahead of the bundle on PATH can keep serving the old binary past a perfectly successful swap.

## Test plan

- Six new tests in `server/services/localLlm.test.js` drive the whole `.app` path with the fs and `runStreaming` seams stubbed: aside-move failure aborts untouched, install failure restores and preserves the download, a failed rollback names the stranded path, a non-directory landing is refused, the happy path clears the aside copy, and a non-advancing version reports failure.
- `/Applications` paths are modeled in memory (the `fs/promises` mock delegates every other path to the real implementation), so no test can touch the developer machine's own install.
- Reverting the production change fails five of the six; verified by probe.
- `server` suite: 89/89 in this file, 43808 passing tree-wide. Two pre-existing timeouts (`jsonWritebackConventions`, `lib/validationSplit`) reproduce identically on unmodified `origin/main` in a clean worktree.

Closes #7238