### PR TITLE
surface yt-dlp's real error instead of a bare "yt-dlp exited 1"

### DIFF
--- a/server/services/ytdlpAudioImport.js
+++ b/server/services/ytdlpAudioImport.js
@@ -29,7 +29,7 @@ import { join, dirname } from 'path';
 import { ServerError } from '../lib/errorHandler.js';
 import { findFfmpeg } from '../lib/ffmpeg.js';
 import { findYtDlp } from '../lib/ytdlp.js';
-import { runYtDlp, ytdlpMarkerArgs } from './ytdlpRun.js';
+import { runYtDlp, ytdlpMarkerArgs, describeYtDlpFailure } from './ytdlpRun.js';
 
 /**
  * Locate yt-dlp + ffmpeg, throwing an actionable ServerError if either is
@@ -109,11 +109,14 @@ export async function downloadAudioToTempMp3({
     // A --match-filters/--max-filesize rejection exits 0 with no output file
     // (yt-dlp treats a filtered-out video as "nothing to do", not an error) —
     // `--print`'s suppression of normal reporting (see ytdlpRun) means the
-    // specific reason never reaches our stdout/stderr parsing, so name the two
-    // known bounds explicitly rather than a bare exit code.
+    // specific reason often never reaches our stdout/stderr parsing, so name the
+    // two known bounds. Only those bounds are ours: describeYtDlpFailure owns
+    // the prose and appends whatever yt-dlp did print, which outranks the guess.
     const reason = exit.code === 0
-      ? `no audio was produced — the source may be longer than ${Math.round(maxDurationSec / 60)} minutes or its audio larger than ${Math.round(maxBytes / 1024 / 1024)}MB, or it may be otherwise unavailable`
-      : (exit.reason || `yt-dlp exited ${exit.code}`);
+      ? describeYtDlpFailure(exit.code, exit.output, {
+        fallback: `no audio was produced — the source may be longer than ${Math.round(maxDurationSec / 60)} minutes or its audio larger than ${Math.round(maxBytes / 1024 / 1024)}MB, or it may be otherwise unavailable`,
+      })
+      : exit.reason; // always populated for a non-zero exit (see runYtDlp)
     await cleanupYtDlpTemp(tempPrefix);
     return { outcome: 'failed', reason };
   }

--- a/server/services/ytdlpAudioImport.js
+++ b/server/services/ytdlpAudioImport.js
@@ -99,7 +99,7 @@ export async function downloadAudioToTempMp3({
     url,
   ];
 
-  const exit = await runYtDlp({ ytDlp, args, onProgress, registerProcess });
+  const exit = await runYtDlp({ ytDlp, args, url, onProgress, registerProcess });
 
   if (exit.canceled) {
     await cleanupYtDlpTemp(tempPrefix);
@@ -114,6 +114,7 @@ export async function downloadAudioToTempMp3({
     // the prose and appends whatever yt-dlp did print, which outranks the guess.
     const reason = exit.code === 0
       ? describeYtDlpFailure(exit.code, exit.output, {
+        url,
         fallback: `no audio was produced — the source may be longer than ${Math.round(maxDurationSec / 60)} minutes or its audio larger than ${Math.round(maxBytes / 1024 / 1024)}MB, or it may be otherwise unavailable`,
       })
       : exit.reason; // always populated for a non-zero exit (see runYtDlp)

--- a/server/services/ytdlpRun.js
+++ b/server/services/ytdlpRun.js
@@ -22,6 +22,7 @@
 import { spawn } from '../lib/childProcess.js';
 import { safeChildProcessOptions } from '../lib/processEnv.js';
 import { createLineReader, createOutputTail } from '../lib/streamLines.js';
+import { isYoutubeVideoUrl } from '../lib/youtubeUrl.js';
 
 /**
  * The wire protocol between our `--progress-template`/`--print` flags and the
@@ -69,10 +70,16 @@ export const ytdlpMarkerArgs = (postprocessStage) => [
  * message alone, so name the remedy rather than leaving the user to re-try.
  *
  * Every alternative below must be diagnostic of THAT class, or the hint sends
- * the user to the one action that cannot help. Deliberately excluded: a bare
- * `Forbidden` (any site's 403 — the x.com login-wall/rate-limit path returns
- * one, and `HTTP Error 403` already covers the YouTube case) and `Sign in to
- * confirm` (YouTube's bot check, whose remedy is cookies, not an upgrade).
+ * the user to the one action that cannot help. Excluded for that reason: `Sign
+ * in to confirm`, YouTube's bot check, whose remedy is cookies rather than an
+ * upgrade.
+ *
+ * The message alone is NOT enough to decide, though — these importers also pull
+ * from x.com/Twitter (login-walled and rate-limited posts return a plain 403)
+ * and, on the reference-audio path, from any public URL. So the hint is gated on
+ * the SOURCE as well: `describeYtDlpFailure` applies it only when the URL is a
+ * YouTube video. A caller that passes no URL gets no hint — silence beats
+ * pointing the user at an upgrade that cannot help.
  */
 const STALE_YTDLP_SIGNATURE = /HTTP Error 403|PO Token|nsig|Failed to extract any player response/i;
 
@@ -91,13 +98,17 @@ const STALE_YTDLP_HINT = 'the installed yt-dlp is likely out of date for YouTube
  *   a run that exited 0 and still produced nothing: only the caller knows which
  *   of its bounds was tripped. yt-dlp's own words outrank a guess, so they are
  *   appended to it whenever there are any.
+ * @param {string}     [o.url]      The source URL, which decides whether the
+ *   stale-player hint applies at all (see `STALE_YTDLP_SIGNATURE`). Omit it and
+ *   the hint is never added.
  */
-export function describeYtDlpFailure(code, output, { fallback } = {}) {
+export function describeYtDlpFailure(code, output, { fallback, url } = {}) {
   const said = (output || '').trim();
   const base = fallback
     ? [fallback, said].filter(Boolean).join(' — yt-dlp said: ')
     : (said ? `yt-dlp failed: ${said}` : `yt-dlp exited ${code}`);
-  return STALE_YTDLP_SIGNATURE.test(said) ? `${base} — ${STALE_YTDLP_HINT}` : base;
+  const stalePlayer = isYoutubeVideoUrl(url) && STALE_YTDLP_SIGNATURE.test(said);
+  return stalePlayer ? `${base} — ${STALE_YTDLP_HINT}` : base;
 }
 
 /**
@@ -106,6 +117,9 @@ export function describeYtDlpFailure(code, output, { fallback } = {}) {
  * @param {object}   opts
  * @param {string}   opts.ytDlp           yt-dlp binary path.
  * @param {string[]} opts.args            Fully-built argv (marker args included).
+ * @param {string}   [opts.url]          The source URL, forwarded to
+ *   `describeYtDlpFailure` so a YouTube-only remedy is never suggested for a
+ *   failure from another site. Omitting it only costs the hint.
  * @param {function} opts.onProgress      ({ percent, stage }) => void — SSE-agnostic.
  * @param {function} opts.registerProcess (proc|null) => void — lets the caller wire cancel.
  * @returns {Promise<{ canceled:boolean, code:number|null, signal:string|null, reason:string|null, title:string, output:string }>}
@@ -115,7 +129,7 @@ export function describeYtDlpFailure(code, output, { fallback } = {}) {
  *   `describeYtDlpFailure`) — and null on a clean exit. `output` is the raw tail
  *   of non-marker output, for callers that compose their own reason.
  */
-export async function runYtDlp({ ytDlp, args, onProgress, registerProcess }) {
+export async function runYtDlp({ ytDlp, args, url, onProgress, registerProcess }) {
   const proc = spawn(ytDlp, args, safeChildProcessOptions({ stdio: ['ignore', 'pipe', 'pipe'] }));
   registerProcess(proc);
 
@@ -174,7 +188,7 @@ export async function runYtDlp({ ytDlp, args, onProgress, registerProcess }) {
   // Exit 0 keeps `reason: null` — the caller owns the "exited 0 but produced
   // nothing" case, where the bound that was tripped is knowable only to it. A
   // spawn failure has no output to explain it, so its own message stands.
-  const reason = code === 0 ? null : (exit.reason ?? describeYtDlpFailure(code, output));
+  const reason = code === 0 ? null : (exit.reason ?? describeYtDlpFailure(code, output, { url }));
 
   return { canceled: false, code, signal: exit.signal ?? null, reason, title, output };
 }

--- a/server/services/ytdlpRun.js
+++ b/server/services/ytdlpRun.js
@@ -21,7 +21,7 @@
 
 import { spawn } from '../lib/childProcess.js';
 import { safeChildProcessOptions } from '../lib/processEnv.js';
-import { createLineReader } from '../lib/streamLines.js';
+import { createLineReader, createOutputTail } from '../lib/streamLines.js';
 
 /**
  * The wire protocol between our `--progress-template`/`--print` flags and the
@@ -62,6 +62,45 @@ export const ytdlpMarkerArgs = (postprocessStage) => [
 ];
 
 /**
+ * YouTube gates its media URLs behind a player-client / PO-token handshake that
+ * yt-dlp tracks release-to-release, so a binary only weeks out of date reports a
+ * video the browser plays fine as a flat `HTTP Error 403: Forbidden`. That is
+ * the most common cause of a failed download here and it is invisible from the
+ * message alone, so name the remedy rather than leaving the user to re-try.
+ *
+ * Every alternative below must be diagnostic of THAT class, or the hint sends
+ * the user to the one action that cannot help. Deliberately excluded: a bare
+ * `Forbidden` (any site's 403 — the x.com login-wall/rate-limit path returns
+ * one, and `HTTP Error 403` already covers the YouTube case) and `Sign in to
+ * confirm` (YouTube's bot check, whose remedy is cookies, not an upgrade).
+ */
+const STALE_YTDLP_SIGNATURE = /HTTP Error 403|PO Token|nsig|Failed to extract any player response/i;
+
+const STALE_YTDLP_HINT = 'the installed yt-dlp is likely out of date for YouTube\'s current player — update it (`yt-dlp -U`, or `brew upgrade yt-dlp`) and retry';
+
+/**
+ * Compose the user-facing reason for a failed yt-dlp run.
+ *
+ * Exported because both importers need it for the case the runner cannot
+ * describe — a clean exit that produced no file — and because the prose is
+ * worth pinning by a unit test rather than only through a spawn.
+ *
+ * @param {number|null} code       Exit code (null when the binary never started).
+ * @param {string}      output     Recent yt-dlp output (the tail).
+ * @param {string}     [o.fallback] The caller's own account of the failure, for
+ *   a run that exited 0 and still produced nothing: only the caller knows which
+ *   of its bounds was tripped. yt-dlp's own words outrank a guess, so they are
+ *   appended to it whenever there are any.
+ */
+export function describeYtDlpFailure(code, output, { fallback } = {}) {
+  const said = (output || '').trim();
+  const base = fallback
+    ? [fallback, said].filter(Boolean).join(' — yt-dlp said: ')
+    : (said ? `yt-dlp failed: ${said}` : `yt-dlp exited ${code}`);
+  return STALE_YTDLP_SIGNATURE.test(said) ? `${base} — ${STALE_YTDLP_HINT}` : base;
+}
+
+/**
  * Spawn yt-dlp, stream its markers to `onProgress`, and classify the exit.
  *
  * @param {object}   opts
@@ -69,15 +108,23 @@ export const ytdlpMarkerArgs = (postprocessStage) => [
  * @param {string[]} opts.args            Fully-built argv (marker args included).
  * @param {function} opts.onProgress      ({ percent, stage }) => void — SSE-agnostic.
  * @param {function} opts.registerProcess (proc|null) => void — lets the caller wire cancel.
- * @returns {Promise<{ canceled:boolean, code:number|null, signal:string|null, reason:string|null, title:string }>}
- *   `canceled` is true when the child died on SIGTERM/SIGKILL. `reason` carries
- *   the spawn-failure message when the binary never started, else null.
+ * @returns {Promise<{ canceled:boolean, code:number|null, signal:string|null, reason:string|null, title:string, output:string }>}
+ *   `canceled` is true when the child died on SIGTERM/SIGKILL. `reason` is the
+ *   user-facing failure prose for any non-zero exit — the spawn-failure message
+ *   when the binary never started, else what yt-dlp printed (see
+ *   `describeYtDlpFailure`) — and null on a clean exit. `output` is the raw tail
+ *   of non-marker output, for callers that compose their own reason.
  */
 export async function runYtDlp({ ytDlp, args, onProgress, registerProcess }) {
   const proc = spawn(ytDlp, args, safeChildProcessOptions({ stdio: ['ignore', 'pipe', 'pipe'] }));
   registerProcess(proc);
 
   let title = '';
+  // Recent non-marker output, kept so a non-zero exit reports what yt-dlp said
+  // instead of just its exit code. Marker lines are our own protocol and each
+  // branch below returns, so progress spam never evicts the `ERROR:` line from
+  // the tail's budget.
+  const tail = createOutputTail();
   const onLine = (line) => {
     if (line.startsWith(YTDLP_MARKERS.TITLE)) {
       title = line.slice(YTDLP_MARKERS.TITLE.length).trim();
@@ -90,7 +137,9 @@ export async function runYtDlp({ ytDlp, args, onProgress, registerProcess }) {
     }
     if (line.startsWith(YTDLP_MARKERS.STAGE)) {
       onProgress({ percent: 100, stage: line.slice(YTDLP_MARKERS.STAGE.length) });
+      return;
     }
+    tail.remember(line);
   };
   // Separate readers per stream — stdout and stderr chunks arrive
   // independently, so a shared buffer can complete a partial line from one
@@ -113,14 +162,17 @@ export async function runYtDlp({ ytDlp, args, onProgress, registerProcess }) {
     return { canceled: true, code: exit.code ?? null, signal: exit.signal, reason: null, title };
   }
   // Flush any final line the child wrote without a trailing newline before exit.
+  // yt-dlp's `ERROR:` line is often exactly that last line, so flushing has to
+  // happen BEFORE the tail is read or the failure reason loses its cause.
   stdoutReader.flush();
   stderrReader.flush();
 
-  return {
-    canceled: false,
-    code: exit.code ?? null,
-    signal: exit.signal ?? null,
-    reason: exit.reason ?? null,
-    title,
-  };
+  const code = exit.code ?? null;
+  const output = tail.text();
+  // Exit 0 keeps `reason: null` — the caller owns the "exited 0 but produced
+  // nothing" case, where the bound that was tripped is knowable only to it. A
+  // spawn failure has no output to explain it, so its own message stands.
+  const reason = code === 0 ? null : (exit.reason ?? describeYtDlpFailure(code, output));
+
+  return { canceled: false, code, signal: exit.signal ?? null, reason, title, output };
 }

--- a/server/services/ytdlpRun.js
+++ b/server/services/ytdlpRun.js
@@ -158,8 +158,10 @@ export async function runYtDlp({ ytDlp, args, onProgress, registerProcess }) {
   if (exit.signal === 'SIGTERM' || exit.signal === 'SIGKILL') {
     // Don't flush on cancel — a SIGKILL'd child leaves only a partial marker
     // line in the carry, and emitting it would fire a stray progress/stage
-    // callback right before the caller reports the cancellation.
-    return { canceled: true, code: exit.code ?? null, signal: exit.signal, reason: null, title };
+    // callback right before the caller reports the cancellation. `output` is
+    // still reported (minus that unflushed carry) so every return from this
+    // function has the one shape its callers can rely on.
+    return { canceled: true, code: exit.code ?? null, signal: exit.signal, reason: null, title, output: tail.text() };
   }
   // Flush any final line the child wrote without a trailing newline before exit.
   // yt-dlp's `ERROR:` line is often exactly that last line, so flushing has to

--- a/server/services/ytdlpRun.test.js
+++ b/server/services/ytdlpRun.test.js
@@ -49,33 +49,44 @@ describe('ytdlpMarkerArgs', () => {
   });
 });
 
+const YT_URL = 'https://youtu.be/aaaaaaaaaaa';
+const X_URL = 'https://x.com/someone/status/1234567890';
+const FORBIDDEN = 'ERROR: unable to download video data: HTTP Error 403: Forbidden';
+
 describe('describeYtDlpFailure', () => {
   it('names the stale-binary remedy for the YouTube gating class', () => {
     // A 403 on media URLs is what a yt-dlp that has fallen behind YouTube's
     // player handshake reports for a video the browser plays fine; without the
     // hint the user has a real message and still no next step.
-    const reason = describeYtDlpFailure(1, 'ERROR: unable to download video data: HTTP Error 403: Forbidden');
+    const reason = describeYtDlpFailure(1, FORBIDDEN, { url: YT_URL });
     expect(reason).toContain('HTTP Error 403: Forbidden');
     expect(reason).toMatch(/yt-dlp -U/);
   });
 
   it('leaves an unrelated failure without the upgrade hint', () => {
-    const reason = describeYtDlpFailure(1, 'ERROR: Video unavailable');
+    const reason = describeYtDlpFailure(1, 'ERROR: Video unavailable', { url: YT_URL });
     expect(reason).toBe('yt-dlp failed: ERROR: Video unavailable');
     expect(reason).not.toMatch(/yt-dlp -U/);
   });
 
-  // Two failures that LOOK like the stale-player class and are not. Advising an
-  // upgrade for either sends the user to the one action that cannot help, so the
-  // exclusions are pinned rather than left to the regex's shape.
+  // Failures that LOOK like the stale-player class and are not. Advising an
+  // upgrade for any of them sends the user to the one action that cannot help,
+  // so each exclusion is pinned rather than left to the regex's shape.
   it('does not advise an upgrade for YouTube\'s bot check, whose remedy is cookies', () => {
-    const reason = describeYtDlpFailure(1, 'ERROR: Sign in to confirm you are not a bot');
+    const reason = describeYtDlpFailure(1, 'ERROR: Sign in to confirm you are not a bot', { url: YT_URL });
     expect(reason).not.toMatch(/yt-dlp -U/);
   });
 
-  it('does not advise an upgrade for a non-YouTube 403', () => {
-    const reason = describeYtDlpFailure(1, 'ERROR: unable to download: Forbidden (rate-limited)');
+  // The message alone can't decide this one: x.com returns a plain 403 for a
+  // login-walled or rate-limited post, which no yt-dlp upgrade fixes.
+  it('does not advise an upgrade for the same 403 from a non-YouTube source', () => {
+    const reason = describeYtDlpFailure(1, FORBIDDEN, { url: X_URL });
+    expect(reason).toContain('HTTP Error 403: Forbidden');
     expect(reason).not.toMatch(/yt-dlp -U/);
+  });
+
+  it('withholds the hint when the caller passed no URL at all', () => {
+    expect(describeYtDlpFailure(1, FORBIDDEN)).not.toMatch(/yt-dlp -U/);
   });
 
   it('falls back to the exit code when there is no output', () => {
@@ -93,7 +104,7 @@ describe('describeYtDlpFailure', () => {
     });
 
     it('still names the upgrade remedy when the printed cause is the gating class', () => {
-      const reason = describeYtDlpFailure(0, 'ERROR: HTTP Error 403: Forbidden', { fallback: 'no video was produced' });
+      const reason = describeYtDlpFailure(0, FORBIDDEN, { fallback: 'no video was produced', url: YT_URL });
       expect(reason).toMatch(/yt-dlp -U/);
     });
   });
@@ -173,6 +184,20 @@ describe('runYtDlp — exit classification', () => {
     const result = await runYtDlp(baseArgs);
     expect(result.reason).toContain('HTTP Error 403: Forbidden');
     expect(result.reason).not.toBe('yt-dlp exited 1');
+  });
+
+  // Pins that the URL actually reaches describeYtDlpFailure — without the
+  // forwarding, both of these would report the same reason.
+  it('forwards the source URL, so the hint follows the site and not just the message', async () => {
+    const child = () => fakeChild({ code: 1, script: [['stderr', `${FORBIDDEN}\n`]] });
+
+    spawn.mockReturnValue(child());
+    const youtube = await runYtDlp({ ...baseArgs, url: YT_URL });
+    expect(youtube.reason).toMatch(/yt-dlp -U/);
+
+    spawn.mockReturnValue(child());
+    const x = await runYtDlp({ ...baseArgs, url: X_URL });
+    expect(x.reason).not.toMatch(/yt-dlp -U/);
   });
 
   it('flushes an unterminated final stderr line into the failure reason', async () => {

--- a/server/services/ytdlpRun.test.js
+++ b/server/services/ytdlpRun.test.js
@@ -12,7 +12,7 @@ import { EventEmitter } from 'events';
 vi.mock('../lib/childProcess.js', async (importOriginal) => ({ ...(await importOriginal()), spawn: vi.fn() }));
 
 const { spawn } = await import('../lib/childProcess.js');
-const { runYtDlp, ytdlpMarkerArgs, YTDLP_MARKERS } = await import('./ytdlpRun.js');
+const { runYtDlp, ytdlpMarkerArgs, YTDLP_MARKERS, describeYtDlpFailure } = await import('./ytdlpRun.js');
 
 /**
  * A fake yt-dlp child. `script` is a list of `[stream, chunk]` pairs written in
@@ -46,6 +46,56 @@ describe('ytdlpMarkerArgs', () => {
     ]));
     // --print implies --simulate and suppresses reporting; both undos must ride along.
     expect(args).toEqual(expect.arrayContaining(['--no-simulate', '--progress']));
+  });
+});
+
+describe('describeYtDlpFailure', () => {
+  it('names the stale-binary remedy for the YouTube gating class', () => {
+    // A 403 on media URLs is what a yt-dlp that has fallen behind YouTube's
+    // player handshake reports for a video the browser plays fine; without the
+    // hint the user has a real message and still no next step.
+    const reason = describeYtDlpFailure(1, 'ERROR: unable to download video data: HTTP Error 403: Forbidden');
+    expect(reason).toContain('HTTP Error 403: Forbidden');
+    expect(reason).toMatch(/yt-dlp -U/);
+  });
+
+  it('leaves an unrelated failure without the upgrade hint', () => {
+    const reason = describeYtDlpFailure(1, 'ERROR: Video unavailable');
+    expect(reason).toBe('yt-dlp failed: ERROR: Video unavailable');
+    expect(reason).not.toMatch(/yt-dlp -U/);
+  });
+
+  // Two failures that LOOK like the stale-player class and are not. Advising an
+  // upgrade for either sends the user to the one action that cannot help, so the
+  // exclusions are pinned rather than left to the regex's shape.
+  it('does not advise an upgrade for YouTube\'s bot check, whose remedy is cookies', () => {
+    const reason = describeYtDlpFailure(1, 'ERROR: Sign in to confirm you are not a bot');
+    expect(reason).not.toMatch(/yt-dlp -U/);
+  });
+
+  it('does not advise an upgrade for a non-YouTube 403', () => {
+    const reason = describeYtDlpFailure(1, 'ERROR: unable to download: Forbidden (rate-limited)');
+    expect(reason).not.toMatch(/yt-dlp -U/);
+  });
+
+  it('falls back to the exit code when there is no output', () => {
+    expect(describeYtDlpFailure(2, '   ')).toBe('yt-dlp exited 2');
+  });
+
+  describe('with a caller fallback (a clean exit that produced nothing)', () => {
+    it('appends what yt-dlp printed to the caller\'s guess', () => {
+      const reason = describeYtDlpFailure(0, 'ERROR: boom', { fallback: 'no video was produced' });
+      expect(reason).toBe('no video was produced — yt-dlp said: ERROR: boom');
+    });
+
+    it('uses the guess alone when yt-dlp printed nothing', () => {
+      expect(describeYtDlpFailure(0, '', { fallback: 'no video was produced' })).toBe('no video was produced');
+    });
+
+    it('still names the upgrade remedy when the printed cause is the gating class', () => {
+      const reason = describeYtDlpFailure(0, 'ERROR: HTTP Error 403: Forbidden', { fallback: 'no video was produced' });
+      expect(reason).toMatch(/yt-dlp -U/);
+    });
   });
 });
 
@@ -106,11 +156,52 @@ describe('runYtDlp — exit classification', () => {
     await expect(runYtDlp(baseArgs)).resolves.toMatchObject({ canceled: true, signal: 'SIGTERM' });
   });
 
-  it('passes a non-zero exit code through without a reason', async () => {
+  it('falls back to the exit code when yt-dlp printed nothing', async () => {
     spawn.mockReturnValue(fakeChild({ code: 1 }));
-    await expect(runYtDlp(baseArgs)).resolves.toMatchObject({ canceled: false, code: 1, reason: null });
+    await expect(runYtDlp(baseArgs)).resolves.toMatchObject({
+      canceled: false, code: 1, reason: 'yt-dlp exited 1',
+    });
   });
 
+  // The reported bug: a real 403 reached the user as a bare "yt-dlp exited 1"
+  // because stderr was read for markers and then dropped.
+  it('reports what yt-dlp printed to stderr rather than just the exit code', async () => {
+    spawn.mockReturnValue(fakeChild({
+      code: 1,
+      script: [['stderr', 'ERROR: unable to download video data: HTTP Error 403: Forbidden\n']],
+    }));
+    const result = await runYtDlp(baseArgs);
+    expect(result.reason).toContain('HTTP Error 403: Forbidden');
+    expect(result.reason).not.toBe('yt-dlp exited 1');
+  });
+
+  it('flushes an unterminated final stderr line into the failure reason', async () => {
+    // yt-dlp's ERROR line is frequently the last thing written, with no newline.
+    spawn.mockReturnValue(fakeChild({ code: 1, script: [['stderr', 'ERROR: Video unavailable']] }));
+    const result = await runYtDlp(baseArgs);
+    expect(result.reason).toContain('Video unavailable'); // prose itself is pinned above
+
+  });
+
+  it('keeps our own marker lines out of the failure reason', async () => {
+    spawn.mockReturnValue(fakeChild({
+      code: 1,
+      script: [['stdout', 'PORTOS_TITLE:Example Clip\nPORTOS_PROGRESS: 12.0%\n'], ['stderr', 'ERROR: boom\n']],
+    }));
+    const result = await runYtDlp(baseArgs);
+    expect(result.reason).toBe('yt-dlp failed: ERROR: boom');
+    expect(result.output).not.toContain('PORTOS_');
+  });
+
+  it('leaves reason null on a clean exit so the caller owns the "produced nothing" case', async () => {
+    spawn.mockReturnValue(fakeChild({ code: 0, script: [['stderr', 'WARNING: something benign\n']] }));
+    const result = await runYtDlp(baseArgs);
+    expect(result.reason).toBeNull();
+    expect(result.output).toContain('WARNING: something benign');
+  });
+
+  // Also pins that a spawn failure keeps its own message rather than falling
+  // through to the empty-output `yt-dlp exited null`.
   it('reports a spawn failure as a reason rather than throwing', async () => {
     const proc = new EventEmitter();
     proc.stdout = new EventEmitter();

--- a/server/services/ytdlpVideoImport.js
+++ b/server/services/ytdlpVideoImport.js
@@ -20,7 +20,7 @@
 import { readdir, unlink } from 'fs/promises';
 import { join, dirname } from 'path';
 import { ensureDir } from '../lib/fileUtils.js';
-import { runYtDlp, ytdlpMarkerArgs } from './ytdlpRun.js';
+import { runYtDlp, ytdlpMarkerArgs, describeYtDlpFailure } from './ytdlpRun.js';
 
 /**
  * Locate the final produced file for a download prefix. yt-dlp writes
@@ -121,10 +121,14 @@ export async function downloadVideoToDir({
     // A --match-filters/--max-filesize rejection exits 0 with no output file
     // (yt-dlp treats a filtered-out video as "nothing to do") — and --print
     // suppresses the specific reason, so name the known bounds. x.com/Twitter
-    // downloads also fail here on login-walled/rate-limited content.
+    // downloads also fail here on login-walled/rate-limited content. Only the
+    // bounds are ours; describeYtDlpFailure owns the prose and appends whatever
+    // yt-dlp actually printed, which outranks the guess.
     const reason = exit.code === 0
-      ? `no video was produced — it may be longer than ${Math.round(maxDurationSec / 60)} minutes or larger than ${Math.round(maxBytes / 1024 / 1024 / 1024)}GB, or (for x.com) login-walled, rate-limited, or otherwise unavailable`
-      : (exit.reason || `yt-dlp exited ${exit.code}`);
+      ? describeYtDlpFailure(exit.code, exit.output, {
+        fallback: `no video was produced — it may be longer than ${Math.round(maxDurationSec / 60)} minutes or larger than ${Math.round(maxBytes / 1024 / 1024 / 1024)}GB, or (for x.com) login-walled, rate-limited, or otherwise unavailable`,
+      })
+      : exit.reason; // always populated for a non-zero exit (see runYtDlp)
     await cleanupProducedFiles(filePrefix, outDir);
     return { outcome: 'failed', reason };
   }

--- a/server/services/ytdlpVideoImport.js
+++ b/server/services/ytdlpVideoImport.js
@@ -109,7 +109,7 @@ export async function downloadVideoToDir({
     url,
   ];
 
-  const exit = await runYtDlp({ ytDlp, args, onProgress, registerProcess });
+  const exit = await runYtDlp({ ytDlp, args, url, onProgress, registerProcess });
 
   if (exit.canceled) {
     await cleanupProducedFiles(filePrefix, outDir);
@@ -126,6 +126,7 @@ export async function downloadVideoToDir({
     // yt-dlp actually printed, which outranks the guess.
     const reason = exit.code === 0
       ? describeYtDlpFailure(exit.code, exit.output, {
+        url,
         fallback: `no video was produced — it may be longer than ${Math.round(maxDurationSec / 60)} minutes or larger than ${Math.round(maxBytes / 1024 / 1024 / 1024)}GB, or (for x.com) login-walled, rate-limited, or otherwise unavailable`,
       })
       : exit.reason; // always populated for a non-zero exit (see runYtDlp)


### PR DESCRIPTION
## Summary

A video download failed and the UI showed only `yt-dlp exited 1`. Root cause: `runYtDlp` read stdout/stderr **only** for the `PORTOS_*` progress markers and discarded every other line, so yt-dlp's actual `ERROR:` message never reached the caller. A YouTube 403, a login wall, an unavailable video and a bad format selection were all indistinguishable.

- **Capture the real message.** Non-marker lines now feed `createOutputTail` — the helper that already exists for this ("turns 'exited with code 1' into the reason the tool printed"). Marker branches all `return` first, so progress output can't evict the `ERROR:` line from the tail's budget, and the readers are flushed *before* the tail is read, because yt-dlp's `ERROR:` is often the last line with no trailing newline.
- **Name the remedy for the one invisible class.** YouTube gates media URLs behind a player-client / PO-token handshake that yt-dlp tracks release-to-release, so a binary a few weeks stale returns a flat 403 for a video the browser plays fine. `describeYtDlpFailure` adds an upgrade hint — gated on **both** the message signature and `isYoutubeVideoUrl`, so an x.com 403 (login-walled / rate-limited) or a reference-audio pull from any public URL never gets YouTube-specific advice. No URL passed means no hint: silence beats misdirection.
- **One owner for the prose.** Both importers delegate their "exited 0 but produced nothing" message to the same helper, passing only the bounds they alone know.

Deliberately excluded from the hint signature: `Sign in to confirm` (YouTube's bot check — the remedy is cookies, not an upgrade).

## Test plan

- `server/services/ytdlpRun.test.js` extended: stderr reaches the reason; an unterminated final line is flushed into it; marker lines stay out; `reason` stays null on a clean exit; the hint follows the *site* (YouTube 403 gets it, the identical x.com 403 does not, no-URL gets none); `runYtDlp` actually forwards the URL.
- Full affected surface green: `ytdlpRun`, `ytdlpVideoImport`, `ytdlpAudioImport`, `videoDownload`, `trackYoutubeImport`, `youtubeIngest`, `roundReferenceAudioImport`, `routes/videoDownload`, plus `lib/importScoping` (the new `lib/youtubeUrl.js` edge stays within the import budget) — 177 tests.
- Verified end to end against the URL that prompted this: previously `yt-dlp exited 1`, now `yt-dlp failed: ERROR: unable to download video data: HTTP Error 403: Forbidden — the installed yt-dlp is likely out of date ...`.