### PR TITLE
fix(a11y): give the five heading-less routes a semantic h1 via PageHeader

### DIFF
--- a/client/src/a11yConventions.test.js
+++ b/client/src/a11yConventions.test.js
@@ -3519,4 +3519,218 @@ function B() { const sensors = useSensors(useSensor(PointerSensor)); return <Dnd
     for (const file of withContext) offenders.push(...offendersIn(file, maskedSourceOf(file)));
     expect(offenders, `DndContext registered without a KeyboardSensor — every dnd-kit handle already announces itself as draggable and tells the user to press Space, so a pointer-only sensor list is a WCAG 2.1.1 failure. Add useSensor(KeyboardSensor, { coordinateGetter }) (sortableKeyboardCoordinates for a SortableContext, createFreeDroppableKeyboardCoordinates from lib/dndKeyboardCoordinates.js for free droppables):\n${offenders.join('\n')}`).toEqual([]);
   });
+
+  // --- routed-page top-level heading (#7245) -------------------------------
+  //
+  // A routed page with no <h1> inverts the document outline: heading
+  // navigation opens at <h2>/<h3> — or worse, a nested page mounts a second
+  // <h1> beside the shell's — which fails WCAG 1.3.1/3.2.4 and was the exact
+  // defect #7245 fixed on the five audited routes.
+  //
+  // "Supplies a heading" means the routed element's file renders an <h1> or the
+  // shared <PageHeader> (which owns the h1), or forwards the question through
+  // the idioms this tree writes for routed components: a re-export barrel
+  // (`export { X } from './X'`, `export { default } from './Page'`), or a thin
+  // page that renders an imported component carrying the heading
+  // (Agents -> AgentList, AppDetail -> AppDetailView).
+  //
+  // Two carve-outs keep the question honest rather than broad:
+  //   - a nested <Route> inherits the heading from its ancestor's element —
+  //     the MediaGen shell owns /media/*'s <h1>, so a tab page mounted in its
+  //     outlet must not add a second;
+  //   - the lists below. HEADINGLESS_ROUTE_ELEMENTS is elements that render no
+  //     page body of their own — the app chrome, a redirect-only element, the
+  //     drawer-only deep link. ROUTE_HEADING_GAP_ALLOWLIST is the pre-existing
+  //     debt: pages whose hand-rolled header still stops below <h1>, on routes
+  //     the #7245 sweep never reached. Each row is a real defect — normalize
+  //     the page onto PageHeader (Ambient: an sr-only h1 — it is deliberately
+  //     chromeless) and delete the row; the stale-entry rule keeps the list
+  //     honest.
+
+  // name -> { file, exportedName } for every component a `<Route element>` in
+  // this source can name: the static relative imports, plus `lazyWithReload`
+  // declarations — `const X = lazyWithReload(() => import('./pages/X'))`, and
+  // the DevTools idiom `.then(m => ({ default: m.X }))`, which binds the page
+  // under a NAMED export of the target module rather than `default`.
+  const routeElementBindings = (appSrc, appFile) => {
+    const bindings = relativeImportBindings(appSrc, appFile);
+    const lazy = /const\s+([A-Z][\w$]*)\s*=\s*lazyWithReload\(\s*\(\)\s*=>\s*import\(\s*['"]([^'"]+)['"]\s*\)\s*(?:\.then\(\s*\w+\s*=>\s*\(\s*\{\s*default\s*:\s*\w+\.([A-Z][\w$]*)\s*\}\s*\)\s*\))?/g;
+    for (const m of appSrc.matchAll(lazy)) {
+      const file = resolveRelativeImport(appFile, m[2]);
+      if (file) bindings.set(m[1], { file, exportedName: m[3] ?? 'default' });
+    }
+    return bindings;
+  };
+
+  // `element={<X … />}` on a <Route> opening tag -> 'X'. Every element this
+  // file writes is a single component element; the first name in the
+  // expression is the component mounted.
+  const routeElementName = (routeTag) => /\belement\s*=\s*\{\s*<\s*([A-Z][\w$.]*)/.exec(routeTag)?.[1] ?? null;
+
+  // File -> does the component it exports under `exportedName` put a top-level
+  // heading on the page? The file's own <h1>/<PageHeader> first — then the
+  // barrel and thin-wrapper idioms. `seen` bounds the chase so a forwarding
+  // cycle resolves to "no" rather than recursing.
+  const suppliesPageHeading = (file, exportedName, seen = new Set()) => {
+    const key = `${file}#${exportedName}`;
+    if (seen.has(key) || seen.size >= 8) return false;
+    seen.add(key);
+    const src = maskedSourceOf(file);
+    const rendered = renderedTagNames(src);
+    if (rendered.has('h1') || rendered.has('PageHeader')) return true;
+    const imports = relativeImportBindings(src, file);
+    // A file that imports the shared header counts even before its tag is
+    // spelled out (#7245's rule) — and covers an aliased render of it.
+    for (const { file: imported } of imports.values()) {
+      if (/(^|\/)PageHeader\.jsx$/.test(imported)) return true;
+    }
+    const forwarded = reExportBindings(src, file).get(exportedName);
+    if (forwarded && suppliesPageHeading(forwarded.file, forwarded.exportedName, seen)) return true;
+    // A thin page that mounts an imported component carrying the heading —
+    // Agents mounts AgentList — satisfies the route without writing its own.
+    for (const [local, binding] of imports) {
+      if (rendered.has(local) && suppliesPageHeading(binding.file, binding.exportedName, seen)) return true;
+    }
+    return false;
+  };
+
+  // Every <Route> element in `appFile` that resolves to a tracked file,
+  // deduped by module+export, each carrying whether an ancestor <Route>'s
+  // element already supplies the heading (a tab shell like MediaGen owns it
+  // for the pages mounted in its outlet).
+  const routedPageElements = (appFile) => {
+    const appSrc = maskedSourceOf(appFile);
+    const bindings = routeElementBindings(appSrc, appFile);
+    const shelledByHeading = (node) => {
+      for (let p = node.parent; p; p = p.parent) {
+        if (p.name !== 'Route' || p.tag === null) continue;
+        const name = routeElementName(p.tag);
+        const binding = name && bindings.get(name);
+        if (binding && suppliesPageHeading(binding.file, binding.exportedName)) return true;
+      }
+      return false;
+    };
+    const elements = new Map();
+    for (const node of forEachOpeningTag(appSrc, 'Route')) {
+      const name = routeElementName(node.tag);
+      if (!name) continue;
+      const binding = bindings.get(name);
+      // A name with no import binding renders no page of its own — Navigate,
+      // and the local RedirectWithSearch/PrefixRedirect helpers.
+      if (!binding) continue;
+      const key = `${binding.file}#${binding.exportedName}`;
+      const shelled = shelledByHeading(node);
+      const prev = elements.get(key);
+      // First-write-wins is wrong here: a file mounted both under a heading
+      // shell and bare keeps the bare verdict, so the exemption can only ever
+      // narrow to a mount that really sits under an h1.
+      if (!prev) elements.set(key, { ...binding, elementName: name, shelled });
+      else if (prev.shelled) prev.shelled = shelled;
+    }
+    return [...elements.values()];
+  };
+
+  const HEADINGLESS_ROUTE_ELEMENTS = new Set([
+    'src/components/Layout.jsx',    // the app chrome — <Outlet/> children own the page h1
+    'src/pages/IMessage.jsx',       // redirect-only: renders <Navigate> to /messages/imessage
+    'src/pages/SyncView.jsx',       // deep link that mounts SyncDetailDrawer over the prior page
+  ]);
+
+  const ROUTE_HEADING_GAP_ALLOWLIST = new Set([
+    'src/pages/Ambient.jsx',        // chromeless ambient display — wants an sr-only h1, not a bar
+    'src/pages/Browser.jsx',
+    'src/pages/CapabilityMap.jsx',
+    'src/pages/ImageClean.jsx',
+    'src/pages/MoodBoardDetail.jsx',
+    'src/pages/RoundEditor.jsx',
+    'src/pages/Security.jsx',
+    'src/pages/UniverseBuilder.jsx',
+    'src/pages/Uploads.jsx',
+  ]);
+
+  it('gives every routed page a top-level heading (#7245)', () => {
+    // Probe first — the tree is green, so nothing in it pins what the walk
+    // rejects, and a silent change of shape would turn the rule vacuous.
+    withVirtualSources({
+      'src/ProbeApp.jsx': `
+        import { Routes, Route, Navigate } from 'react-router';
+        import Good from './pages/ProbeGood';
+        import Bad from './pages/ProbeBad';
+        import Thin from './pages/ProbeThin';
+        import Barrel from './pages/ProbeBarrel';
+        import Shell from './pages/ProbeShell';
+        import ShellBare from './pages/ProbeShellBare';
+        const LazyBad = lazyWithReload(() => import('./pages/ProbeLazyBad'));
+        const LazyGood = lazyWithReload(() => import('./pages/ProbeLazyGood'));
+        const LazyNamed = lazyWithReload(() => import('./pages/ProbeBarrel').then(m => ({ default: m.ProbeGood })));
+        export default function ProbeApp() {
+          return (
+            <Routes>
+              <Route path="/" element={<ShellBare />}>
+                <Route index element={<Good />} />
+                <Route path="bad" element={<Bad />} />
+                <Route path="thin" element={<Thin />} />
+                <Route path="barrel" element={<Barrel />} />
+                <Route path="lazy-bad" element={<LazyBad />} />
+                <Route path="lazy-good" element={<LazyGood />} />
+                <Route path="lazy-named" element={<LazyNamed />} />
+                <Route path="away" element={<Navigate to="/" replace />} />
+                <Route path="gone" element={<Unbound />} />
+                <Route path="shelled" element={<Shell />}>
+                  <Route path="kid" element={<Bad />} />
+                </Route>
+              </Route>
+            </Routes>
+          );
+        }
+      `,
+      'src/pages/ProbeGood.jsx': 'export default function ProbeGood() { return <h1>Good</h1>; }',
+      'src/pages/ProbeBad.jsx': 'export default function ProbeBad() { return <h2>Bad</h2>; }',
+      'src/pages/ProbeThin.jsx': "import ProbeGood from './ProbeGood';\nexport default function ProbeThin() { return <ProbeGood />; }",
+      'src/pages/ProbeBarrel.jsx': "export { default, default as ProbeGood } from './ProbeGood';",
+      'src/pages/ProbeLazyBad.jsx': 'export default function ProbeLazyBad() { return <h2>Lazy</h2>; }',
+      'src/pages/ProbeLazyGood.jsx': "import PageHeader from '../components/PageHeader';\nexport default function ProbeLazyGood() { return <PageHeader title=\"Lazy\" />; }",
+      'src/pages/ProbeShell.jsx': 'export default function ProbeShell() { return <h1>Shell</h1>; }',
+      'src/pages/ProbeShellBare.jsx': 'export default function ProbeShellBare() { return <div />; }',
+    }, () => {
+      const offenders = routedPageElements('src/ProbeApp.jsx')
+        .filter((e) => !e.shelled)
+        .filter((e) => !suppliesPageHeading(e.file, e.exportedName))
+        .map((e) => e.file);
+      // ShellBare (no heading of its own), Bad (h2 only), LazyBad — and NOT:
+      // Good (h1), Thin (delegate owns the h1), Barrel + LazyNamed (barrel
+      // target owns it), LazyGood (PageHeader), Navigate/Unbound (no page),
+      // and the Bad mounted under Shell's h1 outlet.
+      expect(offenders).toEqual([
+        'src/pages/ProbeShellBare.jsx',
+        'src/pages/ProbeBad.jsx',
+        'src/pages/ProbeLazyBad.jsx',
+      ]);
+    });
+
+    const elements = routedPageElements('src/App.jsx');
+    // Assert the walk really read the route table — a walker change that finds
+    // no Route elements must not pass over an empty set.
+    expect(elements.length, 'found no routed page elements in src/App.jsx — has the route table or its lazy-import idiom changed?').toBeGreaterThanOrEqual(90);
+
+    const offenders = elements
+      .filter((e) => !e.shelled)
+      .filter((e) => !HEADINGLESS_ROUTE_ELEMENTS.has(e.file) && !ROUTE_HEADING_GAP_ALLOWLIST.has(e.file))
+      .filter((e) => !suppliesPageHeading(e.file, e.exportedName))
+      .map((e) => `${e.file} (route element <${e.elementName}>)`);
+    expect(offenders, `Routed page renders no <h1> and no <PageHeader> — heading navigation opens below level 1 (WCAG 1.3.1/3.2.4). Give the page the shared PageHeader (or a direct <h1> where the surface is deliberately chromeless); a nested tab page under a heading shell gets a free pass only while the shell owns the h1:\n${offenders.join('\n')}`).toEqual([]);
+  });
+
+  it('keeps no stale entries in the routed-heading exemption lists (#7245)', () => {
+    // The allowlists only shrink. An entry whose element was deleted/renamed —
+    // or whose file now supplies a heading — is dead weight that quietly
+    // re-exempts the next heading omission routed to that file.
+    const routed = new Map(routedPageElements('src/App.jsx').map((e) => [e.file, e]));
+    const stale = [...HEADINGLESS_ROUTE_ELEMENTS, ...ROUTE_HEADING_GAP_ALLOWLIST]
+      .filter((file) => {
+        const entry = routed.get(file);
+        return entry === undefined || suppliesPageHeading(entry.file, entry.exportedName);
+      });
+    expect(stale, `routed-heading exemption entries that no longer match a heading-less routed element — delete them:\n${stale.join('\n')}`).toEqual([]);
+  });
 });

--- a/client/src/components/onboarding/FirstRunCard.jsx
+++ b/client/src/components/onboarding/FirstRunCard.jsx
@@ -132,9 +132,9 @@ export default function FirstRunCard() {
       <div className="flex items-start gap-2 sm:gap-3">
         <Sparkles size={18} className="text-port-accent shrink-0 mt-0.5" />
         <div className="min-w-0 flex-1">
-          <h3 id="first-run-heading" className="text-base font-semibold text-white">
+          <h2 id="first-run-heading" className="text-base font-semibold text-white">
             Where do you want to start?
-          </h3>
+          </h2>
           <p className="hidden sm:block mt-1 text-sm text-gray-400">
             Pick a mission to turn on that slice of PortOS and jump in. Exploring
             on your own or picking a mission hides this on future visits. Pressing

--- a/client/src/pages/Apps.jsx
+++ b/client/src/pages/Apps.jsx
@@ -6,6 +6,7 @@ import toast from '../components/ui/Toast';
 import InlineConfirmRow from '../components/ui/InlineConfirmRow';
 import OverflowMenu from '../components/ui/OverflowMenu';
 import AppIcon from '../components/AppIcon';
+import PageHeader from '../components/PageHeader';
 import PageSkeleton from '../components/ui/PageSkeleton';
 import { SkeletonBlock, SkeletonRegion, skeletonRepeat } from '../components/ui/Skeleton';
 import KanbanBoard from '../components/KanbanBoard';
@@ -212,36 +213,36 @@ export default function Apps() {
 
   return (
     <div>
-      {/* Header */}
-      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 mb-6">
-        <div>
-          <h2 className="text-2xl font-bold text-white">Apps</h2>
-          <p className="text-gray-500 text-sm sm:text-base">Manage registered applications</p>
-        </div>
-        <div className="flex items-center gap-3">
-          {/* Archive Toggle — stays mounted while the archived view is open even
-              once it empties, so the way back never disappears. */}
-          {(showArchived || archivedApps.length > 0) && (
-            <button
-              onClick={() => setShowArchived(!showArchived)}
-              className={`px-3 py-2 rounded-lg text-sm flex items-center gap-2 transition-colors ${
-                showArchived
-                  ? 'bg-port-warning/20 text-port-warning border border-port-warning/30'
-                  : 'bg-port-border text-gray-400 hover:text-white'
-              }`}
+      <PageHeader
+        title="Apps"
+        subtitle="Manage registered applications"
+        className="mb-6"
+        actions={(
+          <>
+            {/* Archive Toggle — stays mounted while the archived view is open even
+                once it empties, so the way back never disappears. */}
+            {(showArchived || archivedApps.length > 0) && (
+              <button
+                onClick={() => setShowArchived(!showArchived)}
+                className={`px-3 py-2 rounded-lg text-sm flex items-center gap-2 transition-colors ${
+                  showArchived
+                    ? 'bg-port-warning/20 text-port-warning border border-port-warning/30'
+                    : 'bg-port-border text-gray-400 hover:text-white'
+                }`}
+              >
+                <Archive size={16} />
+                {showArchived ? `Active (${activeApps.length})` : `Archived (${archivedApps.length})`}
+              </button>
+            )}
+            <Link
+              to="/apps/create"
+              className="px-4 py-2 bg-port-accent hover:bg-port-accent/80 text-white rounded-lg transition-colors text-center"
             >
-              <Archive size={16} />
-              {showArchived ? `Active (${activeApps.length})` : `Archived (${archivedApps.length})`}
-            </button>
-          )}
-          <Link
-            to="/apps/create"
-            className="px-4 py-2 bg-port-accent hover:bg-port-accent/80 text-white rounded-lg transition-colors text-center"
-          >
-            + Add
-          </Link>
-        </div>
-      </div>
+              + Add
+            </Link>
+          </>
+        )}
+      />
 
       {/* In-flight update/standardize — page-level so it survives collapsing
           the row and remounting the page. */}

--- a/client/src/pages/Dashboard.jsx
+++ b/client/src/pages/Dashboard.jsx
@@ -9,6 +9,7 @@ import { WIDGETS_BY_ID, FALLBACK_LAYOUT } from '../components/dashboard/widgetRe
 import WidgetSkeleton from '../components/dashboard/WidgetSkeleton';
 import FirstRunCard from '../components/onboarding/FirstRunCard.jsx';
 import { DASHBOARD_LAYOUT_CHANGED, INSTANCE_FEATURES_CHANGED } from '../constants/events.js';
+import PageHeader from '../components/PageHeader';
 import { ChevronsDownUp, GripHorizontal, Monitor, Move, Save, X } from 'lucide-react';
 import * as api from '../services/api';
 import socket from '../services/socket';
@@ -430,72 +431,76 @@ export default function Dashboard() {
 
   return (
     <div className="space-y-6">
-      <FirstRunCard />
-      <div className="flex flex-row items-center justify-between gap-2 sm:gap-4">
-        <h2 className="flex items-center gap-2.5 text-2xl font-bold text-white">
-          Dashboard
-          <span
-            className="relative inline-flex h-2.5 w-2.5"
-            title={health ? 'Server online' : 'Server offline'}
-            aria-label={health ? 'Server online' : 'Server offline'}
-          >
-            {health && (
-              <span className="absolute inline-flex h-full w-full rounded-full bg-port-success opacity-60 animate-ping" />
-            )}
+      {/* The shared PageHeader owns the page <h1> (#7245) — it must precede
+          FirstRunCard so the rendered outline opens at level 1 and the card's
+          own heading sits one level under it. The server-health dot rides in
+          the actions slot, PageHeader's documented place for status badges. */}
+      <PageHeader
+        title="Dashboard"
+        actions={(
+          <>
             <span
-              className={`relative inline-flex rounded-full h-2.5 w-2.5 ${health ? 'bg-port-success shadow-[0_0_8px_rgb(var(--port-success))]' : 'bg-port-error shadow-[0_0_8px_rgb(var(--port-error))]'}`}
-            />
-          </span>
-        </h2>
-        <div className="flex flex-wrap items-center justify-end gap-2 sm:gap-3">
-          {layouts.length > 0 && !editingGrid && (
-            <LayoutPicker
-              layouts={layouts}
-              activeLayoutId={activeLayoutId}
-              onSelect={selectLayout}
-              onEdit={() => setEditorOpen(true)}
-            />
-          )}
-          {!editingGrid && activeLayout && visibleWidgets.length > 0 && (
-            <button
-              onClick={startGridEdit}
-              className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-port-card border border-port-border hover:border-gray-600 transition-colors text-sm text-gray-400 hover:text-white min-h-[40px]"
-              title="Reorder, move and resize widgets"
+              className="relative inline-flex h-2.5 w-2.5"
+              title={health ? 'Server online' : 'Server offline'}
+              aria-label={health ? 'Server online' : 'Server offline'}
             >
-              <Move size={14} />
-              <span className="hidden sm:inline">Arrange</span>
-            </button>
-          )}
-          {editingGrid && (
-            <>
+              {health && (
+                <span className="absolute inline-flex h-full w-full rounded-full bg-port-success opacity-60 animate-ping" />
+              )}
+              <span
+                className={`relative inline-flex rounded-full h-2.5 w-2.5 ${health ? 'bg-port-success shadow-[0_0_8px_rgb(var(--port-success))]' : 'bg-port-error shadow-[0_0_8px_rgb(var(--port-error))]'}`}
+              />
+            </span>
+            {layouts.length > 0 && !editingGrid && (
+              <LayoutPicker
+                layouts={layouts}
+                activeLayoutId={activeLayoutId}
+                onSelect={selectLayout}
+                onEdit={() => setEditorOpen(true)}
+              />
+            )}
+            {!editingGrid && activeLayout && visibleWidgets.length > 0 && (
               <button
-                onClick={cancelGridEdit}
-                disabled={savingGrid}
-                className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-port-card border border-port-border hover:border-gray-600 transition-colors text-sm text-gray-400 hover:text-white min-h-[40px] disabled:opacity-50"
+                onClick={startGridEdit}
+                className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-port-card border border-port-border hover:border-gray-600 transition-colors text-sm text-gray-400 hover:text-white min-h-[40px]"
+                title="Reorder, move and resize widgets"
               >
-                <X size={14} />
-                <span className="hidden sm:inline">Cancel</span>
+                <Move size={14} />
+                <span className="hidden sm:inline">Arrange</span>
               </button>
-              <button
-                onClick={saveGridEdit}
-                disabled={savingGrid}
-                className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-port-accent text-white hover:bg-port-accent/80 transition-colors text-sm min-h-[40px] disabled:opacity-50"
-              >
-                <Save size={14} />
-                <span className="hidden sm:inline">{savingGrid ? 'Saving…' : 'Save layout'}</span>
-              </button>
-            </>
-          )}
-          <Link
-            to="/ambient"
-            className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-port-card border border-port-border hover:border-gray-600 transition-colors text-sm text-gray-400 hover:text-white min-h-[40px]"
-            title="Ambient display mode"
-          >
-            <Monitor size={14} />
-            <span className="hidden sm:inline">Ambient</span>
-          </Link>
-        </div>
-      </div>
+            )}
+            {editingGrid && (
+              <>
+                <button
+                  onClick={cancelGridEdit}
+                  disabled={savingGrid}
+                  className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-port-card border border-port-border hover:border-gray-600 transition-colors text-sm text-gray-400 hover:text-white min-h-[40px] disabled:opacity-50"
+                >
+                  <X size={14} />
+                  <span className="hidden sm:inline">Cancel</span>
+                </button>
+                <button
+                  onClick={saveGridEdit}
+                  disabled={savingGrid}
+                  className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-port-accent text-white hover:bg-port-accent/80 transition-colors text-sm min-h-[40px] disabled:opacity-50"
+                >
+                  <Save size={14} />
+                  <span className="hidden sm:inline">{savingGrid ? 'Saving…' : 'Save layout'}</span>
+                </button>
+              </>
+            )}
+            <Link
+              to="/ambient"
+              className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-port-card border border-port-border hover:border-gray-600 transition-colors text-sm text-gray-400 hover:text-white min-h-[40px]"
+              title="Ambient display mode"
+            >
+              <Monitor size={14} />
+              <span className="hidden sm:inline">Ambient</span>
+            </Link>
+          </>
+        )}
+      />
+      <FirstRunCard />
 
       {dataError && (
         <div className="p-4 bg-port-error/20 border border-port-error rounded-lg text-port-error">

--- a/client/src/pages/Review.jsx
+++ b/client/src/pages/Review.jsx
@@ -25,6 +25,7 @@ import {
   Activity,
   DatabaseBackup
 } from 'lucide-react';
+import PageHeader from '../components/PageHeader';
 import PageSkeleton from '../components/ui/PageSkeleton';
 import CollapsibleText from '../components/ui/CollapsibleText';
 import MarkdownOutput from '../components/cos/MarkdownOutput';
@@ -298,7 +299,7 @@ export default function Review() {
   if (loading) {
     return <PageSkeleton
         label="Loading review hub"
-        headerRowClass="flex flex-col lg:flex-row lg:items-center justify-between gap-3"
+        header="bar"
         padded
         fullHeight
         titleWidthClass="w-40"
@@ -318,15 +319,13 @@ export default function Review() {
   const remainingActionCount = Math.max(0, actionableItems.length - topActionItems.length);
 
   return (
-    <div className="h-full overflow-auto p-4 md:p-6">
-      <div className="space-y-3">
-        {/* Header */}
-        <div className="flex flex-col lg:flex-row lg:items-center justify-between gap-3">
-          <h2 className="text-xl font-bold text-white flex items-center gap-2">
-            <ClipboardList size={20} />
-            Review Hub
-          </h2>
-          <div className="flex items-center gap-2 flex-wrap">
+    <div className="flex flex-col h-full min-h-0">
+      <PageHeader
+        icon={ClipboardList}
+        iconColor="text-white"
+        title="Review Hub"
+        actions={(
+          <>
             <select
               aria-label="Filter review items by status"
               value={filter}
@@ -356,9 +355,10 @@ export default function Review() {
                 </button>
               </>
             )}
-          </div>
-        </div>
-
+          </>
+        )}
+      />
+      <div className="flex-1 min-h-0 overflow-auto p-4 md:p-6 space-y-3">
         {/* Triage summary */}
         <section className="flex flex-wrap gap-2">
           <SummaryPill icon={BellRing} label="Pending" value={counts?.total ?? 0} tone="text-white" />

--- a/client/src/pages/RoundsGuide.jsx
+++ b/client/src/pages/RoundsGuide.jsx
@@ -11,6 +11,7 @@
 
 import { Link } from 'react-router';
 import { Music, ArrowLeft, Drum, Layers, GraduationCap, FileMusic } from 'lucide-react';
+import PageHeader from '../components/PageHeader';
 import Pill from '../components/ui/Pill';
 import {
   RHYTHM_SHAPES,
@@ -74,18 +75,24 @@ function SectionHeading({ icon: Icon, title, subtitle }) {
 export default function RoundsGuide() {
   return (
     <div className="flex flex-col h-full">
-      <div className="flex items-center gap-3 px-4 py-3 border-b border-port-border bg-port-card shrink-0">
-        <Link
-          to="/rounds"
-          className="p-1 text-gray-400 hover:text-white transition-colors"
-          title="Back to Rounds"
-          aria-label="Back to Rounds"
-        >
-          <ArrowLeft size={18} />
-        </Link>
-        <Music size={18} className="text-port-accent shrink-0" />
-        <span className="text-white font-semibold">Rounds · Learning Guide</span>
-      </div>
+      {/* Shared PageHeader supplies the route's <h1> (#7245); the back link
+          rides in the actions slot — where detail pages park their return
+          navigation — and keeps the 44px touch target. */}
+      <PageHeader
+        icon={Music}
+        title="Rounds · Learning Guide"
+        className="bg-port-card"
+        actions={(
+          <Link
+            to="/rounds"
+            className="inline-flex items-center justify-center min-h-[44px] min-w-[44px] p-1 text-gray-400 hover:text-white transition-colors"
+            title="Back to Rounds"
+            aria-label="Back to Rounds"
+          >
+            <ArrowLeft size={18} />
+          </Link>
+        )}
+      />
 
       <div className="flex-1 overflow-y-auto p-4 md:p-6">
         <div className="max-w-4xl mx-auto space-y-10">

--- a/client/src/pages/ThreejsModels.jsx
+++ b/client/src/pages/ThreejsModels.jsx
@@ -111,7 +111,9 @@ export default function ThreejsModels() {
       <header className="flex items-start gap-3">
         <Box className="mt-0.5 h-7 w-7 shrink-0 text-port-accent" />
         <div>
-          <h1 className="text-xl font-semibold text-white">Three.js Models</h1>
+          {/* h2, not h1 — the MediaGen shell route already owns the page <h1>
+              ("Media Gen") and this tab content mounts inside it (#7245). */}
+          <h2 className="text-xl font-semibold text-white">Three.js Models</h2>
           <p className="mt-1 text-sm text-gray-400">
             Reconstruct a gallery image as validated procedural geometry, preview it live, and export a standalone Three.js factory.
           </p>


### PR DESCRIPTION
Closes #7245.

## What

The five audited routes rendered no top-level heading — heading navigation opened at `<h2>`/`<h3>`, and `/media/threejs` mounted a second `<h1>` inside the MediaGen shell — inverting the document outline (WCAG 1.3.1 / 3.2.4). Per the issue's decided shape, all five normalize onto the shared `PageHeader` rather than promoting the local `<h2>`s:

- **`/` (Dashboard)** — the hand-rolled `<h2>` title row becomes `<PageHeader title="Dashboard">`; the server-health dot, layout picker, Arrange/Cancel/Save and Ambient controls move into the `actions` slot. `PageHeader` now precedes `FirstRunCard` so the rendered outline opens at level 1, and the card's heading drops from `<h3>` to `<h2>` — one level under the page `<h1>`. Widget `<h3>`s stay untouched.
- **`/review`** — `<PageHeader icon={ClipboardList} title="Review Hub">` with the status filter + bulk actions in `actions`. Adopts the standard full-width shell (`flex-col h-full` + fixed header + `flex-1 overflow-auto` body — same shape as Tribe/Timeline/RapidReader) and the matching `PageSkeleton` `header="bar"` loading state.
- **`/apps`** — `<PageHeader title="Apps" subtitle="Manage registered applications">` with the archive toggle and `+ Add` link as actions.
- **`/rounds/guide`** — the icon+`<span>` bar becomes `<PageHeader icon={Music} title="Rounds · Learning Guide">`; the back link moves to `actions` (the detail-page convention, cf. SongBookViewer) and gains the 44px touch target.
- **`/media/threejs`** — the nested page `<h1>` demotes to `<h2>`; the MediaGen route shell already owns the route's `<h1>`.

## Regression coverage

`a11yConventions.test.js` gains a routed-page rule that resolves every `<Route element>` in `App.jsx` — static imports, `lazyWithReload`, and the DevTools `.then(m => ({ default: m.X }))` idiom — follows re-export barrels and thin delegate pages (Agents → AgentList, AppDetail → AppDetailView), exempts children of a heading-owning shell (MediaGen) and non-page elements (Layout, redirect-only IMessage, drawer-only SyncView), and fails any routed page file that renders neither an `<h1>` nor `PageHeader`.

The sweep surfaced nine **pre-existing** heading gaps on routes #7245 never audited (Ambient, Browser, CapabilityMap, ImageClean, MoodBoardDetail, RoundEditor, Security, UniverseBuilder, Uploads). They sit in `ROUTE_HEADING_GAP_ALLOWLIST` as documented debt — the stale-entry rule forces each row's removal as it is fixed, so the list can only shrink. Probe fixtures pin both directions of the detector.

## Testing

- `cd client && npx vitest run` — 950/951 files, 11,622 tests pass. The single failure (`VideoTimelineEditor.keyboard.test.jsx`, an unrelated page) is a parallel-run flake — it passes in isolation and touches nothing here.
- `npx biome lint --error-on-warnings` on all changed files — clean.
- `a11yConventions.test.js` — all 53 rules pass, including the two new routed-heading tests.